### PR TITLE
chore(vbrief): complete 2026-05-12 refinement cohort lifecycle

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -422,5 +422,9 @@ Larger feature work -- only after issues are resolved and content is stable.
 - **#1047** -- Implementation Intent Gate (#810): Taskfile target hardcodes deft/scripts/preflight_implementation.py; safety gate fails open in v0.27 install layout -- `[completed]`
 - **#401** -- feat(skills): prepare PR #441 deft-glossary for merge -- rename to deft-directive-glossary + .agents stub + AGENTS.md routing + CHANGELOG + rebase -- `[completed]`
 - **#757** -- Add probe strategy + deft-gh-slice/triage skills (re-author of #440) -- `[completed]`
+- **#1044** -- agents:refresh appends new v2 block instead of replacing v1 on marker-version drift -- `[completed]`
+- **#1059** -- framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub -- `[completed]`
+- **#1060** -- installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags -- `[completed]`
+- **#1061** -- framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph -- `[completed]`
 - **#1062** -- Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract -- `[completed]`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -422,4 +422,5 @@ Larger feature work -- only after issues are resolved and content is stable.
 - **#1047** -- Implementation Intent Gate (#810): Taskfile target hardcodes deft/scripts/preflight_implementation.py; safety gate fails open in v0.27 install layout -- `[completed]`
 - **#401** -- feat(skills): prepare PR #441 deft-glossary for merge -- rename to deft-directive-glossary + .agents stub + AGENTS.md routing + CHANGELOG + rebase -- `[completed]`
 - **#757** -- Add probe strategy + deft-gh-slice/triage skills (re-author of #440) -- `[completed]`
+- **#1062** -- Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract -- `[completed]`
 

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-05-12T02:42:20Z"
+    "updated": "2026-05-12T04:39:29Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -888,70 +888,6 @@
               "uri": "https://github.com/deftai/directive/issues/762",
               "type": "x-vbrief/github-issue",
               "title": "Issue #762: feat(vbrief): centralize phase taxonomy in PROJECT-DEFINITION.vbrief.json; renderer reads from there"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1044-agentsrefresh-appends-new-v2-block-instead-of-replacing-v1-o",
-        "title": "agents:refresh appends new v2 block instead of replacing v1 on marker-version drift",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-12-1044-agentsrefresh-appends-new-v2-block-instead-of-replacing-v1-o.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1044",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1044: agents:refresh appends new v2 block instead of replacing v1 on marker-version drift"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1059-frameworkdoctor-and-check-updates-fail-on-windows-tasksframe",
-        "title": "framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-12-1059-frameworkdoctor-and-check-updates-fail-on-windows-tasksframe.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1059",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1059: framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1060-installer-writeagentsmd-skips-legacy-agentsmd-on-canonical-i",
-        "title": "installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-12-1060-installer-writeagentsmd-skips-legacy-agentsmd-on-canonical-i.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1060",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1060: installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1061-frameworkdoctor-failure-prose-names-commands-that-dont-exist",
-        "title": "framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-12-1061-frameworkdoctor-failure-prose-names-commands-that-dont-exist.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1061",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1061: framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph"
             }
           ]
         }
@@ -7309,6 +7245,70 @@
         }
       },
       {
+        "id": "2026-05-12-1044-agentsrefresh-appends-new-v2-block-instead-of-replacing-v1-o",
+        "title": "agents:refresh appends new v2 block instead of replacing v1 on marker-version drift",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1044-agentsrefresh-appends-new-v2-block-instead-of-replacing-v1-o.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1044",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1044: agents:refresh appends new v2 block instead of replacing v1 on marker-version drift"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-12-1059-frameworkdoctor-and-check-updates-fail-on-windows-tasksframe",
+        "title": "framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1059-frameworkdoctor-and-check-updates-fail-on-windows-tasksframe.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1059",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1059: framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-12-1060-installer-writeagentsmd-skips-legacy-agentsmd-on-canonical-i",
+        "title": "installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1060-installer-writeagentsmd-skips-legacy-agentsmd-on-canonical-i.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1060",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1060: installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-12-1061-frameworkdoctor-failure-prose-names-commands-that-dont-exist",
+        "title": "framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1061-frameworkdoctor-failure-prose-names-commands-that-dont-exist.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1061",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1061: framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph"
+            }
+          ]
+        }
+      },
+      {
         "id": "2026-05-12-1062-add-install-root-field-to-installversion-manifest-single-sou",
         "title": "Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract",
         "status": "completed",
@@ -7333,6 +7333,7 @@
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'Stale cross-references to legacy paths' shares topics (legacy)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'Strengthen spec validation gate: add CI freshness check detecting stale `SPECIFICATION.md` (schema checks landed in PR #130 -- `spec_validate.py` now enforces vBRIEF v0.5 structure, status enum, legacy key detection)' shares topics (legacy)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'docs(readme): add \"Your Artifacts\" section documenting user-generated artifact locations' shares topics (artifacts)",
+        "Narrative 'LegacyArtifacts' may be stale: completed scope 'installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags' shares topics (legacy)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6' shares topics (legacy)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'rollback: empty `vbrief/legacy/` directory left behind after --rollback' shares topics (legacy)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'rollback: orphaned `LEGACY-REPORT.reviewed.md` after Phase 6c rename (companion to #527)' shares topics (legacy)",

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-05-12T02:01:57Z"
+    "updated": "2026-05-12T02:42:20Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -952,22 +952,6 @@
               "uri": "https://github.com/deftai/directive/issues/1061",
               "type": "x-vbrief/github-issue",
               "title": "Issue #1061: framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1062-add-install-root-field-to-installversion-manifest-single-sou",
-        "title": "Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-12-1062-add-install-root-field-to-installversion-manifest-single-sou.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1062",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1062: Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract"
             }
           ]
         }
@@ -7320,6 +7304,22 @@
               "uri": "https://github.com/mattpocock/skills",
               "type": "x-vbrief/related-repo",
               "title": "mattpocock/skills (inspiration: grill-me, to-issues, triage-issue)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-12-1062-add-install-root-field-to-installversion-manifest-single-sou",
+        "title": "Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1062-add-install-root-field-to-installversion-manifest-single-sou.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1062",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1062: Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract"
             }
           ]
         }

--- a/vbrief/completed/2026-05-12-1044-agentsrefresh-appends-new-v2-block-instead-of-replacing-v1-o.vbrief.json
+++ b/vbrief/completed/2026-05-12-1044-agentsrefresh-appends-new-v2-block-instead-of-replacing-v1-o.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "agents:refresh appends new v2 block instead of replacing v1 on marker-version drift",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "agents:refresh appends new v2 block instead of replacing v1 on marker-version drift",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1044",
@@ -23,6 +23,6 @@
         "title": "Issue #1044: agents:refresh appends new v2 block instead of replacing v1 on marker-version drift"
       }
     ],
-    "updated": "2026-05-12T01:35:10Z"
+    "updated": "2026-05-12T04:39:22Z"
   }
 }

--- a/vbrief/completed/2026-05-12-1059-frameworkdoctor-and-check-updates-fail-on-windows-tasksframe.vbrief.json
+++ b/vbrief/completed/2026-05-12-1059-frameworkdoctor-and-check-updates-fail-on-windows-tasksframe.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1059",
@@ -23,6 +23,6 @@
         "title": "Issue #1059: framework:doctor (and check-updates) fail on Windows -- tasks/framework.yml hardcodes python3, hits Store stub"
       }
     ],
-    "updated": "2026-05-12T01:35:10Z"
+    "updated": "2026-05-12T04:39:23Z"
   }
 }

--- a/vbrief/completed/2026-05-12-1060-installer-writeagentsmd-skips-legacy-agentsmd-on-canonical-i.vbrief.json
+++ b/vbrief/completed/2026-05-12-1060-installer-writeagentsmd-skips-legacy-agentsmd-on-canonical-i.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1060",
@@ -23,6 +23,6 @@
         "title": "Issue #1060: installer: WriteAgentsMD skips legacy AGENTS.md on canonical install -- leaves install-root drift the doctor flags"
       }
     ],
-    "updated": "2026-05-12T01:35:10Z"
+    "updated": "2026-05-12T04:39:23Z"
   }
 }

--- a/vbrief/completed/2026-05-12-1061-frameworkdoctor-failure-prose-names-commands-that-dont-exist.vbrief.json
+++ b/vbrief/completed/2026-05-12-1061-frameworkdoctor-failure-prose-names-commands-that-dont-exist.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1061",
@@ -23,6 +23,6 @@
         "title": "Issue #1061: framework:doctor failure prose names commands that don't exist; sharpen + add UPGRADING.md mitigation paragraph"
       }
     ],
-    "updated": "2026-05-12T01:35:10Z"
+    "updated": "2026-05-12T04:39:23Z"
   }
 }

--- a/vbrief/completed/2026-05-12-1062-add-install-root-field-to-installversion-manifest-single-sou.vbrief.json
+++ b/vbrief/completed/2026-05-12-1062-add-install-root-field-to-installversion-manifest-single-sou.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1062",
@@ -23,6 +23,6 @@
         "title": "Issue #1062: Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract"
       }
     ],
-    "updated": "2026-05-12T01:35:11Z"
+    "updated": "2026-05-12T02:42:09Z"
   }
 }


### PR DESCRIPTION
Lifecycle bookkeeping for the 2026-05-12 refinement cohort. Moves the 5 vBRIEFs from brief/active/ to brief/completed/ after their PRs landed via the v0.29.0 cascade (#1063 / #1064 / #1066 / #1065 / #1067).

No code changes -- only vBRIEF JSON renames + derived-artifact regeneration (ROADMAP.md, PROJECT-DEFINITION.vbrief.json).

Part of v0.29.0 release prep.
