### PR TITLE
feat: add probe strategy and deft-gh-slice/triage skills

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -159,6 +159,14 @@ Load as needed:
 | Language hygiene — Python | `languages/python.md` (Hygiene section) |
 | Language hygiene — Go | `languages/go.md` (Hygiene section) |
 | Language hygiene — TypeScript | `languages/typescript.md` (Hygiene section) |
+| Language hygiene — JavaScript | `languages/javascript.md` (Hygiene section) |
+| Language hygiene — Rust | `languages/rust.md` (Hygiene section) |
+| Language hygiene — C++ | `languages/cpp.md` (Hygiene section) |
+| Language hygiene — C# | `languages/csharp.md` (Hygiene section) |
+| Language hygiene — Java | `languages/java.md` (Hygiene section) |
+| Language hygiene — Kotlin | `languages/kotlin.md` (Hygiene section) |
+| Language hygiene — Swift | `languages/swift.md` (Hygiene section) |
+| Language hygiene — C | `languages/c.md` (Hygiene section) |
 
 ---
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -13,9 +13,13 @@
 - Check for custom rules and preferences
 - Override path via `DEFT_USER_PATH` env var; legacy fallback: `core/user.md`
 
-**[core/glossary.md](./core/glossary.md)** - Term definitions
-- Load: When encountering unfamiliar terms (release, feature, demo sentence, context rot, etc.)
-- Contains: work decomposition hierarchy, GSD → Deft term mapping
+**[core/glossary.md](./core/glossary.md)** - Authoritative vocabulary
+- Load: When any term is undefined or used ambiguously; before introducing a new term
+- Contains: work decomposition hierarchy, hygiene terms, framework design terms, GSD → Deft mapping
+
+**[core/events.md](./core/events.md)** - Domain events
+- Load: When unsure what to do when a condition arises (coverage drops, spec approved, stub found, etc.)
+- Contains: canonical trigger → mandatory response table for 9 session events
 
 ## 📋 Task-Based Loading
 
@@ -123,6 +127,40 @@ Load as needed:
 - Load: When creating, validating, or debugging `.vbrief.json` files
 - Contains: JSON Schema (draft 2020-12) defining `vBRIEFInfo`, `Plan`, `PlanItem`, `Status` enum
 - Source: [github.com/visionik/vBRIEF](https://github.com/visionik/vBRIEF)
+
+## 🏠 Rule Ownership
+
+**Principle**: Each concept in directive has exactly one owning file. Other files reference the owner; they do not restate its rules. When you need to add a rule, identify the correct owner first.
+
+- ! Add rules to the owning file, not to the file where you happen to be working
+- ⊗ Duplicate a rule in a non-owning file — link to the owner instead
+- ! When the owner is unclear, check this map or add to `core/glossary.md` to establish it
+
+| Concept | Owner |
+|---------|-------|
+| Coding standards (modularity, contracts, DRY) | `coding/coding.md` |
+| Codebase hygiene (dead code, error hiding, legacy, circular deps, comments) | `coding/hygiene.md` |
+| Universal testing standards | `coding/testing.md` |
+| Build output validation | `coding/build-output.md` |
+| Toolchain validation | `coding/toolchain.md` |
+| Verification / stub detection | `verification/verification.md` |
+| Legacy / deprecated code detection | `verification/verification.md` |
+| Domain events (trigger → response) | `core/events.md` |
+| Terminology / ubiquitous language | `core/glossary.md` |
+| Work decomposition (release / feature / task) | `core/glossary.md` |
+| Git / commit conventions | `scm/git.md` |
+| CI/CD / GitHub workflows | `scm/github.md` |
+| Build automation / Taskfile | `tools/taskfile.md` |
+| vBRIEF lifecycle and schema | `vbrief/vbrief.md` |
+| Session continuity / checkpoints | `resilience/continue-here.md` |
+| Context engineering strategies | `context/context.md` |
+| Multi-agent coordination | `swarm/swarm.md` |
+| Change lifecycle | `commands.md` |
+| Language hygiene — Python | `languages/python.md` (Hygiene section) |
+| Language hygiene — Go | `languages/go.md` (Hygiene section) |
+| Language hygiene — TypeScript | `languages/typescript.md` (Hygiene section) |
+
+---
 
 ## 🔄 Reference Chains
 

--- a/coding/coding.md
+++ b/coding/coding.md
@@ -42,6 +42,14 @@ See [../scm/git.md](../scm/git.md) for:
 - ! One responsibility per file/module
 - ~ Files <300 lines ideal; files <500 lines recommended; ! files <1000 lines maximum
 - ! Explicit scope in task descriptions
+- ~ DRY: extract shared abstractions when logic is duplicated across 2+ call sites
+- ⊗ Copy-paste logic with minor variations — parameterise instead
+
+**Dependency Direction:**
+- ⊗ Circular imports between modules/packages
+- ~ Layered architecture: high-level modules depend on low-level ones, never the reverse
+- ! Use dependency inversion (interfaces/protocols) to break coupling across layers
+- See [hygiene.md](hygiene.md) for detection tools (madge, pydeps, Go compiler)
 
 **Contract-First:**
 - ! Define interfaces/types/protocols before implementation
@@ -58,6 +66,10 @@ See [../scm/git.md](../scm/git.md) for:
 - ! Document possible exceptions/error codes for all public functions
 - ! Validate all inputs at API boundaries
 - ⊗ Trust caller without validation
+- ⊗ Empty catch/except/recover blocks that swallow errors silently
+- ⊗ Returning neutral/zero values (None, {}, [], 0, false) to mask errors — propagate explicitly
+- ⊗ Log-and-continue: catching an error and proceeding as if it didn't happen, unless provably non-fatal and documented
+- See [hygiene.md](hygiene.md) for full error-hiding anti-pattern catalogue
 
 **Readability:**
 - ! Follow language idioms strictly
@@ -76,6 +88,9 @@ See [../scm/git.md](../scm/git.md) for:
 **Testing:**
 - ! Implementation is INCOMPLETE until tests written AND `task test:coverage` passes
 - See [../coding/testing.md](../coding/testing.md) for universal requirements
+
+**Codebase Hygiene:**
+- See [hygiene.md](hygiene.md) for: dead code removal, circular dependency detection, error hiding patterns, legacy/deprecated code cleanup
 
 **Telemetry:**
 - See [../tools/telemetry.md](../tools/telemetry.md) for recommendations
@@ -152,3 +167,8 @@ See [../scm/git.md](../scm/git.md) for:
 - ⊗ Implementing code without tests
 - ⊗ Claiming "done" before running test:coverage
 - ⊗ Ignoring coverage drops
+- ⊗ Weak types (`any`, `interface{}`, untyped `object`) where concrete types are knowable
+- ⊗ Dead code: unused functions, unreachable branches, stale feature flags, commented-out blocks
+- ⊗ Error hiding: empty catch blocks, silent fallbacks, swallowed exceptions
+- ⊗ Circular imports between modules
+- ⊗ Duplicate logic across 2+ call sites without shared abstraction

--- a/coding/coding.md
+++ b/coding/coding.md
@@ -67,7 +67,7 @@ See [../scm/git.md](../scm/git.md) for:
 - ! Validate all inputs at API boundaries
 - ⊗ Trust caller without validation
 - ⊗ Empty catch/except/recover blocks that swallow errors silently
-- ⊗ Returning neutral/zero values (None, {}, [], 0, false) to mask errors — propagate explicitly
+- ⊗ Returning neutral/zero values (None, {}, [], 0, false, "") to mask errors — propagate explicitly
 - ⊗ Log-and-continue: catching an error and proceeding as if it didn't happen, unless provably non-fatal and documented
 - See [hygiene.md](hygiene.md) for full error-hiding anti-pattern catalogue
 

--- a/coding/hygiene.md
+++ b/coding/hygiene.md
@@ -37,7 +37,7 @@ Circular imports create tight coupling, prevent modular testing, and indicate ar
 - ~ Enforce layered architecture: high-level modules depend on low-level ones, never the reverse
 - ! Use dependency inversion (interfaces/protocols) to break necessary coupling across layers
 - ~ Use language-specific tools to detect cycles:
-  - Python: `pydeps`, `importlab`, or `ruff` (detects some patterns)
+  - Python: `pydeps` or `importlab` for full cycle detection
   - Go: the compiler rejects import cycles — trust the error; fix by extracting shared packages
   - TypeScript/JS: `madge` — visualises and detects circular dependencies
 - ~ For large codebases, add `madge --circular` (or equivalent) as a CI check

--- a/coding/hygiene.md
+++ b/coding/hygiene.md
@@ -1,0 +1,104 @@
+# Codebase Hygiene
+
+Rules for ongoing codebase health — keeping existing code clean, not just writing new code well.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**⚠️ See also**:
+- [coding.md](coding.md) — Code design principles
+- [verification/verification.md](../verification/verification.md) — Stub and legacy detection
+- [coding/testing.md](testing.md) — Test coverage requirements
+
+---
+
+## Dead Code Removal
+
+Dead code accumulates silently and degrades readability and maintainability.
+
+- ! Before marking any refactor or cleanup task done, verify no unreferenced code was left behind
+- ⊗ Commented-out code blocks committed to version control — delete, don't comment out
+- ⊗ Functions, classes, or variables that are defined but never called/imported anywhere
+- ⊗ Unused imports, dependencies, or exports
+- ~ Use language-specific dead code tools as part of periodic hygiene passes:
+  - Python: `vulture` — detects unused functions, classes, variables
+  - Go: `deadcode` (golang.org/x/tools/cmd/deadcode) or `staticcheck` unused analysis
+  - TypeScript/JS: `knip` — detects unused exports, files, and dependencies
+- ~ Run dead code tools before major releases or after significant refactors
+- ? Add dead code tool as a Taskfile target (e.g. `task hygiene`) for periodic use
+
+---
+
+## Circular Dependencies
+
+Circular imports create tight coupling, prevent modular testing, and indicate architectural problems.
+
+- ⊗ Circular imports between modules/packages — detect and eliminate
+- ! When circular dependency exists, resolve by extracting shared types/interfaces to a lower-level module, not by restructuring import order
+- ~ Enforce layered architecture: high-level modules depend on low-level ones, never the reverse
+- ! Use dependency inversion (interfaces/protocols) to break necessary coupling across layers
+- ~ Use language-specific tools to detect cycles:
+  - Python: `pydeps`, `importlab`, or `ruff` (detects some patterns)
+  - Go: the compiler rejects import cycles — trust the error; fix by extracting shared packages
+  - TypeScript/JS: `madge` — visualises and detects circular dependencies
+- ~ For large codebases, add `madge --circular` (or equivalent) as a CI check
+
+---
+
+## Error Handling: No Hiding
+
+Try/catch and equivalent constructs serve a legitimate purpose at **API/input boundaries** — sanitizing unknown or untrusted input. Everywhere else, they should propagate errors explicitly.
+
+**Legitimate uses:**
+- Parsing external input (JSON, user input, file content)
+- Third-party SDK calls that may throw undocumented errors
+- Top-level process handlers (recover from unexpected crashes with logging)
+
+**Illegitimate uses (remove these):**
+
+- ⊗ Empty catch/except/recover blocks that swallow errors silently
+- ⊗ `except Exception: pass` or equivalent — log at minimum, re-raise if appropriate
+- ⊗ Returning neutral/zero values (None, {}, [], 0, false, "") to mask an error — propagate explicitly
+- ⊗ Log-and-continue: catching an error, logging it, and proceeding as if nothing happened — unless the error is provably non-fatal AND that decision is documented in a comment
+- ⊗ Fallback patterns that hide failures from callers (e.g. "if this fails, return cached/stale data" without surfacing the error)
+- ! When removing a try/catch, confirm the error propagates to a caller that can handle it — do not simply delete
+
+---
+
+## Legacy and Deprecated Code
+
+Legacy accumulation makes codebases fragile and hard to reason about. Code should have one active path, not a graveyard of old approaches alongside new ones.
+
+- ⊗ Parallel implementations: old approach and new approach coexisting without a migration path
+- ⊗ Feature flags or toggle branches where the flag is always-on or always-off — collapse to the live path
+- ⊗ Compatibility shims maintained beyond their stated removal date
+- ! When replacing an implementation: delete the old one in the same commit, not "after testing"
+- ~ Scan for these markers as legacy indicators:
+  - Comments: `# deprecated`, `// TODO: remove`, `LEGACY`, `COMPAT`, `OLD_`, `# old way`
+  - Python decorators: `@deprecated`
+  - Go: `// Deprecated:` godoc marker (legitimate when part of a public API — remove the symbol if internal)
+- ~ When encountering legacy code during unrelated work, file a hygiene task rather than ignoring it
+- ⊗ Comments describing in-flight replacement work ("this used to be X, now it's Y") — remove once the migration is complete; they are noise for future readers
+
+---
+
+## DRY: Don't Repeat Yourself
+
+Duplication is the root cause of inconsistent behaviour and maintenance burden.
+
+- ~ Extract shared abstractions when logic is duplicated across 2+ call sites
+- ⊗ Copy-paste logic with minor variations — parameterise instead
+- ! When deduplicating, verify the abstraction is actually shared behaviour, not coincidental similarity
+- ≉ Premature abstraction — only extract when the duplication is real and the shared contract is clear
+
+---
+
+## Comments: Signal vs. Noise
+
+Comments should explain **why**, not **what**. Remove noise; keep signal.
+
+- ⊗ Comments describing what the code does (the code itself shows this)
+- ⊗ In-motion commentary: "replaced X with Y", "temporarily disabled", "new approach below"
+- ⊗ Commented-out code — delete it; version control preserves history
+- ⊗ Section dividers and banners that add no information (e.g. `# --- helpers ---`)
+- ! When editing a file, remove stale comments as you go — do not leave them for later
+- ~ When a comment is needed, be concise: one line explaining the non-obvious reason, not a paragraph

--- a/core/events.md
+++ b/core/events.md
@@ -1,0 +1,114 @@
+# Domain Events
+
+Named occurrences in an agent session that trigger specific, mandatory behaviour.
+
+When an event fires, the listed response is not optional — it is the correct action. Agents must not proceed past an event without executing its response.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ⊗=MUST NOT.
+
+**⚠️ See also**: [commands.md](../commands.md) | [resilience/continue-here.md](../resilience/continue-here.md) | [verification/verification.md](../verification/verification.md) | [coding/hygiene.md](../coding/hygiene.md)
+
+---
+
+## `spec:approved`
+
+**When**: The `status` field in `./vbrief/specification.vbrief.json` is set to `"approved"` by the user.
+
+**Response**:
+- ! Run `task spec:render` (or `python scripts/spec_render.py`) to generate `SPECIFICATION.md`
+- ! Proceed to the build phase
+- ⊗ Edit `SPECIFICATION.md` directly — edit the vBRIEF source and re-render
+
+---
+
+## `coverage:dropped`
+
+**When**: `task test:coverage` reports coverage below the project threshold (default ≥85%).
+
+**Response**:
+- ! Block task/phase completion
+- ⊗ Claim the task or phase is done
+- ! Fix coverage before marking work complete
+
+---
+
+## `stub:detected`
+
+**When**: Scan of completed code reveals: `TODO`/`FIXME`/`HACK`/`XXX` comments, `return null`/`return {}`/`pass`/`unimplemented!()` placeholders, or functions under ~8 lines returning only hardcoded/empty values.
+
+**Response**:
+- ! Block completion
+- ⊗ Mark the task done
+- ! Implement fully, or explicitly defer with documented rationale in the task's vBRIEF narrative
+- See [verification/verification.md](../verification/verification.md) for full stub detection criteria
+
+---
+
+## `session:interrupted`
+
+**When**: Agent context is exhausted, the user asks to pause, or `/deft:checkpoint` is invoked.
+
+**Response**:
+- ! Write `./vbrief/continue.vbrief.json` with current task state and exact next action
+- ⊗ Continue implementation after context exhaustion
+- ⊗ Leave the session without a checkpoint when mid-task
+- See [resilience/continue-here.md](../resilience/continue-here.md) for checkpoint format
+
+---
+
+## `session:resumed`
+
+**When**: User invokes `/deft:continue`.
+
+**Response**:
+- ! Read `./vbrief/continue.vbrief.json` to restore context
+- ! Resume from the recorded next action — do not replay prior history or re-read completed work
+- See [resilience/continue-here.md](../resilience/continue-here.md)
+
+---
+
+## `legacy:detected`
+
+**When**: Review of any file reveals legacy indicators: comments containing `LEGACY`, `COMPAT`, `OLD_`, `TODO: remove`; commented-out code blocks (>1 line); always-on or always-off feature flag branches; or parallel implementations without a documented migration path.
+
+**Response**:
+- ~ File a hygiene task in the active `./vbrief/plan.vbrief.json` if one exists, otherwise note in `meta/improvements.md`
+- ⊗ Ignore and continue — legacy accumulation is a defect, not background noise
+- See [coding/hygiene.md](../coding/hygiene.md) for the full legacy removal protocol
+
+---
+
+## `plan:approved`
+
+**When**: The user explicitly approves a `/deft:change` proposal.
+
+**Response**:
+- ! Set `tasks.vbrief.json` plan `status` to `"approved"`
+- ! Begin `/deft:change:apply`
+- ⊗ Begin implementation without explicit approval
+- ⊗ Treat silence as approval
+
+---
+
+## `change:verified`
+
+**When**: All tasks in `tasks.vbrief.json` reach `status: completed`.
+
+**Response**:
+- ! Run `/deft:change:verify` before archiving
+- ⊗ Archive directly without verification
+- ! Record the verification tier reached per task in `tasks.vbrief.json` metadata
+- See [verification/verification.md](../verification/verification.md) for the verification ladder
+
+---
+
+## `toolchain:missing`
+
+**When**: A required tool (task runner, compiler, test framework, platform SDK) is not found at the pre-implementation gate.
+
+**Response**:
+- ! Stop immediately — do not begin implementation
+- ! Report exactly which tools are missing with install guidance
+- ⊗ Proceed with implementation while bypassing quality gates
+- ⊗ Partially implement using available tools while skipping coverage or lint
+- See [coding/toolchain.md](../coding/toolchain.md)

--- a/core/glossary.md
+++ b/core/glossary.md
@@ -1,6 +1,10 @@
 # Glossary
 
-Terms used across the Deft framework. Includes mappings from external systems.
+The authoritative vocabulary for the Deft framework.
+
+! When a term used in any directive file is not locally defined, load this file to resolve it.
+! When introducing a new term in any directive file, define it here first.
+⊗ Define the same term differently in two files — one definition, one source of truth.
 
 ---
 
@@ -53,6 +57,36 @@ These concepts originate from [GSD](https://github.com/gsd-build/get-shit-done) 
 **Spec delta** — A scoped document capturing how a change modifies existing requirements. Shows new requirements and was/now diffs for modified ones. Linked to the baseline spec via vBRIEF `references` with `type: "x-vbrief/plan"`. Lives in `history/changes/<name>/specs/`. See [context/spec-deltas.md](../context/spec-deltas.md). Invoked as part of `/deft:change`.
 
 **Verify command** — A concrete, runnable command specified per task that confirms the task's work is correct (e.g., `pytest tests/test_auth.py`, `curl localhost:8080/health`). Required by plan checking dimension 2 (completeness). Tasks without a verify command fail the plan check.
+
+---
+
+## Framework Design Terms
+
+Terms describing how directive itself is structured and governed.
+
+**Bounded context** (framework sense) — A file or directory in directive that owns a specific rule domain. Other files reference it; they do not restate its rules. Prevents rule drift through duplication. Examples: `coding/hygiene.md` owns hygiene rules; `coding/testing.md` owns universal testing standards.
+
+**Rule ownership** — The principle that each concept in directive has exactly one owning file. When multiple files need to reference the concept, they link to the owner rather than duplicating the rule. The ownership map lives in [REFERENCES.md](../REFERENCES.md).
+
+**Domain event** — A named occurrence in an agent session that triggers specific, mandatory behaviour. The canonical list is in [core/events.md](./events.md). When an event fires, its response is not optional.
+
+**Ubiquitous language** — The shared, precisely defined vocabulary used consistently across all directive files and by all agents. This glossary is the source of truth. Synonyms and informal restatements of defined terms are not permitted.
+
+---
+
+## Hygiene Terms
+
+Terms used in [coding/hygiene.md](../coding/hygiene.md).
+
+**Hygiene** — The ongoing practice of keeping a codebase clean beyond what individual changes introduce: removing dead code, eliminating circular dependencies, surfacing hidden errors, and removing legacy/deprecated code paths. Distinct from per-change quality gates, which only govern new code.
+
+**Dead code** — Code that is defined but never executed: unused functions, unreachable branches, stale feature flags, and commented-out blocks. Distinct from deprecated code, which may still execute on a legacy path.
+
+**Error hiding** — Any pattern that prevents an error from being observed by the caller or operator: empty catch blocks, silent fallbacks, returning neutral/zero values to mask failures, or log-and-continue without surfacing the error upstream.
+
+**Legacy code** — A code path, implementation, or feature flag that has been superseded but not removed. Identified by markers such as `LEGACY`, `COMPAT`, `OLD_`, `TODO: remove`, or the presence of two parallel implementations without a migration path.
+
+**Circular dependency** — An import cycle where module A depends on module B which depends (directly or transitively) on module A. Indicates architectural coupling that prevents modular testing and signals a layering violation.
 
 ---
 

--- a/docs/more-determinism.md
+++ b/docs/more-determinism.md
@@ -1,0 +1,339 @@
+# Deterministic > Probabilistic: Task Audit & Recommendations
+
+Principle: anything enforced by a prompt is probabilistic — an agent might skip it,
+do it inconsistently, or hallucinate that it passed. Anything enforced by a task is
+deterministic — it either passes or fails with a non-zero exit code.
+
+This document catalogs opportunities to move deft enforcement from prompts to tasks.
+
+Fundamentally this is the start of a new ground rule:
+
+If something CAN be done by a task file task, it MUST be done by a task file task.
+
+
+## 1. Current State
+
+The root `Taskfile.yml` has ~13 tasks. One included sub-taskfile exists
+(`taskfiles/deployments.yml`, 2 tasks). Many framework operations described in
+directives (`toolchain.md`, `verification.md`, `build-output.md`, `commands.md`)
+are enforced only by instructing agents to do the right thing.
+
+---
+
+## 2. Prompt-Driven Operations That Should Become Tasks
+
+### A. Toolchain Verification (`coding/toolchain.md`)
+
+**Today**: Agent is _told_ to run `task --version`, `go version`, etc.
+**Risk**: Agent skips it or checks inconsistently (the Xcode/Swift incident).
+
+**Proposed**: `task toolchain:check`
+- Reads `PROJECT.md` for declared languages/tools
+- Verifies each is installed and functional
+- Exits non-zero on any failure
+- Becomes a `dep` of `check` and the build skill's Step 2
+
+### B. Stub Detection (`verification/verification.md`)
+
+**Today**: Agent is _instructed_ to scan for `TODO`, `FIXME`, `return null`, `pass`, etc.
+**Risk**: Most common agent shortcut — leaving stubs and calling it done.
+
+**Proposed**: `task verify:stubs`
+- `rg`-based scan for patterns listed in `verification.md`
+- Non-zero exit if stubs found in source files (excludes tests, vendor, etc.)
+- Can be a dep of `check`
+
+### C. Build Output Validation (`coding/build-output.md`)
+
+**Today**: Agent is _told_ to verify files exist and are non-empty after `task build`.
+**Risk**: Zero-exit-code build with stale or missing artifacts goes unnoticed.
+
+**Proposed**: `task build:verify`
+- Runs after `build`
+- Checks `dist/` contents against a manifest (could be a `generates:` list or a
+  separate `.build-manifest.yml`)
+- Fails if expected artifacts are missing or empty
+
+### D. Spec Validation + Render Pipeline
+
+**Today**: `spec:validate` and `spec:render` exist but are standalone. The interview
+strategy says "run `task spec:render` if available" — no unified pipeline.
+
+**Proposed**: `task spec:pipeline`
+- Runs `spec:validate` then `spec:render` as deps
+- Single deterministic command for the full spec flow
+
+### E. vBRIEF Schema Compliance
+
+**Today**: Agent is _told_ to generate compliant vBRIEF (FR-6). `spec_validate.py`
+exists but only validates one file at a time.
+
+**Proposed**: `task vbrief:validate`
+- Finds all `*.vbrief.json` in `./vbrief/`
+- Validates each against the schema
+- Fails on any non-conforming file
+
+### F. Change Lifecycle Scaffolding (`commands.md`)
+
+**Today**: `/deft:change <name>` is prompt-driven — the agent creates
+`history/changes/<name>/` with `proposal.md`, `design.md`, `tasks.vbrief.json`,
+and `specs/`. Agent might forget a file or use wrong structure.
+
+**Proposed**: `task change:init`
+- Takes a name via `{{.CLI_ARGS}}`
+- Creates directory structure from a template
+- Scaffolds all required files deterministically
+
+### G. Change Archival
+
+**Today**: `/deft:change:archive` is agent-driven (move folder, date prefix, merge
+spec deltas, validate pre-conditions).
+
+**Proposed**: `task change:archive`
+- Moves the folder with correct date prefix
+- Validates pre-conditions (all tasks completed)
+- Exits non-zero if any task is not `completed`
+
+### H. Cross-Reference Integrity
+
+**Today**: Stale references are found during manual audits (t2.1.1, legacy paths).
+
+**Proposed**: `task validate:links`
+- Checks all `.md` files for internal links (`[text](path)`)
+- Verifies the target file exists
+- Prevents link rot deterministically
+- Excludes `history/archive/` from checking
+
+### I. CHANGELOG Entry Validation
+
+**Today**: AGENTS.md says "Add CHANGELOG.md entry under `[Unreleased]`" — purely
+agent honor system.
+
+**Proposed**: `task changelog:check`
+- Verifies `CHANGELOG.md` has an `[Unreleased]` section
+- Verifies at least one entry exists since the last release tag
+- Can be a dep of `check`
+
+### J. Conventional Commit Validation
+
+**Today**: Commit format is a rule in the agent prompt. No enforcement.
+
+**Proposed**: `task commit:lint`
+- Runs a commit message linter against HEAD (or a range)
+- Can be a git hook or CI check
+- Simple regex-based validation or `commitlint` if available
+
+---
+
+## 3. Phase 0 — Deterministic Scaffolding Per Spec Iteration
+
+### Concept
+
+Every time deft generates a `SPECIFICATION.md`, before Phase 1 implementation
+begins, a **Phase 0** creates the task infrastructure for that specific spec.
+
+### What Phase 0 Generates
+
+For a project with Phases 1–3 in its spec, `task spec:phase0` generates:
+
+```
+tasks/
+└── {project-name}.yml     # Spec-specific taskfile (included from root)
+```
+
+Contents of `{project-name}.yml`:
+
+- **`setup`** — Scaffold project structure per spec (directories, empty files, config)
+- **`toolchain`** — Verify all tools the spec requires (reads from PROJECT.md)
+- **`test:scaffold`** — Generate test file skeletons for each phase's tasks
+  (empty test functions named after acceptance criteria)
+- **`gate:phase-N`** — Per-phase quality gate that runs the subset of tests and
+  checks relevant to that phase
+- **`verify:phase-N`** — Per-phase verification (stub scan + acceptance criteria
+  check for that phase's tasks)
+
+### How It Works
+
+1. After `SPECIFICATION.md` is approved (acceptance gate passes), agent runs
+   `task spec:phase0` (or it auto-runs as a dep of the build handoff)
+2. `spec:phase0` reads the spec's phases and tasks, generates `tasks/{project-name}.yml`
+3. Root `Taskfile.yml` includes the generated taskfile
+4. Implementation uses `task gate:phase-1`, `task gate:phase-2`, etc. instead of
+   relying on the agent to remember quality gates
+
+### Benefits
+
+- **Deterministic gates per phase** — can't "forget" to run tests for Phase 2
+- **Incremental** — `sources`/`generates` means unchanged phases don't re-run
+- **Auditable** — `task --list` shows exactly what gates exist
+- **Composable** — multiple agents working on different phases each have their own gate
+
+---
+
+## 4. Task Directory Restructuring
+
+### Current State
+
+```
+Taskfile.yml              # Root (13 tasks — monolithic)
+taskfiles/
+  deployments.yml         # Cloud-gov sync/export (2 tasks)
+```
+
+### Proposed Structure
+
+```
+Taskfile.yml              # Root: includes + default only
+tasks/
+  core.yml                # validate, fmt, lint, test, test:coverage, check, build, clean, stats
+  spec.yml                # spec:validate, spec:render, spec:pipeline, spec:phase0, vbrief:validate
+  toolchain.yml           # toolchain:check
+  verify.yml              # verify:stubs, verify:links, build:verify
+  change.yml              # change:init, change:archive, changelog:check
+  install.yml             # install, uninstall
+  commit.yml              # commit:lint
+  deployments.yml         # (moved from taskfiles/)
+  {project-name}.yml      # Generated by Phase 0 per spec iteration
+```
+
+### Root Taskfile Becomes Minimal
+
+```yaml
+version: '3'
+
+vars:
+  PROJECT_NAME: deft
+  VERSION: 0.5.2
+
+includes:
+  core:      { taskfile: ./tasks/core.yml }
+  spec:      { taskfile: ./tasks/spec.yml }
+  toolchain: { taskfile: ./tasks/toolchain.yml }
+  verify:    { taskfile: ./tasks/verify.yml }
+  change:    { taskfile: ./tasks/change.yml }
+  install:   { taskfile: ./tasks/install.yml }
+  commit:    { taskfile: ./tasks/commit.yml }
+  deploy:    { taskfile: ./tasks/deployments.yml, optional: true }
+
+tasks:
+  default:
+    desc: List all available tasks
+    cmds: [task --list]
+    silent: true
+```
+
+### Task Visibility
+
+Use `internal: true` for plumbing tasks that support other tasks but shouldn't
+clutter `task --list`. These are still callable directly and as dependencies.
+
+```yaml
+verify:stubs:
+  desc: Scan for TODO/FIXME/stub placeholders
+  # (visible in task --list)
+
+verify:stubs:build-patterns:
+  internal: true
+  # (hidden from task --list, but callable and usable as a dep)
+```
+
+No namespace prefix (like `directive:`) is needed — the file boundary (`tasks/*.yml`)
+provides organizational clarity. Contributors run `task --list` and see a clean,
+categorized list. Internal tasks exist in the same file but are hidden from output.
+
+---
+
+## 5. Internal vs User-Facing Tasks
+
+### Internal to Directive (framework development only)
+
+These tasks only deft contributors use when working _on_ the framework:
+
+- `validate` — markdown validation of framework files
+- `spec:validate` / `spec:render` / `spec:pipeline` — framework's own spec
+- `vbrief:validate` — framework's vBRIEF files
+- `verify:links` — framework cross-reference integrity
+- `stats` — framework statistics
+- `install` / `uninstall` — deft installer management
+- `build` / `clean` — framework distribution packaging
+- `deploy:cloudgov:*` — cloud-gov export
+- `commit:lint` — framework repo commit linting
+- `changelog:check` — framework CHANGELOG
+
+### User-Facing (projects that use deft)
+
+These tasks appear in end-user project Taskfiles:
+
+- `check` — pre-commit gate (universal)
+- `test` / `test:coverage` — universal
+- `fmt` / `lint` — universal
+- `toolchain:check` — verify project tools installed
+- `verify:stubs` — scan for incomplete implementations
+- `build:verify` — post-build artifact validation
+- `change:init` / `change:archive` — change lifecycle
+- `doctor` — system health check
+- `ci:local` — local CI mirror
+
+### Dual-Purpose
+
+Same pattern in both contexts, different project-specific config:
+
+- `check`, `test`, `fmt`, `lint` — same shape, different project
+- `toolchain:check`, `verify:stubs` — same concept, project-specific patterns
+
+---
+
+## 6. Additional Opportunities
+
+### A. `task doctor` — System Health Check
+
+Combines toolchain verification, link validation, vBRIEF schema check, stub scan,
+and coverage threshold into a single diagnostic. Like `brew doctor` for the project.
+
+### B. `task new:strategy` — Strategy Scaffolding
+
+When someone creates a custom strategy, scaffold the file with the correct
+front-matter, type declaration, and register it in `strategies/README.md`.
+
+### C. `task ci:local` — Run CI Locally
+
+Mirror the GitHub Actions workflow locally. Instead of pushing to find out CI fails,
+`task ci:local` runs the same matrix (Python lint/test, Go build) deterministically.
+
+### D. `task release` — Version Bump + CHANGELOG
+
+The three version numbers (Taskfile `0.5.2`, framework `0.5.0`, CLI `0.4.2`) are a
+known open question (PRD OQ-1). A `task release` could manage version unification
+deterministically.
+
+### E. Enhanced `task check`
+
+Current `check` has `deps: [validate, lint, test]`. Proposed enhanced deps:
+
+```yaml
+check:
+  desc: Run all pre-commit checks
+  deps:
+    - toolchain:check
+    - validate
+    - verify:links
+    - verify:stubs
+    - lint
+    - test
+    - changelog:check
+```
+
+This turns `check` into a truly comprehensive deterministic gate.
+
+---
+
+## 7. Priority Order
+
+Biggest wins, ordered by impact:
+
+1. **Phase 0 generation** — makes every spec iteration self-enforcing via generated task targets
+2. **`tasks/` directory split** — scales the task surface without a monolithic Taskfile
+3. **`toolchain:check`** — the single most impactful individual task (prevents the Xcode/Swift incident deterministically)
+4. **`verify:stubs`** — catches the most common agent shortcut without relying on self-policing
+5. **`change:init` / `change:archive`** — the change lifecycle is too complex to leave prompt-driven
+6. **Enhanced `check`** — adding link validation, stub detection, changelog, and toolchain as deps makes the pre-commit gate comprehensive

--- a/languages/c.md
+++ b/languages/c.md
@@ -204,6 +204,23 @@ Items marked ⊗ in Standards above are not repeated here.
 - ≉ **Mixing signed/unsigned**: Explicit casts + `-Wconversion`
 - ≉ **Global mutable state**: Pass state via struct pointers
 
+## Hygiene
+
+**Types:**
+- ⊗ Implicit `int` return type or implicit function declarations — illegal in C99+; always declare explicitly
+- ⊗ `void*` casts without an inline comment explaining why a generic pointer is necessary
+- ⊗ `int` used as a boolean — use `bool` (`<stdbool.h>`, C99+) for clarity
+
+**Error handling:**
+- ⊗ Ignoring return values of `malloc`, `fread`, `fwrite`, `fclose`, or any function that signals failure via return value
+- ⊗ Empty error branches — all error paths must log, clean up, or propagate
+- ~ Use `-Wunused-result` and `__attribute__((warn_unused_result))` to enforce checked return values at the compiler level
+
+**Dead code:**
+- ~ Run `cppcheck --enable=unusedFunction,unusedVariable` to detect dead functions and variables
+- ~ `-Wunused-function` and `-Wunused-variable` compiler flags catch file-local dead code
+- ⊗ `#pragma GCC diagnostic ignored "-Wunused-function"` to suppress rather than remove dead code
+
 ## Compliance Checklist
 
 - ! Doxygen comments for all public APIs

--- a/languages/cpp.md
+++ b/languages/cpp.md
@@ -102,6 +102,23 @@ See [commands.md](./commands.md).
 - **I.13**: Don't pass arrays as single pointers (use `gsl::span<T>`)
 
 **Polymorphism**: ~ Abstract base classes OR concepts (C++20)
+## Hygiene
+
+**Types:**
+- ⊗ `void*` where a typed pointer, `std::variant`, or template parameter is feasible
+- ⊗ C-style casts `(T)x` — use `static_cast`, `reinterpret_cast`, or `dynamic_cast` explicitly
+- ~ Mark functions `[[nodiscard]]` when callers must not ignore the return value
+
+**Error handling:**
+- ⊗ Empty `catch(...)` or `catch(std::exception&) {}` that swallow exceptions silently
+- ⊗ Discarding `[[nodiscard]]` return values without explicit `(void)` cast and inline comment
+- ⊗ Using exceptions for control flow in tight loops — use `std::expected` (C++23) or error codes
+
+**Dead code:**
+- ~ Run `cppcheck --enable=unusedFunction` to detect unreferenced functions
+- ~ clang-tidy `misc-unused-*` and `readability-function-cognitive-complexity` checks surface dead helpers
+- ⊗ `// NOLINT` or `#pragma warning(disable:...)` without an inline explanation
+
 ## Compliance Checklist
 
 - ! Include Doxygen comments for all public APIs

--- a/languages/csharp.md
+++ b/languages/csharp.md
@@ -228,6 +228,24 @@ Items marked ⊗ in Standards above are not repeated here.
 - ≉ **God classes**: Keep <500 lines; extract services/handlers
 - ≉ **`static` utility classes**: Inject via DI for testability
 
+## Hygiene
+
+**Types:**
+- ⊗ `object` as parameter or return type where a concrete or generic type is knowable
+- ⊗ `dynamic` outside genuine late-binding scenarios (COM interop, DLR, legacy)
+- ⊗ `null!` (null-forgiving operator) to suppress nullable warnings without a documented invariant
+- ⊗ `#pragma warning disable` without an inline comment explaining why it is safe
+
+**Error handling:**
+- ⊗ Empty `catch {}` or `catch (Exception) { }` — handle or re-throw
+- ⊗ `catch (Exception e) { }` that swallows without logging — use structured logging and propagate
+- ⊗ Returning `null` or a default value from a public method to mask an exception
+
+**Dead code:**
+- ~ Roslyn IDE analyzers report unused private members; treat `IDE0051` as a warning-as-error in CI
+- ~ Run `dotnet-unused` for projects with large public APIs to detect unreferenced symbols
+- ⊗ `#pragma warning disable IDE0051` to hide dead code from analysis instead of deleting it
+
 ## Compliance Checklist
 
 - ! XML doc comments on all public APIs

--- a/languages/go.md
+++ b/languages/go.md
@@ -54,6 +54,20 @@ for _, tt := range tests {
 
 **Interface**: Define consumer-side, mock with function fields
 
+## Hygiene
+
+**Types:**
+- ⊗ `any` (empty interface) where a concrete type or typed interface is knowable; use generics or explicit interfaces
+- ⊗ Ignore errors with `_` — every error MUST be checked or explicitly propagated with a reason
+
+**Dead code:**
+- ~ Run `staticcheck` (detects unused code, unreachable branches) and `deadcode` (golang.org/x/tools/cmd/deadcode) before releases
+- ⊗ Unexported functions that are never called outside their own file
+
+**Circular dependencies:**
+- The Go compiler rejects import cycles — treat them as build failures, not warnings
+- ! Resolve by extracting shared types to a lower-level package; do not re-order imports
+
 ## Compliance Checklist
 
 - ! Follow go.dev/doc/comment for all exported symbols

--- a/languages/go.md
+++ b/languages/go.md
@@ -58,11 +58,14 @@ for _, tt := range tests {
 
 **Types:**
 - ⊗ `any` (empty interface) where a concrete type or typed interface is knowable; use generics or explicit interfaces
+
+**Error handling:**
 - ⊗ Ignore errors with `_` — every error MUST be checked or explicitly propagated with a reason
+- ⊗ Empty `recover` blocks that swallow panics silently
 
 **Dead code:**
 - ~ Run `staticcheck` (detects unused code, unreachable branches) and `deadcode` (golang.org/x/tools/cmd/deadcode) before releases
-- ⊗ Unexported functions that are never called outside their own file
+- ⊗ Unexported functions that are never called anywhere in the package
 
 **Circular dependencies:**
 - The Go compiler rejects import cycles — treat them as build failures, not warnings

--- a/languages/java.md
+++ b/languages/java.md
@@ -248,6 +248,23 @@ Items marked ⊗ in Standards above are not repeated here.
 - ≉ **God classes**: Keep <500 lines; extract service/strategy/helper
 - ≉ **`Collectors.toList()`**: Prefer `Stream.toList()` (Java 16+)
 
+## Hygiene
+
+**Types:**
+- ⊗ Raw types (`List`, `Map`, `Optional`) without type parameters — always parameterize
+- ⊗ `Object` as parameter or return type where a concrete type or bounded wildcard is knowable
+- ⊗ `@SuppressWarnings("unchecked")` without an inline comment proving the cast is safe
+
+**Error handling:**
+- ⊗ Empty `catch (Exception e) {}` — handle, log with context, or re-throw as a typed exception
+- ⊗ `e.printStackTrace()` as the sole handler — use structured logging and propagate or wrap
+- ⊗ Returning `null` from public methods to signal failure — use `Optional<T>` or throw
+
+**Dead code:**
+- ~ SpotBugs (in build config) detects `DLS_DEAD_LOCAL_STORE` and unreachable code
+- ~ PMD rules `UnusedPrivateMethod` and `UnusedPrivateField` catch dead private symbols
+- ~ Run `gradle dependencies --configuration runtimeClasspath` to audit unused dependencies
+
 ## Compliance Checklist
 
 - ! Javadoc on all public APIs

--- a/languages/javascript.md
+++ b/languages/javascript.md
@@ -133,6 +133,25 @@ Items marked ⊗ in Standards above are not repeated here.
 - ≉ **Barrel re-exports everywhere**: Hurts tree-shaking
 - ≉ **God modules**: Keep files <300 lines
 
+## Hygiene
+
+**Types:**
+- ~ Use JSDoc `@type` annotations or `// @ts-check` to surface weak types without migrating to TypeScript
+- ⊗ Untyped `.json()` parse results passed directly to callers without shape validation
+
+**Error handling:**
+- ⊗ Empty `catch` blocks — handle the specific error or re-throw
+- ⊗ Unhandled promise rejections — every `Promise` must be `.catch()`-ed or returned
+- ⊗ `catch (e) { console.log(e) }` without re-throw — log-and-continue hides failures from callers
+
+**Dead code:**
+- ~ Run `knip` to detect unused exports, files, and dependencies
+- ~ Add `knip` as a `task hygiene` target
+
+**Circular dependencies:**
+- ~ Run `madge --circular src/` to detect cycles
+- ⊗ Circular imports — restructure or extract shared code to a lower-level module
+
 ## Compliance Checklist
 
 - ! JSDoc on all exported APIs

--- a/languages/kotlin.md
+++ b/languages/kotlin.md
@@ -165,6 +165,22 @@ Items marked ⊗ in Standards above are not repeated here.
 - ≉ **`if-else` for sealed dispatch**: Use exhaustive `when`
 - ≉ **String templates in logging**: Use parameterized logging
 
+## Hygiene
+
+**Types:**
+- ⊗ `Any` as parameter or return type where a concrete type or bounded generic is knowable
+- ⊗ `!!` (non-null assertion) outside tests without a documented invariant proving non-null at that point
+- ~ Use sealed classes/interfaces over `Any`-typed discriminated unions
+
+**Error handling:**
+- ⊗ Empty `catch` blocks or catching `Throwable` — already in Standards; treat as a hygiene blocker in review
+- ⊗ `runCatching { }.getOrNull()` to silently discard failures — inspect the `Failure` case
+
+**Dead code:**
+- ~ detekt rules `UnusedPrivateMember` and `UnusedImports` detect dead code; enable in CI
+- ~ Run `gradle dependencies` to audit unused or duplicate dependencies
+- ⊗ `@Suppress("unused")` to hide dead code from detekt instead of deleting it
+
 ## Compliance Checklist
 
 - ! KDoc on all public API

--- a/languages/python.md
+++ b/languages/python.md
@@ -136,6 +136,21 @@ warn_unused_configs=true
 disallow_untyped_defs=true
 ```
 
+## Hygiene
+
+**Types:**
+- ⊗ `# type: ignore` without an inline comment explaining exactly why it is safe
+- ⊗ `Any` as a function return type where the concrete type is knowable
+- ⊗ Bare `object` or untyped containers (`list`, `dict` with no generics) on public APIs
+
+**Error handling:**
+- ⊗ Bare `except:` or `except Exception: pass` — catch the specific exception; log or re-raise
+- ⊗ Returning `None` or a neutral default to mask an exception — let it propagate
+
+**Dead code:**
+- ~ Run `vulture` to detect unused functions, classes, and variables
+- ~ Add `vulture . --min-confidence 80` as a `task hygiene` target
+
 ## Compliance Checklist
 
 - ! Follow PEP 257 (docstrings) and PEP 484 (type hints)

--- a/languages/python.md
+++ b/languages/python.md
@@ -110,8 +110,9 @@ def process_order(order: Order) -> ProcessedOrder:
 [project]
 requires-python=">=3.11"
 dependencies=["flask>=3.0.0"]  # or fastapi/typer[all]/textual[dev]
-[project.optional-dependencies]
+[dependency-groups]  # PEP 735 — uv syncs these automatically without extra flags
 dev=["pytest>=7.4","pytest-cov>=4.1","pytest-mock>=3.12","hypothesis>=6.0","black>=23","isort>=5.12","ruff>=0.1","mypy>=1.7","pydantic>=2.0"]
+[project.optional-dependencies]  # pip/hatch compat — requires: uv sync --extra dev / pip install -e ".[dev]"
 prod=["pydantic>=2.0","logfire>=0.1"]  # ~ Observability for production
 [tool.pytest.ini_options]
 testpaths=["tests"]

--- a/languages/rust.md
+++ b/languages/rust.md
@@ -187,6 +187,22 @@ Items marked ⊗ in Standards above are not repeated here.
 - ≉ **God-struct with many `Option` fields**: Use builder pattern or state types
 - ≉ **`Box<dyn Error>` in libraries**: Define specific error enums
 
+## Hygiene
+
+**Types:**
+- ⊗ `dyn Any` or `Box<dyn Any>` where a concrete type or typed trait object is knowable
+- ⊗ `#[allow(unused)]` or `#[allow(dead_code)]` attributes to suppress rather than remove dead code
+
+**Error handling:**
+- ⊗ `.unwrap()` or `.expect()` outside test code — use `?` or explicit match
+- ⊗ `let _ = result` to silently ignore a `Result` or `Option` — handle or document why safe
+- ⊗ Match arms `_ => {}` or `Err(_) => {}` that swallow errors without logging or propagating
+
+**Dead code:**
+- ~ `cargo check` warns on unused items; `cargo clippy` detects dead helpers and unreachable branches
+- ~ Use `cargo +nightly udeps` to detect unused dependencies in `Cargo.toml`
+- ⊗ Commented-out code — delete; version control preserves history
+
 ## Compliance Checklist
 
 - ! rustdoc on all public items with examples

--- a/languages/swift.md
+++ b/languages/swift.md
@@ -125,6 +125,23 @@ Key settings: `swift-tools-version: 5.9`, platforms `.iOS(.v17)/.macOS(.v14)`, e
 - `--wrapcollections before-first`, `--wraparguments before-first`
 - Enabled: `isEmpty`, `redundantSelf`, `sortImports`, `trailingCommas`
 
+## Hygiene
+
+**Types:**
+- ⊗ Force unwrap `!` without a documented invariant proving non-nil — already in Standards; treat as hygiene blocker in review
+- ⊗ `any Protocol` (existential) where a concrete type or `some Protocol` (opaque) is knowable (SE-0335)
+- ~ Prefer `some` (opaque return type) over `any` when the concrete type is fixed at the call site
+
+**Error handling:**
+- ⊗ `try?` that silently discards errors in non-trivial paths — use `do { try } catch` and handle
+- ⊗ `try!` outside tests without a compile-time guarantee of non-throwing
+- ⊗ Empty `catch {}` blocks
+
+**Dead code:**
+- ~ Run `periphery scan` (`Periphery`) to detect unused declarations, types, and protocols
+- ~ SwiftLint `unused_declaration` opt-in rule catches file-local dead code
+- ⊗ `// swiftlint:disable unused_declaration` to suppress rather than remove dead code
+
 ## Compliance Checklist
 
 - ! Follow Swift API Design Guidelines for all public APIs

--- a/languages/typescript.md
+++ b/languages/typescript.md
@@ -28,8 +28,10 @@ See [testing.md](../coding/testing.md).
 
 ### Types
 - ! Use strict mode
-- ⊗ Use `any`
-- ~ Prefer `unknown` for type-safe unknowns
+- ⊗ Use `any` — including `as any` or `as unknown as T` casts to bypass type checking
+- ~ Prefer `unknown` for inputs from untrusted sources; narrow with type guards before use
+- ⊗ `unknown` as a function return type where the concrete type is knowable
+- ⊗ `@ts-ignore` or `@ts-expect-error` without an inline comment explaining why it is safe
 
 ### Telemetry
 - See [telemetry.md](../tools/telemetry.md)
@@ -107,6 +109,20 @@ Key settings: `globals: true`, `environment: "node"` (or `jsdom`), `coverage.pro
 ## .eslintrc.json
 
 Key settings: `@typescript-eslint/parser`, extends `recommended` + `recommended-requiring-type-checking`, rules: `no-explicit-any: error`, `no-unused-vars: [error, { argsIgnorePattern: "^_" }]`, `explicit-function-return-type: [warn, { allowExpressions: true }]`.
+
+## Hygiene
+
+**Dead code:**
+- ~ Run `knip` to detect unused exports, files, and dependencies
+- ~ Add `knip` as a `task hygiene` target; treat unused exports in library code as errors
+
+**Circular dependencies:**
+- ~ Run `madge --circular src/` to detect cycles; resolve by extracting shared types to a lower-level module
+- ⊗ Circular imports between modules — use dependency inversion (interfaces/types in a shared module)
+
+**Error handling:**
+- ⊗ Empty `catch` blocks or `catch (e) {}` — log or re-throw
+- ⊗ Returning `null`, `undefined`, or a neutral default to mask a thrown error
 
 ## Compliance Checklist
 

--- a/main.md
+++ b/main.md
@@ -47,6 +47,7 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 - ! Explain tradeoffs when multiple approaches exist
 - ~ Suggest improvements even when not asked
 - ! Before implementing any planned change that touches 3+ files or has an accepted plan artifact, propose `/deft:change <name>` and wait for confirmation
+- ! When a session condition arises (coverage drops, spec approved, stub found, context exhausted, etc.), treat it as a domain event — see [core/events.md](./core/events.md) for the mandatory response
 
 **Communication:**
 - ! Be concise and precise

--- a/skills/deft-gh-slice/SKILL.md
+++ b/skills/deft-gh-slice/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: deft-gh-slice
+description: >
+  Break a SPECIFICATION.md, PRD, or plan into independently-grabbable GitHub
+  Issues using tracer-bullet vertical slices. Use after spec generation, when
+  the user wants to create implementation tickets, or when breaking work into
+  parallel-assignable issues. Requires the GitHub CLI (gh).
+metadata:
+  clawdbot:
+    requires:
+      bins: ["gh"]
+---
+
+# Deft GH Slice
+
+Convert a specification or plan into independently-grabbable GitHub Issues using tracer-bullet vertical slices.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+> Inspired by [to-issues](https://github.com/mattpocock/skills/tree/main/to-issues) from [mattpocock/skills](https://github.com/mattpocock/skills). Adapted to deft's spec-driven workflow and GitHub CLI conventions.
+
+## When to Use
+
+- After `deft-setup` completes and `SPECIFICATION.md` is approved
+- User says "create issues", "slice this into tickets", or "break this into GitHub issues"
+- When a spec needs to be handed off to multiple agents or collaborators working in parallel
+
+## Prerequisites
+
+- ! Verify `gh` is authenticated: `gh auth status` — stop and report if not
+- ~ Confirm the current git remote maps to the intended GitHub repository
+
+---
+
+## Process
+
+### Step 1: Gather context
+
+- ! Work from whatever is already in the conversation context
+- ~ If a `SPECIFICATION.md` exists at the project root, read it
+- ~ If the user passes a GitHub issue number or URL, fetch it: `gh issue view <number> --comments`
+- ⊗ Ask the user to re-explain content that is already available in context
+
+### Step 2: Explore the codebase (if needed)
+
+- ? If you have not already explored the codebase, do so to understand what is already built vs what remains
+- ~ Use existing code as a signal for which slices may already be partially complete
+
+### Step 3: Draft vertical slices
+
+Break the plan into **tracer bullet** issues — thin vertical slices that cut through ALL integration layers end-to-end, not horizontal slices of one layer.
+
+Each slice is either:
+- **AFK** — can be implemented and merged without human interaction (preferred)
+- **HITL** (Human In The Loop) — requires a decision, design review, or approval before proceeding
+
+**Vertical slice rules:**
+- ! Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- ! A completed slice is independently demoable or verifiable
+- ~ Prefer many thin slices over few thick ones
+- ~ Prefer AFK over HITL wherever possible
+- ⊗ Create horizontal slices (e.g. "implement all data models", "write all tests")
+
+### Step 4: Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Type**: AFK / HITL
+- **Blocked by**: which other slices must complete first (or "none")
+- **Tasks covered**: which SPECIFICATION.md tasks or phases this addresses
+
+Then ask:
+
+1. Does the granularity feel right? (too coarse / too fine)
+2. Are the dependency relationships correct?
+3. Should any slices be merged or split?
+4. Are HITL/AFK labels correct?
+
+Iterate until the user approves the breakdown.
+
+! Wait for explicit approval before proceeding to issue creation.
+
+### Step 5: Create the GitHub issues
+
+- ! Create issues in dependency order (blockers first) so you can reference real issue numbers
+- ! Use `gh issue create` for each approved slice with the template below
+- ! Trace each issue back to the relevant SPECIFICATION.md phase/task IDs where applicable
+- ⊗ Modify or close any existing parent issue
+
+**Issue template:**
+
+```
+## Parent
+
+#<parent-issue-number>
+(omit this section if the source was not a GitHub issue)
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end
+behavior, not layer-by-layer implementation. Reference the relevant
+SPECIFICATION.md phase/task IDs (e.g. "Implements Phase 2 / Task 2.1.3").
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] All new tests pass
+- [ ] task check passes
+
+## Type
+
+AFK / HITL
+
+## Blocked by
+
+- Blocked by #<issue-number>
+(or "None — can start immediately")
+```
+
+After all issues are created, print a summary table: issue number, title, type, and blockers.
+
+---
+
+## Anti-Patterns
+
+- ⊗ Creating horizontal slices (all models, all tests, all routes in one ticket)
+- ⊗ Creating issues before the user approves the breakdown
+- ⊗ Proceeding without `gh` authentication
+- ⊗ Omitting dependency ordering — blockers must be created first
+- ⊗ Describing implementation internals instead of observable behavior in issue bodies

--- a/skills/deft-gh-triage/SKILL.md
+++ b/skills/deft-gh-triage/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: deft-gh-triage
+description: >
+  Triage a bug or issue by exploring the codebase to find the root cause, then
+  create a GitHub Issue with a TDD-based fix plan. Use when a user reports a
+  bug, wants to investigate a problem, or mentions "triage". Requires the
+  GitHub CLI (gh).
+metadata:
+  clawdbot:
+    requires:
+      bins: ["gh"]
+---
+
+# Deft GH Triage
+
+Investigate a reported problem, identify the root cause, and file a GitHub Issue with a concrete TDD fix plan.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+> Inspired by [triage-issue](https://github.com/mattpocock/skills/tree/main/triage-issue) from [mattpocock/skills](https://github.com/mattpocock/skills). Adapted to deft's TDD standards, RFC2119 notation, and GitHub CLI conventions.
+
+## When to Use
+
+- User reports a bug or unexpected behavior
+- User says "triage this", "investigate", or "file an issue for this bug"
+- A GitHub issue exists but lacks root cause analysis or a fix plan
+- You want to produce a ticket before handing off a fix to another agent
+
+## Prerequisites
+
+- ! Verify `gh` is authenticated: `gh auth status` — stop and report if not
+
+---
+
+## Process
+
+This is a mostly hands-off workflow — minimize questions to the user. Investigate first, ask only when stuck.
+
+### Step 1: Capture the problem
+
+- ~ If the user has described the problem, use that description directly
+- ~ If no description exists, ask ONE question: "What's the problem you're seeing?"
+- ⊗ Ask follow-up questions before starting investigation
+
+### Step 2: Explore and diagnose
+
+Deeply investigate the codebase. Your goal is to find:
+
+- **Where** the bug manifests — entry points, API responses, UI behaviour, CLI output
+- **What** code path is involved — trace the flow from trigger to failure
+- **Why** it fails — the root cause, not just the symptom
+- **What** related code exists — similar patterns, existing tests, adjacent modules
+
+Look at:
+- ! Related source files and their dependencies
+- ! Existing tests — what's covered, what's missing
+- ~ Recent changes to affected files: `git --no-pager log --oneline -20 -- <file>`
+- ~ Error handling in the code path
+- ~ Similar patterns elsewhere in the codebase that work correctly
+
+### Step 3: Identify the fix approach
+
+Based on your investigation, determine:
+
+- ! The minimal change needed to fix the root cause
+- ! Which modules or interfaces are affected
+- ! What behaviours need to be verified via tests
+- ~ Whether this is a regression, missing feature, or design flaw
+
+### Step 4: Design the TDD fix plan
+
+Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical slice:
+
+- **RED**: A specific failing test that captures the broken or missing behaviour
+- **GREEN**: The minimal code change to make that test pass
+
+**Rules:**
+- ! Tests verify behaviour through public interfaces, not implementation details
+- ! One test at a time — vertical slices, NOT all tests first then all code
+- ! Tests must survive internal refactors (assert on observable outcomes, not internal state)
+- ~ Include a final REFACTOR step if cleanup is needed after all tests pass
+- ⊗ Suggest fixes that couple to current file layout or internal structure — describe behaviours and contracts instead
+
+### Step 5: Create the GitHub Issue
+
+- ! Create the issue immediately using `gh issue create` — do NOT ask the user to review first
+- ! Use the template below
+- ! After creating, print the issue URL and a one-line summary of the root cause
+
+**Issue template:**
+
+```
+## Problem
+
+What happens (actual behavior):
+
+What should happen (expected behavior):
+
+How to reproduce (if applicable):
+
+## Root Cause Analysis
+
+Describe what you found during investigation:
+- The code path involved
+- Why the current code fails
+- Any contributing factors
+
+Do NOT include specific file paths, line numbers, or implementation details
+that couple to the current code layout. Describe modules, behaviours, and
+contracts. The issue should remain useful after major refactors.
+
+## TDD Fix Plan
+
+1. **RED**: Write a test that [describes expected behavior]
+   **GREEN**: [Minimal change to make it pass]
+
+2. **RED**: Write a test that [describes next behavior]
+   **GREEN**: [Minimal change to make it pass]
+
+**REFACTOR**: [Any cleanup needed after all tests pass — omit if not needed]
+
+## Acceptance Criteria
+
+- [ ] Root cause is addressed, not just the symptom
+- [ ] All RED tests are now GREEN
+- [ ] Existing tests still pass
+- [ ] task check passes
+```
+
+---
+
+## Anti-Patterns
+
+- ⊗ Asking the user for information the codebase can answer
+- ⊗ Describing the fix in terms of specific files or line numbers (couples to current layout)
+- ⊗ Writing all tests first then all code — each RED-GREEN is one vertical slice
+- ⊗ Asking the user to review the issue before filing it — file immediately
+- ⊗ Fixing the symptom without identifying the root cause
+- ⊗ Proceeding without `gh` authentication

--- a/skills/deft-setup/SKILL.md
+++ b/skills/deft-setup/SKILL.md
@@ -73,7 +73,8 @@ Python, R, Rust, SQL, Swift, TypeScript, VHDL, Visual Basic, Zig, 6502-DASM
 3. **map** — Analyze existing codebase conventions before adding features
 4. **discuss** — Front-load decisions and alignment before planning
 5. **research** — Investigate the domain before planning
-6. **speckit** — Five-phase spec-driven workflow for large/complex projects
+6. **probe** — Stress-test a plan adversarially, resolve every decision branch
+7. **speckit** — Five-phase spec-driven workflow for large/complex projects
 
 > 💡 Strategies can be chained — after one completes, you'll be asked if you want to run another.
 

--- a/skills/deft-setup/SKILL.md
+++ b/skills/deft-setup/SKILL.md
@@ -336,7 +336,7 @@ task clean         # Clean artifacts
 **Dispatch:**
 
 - **interview** (or default) → Continue to the Sizing Gate below ✅
-- **anything else** (discuss, yolo, speckit, research, brownfield, map, etc.) →
+- **anything else** (discuss, yolo, speckit, research, brownfield, map, probe, etc.) →
   1. ! Read `deft/strategies/{strategy-name}.md` **right now, in this same turn**
   2. ! Begin the strategy’s workflow immediately — ask its first question
   3. ! **STOP reading this section** — do NOT use the interview process below

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -12,7 +12,8 @@ Development strategies define the workflow from idea to implementation.
 | [map.md](./map.md) | `/deft:run:map` | preparatory | Existing codebases | Map → Chaining Gate |
 | [brownfield.md](./brownfield.md) | `/deft:run:brownfield` | preparatory | Existing codebases | Map → Chaining Gate |
 | [discuss.md](./discuss.md) | `/deft:run:discuss` | preparatory | Alignment before planning | Feynman technique → locked decisions → Chaining Gate |
-| [research.md](./research.md) | `/deft:run:research` | preparatory | Pre-implementation research | Research → Don’t Hand-Roll + Common Pitfalls → Chaining Gate |
+| [research.md](./research.md) | `/deft:run:research` | preparatory | Pre-implementation research | Research → Don't Hand-Roll + Common Pitfalls → Chaining Gate |
+| [probe.md](./probe.md) | `/deft:run:probe` | preparatory | Stress-test a plan or design | Relentless interrogation → locked decisions + surfaced risks → Chaining Gate |
 | rapid.md | `/deft:run:rapid` | spec-generating | Quick prototypes | Forced-Light path (future) |
 | enterprise.md | `/deft:run:enterprise` | spec-generating | Compliance-heavy | Forced-Full path (future) |
 

--- a/strategies/interview.md
+++ b/strategies/interview.md
@@ -48,6 +48,7 @@ Present two groups sourced from the `Type` column in
 - Research — investigate the domain, find libraries, identify pitfalls
 - Discuss — lock key decisions using Feynman technique
 - Map/Brownfield — analyze existing codebase conventions
+- Probe — stress-test the plan, resolve every decision branch adversarially
 
 **Switch spec-generating strategy** (type: `spec-generating` — replaces current pipeline):
 - Yolo — auto-pilot, Johnbot picks all answers

--- a/strategies/interview.md
+++ b/strategies/interview.md
@@ -80,12 +80,13 @@ Ready to generate the specification. Before we proceed, would you like to:
 2. Run a research phase — investigate the domain, find libraries, identify pitfalls
 3. Run a discuss phase — lock key decisions using Feynman technique
 4. Run a map/brownfield phase — analyze existing codebase conventions
+5. Run a probe phase — stress-test the plan, resolve every decision branch adversarially
 
 --- Switch strategy ---
-5. Switch to yolo — auto-pilot picks all answers
-6. Switch to speckit — formal five-phase spec process
+6. Switch to yolo — auto-pilot picks all answers
+7. Switch to speckit — formal five-phase spec process
 
-7. Other (specify)
+8. Other (specify)
 ```
 
 ---

--- a/strategies/probe.md
+++ b/strategies/probe.md
@@ -65,6 +65,10 @@ Walk the decision tree depth-first. For each unresolved branch:
 
 ## Output
 
+`{scope}` is the project name from `PROJECT.md`, or the feature/component name if
+probing a sub-scope. Use the same value consistently throughout the session.
+Examples: `my-app-probe.md`, `auth-probe.md`.
+
 - ! Produce `{scope}-probe.md` with three sections:
   - **Locked decisions** — what was resolved and why
   - **Surfaced risks** — concerns raised, even if not fully resolved

--- a/strategies/probe.md
+++ b/strategies/probe.md
@@ -1,0 +1,103 @@
+# Probe Strategy
+
+Stress-test a plan before committing to it — relentless interrogation until every branch of the decision tree is resolved.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**⚠️ See also**: [strategies/discuss.md](./discuss.md) | [strategies/interview.md](./interview.md) | [core/glossary.md](../core/glossary.md)
+
+> Inspired by [grill-me](https://github.com/mattpocock/skills/tree/main/grill-me) from [mattpocock/skills](https://github.com/mattpocock/skills). Adapted to directive's preparatory strategy pattern.
+
+---
+
+## When to Use
+
+- ~ Before committing to any significant design decision or architecture choice
+- ~ When a plan has been drafted but not yet stress-tested
+- ! When the user explicitly asks to be probed or challenged on their plan
+- ? Skip when the path forward is unambiguous and small in scope
+
+## Core Principle
+
+The goal is not alignment — that's `discuss`. Probe is adversarial discovery. It assumes the plan has holes and sets out to find them. Every assumption is challenged, every edge case explored, every dependency branch walked until nothing is unresolved. Where `discuss` builds consensus, `probe` finds what's missing.
+
+---
+
+## Process
+
+### Step 1: Establish the plan
+
+- ! Read whatever plan, design, or spec exists in the conversation context
+- ~ If no plan is in context, ask ONE question: "What's the plan you want me to probe?"
+- ~ If codebase context is relevant, explore it to answer what you can before asking
+- ⊗ Ask follow-up questions before reading available context
+
+### Step 2: Interrogate relentlessly
+
+Walk the decision tree depth-first. For each unresolved branch:
+
+- ! Ask **ONE** focused question per message
+- ! For each question, provide your recommended answer with brief reasoning
+- ! If the codebase can answer a question, explore it instead of asking the user
+- ~ Follow the thread — if an answer opens new branches, pursue them before moving on
+- ⊗ Ask multiple questions at once
+- ⊗ Accept vague answers — push back: "What does that mean concretely?"
+- ⊗ Move to the next branch before the current one is fully resolved
+
+### Question focus areas
+
+- ! **Assumptions** — "This assumes X is guaranteed — is it?"
+- ! **Edge cases** — "What happens when Y is empty / null / at the limit?"
+- ! **Dependencies** — "This requires Z to exist — what if it doesn't?"
+- ! **Failure modes** — "How does this fail? How is that surfaced to the user?"
+- ! **Scaling** — "Does this hold at 10× the expected volume?"
+- ~ **Security surface** — "Who can reach this? What's the blast radius if it's wrong?"
+- ~ **Reversibility** — "Can this decision be changed later? What's the migration cost?"
+
+### Transition criteria (probe complete)
+
+- ! All major decision branches have been resolved
+- ! No open assumptions remain
+- ~ User has acknowledged the risks of any deliberately deferred decisions
+- ~ No new branches are surfaced by the last 2–3 questions
+
+---
+
+## Output
+
+- ! Produce `{scope}-probe.md` with three sections:
+  - **Locked decisions** — what was resolved and why
+  - **Surfaced risks** — concerns raised, even if not fully resolved
+  - **Deferred decisions** — explicitly acknowledged items with justification
+- ! Each entry includes: **question asked**, **answer given**, **status** (locked / deferred / risk-accepted)
+- ~ Persist significant decisions as vBRIEF narratives on the relevant plan items
+
+---
+
+## Then: Chaining Gate
+
+After the probe is complete and `{scope}-probe.md` is written, return to the
+[chaining gate](./interview.md#chaining-gate).
+
+- ! On completion, register artifacts in `./vbrief/plan.vbrief.json`:
+  - Update `completedStrategies`: increment `runCount` for `"probe"`,
+    append artifact path (`{scope}-probe.md`)
+  - Append the path to the flat `artifacts` array
+- ! Return to [interview.md Chaining Gate](./interview.md#chaining-gate)
+- ! The locked decisions and surfaced risks from `{scope}-probe.md` MUST flow
+  into subsequent strategies and spec generation:
+  - Locked decisions become constraints in the specification
+  - Surfaced risks become NFRs or explicit acceptance criteria
+  - Deferred decisions appear as open questions in the spec
+- ⊗ End the session after probe without returning to the chaining gate
+
+---
+
+## Anti-Patterns
+
+- ⊗ Accepting "we'll figure it out later" without marking it as explicitly deferred
+- ⊗ Asking generic checklist questions instead of following the decision tree
+- ⊗ Letting vague answers pass without pushing for concrete specifics
+- ⊗ Using codebase exploration as a substitute for asking the user about deliberate design choices
+- ⊗ Stopping when the conversation feels comfortable — stop when no new branches emerge
+- ⊗ Ending after probe without chaining back to the gate

--- a/verification/verification.md
+++ b/verification/verification.md
@@ -60,6 +60,16 @@ Connections between artifacts that must be present.
   - Functions under ~8 lines that return hardcoded/empty values
 - ⊗ Accept stubs as completed work
 
+## Legacy and Deprecated Code Detection
+
+- ~ When reviewing or modifying any file, scan for legacy indicators and file a hygiene task if found:
+  - Comments: `LEGACY`, `COMPAT`, `OLD_`, `# old way`, `// deprecated`, `TODO: remove`
+  - Commented-out code blocks (more than 1 line)
+  - Feature flag branches where the flag is hardcoded to always-on or always-off
+  - Parallel implementations: old and new approach coexisting without a documented migration path
+- ⊗ Leave legacy markers in place after a migration is complete; remove them in the same commit as the migration
+- ~ See [coding/hygiene.md](../coding/hygiene.md) for the full legacy removal protocol
+
 ---
 
 ## Verification Ladder (4 Tiers)


### PR DESCRIPTION
## Summary

Adds three new additions to directive, inspired by [mattpocock/skills](https://github.com/mattpocock/skills). Each is adapted to directive's conventions (RFC2119 notation, chaining gate integration, vBRIEF state tracking, deft naming patterns).

## Changes

### `strategies/probe.md` — new preparatory strategy
Adversarial plan stress-testing: walks the decision tree depth-first, challenges every assumption, and surfaces risks before spec generation. Sits alongside `discuss` and `research` in the chaining gate.

> Inspired by [grill-me](https://github.com/mattpocock/skills/tree/main/grill-me) · mattpocock/skills

### `skills/deft-gh-slice/SKILL.md` — new skill
Converts an approved `SPECIFICATION.md` (or PRD/plan) into tracer-bullet GitHub Issues as independently-assignable vertical slices. Quizzes the user on granularity before creating any issues. Requires `gh` CLI.

> Inspired by [to-issues](https://github.com/mattpocock/skills/tree/main/to-issues) · mattpocock/skills

### `skills/deft-gh-triage/SKILL.md` — new skill
Investigates a reported bug by exploring the codebase, identifies the root cause, and files a GitHub Issue with a concrete TDD RED-GREEN fix plan. Mostly hands-off — minimal questions, investigate first. Requires `gh` CLI.

> Inspired by [triage-issue](https://github.com/mattpocock/skills/tree/main/triage-issue) · mattpocock/skills

## Supporting updates

- `strategies/README.md`: probe added to strategy table (type: preparatory)
- `strategies/interview.md`: probe listed in chaining gate options
- `skills/deft-setup/SKILL.md`: probe added to Available Strategies list

---

[Warp conversation](https://app.warp.dev/conversation/7cda1a11-1345-403d-960f-59e3de328254)