### PR TITLE
chore(vbrief): #441 close-out -- move scope vBRIEF active/ -> completed/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmd/deft-install installer conformance audit for cohort #992: 3/8 assertions pass (marker v2 only); 5/8 fail (legacy deft/ deposit, no .gitignore upkeep on `.deft-cache/` / `vbrief/.eval/`, no `.deft/core/` deposit, no consumer-root `vbrief/` + schemas); drifts tracked as #1020 (adoption-blocker); see docs/audit-2026-05-10-installer-conformance.md
 
 ### Refinement
+- **chore(vbrief): #441 close-out -- scope vBRIEF moved active/ -> completed/ after PR #441 merged at 57bab6f.** Lifecycle bookkeeping for the maintainer-side merge-prep work that landed the `deft-directive-glossary` skill (rename + .agents/ stub + AGENTS.md routing + CHANGELOG entry). `plan.status` flipped `running` -> `completed` via `task scope:complete`. No code change.
 - **chore(992): cohort #992 closure -- vBRIEF moved active/ -> completed/; all 9 acceptance criteria items flipped to `completed` status; #1020 (cmd/deft-install F2 drift) tracked separately as adoption-blocker; closes #992**
 
 ## [0.27.1] - 2026-05-10

--- a/vbrief/completed/2026-05-11-441-prepare-pr441-deft-glossary-skill-for-merge.vbrief.json
+++ b/vbrief/completed/2026-05-11-441-prepare-pr441-deft-glossary-skill-for-merge.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(skills): prepare PR #441 deft-glossary for merge -- rename to deft-directive-glossary + .agents stub + AGENTS.md routing + CHANGELOG + rebase",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "PR #441 (feat(skills): add deft-glossary skill) is 22 days old, MERGEABLE + green CI but BEHIND master and violates four merge-bar contracts surfaced by Greptile review and by the current test suite. This scope covers the maintainer-side fixups needed to land the skill cleanly.",
       "Origin": "Maintainer-driven from PR review of https://github.com/deftai/directive/pull/441 (no underlying issue; PR is the canonical artifact).",
@@ -92,6 +92,6 @@
         "test_contracts_unblocked": "test_skills_dir_only_deft_directive_prefixed, test_skills_dir_has_no_bare_deft_prefix, test_agents_md_routing_path_exists, test_agents_md_routing_uses_directive_prefix"
       }
     },
-    "updated": "2026-05-11T03:14:47Z"
+    "updated": "2026-05-11T03:29:19Z"
   }
 }


### PR DESCRIPTION
chore(vbrief): #441 close-out -- move scope vBRIEF active/ -> completed/

Post-merge lifecycle bookkeeping for the deft-directive-glossary skill that
landed via PR #441 squash-merged at 57bab6f.

- task scope:complete moves the scope vBRIEF from vbrief/active/ to
  vbrief/completed/ and flips plan.status running -> completed.
- CHANGELOG.md [Unreleased] -> Refinement gains a one-line bookkeeping
  entry per AGENTS.md pre-commit convention.
- task check passes locally except for the pre-existing Windows-only
  scm.py -> gh subprocess DLL init failure documented on the prior PR
  (test_scm_issue_view_rest_returns_nonempty_json, reproduces on pristine
  origin/master, unrelated to this change; CI Linux/macOS lanes pass).

Refs #441.
