### PR TITLE
fix(triage): cache-walk bulk operations + integration test + gitignore (#915)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ vbrief/*.premigrate.*
 # `gh issue list` populated by `task triage:cache`; never versioned. See
 # scripts/triage_cache.py for the layout (.deft-cache/issues/<owner>-<repo>/).
 .deft-cache/
+
+# Local triage audit/eval scratch (#845 Story 2 + #915). Holds the
+# append-only candidates.jsonl audit log written by triage actions and
+# transient evaluation artefacts. Never versioned -- the log is per-machine
+# operator state and would leak triage timing/identity if shared.
+vbrief/.eval/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **triage: vbrief/.eval/ added to .gitignore; bootstrap ensures the line idempotently for upgrading projects (#915).**
+- **tests: integration test for triage v1 cache contract (tests/integration/test_triage_smoke.py); regression coverage for the #915 cache-bypass class.**
 
 ### Changed
 
@@ -15,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fix(triage): rename fragment-include task names so the documented `triage:*` surface (`task triage:cache`, `task triage:accept`, `task triage:bulk-defer`, etc.) is reachable verbatim (#913)**
 - **fix(triage): pass --limit / --state / --label / --force / --use-gitcrawl / --ttl-seconds through from `task triage:bootstrap` to the underlying populate step (#914, #900).**
 - **fix(triage): disable `task triage:bulk-*` tasks at the Taskfile layer pending v0.25.2 (#915)**
+- **triage: bulk operations now read from .deft-cache/issues/ (source of truth) and skip issues with terminal audit-log records; restores Tier-1 / Tier-2 contracts described in #845 epic (#915).**
+- **triage: re-enable task triage:bulk-* (gated in v0.25.1+1 / PR #916 pending the cache-walk rewrite).**
 
 ### Removed
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -430,28 +430,28 @@ tasks:
           CLI_ARGS: "{{.CLI_ARGS}}"
 
   triage:bulk-accept:
-    desc: "[DISABLED v0.25.x] Bulk accept is gated pending v0.25.2 (#915). Use task triage:accept per issue."
+    desc: "Bulk accept cached candidates -- task triage:bulk-accept -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action] (#845 Story 4 / #915)"
     cmds:
       - task: triage-bulk:bulk-accept
         vars:
           CLI_ARGS: "{{.CLI_ARGS}}"
 
   triage:bulk-reject:
-    desc: "[DISABLED v0.25.x] Bulk reject is gated pending v0.25.2 (#915). Use task triage:reject per issue."
+    desc: "Bulk reject cached candidates -- task triage:bulk-reject -- --repo OWNER/NAME --reason 'why' [--label L] [--author A] [--age-days N] [--cluster C] [--re-action] (#845 Story 4 / #915)"
     cmds:
       - task: triage-bulk:bulk-reject
         vars:
           CLI_ARGS: "{{.CLI_ARGS}}"
 
   triage:bulk-defer:
-    desc: "[DISABLED v0.25.x] Bulk defer is gated pending v0.25.2 (#915). Use task triage:defer per issue."
+    desc: "Bulk defer cached candidates -- task triage:bulk-defer -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action] (#845 Story 4 / #915)"
     cmds:
       - task: triage-bulk:bulk-defer
         vars:
           CLI_ARGS: "{{.CLI_ARGS}}"
 
   triage:bulk-needs-ac:
-    desc: "[DISABLED v0.25.x] Bulk needs-ac is gated pending v0.25.2 (#915). Use task triage:needs-ac per issue."
+    desc: "Bulk needs-ac cached candidates -- task triage:bulk-needs-ac -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action] (#845 Story 4 / #915)"
     cmds:
       - task: triage-bulk:bulk-needs-ac
         vars:

--- a/scripts/triage_bootstrap.py
+++ b/scripts/triage_bootstrap.py
@@ -90,6 +90,14 @@ CACHE_DIR_NAME = ".deft-cache"
 #: existing ``.gitignore`` (e.g. ``dist/``, ``backup/``, ``.deft/``).
 GITIGNORE_LINE = ".deft-cache/"
 
+#: Canonical gitignore line for the per-machine triage audit / eval scratch
+#: directory (#915). Story 2's ``candidates_log`` writes
+#: ``vbrief/.eval/candidates.jsonl`` inside the project tree; we never want
+#: it versioned (operator state, leaks triage timing/identity). The bootstrap
+#: ensures the line is present on a re-run for projects that pre-date the
+#: v0.25.2 ``.gitignore`` shipped with #915.
+GITIGNORE_EVAL_LINE = "vbrief/.eval/"
+
 #: Canonical audit-log path relative to the project root. Story 2 writes
 #: append-only JSONL here; Story 6's bootstrap backfills ``accepted`` entries
 #: for items that have already been triaged into a lifecycle folder.
@@ -802,6 +810,107 @@ def step_ensure_gitignore_entry(project_root: Path) -> StepOutcome:
 
 
 # ---------------------------------------------------------------------------
+# Step 3b -- ensure vbrief/.eval/ is gitignored (#915)
+# ---------------------------------------------------------------------------
+
+
+def step_ensure_gitignore_eval_dir(project_root: Path) -> StepOutcome:
+    """Append ``vbrief/.eval/`` to ``.gitignore`` when absent (#915).
+
+    Companion to :func:`step_ensure_gitignore_entry`: ensures the
+    triage audit / eval scratch directory is git-ignored on projects that
+    pre-date the v0.25.2 ``.gitignore`` shipped with #915. Idempotent --
+    a re-run is a no-op when the line is already present (active or
+    commented-out per the NFR-2 opt-in convention used for ``.deft-cache/``).
+
+    Sequenced AFTER :func:`step_ensure_gitignore_entry` so on a greenfield
+    project the parent step has already created ``.gitignore`` with at
+    least the ``.deft-cache/`` line; we then append the eval-dir entry to
+    the same file. On an upgrading project (``.gitignore`` exists, neither
+    line present) both steps still land their own entry.
+    """
+    gitignore_path = project_root / ".gitignore"
+    if not gitignore_path.exists():
+        # The companion step is supposed to create .gitignore on a greenfield
+        # project; if we still see no file here, surface that rather than
+        # silently writing a fresh single-line file (which would trample any
+        # parallel write).
+        return StepOutcome(
+            name="ensure_gitignore_eval_dir",
+            ok=True,
+            message=(
+                "skipped (.gitignore not present after ensure_gitignore_entry; "
+                "re-run bootstrap to retry)"
+            ),
+            details={"created": False, "appended": False, "skipped": "no-gitignore"},
+        )
+
+    try:
+        existing = gitignore_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return StepOutcome(
+            name="ensure_gitignore_eval_dir",
+            ok=False,
+            message="could not read .gitignore",
+            error=str(exc),
+        )
+
+    has_commented_form = any(
+        _is_commented_gitignore_line(raw, GITIGNORE_EVAL_LINE) for raw in existing.splitlines()
+    )
+
+    if _gitignore_already_covers(existing, GITIGNORE_EVAL_LINE):
+        return StepOutcome(
+            name="ensure_gitignore_eval_dir",
+            ok=True,
+            message=f"{GITIGNORE_EVAL_LINE} already in .gitignore (no-op)",
+            details={"created": False, "appended": False, "already_present": True},
+        )
+
+    if has_commented_form:
+        return StepOutcome(
+            name="ensure_gitignore_eval_dir",
+            ok=True,
+            message=(
+                f"{GITIGNORE_EVAL_LINE} is commented out (operator opt-in to "
+                "commit triage audit/eval scratch; not re-adding)"
+            ),
+            details={
+                "created": False,
+                "appended": False,
+                "opt_in_commit_eval": True,
+            },
+        )
+
+    suffix = "" if existing.endswith("\n") or existing == "" else "\n"
+    new_content = (
+        existing
+        + suffix
+        + "\n# Triage v1 audit/eval scratch (#915). Holds candidates.jsonl + transient\n"
+        + "# evaluation artefacts written by triage actions. Per-machine operator state;\n"
+        + "# never versioned (would leak triage timing/identity). Comment this line out\n"
+        + "# to opt in to committing the audit log.\n"
+        + GITIGNORE_EVAL_LINE
+        + "\n"
+    )
+    try:
+        gitignore_path.write_text(new_content, encoding="utf-8")
+    except OSError as exc:
+        return StepOutcome(
+            name="ensure_gitignore_eval_dir",
+            ok=False,
+            message="could not write .gitignore",
+            error=str(exc),
+        )
+    return StepOutcome(
+        name="ensure_gitignore_eval_dir",
+        ok=True,
+        message=f"appended {GITIGNORE_EVAL_LINE} to .gitignore",
+        details={"created": False, "appended": True},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Step 4 -- ensure gitcrawl is installed (best-effort)
 # ---------------------------------------------------------------------------
 
@@ -1058,14 +1167,15 @@ def run_bootstrap(
 ) -> BootstrapResult:
     """Run the bootstrap pipeline, returning the aggregate result.
 
-    Dispatches the four mutating steps documented in the module docstring
+    Dispatches the five mutating steps documented in the module docstring
     (populate_cache, backfill_audit_log, ensure_gitignore_entry,
-    ensure_gitcrawl) and appends one ``StepOutcome`` per step. The fifth
-    documented step (``recap``) is rendered by
-    :meth:`BootstrapResult.summary` and printed in :func:`main` rather
-    than dispatched as a separate ``StepOutcome``; the recap therefore
-    produces no entry in ``result.steps``. ``len(result.steps) == 4`` is
-    the expected post-condition.
+    ensure_gitignore_eval_dir, ensure_gitcrawl) and appends one
+    ``StepOutcome`` per step. The recap (``BootstrapResult.summary``)
+    renders in :func:`main` rather than as a separate ``StepOutcome``;
+    ``len(result.steps) == 5`` is the expected post-condition. Pre-#915
+    callers that asserted four entries must update -- the new
+    ``ensure_gitignore_eval_dir`` step is sequenced between
+    ``ensure_gitignore_entry`` and ``ensure_gitcrawl``.
 
     Separated from :func:`main` so tests drive the function directly
     without argparse plumbing.
@@ -1093,6 +1203,7 @@ def run_bootstrap(
     )
     result.steps.append(step_backfill_audit_log(project_root, repo))
     result.steps.append(step_ensure_gitignore_entry(project_root))
+    result.steps.append(step_ensure_gitignore_eval_dir(project_root))
     result.steps.append(step_ensure_gitcrawl(skip=skip_gitcrawl))
 
     # Aggregate exit code: any step with ok=False sets exit 1.

--- a/scripts/triage_bootstrap.py
+++ b/scripts/triage_bootstrap.py
@@ -832,16 +832,19 @@ def step_ensure_gitignore_eval_dir(project_root: Path) -> StepOutcome:
     gitignore_path = project_root / ".gitignore"
     if not gitignore_path.exists():
         # The companion step is supposed to create .gitignore on a greenfield
-        # project; if we still see no file here, surface that rather than
-        # silently writing a fresh single-line file (which would trample any
-        # parallel write).
+        # project; if we still see no file here, surface ok=False so callers
+        # inspecting result.steps[3].ok directly see the step did not achieve
+        # its goal -- the prior step's ok=False already drives the aggregate
+        # exit code, but a direct caller (or future event consumer) that pins
+        # on per-step ok needs an honest signal here.
         return StepOutcome(
             name="ensure_gitignore_eval_dir",
-            ok=True,
+            ok=False,
             message=(
-                "skipped (.gitignore not present after ensure_gitignore_entry; "
-                "re-run bootstrap to retry)"
+                ".gitignore not present after ensure_gitignore_entry; "
+                f"{GITIGNORE_EVAL_LINE} not written -- re-run bootstrap to retry"
             ),
+            error="prior ensure_gitignore_entry step did not create .gitignore",
             details={"created": False, "appended": False, "skipped": "no-gitignore"},
         )
 

--- a/scripts/triage_bulk.py
+++ b/scripts/triage_bulk.py
@@ -376,11 +376,16 @@ def _exclude_logged(
             continue
         kept.append(issue)
 
-    if skipped and out is not None:
+    if skipped:
         msg = f"[triage:bulk] skipped {skipped} candidate(s) with prior audit-log records"
         if not re_action:
             msg += " (pass --re-action to override defer/needs-ac records)"
-        print(msg, file=out)
+        # Default to stderr when callers invoke `_exclude_logged` directly with
+        # out=None -- the prior `if out is not None` short-circuit was dead
+        # code under bulk_action (which always passes a non-None sink) AND
+        # silently dropped the diagnostic for direct callers (Greptile #920).
+        sink = out if out is not None else sys.stderr
+        print(msg, file=sink)
     return kept
 
 

--- a/scripts/triage_bulk.py
+++ b/scripts/triage_bulk.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""triage_bulk.py -- Story 4 bulk triage ops over filtered candidates (#845).
+"""triage_bulk.py -- Story 4 bulk triage ops over cached candidates (#845).
 
 Public surface:
 
@@ -20,11 +20,45 @@ Filter flags (combinable, AND semantics):
 - ``--age-days <N>``  match issues whose ``createdAt`` is older than ``now - N days``.
 - ``--cluster <slug>`` match a ``cluster:<slug>`` (or bare ``<slug>``) label.
 
-Zero-match exits cleanly with status 0 and a single stdout line so this script
-is safe to run inside a swarm pipeline.
+Cache contract (#915 fix)
+-------------------------
 
-Looping over Story 3 (``triage_actions``) is intentional; bulk MUST NOT expose
-its own parallel surface (#845 Story 4 Constraint).
+The candidate universe is the local Tier-1 cache: ``.deft-cache/issues/<owner>-<repo>/*.json``
+(written by Story 1's :func:`triage_cache.populate`). Live ``gh issue list``
+calls are forbidden in this module -- the cache is the read surface for the
+triage workflow and bypassing it violates the contract documented in
+``skills/deft-directive-refinement/SKILL.md`` and the #845 epic vBRIEF.
+
+When the per-repo cache directory is missing or empty, :func:`bulk_action`
+raises :class:`CacheEmptyError` and :func:`main` exits with status ``2`` and
+the canonical message::
+
+    triage_bulk: cache is empty for {repo}; run `task triage:bootstrap` first.
+
+Audit-log short-circuit (#915 fix)
+----------------------------------
+
+Before applying the chosen action, the cached candidate set is intersected
+with Story 2's append-only audit log (:mod:`candidates_log`). For each
+candidate, the LATEST recorded decision (by ``timestamp``) determines
+whether the candidate is skipped:
+
+- **Terminal decisions** (``accept``, ``reject``, ``mark-duplicate``) are
+  ALWAYS skipped -- a re-run never repeats a terminal action.
+- **In-progress decisions** (``defer``, ``needs-ac``) are skipped UNLESS
+  the operator passes ``--re-action`` (CLI) / ``re_action=True`` (Python).
+- ``reset`` is non-skipping by design (the operator explicitly wiped the
+  prior verdict; the candidate is back in scope).
+
+The intersection prevents the append-only log from being poisoned by
+repeated bulk-defer / bulk-needs-ac runs and makes ``bulk_action``
+idempotent on a steady cache.
+
+Zero-match exits cleanly with status 0 and a single stdout line so this
+script is safe to run inside a swarm pipeline.
+
+Looping over Story 3 (``triage_actions``) is intentional; bulk MUST NOT
+expose its own parallel surface (#845 Story 4 Constraint).
 """
 
 from __future__ import annotations
@@ -33,12 +67,16 @@ import argparse
 import contextlib
 import importlib
 import json
-import os
-import subprocess
 import sys
 from collections.abc import Callable, Iterable
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
+
+# Surface sibling ``scripts`` modules so the cache walk and audit-log read
+# resolve when this file is invoked via ``python scripts/triage_bulk.py``
+# from a Taskfile dispatch (mirrors the pattern in triage_bootstrap.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # Mapping from CLI sub-action keyword to the ``triage_actions`` module attribute
 # resolved at runtime. Story 3's contracted public surface is documented in
@@ -49,6 +87,25 @@ ACTION_FN_NAMES: dict[str, str] = {
     "defer": "defer",
     "needs-ac": "needs_ac",
 }
+
+#: Audit-log decisions that ALWAYS short-circuit a bulk action. A bulk run
+#: that re-applies a terminal verdict is the audit-log poisoning class the
+#: #915 fix exists to prevent.
+TERMINAL_DECISIONS: frozenset[str] = frozenset({"accept", "reject", "mark-duplicate"})
+
+#: Audit-log decisions that short-circuit a bulk action UNLESS the operator
+#: opts in via ``--re-action``. ``defer`` / ``needs-ac`` are non-terminal but
+#: are still in-progress -- a second pass should not silently re-defer them.
+IN_PROGRESS_DECISIONS: frozenset[str] = frozenset({"defer", "needs-ac"})
+
+
+class CacheEmptyError(RuntimeError):
+    """Raised by :func:`bulk_action` when the per-repo cache is missing/empty.
+
+    :func:`main` translates this into an exit-2 with the canonical stderr
+    message; programmatic callers that want a different recovery path can
+    catch the exception directly.
+    """
 
 
 def _load_triage_actions() -> Any:
@@ -71,85 +128,117 @@ def _load_triage_actions() -> Any:
     )
 
 
-#: Default ceiling for ``gh issue list --limit``. Must stay aligned with
-#: ``DEFAULT_MAX_OPEN_ISSUES`` in ``scripts/reconcile_issues.py`` (#764).
-#: Operators with larger backlogs can override via the ``--limit`` CLI flag
-#: or the ``DEFT_TRIAGE_BULK_LIMIT`` env-var; both surfaces are wired below
-#: (see ``_build_parser`` and ``_resolve_limit``).
-DEFAULT_ISSUE_LIST_LIMIT = 1000
+def _load_triage_cache() -> Any:
+    """Lazy-import Story 1's :mod:`triage_cache` (for ``cache_dir``)."""
 
-#: Env-var override for ``DEFAULT_ISSUE_LIST_LIMIT`` consumed by
-#: :func:`_resolve_limit` when no explicit ``--limit`` flag is passed.
-LIMIT_ENV_VAR = "DEFT_TRIAGE_BULK_LIMIT"
-
-
-def _resolve_limit(cli_value: int | None) -> int:
-    """Pick the effective limit -- CLI > env-var > module default.
-
-    Returns ``DEFAULT_ISSUE_LIST_LIMIT`` if the env-var is set to a value
-    that does not parse as a positive integer; this matches the
-    ``DEFT_NO_NETWORK`` / ``DEFT_REMOTE_PROBE_TIMEOUT`` defensive style in
-    ``run`` (#801).
-    """
-
-    if cli_value is not None:
-        return max(1, int(cli_value))
-    raw = os.environ.get(LIMIT_ENV_VAR, "").strip()
-    if not raw:
-        return DEFAULT_ISSUE_LIST_LIMIT
-    try:
-        parsed = int(raw)
-    except ValueError:
-        return DEFAULT_ISSUE_LIST_LIMIT
-    return max(1, parsed)
+    for candidate in ("triage_cache", "scripts.triage_cache"):
+        try:
+            return importlib.import_module(candidate)
+        except ModuleNotFoundError:
+            continue
+    raise RuntimeError(
+        "triage_cache module not available -- Story 1 has not landed in this "
+        "checkout. Cannot walk the cache without it."
+    )
 
 
-def _list_open_issues(
+def _load_candidates_log() -> Any:
+    """Lazy-import Story 2's :mod:`candidates_log` (for ``read_all``)."""
+
+    for candidate in ("candidates_log", "scripts.candidates_log"):
+        try:
+            return importlib.import_module(candidate)
+        except ModuleNotFoundError:
+            continue
+    raise RuntimeError(
+        "candidates_log module not available -- Story 2 has not landed in "
+        "this checkout. Cannot intersect the cached candidate set with the "
+        "audit log."
+    )
+
+
+def _resolve_cache_dir(
     repo: str,
     *,
-    limit: int = DEFAULT_ISSUE_LIST_LIMIT,
+    cache_root: Path | None = None,
+    triage_cache_module: Any | None = None,
+) -> Path:
+    """Return the per-repo cache directory ``<cache_root>/<owner>-<repo>/``.
+
+    Delegates to :func:`triage_cache.cache_dir` so the layout stays in
+    lockstep with Story 1 (flattened ``owner-repo`` for Windows path-length
+    safety). The ``triage_cache_module`` hook keeps this unit-testable
+    without forking a real Python import.
+    """
+
+    module = triage_cache_module if triage_cache_module is not None else _load_triage_cache()
+    cache_dir_fn = getattr(module, "cache_dir", None)
+    if not callable(cache_dir_fn):
+        raise RuntimeError("triage_cache.cache_dir not callable (Story 1 contract violated)")
+    return Path(cache_dir_fn(repo, cache_root=cache_root))
+
+
+def _list_cached_candidates(
+    repo: str,
+    *,
+    cache_root: Path | None = None,
+    triage_cache_module: Any | None = None,
     out: Any | None = None,
 ) -> list[dict[str, Any]]:
-    """List open issues via ``gh issue list``.
+    """Walk the per-repo cache and return parsed issue payloads.
 
-    Returns the parsed JSON array. Errors propagate to the caller so the
-    Taskfile target surfaces the failure. When the returned count meets the
-    requested ``limit`` an explicit warning is emitted on ``out`` so silent
-    truncation cannot masquerade as a complete bulk operation (Greptile P2
-    on PR #875).
+    Reads every ``<cache_root>/<owner>-<repo>/*.json`` sidecar (the JSON
+    file written by :func:`triage_cache.populate`) and returns a list of
+    dicts in the same shape ``_filter_issues`` expects -- the cached
+    payload already carries ``number``, ``title``, ``labels``, ``author``,
+    ``createdAt``, ``updatedAt`` per ``triage_cache._GH_FIELDS``.
+
+    Tolerance contract: a malformed JSON sidecar (truncated write, manual
+    edit, encoding glitch) is logged on ``out`` and skipped -- the rest of
+    the cache is still surfaced. The bulk operation never aborts mid-walk
+    on a single bad file.
+
+    Returns an empty list when the cache directory is missing or empty.
+    Callers translate that into the canonical empty-cache hard-fail.
     """
 
     sink = out or sys.stderr
-    cmd = [
-        "gh",
-        "issue",
-        "list",
-        "--repo",
-        repo,
-        "--state",
-        "open",
-        "--limit",
-        str(limit),
-        "--json",
-        "number,title,labels,author,createdAt,updatedAt",
-    ]
-    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603
-    payload = completed.stdout or "[]"
-    parsed = json.loads(payload)
-    if not isinstance(parsed, list):
+    cache_path = _resolve_cache_dir(
+        repo, cache_root=cache_root, triage_cache_module=triage_cache_module
+    )
+
+    if not cache_path.exists() or not cache_path.is_dir():
         return []
-    issues = [item for item in parsed if isinstance(item, dict)]
-    if len(issues) >= limit:
-        print(
-            (
-                f"[triage:bulk] WARN: gh issue list returned {len(issues)} "
-                f"issue(s) -- equal to --limit {limit}. The bulk action will "
-                f"only operate on this slice; re-run with --limit <N> "
-                f"(N > {limit}) or set {LIMIT_ENV_VAR}=<N> to widen the window."
-            ),
-            file=sink,
-        )
-    return issues
+
+    candidates: list[dict[str, Any]] = []
+    for json_path in sorted(cache_path.glob("*.json")):
+        try:
+            raw = json_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(
+                f"[triage:bulk] WARN: skipping unreadable cache file "
+                f"{json_path.name}: {type(exc).__name__}: {exc}",
+                file=sink,
+            )
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            print(
+                f"[triage:bulk] WARN: skipping malformed cache file "
+                f"{json_path.name}: {exc}",
+                file=sink,
+            )
+            continue
+        if not isinstance(payload, dict):
+            print(
+                f"[triage:bulk] WARN: skipping non-object cache file "
+                f"{json_path.name} (got {type(payload).__name__})",
+                file=sink,
+            )
+            continue
+        candidates.append(payload)
+    return candidates
 
 
 def _filter_issues(
@@ -201,6 +290,98 @@ def _filter_issues(
 
         matched.append(issue)
     return matched
+
+
+def _build_skip_set(re_action: bool) -> frozenset[str]:
+    """Return the set of latest-decision values that disqualify a candidate.
+
+    Terminal decisions (``accept``, ``reject``, ``mark-duplicate``) ALWAYS
+    skip. In-progress decisions (``defer``, ``needs-ac``) skip unless
+    ``re_action`` is True -- the explicit opt-in path for re-running a
+    bulk-defer / bulk-needs-ac on a backlog the operator already touched.
+    """
+
+    if re_action:
+        return TERMINAL_DECISIONS
+    return TERMINAL_DECISIONS | IN_PROGRESS_DECISIONS
+
+
+def _latest_decision_by_issue(
+    repo: str, *, candidates_log_module: Any | None = None
+) -> dict[int, dict[str, Any]]:
+    """Return ``{issue_number: latest-entry-dict}`` for ``repo``.
+
+    Sorted by ISO-8601 ``timestamp`` lexicographic order (Story 2's
+    candidates_log enforces UTC-Z suffixes so this is chronologically
+    correct). Issues with no audit history are absent from the map.
+    """
+
+    module = (
+        candidates_log_module if candidates_log_module is not None else _load_candidates_log()
+    )
+    read_all = getattr(module, "read_all", None)
+    if not callable(read_all):
+        raise RuntimeError("candidates_log.read_all not callable (Story 2 contract violated)")
+
+    latest: dict[int, dict[str, Any]] = {}
+    for entry in read_all(repo=repo):
+        if not isinstance(entry, dict):
+            continue
+        n = entry.get("issue_number")
+        if not isinstance(n, int) or isinstance(n, bool):
+            continue
+        ts = str(entry.get("timestamp", ""))
+        prior = latest.get(n)
+        if prior is None or ts > str(prior.get("timestamp", "")):
+            latest[n] = entry
+    return latest
+
+
+def _exclude_logged(
+    candidates: Iterable[dict[str, Any]],
+    *,
+    repo: str,
+    re_action: bool,
+    candidates_log_module: Any | None = None,
+    out: Any | None = None,
+) -> list[dict[str, Any]]:
+    """Drop candidates whose latest audit decision is in the skip set.
+
+    See :func:`_build_skip_set` for the skip-set rules. Emits a single-line
+    summary on ``out`` so the operator sees how many candidates were
+    short-circuited by Tier-2 -- silent drops would mask the audit-log
+    contract.
+    """
+
+    skip_set = _build_skip_set(re_action)
+    latest = _latest_decision_by_issue(
+        repo, candidates_log_module=candidates_log_module
+    )
+
+    kept: list[dict[str, Any]] = []
+    skipped = 0
+    for issue in candidates:
+        try:
+            n = int(issue["number"])
+        except (KeyError, TypeError, ValueError):
+            # Malformed cache record -- the per-action loop will report it.
+            kept.append(issue)
+            continue
+        prior = latest.get(n)
+        if prior is None:
+            kept.append(issue)
+            continue
+        if str(prior.get("decision", "")) in skip_set:
+            skipped += 1
+            continue
+        kept.append(issue)
+
+    if skipped and out is not None:
+        msg = f"[triage:bulk] skipped {skipped} candidate(s) with prior audit-log records"
+        if not re_action:
+            msg += " (pass --re-action to override defer/needs-ac records)"
+        print(msg, file=out)
+    return kept
 
 
 def _resolve_action(actions_module: Any, action_key: str) -> Callable[..., Any]:
@@ -271,19 +452,30 @@ def bulk_action(
     age_days: int | None = None,
     cluster: str | None = None,
     reason: str | None = None,
-    limit: int | None = None,
+    re_action: bool = False,
+    cache_root: Path | None = None,
     actions_module: Any | None = None,
+    triage_cache_module: Any | None = None,
+    candidates_log_module: Any | None = None,
     issues_provider: Callable[[str], list[dict[str, Any]]] | None = None,
     now: datetime | None = None,
     out: Any | None = None,
 ) -> int:
     """Execute ``action_key`` over the filtered candidate set.
 
-    Returns the count of issues actioned. Zero matches returns ``0`` and emits
-    a single-line summary -- the caller MUST treat this as a clean exit.
+    Returns the count of issues actioned. Zero matches returns ``0`` and
+    emits a single-line summary -- the caller MUST treat this as a clean
+    exit.
 
-    Dependency-injection hooks keep this surface unit-testable without forking
-    a real ``gh`` subprocess or importing a not-yet-landed Story 3 module.
+    Raises :class:`CacheEmptyError` when the per-repo cache directory is
+    missing or empty -- the empty-cache hard-fail required by the #915 fix.
+    Callers (CLI ``main``) translate this into an exit-2 with the canonical
+    stderr message. Programmatic callers that want a degraded recovery path
+    can catch :class:`CacheEmptyError` directly.
+
+    Dependency-injection hooks keep this surface unit-testable without
+    forking a real ``gh`` subprocess or importing not-yet-landed sibling
+    modules.
     """
 
     if action_key not in ACTION_FN_NAMES:
@@ -291,23 +483,36 @@ def bulk_action(
 
     sink = out or sys.stdout
     if issues_provider is not None:
-        fetch = issues_provider
+        candidates = issues_provider(repo)
     else:
-        # Forward ``sink`` so the truncation warning lands on the caller's
-        # output stream (Greptile P2 on PR #875). The lambda preserves the
-        # sentinel-default semantics of ``_list_open_issues``.
-        effective_limit = _resolve_limit(limit)
-        fetch = lambda repo_arg: _list_open_issues(  # noqa: E731
-            repo_arg, limit=effective_limit, out=sink
+        candidates = _list_cached_candidates(
+            repo,
+            cache_root=cache_root,
+            triage_cache_module=triage_cache_module,
+            out=sink,
         )
-    issues = fetch(repo)
+
+    if not candidates:
+        raise CacheEmptyError(
+            f"triage_bulk: cache is empty for {repo}; "
+            "run `task triage:bootstrap` first."
+        )
+
     matched = _filter_issues(
-        issues,
+        candidates,
         label=label,
         author=author,
         age_days=age_days,
         cluster=cluster,
         now=now,
+    )
+
+    matched = _exclude_logged(
+        matched,
+        repo=repo,
+        re_action=re_action,
+        candidates_log_module=candidates_log_module,
+        out=sink,
     )
 
     if not matched:
@@ -338,7 +543,7 @@ def bulk_action(
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="triage_bulk",
-        description="Bulk triage operations over filtered candidate sets (#845 Story 4)",
+        description="Bulk triage operations over cached candidate sets (#845 Story 4 / #915)",
     )
     parser.add_argument(
         "action",
@@ -367,13 +572,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="reject only: reason recorded in audit log + upstream issue close comment",
     )
     parser.add_argument(
-        "--limit",
-        type=int,
-        default=None,
+        "--re-action",
+        action="store_true",
+        dest="re_action",
         help=(
-            "override the gh issue list --limit ceiling (default "
-            f"{DEFAULT_ISSUE_LIST_LIMIT}; env-var {LIMIT_ENV_VAR} is honored "
-            "when --limit is not passed)"
+            "Re-action candidates whose LATEST audit-log record is `defer` or "
+            "`needs-ac` (#915). Without this flag, in-progress records "
+            "short-circuit the bulk run; terminal records "
+            "(accept|reject|mark-duplicate) ALWAYS short-circuit regardless."
         ),
     )
     return parser
@@ -395,16 +601,20 @@ def _reconfigure_utf8() -> None:
 def main(argv: list[str] | None = None) -> int:
     _reconfigure_utf8()
     args = _build_parser().parse_args(argv)
-    bulk_action(
-        args.action,
-        args.repo,
-        label=args.label,
-        author=args.author,
-        age_days=args.age_days,
-        cluster=args.cluster,
-        reason=args.reason,
-        limit=args.limit,
-    )
+    try:
+        bulk_action(
+            args.action,
+            args.repo,
+            label=args.label,
+            author=args.author,
+            age_days=args.age_days,
+            cluster=args.cluster,
+            reason=args.reason,
+            re_action=args.re_action,
+        )
+    except CacheEmptyError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     # Zero-match is a clean exit per #845 Story 4 Constraint.
     return 0
 

--- a/tasks/triage-bulk.yml
+++ b/tasks/triage-bulk.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-# tasks/triage-bulk.yml -- Story 4 of #845.
+# tasks/triage-bulk.yml -- Story 4 of #845 + #915 cache-walk re-enable.
 #
 # Wired into the parent ../Taskfile.yml `includes:` block under namespace
 # key `triage-bulk` (#845 Story 6). The user-facing `task triage:bulk-accept`
@@ -8,15 +8,20 @@ version: '3'
 # `triage:refresh-active` surface lives as root-level alias tasks in
 # Taskfile.yml that delegate here (#913); inner tasks below are
 # `internal: true` so the fragment-namespace forms (`triage-bulk:bulk-*`)
-# are hidden from `task -l`. The disable-gate `cmds:` blocks for
-# `bulk-accept` / `bulk-reject` / `bulk-defer` / `bulk-needs-ac` (#915) are
-# unchanged: invoking either via the alias or via the namespaced form
-# still exits 2 with the ASCII-only pointer to the single-issue alternatives.
+# are hidden from `task -l`.
+#
+# The disable-gate `cmds:` blocks introduced by PR #916 (#915 hot-fix) were
+# REVERSED here once scripts/triage_bulk.py was rewritten to walk
+# .deft-cache/issues/<owner>-<repo>/ instead of live `gh issue list`. The
+# four `bulk-*` targets now invoke triage_bulk.py directly again, exactly
+# as before #916. The cache-empty hard-fail (exit 2) and Tier-2 audit-log
+# short-circuit are enforced inside triage_bulk.py itself (#915 fix).
 #
 # Per `conventions/task-caching.md` (#574): every target here accepts user
 # flags via `{{.CLI_ARGS}}` (--label, --author, --age-days, --cluster,
-# --reason, --repo) so MUST NOT declare `sources:` / `generates:` -- the
-# cached cmds: skip would silently swallow the recovery flag.
+# --reason, --repo, --re-action) so MUST NOT declare `sources:` /
+# `generates:` -- the cached cmds: skip would silently swallow the
+# recovery flag.
 #
 # Path resolution mirrors the convention from tasks/issue.yml + tasks/policy.yml:
 # `DEFT_ROOT` is defined locally via `joinPath .TASKFILE_DIR ".."` so
@@ -28,52 +33,40 @@ vars:
 
 tasks:
   bulk-accept:
-    desc: "[DISABLED v0.25.x] Bulk accept is gated pending v0.25.2 (#915). Use task triage:accept per issue."
+    desc: "Bulk accept candidates (#845 Story 4) -- task triage:bulk-accept -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
     dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
     cmds:
-      - |
-        echo "ERROR: task triage:bulk-accept is disabled in v0.25.0/v0.25.1 (#915)."
-        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
-        echo "  Use single-issue actions until v0.25.2 ships:"
-        echo "    task triage:accept -- --repo OWNER/NAME --issue N"
-        exit 2
+      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" accept {{.CLI_ARGS}}
 
   bulk-reject:
-    desc: "[DISABLED v0.25.x] Bulk reject is gated pending v0.25.2 (#915). Use task triage:reject per issue."
+    desc: "Bulk reject candidates (#845 Story 4) -- task triage:bulk-reject -- --repo OWNER/NAME --reason 'why' [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
     dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
     cmds:
-      - |
-        echo "ERROR: task triage:bulk-reject is disabled in v0.25.0/v0.25.1 (#915)."
-        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
-        echo "  Use single-issue actions until v0.25.2 ships:"
-        echo "    task triage:reject -- --repo OWNER/NAME --issue N --reason 'why'"
-        exit 2
+      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" reject {{.CLI_ARGS}}
 
   bulk-defer:
-    desc: "[DISABLED v0.25.x] Bulk defer is gated pending v0.25.2 (#915). Use task triage:defer per issue."
+    desc: "Bulk defer candidates (#845 Story 4) -- task triage:bulk-defer -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
     dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
     cmds:
-      - |
-        echo "ERROR: task triage:bulk-defer is disabled in v0.25.0/v0.25.1 (#915)."
-        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
-        echo "  Use single-issue actions until v0.25.2 ships:"
-        echo "    task triage:defer -- --repo OWNER/NAME --issue N"
-        exit 2
+      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" defer {{.CLI_ARGS}}
 
   bulk-needs-ac:
-    desc: "[DISABLED v0.25.x] Bulk needs-ac is gated pending v0.25.2 (#915). Use task triage:needs-ac per issue."
+    desc: "Bulk needs-ac candidates (#845 Story 4) -- task triage:bulk-needs-ac -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
     dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
     cmds:
-      - |
-        echo "ERROR: task triage:bulk-needs-ac is disabled in v0.25.0/v0.25.1 (#915)."
-        echo "  bulk-* bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl."
-        echo "  Use single-issue actions until v0.25.2 ships:"
-        echo "    task triage:needs-ac -- --repo OWNER/NAME --issue N"
-        exit 2
+      - uv run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" needs-ac {{.CLI_ARGS}}
 
   refresh-active:
     desc: "Pre-swarm freshness gate (#845 Story 4) -- detects drift between cached and live `gh issue view` for every issue referenced in vbrief/active/*.vbrief.json"

--- a/tests/integration/test_triage_smoke.py
+++ b/tests/integration/test_triage_smoke.py
@@ -107,9 +107,13 @@ def isolated_runtime(
             encoding="utf-8",
         )
     else:
+        # Use the full absolute interpreter path in the shebang -- a versioned
+        # `python3.12` form via env(1) can be unresolvable on UV-managed Python
+        # installations or stripped CI images, which would mask the canary's
+        # regression-detection role with a silent exec error (Greptile #920).
         sh_helper = fake_path / "gh"
         sh_helper.write_text(
-            f"#!/usr/bin/env {Path(sys.executable).name}\n{_FAKE_GH_PY}",
+            f"#!{sys.executable}\n{_FAKE_GH_PY}",
             encoding="utf-8",
         )
         sh_helper.chmod(sh_helper.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)

--- a/tests/integration/test_triage_smoke.py
+++ b/tests/integration/test_triage_smoke.py
@@ -1,0 +1,236 @@
+"""tests/integration/test_triage_smoke.py -- end-to-end smoke for #915.
+
+Regression coverage for the v1 cache contract bugfix shipped with #915.
+
+Covers three scenarios end-to-end through ``triage_bulk.main``:
+
+1. ``test_bulk_defer_actions_only_cached`` -- with 5 cached issues AND a
+   fake-gh shim on PATH that would return 50 different live issues, the
+   bulk-defer run actions ONLY the 5 cached issues. The fake-gh shim
+   never executes (the rewritten triage_bulk.py is cache-only), but its
+   presence on PATH proves no live-gh fallback survived the rewrite.
+2. ``test_bulk_defer_idempotent`` -- a second run of bulk-defer over the
+   same cache appends ZERO new audit records (the Tier-2 short-circuit
+   honours the prior `defer` records).
+3. ``test_empty_cache_hard_fails`` -- bulk-defer against an empty cache
+   exits 2 with the canonical stderr message ``cache is empty for {repo}``
+   and never appends audit records.
+
+The audit log is redirected to the test's tmp directory by monkeypatching
+``candidates_log.DEFAULT_LOG_PATH`` and the cache root is redirected via
+``triage_cache.DEFAULT_CACHE_ROOT``. No live network calls; deterministic.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import stat
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+triage_bulk = importlib.import_module("triage_bulk")
+triage_cache = importlib.import_module("triage_cache")
+candidates_log = importlib.import_module("candidates_log")
+
+
+REPO = "deftai/directive"
+REPO_DIR_NAME = "deftai-directive"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _cached_issue(number: int, *, label: str = "triage") -> dict[str, object]:
+    """Build a sidecar payload mirroring ``triage_cache._GH_FIELDS``."""
+    created = (datetime.now(UTC) - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return {
+        "number": number,
+        "title": f"Cached issue {number}",
+        "body": "",
+        "state": "open",
+        "labels": [{"name": label}],
+        "author": {"login": "octocat"},
+        "createdAt": created,
+        "updatedAt": created,
+        "url": f"https://github.com/{REPO}/issues/{number}",
+    }
+
+
+@pytest.fixture
+def isolated_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path]:
+    """Redirect cache root + audit log into ``tmp_path`` for the duration.
+
+    Returns ``(cache_root, audit_log_path)`` so the test can assert against
+    the redirected locations. Also installs a fake ``gh`` shim on PATH that
+    would crash with a clear marker if any live-gh call survived the
+    rewrite.
+    """
+    cache_root = tmp_path / ".deft-cache" / "issues"
+    audit_log = tmp_path / "vbrief" / ".eval" / "candidates.jsonl"
+
+    monkeypatch.setattr(triage_cache, "DEFAULT_CACHE_ROOT", cache_root)
+    monkeypatch.setattr(candidates_log, "DEFAULT_LOG_PATH", audit_log)
+
+    # Fake-gh shim on PATH: any subprocess call to `gh` from triage_bulk.py
+    # would invoke this and SHOULD never happen post-#915. The shim writes
+    # 50 distinct issue payloads to stdout to mimic a populated remote and
+    # exits 0 -- so a regression that re-introduced the live-gh fallback
+    # would silently action 50 issues and the assertion in the calling
+    # test would fail loudly.
+    fake_path = tmp_path / "fake-bin"
+    fake_path.mkdir()
+    if sys.platform == "win32":
+        # Windows resolves PATH lookups via PATHEXT; ship both a .cmd
+        # wrapper (covers the bare ``gh`` invocation) and a python script
+        # the .cmd dispatches to, so the canary works regardless of the
+        # subprocess shell argv expansion.
+        py_helper = fake_path / "_fake_gh.py"
+        py_helper.write_text(_FAKE_GH_PY, encoding="utf-8")
+        cmd_wrapper = fake_path / "gh.cmd"
+        cmd_wrapper.write_text(
+            f'@echo off\r\n"{sys.executable}" "{py_helper}" %*\r\n',
+            encoding="utf-8",
+        )
+    else:
+        sh_helper = fake_path / "gh"
+        sh_helper.write_text(
+            f"#!/usr/bin/env {Path(sys.executable).name}\n{_FAKE_GH_PY}",
+            encoding="utf-8",
+        )
+        sh_helper.chmod(sh_helper.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    monkeypatch.setenv("PATH", str(fake_path) + os.pathsep + os.environ.get("PATH", ""))
+    return cache_root, audit_log
+
+
+_FAKE_GH_PY = '''import json
+import sys
+
+# Emit 50 distinct "live" issues if anyone actually calls us. The numbers
+# are intentionally disjoint from the test cache (1..5) so any contamination
+# would be obvious in test failures.
+payload = [
+    {
+        "number": n,
+        "title": f"FAKE-LIVE issue {n}",
+        "body": "",
+        "state": "open",
+        "labels": [],
+        "author": {"login": "ghost"},
+        "createdAt": "2026-05-01T00:00:00Z",
+        "updatedAt": "2026-05-01T00:00:00Z",
+        "url": f"https://example.invalid/issues/{n}",
+    }
+    for n in range(100, 150)
+]
+sys.stdout.write(json.dumps(payload))
+sys.exit(0)
+'''
+
+
+def _populate_cache(cache_root: Path, count: int = 5) -> list[int]:
+    """Create ``count`` issue sidecars under ``cache_root/<owner-repo>/``."""
+    repo_dir = cache_root / REPO_DIR_NAME
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    numbers = list(range(1, count + 1))
+    for n in numbers:
+        (repo_dir / f"{n}.json").write_text(
+            json.dumps(_cached_issue(n)), encoding="utf-8"
+        )
+    return numbers
+
+
+def _read_audit_records(audit_log: Path) -> list[dict[str, object]]:
+    """Return the list of audit records currently on disk (or [])."""
+    if not audit_log.exists():
+        return []
+    records: list[dict[str, object]] = []
+    for raw in audit_log.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        records.append(json.loads(line))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_defer_actions_only_cached(
+    isolated_runtime: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """5 cached + 50 fake-live -> exactly 5 actioned, fake-gh never consulted."""
+    cache_root, audit_log = isolated_runtime
+    cached_numbers = _populate_cache(cache_root, count=5)
+
+    rc = triage_bulk.main(["defer", "--repo", REPO])
+    assert rc == 0, capsys.readouterr().err
+
+    records = _read_audit_records(audit_log)
+    actioned = sorted(r["issue_number"] for r in records)
+    assert actioned == cached_numbers, (
+        f"bulk-defer must only action cached issues; got {actioned}, "
+        f"expected {cached_numbers}"
+    )
+    # Defensive: no record should reference a fake-live issue number (100-149).
+    assert not any(100 <= int(r["issue_number"]) < 150 for r in records), (
+        "fake-gh issues leaked into the audit log -- live-gh fallback regressed"
+    )
+    assert all(r["decision"] == "defer" for r in records)
+
+
+def test_bulk_defer_idempotent(
+    isolated_runtime: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Second bulk-defer run produces ZERO new audit records."""
+    cache_root, audit_log = isolated_runtime
+    _populate_cache(cache_root, count=5)
+
+    rc1 = triage_bulk.main(["defer", "--repo", REPO])
+    assert rc1 == 0, capsys.readouterr().err
+    first_count = len(_read_audit_records(audit_log))
+    assert first_count == 5
+
+    rc2 = triage_bulk.main(["defer", "--repo", REPO])
+    assert rc2 == 0, capsys.readouterr().err
+    second_count = len(_read_audit_records(audit_log))
+    assert second_count == first_count, (
+        f"idempotent invariant violated: pass-1 wrote {first_count} records, "
+        f"pass-2 wrote {second_count - first_count} new ones"
+    )
+
+
+def test_empty_cache_hard_fails(
+    isolated_runtime: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Empty cache -> exit 2 + canonical stderr; no audit records appended."""
+    _cache_root, audit_log = isolated_runtime
+    # Deliberately do NOT populate the cache.
+
+    rc = triage_bulk.main(["defer", "--repo", REPO])
+    assert rc == 2
+
+    captured = capsys.readouterr()
+    assert "cache is empty for deftai/directive" in captured.err
+    assert "task triage:bootstrap" in captured.err
+
+    assert _read_audit_records(audit_log) == []

--- a/tests/integration/test_triage_smoke.py
+++ b/tests/integration/test_triage_smoke.py
@@ -30,6 +30,7 @@ import stat
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -52,7 +53,7 @@ REPO_DIR_NAME = "deftai-directive"
 # ---------------------------------------------------------------------------
 
 
-def _cached_issue(number: int, *, label: str = "triage") -> dict[str, object]:
+def _cached_issue(number: int, *, label: str = "triage") -> dict[str, Any]:
     """Build a sidecar payload mirroring ``triage_cache._GH_FIELDS``."""
     created = (datetime.now(UTC) - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
     return {
@@ -154,11 +155,11 @@ def _populate_cache(cache_root: Path, count: int = 5) -> list[int]:
     return numbers
 
 
-def _read_audit_records(audit_log: Path) -> list[dict[str, object]]:
+def _read_audit_records(audit_log: Path) -> list[dict[str, Any]]:
     """Return the list of audit records currently on disk (or [])."""
     if not audit_log.exists():
         return []
-    records: list[dict[str, object]] = []
+    records: list[dict[str, Any]] = []
     for raw in audit_log.read_text(encoding="utf-8").splitlines():
         line = raw.strip()
         if not line:

--- a/tests/test_triage_bootstrap.py
+++ b/tests/test_triage_bootstrap.py
@@ -122,6 +122,7 @@ def test_fresh_project_end_to_end(bootstrap, tmp_path: Path) -> None:
         "populate_cache",
         "backfill_audit_log",
         "ensure_gitignore_entry",
+        "ensure_gitignore_eval_dir",
         "ensure_gitcrawl",
     ]
     # Steps without --repo should skip-with-OK.
@@ -129,12 +130,18 @@ def test_fresh_project_end_to_end(bootstrap, tmp_path: Path) -> None:
     assert populate.ok and populate.details.get("skipped") == "no-repo"
     backfill = result.steps[1]
     assert backfill.ok and backfill.details.get("skipped") == "no-repo"
-    # Gitignore created.
+    # Gitignore created with both lines (#915).
     gitignore = tmp_path / ".gitignore"
     assert gitignore.exists()
-    assert ".deft-cache/" in gitignore.read_text(encoding="utf-8")
-    # Gitcrawl deferred.
-    gitcrawl = result.steps[3]
+    gitignore_text = gitignore.read_text(encoding="utf-8")
+    assert ".deft-cache/" in gitignore_text
+    assert "vbrief/.eval/" in gitignore_text
+    # ensure_gitignore_eval_dir landed an append on the freshly-created file.
+    eval_step = result.steps[3]
+    assert eval_step.ok
+    assert eval_step.details.get("appended") is True
+    # Gitcrawl deferred (now at index 4 after the new eval-dir step).
+    gitcrawl = result.steps[4]
     assert gitcrawl.ok
     assert gitcrawl.details.get("action") == "deferred-no-pipx"
 

--- a/tests/test_triage_bulk.py
+++ b/tests/test_triage_bulk.py
@@ -1,13 +1,22 @@
-"""Tests for scripts/triage_bulk.py (#845 Story 4 AC #4 -- bulk cases).
+"""Tests for scripts/triage_bulk.py (#845 Story 4 + #915 cache-walk fix).
 
-Covers Test narrative items (1)-(3) from the Story 4 vBRIEF:
+Covers Test narrative items (1)-(3) from the Story 4 vBRIEF AND the
+#915 hardening:
 
 - (1) bulk-accept with --label fixture
 - (2) combined --label --age-days filters
 - (3) zero-match returns clean exit
+- (#915) cache-walk source: ``_list_cached_candidates`` parses sidecars,
+  tolerates malformed JSON, returns ``[]`` on missing dir
+- (#915) audit-log skip: terminal records ALWAYS short-circuit; in-progress
+  records short-circuit unless ``re_action=True``
+- (#915) empty-cache hard-fail: ``bulk_action`` raises ``CacheEmptyError``;
+  ``main`` translates to exit 2 with the canonical stderr message
 
 Story 3's ``triage_actions`` module may not yet be on the import path. Tests
 inject a stub via the ``actions_module`` parameter to keep the suite hermetic.
+``candidates_log_module`` is also injected so tests do not depend on the
+ambient ``vbrief/.eval/candidates.jsonl`` file.
 """
 
 from __future__ import annotations
@@ -45,15 +54,18 @@ def _issue(
     author: str = "octocat",
     days_old: int = 0,
 ) -> dict[str, object]:
-    """Build a minimal ``gh issue list --json`` shaped record."""
+    """Build a minimal cached-issue payload (matches ``triage_cache._GH_FIELDS``)."""
     created = datetime.now(UTC) - timedelta(days=days_old)
     return {
         "number": number,
         "title": f"Issue {number}",
+        "body": "",
+        "state": "open",
         "labels": [{"name": name} for name in (labels or [])],
         "author": {"login": author},
         "createdAt": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "updatedAt": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "url": f"https://github.com/deftai/directive/issues/{number}",
     }
 
 
@@ -81,12 +93,43 @@ def stub_actions_module() -> SimpleNamespace:
     )
 
 
+@pytest.fixture
+def empty_audit_log() -> SimpleNamespace:
+    """A namespace stub of ``candidates_log`` with an empty ``read_all``."""
+    return SimpleNamespace(read_all=lambda **_kw: [])
+
+
+def _audit_log_with(*entries: dict[str, Any]) -> SimpleNamespace:
+    """Build a ``candidates_log`` stub whose ``read_all`` yields the entries."""
+    return SimpleNamespace(read_all=lambda **_kw: list(entries))
+
+
+def _audit_entry(
+    issue_number: int,
+    decision: str,
+    *,
+    timestamp: str = "2026-05-05T10:00:00Z",
+    repo: str = "deftai/directive",
+) -> dict[str, Any]:
+    """Build a minimal audit-log entry of the shape ``read_all`` yields."""
+    return {
+        "decision_id": "00000000-0000-0000-0000-000000000000",
+        "timestamp": timestamp,
+        "repo": repo,
+        "issue_number": issue_number,
+        "decision": decision,
+        "actor": "agent:test",
+    }
+
+
 # ---------------------------------------------------------------------------
-# Tests
+# Tests -- filter semantics (Story 4 AC #4 narrative items 1-3)
 # ---------------------------------------------------------------------------
 
 
-def test_bulk_accept_filters_by_label(stub_actions_module: SimpleNamespace) -> None:
+def test_bulk_accept_filters_by_label(
+    stub_actions_module: SimpleNamespace, empty_audit_log: SimpleNamespace
+) -> None:
     """(1) bulk-accept --label fixture loops Story 3.accept only over matched."""
     issues = [
         _issue(101, labels=["triage", "bug"]),
@@ -100,6 +143,7 @@ def test_bulk_accept_filters_by_label(stub_actions_module: SimpleNamespace) -> N
         "deftai/directive",
         label="bug",
         actions_module=stub_actions_module,
+        candidates_log_module=empty_audit_log,
         issues_provider=lambda _repo: issues,
         out=out,
     )
@@ -114,7 +158,7 @@ def test_bulk_accept_filters_by_label(stub_actions_module: SimpleNamespace) -> N
 
 
 def test_bulk_accept_combined_label_and_age_days(
-    stub_actions_module: SimpleNamespace,
+    stub_actions_module: SimpleNamespace, empty_audit_log: SimpleNamespace
 ) -> None:
     """(2) Combined --label --age-days filters apply with AND semantics."""
     issues = [
@@ -131,6 +175,7 @@ def test_bulk_accept_combined_label_and_age_days(
         label="bug",
         age_days=7,
         actions_module=stub_actions_module,
+        candidates_log_module=empty_audit_log,
         issues_provider=lambda _repo: issues,
         out=out,
     )
@@ -141,7 +186,7 @@ def test_bulk_accept_combined_label_and_age_days(
 
 
 def test_bulk_action_zero_match_clean_exit(
-    stub_actions_module: SimpleNamespace,
+    stub_actions_module: SimpleNamespace, empty_audit_log: SimpleNamespace
 ) -> None:
     """(3) Zero-match exits cleanly with status 0 + single summary line."""
     issues = [_issue(301, labels=["docs"])]
@@ -152,6 +197,7 @@ def test_bulk_action_zero_match_clean_exit(
         "deftai/directive",
         label="nonexistent-label",
         actions_module=stub_actions_module,
+        candidates_log_module=empty_audit_log,
         issues_provider=lambda _repo: issues,
         out=out,
     )
@@ -164,45 +210,252 @@ def test_bulk_action_zero_match_clean_exit(
     assert "actioned" not in rendered.replace("zero matches", "")
 
 
-def test_list_open_issues_warns_when_at_limit(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Greptile P2 (PR #875): emit an explicit truncation warning when the
-    returned issue count meets ``--limit`` -- silent truncation is forbidden.
-    """
-    payload_issues = [{"number": i, "labels": [], "author": {}} for i in range(5)]
+# ---------------------------------------------------------------------------
+# Tests -- _list_cached_candidates contract (#915)
+# ---------------------------------------------------------------------------
 
-    class _Fake:
-        stdout = json.dumps(payload_issues)
 
-    def _fake_run(_cmd, **_kwargs):
-        return _Fake()
+def test_list_cached_candidates_returns_empty_on_missing_dir(tmp_path: Path) -> None:
+    """Missing cache dir -> empty list (caller translates to hard-fail)."""
+    sink = io.StringIO()
+    out = triage_bulk._list_cached_candidates(
+        "deftai/directive",
+        cache_root=tmp_path / "nonexistent",
+        out=sink,
+    )
+    assert out == []
 
-    monkeypatch.setattr(triage_bulk.subprocess, "run", _fake_run)
+
+def test_list_cached_candidates_parses_sidecars(tmp_path: Path) -> None:
+    """Populated cache -> returns the parsed JSON payloads."""
+    cache_root = tmp_path / "issues"
+    repo_dir = cache_root / "deftai-directive"
+    repo_dir.mkdir(parents=True)
+    payload_a = _issue(11, labels=["bug"])
+    payload_b = _issue(22, labels=["docs"])
+    (repo_dir / "11.json").write_text(json.dumps(payload_a), encoding="utf-8")
+    (repo_dir / "22.json").write_text(json.dumps(payload_b), encoding="utf-8")
     sink = io.StringIO()
 
-    issues = triage_bulk._list_open_issues("deftai/directive", limit=5, out=sink)
+    out = triage_bulk._list_cached_candidates(
+        "deftai/directive", cache_root=cache_root, out=sink
+    )
 
-    assert len(issues) == 5
+    assert sorted(item["number"] for item in out) == [11, 22]
+    # No warnings emitted for clean files.
+    assert "WARN" not in sink.getvalue()
+
+
+def test_list_cached_candidates_tolerates_invalid_json(tmp_path: Path) -> None:
+    """A malformed sidecar is logged and skipped; valid entries still surface."""
+    cache_root = tmp_path / "issues"
+    repo_dir = cache_root / "deftai-directive"
+    repo_dir.mkdir(parents=True)
+    (repo_dir / "1.json").write_text(json.dumps(_issue(1)), encoding="utf-8")
+    (repo_dir / "2.json").write_text("{not valid json", encoding="utf-8")
+    (repo_dir / "3.json").write_text("[1, 2, 3]", encoding="utf-8")  # not a dict
+    (repo_dir / "4.json").write_text(json.dumps(_issue(4)), encoding="utf-8")
+    sink = io.StringIO()
+
+    out = triage_bulk._list_cached_candidates(
+        "deftai/directive", cache_root=cache_root, out=sink
+    )
+
+    assert sorted(item["number"] for item in out) == [1, 4]
     rendered = sink.getvalue()
+    assert "2.json" in rendered  # malformed file flagged
+    assert "3.json" in rendered  # non-dict file flagged
     assert "WARN" in rendered
-    assert "--limit 5" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Tests -- empty cache hard-fail (#915)
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_action_raises_cache_empty_on_no_candidates(
+    stub_actions_module: SimpleNamespace, empty_audit_log: SimpleNamespace
+) -> None:
+    """``bulk_action`` raises ``CacheEmptyError`` when the candidate set is empty."""
+    with pytest.raises(triage_bulk.CacheEmptyError, match="cache is empty for deftai/directive"):
+        triage_bulk.bulk_action(
+            "defer",
+            "deftai/directive",
+            actions_module=stub_actions_module,
+            candidates_log_module=empty_audit_log,
+            issues_provider=lambda _repo: [],
+        )
+
+
+def test_main_empty_cache_returns_exit_2(
+    stub_actions_module: SimpleNamespace,
+    empty_audit_log: SimpleNamespace,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main`` translates ``CacheEmptyError`` into exit 2 + canonical stderr."""
+    monkeypatch.setitem(sys.modules, "triage_actions", stub_actions_module)
+    monkeypatch.setitem(sys.modules, "candidates_log", empty_audit_log)
+    # Force the cache walk to return empty regardless of fs state.
+    monkeypatch.setattr(
+        triage_bulk, "_list_cached_candidates", lambda *_a, **_kw: []
+    )
+
+    rc = triage_bulk.main(["defer", "--repo", "deftai/directive"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "cache is empty for deftai/directive" in captured.err
+    assert "task triage:bootstrap" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Tests -- audit-log skip semantics (#915)
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_skips_issues_with_terminal_audit_records(
+    stub_actions_module: SimpleNamespace,
+) -> None:
+    """Terminal decisions (accept/reject/mark-duplicate) ALWAYS short-circuit."""
+    issues = [_issue(401), _issue(402), _issue(403)]
+    audit = _audit_log_with(
+        _audit_entry(401, "accept"),
+        _audit_entry(402, "reject"),
+    )
+    out = io.StringIO()
+
+    actioned = triage_bulk.bulk_action(
+        "defer",
+        "deftai/directive",
+        actions_module=stub_actions_module,
+        candidates_log_module=audit,
+        issues_provider=lambda _repo: issues,
+        out=out,
+    )
+
+    assert actioned == 1
+    actioned_numbers = sorted(call[1] for call in stub_actions_module.calls)
+    assert actioned_numbers == [403]
+    rendered = out.getvalue()
+    assert "skipped 2 candidate(s) with prior audit-log records" in rendered
+
+
+def test_bulk_skips_in_progress_records_without_re_action(
+    stub_actions_module: SimpleNamespace,
+) -> None:
+    """defer/needs-ac records short-circuit when ``re_action`` is False."""
+    issues = [_issue(501), _issue(502), _issue(503)]
+    audit = _audit_log_with(
+        _audit_entry(501, "defer"),
+        _audit_entry(502, "needs-ac"),
+    )
+    out = io.StringIO()
+
+    actioned = triage_bulk.bulk_action(
+        "defer",
+        "deftai/directive",
+        actions_module=stub_actions_module,
+        candidates_log_module=audit,
+        issues_provider=lambda _repo: issues,
+        out=out,
+    )
+
+    assert actioned == 1
+    assert sorted(call[1] for call in stub_actions_module.calls) == [503]
+    assert "pass --re-action to override defer/needs-ac records" in out.getvalue()
+
+
+def test_bulk_re_action_overrides_in_progress_but_not_terminal(
+    stub_actions_module: SimpleNamespace,
+) -> None:
+    """``re_action=True`` re-actions defer/needs-ac but still skips terminal."""
+    issues = [_issue(601), _issue(602), _issue(603), _issue(604)]
+    audit = _audit_log_with(
+        _audit_entry(601, "defer"),
+        _audit_entry(602, "needs-ac"),
+        _audit_entry(603, "accept"),  # terminal -- still skipped
+    )
+
+    actioned = triage_bulk.bulk_action(
+        "defer",
+        "deftai/directive",
+        re_action=True,
+        actions_module=stub_actions_module,
+        candidates_log_module=audit,
+        issues_provider=lambda _repo: issues,
+        out=io.StringIO(),
+    )
+
+    assert actioned == 3
+    actioned_numbers = sorted(call[1] for call in stub_actions_module.calls)
+    assert actioned_numbers == [601, 602, 604]
+
+
+def test_bulk_uses_latest_audit_entry_per_issue(
+    stub_actions_module: SimpleNamespace,
+) -> None:
+    """When multiple records exist for an issue, the latest timestamp wins."""
+    issues = [_issue(701)]
+    audit = _audit_log_with(
+        # First defer, then reset -> latest is reset (non-skipping).
+        _audit_entry(701, "defer", timestamp="2026-05-01T10:00:00Z"),
+        {
+            "decision_id": "11111111-1111-1111-1111-111111111111",
+            "timestamp": "2026-05-02T10:00:00Z",
+            "repo": "deftai/directive",
+            "issue_number": 701,
+            "decision": "reset",
+            "actor": "agent:test",
+            "prior_decision_id": "00000000-0000-0000-0000-000000000000",
+        },
+    )
+
+    actioned = triage_bulk.bulk_action(
+        "defer",
+        "deftai/directive",
+        actions_module=stub_actions_module,
+        candidates_log_module=audit,
+        issues_provider=lambda _repo: issues,
+        out=io.StringIO(),
+    )
+
+    assert actioned == 1
+    assert sorted(call[1] for call in stub_actions_module.calls) == [701]
+
+
+# ---------------------------------------------------------------------------
+# Tests -- argparse + signature-mismatch fallback
+# ---------------------------------------------------------------------------
+
+
+def test_argparse_accepts_re_action_flag(
+    stub_actions_module: SimpleNamespace,
+    empty_audit_log: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--re-action`` parses cleanly through argparse and forwards to bulk_action."""
+    monkeypatch.setitem(sys.modules, "triage_actions", stub_actions_module)
+    monkeypatch.setitem(sys.modules, "candidates_log", empty_audit_log)
+    monkeypatch.setattr(
+        triage_bulk, "_list_cached_candidates", lambda *_a, **_kw: [_issue(1, labels=["bug"])]
+    )
+
+    rc = triage_bulk.main(
+        ["defer", "--repo", "deftai/directive", "--label", "bug", "--re-action"]
+    )
+    assert rc == 0
 
 
 def test_invoke_action_propagates_typeerror_from_action_body(
-    stub_actions_module: SimpleNamespace,
+    stub_actions_module: SimpleNamespace, empty_audit_log: SimpleNamespace
 ) -> None:
-    """Greptile P2 (PR #875): a ``TypeError`` raised *inside* a Story 3 action
-    MUST surface to the operator instead of being swallowed by the
-    signature-mismatch fallback.
-    """
+    """A ``TypeError`` raised *inside* a Story 3 action MUST surface."""
 
     def _broken_accept(_n: int, _repo: str, **_kwargs: object) -> None:
-        # Genuine bug inside Story 3 -- not a call-site signature issue.
         raise TypeError("unsupported operand type(s) for +: 'int' and 'str'")
 
     stub_actions_module.accept = _broken_accept
-    issues = [{"number": 1, "labels": [{"name": "bug"}], "author": {}}]
+    issues = [_issue(1, labels=["bug"])]
 
     with pytest.raises(TypeError, match="unsupported operand"):
         triage_bulk.bulk_action(
@@ -210,27 +463,20 @@ def test_invoke_action_propagates_typeerror_from_action_body(
             "deftai/directive",
             label="bug",
             actions_module=stub_actions_module,
+            candidates_log_module=empty_audit_log,
             issues_provider=lambda _repo: issues,
             out=io.StringIO(),
         )
 
 
 def test_invoke_action_tolerates_signature_mismatch_in_call_site(
-    stub_actions_module: SimpleNamespace,
+    stub_actions_module: SimpleNamespace, empty_audit_log: SimpleNamespace
 ) -> None:
-    """Companion to the above: a real signature mismatch (kwarg unsupported)
-    still falls back to the positional shape.
-    """
+    """Companion: a real signature mismatch falls back to the positional shape."""
     captured: list[tuple[int, str, str | None]] = []
     call_log: list[str] = []
 
     def _smart_reject(*args: Any, **kwargs: Any) -> None:
-        # First call raises the canonical kwarg-unsupported signature
-        # ``TypeError``; the fallback positional call then succeeds.
-        # ``*args: Any`` (rather than ``object``) is required so mypy
-        # admits ``int(args[0])`` / ``str(args[1])`` -- the ``object``
-        # annotation has no overload for ``int(...)`` (Python CI mypy
-        # call-overload regression on PR #875 post-rebase).
         if kwargs:
             call_log.append("kwarg")
             raise TypeError("got an unexpected keyword argument 'reason'")
@@ -238,7 +484,7 @@ def test_invoke_action_tolerates_signature_mismatch_in_call_site(
         captured.append((int(args[0]), str(args[1]), str(args[2]) if len(args) > 2 else None))
 
     stub_actions_module.reject = _smart_reject
-    issues = [{"number": 7, "labels": [{"name": "bug"}], "author": {}}]
+    issues = [_issue(7, labels=["bug"])]
 
     actioned = triage_bulk.bulk_action(
         "reject",
@@ -246,6 +492,7 @@ def test_invoke_action_tolerates_signature_mismatch_in_call_site(
         label="bug",
         reason="obsolete",
         actions_module=stub_actions_module,
+        candidates_log_module=empty_audit_log,
         issues_provider=lambda _repo: issues,
         out=io.StringIO(),
     )
@@ -255,51 +502,18 @@ def test_invoke_action_tolerates_signature_mismatch_in_call_site(
     assert captured == [(7, "deftai/directive", "obsolete")]
 
 
-def test_resolve_limit_prefers_cli_then_env_then_default(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Greptile P1 (PR #875): the documented ``--limit`` / env-var overrides
-    MUST resolve in CLI > env-var > default order, with malformed env-var
-    values falling back to the default.
-    """
-    monkeypatch.delenv(triage_bulk.LIMIT_ENV_VAR, raising=False)
-    assert triage_bulk._resolve_limit(None) == triage_bulk.DEFAULT_ISSUE_LIST_LIMIT
-    assert triage_bulk._resolve_limit(2500) == 2500
-
-    monkeypatch.setenv(triage_bulk.LIMIT_ENV_VAR, "3000")
-    assert triage_bulk._resolve_limit(None) == 3000
-    # CLI still wins over env when both are present.
-    assert triage_bulk._resolve_limit(500) == 500
-
-    # Malformed env-var value -> default fallback (defensive parse).
-    monkeypatch.setenv(triage_bulk.LIMIT_ENV_VAR, "not-an-int")
-    assert triage_bulk._resolve_limit(None) == triage_bulk.DEFAULT_ISSUE_LIST_LIMIT
+# ---------------------------------------------------------------------------
+# Tests -- skip-set helper (pure function)
+# ---------------------------------------------------------------------------
 
 
-def test_argparse_accepts_limit_flag(
-    stub_actions_module: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Greptile P1 (PR #875): ``--limit N`` parses cleanly through argparse
-    -- it MUST NOT raise ``unrecognized arguments``.
-    """
-    monkeypatch.setitem(sys.modules, "triage_actions", stub_actions_module)
-    monkeypatch.setattr(triage_bulk, "_list_open_issues", lambda *_args, **_kw: [])
-
-    rc = triage_bulk.main(
-        ["accept", "--repo", "deftai/directive", "--label", "bug", "--limit", "50"]
-    )
-    assert rc == 0
+def test_build_skip_set_default_includes_terminal_and_in_progress() -> None:
+    skip = triage_bulk._build_skip_set(False)
+    assert skip == {"accept", "reject", "mark-duplicate", "defer", "needs-ac"}
 
 
-def test_main_zero_match_exits_zero(
-    stub_actions_module: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The CLI ``main`` returns 0 on zero-match per Story 4 Constraint."""
-    monkeypatch.setitem(sys.modules, "triage_actions", stub_actions_module)
-    # Stub matches the post-PR-#875 signature (`limit` + `out` kwargs).
-    monkeypatch.setattr(triage_bulk, "_list_open_issues", lambda *_a, **_k: [])
-
-    rc = triage_bulk.main(["accept", "--repo", "deftai/directive", "--label", "anything"])
-    assert rc == 0
+def test_build_skip_set_re_action_excludes_in_progress() -> None:
+    skip = triage_bulk._build_skip_set(True)
+    assert skip == {"accept", "reject", "mark-duplicate"}
+    assert "defer" not in skip
+    assert "needs-ac" not in skip

--- a/vbrief/active/2026-05-05-915-fix-triage-cache-bypass.vbrief.json
+++ b/vbrief/active/2026-05-05-915-fix-triage-cache-bypass.vbrief.json
@@ -1,0 +1,65 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "P0 cache-bypass + audit-log poisoning fix for scripts/triage_bulk.py (#915). Replaces the live `gh issue list` candidate source with a Tier-1 cache walk, intersects with Tier-2 audit log to skip already-actioned candidates, hard-fails on empty cache, removes the live-gh fallback path, and re-enables the four task triage:bulk-* surfaces gated by PR #916.",
+    "created": "2026-05-05T15:58:23Z",
+    "updated": "2026-05-05T16:01:35Z"
+  },
+  "plan": {
+    "title": "P0: triage_bulk.py bypasses Tier-1 cache and Tier-2 audit log -- iterates live gh issue list (#845 Story 4)",
+    "status": "running",
+    "narratives": {
+      "Overview": "scripts/triage_bulk.py iterates live `gh issue list` output and skips the .deft-cache/issues sidecar entirely. It also never reads vbrief/.eval/candidates.jsonl, so repeat runs silently re-action issues and poison the append-only audit log. Together this violates the Tier-1 / Tier-2 contracts documented in skills/deft-directive-refinement/SKILL.md and the #845 epic vBRIEF: cache is supposed to be the read surface, the audit log is supposed to short-circuit terminal/in-progress decisions. The fix rewrites the candidate source to walk .deft-cache/issues/<owner>-<repo>/*.json, intersects results with candidates_log records to skip terminal (accept | reject | mark-duplicate) and in-progress (defer | needs-ac) decisions (the latter overridable via a new --re-action flag), hard-fails with exit 2 when the cache is empty (no live-gh fallback), and re-enables the four task triage:bulk-* surfaces that PR #916 gated. A new tests/integration/test_triage_smoke.py file regression-covers the cache-only contract end-to-end via a fake-gh shim on PATH; tests/test_triage_bulk.py gains unit tests for _list_cached_candidates."
+    },
+    "items": [
+      {
+        "id": "ac-1",
+        "title": "scripts/triage_bulk.py reads candidates from .deft-cache/issues/<owner>-<repo>/*.json (Tier-1) -- live `gh issue list` is no longer called.",
+        "status": "pending"
+      },
+      {
+        "id": "ac-2",
+        "title": "Bulk operations skip issues with terminal audit-log records (accept | reject | mark-duplicate) and in-progress records (defer | needs-ac) UNLESS --re-action is passed.",
+        "status": "pending"
+      },
+      {
+        "id": "ac-3",
+        "title": "Empty cache -> exit 2 with stderr message `triage_bulk: cache is empty for {repo}; run \\`task triage:bootstrap\\` first.`",
+        "status": "pending"
+      },
+      {
+        "id": "ac-4",
+        "title": "tasks/triage-bulk.yml: bulk-accept / bulk-reject / bulk-defer / bulk-needs-ac restored to original cmds: invocations of triage_bulk.py with PYTHONUTF8 env block and non-DISABLED desc; refresh-active untouched. The four triage:bulk-* root aliases dispatch to the re-enabled inner tasks.",
+        "status": "pending"
+      },
+      {
+        "id": "ac-5",
+        "title": ".gitignore gains a `vbrief/.eval/` entry; scripts/triage_bootstrap.py adds an idempotent step_ensure_gitignore_eval_dir() step so upgrading projects auto-add the line on next bootstrap run.",
+        "status": "pending"
+      },
+      {
+        "id": "ac-6",
+        "title": "tests/integration/test_triage_smoke.py: test_bulk_defer_actions_only_cached, test_bulk_defer_idempotent, test_empty_cache_hard_fails -- all three pass via a fake-gh PATH shim, no live network calls.",
+        "status": "pending"
+      },
+      {
+        "id": "ac-7",
+        "title": "tests/test_triage_bulk.py: unit coverage for _list_cached_candidates -- missing dir -> hard fail path, populated dir -> parsed issue dicts, invalid JSON -> warn+skip with valid entries returned.",
+        "status": "pending"
+      },
+      {
+        "id": "ac-8",
+        "title": "CHANGELOG.md: Unreleased -> Fixed entries describing the cache-walk rewrite and the bulk-* re-enable; Unreleased -> Added entries for vbrief/.eval gitignore + bootstrap ensure step + integration test.",
+        "status": "pending"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/915",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #915: P0 -- bulk operations bypass cache"
+      }
+    ],
+    "updated": "2026-05-05T16:01:21Z"
+  }
+}


### PR DESCRIPTION
Closes #915

## Summary

P0 fix for `scripts/triage_bulk.py`: replace the live `gh issue list` candidate source with a Tier-1 `.deft-cache/issues/` walk, intersect with the Tier-2 `vbrief/.eval/candidates.jsonl` audit log to skip already-actioned candidates (terminal records always; in-progress records unless `--re-action`), hard-fail with exit 2 on an empty cache, and re-enable the four `task triage:bulk-*` surfaces gated by PR #916.

## Changes

- `scripts/triage_bulk.py` rewritten:
  - New `_list_cached_candidates(repo, *, cache_root=...)` walks `.deft-cache/issues/<owner>-<repo>/*.json`, parses each JSON sidecar (matching `triage_cache._GH_FIELDS`), and tolerates malformed JSON files (warn + skip).
  - New `_exclude_logged(...)` intersects with `candidates_log.read_all(repo=repo)` to skip terminal decisions (`accept | reject | mark-duplicate`) ALWAYS and in-progress decisions (`defer | needs-ac`) unless `--re-action` is passed.
  - New `CacheEmptyError` raised on missing/empty cache; `main` exits 2 with `triage_bulk: cache is empty for {repo}; run \`task triage:bootstrap\` first.` on stderr.
  - Live `gh issue list` fallback removed entirely; `_list_open_issues` / `_resolve_limit` / `DEFAULT_ISSUE_LIST_LIMIT` / `LIMIT_ENV_VAR` all gone.
  - New `--re-action` argparse flag with help describing the in-progress-override semantics.
- `tasks/triage-bulk.yml`: restored original `cmds:` for `bulk-accept | bulk-reject | bulk-defer | bulk-needs-ac` (PYTHONUTF8 env block, dispatched to `triage_bulk.py`); dropped `[DISABLED v0.25.x]` from the four `desc:` strings; `internal: true` and the `refresh-active` task left untouched (Agent A's #913 surface).
- Root `Taskfile.yml`: dropped `[DISABLED v0.25.x]` from the four `triage:bulk-*` alias `desc:` strings so the documented user surface (`task triage:bulk-defer -- --repo OWNER/NAME [--re-action]`) renders correctly in `task -l`.
- `.gitignore`: added `vbrief/.eval/` alongside the existing `.deft-cache/` entry.
- `scripts/triage_bootstrap.py`: new `step_ensure_gitignore_eval_dir(project_root)` step mirrors the `.deft-cache/` ensure step and is wired into `run_bootstrap` between `ensure_gitignore_entry` and `ensure_gitcrawl`. Step list goes from 4 -> 5; B's argparse surface is untouched.
- New `tests/integration/test_triage_smoke.py` (3 tests):
  - `test_bulk_defer_actions_only_cached`: 5 cached + fake-gh shim returning 50 live -> exactly 5 actioned, fake-gh never consulted.
  - `test_bulk_defer_idempotent`: second pass appends ZERO new audit records (Tier-2 short-circuit).
  - `test_empty_cache_hard_fails`: empty cache -> exit 2 + canonical stderr; no audit records.
  - Fake-gh shim materialised on PATH via `monkeypatch.setenv("PATH", ...)`; cache root and audit log redirected to `tmp_path`.
- `tests/test_triage_bulk.py` rewritten for the new contract (cache-walk source, audit-log intersect, `--re-action` flag, empty-cache hard-fail, latest-decision-wins ordering) plus retained signature-mismatch fallback coverage.
- `tests/test_triage_bootstrap.py`: extended `test_fresh_project_end_to_end` to cover the new 5-step pipeline and the new `vbrief/.eval/` gitignore line.
- `CHANGELOG.md`: two `Fixed` entries (cache-walk rewrite, bulk-* re-enable) and two `Added` entries (gitignore + bootstrap ensure step, integration test) under `[Unreleased]`.

## Acceptance verification

- `task triage:bulk-defer -- --repo X` against an N-sidecar cache writes <= N audit records.
- A second invocation against the same cache writes 0 records.
- Empty cache -> exit 2 with the documented stderr message.
- An issue that exists on `gh issue list` but NOT in the cache is **never** actioned.
- `task check`: 3993 passed, 3 skipped, 1 xfailed (matches pre-PR baseline; 4 broken-link warnings are pre-existing per CHANGELOG).
- `task vbrief:validate`: clean (354 scope vBRIEFs, 2 pre-existing PRD/SPECIFICATION staleness warnings).

## Notes

- `--re-action` flag name: no stronger convention found in the codebase; closest neighbour was `--force` on `triage_bootstrap` (different semantics).
- Files outside the dispatcher's allowed set are not touched. The only edits to root `Taskfile.yml` are the four `desc:` strings on the `triage:bulk-*` alias block (mechanical re-enable; cmd routing unchanged); flagged this in the milestone-1 status.
- All file edits flow through `create_file` / `edit_files` (Python pathlib + UTF-8) per the AGENTS.md PowerShell 5.1 non-ASCII rule.
