### PR TITLE
feat(directive): add decomposition readiness layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ When user input matches a trigger keyword, read the corresponding skill:
 
 - "review cycle" / "check reviews" / "run review cycle" → `skills/deft-directive-review-cycle/SKILL.md`
 - "swarm" / "parallel agents" / "run agents" → `skills/deft-directive-swarm/SKILL.md` — chains to `deft-directive-review-cycle` at Phase 5
+- "decompose" / "story decomposition" / "swarm readiness" → `skills/deft-directive-decompose/SKILL.md` — converts phase/epic scopes into swarm-ready story vBRIEFs before swarm allocation
 - "refinement" / "reprioritize" / "refine" → `skills/deft-directive-refinement/SKILL.md` — chains to `deft-directive-review-cycle` at exit
 - "build" / "implement" / "implement spec" → `skills/deft-directive-build/SKILL.md`
 - "cost" / "budget" / "pre-build cost" / "how much will this cost" → `skills/deft-directive-cost/SKILL.md`
@@ -155,4 +156,3 @@ Cross-references: `pyproject.toml` (marker registration + default opt-out), `Tas
 
 Note: paths here are root-relative — this repo IS the deft directory.
 Install-generated AGENTS.md uses deft/-prefixed paths.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **feat(directive): add story decomposition and swarm-readiness gates** -- introduces Phase 4.5 Story Decomposition / Swarm Readiness between Speckit phase/epic scope emission and swarm implementation. Adds deterministic `task scope:decompose` and `task swarm:readiness` commands, a canonical `plan.metadata.kind` / `plan.metadata.swarm` story contract, a new `deft-directive-decompose` skill, swarm Phase 0 readiness gating, acceptance-preserving spec rendering, and regression coverage for decomposition, readiness, Speckit translation, and stale vBRIEF template guidance.
 
 ### Changed
 
@@ -2830,4 +2831,3 @@ If you have custom scripts or references to deft files, update these paths:
 [0.2.0]: https://github.com/visionik/warping/releases/tag/v0.2.0
 
 [0.1.0]: https://github.com/visionik/warping/releases/tag/v0.1.0
-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -97,6 +97,9 @@ includes:
   scope:
     taskfile: ./tasks/scope.yml
     optional: true
+  swarm:
+    taskfile: ./tasks/swarm.yml
+    optional: true
   roadmap:
     taskfile: ./tasks/roadmap.yml
     optional: true

--- a/scripts/_vbrief_speckit.py
+++ b/scripts/_vbrief_speckit.py
@@ -23,7 +23,7 @@ from _vbrief_build import (
 def edge_nodes(edge: dict) -> tuple[str, str]:
     """Return (from_id, to_id) for a vBRIEF edge, reading both dialects.
 
-    The canonical v0.5 key names are ``from`` / ``to``, but earlier speckit
+    The canonical v0.6 key names are ``from`` / ``to``, but earlier speckit
     drafts used ``source`` / ``target``.  Prefer the canonical keys when
     they are populated and fall back to the legacy keys.
     """
@@ -119,7 +119,7 @@ def create_speckit_scope_vbrief(
         if isinstance(value, str) and value.strip():
             narratives[extra] = value.strip()
 
-    references = [{"type": "x-vbrief/plan", "url": spec_ref}]
+    references = [{"type": "x-vbrief/plan", "uri": spec_ref}]
     for ref in item.get("references", []) or []:
         if isinstance(ref, dict) and ref.get("type") != "x-vbrief/plan":
             references.append(ref)
@@ -129,10 +129,11 @@ def create_speckit_scope_vbrief(
         "status": "pending",
         "narratives": narratives,
         "items": [],
+        "metadata": {"kind": "phase"},
         "references": references,
     }
     if dependencies:
-        plan["metadata"] = {"dependencies": list(dependencies)}
+        plan["metadata"]["dependencies"] = list(dependencies)
 
     return {
         "vBRIEFInfo": {
@@ -148,7 +149,7 @@ def migrate_speckit_plan(
     *,
     pending_dir: Path | None = None,
     date: str | None = None,
-    spec_ref: str = "../specification.vbrief.json",
+    spec_ref: str = "./specification.vbrief.json",
     today: str | None = None,
 ) -> tuple[bool, list[str]]:
     """Translate a speckit-shaped ``plan.vbrief.json`` into scope vBRIEFs.

--- a/scripts/migrate_vbrief.py
+++ b/scripts/migrate_vbrief.py
@@ -2316,7 +2316,7 @@ def _create_speckit_scope_vbrief(
             narratives[extra] = value.strip()
 
     references = [
-        {"type": "x-vbrief/plan", "url": spec_ref},
+        {"type": "x-vbrief/plan", "uri": spec_ref},
     ]
     # Copy any origin-provenance refs from the item (e.g. github-issue).
     for ref in item.get("references", []) or []:
@@ -2328,10 +2328,11 @@ def _create_speckit_scope_vbrief(
         "status": "pending",
         "narratives": narratives,
         "items": [],
+        "metadata": {"kind": "phase"},
         "references": references,
     }
     if dependencies:
-        plan["metadata"] = {"dependencies": list(dependencies)}
+        plan["metadata"]["dependencies"] = list(dependencies)
 
     return {
         "vBRIEFInfo": {
@@ -2347,7 +2348,7 @@ def migrate_speckit_plan(
     *,
     pending_dir: Path | None = None,
     date: str | None = None,
-    spec_ref: str = "../specification.vbrief.json",
+    spec_ref: str = "./specification.vbrief.json",
 ) -> tuple[bool, list[str]]:
     """Translate a speckit-shaped ``plan.vbrief.json`` into scope vBRIEFs.
 

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Apply or validate an approved epic/phase -> story decomposition draft.
+
+The command is intentionally deterministic: it never invents stories from a
+parent scope. A caller supplies a draft with child story definitions; this
+script validates that draft, writes the child story vBRIEFs, and updates the
+parent scope references.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from _vbrief_build import EMITTED_VBRIEF_VERSION, slugify  # noqa: E402
+
+reconfigure_stdio()
+
+LIFECYCLE_FOLDERS = {"proposed", "pending", "active", "completed", "cancelled"}
+READY = "ready"
+
+
+class DecompositionError(ValueError):
+    """Raised when a decomposition draft is not safe to apply."""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DecompositionError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DecompositionError(f"{path}: expected a JSON object")
+    return data
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _resolve_path(project_root: Path, value: str | None) -> Path | None:
+    if not value:
+        return None
+    path = Path(value)
+    return path if path.is_absolute() else project_root / path
+
+
+def _vbrief_dir(project_root: Path) -> Path:
+    return project_root / "vbrief"
+
+
+def _rel_to_vbrief(vbrief_dir: Path, path: Path) -> str:
+    rel = path.resolve().relative_to(vbrief_dir.resolve()).as_posix()
+    return f"./{rel}"
+
+
+def _scope_folder(parent_path: Path, vbrief_dir: Path) -> Path:
+    if parent_path.parent.name in LIFECYCLE_FOLDERS:
+        return parent_path.parent
+    return vbrief_dir / "pending"
+
+
+def _default_status_for_folder(folder: Path) -> str:
+    return {
+        "proposed": "proposed",
+        "pending": "pending",
+        "active": "running",
+        "completed": "completed",
+        "cancelled": "cancelled",
+    }.get(folder.name, "pending")
+
+
+def _story_specs(draft: dict[str, Any]) -> list[dict[str, Any]]:
+    stories = draft.get("stories", draft.get("children", []))
+    if isinstance(stories, dict):
+        stories = list(stories.values())
+    if not isinstance(stories, list):
+        raise DecompositionError("draft must contain a stories array")
+    normalized: list[dict[str, Any]] = []
+    for index, story in enumerate(stories, start=1):
+        if not isinstance(story, dict):
+            raise DecompositionError(f"stories[{index}] must be an object")
+        normalized.append(story)
+    return normalized
+
+
+def _story_id(story: dict[str, Any], index: int) -> str:
+    raw = story.get("id") or story.get("story_id") or story.get("key")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    title = str(story.get("title") or f"story-{index}")
+    return slugify(title) or f"story-{index}"
+
+
+def _swarm_meta(story: dict[str, Any]) -> dict[str, Any]:
+    metadata = story.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    swarm = story.get("swarm") or metadata.get("swarm") or {}
+    if not isinstance(swarm, dict):
+        swarm = {}
+    # Accept the convenient draft shape where canonical swarm fields live at
+    # the story top level, then store them under plan.metadata.swarm.
+    for key in (
+        "readiness",
+        "parallel_safe",
+        "file_scope",
+        "verify_commands",
+        "expected_outputs",
+        "depends_on",
+        "conflict_group",
+        "size",
+        "file_scope_confidence",
+        "model_tier",
+        "missing_traces_justification",
+    ):
+        if key in story and key not in swarm:
+            swarm[key] = story[key]
+    swarm.setdefault("readiness", READY)
+    swarm.setdefault("parallel_safe", True)
+    swarm.setdefault("depends_on", [])
+    return swarm
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _item_has_acceptance(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        value = narrative.get("Acceptance")
+        if isinstance(value, str) and value.strip():
+            return True
+    for child_key in ("items", "subItems"):
+        children = item.get(child_key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_acceptance(child):
+                    return True
+    return False
+
+
+def _items_have_acceptance(items: list[Any]) -> bool:
+    return any(isinstance(item, dict) and _item_has_acceptance(item) for item in items)
+
+
+def _item_has_traces(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        value = narrative.get("Traces")
+        if isinstance(value, str) and value.strip():
+            return True
+    for child_key in ("items", "subItems"):
+        children = item.get(child_key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_traces(child):
+                    return True
+    return False
+
+
+def _story_has_traces(story: dict[str, Any], items: list[Any], swarm: dict[str, Any]) -> bool:
+    narratives = story.get("narratives")
+    if isinstance(narratives, dict):
+        value = narratives.get("Traces")
+        if isinstance(value, str) and value.strip():
+            return True
+    if _as_str_list(story.get("traces")):
+        return True
+    if any(isinstance(item, dict) and _item_has_traces(item) for item in items):
+        return True
+    if _as_str_list(swarm.get("missing_traces_justification")):
+        return True
+    refs = story.get("references")
+    if isinstance(refs, list):
+        for ref in refs:
+            if isinstance(ref, dict) and ref.get("type") == "x-vbrief/spec-section":
+                return True
+    return False
+
+
+def _items_from_story(story_id: str, story: dict[str, Any]) -> list[Any]:
+    items = story.get("items")
+    if isinstance(items, list) and items:
+        return items
+    acceptance = _as_str_list(story.get("acceptance"))
+    if not acceptance:
+        acceptance = _as_str_list(story.get("acceptance_items"))
+    traces = ", ".join(_as_str_list(story.get("traces")))
+    generated: list[dict[str, Any]] = []
+    for index, criterion in enumerate(acceptance, start=1):
+        narrative = {"Acceptance": criterion}
+        if traces:
+            narrative["Traces"] = traces
+        generated.append(
+            {
+                "id": f"{story_id}-a{index}",
+                "title": criterion,
+                "status": "pending",
+                "narrative": narrative,
+            }
+        )
+    return generated
+
+
+def _validate_dag(story_ids: list[str], deps_by_story: dict[str, list[str]]) -> None:
+    known = set(story_ids)
+    for story_id, deps in deps_by_story.items():
+        for dep in deps:
+            if dep not in known:
+                raise DecompositionError(f"{story_id}: depends_on references unknown story {dep!r}")
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(story_id: str, path: list[str]) -> None:
+        if story_id in visited:
+            return
+        if story_id in visiting:
+            cycle = " -> ".join([*path, story_id])
+            raise DecompositionError(f"dependency cycle detected: {cycle}")
+        visiting.add(story_id)
+        for dep in deps_by_story.get(story_id, []):
+            visit(dep, [*path, story_id])
+        visiting.remove(story_id)
+        visited.add(story_id)
+
+    for story_id in story_ids:
+        visit(story_id, [])
+
+
+def validate_draft(stories: list[dict[str, Any]]) -> list[str]:
+    """Validate draft story contracts and return ordered story ids."""
+    story_ids: list[str] = []
+    deps_by_story: dict[str, list[str]] = {}
+    seen: set[str] = set()
+    for index, story in enumerate(stories, start=1):
+        story_id = _story_id(story, index)
+        if story_id in seen:
+            raise DecompositionError(f"duplicate story id {story_id!r}")
+        seen.add(story_id)
+        story_ids.append(story_id)
+        swarm = _swarm_meta(story)
+        deps = _as_str_list(swarm.get("depends_on") or story.get("depends_on"))
+        deps_by_story[story_id] = deps
+
+        if swarm.get("readiness") != READY:
+            continue
+
+        items = _items_from_story(story_id, story)
+        missing: list[str] = []
+        if not items:
+            missing.append("plan.items")
+        if items and not _items_have_acceptance(items):
+            missing.append("plan.items[].narrative.Acceptance")
+        if not _as_str_list(swarm.get("file_scope")):
+            missing.append("plan.metadata.swarm.file_scope")
+        if not _as_str_list(swarm.get("verify_commands")):
+            missing.append("plan.metadata.swarm.verify_commands")
+        if not _story_has_traces(story, items, swarm):
+            missing.append("Traces or missing_traces_justification")
+        if missing:
+            raise DecompositionError(f"{story_id}: ready story missing {', '.join(missing)}")
+
+    _validate_dag(story_ids, deps_by_story)
+    return story_ids
+
+
+def _normalize_references(refs: Any) -> list[dict[str, Any]]:
+    if not isinstance(refs, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for ref in refs:
+        if isinstance(ref, dict):
+            normalized.append(copy.deepcopy(ref))
+    return normalized
+
+
+def _dedupe_references(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for ref in refs:
+        key = (
+            str(ref.get("uri") or ref.get("url") or ""),
+            str(ref.get("type") or ""),
+            str(ref.get("title") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ref)
+    return out
+
+
+def _story_narratives(story: dict[str, Any]) -> dict[str, str]:
+    narratives: dict[str, str] = {}
+    raw = story.get("narratives")
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            if isinstance(value, str) and value.strip():
+                narratives[key] = value.strip()
+    for draft_key, narrative_key in (
+        ("description", "Description"),
+        ("summary", "Description"),
+        ("traces", "Traces"),
+    ):
+        if narrative_key in narratives:
+            continue
+        values = _as_str_list(story.get(draft_key))
+        if values:
+            narratives[narrative_key] = ", ".join(values)
+    return narratives
+
+
+def _child_filename(story: dict[str, Any], story_id: str, title: str, date: str) -> str:
+    filename = story.get("filename")
+    if isinstance(filename, str) and filename.endswith(".vbrief.json"):
+        return filename
+    slug = slugify(title) or slugify(story_id) or "story"
+    return f"{date}-{slug}.vbrief.json"
+
+
+def _build_child_vbrief(
+    *,
+    story: dict[str, Any],
+    story_id: str,
+    story_index: int,
+    parent: dict[str, Any],
+    parent_rel: str,
+    status: str,
+) -> dict[str, Any]:
+    title = str(story.get("title") or story_id)
+    swarm = _swarm_meta(story)
+    items = _items_from_story(story_id, story)
+    metadata = (
+        copy.deepcopy(story.get("metadata"))
+        if isinstance(story.get("metadata"), dict)
+        else {}
+    )
+    metadata["kind"] = "story"
+    metadata["swarm"] = swarm
+
+    parent_plan = parent.get("plan", {}) if isinstance(parent, dict) else {}
+    parent_refs = (
+        _normalize_references(parent_plan.get("references"))
+        if isinstance(parent_plan, dict)
+        else []
+    )
+    story_refs = _normalize_references(story.get("references"))
+
+    return {
+        "vBRIEFInfo": {
+            "version": EMITTED_VBRIEF_VERSION,
+            "description": f"Story vBRIEF {story_index} decomposed from {parent_rel}",
+        },
+        "plan": {
+            "id": story_id,
+            "title": title,
+            "status": str(story.get("status") or status),
+            "planRef": parent_rel,
+            "narratives": _story_narratives(story),
+            "items": items,
+            "metadata": metadata,
+            "references": _dedupe_references([*parent_refs, *story_refs]),
+        },
+    }
+
+
+def apply_decomposition(
+    *,
+    project_root: Path,
+    parent_path: Path,
+    draft_path: Path,
+    check_only: bool,
+    date: str,
+) -> list[str]:
+    vbrief_dir = _vbrief_dir(project_root)
+    parent = _load_json(parent_path)
+    draft = _load_json(draft_path)
+    stories = _story_specs(draft)
+    story_ids = validate_draft(stories)
+    output_dir = _resolve_path(
+        project_root, str(draft.get("output_dir", ""))
+    ) or _scope_folder(parent_path, vbrief_dir)
+    if output_dir.name not in LIFECYCLE_FOLDERS:
+        raise DecompositionError("output_dir must be a vbrief lifecycle folder")
+    status = str(draft.get("status") or _default_status_for_folder(output_dir))
+    parent_rel = _rel_to_vbrief(vbrief_dir, parent_path)
+
+    actions = [f"VALIDATED {len(stories)} story decomposition draft"]
+    child_paths: list[tuple[Path, str, str]] = []
+    child_docs: list[dict[str, Any]] = []
+    for index, story in enumerate(stories, start=1):
+        story_id = story_ids[index - 1]
+        title = str(story.get("title") or story_id)
+        filename = _child_filename(story, story_id, title, date)
+        target = output_dir / filename
+        if target.exists() and not check_only:
+            raise DecompositionError(f"{target}: refusing to overwrite existing child story")
+        child = _build_child_vbrief(
+            story=story,
+            story_id=story_id,
+            story_index=index,
+            parent=parent,
+            parent_rel=parent_rel,
+            status=status,
+        )
+        child_paths.append((target, story_id, title))
+        child_docs.append(child)
+        verb = "CHECK" if check_only else "CREATE"
+        actions.append(f"{verb} {_rel_to_vbrief(vbrief_dir, target)}")
+
+    if check_only:
+        return actions
+
+    for target, _story_id, _title in child_paths:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    for (target, _story_id, _title), child in zip(child_paths, child_docs, strict=True):
+        _write_json(target, child)
+
+    parent_plan = parent.setdefault("plan", {})
+    if not isinstance(parent_plan, dict):
+        raise DecompositionError(f"{parent_path}: plan must be an object")
+    metadata = parent_plan.setdefault("metadata", {})
+    if isinstance(metadata, dict):
+        metadata.setdefault("kind", "epic")
+    references = parent_plan.setdefault("references", [])
+    if not isinstance(references, list):
+        references = []
+        parent_plan["references"] = references
+    for target, _story_id, title in child_paths:
+        references.append(
+            {
+                "uri": _rel_to_vbrief(vbrief_dir, target),
+                "type": "x-vbrief/plan",
+                "title": title,
+            }
+        )
+    parent_plan["references"] = _dedupe_references(
+        [ref for ref in references if isinstance(ref, dict)]
+    )
+    _write_json(parent_path, parent)
+    actions.append(f"UPDATE {parent_rel} references")
+    return actions
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and apply an approved epic/phase story decomposition draft."
+    )
+    parser.add_argument("parent", nargs="?", help="Parent epic/phase vBRIEF path")
+    parser.add_argument("--draft", help="Approved decomposition JSON draft")
+    parser.add_argument("--check", action="store_true", help="Validate only; do not write")
+    parser.add_argument("--date", help="Creation date for generated child filenames")
+    parser.add_argument("--project-root", default=".", help="Project root containing vbrief/")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    project_root = Path(args.project_root).resolve()
+    parent_path = _resolve_path(project_root, args.parent)
+    draft_path = _resolve_path(project_root, args.draft)
+    if parent_path is None or draft_path is None:
+        if args.check:
+            print("OK no decomposition draft supplied; nothing to apply.")
+            return 0
+        print("ERROR: parent path and --draft are required", file=sys.stderr)
+        return 2
+    if not parent_path.is_file():
+        print(f"ERROR: parent vBRIEF not found: {parent_path}", file=sys.stderr)
+        return 2
+    if not draft_path.is_file():
+        print(f"ERROR: decomposition draft not found: {draft_path}", file=sys.stderr)
+        return 2
+    date = args.date or datetime.now(UTC).strftime("%Y-%m-%d")
+    try:
+        actions = apply_decomposition(
+            project_root=project_root,
+            parent_path=parent_path,
+            draft_path=draft_path,
+            check_only=args.check,
+            date=date,
+        )
+    except DecompositionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    for action in actions:
+        print(action)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spec_render.py
+++ b/scripts/spec_render.py
@@ -207,6 +207,28 @@ def _scope_summary_narrative(plan: dict) -> str:
     return ""
 
 
+def _split_acceptance(value: object) -> list[str]:
+    """Normalize acceptance text/list values into visible markdown bullets."""
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if not isinstance(value, str):
+        return []
+    parts: list[str] = []
+    for line in value.splitlines():
+        for chunk in line.split(";"):
+            cleaned = chunk.strip().lstrip("-* ").strip()
+            if cleaned:
+                parts.append(cleaned)
+    return parts
+
+
+def _item_acceptance(item: dict) -> list[str]:
+    narrative = item.get("narrative")
+    if not isinstance(narrative, dict):
+        return []
+    return _split_acceptance(narrative.get("Acceptance"))
+
+
 def _render_scope_block(stem: str, vbrief: dict) -> list[str]:
     """Render a single scope vBRIEF as a markdown block inside Implementation Plan."""
     plan = vbrief.get("plan", {})
@@ -223,6 +245,15 @@ def _render_scope_block(stem: str, vbrief: dict) -> list[str]:
     if summary:
         lines.append(f"{summary}\n")
 
+    narratives = plan.get("narratives", {})
+    if isinstance(narratives, dict):
+        scope_acceptance = _split_acceptance(narratives.get("Acceptance"))
+        if scope_acceptance:
+            lines.append("**Scope Acceptance**:\n")
+            for criterion in scope_acceptance:
+                lines.append(f"- {criterion}")
+            lines.append("")
+
     # Acceptance items -- each plan.items entry rendered as a bullet with status.
     items = plan.get("items", [])
     if isinstance(items, list) and items:
@@ -236,6 +267,9 @@ def _render_scope_block(stem: str, vbrief: dict) -> list[str]:
             if item_status:
                 bullet += f" `[{item_status}]`"
             lines.append(bullet)
+            for criterion in _item_acceptance(item):
+                if criterion != item_title:
+                    lines.append(f"  - Acceptance: {criterion}")
         lines.append("")
     return lines
 

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Report whether vBRIEF candidates are ready for concurrent swarm allocation."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+
+reconfigure_stdio()
+
+LIFECYCLE_FOLDERS = ("proposed", "pending", "active", "completed", "cancelled")
+READY = "ready"
+
+
+@dataclass
+class Candidate:
+    path: Path
+    relpath: str
+    data: dict[str, Any]
+    plan: dict[str, Any]
+    story_id: str
+    title: str
+    status: str
+    folder: str
+    kind: str
+    swarm: dict[str, Any]
+    missing: list[str] = field(default_factory=list)
+    blocked: list[str] = field(default_factory=list)
+    decomposition_needed: bool = False
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _project_rel(project_root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(project_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _expand_paths(project_root: Path, patterns: list[str]) -> list[Path]:
+    if not patterns:
+        patterns = ["vbrief/active/*.vbrief.json"]
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in patterns:
+        raw = Path(pattern)
+        matches: list[str]
+        if any(ch in pattern for ch in "*?["):
+            matches = glob.glob(str(raw if raw.is_absolute() else project_root / pattern))
+        else:
+            matches = [str(raw if raw.is_absolute() else project_root / pattern)]
+        for match in matches:
+            path = Path(match).resolve()
+            if path in seen or not path.is_file():
+                continue
+            seen.add(path)
+            out.append(path)
+    return sorted(out)
+
+
+def _folder_for(path: Path) -> str:
+    return path.parent.name if path.parent.name in LIFECYCLE_FOLDERS else ""
+
+
+def _plan(data: dict[str, Any]) -> dict[str, Any]:
+    plan = data.get("plan")
+    return plan if isinstance(plan, dict) else {}
+
+
+def _metadata(plan: dict[str, Any]) -> dict[str, Any]:
+    metadata = plan.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _swarm(metadata: dict[str, Any]) -> dict[str, Any]:
+    swarm = metadata.get("swarm")
+    return swarm if isinstance(swarm, dict) else {}
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _has_child_plan_refs(plan: dict[str, Any]) -> bool:
+    refs = plan.get("references")
+    if not isinstance(refs, list):
+        return False
+    return any(isinstance(ref, dict) and ref.get("type") == "x-vbrief/plan" for ref in refs)
+
+
+def _looks_like_phase(path: Path, plan: dict[str, Any]) -> bool:
+    title = str(plan.get("title") or "")
+    plan_id = str(plan.get("id") or "")
+    narratives = plan.get("narratives")
+    has_acceptance_narrative = (
+        isinstance(narratives, dict)
+        and isinstance(narratives.get("Acceptance"), str)
+        and bool(narratives["Acceptance"].strip())
+    )
+    has_items = bool(plan.get("items"))
+    stem = path.name
+    return (
+        "-ip" in stem
+        or title.lower().startswith("ip-")
+        or plan_id.lower().startswith("ip-")
+        or (not has_items and has_acceptance_narrative)
+    )
+
+
+def _kind(path: Path, plan: dict[str, Any]) -> str:
+    metadata = _metadata(plan)
+    explicit = metadata.get("kind")
+    if explicit in {"story", "epic", "phase"}:
+        return str(explicit)
+    if _has_child_plan_refs(plan):
+        return "epic"
+    if _looks_like_phase(path, plan):
+        return "phase"
+    return "story"
+
+
+def _story_id(path: Path, plan: dict[str, Any]) -> str:
+    value = plan.get("id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    name = path.name
+    return name[: -len(".vbrief.json")] if name.endswith(".vbrief.json") else path.stem
+
+
+def _item_has_acceptance(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        acceptance = narrative.get("Acceptance")
+        if isinstance(acceptance, str) and acceptance.strip():
+            return True
+    for key in ("items", "subItems"):
+        children = item.get(key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_acceptance(child):
+                    return True
+    return False
+
+
+def _items_have_acceptance(items: Any) -> bool:
+    if not isinstance(items, list):
+        return False
+    return any(isinstance(item, dict) and _item_has_acceptance(item) for item in items)
+
+
+def _item_has_traces(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        traces = narrative.get("Traces")
+        if isinstance(traces, str) and traces.strip():
+            return True
+    for key in ("items", "subItems"):
+        children = item.get(key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_traces(child):
+                    return True
+    return False
+
+
+def _has_traces(plan: dict[str, Any], swarm: dict[str, Any]) -> bool:
+    narratives = plan.get("narratives")
+    if isinstance(narratives, dict):
+        traces = narratives.get("Traces")
+        if isinstance(traces, str) and traces.strip():
+            return True
+    items = plan.get("items")
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict) and _item_has_traces(item):
+                return True
+    refs = plan.get("references")
+    if isinstance(refs, list):
+        for ref in refs:
+            if isinstance(ref, dict) and ref.get("type") == "x-vbrief/spec-section":
+                return True
+    return bool(_as_str_list(swarm.get("missing_traces_justification")))
+
+
+def _all_scope_ids(project_root: Path) -> dict[str, tuple[Path, str]]:
+    ids: dict[str, tuple[Path, str]] = {}
+    vbrief_dir = project_root / "vbrief"
+    for folder in LIFECYCLE_FOLDERS:
+        for path in sorted((vbrief_dir / folder).glob("*.vbrief.json")):
+            data = _load_json(path)
+            if not data:
+                continue
+            plan = _plan(data)
+            scope_id = _story_id(path, plan)
+            ids[scope_id] = (path, str(plan.get("status") or ""))
+            name = path.name
+            stem = name[: -len(".vbrief.json")] if name.endswith(".vbrief.json") else path.stem
+            ids.setdefault(stem, (path, str(plan.get("status") or "")))
+    return ids
+
+
+def _candidate(path: Path, project_root: Path) -> Candidate | None:
+    data = _load_json(path)
+    if not data:
+        return None
+    plan = _plan(data)
+    metadata = _metadata(plan)
+    swarm = _swarm(metadata)
+    return Candidate(
+        path=path,
+        relpath=_project_rel(project_root, path),
+        data=data,
+        plan=plan,
+        story_id=_story_id(path, plan),
+        title=str(plan.get("title") or path.name),
+        status=str(plan.get("status") or ""),
+        folder=_folder_for(path),
+        kind=_kind(path, plan),
+        swarm=swarm,
+    )
+
+
+def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, str]]) -> None:
+    if candidate.kind in {"epic", "phase"}:
+        candidate.decomposition_needed = True
+        return
+    if candidate.kind != "story":
+        candidate.missing.append("plan.metadata.kind=story")
+    if candidate.folder == "active" and candidate.status != "running":
+        candidate.blocked.append("active candidate plan.status must be running")
+    if candidate.status == "running" and candidate.folder != "active":
+        candidate.blocked.append("plan.status=running is only valid in vbrief/active/")
+    if candidate.status == "blocked":
+        candidate.blocked.append("plan.status=blocked")
+
+    items = candidate.plan.get("items")
+    if not isinstance(items, list) or not items:
+        candidate.missing.append("plan.items")
+    elif not _items_have_acceptance(items):
+        candidate.missing.append("plan.items[].narrative.Acceptance")
+
+    if candidate.swarm.get("readiness") != READY:
+        candidate.missing.append("plan.metadata.swarm.readiness=ready")
+    if candidate.swarm.get("parallel_safe") is not True:
+        candidate.missing.append("plan.metadata.swarm.parallel_safe=true")
+    if not _as_str_list(candidate.swarm.get("file_scope")):
+        candidate.missing.append("plan.metadata.swarm.file_scope")
+    if not _as_str_list(candidate.swarm.get("verify_commands")):
+        candidate.missing.append("plan.metadata.swarm.verify_commands")
+    if not _has_traces(candidate.plan, candidate.swarm):
+        candidate.missing.append("Traces or missing_traces_justification")
+    if candidate.swarm.get("size") == "large" and candidate.swarm.get("parallel_safe") is True:
+        candidate.blocked.append("size=large cannot be parallel_safe=true")
+    if (
+        candidate.swarm.get("file_scope_confidence") == "low"
+        and candidate.swarm.get("parallel_safe") is True
+    ):
+        candidate.blocked.append("low-confidence file scope cannot be parallel-safe by default")
+
+    for dep in _as_str_list(candidate.swarm.get("depends_on")):
+        if dep not in known_ids:
+            candidate.blocked.append(f"dependency {dep!r} does not resolve")
+
+
+def _candidate_dep_graph(
+    candidates: list[Candidate],
+    known_ids: dict[str, tuple[Path, str]],
+) -> dict[str, list[str]]:
+    candidate_ids = {candidate.story_id for candidate in candidates}
+    graph: dict[str, list[str]] = {}
+    for candidate in candidates:
+        deps: list[str] = []
+        for dep in _as_str_list(candidate.swarm.get("depends_on")):
+            if dep in candidate_ids:
+                deps.append(dep)
+                continue
+            known = known_ids.get(dep)
+            if known is None:
+                continue
+            _dep_path, dep_status = known
+            if dep_status not in {"completed", "failed", "cancelled"}:
+                candidate.blocked.append(f"dependency {dep!r} is not completed or a candidate")
+        graph[candidate.story_id] = deps
+    return graph
+
+
+def _mark_cycles(candidates: list[Candidate], graph: dict[str, list[str]]) -> None:
+    by_id = {candidate.story_id: candidate for candidate in candidates}
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(story_id: str, path: list[str]) -> None:
+        if story_id in visited:
+            return
+        if story_id in visiting:
+            cycle = [*path, story_id]
+            message = f"dependency cycle: {' -> '.join(cycle)}"
+            for node in cycle:
+                if node in by_id and message not in by_id[node].blocked:
+                    by_id[node].blocked.append(message)
+            return
+        visiting.add(story_id)
+        for dep in graph.get(story_id, []):
+            visit(dep, [*path, story_id])
+        visiting.remove(story_id)
+        visited.add(story_id)
+
+    for candidate in candidates:
+        visit(candidate.story_id, [])
+
+
+def _ready_stories(candidates: list[Candidate]) -> list[Candidate]:
+    return [
+        candidate
+        for candidate in candidates
+        if candidate.kind == "story"
+        and not candidate.missing
+        and not candidate.blocked
+        and not candidate.decomposition_needed
+    ]
+
+
+def _dependency_waves(candidates: list[Candidate], graph: dict[str, list[str]]) -> list[list[str]]:
+    ready_ids = {candidate.story_id for candidate in _ready_stories(candidates)}
+    remaining = set(ready_ids)
+    waves: list[list[str]] = []
+    while remaining:
+        wave = sorted(
+            story_id
+            for story_id in remaining
+            if all(dep not in remaining for dep in graph.get(story_id, []))
+        )
+        if not wave:
+            waves.append(sorted(remaining))
+            break
+        waves.append(wave)
+        remaining.difference_update(wave)
+    return waves
+
+
+def _transitive_deps(story_id: str, graph: dict[str, list[str]]) -> set[str]:
+    out: set[str] = set()
+    stack = list(graph.get(story_id, []))
+    while stack:
+        dep = stack.pop()
+        if dep in out:
+            continue
+        out.add(dep)
+        stack.extend(graph.get(dep, []))
+    return out
+
+
+def _file_overlaps(
+    candidates: list[Candidate],
+    graph: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    file_to_ids: dict[str, list[str]] = defaultdict(list)
+    for candidate in _ready_stories(candidates):
+        if candidate.swarm.get("parallel_safe") is not True:
+            continue
+        for file_path in _as_str_list(candidate.swarm.get("file_scope")):
+            file_to_ids[file_path].append(candidate.story_id)
+
+    overlaps: dict[str, list[str]] = {}
+    for file_path, ids in file_to_ids.items():
+        unsafe_pairs: set[str] = set()
+        for index, left in enumerate(ids):
+            for right in ids[index + 1:]:
+                if right in _transitive_deps(left, graph) or left in _transitive_deps(right, graph):
+                    continue
+                unsafe_pairs.add(left)
+                unsafe_pairs.add(right)
+        if unsafe_pairs:
+            overlaps[file_path] = sorted(unsafe_pairs)
+    return overlaps
+
+
+def _conflict_groups(candidates: list[Candidate]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = defaultdict(list)
+    for candidate in candidates:
+        group = candidate.swarm.get("conflict_group")
+        if isinstance(group, str) and group.strip():
+            groups[group].append(candidate.story_id)
+    return dict(sorted(groups.items()))
+
+
+def _render_report(
+    candidates: list[Candidate],
+    graph: dict[str, list[str]],
+    overlaps: dict[str, list[str]],
+) -> str:
+    ready = _ready_stories(candidates)
+    blocked = [
+        candidate
+        for candidate in candidates
+        if candidate.kind == "story" and (candidate.missing or candidate.blocked)
+    ]
+    needs_decomposition = [candidate for candidate in candidates if candidate.decomposition_needed]
+    lines: list[str] = ["Swarm readiness report", ""]
+
+    lines.append("Ready stories:")
+    if ready:
+        for candidate in ready:
+            lines.append(f"- {candidate.story_id}: {candidate.title} ({candidate.relpath})")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Blocked stories:")
+    if blocked:
+        for candidate in blocked:
+            reasons = [*candidate.missing, *candidate.blocked]
+            lines.append(f"- {candidate.story_id}: {candidate.title} -- {'; '.join(reasons)}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Decomposition-needed epics/phases:")
+    if needs_decomposition:
+        for candidate in needs_decomposition:
+            lines.append(f"- {candidate.story_id}: kind={candidate.kind} ({candidate.relpath})")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Dependency waves:")
+    waves = _dependency_waves(candidates, graph)
+    if waves:
+        for index, wave in enumerate(waves, start=1):
+            lines.append(f"- wave {index}: {', '.join(wave)}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Conflict groups:")
+    groups = _conflict_groups(candidates)
+    if groups:
+        for group, ids in groups.items():
+            lines.append(f"- {group}: {', '.join(sorted(ids))}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("File overlap matrix:")
+    if overlaps:
+        for file_path, ids in sorted(overlaps.items()):
+            lines.append(f"- {file_path}: {', '.join(ids)}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Missing fields:")
+    missing_any = False
+    for candidate in candidates:
+        if candidate.missing:
+            missing_any = True
+            lines.append(f"- {candidate.story_id}: {', '.join(candidate.missing)}")
+    if not missing_any:
+        lines.append("- none")
+    return "\n".join(lines)
+
+
+def readiness_report(project_root: Path, paths: list[Path]) -> tuple[int, str]:
+    candidates = [candidate for path in paths if (candidate := _candidate(path, project_root))]
+    if not candidates:
+        return 1, "Swarm readiness report\n\nNo candidate vBRIEFs found."
+    known_ids = _all_scope_ids(project_root)
+    for candidate in candidates:
+        known_ids.setdefault(candidate.story_id, (candidate.path, candidate.status))
+    for candidate in candidates:
+        _validate_candidate(candidate, known_ids)
+    graph = _candidate_dep_graph(candidates, known_ids)
+    _mark_cycles(candidates, graph)
+    overlaps = _file_overlaps(candidates, graph)
+    report = _render_report(candidates, graph, overlaps)
+    failed = any(
+        candidate.missing or candidate.blocked or candidate.decomposition_needed
+        for candidate in candidates
+    ) or bool(overlaps)
+    return 1 if failed else 0, report
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Report whether vBRIEF candidates are ready for concurrent swarm allocation."
+    )
+    parser.add_argument("paths", nargs="*", help="Candidate vBRIEF paths or globs")
+    parser.add_argument("--project-root", default=".", help="Project root containing vbrief/")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    project_root = Path(args.project_root).resolve()
+    paths = _expand_paths(project_root, args.paths)
+    code, report = readiness_report(project_root, paths)
+    print(report)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/deft-directive-decompose/SKILL.md
+++ b/skills/deft-directive-decompose/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: deft-directive-decompose
+description: >
+  Convert approved specification/phase/epic scope vBRIEFs into swarm-ready
+  story vBRIEFs before concurrent agent allocation.
+---
+
+# Deft Directive Decompose
+
+Use this skill when a specification, Phase 4 implementation scope, or epic vBRIEF is too broad for direct concurrent swarm work and must be decomposed into story-level vBRIEFs.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**See also**: [strategies/speckit.md](../../strategies/speckit.md) Phase 4.5 | [vbrief/vbrief.md](../../vbrief/vbrief.md) Swarm-Ready Story Contract | [deft-directive-swarm](../deft-directive-swarm/SKILL.md)
+
+## Purpose
+
+Convert approved specification/phase/epic scope vBRIEFs into swarm-ready child story vBRIEFs. Story vBRIEFs are the only valid input for concurrent swarm worker allocation.
+
+## Phase 0: Inspect
+
+- ! Read `vbrief/specification.vbrief.json` and relevant scope vBRIEFs from `vbrief/proposed/`, `vbrief/pending/`, and `vbrief/active/`
+- ! Identify broad scopes with `plan.metadata.kind = "phase"` or `"epic"` or scopes with broad `plan.narratives.Acceptance` and empty `plan.items`
+- ! Preserve parent acceptance as context; do not treat it as executable story acceptance
+- ! Identify requirement traces, likely file scope, verification commands, outputs/evidence, dependencies, and conflict groups
+- ⊗ Allocate a broad phase/epic scope to concurrent workers during this skill
+
+## Phase 1: Draft
+
+- ! Draft a decomposition JSON proposal with child stories only; do not write child vBRIEFs yet
+- ! Each story MUST include `id`, `title`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`
+- ! Model dependencies as story IDs and ensure they form a DAG
+- ! Mark a story `parallel_safe: false` when the expected file scope is broad, low-confidence, or likely to collide
+- ⊗ Use deprecated `subItems` in newly drafted story items; use `items`
+
+## Phase 2: Approval
+
+- ! Present the decomposition draft to the user before writing files
+- ! Ask for explicit approval to apply the draft
+- ! If the user requests changes, revise the draft and re-present it
+- ⊗ Run `task scope:decompose` before explicit approval
+
+## Phase 3: Apply
+
+- ! Validate the approved draft first:
+
+```bash
+task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json> --check
+```
+
+- ! Apply the approved draft:
+
+```bash
+task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>
+```
+
+The command creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent, updates parent references to include the children, rejects dependency cycles, and rejects ready stories missing executable acceptance, file scope, verify commands, or traces.
+
+## Phase 4: Readiness
+
+- ! Run readiness after decomposition:
+
+```bash
+task swarm:readiness -- vbrief/active/*.vbrief.json
+```
+
+- ~ If child stories are still pending, run readiness against their explicit paths for a dry readiness review before activation
+- ! Route blocked or overlapping stories back to Phase 1 for draft refinement
+- ! Leave lifecycle promotion/activation to the existing approved flow (`task scope:promote`, `task scope:activate`, and the swarm skill lifecycle bridge)
+- ⊗ Promote or activate child stories solely because decomposition succeeded
+
+## Exit
+
+deft-directive-decompose complete -- exiting skill. Next, activate the approved child story vBRIEFs through the existing lifecycle flow, then run `skills/deft-directive-swarm/SKILL.md` for concurrent allocation.

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -111,20 +111,24 @@ Cross-references:
 - Underlying CLI: `scripts/scope_lifecycle.py` (the deterministic state machine; idempotent on same-folder moves; three-state exit 0 / 1 / 2).
 - Recurrence record: issue #1025 (2026-05-10 first-session consumer tic-tac-toe swarm; monitor hit `Invalid transition: 'activate' requires file in pending/` on all four candidate vBRIEFs because they were still in `proposed/`).
 
-### Step 1: Read Project State
+### Step 1: Read Project State and Readiness Report
 
-- ! Scan `vbrief/active/` for all story-level vBRIEFs (files matching `*.vbrief.json`)
-- ! For each candidate vBRIEF, MUST run `task vbrief:preflight -- <path>` (the structural intent gate, #810; wraps `scripts/preflight_implementation.py` so the same invocation works whether deft is the project root or installed as a `deft/` subdirectory) to validate eligibility before any allocation work. Skip any vBRIEF that exits non-zero -- the helper's stderr message is the actionable redirect (`task vbrief:activate <path>`). Surface the exit message in the Phase 0 Step 4 analysis so the user can route the lifecycle move; do NOT attempt to allocate, dispatch, or implement against a vBRIEF that fails the preflight.
-- ! Read each vBRIEF's `plan.title`, `plan.status`, `plan.items`, `references`, and `planRef` (for epic linkage)
+- ! Scan `vbrief/active/` for candidate vBRIEFs (files matching `*.vbrief.json`)
+- ! For each candidate vBRIEF, MUST run `task vbrief:preflight -- <path>` (the structural intent gate, #810; wraps `scripts/preflight_implementation.py` so the same invocation works whether deft is the project root or installed as a `deft/` subdirectory) to validate lifecycle eligibility before allocation work. Skip any vBRIEF that exits non-zero -- the helper's stderr message is the actionable redirect (`task vbrief:activate <path>`). Surface the exit message in the Phase 0 Step 4 analysis so the user can route the lifecycle move; do NOT attempt to allocate, dispatch, or implement against a vBRIEF that fails the preflight.
+- ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before any agent allocation. This deterministic report is the allocator's source of truth for ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields.
+- ! Treat `plan.metadata.kind = "epic"` and `plan.metadata.kind = "phase"` as **needs decomposition**, not merely incomplete. Route broad scopes to `skills/deft-directive-decompose/SKILL.md` instead of assigning them to workers.
+- ! Read only readiness-approved story fields for allocation: `plan.title`, `plan.status`, non-empty `plan.items`, `planRef`, `references`, `plan.metadata.kind`, and `plan.metadata.swarm`.
 - ! Read `vbrief/PROJECT-DEFINITION.vbrief.json` for project-wide context (narratives, scope registry)
-- ! Cross-reference: every candidate vBRIEF should have acceptance criteria in its `plan.items`
 - ! Determine the base branch: ask the user which branch to target for worktree creation, PR targets, and rebase cascade (default: `master`). Record this as the **configured base branch** for all subsequent phases.
 - ⊗ Spawn an implementation agent (via `start_agent`, `oz agent run`, Warp tab dispatch, or any other path) for a vBRIEF that has not passed `task vbrief:preflight` (which wraps `scripts/preflight_implementation.py`) -- the gate is the only authorization signal; affirmative continuation phrases and workflow-shape vocabulary are NOT (#810).
+- ⊗ Allocate concurrent workers unless candidates are swarm-ready `kind=story` vBRIEFs with non-empty executable `plan.items` and `task swarm:readiness` exits 0.
+- ⊗ Use manual file-overlap reasoning as the only safety check; use the readiness report first, then explain any additional human judgment.
 
 ### Step 2: Surface Blockers
 
 - ! Identify blocked vBRIEFs (status `blocked`) and their blocking reasons (check `narrative` fields)
 - ! Identify vBRIEFs with incomplete acceptance criteria (no `plan.items` or empty items array)
+- ! Identify epic/phase scope vBRIEFs from the readiness report and route them to decomposition
 - ! Identify dependency conflicts between candidate vBRIEFs (e.g. story A depends on story B via `planRef` or `edges`, but B is assigned to a different agent or is incomplete)
 - ! Flag any candidate vBRIEFs whose prerequisites are unmet
 
@@ -142,8 +146,10 @@ Cross-references:
 ! Present a summary to the user containing:
 
 - **Candidate vBRIEFs**: story-level vBRIEFs eligible for assignment (with titles, statuses, and origin references)
+- **Readiness report**: ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`
 - **Preflight rejections (#810)**: any vBRIEFs that failed `task vbrief:preflight` (wraps `scripts/preflight_implementation.py`) in Step 1 -- include the file path AND the helper's exit message verbatim so the user can route the appropriate `task vbrief:activate <path>` move. These vBRIEFs MUST NOT be allocated until they pass the preflight on a re-run.
 - **Blockers found**: blocked vBRIEFs, unresolved dependencies, items requiring design decisions
+- **Decomposition needed**: epic/phase scopes that must go through `skills/deft-directive-decompose/SKILL.md` before swarm allocation
 - **Incomplete vBRIEFs**: stories with missing or empty acceptance criteria
 - **Allocation plan**: which agent gets which vBRIEF(s), with reasoning for batching decisions
 - **Tentative version bump**: current version (from CHANGELOG.md or latest git tag) and proposed next version (patch/minor/major) based on the scope and nature of candidate items — this is advisory and will be confirmed before merge cascade
@@ -167,7 +173,7 @@ Cross-references:
 
 ### Step 2: File-Overlap Audit
 
-! Before assigning tasks to agents, list every file each vBRIEF's acceptance criteria are expected to touch.
+! Before assigning tasks to agents, start from the `task swarm:readiness` file-overlap matrix and conflict groups, then list every file each vBRIEF's acceptance criteria are expected to touch.
 
 - ! Verify ZERO file overlap between agents — no two agents may modify the same file
 - ! Check **transitive** file touches, not just primary scope — trace each vBRIEF's acceptance criteria to specific files. A task may require changes to files outside its obvious scope (e.g., an enforcement task adding an anti-pattern to a skill file owned by another agent).

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -8,7 +8,7 @@ Development strategies define the workflow from idea to implementation.
 |----------|---------|------|----------|--------|
 | [interview.md](./interview.md) | `/deft:run:interview` | spec-generating | Standard projects (default) | Sizing gate: Light (Interview → SPECIFICATION) or Full (Interview → PRD → SPECIFICATION) |
 | [yolo.md](./yolo.md) | `/deft:run:yolo` | spec-generating | Quick prototyping | Auto-pilot sizing gate: Light or Full (Johnbot picks) |
-| [speckit.md](./speckit.md) | `/deft:run:speckit` | spec-generating | Large/complex projects | Principles → Specify → Plan → Tasks → Implement |
+| [speckit.md](./speckit.md) | `/deft:run:speckit` | spec-generating | Large/complex projects | Principles → Specify → Plan → Phase/Epic Scope → Story Readiness → Implement |
 | [map.md](./map.md) | `/deft:run:map` | preparatory | Existing codebases | Map → Chaining Gate |
 | [discuss.md](./discuss.md) | `/deft:run:discuss` | preparatory | Alignment before planning | Feynman technique → locked decisions → Chaining Gate |
 | [probe.md](./probe.md) | `/deft:run:probe` | preparatory | Adversarial plan stress-testing | Walk decision tree → challenge assumptions → surface risks → Chaining Gate |

--- a/strategies/interview.md
+++ b/strategies/interview.md
@@ -57,7 +57,7 @@ See `strategies/map.md` for standalone behavior.
 
 **Switch spec-generating strategy** (type: `spec-generating` — replaces current pipeline):
 - Yolo — auto-pilot, Johnbot picks all answers
-- SpecKit — five-phase formal spec process
+- SpecKit — formal spec process with story readiness before implementation
 
 ### Run Count Annotations
 
@@ -89,7 +89,7 @@ Ready to generate the specification. Before we proceed, would you like to:
 
 --- Switch strategy ---
 6. Switch to yolo — auto-pilot picks all answers
-7. Switch to speckit — formal five-phase spec process
+7. Switch to speckit — formal spec process with story readiness before implementation
 
 8. Other (specify)
 ```

--- a/strategies/speckit.md
+++ b/strategies/speckit.md
@@ -1,6 +1,6 @@
 # SpecKit Strategy
 
-A five-phase spec-driven development workflow inspired by [GitHub's spec-kit](https://github.com/github/spec-kit).
+A spec-driven development workflow inspired by [GitHub's spec-kit](https://github.com/github/spec-kit), with a Phase 4.5 readiness layer for decomposing broad implementation scopes into swarm-safe stories.
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
@@ -22,19 +22,22 @@ flowchart LR
         P["📜 Principles<br/><i>PROJECT-DEFINITION.vbrief.json</i>"]
         S["📝 Specify<br/><i>WHAT/WHY → specification.vbrief.json</i>"]
         PL["🏗️ Plan<br/><i>HOW → specification.vbrief.json</i>"]
-        T["✅ Tasks<br/><i>Executable list</i>"]
+        T["✅ Scope<br/><i>Phase/epic vBRIEFs</i>"]
+        D["🧩 Decompose<br/><i>Story readiness</i>"]
         I["🔨 Implement<br/><i>Execute</i>"]
     end
 
     P -->|"Established"| S
     S -->|"Approved"| PL
     PL -->|"Reviewed"| T
-    T -->|"Ready"| I
+    T -->|"Approved"| D
+    D -->|"Ready stories"| I
 
     style P fill:#c4b5fd,stroke:#7c3aed,color:#000
     style S fill:#fef08a,stroke:#ca8a04,color:#000
     style PL fill:#6ee7b7,stroke:#059669,color:#000
     style T fill:#7dd3fc,stroke:#0284c7,color:#000
+    style D fill:#fde68a,stroke:#d97706,color:#000
     style I fill:#f0abfc,stroke:#a855f7,color:#000
 ```
 
@@ -143,13 +146,15 @@ Add the following narrative keys to `vbrief/specification.vbrief.json` `plan.nar
 
 ---
 
-## Phase 4: Tasks (Scope vBRIEF Emission)
+## Phase 4: Implementation Phase / Epic Scope Emission
 
-**Goal:** Emit one scope vBRIEF per implementation phase so downstream tooling (`task roadmap:render`, `task project:render`, swarm allocation) can operate against the lifecycle model described in [vbrief/vbrief.md](../vbrief/vbrief.md).
+**Goal:** Emit one broad scope vBRIEF per implementation phase or epic so downstream tooling (`task roadmap:render`, `task project:render`, and Phase 4.5 decomposition) can operate against the lifecycle model described in [vbrief/vbrief.md](../vbrief/vbrief.md).
 
 **Input:** Approved HOW narratives in `vbrief/specification.vbrief.json` (`ImplementationPhases` narrative describes IP-1..IP-N).
 
-**Output:** N scope vBRIEFs in `./vbrief/pending/`, one per implementation phase, using the filename convention `YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (NNN = 3-digit zero-padded, 001..N). See [vbrief/vbrief.md — speckit Phase 4 scope vBRIEFs](../vbrief/vbrief.md#speckit-phase-4-scope-vbriefs) for the canonical convention.
+**Output:** N phase/epic scope vBRIEFs in `./vbrief/pending/`, one per implementation phase or epic, using the filename convention `YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (NNN = 3-digit zero-padded, 001..N). See [vbrief/vbrief.md — speckit Phase 4 scope vBRIEFs](../vbrief/vbrief.md#speckit-phase-4-scope-vbriefs) for the canonical convention.
+
+Phase 4 scopes are planning containers. They MAY keep broad acceptance in `plan.narratives.Acceptance` and MAY have `plan.items: []`. They are not valid concurrent swarm worker inputs unless explicitly marked as a single-story scope. Broad phase/epic scopes MUST pass through Phase 4.5 before swarm allocation.
 
 ### Scope vBRIEF Shape
 
@@ -161,11 +166,12 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ! `plan.narratives.Acceptance` — acceptance criteria copied from the spec
 - ! `plan.narratives.Traces` — FR/NFR/IP IDs the phase covers (e.g. `FR-001, FR-003, NFR-002, IP-3`)
 - ! `plan.references` — link back to the parent `vbrief/specification.vbrief.json` (`type: x-vbrief/plan`)
+- ! `plan.metadata.kind` — `phase` or `epic`
 - ! `plan.metadata.dependencies` — array of IP IDs this phase depends on / is blocked by (plan-level; mirrors the `edges[].blocks` structure used in earlier drafts)
 
 ```json
 {
-  "vBRIEFInfo": { "version": "0.5" },
+  "vBRIEFInfo": { "version": "0.6" },
   "plan": {
     "title": "IP-3: Implement data layer",
     "status": "pending",
@@ -175,10 +181,11 @@ For each implementation phase IP-N, write a scope vBRIEF with:
       "Traces": "FR-001, FR-003, NFR-002, IP-3"
     },
     "metadata": {
+      "kind": "phase",
       "dependencies": ["ip-1", "ip-2"]
     },
     "references": [
-      { "type": "x-vbrief/plan", "url": "../specification.vbrief.json" }
+      { "type": "x-vbrief/plan", "uri": "./specification.vbrief.json" }
     ],
     "items": []
   }
@@ -204,8 +211,10 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ! Derive one scope vBRIEF per implementation phase from `ImplementationPhases`
 - ! Populate `Description`, `Acceptance`, and `Traces` narratives per [vbrief/vbrief.md — canonical narrative keys](../vbrief/vbrief.md#scope-vbrief-narrative-keys)
 - ! Use `plan.metadata.dependencies` (plan-level) rather than item-level `blocks` edges for cross-scope dependencies
+- ! Use `plan.metadata.kind = "phase"` or `"epic"` for broad implementation scopes
 - ~ Size each phase for 1-4 hours of work so the swarm allocator can distribute cleanly
 - ⊗ Create phases not traceable to a spec requirement
+- ⊗ Allocate Phase 4 phase/epic scope vBRIEFs directly to concurrent swarm workers
 
 ### Transition Criteria
 
@@ -216,11 +225,80 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 
 ---
 
+## Phase 4.5: Story Decomposition / Swarm Readiness
+
+**Goal:** Convert approved Phase 4 phase/epic scopes into child story vBRIEFs suitable for parallel agents.
+
+**Input:** Phase 4 phase/epic vBRIEFs in `./vbrief/pending/` or `./vbrief/active/`.
+
+**Output:** Story-level child vBRIEFs whose executable acceptance criteria live in `plan.items` and whose `plan.metadata.swarm` contract proves they are safe to allocate.
+
+### Process
+
+1. ! Inspect approved specification narratives and Phase 4 scope vBRIEFs.
+2. ! Identify `plan.metadata.kind = "phase"` or `"epic"` scopes that are too broad for direct implementation.
+3. ! Draft a deterministic decomposition proposal: stories, dependencies, expected file scope, verification commands, traces, and conflict groups.
+4. ! Ask for explicit user approval before writing child story vBRIEFs.
+5. ! Apply the approved draft with `task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>`.
+6. ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before concurrent allocation, or point it at the candidate child story files for a dry readiness review before activation.
+
+### Story vBRIEF Requirements
+
+Each Phase 4.5 child story vBRIEF MUST include:
+
+- ! `plan.metadata.kind = "story"`
+- ! non-empty `plan.items`
+- ! executable acceptance in each story's `plan.items`
+- ! explicit dependencies in `plan.metadata.swarm.depends_on`
+- ! traceability back to requirements via `Traces` narratives or explicit trace justification
+- ! expected file scope in `plan.metadata.swarm.file_scope`
+- ! verify commands in `plan.metadata.swarm.verify_commands`
+- ! expected outputs/evidence in `plan.metadata.swarm.expected_outputs`
+- ! swarm readiness metadata in `plan.metadata.swarm`
+- ! `planRef` pointing to the parent phase/epic scope
+- ! parent phase/epic `references` updated to point to every child story
+
+### Decomposition Command
+
+Use the deterministic command surface:
+
+```bash
+task scope:decompose -- vbrief/pending/2026-05-12-ip001-auth.vbrief.json --draft decomposition.json
+task scope:decompose -- vbrief/pending/2026-05-12-ip001-auth.vbrief.json --draft decomposition.json --check
+task scope:decompose -- --check
+```
+
+The command validates and applies a proposed decomposition rather than freely inventing one. It creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent scope, updates parent references to include children, validates the dependency DAG, rejects dependency cycles, and rejects ready stories missing acceptance, file scope, verify commands, or traces.
+
+Parent phase/epic acceptance MAY remain in `plan.narratives.Acceptance` as context. Executable acceptance for swarm work MUST be redistributed into child story `plan.items`.
+
+### Swarm Readiness Command
+
+Use the readiness gate before swarm allocation:
+
+```bash
+task swarm:readiness -- vbrief/active/*.vbrief.json
+```
+
+The readiness report lists ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, a file-overlap matrix, and missing fields. It exits non-zero when candidate work is not swarm-ready.
+
+### Transition Criteria
+
+- ! Candidate swarm work consists only of `kind=story` vBRIEFs
+- ! Every candidate story has non-empty `plan.items`
+- ! Every candidate story has file scope, verify commands, traces or trace justification, and readiness metadata
+- ! Dependencies resolve and form a DAG
+- ! No unsafe file-scope overlap exists among parallel stories
+- ! No `size=large` story is marked `parallel_safe=true`
+- ! Low-confidence file scopes are not treated as parallel-safe by default
+
+---
+
 ## Phase 5: Implement
 
 **Goal:** Execute scope vBRIEFs following test-first discipline.
 
-**Input:** Scope vBRIEFs in `./vbrief/pending/` (promote to `./vbrief/active/` via `task scope:activate` when work begins). `./vbrief/plan.vbrief.json` holds the current session's tactical todo list and carries a `planRef` to the active scope.
+**Input:** Story-level scope vBRIEFs in `./vbrief/pending/` (promote to `./vbrief/active/` via `task scope:activate` when work begins). `./vbrief/plan.vbrief.json` holds the current session's tactical todo list and carries a `planRef` to the active scope. Concurrent swarm implementation requires Phase 4.5-ready stories.
 
 ### Process
 
@@ -229,7 +307,7 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ! Refactor while keeping tests green (Refactor)
 - ! Update scope vBRIEF `plan.status` and folder via `task scope:*` commands as work progresses (`pending` → `running` → `completed`)
 - ! Update `./vbrief/plan.vbrief.json` session todos as tactical steps progress (session-scoped; do NOT put the project-wide IP list here)
-- ~ Work on scope vBRIEFs whose `plan.metadata.dependencies` are already completed in parallel when possible
+- ~ Work on story vBRIEFs whose `plan.metadata.swarm.depends_on` entries are already completed in parallel when possible
 
 ### File Creation Order
 
@@ -245,6 +323,7 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ⊗ Implement without failing tests first
 - ⊗ Skip refactoring phase
 - ⊗ Write the project-wide IP list to `plan.vbrief.json` — use `vbrief/pending/` scope vBRIEFs as the durable task tracker
+- ⊗ Allocate broad `kind=epic` or `kind=phase` scopes to concurrent swarm workers before decomposition
 
 ---
 
@@ -257,9 +336,10 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 | 3. Plan | `vbrief/specification.vbrief.json` | HOW narratives (enriches Phase 2) |
 | 3b. Render SPECIFICATION | `SPECIFICATION.md` (rendered via `task spec:render`) | Read-only human review export |
 | 3c. Render PRD | `PRD.md` (rendered via `task prd:render`) | Optional stakeholder-review export |
-| 4. Tasks | `./vbrief/pending/YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (one per IP) | Scope vBRIEFs drive roadmap/project render + swarm |
+| 4. Tasks | `./vbrief/pending/YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (one per IP/epic) | Phase/epic scope vBRIEFs drive roadmap/project render + decomposition |
+| 4.5. Story decomposition | Child story vBRIEFs with `plan.metadata.swarm` | Swarm-ready executable units |
 | 4b. Session todos | `./vbrief/plan.vbrief.json` | Session-level tactical plan (carries `planRef` to active scope) |
-| 5. Implement | Code + tests | Working software |
+| 5. Implement | Code + tests | Working software, optionally via swarm |
 
 ## Directory Structure
 
@@ -269,8 +349,8 @@ project/
 │   ├── PROJECT-DEFINITION.vbrief.json  # Phase 1: Principles narrative
 │   ├── specification.vbrief.json       # Phase 2+3: WHAT/WHY + HOW narratives
 │   ├── plan.vbrief.json                # Phase 4b: session todos (planRef to active scope)
-│   └── pending/                        # Phase 4: IP-level scope vBRIEFs
-│       └── YYYY-MM-DD-ip001-….vbrief.json
+│   └── pending/                        # Phase 4/4.5: IP-level scopes + child stories
+│       └── YYYY-MM-DD-ip001-....vbrief.json
 ├── SPECIFICATION.md                    # Rendered export (task spec:render)
 ├── PRD.md                              # Optional rendered export (task prd:render)
 └── src/                                # Phase 5

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -107,3 +107,11 @@ tasks:
       PYTHONUTF8: "1"
     cmds:
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" unblock {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+
+  decompose:
+    desc: "Apply/check an approved epic/phase -> story decomposition draft"
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_decompose.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+  readiness:
+    desc: "Report whether story vBRIEFs are ready for concurrent swarm allocation"
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/swarm_readiness.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/templates/make-spec.md
+++ b/templates/make-spec.md
@@ -58,7 +58,7 @@ N. [feature]
 
 ### Full Path: PRD Generation
 
-Only on the **Full** path — generate `PRD.md` before the specification:
+Only on the **Full** path — generate `PRD.md` as a rendered stakeholder-review export before the specification source is finalized:
 
 ```markdown
 # [Project Name] PRD
@@ -94,28 +94,29 @@ Any remaining decisions deferred to implementation.
 - ! Focus on WHAT, not HOW
 - ! Use RFC 2119 language (MUST, SHOULD, MAY)
 - ! Number all requirements for traceability
-- ! User MUST review and approve PRD before specification generation begins
+- ! User MUST review and approve the rendered PRD export before specification generation begins
+- ! `vbrief/specification.vbrief.json` and scope vBRIEFs remain authoritative; rendered PRD/SPEC files are exports, not the source of truth
 
 ### Specification Flow (both paths)
 
-1. ! Write scope vBRIEF(s) to `./vbrief/proposed/` with `status: draft` using `YYYY-MM-DD-descriptive-slug.vbrief.json` naming
+1. ! Write scope vBRIEF(s) to `./vbrief/proposed/` with `status: proposed` using `YYYY-MM-DD-descriptive-slug.vbrief.json` naming
 2. ! Summarize what was decided and ask the user to review
-3. ! On user approval, update `status` to `approved` and move to `./vbrief/pending/` (or use `task scope:promote`)
+3. ! On user approval, use `task scope:promote` to move to `./vbrief/pending/` with `status: pending`
 4. ! Update `./vbrief/PROJECT-DEFINITION.vbrief.json` items registry to include the new scope vBRIEF(s)
 5. ? For project-wide spec: write `./vbrief/specification.vbrief.json` and run `task spec:render` to generate `SPECIFICATION.md`
 
 ! The vBRIEF file MUST use this exact top-level structure:
 
 - ! All `narratives` and `narrative` values MUST be plain strings — never objects or arrays
-- ! Nested children within a PlanItem MUST use `subItems` (not `items`)
-- ⊗ Use `items` inside a PlanItem — only `plan.items` is valid; within items use `subItems`
+- ! Nested children within a PlanItem MUST use `items` (the preferred v0.6 PlanItem field)
+- ≉ Use deprecated `subItems` for new content; it remains a compatibility alias only
 
 ```json
 {
   "vBRIEFInfo": { "version": "0.6" },
   "plan": {
     "title": "Project Name SPECIFICATION",
-    "status": "draft",
+    "status": "proposed",
     "narratives": {
       "Overview": "Brief project summary as a plain string.",
       "Architecture": "System design as a plain string."
@@ -125,12 +126,12 @@ Any remaining decisions deferred to implementation.
         "id": "phase-1",
         "title": "Phase 1: Foundation",
         "status": "pending",
-        "subItems": [
+        "items": [
           {
             "id": "1.1",
             "title": "Subphase 1.1: Setup",
             "status": "pending",
-            "subItems": [
+            "items": [
               {
                 "id": "1.1.1",
                 "title": "Task description",

--- a/tests/cli/test_migrate_vbrief.py
+++ b/tests/cli/test_migrate_vbrief.py
@@ -1419,7 +1419,7 @@ def _write_speckit_plan(
     """Write a speckit-shaped plan.vbrief.json fixture."""
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     data = {
-        "vBRIEFInfo": {"version": "0.5", "description": "speckit plan fixture"},
+        "vBRIEFInfo": {"version": "0.6", "description": "speckit plan fixture"},
         "plan": {
             "title": "speckit IPs",
             "status": "running",
@@ -1514,6 +1514,7 @@ class TestCreateSpeckitScopeVbrief:
         result = _create_speckit_scope_vbrief(
             item, ip_index=3, dependencies=["ip-1"], spec_ref="../specification.vbrief.json"
         )
+        assert result["plan"]["metadata"]["kind"] == "phase"
         assert result["plan"]["metadata"]["dependencies"] == ["ip-1"]
 
     def test_reference_links_back_to_spec(self):
@@ -1524,7 +1525,7 @@ class TestCreateSpeckitScopeVbrief:
         refs = result["plan"]["references"]
         assert any(
             r.get("type") == "x-vbrief/plan"
-            and r.get("url") == "../specification.vbrief.json"
+            and r.get("uri") == "../specification.vbrief.json"
             for r in refs
         )
 
@@ -1640,7 +1641,9 @@ class TestMigrateSpeckitPlan:
         assert data["plan"]["narratives"]["Traces"] == "FR-1, IP-1"
         refs = data["plan"]["references"]
         assert refs[0]["type"] == "x-vbrief/plan"
-        assert "specification.vbrief.json" in refs[0]["url"]
+        assert "specification.vbrief.json" in refs[0]["uri"]
+        assert "url" not in refs[0]
+        assert data["plan"]["metadata"]["kind"] == "phase"
 
     def test_plan_rewritten_to_session_scaffold(self, tmp_path):
         plan_path = tmp_path / "vbrief" / "plan.vbrief.json"

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "scope_decompose.py"
+
+
+def _write_json(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _parent(project: Path, folder: str = "pending") -> Path:
+    return _write_json(
+        project / "vbrief" / folder / "2026-05-12-ip001-auth.vbrief.json",
+        {
+            "vBRIEFInfo": {"version": "0.6"},
+            "plan": {
+                "id": "ip-1",
+                "title": "IP-1: Auth",
+                "status": "pending" if folder == "pending" else "running",
+                "narratives": {
+                    "Acceptance": "Auth epic acceptance remains as context.",
+                    "Traces": "FR-1, IP-1",
+                },
+                "items": [],
+                "metadata": {"kind": "phase", "dependencies": []},
+                "references": [
+                    {
+                        "uri": "./specification.vbrief.json",
+                        "type": "x-vbrief/plan",
+                        "title": "Specification",
+                    }
+                ],
+            },
+        },
+    )
+
+
+def _draft(project: Path, *, cycle: bool = False, output_dir: str | None = None) -> Path:
+    stories = [
+        {
+            "id": "story-auth-model",
+            "title": "Auth model",
+            "acceptance": ["Auth model persists users"],
+            "traces": ["FR-1"],
+            "swarm": {
+                "readiness": "ready",
+                "parallel_safe": True,
+                "file_scope": ["src/auth/model.ts", "tests/auth/model.test.ts"],
+                "verify_commands": ["npm test -- auth/model"],
+                "expected_outputs": ["auth model tests pass"],
+                "depends_on": ["story-auth-routes"] if cycle else [],
+                "conflict_group": "auth",
+                "size": "small",
+                "file_scope_confidence": "high",
+                "model_tier": "medium",
+            },
+        },
+        {
+            "id": "story-auth-routes",
+            "title": "Auth routes",
+            "acceptance": ["Auth routes return tokens"],
+            "traces": ["FR-2"],
+            "swarm": {
+                "readiness": "ready",
+                "parallel_safe": True,
+                "file_scope": ["src/auth/routes.ts", "tests/auth/routes.test.ts"],
+                "verify_commands": ["npm test -- auth/routes"],
+                "expected_outputs": ["auth route tests pass"],
+                "depends_on": ["story-auth-model"],
+                "conflict_group": "auth",
+                "size": "small",
+                "file_scope_confidence": "high",
+                "model_tier": "medium",
+            },
+        },
+    ]
+    draft = {"stories": stories}
+    if output_dir:
+        draft["output_dir"] = output_dir
+        draft["status"] = "running"
+    return _write_json(project / "decomposition.json", draft)
+
+
+def _run(project: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args, "--project-root", str(project)],
+        cwd=project,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_scope_decompose_creates_child_stories_and_updates_parent_refs(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--date",
+        "2026-05-12",
+    )
+
+    assert result.returncode == 0, result.stderr
+    child_paths = sorted((tmp_path / "vbrief" / "pending").glob("2026-05-12-auth-*.vbrief.json"))
+    assert len(child_paths) == 2
+    child = json.loads(child_paths[0].read_text(encoding="utf-8"))
+    assert child["plan"]["planRef"] == "./pending/2026-05-12-ip001-auth.vbrief.json"
+    assert child["plan"]["metadata"]["kind"] == "story"
+    assert child["plan"]["metadata"]["swarm"]["readiness"] == "ready"
+    assert child["plan"]["items"]
+    assert child["plan"]["references"][0]["uri"] == "./specification.vbrief.json"
+
+    updated_parent = json.loads(parent.read_text(encoding="utf-8"))
+    child_uris = {
+        f"./pending/{path.name}"
+        for path in child_paths
+    }
+    child_refs = [
+        ref
+        for ref in updated_parent["plan"]["references"]
+        if ref.get("type") == "x-vbrief/plan" and ref.get("uri") in child_uris
+    ]
+    assert len(child_refs) == 2
+    assert updated_parent["plan"]["narratives"]["Acceptance"].startswith("Auth epic")
+
+
+def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path, cycle=True)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert "dependency cycle" in result.stderr
+
+
+def test_scope_decompose_rejects_ready_story_missing_required_fields(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _write_json(
+        tmp_path / "bad-decomposition.json",
+        {
+            "stories": [
+                {
+                    "id": "story-bad",
+                    "title": "Bad story",
+                    "swarm": {"readiness": "ready", "parallel_safe": True},
+                }
+            ]
+        },
+    )
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert "plan.items" in result.stderr
+    assert "file_scope" in result.stderr
+    assert "verify_commands" in result.stderr
+
+
+def test_scope_decompose_to_active_stories_passes_readiness(tmp_path: Path) -> None:
+    parent = _parent(tmp_path, folder="active")
+    draft = _draft(tmp_path, output_dir="vbrief/active")
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--date",
+        "2026-05-12",
+    )
+
+    assert result.returncode == 0, result.stderr
+    story_paths = [
+        path
+        for path in sorted((tmp_path / "vbrief" / "active").glob("*.vbrief.json"))
+        if path.name != parent.name
+    ]
+    readiness = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "swarm_readiness.py"),
+            *(str(path.relative_to(tmp_path)) for path in story_paths),
+            "--project-root",
+            str(tmp_path),
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert readiness.returncode == 0, readiness.stdout + readiness.stderr
+    assert "Ready stories:" in readiness.stdout
+    assert "story-auth-model" in readiness.stdout
+    assert "story-auth-routes" in readiness.stdout

--- a/tests/cli/test_spec_render.py
+++ b/tests/cli/test_spec_render.py
@@ -328,6 +328,54 @@ def test_aggregator_emits_implementation_plan_section(render_mod, tmp_path) -> N
     assert pending_pos < active_pos < completed_pos
 
 
+def test_aggregator_preserves_epic_and_story_acceptance(render_mod, tmp_path) -> None:
+    """Lifecycle rendering must show broad epic acceptance and story item acceptance."""
+    vbrief_dir = tmp_path / "vbrief"
+    spec_path = _write_spec(vbrief_dir, {"Overview": "Acceptance visibility."})
+    _write_scope(
+        vbrief_dir / "pending",
+        "2026-05-12-ip001-auth.vbrief.json",
+        _scope(
+            "IP-1: Auth epic",
+            "pending",
+            {
+                "Description": "Broad auth phase.",
+                "Acceptance": "Parent acceptance remains visible.",
+                "Traces": "FR-1",
+            },
+            items=[],
+        ),
+    )
+    _write_scope(
+        vbrief_dir / "active",
+        "2026-05-12-auth-story.vbrief.json",
+        _scope(
+            "Auth story",
+            "running",
+            {"Description": "Executable auth story."},
+            items=[
+                {
+                    "id": "story-a",
+                    "title": "Implement login",
+                    "status": "pending",
+                    "narrative": {
+                        "Acceptance": "Login returns a token.",
+                        "Traces": "FR-1",
+                    },
+                }
+            ],
+        ),
+    )
+
+    out = tmp_path / "SPECIFICATION.md"
+    ok, msg = render_mod.render_spec(str(spec_path), str(out))
+    assert ok, msg
+    content = out.read_text(encoding="utf-8")
+    assert "**Scope Acceptance**:" in content
+    assert "Parent acceptance remains visible." in content
+    assert "Login returns a token." in content
+
+
 def test_include_scopes_off_suppresses_aggregator(render_mod, tmp_path) -> None:
     """--include-scopes=off skips the aggregator and preserves pre-#435 output (#435 regression)."""
     vbrief_dir = tmp_path / "vbrief"

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "swarm_readiness.py"
+
+
+def _write_json(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _story(
+    project: Path,
+    story_id: str,
+    *,
+    file_scope: list[str] | None = None,
+    verify_commands: list[str] | None = None,
+    acceptance: str = "Story acceptance passes",
+    depends_on: list[str] | None = None,
+    size: str = "small",
+    confidence: str = "high",
+) -> Path:
+    return _write_json(
+        project / "vbrief" / "active" / f"2026-05-12-{story_id}.vbrief.json",
+        {
+            "vBRIEFInfo": {"version": "0.6"},
+            "plan": {
+                "id": story_id,
+                "title": story_id,
+                "status": "running",
+                "narratives": {"Traces": "FR-1"},
+                "items": [
+                    {
+                        "id": f"{story_id}-a1",
+                        "title": "Acceptance item",
+                        "status": "pending",
+                        "narrative": {"Acceptance": acceptance, "Traces": "FR-1"},
+                    }
+                ],
+                "metadata": {
+                    "kind": "story",
+                    "swarm": {
+                        "readiness": "ready",
+                        "parallel_safe": True,
+                        "file_scope": [f"src/{story_id}.ts"] if file_scope is None else file_scope,
+                        "verify_commands": (
+                            [f"npm test -- {story_id}"]
+                            if verify_commands is None
+                            else verify_commands
+                        ),
+                        "expected_outputs": ["focused tests pass"],
+                        "depends_on": depends_on or [],
+                        "conflict_group": "auth",
+                        "size": size,
+                        "file_scope_confidence": confidence,
+                        "model_tier": "medium",
+                    },
+                },
+            },
+        },
+    )
+
+
+def _run(project: Path, *paths: Path) -> subprocess.CompletedProcess[str]:
+    args = [str(path.relative_to(project)) for path in paths]
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args, "--project-root", str(project)],
+        cwd=project,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_readiness_passes_for_ready_story(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-ready")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Ready stories:" in result.stdout
+    assert "story-ready" in result.stdout
+    assert "Blocked stories:\n- none" in result.stdout
+
+
+def test_readiness_fails_missing_acceptance_file_scope_and_verify_commands(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-missing", file_scope=[], verify_commands=[], acceptance="")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "plan.items[].narrative.Acceptance" in result.stdout
+    assert "plan.metadata.swarm.file_scope" in result.stdout
+    assert "plan.metadata.swarm.verify_commands" in result.stdout
+
+
+def test_readiness_reports_epic_phase_as_decomposition_needed(tmp_path: Path) -> None:
+    phase = _write_json(
+        tmp_path / "vbrief" / "active" / "2026-05-12-ip001-auth.vbrief.json",
+        {
+            "vBRIEFInfo": {"version": "0.6"},
+            "plan": {
+                "id": "ip-1",
+                "title": "IP-1: Auth",
+                "status": "running",
+                "narratives": {"Acceptance": "Broad epic acceptance", "Traces": "FR-1"},
+                "items": [],
+                "metadata": {"kind": "phase"},
+            },
+        },
+    )
+
+    result = _run(tmp_path, phase)
+
+    assert result.returncode == 1
+    assert "Decomposition-needed epics/phases:" in result.stdout
+    assert "kind=phase" in result.stdout
+
+
+def test_readiness_detects_unsafe_file_overlap(tmp_path: Path) -> None:
+    left = _story(tmp_path, "story-left", file_scope=["src/shared.ts"])
+    right = _story(tmp_path, "story-right", file_scope=["src/shared.ts"])
+
+    result = _run(tmp_path, left, right)
+
+    assert result.returncode == 1
+    assert "File overlap matrix:" in result.stdout
+    assert "src/shared.ts" in result.stdout
+    assert "story-left" in result.stdout
+    assert "story-right" in result.stdout
+
+
+def test_readiness_rejects_large_parallel_safe_story(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-large", size="large")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "size=large cannot be parallel_safe=true" in result.stdout
+
+
+def test_readiness_rejects_low_confidence_parallel_safe_story(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-low-confidence", confidence="low")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "low-confidence file scope cannot be parallel-safe by default" in result.stdout

--- a/tests/content/test_decomposition_readiness.py
+++ b/tests/content/test_decomposition_readiness.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_speckit_documents_phase_45() -> None:
+    text = _read("strategies/speckit.md")
+    assert "## Phase 4.5: Story Decomposition / Swarm Readiness" in text
+    assert "task scope:decompose" in text
+    assert "task swarm:readiness" in text
+    assert "plan.metadata.swarm" in text
+
+
+def test_vbrief_documents_epic_phase_story_swarm_semantics() -> None:
+    text = _read("vbrief/vbrief.md")
+    for token in (
+        'kind = "epic"',
+        'kind = "phase"',
+        'kind = "story"',
+        "plan.metadata.swarm",
+        "Story vBRIEFs are the only valid inputs for concurrent swarm worker allocation.",
+        "parallel_safe",
+        "file_scope_confidence",
+    ):
+        assert token in text
+
+
+def test_swarm_skill_requires_readiness_before_allocation() -> None:
+    text = _read("skills/deft-directive-swarm/SKILL.md")
+    assert "task swarm:readiness -- vbrief/active/*.vbrief.json" in text
+    assert "needs decomposition" in text
+    assert "Allocate concurrent workers unless candidates are swarm-ready" in text
+    assert "skills/deft-directive-decompose/SKILL.md" in text
+
+
+def test_decompose_skill_exists_and_uses_deterministic_commands() -> None:
+    text = _read("skills/deft-directive-decompose/SKILL.md")
+    assert "task scope:decompose" in text
+    assert "task swarm:readiness" in text
+    assert "explicit approval" in text
+    assert "Leave lifecycle promotion/activation to the existing approved flow" in text
+
+
+def test_make_spec_no_longer_teaches_stale_planitem_patterns() -> None:
+    text = _read("templates/make-spec.md")
+    assert 'vBRIEFInfo": { "version": "0.6" }' in text
+    assert "Nested children within a PlanItem MUST use `items`" in text
+    assert "Use deprecated `subItems` for new content" in text
+    assert '"subItems"' not in text
+    assert "rendered PRD export" in text
+    assert "rendered PRD/SPEC files are exports" in text

--- a/tests/content/test_speckit_phase4.py
+++ b/tests/content/test_speckit_phase4.py
@@ -1,7 +1,8 @@
 """test_speckit_phase4.py -- Content tests for #436.
 
 Verifies:
-- strategies/speckit.md Phase 4 emits scope vBRIEFs per implementation phase
+- strategies/speckit.md Phase 4 emits phase/epic scope vBRIEFs per implementation phase
+- strategies/speckit.md Phase 4.5 emits swarm-ready story vBRIEFs
 - Artifacts Summary includes 3c PRD render row and Phase 4 pending/ entry
 - plan.vbrief.json is documented as session-todo only (not project plan)
 - vbrief/vbrief.md documents the ip<NNN> 3-digit padded filename convention,
@@ -28,9 +29,12 @@ class TestSpeckitPhase4Emission:
     _text = _read("strategies/speckit.md")
 
     def test_phase_4_heading_updated(self) -> None:
-        assert "## Phase 4: Tasks (Scope vBRIEF Emission)" in self._text, (
-            "speckit Phase 4 heading must announce scope vBRIEF emission (#436)"
+        assert "## Phase 4: Implementation Phase / Epic Scope Emission" in self._text, (
+            "speckit Phase 4 heading must announce phase/epic scope emission"
         )
+
+    def test_phase_45_heading_present(self) -> None:
+        assert "## Phase 4.5: Story Decomposition / Swarm Readiness" in self._text
 
     def test_phase_4_writes_to_pending_folder(self) -> None:
         assert "./vbrief/pending/" in self._text, (
@@ -60,6 +64,20 @@ class TestSpeckitPhase4Emission:
             "plan.metadata.dependencies (#436)"
         )
 
+    def test_phase_4_marks_kind_phase_or_epic(self) -> None:
+        assert 'plan.metadata.kind = "phase"' in self._text
+        assert '"epic"' in self._text
+
+    def test_phase_45_requires_story_swarm_metadata(self) -> None:
+        for token in (
+            'plan.metadata.kind = "story"',
+            "non-empty `plan.items`",
+            "plan.metadata.swarm.file_scope",
+            "plan.metadata.swarm.verify_commands",
+            "planRef",
+        ):
+            assert token in self._text
+
     def test_phase_4_plan_vbrief_is_session_todo(self) -> None:
         assert "session-todo role" in self._text, (
             "speckit.md must describe plan.vbrief.json as the session-todo role (#436)"
@@ -83,6 +101,9 @@ class TestSpeckitPhase4Emission:
         assert "`./vbrief/pending/YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json`" in self._text, (
             "Artifacts Summary must show Phase 4 -> pending scope vBRIEF path (#436)"
         )
+
+    def test_artifacts_summary_includes_phase_45(self) -> None:
+        assert "4.5. Story decomposition" in self._text
 
     def test_migrator_flag_documented(self) -> None:
         assert "--speckit-plan" in self._text, (

--- a/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
+++ b/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
@@ -1,0 +1,95 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF for Directive story decomposition and swarm readiness.",
+    "created": "2026-05-12T00:00:00Z"
+  },
+  "plan": {
+    "id": "directive-decomposition-readiness",
+    "title": "Directive story decomposition and swarm readiness",
+    "status": "completed",
+    "narratives": {
+      "Problem": "Directive needs a first-class bridge from Speckit Phase 4 phase/epic scope output to story-level vBRIEFs that can be safely assigned to concurrent swarm workers.",
+      "Overview": "Add Phase 4.5 Story Decomposition / Swarm Readiness, deterministic decomposition and readiness commands, a canonical story metadata contract, skill updates, renderer acceptance preservation, and tests.",
+      "Constraint": "Keep schema compatibility by using plan.metadata.kind and plan.metadata.swarm. Do not make this Appcellerator-specific. Do not allow swarm allocation from broad phase/epic scopes unless explicitly handled as a non-concurrent single-story scope.",
+      "Test": "Focused checks passed for decomposition, readiness, rendering, content contracts, and Speckit translation. Full task check passed: 4971 passed, 5 skipped, 8 deselected, 1 xfailed."
+    },
+    "items": [
+      {
+        "id": "phase-45-docs",
+        "title": "Document Phase 4.5 and vBRIEF story contract",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "strategies/speckit.md and vbrief/vbrief.md define phase/epic/story semantics and required swarm-ready story fields.",
+          "Traces": "user-request"
+        }
+      },
+      {
+        "id": "deterministic-commands",
+        "title": "Add scope:decompose and swarm:readiness commands",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Taskfile exposes deterministic decomposition and readiness commands backed by tested Python scripts.",
+          "Traces": "user-request"
+        }
+      },
+      {
+        "id": "skill-render-template-updates",
+        "title": "Update skills, renderers, templates, and stale Speckit examples",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Swarm Phase 0 uses readiness reports; Speckit/template examples use v0.6, uri references, and PlanItem items; spec_render preserves epic and story acceptance.",
+          "Traces": "user-request"
+        }
+      },
+      {
+        "id": "verification",
+        "title": "Add tests and run PR readiness gates",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Content, CLI, translator, renderer, and end-to-end fixture tests pass; task check is run before declaring PR readiness.",
+          "Traces": "user-request"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "blocked",
+        "parallel_safe": false,
+        "file_scope": [
+          "strategies/speckit.md",
+          "vbrief/vbrief.md",
+          "scripts/scope_decompose.py",
+          "scripts/swarm_readiness.py",
+          "skills/deft-directive-swarm/SKILL.md",
+          "skills/deft-directive-decompose/SKILL.md",
+          "tests/cli/test_scope_decompose.py",
+          "tests/cli/test_swarm_readiness.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_scope_decompose.py tests/cli/test_swarm_readiness.py tests/cli/test_spec_render.py tests/content/test_decomposition_readiness.py tests/content/test_speckit_phase4.py tests/cli/test_migrate_vbrief.py -q",
+          "task check"
+        ],
+        "expected_outputs": [
+          "focused pytest suite passes",
+          "full task check status recorded"
+        ],
+        "depends_on": [],
+        "conflict_group": "directive-lifecycle",
+        "size": "large",
+        "file_scope_confidence": "medium",
+        "model_tier": "high",
+        "missing_traces_justification": "User-provided change request in this conversation is the source scope; no external issue was supplied."
+      }
+    },
+    "references": [
+      {
+        "uri": "urn:deft:user-request:2026-05-12-directive-decomposition-readiness",
+        "type": "x-vbrief/user-request",
+        "title": "User request: implement Directive decomposition/readiness layer"
+      }
+    ],
+    "updated": "2026-05-12T18:50:52Z"
+  }
+}

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -19,6 +19,8 @@ Key `task` commands for working with vBRIEF files:
 - `task issue:ingest -- <N>` / `task issue:ingest -- --all [--label L] [--status S] [--dry-run]` — Ingest GitHub issues as scope vBRIEFs in `vbrief/proposed/` (deduplicates via existing references)
 - `task vbrief:validate` — Validate schema, filenames, folder/status consistency (part of `task check`)
 - `task scope:promote|activate|complete|cancel|restore|block|unblock <file>` — Lifecycle transitions
+- `task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>` — Apply an approved phase/epic to story decomposition
+- `task swarm:readiness -- vbrief/active/*.vbrief.json` — Report whether candidate stories are safe for concurrent swarm allocation
 
 For interactive creation workflows, use `run` commands (`.deft/core/run bootstrap`, `.deft/core/run spec`). See [commands.md](../commands.md) for the full command lifecycle.
 
@@ -121,6 +123,58 @@ Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Link
 - ! Story vBRIEFs MUST carry `planRef` back to their parent epic
 - ~ The decision to create an epic vs. a standalone story is made collaboratively between user and agent
 
+### Scope Kinds and Swarm Semantics
+
+Directive uses `plan.metadata.kind` to distinguish broad planning scopes from executable swarm units:
+
+- `kind = "epic"` or `kind = "phase"` — broad implementation scope. MAY use `plan.narratives.Acceptance` for parent-level acceptance context and MAY have `plan.items: []`.
+- `kind = "story"` — executable implementation unit. MUST use non-empty `plan.items` for executable acceptance.
+
+- ! Story vBRIEFs are the only valid inputs for concurrent swarm worker allocation.
+- ! Epic/phase vBRIEFs MUST be decomposed before swarm allocation unless explicitly marked as a single-story scope.
+- ! Swarm allocation MUST NOT treat broad acceptance in `plan.narratives.Acceptance` as executable story acceptance.
+- ~ Phase 4 speckit output SHOULD use `kind = "phase"` or `kind = "epic"`; Phase 4.5 decomposition emits `kind = "story"` children.
+
+### Swarm-Ready Story Contract
+
+Swarm-ready story metadata lives under `plan.metadata.swarm` so the v0.6 schema remains compatible:
+
+```json
+{
+  "plan": {
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": ["src/foo.ts", "tests/foo.test.ts"],
+        "verify_commands": ["npm test -- foo"],
+        "expected_outputs": ["focused tests pass"],
+        "depends_on": ["story-id"],
+        "conflict_group": "backend-api",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    }
+  }
+}
+```
+
+For `kind = "story"` and `swarm.readiness = "ready"`:
+
+- ! `plan.items` MUST be non-empty
+- ! executable acceptance MUST live in `plan.items[].narrative.Acceptance`
+- ! dependency IDs MUST live in `plan.metadata.swarm.depends_on`
+- ! `file_scope` MUST be non-empty
+- ! `verify_commands` MUST be non-empty
+- ! `expected_outputs` SHOULD describe the evidence the worker is expected to produce
+- ! traces MUST exist through item/story `Traces`, `x-vbrief/spec-section` references, or an explicit `missing_traces_justification`
+- ! `planRef` MUST point to the parent phase/epic when the story was decomposed from one
+- ! parent phase/epic `references` MUST include child story paths with `type: x-vbrief/plan`
+- ⊗ Set `parallel_safe: true` on a `size: "large"` story
+- ⊗ Treat `file_scope_confidence: "low"` as parallel-safe by default
+
 **Epic → Stories** (via `references`):
 ```json
 {
@@ -165,13 +219,15 @@ When a scope grows too large, the parent vBRIEF becomes an epic and children are
 
 1. Agent identifies the scope is too large (collaboratively with user)
 2. Parent vBRIEF promoted to epic
-3. Child story vBRIEFs created with `planRef` back to parent
-4. Parent epic's `references` updated to list all child paths
-5. Update `plan.vbrief.json` (and `continue.vbrief.json` if present) `planRef` to reference child scope vBRIEFs
-6. Acceptance criteria redistributed by agent with user approval
-7. Origin provenance stays on the parent epic; children inherit via epic relationship
+3. Agent drafts a decomposition proposal and gets explicit user approval
+4. `task scope:decompose -- <parent> --draft <draft.json>` creates child story vBRIEFs with `planRef` back to parent
+5. Parent epic's `references` updated to list all child paths
+6. Update `plan.vbrief.json` (and `continue.vbrief.json` if present) `planRef` to reference child scope vBRIEFs
+7. Acceptance criteria redistributed by agent with user approval
+8. Origin provenance stays on the parent epic; children inherit via epic relationship
 
-- ! Scope splitting is agent-driven using existing tools — no dedicated split command
+- ! Scope splitting MUST use an approved draft and `task scope:decompose` for child writes
+- ! Run `task swarm:readiness` after decomposition before concurrent worker allocation
 - ~ Uses existing `scope:*` commands for lifecycle transitions after splitting
 
 ### General Rules


### PR DESCRIPTION
## Summary

Adds a first-class Directive story decomposition/readiness layer between Speckit Phase 4 and swarm implementation.

Highlights:
- Documents Phase 4.5 Story Decomposition / Swarm Readiness.
- Adds deterministic `task scope:decompose` and `task swarm:readiness` commands.
- Defines the canonical `plan.metadata.kind` / `plan.metadata.swarm` story contract.
- Updates swarm allocation to require readiness reports before worker dispatch.
- Adds `deft-directive-decompose` skill and fixes Speckit/template v0.6 reference patterns.
- Preserves epic acceptance and story acceptance in spec rendering.

## Related Issues

N/A - user-requested framework change in this session.

## Checklist

- [x] `/deft:change <name>` - scope vBRIEF created, activated, and completed for this work
- [x] `CHANGELOG.md` - added entry under `[Unreleased]`
- [x] `ROADMAP.md` - N/A, no tracked issue state changed
- [x] Tests pass locally: `task check` -> 4971 passed, 5 skipped, 8 deselected, 1 xfailed

## Verification

- `uv run pytest tests/cli/test_scope_decompose.py tests/cli/test_swarm_readiness.py tests/cli/test_spec_render.py tests/content/test_decomposition_readiness.py tests/content/test_speckit_phase4.py tests/cli/test_migrate_vbrief.py -q` -> 243 passed
- `uv run python scripts/vbrief_validate.py --vbrief-dir vbrief` -> passed with existing warnings
- `git diff --check` -> clean
- conflict-marker scan -> clean
- `task check` -> 4971 passed, 5 skipped, 8 deselected, 1 xfailed

## Post-Merge

- [ ] N/A for issue auto-close; no GitHub issue is linked by this PR body.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
