### PR TITLE
fix(triage): disable bulk-* tasks pending v0.25.2 (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **fix(triage): disable `task triage:bulk-*` tasks at the Taskfile layer pending v0.25.2 (#915)** -- bulk operations as shipped in v0.25.0/v0.25.1 bypass the .deft-cache contract and silently poison `vbrief/.eval/candidates.jsonl`; gating the user-facing surface is a low-cost protective measure until the cache-walk rewrite ships. The four bulk-* tasks (`bulk-accept`, `bulk-reject`, `bulk-defer`, `bulk-needs-ac`) in `tasks/triage-bulk.yml` now exit 2 with an ASCII-only error pointer to #915 and the single-issue alternatives (`task triage:accept` / `triage:reject` / `triage:defer` / `triage:needs-ac`); each `desc:` is prefixed with `[DISABLED v0.25.x]` so `task -l` surfaces the disabled state. `task triage-bulk:refresh-active` is intentionally untouched (does not bypass the cache contract) and `scripts/triage_bulk.py` is intentionally untouched (the cache-walk rewrite is owned by the v0.25.2 fix). Refs #915.
 
 ### Removed
 

--- a/tasks/triage-bulk.yml
+++ b/tasks/triage-bulk.yml
@@ -22,36 +22,48 @@ vars:
 
 tasks:
   bulk-accept:
-    desc: "Bulk accept candidates (#845 Story 4) -- task triage:bulk-accept -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C]"
+    desc: "[DISABLED v0.25.x] Bulk accept is gated pending v0.25.2 (#915). Use task triage:accept per issue."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" accept {{.CLI_ARGS}}
+      - |
+        echo "ERROR: task triage:bulk-accept is disabled in v0.25.0/v0.25.1 (#915)."
+        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
+        echo "  Use single-issue actions until v0.25.2 ships:"
+        echo "    task triage:accept -- --repo OWNER/NAME --issue N"
+        exit 2
 
   bulk-reject:
-    desc: "Bulk reject candidates (#845 Story 4) -- task triage:bulk-reject -- --repo OWNER/NAME --reason 'why' [--label L] [--author A] [--age-days N] [--cluster C]"
+    desc: "[DISABLED v0.25.x] Bulk reject is gated pending v0.25.2 (#915). Use task triage:reject per issue."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" reject {{.CLI_ARGS}}
+      - |
+        echo "ERROR: task triage:bulk-reject is disabled in v0.25.0/v0.25.1 (#915)."
+        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
+        echo "  Use single-issue actions until v0.25.2 ships:"
+        echo "    task triage:reject -- --repo OWNER/NAME --issue N --reason 'why'"
+        exit 2
 
   bulk-defer:
-    desc: "Bulk defer candidates (#845 Story 4) -- task triage:bulk-defer -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C]"
+    desc: "[DISABLED v0.25.x] Bulk defer is gated pending v0.25.2 (#915). Use task triage:defer per issue."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" defer {{.CLI_ARGS}}
+      - |
+        echo "ERROR: task triage:bulk-defer is disabled in v0.25.0/v0.25.1 (#915)."
+        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
+        echo "  Use single-issue actions until v0.25.2 ships:"
+        echo "    task triage:defer -- --repo OWNER/NAME --issue N"
+        exit 2
 
   bulk-needs-ac:
-    desc: "Bulk needs-ac candidates (#845 Story 4) -- task triage:bulk-needs-ac -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C]"
+    desc: "[DISABLED v0.25.x] Bulk needs-ac is gated pending v0.25.2 (#915). Use task triage:needs-ac per issue."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" needs-ac {{.CLI_ARGS}}
+      - |
+        echo "ERROR: task triage:bulk-needs-ac is disabled in v0.25.0/v0.25.1 (#915)."
+        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
+        echo "  Use single-issue actions until v0.25.2 ships:"
+        echo "    task triage:needs-ac -- --repo OWNER/NAME --issue N"
+        exit 2
 
   refresh-active:
     desc: "Pre-swarm freshness gate (#845 Story 4) -- detects drift between cached and live `gh issue view` for every issue referenced in vbrief/active/*.vbrief.json"

--- a/vbrief/active/2026-05-05-915-hotfix-disable-triage-bulk.vbrief.json
+++ b/vbrief/active/2026-05-05-915-hotfix-disable-triage-bulk.vbrief.json
@@ -1,0 +1,52 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Hot-fix: gate the user-facing `task triage:bulk-*` surface at the Taskfile layer pending the v0.25.2 cache-walk rewrite of scripts/triage_bulk.py (#915). Bulk operations as shipped in v0.25.0 / v0.25.1 bypass the .deft-cache contract and silently poison vbrief/.eval/candidates.jsonl; gating the four bulk-* tasks (bulk-accept / bulk-reject / bulk-defer / bulk-needs-ac) is a low-cost protective measure until the proper fix ships.",
+    "created": "2026-05-05T14:35:06Z",
+    "updated": "2026-05-05T14:37:30Z"
+  },
+  "plan": {
+    "title": "fix(triage): disable bulk-* tasks pending v0.25.2 (#915 hot-fix)",
+    "status": "running",
+    "narratives": {
+      "Problem": "scripts/triage_bulk.py bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl on every bulk-* invocation (#915). The proper fix is the cache-walk rewrite slated for v0.25.2; until it ships, every operator who runs `task triage:bulk-accept` / `bulk-reject` / `bulk-defer` / `bulk-needs-ac` against v0.25.0 or v0.25.1 corrupts the audit log. Single-issue triage actions (`task triage:accept` / `triage:reject` / `triage:defer` / `triage:needs-ac`) and the freshness gate (`task triage-bulk:refresh-active`) are NOT affected and remain the supported path.",
+      "Action": "Gate the four bulk-* tasks at the Taskfile layer. Replace each cmds: block in tasks/triage-bulk.yml with a multi-line shell that prints an ASCII-only error message (citing #915 + pointing at the single-issue alternative) and exits 2. Update each task's `desc:` to begin with `[DISABLED v0.25.x]` so `task -l` surfaces the disabled state. Drop the per-task `env: PYTHONUTF8: \"1\"` block since python is no longer invoked. The refresh-active task is intentionally untouched -- it does not bypass the cache contract and remains the canonical pre-swarm freshness gate. scripts/triage_bulk.py itself is intentionally untouched -- the cache-walk rewrite is owned by the v0.25.2 fix.",
+      "Outcome": "Running `task triage-bulk:bulk-accept` / `bulk-reject` / `bulk-defer` / `bulk-needs-ac` exits 2 with a clear pointer to #915 and the single-issue alternatives. `task -l` shows the four tasks prefixed with `[DISABLED v0.25.x]` so the disabled state is visible without invoking the task. `task triage-bulk:refresh-active` continues to run normally. CHANGELOG.md `[Unreleased]` `### Fixed` carries a single bullet documenting the gate and pointing at #915. Re-enabling lands in v0.25.2 alongside the cache-walk rewrite of scripts/triage_bulk.py."
+    },
+    "items": [
+      {
+        "id": "gate-bulk-accept",
+        "title": "Replace tasks/triage-bulk.yml::bulk-accept cmds with disabled echo + exit 2; update desc to [DISABLED v0.25.x]",
+        "status": "proposed"
+      },
+      {
+        "id": "gate-bulk-reject",
+        "title": "Replace tasks/triage-bulk.yml::bulk-reject cmds with disabled echo + exit 2; update desc to [DISABLED v0.25.x]",
+        "status": "proposed"
+      },
+      {
+        "id": "gate-bulk-defer",
+        "title": "Replace tasks/triage-bulk.yml::bulk-defer cmds with disabled echo + exit 2; update desc to [DISABLED v0.25.x]",
+        "status": "proposed"
+      },
+      {
+        "id": "gate-bulk-needs-ac",
+        "title": "Replace tasks/triage-bulk.yml::bulk-needs-ac cmds with disabled echo + exit 2; update desc to [DISABLED v0.25.x]",
+        "status": "proposed"
+      },
+      {
+        "id": "changelog-unreleased-fixed",
+        "title": "Append [Unreleased] ### Fixed bullet to CHANGELOG.md citing #915",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/915",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #915: scripts/triage_bulk.py bypasses .deft-cache contract and poisons vbrief/.eval/candidates.jsonl"
+      }
+    ],
+    "updated": "2026-05-05T14:37:25Z"
+  }
+}


### PR DESCRIPTION
## Summary

Hot-fix that gates the user-facing `task triage:bulk-*` surface at the
Taskfile layer, pending the proper cache-walk rewrite of
`scripts/triage_bulk.py` slated for v0.25.2 (#915).

## Why hot-fix instead of waiting for v0.25.2

`scripts/triage_bulk.py` as shipped in v0.25.0 / v0.25.1 bypasses the
`.deft-cache` contract and silently poisons
`vbrief/.eval/candidates.jsonl` on every bulk-* invocation. Until the
v0.25.2 cache-walk rewrite ships, every operator who runs
`task triage:bulk-accept` / `bulk-reject` / `bulk-defer` /
`bulk-needs-ac` against v0.25.0 or v0.25.1 corrupts the audit log.

Gating the user-facing surface at the Taskfile layer is a low-cost,
fail-loud protective measure with zero blast radius on the rest of the
triage workflow.

## What is disabled

The four bulk-* tasks in `tasks/triage-bulk.yml`:

- `bulk-accept`
- `bulk-reject`
- `bulk-defer`
- `bulk-needs-ac`

Each task's `cmds:` block is replaced with a multi-line shell that
prints an ASCII-only error message citing #915 and pointing operators
at the matching single-issue alternative, then exits 2. Each task's
`desc:` is prefixed with `[DISABLED v0.25.x]` so `task -l` surfaces
the disabled state without needing to invoke the task. Per-task
`env: PYTHONUTF8: "1"` is dropped from the four bulk-* tasks since
`uv run python` is no longer invoked.

## What is NOT disabled

- `task triage-bulk:refresh-active` -- intentionally untouched
  (does not bypass the cache contract; remains the canonical
  pre-swarm freshness gate).
- `task triage:accept` / `triage:reject` / `triage:defer` /
  `triage:needs-ac` -- single-issue actions remain the supported
  path until v0.25.2 ships.
- `scripts/triage_bulk.py` -- intentionally untouched. The
  cache-walk rewrite is owned by the v0.25.2 fix; this PR is
  scoped to the user-facing Taskfile surface only.

## Test plan

Visual verification via the rendered YAML and `task -l` is
sufficient -- running the disabled `task triage:bulk-*` commands to
test the gate is exactly what we are protecting against.

Manual checks:

- `task -l` shows `bulk-accept` / `bulk-reject` / `bulk-defer` /
  `bulk-needs-ac` with `[DISABLED v0.25.x]` desc prefixes.
- `task triage-bulk:refresh-active` continues to dispatch normally
  (byte-untouched).
- `task check` exits 0 (validate + lint + test + verify:encoding +
  verify:branch + rule-ownership + links + stubs + vbrief:validate).
  3975 passed, 3 skipped, 1 xfailed.

## Follow-up references

- #915 -- root cause: `scripts/triage_bulk.py` cache bypass +
  audit-log poisoning. v0.25.2 cache-walk rewrite is the proper fix
  this PR temporarily gates around.
- #913 / #914 -- adjacent triage-cache items.
- #915 follow-up comment -- gitignore semantics for
  `vbrief/.eval/candidates.jsonl` integrity.

## Closing keyword

`Refs #915` (NOT `Closes #915`). The underlying bug is fixed by the
v0.25.2 cache-walk rewrite of `scripts/triage_bulk.py`, not by this
gate. The issue MUST stay open until v0.25.2 ships and the bulk-*
tasks are re-enabled with the cache-walking implementation.
