### PR TITLE
chore(vbrief): complete 915 fix-triage-cache-bypass (active -> completed)

### DIFF
--- a/vbrief/completed/2026-05-05-915-fix-triage-cache-bypass.vbrief.json
+++ b/vbrief/completed/2026-05-05-915-fix-triage-cache-bypass.vbrief.json
@@ -7,7 +7,7 @@
   },
   "plan": {
     "title": "P0: triage_bulk.py bypasses Tier-1 cache and Tier-2 audit log -- iterates live gh issue list (#845 Story 4)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "scripts/triage_bulk.py iterates live `gh issue list` output and skips the .deft-cache/issues sidecar entirely. It also never reads vbrief/.eval/candidates.jsonl, so repeat runs silently re-action issues and poison the append-only audit log. Together this violates the Tier-1 / Tier-2 contracts documented in skills/deft-directive-refinement/SKILL.md and the #845 epic vBRIEF: cache is supposed to be the read surface, the audit log is supposed to short-circuit terminal/in-progress decisions. The fix rewrites the candidate source to walk .deft-cache/issues/<owner>-<repo>/*.json, intersects results with candidates_log records to skip terminal (accept | reject | mark-duplicate) and in-progress (defer | needs-ac) decisions (the latter overridable via a new --re-action flag), hard-fails with exit 2 when the cache is empty (no live-gh fallback), and re-enables the four task triage:bulk-* surfaces that PR #916 gated. A new tests/integration/test_triage_smoke.py file regression-covers the cache-only contract end-to-end via a fake-gh shim on PATH; tests/test_triage_bulk.py gains unit tests for _list_cached_candidates."
     },
@@ -60,6 +60,6 @@
         "title": "Issue #915: P0 -- bulk operations bypass cache"
       }
     ],
-    "updated": "2026-05-05T16:01:21Z"
+    "updated": "2026-05-05T16:44:49Z"
   }
 }


### PR DESCRIPTION
Post-merge lifecycle move for #915 cache-walk fix shipped via PR #920. Moves the vBRIEF from brief/active/ to brief/completed/ and flips plan.status from unning to completed per the swarm-cohort scope-complete convention (mirrors #913 chore commit 1ed52fa).

No code changes.