### PR TITLE
chore(vbrief): lifecycle-complete #1072 + #1073 post-merge

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -429,4 +429,6 @@ Larger feature work -- only after issues are resolved and content is stable.
 - **#1062** -- Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract -- `[completed]`
 - **#1070** -- chore(security): supply-chain quick wins -- PEM fixture, curl|bash, dependabot.yml (parent #1069) -- `[completed]`
 - **#1071** -- chore(security): resolve 40 OSV advisories across committed manifests (parent #1069) -- `[completed]`
+- **#1072** -- chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069) -- `[completed]`
+- **#1073** -- docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069) -- `[completed]`
 

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-05-12T16:34:06Z"
+    "updated": "2026-05-12T17:22:26Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -920,38 +920,6 @@
               "uri": "https://github.com/deftai/directive/issues/762",
               "type": "x-vbrief/github-issue",
               "title": "Issue #762: feat(vbrief): centralize phase taxonomy in PROJECT-DEFINITION.vbrief.json; renderer reads from there"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1072-choresecurity-pin-github-actions-to-shas-least-privilege-per",
-        "title": "chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069)",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-12-1072-choresecurity-pin-github-actions-to-shas-least-privilege-per.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1072",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1072: chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1073-docssecurity-record-2026-05-12-audit-baseline-in-docssecurit",
-        "title": "docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069)",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-12-1073-docssecurity-record-2026-05-12-audit-baseline-in-docssecurit.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1073",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1073: docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069)"
             }
           ]
         }
@@ -7416,6 +7384,38 @@
               "uri": "https://github.com/deftai/directive/issues/1071",
               "type": "x-vbrief/github-issue",
               "title": "Issue #1071: chore(security): resolve 40 OSV advisories across committed manifests (parent #1069)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-12-1072-choresecurity-pin-github-actions-to-shas-least-privilege-per",
+        "title": "chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069)",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1072-choresecurity-pin-github-actions-to-shas-least-privilege-per.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1072",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1072: chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-12-1073-docssecurity-record-2026-05-12-audit-baseline-in-docssecurit",
+        "title": "docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069)",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1073-docssecurity-record-2026-05-12-audit-baseline-in-docssecurit.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1073",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1073: docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069)"
             }
           ]
         }

--- a/vbrief/completed/2026-05-12-1072-choresecurity-pin-github-actions-to-shas-least-privilege-per.vbrief.json
+++ b/vbrief/completed/2026-05-12-1072-choresecurity-pin-github-actions-to-shas-least-privilege-per.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1072",
@@ -19,6 +19,6 @@
         "title": "Issue #1072: chore(security): pin GitHub Actions to SHAs + least-privilege permissions + PyPI OIDC (parent #1069)"
       }
     ],
-    "updated": "2026-05-12T16:34:05Z"
+    "updated": "2026-05-12T17:22:26Z"
   }
 }

--- a/vbrief/completed/2026-05-12-1073-docssecurity-record-2026-05-12-audit-baseline-in-docssecurit.vbrief.json
+++ b/vbrief/completed/2026-05-12-1073-docssecurity-record-2026-05-12-audit-baseline-in-docssecurit.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1073",
@@ -19,6 +19,6 @@
         "title": "Issue #1073: docs(security): record 2026-05-12 audit baseline in docs/security.md (parent #1069)"
       }
     ],
-    "updated": "2026-05-12T16:34:05Z"
+    "updated": "2026-05-12T17:22:26Z"
   }
 }


### PR DESCRIPTION
## Summary

Lifecycle-complete cohort closure for the 2026-05-12 supply-chain audit (#1069). Moves the two merged child scope vBRIEFs `vbrief/active/` -> `vbrief/completed/` and re-renders derived artifacts (PROJECT-DEFINITION.vbrief.json + ROADMAP.md) as the single batch checkpoint per refinement Phase 4.

## Cohort summary

| Scope | Implementation PR | Closed |
|---|---|---|
| #1069 | (umbrella) | by PR #1086 |
| #1070 | #1077 (PEM fixture + curl/bash + dependabot) | v0.29.1 |
| #1071 | #1076 (OSV advisories -> Go 1.25) | v0.29.1 |
| #1072 | #1087 (Actions SHA-pin + least-priv permissions) | this cycle |
| #1073 | #1086 (docs/security.md baseline) | this cycle |

#1084 (PyPI OIDC trusted-publishing) intentionally stays OPEN; blocked-by #11 (deft is not yet on PyPI).

## Changes

- `vbrief/active/2026-05-12-1072-...vbrief.json` -> `vbrief/completed/...` (status: completed)
- `vbrief/active/2026-05-12-1073-...vbrief.json` -> `vbrief/completed/...` (status: completed)
- `vbrief/PROJECT-DEFINITION.vbrief.json` items registry refreshed (400 scope items)
- `ROADMAP.md` re-rendered

## Checklist

- [x] `task scope:complete` on both vBRIEFs; `plan.status` flipped `running` -> `completed`
- [x] `task project:render` + `task roadmap:render` single batch checkpoint
- [x] No upstream issues closed by this PR -- lifecycle bookkeeping only (the implementation PRs already closed #1069/#1072/#1073 via squash-merge closing keywords)

## Related issues

Refs #1069, #1072, #1073, #1084.
