### PR TITLE
chore(vbrief,gitignore): post-v0.25.2 housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ vbrief/*.premigrate.*
 # transient evaluation artefacts. Never versioned -- the log is per-machine
 # operator state and would leak triage timing/identity if shared.
 vbrief/.eval/
+
+# Monitor scratch (poller scripts, banner-edit helpers, etc.)
+.swarm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **chore(vbrief,gitignore): post-v0.25.2 housekeeping** -- moves the two trailing v0.25.2-cohort vBRIEFs from `vbrief/active/` to `vbrief/completed/` (#914 bootstrap flag passthrough; #916 hot-fix gate) via `task reconcile:issues -- --apply-lifecycle-fixes`. The v0.25.2 cut shipped with `--allow-vbrief-drift` because the lifecycle reconcile was deferred to this housekeeping pass; the moves close the drift retroactively. Also adds `.swarm/` to `.gitignore` so monitor-scratch (poller scripts, banner-edit / pin-issue helpers, install-go-clean.ps1, etc.) does not pollute the working tree on future swarm sessions. Refs #915, #734.
 
 ### Fixed
 

--- a/vbrief/completed/2026-05-05-914-fix-bootstrap-flag-passthrough.vbrief.json
+++ b/vbrief/completed/2026-05-05-914-fix-bootstrap-flag-passthrough.vbrief.json
@@ -1,11 +1,11 @@
 {
   "vBRIEFInfo": {
     "version": "0.6",
-    "updated": "2026-05-05T15:38:42Z"
+    "updated": "2026-05-05T18:14:38Z"
   },
   "plan": {
     "title": "task: triage:bootstrap doesn't pass --limit / --state / --label through to populate (#900)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "Fix scripts/triage_bootstrap.py argparse to accept the full set of populate-side flags (--limit, --state, --label, --force, --use-gitcrawl, --ttl-seconds) and forward them to triage_cache.populate(...). The bootstrap is documented as a transparent wrapper but currently narrows the populate flag surface; #914 closes that gap so the skill's recommended scoped first-run incantation works verbatim."
     },
@@ -48,6 +48,6 @@
         "title": "Issue #914: task: triage:bootstrap doesn't pass --limit / --state / --label through to populate (#900)"
       }
     ],
-    "updated": "2026-05-05T15:18:04Z"
+    "updated": "2026-05-05T18:14:38Z"
   }
 }

--- a/vbrief/completed/2026-05-05-915-hotfix-disable-triage-bulk.vbrief.json
+++ b/vbrief/completed/2026-05-05-915-hotfix-disable-triage-bulk.vbrief.json
@@ -3,11 +3,11 @@
     "version": "0.6",
     "description": "Hot-fix: gate the user-facing `task triage:bulk-*` surface at the Taskfile layer pending the v0.25.2 cache-walk rewrite of scripts/triage_bulk.py (#915). Bulk operations as shipped in v0.25.0 / v0.25.1 bypass the .deft-cache contract and silently poison vbrief/.eval/candidates.jsonl; gating the four bulk-* tasks (bulk-accept / bulk-reject / bulk-defer / bulk-needs-ac) is a low-cost protective measure until the proper fix ships.",
     "created": "2026-05-05T14:35:06Z",
-    "updated": "2026-05-05T14:37:30Z"
+    "updated": "2026-05-05T18:14:38Z"
   },
   "plan": {
     "title": "fix(triage): disable bulk-* tasks pending v0.25.2 (#915 hot-fix)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Problem": "scripts/triage_bulk.py bypasses the .deft-cache contract and poisons vbrief/.eval/candidates.jsonl on every bulk-* invocation (#915). The proper fix is the cache-walk rewrite slated for v0.25.2; until it ships, every operator who runs `task triage:bulk-accept` / `bulk-reject` / `bulk-defer` / `bulk-needs-ac` against v0.25.0 or v0.25.1 corrupts the audit log. Single-issue triage actions (`task triage:accept` / `triage:reject` / `triage:defer` / `triage:needs-ac`) and the freshness gate (`task triage-bulk:refresh-active`) are NOT affected and remain the supported path.",
       "Action": "Gate the four bulk-* tasks at the Taskfile layer. Replace each cmds: block in tasks/triage-bulk.yml with a multi-line shell that prints an ASCII-only error message (citing #915 + pointing at the single-issue alternative) and exits 2. Update each task's `desc:` to begin with `[DISABLED v0.25.x]` so `task -l` surfaces the disabled state. Drop the per-task `env: PYTHONUTF8: \"1\"` block since python is no longer invoked. The refresh-active task is intentionally untouched -- it does not bypass the cache contract and remains the canonical pre-swarm freshness gate. scripts/triage_bulk.py itself is intentionally untouched -- the cache-walk rewrite is owned by the v0.25.2 fix.",
@@ -47,6 +47,6 @@
         "title": "Issue #915: scripts/triage_bulk.py bypasses .deft-cache contract and poisons vbrief/.eval/candidates.jsonl"
       }
     ],
-    "updated": "2026-05-05T14:37:25Z"
+    "updated": "2026-05-05T18:14:38Z"
   }
 }


### PR DESCRIPTION
## Summary

Post-v0.25.2 housekeeping. Closes the lifecycle drift the v0.25.2 cut deferred via `--allow-vbrief-drift`, and adds `.swarm/` to `.gitignore` so monitor-scratch from future swarm sessions doesn't pollute working trees.

## Changes

- **vBRIEF lifecycle moves** — runs `task reconcile:issues -- --apply-lifecycle-fixes` and stages the two clean renames it produces:
  - `vbrief/active/2026-05-05-914-fix-bootstrap-flag-passthrough.vbrief.json` → `vbrief/completed/` (Agent B's #914 fix; was stuck in `active/` because B exited early after escalating the rebase to monitor)
  - `vbrief/active/2026-05-05-915-hotfix-disable-triage-bulk.vbrief.json` → `vbrief/completed/` (the #916 hot-fix gate vBRIEF; was stuck since #916 merged earlier today)
- **`.gitignore`** — adds `.swarm/` entry so monitor-side scratch files (the canonical Greptile poller scripts dropped by `templates/swarm-greptile-poller-prompt.md`, banner-edit / pin-issue helper scripts, install-go-clean.ps1, etc.) are not surfaced as untracked files on every `git status`. They live entirely outside version control going forward.
- **CHANGELOG.md** — entry under `[Unreleased]` / `### Changed` recording both moves and the gitignore addition.

## Why this didn't ship in v0.25.2

The v0.25.2 release pipeline ran with `--allow-vbrief-drift` because the lifecycle reconcile would have surfaced the two trailing vBRIEFs and refused with `EXIT_VIOLATION`. The handoff explicitly authorized deferring the drift to a post-release housekeeping pass since this was a critical hot-fix release for the #915 P0 cache-bypass bug. This PR closes the drift retroactively.

## Refs

- #915 (P0 cache-bypass — load-bearing fix shipped in v0.25.2)
- #734 (vBRIEF-lifecycle reconciliation gate)
- v0.25.2 release: https://github.com/deftai/directive/releases/tag/v0.25.2
