### PR TITLE
fix(triage): correct fragment-include task names (#913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- **fix(triage): disable `task triage:bulk-*` tasks at the Taskfile layer pending v0.25.2 (#915)** -- bulk operations as shipped in v0.25.0/v0.25.1 bypass the .deft-cache contract and silently poison `vbrief/.eval/candidates.jsonl`; gating the user-facing surface is a low-cost protective measure until the cache-walk rewrite ships. The four bulk-* tasks (`bulk-accept`, `bulk-reject`, `bulk-defer`, `bulk-needs-ac`) in `tasks/triage-bulk.yml` now exit 2 with an ASCII-only error pointer to #915 and the single-issue alternatives (`task triage:accept` / `triage:reject` / `triage:defer` / `triage:needs-ac`); each `desc:` is prefixed with `[DISABLED v0.25.x]` so `task -l` surfaces the disabled state. `task triage-bulk:refresh-active` is intentionally untouched (does not bypass the cache contract) and `scripts/triage_bulk.py` is intentionally untouched (the cache-walk rewrite is owned by the v0.25.2 fix). Refs #915.
+- **fix(triage): rename fragment-include task names so the documented `triage:*` surface (`task triage:cache`, `task triage:accept`, `task triage:bulk-defer`, etc.) is reachable verbatim (#913)**
+- **fix(triage): disable `task triage:bulk-*` tasks at the Taskfile layer pending v0.25.2 (#915)**
 
 ### Removed
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -331,21 +331,139 @@ tasks:
       - uv run python "{{.TASKFILE_DIR}}/scripts/release_e2e.py" {{.CLI_ARGS}}
 
   # ------------------------------------------------------------------
-  # Triage v1 user-facing alias tasks (#845).
+  # Triage v1 user-facing alias tasks (#845, #913).
   #
   # The four triage fragments are namespaced under their unique include
   # keys (`triage-cache`, `triage-actions`, `triage-bulk`,
-  # `triage-bootstrap`). The aliases below provide the documented
-  # `task triage:<verb>` user-facing surface that vBRIEFs and UPGRADING.md
-  # describe. Each alias delegates to the underlying namespaced task and
-  # forwards `{{.CLI_ARGS}}` so flags (`--repo`, `--reason`, etc.) reach
-  # the script. Aliases are inline at the root Taskfile rather than in a
-  # separate fragment because they cross include namespaces and must
-  # exist regardless of which fragments are present (the underlying
-  # `task: <name>` reference is itself a no-op when the include is
-  # `optional: true` and absent, but tests pin the aliases so consumers
-  # see consistent help text).
+  # `triage-bootstrap`) -- a single shared `triage:` include namespace
+  # is not supported by go-task v3 (two includes cannot share a key).
+  # The aliases below provide the documented `task triage:<verb>`
+  # user-facing surface that vBRIEFs / UPGRADING.md / scripts/triage_*.py
+  # describe. Each alias delegates to the underlying namespaced task
+  # and forwards `{{.CLI_ARGS}}` so flags (`--repo`, `--reason`, etc.)
+  # reach the script. The inner tasks in each fragment are
+  # `internal: true` so the fragment-namespace forms
+  # (`triage-cache:cache`, `triage-actions:accept`, `triage-bulk:bulk-defer`,
+  # `triage-bootstrap:bootstrap`) drop out of `task -l`; only the
+  # documented `triage:*` aliases below appear in the listing. The
+  # internal tasks remain CALLABLE for legacy invocations (e.g. recap
+  # text in `scripts/triage_bootstrap.py` still prints the namespaced
+  # forms, which continue to dispatch correctly via the fragment
+  # include).
+  #
+  # Aliases are inline at the root Taskfile rather than in a separate
+  # fragment because they cross include namespaces and must exist
+  # regardless of which fragments are present.
+  #
+  # Mirrors the established #718 release-pipeline flatten precedent
+  # (release: tasks defined inline at the root Taskfile so go-task
+  # does not double-prefix them).
   # ------------------------------------------------------------------
+  triage:cache:
+    desc: "Populate the local issue cache (.deft-cache/issues/<owner>-<repo>/) -- task triage:cache -- --repo owner/repo [--force] [--use-gitcrawl]"
+    cmds:
+      - task: triage-cache:cache
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:show:
+    desc: "Print the cached, quarantined .md body for an issue -- task triage:show -- --repo owner/repo --issue 845"
+    cmds:
+      - task: triage-cache:show
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:accept:
+    desc: "Accept an issue for triage. Records an audit entry. (#845 Story 3)"
+    cmds:
+      - task: triage-actions:accept
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:reject:
+    desc: "Reject an issue. Closes upstream via gh + applies triage-rejected label; rolls audit back on gh failure. (#845 Story 3)"
+    cmds:
+      - task: triage-actions:reject
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:defer:
+    desc: "Defer an issue. Records an audit entry. (#845 Story 3)"
+    cmds:
+      - task: triage-actions:defer
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:needs-ac:
+    desc: "Mark an issue as needing acceptance criteria + post AC-request comment upstream. (#845 Story 3)"
+    cmds:
+      - task: triage-actions:needs-ac
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:mark-duplicate:
+    desc: "Link an issue as a duplicate of another (validated against Story 1 cache). (#845 Story 3)"
+    cmds:
+      - task: triage-actions:mark-duplicate
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:status:
+    desc: "Print the latest triage decision for an issue. Read-only. (#845 Story 3)"
+    cmds:
+      - task: triage-actions:status
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:reset:
+    desc: "Reset an issue's triage state. Appends a reset audit entry referencing prior; does NOT delete history. (#845 Story 3)"
+    cmds:
+      - task: triage-actions:reset
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:history:
+    desc: "Print the full triage timeline for an issue, ordered by timestamp. Read-only. (#845 Story 3)"
+    cmds:
+      - task: triage-actions:history
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:bulk-accept:
+    desc: "[DISABLED v0.25.x] Bulk accept is gated pending v0.25.2 (#915). Use task triage:accept per issue."
+    cmds:
+      - task: triage-bulk:bulk-accept
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:bulk-reject:
+    desc: "[DISABLED v0.25.x] Bulk reject is gated pending v0.25.2 (#915). Use task triage:reject per issue."
+    cmds:
+      - task: triage-bulk:bulk-reject
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:bulk-defer:
+    desc: "[DISABLED v0.25.x] Bulk defer is gated pending v0.25.2 (#915). Use task triage:defer per issue."
+    cmds:
+      - task: triage-bulk:bulk-defer
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:bulk-needs-ac:
+    desc: "[DISABLED v0.25.x] Bulk needs-ac is gated pending v0.25.2 (#915). Use task triage:needs-ac per issue."
+    cmds:
+      - task: triage-bulk:bulk-needs-ac
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:refresh-active:
+    desc: "Pre-swarm freshness gate (#845 Story 4) -- detects drift between cached and live `gh issue view` for every issue referenced in vbrief/active/*.vbrief.json"
+    cmds:
+      - task: triage-bulk:refresh-active
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
   triage:bootstrap:
     desc: "Run the triage v1 idempotent installer (#845 Story 6)."
     cmds:

--- a/tasks/triage-actions.yml
+++ b/tasks/triage-actions.yml
@@ -2,11 +2,16 @@ version: '3'
 
 # tasks/triage-actions.yml -- per-issue triage commands (#845 Story 3).
 #
-# STANDALONE Taskfile fragment: NOT yet wired into the parent Taskfile.yml
-# `includes:` block. Story 6 (#845 bootstrap) owns the integration step --
-# this fragment only declares the triage:* targets so consumers can dispatch
-# `task -t tasks/triage-actions.yml triage:accept --issue 845 --repo ...`
-# (or use the standard include syntax once Story 6 lands).
+# Wired into the parent Taskfile.yml `includes:` block under namespace key
+# `triage-actions` (#845 Story 6). Inner task names below dropped the
+# `triage:` prefix in #913 -- the prior names produced a doubled prefix
+# (`triage-actions:triage:accept`) under go-task's include-namespace
+# concatenation. Combined with `internal: true` the fragment-namespace
+# forms (`triage-actions:accept` / `triage-actions:reject` / ...) are
+# hidden from `task -l`; the documented `task triage:accept` / `triage:reject`
+# / `triage:defer` / `triage:needs-ac` / `triage:mark-duplicate` /
+# `triage:status` / `triage:reset` / `triage:history` surface lives as
+# root-level alias tasks in Taskfile.yml that delegate here.
 #
 # Per `conventions/task-caching.md`: NO `sources:` / `generates:` because every
 # target accepts user-facing flags via `{{.CLI_ARGS}}` (--issue, --repo,
@@ -24,64 +29,72 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  triage:accept:
+  accept:
     desc: "Accept an issue for triage. Records an audit entry. (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
     cmds:
       - uv run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" accept {{.CLI_ARGS}}
 
-  triage:reject:
+  reject:
     desc: "Reject an issue. Closes upstream via gh + applies triage-rejected label; rolls audit back on gh failure. (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
     cmds:
       - uv run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" reject {{.CLI_ARGS}}
 
-  triage:defer:
+  defer:
     desc: "Defer an issue. Records an audit entry. (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
     cmds:
       - uv run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" defer {{.CLI_ARGS}}
 
-  triage:needs-ac:
+  needs-ac:
     desc: "Mark an issue as needing acceptance criteria + post AC-request comment upstream. (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
     cmds:
       - uv run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" needs-ac {{.CLI_ARGS}}
 
-  triage:mark-duplicate:
+  mark-duplicate:
     desc: "Link an issue as a duplicate of another (validated against Story 1 cache). (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
     cmds:
       - uv run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" mark-duplicate {{.CLI_ARGS}}
 
-  triage:status:
+  status:
     desc: "Print the latest triage decision for an issue. Read-only. (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
     cmds:
       - uv run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" status {{.CLI_ARGS}}
 
-  triage:reset:
+  reset:
     desc: "Reset an issue's triage state. Appends a reset audit entry referencing prior; does NOT delete history. (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
     cmds:
       - uv run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" reset {{.CLI_ARGS}}
 
-  triage:history:
+  history:
     desc: "Print the full triage timeline for an issue, ordered by timestamp. Read-only. (#845 Story 3)"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"

--- a/tasks/triage-bootstrap.yml
+++ b/tasks/triage-bootstrap.yml
@@ -34,6 +34,7 @@ vars:
 tasks:
   bootstrap:
     desc: "Idempotent triage v1 installer (#845): populate cache, backfill audit log, gitignore, gitcrawl. Re-runnable. -- task triage:bootstrap [-- --repo OWNER/NAME] [--skip-gitcrawl] [--json]"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       # PYTHONUTF8=1 is set at the root Taskfile.yml level (#540) and

--- a/tasks/triage-bulk.yml
+++ b/tasks/triage-bulk.yml
@@ -2,10 +2,16 @@ version: '3'
 
 # tasks/triage-bulk.yml -- Story 4 of #845.
 #
-# STANDALONE Taskfile fragment. NOT yet wired into the parent ../Taskfile.yml
-# `includes:` block -- the cross-cutting wiring is owned by Story 6 (Agent A6,
-# scripts/triage_bootstrap.py + tasks/triage-bootstrap.yml). This file
-# documents the user-facing surface so Story 6 can ingest it verbatim.
+# Wired into the parent ../Taskfile.yml `includes:` block under namespace
+# key `triage-bulk` (#845 Story 6). The user-facing `task triage:bulk-accept`
+# / `triage:bulk-reject` / `triage:bulk-defer` / `triage:bulk-needs-ac` /
+# `triage:refresh-active` surface lives as root-level alias tasks in
+# Taskfile.yml that delegate here (#913); inner tasks below are
+# `internal: true` so the fragment-namespace forms (`triage-bulk:bulk-*`)
+# are hidden from `task -l`. The disable-gate `cmds:` blocks for
+# `bulk-accept` / `bulk-reject` / `bulk-defer` / `bulk-needs-ac` (#915) are
+# unchanged: invoking either via the alias or via the namespaced form
+# still exits 2 with the ASCII-only pointer to the single-issue alternatives.
 #
 # Per `conventions/task-caching.md` (#574): every target here accepts user
 # flags via `{{.CLI_ARGS}}` (--label, --author, --age-days, --cluster,
@@ -23,6 +29,7 @@ vars:
 tasks:
   bulk-accept:
     desc: "[DISABLED v0.25.x] Bulk accept is gated pending v0.25.2 (#915). Use task triage:accept per issue."
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - |
@@ -34,6 +41,7 @@ tasks:
 
   bulk-reject:
     desc: "[DISABLED v0.25.x] Bulk reject is gated pending v0.25.2 (#915). Use task triage:reject per issue."
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - |
@@ -45,6 +53,7 @@ tasks:
 
   bulk-defer:
     desc: "[DISABLED v0.25.x] Bulk defer is gated pending v0.25.2 (#915). Use task triage:defer per issue."
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - |
@@ -56,6 +65,7 @@ tasks:
 
   bulk-needs-ac:
     desc: "[DISABLED v0.25.x] Bulk needs-ac is gated pending v0.25.2 (#915). Use task triage:needs-ac per issue."
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - |
@@ -67,6 +77,7 @@ tasks:
 
   refresh-active:
     desc: "Pre-swarm freshness gate (#845 Story 4) -- detects drift between cached and live `gh issue view` for every issue referenced in vbrief/active/*.vbrief.json"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"

--- a/tasks/triage-cache.yml
+++ b/tasks/triage-cache.yml
@@ -2,10 +2,16 @@ version: '3'
 
 # Standalone Taskfile fragment for #845 Story 1 -- the triage cache surface.
 #
-# Wave-1 owner: Agent A1 (this PR). The parent ``Taskfile.yml`` ``includes:``
-# wiring is owned by Story 6 (Agent A6) and intentionally NOT performed here.
-# To exercise these tasks before the wiring lands, run them directly via
-# ``task --taskfile tasks/triage-cache.yml triage:cache -- --repo owner/repo``.
+# Wave-1 owner: Agent A1. The parent ``Taskfile.yml`` ``includes:`` block
+# wires this fragment under namespace key ``triage-cache`` (#845 Story 6);
+# the user-facing surface (``task triage:cache`` / ``task triage:show``)
+# lives as root-level alias tasks in Taskfile.yml that delegate here
+# (#913). Inner tasks below are ``internal: true`` so go-task hides
+# the fragment-namespace forms from ``task -l`` -- the documented
+# ``triage:*`` surface is the only thing operators see in the listing,
+# while the underlying targets remain callable from the alias delegation
+# (and from explicit ``task triage-cache:cache`` invocations for legacy
+# recap text in ``scripts/triage_bootstrap.py``).
 #
 # Per ``conventions/task-caching.md`` (#574), tasks that accept user-facing
 # recovery flags via ``{{.CLI_ARGS}}`` (here: ``--repo`` / ``--force`` /
@@ -23,6 +29,7 @@ vars:
 tasks:
   cache:
     desc: "Populate the local issue cache (.deft-cache/issues/<owner>-<repo>/) -- task triage:cache -- --repo owner/repo [--force] [--use-gitcrawl]"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
@@ -31,6 +38,7 @@ tasks:
 
   show:
     desc: "Print the cached, quarantined .md body for an issue -- task triage:show -- --repo owner/repo --issue 845"
+    internal: true
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"

--- a/vbrief/active/2026-05-05-913-fix-triage-task-aliases.vbrief.json
+++ b/vbrief/active/2026-05-05-913-fix-triage-task-aliases.vbrief.json
@@ -1,0 +1,63 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Rename triage v1 fragment-include task names so the documented task triage:* surface is reachable verbatim from task -l (#913). Skill docs and CHANGELOG advertise task triage:cache / task triage:show / task triage:accept|reject|defer|needs-ac|mark-duplicate|status|reset|history / task triage:bulk-accept|bulk-reject|bulk-defer|bulk-needs-ac|refresh-active / task triage:bootstrap, but go-task installs them under fragment-include prefixes (triage-cache:cache, triage-actions:triage:accept with a doubled prefix, triage-bulk:bulk-accept, etc.). Pick option (1) from #913: hide the include-namespace forms via internal: true and add root-level alias tasks that delegate verbatim. scripts/triage_bulk.py / scripts/triage_cache.py / scripts/triage_bootstrap.py are intentionally untouched (Agents B/C scope).",
+    "created": "2026-05-05T15:15:00Z",
+    "updated": "2026-05-05T15:21:05Z"
+  },
+  "plan": {
+    "title": "task: triage v1 fragment-include task names don't match documented triage:* surface",
+    "status": "running",
+    "narratives": {
+      "Overview": "Rename includes-block + inner task names (and add root-level alias tasks where namespace collisions block a single triage: include) so task -l exposes only the documented triage:* surface. The four fragment files keep their inner logic and are reached via internal-marked include namespaces; the root Taskfile.yml owns the user-facing triage:* aliases that delegate to those internal tasks. Mirrors the established #718 release-pipeline flatten precedent (release: tasks defined inline at the root Taskfile so go-task does not double-prefix them).",
+      "Action": "1) tasks/triage-cache.yml: add internal: true to cache and show. 2) tasks/triage-actions.yml: drop the triage: prefix from inner task names (accept, reject, defer, needs-ac, mark-duplicate, status, reset, history) and add internal: true so the doubled prefix bug disappears. 3) tasks/triage-bulk.yml: add internal: true to bulk-accept, bulk-reject, bulk-defer, bulk-needs-ac, refresh-active (do not touch the disable-gate cmds). 4) tasks/triage-bootstrap.yml: add internal: true to bootstrap. 5) Taskfile.yml: replace the single triage:bootstrap alias with the full 16-alias surface (triage:cache, triage:show, triage:accept|reject|defer|needs-ac|mark-duplicate|status|reset|history, triage:bulk-accept|bulk-reject|bulk-defer|bulk-needs-ac|refresh-active, triage:bootstrap), each delegating to the underlying include-namespace task and forwarding CLI_ARGS. 6) CHANGELOG.md [Unreleased] / Fixed bullet citing #913.",
+      "Outcome": "task -l shows the documented triage:* names verbatim and no triage-cache:, triage-actions:triage:, triage-bulk:, or triage-bootstrap: prefixes appear. The skill smoke test in skills/deft-directive-refinement/SKILL.md Phase 0 runs cleanly using only the documented surface. CHANGELOG carries one Fixed bullet citing #913. scripts/triage_bootstrap.py recap text continues to print the namespaced forms; those forms continue to resolve as internal tasks so the recap is not stale-but-broken (cleanup of the recap text is deferred to Agents B/C scope). Existing tests/test_triage_bootstrap.py recap pins (test_namespaced_forms_present, test_shorthand_forms_not_advertised, test_recap_carries_deferral_note, test_taskfile_includes_wired_for_four_fragments) continue to pass byte-identically.",
+      "Test": "Acceptance per #913: (1) every documented triage:* task resolves under task -l; (2) no triage-cache:, triage-actions:triage:, or triage-bulk: prefixes are visible in task -l; (3) task triage:cache, task triage:accept, task triage:bulk-defer, task triage:bootstrap, etc. dispatch to their underlying script via the alias delegation. Validation: task -l | Select-String triage; task triage:bootstrap -- --help (smoke); task check (full pre-commit aggregate)."
+    },
+    "items": [
+      {
+        "id": "913-internal-mark-fragments",
+        "title": "Add internal: true to every inner task across tasks/triage-cache.yml, tasks/triage-actions.yml, tasks/triage-bulk.yml, tasks/triage-bootstrap.yml so the include-namespace forms drop out of task -l",
+        "status": "proposed"
+      },
+      {
+        "id": "913-rename-actions-inner-names",
+        "title": "Drop the triage: prefix from inner task names in tasks/triage-actions.yml (accept, reject, defer, needs-ac, mark-duplicate, status, reset, history) so the doubled triage-actions:triage:* prefix disappears",
+        "status": "proposed"
+      },
+      {
+        "id": "913-add-root-aliases",
+        "title": "Replace the single triage:bootstrap alias in Taskfile.yml with the full 16-alias surface (cache, show, accept, reject, defer, needs-ac, mark-duplicate, status, reset, history, bulk-accept, bulk-reject, bulk-defer, bulk-needs-ac, refresh-active, bootstrap), each delegating to the underlying internal include-namespace task and forwarding CLI_ARGS",
+        "status": "proposed"
+      },
+      {
+        "id": "913-changelog-unreleased-fixed",
+        "title": "Append a single bullet to CHANGELOG.md [Unreleased] / Fixed citing #913 (triage: rename fragment-include task names so the documented surface is reachable verbatim)",
+        "status": "proposed"
+      },
+      {
+        "id": "913-acceptance-task-list",
+        "title": "Acceptance: task -l | Select-String triage exposes only the documented triage:* names; no fragment-prefixed names visible",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/913",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #913: task: triage v1 fragment-include task names don't match documented triage:* surface"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/845",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #845 (parent epic): pre-ingest triage workflow + sidecar issue cache"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/718",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #718: release task name doubled-prefix bug (precedent for inline-flatten pattern)"
+      }
+    ],
+    "updated": "2026-05-05T15:20:57Z"
+  }
+}


### PR DESCRIPTION
## Summary

Renames the four triage v1 fragment-include task surfaces so the documented `task triage:*` invocations are reachable verbatim from `task -l`. Fixes #913.

Pre-fix `task -l | Select-String triage` exposed broken / doubled-prefix names:

- `triage-cache:cache`, `triage-cache:show` (skills say `triage:cache` / `triage:show`)
- `triage-actions:triage:accept` and 7 siblings -- the doubled `triage:` prefix (skills say `triage:accept`, etc.)
- `triage-bulk:bulk-accept` and 4 siblings (skills say `triage:bulk-accept`, etc., and `triage:refresh-active`)
- only `triage:bootstrap` matched the docs (because Story 6 wired that one alias)

Post-fix `task -l | Select-String triage` shows ONLY the documented names.

## Changes

- `tasks/triage-cache.yml`: mark `cache` and `show` `internal: true`.
- `tasks/triage-actions.yml`: drop `triage:` prefix from inner names (`accept`, `reject`, `defer`, `needs-ac`, `mark-duplicate`, `status`, `reset`, `history`); mark each `internal: true`.
- `tasks/triage-bulk.yml`: mark `bulk-accept`, `bulk-reject`, `bulk-defer`, `bulk-needs-ac`, `refresh-active` `internal: true`. Disable-gate `cmds:` blocks (#915) intentionally untouched.
- `tasks/triage-bootstrap.yml`: mark `bootstrap` `internal: true`.
- `Taskfile.yml`: replace the single `triage:bootstrap` alias with the full 16-alias surface (`triage:cache`, `triage:show`, `triage:accept`, `triage:reject`, `triage:defer`, `triage:needs-ac`, `triage:mark-duplicate`, `triage:status`, `triage:reset`, `triage:history`, `triage:bulk-accept`, `triage:bulk-reject`, `triage:bulk-defer`, `triage:bulk-needs-ac`, `triage:refresh-active`, `triage:bootstrap`), each delegating via `task: <namespace>:<inner>` and forwarding `{{.CLI_ARGS}}` verbatim. Mirrors the established #718 release-pipeline flatten precedent.
- `CHANGELOG.md`: append single bullet under `[Unreleased]` / `### Fixed` citing #913.

## vBRIEF references

- `vbrief/active/2026-05-05-913-fix-triage-task-aliases.vbrief.json` (status: running, plan.references include #913, #845, #718)

## Checklist

- [x] `task check` passes (3975 passed, 3 skipped, 1 xfailed; ~3 min).
- [x] `task -l | Select-String triage` shows only documented `triage:*` names; no `triage-cache:`, `triage-actions:triage:`, or `triage-bulk:` prefixes anywhere.
- [x] `task triage:bootstrap -- --help` smoke test reaches the script through the alias delegation (argparse usage banner emitted).
- [x] `tests/test_triage_bootstrap.py::TestRecapNamespacedForms` and `test_taskfile_includes_wired_for_four_fragments` continue to pass byte-identically (recap text in `scripts/triage_bootstrap.py` keeps printing the namespaced forms; those forms remain callable as internal tasks).
- [x] Out of scope: `scripts/triage_bootstrap.py`, `scripts/triage_bulk.py`, `scripts/triage_cache.py` intentionally untouched (Agents B/C swarm scope).
- [x] Encoding gate clean (`verify_encoding`: 7 files clean, no mojibake / U+FFFD / unexpected-BOM).

## Test plan

```
task -l | Select-String triage              # documented names only
task triage:bootstrap -- --help             # alias delegates to script
task check                                   # full pre-commit aggregate
```

Closes #913.
