### PR TITLE
chore(vbrief): lifecycle-sync #1069 umbrella scope vBRIEF -> completed/

### DIFF
--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-05-12T17:22:26Z"
+    "updated": "2026-05-12T17:27:10Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -131,22 +131,6 @@
               "uri": "https://github.com/deftai/deft-agent-bench",
               "type": "x-vbrief/related-repo",
               "title": "deft-agent-bench (internal): bench infrastructure for this validation effort"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-12-1069-choresecurity-supply-chain-ci-hygiene-gitleaks-pem-fixture-c",
-        "title": "chore(security): supply-chain & CI hygiene — gitleaks PEM fixture, curl|bash in CI, 40 OSV advisories, no Dependabot",
-        "status": "proposed",
-        "metadata": {
-          "source_path": "proposed/2026-05-12-1069-choresecurity-supply-chain-ci-hygiene-gitleaks-pem-fixture-c.vbrief.json",
-          "lifecycle_folder": "proposed",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1069",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1069: chore(security): supply-chain & CI hygiene — gitleaks PEM fixture, curl|bash in CI, 40 OSV advisories, no Dependabot"
             }
           ]
         }
@@ -7352,6 +7336,22 @@
               "uri": "https://github.com/deftai/directive/issues/1062",
               "type": "x-vbrief/github-issue",
               "title": "Issue #1062: Add install_root field to <install>/VERSION manifest -- single source of truth for install-layout contract"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-12-1069-choresecurity-supply-chain-ci-hygiene-gitleaks-pem-fixture-c",
+        "title": "chore(security): supply-chain & CI hygiene — gitleaks PEM fixture, curl|bash in CI, 40 OSV advisories, no Dependabot",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-12-1069-choresecurity-supply-chain-ci-hygiene-gitleaks-pem-fixture-c.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1069",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1069: chore(security): supply-chain & CI hygiene — gitleaks PEM fixture, curl|bash in CI, 40 OSV advisories, no Dependabot"
             }
           ]
         }

--- a/vbrief/completed/2026-05-12-1069-choresecurity-supply-chain-ci-hygiene-gitleaks-pem-fixture-c.vbrief.json
+++ b/vbrief/completed/2026-05-12-1069-choresecurity-supply-chain-ci-hygiene-gitleaks-pem-fixture-c.vbrief.json
@@ -1,11 +1,12 @@
 {
   "vBRIEFInfo": {
     "version": "0.6",
-    "description": "Scope vBRIEF ingested from GitHub issue #1069"
+    "description": "Scope vBRIEF ingested from GitHub issue #1069",
+    "updated": "2026-05-12T17:26:46Z"
   },
   "plan": {
     "title": "chore(security): supply-chain & CI hygiene — gitleaks PEM fixture, curl|bash in CI, 40 OSV advisories, no Dependabot",
-    "status": "proposed",
+    "status": "completed",
     "narratives": {
       "Description": "chore(security): supply-chain & CI hygiene — gitleaks PEM fixture, curl|bash in CI, 40 OSV advisories, no Dependabot",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1069",
@@ -18,6 +19,7 @@
         "type": "x-vbrief/github-issue",
         "title": "Issue #1069: chore(security): supply-chain & CI hygiene — gitleaks PEM fixture, curl|bash in CI, 40 OSV advisories, no Dependabot"
       }
-    ]
+    ],
+    "updated": "2026-05-12T17:26:46Z"
   }
 }


### PR DESCRIPTION
Move the #1069 omnibus tracker vBRIEF \brief/proposed/\ -> \brief/completed/\ via \	ask reconcile:issues -- --apply-lifecycle-fixes\ so the on-disk lifecycle folders align with the upstream closure of #1069 (PR #1086 closed the umbrella at 17:23:38Z). Required to clear the #734 release-pipeline lifecycle-sync gate ahead of cutting v0.29.2.\n\nLifecycle bookkeeping only -- no upstream issues closed by this PR.\n\nRefs #1069.