### PR TITLE
fix(triage): try uv before pipx in step_ensure_gitcrawl + structured deferred outcome + fallback docs (#901)

### DIFF
--- a/docs/gitcrawl-fallback.md
+++ b/docs/gitcrawl-fallback.md
@@ -1,0 +1,106 @@
+# Gitcrawl Fallback (gh-only mode)
+
+## What this document is
+
+`task triage:bootstrap` tries to install [`gitcrawl`](https://pypi.org/project/gitcrawl/) so the local issue cache can pull richer data than the GitHub CLI (`gh`) alone provides. On Windows in particular, the install can fail silently when neither `uv` nor `pipx` is on PATH, or when the install attempt itself fails. When that happens the bootstrap **defers** the install and continues -- the rest of triage still works against `gh`, just with fewer fields.
+
+This document tells you, the maintainer using deft, what that fallback means, what data you lose, and how to install gitcrawl manually if you want it.
+
+## When does this fire?
+
+You will see a recap line like the following when you run `task triage:bootstrap`:
+
+```
+✗ ensure_gitcrawl: deferred -- gitcrawl unavailable on this platform (...);
+  falling back to gh-only mode for triage (missing: body_html, reactions, comments_full).
+  Install manually: uv tool install gitcrawl  OR  pipx install gitcrawl
+```
+
+The deferral fires when **all** of the following are true:
+
+1. `gitcrawl` is not already on your PATH.
+2. The bootstrap could not install it via `uv tool install gitcrawl` (uv missing, or the install command exited non-zero).
+3. The bootstrap could not install it via the historical `pipx install gitcrawl` fallback either.
+
+The bootstrap exit code stays `0` -- the rest of the triage flow runs normally. Only the gitcrawl-specific fields are missing.
+
+## What you lose in gh-only mode
+
+The local issue cache (`.deft-cache/issues/<owner>-<repo>/<N>.json`) is populated from one of two sources:
+
+- **gitcrawl path (preferred)**: returns the GitHub issue **plus** rich metadata that the REST `gh issue view` shape does not surface.
+- **`gh` fallback path (gh-only mode)**: returns the basic issue payload only.
+
+In gh-only mode the following fields are **not** in the cache and are **not** available to the refinement / triage skill when it walks each candidate:
+
+- `body_html` -- the rendered HTML form of the issue body. The `gh` JSON output gives you the markdown source but not the rendered HTML, so any rendering / link-extraction step that operates on HTML is unavailable.
+- `reactions` -- 👍 / 👎 / 🎉 / ❤️ / 🚀 / 👀 / 😄 / 😕 counts on the issue. Reaction counts are a useful weak signal of community demand during refinement and are absent in gh-only mode.
+- `comments_full` -- the full comment thread with author, timestamps, and body for every comment. The `gh` fallback returns the issue itself but not the full comment expansion.
+
+## Why this matters during triage
+
+The refinement skill's Phase 0 walks each cached candidate one by one. The agent surfaces the title, origin URL, labels, and body excerpt to you so you can decide accept / reject / defer / needs-AC / mark-duplicate.
+
+In gh-only mode:
+
+- You can still triage. Title, body text, labels, and origin URL are all present.
+- Reaction-weighted heuristics (e.g. "issues with more 👍 surface first") are **not** available.
+- Cross-comment context ("did the original reporter clarify in a follow-up?") is **not** present in the cache; you can still click through to GitHub for context if needed.
+
+If your triage workflow does not depend on reactions or full comment threads, gh-only mode is fine. If it does, install gitcrawl manually using one of the commands below.
+
+## Manual install commands
+
+Pick whichever installer you already have. You only need one.
+
+### Recommended: uv (already a deft requirement)
+
+```
+uv tool install gitcrawl
+```
+
+uv is already on your machine if you have run any deft task -- every deft task script runs via `uv run python ...`. This is the quickest path.
+
+### Alternative: pipx
+
+```
+pipx install gitcrawl
+```
+
+If you have pipx for other tooling, this works the same way. On Windows, install pipx itself per the [pipx installation docs](https://pipx.pypa.io/stable/installation/).
+
+### After install
+
+Re-run the bootstrap so the cache is repopulated with the rich gitcrawl payload:
+
+```
+task triage:bootstrap
+```
+
+The `ensure_gitcrawl` step will now report `already on PATH (no-op)`, and the next `task triage:cache` run will populate the cache via the gitcrawl path.
+
+## Verifying gh-only mode is what you have
+
+If the recap above scrolled off your terminal, you can re-run with the `--json` flag to inspect the structured outcome:
+
+```
+uv run python scripts/triage_bootstrap.py --json | python -m json.tool
+```
+
+Look for the `ensure_gitcrawl` step. Its `details` payload will include:
+
+```
+"falling_back_to": "gh-only",
+"missing_fields": ["body_html", "reactions", "comments_full"],
+"install_hint": "Install manually: uv tool install gitcrawl  OR  pipx install gitcrawl"
+```
+
+## Why not fail the bootstrap?
+
+`gitcrawl` is **best-effort** by design. The triage workflow is built on a documented fallback to `gh issue list` (Story 1 of the #845 cascade) precisely so that consumers without gitcrawl on PATH can still use triage. Failing the bootstrap on a missing optional installer would punish first-time Windows users who do not have `pipx` pre-installed; deferring with a structured, visible status line is the better trade-off.
+
+## Related
+
+- `scripts/triage_bootstrap.py::step_ensure_gitcrawl` -- the install attempt and deferral logic.
+- `scripts/triage_cache.py` -- the cache writer that consumes either gitcrawl or `gh` as the data source.
+- `docs/privacy-nfr.md` -- the privacy contract for `.deft-cache/` (gitignore default + opt-in commit-cache).

--- a/scripts/triage_bootstrap.py
+++ b/scripts/triage_bootstrap.py
@@ -788,16 +788,131 @@ def step_ensure_gitignore_entry(project_root: Path) -> StepOutcome:
 # Step 4 -- ensure gitcrawl is installed (best-effort)
 # ---------------------------------------------------------------------------
 
+#: Fields ``gitcrawl`` exposes that the ``gh`` CLI fallback path does NOT.
+#: When the bootstrap defers gitcrawl installation, the consumer's triage
+#: surface degrades to a ``gh``-only fetch path and these fields are no
+#: longer available -- the structured outcome surfaces the gap so the user
+#: knows what they are missing in the gh-only mode (see
+#: ``docs/gitcrawl-fallback.md`` for the user-facing explanation).
+GITCRAWL_ONLY_FIELDS = ("body_html", "reactions", "comments_full")
+
+#: Canonical install hint surfaced in the deferred ``StepOutcome.details``
+#: and the user-visible status line. ``uv`` is the preferred path because it
+#: is already a deft requirement (#901); ``pipx`` is the historical fallback.
+GITCRAWL_INSTALL_HINT = (
+    "Install manually: uv tool install gitcrawl  OR  pipx install gitcrawl"
+)
+
+#: Canonical name for the gh-only fallback mode surfaced via
+#: ``StepOutcome.details['falling_back_to']``.
+GITCRAWL_FALLBACK_MODE = "gh-only"
+
+
+def _gitcrawl_deferred_outcome(
+    *,
+    action: str,
+    reason: str,
+    error: str | None = None,
+    uv_attempted: bool = False,
+    pipx_attempted: bool = False,
+) -> StepOutcome:
+    """Build the canonical structured deferred outcome for ``step_ensure_gitcrawl``.
+
+    Centralised so every deferred branch (no installer / install raised /
+    install exited non-zero) emits the same user-visible status line shape
+    AND the same ``details`` payload (#901). The payload is consumed by
+    downstream tooling and tests, so the keys are intentionally stable.
+
+    Args:
+        action: Sub-state key (``deferred-no-pipx`` / ``deferred-no-installer``
+            / ``deferred-install-failed``) used by tests and the
+            ``--json`` emitter to distinguish branches without re-parsing
+            the message.
+        reason: Short branch-specific reason fragment spliced into the
+            user-visible status line (e.g. ``"neither uv nor pipx on PATH"``).
+        error: Optional captured stderr / exception text for the
+            ``StepOutcome.error`` field (truncated by the caller).
+        uv_attempted: True when the bootstrap reached the ``uv`` install
+            subprocess (regardless of outcome).
+        pipx_attempted: True when the bootstrap reached the ``pipx`` install
+            subprocess (regardless of outcome).
+    """
+    missing_fields = list(GITCRAWL_ONLY_FIELDS)
+    message = (
+        f"deferred -- gitcrawl unavailable on this platform ({reason}); "
+        f"falling back to {GITCRAWL_FALLBACK_MODE} mode for triage "
+        f"(missing: {', '.join(missing_fields)}). "
+        f"{GITCRAWL_INSTALL_HINT}"
+    )
+    return StepOutcome(
+        name="ensure_gitcrawl",
+        ok=True,
+        message=message,
+        error=error,
+        details={
+            "installed": False,
+            "action": action,
+            "falling_back_to": GITCRAWL_FALLBACK_MODE,
+            "missing_fields": missing_fields,
+            "install_hint": GITCRAWL_INSTALL_HINT,
+            "uv_attempted": uv_attempted,
+            "pipx_attempted": pipx_attempted,
+        },
+    )
+
+
+def _try_install_gitcrawl(installer: str, argv: list[str]) -> tuple[bool, str | None]:
+    """Run ``argv`` to install gitcrawl; return (success, error_text).
+
+    Returns ``(True, None)`` on a clean success. On any failure (subprocess
+    error or non-zero exit) returns ``(False, <captured error text>)`` so
+    the caller can decide whether to fall through to the next installer.
+    The ``installer`` arg is only used to label the captured error text
+    (e.g. ``uv: ...`` / ``pipx: ...``).
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 -- explicit args, no shell
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return False, f"{installer}: {type(exc).__name__}: {exc}"
+    if proc.returncode == 0:
+        return True, None
+    captured = (proc.stderr or proc.stdout or "").strip()[:512]
+    return False, f"{installer}: exit {proc.returncode} {captured}".strip()
+
 
 def step_ensure_gitcrawl(skip: bool = False) -> StepOutcome:
     """Install ``gitcrawl`` when missing.
 
     ``gitcrawl`` is the GitHub-aware crawler Story 1 prefers when populating
     the cache (with a fallback to ``gh issue list`` when absent). The bootstrap
-    tries ``pipx install gitcrawl`` and falls back to a print-only diagnostic
-    when neither pipx nor gitcrawl can be detected. Installation is best-effort:
-    the bootstrap does NOT fail if gitcrawl can't be installed because Story 1
-    has a documented fallback.
+    tries ``uv tool install gitcrawl`` FIRST (#901 -- ``uv`` is already a
+    deft requirement), and only falls back to ``pipx install gitcrawl`` when
+    ``uv`` is unavailable or the ``uv`` install fails. When BOTH installers
+    fail (or neither is on PATH), the step defers with a structured
+    :class:`StepOutcome` whose ``details`` payload surfaces:
+
+    - ``falling_back_to``: the canonical fallback mode (``"gh-only"``).
+    - ``missing_fields``: the list of fields the ``gh``-only path cannot
+      provide that ``gitcrawl`` would (``body_html``, ``reactions``,
+      ``comments_full``).
+    - ``install_hint``: a one-line manual-install hint for the operator.
+
+    The deferred status line is intentionally part of the recap stdout (not
+    a ``--verbose``-only diagnostic) so a Windows consumer who hits this
+    path on first ``task triage:bootstrap`` SEES that the gitcrawl install
+    deferred AND knows what fields they are missing in the gh-only fallback.
+    See ``docs/gitcrawl-fallback.md`` for the user-facing explanation of
+    the gh-only field gap.
+
+    Installation is best-effort: the bootstrap does NOT fail if gitcrawl
+    can't be installed because Story 1 has a documented ``gh issue list``
+    fallback.
 
     The ``skip`` flag is a test-only escape hatch; CLI consumers should not
     pass it.
@@ -818,56 +933,92 @@ def step_ensure_gitcrawl(skip: bool = False) -> StepOutcome:
             details={"installed": True, "action": "noop"},
         )
 
+    # ---- Phase 1: try ``uv tool install gitcrawl`` ------------------------
+    # uv is preferred over pipx because it is already a deft requirement;
+    # asking the user to also install pipx is a needless second hurdle on
+    # Windows where pipx is rarely pre-installed (#901).
+    uv = shutil.which("uv")
+    uv_attempted = False
+    uv_error: str | None = None
+    if uv is not None:
+        uv_attempted = True
+        ok, uv_error = _try_install_gitcrawl("uv", [uv, "tool", "install", "gitcrawl"])
+        if ok:
+            return StepOutcome(
+                name="ensure_gitcrawl",
+                ok=True,
+                message="installed via uv tool install",
+                details={
+                    "installed": True,
+                    "action": "uv-install",
+                    "uv_attempted": True,
+                    "pipx_attempted": False,
+                },
+            )
+
+    # ---- Phase 2: fall back to ``pipx install gitcrawl`` ------------------
     pipx = shutil.which("pipx")
-    if pipx is None:
-        return StepOutcome(
-            name="ensure_gitcrawl",
-            ok=True,
-            message=(
-                "deferred -- pipx not on PATH; install gitcrawl manually if "
-                "you want gh-API-free cache populates "
-                "(Story 1 falls back to 'gh issue list')"
-            ),
-            details={"installed": False, "action": "deferred-no-pipx"},
+    pipx_attempted = False
+    pipx_error: str | None = None
+    if pipx is not None:
+        pipx_attempted = True
+        ok, pipx_error = _try_install_gitcrawl("pipx", [pipx, "install", "gitcrawl"])
+        if ok:
+            return StepOutcome(
+                name="ensure_gitcrawl",
+                ok=True,
+                message=(
+                    "installed via pipx"
+                    + (" (uv attempt failed; see error)" if uv_attempted else "")
+                ),
+                error=uv_error if uv_attempted else None,
+                details={
+                    "installed": True,
+                    "action": "pipx-install",
+                    "uv_attempted": uv_attempted,
+                    "pipx_attempted": True,
+                },
+            )
+
+    # ---- Phase 3: defer with a structured outcome -------------------------
+    # Branch A: neither installer was on PATH. Preserve the historical
+    # ``deferred-no-pipx`` action key so existing consumers that pin on it
+    # keep working; the new structured fields (``falling_back_to`` /
+    # ``missing_fields`` / ``install_hint``) ride alongside.
+    if not uv_attempted and not pipx_attempted:
+        return _gitcrawl_deferred_outcome(
+            action="deferred-no-pipx",
+            reason="neither uv nor pipx on PATH",
+            uv_attempted=False,
+            pipx_attempted=False,
         )
 
-    try:
-        proc = subprocess.run(  # noqa: S603 -- explicit args, no shell
-            [pipx, "install", "gitcrawl"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=120,
-        )
-    except (subprocess.SubprocessError, OSError) as exc:
-        return StepOutcome(
-            name="ensure_gitcrawl",
-            ok=True,
-            message=(
-                f"deferred -- pipx install raised {type(exc).__name__} "
-                "(Story 1 has a 'gh issue list' fallback)"
-            ),
-            error=str(exc),
-            details={"installed": False, "action": "deferred-error"},
-        )
+    # Branch B: at least one installer was attempted and failed. Surface
+    # the captured error text(s) so the operator can diagnose without
+    # re-running with --verbose.
+    error_parts: list[str] = []
+    if uv_error:
+        error_parts.append(uv_error)
+    if pipx_error:
+        error_parts.append(pipx_error)
+    combined_error = " | ".join(error_parts)[:1024] or None
 
-    if proc.returncode == 0:
-        return StepOutcome(
-            name="ensure_gitcrawl",
-            ok=True,
-            message="installed via pipx",
-            details={"installed": True, "action": "pipx-install"},
-        )
+    if uv_attempted and not pipx_attempted:
+        # uv failed; pipx not available to retry.
+        reason = "uv install failed and pipx not on PATH"
+    elif not uv_attempted and pipx_attempted:
+        # uv missing; pipx was tried and failed (matches the legacy
+        # pre-#901 single-installer failure path).
+        reason = "pipx install failed and uv not on PATH"
+    else:
+        reason = "both uv and pipx install attempts failed"
 
-    return StepOutcome(
-        name="ensure_gitcrawl",
-        ok=True,
-        message=(
-            f"deferred -- pipx install exited {proc.returncode} "
-            "(Story 1 has a 'gh issue list' fallback)"
-        ),
-        error=(proc.stderr or proc.stdout or "").strip()[:512],
-        details={"installed": False, "action": "deferred-pipx-fail"},
+    return _gitcrawl_deferred_outcome(
+        action="deferred-install-failed",
+        reason=reason,
+        error=combined_error,
+        uv_attempted=uv_attempted,
+        pipx_attempted=pipx_attempted,
     )
 
 

--- a/skills/deft-directive-refinement/SKILL.md
+++ b/skills/deft-directive-refinement/SKILL.md
@@ -76,6 +76,8 @@ The agent may suggest the next phase, but the user decides. Phases can be entere
 
 ! Phase 0 is the canonical pre-ingest entry point introduced under #845. It operates on the **three-tier inventory model** so that `vbrief/proposed/` only ever contains items the user has explicitly accepted. Phase 0 ! MUST chain into Phase 1 -- Ingest on completion (or auto-skip into Phase 1 when the cache is empty -- see Step 1 below). Numbered prompts in Phase 0 ! MUST follow [`../../contracts/deterministic-questions.md`](../../contracts/deterministic-questions.md) -- the final two numbered options are `Discuss` and `Back`, in that order, and the Discuss-pause semantic from the contract applies verbatim.
 
+**See also (#901): [`../../docs/gitcrawl-fallback.md`](../../docs/gitcrawl-fallback.md)** -- when `task triage:bootstrap` defers the gitcrawl install (e.g. on Windows without `uv` or `pipx` on PATH), Phase 0 still runs but the cache is populated via the `gh`-only path and is missing `body_html` / `reactions` / `comments_full`. The doc explains the gh-only field gap, lists the manual install commands (`uv tool install gitcrawl` or `pipx install gitcrawl`), and describes the expected behavior on the gh-only fallback path.
+
 ### Three-Tier Inventory Model
 
 Phase 0 reads and writes three distinct tiers; ! MUST NOT collapse any pair into a single store:

--- a/tests/test_triage_bootstrap.py
+++ b/tests/test_triage_bootstrap.py
@@ -276,6 +276,285 @@ def test_gitcrawl_already_installed_is_noop(bootstrap, tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# #901 -- step_ensure_gitcrawl: try uv before pipx + structured deferred outcome
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompletedProcess:
+    """Minimal stand-in for ``subprocess.CompletedProcess`` used by tests."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _which_factory(*available: str):
+    """Return a ``shutil.which`` replacement that resolves only the named bins.
+
+    Each name in ``available`` is mapped to a fake absolute path so the
+    bootstrap's ``shutil.which(<bin>)`` checks return truthy for it. Every
+    other lookup returns ``None``. The test suite uses this to drive the
+    uv-first / pipx-fallback / both-missing branches deterministically.
+    """
+    table = {name: f"/usr/local/bin/{name}" for name in available}
+
+    def _which(cmd: str) -> str | None:
+        return table.get(cmd)
+
+    return _which
+
+
+def test_step_ensure_gitcrawl_uv_first_pipx_fallback(bootstrap, monkeypatch) -> None:
+    """uv MUST be tried before pipx; on uv success, pipx MUST NOT be invoked.
+
+    Drives the new #901 install order: when ``uv`` is on PATH and ``uv tool
+    install gitcrawl`` exits 0, the step returns the ``uv-install`` action
+    and never spawns the pipx subprocess. This pins the ordering so a
+    future refactor cannot silently revert to pipx-first.
+    """
+    monkeypatch.setattr(bootstrap.shutil, "which", _which_factory("uv", "pipx"))
+
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **_kwargs):
+        calls.append(list(argv))
+        # uv install succeeds; if pipx is ever invoked the test will see it
+        # in `calls` and fail the ordering assertion below.
+        return _FakeCompletedProcess(returncode=0, stdout="installed", stderr="")
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _fake_run)
+
+    outcome = bootstrap.step_ensure_gitcrawl(skip=False)
+
+    assert outcome.ok
+    assert outcome.details.get("installed") is True
+    assert outcome.details.get("action") == "uv-install"
+    assert outcome.details.get("uv_attempted") is True
+    assert outcome.details.get("pipx_attempted") is False
+    # Exactly one subprocess call -- uv tool install gitcrawl. pipx MUST NOT
+    # have been invoked once uv succeeded.
+    assert len(calls) == 1, f"expected single subprocess call, got: {calls}"
+    argv = calls[0]
+    assert argv[1:] == ["tool", "install", "gitcrawl"], (
+        f"first subprocess call must be `uv tool install gitcrawl`; got {argv}"
+    )
+    # Defence-in-depth: ensure no pipx subprocess hid in the calls list.
+    assert not any("pipx" in part for part in argv), (
+        "pipx must not be invoked on the uv-success path"
+    )
+
+
+def test_step_ensure_gitcrawl_uv_failure_falls_back_to_pipx(
+    bootstrap, monkeypatch
+) -> None:
+    """On uv install failure, pipx MUST be tried as the fallback."""
+    monkeypatch.setattr(bootstrap.shutil, "which", _which_factory("uv", "pipx"))
+
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **_kwargs):
+        calls.append(list(argv))
+        # uv exits non-zero; pipx exits zero.
+        if argv[0].endswith("uv") or argv[0] == "uv" or "uv" in argv[0]:
+            return _FakeCompletedProcess(returncode=1, stderr="uv failed")
+        return _FakeCompletedProcess(returncode=0, stdout="installed via pipx")
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _fake_run)
+
+    outcome = bootstrap.step_ensure_gitcrawl(skip=False)
+
+    assert outcome.ok
+    assert outcome.details.get("installed") is True
+    assert outcome.details.get("action") == "pipx-install"
+    assert outcome.details.get("uv_attempted") is True
+    assert outcome.details.get("pipx_attempted") is True
+    # Two subprocess calls -- uv first, pipx second.
+    assert len(calls) == 2, f"expected uv then pipx; got: {calls}"
+    assert calls[0][1:] == ["tool", "install", "gitcrawl"], (
+        f"first call must be uv; got {calls[0]}"
+    )
+    assert calls[1][1:] == ["install", "gitcrawl"], (
+        f"second call must be pipx; got {calls[1]}"
+    )
+
+
+def test_step_ensure_gitcrawl_defers_with_structured_outcome(
+    bootstrap, monkeypatch
+) -> None:
+    """When BOTH uv and pipx are missing, the step MUST defer with structured details.
+
+    The deferred ``StepOutcome.details`` MUST carry the canonical
+    ``falling_back_to`` / ``missing_fields`` / ``install_hint`` keys so
+    downstream tooling and the user-facing recap can surface the gh-only
+    fallback state without re-parsing the message string.
+    """
+    monkeypatch.setattr(bootstrap.shutil, "which", _which_factory())  # nothing on PATH
+
+    def _fake_run(argv, **_kwargs):  # pragma: no cover -- must not be called
+        raise AssertionError(
+            f"subprocess.run must NOT be called when neither uv nor pipx is "
+            f"on PATH; got argv={argv!r}"
+        )
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _fake_run)
+
+    outcome = bootstrap.step_ensure_gitcrawl(skip=False)
+
+    assert outcome.ok, "deferral MUST keep ok=True so bootstrap exit code stays 0"
+    assert outcome.details.get("installed") is False
+    assert outcome.details.get("falling_back_to") == "gh-only"
+    missing = outcome.details.get("missing_fields")
+    assert isinstance(missing, list)
+    # The acceptance-criteria minimum is body_html + reactions; we ship
+    # comments_full as well. Pin the canonical set so a future loosening
+    # is caught.
+    assert set(missing) >= {"body_html", "reactions"}, (
+        f"missing_fields must include at least body_html and reactions; got {missing}"
+    )
+    assert "comments_full" in missing, (
+        "comments_full is part of the canonical gitcrawl-only field set"
+    )
+    install_hint = outcome.details.get("install_hint")
+    assert isinstance(install_hint, str) and install_hint
+    assert "uv tool install gitcrawl" in install_hint
+    assert "pipx install gitcrawl" in install_hint
+    # Backwards-compat action key when neither installer was attempted.
+    assert outcome.details.get("action") == "deferred-no-pipx"
+    assert outcome.details.get("uv_attempted") is False
+    assert outcome.details.get("pipx_attempted") is False
+
+
+def test_step_ensure_gitcrawl_defers_when_both_installers_fail(
+    bootstrap, monkeypatch
+) -> None:
+    """Both installers present but BOTH fail -> structured deferred outcome."""
+    monkeypatch.setattr(bootstrap.shutil, "which", _which_factory("uv", "pipx"))
+
+    def _fake_run(argv, **_kwargs):
+        # Both installers exit non-zero.
+        return _FakeCompletedProcess(
+            returncode=2,
+            stdout="",
+            stderr=f"{argv[0]} simulated failure",
+        )
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _fake_run)
+
+    outcome = bootstrap.step_ensure_gitcrawl(skip=False)
+
+    assert outcome.ok, "deferral on install failure MUST keep ok=True"
+    assert outcome.details.get("installed") is False
+    assert outcome.details.get("action") == "deferred-install-failed"
+    assert outcome.details.get("falling_back_to") == "gh-only"
+    assert outcome.details.get("uv_attempted") is True
+    assert outcome.details.get("pipx_attempted") is True
+    assert isinstance(outcome.details.get("missing_fields"), list)
+    assert outcome.error is not None and "uv" in outcome.error
+
+
+def test_step_ensure_gitcrawl_status_line_visible(bootstrap, monkeypatch) -> None:
+    """The deferred status line MUST be in the user-visible recap stdout.
+
+    Acceptance criterion 1c: the status line that reports the gh-only
+    fallback MUST be visible in normal ``task triage:bootstrap`` stdout,
+    not buried in --verbose-only output. We render the recap via
+    :meth:`BootstrapResult.summary` and assert the canonical fallback
+    tokens land in it.
+    """
+    monkeypatch.setattr(bootstrap.shutil, "which", _which_factory())
+
+    def _fake_run(argv, **_kwargs):  # pragma: no cover -- must not be called
+        raise AssertionError(f"unexpected subprocess.run call: {argv!r}")
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _fake_run)
+
+    outcome = bootstrap.step_ensure_gitcrawl(skip=False)
+
+    # The message body itself must surface the canonical user-visible tokens.
+    msg = outcome.message
+    assert "gh-only" in msg, f"status line missing gh-only mode marker: {msg!r}"
+    assert "falling back" in msg.lower(), (
+        f"status line must say we are falling back: {msg!r}"
+    )
+    assert "gitcrawl" in msg.lower()
+    # The install hint MUST be in the user-visible status line so a copy-paste
+    # gives the user a working command.
+    assert "uv tool install gitcrawl" in msg
+    assert "pipx install gitcrawl" in msg
+
+    # End-to-end: render the same outcome through the bootstrap recap and
+    # confirm the tokens reach the recap stdout (not just the StepOutcome).
+    result = bootstrap.BootstrapResult(
+        project_root=Path("."), repo="deftai/directive"
+    )
+    # Pad with passing entries for the other three steps so the success-path
+    # "Next steps" block also renders -- a regression guard against any future
+    # change that demotes the gitcrawl status line into the failure-only path.
+    for name in ("populate_cache", "backfill_audit_log", "ensure_gitignore_entry"):
+        result.steps.append(
+            bootstrap.StepOutcome(name=name, ok=True, message="stub")
+        )
+    result.steps.append(outcome)
+    recap = result.summary()
+    assert "ensure_gitcrawl:" in recap
+    assert "gh-only" in recap, (
+        "recap stdout MUST surface the gh-only fallback marker -- the status "
+        "line cannot be buried in --verbose-only output (acceptance 1c)"
+    )
+    assert "falling back" in recap.lower()
+    assert "uv tool install gitcrawl" in recap
+
+
+def test_step_ensure_gitcrawl_uv_only_install_succeeds_without_pipx(
+    bootstrap, monkeypatch
+) -> None:
+    """When only uv is on PATH (no pipx), uv MUST still be tried first.
+
+    Pins the path that motivates #901: a Windows consumer who has uv (deft
+    requirement) but no pipx still gets gitcrawl installed via uv, without
+    being forced to install pipx as a second hurdle.
+    """
+    monkeypatch.setattr(bootstrap.shutil, "which", _which_factory("uv"))
+
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **_kwargs):
+        calls.append(list(argv))
+        return _FakeCompletedProcess(returncode=0, stdout="installed")
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _fake_run)
+
+    outcome = bootstrap.step_ensure_gitcrawl(skip=False)
+
+    assert outcome.ok
+    assert outcome.details.get("action") == "uv-install"
+    assert len(calls) == 1
+    assert calls[0][1:] == ["tool", "install", "gitcrawl"]
+
+
+def test_step_ensure_gitcrawl_uv_failure_pipx_missing_defers(
+    bootstrap, monkeypatch
+) -> None:
+    """uv attempted and failed; pipx not on PATH -> deferred-install-failed."""
+    monkeypatch.setattr(bootstrap.shutil, "which", _which_factory("uv"))
+
+    def _fake_run(argv, **_kwargs):
+        return _FakeCompletedProcess(returncode=1, stderr="uv broke")
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _fake_run)
+
+    outcome = bootstrap.step_ensure_gitcrawl(skip=False)
+
+    assert outcome.ok
+    assert outcome.details.get("action") == "deferred-install-failed"
+    assert outcome.details.get("falling_back_to") == "gh-only"
+    assert outcome.details.get("uv_attempted") is True
+    assert outcome.details.get("pipx_attempted") is False
+    assert outcome.error is not None and "uv" in outcome.error
+
+
+# ---------------------------------------------------------------------------
 # Greptile P2 regression guard -- _is_commented_gitignore_line tightening
 # ---------------------------------------------------------------------------
 

--- a/vbrief/active/2026-05-04-901-task-triagebootstrap-step-ensure-gitcrawl-defers-silently-on.vbrief.json
+++ b/vbrief/active/2026-05-04-901-task-triagebootstrap-step-ensure-gitcrawl-defers-silently-on.vbrief.json
@@ -2,11 +2,11 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Scope vBRIEF ingested from GitHub issue #901",
-    "updated": "2026-05-04T21:35:21Z"
+    "updated": "2026-05-04T21:59:05Z"
   },
   "plan": {
     "title": "task triage:bootstrap step ensure_gitcrawl defers silently on Windows; users get no signal about the gh-only fallback",
-    "status": "pending",
+    "status": "running",
     "narratives": {
       "Description": "task triage:bootstrap step ensure_gitcrawl defers silently on Windows; users get no signal about the gh-only fallback",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/901",


### PR DESCRIPTION
## Summary

Closes #901.

`task triage:bootstrap` step `ensure_gitcrawl` previously deferred silently when `pipx` was missing on Windows -- the user got no signal that triage had quietly fallen back to a `gh`-only fetch path and no clear pointer at what fields they were missing. This PR:

- Tries `uv tool install gitcrawl` BEFORE `pipx install gitcrawl` (`uv` is already a deft requirement, so a Windows user with no `pipx` no longer hits a needless second install hurdle).
- On both-installer failure (or neither installer present) defers with a structured `StepOutcome` whose `details` payload surfaces `falling_back_to: "gh-only"`, `missing_fields: ["body_html", "reactions", "comments_full"]`, and an `install_hint` (`"Install manually: uv tool install gitcrawl  OR  pipx install gitcrawl"`).
- Renders the deferred status line in the normal `task triage:bootstrap` recap stdout (acceptance 1c) -- not buried in `--verbose`-only output -- so the user SEES the gh-only fallback AND knows what fields are missing.
- Adds `docs/gitcrawl-fallback.md` documenting the gh-only field gap, manual install commands, and expected behavior on the gh-only fallback path (audience: end-user maintainer).
- Adds a Phase 0 See-also link to the new doc in `skills/deft-directive-refinement/SKILL.md`.

## Related Issues

Closes #901.

## File-overlap coordination with #900

This PR and the parallel #900 fix both touch `scripts/triage_bootstrap.py` and `skills/deft-directive-refinement/SKILL.md`. The split is strict and disjoint:

- `scripts/triage_bootstrap.py`: this PR owns ONLY `step_ensure_gitcrawl` (and its new private helpers `_gitcrawl_deferred_outcome` / `_try_install_gitcrawl` + the new module-level constants `GITCRAWL_ONLY_FIELDS` / `GITCRAWL_INSTALL_HINT` / `GITCRAWL_FALLBACK_MODE`). #900 owns `_build_parser` and `run_bootstrap`. This PR does NOT modify `_build_parser` or `run_bootstrap`.
- `skills/deft-directive-refinement/SKILL.md`: this PR adds ONLY a new See-also paragraph at the top of `## Phase 0 -- Triage` linking the new `docs/gitcrawl-fallback.md`. #900 owns the Phase 0 Step 1 populate-flags paragraph. This PR does NOT modify that paragraph.
- `tests/test_triage_bootstrap.py`: this PR's new test functions are namespaced under `test_step_ensure_gitcrawl_*` (uv-first / uv-failure-fallback-pipx / both-missing-defers / both-failed-defers / status-line-visible / uv-only-no-pipx / uv-failed-pipx-missing). This PR does NOT add tests under `test_parser_*`, `test_run_bootstrap_*`, or `test_populate_*` (those namespaces belong to #900).

The two fixes can land in either order without conflict.

## Changes

- `scripts/triage_bootstrap.py`: rewrote `step_ensure_gitcrawl` for the uv-first install order + structured deferred outcome; new private helpers (`_gitcrawl_deferred_outcome`, `_try_install_gitcrawl`) and module-level constants (`GITCRAWL_ONLY_FIELDS`, `GITCRAWL_INSTALL_HINT`, `GITCRAWL_FALLBACK_MODE`).
- `docs/gitcrawl-fallback.md`: new end-user maintainer doc covering the gh-only field gap, manual install commands, and verifying gh-only mode.
- `skills/deft-directive-refinement/SKILL.md`: new Phase 0 See-also paragraph linking the doc (added immediately after the Phase 0 intro paragraph; does NOT touch Phase 0 Step 1 / populate-flags / any other Phase 0 content).
- `tests/test_triage_bootstrap.py`: 7 new tests in the `test_step_ensure_gitcrawl_*` namespace (uv-first + pipx fallback, uv-failure-falls-back-to-pipx, both-missing structured deferral, both-failed structured deferral, status-line-visible end-to-end recap render, uv-only-no-pipx, uv-failed-pipx-missing).
- `CHANGELOG.md`: `[Unreleased]` entry under `### Added` in user-facing terms.
- `vbrief/active/2026-05-04-901-...vbrief.json`: lifecycle move from `vbrief/pending/` (status flipped to `running` via `task vbrief:activate`).

## vBRIEF References

`vbrief/active/2026-05-04-901-task-triagebootstrap-step-ensure-gitcrawl-defers-silently-on.vbrief.json`

## Checklist

- [x] `/deft:change <name>` -- N/A (single-issue fix; not cross-cutting/architectural/high-risk; scope strictly bounded to `step_ensure_gitcrawl` per the file-overlap coordination with #900).
- [x] `CHANGELOG.md` -- entry added under `[Unreleased]` `### Added` in user-facing terms.
- [x] `ROADMAP.md` -- N/A; ROADMAP updates batch at release time per AGENTS.md.
- [x] Tests pass locally -- the new `test_step_ensure_gitcrawl_*` tests (7) plus the existing `test_fresh_project_end_to_end` and `test_gitcrawl_already_installed_is_noop` all pass (`uv run pytest tests/test_triage_bootstrap.py` -> 42 passed). The full `task check` aggregate hit pre-existing Windows pytest tempdir cleanup errors (#281 territory) unrelated to this PR; the deterministic gates (`task validate`, `task verify:encoding`, `task verify:branch`, `task vbrief:validate`) all pass.

## Testing

```
uv run pytest tests/test_triage_bootstrap.py
# 42 passed in 0.17s
```

Acceptance criteria covered by the new tests:

1. `test_step_ensure_gitcrawl_uv_first_pipx_fallback` -- pins the new uv-first install order; pipx MUST NOT be invoked when uv succeeds.
2. `test_step_ensure_gitcrawl_uv_failure_falls_back_to_pipx` -- pipx MUST be tried as fallback when uv fails.
3. `test_step_ensure_gitcrawl_defers_with_structured_outcome` -- both installers missing -> structured details (falling_back_to / missing_fields / install_hint) on the deferred outcome.
4. `test_step_ensure_gitcrawl_defers_when_both_installers_fail` -- both installers present but both fail -> structured details + captured error text.
5. `test_step_ensure_gitcrawl_status_line_visible` -- the user-visible recap stdout MUST surface the `gh-only` fallback marker and install hint (acceptance 1c -- not buried in `--verbose`-only output).
6. `test_step_ensure_gitcrawl_uv_only_install_succeeds_without_pipx` -- the motivating case: a Windows consumer with uv but no pipx still gets gitcrawl installed without needing to install pipx as a second hurdle.
7. `test_step_ensure_gitcrawl_uv_failure_pipx_missing_defers` -- uv attempted and failed; pipx not on PATH -> structured deferred outcome with combined error text.

## Post-Merge

- [ ] Verify issue auto-close: `gh issue view 901 --repo deftai/directive --json state --jq .state`. If still open, close manually citing this PR.
- [ ] No branch-protection changes needed.
