### PR TITLE
feat(skills): add deft-write-skill meta-skill

### DIFF
--- a/skills/deft-article-review/SKILL.md
+++ b/skills/deft-article-review/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: deft-article-review
+description: >
+  Evaluate an article, paper, or post for lessons that could improve directive.
+  Analyzes two axes: how concepts improve directive's own implementation, and how
+  they improve the projects directive creates. Produces filtered suggestions,
+  iterates with the user, and optionally creates GitHub issues on the directive
+  repo. Use when evaluating an article, paper, post, or URL for directive
+  improvements, or when the user says "analyze this article", "evaluate this
+  article", or "what can we learn from this for directive".
+triggers:
+  - evaluate article
+  - analyze article
+  - review article for directive
+  - extract lessons
+  - what can we learn from this
+  - article for directive
+metadata:
+  clawdbot:
+    requires:
+      bins: ["gh"]
+---
+
+# Deft Article Review
+
+Evaluate an article, paper, or blog post for lessons that could improve directive —
+both how directive itself is implemented and what directive helps create.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+## When to Use
+
+- User shares a URL, local file path, or pasted text to analyze for directive improvements
+- User says "what can we learn from this for directive" or "evaluate this article"
+- After reading a research paper, practitioner post, or technical write-up that seems relevant
+
+## Prerequisites
+
+- ! If a URL is provided, fetch and read the full content before beginning analysis
+- ! If a local file path is provided, read the file
+- ! If pasted text, work from the provided content
+- ⊗ Begin analysis before reading the full content
+
+---
+
+## Process
+
+### Step 1: Ingest the article
+
+- ! Read the full content — do not skim or skip sections
+- ~ Note the source type (research paper, practitioner blog, product docs, etc.) as it affects how much weight to give conclusions
+
+### Step 2: Evaluate Axis 1 — How can this improve directive's own implementation?
+
+Look for lessons applicable to how directive itself is built, structured, and maintained:
+
+- ! Skills and strategies: are there new skills, strategies, or workflow patterns directive should adopt?
+- ! Framework architecture: does this suggest changes to lazy loading, vBRIEF, AGENTS.md structure, or the patterns/ directory?
+- ! Agent safety and reliability: does this reveal new failure modes or defenses directive should encode?
+- ! Tooling: does this suggest new tasks, task patterns, or SCM conventions directive should add?
+- ~ Naming, directory structure, or documentation conventions worth adopting
+
+### Step 3: Evaluate Axis 2 — How can this improve the projects directive creates?
+
+Look for lessons applicable to projects that directive-guided agents build:
+
+- ! Coding standards: new rules for languages/, coding/, or patterns/ that would improve project quality
+- ! Security: new vulnerabilities or defenses projects should implement (e.g., agent trap defenses, LLM application security)
+- ! Architecture patterns: new patterns/ content for multi-agent, LLM apps, safety-critical, or other system types
+- ! Testing, observability, or deployment practices worth encoding as directive standards
+- ~ Stack recommendations or technology choices with clear rationale
+
+### Step 4: Filter and prioritize
+
+- ! Discard ideas that are not genuinely actionable or relevant — not everything in an article applies to directive
+- ! Rate each suggestion: **High** (actionable now, clear value), **Medium** (worth considering, needs evaluation), **Low/Speculative** (interesting but hypothetical)
+- ! Note which existing directive files or issues each suggestion would affect
+- ⊗ Present every idea uncritically — only surface ideas with real directive relevance
+
+### Step 5: Present suggestions to the user
+
+Present a structured summary organized by axis. For each suggestion:
+- Brief description of the idea
+- Why it's relevant to directive specifically
+- Which file(s) or directory it would affect
+- Confidence rating (High / Medium / Low)
+
+! After presenting, explicitly ask:
+> "Does any of this resonate? Do you want to modify, combine, or drop any of these before we decide what to file?"
+
+Allow the user to comment, change framing, merge suggestions, or remove any. Iterate until the user is satisfied with the set.
+
+### Step 6: Offer issue creation
+
+! Ask the user:
+> "Should I create GitHub issues for any of these? I can create one per suggestion or group related ones."
+
+- ! If yes: create issues on `deftai/directive` using `gh issue create` with:
+  - A clear title following conventional commit style (`feat(area):`, `refactor(area):`, `research(area):`, etc.)
+  - Body that describes the suggestion, the source article, and the specific directive files affected
+  - A note if the suggestion is speculative/research-grade vs. immediately actionable
+- ! After creating issues, print the issue URLs
+- ⊗ Create issues without explicit user confirmation
+
+### Step 7: Offer further exploration
+
+! After completing the above, ask:
+> "Is there anything else from this article worth exploring — related tools, referenced papers, or follow-on questions?"
+
+If yes, follow the thread. This may include fetching related URLs, evaluating referenced work, or researching specific concepts mentioned in the article.
+
+---
+
+## Anti-Patterns
+
+- ⊗ Treating every idea in the article as directive-relevant — filter aggressively
+- ⊗ Creating issues before the user approves the suggestion set
+- ⊗ Skipping the user feedback step and going straight to issue creation
+- ⊗ Summarizing without reading the full content
+- ⊗ Presenting unrated suggestions — every suggestion needs a confidence level
+- ⊗ Filing a single giant issue for all suggestions — one issue per distinct suggestion or related group

--- a/skills/deft-article-review/SKILL.md
+++ b/skills/deft-article-review/SKILL.md
@@ -28,6 +28,22 @@ both how directive itself is implemented and what directive helps create.
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
+---
+
+## Directive Reference
+
+Use this summary to evaluate whether article ideas are genuinely novel or already covered by the framework.
+
+**Directive** is a development framework that combines indexed documentation, task automation, and AI-assisted workflows.
+
+**main.md (front door)** — Central entry/index for a Karpathy-wiki-style set of lazy-loaded markdown rules organized into sections: `coding/`, `languages/`, `interfaces/`, `tools/`, `scm/`, `contracts/`, `swarm/`, `strategies/`, `vbrief/`, and `templates/`. Agents load only what's relevant.
+
+**Taskfiles (go-task)** — Single entrypoint for all repeatable operations. Core flows: `task dev`, `task test`, `task build`, `task release`. Composed via `deps`; logic lives in scripts/binaries. Caching via `sources/generates + method: checksum`. Namespaced tasks (`docker:build`, `db:migrate`). Every user-facing task has a `desc`; internal wiring marked `internal: true`.
+
+**vbrief** — Structured JSON artifacts in `./vbrief/` covering current state and forward planning: `plan.vbrief.json` (todos/progress), `specification.vbrief.json` (project specs), `playbook-{name}.vbrief.json` (reusable playbooks), `continue.vbrief.json` (interruption recovery). Drives the full lifecycle: planning → specification → execution → checkpointing → resumption. Refreshed via `deft-sync` at session start.
+
+**Skills** — Versioned, reusable workflows triggered by keywords: `deft-setup` (bootstrap), `deft-build` (implement from spec), `deft-sync` (refresh framework + vbrief), `deft-pre-pr` (quality loop), `deft-review-cycle` (PR bot feedback), `deft-swarm` (parallel agent orchestration), `deft-roadmap-refresh` (issue triage), `deft-interview` (structured Q&A). Skills chain together and encode lessons from prior runs.
+
 ## When to Use
 
 - User shares a URL, local file path, or pasted text to analyze for directive improvements
@@ -77,7 +93,16 @@ Look for lessons applicable to projects that directive-guided agents build:
 - ! Note which existing directive files or issues each suggestion would affect
 - ⊗ Present every idea uncritically — only surface ideas with real directive relevance
 
-### Step 5: Present suggestions to the user
+### Step 5: Cross-reference open issues
+
+- ! Run `gh issue list --repo deftai/directive --state open --limit 100` to retrieve the current open issue backlog
+- ! For each suggestion from Step 4, check whether an open issue already covers it — fully or partially
+- ! If a suggestion duplicates an open issue: drop it from the proposal and note the existing issue number
+- ! If a suggestion extends or relates to an open issue: flag it as "extends #N" rather than proposing a standalone new issue
+- ~ Scan the open issue list for trends (e.g. a cluster of agent-safety issues, a cluster of pattern/ gaps) — use trends to sharpen framing or prioritization of remaining suggestions
+- ⊗ Propose a new issue for something already tracked — deduplication is mandatory
+
+### Step 6: Present suggestions to the user
 
 Present a structured summary organized by axis. For each suggestion:
 - Brief description of the idea
@@ -90,7 +115,7 @@ Present a structured summary organized by axis. For each suggestion:
 
 Allow the user to comment, change framing, merge suggestions, or remove any. Iterate until the user is satisfied with the set.
 
-### Step 6: Offer issue creation
+### Step 7: Offer issue creation
 
 ! Ask the user:
 > "Should I create GitHub issues for any of these? I can create one per suggestion or group related ones."
@@ -99,10 +124,11 @@ Allow the user to comment, change framing, merge suggestions, or remove any. Ite
   - A clear title following conventional commit style (`feat(area):`, `refactor(area):`, `research(area):`, etc.)
   - Body that describes the suggestion, the source article, and the specific directive files affected
   - A note if the suggestion is speculative/research-grade vs. immediately actionable
+  - A reference to any related open issues ("extends #N", "related to #N")
 - ! After creating issues, print the issue URLs
 - ⊗ Create issues without explicit user confirmation
 
-### Step 7: Offer further exploration
+### Step 8: Offer further exploration
 
 ! After completing the above, ask:
 > "Is there anything else from this article worth exploring — related tools, referenced papers, or follow-on questions?"
@@ -119,3 +145,5 @@ If yes, follow the thread. This may include fetching related URLs, evaluating re
 - ⊗ Summarizing without reading the full content
 - ⊗ Presenting unrated suggestions — every suggestion needs a confidence level
 - ⊗ Filing a single giant issue for all suggestions — one issue per distinct suggestion or related group
+- ⊗ Proposing a new issue without first checking whether it duplicates an open one
+- ⊗ Evaluating directive relevance without consulting the Directive Reference section above

--- a/skills/deft-write-skill/SKILL.md
+++ b/skills/deft-write-skill/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: deft-write-skill
+description: >
+  Create new deft skills with proper structure, RFC2119 notation, triggers,
+  and progressive disclosure. Use when user wants to create, write, or build
+  a new deft skill.
+triggers:
+  - write a skill
+  - create a skill
+  - new skill
+  - build a skill
+---
+
+# Deft Write Skill
+
+Create new deft skills that follow directive's conventions: RFC2119 notation, YAML frontmatter with triggers, clear When-to-Use sections, and proper naming.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+> Inspired by [write-a-skill](https://github.com/mattpocock/skills/tree/main/write-a-skill) from [mattpocock/skills](https://github.com/mattpocock/skills). Adapted to deft's SKILL.md conventions, RFC2119 notation, and naming patterns.
+
+## When to Use
+
+- User wants to create a new skill for a workflow directive doesn't cover yet
+- Formalizing an ad-hoc process that keeps repeating into a reusable skill
+- Extending directive with project-specific or domain-specific skills
+
+---
+
+## Deft Skill Naming Conventions
+
+| Skill type | Naming pattern | Example |
+|---|---|---|
+| Framework / meta | `deft-{verb}` | `deft-build`, `deft-setup` |
+| GitHub-integrated | `deft-gh-{verb}` | `deft-gh-triage`, `deft-gh-slice` |
+| Domain / project-specific | `{project}-{verb}` | `my-app-deploy` |
+
+---
+
+## Process
+
+### Step 1: Gather requirements
+
+Ask the user (one question at a time):
+
+1. What task or domain does this skill cover?
+2. What specific use cases should it handle?
+3. Does it require external tools (e.g., `gh`, `docker`, database CLIs)?
+4. Should it produce files, run commands, or guide a conversation?
+5. Any reference material or existing workflows to model from?
+
+### Step 2: Draft the skill
+
+- ! Follow the deft SKILL.md template below
+- ! Keep SKILL.md under 150 lines — split into `REFERENCE.md` if needed
+- ! Write the `description` field as if it's the only thing the agent will see when deciding whether to invoke this skill
+- ~ Use the trigger words the user would naturally say
+- ! Use RFC2119 notation throughout (!=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY)
+- ~ Include attribution blockquote if inspired by an external source
+
+### Step 3: Review with user
+
+Present the draft and ask:
+- Does this cover your use cases?
+- Anything missing or unclear?
+- Should any section be more or less detailed?
+
+Iterate until approved.
+
+### Step 4: Create the skill
+
+- ! Create the directory `skills/{skill-name}/`
+- ! Write `skills/{skill-name}/SKILL.md`
+- ~ Create `skills/{skill-name}/REFERENCE.md` if content exceeds 150 lines
+- ~ Create `skills/{skill-name}/scripts/` for deterministic helper scripts
+
+---
+
+## Deft SKILL.md Template
+
+```markdown
+---
+name: {skill-name}
+description: >
+  {What it does in 1–2 sentences}. Use when {specific triggers —
+  what the user would say or what context activates this skill}.
+triggers:
+  - {trigger phrase 1}
+  - {trigger phrase 2}
+[metadata:
+  clawdbot:
+    requires:
+      bins: ["gh"]   # only if external CLI is needed]
+---
+
+# {Skill Title}
+
+{One-line description of what this skill does.}
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+[> Inspired by ... — optional attribution]
+
+## When to Use
+
+- {Use case 1}
+- {Use case 2}
+
+[## Prerequisites
+
+- ! Verify {tool} is available — stop and report if not]
+
+---
+
+## Process
+
+### Step 1: {Name}
+
+- ! {mandatory action}
+- ~ {recommended action}
+- ⊗ {forbidden action}
+
+### Step 2: {Name}
+
+...
+
+---
+
+## Anti-Patterns
+
+- ⊗ {what NOT to do}
+- ⊗ {what NOT to do}
+```
+
+---
+
+## Description Writing Rules
+
+The description is **the only thing the agent sees** when deciding whether to load this skill. Write it to answer:
+1. What capability does this provide?
+2. When should it trigger? (use "Use when..." pattern)
+
+- ! Max 1024 characters
+- ! Include "Use when [specific triggers]" in the description
+- ⊗ Vague descriptions ("helps with things") — the agent can't distinguish between skills
+- ! First sentence: what it does. Second sentence: when to use it.
+
+---
+
+## Anti-Patterns
+
+- ⊗ Omitting RFC2119 notation — deft skills use it consistently
+- ⊗ Putting all content in SKILL.md when it exceeds 150 lines — split into REFERENCE.md
+- ⊗ Vague trigger phrases — use phrases the user would actually type
+- ⊗ Naming a GitHub-integrated skill without `gh` in the name
+- ⊗ Writing the description without a "Use when..." clause


### PR DESCRIPTION
## Summary

Adds `deft-write-skill` — a meta-skill for creating new deft skills with correct structure.

Guides through requirements gathering, drafts following deft's SKILL.md template (RFC2119 notation, `triggers:` frontmatter, naming conventions), reviews with the user, then creates the skill directory and files.

Includes:
- Naming conventions table (`deft-{verb}`, `deft-gh-{verb}`, `{project}-{verb}`)
- Full SKILL.md template with all deft-specific fields
- Description writing rules (the description is the only signal the agent has when deciding whether to invoke a skill)

> Inspired by [write-a-skill](https://github.com/mattpocock/skills/tree/main/write-a-skill) · mattpocock/skills

---

[Warp conversation](https://app.warp.dev/conversation/7cda1a11-1345-403d-960f-59e3de328254)