### PR TITLE
feat(directive): add decomposition readiness layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ When user input matches a trigger keyword, read the corresponding skill:
 
 - "review cycle" / "check reviews" / "run review cycle" → `skills/deft-directive-review-cycle/SKILL.md`
 - "swarm" / "parallel agents" / "run agents" → `skills/deft-directive-swarm/SKILL.md` — chains to `deft-directive-review-cycle` at Phase 5
+- "decompose" / "story decomposition" / "swarm readiness" → `skills/deft-directive-decompose/SKILL.md` — converts phase/epic scopes into swarm-ready story vBRIEFs before swarm allocation
 - "refinement" / "reprioritize" / "refine" → `skills/deft-directive-refinement/SKILL.md` — chains to `deft-directive-review-cycle` at exit
 - "build" / "implement" / "implement spec" → `skills/deft-directive-build/SKILL.md`
 - "cost" / "budget" / "pre-build cost" / "how much will this cost" → `skills/deft-directive-cost/SKILL.md`
@@ -156,4 +157,3 @@ Cross-references: `pyproject.toml` (marker registration + default opt-out), `Tas
 
 Note: paths here are root-relative — this repo IS the deft directory.
 Install-generated AGENTS.md uses deft/-prefixed paths.
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ When user input matches a trigger keyword, read the corresponding skill:
 
 - "review cycle" / "check reviews" / "run review cycle" → `skills/deft-directive-review-cycle/SKILL.md`
 - "swarm" / "parallel agents" / "run agents" → `skills/deft-directive-swarm/SKILL.md` — chains to `deft-directive-review-cycle` at Phase 5
-- "decompose" / "story decomposition" / "swarm readiness" → `skills/deft-directive-decompose/SKILL.md` — converts phase/epic scopes into swarm-ready story vBRIEFs before swarm allocation
+- "decompose" / "story decomposition" / "swarm readiness" → `skills/deft-directive-decompose/SKILL.md` — converts phase/epic scopes into swarm-ready story vBRIEFs before swarm allocation.
 - "refinement" / "reprioritize" / "refine" → `skills/deft-directive-refinement/SKILL.md` — chains to `deft-directive-review-cycle` at exit
 - "build" / "implement" / "implement spec" → `skills/deft-directive-build/SKILL.md`
 - "cost" / "budget" / "pre-build cost" / "how much will this cost" → `skills/deft-directive-cost/SKILL.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `deft-directive-gh-arch` skill -- explore codebase for shallow modules, design competing interfaces in parallel, file refactor RFC as GitHub Issue (re-land of #442; original author @visionik).
+- **feat(directive): add story decomposition and swarm-readiness gates** -- introduces Phase 4.5 Story Decomposition / Swarm Readiness between Speckit phase/epic scope emission and swarm implementation. Adds deterministic `task scope:decompose` and `task swarm:readiness` commands, a canonical `plan.metadata.kind` / `plan.metadata.swarm` story contract, a new `deft-directive-decompose` skill, swarm Phase 0 readiness gating, acceptance-preserving spec rendering, and regression coverage for decomposition, readiness, Speckit translation, and stale vBRIEF template guidance.
 
 ### Changed
 
@@ -2867,4 +2868,3 @@ If you have custom scripts or references to deft files, update these paths:
 [0.2.0]: https://github.com/visionik/warping/releases/tag/v0.2.0
 
 [0.1.0]: https://github.com/visionik/warping/releases/tag/v0.1.0
-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -97,6 +97,9 @@ includes:
   scope:
     taskfile: ./tasks/scope.yml
     optional: true
+  swarm:
+    taskfile: ./tasks/swarm.yml
+    optional: true
   roadmap:
     taskfile: ./tasks/roadmap.yml
     optional: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,7 +99,7 @@ includes:
     optional: true
   swarm:
     taskfile: ./tasks/swarm.yml
-    optional: true
+    optional: false
   roadmap:
     taskfile: ./tasks/roadmap.yml
     optional: true

--- a/scripts/_vbrief_build.py
+++ b/scripts/_vbrief_build.py
@@ -103,6 +103,27 @@ def reference_with_default_trust(ref: dict[str, Any]) -> dict[str, Any]:
         normalized["TrustLevel"] = "external"
     return normalized
 
+
+def _github_issue_reference(
+    *, repo_url: str, number: Any, title: Any
+) -> dict[str, str] | None:
+    cleaned_repo = str(repo_url or "").strip().rstrip("/")
+    cleaned_number = str(number or "").strip().lstrip("#").strip()
+    if not cleaned_repo or not cleaned_number:
+        return None
+    cleaned_title = str(title or "").strip()
+    ref_title = (
+        f"Issue #{cleaned_number}: {cleaned_title}"
+        if cleaned_title and cleaned_title != "Untitled"
+        else f"Issue #{cleaned_number}"
+    )
+    return {
+        "uri": f"{cleaned_repo}/issues/{cleaned_number}",
+        "type": "x-vbrief/github-issue",
+        "title": ref_title,
+    }
+
+
 # ----------------------------------------------------------------------------
 # Scope vBRIEF construction
 # ----------------------------------------------------------------------------
@@ -142,8 +163,8 @@ def create_scope_vbrief(
         to the canonical shape -- see ``scripts/reconcile_issues.py``
         for a bilingual reader example.
     """
-    number = item.get("number", "")
-    title = item.get("title", "Untitled")
+    number = str(item.get("number", "") or "").strip().lstrip("#").strip()
+    title = str(item.get("title", "Untitled") or "Untitled").strip() or "Untitled"
     phase = item.get("phase", "")
     tier = item.get("tier", "")
 
@@ -182,16 +203,12 @@ def create_scope_vbrief(
     # so we cannot honestly emit a reference without a resolvable URL.
     # ROADMAP bare-text rows (no issue number) legitimately ship with no
     # origin reference; the migrator logs them as proposed/ orphans.
-    if number and repo_url:
-        ref_title = (
-            f"Issue #{number}: {title}" if title and title != "Untitled"
-            else f"Issue #{number}"
-        )
-        canonical_ref: dict = {
-            "uri": f"{repo_url}/issues/{number}",
-            "type": "x-vbrief/github-issue",
-            "title": ref_title,
-        }
+    canonical_ref = _github_issue_reference(
+        repo_url=repo_url,
+        number=number,
+        title=title,
+    )
+    if canonical_ref is not None:
         vbrief["plan"]["references"] = [reference_with_default_trust(canonical_ref)]
 
     return vbrief

--- a/scripts/_vbrief_build.py
+++ b/scripts/_vbrief_build.py
@@ -124,6 +124,16 @@ def _github_issue_reference(
     }
 
 
+def _reference_has_required_fields(ref: dict[str, Any] | None) -> bool:
+    if ref is None:
+        return False
+    for key in ("uri", "type"):
+        value = ref.get(key)
+        if not isinstance(value, str) or not value.strip():
+            return False
+    return True
+
+
 # ----------------------------------------------------------------------------
 # Scope vBRIEF construction
 # ----------------------------------------------------------------------------
@@ -208,8 +218,13 @@ def create_scope_vbrief(
         number=number,
         title=title,
     )
-    if canonical_ref is not None:
-        vbrief["plan"]["references"] = [reference_with_default_trust(canonical_ref)]
+    trusted_ref = (
+        reference_with_default_trust(canonical_ref)
+        if _reference_has_required_fields(canonical_ref)
+        else None
+    )
+    if trusted_ref is not None and _reference_has_required_fields(trusted_ref):
+        vbrief["plan"]["references"] = [trusted_ref]
 
     return vbrief
 

--- a/scripts/_vbrief_build.py
+++ b/scripts/_vbrief_build.py
@@ -11,8 +11,10 @@ Story: #454 (task issue:ingest).
 
 from __future__ import annotations
 
+import copy
 import re
 from datetime import UTC, datetime
+from typing import Any
 
 # ----------------------------------------------------------------------------
 # Date helper
@@ -76,6 +78,31 @@ def slugify(text: str) -> str:
 # migrate:vbrief`" at a glance and keeps the payload compatible with the
 # vendored v0.6 schema without touching it.
 MIGRATOR_METADATA_KEY: str = "x-migrator"
+
+# ----------------------------------------------------------------------------
+# Reference provenance / trust helpers (#480)
+# ----------------------------------------------------------------------------
+
+INTERNAL_REFERENCE_TYPES = {"x-vbrief/plan", "x-vbrief/spec-section", "x-vbrief/user-request"}
+EXTERNAL_REFERENCE_TYPES = {
+    "x-vbrief/github-issue",
+    "x-vbrief/github-pr",
+    "x-vbrief/jira-ticket",
+    "x-vbrief/web-page",
+}
+
+
+def reference_with_default_trust(ref: dict[str, Any]) -> dict[str, Any]:
+    """Return a copied reference with the default TrustLevel filled when known."""
+    normalized = copy.deepcopy(ref)
+    if "TrustLevel" in normalized:
+        return normalized
+    ref_type = normalized.get("type")
+    if ref_type in INTERNAL_REFERENCE_TYPES:
+        normalized["TrustLevel"] = "internal"
+    elif ref_type in EXTERNAL_REFERENCE_TYPES:
+        normalized["TrustLevel"] = "external"
+    return normalized
 
 # ----------------------------------------------------------------------------
 # Scope vBRIEF construction
@@ -166,7 +193,7 @@ def create_scope_vbrief(
             "type": "x-vbrief/github-issue",
             "title": ref_title,
         }
-        vbrief["plan"]["references"] = [canonical_ref]
+        vbrief["plan"]["references"] = [reference_with_default_trust(canonical_ref)]
 
     return vbrief
 
@@ -175,6 +202,7 @@ __all__ = [
     "EMITTED_VBRIEF_VERSION",
     "MIGRATOR_METADATA_KEY",
     "TODAY",
+    "reference_with_default_trust",
     "slugify",
     "create_scope_vbrief",
 ]

--- a/scripts/_vbrief_build.py
+++ b/scripts/_vbrief_build.py
@@ -72,11 +72,10 @@ def slugify(text: str) -> str:
 # without it leaking into user-visible narratives.
 #
 # The surface key is a string (``"x-migrator"``) rather than a dotted
-# path because ``plan.metadata`` is schema-defined as ``{type: object}``
-# with no structural constraints -- any key is legal. Using the
-# ``x-migrator`` namespace signals "this value comes from `task
-# migrate:vbrief`" at a glance and keeps the payload compatible with the
-# vendored v0.6 schema without touching it.
+# path because ``plan.metadata`` is the extension point for tool-specific
+# metadata. Using the ``x-migrator`` namespace signals "this value comes
+# from `task migrate:vbrief`" at a glance and keeps the payload compatible
+# with the vendored v0.6 schema without touching it.
 MIGRATOR_METADATA_KEY: str = "x-migrator"
 
 # ----------------------------------------------------------------------------

--- a/scripts/_vbrief_speckit.py
+++ b/scripts/_vbrief_speckit.py
@@ -20,10 +20,27 @@ from _vbrief_build import (
 )
 
 
+def _reference_with_default_trust(ref: dict) -> dict:
+    normalized = dict(ref)
+    if "TrustLevel" in normalized:
+        return normalized
+    ref_type = normalized.get("type")
+    if ref_type in {"x-vbrief/plan", "x-vbrief/spec-section", "x-vbrief/user-request"}:
+        normalized["TrustLevel"] = "internal"
+    elif ref_type in {
+        "x-vbrief/github-issue",
+        "x-vbrief/github-pr",
+        "x-vbrief/jira-ticket",
+        "x-vbrief/web-page",
+    }:
+        normalized["TrustLevel"] = "external"
+    return normalized
+
+
 def edge_nodes(edge: dict) -> tuple[str, str]:
     """Return (from_id, to_id) for a vBRIEF edge, reading both dialects.
 
-    The canonical v0.5 key names are ``from`` / ``to``, but earlier speckit
+    The canonical v0.6 key names are ``from`` / ``to``, but earlier speckit
     drafts used ``source`` / ``target``.  Prefer the canonical keys when
     they are populated and fall back to the legacy keys.
     """
@@ -119,20 +136,23 @@ def create_speckit_scope_vbrief(
         if isinstance(value, str) and value.strip():
             narratives[extra] = value.strip()
 
-    references = [{"type": "x-vbrief/plan", "url": spec_ref}]
+    references = [
+        {"type": "x-vbrief/plan", "uri": spec_ref, "TrustLevel": "internal"}
+    ]
     for ref in item.get("references", []) or []:
         if isinstance(ref, dict) and ref.get("type") != "x-vbrief/plan":
-            references.append(ref)
+            references.append(_reference_with_default_trust(ref))
 
     plan: dict = {
         "title": title,
         "status": "pending",
         "narratives": narratives,
         "items": [],
+        "metadata": {"kind": "phase"},
         "references": references,
     }
     if dependencies:
-        plan["metadata"] = {"dependencies": list(dependencies)}
+        plan["metadata"]["dependencies"] = list(dependencies)
 
     return {
         "vBRIEFInfo": {
@@ -148,7 +168,7 @@ def migrate_speckit_plan(
     *,
     pending_dir: Path | None = None,
     date: str | None = None,
-    spec_ref: str = "../specification.vbrief.json",
+    spec_ref: str = "./specification.vbrief.json",
     today: str | None = None,
 ) -> tuple[bool, list[str]]:
     """Translate a speckit-shaped ``plan.vbrief.json`` into scope vBRIEFs.

--- a/scripts/_vbrief_speckit.py
+++ b/scripts/_vbrief_speckit.py
@@ -96,21 +96,22 @@ def create_speckit_scope_vbrief(
     ``x-vbrief/plan`` reference.
     """
     spec_ref = _vbrief_relative_spec_ref(spec_ref)
-    title = _non_empty_text(item.get("title"), f"IP-{ip_index}")
+    fallback_title = f"IP-{ip_index}"
+    title = _non_empty_text(item.get("title"), fallback_title)
     narrative = item.get("narrative") or {}
     if not isinstance(narrative, dict):
         narrative = {}
 
-    def _pick(*keys: str, default: str = "") -> str:
+    def _pick(*keys: str) -> str:
         for key in keys:
             value = narrative.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
-        return default.strip()
+        return ""
 
-    description = _pick("Description", "Summary", default=title)
-    acceptance = _pick("Acceptance", "AcceptanceCriteria", default="")
-    traces = _pick("Traces", "Trace", "Requirements", default=f"IP-{ip_index}")
+    description = _pick("Description", "Summary") or title or fallback_title
+    acceptance = _pick("Acceptance", "AcceptanceCriteria")
+    traces = _pick("Traces", "Trace", "Requirements") or fallback_title
 
     default_acceptance = (
         f"Acceptance criteria for IP-{ip_index} "

--- a/scripts/_vbrief_speckit.py
+++ b/scripts/_vbrief_speckit.py
@@ -24,9 +24,9 @@ from _vbrief_build import (
 def edge_nodes(edge: dict) -> tuple[str, str]:
     """Return (from_id, to_id) for a vBRIEF edge, reading both dialects.
 
-    The canonical v0.6 key names are ``from`` / ``to``, but earlier speckit
-    drafts used ``source`` / ``target``.  Prefer the canonical keys when
-    they are populated and fall back to the legacy keys.
+    Speckit plan edges use ``from`` / ``to`` in current drafts, but earlier
+    drafts used ``source`` / ``target``. Prefer the current keys when they
+    are populated and fall back to the legacy keys.
     """
     if not isinstance(edge, dict):
         return "", ""
@@ -76,6 +76,11 @@ def speckit_ip_index(item: dict, fallback_index: int) -> int:
     return fallback_index
 
 
+def _non_empty_text(value: object, fallback: str) -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
 def create_speckit_scope_vbrief(
     item: dict,
     *,
@@ -91,7 +96,7 @@ def create_speckit_scope_vbrief(
     ``x-vbrief/plan`` reference.
     """
     spec_ref = _vbrief_relative_spec_ref(spec_ref)
-    title = str(item.get("title", f"IP-{ip_index}") or f"IP-{ip_index}")
+    title = _non_empty_text(item.get("title"), f"IP-{ip_index}")
     narrative = item.get("narrative") or {}
     if not isinstance(narrative, dict):
         narrative = {}
@@ -101,7 +106,7 @@ def create_speckit_scope_vbrief(
             value = narrative.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
-        return default
+        return default.strip()
 
     description = _pick("Description", "Summary", default=title)
     acceptance = _pick("Acceptance", "AcceptanceCriteria", default="")

--- a/scripts/_vbrief_speckit.py
+++ b/scripts/_vbrief_speckit.py
@@ -90,6 +90,7 @@ def create_speckit_scope_vbrief(
     and links back to the parent ``specification.vbrief.json`` via a
     ``x-vbrief/plan`` reference.
     """
+    spec_ref = _vbrief_relative_spec_ref(spec_ref)
     title = str(item.get("title", f"IP-{ip_index}") or f"IP-{ip_index}")
     narrative = item.get("narrative") or {}
     if not isinstance(narrative, dict):
@@ -145,6 +146,14 @@ def create_speckit_scope_vbrief(
         },
         "plan": plan,
     }
+
+
+def _vbrief_relative_spec_ref(spec_ref: str) -> str:
+    """Return a vbrief-directory-relative reference for the parent spec."""
+    normalized = spec_ref.strip()
+    while normalized.startswith("../"):
+        normalized = normalized[3:]
+    return normalized or "specification.vbrief.json"
 
 
 def migrate_speckit_plan(

--- a/scripts/_vbrief_speckit.py
+++ b/scripts/_vbrief_speckit.py
@@ -16,25 +16,9 @@ from pathlib import Path
 
 from _vbrief_build import (
     EMITTED_VBRIEF_VERSION as _EMITTED_VBRIEF_VERSION,
+    reference_with_default_trust as _reference_with_default_trust,
     slugify as _slugify_shared,
 )
-
-
-def _reference_with_default_trust(ref: dict) -> dict:
-    normalized = dict(ref)
-    if "TrustLevel" in normalized:
-        return normalized
-    ref_type = normalized.get("type")
-    if ref_type in {"x-vbrief/plan", "x-vbrief/spec-section", "x-vbrief/user-request"}:
-        normalized["TrustLevel"] = "internal"
-    elif ref_type in {
-        "x-vbrief/github-issue",
-        "x-vbrief/github-pr",
-        "x-vbrief/jira-ticket",
-        "x-vbrief/web-page",
-    }:
-        normalized["TrustLevel"] = "external"
-    return normalized
 
 
 def edge_nodes(edge: dict) -> tuple[str, str]:
@@ -137,7 +121,7 @@ def create_speckit_scope_vbrief(
             narratives[extra] = value.strip()
 
     references = [
-        {"type": "x-vbrief/plan", "uri": spec_ref, "TrustLevel": "internal"}
+        _reference_with_default_trust({"type": "x-vbrief/plan", "uri": spec_ref})
     ]
     for ref in item.get("references", []) or []:
         if isinstance(ref, dict) and ref.get("type") != "x-vbrief/plan":

--- a/scripts/_vbrief_speckit.py
+++ b/scripts/_vbrief_speckit.py
@@ -152,7 +152,7 @@ def migrate_speckit_plan(
     *,
     pending_dir: Path | None = None,
     date: str | None = None,
-    spec_ref: str = "./specification.vbrief.json",
+    spec_ref: str = "specification.vbrief.json",
     today: str | None = None,
 ) -> tuple[bool, list[str]]:
     """Translate a speckit-shaped ``plan.vbrief.json`` into scope vBRIEFs.

--- a/scripts/_vbrief_story_quality.py
+++ b/scripts/_vbrief_story_quality.py
@@ -1,0 +1,180 @@
+"""Shared story-quality checks for decomposition and swarm readiness."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+BROAD_FILE_SCOPE_ROOTS = {"backend", "frontend", "docs", "vbrief"}
+GENERIC_VERIFY_COMMANDS = {
+    "cargo test",
+    "go test ./...",
+    "npm run test",
+    "npm test",
+    "pytest",
+    "task check",
+}
+PLACEHOLDER_ACCEPTANCE_PATTERNS = (
+    "acceptance criteria for",
+    "copy from parent",
+    "copy from specification",
+    "placeholder",
+    "refine from parent",
+    "tbd",
+    "to be defined",
+    "to refine",
+    "to refine from parent scope",
+    "todo",
+)
+DOCS_ONLY_ACCEPTANCE_PATTERNS = (
+    "docs updated",
+    "documentation updated",
+    "readme updated",
+    "update docs",
+    "update documentation",
+    "update readme",
+)
+OBSERVABLE_TERMS = (
+    "blocks",
+    "creates",
+    "deletes",
+    "displays",
+    "emits",
+    "fails",
+    "persists",
+    "records",
+    "redirects",
+    "rejects",
+    "renders",
+    "returns",
+    "saves",
+    "shows",
+    "stores",
+    "updates",
+    "validates",
+    "when ",
+    "given ",
+    "then ",
+)
+USER_STORY_RE = re.compile(
+    r"^\s*As\s+a[n]?\s+[^,]+,\s*I\s+want\s+.+,\s*so\s+that\s+.+\.\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def acceptance_texts_from_items(items: Any) -> list[str]:
+    texts: list[str] = []
+    if not isinstance(items, list):
+        return texts
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        narrative = item.get("narrative")
+        if isinstance(narrative, dict):
+            acceptance = narrative.get("Acceptance")
+            if isinstance(acceptance, str) and acceptance.strip():
+                texts.append(acceptance.strip())
+        for child_key in ("items", "subItems"):
+            texts.extend(acceptance_texts_from_items(item.get(child_key)))
+    return texts
+
+
+def story_quality_issues(
+    *,
+    title: str,
+    description: str,
+    user_story: str,
+    acceptance_texts: list[str],
+    acceptance_count_justification: str,
+    swarm: dict[str, Any],
+    concurrent_ready: bool = True,
+) -> list[str]:
+    issues: list[str] = []
+    if not USER_STORY_RE.match(user_story or ""):
+        issues.append(
+            "UserStory must match 'As a <role>, I want <capability>, so that <outcome>.'"
+        )
+    if not (2 <= len(acceptance_texts) <= 5) and not acceptance_count_justification.strip():
+        issues.append("2-5 acceptance criteria required unless justified")
+
+    normalized_title = _normalize(title)
+    normalized_description = _normalize(description)
+    for criterion in acceptance_texts:
+        normalized = _normalize(criterion)
+        lower = criterion.lower()
+        if any(pattern in lower for pattern in PLACEHOLDER_ACCEPTANCE_PATTERNS):
+            issues.append("placeholder acceptance criterion")
+        if normalized and normalized in {normalized_title, normalized_description}:
+            issues.append("acceptance criterion duplicates title or description")
+        if any(pattern in lower for pattern in DOCS_ONLY_ACCEPTANCE_PATTERNS):
+            issues.append("vague docs-only acceptance criterion")
+        if not _looks_observable(lower):
+            issues.append("acceptance criterion must describe observable behavior")
+
+    if concurrent_ready:
+        issues.extend(_file_scope_issues(swarm))
+        issues.extend(_verify_command_issues(swarm))
+        if swarm.get("parallel_safe") is False:
+            issues.append(
+                "readiness=ready requires parallel_safe=true; use readiness=sequential "
+                "or needs_refinement for non-concurrent work"
+            )
+        if swarm.get("file_scope_confidence") == "low":
+            issues.append("readiness=ready requires file_scope_confidence above low")
+    return _dedupe(issues)
+
+
+def _file_scope_issues(swarm: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    for file_path in as_str_list(swarm.get("file_scope")):
+        normalized = file_path.strip().strip("/")
+        root = normalized.split("/", 1)[0]
+        if (
+            normalized.endswith("/**")
+            or "**" in normalized
+            or normalized in BROAD_FILE_SCOPE_ROOTS
+            or file_path.rstrip("/") in BROAD_FILE_SCOPE_ROOTS
+            or (root in BROAD_FILE_SCOPE_ROOTS and normalized in {root, f"{root}/*"})
+        ):
+            issues.append(f"broad file_scope is not swarm-ready: {file_path}")
+    return issues
+
+
+def _verify_command_issues(swarm: dict[str, Any]) -> list[str]:
+    commands = [command.lower() for command in as_str_list(swarm.get("verify_commands"))]
+    if len(commands) == 1 and _normalize_command(commands[0]) in GENERIC_VERIFY_COMMANDS:
+        return [f"generic verify command is not swarm-ready: {commands[0]}"]
+    return []
+
+
+def _looks_observable(lower: str) -> bool:
+    return any(term in lower for term in OBSERVABLE_TERMS)
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+
+def _normalize_command(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out

--- a/scripts/_vbrief_story_quality.py
+++ b/scripts/_vbrief_story_quality.py
@@ -6,6 +6,35 @@ import re
 from typing import Any
 
 BROAD_FILE_SCOPE_ROOTS = {"backend", "frontend", "docs", "vbrief"}
+CODE_PATH_TERMS = (
+    "api",
+    "cli",
+    "component",
+    "config",
+    "database",
+    "endpoint",
+    "file",
+    "handler",
+    "model",
+    "module",
+    "repository",
+    "route",
+    "schema",
+    "script",
+    "service",
+    "source",
+    "src/",
+)
+VERIFY_EVIDENCE_TERMS = (
+    "assert",
+    "evidence",
+    "fixture",
+    "report",
+    "spec",
+    "test",
+    "tests/",
+    "verify",
+)
 GENERIC_VERIFY_COMMANDS = {
     "cargo test",
     "go test ./...",
@@ -33,6 +62,25 @@ DOCS_ONLY_ACCEPTANCE_PATTERNS = (
     "update docs",
     "update documentation",
     "update readme",
+)
+GENERIC_IMPLEMENTATION_PATTERNS = (
+    "add tests so it works",
+    "change the code",
+    "implement the feature",
+    "make it work",
+    "update the code",
+    "works as expected",
+)
+VAGUE_ACCEPTANCE_PATTERNS = (
+    "displays a message",
+    "handles errors",
+    "is implemented",
+    "is updated",
+    "passes tests",
+    "shows a message",
+    "the system displays a message",
+    "updates the ui",
+    "works as expected",
 )
 OBSERVABLE_TERMS = (
     "blocks",
@@ -89,6 +137,75 @@ def acceptance_texts_from_items(items: Any) -> list[str]:
     return texts
 
 
+def item_has_acceptance(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        value = narrative.get("Acceptance")
+        if isinstance(value, str) and value.strip():
+            return True
+    for child_key in ("items", "subItems"):
+        children = item.get(child_key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and item_has_acceptance(child):
+                    return True
+    return False
+
+
+def items_have_acceptance(items: Any) -> bool:
+    if not isinstance(items, list):
+        return False
+    return any(isinstance(item, dict) and item_has_acceptance(item) for item in items)
+
+
+def item_has_traces(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        value = narrative.get("Traces")
+        if isinstance(value, str) and value.strip():
+            return True
+    for child_key in ("items", "subItems"):
+        children = item.get(child_key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and item_has_traces(child):
+                    return True
+    return False
+
+
+def missing_required_swarm_fields(swarm: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    for key in ("file_scope", "verify_commands", "expected_outputs"):
+        if not as_str_list(swarm.get(key)):
+            missing.append(f"plan.metadata.swarm.{key}")
+    if "depends_on" not in swarm:
+        missing.append("plan.metadata.swarm.depends_on")
+    for key in ("conflict_group", "size", "file_scope_confidence", "model_tier"):
+        value = swarm.get(key)
+        if not isinstance(value, str) or not value.strip():
+            missing.append(f"plan.metadata.swarm.{key}")
+    return missing
+
+
+def deprecated_subitems_issues(items: Any, prefix: str = "plan.items") -> list[str]:
+    issues: list[str] = []
+
+    def visit(children: Any, path: str) -> None:
+        if not isinstance(children, list):
+            return
+        for index, item in enumerate(children):
+            if not isinstance(item, dict):
+                continue
+            item_path = f"{path}[{index}]"
+            if "subItems" in item:
+                issues.append(f"{item_path}.subItems is deprecated; use items")
+            visit(item.get("items"), f"{item_path}.items")
+            visit(item.get("subItems"), f"{item_path}.subItems")
+
+    visit(items, prefix)
+    return issues
+
+
 def story_quality_issues(
     *,
     title: str,
@@ -121,6 +238,10 @@ def story_quality_issues(
             issues.append("acceptance criterion duplicates title or description")
         if any(pattern in lower for pattern in DOCS_ONLY_ACCEPTANCE_PATTERNS):
             issues.append("vague docs-only acceptance criterion")
+        if _word_count(criterion) < 8 or any(
+            pattern in lower for pattern in VAGUE_ACCEPTANCE_PATTERNS
+        ):
+            issues.append("acceptance criterion must describe specific observable behavior")
         if not _looks_observable(lower):
             issues.append("acceptance criterion must describe observable behavior")
 
@@ -143,8 +264,7 @@ def _file_scope_issues(swarm: dict[str, Any]) -> list[str]:
         normalized = file_path.strip().strip("/")
         root = normalized.split("/", 1)[0]
         if (
-            normalized.endswith("/**")
-            or "**" in normalized
+            any(ch in normalized for ch in "*?[")
             or normalized in BROAD_FILE_SCOPE_ROOTS
             or file_path.rstrip("/") in BROAD_FILE_SCOPE_ROOTS
             or (root in BROAD_FILE_SCOPE_ROOTS and normalized in {root, f"{root}/*"})
@@ -171,12 +291,23 @@ def _description_issues(description: str) -> list[str]:
 def _implementation_plan_issues(implementation_plan: str) -> list[str]:
     if not implementation_plan.strip():
         return ["plan.narratives.ImplementationPlan is required"]
+    issues: list[str] = []
     if _step_count(implementation_plan) < 2 or _word_count(implementation_plan) < 20:
-        return ["plan.narratives.ImplementationPlan must contain at least two concrete steps"]
+        issues.append(
+            "plan.narratives.ImplementationPlan must contain at least two concrete steps"
+        )
     lower = implementation_plan.lower()
     if any(pattern in lower for pattern in PLACEHOLDER_ACCEPTANCE_PATTERNS):
-        return ["plan.narratives.ImplementationPlan must not be placeholder text"]
-    return []
+        issues.append("plan.narratives.ImplementationPlan must not be placeholder text")
+    if any(pattern in lower for pattern in GENERIC_IMPLEMENTATION_PATTERNS) or not (
+        any(term in lower for term in CODE_PATH_TERMS)
+        and any(term in lower for term in VERIFY_EVIDENCE_TERMS)
+    ):
+        issues.append(
+            "plan.narratives.ImplementationPlan must identify concrete code paths "
+            "and verification evidence"
+        )
+    return issues
 
 
 def _looks_observable(lower: str) -> bool:

--- a/scripts/_vbrief_story_quality.py
+++ b/scripts/_vbrief_story_quality.py
@@ -93,6 +93,7 @@ def story_quality_issues(
     *,
     title: str,
     description: str,
+    implementation_plan: str,
     user_story: str,
     acceptance_texts: list[str],
     acceptance_count_justification: str,
@@ -104,6 +105,8 @@ def story_quality_issues(
         issues.append(
             "UserStory must match 'As a <role>, I want <capability>, so that <outcome>.'"
         )
+    issues.extend(_description_issues(description))
+    issues.extend(_implementation_plan_issues(implementation_plan))
     if not (2 <= len(acceptance_texts) <= 5) and not acceptance_count_justification.strip():
         issues.append("2-5 acceptance criteria required unless justified")
 
@@ -157,8 +160,47 @@ def _verify_command_issues(swarm: dict[str, Any]) -> list[str]:
     return []
 
 
+def _description_issues(description: str) -> list[str]:
+    if not description.strip():
+        return ["plan.narratives.Description is required"]
+    if _sentence_count(description) < 2 or _word_count(description) < 20:
+        return ["plan.narratives.Description must contain at least two concrete sentences"]
+    return []
+
+
+def _implementation_plan_issues(implementation_plan: str) -> list[str]:
+    if not implementation_plan.strip():
+        return ["plan.narratives.ImplementationPlan is required"]
+    if _step_count(implementation_plan) < 2 or _word_count(implementation_plan) < 20:
+        return ["plan.narratives.ImplementationPlan must contain at least two concrete steps"]
+    lower = implementation_plan.lower()
+    if any(pattern in lower for pattern in PLACEHOLDER_ACCEPTANCE_PATTERNS):
+        return ["plan.narratives.ImplementationPlan must not be placeholder text"]
+    return []
+
+
 def _looks_observable(lower: str) -> bool:
     return any(term in lower for term in OBSERVABLE_TERMS)
+
+
+def _sentence_count(value: str) -> int:
+    return len([part for part in re.split(r"[.!?]+(?:\s+|$)", value.strip()) if part.strip()])
+
+
+def _step_count(value: str) -> int:
+    lines = [line.strip() for line in value.splitlines() if line.strip()]
+    bullet_lines = [
+        line
+        for line in lines
+        if re.match(r"^([-*]|\d+[.)])\s+", line)
+    ]
+    if len(bullet_lines) >= 2:
+        return len(bullet_lines)
+    return _sentence_count(value)
+
+
+def _word_count(value: str) -> int:
+    return len(re.findall(r"\b\w+\b", value))
 
 
 def _normalize(value: str) -> str:

--- a/scripts/migrate_vbrief.py
+++ b/scripts/migrate_vbrief.py
@@ -2270,6 +2270,23 @@ def _speckit_ip_index(item: dict, fallback_index: int) -> int:
     return fallback_index
 
 
+def _speckit_reference_with_default_trust(ref: dict) -> dict:
+    normalized = dict(ref)
+    if "TrustLevel" in normalized:
+        return normalized
+    ref_type = normalized.get("type")
+    if ref_type in {"x-vbrief/plan", "x-vbrief/spec-section", "x-vbrief/user-request"}:
+        normalized["TrustLevel"] = "internal"
+    elif ref_type in {
+        "x-vbrief/github-issue",
+        "x-vbrief/github-pr",
+        "x-vbrief/jira-ticket",
+        "x-vbrief/web-page",
+    }:
+        normalized["TrustLevel"] = "external"
+    return normalized
+
+
 def _create_speckit_scope_vbrief(
     item: dict,
     *,
@@ -2316,22 +2333,23 @@ def _create_speckit_scope_vbrief(
             narratives[extra] = value.strip()
 
     references = [
-        {"type": "x-vbrief/plan", "url": spec_ref},
+        {"type": "x-vbrief/plan", "uri": spec_ref, "TrustLevel": "internal"},
     ]
     # Copy any origin-provenance refs from the item (e.g. github-issue).
     for ref in item.get("references", []) or []:
         if isinstance(ref, dict) and ref.get("type") != "x-vbrief/plan":
-            references.append(ref)
+            references.append(_speckit_reference_with_default_trust(ref))
 
     plan: dict = {
         "title": title,
         "status": "pending",
         "narratives": narratives,
         "items": [],
+        "metadata": {"kind": "phase"},
         "references": references,
     }
     if dependencies:
-        plan["metadata"] = {"dependencies": list(dependencies)}
+        plan["metadata"]["dependencies"] = list(dependencies)
 
     return {
         "vBRIEFInfo": {
@@ -2347,7 +2365,7 @@ def migrate_speckit_plan(
     *,
     pending_dir: Path | None = None,
     date: str | None = None,
-    spec_ref: str = "../specification.vbrief.json",
+    spec_ref: str = "./specification.vbrief.json",
 ) -> tuple[bool, list[str]]:
     """Translate a speckit-shaped ``plan.vbrief.json`` into scope vBRIEFs.
 

--- a/scripts/migrate_vbrief.py
+++ b/scripts/migrate_vbrief.py
@@ -58,6 +58,14 @@ from _vbrief_build import (  # noqa: E402 -- after sys.path mutate + lazy emit h
     reference_with_default_trust as _reference_with_default_trust,
     slugify as _slugify_shared,
 )
+from _vbrief_speckit import (  # noqa: E402
+    create_speckit_scope_vbrief as _create_speckit_scope_vbrief_shared,
+    dependencies_for_item as _dependencies_for_item_shared,
+    edge_nodes as _edge_nodes_shared,
+    migrate_speckit_plan as _migrate_speckit_plan_shared,
+    speckit_ip_index as _speckit_ip_index_shared,
+    speckit_ip_slug as _speckit_ip_slug_shared,
+)
 from _vbrief_validation import (  # noqa: E402
     finalize_migration,
     slug_fallback_id,
@@ -2209,70 +2217,23 @@ def migrate(
 
 
 def _edge_nodes(edge: dict) -> tuple[str, str]:
-    """Return (from_id, to_id) for a vBRIEF edge, reading both dialects.
-
-    The canonical v0.5 key names are ``from`` / ``to``, but earlier speckit
-    drafts used ``source`` / ``target``.  Prefer the canonical keys when they
-    are populated and fall back to the legacy keys so a single translator can
-    handle both shapes (covers the #458 migrate_vbrief.py touchpoint).
-    """
-    if not isinstance(edge, dict):
-        return "", ""
-    src = edge.get("from") or edge.get("source", "")
-    tgt = edge.get("to") or edge.get("target", "")
-    return str(src or ""), str(tgt or "")
+    """Compatibility shim for the shared Speckit translator."""
+    return _edge_nodes_shared(edge)
 
 
 def _dependencies_for_item(item_id: str, edges: list[dict]) -> list[str]:
-    """Return the list of item IDs that block ``item_id`` (bilingual reader).
-
-    An edge with ``type == 'blocks'`` and target equal to ``item_id`` means the
-    edge's source blocks this item — so the source is a dependency of it.
-    """
-    deps: list[str] = []
-    for edge in edges or []:
-        if not isinstance(edge, dict):
-            continue
-        if edge.get("type", "") != "blocks":
-            continue
-        src, tgt = _edge_nodes(edge)
-        if tgt == item_id and src and src not in deps:
-            deps.append(src)
-    return deps
+    """Compatibility shim for the shared Speckit translator."""
+    return _dependencies_for_item_shared(item_id, edges)
 
 
 def _speckit_ip_slug(title: str, item_id: str) -> str:
-    """Return a slug for a speckit IP item filename.
-
-    Strips any leading ``IP-N:`` / ``IP\u00a0N:`` / ``IPN-`` prefix so the slug
-    focuses on the descriptive part (e.g. ``IP-3: Implement data layer`` ->
-    ``implement-data-layer``).  Falls back to the item_id slug when no title
-    is available.
-    """
-    source = (title or item_id or "").strip()
-    # Strip leading IP-N: or IP N: or IPN- prefixes (case-insensitive).
-    source = re.sub(r"^\s*IP[\s-]*\d+\s*[:\-]\s*", "", source, flags=re.IGNORECASE)
-    slug = _slugify(source)
-    return slug or _slugify(item_id) or "ip-phase"
+    """Compatibility shim for the shared Speckit translator."""
+    return _speckit_ip_slug_shared(title, item_id)
 
 
 def _speckit_ip_index(item: dict, fallback_index: int) -> int:
-    """Derive the numeric IP index for a speckit plan item.
-
-    Resolution order:
-    1. Trailing digits on ``item.id`` (e.g. ``ip-3``, ``IP-12``, ``t4`` -> 3/12/4).
-    2. Leading digits on ``item.title`` (e.g. ``IP-7: Foo`` -> 7).
-    3. ``fallback_index`` (1-based position in the items list).
-    """
-    item_id = str(item.get("id", "") or "")
-    tail = re.search(r"(\d+)\s*$", item_id)
-    if tail:
-        return int(tail.group(1))
-    title = str(item.get("title", "") or "")
-    lead = re.search(r"IP[\s-]*(\d+)", title, flags=re.IGNORECASE)
-    if lead:
-        return int(lead.group(1))
-    return fallback_index
+    """Compatibility shim for the shared Speckit translator."""
+    return _speckit_ip_index_shared(item, fallback_index)
 
 
 def _create_speckit_scope_vbrief(
@@ -2282,70 +2243,13 @@ def _create_speckit_scope_vbrief(
     dependencies: list[str],
     spec_ref: str,
 ) -> dict:
-    """Build a Phase 4 scope vBRIEF dict for a speckit implementation phase.
-
-    Populates the canonical narrative keys (``Description``, ``Acceptance``,
-    ``Traces``), writes ``plan.metadata.dependencies`` at the plan level, and
-    links back to the parent ``specification.vbrief.json`` via a
-    ``x-vbrief/plan`` reference.
-    """
-    title = str(item.get("title", f"IP-{ip_index}") or f"IP-{ip_index}")
-    narrative = item.get("narrative") or {}
-    if not isinstance(narrative, dict):
-        narrative = {}
-
-    def _pick(*keys: str, default: str = "") -> str:
-        for key in keys:
-            value = narrative.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return default
-
-    description = _pick("Description", "Summary", default=title)
-    acceptance = _pick("Acceptance", "AcceptanceCriteria", default="")
-    traces = _pick("Traces", "Trace", "Requirements", default=f"IP-{ip_index}")
-
-    default_acceptance = (
-        f"Acceptance criteria for IP-{ip_index} "
-        f"(copy from specification.vbrief.json)."
+    """Compatibility shim for the shared Speckit translator."""
+    return _create_speckit_scope_vbrief_shared(
+        item,
+        ip_index=ip_index,
+        dependencies=dependencies,
+        spec_ref=spec_ref,
     )
-    narratives: dict[str, str] = {
-        "Description": description,
-        "Acceptance": acceptance or default_acceptance,
-        "Traces": traces,
-    }
-    # Preserve optional canonical-adjacent keys if present.
-    for extra in ("Phase", "PhaseDescription", "Tier"):
-        value = narrative.get(extra)
-        if isinstance(value, str) and value.strip():
-            narratives[extra] = value.strip()
-
-    references = [
-        _reference_with_default_trust({"type": "x-vbrief/plan", "uri": spec_ref}),
-    ]
-    # Copy any origin-provenance refs from the item (e.g. github-issue).
-    for ref in item.get("references", []) or []:
-        if isinstance(ref, dict) and ref.get("type") != "x-vbrief/plan":
-            references.append(_reference_with_default_trust(ref))
-
-    plan: dict = {
-        "title": title,
-        "status": "pending",
-        "narratives": narratives,
-        "items": [],
-        "metadata": {"kind": "phase"},
-        "references": references,
-    }
-    if dependencies:
-        plan["metadata"]["dependencies"] = list(dependencies)
-
-    return {
-        "vBRIEFInfo": {
-            "version": EMITTED_VBRIEF_VERSION,
-            "description": f"Scope vBRIEF for speckit IP-{ip_index}",
-        },
-        "plan": plan,
-    }
 
 
 def migrate_speckit_plan(
@@ -2355,92 +2259,14 @@ def migrate_speckit_plan(
     date: str | None = None,
     spec_ref: str = "./specification.vbrief.json",
 ) -> tuple[bool, list[str]]:
-    """Translate a speckit-shaped ``plan.vbrief.json`` into scope vBRIEFs.
-
-    Each ``plan.items`` entry becomes a file in ``pending_dir`` named
-    ``YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json``.  Dependencies are read from
-    ``plan.edges`` with ``type == 'blocks'`` using the bilingual edge reader
-    (``from/to`` preferred, ``source/target`` fallback) so both legacy and
-    canonical edge shapes translate correctly.  The source ``plan.vbrief.json``
-    is rewritten to the canonical session-todo scaffold described in
-    ``vbrief/vbrief.md#planvbriefjson`` (empty items, session-level title).
-
-    Returns ``(ok, actions)`` where ``actions`` is a human-readable list.
-    """
-    actions: list[str] = []
-    if not plan_path.is_file():
-        return False, [f"ERROR: plan.vbrief.json not found at {plan_path}"]
-
-    try:
-        plan_data = json.loads(plan_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return False, [f"ERROR: invalid JSON in {plan_path.name}: {exc}"]
-
-    plan = plan_data.get("plan", {}) if isinstance(plan_data, dict) else {}
-    items = plan.get("items", []) if isinstance(plan, dict) else []
-    edges = plan.get("edges", []) if isinstance(plan, dict) else []
-
-    if not items:
-        return False, [
-            "ERROR: plan.vbrief.json has no items to migrate (empty speckit plan?)"
-        ]
-
-    pending_dir = pending_dir or (plan_path.parent / "pending")
-    pending_dir.mkdir(parents=True, exist_ok=True)
-    date = date or _TODAY
-
-    created_paths: list[Path] = []
-    for idx, item in enumerate(items, start=1):
-        if not isinstance(item, dict):
-            continue
-        ip_index = _speckit_ip_index(item, idx)
-        item_id = str(item.get("id", "") or f"ip-{ip_index}")
-        dependencies = _dependencies_for_item(item_id, edges)
-        slug = _speckit_ip_slug(str(item.get("title", "")), item_id)
-        ip_token = f"ip{ip_index:03d}"
-        filename = f"{date}-{ip_token}-{slug}.vbrief.json"
-        target = pending_dir / filename
-        if target.exists():
-            actions.append(f"SKIP   pending/{filename} already exists")
-            created_paths.append(target)
-            continue
-        scope = _create_speckit_scope_vbrief(
-            item,
-            ip_index=ip_index,
-            dependencies=dependencies,
-            spec_ref=spec_ref,
-        )
-        target.write_text(
-            json.dumps(scope, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
-        actions.append(f"CREATE pending/{filename} (IP-{ip_index})")
-        created_paths.append(target)
-
-    # Rewrite plan.vbrief.json to the session-todo scaffold, preserving the
-    # envelope title so context isn't lost.
-    envelope = plan_data.get("vBRIEFInfo", {}) if isinstance(plan_data, dict) else {}
-    # #533: force the emitted envelope to the current canonical version so a
-    # v0.5 speckit plan migrated today produces a v0.6 session scaffold.
-    envelope["version"] = EMITTED_VBRIEF_VERSION
-    envelope["description"] = (
-        "Session-level tactical plan (migrated from speckit plan). "
-        "Scope vBRIEFs live in vbrief/pending/."
+    """Compatibility shim for the shared Speckit translator."""
+    return _migrate_speckit_plan_shared(
+        plan_path,
+        pending_dir=pending_dir,
+        date=date,
+        spec_ref=spec_ref,
+        today=_TODAY,
     )
-    session_plan = {
-        "vBRIEFInfo": envelope,
-        "plan": {
-            "title": str(plan.get("title", "Session plan")) or "Session plan",
-            "status": "running",
-            "items": [],
-        },
-    }
-    plan_path.write_text(
-        json.dumps(session_plan, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    actions.append(f"REWRITE {plan_path.name} -> session-todo scaffold")
-    return True, actions
 
 
 # Pattern shared with ``reconcile_issues.ISSUE_URL_PATTERN``: matches the

--- a/scripts/migrate_vbrief.py
+++ b/scripts/migrate_vbrief.py
@@ -55,6 +55,7 @@ def _emit_event(name: str, payload: dict[str, Any]) -> None:
 from _vbrief_build import (  # noqa: E402 -- after sys.path mutate + lazy emit helper
     EMITTED_VBRIEF_VERSION,  # canonical emitted version per #533
     create_scope_vbrief as _create_scope_vbrief_shared,
+    reference_with_default_trust as _reference_with_default_trust,
     slugify as _slugify_shared,
 )
 from _vbrief_validation import (  # noqa: E402
@@ -840,11 +841,15 @@ def _build_project_definition(
                 if item_title and item_title != "Untitled"
                 else f"Issue #{number}"
             )
-            item["references"] = [{
-                "uri": f"{repo_url}/issues/{number}",
-                "type": "x-vbrief/github-issue",
-                "title": ref_title,
-            }]
+            item["references"] = [
+                _reference_with_default_trust(
+                    {
+                        "uri": f"{repo_url}/issues/{number}",
+                        "type": "x-vbrief/github-issue",
+                        "title": ref_title,
+                    }
+                )
+            ]
         items.append(item)
 
     return {
@@ -2270,23 +2275,6 @@ def _speckit_ip_index(item: dict, fallback_index: int) -> int:
     return fallback_index
 
 
-def _speckit_reference_with_default_trust(ref: dict) -> dict:
-    normalized = dict(ref)
-    if "TrustLevel" in normalized:
-        return normalized
-    ref_type = normalized.get("type")
-    if ref_type in {"x-vbrief/plan", "x-vbrief/spec-section", "x-vbrief/user-request"}:
-        normalized["TrustLevel"] = "internal"
-    elif ref_type in {
-        "x-vbrief/github-issue",
-        "x-vbrief/github-pr",
-        "x-vbrief/jira-ticket",
-        "x-vbrief/web-page",
-    }:
-        normalized["TrustLevel"] = "external"
-    return normalized
-
-
 def _create_speckit_scope_vbrief(
     item: dict,
     *,
@@ -2333,12 +2321,12 @@ def _create_speckit_scope_vbrief(
             narratives[extra] = value.strip()
 
     references = [
-        {"type": "x-vbrief/plan", "uri": spec_ref, "TrustLevel": "internal"},
+        _reference_with_default_trust({"type": "x-vbrief/plan", "uri": spec_ref}),
     ]
     # Copy any origin-provenance refs from the item (e.g. github-issue).
     for ref in item.get("references", []) or []:
         if isinstance(ref, dict) and ref.get("type") != "x-vbrief/plan":
-            references.append(_speckit_reference_with_default_trust(ref))
+            references.append(_reference_with_default_trust(ref))
 
     plan: dict = {
         "title": title,

--- a/scripts/migrate_vbrief.py
+++ b/scripts/migrate_vbrief.py
@@ -2257,7 +2257,7 @@ def migrate_speckit_plan(
     *,
     pending_dir: Path | None = None,
     date: str | None = None,
-    spec_ref: str = "./specification.vbrief.json",
+    spec_ref: str = "specification.vbrief.json",
 ) -> tuple[bool, list[str]]:
     """Compatibility shim for the shared Speckit translator."""
     return _migrate_speckit_plan_shared(

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -481,7 +481,7 @@ def apply_decomposition(
         raise DecompositionError(
             "output_dir must not be vbrief/active; write pending stories and use "
             "task scope:activate when work begins"
-        )
+        ) from None
     status = _normalize_status(draft.get("status"), _default_status_for_folder(output_dir))
     if status in ACTIVE_DECOMPOSITION_STATUSES:
         raise DecompositionError(

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -129,9 +129,6 @@ def _swarm_meta(story: dict[str, Any]) -> dict[str, Any]:
     ):
         if key in story and key not in swarm:
             swarm[key] = story[key]
-    swarm.setdefault("readiness", READY)
-    swarm.setdefault("parallel_safe", True)
-    swarm.setdefault("depends_on", [])
     return swarm
 
 
@@ -197,6 +194,20 @@ def _story_has_traces(story: dict[str, Any], items: list[Any], swarm: dict[str, 
             if isinstance(ref, dict) and ref.get("type") == "x-vbrief/spec-section":
                 return True
     return False
+
+
+def _missing_required_swarm_fields(swarm: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    for key in ("file_scope", "verify_commands", "expected_outputs"):
+        if not _as_str_list(swarm.get(key)):
+            missing.append(f"plan.metadata.swarm.{key}")
+    if "depends_on" not in swarm:
+        missing.append("plan.metadata.swarm.depends_on")
+    for key in ("conflict_group", "size", "file_scope_confidence", "model_tier"):
+        value = swarm.get(key)
+        if not isinstance(value, str) or not value.strip():
+            missing.append(f"plan.metadata.swarm.{key}")
+    return missing
 
 
 def _items_from_story(story_id: str, story: dict[str, Any]) -> list[Any]:
@@ -265,19 +276,18 @@ def validate_draft(stories: list[dict[str, Any]]) -> list[str]:
         deps = _as_str_list(swarm.get("depends_on") or story.get("depends_on"))
         deps_by_story[story_id] = deps
 
-        if swarm.get("readiness") != READY:
-            continue
-
         items = _items_from_story(story_id, story)
         missing: list[str] = []
+        if swarm.get("readiness") != READY:
+            missing.append("plan.metadata.swarm.readiness=ready")
+        parallel_safe = swarm.get("parallel_safe")
+        if parallel_safe is not True and parallel_safe is not False:
+            missing.append("plan.metadata.swarm.parallel_safe")
         if not items:
             missing.append("plan.items")
         if items and not _items_have_acceptance(items):
             missing.append("plan.items[].narrative.Acceptance")
-        if not _as_str_list(swarm.get("file_scope")):
-            missing.append("plan.metadata.swarm.file_scope")
-        if not _as_str_list(swarm.get("verify_commands")):
-            missing.append("plan.metadata.swarm.verify_commands")
+        missing.extend(_missing_required_swarm_fields(swarm))
         if not _story_has_traces(story, items, swarm):
             missing.append("Traces or missing_traces_justification")
         if missing:

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -374,6 +374,14 @@ def _normalize_references(refs: Any) -> list[dict[str, Any]]:
     return normalized
 
 
+def _child_provenance_references(refs: Any) -> list[dict[str, Any]]:
+    return [
+        ref
+        for ref in _normalize_references(refs)
+        if "acceptance" not in str(ref.get("type") or "").lower()
+    ]
+
+
 def _dedupe_references(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
@@ -445,7 +453,7 @@ def _build_child_vbrief(
 
     parent_plan = parent.get("plan", {}) if isinstance(parent, dict) else {}
     parent_refs = (
-        _normalize_references(parent_plan.get("references"))
+        _child_provenance_references(parent_plan.get("references"))
         if isinstance(parent_plan, dict)
         else []
     )

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -69,8 +69,10 @@ def _vbrief_dir(project_root: Path) -> Path:
 
 
 def _rel_to_vbrief(vbrief_dir: Path, path: Path) -> str:
-    rel = path.resolve().relative_to(vbrief_dir.resolve()).as_posix()
-    return f"./{rel}"
+    try:
+        return path.resolve().relative_to(vbrief_dir.resolve()).as_posix()
+    except ValueError as exc:
+        raise DecompositionError(f"{path}: path must be inside {vbrief_dir}") from exc
 
 
 def _scope_folder(parent_path: Path, vbrief_dir: Path) -> Path:
@@ -495,6 +497,10 @@ def apply_decomposition(
     ) or _scope_folder(parent_path, vbrief_dir)
     if output_dir.name not in LIFECYCLE_FOLDERS:
         raise DecompositionError("output_dir must be a vbrief lifecycle folder")
+    try:
+        output_dir.resolve().relative_to(vbrief_dir.resolve())
+    except ValueError as exc:
+        raise DecompositionError("output_dir must be inside vbrief/") from exc
     status = str(draft.get("status") or _default_status_for_folder(output_dir))
     parent_rel = _rel_to_vbrief(vbrief_dir, parent_path)
 

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -82,7 +82,7 @@ def _rel_to_vbrief(vbrief_dir: Path, path: Path) -> str:
         raise DecompositionError(f"{path}: path must be inside {vbrief_dir}") from exc
 
 
-def _scope_folder(parent_path: Path, vbrief_dir: Path) -> Path:
+def _pending_scope_folder(vbrief_dir: Path) -> Path:
     return vbrief_dir / "pending"
 
 
@@ -94,6 +94,13 @@ def _default_status_for_folder(folder: Path) -> str:
         "completed": "completed",
         "cancelled": "cancelled",
     }.get(folder.name, "pending")
+
+
+def _normalize_status(value: Any, default: str) -> str:
+    if value is None:
+        return default
+    status = str(value).strip().lower()
+    return status or default
 
 
 def _story_specs(draft: dict[str, Any]) -> list[dict[str, Any]]:
@@ -463,7 +470,7 @@ def apply_decomposition(
     story_ids = validate_draft(stories)
     output_dir = _resolve_path(
         project_root, draft.get("output_dir") or ""
-    ) or _scope_folder(parent_path, vbrief_dir)
+    ) or _pending_scope_folder(vbrief_dir)
     if output_dir.name not in LIFECYCLE_FOLDERS:
         raise DecompositionError("output_dir must be a vbrief lifecycle folder")
     try:
@@ -475,7 +482,7 @@ def apply_decomposition(
             "output_dir must not be vbrief/active; write pending stories and use "
             "task scope:activate when work begins"
         )
-    status = str(draft.get("status") or _default_status_for_folder(output_dir))
+    status = _normalize_status(draft.get("status"), _default_status_for_folder(output_dir))
     if status in ACTIVE_DECOMPOSITION_STATUSES:
         raise DecompositionError(
             "decomposition cannot create active/running child stories; write pending "
@@ -489,7 +496,7 @@ def apply_decomposition(
     for index, story in enumerate(stories, start=1):
         story_id = story_ids[index - 1]
         title = str(story.get("title") or story_id)
-        story_status = str(story.get("status") or status)
+        story_status = _normalize_status(story.get("status"), status)
         if story_status in ACTIVE_DECOMPOSITION_STATUSES:
             raise DecompositionError(
                 f"{story_id}: decomposition cannot create active/running child stories; "

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -463,7 +463,7 @@ def apply_decomposition(
     stories = _story_specs(draft)
     story_ids = validate_draft(stories)
     output_dir = _resolve_path(
-        project_root, str(draft.get("output_dir", ""))
+        project_root, draft.get("output_dir") or ""
     ) or _scope_folder(parent_path, vbrief_dir)
     if output_dir.name not in LIFECYCLE_FOLDERS:
         raise DecompositionError("output_dir must be a vbrief lifecycle folder")

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -20,19 +20,16 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _stdio_utf8 import reconfigure_stdio  # noqa: E402
-from _vbrief_build import EMITTED_VBRIEF_VERSION, slugify  # noqa: E402
+from _vbrief_build import (  # noqa: E402
+    EMITTED_VBRIEF_VERSION,
+    reference_with_default_trust as _reference_with_default_trust,
+    slugify,
+)
 
 reconfigure_stdio()
 
 LIFECYCLE_FOLDERS = {"proposed", "pending", "active", "completed", "cancelled"}
 READY = "ready"
-INTERNAL_REFERENCE_TYPES = {"x-vbrief/plan", "x-vbrief/spec-section", "x-vbrief/user-request"}
-EXTERNAL_REFERENCE_TYPES = {
-    "x-vbrief/github-issue",
-    "x-vbrief/github-pr",
-    "x-vbrief/jira-ticket",
-    "x-vbrief/web-page",
-}
 
 
 class DecompositionError(ValueError):
@@ -299,18 +296,6 @@ def _normalize_references(refs: Any) -> list[dict[str, Any]]:
     return normalized
 
 
-def _reference_with_default_trust(ref: dict[str, Any]) -> dict[str, Any]:
-    normalized = copy.deepcopy(ref)
-    if "TrustLevel" in normalized:
-        return normalized
-    ref_type = normalized.get("type")
-    if ref_type in INTERNAL_REFERENCE_TYPES:
-        normalized["TrustLevel"] = "internal"
-    elif ref_type in EXTERNAL_REFERENCE_TYPES:
-        normalized["TrustLevel"] = "external"
-    return normalized
-
-
 def _dedupe_references(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
@@ -465,12 +450,13 @@ def apply_decomposition(
         parent_plan["references"] = references
     for target, _story_id, title in child_paths:
         references.append(
-            {
-                "uri": _rel_to_vbrief(vbrief_dir, target),
-                "type": "x-vbrief/plan",
-                "title": title,
-                "TrustLevel": "internal",
-            }
+            _reference_with_default_trust(
+                {
+                    "uri": _rel_to_vbrief(vbrief_dir, target),
+                    "type": "x-vbrief/plan",
+                    "title": title,
+                }
+            )
         )
     parent_plan["references"] = _dedupe_references(
         [ref for ref in references if isinstance(ref, dict)]

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -209,6 +209,19 @@ def _story_description(story: dict[str, Any]) -> str:
     return ""
 
 
+def _story_implementation_plan(story: dict[str, Any]) -> str:
+    narratives = story.get("narratives")
+    if isinstance(narratives, dict):
+        value = narratives.get("ImplementationPlan")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("implementation_plan", "ImplementationPlan"):
+        values = _as_str_list(story.get(key))
+        if values:
+            return "\n".join(values)
+    return ""
+
+
 def _story_user_story(story: dict[str, Any]) -> str:
     narratives = story.get("narratives")
     if isinstance(narratives, dict):
@@ -336,6 +349,7 @@ def validate_draft(stories: list[dict[str, Any]]) -> list[str]:
             story_quality_issues(
                 title=str(story.get("title") or story_id),
                 description=_story_description(story),
+                implementation_plan=_story_implementation_plan(story),
                 user_story=_story_user_story(story),
                 acceptance_texts=acceptance_texts_from_items(items),
                 acceptance_count_justification=_acceptance_count_justification(story, swarm),
@@ -386,6 +400,8 @@ def _story_narratives(story: dict[str, Any]) -> dict[str, str]:
     for draft_key, narrative_key in (
         ("description", "Description"),
         ("summary", "Description"),
+        ("implementation_plan", "ImplementationPlan"),
+        ("ImplementationPlan", "ImplementationPlan"),
         ("user_story", "UserStory"),
         ("UserStory", "UserStory"),
         ("traces", "Traces"),
@@ -394,7 +410,8 @@ def _story_narratives(story: dict[str, Any]) -> dict[str, str]:
             continue
         values = _as_str_list(story.get(draft_key))
         if values:
-            narratives[narrative_key] = ", ".join(values)
+            separator = "\n" if narrative_key == "ImplementationPlan" else ", "
+            narratives[narrative_key] = separator.join(values)
     return narratives
 
 

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -27,7 +27,11 @@ from _vbrief_build import (  # noqa: E402
 )
 from _vbrief_story_quality import (  # noqa: E402
     acceptance_texts_from_items,
-    as_str_list as _quality_as_str_list,
+    as_str_list as _as_str_list,
+    deprecated_subitems_issues,
+    item_has_traces,
+    items_have_acceptance,
+    missing_required_swarm_fields,
     story_quality_issues,
 )
 
@@ -45,6 +49,8 @@ class DecompositionError(ValueError):
 def _load_json(path: Path) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise DecompositionError(f"{path}: cannot read file: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise DecompositionError(f"{path}: invalid JSON: {exc}") from exc
     if not isinstance(data, dict):
@@ -140,44 +146,6 @@ def _swarm_meta(story: dict[str, Any]) -> dict[str, Any]:
     return swarm
 
 
-def _as_str_list(value: Any) -> list[str]:
-    return _quality_as_str_list(value)
-
-
-def _item_has_acceptance(item: dict[str, Any]) -> bool:
-    narrative = item.get("narrative")
-    if isinstance(narrative, dict):
-        value = narrative.get("Acceptance")
-        if isinstance(value, str) and value.strip():
-            return True
-    for child_key in ("items", "subItems"):
-        children = item.get(child_key)
-        if isinstance(children, list):
-            for child in children:
-                if isinstance(child, dict) and _item_has_acceptance(child):
-                    return True
-    return False
-
-
-def _items_have_acceptance(items: list[Any]) -> bool:
-    return any(isinstance(item, dict) and _item_has_acceptance(item) for item in items)
-
-
-def _item_has_traces(item: dict[str, Any]) -> bool:
-    narrative = item.get("narrative")
-    if isinstance(narrative, dict):
-        value = narrative.get("Traces")
-        if isinstance(value, str) and value.strip():
-            return True
-    for child_key in ("items", "subItems"):
-        children = item.get(child_key)
-        if isinstance(children, list):
-            for child in children:
-                if isinstance(child, dict) and _item_has_traces(child):
-                    return True
-    return False
-
-
 def _story_has_traces(story: dict[str, Any], items: list[Any], swarm: dict[str, Any]) -> bool:
     narratives = story.get("narratives")
     if isinstance(narratives, dict):
@@ -186,7 +154,7 @@ def _story_has_traces(story: dict[str, Any], items: list[Any], swarm: dict[str, 
             return True
     if _as_str_list(story.get("traces")):
         return True
-    if any(isinstance(item, dict) and _item_has_traces(item) for item in items):
+    if any(isinstance(item, dict) and item_has_traces(item) for item in items):
         return True
     if _as_str_list(swarm.get("missing_traces_justification")):
         return True
@@ -250,20 +218,6 @@ def _acceptance_count_justification(story: dict[str, Any], swarm: dict[str, Any]
         if isinstance(value, str) and value.strip():
             return value.strip()
     return ""
-
-
-def _missing_required_swarm_fields(swarm: dict[str, Any]) -> list[str]:
-    missing: list[str] = []
-    for key in ("file_scope", "verify_commands", "expected_outputs"):
-        if not _as_str_list(swarm.get(key)):
-            missing.append(f"plan.metadata.swarm.{key}")
-    if "depends_on" not in swarm:
-        missing.append("plan.metadata.swarm.depends_on")
-    for key in ("conflict_group", "size", "file_scope_confidence", "model_tier"):
-        value = swarm.get(key)
-        if not isinstance(value, str) or not value.strip():
-            missing.append(f"plan.metadata.swarm.{key}")
-    return missing
 
 
 def _items_from_story(story_id: str, story: dict[str, Any]) -> list[Any]:
@@ -333,7 +287,22 @@ def validate_draft(stories: list[dict[str, Any]]) -> list[str]:
         deps_by_story[story_id] = deps
 
         items = _items_from_story(story_id, story)
+        description = _story_description(story)
+        implementation_plan = _story_implementation_plan(story)
+        user_story = _story_user_story(story)
         issues: list[str] = []
+        raw_id = story.get("id") or story.get("story_id") or story.get("key")
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            issues.append("id")
+        raw_title = story.get("title")
+        if not isinstance(raw_title, str) or not raw_title.strip():
+            issues.append("title")
+        if not description:
+            issues.append("plan.narratives.Description")
+        if not implementation_plan:
+            issues.append("plan.narratives.ImplementationPlan")
+        if not user_story:
+            issues.append("plan.narratives.UserStory")
         readiness = swarm.get("readiness")
         if readiness not in STORY_READINESS_STATES:
             issues.append("plan.metadata.swarm.readiness")
@@ -342,17 +311,18 @@ def validate_draft(stories: list[dict[str, Any]]) -> list[str]:
             issues.append("plan.metadata.swarm.parallel_safe")
         if not items:
             issues.append("plan.items")
-        if items and not _items_have_acceptance(items):
+        if items and not items_have_acceptance(items):
             issues.append("plan.items[].narrative.Acceptance")
-        issues.extend(_missing_required_swarm_fields(swarm))
+        issues.extend(deprecated_subitems_issues(items))
+        issues.extend(missing_required_swarm_fields(swarm))
         if not _story_has_traces(story, items, swarm):
             issues.append("Traces or missing_traces_justification")
         issues.extend(
             story_quality_issues(
                 title=str(story.get("title") or story_id),
-                description=_story_description(story),
-                implementation_plan=_story_implementation_plan(story),
-                user_story=_story_user_story(story),
+                description=description,
+                implementation_plan=implementation_plan,
+                user_story=user_story,
                 acceptance_texts=acceptance_texts_from_items(items),
                 acceptance_count_justification=_acceptance_count_justification(story, swarm),
                 swarm=swarm,

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -498,8 +498,10 @@ def apply_decomposition(
         title = str(story.get("title") or story_id)
         filename = _child_filename(story, story_id, title, date)
         target = output_dir / filename
-        if target.exists() and not check_only:
-            raise DecompositionError(f"{target}: refusing to overwrite existing child story")
+        if not check_only and (target.is_file() or target.is_dir() or target.is_symlink()):
+            raise DecompositionError(
+                f"{target}: child story path already exists; overwriting is not supported"
+            )
         child = _build_child_vbrief(
             story=story,
             story_id=story_id,
@@ -516,21 +518,31 @@ def apply_decomposition(
     if check_only:
         return actions
 
+    parent_plan = parent.get("plan")
+    if parent_plan is None:
+        parent_plan = {}
+        parent["plan"] = parent_plan
+    if not isinstance(parent_plan, dict):
+        raise DecompositionError(f"{parent_path}: plan must be an object")
+    metadata = parent_plan.get("metadata")
+    if metadata is None:
+        metadata = {}
+        parent_plan["metadata"] = metadata
+    if not isinstance(metadata, dict):
+        raise DecompositionError(f"{parent_path}: plan.metadata must be an object")
+    metadata.setdefault("kind", "epic")
+    references = parent_plan.get("references")
+    if references is None:
+        references = []
+        parent_plan["references"] = references
+    if not isinstance(references, list):
+        raise DecompositionError(f"{parent_path}: plan.references must be an array")
+
     for target, _story_id, _title in child_paths:
         target.parent.mkdir(parents=True, exist_ok=True)
     for (target, _story_id, _title), child in zip(child_paths, child_docs, strict=True):
         _write_json(target, child)
 
-    parent_plan = parent.setdefault("plan", {})
-    if not isinstance(parent_plan, dict):
-        raise DecompositionError(f"{parent_path}: plan must be an object")
-    metadata = parent_plan.setdefault("metadata", {})
-    if isinstance(metadata, dict):
-        metadata.setdefault("kind", "epic")
-    references = parent_plan.setdefault("references", [])
-    if not isinstance(references, list):
-        references = []
-        parent_plan["references"] = references
     for target, _story_id, title in child_paths:
         references.append(
             _reference_with_default_trust(

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -38,6 +38,7 @@ from _vbrief_story_quality import (  # noqa: E402
 reconfigure_stdio()
 
 LIFECYCLE_FOLDERS = {"proposed", "pending", "active", "completed", "cancelled"}
+ACTIVE_DECOMPOSITION_STATUSES = {"active", "running"}
 READY = "ready"
 STORY_READINESS_STATES = {READY, "sequential", "needs_refinement"}
 
@@ -54,7 +55,7 @@ def _load_json(path: Path) -> dict[str, Any]:
     except json.JSONDecodeError as exc:
         raise DecompositionError(f"{path}: invalid JSON: {exc}") from exc
     if not isinstance(data, dict):
-        raise DecompositionError(f"{path}: expected a JSON object")
+        raise DecompositionError(f"{path}: expected a JSON object") from None
     return data
 
 
@@ -82,8 +83,6 @@ def _rel_to_vbrief(vbrief_dir: Path, path: Path) -> str:
 
 
 def _scope_folder(parent_path: Path, vbrief_dir: Path) -> Path:
-    if parent_path.parent.name in LIFECYCLE_FOLDERS:
-        return parent_path.parent
     return vbrief_dir / "pending"
 
 
@@ -439,7 +438,7 @@ def _build_child_vbrief(
         "plan": {
             "id": story_id,
             "title": title,
-            "status": str(story.get("status") or status),
+            "status": status,
             "planRef": parent_rel,
             "narratives": _story_narratives(story),
             "items": items,
@@ -471,7 +470,17 @@ def apply_decomposition(
         output_dir.resolve().relative_to(vbrief_dir.resolve())
     except ValueError as exc:
         raise DecompositionError("output_dir must be inside vbrief/") from exc
+    if output_dir.name == "active":
+        raise DecompositionError(
+            "output_dir must not be vbrief/active; write pending stories and use "
+            "task scope:activate when work begins"
+        )
     status = str(draft.get("status") or _default_status_for_folder(output_dir))
+    if status in ACTIVE_DECOMPOSITION_STATUSES:
+        raise DecompositionError(
+            "decomposition cannot create active/running child stories; write pending "
+            "stories and use task scope:activate when work begins"
+        )
     parent_rel = _rel_to_vbrief(vbrief_dir, parent_path)
 
     actions = [f"VALIDATED {len(stories)} story decomposition draft"]
@@ -480,6 +489,12 @@ def apply_decomposition(
     for index, story in enumerate(stories, start=1):
         story_id = story_ids[index - 1]
         title = str(story.get("title") or story_id)
+        story_status = str(story.get("status") or status)
+        if story_status in ACTIVE_DECOMPOSITION_STATUSES:
+            raise DecompositionError(
+                f"{story_id}: decomposition cannot create active/running child stories; "
+                "write pending stories and use task scope:activate when work begins"
+            )
         filename = _child_filename(story, story_id, title, date)
         target = output_dir / filename
         if not check_only and (target.is_file() or target.is_dir() or target.is_symlink()):
@@ -492,7 +507,7 @@ def apply_decomposition(
             story_index=index,
             parent=parent,
             parent_rel=parent_rel,
-            status=status,
+            status=story_status,
         )
         child_paths.append((target, story_id, title))
         child_docs.append(child)

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Apply or validate an approved epic/phase -> story decomposition draft.
+
+The command is intentionally deterministic: it never invents stories from a
+parent scope. A caller supplies a draft with child story definitions; this
+script validates that draft, writes the child story vBRIEFs, and updates the
+parent scope references.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from _vbrief_build import EMITTED_VBRIEF_VERSION, slugify  # noqa: E402
+
+reconfigure_stdio()
+
+LIFECYCLE_FOLDERS = {"proposed", "pending", "active", "completed", "cancelled"}
+READY = "ready"
+INTERNAL_REFERENCE_TYPES = {"x-vbrief/plan", "x-vbrief/spec-section", "x-vbrief/user-request"}
+EXTERNAL_REFERENCE_TYPES = {
+    "x-vbrief/github-issue",
+    "x-vbrief/github-pr",
+    "x-vbrief/jira-ticket",
+    "x-vbrief/web-page",
+}
+
+
+class DecompositionError(ValueError):
+    """Raised when a decomposition draft is not safe to apply."""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DecompositionError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DecompositionError(f"{path}: expected a JSON object")
+    return data
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _resolve_path(project_root: Path, value: str | None) -> Path | None:
+    if not value:
+        return None
+    path = Path(value)
+    return path if path.is_absolute() else project_root / path
+
+
+def _vbrief_dir(project_root: Path) -> Path:
+    return project_root / "vbrief"
+
+
+def _rel_to_vbrief(vbrief_dir: Path, path: Path) -> str:
+    rel = path.resolve().relative_to(vbrief_dir.resolve()).as_posix()
+    return f"./{rel}"
+
+
+def _scope_folder(parent_path: Path, vbrief_dir: Path) -> Path:
+    if parent_path.parent.name in LIFECYCLE_FOLDERS:
+        return parent_path.parent
+    return vbrief_dir / "pending"
+
+
+def _default_status_for_folder(folder: Path) -> str:
+    return {
+        "proposed": "proposed",
+        "pending": "pending",
+        "active": "running",
+        "completed": "completed",
+        "cancelled": "cancelled",
+    }.get(folder.name, "pending")
+
+
+def _story_specs(draft: dict[str, Any]) -> list[dict[str, Any]]:
+    stories = draft.get("stories", draft.get("children", []))
+    if isinstance(stories, dict):
+        stories = list(stories.values())
+    if not isinstance(stories, list):
+        raise DecompositionError("draft must contain a stories array")
+    normalized: list[dict[str, Any]] = []
+    for index, story in enumerate(stories, start=1):
+        if not isinstance(story, dict):
+            raise DecompositionError(f"stories[{index}] must be an object")
+        normalized.append(story)
+    return normalized
+
+
+def _story_id(story: dict[str, Any], index: int) -> str:
+    raw = story.get("id") or story.get("story_id") or story.get("key")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    title = str(story.get("title") or f"story-{index}")
+    return slugify(title) or f"story-{index}"
+
+
+def _swarm_meta(story: dict[str, Any]) -> dict[str, Any]:
+    metadata = story.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    swarm = story.get("swarm") or metadata.get("swarm") or {}
+    if not isinstance(swarm, dict):
+        swarm = {}
+    # Accept the convenient draft shape where canonical swarm fields live at
+    # the story top level, then store them under plan.metadata.swarm.
+    for key in (
+        "readiness",
+        "parallel_safe",
+        "file_scope",
+        "verify_commands",
+        "expected_outputs",
+        "depends_on",
+        "conflict_group",
+        "size",
+        "file_scope_confidence",
+        "model_tier",
+        "missing_traces_justification",
+    ):
+        if key in story and key not in swarm:
+            swarm[key] = story[key]
+    swarm.setdefault("readiness", READY)
+    swarm.setdefault("parallel_safe", True)
+    swarm.setdefault("depends_on", [])
+    return swarm
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _item_has_acceptance(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        value = narrative.get("Acceptance")
+        if isinstance(value, str) and value.strip():
+            return True
+    for child_key in ("items", "subItems"):
+        children = item.get(child_key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_acceptance(child):
+                    return True
+    return False
+
+
+def _items_have_acceptance(items: list[Any]) -> bool:
+    return any(isinstance(item, dict) and _item_has_acceptance(item) for item in items)
+
+
+def _item_has_traces(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        value = narrative.get("Traces")
+        if isinstance(value, str) and value.strip():
+            return True
+    for child_key in ("items", "subItems"):
+        children = item.get(child_key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_traces(child):
+                    return True
+    return False
+
+
+def _story_has_traces(story: dict[str, Any], items: list[Any], swarm: dict[str, Any]) -> bool:
+    narratives = story.get("narratives")
+    if isinstance(narratives, dict):
+        value = narratives.get("Traces")
+        if isinstance(value, str) and value.strip():
+            return True
+    if _as_str_list(story.get("traces")):
+        return True
+    if any(isinstance(item, dict) and _item_has_traces(item) for item in items):
+        return True
+    if _as_str_list(swarm.get("missing_traces_justification")):
+        return True
+    refs = story.get("references")
+    if isinstance(refs, list):
+        for ref in refs:
+            if isinstance(ref, dict) and ref.get("type") == "x-vbrief/spec-section":
+                return True
+    return False
+
+
+def _items_from_story(story_id: str, story: dict[str, Any]) -> list[Any]:
+    items = story.get("items")
+    if isinstance(items, list) and items:
+        return items
+    acceptance = _as_str_list(story.get("acceptance"))
+    if not acceptance:
+        acceptance = _as_str_list(story.get("acceptance_items"))
+    traces = ", ".join(_as_str_list(story.get("traces")))
+    generated: list[dict[str, Any]] = []
+    for index, criterion in enumerate(acceptance, start=1):
+        narrative = {"Acceptance": criterion}
+        if traces:
+            narrative["Traces"] = traces
+        generated.append(
+            {
+                "id": f"{story_id}-a{index}",
+                "title": criterion,
+                "status": "pending",
+                "narrative": narrative,
+            }
+        )
+    return generated
+
+
+def _validate_dag(story_ids: list[str], deps_by_story: dict[str, list[str]]) -> None:
+    known = set(story_ids)
+    for story_id, deps in deps_by_story.items():
+        for dep in deps:
+            if dep not in known:
+                raise DecompositionError(f"{story_id}: depends_on references unknown story {dep!r}")
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(story_id: str, path: list[str]) -> None:
+        if story_id in visited:
+            return
+        if story_id in visiting:
+            cycle = " -> ".join([*path, story_id])
+            raise DecompositionError(f"dependency cycle detected: {cycle}")
+        visiting.add(story_id)
+        for dep in deps_by_story.get(story_id, []):
+            visit(dep, [*path, story_id])
+        visiting.remove(story_id)
+        visited.add(story_id)
+
+    for story_id in story_ids:
+        visit(story_id, [])
+
+
+def validate_draft(stories: list[dict[str, Any]]) -> list[str]:
+    """Validate draft story contracts and return ordered story ids."""
+    story_ids: list[str] = []
+    deps_by_story: dict[str, list[str]] = {}
+    seen: set[str] = set()
+    for index, story in enumerate(stories, start=1):
+        story_id = _story_id(story, index)
+        if story_id in seen:
+            raise DecompositionError(f"duplicate story id {story_id!r}")
+        seen.add(story_id)
+        story_ids.append(story_id)
+        swarm = _swarm_meta(story)
+        deps = _as_str_list(swarm.get("depends_on") or story.get("depends_on"))
+        deps_by_story[story_id] = deps
+
+        if swarm.get("readiness") != READY:
+            continue
+
+        items = _items_from_story(story_id, story)
+        missing: list[str] = []
+        if not items:
+            missing.append("plan.items")
+        if items and not _items_have_acceptance(items):
+            missing.append("plan.items[].narrative.Acceptance")
+        if not _as_str_list(swarm.get("file_scope")):
+            missing.append("plan.metadata.swarm.file_scope")
+        if not _as_str_list(swarm.get("verify_commands")):
+            missing.append("plan.metadata.swarm.verify_commands")
+        if not _story_has_traces(story, items, swarm):
+            missing.append("Traces or missing_traces_justification")
+        if missing:
+            raise DecompositionError(f"{story_id}: ready story missing {', '.join(missing)}")
+
+    _validate_dag(story_ids, deps_by_story)
+    return story_ids
+
+
+def _normalize_references(refs: Any) -> list[dict[str, Any]]:
+    if not isinstance(refs, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for ref in refs:
+        if isinstance(ref, dict):
+            normalized.append(_reference_with_default_trust(ref))
+    return normalized
+
+
+def _reference_with_default_trust(ref: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(ref)
+    if "TrustLevel" in normalized:
+        return normalized
+    ref_type = normalized.get("type")
+    if ref_type in INTERNAL_REFERENCE_TYPES:
+        normalized["TrustLevel"] = "internal"
+    elif ref_type in EXTERNAL_REFERENCE_TYPES:
+        normalized["TrustLevel"] = "external"
+    return normalized
+
+
+def _dedupe_references(refs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for ref in refs:
+        key = (
+            str(ref.get("uri") or ref.get("url") or ""),
+            str(ref.get("type") or ""),
+            str(ref.get("title") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ref)
+    return out
+
+
+def _story_narratives(story: dict[str, Any]) -> dict[str, str]:
+    narratives: dict[str, str] = {}
+    raw = story.get("narratives")
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            if isinstance(value, str) and value.strip():
+                narratives[key] = value.strip()
+    for draft_key, narrative_key in (
+        ("description", "Description"),
+        ("summary", "Description"),
+        ("traces", "Traces"),
+    ):
+        if narrative_key in narratives:
+            continue
+        values = _as_str_list(story.get(draft_key))
+        if values:
+            narratives[narrative_key] = ", ".join(values)
+    return narratives
+
+
+def _child_filename(story: dict[str, Any], story_id: str, title: str, date: str) -> str:
+    filename = story.get("filename")
+    if isinstance(filename, str) and filename.endswith(".vbrief.json"):
+        return filename
+    slug = slugify(title) or slugify(story_id) or "story"
+    return f"{date}-{slug}.vbrief.json"
+
+
+def _build_child_vbrief(
+    *,
+    story: dict[str, Any],
+    story_id: str,
+    story_index: int,
+    parent: dict[str, Any],
+    parent_rel: str,
+    status: str,
+) -> dict[str, Any]:
+    title = str(story.get("title") or story_id)
+    swarm = _swarm_meta(story)
+    items = _items_from_story(story_id, story)
+    metadata = (
+        copy.deepcopy(story.get("metadata"))
+        if isinstance(story.get("metadata"), dict)
+        else {}
+    )
+    metadata["kind"] = "story"
+    metadata["swarm"] = swarm
+
+    parent_plan = parent.get("plan", {}) if isinstance(parent, dict) else {}
+    parent_refs = (
+        _normalize_references(parent_plan.get("references"))
+        if isinstance(parent_plan, dict)
+        else []
+    )
+    story_refs = _normalize_references(story.get("references"))
+
+    return {
+        "vBRIEFInfo": {
+            "version": EMITTED_VBRIEF_VERSION,
+            "description": f"Story vBRIEF {story_index} decomposed from {parent_rel}",
+        },
+        "plan": {
+            "id": story_id,
+            "title": title,
+            "status": str(story.get("status") or status),
+            "planRef": parent_rel,
+            "narratives": _story_narratives(story),
+            "items": items,
+            "metadata": metadata,
+            "references": _dedupe_references([*parent_refs, *story_refs]),
+        },
+    }
+
+
+def apply_decomposition(
+    *,
+    project_root: Path,
+    parent_path: Path,
+    draft_path: Path,
+    check_only: bool,
+    date: str,
+) -> list[str]:
+    vbrief_dir = _vbrief_dir(project_root)
+    parent = _load_json(parent_path)
+    draft = _load_json(draft_path)
+    stories = _story_specs(draft)
+    story_ids = validate_draft(stories)
+    output_dir = _resolve_path(
+        project_root, str(draft.get("output_dir", ""))
+    ) or _scope_folder(parent_path, vbrief_dir)
+    if output_dir.name not in LIFECYCLE_FOLDERS:
+        raise DecompositionError("output_dir must be a vbrief lifecycle folder")
+    status = str(draft.get("status") or _default_status_for_folder(output_dir))
+    parent_rel = _rel_to_vbrief(vbrief_dir, parent_path)
+
+    actions = [f"VALIDATED {len(stories)} story decomposition draft"]
+    child_paths: list[tuple[Path, str, str]] = []
+    child_docs: list[dict[str, Any]] = []
+    for index, story in enumerate(stories, start=1):
+        story_id = story_ids[index - 1]
+        title = str(story.get("title") or story_id)
+        filename = _child_filename(story, story_id, title, date)
+        target = output_dir / filename
+        if target.exists() and not check_only:
+            raise DecompositionError(f"{target}: refusing to overwrite existing child story")
+        child = _build_child_vbrief(
+            story=story,
+            story_id=story_id,
+            story_index=index,
+            parent=parent,
+            parent_rel=parent_rel,
+            status=status,
+        )
+        child_paths.append((target, story_id, title))
+        child_docs.append(child)
+        verb = "CHECK" if check_only else "CREATE"
+        actions.append(f"{verb} {_rel_to_vbrief(vbrief_dir, target)}")
+
+    if check_only:
+        return actions
+
+    for target, _story_id, _title in child_paths:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    for (target, _story_id, _title), child in zip(child_paths, child_docs, strict=True):
+        _write_json(target, child)
+
+    parent_plan = parent.setdefault("plan", {})
+    if not isinstance(parent_plan, dict):
+        raise DecompositionError(f"{parent_path}: plan must be an object")
+    metadata = parent_plan.setdefault("metadata", {})
+    if isinstance(metadata, dict):
+        metadata.setdefault("kind", "epic")
+    references = parent_plan.setdefault("references", [])
+    if not isinstance(references, list):
+        references = []
+        parent_plan["references"] = references
+    for target, _story_id, title in child_paths:
+        references.append(
+            {
+                "uri": _rel_to_vbrief(vbrief_dir, target),
+                "type": "x-vbrief/plan",
+                "title": title,
+                "TrustLevel": "internal",
+            }
+        )
+    parent_plan["references"] = _dedupe_references(
+        [ref for ref in references if isinstance(ref, dict)]
+    )
+    _write_json(parent_path, parent)
+    actions.append(f"UPDATE {parent_rel} references")
+    return actions
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and apply an approved epic/phase story decomposition draft."
+    )
+    parser.add_argument("parent", nargs="?", help="Parent epic/phase vBRIEF path")
+    parser.add_argument("--draft", help="Approved decomposition JSON draft")
+    parser.add_argument("--check", action="store_true", help="Validate only; do not write")
+    parser.add_argument("--date", help="Creation date for generated child filenames")
+    parser.add_argument("--project-root", default=".", help="Project root containing vbrief/")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    project_root = Path(args.project_root).resolve()
+    parent_path = _resolve_path(project_root, args.parent)
+    draft_path = _resolve_path(project_root, args.draft)
+    if parent_path is None or draft_path is None:
+        if args.check:
+            print("OK no decomposition draft supplied; nothing to apply.")
+            return 0
+        print("ERROR: parent path and --draft are required", file=sys.stderr)
+        return 2
+    if not parent_path.is_file():
+        print(f"ERROR: parent vBRIEF not found: {parent_path}", file=sys.stderr)
+        return 2
+    if not draft_path.is_file():
+        print(f"ERROR: decomposition draft not found: {draft_path}", file=sys.stderr)
+        return 2
+    date = args.date or datetime.now(UTC).strftime("%Y-%m-%d")
+    try:
+        actions = apply_decomposition(
+            project_root=project_root,
+            parent_path=parent_path,
+            draft_path=draft_path,
+            check_only=args.check,
+            date=date,
+        )
+    except DecompositionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    for action in actions:
+        print(action)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -237,7 +237,8 @@ def _validate_dag(story_ids: list[str], deps_by_story: dict[str, list[str]]) -> 
         if story_id in visited:
             return
         if story_id in visiting:
-            cycle = " -> ".join([*path, story_id])
+            start = path.index(story_id) if story_id in path else 0
+            cycle = " -> ".join([*path[start:], story_id])
             raise DecompositionError(f"dependency cycle detected: {cycle}")
         visiting.add(story_id)
         for dep in deps_by_story.get(story_id, []):

--- a/scripts/scope_decompose.py
+++ b/scripts/scope_decompose.py
@@ -25,11 +25,17 @@ from _vbrief_build import (  # noqa: E402
     reference_with_default_trust as _reference_with_default_trust,
     slugify,
 )
+from _vbrief_story_quality import (  # noqa: E402
+    acceptance_texts_from_items,
+    as_str_list as _quality_as_str_list,
+    story_quality_issues,
+)
 
 reconfigure_stdio()
 
 LIFECYCLE_FOLDERS = {"proposed", "pending", "active", "completed", "cancelled"}
 READY = "ready"
+STORY_READINESS_STATES = {READY, "sequential", "needs_refinement"}
 
 
 class DecompositionError(ValueError):
@@ -133,13 +139,7 @@ def _swarm_meta(story: dict[str, Any]) -> dict[str, Any]:
 
 
 def _as_str_list(value: Any) -> list[str]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        return [value] if value.strip() else []
-    if isinstance(value, list):
-        return [str(item) for item in value if str(item).strip()]
-    return []
+    return _quality_as_str_list(value)
 
 
 def _item_has_acceptance(item: dict[str, Any]) -> bool:
@@ -194,6 +194,47 @@ def _story_has_traces(story: dict[str, Any], items: list[Any], swarm: dict[str, 
             if isinstance(ref, dict) and ref.get("type") == "x-vbrief/spec-section":
                 return True
     return False
+
+
+def _story_description(story: dict[str, Any]) -> str:
+    narratives = story.get("narratives")
+    if isinstance(narratives, dict):
+        value = narratives.get("Description")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("description", "summary"):
+        value = story.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _story_user_story(story: dict[str, Any]) -> str:
+    narratives = story.get("narratives")
+    if isinstance(narratives, dict):
+        value = narratives.get("UserStory")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("user_story", "UserStory"):
+        value = story.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _acceptance_count_justification(story: dict[str, Any], swarm: dict[str, Any]) -> str:
+    for value in (
+        swarm.get("acceptance_criteria_justification"),
+        story.get("acceptance_criteria_justification"),
+    ):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    narratives = story.get("narratives")
+    if isinstance(narratives, dict):
+        value = narratives.get("AcceptanceJustification")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
 
 
 def _missing_required_swarm_fields(swarm: dict[str, Any]) -> list[str]:
@@ -277,21 +318,33 @@ def validate_draft(stories: list[dict[str, Any]]) -> list[str]:
         deps_by_story[story_id] = deps
 
         items = _items_from_story(story_id, story)
-        missing: list[str] = []
-        if swarm.get("readiness") != READY:
-            missing.append("plan.metadata.swarm.readiness=ready")
+        issues: list[str] = []
+        readiness = swarm.get("readiness")
+        if readiness not in STORY_READINESS_STATES:
+            issues.append("plan.metadata.swarm.readiness")
         parallel_safe = swarm.get("parallel_safe")
         if parallel_safe is not True and parallel_safe is not False:
-            missing.append("plan.metadata.swarm.parallel_safe")
+            issues.append("plan.metadata.swarm.parallel_safe")
         if not items:
-            missing.append("plan.items")
+            issues.append("plan.items")
         if items and not _items_have_acceptance(items):
-            missing.append("plan.items[].narrative.Acceptance")
-        missing.extend(_missing_required_swarm_fields(swarm))
+            issues.append("plan.items[].narrative.Acceptance")
+        issues.extend(_missing_required_swarm_fields(swarm))
         if not _story_has_traces(story, items, swarm):
-            missing.append("Traces or missing_traces_justification")
-        if missing:
-            raise DecompositionError(f"{story_id}: ready story missing {', '.join(missing)}")
+            issues.append("Traces or missing_traces_justification")
+        issues.extend(
+            story_quality_issues(
+                title=str(story.get("title") or story_id),
+                description=_story_description(story),
+                user_story=_story_user_story(story),
+                acceptance_texts=acceptance_texts_from_items(items),
+                acceptance_count_justification=_acceptance_count_justification(story, swarm),
+                swarm=swarm,
+                concurrent_ready=readiness == READY,
+            )
+        )
+        if issues:
+            raise DecompositionError(f"{story_id}: story invalid: {', '.join(issues)}")
 
     _validate_dag(story_ids, deps_by_story)
     return story_ids
@@ -333,6 +386,8 @@ def _story_narratives(story: dict[str, Any]) -> dict[str, str]:
     for draft_key, narrative_key in (
         ("description", "Description"),
         ("summary", "Description"),
+        ("user_story", "UserStory"),
+        ("UserStory", "UserStory"),
         ("traces", "Traces"),
     ):
         if narrative_key in narratives:

--- a/scripts/spec_render.py
+++ b/scripts/spec_render.py
@@ -407,8 +407,8 @@ def render_spec(
                 if key == "Traces":
                     lines.append(f"**Traces**: {val}\n")
                 elif key == "Acceptance":
-                    for criterion in _split_acceptance(val):
-                        lines.append(f"- {criterion}")
+                    for acceptance_line in _split_acceptance(val):
+                        lines.append(f"- {acceptance_line}")
                     lines.append("")
                 else:
                     lines.append(f"{val}\n")

--- a/scripts/spec_render.py
+++ b/scripts/spec_render.py
@@ -215,10 +215,13 @@ def _split_acceptance(value: object) -> list[str]:
         return []
     parts: list[str] = []
     for line in value.splitlines():
-        for chunk in line.split(";"):
-            cleaned = chunk.strip().lstrip("-* ").strip()
-            if cleaned:
-                parts.append(cleaned)
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+        if cleaned.startswith(("- ", "* ")):
+            cleaned = cleaned[2:].strip()
+        if cleaned:
+            parts.append(cleaned)
     return parts
 
 
@@ -404,11 +407,7 @@ def render_spec(
                 if key == "Traces":
                     lines.append(f"**Traces**: {val}\n")
                 elif key == "Acceptance":
-                    if isinstance(val, list):
-                        criteria = val
-                    else:
-                        criteria = [c for c in str(val).split("; ") if c]
-                    for criterion in criteria:
+                    for criterion in _split_acceptance(val):
                         lines.append(f"- {criterion}")
                     lines.append("")
                 else:

--- a/scripts/spec_render.py
+++ b/scripts/spec_render.py
@@ -207,6 +207,28 @@ def _scope_summary_narrative(plan: dict) -> str:
     return ""
 
 
+def _split_acceptance(value: object) -> list[str]:
+    """Normalize acceptance text/list values into visible markdown bullets."""
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if not isinstance(value, str):
+        return []
+    parts: list[str] = []
+    for line in value.splitlines():
+        for chunk in line.split(";"):
+            cleaned = chunk.strip().lstrip("-* ").strip()
+            if cleaned:
+                parts.append(cleaned)
+    return parts
+
+
+def _item_acceptance(item: dict) -> list[str]:
+    narrative = item.get("narrative")
+    if not isinstance(narrative, dict):
+        return []
+    return _split_acceptance(narrative.get("Acceptance"))
+
+
 def _render_scope_block(stem: str, vbrief: dict) -> list[str]:
     """Render a single scope vBRIEF as a markdown block inside Implementation Plan."""
     plan = vbrief.get("plan", {})
@@ -223,6 +245,15 @@ def _render_scope_block(stem: str, vbrief: dict) -> list[str]:
     if summary:
         lines.append(f"{summary}\n")
 
+    narratives = plan.get("narratives", {})
+    if isinstance(narratives, dict):
+        scope_acceptance = _split_acceptance(narratives.get("Acceptance"))
+        if scope_acceptance:
+            lines.append("**Scope Acceptance**:\n")
+            for criterion in scope_acceptance:
+                lines.append(f"- {criterion}")
+            lines.append("")
+
     # Acceptance items -- each plan.items entry rendered as a bullet with status.
     items = plan.get("items", [])
     if isinstance(items, list) and items:
@@ -236,6 +267,9 @@ def _render_scope_block(stem: str, vbrief: dict) -> list[str]:
             if item_status:
                 bullet += f" `[{item_status}]`"
             lines.append(bullet)
+            for criterion in _item_acceptance(item):
+                if criterion != item_title:
+                    lines.append(f"  - Acceptance: {criterion}")
         lines.append("")
     return lines
 

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -275,7 +275,7 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
     if candidate.kind in {"epic", "phase"}:
         candidate.decomposition_needed = True
         return
-    if candidate.kind != "story":
+    if candidate.kind != "story" or _metadata(candidate.plan).get("kind") != "story":
         candidate.missing.append("plan.metadata.kind=story")
     if candidate.folder == "active" and candidate.status != "running":
         candidate.blocked.append("active candidate plan.status must be running")

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -385,8 +385,6 @@ def _file_overlaps(
 ) -> dict[str, list[str]]:
     file_to_ids: dict[str, list[str]] = defaultdict(list)
     for candidate in _ready_stories(candidates):
-        if candidate.swarm.get("parallel_safe") is not True:
-            continue
         for file_path in _as_str_list(candidate.swarm.get("file_scope")):
             file_to_ids[file_path].append(candidate.story_id)
 

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -368,6 +368,33 @@ def _mark_cycles(candidates: list[Candidate], graph: dict[str, list[str]]) -> No
         visit(candidate.story_id, [])
 
 
+def _propagate_blocked_dependencies(
+    candidates: list[Candidate],
+    graph: dict[str, list[str]],
+) -> None:
+    by_id = {candidate.story_id: candidate for candidate in candidates}
+    changed = True
+    while changed:
+        changed = False
+        for candidate in candidates:
+            if candidate.kind != "story":
+                continue
+            for dep in graph.get(candidate.story_id, []):
+                dep_candidate = by_id.get(dep)
+                if dep_candidate is None:
+                    continue
+                if (
+                    not dep_candidate.missing
+                    and not dep_candidate.blocked
+                    and not dep_candidate.decomposition_needed
+                ):
+                    continue
+                message = f"dependency {dep!r} is blocked"
+                if message not in candidate.blocked:
+                    candidate.blocked.append(message)
+                    changed = True
+
+
 def _ready_stories(candidates: list[Candidate]) -> list[Candidate]:
     return [
         candidate
@@ -528,6 +555,7 @@ def readiness_report(project_root: Path, paths: list[Path]) -> tuple[int, str]:
         _validate_candidate(candidate, known_ids)
     graph = _candidate_dep_graph(candidates, known_ids)
     _mark_cycles(candidates, graph)
+    _propagate_blocked_dependencies(candidates, graph)
     overlaps = _file_overlaps(candidates, graph)
     report = _render_report(candidates, graph, overlaps)
     failed = any(

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -206,6 +206,20 @@ def _has_traces(plan: dict[str, Any], swarm: dict[str, Any]) -> bool:
     return bool(_as_str_list(swarm.get("missing_traces_justification")))
 
 
+def _missing_required_swarm_fields(swarm: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    for key in ("file_scope", "verify_commands", "expected_outputs"):
+        if not _as_str_list(swarm.get(key)):
+            missing.append(f"plan.metadata.swarm.{key}")
+    if "depends_on" not in swarm:
+        missing.append("plan.metadata.swarm.depends_on")
+    for key in ("conflict_group", "size", "file_scope_confidence", "model_tier"):
+        value = swarm.get(key)
+        if not isinstance(value, str) or not value.strip():
+            missing.append(f"plan.metadata.swarm.{key}")
+    return missing
+
+
 def _all_scope_ids(project_root: Path) -> dict[str, tuple[Path, str]]:
     ids: dict[str, tuple[Path, str]] = {}
     vbrief_dir = project_root / "vbrief"
@@ -270,10 +284,7 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
         candidate.missing.append("plan.metadata.swarm.parallel_safe")
     elif parallel_safe is False:
         candidate.sequential.append("parallel_safe=false: requires sequential allocation")
-    if not _as_str_list(candidate.swarm.get("file_scope")):
-        candidate.missing.append("plan.metadata.swarm.file_scope")
-    if not _as_str_list(candidate.swarm.get("verify_commands")):
-        candidate.missing.append("plan.metadata.swarm.verify_commands")
+    candidate.missing.extend(_missing_required_swarm_fields(candidate.swarm))
     if not _has_traces(candidate.plan, candidate.swarm):
         candidate.missing.append("Traces or missing_traces_justification")
     if candidate.swarm.get("size") == "large" and candidate.swarm.get("parallel_safe") is True:

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -302,6 +302,7 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
         story_quality_issues(
             title=candidate.title,
             description=_plan_narrative(candidate.plan, "Description"),
+            implementation_plan=_plan_narrative(candidate.plan, "ImplementationPlan"),
             user_story=_plan_narrative(candidate.plan, "UserStory"),
             acceptance_texts=acceptance_texts_from_items(items),
             acceptance_count_justification=_acceptance_count_justification(

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -36,6 +36,7 @@ class Candidate:
     swarm: dict[str, Any]
     missing: list[str] = field(default_factory=list)
     blocked: list[str] = field(default_factory=list)
+    sequential: list[str] = field(default_factory=list)
     decomposition_needed: bool = False
 
 
@@ -264,8 +265,11 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
 
     if candidate.swarm.get("readiness") != READY:
         candidate.missing.append("plan.metadata.swarm.readiness=ready")
-    if candidate.swarm.get("parallel_safe") is not True:
-        candidate.missing.append("plan.metadata.swarm.parallel_safe=true")
+    parallel_safe = candidate.swarm.get("parallel_safe")
+    if parallel_safe is not True and parallel_safe is not False:
+        candidate.missing.append("plan.metadata.swarm.parallel_safe")
+    elif parallel_safe is False:
+        candidate.sequential.append("parallel_safe=false: requires sequential allocation")
     if not _as_str_list(candidate.swarm.get("file_scope")):
         candidate.missing.append("plan.metadata.swarm.file_scope")
     if not _as_str_list(candidate.swarm.get("verify_commands")):
@@ -316,7 +320,8 @@ def _mark_cycles(candidates: list[Candidate], graph: dict[str, list[str]]) -> No
         if story_id in visited:
             return
         if story_id in visiting:
-            cycle = [*path, story_id]
+            start = path.index(story_id) if story_id in path else 0
+            cycle = [*path[start:], story_id]
             message = f"dependency cycle: {' -> '.join(cycle)}"
             for node in cycle:
                 if node in by_id and message not in by_id[node].blocked:
@@ -339,6 +344,7 @@ def _ready_stories(candidates: list[Candidate]) -> list[Candidate]:
         if candidate.kind == "story"
         and not candidate.missing
         and not candidate.blocked
+        and not candidate.sequential
         and not candidate.decomposition_needed
     ]
 
@@ -418,6 +424,14 @@ def _render_report(
         for candidate in candidates
         if candidate.kind == "story" and (candidate.missing or candidate.blocked)
     ]
+    sequential = [
+        candidate
+        for candidate in candidates
+        if candidate.kind == "story"
+        and candidate.sequential
+        and not candidate.missing
+        and not candidate.blocked
+    ]
     needs_decomposition = [candidate for candidate in candidates if candidate.decomposition_needed]
     lines: list[str] = ["Swarm readiness report", ""]
 
@@ -434,6 +448,16 @@ def _render_report(
         for candidate in blocked:
             reasons = [*candidate.missing, *candidate.blocked]
             lines.append(f"- {candidate.story_id}: {candidate.title} -- {'; '.join(reasons)}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Sequential stories:")
+    if sequential:
+        for candidate in sequential:
+            lines.append(
+                f"- {candidate.story_id}: {candidate.title} -- {'; '.join(candidate.sequential)}"
+            )
     else:
         lines.append("- none")
     lines.append("")
@@ -497,7 +521,10 @@ def readiness_report(project_root: Path, paths: list[Path]) -> tuple[int, str]:
     overlaps = _file_overlaps(candidates, graph)
     report = _render_report(candidates, graph, overlaps)
     failed = any(
-        candidate.missing or candidate.blocked or candidate.decomposition_needed
+        candidate.missing
+        or candidate.blocked
+        or candidate.sequential
+        or candidate.decomposition_needed
         for candidate in candidates
     ) or bool(overlaps)
     return 1 if failed else 0, report

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Report whether vBRIEF candidates are ready for concurrent swarm allocation."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+
+reconfigure_stdio()
+
+LIFECYCLE_FOLDERS = ("proposed", "pending", "active", "completed", "cancelled")
+READY = "ready"
+
+
+@dataclass
+class Candidate:
+    path: Path
+    relpath: str
+    data: dict[str, Any]
+    plan: dict[str, Any]
+    story_id: str
+    title: str
+    status: str
+    folder: str
+    kind: str
+    swarm: dict[str, Any]
+    missing: list[str] = field(default_factory=list)
+    blocked: list[str] = field(default_factory=list)
+    decomposition_needed: bool = False
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _project_rel(project_root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(project_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _expand_paths(project_root: Path, patterns: list[str]) -> list[Path]:
+    if not patterns:
+        patterns = ["vbrief/active/*.vbrief.json"]
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in patterns:
+        raw = Path(pattern)
+        matches: list[str]
+        if any(ch in pattern for ch in "*?["):
+            matches = glob.glob(str(raw if raw.is_absolute() else project_root / pattern))
+        else:
+            matches = [str(raw if raw.is_absolute() else project_root / pattern)]
+        for match in matches:
+            path = Path(match).resolve()
+            if path in seen or not path.is_file():
+                continue
+            seen.add(path)
+            out.append(path)
+    return sorted(out)
+
+
+def _folder_for(path: Path) -> str:
+    return path.parent.name if path.parent.name in LIFECYCLE_FOLDERS else ""
+
+
+def _plan(data: dict[str, Any]) -> dict[str, Any]:
+    plan = data.get("plan")
+    return plan if isinstance(plan, dict) else {}
+
+
+def _metadata(plan: dict[str, Any]) -> dict[str, Any]:
+    metadata = plan.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _swarm(metadata: dict[str, Any]) -> dict[str, Any]:
+    swarm = metadata.get("swarm")
+    return swarm if isinstance(swarm, dict) else {}
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _has_child_plan_refs(plan: dict[str, Any]) -> bool:
+    refs = plan.get("references")
+    if not isinstance(refs, list):
+        return False
+    return any(isinstance(ref, dict) and ref.get("type") == "x-vbrief/plan" for ref in refs)
+
+
+def _looks_like_phase(path: Path, plan: dict[str, Any]) -> bool:
+    title = str(plan.get("title") or "")
+    plan_id = str(plan.get("id") or "")
+    narratives = plan.get("narratives")
+    has_acceptance_narrative = (
+        isinstance(narratives, dict)
+        and isinstance(narratives.get("Acceptance"), str)
+        and bool(narratives["Acceptance"].strip())
+    )
+    has_items = bool(plan.get("items"))
+    stem = path.name
+    return (
+        "-ip" in stem
+        or title.lower().startswith("ip-")
+        or plan_id.lower().startswith("ip-")
+        or (not has_items and has_acceptance_narrative)
+    )
+
+
+def _kind(path: Path, plan: dict[str, Any]) -> str:
+    metadata = _metadata(plan)
+    explicit = metadata.get("kind")
+    if explicit in {"story", "epic", "phase"}:
+        return str(explicit)
+    if _has_child_plan_refs(plan):
+        return "epic"
+    if _looks_like_phase(path, plan):
+        return "phase"
+    return "story"
+
+
+def _story_id(path: Path, plan: dict[str, Any]) -> str:
+    value = plan.get("id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    name = path.name
+    return name[: -len(".vbrief.json")] if name.endswith(".vbrief.json") else path.stem
+
+
+def _item_has_acceptance(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        acceptance = narrative.get("Acceptance")
+        if isinstance(acceptance, str) and acceptance.strip():
+            return True
+    for key in ("items", "subItems"):
+        children = item.get(key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_acceptance(child):
+                    return True
+    return False
+
+
+def _items_have_acceptance(items: Any) -> bool:
+    if not isinstance(items, list):
+        return False
+    return any(isinstance(item, dict) and _item_has_acceptance(item) for item in items)
+
+
+def _item_has_traces(item: dict[str, Any]) -> bool:
+    narrative = item.get("narrative")
+    if isinstance(narrative, dict):
+        traces = narrative.get("Traces")
+        if isinstance(traces, str) and traces.strip():
+            return True
+    for key in ("items", "subItems"):
+        children = item.get(key)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict) and _item_has_traces(child):
+                    return True
+    return False
+
+
+def _has_traces(plan: dict[str, Any], swarm: dict[str, Any]) -> bool:
+    narratives = plan.get("narratives")
+    if isinstance(narratives, dict):
+        traces = narratives.get("Traces")
+        if isinstance(traces, str) and traces.strip():
+            return True
+    items = plan.get("items")
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict) and _item_has_traces(item):
+                return True
+    refs = plan.get("references")
+    if isinstance(refs, list):
+        for ref in refs:
+            if isinstance(ref, dict) and ref.get("type") == "x-vbrief/spec-section":
+                return True
+    return bool(_as_str_list(swarm.get("missing_traces_justification")))
+
+
+def _all_scope_ids(project_root: Path) -> dict[str, tuple[Path, str]]:
+    ids: dict[str, tuple[Path, str]] = {}
+    vbrief_dir = project_root / "vbrief"
+    for folder in LIFECYCLE_FOLDERS:
+        for path in sorted((vbrief_dir / folder).glob("*.vbrief.json")):
+            data = _load_json(path)
+            if not data:
+                continue
+            plan = _plan(data)
+            scope_id = _story_id(path, plan)
+            ids[scope_id] = (path, str(plan.get("status") or ""))
+            name = path.name
+            stem = name[: -len(".vbrief.json")] if name.endswith(".vbrief.json") else path.stem
+            ids.setdefault(stem, (path, str(plan.get("status") or "")))
+    return ids
+
+
+def _candidate(path: Path, project_root: Path) -> Candidate | None:
+    data = _load_json(path)
+    if not data:
+        return None
+    plan = _plan(data)
+    metadata = _metadata(plan)
+    swarm = _swarm(metadata)
+    return Candidate(
+        path=path,
+        relpath=_project_rel(project_root, path),
+        data=data,
+        plan=plan,
+        story_id=_story_id(path, plan),
+        title=str(plan.get("title") or path.name),
+        status=str(plan.get("status") or ""),
+        folder=_folder_for(path),
+        kind=_kind(path, plan),
+        swarm=swarm,
+    )
+
+
+def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, str]]) -> None:
+    if candidate.kind in {"epic", "phase"}:
+        candidate.decomposition_needed = True
+        return
+    if candidate.kind != "story":
+        candidate.missing.append("plan.metadata.kind=story")
+    if candidate.folder == "active" and candidate.status != "running":
+        candidate.blocked.append("active candidate plan.status must be running")
+    if candidate.status == "running" and candidate.folder != "active":
+        candidate.blocked.append("plan.status=running is only valid in vbrief/active/")
+    if candidate.status == "blocked":
+        candidate.blocked.append("plan.status=blocked")
+
+    items = candidate.plan.get("items")
+    if not isinstance(items, list) or not items:
+        candidate.missing.append("plan.items")
+    elif not _items_have_acceptance(items):
+        candidate.missing.append("plan.items[].narrative.Acceptance")
+
+    if candidate.swarm.get("readiness") != READY:
+        candidate.missing.append("plan.metadata.swarm.readiness=ready")
+    if candidate.swarm.get("parallel_safe") is not True:
+        candidate.missing.append("plan.metadata.swarm.parallel_safe=true")
+    if not _as_str_list(candidate.swarm.get("file_scope")):
+        candidate.missing.append("plan.metadata.swarm.file_scope")
+    if not _as_str_list(candidate.swarm.get("verify_commands")):
+        candidate.missing.append("plan.metadata.swarm.verify_commands")
+    if not _has_traces(candidate.plan, candidate.swarm):
+        candidate.missing.append("Traces or missing_traces_justification")
+    if candidate.swarm.get("size") == "large" and candidate.swarm.get("parallel_safe") is True:
+        candidate.blocked.append("size=large cannot be parallel_safe=true")
+    if (
+        candidate.swarm.get("file_scope_confidence") == "low"
+        and candidate.swarm.get("parallel_safe") is True
+    ):
+        candidate.blocked.append("low-confidence file scope cannot be parallel-safe by default")
+
+    for dep in _as_str_list(candidate.swarm.get("depends_on")):
+        if dep not in known_ids:
+            candidate.blocked.append(f"dependency {dep!r} does not resolve")
+
+
+def _candidate_dep_graph(
+    candidates: list[Candidate],
+    known_ids: dict[str, tuple[Path, str]],
+) -> dict[str, list[str]]:
+    candidate_ids = {candidate.story_id for candidate in candidates}
+    graph: dict[str, list[str]] = {}
+    for candidate in candidates:
+        deps: list[str] = []
+        for dep in _as_str_list(candidate.swarm.get("depends_on")):
+            if dep in candidate_ids:
+                deps.append(dep)
+                continue
+            known = known_ids.get(dep)
+            if known is None:
+                continue
+            _dep_path, dep_status = known
+            if dep_status not in {"completed", "failed", "cancelled"}:
+                candidate.blocked.append(f"dependency {dep!r} is not completed or a candidate")
+        graph[candidate.story_id] = deps
+    return graph
+
+
+def _mark_cycles(candidates: list[Candidate], graph: dict[str, list[str]]) -> None:
+    by_id = {candidate.story_id: candidate for candidate in candidates}
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(story_id: str, path: list[str]) -> None:
+        if story_id in visited:
+            return
+        if story_id in visiting:
+            cycle = [*path, story_id]
+            message = f"dependency cycle: {' -> '.join(cycle)}"
+            for node in cycle:
+                if node in by_id and message not in by_id[node].blocked:
+                    by_id[node].blocked.append(message)
+            return
+        visiting.add(story_id)
+        for dep in graph.get(story_id, []):
+            visit(dep, [*path, story_id])
+        visiting.remove(story_id)
+        visited.add(story_id)
+
+    for candidate in candidates:
+        visit(candidate.story_id, [])
+
+
+def _ready_stories(candidates: list[Candidate]) -> list[Candidate]:
+    return [
+        candidate
+        for candidate in candidates
+        if candidate.kind == "story"
+        and not candidate.missing
+        and not candidate.blocked
+        and not candidate.decomposition_needed
+    ]
+
+
+def _dependency_waves(candidates: list[Candidate], graph: dict[str, list[str]]) -> list[list[str]]:
+    ready_ids = {candidate.story_id for candidate in _ready_stories(candidates)}
+    remaining = set(ready_ids)
+    waves: list[list[str]] = []
+    while remaining:
+        wave = sorted(
+            story_id
+            for story_id in remaining
+            if all(dep not in remaining for dep in graph.get(story_id, []))
+        )
+        if not wave:
+            waves.append(sorted(remaining))
+            break
+        waves.append(wave)
+        remaining.difference_update(wave)
+    return waves
+
+
+def _transitive_deps(story_id: str, graph: dict[str, list[str]]) -> set[str]:
+    out: set[str] = set()
+    stack = list(graph.get(story_id, []))
+    while stack:
+        dep = stack.pop()
+        if dep in out:
+            continue
+        out.add(dep)
+        stack.extend(graph.get(dep, []))
+    return out
+
+
+def _file_overlaps(
+    candidates: list[Candidate],
+    graph: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    file_to_ids: dict[str, list[str]] = defaultdict(list)
+    for candidate in _ready_stories(candidates):
+        if candidate.swarm.get("parallel_safe") is not True:
+            continue
+        for file_path in _as_str_list(candidate.swarm.get("file_scope")):
+            file_to_ids[file_path].append(candidate.story_id)
+
+    overlaps: dict[str, list[str]] = {}
+    for file_path, ids in file_to_ids.items():
+        unsafe_pairs: set[str] = set()
+        for index, left in enumerate(ids):
+            for right in ids[index + 1:]:
+                if right in _transitive_deps(left, graph) or left in _transitive_deps(right, graph):
+                    continue
+                unsafe_pairs.add(left)
+                unsafe_pairs.add(right)
+        if unsafe_pairs:
+            overlaps[file_path] = sorted(unsafe_pairs)
+    return overlaps
+
+
+def _conflict_groups(candidates: list[Candidate]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = defaultdict(list)
+    for candidate in candidates:
+        group = candidate.swarm.get("conflict_group")
+        if isinstance(group, str) and group.strip():
+            groups[group].append(candidate.story_id)
+    return dict(sorted(groups.items()))
+
+
+def _render_report(
+    candidates: list[Candidate],
+    graph: dict[str, list[str]],
+    overlaps: dict[str, list[str]],
+) -> str:
+    ready = _ready_stories(candidates)
+    blocked = [
+        candidate
+        for candidate in candidates
+        if candidate.kind == "story" and (candidate.missing or candidate.blocked)
+    ]
+    needs_decomposition = [candidate for candidate in candidates if candidate.decomposition_needed]
+    lines: list[str] = ["Swarm readiness report", ""]
+
+    lines.append("Ready stories:")
+    if ready:
+        for candidate in ready:
+            lines.append(f"- {candidate.story_id}: {candidate.title} ({candidate.relpath})")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Blocked stories:")
+    if blocked:
+        for candidate in blocked:
+            reasons = [*candidate.missing, *candidate.blocked]
+            lines.append(f"- {candidate.story_id}: {candidate.title} -- {'; '.join(reasons)}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Decomposition-needed epics/phases:")
+    if needs_decomposition:
+        for candidate in needs_decomposition:
+            lines.append(f"- {candidate.story_id}: kind={candidate.kind} ({candidate.relpath})")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Dependency waves:")
+    waves = _dependency_waves(candidates, graph)
+    if waves:
+        for index, wave in enumerate(waves, start=1):
+            lines.append(f"- wave {index}: {', '.join(wave)}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Conflict groups:")
+    groups = _conflict_groups(candidates)
+    if groups:
+        for group, ids in groups.items():
+            lines.append(f"- {group}: {', '.join(sorted(ids))}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("File overlap matrix:")
+    if overlaps:
+        for file_path, ids in sorted(overlaps.items()):
+            lines.append(f"- {file_path}: {', '.join(ids)}")
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Missing fields:")
+    missing_any = False
+    for candidate in candidates:
+        if candidate.missing:
+            missing_any = True
+            lines.append(f"- {candidate.story_id}: {', '.join(candidate.missing)}")
+    if not missing_any:
+        lines.append("- none")
+    return "\n".join(lines)
+
+
+def readiness_report(project_root: Path, paths: list[Path]) -> tuple[int, str]:
+    candidates = [candidate for path in paths if (candidate := _candidate(path, project_root))]
+    if not candidates:
+        return 1, "Swarm readiness report\n\nNo candidate vBRIEFs found."
+    known_ids = _all_scope_ids(project_root)
+    for candidate in candidates:
+        known_ids.setdefault(candidate.story_id, (candidate.path, candidate.status))
+    for candidate in candidates:
+        _validate_candidate(candidate, known_ids)
+    graph = _candidate_dep_graph(candidates, known_ids)
+    _mark_cycles(candidates, graph)
+    overlaps = _file_overlaps(candidates, graph)
+    report = _render_report(candidates, graph, overlaps)
+    failed = any(
+        candidate.missing or candidate.blocked or candidate.decomposition_needed
+        for candidate in candidates
+    ) or bool(overlaps)
+    return 1 if failed else 0, report
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Report whether vBRIEF candidates are ready for concurrent swarm allocation."
+    )
+    parser.add_argument("paths", nargs="*", help="Candidate vBRIEF paths or globs")
+    parser.add_argument("--project-root", default=".", help="Project root containing vbrief/")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    project_root = Path(args.project_root).resolve()
+    paths = _expand_paths(project_root, args.paths)
+    code, report = readiness_report(project_root, paths)
+    print(report)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -309,6 +309,7 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
                 candidate.plan, candidate.swarm
             ),
             swarm=candidate.swarm,
+            concurrent_ready=candidate.swarm.get("readiness") == READY,
         )
     )
     if candidate.swarm.get("size") == "large" and candidate.swarm.get("parallel_safe") is True:

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -15,6 +15,11 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from _vbrief_story_quality import (  # noqa: E402
+    acceptance_texts_from_items,
+    as_str_list as _quality_as_str_list,
+    story_quality_issues,
+)
 
 reconfigure_stdio()
 
@@ -36,7 +41,6 @@ class Candidate:
     swarm: dict[str, Any]
     missing: list[str] = field(default_factory=list)
     blocked: list[str] = field(default_factory=list)
-    sequential: list[str] = field(default_factory=list)
     decomposition_needed: bool = False
 
 
@@ -96,13 +100,7 @@ def _swarm(metadata: dict[str, Any]) -> dict[str, Any]:
 
 
 def _as_str_list(value: Any) -> list[str]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        return [value] if value.strip() else []
-    if isinstance(value, list):
-        return [str(item) for item in value if str(item).strip()]
-    return []
+    return _quality_as_str_list(value)
 
 
 def _has_child_plan_refs(plan: dict[str, Any]) -> bool:
@@ -206,6 +204,21 @@ def _has_traces(plan: dict[str, Any], swarm: dict[str, Any]) -> bool:
     return bool(_as_str_list(swarm.get("missing_traces_justification")))
 
 
+def _plan_narrative(plan: dict[str, Any], key: str) -> str:
+    narratives = plan.get("narratives")
+    if not isinstance(narratives, dict):
+        return ""
+    value = narratives.get(key)
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+def _acceptance_count_justification(plan: dict[str, Any], swarm: dict[str, Any]) -> str:
+    value = swarm.get("acceptance_criteria_justification")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return _plan_narrative(plan, "AcceptanceJustification")
+
+
 def _missing_required_swarm_fields(swarm: dict[str, Any]) -> list[str]:
     missing: list[str] = []
     for key in ("file_scope", "verify_commands", "expected_outputs"):
@@ -278,22 +291,27 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
         candidate.missing.append("plan.items[].narrative.Acceptance")
 
     if candidate.swarm.get("readiness") != READY:
-        candidate.missing.append("plan.metadata.swarm.readiness=ready")
+        candidate.missing.append("plan.metadata.swarm.readiness=ready for concurrent allocation")
     parallel_safe = candidate.swarm.get("parallel_safe")
     if parallel_safe is not True and parallel_safe is not False:
         candidate.missing.append("plan.metadata.swarm.parallel_safe")
-    elif parallel_safe is False:
-        candidate.sequential.append("parallel_safe=false: requires sequential allocation")
     candidate.missing.extend(_missing_required_swarm_fields(candidate.swarm))
     if not _has_traces(candidate.plan, candidate.swarm):
         candidate.missing.append("Traces or missing_traces_justification")
+    candidate.blocked.extend(
+        story_quality_issues(
+            title=candidate.title,
+            description=_plan_narrative(candidate.plan, "Description"),
+            user_story=_plan_narrative(candidate.plan, "UserStory"),
+            acceptance_texts=acceptance_texts_from_items(items),
+            acceptance_count_justification=_acceptance_count_justification(
+                candidate.plan, candidate.swarm
+            ),
+            swarm=candidate.swarm,
+        )
+    )
     if candidate.swarm.get("size") == "large" and candidate.swarm.get("parallel_safe") is True:
         candidate.blocked.append("size=large cannot be parallel_safe=true")
-    if (
-        candidate.swarm.get("file_scope_confidence") == "low"
-        and candidate.swarm.get("parallel_safe") is True
-    ):
-        candidate.blocked.append("low-confidence file scope cannot be parallel-safe by default")
 
     for dep in _as_str_list(candidate.swarm.get("depends_on")):
         if dep not in known_ids:
@@ -355,7 +373,6 @@ def _ready_stories(candidates: list[Candidate]) -> list[Candidate]:
         if candidate.kind == "story"
         and not candidate.missing
         and not candidate.blocked
-        and not candidate.sequential
         and not candidate.decomposition_needed
     ]
 
@@ -433,14 +450,6 @@ def _render_report(
         for candidate in candidates
         if candidate.kind == "story" and (candidate.missing or candidate.blocked)
     ]
-    sequential = [
-        candidate
-        for candidate in candidates
-        if candidate.kind == "story"
-        and candidate.sequential
-        and not candidate.missing
-        and not candidate.blocked
-    ]
     needs_decomposition = [candidate for candidate in candidates if candidate.decomposition_needed]
     lines: list[str] = ["Swarm readiness report", ""]
 
@@ -457,16 +466,6 @@ def _render_report(
         for candidate in blocked:
             reasons = [*candidate.missing, *candidate.blocked]
             lines.append(f"- {candidate.story_id}: {candidate.title} -- {'; '.join(reasons)}")
-    else:
-        lines.append("- none")
-    lines.append("")
-
-    lines.append("Sequential stories:")
-    if sequential:
-        for candidate in sequential:
-            lines.append(
-                f"- {candidate.story_id}: {candidate.title} -- {'; '.join(candidate.sequential)}"
-            )
     else:
         lines.append("- none")
     lines.append("")
@@ -532,7 +531,6 @@ def readiness_report(project_root: Path, paths: list[Path]) -> tuple[int, str]:
     failed = any(
         candidate.missing
         or candidate.blocked
-        or candidate.sequential
         or candidate.decomposition_needed
         for candidate in candidates
     ) or bool(overlaps)

--- a/scripts/swarm_readiness.py
+++ b/scripts/swarm_readiness.py
@@ -17,7 +17,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _stdio_utf8 import reconfigure_stdio  # noqa: E402
 from _vbrief_story_quality import (  # noqa: E402
     acceptance_texts_from_items,
-    as_str_list as _quality_as_str_list,
+    as_str_list as _as_str_list,
+    deprecated_subitems_issues,
+    item_has_traces,
+    items_have_acceptance,
+    missing_required_swarm_fields,
     story_quality_issues,
 )
 
@@ -99,10 +103,6 @@ def _swarm(metadata: dict[str, Any]) -> dict[str, Any]:
     return swarm if isinstance(swarm, dict) else {}
 
 
-def _as_str_list(value: Any) -> list[str]:
-    return _quality_as_str_list(value)
-
-
 def _has_child_plan_refs(plan: dict[str, Any]) -> bool:
     refs = plan.get("references")
     if not isinstance(refs, list):
@@ -149,42 +149,6 @@ def _story_id(path: Path, plan: dict[str, Any]) -> str:
     return name[: -len(".vbrief.json")] if name.endswith(".vbrief.json") else path.stem
 
 
-def _item_has_acceptance(item: dict[str, Any]) -> bool:
-    narrative = item.get("narrative")
-    if isinstance(narrative, dict):
-        acceptance = narrative.get("Acceptance")
-        if isinstance(acceptance, str) and acceptance.strip():
-            return True
-    for key in ("items", "subItems"):
-        children = item.get(key)
-        if isinstance(children, list):
-            for child in children:
-                if isinstance(child, dict) and _item_has_acceptance(child):
-                    return True
-    return False
-
-
-def _items_have_acceptance(items: Any) -> bool:
-    if not isinstance(items, list):
-        return False
-    return any(isinstance(item, dict) and _item_has_acceptance(item) for item in items)
-
-
-def _item_has_traces(item: dict[str, Any]) -> bool:
-    narrative = item.get("narrative")
-    if isinstance(narrative, dict):
-        traces = narrative.get("Traces")
-        if isinstance(traces, str) and traces.strip():
-            return True
-    for key in ("items", "subItems"):
-        children = item.get(key)
-        if isinstance(children, list):
-            for child in children:
-                if isinstance(child, dict) and _item_has_traces(child):
-                    return True
-    return False
-
-
 def _has_traces(plan: dict[str, Any], swarm: dict[str, Any]) -> bool:
     narratives = plan.get("narratives")
     if isinstance(narratives, dict):
@@ -194,7 +158,7 @@ def _has_traces(plan: dict[str, Any], swarm: dict[str, Any]) -> bool:
     items = plan.get("items")
     if isinstance(items, list):
         for item in items:
-            if isinstance(item, dict) and _item_has_traces(item):
+            if isinstance(item, dict) and item_has_traces(item):
                 return True
     refs = plan.get("references")
     if isinstance(refs, list):
@@ -217,20 +181,6 @@ def _acceptance_count_justification(plan: dict[str, Any], swarm: dict[str, Any])
     if isinstance(value, str) and value.strip():
         return value.strip()
     return _plan_narrative(plan, "AcceptanceJustification")
-
-
-def _missing_required_swarm_fields(swarm: dict[str, Any]) -> list[str]:
-    missing: list[str] = []
-    for key in ("file_scope", "verify_commands", "expected_outputs"):
-        if not _as_str_list(swarm.get(key)):
-            missing.append(f"plan.metadata.swarm.{key}")
-    if "depends_on" not in swarm:
-        missing.append("plan.metadata.swarm.depends_on")
-    for key in ("conflict_group", "size", "file_scope_confidence", "model_tier"):
-        value = swarm.get(key)
-        if not isinstance(value, str) or not value.strip():
-            missing.append(f"plan.metadata.swarm.{key}")
-    return missing
 
 
 def _all_scope_ids(project_root: Path) -> dict[str, tuple[Path, str]]:
@@ -277,6 +227,19 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
         return
     if candidate.kind != "story" or _metadata(candidate.plan).get("kind") != "story":
         candidate.missing.append("plan.metadata.kind=story")
+    if not isinstance(candidate.plan.get("id"), str) or not candidate.plan["id"].strip():
+        candidate.missing.append("plan.id")
+    if not isinstance(candidate.plan.get("title"), str) or not candidate.plan["title"].strip():
+        candidate.missing.append("plan.title")
+    description = _plan_narrative(candidate.plan, "Description")
+    implementation_plan = _plan_narrative(candidate.plan, "ImplementationPlan")
+    user_story = _plan_narrative(candidate.plan, "UserStory")
+    if not description:
+        candidate.missing.append("plan.narratives.Description")
+    if not implementation_plan:
+        candidate.missing.append("plan.narratives.ImplementationPlan")
+    if not user_story:
+        candidate.missing.append("plan.narratives.UserStory")
     if candidate.folder == "active" and candidate.status != "running":
         candidate.blocked.append("active candidate plan.status must be running")
     if candidate.status == "running" and candidate.folder != "active":
@@ -287,23 +250,25 @@ def _validate_candidate(candidate: Candidate, known_ids: dict[str, tuple[Path, s
     items = candidate.plan.get("items")
     if not isinstance(items, list) or not items:
         candidate.missing.append("plan.items")
-    elif not _items_have_acceptance(items):
-        candidate.missing.append("plan.items[].narrative.Acceptance")
+    else:
+        if not items_have_acceptance(items):
+            candidate.missing.append("plan.items[].narrative.Acceptance")
+        candidate.blocked.extend(deprecated_subitems_issues(items))
 
     if candidate.swarm.get("readiness") != READY:
         candidate.missing.append("plan.metadata.swarm.readiness=ready for concurrent allocation")
     parallel_safe = candidate.swarm.get("parallel_safe")
     if parallel_safe is not True and parallel_safe is not False:
         candidate.missing.append("plan.metadata.swarm.parallel_safe")
-    candidate.missing.extend(_missing_required_swarm_fields(candidate.swarm))
+    candidate.missing.extend(missing_required_swarm_fields(candidate.swarm))
     if not _has_traces(candidate.plan, candidate.swarm):
         candidate.missing.append("Traces or missing_traces_justification")
     candidate.blocked.extend(
         story_quality_issues(
             title=candidate.title,
-            description=_plan_narrative(candidate.plan, "Description"),
-            implementation_plan=_plan_narrative(candidate.plan, "ImplementationPlan"),
-            user_story=_plan_narrative(candidate.plan, "UserStory"),
+            description=description,
+            implementation_plan=implementation_plan,
+            user_story=user_story,
             acceptance_texts=acceptance_texts_from_items(items),
             acceptance_count_justification=_acceptance_count_justification(
                 candidate.plan, candidate.swarm

--- a/skills/deft-directive-decompose/SKILL.md
+++ b/skills/deft-directive-decompose/SKILL.md
@@ -68,15 +68,15 @@ task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>
 
 The command creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent, updates parent references to include the children, rejects dependency cycles, and rejects ready stories missing executable acceptance, user-story shape, concrete acceptance, narrow file scope, focused verify commands, or traces.
 
-## Phase 4: Readiness
+## Phase 4: Pending Readiness
 
-- ! Run readiness after decomposition:
+- ! Run readiness against the generated pending child story paths after decomposition:
 
 ```bash
-task swarm:readiness -- vbrief/active/*.vbrief.json
+task swarm:readiness -- vbrief/pending/<child-story-1>.vbrief.json vbrief/pending/<child-story-2>.vbrief.json
 ```
 
-- ~ If child stories are still pending, run readiness against their explicit paths for a dry readiness review before activation
+- ! Treat this as a dry readiness review before activation; do not allocate workers from pending paths
 - ! Route blocked or overlapping stories back to Phase 1 for draft refinement
 - ! Leave lifecycle promotion/activation to the existing approved flow (`task scope:promote`, `task scope:activate`, and the swarm skill lifecycle bridge).
 - ⊗ Promote or activate child stories solely because decomposition succeeded.

--- a/skills/deft-directive-decompose/SKILL.md
+++ b/skills/deft-directive-decompose/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: deft-directive-decompose
+description: >
+  Convert approved specification/phase/epic scope vBRIEFs into swarm-ready
+  story vBRIEFs before concurrent agent allocation.
+---
+
+# Deft Directive Decompose
+
+Use this skill when a specification, Phase 4 implementation scope, or epic vBRIEF is too broad for direct concurrent swarm work and must be decomposed into story-level vBRIEFs.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**See also**: [strategies/speckit.md](../../strategies/speckit.md) Phase 4.5 | [vbrief/vbrief.md](../../vbrief/vbrief.md) Swarm-Ready Story Contract | [deft-directive-swarm](../deft-directive-swarm/SKILL.md)
+
+## Purpose
+
+Convert approved specification/phase/epic scope vBRIEFs into swarm-ready child story vBRIEFs. Story vBRIEFs are the only valid input for concurrent swarm worker allocation.
+
+## Phase 0: Inspect
+
+- ! Read `vbrief/specification.vbrief.json` and relevant scope vBRIEFs from `vbrief/proposed/`, `vbrief/pending/`, and `vbrief/active/`
+- ! Identify broad scopes with `plan.metadata.kind = "phase"` or `"epic"` or scopes with broad `plan.narratives.Acceptance` and empty `plan.items`
+- ! Preserve parent acceptance as context; do not treat it as executable story acceptance
+- ! Identify requirement traces, likely file scope, verification commands, outputs/evidence, dependencies, and conflict groups
+- ⊗ Allocate a broad phase/epic scope to concurrent workers during this skill
+
+## Phase 1: Draft
+
+- ! Draft a decomposition JSON proposal with child stories only; do not write child vBRIEFs yet
+- ! Each story MUST include `id`, `title`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`
+- ! Model dependencies as story IDs and ensure they form a DAG
+- ! Mark a story `parallel_safe: false` when the expected file scope is broad, low-confidence, or likely to collide
+- ⊗ Use deprecated `subItems` in newly drafted story items; use `items`
+
+## Phase 2: Approval
+
+- ! Present the decomposition draft to the user before writing files
+- ! Ask for explicit approval to apply the draft
+- ! If the user requests changes, revise the draft and re-present it
+- ⊗ Run `task scope:decompose` before explicit approval
+
+## Phase 3: Apply
+
+- ! Validate the approved draft first:
+
+```bash
+task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json> --check
+```
+
+- ! Apply the approved draft:
+
+```bash
+task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>
+```
+
+The command creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent, updates parent references to include the children, rejects dependency cycles, and rejects ready stories missing executable acceptance, file scope, verify commands, or traces.
+
+## Phase 4: Readiness
+
+- ! Run readiness after decomposition:
+
+```bash
+task swarm:readiness -- vbrief/active/*.vbrief.json
+```
+
+- ~ If child stories are still pending, run readiness against their explicit paths for a dry readiness review before activation
+- ! Route blocked or overlapping stories back to Phase 1 for draft refinement
+- ! Leave lifecycle promotion/activation to the existing approved flow (`task scope:promote`, `task scope:activate`, and the swarm skill lifecycle bridge)
+- ⊗ Promote or activate child stories solely because decomposition succeeded
+
+## Exit
+
+deft-directive-decompose complete -- exiting skill. Next, activate the approved child story vBRIEFs through the existing lifecycle flow, then run `skills/deft-directive-swarm/SKILL.md` for concurrent allocation.

--- a/skills/deft-directive-decompose/SKILL.md
+++ b/skills/deft-directive-decompose/SKILL.md
@@ -22,15 +22,24 @@ Convert approved specification/phase/epic scope vBRIEFs into swarm-ready child s
 - ! Read `vbrief/specification.vbrief.json` and relevant scope vBRIEFs from `vbrief/proposed/`, `vbrief/pending/`, and `vbrief/active/`
 - ! Identify broad scopes with `plan.metadata.kind = "phase"` or `"epic"` or scopes with broad `plan.narratives.Acceptance` and empty `plan.items`
 - ! Preserve parent acceptance as context; do not treat it as executable story acceptance
+- ! Treat parent `plan.items` as input signals only; they are not automatically child stories
+- ! Inspect relevant codebase paths before drafting file scope so stories reflect real product/code boundaries, not only parent scope prose
 - ! Identify requirement traces, likely file scope, verification commands, outputs/evidence, dependencies, and conflict groups
 - ⊗ Allocate a broad phase/epic scope to concurrent workers during this skill
 
 ## Phase 1: Draft
 
 - ! Draft a decomposition JSON proposal with child stories only; do not write child vBRIEFs yet
-- ! Each story MUST include `id`, `title`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`
+- ! Each story MUST include `id`, `title`, `UserStory`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`
+- ! `UserStory` MUST use the exact product-story shape `As a <role>, I want <capability>, so that <outcome>.`
+- ! Each ready story MUST have 2-5 concrete acceptance criteria unless `swarm.acceptance_criteria_justification` explains the exception
+- ! Acceptance criteria MUST be observable behavior, preferably Given/When/Then or equivalent testable product behavior
+- ⊗ Mark a story ready when acceptance says only "to refine from parent scope", duplicates the title/description, is placeholder text, or is vague docs-only acceptance
+- ⊗ Mark a story ready with broad write scope such as `backend/**`, `frontend/**`, `docs/**`, `vbrief/**`, or any other directory glob
+- ⊗ Mark a story ready when verification is only generic validation such as `task check`
+- ⊗ Mark a story ready with `parallel_safe: false` or `file_scope_confidence: low`; use `readiness: sequential` or `readiness: needs_refinement` instead
 - ! Model dependencies as story IDs and ensure they form a DAG
-- ! Mark a story `parallel_safe: false` when the expected file scope is broad, low-confidence, or likely to collide
+- ~ Draft sequential-safe or low-confidence work as `readiness: sequential` or `readiness: needs_refinement`; it is not eligible for concurrent allocation
 - ⊗ Use deprecated `subItems` in newly drafted story items; use `items`
 
 ## Phase 2: Approval
@@ -54,7 +63,7 @@ task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json> --chec
 task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>
 ```
 
-The command creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent, updates parent references to include the children, rejects dependency cycles, and rejects ready stories missing executable acceptance, file scope, verify commands, or traces.
+The command creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent, updates parent references to include the children, rejects dependency cycles, and rejects ready stories missing executable acceptance, user-story shape, concrete acceptance, narrow file scope, focused verify commands, or traces.
 
 ## Phase 4: Readiness
 

--- a/skills/deft-directive-decompose/SKILL.md
+++ b/skills/deft-directive-decompose/SKILL.md
@@ -30,7 +30,9 @@ Convert approved specification/phase/epic scope vBRIEFs into swarm-ready child s
 ## Phase 1: Draft
 
 - ! Draft a decomposition JSON proposal with child stories only; do not write child vBRIEFs yet
-- ! Each story MUST include `id`, `title`, `UserStory`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`
+- ! Each story MUST include `id`, `title`, `Description`, `ImplementationPlan`, `UserStory`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`
+- ! `Description` MUST provide at least two concrete sentences explaining the user/product behavior, boundaries, and why this story is independently buildable
+- ! `ImplementationPlan` MUST provide at least two concrete implementation steps that identify the expected code path, state/data changes, and test/evidence approach
 - ! `UserStory` MUST use the exact product-story shape `As a <role>, I want <capability>, so that <outcome>.`
 - ! Each ready story MUST have 2-5 concrete acceptance criteria unless `swarm.acceptance_criteria_justification` explains the exception
 - ! Acceptance criteria MUST be observable behavior, preferably Given/When/Then or equivalent testable product behavior

--- a/skills/deft-directive-decompose/SKILL.md
+++ b/skills/deft-directive-decompose/SKILL.md
@@ -30,7 +30,7 @@ Convert approved specification/phase/epic scope vBRIEFs into swarm-ready child s
 ## Phase 1: Draft
 
 - ! Draft a decomposition JSON proposal with child stories only; do not write child vBRIEFs yet
-- ! Each story MUST include `id`, `title`, `Description`, `ImplementationPlan`, `UserStory`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`
+- ! Each story MUST include `id`, `title`, `Description`, `ImplementationPlan`, `UserStory`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`.
 - ! `Description` MUST provide at least two concrete sentences explaining the user/product behavior, boundaries, and why this story is independently buildable
 - ! `ImplementationPlan` MUST provide at least two concrete implementation steps that identify the expected code path, state/data changes, and test/evidence approach
 - ! `UserStory` MUST use the exact product-story shape `As a <role>, I want <capability>, so that <outcome>.`
@@ -49,7 +49,8 @@ Convert approved specification/phase/epic scope vBRIEFs into swarm-ready child s
 - ! Present the decomposition draft to the user before writing files
 - ! Ask for explicit approval to apply the draft
 - ! If the user requests changes, revise the draft and re-present it
-- ⊗ Run `task scope:decompose` before explicit approval
+- ? Run `task scope:decompose ... --check` before explicit approval only to validate a draft without writing files.
+- ⊗ Apply `task scope:decompose` without `--check` before explicit approval.
 
 ## Phase 3: Apply
 
@@ -77,8 +78,8 @@ task swarm:readiness -- vbrief/active/*.vbrief.json
 
 - ~ If child stories are still pending, run readiness against their explicit paths for a dry readiness review before activation
 - ! Route blocked or overlapping stories back to Phase 1 for draft refinement
-- ! Leave lifecycle promotion/activation to the existing approved flow (`task scope:promote`, `task scope:activate`, and the swarm skill lifecycle bridge)
-- ⊗ Promote or activate child stories solely because decomposition succeeded
+- ! Leave lifecycle promotion/activation to the existing approved flow (`task scope:promote`, `task scope:activate`, and the swarm skill lifecycle bridge).
+- ⊗ Promote or activate child stories solely because decomposition succeeded.
 
 ## Exit
 

--- a/skills/deft-directive-decompose/SKILL.md
+++ b/skills/deft-directive-decompose/SKILL.md
@@ -19,36 +19,36 @@ Convert approved specification/phase/epic scope vBRIEFs into swarm-ready child s
 
 ## Phase 0: Inspect
 
-- ! Read `vbrief/specification.vbrief.json` and relevant scope vBRIEFs from `vbrief/proposed/`, `vbrief/pending/`, and `vbrief/active/`
-- ! Identify broad scopes with `plan.metadata.kind = "phase"` or `"epic"` or scopes with broad `plan.narratives.Acceptance` and empty `plan.items`
-- ! Preserve parent acceptance as context; do not treat it as executable story acceptance
-- ! Treat parent `plan.items` as input signals only; they are not automatically child stories
-- ! Inspect relevant codebase paths before drafting file scope so stories reflect real product/code boundaries, not only parent scope prose
-- ! Identify requirement traces, likely file scope, verification commands, outputs/evidence, dependencies, and conflict groups
-- ⊗ Allocate a broad phase/epic scope to concurrent workers during this skill
+- ! Read `vbrief/specification.vbrief.json` and relevant scope vBRIEFs from `vbrief/proposed/`, `vbrief/pending/`, and `vbrief/active/`.
+- ! Identify broad scopes with `plan.metadata.kind = "phase"` or `"epic"` or scopes with broad `plan.narratives.Acceptance` and empty `plan.items`.
+- ! Preserve parent acceptance as context; do not treat it as executable story acceptance.
+- ! Treat parent `plan.items` as input signals only; they are not automatically child stories.
+- ! Inspect relevant codebase paths before drafting file scope so stories reflect real product/code boundaries, not only parent scope prose.
+- ! Identify requirement traces, likely file scope, verification commands, outputs/evidence, dependencies, and conflict groups.
+- ⊗ Allocate a broad phase/epic scope to concurrent workers during this skill.
 
 ## Phase 1: Draft
 
-- ! Draft a decomposition JSON proposal with child stories only; do not write child vBRIEFs yet
+- ! Draft a decomposition JSON proposal with child stories only; do not write child vBRIEFs yet.
 - ! Each story MUST include `id`, `title`, `Description`, `ImplementationPlan`, `UserStory`, executable `items` or `acceptance`, `traces` or explicit trace justification, `swarm.file_scope`, `swarm.verify_commands`, `swarm.expected_outputs`, `swarm.depends_on`, `swarm.conflict_group`, `swarm.size`, `swarm.file_scope_confidence`, and `swarm.model_tier`.
-- ! `Description` MUST provide at least two concrete sentences explaining the user/product behavior, boundaries, and why this story is independently buildable
-- ! `ImplementationPlan` MUST provide at least two concrete implementation steps that identify the expected code path, state/data changes, and test/evidence approach
-- ! `UserStory` MUST use the exact product-story shape `As a <role>, I want <capability>, so that <outcome>.`
-- ! Each ready story MUST have 2-5 concrete acceptance criteria unless `swarm.acceptance_criteria_justification` explains the exception
-- ! Acceptance criteria MUST be observable behavior, preferably Given/When/Then or equivalent testable product behavior
-- ⊗ Mark a story ready when acceptance says only "to refine from parent scope", duplicates the title/description, is placeholder text, or is vague docs-only acceptance
-- ⊗ Mark a story ready with broad write scope such as `backend/**`, `frontend/**`, `docs/**`, `vbrief/**`, or any other directory glob
-- ⊗ Mark a story ready when verification is only generic validation such as `task check`
-- ⊗ Mark a story ready with `parallel_safe: false` or `file_scope_confidence: low`; use `readiness: sequential` or `readiness: needs_refinement` instead
-- ! Model dependencies as story IDs and ensure they form a DAG
-- ~ Draft sequential-safe or low-confidence work as `readiness: sequential` or `readiness: needs_refinement`; it is not eligible for concurrent allocation
-- ⊗ Use deprecated `subItems` in newly drafted story items; use `items`
+- ! `Description` MUST provide at least two concrete sentences explaining the user/product behavior, boundaries, and why this story is independently buildable.
+- ! `ImplementationPlan` MUST provide at least two concrete implementation steps that identify the expected code path, state/data changes, and test/evidence approach.
+- ! `UserStory` MUST use the exact product-story shape `As a <role>, I want <capability>, so that <outcome>.`.
+- ! Each ready story MUST have 2-5 concrete acceptance criteria unless `swarm.acceptance_criteria_justification` explains the exception.
+- ! Acceptance criteria MUST be observable behavior, preferably Given/When/Then or equivalent testable product behavior.
+- ⊗ Mark a story ready when acceptance says only "to refine from parent scope", duplicates the title/description, is placeholder text, or is vague docs-only acceptance.
+- ⊗ Mark a story ready with broad write scope such as `backend/**`, `frontend/**`, `docs/**`, `vbrief/**`, or any other directory glob.
+- ⊗ Mark a story ready when verification is only generic validation such as `task check`.
+- ⊗ Mark a story ready with `parallel_safe: false` or `file_scope_confidence: low`; use `readiness: sequential` or `readiness: needs_refinement` instead.
+- ! Model dependencies as story IDs and ensure they form a DAG.
+- ~ Draft sequential-safe or low-confidence work as `readiness: sequential` or `readiness: needs_refinement`; it is not eligible for concurrent allocation.
+- ⊗ Use deprecated `subItems` in newly drafted story items; use `items`.
 
 ## Phase 2: Approval
 
-- ! Present the decomposition draft to the user before writing files
-- ! Ask for explicit approval to apply the draft
-- ! If the user requests changes, revise the draft and re-present it
+- ! Present the decomposition draft to the user before writing files.
+- ! Ask for explicit approval to apply the draft.
+- ! If the user requests changes, revise the draft and re-present it.
 - ? Run `task scope:decompose ... --check` before explicit approval only to validate a draft without writing files.
 - ⊗ Apply `task scope:decompose` without `--check` before explicit approval.
 
@@ -76,8 +76,8 @@ The command creates child story vBRIEFs, preserves origin/provenance references,
 task swarm:readiness -- vbrief/pending/<child-story-1>.vbrief.json vbrief/pending/<child-story-2>.vbrief.json
 ```
 
-- ! Treat this as a dry readiness review before activation; do not allocate workers from pending paths
-- ! Route blocked or overlapping stories back to Phase 1 for draft refinement
+- ! Treat this as a dry readiness review before activation; do not allocate workers from pending paths.
+- ! Route blocked or overlapping stories back to Phase 1 for draft refinement.
 - ! Leave lifecycle promotion/activation to the existing approved flow (`task scope:promote`, `task scope:activate`, and the swarm skill lifecycle bridge).
 - ⊗ Promote or activate child stories solely because decomposition succeeded.
 

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -115,7 +115,7 @@ Cross-references:
 
 - ! Scan `vbrief/active/` for candidate vBRIEFs (files matching `*.vbrief.json`)
 - ! For each candidate vBRIEF, MUST run `task vbrief:preflight -- <path>` (the structural intent gate, #810; wraps `scripts/preflight_implementation.py` so the same invocation works whether deft is the project root or installed as a `deft/` subdirectory) to validate lifecycle eligibility before allocation work. Skip any vBRIEF that exits non-zero -- the helper's stderr message is the actionable redirect (`task vbrief:activate <path>`). Surface the exit message in the Phase 0 Step 4 analysis so the user can route the lifecycle move; do NOT attempt to allocate, dispatch, or implement against a vBRIEF that fails the preflight.
-- ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before any agent allocation. This deterministic report is the allocator's source of truth for ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields.
+- ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before any agent allocation. This deterministic report is the allocator's source of truth for ready stories, sequential-only stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields.
 - ! Treat `plan.metadata.kind = "epic"` and `plan.metadata.kind = "phase"` as **needs decomposition**, not merely incomplete. Route broad scopes to `skills/deft-directive-decompose/SKILL.md` instead of assigning them to workers.
 - ! Read only readiness-approved story fields for allocation: `plan.title`, `plan.status`, non-empty `plan.items`, `planRef`, `references`, `plan.metadata.kind`, and `plan.metadata.swarm`.
 - ! Read `vbrief/PROJECT-DEFINITION.vbrief.json` for project-wide context (narratives, scope registry)
@@ -146,7 +146,7 @@ Cross-references:
 ! Present a summary to the user containing:
 
 - **Candidate vBRIEFs**: story-level vBRIEFs eligible for assignment (with titles, statuses, and origin references)
-- **Readiness report**: ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`
+- **Readiness report**: ready stories, sequential-only stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`
 - **Preflight rejections (#810)**: any vBRIEFs that failed `task vbrief:preflight` (wraps `scripts/preflight_implementation.py`) in Step 1 -- include the file path AND the helper's exit message verbatim so the user can route the appropriate `task vbrief:activate <path>` move. These vBRIEFs MUST NOT be allocated until they pass the preflight on a re-run.
 - **Blockers found**: blocked vBRIEFs, unresolved dependencies, items requiring design decisions
 - **Decomposition needed**: epic/phase scopes that must go through `skills/deft-directive-decompose/SKILL.md` before swarm allocation

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -115,7 +115,7 @@ Cross-references:
 
 - ! Scan `vbrief/active/` for candidate vBRIEFs (files matching `*.vbrief.json`)
 - ! For each candidate vBRIEF, MUST run `task vbrief:preflight -- <path>` (the structural intent gate, #810; wraps `scripts/preflight_implementation.py` so the same invocation works whether deft is the project root or installed as a `deft/` subdirectory) to validate lifecycle eligibility before allocation work. Skip any vBRIEF that exits non-zero -- the helper's stderr message is the actionable redirect (`task vbrief:activate <path>`). Surface the exit message in the Phase 0 Step 4 analysis so the user can route the lifecycle move; do NOT attempt to allocate, dispatch, or implement against a vBRIEF that fails the preflight.
-- ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before any agent allocation. This deterministic report is the allocator's source of truth for ready stories, sequential-only stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields.
+- ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before any agent allocation. This deterministic report is the allocator's source of truth for ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields.
 - ! Treat `plan.metadata.kind = "epic"` and `plan.metadata.kind = "phase"` as **needs decomposition**, not merely incomplete. Route broad scopes to `skills/deft-directive-decompose/SKILL.md` instead of assigning them to workers.
 - ! Read only readiness-approved story fields for allocation: `plan.title`, `plan.status`, non-empty `plan.items`, `planRef`, `references`, `plan.metadata.kind`, and `plan.metadata.swarm`.
 - ! Read `vbrief/PROJECT-DEFINITION.vbrief.json` for project-wide context (narratives, scope registry)
@@ -146,7 +146,7 @@ Cross-references:
 ! Present a summary to the user containing:
 
 - **Candidate vBRIEFs**: story-level vBRIEFs eligible for assignment (with titles, statuses, and origin references)
-- **Readiness report**: ready stories, sequential-only stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`
+- **Readiness report**: ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`
 - **Preflight rejections (#810)**: any vBRIEFs that failed `task vbrief:preflight` (wraps `scripts/preflight_implementation.py`) in Step 1 -- include the file path AND the helper's exit message verbatim so the user can route the appropriate `task vbrief:activate <path>` move. These vBRIEFs MUST NOT be allocated until they pass the preflight on a re-run.
 - **Blockers found**: blocked vBRIEFs, unresolved dependencies, items requiring design decisions
 - **Decomposition needed**: epic/phase scopes that must go through `skills/deft-directive-decompose/SKILL.md` before swarm allocation

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -111,20 +111,24 @@ Cross-references:
 - Underlying CLI: `scripts/scope_lifecycle.py` (the deterministic state machine; idempotent on same-folder moves; three-state exit 0 / 1 / 2).
 - Recurrence record: issue #1025 (2026-05-10 first-session consumer tic-tac-toe swarm; monitor hit `Invalid transition: 'activate' requires file in pending/` on all four candidate vBRIEFs because they were still in `proposed/`).
 
-### Step 1: Read Project State
+### Step 1: Read Project State and Readiness Report
 
-- ! Scan `vbrief/active/` for all story-level vBRIEFs (files matching `*.vbrief.json`)
-- ! For each candidate vBRIEF, MUST run `task vbrief:preflight -- <path>` (the structural intent gate, #810; wraps `scripts/preflight_implementation.py` so the same invocation works whether deft is the project root or installed as a `deft/` subdirectory) to validate eligibility before any allocation work. Skip any vBRIEF that exits non-zero -- the helper's stderr message is the actionable redirect (`task vbrief:activate <path>`). Surface the exit message in the Phase 0 Step 4 analysis so the user can route the lifecycle move; do NOT attempt to allocate, dispatch, or implement against a vBRIEF that fails the preflight.
-- ! Read each vBRIEF's `plan.title`, `plan.status`, `plan.items`, `references`, and `planRef` (for epic linkage)
+- ! Scan `vbrief/active/` for candidate vBRIEFs (files matching `*.vbrief.json`)
+- ! For each candidate vBRIEF, MUST run `task vbrief:preflight -- <path>` (the structural intent gate, #810; wraps `scripts/preflight_implementation.py` so the same invocation works whether deft is the project root or installed as a `deft/` subdirectory) to validate lifecycle eligibility before allocation work. Skip any vBRIEF that exits non-zero -- the helper's stderr message is the actionable redirect (`task vbrief:activate <path>`). Surface the exit message in the Phase 0 Step 4 analysis so the user can route the lifecycle move; do NOT attempt to allocate, dispatch, or implement against a vBRIEF that fails the preflight.
+- ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before any agent allocation. This deterministic report is the allocator's source of truth for ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields.
+- ! Treat `plan.metadata.kind = "epic"` and `plan.metadata.kind = "phase"` as **needs decomposition**, not merely incomplete. Route broad scopes to `skills/deft-directive-decompose/SKILL.md` instead of assigning them to workers.
+- ! Read only readiness-approved story fields for allocation: `plan.title`, `plan.status`, non-empty `plan.items`, `planRef`, `references`, `plan.metadata.kind`, and `plan.metadata.swarm`.
 - ! Read `vbrief/PROJECT-DEFINITION.vbrief.json` for project-wide context (narratives, scope registry)
-- ! Cross-reference: every candidate vBRIEF should have acceptance criteria in its `plan.items`
 - ! Determine the base branch: ask the user which branch to target for worktree creation, PR targets, and rebase cascade (default: `master`). Record this as the **configured base branch** for all subsequent phases.
 - ⊗ Spawn an implementation agent (via `start_agent`, `oz agent run`, Warp tab dispatch, or any other path) for a vBRIEF that has not passed `task vbrief:preflight` (which wraps `scripts/preflight_implementation.py`) -- the gate is the only authorization signal; affirmative continuation phrases and workflow-shape vocabulary are NOT (#810).
+- ⊗ Allocate concurrent workers unless candidates are swarm-ready `kind=story` vBRIEFs with non-empty executable `plan.items` and `task swarm:readiness` exits 0.
+- ⊗ Use manual file-overlap reasoning as the only safety check; use the readiness report first, then explain any additional human judgment.
 
 ### Step 2: Surface Blockers
 
 - ! Identify blocked vBRIEFs (status `blocked`) and their blocking reasons (check `narrative` fields)
 - ! Identify vBRIEFs with incomplete acceptance criteria (no `plan.items` or empty items array)
+- ! Identify epic/phase scope vBRIEFs from the readiness report and route them to decomposition
 - ! Identify dependency conflicts between candidate vBRIEFs (e.g. story A depends on story B via `planRef` or `edges`, but B is assigned to a different agent or is incomplete)
 - ! Flag any candidate vBRIEFs whose prerequisites are unmet
 
@@ -142,8 +146,10 @@ Cross-references:
 ! Present a summary to the user containing:
 
 - **Candidate vBRIEFs**: story-level vBRIEFs eligible for assignment (with titles, statuses, and origin references)
+- **Readiness report**: ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`
 - **Preflight rejections (#810)**: any vBRIEFs that failed `task vbrief:preflight` (wraps `scripts/preflight_implementation.py`) in Step 1 -- include the file path AND the helper's exit message verbatim so the user can route the appropriate `task vbrief:activate <path>` move. These vBRIEFs MUST NOT be allocated until they pass the preflight on a re-run.
 - **Blockers found**: blocked vBRIEFs, unresolved dependencies, items requiring design decisions
+- **Decomposition needed**: epic/phase scopes that must go through `skills/deft-directive-decompose/SKILL.md` before swarm allocation
 - **Incomplete vBRIEFs**: stories with missing or empty acceptance criteria
 - **Allocation plan**: which agent gets which vBRIEF(s), with reasoning for batching decisions
 - **Tentative version bump**: current version (from CHANGELOG.md or latest git tag) and proposed next version (patch/minor/major) based on the scope and nature of candidate items — this is advisory and will be confirmed before merge cascade
@@ -167,7 +173,7 @@ Cross-references:
 
 ### Step 2: File-Overlap Audit
 
-! Before assigning tasks to agents, list every file each vBRIEF's acceptance criteria are expected to touch.
+! Before assigning tasks to agents, start from the `task swarm:readiness` file-overlap matrix and conflict groups, then list every file each vBRIEF's acceptance criteria are expected to touch.
 
 - ! Verify ZERO file overlap between agents — no two agents may modify the same file
 - ! Check **transitive** file touches, not just primary scope — trace each vBRIEF's acceptance criteria to specific files. A task may require changes to files outside its obvious scope (e.g., an enforcement task adding an anti-pattern to a skill file owned by another agent).

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -146,7 +146,7 @@ Cross-references:
 ! Present a summary to the user containing:
 
 - **Candidate vBRIEFs**: story-level vBRIEFs eligible for assignment (with titles, statuses, and origin references)
-- **Readiness report**: ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`
+- **Readiness report**: ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, file overlap matrix, and missing fields from `task swarm:readiness`.
 - **Preflight rejections (#810)**: any vBRIEFs that failed `task vbrief:preflight` (wraps `scripts/preflight_implementation.py`) in Step 1 -- include the file path AND the helper's exit message verbatim so the user can route the appropriate `task vbrief:activate <path>` move. These vBRIEFs MUST NOT be allocated until they pass the preflight on a re-run.
 - **Blockers found**: blocked vBRIEFs, unresolved dependencies, items requiring design decisions
 - **Decomposition needed**: epic/phase scopes that must go through `skills/deft-directive-decompose/SKILL.md` before swarm allocation

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -8,7 +8,7 @@ Development strategies define the workflow from idea to implementation.
 |----------|---------|------|----------|--------|
 | [interview.md](./interview.md) | `/deft:run:interview` | spec-generating | Standard projects (default) | Sizing gate: Light (Interview → SPECIFICATION) or Full (Interview → PRD → SPECIFICATION) |
 | [yolo.md](./yolo.md) | `/deft:run:yolo` | spec-generating | Quick prototyping | Auto-pilot sizing gate: Light or Full (Johnbot picks) |
-| [speckit.md](./speckit.md) | `/deft:run:speckit` | spec-generating | Large/complex projects | Principles → Specify → Plan → Tasks → Implement |
+| [speckit.md](./speckit.md) | `/deft:run:speckit` | spec-generating | Large/complex projects | Principles → Specify → Plan → Phase/Epic Scope → Story Readiness → Implement |
 | [map.md](./map.md) | `/deft:run:map` | preparatory | Existing codebases | Map → Chaining Gate |
 | [discuss.md](./discuss.md) | `/deft:run:discuss` | preparatory | Alignment before planning | Feynman technique → locked decisions → Chaining Gate |
 | [probe.md](./probe.md) | `/deft:run:probe` | preparatory | Adversarial plan stress-testing | Walk decision tree → challenge assumptions → surface risks → Chaining Gate |

--- a/strategies/interview.md
+++ b/strategies/interview.md
@@ -57,7 +57,7 @@ See `strategies/map.md` for standalone behavior.
 
 **Switch spec-generating strategy** (type: `spec-generating` — replaces current pipeline):
 - Yolo — auto-pilot, Johnbot picks all answers
-- SpecKit — five-phase formal spec process
+- SpecKit — formal spec process with story readiness before implementation
 
 ### Run Count Annotations
 
@@ -89,7 +89,7 @@ Ready to generate the specification. Before we proceed, would you like to:
 
 --- Switch strategy ---
 6. Switch to yolo — auto-pilot picks all answers
-7. Switch to speckit — formal five-phase spec process
+7. Switch to speckit — formal spec process with story readiness before implementation
 
 8. Other (specify)
 ```

--- a/strategies/speckit.md
+++ b/strategies/speckit.md
@@ -185,7 +185,7 @@ For each implementation phase IP-N, write a scope vBRIEF with:
       "dependencies": ["ip-1", "ip-2"]
     },
     "references": [
-      { "type": "x-vbrief/plan", "uri": "./specification.vbrief.json", "TrustLevel": "internal" }
+      { "type": "x-vbrief/plan", "uri": "specification.vbrief.json", "TrustLevel": "internal" }
     ],
     "items": []
   }

--- a/strategies/speckit.md
+++ b/strategies/speckit.md
@@ -280,7 +280,7 @@ Use the readiness gate before swarm allocation:
 task swarm:readiness -- vbrief/active/*.vbrief.json
 ```
 
-The readiness report lists ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, a file-overlap matrix, and missing fields. It exits non-zero when candidate work is not swarm-ready.
+The readiness report lists ready stories, sequential-only stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, a file-overlap matrix, and missing fields. It exits non-zero when candidate work is not swarm-ready for concurrent allocation.
 
 ### Transition Criteria
 

--- a/strategies/speckit.md
+++ b/strategies/speckit.md
@@ -1,6 +1,6 @@
 # SpecKit Strategy
 
-A five-phase spec-driven development workflow inspired by [GitHub's spec-kit](https://github.com/github/spec-kit).
+A spec-driven development workflow inspired by [GitHub's spec-kit](https://github.com/github/spec-kit), with a Phase 4.5 readiness layer for decomposing broad implementation scopes into swarm-safe stories.
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
@@ -22,19 +22,22 @@ flowchart LR
         P["📜 Principles<br/><i>PROJECT-DEFINITION.vbrief.json</i>"]
         S["📝 Specify<br/><i>WHAT/WHY → specification.vbrief.json</i>"]
         PL["🏗️ Plan<br/><i>HOW → specification.vbrief.json</i>"]
-        T["✅ Tasks<br/><i>Executable list</i>"]
+        T["✅ Scope<br/><i>Phase/epic vBRIEFs</i>"]
+        D["🧩 Decompose<br/><i>Story readiness</i>"]
         I["🔨 Implement<br/><i>Execute</i>"]
     end
 
     P -->|"Established"| S
     S -->|"Approved"| PL
     PL -->|"Reviewed"| T
-    T -->|"Ready"| I
+    T -->|"Approved"| D
+    D -->|"Ready stories"| I
 
     style P fill:#c4b5fd,stroke:#7c3aed,color:#000
     style S fill:#fef08a,stroke:#ca8a04,color:#000
     style PL fill:#6ee7b7,stroke:#059669,color:#000
     style T fill:#7dd3fc,stroke:#0284c7,color:#000
+    style D fill:#fde68a,stroke:#d97706,color:#000
     style I fill:#f0abfc,stroke:#a855f7,color:#000
 ```
 
@@ -143,13 +146,15 @@ Add the following narrative keys to `vbrief/specification.vbrief.json` `plan.nar
 
 ---
 
-## Phase 4: Tasks (Scope vBRIEF Emission)
+## Phase 4: Implementation Phase / Epic Scope Emission
 
-**Goal:** Emit one scope vBRIEF per implementation phase so downstream tooling (`task roadmap:render`, `task project:render`, swarm allocation) can operate against the lifecycle model described in [vbrief/vbrief.md](../vbrief/vbrief.md).
+**Goal:** Emit one broad scope vBRIEF per implementation phase or epic so downstream tooling (`task roadmap:render`, `task project:render`, and Phase 4.5 decomposition) can operate against the lifecycle model described in [vbrief/vbrief.md](../vbrief/vbrief.md).
 
 **Input:** Approved HOW narratives in `vbrief/specification.vbrief.json` (`ImplementationPhases` narrative describes IP-1..IP-N).
 
-**Output:** N scope vBRIEFs in `./vbrief/pending/`, one per implementation phase, using the filename convention `YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (NNN = 3-digit zero-padded, 001..N). See [vbrief/vbrief.md — speckit Phase 4 scope vBRIEFs](../vbrief/vbrief.md#speckit-phase-4-scope-vbriefs) for the canonical convention.
+**Output:** N phase/epic scope vBRIEFs in `./vbrief/pending/`, one per implementation phase or epic, using the filename convention `YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (NNN = 3-digit zero-padded, 001..N). See [vbrief/vbrief.md — speckit Phase 4 scope vBRIEFs](../vbrief/vbrief.md#speckit-phase-4-scope-vbriefs) for the canonical convention.
+
+Phase 4 scopes are planning containers. They MAY keep broad acceptance in `plan.narratives.Acceptance` and MAY have `plan.items: []`. They are not valid concurrent swarm worker inputs unless explicitly marked as a single-story scope. Broad phase/epic scopes MUST pass through Phase 4.5 before swarm allocation.
 
 ### Scope vBRIEF Shape
 
@@ -160,12 +165,13 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ! `plan.narratives.Description` — short human summary of the phase
 - ! `plan.narratives.Acceptance` — acceptance criteria copied from the spec
 - ! `plan.narratives.Traces` — FR/NFR/IP IDs the phase covers (e.g. `FR-001, FR-003, NFR-002, IP-3`)
-- ! `plan.references` — link back to the parent `vbrief/specification.vbrief.json` (`type: x-vbrief/plan`)
+- ! `plan.references` — link back to the parent `vbrief/specification.vbrief.json` (`type: x-vbrief/plan`, `TrustLevel: internal`)
+- ! `plan.metadata.kind` — `phase` or `epic`
 - ! `plan.metadata.dependencies` — array of IP IDs this phase depends on / is blocked by (plan-level; mirrors the `edges[].blocks` structure used in earlier drafts)
 
 ```json
 {
-  "vBRIEFInfo": { "version": "0.5" },
+  "vBRIEFInfo": { "version": "0.6" },
   "plan": {
     "title": "IP-3: Implement data layer",
     "status": "pending",
@@ -175,10 +181,11 @@ For each implementation phase IP-N, write a scope vBRIEF with:
       "Traces": "FR-001, FR-003, NFR-002, IP-3"
     },
     "metadata": {
+      "kind": "phase",
       "dependencies": ["ip-1", "ip-2"]
     },
     "references": [
-      { "type": "x-vbrief/plan", "url": "../specification.vbrief.json" }
+      { "type": "x-vbrief/plan", "uri": "./specification.vbrief.json", "TrustLevel": "internal" }
     ],
     "items": []
   }
@@ -204,15 +211,86 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ! Derive one scope vBRIEF per implementation phase from `ImplementationPhases`
 - ! Populate `Description`, `Acceptance`, and `Traces` narratives per [vbrief/vbrief.md — canonical narrative keys](../vbrief/vbrief.md#scope-vbrief-narrative-keys)
 - ! Use `plan.metadata.dependencies` (plan-level) rather than item-level `blocks` edges for cross-scope dependencies
+- ! Use `plan.metadata.kind = "phase"` or `"epic"` for broad implementation scopes
 - ~ Size each phase for 1-4 hours of work so the swarm allocator can distribute cleanly
 - ⊗ Create phases not traceable to a spec requirement
+- ⊗ Allocate Phase 4 phase/epic scope vBRIEFs directly to concurrent swarm workers
 
 ### Transition Criteria
 
 - ! Every implementation phase from `ImplementationPhases` has a matching scope vBRIEF in `./vbrief/pending/`
 - ! Each scope vBRIEF has `Description`, `Acceptance`, and `Traces` narratives
-- ! Each scope vBRIEF carries a `references` entry linking back to `vbrief/specification.vbrief.json`
+- ! Each scope vBRIEF carries a `references` entry linking back to `vbrief/specification.vbrief.json` with `TrustLevel: internal`
 - ! Cross-scope dependencies in `plan.metadata.dependencies` form a valid DAG (no cycles)
+
+---
+
+## Phase 4.5: Story Decomposition / Swarm Readiness
+
+**Goal:** Convert approved Phase 4 phase/epic scopes into child story vBRIEFs suitable for parallel agents.
+
+**Input:** Phase 4 phase/epic vBRIEFs in `./vbrief/pending/` or `./vbrief/active/`.
+
+**Output:** Story-level child vBRIEFs whose executable acceptance criteria live in `plan.items` and whose `plan.metadata.swarm` contract proves they are safe to allocate.
+
+### Process
+
+1. ! Inspect approved specification narratives and Phase 4 scope vBRIEFs.
+2. ! Identify `plan.metadata.kind = "phase"` or `"epic"` scopes that are too broad for direct implementation.
+3. ! Draft a deterministic decomposition proposal: stories, dependencies, expected file scope, verification commands, traces, and conflict groups.
+4. ! Ask for explicit user approval before writing child story vBRIEFs.
+5. ! Apply the approved draft with `task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>`.
+6. ! Run `task swarm:readiness -- vbrief/active/*.vbrief.json` before concurrent allocation, or point it at the candidate child story files for a dry readiness review before activation.
+
+### Story vBRIEF Requirements
+
+Each Phase 4.5 child story vBRIEF MUST include:
+
+- ! `plan.metadata.kind = "story"`
+- ! non-empty `plan.items`
+- ! executable acceptance in each story's `plan.items`
+- ! explicit dependencies in `plan.metadata.swarm.depends_on`
+- ! traceability back to requirements via `Traces` narratives or explicit trace justification
+- ! expected file scope in `plan.metadata.swarm.file_scope`
+- ! verify commands in `plan.metadata.swarm.verify_commands`
+- ! expected outputs/evidence in `plan.metadata.swarm.expected_outputs`
+- ! swarm readiness metadata in `plan.metadata.swarm`
+- ! `planRef` pointing to the parent phase/epic scope
+- ! parent phase/epic `references` updated to point to every child story
+
+### Decomposition Command
+
+Use the deterministic command surface:
+
+```bash
+task scope:decompose -- vbrief/pending/2026-05-12-ip001-auth.vbrief.json --draft decomposition.json
+task scope:decompose -- vbrief/pending/2026-05-12-ip001-auth.vbrief.json --draft decomposition.json --check
+task scope:decompose -- --check
+```
+
+The command validates and applies a proposed decomposition rather than freely inventing one. It creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent scope, updates parent references to include children, validates the dependency DAG, rejects dependency cycles, and rejects ready stories missing acceptance, file scope, verify commands, or traces.
+
+Parent phase/epic acceptance MAY remain in `plan.narratives.Acceptance` as context. Executable acceptance for swarm work MUST be redistributed into child story `plan.items`.
+
+### Swarm Readiness Command
+
+Use the readiness gate before swarm allocation:
+
+```bash
+task swarm:readiness -- vbrief/active/*.vbrief.json
+```
+
+The readiness report lists ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, a file-overlap matrix, and missing fields. It exits non-zero when candidate work is not swarm-ready.
+
+### Transition Criteria
+
+- ! Candidate swarm work consists only of `kind=story` vBRIEFs
+- ! Every candidate story has non-empty `plan.items`
+- ! Every candidate story has file scope, verify commands, traces or trace justification, and readiness metadata
+- ! Dependencies resolve and form a DAG
+- ! No unsafe file-scope overlap exists among parallel stories
+- ! No `size=large` story is marked `parallel_safe=true`
+- ! Low-confidence file scopes are not treated as parallel-safe by default
 
 ---
 
@@ -220,7 +298,7 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 
 **Goal:** Execute scope vBRIEFs following test-first discipline.
 
-**Input:** Scope vBRIEFs in `./vbrief/pending/` (promote to `./vbrief/active/` via `task scope:activate` when work begins). `./vbrief/plan.vbrief.json` holds the current session's tactical todo list and carries a `planRef` to the active scope.
+**Input:** Story-level scope vBRIEFs in `./vbrief/pending/` (promote to `./vbrief/active/` via `task scope:activate` when work begins). `./vbrief/plan.vbrief.json` holds the current session's tactical todo list and carries a `planRef` to the active scope. Concurrent swarm implementation requires Phase 4.5-ready stories.
 
 ### Process
 
@@ -229,7 +307,7 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ! Refactor while keeping tests green (Refactor)
 - ! Update scope vBRIEF `plan.status` and folder via `task scope:*` commands as work progresses (`pending` → `running` → `completed`)
 - ! Update `./vbrief/plan.vbrief.json` session todos as tactical steps progress (session-scoped; do NOT put the project-wide IP list here)
-- ~ Work on scope vBRIEFs whose `plan.metadata.dependencies` are already completed in parallel when possible
+- ~ Work on story vBRIEFs whose `plan.metadata.swarm.depends_on` entries are already completed in parallel when possible
 
 ### File Creation Order
 
@@ -245,6 +323,7 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 - ⊗ Implement without failing tests first
 - ⊗ Skip refactoring phase
 - ⊗ Write the project-wide IP list to `plan.vbrief.json` — use `vbrief/pending/` scope vBRIEFs as the durable task tracker
+- ⊗ Allocate broad `kind=epic` or `kind=phase` scopes to concurrent swarm workers before decomposition
 
 ---
 
@@ -257,9 +336,10 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 | 3. Plan | `vbrief/specification.vbrief.json` | HOW narratives (enriches Phase 2) |
 | 3b. Render SPECIFICATION | `SPECIFICATION.md` (rendered via `task spec:render`) | Read-only human review export |
 | 3c. Render PRD | `PRD.md` (rendered via `task prd:render`) | Optional stakeholder-review export |
-| 4. Tasks | `./vbrief/pending/YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (one per IP) | Scope vBRIEFs drive roadmap/project render + swarm |
+| 4. Tasks | `./vbrief/pending/YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json` (one per IP/epic) | Phase/epic scope vBRIEFs drive roadmap/project render + decomposition |
+| 4.5. Story decomposition | Child story vBRIEFs with `plan.metadata.swarm` | Swarm-ready executable units |
 | 4b. Session todos | `./vbrief/plan.vbrief.json` | Session-level tactical plan (carries `planRef` to active scope) |
-| 5. Implement | Code + tests | Working software |
+| 5. Implement | Code + tests | Working software, optionally via swarm |
 
 ## Directory Structure
 
@@ -269,8 +349,8 @@ project/
 │   ├── PROJECT-DEFINITION.vbrief.json  # Phase 1: Principles narrative
 │   ├── specification.vbrief.json       # Phase 2+3: WHAT/WHY + HOW narratives
 │   ├── plan.vbrief.json                # Phase 4b: session todos (planRef to active scope)
-│   └── pending/                        # Phase 4: IP-level scope vBRIEFs
-│       └── YYYY-MM-DD-ip001-….vbrief.json
+│   └── pending/                        # Phase 4/4.5: IP-level scopes + child stories
+│       └── YYYY-MM-DD-ip001-....vbrief.json
 ├── SPECIFICATION.md                    # Rendered export (task spec:render)
 ├── PRD.md                              # Optional rendered export (task prd:render)
 └── src/                                # Phase 5

--- a/strategies/speckit.md
+++ b/strategies/speckit.md
@@ -249,6 +249,8 @@ Each Phase 4.5 child story vBRIEF MUST include:
 - ! `plan.metadata.kind = "story"`
 - ! non-empty `plan.items`
 - ! executable acceptance in each story's `plan.items`
+- ! `plan.narratives.UserStory` in the form `As a <role>, I want <capability>, so that <outcome>.`
+- ! 2-5 concrete, observable acceptance criteria unless explicitly justified
 - ! explicit dependencies in `plan.metadata.swarm.depends_on`
 - ! traceability back to requirements via `Traces` narratives or explicit trace justification
 - ! expected file scope in `plan.metadata.swarm.file_scope`
@@ -268,7 +270,7 @@ task scope:decompose -- vbrief/pending/2026-05-12-ip001-auth.vbrief.json --draft
 task scope:decompose -- --check
 ```
 
-The command validates and applies a proposed decomposition rather than freely inventing one. It creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent scope, updates parent references to include children, validates the dependency DAG, rejects dependency cycles, and rejects ready stories missing acceptance, file scope, verify commands, or traces.
+The command validates and applies a proposed decomposition rather than freely inventing one. It creates child story vBRIEFs, preserves origin/provenance references, sets each child `planRef` to the parent scope, updates parent references to include children, validates the dependency DAG, rejects dependency cycles, and rejects ready stories missing user-story shape, concrete observable acceptance, narrow file scope, focused verify commands, or traces. Parent `plan.items` are input signals, not automatic child stories.
 
 Parent phase/epic acceptance MAY remain in `plan.narratives.Acceptance` as context. Executable acceptance for swarm work MUST be redistributed into child story `plan.items`.
 
@@ -280,17 +282,17 @@ Use the readiness gate before swarm allocation:
 task swarm:readiness -- vbrief/active/*.vbrief.json
 ```
 
-The readiness report lists ready stories, sequential-only stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, a file-overlap matrix, and missing fields. It exits non-zero when candidate work is not swarm-ready for concurrent allocation.
+The readiness report lists ready stories, blocked stories, decomposition-needed epics/phases, dependency waves, conflict groups, a file-overlap matrix, and missing fields. It exits non-zero when candidate work is not swarm-ready for concurrent allocation. `readiness=ready` means ready for concurrent allocation; sequential-safe or low-confidence work MUST use another state such as `sequential` or `needs_refinement` and will fail this gate until refined or scheduled outside concurrent swarm allocation.
 
 ### Transition Criteria
 
 - ! Candidate swarm work consists only of `kind=story` vBRIEFs
 - ! Every candidate story has non-empty `plan.items`
-- ! Every candidate story has file scope, verify commands, traces or trace justification, and readiness metadata
+- ! Every candidate story has a product-shaped `UserStory`, 2-5 observable acceptance criteria unless justified, file scope, verify commands, traces or trace justification, and readiness metadata
 - ! Dependencies resolve and form a DAG
 - ! No unsafe file-scope overlap exists among parallel stories
 - ! No `size=large` story is marked `parallel_safe=true`
-- ! Low-confidence file scopes are not treated as parallel-safe by default
+- ! No ready story uses broad file globs, only generic verification such as `task check`, `parallel_safe=false`, or `file_scope_confidence=low`
 
 ---
 

--- a/strategies/speckit.md
+++ b/strategies/speckit.md
@@ -160,6 +160,7 @@ Phase 4 scopes are planning containers. They MAY keep broad acceptance in `plan.
 
 For each implementation phase IP-N, write a scope vBRIEF with:
 
+- ! `vBRIEFInfo.version` — current `scripts/_vbrief_build.py::EMITTED_VBRIEF_VERSION`
 - ! `plan.title` — phase title (e.g. "IP-3: Implement data layer")
 - ! `plan.status` — `pending`
 - ! `plan.narratives.Description` — short human summary of the phase
@@ -171,7 +172,7 @@ For each implementation phase IP-N, write a scope vBRIEF with:
 
 ```json
 {
-  "vBRIEFInfo": { "version": "0.6" },
+  "vBRIEFInfo": { "version": "<EMITTED_VBRIEF_VERSION>" },
   "plan": {
     "title": "IP-3: Implement data layer",
     "status": "pending",
@@ -290,7 +291,7 @@ The readiness report lists ready stories, blocked stories, decomposition-needed 
 
 - ! Candidate swarm work consists only of `kind=story` vBRIEFs
 - ! Every candidate story has non-empty `plan.items`
-- ! Every candidate story has a product-shaped `UserStory`, 2-5 observable acceptance criteria unless justified, file scope, verify commands, traces or trace justification, and readiness metadata
+- ! Every candidate story has a product-shaped `UserStory`, 2-5 observable acceptance criteria unless justified, file scope, verify commands, traces or trace justification, and readiness metadata.
 - ! Dependencies resolve and form a DAG
 - ! No unsafe file-scope overlap exists among parallel stories
 - ! No `size=large` story is marked `parallel_safe=true`

--- a/strategies/speckit.md
+++ b/strategies/speckit.md
@@ -248,6 +248,8 @@ Each Phase 4.5 child story vBRIEF MUST include:
 
 - ! `plan.metadata.kind = "story"`
 - ! non-empty `plan.items`
+- ! `plan.narratives.Description` with at least two concrete sentences
+- ! `plan.narratives.ImplementationPlan` with at least two concrete implementation steps
 - ! executable acceptance in each story's `plan.items`
 - ! `plan.narratives.UserStory` in the form `As a <role>, I want <capability>, so that <outcome>.`
 - ! 2-5 concrete, observable acceptance criteria unless explicitly justified

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -107,3 +107,11 @@ tasks:
       PYTHONUTF8: "1"
     cmds:
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" unblock {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+
+  decompose:
+    desc: "Apply/check an approved epic/phase -> story decomposition draft"
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_decompose.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -114,4 +114,5 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
+      # Keep CLI_ARGS bare; go-task shell-escapes pass-through args and quoting breaks multi-arg calls.
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_decompose.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -10,4 +10,5 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
+      # Keep CLI_ARGS bare; go-task shell-escapes pass-through args and quoting breaks globs/multi-arg calls.
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/swarm_readiness.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+  readiness:
+    desc: "Report whether story vBRIEFs are ready for concurrent swarm allocation"
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/swarm_readiness.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/templates/make-spec.md
+++ b/templates/make-spec.md
@@ -58,7 +58,7 @@ N. [feature]
 
 ### Full Path: PRD Generation
 
-Only on the **Full** path — generate `PRD.md` before the specification:
+Only on the **Full** path — generate `PRD.md` as a rendered stakeholder-review export before the specification source is finalized:
 
 ```markdown
 # [Project Name] PRD
@@ -94,28 +94,29 @@ Any remaining decisions deferred to implementation.
 - ! Focus on WHAT, not HOW
 - ! Use RFC 2119 language (MUST, SHOULD, MAY)
 - ! Number all requirements for traceability
-- ! User MUST review and approve PRD before specification generation begins
+- ! User MUST review and approve the rendered PRD export before specification generation begins
+- ! `vbrief/specification.vbrief.json` and scope vBRIEFs remain authoritative; rendered PRD/SPEC files are exports, not the source of truth
 
 ### Specification Flow (both paths)
 
-1. ! Write scope vBRIEF(s) to `./vbrief/proposed/` with `status: draft` using `YYYY-MM-DD-descriptive-slug.vbrief.json` naming
+1. ! Write scope vBRIEF(s) to `./vbrief/proposed/` with `status: proposed` using `YYYY-MM-DD-descriptive-slug.vbrief.json` naming
 2. ! Summarize what was decided and ask the user to review
-3. ! On user approval, update `status` to `approved` and move to `./vbrief/pending/` (or use `task scope:promote`)
+3. ! On user approval, use `task scope:promote` to move to `./vbrief/pending/` with `status: pending`
 4. ! Update `./vbrief/PROJECT-DEFINITION.vbrief.json` items registry to include the new scope vBRIEF(s)
 5. ? For project-wide spec: write `./vbrief/specification.vbrief.json` and run `task spec:render` to generate `SPECIFICATION.md`
 
 ! The vBRIEF file MUST use this exact top-level structure:
 
 - ! All `narratives` and `narrative` values MUST be plain strings — never objects or arrays
-- ! Nested children within a PlanItem MUST use `subItems` (not `items`)
-- ⊗ Use `items` inside a PlanItem — only `plan.items` is valid; within items use `subItems`
+- ! Nested children within a PlanItem MUST use `items` (the preferred v0.6 PlanItem field)
+- ≉ Use deprecated `subItems` for new content; it remains a compatibility alias only
 
 ```json
 {
   "vBRIEFInfo": { "version": "0.6" },
   "plan": {
     "title": "Project Name SPECIFICATION",
-    "status": "draft",
+    "status": "proposed",
     "narratives": {
       "Overview": "Brief project summary as a plain string.",
       "Architecture": "System design as a plain string."
@@ -125,12 +126,12 @@ Any remaining decisions deferred to implementation.
         "id": "phase-1",
         "title": "Phase 1: Foundation",
         "status": "pending",
-        "subItems": [
+        "items": [
           {
             "id": "1.1",
             "title": "Subphase 1.1: Setup",
             "status": "pending",
-            "subItems": [
+            "items": [
               {
                 "id": "1.1.1",
                 "title": "Task description",

--- a/tests/cli/test_migrate_vbrief.py
+++ b/tests/cli/test_migrate_vbrief.py
@@ -443,6 +443,7 @@ class TestBuildProjectDefinition:
         ref = plan_items[0]["references"][0]
         assert ref["type"] == "x-vbrief/github-issue"
         assert ref["uri"] == "https://github.com/owner/repo/issues/42"
+        assert ref["TrustLevel"] == "external"
         assert ref["title"] == "Issue #42: Test item"
         # Legacy keys must not leak into the canonical shape (#613).
         assert "id" not in ref
@@ -513,6 +514,7 @@ class TestCreateScopeVbrief:
         assert ref["uri"] == "https://github.com/owner/repo/issues/99"
         assert ref["type"] == "x-vbrief/github-issue"
         assert ref["title"] == "Issue #99: Test feature"
+        assert ref["TrustLevel"] == "external"
 
     def test_origin_provenance_canonical_shape(self):
         """#613: refs carry {uri, type: x-vbrief/github-issue, title}."""
@@ -525,6 +527,7 @@ class TestCreateScopeVbrief:
         assert refs[0]["type"] == "x-vbrief/github-issue"
         assert refs[0]["uri"] == "https://github.com/owner/repo/issues/123"
         assert refs[0]["title"] == "Issue #123: Bug fix"
+        assert refs[0]["TrustLevel"] == "external"
         # Legacy fields must not leak into the canonical shape.
         assert "id" not in refs[0]
         assert "url" not in refs[0]

--- a/tests/cli/test_migrate_vbrief.py
+++ b/tests/cli/test_migrate_vbrief.py
@@ -1515,7 +1515,7 @@ class TestCreateSpeckitScopeVbrief:
             item,
             ip_index=3,
             dependencies=["ip-1", "ip-2"],
-            spec_ref="../specification.vbrief.json",
+            spec_ref="specification.vbrief.json",
         )
         narratives = result["plan"]["narratives"]
         assert narratives["Description"] == "Stand up repositories."
@@ -1525,7 +1525,10 @@ class TestCreateSpeckitScopeVbrief:
     def test_dependencies_written_at_plan_level(self):
         item = {"id": "ip-3", "title": "IP-3: X"}
         result = _create_speckit_scope_vbrief(
-            item, ip_index=3, dependencies=["ip-1"], spec_ref="../specification.vbrief.json"
+            item,
+            ip_index=3,
+            dependencies=["ip-1"],
+            spec_ref="specification.vbrief.json",
         )
         assert result["plan"]["metadata"]["kind"] == "phase"
         assert result["plan"]["metadata"]["dependencies"] == ["ip-1"]
@@ -1533,12 +1536,12 @@ class TestCreateSpeckitScopeVbrief:
     def test_reference_links_back_to_spec(self):
         item = {"id": "ip-1", "title": "IP-1: Bootstrap"}
         result = _create_speckit_scope_vbrief(
-            item, ip_index=1, dependencies=[], spec_ref="../specification.vbrief.json"
+            item, ip_index=1, dependencies=[], spec_ref="specification.vbrief.json"
         )
         refs = result["plan"]["references"]
         assert any(
             r.get("type") == "x-vbrief/plan"
-            and r.get("uri") == "../specification.vbrief.json"
+            and r.get("uri") == "specification.vbrief.json"
             and r.get("TrustLevel") == "internal"
             for r in refs
         )
@@ -1546,14 +1549,14 @@ class TestCreateSpeckitScopeVbrief:
     def test_status_is_pending(self):
         item = {"id": "ip-1", "title": "IP-1: Bootstrap"}
         result = _create_speckit_scope_vbrief(
-            item, ip_index=1, dependencies=[], spec_ref="../specification.vbrief.json"
+            item, ip_index=1, dependencies=[], spec_ref="specification.vbrief.json"
         )
         assert result["plan"]["status"] == "pending"
 
     def test_synthesizes_acceptance_when_missing(self):
         item = {"id": "ip-5", "title": "IP-5: Ship"}
         result = _create_speckit_scope_vbrief(
-            item, ip_index=5, dependencies=[], spec_ref="../specification.vbrief.json"
+            item, ip_index=5, dependencies=[], spec_ref="specification.vbrief.json"
         )
         assert "IP-5" in result["plan"]["narratives"]["Acceptance"]
 
@@ -1655,7 +1658,7 @@ class TestMigrateSpeckitPlan:
         assert data["plan"]["narratives"]["Traces"] == "FR-1, IP-1"
         refs = data["plan"]["references"]
         assert refs[0]["type"] == "x-vbrief/plan"
-        assert "specification.vbrief.json" in refs[0]["uri"]
+        assert refs[0]["uri"] == "specification.vbrief.json"
         assert refs[0]["TrustLevel"] == "internal"
         assert "url" not in refs[0]
         assert data["plan"]["metadata"]["kind"] == "phase"

--- a/tests/cli/test_migrate_vbrief.py
+++ b/tests/cli/test_migrate_vbrief.py
@@ -1419,7 +1419,7 @@ def _write_speckit_plan(
     """Write a speckit-shaped plan.vbrief.json fixture."""
     plan_path.parent.mkdir(parents=True, exist_ok=True)
     data = {
-        "vBRIEFInfo": {"version": "0.5", "description": "speckit plan fixture"},
+        "vBRIEFInfo": {"version": "0.6", "description": "speckit plan fixture"},
         "plan": {
             "title": "speckit IPs",
             "status": "running",
@@ -1514,6 +1514,7 @@ class TestCreateSpeckitScopeVbrief:
         result = _create_speckit_scope_vbrief(
             item, ip_index=3, dependencies=["ip-1"], spec_ref="../specification.vbrief.json"
         )
+        assert result["plan"]["metadata"]["kind"] == "phase"
         assert result["plan"]["metadata"]["dependencies"] == ["ip-1"]
 
     def test_reference_links_back_to_spec(self):
@@ -1524,7 +1525,8 @@ class TestCreateSpeckitScopeVbrief:
         refs = result["plan"]["references"]
         assert any(
             r.get("type") == "x-vbrief/plan"
-            and r.get("url") == "../specification.vbrief.json"
+            and r.get("uri") == "../specification.vbrief.json"
+            and r.get("TrustLevel") == "internal"
             for r in refs
         )
 
@@ -1640,7 +1642,10 @@ class TestMigrateSpeckitPlan:
         assert data["plan"]["narratives"]["Traces"] == "FR-1, IP-1"
         refs = data["plan"]["references"]
         assert refs[0]["type"] == "x-vbrief/plan"
-        assert "specification.vbrief.json" in refs[0]["url"]
+        assert "specification.vbrief.json" in refs[0]["uri"]
+        assert refs[0]["TrustLevel"] == "internal"
+        assert "url" not in refs[0]
+        assert data["plan"]["metadata"]["kind"] == "phase"
 
     def test_plan_rewritten_to_session_scaffold(self, tmp_path):
         plan_path = tmp_path / "vbrief" / "plan.vbrief.json"

--- a/tests/cli/test_migrate_vbrief.py
+++ b/tests/cli/test_migrate_vbrief.py
@@ -548,6 +548,16 @@ class TestCreateScopeVbrief:
         result = _create_scope_vbrief(item, repo_url="")
         assert "references" not in result["plan"]
 
+    def test_blank_origin_values_do_not_emit_empty_reference(self):
+        """Origin references are omitted unless both issue and repo are meaningful."""
+        missing_issue = _create_scope_vbrief(
+            {"number": "   ", "title": "Bug fix"}, repo_url="https://github.com/owner/repo"
+        )
+        missing_repo = _create_scope_vbrief({"number": "123", "title": "Bug fix"}, repo_url="   ")
+
+        assert "references" not in missing_issue["plan"]
+        assert "references" not in missing_repo["plan"]
+
     def test_tier_moved_to_migrator_metadata(self):
         """#616: Tier is migrator provenance, not a narrative."""
         item = {"number": "99", "title": "Feature", "phase": "Phase 2", "tier": "Tier 1"}
@@ -1559,6 +1569,14 @@ class TestCreateSpeckitScopeVbrief:
             item, ip_index=5, dependencies=[], spec_ref="specification.vbrief.json"
         )
         assert "IP-5" in result["plan"]["narratives"]["Acceptance"]
+
+    def test_blank_title_and_bad_narrative_have_non_empty_description(self):
+        item = {"id": "", "title": "   ", "narrative": "not a dict"}
+        result = _create_speckit_scope_vbrief(
+            item, ip_index=4, dependencies=[], spec_ref="specification.vbrief.json"
+        )
+        assert result["plan"]["title"] == "IP-4"
+        assert result["plan"]["narratives"]["Description"] == "IP-4"
 
 
 class TestMigrateSpeckitPlan:

--- a/tests/cli/test_migrate_vbrief.py
+++ b/tests/cli/test_migrate_vbrief.py
@@ -532,6 +532,16 @@ class TestCreateScopeVbrief:
         assert "id" not in refs[0]
         assert "url" not in refs[0]
 
+    def test_origin_provenance_trust_level_when_title_is_empty(self):
+        """Issue refs still receive default trust when the item title is empty."""
+        item = {"number": "123", "title": "", "phase": "Phase 2"}
+        result = _create_scope_vbrief(
+            item, repo_url="https://github.com/owner/repo"
+        )
+        ref = result["plan"]["references"][0]
+        assert ref["title"] == "Issue #123"
+        assert ref["TrustLevel"] == "external"
+
     def test_no_reference_without_repo_url(self):
         """#613: schema requires uri; if no repo_url we cannot build it."""
         item = {"number": "123", "title": "Bug fix", "phase": "Phase 2"}

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "scope_decompose.py"
+
+
+def _load_scope_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("scope_decompose_script", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _write_json(path: Path, data: dict) -> Path:
@@ -161,6 +172,19 @@ def _run(project: Path, *args: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         check=False,
     )
+
+
+def test_load_json_wraps_read_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    module = _load_scope_module()
+    path = tmp_path / "decomposition.json"
+
+    def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        raise OSError("boom")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    with pytest.raises(module.DecompositionError, match="cannot read file"):
+        module._load_json(path)
 
 
 def test_scope_decompose_creates_child_stories_and_updates_parent_refs(tmp_path: Path) -> None:
@@ -409,6 +433,10 @@ def test_scope_decompose_rejects_ready_story_missing_required_fields(tmp_path: P
             "broad file_scope is not swarm-ready",
         ),
         (
+            lambda story: story["swarm"].update({"file_scope": ["src/*.ts"]}),
+            "broad file_scope is not swarm-ready",
+        ),
+        (
             lambda story: story["swarm"].update({"verify_commands": ["task check"]}),
             "generic verify command is not swarm-ready",
         ),
@@ -432,6 +460,31 @@ def test_scope_decompose_rejects_ready_story_missing_required_fields(tmp_path: P
             lambda story: story.update({"implementation_plan": "Update model code."}),
             "plan.narratives.ImplementationPlan must contain at least two concrete steps",
         ),
+        (
+            lambda story: story.update(
+                {
+                    "implementation_plan": [
+                        "Update the code so the feature is implemented in the application.",
+                        "Add tests so it works as expected for users.",
+                    ]
+                }
+            ),
+            "plan.narratives.ImplementationPlan must identify concrete code paths",
+        ),
+        (
+            lambda story: story.update(
+                {
+                    "acceptance": [
+                        "The system displays a message",
+                        (
+                            "Given a valid payload, when auth saves it, "
+                            "then it returns success."
+                        ),
+                    ]
+                }
+            ),
+            "acceptance criterion must describe specific observable behavior",
+        ),
     ],
 )
 def test_scope_decompose_rejects_low_quality_ready_story(
@@ -453,6 +506,40 @@ def test_scope_decompose_rejects_low_quality_ready_story(
 
     assert result.returncode == 1
     assert expected in result.stderr
+
+
+def test_scope_decompose_rejects_deprecated_subitems_in_story_items(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    data = json.loads(draft.read_text(encoding="utf-8"))
+    first_story = data["stories"][0]
+    first_story["items"] = [
+        {
+            "id": "story-auth-model-a1",
+            "title": "Persist user payload",
+            "status": "pending",
+            "narrative": {
+                "Acceptance": (
+                    "Given a valid payload, when auth saves it, then it returns success."
+                ),
+                "Traces": "FR-1",
+            },
+            "subItems": [],
+        }
+    ]
+    del first_story["acceptance"]
+    draft.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert "subItems is deprecated; use items" in result.stderr
 
 
 def test_scope_decompose_allows_non_ready_sequential_story(tmp_path: Path) -> None:

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -157,7 +157,7 @@ def _draft(project: Path, *, cycle: bool = False, output_dir: str | None = None)
             },
         },
     ]
-    draft = {"stories": stories}
+    draft: dict[str, object] = {"stories": stories}
     if output_dir:
         draft["output_dir"] = output_dir
         draft["status"] = "running"

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "scope_decompose.py"
 
@@ -48,7 +50,20 @@ def _draft(project: Path, *, cycle: bool = False, output_dir: str | None = None)
         {
             "id": "story-auth-model",
             "title": "Auth model",
-            "acceptance": ["Auth model persists users"],
+            "user_story": (
+                "As an auth maintainer, I want persisted user records, "
+                "so that login state survives requests."
+            ),
+            "acceptance": [
+                (
+                    "Given a valid user payload, when the auth model saves it, "
+                    "then the user record persists."
+                ),
+                (
+                    "Given an existing user, when the auth model loads it, "
+                    "then the saved identity returns."
+                ),
+            ],
             "traces": ["FR-1"],
             "swarm": {
                 "readiness": "ready",
@@ -66,7 +81,20 @@ def _draft(project: Path, *, cycle: bool = False, output_dir: str | None = None)
         {
             "id": "story-auth-routes",
             "title": "Auth routes",
-            "acceptance": ["Auth routes return tokens"],
+            "user_story": (
+                "As an API consumer, I want auth routes to return tokens, "
+                "so that I can start a session."
+            ),
+            "acceptance": [
+                (
+                    "Given valid credentials, when the login route runs, "
+                    "then it returns an access token."
+                ),
+                (
+                    "Given invalid credentials, when the login route runs, "
+                    "then it rejects the request."
+                ),
+            ],
             "traces": ["FR-2"],
             "swarm": {
                 "readiness": "ready",
@@ -161,7 +189,17 @@ def test_scope_decompose_cycle_report_excludes_upstream_story(tmp_path: Path) ->
         return {
             "id": story_id,
             "title": story_id,
-            "acceptance": [f"{story_id} acceptance"],
+            "user_story": (
+                f"As a developer, I want {story_id} behavior isolated, "
+                "so that dependency order stays safe."
+            ),
+            "acceptance": [
+                f"Given {story_id} input, when the story runs, then it returns a scoped result.",
+                (
+                    f"Given {story_id} failure input, when the story runs, "
+                    "then it rejects the request."
+                ),
+            ],
             "traces": ["FR-1"],
             "swarm": {
                 "readiness": "ready",
@@ -228,6 +266,98 @@ def test_scope_decompose_rejects_ready_story_missing_required_fields(tmp_path: P
     assert "plan.items" in result.stderr
     assert "file_scope" in result.stderr
     assert "verify_commands" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        (
+            lambda story: story.update(
+                {
+                    "acceptance": [
+                        "to refine from parent scope",
+                        "Given a valid payload, when auth saves it, then it returns success.",
+                    ]
+                }
+            ),
+            "placeholder acceptance criterion",
+        ),
+        (
+            lambda story: story.update(
+                {
+                    "acceptance": [
+                        story["title"],
+                        "Given a valid payload, when auth saves it, then it returns success.",
+                    ]
+                }
+            ),
+            "acceptance criterion duplicates title or description",
+        ),
+        (
+            lambda story: story["swarm"].update({"file_scope": ["backend/**"]}),
+            "broad file_scope is not swarm-ready",
+        ),
+        (
+            lambda story: story["swarm"].update({"verify_commands": ["task check"]}),
+            "generic verify command is not swarm-ready",
+        ),
+        (
+            lambda story: story["swarm"].update({"parallel_safe": False}),
+            "readiness=ready requires parallel_safe=true",
+        ),
+        (
+            lambda story: story["swarm"].update({"file_scope_confidence": "low"}),
+            "readiness=ready requires file_scope_confidence above low",
+        ),
+        (
+            lambda story: story.update({"user_story": "Build auth model."}),
+            "UserStory must match",
+        ),
+    ],
+)
+def test_scope_decompose_rejects_low_quality_ready_story(
+    tmp_path: Path, mutate, expected: str
+) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    data = json.loads(draft.read_text(encoding="utf-8"))
+    mutate(data["stories"][0])
+    draft.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert expected in result.stderr
+
+
+def test_scope_decompose_allows_non_ready_sequential_story(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    data = json.loads(draft.read_text(encoding="utf-8"))
+    data["stories"][0]["swarm"].update(
+        {
+            "readiness": "sequential",
+            "parallel_safe": False,
+            "file_scope_confidence": "low",
+        }
+    )
+    draft.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_scope_decompose_to_active_stories_passes_readiness(tmp_path: Path) -> None:

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -293,6 +293,25 @@ def test_scope_decompose_rejects_output_dir_outside_vbrief(tmp_path: Path) -> No
     assert "Traceback" not in result.stderr
 
 
+def test_scope_decompose_null_output_dir_uses_parent_lifecycle_folder(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    draft_data = json.loads(draft.read_text(encoding="utf-8"))
+    draft_data["output_dir"] = None
+    _write_json(draft, draft_data)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "CHECK pending/" in result.stdout
+
+
 def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None:
     parent = _parent(tmp_path)
     draft = _draft(tmp_path, cycle=True)

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -196,6 +196,48 @@ def test_scope_decompose_creates_child_stories_and_updates_parent_refs(tmp_path:
     assert updated_parent["plan"]["narratives"]["Acceptance"].startswith("Auth epic")
 
 
+def test_scope_decompose_rejects_existing_child_path(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    _write_json(
+        tmp_path / "vbrief" / "pending" / "2026-05-12-auth-model.vbrief.json",
+        {"existing": True},
+    )
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--date",
+        "2026-05-12",
+    )
+
+    assert result.returncode == 1
+    assert "overwriting is not supported" in result.stderr
+
+
+def test_scope_decompose_rejects_non_object_parent_metadata(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    parent_data = json.loads(parent.read_text(encoding="utf-8"))
+    parent_data["plan"]["metadata"] = "phase"
+    _write_json(parent, parent_data)
+    draft = _draft(tmp_path)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--date",
+        "2026-05-12",
+    )
+
+    assert result.returncode == 1
+    assert "plan.metadata must be an object" in result.stderr
+    assert not list((tmp_path / "vbrief" / "pending").glob("2026-05-12-auth-*.vbrief.json"))
+
+
 def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None:
     parent = _parent(tmp_path)
     draft = _draft(tmp_path, cycle=True)

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -312,6 +312,42 @@ def test_scope_decompose_null_output_dir_uses_parent_lifecycle_folder(tmp_path: 
     assert "CHECK pending/" in result.stdout
 
 
+def test_scope_decompose_rejects_active_output_dir(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    draft_data = json.loads(draft.read_text(encoding="utf-8"))
+    draft_data["output_dir"] = "vbrief/active"
+    _write_json(draft, draft_data)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+    )
+
+    assert result.returncode == 1
+    assert "output_dir must not be vbrief/active" in result.stderr
+
+
+def test_scope_decompose_rejects_running_child_status(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    draft_data = json.loads(draft.read_text(encoding="utf-8"))
+    draft_data["stories"][0]["status"] = "running"
+    _write_json(draft, draft_data)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+    )
+
+    assert result.returncode == 1
+    assert "cannot create active/running child stories" in result.stderr
+
+
 def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None:
     parent = _parent(tmp_path)
     draft = _draft(tmp_path, cycle=True)
@@ -585,9 +621,9 @@ def test_scope_decompose_allows_non_ready_sequential_story(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
 
 
-def test_scope_decompose_to_active_stories_passes_readiness(tmp_path: Path) -> None:
+def test_scope_decompose_from_active_parent_writes_pending_stories(tmp_path: Path) -> None:
     parent = _parent(tmp_path, folder="active")
-    draft = _draft(tmp_path, output_dir="vbrief/active")
+    draft = _draft(tmp_path)
 
     result = _run(
         tmp_path,
@@ -599,11 +635,15 @@ def test_scope_decompose_to_active_stories_passes_readiness(tmp_path: Path) -> N
     )
 
     assert result.returncode == 0, result.stderr
-    story_paths = [
+    story_paths = sorted((tmp_path / "vbrief" / "pending").glob("*.vbrief.json"))
+    assert len(story_paths) == 2
+    assert not [
         path
-        for path in sorted((tmp_path / "vbrief" / "active").glob("*.vbrief.json"))
+        for path in (tmp_path / "vbrief" / "active").glob("*.vbrief.json")
         if path.name != parent.name
     ]
+    child = json.loads(story_paths[0].read_text(encoding="utf-8"))
+    assert child["plan"]["status"] == "pending"
     readiness = subprocess.run(
         [
             sys.executable,

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -170,8 +170,10 @@ def test_scope_decompose_cycle_report_excludes_upstream_story(tmp_path: Path) ->
                 "verify_commands": [f"npm test -- {story_id}"],
                 "expected_outputs": ["tests pass"],
                 "depends_on": deps,
+                "conflict_group": "auth",
                 "size": "small",
                 "file_scope_confidence": "high",
+                "model_tier": "medium",
             },
         }
 

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "scope_decompose.py"
+
+
+def _write_json(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _parent(project: Path, folder: str = "pending") -> Path:
+    return _write_json(
+        project / "vbrief" / folder / "2026-05-12-ip001-auth.vbrief.json",
+        {
+            "vBRIEFInfo": {"version": "0.6"},
+            "plan": {
+                "id": "ip-1",
+                "title": "IP-1: Auth",
+                "status": "pending" if folder == "pending" else "running",
+                "narratives": {
+                    "Acceptance": "Auth epic acceptance remains as context.",
+                    "Traces": "FR-1, IP-1",
+                },
+                "items": [],
+                "metadata": {"kind": "phase", "dependencies": []},
+                "references": [
+                    {
+                        "uri": "./specification.vbrief.json",
+                        "type": "x-vbrief/plan",
+                        "title": "Specification",
+                        "TrustLevel": "internal",
+                    }
+                ],
+            },
+        },
+    )
+
+
+def _draft(project: Path, *, cycle: bool = False, output_dir: str | None = None) -> Path:
+    stories = [
+        {
+            "id": "story-auth-model",
+            "title": "Auth model",
+            "acceptance": ["Auth model persists users"],
+            "traces": ["FR-1"],
+            "swarm": {
+                "readiness": "ready",
+                "parallel_safe": True,
+                "file_scope": ["src/auth/model.ts", "tests/auth/model.test.ts"],
+                "verify_commands": ["npm test -- auth/model"],
+                "expected_outputs": ["auth model tests pass"],
+                "depends_on": ["story-auth-routes"] if cycle else [],
+                "conflict_group": "auth",
+                "size": "small",
+                "file_scope_confidence": "high",
+                "model_tier": "medium",
+            },
+        },
+        {
+            "id": "story-auth-routes",
+            "title": "Auth routes",
+            "acceptance": ["Auth routes return tokens"],
+            "traces": ["FR-2"],
+            "swarm": {
+                "readiness": "ready",
+                "parallel_safe": True,
+                "file_scope": ["src/auth/routes.ts", "tests/auth/routes.test.ts"],
+                "verify_commands": ["npm test -- auth/routes"],
+                "expected_outputs": ["auth route tests pass"],
+                "depends_on": ["story-auth-model"],
+                "conflict_group": "auth",
+                "size": "small",
+                "file_scope_confidence": "high",
+                "model_tier": "medium",
+            },
+        },
+    ]
+    draft = {"stories": stories}
+    if output_dir:
+        draft["output_dir"] = output_dir
+        draft["status"] = "running"
+    return _write_json(project / "decomposition.json", draft)
+
+
+def _run(project: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args, "--project-root", str(project)],
+        cwd=project,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_scope_decompose_creates_child_stories_and_updates_parent_refs(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--date",
+        "2026-05-12",
+    )
+
+    assert result.returncode == 0, result.stderr
+    child_paths = sorted((tmp_path / "vbrief" / "pending").glob("2026-05-12-auth-*.vbrief.json"))
+    assert len(child_paths) == 2
+    child = json.loads(child_paths[0].read_text(encoding="utf-8"))
+    assert child["plan"]["planRef"] == "./pending/2026-05-12-ip001-auth.vbrief.json"
+    assert child["plan"]["metadata"]["kind"] == "story"
+    assert child["plan"]["metadata"]["swarm"]["readiness"] == "ready"
+    assert child["plan"]["items"]
+    assert child["plan"]["references"][0]["uri"] == "./specification.vbrief.json"
+    assert child["plan"]["references"][0]["TrustLevel"] == "internal"
+
+    updated_parent = json.loads(parent.read_text(encoding="utf-8"))
+    child_uris = {
+        f"./pending/{path.name}"
+        for path in child_paths
+    }
+    child_refs = [
+        ref
+        for ref in updated_parent["plan"]["references"]
+        if ref.get("type") == "x-vbrief/plan" and ref.get("uri") in child_uris
+    ]
+    assert len(child_refs) == 2
+    assert {ref["TrustLevel"] for ref in child_refs} == {"internal"}
+    assert updated_parent["plan"]["narratives"]["Acceptance"].startswith("Auth epic")
+
+
+def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path, cycle=True)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert "dependency cycle" in result.stderr
+
+
+def test_scope_decompose_rejects_ready_story_missing_required_fields(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _write_json(
+        tmp_path / "bad-decomposition.json",
+        {
+            "stories": [
+                {
+                    "id": "story-bad",
+                    "title": "Bad story",
+                    "swarm": {"readiness": "ready", "parallel_safe": True},
+                }
+            ]
+        },
+    )
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert "plan.items" in result.stderr
+    assert "file_scope" in result.stderr
+    assert "verify_commands" in result.stderr
+
+
+def test_scope_decompose_to_active_stories_passes_readiness(tmp_path: Path) -> None:
+    parent = _parent(tmp_path, folder="active")
+    draft = _draft(tmp_path, output_dir="vbrief/active")
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--date",
+        "2026-05-12",
+    )
+
+    assert result.returncode == 0, result.stderr
+    story_paths = [
+        path
+        for path in sorted((tmp_path / "vbrief" / "active").glob("*.vbrief.json"))
+        if path.name != parent.name
+    ]
+    readiness = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "swarm_readiness.py"),
+            *(str(path.relative_to(tmp_path)) for path in story_paths),
+            "--project-root",
+            str(tmp_path),
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert readiness.returncode == 0, readiness.stdout + readiness.stderr
+    assert "Ready stories:" in readiness.stdout
+    assert "story-auth-model" in readiness.stdout
+    assert "story-auth-routes" in readiness.stdout

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -50,6 +50,21 @@ def _draft(project: Path, *, cycle: bool = False, output_dir: str | None = None)
         {
             "id": "story-auth-model",
             "title": "Auth model",
+            "description": (
+                "Persisted auth model behavior stores user identity and session state for the "
+                "authentication workflow. The story covers focused model changes plus matching "
+                "unit tests for save and load behavior."
+            ),
+            "implementation_plan": [
+                (
+                    "Update the auth model persistence code so valid user payloads are saved "
+                    "and loaded through the existing model boundary."
+                ),
+                (
+                    "Add focused model tests for successful persistence and missing-record "
+                    "behavior using the auth model test fixture."
+                ),
+            ],
             "user_story": (
                 "As an auth maintainer, I want persisted user records, "
                 "so that login state survives requests."
@@ -81,6 +96,21 @@ def _draft(project: Path, *, cycle: bool = False, output_dir: str | None = None)
         {
             "id": "story-auth-routes",
             "title": "Auth routes",
+            "description": (
+                "Auth route behavior turns credential checks into API responses for session "
+                "creation. The story stays within route handling and focused route tests so it "
+                "can run after the auth model contract is stable."
+            ),
+            "implementation_plan": [
+                (
+                    "Wire the login route to the auth model result and return the token "
+                    "response for valid credentials."
+                ),
+                (
+                    "Add route-level tests for successful token return and invalid "
+                    "credential rejection."
+                ),
+            ],
             "user_story": (
                 "As an API consumer, I want auth routes to return tokens, "
                 "so that I can start a session."
@@ -189,6 +219,14 @@ def test_scope_decompose_cycle_report_excludes_upstream_story(tmp_path: Path) ->
         return {
             "id": story_id,
             "title": story_id,
+            "description": (
+                f"{story_id} covers a narrow dependency-graph behavior for decomposition safety. "
+                "The story text is intentionally concrete enough to exercise cycle validation."
+            ),
+            "implementation_plan": [
+                f"Implement the {story_id} scoped behavior inside its isolated source file.",
+                f"Add a focused test proving {story_id} returns success and rejects failure input.",
+            ],
             "user_story": (
                 f"As a developer, I want {story_id} behavior isolated, "
                 "so that dependency order stays safe."
@@ -312,6 +350,14 @@ def test_scope_decompose_rejects_ready_story_missing_required_fields(tmp_path: P
         (
             lambda story: story.update({"user_story": "Build auth model."}),
             "UserStory must match",
+        ),
+        (
+            lambda story: story.update({"description": "Persist auth records."}),
+            "plan.narratives.Description must contain at least two concrete sentences",
+        ),
+        (
+            lambda story: story.update({"implementation_plan": "Update model code."}),
+            "plan.narratives.ImplementationPlan must contain at least two concrete steps",
         ),
     ],
 )

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -154,6 +154,51 @@ def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None
     assert "dependency cycle" in result.stderr
 
 
+def test_scope_decompose_cycle_report_excludes_upstream_story(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+
+    def story(story_id: str, deps: list[str]) -> dict:
+        return {
+            "id": story_id,
+            "title": story_id,
+            "acceptance": [f"{story_id} acceptance"],
+            "traces": ["FR-1"],
+            "swarm": {
+                "readiness": "ready",
+                "parallel_safe": True,
+                "file_scope": [f"src/{story_id}.ts"],
+                "verify_commands": [f"npm test -- {story_id}"],
+                "expected_outputs": ["tests pass"],
+                "depends_on": deps,
+                "size": "small",
+                "file_scope_confidence": "high",
+            },
+        }
+
+    draft = _write_json(
+        tmp_path / "decomposition.json",
+        {
+            "stories": [
+                story("story-entry", ["story-branch"]),
+                story("story-branch", ["story-loop"]),
+                story("story-loop", ["story-branch"]),
+            ]
+        },
+    )
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--check",
+    )
+
+    assert result.returncode == 1
+    assert "dependency cycle detected: story-branch -> story-loop -> story-branch" in result.stderr
+    assert "story-entry -> story-branch -> story-loop -> story-branch" not in result.stderr
+
+
 def test_scope_decompose_rejects_ready_story_missing_required_fields(tmp_path: Path) -> None:
     parent = _parent(tmp_path)
     draft = _write_json(

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -38,6 +38,12 @@ def _parent(project: Path, folder: str = "pending") -> Path:
                         "type": "x-vbrief/plan",
                         "title": "Specification",
                         "TrustLevel": "internal",
+                    },
+                    {
+                        "uri": "./pending/2026-05-12-ip001-auth.vbrief.json#Acceptance",
+                        "type": "x-vbrief/acceptance",
+                        "title": "Parent Acceptance",
+                        "TrustLevel": "internal",
                     }
                 ],
             },
@@ -180,6 +186,10 @@ def test_scope_decompose_creates_child_stories_and_updates_parent_refs(tmp_path:
     assert child["plan"]["items"]
     assert child["plan"]["references"][0]["uri"] == "./specification.vbrief.json"
     assert child["plan"]["references"][0]["TrustLevel"] == "internal"
+    assert all(
+        "acceptance" not in ref.get("type", "").lower()
+        for ref in child["plan"]["references"]
+    )
 
     updated_parent = json.loads(parent.read_text(encoding="utf-8"))
     child_uris = {

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -348,6 +348,45 @@ def test_scope_decompose_rejects_running_child_status(tmp_path: Path) -> None:
     assert "cannot create active/running child stories" in result.stderr
 
 
+def test_scope_decompose_rejects_normalized_active_draft_status(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    draft_data = json.loads(draft.read_text(encoding="utf-8"))
+    draft_data["status"] = " Active "
+    _write_json(draft, draft_data)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+    )
+
+    assert result.returncode == 1
+    assert "cannot create active/running child stories" in result.stderr
+
+
+def test_scope_decompose_rejects_normalized_running_child_status(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    draft_data = json.loads(draft.read_text(encoding="utf-8"))
+    draft_data["stories"][0]["status"] = " RUNNING "
+    _write_json(draft, draft_data)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+    )
+
+    assert result.returncode == 1
+    assert (
+        "story-auth-model: decomposition cannot create active/running child stories"
+        in result.stderr
+    )
+
+
 def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None:
     parent = _parent(tmp_path)
     draft = _draft(tmp_path, cycle=True)

--- a/tests/cli/test_scope_decompose.py
+++ b/tests/cli/test_scope_decompose.py
@@ -34,13 +34,13 @@ def _parent(project: Path, folder: str = "pending") -> Path:
                 "metadata": {"kind": "phase", "dependencies": []},
                 "references": [
                     {
-                        "uri": "./specification.vbrief.json",
+                        "uri": "specification.vbrief.json",
                         "type": "x-vbrief/plan",
                         "title": "Specification",
                         "TrustLevel": "internal",
                     },
                     {
-                        "uri": "./pending/2026-05-12-ip001-auth.vbrief.json#Acceptance",
+                        "uri": "pending/2026-05-12-ip001-auth.vbrief.json#Acceptance",
                         "type": "x-vbrief/acceptance",
                         "title": "Parent Acceptance",
                         "TrustLevel": "internal",
@@ -180,11 +180,11 @@ def test_scope_decompose_creates_child_stories_and_updates_parent_refs(tmp_path:
     child_paths = sorted((tmp_path / "vbrief" / "pending").glob("2026-05-12-auth-*.vbrief.json"))
     assert len(child_paths) == 2
     child = json.loads(child_paths[0].read_text(encoding="utf-8"))
-    assert child["plan"]["planRef"] == "./pending/2026-05-12-ip001-auth.vbrief.json"
+    assert child["plan"]["planRef"] == "pending/2026-05-12-ip001-auth.vbrief.json"
     assert child["plan"]["metadata"]["kind"] == "story"
     assert child["plan"]["metadata"]["swarm"]["readiness"] == "ready"
     assert child["plan"]["items"]
-    assert child["plan"]["references"][0]["uri"] == "./specification.vbrief.json"
+    assert child["plan"]["references"][0]["uri"] == "specification.vbrief.json"
     assert child["plan"]["references"][0]["TrustLevel"] == "internal"
     assert all(
         "acceptance" not in ref.get("type", "").lower()
@@ -193,7 +193,7 @@ def test_scope_decompose_creates_child_stories_and_updates_parent_refs(tmp_path:
 
     updated_parent = json.loads(parent.read_text(encoding="utf-8"))
     child_uris = {
-        f"./pending/{path.name}"
+        f"pending/{path.name}"
         for path in child_paths
     }
     child_refs = [
@@ -246,6 +246,27 @@ def test_scope_decompose_rejects_non_object_parent_metadata(tmp_path: Path) -> N
     assert result.returncode == 1
     assert "plan.metadata must be an object" in result.stderr
     assert not list((tmp_path / "vbrief" / "pending").glob("2026-05-12-auth-*.vbrief.json"))
+
+
+def test_scope_decompose_rejects_output_dir_outside_vbrief(tmp_path: Path) -> None:
+    parent = _parent(tmp_path)
+    draft = _draft(tmp_path)
+    draft_data = json.loads(draft.read_text(encoding="utf-8"))
+    draft_data["output_dir"] = str(tmp_path / "outside" / "active")
+    _write_json(draft, draft_data)
+
+    result = _run(
+        tmp_path,
+        str(parent.relative_to(tmp_path)),
+        "--draft",
+        str(draft.relative_to(tmp_path)),
+        "--date",
+        "2026-05-12",
+    )
+
+    assert result.returncode == 1
+    assert "output_dir must be inside vbrief/" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_scope_decompose_check_rejects_dependency_cycles(tmp_path: Path) -> None:

--- a/tests/cli/test_scope_decompose_unit.py
+++ b/tests/cli/test_scope_decompose_unit.py
@@ -348,24 +348,24 @@ class TestStoryQualityIssues:
 
     @pytest.fixture
     def base_kwargs(self) -> dict[str, Any]:
-        return dict(
-            title="Auth model",
-            description=(
+        return {
+            "title": "Auth model",
+            "description": (
                 "Auth model persistence stores user identity and session "
                 "state. The story covers focused model changes plus matching "
                 "unit tests for save and load behavior."
             ),
-            implementation_plan=(
+            "implementation_plan": (
                 "- Update the src/auth model persistence code so valid "
                 "payloads are saved through the model boundary.\n"
                 "- Add focused tests for successful persistence and a "
                 "missing-record fixture in tests/auth/model."
             ),
-            user_story=(
+            "user_story": (
                 "As an auth maintainer, I want persisted user records, "
                 "so that login state survives requests."
             ),
-            acceptance_texts=[
+            "acceptance_texts": [
                 (
                     "Given a valid user payload, when the auth model saves "
                     "it, then the user record persists."
@@ -375,15 +375,15 @@ class TestStoryQualityIssues:
                     "then the saved identity returns."
                 ),
             ],
-            acceptance_count_justification="",
-            swarm={
+            "acceptance_count_justification": "",
+            "swarm": {
                 "file_scope": ["src/auth/model.ts", "tests/auth/model.test.ts"],
                 "verify_commands": ["npm test -- auth/model"],
                 "parallel_safe": True,
                 "file_scope_confidence": "high",
             },
-            concurrent_ready=True,
-        )
+            "concurrent_ready": True,
+        }
 
     def test_happy_path_has_no_issues(
         self, quality: ModuleType, base_kwargs: dict[str, Any]

--- a/tests/cli/test_scope_decompose_unit.py
+++ b/tests/cli/test_scope_decompose_unit.py
@@ -1,0 +1,1397 @@
+"""In-process unit tests for the decomposition readiness layer.
+
+The companion file ``tests/cli/test_scope_decompose.py`` drives the CLI through
+``subprocess.run([sys.executable, ...])``. Coverage.py does not follow child
+processes by default, so those integration tests barely register the script
+bodies and leave ``scripts/scope_decompose.py`` and
+``scripts/_vbrief_story_quality.py`` well below the
+``[tool.coverage.report].fail_under = 85`` gate in ``pyproject.toml``.
+
+These tests exercise the same public API surfaces directly, in-process, so
+coverage.py credits every executed line. The subprocess-based integration
+tests in ``tests/cli/test_scope_decompose.py`` are intentionally preserved
+verbatim: they remain the CLI contract suite.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load_scope_module() -> ModuleType:
+    """Import ``scripts/scope_decompose.py`` as a real module.
+
+    Mirrors the helper used by the CLI integration suite so coverage.py
+    records the executed source lines, not a subprocess copy.
+    """
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "scope_decompose_unit_module",
+        SCRIPTS_DIR / "scope_decompose.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_quality_module() -> ModuleType:
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "vbrief_story_quality_unit_module",
+        SCRIPTS_DIR / "_vbrief_story_quality.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def scope() -> ModuleType:
+    return _load_scope_module()
+
+
+@pytest.fixture(scope="module")
+def quality() -> ModuleType:
+    return _load_quality_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors of the CLI-suite fixtures, kept self-contained on purpose)
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _good_story(
+    story_id: str = "story-auth-model",
+    title: str = "Auth model",
+    deps: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": story_id,
+        "title": title,
+        "description": (
+            f"{title} persistence behavior stores user identity and session "
+            "state for the authentication workflow. The story covers focused "
+            "model changes plus matching unit tests for save and load."
+        ),
+        "implementation_plan": [
+            (
+                "Update the auth model persistence code so valid user payloads "
+                "are saved through the existing model boundary."
+            ),
+            (
+                "Add focused model tests for successful persistence and "
+                "missing-record behavior using the auth model test fixture."
+            ),
+        ],
+        "user_story": (
+            "As an auth maintainer, I want persisted user records, "
+            "so that login state survives requests."
+        ),
+        "acceptance": [
+            (
+                "Given a valid user payload, when the auth model saves it, "
+                "then the user record persists."
+            ),
+            (
+                "Given an existing user, when the auth model loads it, "
+                "then the saved identity returns."
+            ),
+        ],
+        "traces": ["FR-1"],
+        "swarm": {
+            "readiness": "ready",
+            "parallel_safe": True,
+            "file_scope": ["src/auth/model.ts", "tests/auth/model.test.ts"],
+            "verify_commands": ["npm test -- auth/model"],
+            "expected_outputs": ["auth model tests pass"],
+            "depends_on": deps or [],
+            "conflict_group": "auth",
+            "size": "small",
+            "file_scope_confidence": "high",
+            "model_tier": "medium",
+        },
+    }
+
+
+def _good_draft(*, output_dir: str | None = None, status: str | None = None) -> dict[str, Any]:
+    draft: dict[str, Any] = {
+        "stories": [
+            _good_story(),
+            _good_story(
+                story_id="story-auth-routes",
+                title="Auth routes",
+                deps=["story-auth-model"],
+            ),
+        ]
+    }
+    # The second story's file_scope must differ from the first to stay narrow.
+    draft["stories"][1]["swarm"]["file_scope"] = [
+        "src/auth/routes.ts",
+        "tests/auth/routes.test.ts",
+    ]
+    draft["stories"][1]["swarm"]["verify_commands"] = ["npm test -- auth/routes"]
+    if output_dir is not None:
+        draft["output_dir"] = output_dir
+    if status is not None:
+        draft["status"] = status
+    return draft
+
+
+def _good_parent() -> dict[str, Any]:
+    return {
+        "vBRIEFInfo": {"version": "0.6"},
+        "plan": {
+            "id": "ip-1",
+            "title": "IP-1: Auth",
+            "status": "pending",
+            "narratives": {
+                "Acceptance": "Auth epic acceptance remains as context.",
+                "Traces": "FR-1, IP-1",
+            },
+            "items": [],
+            "metadata": {"kind": "phase", "dependencies": []},
+            "references": [
+                {
+                    "uri": "specification.vbrief.json",
+                    "type": "x-vbrief/plan",
+                    "title": "Specification",
+                    "TrustLevel": "internal",
+                },
+                {
+                    "uri": "pending/2026-05-12-ip001-auth.vbrief.json#Acceptance",
+                    "type": "x-vbrief/acceptance",
+                    "title": "Parent Acceptance",
+                    "TrustLevel": "internal",
+                },
+            ],
+        },
+    }
+
+
+def _write_parent(project: Path, *, folder: str = "pending") -> Path:
+    parent = copy.deepcopy(_good_parent())
+    if folder != "pending":
+        parent["plan"]["status"] = "running" if folder == "active" else folder
+    return _write_json(
+        project / "vbrief" / folder / "2026-05-12-ip001-auth.vbrief.json",
+        parent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _vbrief_story_quality.py: helpers and rule predicates
+# ---------------------------------------------------------------------------
+
+
+class TestQualityHelpers:
+    def test_as_str_list_variants(self, quality: ModuleType) -> None:
+        assert quality.as_str_list(None) == []
+        assert quality.as_str_list("") == []
+        assert quality.as_str_list("  ") == []
+        assert quality.as_str_list("alpha") == ["alpha"]
+        assert quality.as_str_list(["a", "", " b ", 3]) == ["a", "b", "3"]
+        # Non-string / non-list values return empty.
+        assert quality.as_str_list({"a": 1}) == []
+        assert quality.as_str_list(42) == []
+
+    def test_acceptance_texts_from_items_walks_nested(self, quality: ModuleType) -> None:
+        items = [
+            {
+                "narrative": {"Acceptance": "Top-level acceptance text"},
+                "items": [
+                    {
+                        "narrative": {"Acceptance": "Child acceptance text"},
+                        "subItems": [
+                            {"narrative": {"Acceptance": "Grandchild acceptance text"}},
+                        ],
+                    }
+                ],
+            },
+            "not-a-dict",
+            {"narrative": "not-a-dict"},
+            {"narrative": {"Acceptance": "   "}},
+        ]
+        result = quality.acceptance_texts_from_items(items)
+        assert result == [
+            "Top-level acceptance text",
+            "Child acceptance text",
+            "Grandchild acceptance text",
+        ]
+        assert quality.acceptance_texts_from_items("not-a-list") == []
+
+    def test_item_has_acceptance_and_traces(self, quality: ModuleType) -> None:
+        assert quality.item_has_acceptance({"narrative": {"Acceptance": "yes"}}) is True
+        assert (
+            quality.item_has_acceptance(
+                {
+                    "items": [
+                        {"narrative": {"Acceptance": "deep"}},
+                    ]
+                }
+            )
+            is True
+        )
+        assert (
+            quality.item_has_acceptance(
+                {
+                    "subItems": [
+                        {"narrative": {"Acceptance": "deep"}},
+                    ]
+                }
+            )
+            is True
+        )
+        assert quality.item_has_acceptance({"narrative": {"Acceptance": ""}}) is False
+        assert quality.item_has_acceptance({"items": "not-a-list"}) is False
+        assert quality.item_has_acceptance({}) is False
+
+        assert quality.item_has_traces({"narrative": {"Traces": "FR-1"}}) is True
+        assert (
+            quality.item_has_traces(
+                {"items": [{"narrative": {"Traces": "FR-1"}}]}
+            )
+            is True
+        )
+        assert (
+            quality.item_has_traces(
+                {"subItems": [{"narrative": {"Traces": "FR-1"}}]}
+            )
+            is True
+        )
+        assert quality.item_has_traces({}) is False
+
+    def test_items_have_acceptance(self, quality: ModuleType) -> None:
+        assert quality.items_have_acceptance("not-list") is False
+        assert quality.items_have_acceptance([]) is False
+        assert quality.items_have_acceptance([{"no": "acc"}]) is False
+        assert (
+            quality.items_have_acceptance(
+                [{"narrative": {"Acceptance": "yes"}}]
+            )
+            is True
+        )
+
+    def test_missing_required_swarm_fields(self, quality: ModuleType) -> None:
+        # Empty swarm -> every required field reported.
+        missing = quality.missing_required_swarm_fields({})
+        expected = {
+            "plan.metadata.swarm.file_scope",
+            "plan.metadata.swarm.verify_commands",
+            "plan.metadata.swarm.expected_outputs",
+            "plan.metadata.swarm.depends_on",
+            "plan.metadata.swarm.conflict_group",
+            "plan.metadata.swarm.size",
+            "plan.metadata.swarm.file_scope_confidence",
+            "plan.metadata.swarm.model_tier",
+        }
+        assert set(missing) == expected
+
+        # depends_on present (even empty) drops only the depends_on entry.
+        partial = quality.missing_required_swarm_fields({"depends_on": []})
+        assert "plan.metadata.swarm.depends_on" not in partial
+
+        # All required fields present and well-typed -> no issues.
+        full = {
+            "file_scope": ["src/x.ts"],
+            "verify_commands": ["npm test"],
+            "expected_outputs": ["passes"],
+            "depends_on": [],
+            "conflict_group": "auth",
+            "size": "small",
+            "file_scope_confidence": "high",
+            "model_tier": "medium",
+        }
+        assert quality.missing_required_swarm_fields(full) == []
+
+    def test_deprecated_subitems_issues(self, quality: ModuleType) -> None:
+        assert quality.deprecated_subitems_issues(None) == []
+        items = [
+            {
+                "items": [
+                    "not-a-dict",
+                    {"subItems": []},
+                ],
+                "subItems": [{"subItems": []}],
+            },
+            "not-a-dict",
+        ]
+        issues = quality.deprecated_subitems_issues(items)
+        assert any("subItems is deprecated" in issue for issue in issues)
+        # The deprecated path is reported with the dotted path that includes
+        # the index of the offending item.
+        assert any(".items[1].subItems is deprecated" in issue for issue in issues)
+
+
+class TestStoryQualityIssues:
+    """Drive ``story_quality_issues`` through every failure mode."""
+
+    @pytest.fixture
+    def base_kwargs(self) -> dict[str, Any]:
+        return dict(
+            title="Auth model",
+            description=(
+                "Auth model persistence stores user identity and session "
+                "state. The story covers focused model changes plus matching "
+                "unit tests for save and load behavior."
+            ),
+            implementation_plan=(
+                "- Update the src/auth model persistence code so valid "
+                "payloads are saved through the model boundary.\n"
+                "- Add focused tests for successful persistence and a "
+                "missing-record fixture in tests/auth/model."
+            ),
+            user_story=(
+                "As an auth maintainer, I want persisted user records, "
+                "so that login state survives requests."
+            ),
+            acceptance_texts=[
+                (
+                    "Given a valid user payload, when the auth model saves "
+                    "it, then the user record persists."
+                ),
+                (
+                    "Given an existing user, when the auth model loads it, "
+                    "then the saved identity returns."
+                ),
+            ],
+            acceptance_count_justification="",
+            swarm={
+                "file_scope": ["src/auth/model.ts", "tests/auth/model.test.ts"],
+                "verify_commands": ["npm test -- auth/model"],
+                "parallel_safe": True,
+                "file_scope_confidence": "high",
+            },
+            concurrent_ready=True,
+        )
+
+    def test_happy_path_has_no_issues(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        assert quality.story_quality_issues(**base_kwargs) == []
+
+    def test_user_story_format_required(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["user_story"] = "Just build the thing."
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any("UserStory must match" in issue for issue in issues)
+
+    def test_description_too_short(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["description"] = "Persist auth records."
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any("Description must contain at least two" in issue for issue in issues)
+
+    def test_description_missing(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["description"] = ""
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert "plan.narratives.Description is required" in issues
+
+    def test_implementation_plan_missing(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["implementation_plan"] = ""
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert "plan.narratives.ImplementationPlan is required" in issues
+
+    def test_implementation_plan_too_short(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["implementation_plan"] = "Update model code."
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any(
+            "ImplementationPlan must contain at least two" in issue for issue in issues
+        )
+
+    def test_implementation_plan_generic(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["implementation_plan"] = (
+            "- Update the code so the feature is implemented in the application.\n"
+            "- Add tests so it works as expected for users."
+        )
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any(
+            "concrete code paths" in issue for issue in issues
+        )
+
+    def test_implementation_plan_placeholder(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["implementation_plan"] = (
+            "- TODO refine from parent scope\n- TBD\n- placeholder"
+        )
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any(
+            "ImplementationPlan must not be placeholder text" in issue for issue in issues
+        )
+
+    def test_acceptance_count_outside_range(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        # Provide a single acceptance with no justification.
+        base_kwargs["acceptance_texts"] = [
+            "Given a valid payload, when auth saves it, then it persists."
+        ]
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert "2-5 acceptance criteria required unless justified" in issues
+
+    def test_acceptance_count_justified(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["acceptance_texts"] = [
+            "Given a valid payload, when auth saves it, then it persists."
+        ]
+        base_kwargs["acceptance_count_justification"] = (
+            "A single acceptance criterion is sufficient because the story "
+            "only exposes one observable outcome."
+        )
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert "2-5 acceptance criteria required unless justified" not in issues
+
+    @pytest.mark.parametrize(
+        ("criterion", "expected_fragment"),
+        [
+            ("to refine from parent scope", "placeholder acceptance criterion"),
+            ("docs updated for the new behavior", "docs-only acceptance criterion"),
+            ("It is updated.", "specific observable behavior"),
+            (
+                # No OBSERVABLE_TERMS, no vague patterns, >=8 words: hits only
+                # the "must describe observable behavior" rule.
+                "A user with valid credentials logs into the system successfully today.",
+                "acceptance criterion must describe observable behavior",
+            ),
+        ],
+    )
+    def test_acceptance_quality_patterns(
+        self,
+        quality: ModuleType,
+        base_kwargs: dict[str, Any],
+        criterion: str,
+        expected_fragment: str,
+    ) -> None:
+        base_kwargs["acceptance_texts"] = [
+            criterion,
+            (
+                "Given an existing user, when the auth model loads it, "
+                "then the saved identity returns."
+            ),
+        ]
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any(expected_fragment in issue for issue in issues), issues
+
+    def test_acceptance_duplicates_title(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        title = base_kwargs["title"]
+        base_kwargs["acceptance_texts"] = [
+            title,
+            (
+                "Given an existing user, when the auth model loads it, "
+                "then the saved identity returns."
+            ),
+        ]
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert "acceptance criterion duplicates title or description" in issues
+
+    @pytest.mark.parametrize(
+        ("file_scope", "expected_fragment"),
+        [
+            (["backend"], "broad file_scope"),
+            (["backend/**"], "broad file_scope"),
+            (["src/*.ts"], "broad file_scope"),
+            (["docs"], "broad file_scope"),
+            (["vbrief/"], "broad file_scope"),
+        ],
+    )
+    def test_broad_file_scope(
+        self,
+        quality: ModuleType,
+        base_kwargs: dict[str, Any],
+        file_scope: list[str],
+        expected_fragment: str,
+    ) -> None:
+        base_kwargs["swarm"] = dict(base_kwargs["swarm"], file_scope=file_scope)
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any(expected_fragment in issue for issue in issues), issues
+
+    @pytest.mark.parametrize(
+        "command",
+        ["task check", "pytest", "go test ./...", "npm test", "npm run test", "cargo test"],
+    )
+    def test_generic_verify_command_rejected(
+        self, quality: ModuleType, base_kwargs: dict[str, Any], command: str
+    ) -> None:
+        base_kwargs["swarm"] = dict(base_kwargs["swarm"], verify_commands=[command])
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any("generic verify command" in issue for issue in issues), issues
+
+    def test_parallel_safe_false_blocks_ready(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["swarm"] = dict(base_kwargs["swarm"], parallel_safe=False)
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any("parallel_safe=true" in issue for issue in issues)
+
+    def test_file_scope_confidence_low_blocks_ready(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        base_kwargs["swarm"] = dict(base_kwargs["swarm"], file_scope_confidence="low")
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert any(
+            "file_scope_confidence above low" in issue for issue in issues
+        )
+
+    def test_non_concurrent_skips_swarm_rules(
+        self, quality: ModuleType, base_kwargs: dict[str, Any]
+    ) -> None:
+        # Non-concurrent stories should not be blocked by swarm-only rules.
+        base_kwargs["swarm"] = dict(
+            base_kwargs["swarm"],
+            parallel_safe=False,
+            file_scope_confidence="low",
+            file_scope=["backend"],
+            verify_commands=["task check"],
+        )
+        base_kwargs["concurrent_ready"] = False
+        issues = quality.story_quality_issues(**base_kwargs)
+        assert not any("broad file_scope" in issue for issue in issues)
+        assert not any("generic verify command" in issue for issue in issues)
+        assert not any("parallel_safe=true" in issue for issue in issues)
+        assert not any(
+            "file_scope_confidence above low" in issue for issue in issues
+        )
+
+
+# ---------------------------------------------------------------------------
+# scope_decompose.py: pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestScopeHelpers:
+    def test_load_json_round_trip(self, scope: ModuleType, tmp_path: Path) -> None:
+        path = tmp_path / "doc.json"
+        path.write_text(json.dumps({"a": 1}), encoding="utf-8")
+        assert scope._load_json(path) == {"a": 1}
+
+    def test_load_json_invalid_payload(self, scope: ModuleType, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("not-json", encoding="utf-8")
+        with pytest.raises(scope.DecompositionError, match="invalid JSON"):
+            scope._load_json(path)
+
+    def test_load_json_non_object_payload(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "list.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        with pytest.raises(scope.DecompositionError, match="expected a JSON object"):
+            scope._load_json(path)
+
+    def test_resolve_path_variants(self, scope: ModuleType, tmp_path: Path) -> None:
+        assert scope._resolve_path(tmp_path, None) is None
+        assert scope._resolve_path(tmp_path, "") is None
+        rel = scope._resolve_path(tmp_path, "vbrief/pending")
+        assert rel == tmp_path / "vbrief" / "pending"
+        absolute = (tmp_path / "vbrief" / "pending").resolve()
+        assert scope._resolve_path(tmp_path, str(absolute)) == Path(str(absolute))
+
+    def test_rel_to_vbrief_outside(self, scope: ModuleType, tmp_path: Path) -> None:
+        vbrief = tmp_path / "vbrief"
+        vbrief.mkdir()
+        other = tmp_path / "other.json"
+        other.write_text("{}", encoding="utf-8")
+        with pytest.raises(scope.DecompositionError, match="path must be inside"):
+            scope._rel_to_vbrief(vbrief, other)
+
+    def test_default_status_for_folder(self, scope: ModuleType, tmp_path: Path) -> None:
+        for name, expected in (
+            ("proposed", "proposed"),
+            ("pending", "pending"),
+            ("active", "running"),
+            ("completed", "completed"),
+            ("cancelled", "cancelled"),
+            ("unknown", "pending"),
+        ):
+            folder = tmp_path / name
+            assert scope._default_status_for_folder(folder) == expected
+
+    def test_normalize_status(self, scope: ModuleType) -> None:
+        assert scope._normalize_status(None, "pending") == "pending"
+        assert scope._normalize_status(" Active ", "pending") == "active"
+        # Empty/whitespace-only falls back to default.
+        assert scope._normalize_status("   ", "running") == "running"
+
+    def test_story_specs_variants(self, scope: ModuleType) -> None:
+        # Dict-of-stories shape collapses to a list.
+        specs = scope._story_specs(
+            {"stories": {"a": {"id": "a"}, "b": {"id": "b"}}}
+        )
+        ids = sorted(spec["id"] for spec in specs)
+        assert ids == ["a", "b"]
+        # Children key fallback.
+        specs = scope._story_specs({"children": [{"id": "c"}]})
+        assert specs[0]["id"] == "c"
+        # Missing stories raises.
+        with pytest.raises(scope.DecompositionError, match="stories array"):
+            scope._story_specs({"stories": "nope"})
+        with pytest.raises(scope.DecompositionError, match="must be an object"):
+            scope._story_specs({"stories": ["not-a-dict"]})
+
+    def test_story_id_fallbacks(self, scope: ModuleType) -> None:
+        assert scope._story_id({"id": "alpha"}, 1) == "alpha"
+        assert scope._story_id({"story_id": "beta"}, 1) == "beta"
+        assert scope._story_id({"key": "gamma"}, 1) == "gamma"
+        assert scope._story_id({"title": "My Title"}, 1) == "my-title"
+        assert scope._story_id({}, 4) == "story-4"
+        # Whitespace id falls through to title.
+        assert scope._story_id({"id": "   ", "title": "Hello"}, 1) == "hello"
+
+    def test_swarm_meta_promotes_top_level_keys(self, scope: ModuleType) -> None:
+        story = {
+            "swarm": {"size": "small"},
+            "readiness": "ready",
+            "parallel_safe": True,
+            "file_scope": ["src/x.ts"],
+            "verify_commands": ["npm test"],
+            "expected_outputs": ["ok"],
+            "depends_on": [],
+            "conflict_group": "auth",
+            "file_scope_confidence": "high",
+            "model_tier": "medium",
+            "missing_traces_justification": ["because"],
+        }
+        swarm = scope._swarm_meta(story)
+        assert swarm["readiness"] == "ready"
+        assert swarm["size"] == "small"
+        assert swarm["missing_traces_justification"] == ["because"]
+
+    def test_swarm_meta_uses_metadata_swarm(self, scope: ModuleType) -> None:
+        story = {"metadata": {"swarm": {"size": "tiny"}}}
+        assert scope._swarm_meta(story)["size"] == "tiny"
+
+    def test_swarm_meta_handles_invalid_shapes(self, scope: ModuleType) -> None:
+        assert scope._swarm_meta({"swarm": "nope"}) == {}
+        assert scope._swarm_meta({"metadata": "nope"}) == {}
+
+    def test_story_has_traces_sources(self, scope: ModuleType) -> None:
+        # narratives.Traces present.
+        assert (
+            scope._story_has_traces(
+                {"narratives": {"Traces": "FR-1"}}, [], {}
+            )
+            is True
+        )
+        # Top-level traces list.
+        assert scope._story_has_traces({"traces": ["FR-1"]}, [], {}) is True
+        # Item-level traces narrative.
+        assert (
+            scope._story_has_traces(
+                {},
+                [{"narrative": {"Traces": "FR-1"}}],
+                {},
+            )
+            is True
+        )
+        # Missing traces justification on swarm.
+        assert (
+            scope._story_has_traces(
+                {}, [], {"missing_traces_justification": ["because"]}
+            )
+            is True
+        )
+        # Spec-section reference.
+        assert (
+            scope._story_has_traces(
+                {
+                    "references": [
+                        {"type": "x-vbrief/spec-section", "uri": "spec#x"}
+                    ]
+                },
+                [],
+                {},
+            )
+            is True
+        )
+        # None of the above.
+        assert scope._story_has_traces({}, [], {}) is False
+
+    def test_story_description_implementation_user_story(
+        self, scope: ModuleType
+    ) -> None:
+        # narratives win.
+        assert (
+            scope._story_description(
+                {"narratives": {"Description": "  hello "}}
+            )
+            == "hello"
+        )
+        # Falls back to description / summary.
+        assert scope._story_description({"summary": "summary text"}) == "summary text"
+        assert scope._story_description({}) == ""
+
+        # ImplementationPlan: narratives, key, list join.
+        assert (
+            scope._story_implementation_plan(
+                {"narratives": {"ImplementationPlan": "step"}}
+            )
+            == "step"
+        )
+        assert (
+            scope._story_implementation_plan(
+                {"implementation_plan": ["one", "two"]}
+            )
+            == "one\ntwo"
+        )
+        assert scope._story_implementation_plan({}) == ""
+
+        # UserStory.
+        assert (
+            scope._story_user_story({"narratives": {"UserStory": "story"}})
+            == "story"
+        )
+        assert scope._story_user_story({"UserStory": "alt"}) == "alt"
+        assert scope._story_user_story({}) == ""
+
+    def test_acceptance_count_justification_sources(self, scope: ModuleType) -> None:
+        assert (
+            scope._acceptance_count_justification(
+                {"acceptance_criteria_justification": "story-level"},
+                {},
+            )
+            == "story-level"
+        )
+        assert (
+            scope._acceptance_count_justification(
+                {},
+                {"acceptance_criteria_justification": "swarm-level"},
+            )
+            == "swarm-level"
+        )
+        assert (
+            scope._acceptance_count_justification(
+                {"narratives": {"AcceptanceJustification": "narrative-level"}},
+                {},
+            )
+            == "narrative-level"
+        )
+        assert scope._acceptance_count_justification({}, {}) == ""
+
+    def test_items_from_story_uses_existing_items(self, scope: ModuleType) -> None:
+        items = [{"id": "x", "narrative": {"Acceptance": "ok"}}]
+        assert scope._items_from_story("story-x", {"items": items}) is items
+
+    def test_items_from_story_generates_from_acceptance(self, scope: ModuleType) -> None:
+        story = {
+            "acceptance": [
+                "Given a payload, when saved, then it persists.",
+                "Given a payload, when loaded, then it returns.",
+            ],
+            "traces": ["FR-1", "FR-2"],
+        }
+        generated = scope._items_from_story("story-x", story)
+        assert len(generated) == 2
+        first = generated[0]
+        assert first["id"] == "story-x-a1"
+        assert first["narrative"]["Acceptance"].startswith("Given a payload")
+        assert first["narrative"]["Traces"] == "FR-1, FR-2"
+
+    def test_items_from_story_uses_acceptance_items_fallback(
+        self, scope: ModuleType
+    ) -> None:
+        story = {
+            "acceptance_items": [
+                "Given a payload, when saved, then it persists.",
+            ],
+        }
+        generated = scope._items_from_story("story-x", story)
+        assert generated[0]["id"] == "story-x-a1"
+
+    def test_validate_dag_unknown_dep_and_cycle(self, scope: ModuleType) -> None:
+        # Unknown dep.
+        with pytest.raises(scope.DecompositionError, match="unknown story"):
+            scope._validate_dag(["a"], {"a": ["b"]})
+
+        # Cycle detection.
+        with pytest.raises(scope.DecompositionError, match="dependency cycle"):
+            scope._validate_dag(
+                ["a", "b", "c"],
+                {"a": ["b"], "b": ["c"], "c": ["b"]},
+            )
+
+        # Self-cycle.
+        with pytest.raises(scope.DecompositionError, match="dependency cycle"):
+            scope._validate_dag(["a"], {"a": ["a"]})
+
+        # Valid DAG returns None.
+        assert (
+            scope._validate_dag(
+                ["a", "b"], {"a": ["b"], "b": []}
+            )
+            is None
+        )
+
+    def test_validate_draft_duplicate_story_id(self, scope: ModuleType) -> None:
+        stories = [_good_story(), _good_story()]
+        with pytest.raises(scope.DecompositionError, match="duplicate story id"):
+            scope.validate_draft(stories)
+
+    def test_validate_draft_happy_path_returns_story_ids(
+        self, scope: ModuleType
+    ) -> None:
+        stories = [
+            _good_story(),
+            _good_story(
+                story_id="story-auth-routes",
+                title="Auth routes",
+                deps=["story-auth-model"],
+            ),
+        ]
+        stories[1]["swarm"]["file_scope"] = [
+            "src/auth/routes.ts",
+            "tests/auth/routes.test.ts",
+        ]
+        stories[1]["swarm"]["verify_commands"] = ["npm test -- auth/routes"]
+        assert scope.validate_draft(stories) == [
+            "story-auth-model",
+            "story-auth-routes",
+        ]
+
+    def test_validate_draft_reports_missing_required_fields(
+        self, scope: ModuleType
+    ) -> None:
+        stories = [
+            {
+                "id": "story-bad",
+                "title": "Bad story",
+                "swarm": {"readiness": "ready", "parallel_safe": True},
+            }
+        ]
+        with pytest.raises(scope.DecompositionError) as excinfo:
+            scope.validate_draft(stories)
+        message = str(excinfo.value)
+        assert "plan.items" in message
+        assert "file_scope" in message
+        assert "verify_commands" in message
+
+    def test_validate_draft_rejects_missing_id_and_title(
+        self, scope: ModuleType
+    ) -> None:
+        story = _good_story()
+        story.pop("id")
+        story.pop("title")
+        with pytest.raises(scope.DecompositionError) as excinfo:
+            scope.validate_draft([story])
+        assert "id" in str(excinfo.value)
+        assert "title" in str(excinfo.value)
+
+    def test_validate_draft_rejects_invalid_readiness(
+        self, scope: ModuleType
+    ) -> None:
+        story = _good_story()
+        story["swarm"]["readiness"] = "nope"
+        with pytest.raises(scope.DecompositionError, match="readiness"):
+            scope.validate_draft([story])
+
+    def test_validate_draft_rejects_missing_parallel_safe(
+        self, scope: ModuleType
+    ) -> None:
+        story = _good_story()
+        story["swarm"].pop("parallel_safe")
+        with pytest.raises(scope.DecompositionError, match="parallel_safe"):
+            scope.validate_draft([story])
+
+    def test_validate_draft_rejects_missing_traces(self, scope: ModuleType) -> None:
+        story = _good_story()
+        story.pop("traces")
+        with pytest.raises(
+            scope.DecompositionError, match="Traces or missing_traces_justification"
+        ):
+            scope.validate_draft([story])
+
+    def test_normalize_references_filters_non_dicts(self, scope: ModuleType) -> None:
+        refs = [
+            {"uri": "u", "type": "x-vbrief/plan", "title": "T"},
+            "not-a-dict",
+            {"uri": "u2", "type": "x-vbrief/github-issue", "title": "G"},
+        ]
+        normalized = scope._normalize_references(refs)
+        assert [ref["TrustLevel"] for ref in normalized] == ["internal", "external"]
+        # Non-list input returns empty.
+        assert scope._normalize_references("nope") == []
+
+    def test_child_provenance_references_strips_acceptance(
+        self, scope: ModuleType
+    ) -> None:
+        refs = [
+            {"uri": "u", "type": "x-vbrief/plan", "title": "T"},
+            {"uri": "u2", "type": "x-vbrief/acceptance", "title": "AC"},
+        ]
+        provenance = scope._child_provenance_references(refs)
+        assert len(provenance) == 1
+        assert provenance[0]["type"] == "x-vbrief/plan"
+
+    def test_dedupe_references_collapses_duplicates(self, scope: ModuleType) -> None:
+        refs = [
+            {"uri": "u", "type": "x-vbrief/plan", "title": "T"},
+            {"uri": "u", "type": "x-vbrief/plan", "title": "T"},
+            {"uri": "v", "type": "x-vbrief/plan", "title": "T2"},
+        ]
+        assert len(scope._dedupe_references(refs)) == 2
+
+    def test_story_narratives_merges_draft_keys(self, scope: ModuleType) -> None:
+        narratives = scope._story_narratives(
+            {
+                "narratives": {"Description": "explicit description"},
+                "summary": "ignored because Description already set",
+                "implementation_plan": ["step one", "step two"],
+                "user_story": "As a user, I want X, so that Y.",
+                "traces": ["FR-1", "FR-2"],
+            }
+        )
+        assert narratives["Description"] == "explicit description"
+        assert narratives["ImplementationPlan"] == "step one\nstep two"
+        assert narratives["UserStory"].startswith("As a user")
+        assert narratives["Traces"] == "FR-1, FR-2"
+
+    def test_story_narratives_uses_summary_when_description_missing(
+        self, scope: ModuleType
+    ) -> None:
+        narratives = scope._story_narratives({"summary": "summary text"})
+        assert narratives["Description"] == "summary text"
+
+    def test_child_filename_uses_existing(self, scope: ModuleType) -> None:
+        assert (
+            scope._child_filename(
+                {"filename": "custom.vbrief.json"}, "story-x", "Title", "2026-01-01"
+            )
+            == "custom.vbrief.json"
+        )
+
+    def test_child_filename_generates(self, scope: ModuleType) -> None:
+        assert (
+            scope._child_filename({}, "story-x", "My Title", "2026-01-01")
+            == "2026-01-01-my-title.vbrief.json"
+        )
+        # Empty title falls back to slugified id.
+        assert (
+            scope._child_filename({}, "story-x", "", "2026-01-01")
+            == "2026-01-01-story-x.vbrief.json"
+        )
+
+    def test_build_child_vbrief_shape(self, scope: ModuleType) -> None:
+        story = _good_story()
+        parent = _good_parent()
+        child = scope._build_child_vbrief(
+            story=story,
+            story_id="story-auth-model",
+            story_index=1,
+            parent=parent,
+            parent_rel="pending/parent.vbrief.json",
+            status="pending",
+        )
+        assert child["plan"]["id"] == "story-auth-model"
+        assert child["plan"]["planRef"] == "pending/parent.vbrief.json"
+        assert child["plan"]["metadata"]["kind"] == "story"
+        assert child["plan"]["metadata"]["swarm"]["readiness"] == "ready"
+        # The acceptance-typed parent reference is filtered out of the
+        # child's references; only the plan-typed one remains.
+        assert all(
+            ref.get("type") != "x-vbrief/acceptance"
+            for ref in child["plan"]["references"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# scope_decompose.apply_decomposition: end-to-end in-process
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDecomposition:
+    def test_check_only_returns_actions(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        actions = scope.apply_decomposition(
+            project_root=tmp_path,
+            parent_path=parent,
+            draft_path=draft,
+            check_only=True,
+            date="2026-05-12",
+        )
+        assert actions[0].startswith("VALIDATED 2 story")
+        assert any(action.startswith("CHECK pending/") for action in actions)
+        # Nothing was written.
+        assert not list(
+            (tmp_path / "vbrief" / "pending").glob("2026-05-12-auth-*.vbrief.json")
+        )
+
+    def test_apply_writes_children_and_updates_parent(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        actions = scope.apply_decomposition(
+            project_root=tmp_path,
+            parent_path=parent,
+            draft_path=draft,
+            check_only=False,
+            date="2026-05-12",
+        )
+        assert actions[-1].endswith("references")
+        children = sorted(
+            (tmp_path / "vbrief" / "pending").glob("2026-05-12-auth-*.vbrief.json")
+        )
+        assert len(children) == 2
+        updated = json.loads(parent.read_text(encoding="utf-8"))
+        plan_refs = [
+            ref for ref in updated["plan"]["references"] if ref.get("type") == "x-vbrief/plan"
+        ]
+        # Both child stories appended, plus the original Specification ref.
+        assert len(plan_refs) >= 3
+
+    def test_apply_rejects_existing_child(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        _write_json(
+            tmp_path / "vbrief" / "pending" / "2026-05-12-auth-model.vbrief.json",
+            {"existing": True},
+        )
+        with pytest.raises(
+            scope.DecompositionError, match="overwriting is not supported"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=False,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_output_dir_outside_vbrief(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        outside = (tmp_path / "outside" / "pending").resolve()
+        draft = _write_json(
+            tmp_path / "decomp.json",
+            _good_draft(output_dir=str(outside)),
+        )
+        with pytest.raises(
+            scope.DecompositionError, match="output_dir must be inside vbrief/"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=True,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_non_lifecycle_output_dir(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft = _write_json(
+            tmp_path / "decomp.json",
+            _good_draft(output_dir="vbrief/scratch"),
+        )
+        with pytest.raises(
+            scope.DecompositionError, match="vbrief lifecycle folder"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=True,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_active_output_dir(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft = _write_json(
+            tmp_path / "decomp.json",
+            _good_draft(output_dir="vbrief/active"),
+        )
+        with pytest.raises(
+            scope.DecompositionError, match="must not be vbrief/active"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=True,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_active_draft_status(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft = _write_json(
+            tmp_path / "decomp.json",
+            _good_draft(status=" Active "),
+        )
+        with pytest.raises(
+            scope.DecompositionError,
+            match="decomposition cannot create active/running",
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=True,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_running_child_status(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft_data = _good_draft()
+        draft_data["stories"][0]["status"] = "running"
+        draft = _write_json(tmp_path / "decomp.json", draft_data)
+        with pytest.raises(
+            scope.DecompositionError, match="story-auth-model"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=True,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_parent_plan_metadata_not_object(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent_data = _good_parent()
+        parent_data["plan"]["metadata"] = "phase"
+        parent = _write_json(
+            tmp_path / "vbrief" / "pending" / "2026-05-12-ip001-auth.vbrief.json",
+            parent_data,
+        )
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        with pytest.raises(
+            scope.DecompositionError, match="plan.metadata must be an object"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=False,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_parent_plan_not_object(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent_data = _good_parent()
+        parent_data["plan"] = "not-an-object"
+        parent = _write_json(
+            tmp_path / "vbrief" / "pending" / "2026-05-12-ip001-auth.vbrief.json",
+            parent_data,
+        )
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        with pytest.raises(
+            scope.DecompositionError, match="plan must be an object"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=False,
+                date="2026-05-12",
+            )
+
+    def test_apply_rejects_parent_references_not_list(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        parent_data = _good_parent()
+        parent_data["plan"]["references"] = "nope"
+        parent = _write_json(
+            tmp_path / "vbrief" / "pending" / "2026-05-12-ip001-auth.vbrief.json",
+            parent_data,
+        )
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        with pytest.raises(
+            scope.DecompositionError, match="plan.references must be an array"
+        ):
+            scope.apply_decomposition(
+                project_root=tmp_path,
+                parent_path=parent,
+                draft_path=draft,
+                check_only=False,
+                date="2026-05-12",
+            )
+
+    def test_apply_seeds_missing_parent_plan_and_metadata(
+        self, scope: ModuleType, tmp_path: Path
+    ) -> None:
+        # Parent missing plan entirely -- apply_decomposition seeds it.
+        parent_data: dict[str, Any] = {"vBRIEFInfo": {"version": "0.6"}}
+        parent = _write_json(
+            tmp_path / "vbrief" / "pending" / "2026-05-12-ip001-auth.vbrief.json",
+            parent_data,
+        )
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        scope.apply_decomposition(
+            project_root=tmp_path,
+            parent_path=parent,
+            draft_path=draft,
+            check_only=False,
+            date="2026-05-12",
+        )
+        updated = json.loads(parent.read_text(encoding="utf-8"))
+        assert isinstance(updated["plan"], dict)
+        assert isinstance(updated["plan"]["metadata"], dict)
+        assert updated["plan"]["metadata"]["kind"] == "epic"
+        assert any(
+            ref.get("type") == "x-vbrief/plan"
+            for ref in updated["plan"]["references"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# scope_decompose.main: CLI dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMainCLI:
+    def test_main_check_with_no_args_succeeds(
+        self,
+        scope: ModuleType,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = scope.main(["--check", "--project-root", str(tmp_path)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "no decomposition draft" in captured.out
+
+    def test_main_missing_args_errors(
+        self,
+        scope: ModuleType,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = scope.main(["--project-root", str(tmp_path)])
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "parent path and --draft are required" in captured.err
+
+    def test_main_missing_parent_file(
+        self,
+        scope: ModuleType,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        rc = scope.main(
+            [
+                "missing-parent.vbrief.json",
+                "--draft",
+                str(draft),
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "parent vBRIEF not found" in captured.err
+
+    def test_main_missing_draft_file(
+        self,
+        scope: ModuleType,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        rc = scope.main(
+            [
+                str(parent),
+                "--draft",
+                str(tmp_path / "does-not-exist.json"),
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "decomposition draft not found" in captured.err
+
+    def test_main_success_prints_actions(
+        self,
+        scope: ModuleType,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft = _write_json(tmp_path / "decomp.json", _good_draft())
+        rc = scope.main(
+            [
+                str(parent),
+                "--draft",
+                str(draft),
+                "--date",
+                "2026-05-12",
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "VALIDATED 2 story" in captured.out
+
+    def test_main_translates_decomposition_error_to_exit_1(
+        self,
+        scope: ModuleType,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parent = _write_parent(tmp_path)
+        draft_data = _good_draft()
+        draft_data["stories"][0]["swarm"]["file_scope"] = ["backend"]  # broad scope
+        draft = _write_json(tmp_path / "decomp.json", draft_data)
+        rc = scope.main(
+            [
+                str(parent),
+                "--draft",
+                str(draft),
+                "--check",
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "broad file_scope" in captured.err

--- a/tests/cli/test_spec.py
+++ b/tests/cli/test_spec.py
@@ -103,7 +103,7 @@ _FULL_APPROVED = {
                 "status": "pending",
                 "narrative": {
                     "Description": "This is the narrative.",
-                    "Acceptance": "Criterion A; Criterion B",
+                    "Acceptance": "- Criterion A\n- Criterion B",
                 },
             },
             {
@@ -592,4 +592,3 @@ def test_render_item_with_traces(render_mod, tmp_path) -> None:
     render_mod.render_spec(str(spec_file), str(out_file))
     content = out_file.read_text(encoding="utf-8")
     assert "**Traces**: FR-1, FR-2" in content
-

--- a/tests/cli/test_spec_render.py
+++ b/tests/cli/test_spec_render.py
@@ -242,6 +242,31 @@ def test_acceptance_semicolon_text_stays_single_criterion(render_mod, tmp_path) 
     assert "- email must be unique within a tenant" not in content
 
 
+def test_acceptance_indented_markdown_bullets_render_cleanly(render_mod, tmp_path) -> None:
+    """Indented markdown bullets should render the same as flush-left bullets."""
+    narratives = {"Overview": "Indented acceptance regression."}
+    items = [
+        {
+            "id": "T1",
+            "title": "Normalize bullets",
+            "status": "pending",
+            "narrative": {"Acceptance": "  - Criterion A\n    * Criterion B"},
+        }
+    ]
+    spec_path = _write_spec(
+        tmp_path / "vbrief", narratives, items=items, title="Indented Bullet Spec"
+    )
+    out = tmp_path / "SPECIFICATION.md"
+    ok, msg = render_mod.render_spec(str(spec_path), str(out))
+    assert ok, msg
+
+    content = out.read_text(encoding="utf-8")
+    assert "- Criterion A" in content
+    assert "- Criterion B" in content
+    assert "-   - Criterion A" not in content
+    assert "-     * Criterion B" not in content
+
+
 # ---------------------------------------------------------------------------
 # #435 -- lifecycle-scope aggregator
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_spec_render.py
+++ b/tests/cli/test_spec_render.py
@@ -328,6 +328,54 @@ def test_aggregator_emits_implementation_plan_section(render_mod, tmp_path) -> N
     assert pending_pos < active_pos < completed_pos
 
 
+def test_aggregator_preserves_epic_and_story_acceptance(render_mod, tmp_path) -> None:
+    """Lifecycle rendering must show broad epic acceptance and story item acceptance."""
+    vbrief_dir = tmp_path / "vbrief"
+    spec_path = _write_spec(vbrief_dir, {"Overview": "Acceptance visibility."})
+    _write_scope(
+        vbrief_dir / "pending",
+        "2026-05-12-ip001-auth.vbrief.json",
+        _scope(
+            "IP-1: Auth epic",
+            "pending",
+            {
+                "Description": "Broad auth phase.",
+                "Acceptance": "Parent acceptance remains visible.",
+                "Traces": "FR-1",
+            },
+            items=[],
+        ),
+    )
+    _write_scope(
+        vbrief_dir / "active",
+        "2026-05-12-auth-story.vbrief.json",
+        _scope(
+            "Auth story",
+            "running",
+            {"Description": "Executable auth story."},
+            items=[
+                {
+                    "id": "story-a",
+                    "title": "Implement login",
+                    "status": "pending",
+                    "narrative": {
+                        "Acceptance": "Login returns a token.",
+                        "Traces": "FR-1",
+                    },
+                }
+            ],
+        ),
+    )
+
+    out = tmp_path / "SPECIFICATION.md"
+    ok, msg = render_mod.render_spec(str(spec_path), str(out))
+    assert ok, msg
+    content = out.read_text(encoding="utf-8")
+    assert "**Scope Acceptance**:" in content
+    assert "Parent acceptance remains visible." in content
+    assert "Login returns a token." in content
+
+
 def test_include_scopes_off_suppresses_aggregator(render_mod, tmp_path) -> None:
     """--include-scopes=off skips the aggregator and preserves pre-#435 output (#435 regression)."""
     vbrief_dir = tmp_path / "vbrief"

--- a/tests/cli/test_spec_render.py
+++ b/tests/cli/test_spec_render.py
@@ -186,7 +186,7 @@ def test_legacy_interview_shape_renders_overview_and_items(render_mod, tmp_path)
             "id": "T1",
             "title": "Do the thing",
             "status": "pending",
-            "narrative": {"Description": "Get it done.", "Acceptance": "A; B"},
+            "narrative": {"Description": "Get it done.", "Acceptance": "- A\n- B"},
         },
         {
             "id": "T2",
@@ -212,6 +212,34 @@ def test_legacy_interview_shape_renders_overview_and_items(render_mod, tmp_path)
     # Acceptance rendered as bullets (pre-existing behavior preserved)
     assert "- A" in content
     assert "- B" in content
+
+
+def test_acceptance_semicolon_text_stays_single_criterion(render_mod, tmp_path) -> None:
+    """A semicolon inside one sentence should not split acceptance bullets."""
+    narratives = {"Overview": "Semicolon regression."}
+    items = [
+        {
+            "id": "T1",
+            "title": "Validate uniqueness",
+            "status": "pending",
+            "narrative": {
+                "Acceptance": "User name must be unique; email must be unique within a tenant"
+            },
+        }
+    ]
+    spec_path = _write_spec(
+        tmp_path / "vbrief", narratives, items=items, title="Semicolon Spec"
+    )
+    out = tmp_path / "SPECIFICATION.md"
+    ok, msg = render_mod.render_spec(str(spec_path), str(out))
+    assert ok, msg
+
+    content = out.read_text(encoding="utf-8")
+    assert (
+        "- User name must be unique; email must be unique within a tenant"
+        in content
+    )
+    assert "- email must be unique within a tenant" not in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -25,6 +25,7 @@ def _story(
     depends_on: list[str] | None = None,
     size: str = "small",
     confidence: str = "high",
+    parallel_safe: bool = True,
 ) -> Path:
     return _write_json(
         project / "vbrief" / "active" / f"2026-05-12-{story_id}.vbrief.json",
@@ -47,7 +48,7 @@ def _story(
                     "kind": "story",
                     "swarm": {
                         "readiness": "ready",
-                        "parallel_safe": True,
+                        "parallel_safe": parallel_safe,
                         "file_scope": [f"src/{story_id}.ts"] if file_scope is None else file_scope,
                         "verify_commands": (
                             [f"npm test -- {story_id}"]
@@ -145,6 +146,18 @@ def test_readiness_rejects_large_parallel_safe_story(tmp_path: Path) -> None:
     assert "size=large cannot be parallel_safe=true" in result.stdout
 
 
+def test_readiness_reports_parallel_safe_false_as_sequential(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-sequential", parallel_safe=False)
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "Sequential stories:" in result.stdout
+    assert "story-sequential" in result.stdout
+    assert "parallel_safe=false: requires sequential allocation" in result.stdout
+    assert "plan.metadata.swarm.parallel_safe=true" not in result.stdout
+
+
 def test_readiness_rejects_low_confidence_parallel_safe_story(tmp_path: Path) -> None:
     story = _story(tmp_path, "story-low-confidence", confidence="low")
 
@@ -152,3 +165,15 @@ def test_readiness_rejects_low_confidence_parallel_safe_story(tmp_path: Path) ->
 
     assert result.returncode == 1
     assert "low-confidence file scope cannot be parallel-safe by default" in result.stdout
+
+
+def test_readiness_cycle_report_excludes_upstream_non_cycle_node(tmp_path: Path) -> None:
+    upstream = _story(tmp_path, "story-upstream", depends_on=["story-cycle-a"])
+    cycle_a = _story(tmp_path, "story-cycle-a", depends_on=["story-cycle-b"])
+    cycle_b = _story(tmp_path, "story-cycle-b", depends_on=["story-cycle-a"])
+
+    result = _run(tmp_path, upstream, cycle_a, cycle_b)
+
+    assert result.returncode == 1
+    assert "dependency cycle: story-cycle-a -> story-cycle-b -> story-cycle-a" in result.stdout
+    assert "dependency cycle: story-upstream" not in result.stdout

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -303,3 +303,11 @@ def test_readiness_cycle_report_excludes_upstream_non_cycle_node(tmp_path: Path)
     assert result.returncode == 1
     assert "dependency cycle: story-cycle-a -> story-cycle-b -> story-cycle-a" in result.stdout
     assert "dependency cycle: story-upstream" not in result.stdout
+    assert (
+        "story-upstream: story-upstream -- dependency 'story-cycle-a' is blocked"
+        in result.stdout
+    )
+    ready_section = result.stdout.split("Ready stories:", 1)[1].split("\n\n", 1)[0]
+    waves_section = result.stdout.split("Dependency waves:", 1)[1].split("\n\n", 1)[0]
+    assert "story-upstream" not in ready_section
+    assert "story-upstream" not in waves_section

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -46,7 +46,16 @@ def _story(
                 "title": story_id,
                 "status": "running",
                 "narratives": {
-                    "Description": f"{story_id} implements a focused product behavior.",
+                    "Description": (
+                        f"{story_id} implements a focused product behavior for the active "
+                        "workflow. The story stays within a narrow code path and includes "
+                        "targeted tests for success and failure behavior."
+                    ),
+                    "ImplementationPlan": (
+                        f"1. Update the {story_id} source path to implement the focused "
+                        "workflow behavior.\n"
+                        f"2. Add targeted tests for {story_id} success and failure outcomes."
+                    ),
                     "Traces": "FR-1",
                     "UserStory": (
                         f"As a product user, I want {story_id} behavior, "
@@ -151,6 +160,18 @@ def test_readiness_fails_missing_required_swarm_metadata(tmp_path: Path) -> None
         (
             lambda data: data["plan"]["narratives"].update({"UserStory": "Build auth."}),
             "UserStory must match",
+        ),
+        (
+            lambda data: data["plan"]["narratives"].update(
+                {"Description": "Implement the behavior."}
+            ),
+            "plan.narratives.Description must contain at least two concrete sentences",
+        ),
+        (
+            lambda data: data["plan"]["narratives"].update(
+                {"ImplementationPlan": "Change the code."}
+            ),
+            "plan.narratives.ImplementationPlan must contain at least two concrete steps",
         ),
         (
             lambda data: data["plan"]["items"][0]["narrative"].update(

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -101,6 +101,32 @@ def test_readiness_fails_missing_acceptance_file_scope_and_verify_commands(tmp_p
     assert "plan.metadata.swarm.verify_commands" in result.stdout
 
 
+def test_readiness_fails_missing_required_swarm_metadata(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-missing-swarm-metadata")
+    data = json.loads(story.read_text(encoding="utf-8"))
+    swarm = data["plan"]["metadata"]["swarm"]
+    for key in (
+        "expected_outputs",
+        "depends_on",
+        "conflict_group",
+        "size",
+        "file_scope_confidence",
+        "model_tier",
+    ):
+        del swarm[key]
+    story.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "plan.metadata.swarm.expected_outputs" in result.stdout
+    assert "plan.metadata.swarm.depends_on" in result.stdout
+    assert "plan.metadata.swarm.conflict_group" in result.stdout
+    assert "plan.metadata.swarm.size" in result.stdout
+    assert "plan.metadata.swarm.file_scope_confidence" in result.stdout
+    assert "plan.metadata.swarm.model_tier" in result.stdout
+
+
 def test_readiness_reports_epic_phase_as_decomposition_needed(tmp_path: Path) -> None:
     phase = _write_json(
         tmp_path / "vbrief" / "active" / "2026-05-12-ip001-auth.vbrief.json",

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "swarm_readiness.py"
 
@@ -21,12 +23,20 @@ def _story(
     *,
     file_scope: list[str] | None = None,
     verify_commands: list[str] | None = None,
-    acceptance: str = "Story acceptance passes",
+    acceptance: str | list[str] | None = None,
     depends_on: list[str] | None = None,
     size: str = "small",
     confidence: str = "high",
     parallel_safe: bool = True,
 ) -> Path:
+    acceptance_values = (
+        [
+            f"Given {story_id} input, when the story runs, then it returns a scoped result.",
+            f"Given {story_id} failure input, when the story runs, then it rejects the request.",
+        ]
+        if acceptance is None
+        else ([acceptance] if isinstance(acceptance, str) else acceptance)
+    )
     return _write_json(
         project / "vbrief" / "active" / f"2026-05-12-{story_id}.vbrief.json",
         {
@@ -35,14 +45,22 @@ def _story(
                 "id": story_id,
                 "title": story_id,
                 "status": "running",
-                "narratives": {"Traces": "FR-1"},
+                "narratives": {
+                    "Description": f"{story_id} implements a focused product behavior.",
+                    "Traces": "FR-1",
+                    "UserStory": (
+                        f"As a product user, I want {story_id} behavior, "
+                        "so that I can complete the workflow."
+                    ),
+                },
                 "items": [
                     {
-                        "id": f"{story_id}-a1",
-                        "title": "Acceptance item",
+                        "id": f"{story_id}-a{index}",
+                        "title": f"Acceptance item {index}",
                         "status": "pending",
-                        "narrative": {"Acceptance": acceptance, "Traces": "FR-1"},
+                        "narrative": {"Acceptance": criterion, "Traces": "FR-1"},
                     }
+                    for index, criterion in enumerate(acceptance_values, start=1)
                 ],
                 "metadata": {
                     "kind": "story",
@@ -127,6 +145,49 @@ def test_readiness_fails_missing_required_swarm_metadata(tmp_path: Path) -> None
     assert "plan.metadata.swarm.model_tier" in result.stdout
 
 
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        (
+            lambda data: data["plan"]["narratives"].update({"UserStory": "Build auth."}),
+            "UserStory must match",
+        ),
+        (
+            lambda data: data["plan"]["items"][0]["narrative"].update(
+                {"Acceptance": "to refine from parent scope"}
+            ),
+            "placeholder acceptance criterion",
+        ),
+        (
+            lambda data: data["plan"]["items"][0]["narrative"].update(
+                {"Acceptance": data["plan"]["title"]}
+            ),
+            "acceptance criterion duplicates title or description",
+        ),
+        (
+            lambda data: data["plan"]["metadata"]["swarm"].update({"file_scope": ["frontend/**"]}),
+            "broad file_scope is not swarm-ready",
+        ),
+        (
+            lambda data: data["plan"]["metadata"]["swarm"].update(
+                {"verify_commands": ["task check"]}
+            ),
+            "generic verify command is not swarm-ready",
+        ),
+    ],
+)
+def test_readiness_rejects_low_quality_ready_story(tmp_path: Path, mutate, expected: str) -> None:
+    story = _story(tmp_path, "story-low-quality")
+    data = json.loads(story.read_text(encoding="utf-8"))
+    mutate(data)
+    story.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert expected in result.stdout
+
+
 def test_readiness_reports_epic_phase_as_decomposition_needed(tmp_path: Path) -> None:
     phase = _write_json(
         tmp_path / "vbrief" / "active" / "2026-05-12-ip001-auth.vbrief.json",
@@ -172,16 +233,16 @@ def test_readiness_rejects_large_parallel_safe_story(tmp_path: Path) -> None:
     assert "size=large cannot be parallel_safe=true" in result.stdout
 
 
-def test_readiness_reports_parallel_safe_false_as_sequential(tmp_path: Path) -> None:
+def test_readiness_rejects_ready_parallel_safe_false_story(tmp_path: Path) -> None:
     story = _story(tmp_path, "story-sequential", parallel_safe=False)
 
     result = _run(tmp_path, story)
 
     assert result.returncode == 1
-    assert "Sequential stories:" in result.stdout
+    assert "Blocked stories:" in result.stdout
     assert "story-sequential" in result.stdout
-    assert "parallel_safe=false: requires sequential allocation" in result.stdout
-    assert "plan.metadata.swarm.parallel_safe=true" not in result.stdout
+    assert "readiness=ready requires parallel_safe=true" in result.stdout
+    assert "Sequential stories:" not in result.stdout
 
 
 def test_readiness_rejects_low_confidence_parallel_safe_story(tmp_path: Path) -> None:
@@ -190,7 +251,7 @@ def test_readiness_rejects_low_confidence_parallel_safe_story(tmp_path: Path) ->
     result = _run(tmp_path, story)
 
     assert result.returncode == 1
-    assert "low-confidence file scope cannot be parallel-safe by default" in result.stdout
+    assert "readiness=ready requires file_scope_confidence above low" in result.stdout
 
 
 def test_readiness_cycle_report_excludes_upstream_non_cycle_node(tmp_path: Path) -> None:

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "swarm_readiness.py"
+
+
+def _write_json(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _story(
+    project: Path,
+    story_id: str,
+    *,
+    file_scope: list[str] | None = None,
+    verify_commands: list[str] | None = None,
+    acceptance: str = "Story acceptance passes",
+    depends_on: list[str] | None = None,
+    size: str = "small",
+    confidence: str = "high",
+) -> Path:
+    return _write_json(
+        project / "vbrief" / "active" / f"2026-05-12-{story_id}.vbrief.json",
+        {
+            "vBRIEFInfo": {"version": "0.6"},
+            "plan": {
+                "id": story_id,
+                "title": story_id,
+                "status": "running",
+                "narratives": {"Traces": "FR-1"},
+                "items": [
+                    {
+                        "id": f"{story_id}-a1",
+                        "title": "Acceptance item",
+                        "status": "pending",
+                        "narrative": {"Acceptance": acceptance, "Traces": "FR-1"},
+                    }
+                ],
+                "metadata": {
+                    "kind": "story",
+                    "swarm": {
+                        "readiness": "ready",
+                        "parallel_safe": True,
+                        "file_scope": [f"src/{story_id}.ts"] if file_scope is None else file_scope,
+                        "verify_commands": (
+                            [f"npm test -- {story_id}"]
+                            if verify_commands is None
+                            else verify_commands
+                        ),
+                        "expected_outputs": ["focused tests pass"],
+                        "depends_on": depends_on or [],
+                        "conflict_group": "auth",
+                        "size": size,
+                        "file_scope_confidence": confidence,
+                        "model_tier": "medium",
+                    },
+                },
+            },
+        },
+    )
+
+
+def _run(project: Path, *paths: Path) -> subprocess.CompletedProcess[str]:
+    args = [str(path.relative_to(project)) for path in paths]
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args, "--project-root", str(project)],
+        cwd=project,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_readiness_passes_for_ready_story(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-ready")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Ready stories:" in result.stdout
+    assert "story-ready" in result.stdout
+    assert "Blocked stories:\n- none" in result.stdout
+
+
+def test_readiness_fails_missing_acceptance_file_scope_and_verify_commands(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-missing", file_scope=[], verify_commands=[], acceptance="")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "plan.items[].narrative.Acceptance" in result.stdout
+    assert "plan.metadata.swarm.file_scope" in result.stdout
+    assert "plan.metadata.swarm.verify_commands" in result.stdout
+
+
+def test_readiness_reports_epic_phase_as_decomposition_needed(tmp_path: Path) -> None:
+    phase = _write_json(
+        tmp_path / "vbrief" / "active" / "2026-05-12-ip001-auth.vbrief.json",
+        {
+            "vBRIEFInfo": {"version": "0.6"},
+            "plan": {
+                "id": "ip-1",
+                "title": "IP-1: Auth",
+                "status": "running",
+                "narratives": {"Acceptance": "Broad epic acceptance", "Traces": "FR-1"},
+                "items": [],
+                "metadata": {"kind": "phase"},
+            },
+        },
+    )
+
+    result = _run(tmp_path, phase)
+
+    assert result.returncode == 1
+    assert "Decomposition-needed epics/phases:" in result.stdout
+    assert "kind=phase" in result.stdout
+
+
+def test_readiness_detects_unsafe_file_overlap(tmp_path: Path) -> None:
+    left = _story(tmp_path, "story-left", file_scope=["src/shared.ts"])
+    right = _story(tmp_path, "story-right", file_scope=["src/shared.ts"])
+
+    result = _run(tmp_path, left, right)
+
+    assert result.returncode == 1
+    assert "File overlap matrix:" in result.stdout
+    assert "src/shared.ts" in result.stdout
+    assert "story-left" in result.stdout
+    assert "story-right" in result.stdout
+
+
+def test_readiness_rejects_large_parallel_safe_story(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-large", size="large")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "size=large cannot be parallel_safe=true" in result.stdout
+
+
+def test_readiness_rejects_low_confidence_parallel_safe_story(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-low-confidence", confidence="low")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "low-confidence file scope cannot be parallel-safe by default" in result.stdout

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -187,6 +187,17 @@ def test_readiness_requires_explicit_story_kind(tmp_path: Path) -> None:
             "plan.narratives.ImplementationPlan must contain at least two concrete steps",
         ),
         (
+            lambda data: data["plan"]["narratives"].update(
+                {
+                    "ImplementationPlan": (
+                        "1. Update the code so the feature is implemented in the application.\n"
+                        "2. Add tests so it works as expected for users."
+                    )
+                }
+            ),
+            "plan.narratives.ImplementationPlan must identify concrete code paths",
+        ),
+        (
             lambda data: data["plan"]["items"][0]["narrative"].update(
                 {"Acceptance": "to refine from parent scope"}
             ),
@@ -199,7 +210,17 @@ def test_readiness_requires_explicit_story_kind(tmp_path: Path) -> None:
             "acceptance criterion duplicates title or description",
         ),
         (
+            lambda data: data["plan"]["items"][0]["narrative"].update(
+                {"Acceptance": "The system displays a message"}
+            ),
+            "acceptance criterion must describe specific observable behavior",
+        ),
+        (
             lambda data: data["plan"]["metadata"]["swarm"].update({"file_scope": ["frontend/**"]}),
+            "broad file_scope is not swarm-ready",
+        ),
+        (
+            lambda data: data["plan"]["metadata"]["swarm"].update({"file_scope": ["src/*.ts"]}),
             "broad file_scope is not swarm-ready",
         ),
         (
@@ -220,6 +241,18 @@ def test_readiness_rejects_low_quality_ready_story(tmp_path: Path, mutate, expec
 
     assert result.returncode == 1
     assert expected in result.stdout
+
+
+def test_readiness_rejects_deprecated_subitems_in_story_items(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-subitems")
+    data = json.loads(story.read_text(encoding="utf-8"))
+    data["plan"]["items"][0]["subItems"] = []
+    story.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "subItems is deprecated; use items" in result.stdout
 
 
 def test_readiness_reports_epic_phase_as_decomposition_needed(tmp_path: Path) -> None:

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -28,6 +28,7 @@ def _story(
     size: str = "small",
     confidence: str = "high",
     parallel_safe: bool = True,
+    readiness: str = "ready",
 ) -> Path:
     acceptance_values = (
         [
@@ -74,7 +75,7 @@ def _story(
                 "metadata": {
                     "kind": "story",
                     "swarm": {
-                        "readiness": "ready",
+                        "readiness": readiness,
                         "parallel_safe": parallel_safe,
                         "file_scope": [f"src/{story_id}.ts"] if file_scope is None else file_scope,
                         "verify_commands": (
@@ -264,6 +265,23 @@ def test_readiness_rejects_ready_parallel_safe_false_story(tmp_path: Path) -> No
     assert "story-sequential" in result.stdout
     assert "readiness=ready requires parallel_safe=true" in result.stdout
     assert "Sequential stories:" not in result.stdout
+
+
+def test_readiness_does_not_apply_ready_only_checks_to_sequential_story(
+    tmp_path: Path,
+) -> None:
+    story = _story(
+        tmp_path,
+        "story-sequential",
+        parallel_safe=False,
+        readiness="sequential",
+    )
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "plan.metadata.swarm.readiness=ready for concurrent allocation" in result.stdout
+    assert "readiness=ready requires parallel_safe=true" not in result.stdout
 
 
 def test_readiness_rejects_low_confidence_parallel_safe_story(tmp_path: Path) -> None:

--- a/tests/cli/test_swarm_readiness.py
+++ b/tests/cli/test_swarm_readiness.py
@@ -155,6 +155,18 @@ def test_readiness_fails_missing_required_swarm_metadata(tmp_path: Path) -> None
     assert "plan.metadata.swarm.model_tier" in result.stdout
 
 
+def test_readiness_requires_explicit_story_kind(tmp_path: Path) -> None:
+    story = _story(tmp_path, "story-missing-kind")
+    data = json.loads(story.read_text(encoding="utf-8"))
+    del data["plan"]["metadata"]["kind"]
+    story.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = _run(tmp_path, story)
+
+    assert result.returncode == 1
+    assert "plan.metadata.kind=story" in result.stdout
+
+
 @pytest.mark.parametrize(
     ("mutate", "expected"),
     [

--- a/tests/content/test_decomposition_readiness.py
+++ b/tests/content/test_decomposition_readiness.py
@@ -15,6 +15,7 @@ def test_speckit_documents_phase_45() -> None:
     assert "task scope:decompose" in text
     assert "task swarm:readiness" in text
     assert "plan.metadata.swarm" in text
+    assert "Parent `plan.items` are input signals, not automatic child stories" in text
 
 
 def test_vbrief_documents_epic_phase_story_swarm_semantics() -> None:
@@ -28,6 +29,9 @@ def test_vbrief_documents_epic_phase_story_swarm_semantics() -> None:
         "TrustLevel: internal",
         "parallel_safe",
         "file_scope_confidence",
+        "As a <role>, I want <capability>, so that <outcome>.",
+        "2-5 concrete acceptance criteria",
+        "readiness = \"sequential\"",
     ):
         assert token in text
 
@@ -46,6 +50,10 @@ def test_decompose_skill_exists_and_uses_deterministic_commands() -> None:
     assert "task swarm:readiness" in text
     assert "explicit approval" in text
     assert "Leave lifecycle promotion/activation to the existing approved flow" in text
+    assert "parent `plan.items` as input signals only" in text
+    assert "As a <role>, I want <capability>, so that <outcome>." in text
+    assert "2-5 concrete acceptance criteria" in text
+    assert "to refine from parent scope" in text
 
 
 def test_make_spec_no_longer_teaches_stale_planitem_patterns() -> None:

--- a/tests/content/test_decomposition_readiness.py
+++ b/tests/content/test_decomposition_readiness.py
@@ -16,6 +16,7 @@ def test_speckit_documents_phase_45() -> None:
     assert "task swarm:readiness" in text
     assert "plan.metadata.swarm" in text
     assert "Parent `plan.items` are input signals, not automatic child stories" in text
+    assert "plan.narratives.ImplementationPlan" in text
 
 
 def test_vbrief_documents_epic_phase_story_swarm_semantics() -> None:
@@ -27,6 +28,8 @@ def test_vbrief_documents_epic_phase_story_swarm_semantics() -> None:
         "plan.metadata.swarm",
         "Story vBRIEFs are the only valid inputs for concurrent swarm worker allocation.",
         "TrustLevel: internal",
+        "plan.narratives.Description",
+        "plan.narratives.ImplementationPlan",
         "parallel_safe",
         "file_scope_confidence",
         "As a <role>, I want <capability>, so that <outcome>.",
@@ -52,6 +55,7 @@ def test_decompose_skill_exists_and_uses_deterministic_commands() -> None:
     assert "Leave lifecycle promotion/activation to the existing approved flow" in text
     assert "parent `plan.items` as input signals only" in text
     assert "As a <role>, I want <capability>, so that <outcome>." in text
+    assert "ImplementationPlan" in text
     assert "2-5 concrete acceptance criteria" in text
     assert "to refine from parent scope" in text
 

--- a/tests/content/test_decomposition_readiness.py
+++ b/tests/content/test_decomposition_readiness.py
@@ -51,6 +51,8 @@ def test_decompose_skill_exists_and_uses_deterministic_commands() -> None:
     text = _read("skills/deft-directive-decompose/SKILL.md")
     assert "task scope:decompose" in text
     assert "task swarm:readiness" in text
+    assert "task swarm:readiness -- vbrief/pending/<child-story-1>.vbrief.json" in text
+    assert "task swarm:readiness -- vbrief/active/*.vbrief.json" not in text
     assert "explicit approval" in text
     assert "Leave lifecycle promotion/activation to the existing approved flow" in text
     assert "parent `plan.items` as input signals only" in text

--- a/tests/content/test_decomposition_readiness.py
+++ b/tests/content/test_decomposition_readiness.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_speckit_documents_phase_45() -> None:
+    text = _read("strategies/speckit.md")
+    assert "## Phase 4.5: Story Decomposition / Swarm Readiness" in text
+    assert "task scope:decompose" in text
+    assert "task swarm:readiness" in text
+    assert "plan.metadata.swarm" in text
+
+
+def test_vbrief_documents_epic_phase_story_swarm_semantics() -> None:
+    text = _read("vbrief/vbrief.md")
+    for token in (
+        'kind = "epic"',
+        'kind = "phase"',
+        'kind = "story"',
+        "plan.metadata.swarm",
+        "Story vBRIEFs are the only valid inputs for concurrent swarm worker allocation.",
+        "TrustLevel: internal",
+        "parallel_safe",
+        "file_scope_confidence",
+    ):
+        assert token in text
+
+
+def test_swarm_skill_requires_readiness_before_allocation() -> None:
+    text = _read("skills/deft-directive-swarm/SKILL.md")
+    assert "task swarm:readiness -- vbrief/active/*.vbrief.json" in text
+    assert "needs decomposition" in text
+    assert "Allocate concurrent workers unless candidates are swarm-ready" in text
+    assert "skills/deft-directive-decompose/SKILL.md" in text
+
+
+def test_decompose_skill_exists_and_uses_deterministic_commands() -> None:
+    text = _read("skills/deft-directive-decompose/SKILL.md")
+    assert "task scope:decompose" in text
+    assert "task swarm:readiness" in text
+    assert "explicit approval" in text
+    assert "Leave lifecycle promotion/activation to the existing approved flow" in text
+
+
+def test_make_spec_no_longer_teaches_stale_planitem_patterns() -> None:
+    text = _read("templates/make-spec.md")
+    assert 'vBRIEFInfo": { "version": "0.6" }' in text
+    assert "Nested children within a PlanItem MUST use `items`" in text
+    assert "Use deprecated `subItems` for new content" in text
+    assert '"subItems"' not in text
+    assert "rendered PRD export" in text
+    assert "rendered PRD/SPEC files are exports" in text

--- a/tests/content/test_speckit_phase4.py
+++ b/tests/content/test_speckit_phase4.py
@@ -1,7 +1,8 @@
 """test_speckit_phase4.py -- Content tests for #436.
 
 Verifies:
-- strategies/speckit.md Phase 4 emits scope vBRIEFs per implementation phase
+- strategies/speckit.md Phase 4 emits phase/epic scope vBRIEFs per implementation phase
+- strategies/speckit.md Phase 4.5 emits swarm-ready story vBRIEFs
 - Artifacts Summary includes 3c PRD render row and Phase 4 pending/ entry
 - plan.vbrief.json is documented as session-todo only (not project plan)
 - vbrief/vbrief.md documents the ip<NNN> 3-digit padded filename convention,
@@ -28,9 +29,12 @@ class TestSpeckitPhase4Emission:
     _text = _read("strategies/speckit.md")
 
     def test_phase_4_heading_updated(self) -> None:
-        assert "## Phase 4: Tasks (Scope vBRIEF Emission)" in self._text, (
-            "speckit Phase 4 heading must announce scope vBRIEF emission (#436)"
+        assert "## Phase 4: Implementation Phase / Epic Scope Emission" in self._text, (
+            "speckit Phase 4 heading must announce phase/epic scope emission"
         )
+
+    def test_phase_45_heading_present(self) -> None:
+        assert "## Phase 4.5: Story Decomposition / Swarm Readiness" in self._text
 
     def test_phase_4_writes_to_pending_folder(self) -> None:
         assert "./vbrief/pending/" in self._text, (
@@ -60,6 +64,20 @@ class TestSpeckitPhase4Emission:
             "plan.metadata.dependencies (#436)"
         )
 
+    def test_phase_4_marks_kind_phase_or_epic(self) -> None:
+        assert 'plan.metadata.kind = "phase"' in self._text
+        assert '"epic"' in self._text
+
+    def test_phase_45_requires_story_swarm_metadata(self) -> None:
+        for token in (
+            'plan.metadata.kind = "story"',
+            "non-empty `plan.items`",
+            "plan.metadata.swarm.file_scope",
+            "plan.metadata.swarm.verify_commands",
+            "planRef",
+        ):
+            assert token in self._text
+
     def test_phase_4_plan_vbrief_is_session_todo(self) -> None:
         assert "session-todo role" in self._text, (
             "speckit.md must describe plan.vbrief.json as the session-todo role (#436)"
@@ -83,6 +101,9 @@ class TestSpeckitPhase4Emission:
         assert "`./vbrief/pending/YYYY-MM-DD-ip<NNN>-<slug>.vbrief.json`" in self._text, (
             "Artifacts Summary must show Phase 4 -> pending scope vBRIEF path (#436)"
         )
+
+    def test_artifacts_summary_includes_phase_45(self) -> None:
+        assert "4.5. Story decomposition" in self._text
 
     def test_migrator_flag_documented(self) -> None:
         assert "--speckit-plan" in self._text, (

--- a/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
+++ b/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
@@ -38,7 +38,7 @@
         "title": "Update skills, renderers, templates, and stale Speckit examples",
         "status": "completed",
         "narrative": {
-          "Acceptance": "Swarm Phase 0 uses readiness reports; Speckit/template examples use v0.6, uri references, and PlanItem items; spec_render preserves epic and story acceptance.",
+          "Acceptance": "skills/deft-directive-swarm/SKILL.md requires readiness reports before allocation; strategies/speckit.md and templates/make-spec.md use v0.6, uri references, and PlanItem items; tests/cli/test_spec_render.py covers epic and story acceptance rendering.",
           "Traces": "user-request"
         }
       },

--- a/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
+++ b/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
@@ -1,0 +1,96 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF for Directive story decomposition and swarm readiness.",
+    "created": "2026-05-12T00:00:00Z"
+  },
+  "plan": {
+    "id": "directive-decomposition-readiness",
+    "title": "Directive story decomposition and swarm readiness",
+    "status": "completed",
+    "narratives": {
+      "Problem": "Directive needs a first-class bridge from Speckit Phase 4 phase/epic scope output to story-level vBRIEFs that can be safely assigned to concurrent swarm workers.",
+      "Overview": "Add Phase 4.5 Story Decomposition / Swarm Readiness, deterministic decomposition and readiness commands, a canonical story metadata contract, skill updates, renderer acceptance preservation, and tests.",
+      "Constraint": "Keep schema compatibility by using plan.metadata.kind and plan.metadata.swarm. Do not make this Appcellerator-specific. Do not allow swarm allocation from broad phase/epic scopes unless explicitly handled as a non-concurrent single-story scope.",
+      "Test": "Focused checks passed for decomposition, readiness, rendering, content contracts, and Speckit translation. Full task check passed: 4971 passed, 5 skipped, 8 deselected, 1 xfailed."
+    },
+    "items": [
+      {
+        "id": "phase-45-docs",
+        "title": "Document Phase 4.5 and vBRIEF story contract",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "strategies/speckit.md and vbrief/vbrief.md define phase/epic/story semantics and required swarm-ready story fields.",
+          "Traces": "user-request"
+        }
+      },
+      {
+        "id": "deterministic-commands",
+        "title": "Add scope:decompose and swarm:readiness commands",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Taskfile exposes deterministic decomposition and readiness commands backed by tested Python scripts.",
+          "Traces": "user-request"
+        }
+      },
+      {
+        "id": "skill-render-template-updates",
+        "title": "Update skills, renderers, templates, and stale Speckit examples",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Swarm Phase 0 uses readiness reports; Speckit/template examples use v0.6, uri references, and PlanItem items; spec_render preserves epic and story acceptance.",
+          "Traces": "user-request"
+        }
+      },
+      {
+        "id": "verification",
+        "title": "Add tests and run PR readiness gates",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Content, CLI, translator, renderer, and end-to-end fixture tests pass; task check is run before declaring PR readiness.",
+          "Traces": "user-request"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "blocked",
+        "parallel_safe": false,
+        "file_scope": [
+          "strategies/speckit.md",
+          "vbrief/vbrief.md",
+          "scripts/scope_decompose.py",
+          "scripts/swarm_readiness.py",
+          "skills/deft-directive-swarm/SKILL.md",
+          "skills/deft-directive-decompose/SKILL.md",
+          "tests/cli/test_scope_decompose.py",
+          "tests/cli/test_swarm_readiness.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_scope_decompose.py tests/cli/test_swarm_readiness.py tests/cli/test_spec_render.py tests/content/test_decomposition_readiness.py tests/content/test_speckit_phase4.py tests/cli/test_migrate_vbrief.py -q",
+          "task check"
+        ],
+        "expected_outputs": [
+          "focused pytest suite passes",
+          "full task check status recorded"
+        ],
+        "depends_on": [],
+        "conflict_group": "directive-lifecycle",
+        "size": "large",
+        "file_scope_confidence": "medium",
+        "model_tier": "high",
+        "missing_traces_justification": "User-provided change request in this conversation is the source scope; no external issue was supplied."
+      }
+    },
+    "references": [
+      {
+        "uri": "urn:deft:user-request:2026-05-12-directive-decomposition-readiness",
+        "type": "x-vbrief/user-request",
+        "title": "User request: implement Directive decomposition/readiness layer",
+        "TrustLevel": "internal"
+      }
+    ],
+    "updated": "2026-05-12T18:50:52Z"
+  }
+}

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -228,7 +228,7 @@ For `kind = "story"` and `swarm.readiness = "ready"`:
 - ⊗ Use `swarm.readiness = "ready"` with `parallel_safe: false`; use `readiness: "sequential"` or `readiness: "needs_refinement"` for non-concurrent work
 - ⊗ Set `parallel_safe: true` on a `size: "large"` story
 - ⊗ Use `swarm.readiness = "ready"` with `file_scope_confidence: "low"`
-- ⊗ Use placeholder acceptance such as "to refine from parent scope", criteria identical to the title/description, vague docs-only acceptance, broad file globs such as `backend/**`, `frontend/**`, `docs/**`, `vbrief/**`, or generic verification such as only `task check`
+- ⊗ Use placeholder acceptance such as "to refine from parent scope", criteria identical to the title/description, vague docs-only acceptance, broad file globs such as `backend/**`, `frontend/**`, `docs/**`, `vbrief/**`, or generic verification such as only `task check`.
 
 Sequential-safe work MAY use `swarm.readiness = "sequential"` and refinement work MAY use `swarm.readiness = "needs_refinement"`, but `task swarm:readiness` fails non-zero for both because neither state is eligible for concurrent worker allocation.
 

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -184,6 +184,9 @@ Swarm-ready story metadata lives under `plan.metadata.swarm` so the v0.6 schema 
 ```json
 {
   "plan": {
+    "narratives": {
+      "UserStory": "As a user, I want focused behavior, so that I can complete a workflow."
+    },
     "metadata": {
       "kind": "story",
       "swarm": {
@@ -205,18 +208,25 @@ Swarm-ready story metadata lives under `plan.metadata.swarm` so the v0.6 schema 
 
 For `kind = "story"` and `swarm.readiness = "ready"`:
 
+- ! `ready` means ready for concurrent swarm allocation, not merely ready for sequential work
+- ! `plan.narratives.UserStory` MUST use `As a <role>, I want <capability>, so that <outcome>.`
 - ! `plan.items` MUST be non-empty
 - ! executable acceptance MUST live in `plan.items[].narrative.Acceptance`
+- ! ready stories MUST carry 2-5 concrete acceptance criteria unless `swarm.acceptance_criteria_justification` explains the exception
+- ! acceptance MUST describe observable behavior, preferably Given/When/Then or equivalent testable behavior
 - ! dependency IDs MUST live in `plan.metadata.swarm.depends_on`
 - ! `file_scope` MUST be non-empty
 - ! `verify_commands` MUST be non-empty
-- ! `expected_outputs` SHOULD describe the evidence the worker is expected to produce
+- ! `expected_outputs` MUST describe the evidence the worker is expected to produce
 - ! traces MUST exist through item/story `Traces`, `x-vbrief/spec-section` references, or an explicit `missing_traces_justification`
 - ! `planRef` MUST point to the parent phase/epic when the story was decomposed from one
 - ! parent phase/epic `references` MUST include child story paths with `type: x-vbrief/plan` and `TrustLevel: internal`
-- ~ `parallel_safe: false` is a valid explicit declaration for sequential-only work, but it is not ready for concurrent swarm allocation
+- ⊗ Use `swarm.readiness = "ready"` with `parallel_safe: false`; use `readiness: "sequential"` or `readiness: "needs_refinement"` for non-concurrent work
 - ⊗ Set `parallel_safe: true` on a `size: "large"` story
-- ⊗ Treat `file_scope_confidence: "low"` as parallel-safe by default
+- ⊗ Use `swarm.readiness = "ready"` with `file_scope_confidence: "low"`
+- ⊗ Use placeholder acceptance such as "to refine from parent scope", criteria identical to the title/description, vague docs-only acceptance, broad file globs such as `backend/**`, `frontend/**`, `docs/**`, `vbrief/**`, or generic verification such as only `task check`
+
+Sequential-safe work MAY use `swarm.readiness = "sequential"` and refinement work MAY use `swarm.readiness = "needs_refinement"`, but `task swarm:readiness` fails non-zero for both because neither state is eligible for concurrent worker allocation.
 
 **Epic → Stories** (via `references`):
 ```json

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -214,6 +214,7 @@ For `kind = "story"` and `swarm.readiness = "ready"`:
 - ! traces MUST exist through item/story `Traces`, `x-vbrief/spec-section` references, or an explicit `missing_traces_justification`
 - ! `planRef` MUST point to the parent phase/epic when the story was decomposed from one
 - ! parent phase/epic `references` MUST include child story paths with `type: x-vbrief/plan` and `TrustLevel: internal`
+- ~ `parallel_safe: false` is a valid explicit declaration for sequential-only work, but it is not ready for concurrent swarm allocation
 - ⊗ Set `parallel_safe: true` on a `size: "large"` story
 - ⊗ Treat `file_scope_confidence: "low"` as parallel-safe by default
 

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -185,6 +185,8 @@ Swarm-ready story metadata lives under `plan.metadata.swarm` so the v0.6 schema 
 {
   "plan": {
     "narratives": {
+      "Description": "This story delivers one focused behavior inside a narrow product workflow. It identifies the implementation boundary and the evidence needed for an independent agent build.",
+      "ImplementationPlan": "1. Update the focused source path and any directly owned test fixture.\n2. Add targeted tests that prove the behavior and capture the expected evidence.",
       "UserStory": "As a user, I want focused behavior, so that I can complete a workflow."
     },
     "metadata": {
@@ -209,6 +211,8 @@ Swarm-ready story metadata lives under `plan.metadata.swarm` so the v0.6 schema 
 For `kind = "story"` and `swarm.readiness = "ready"`:
 
 - ! `ready` means ready for concurrent swarm allocation, not merely ready for sequential work
+- ! `plan.narratives.Description` MUST contain at least two concrete sentences
+- ! `plan.narratives.ImplementationPlan` MUST contain at least two concrete implementation steps
 - ! `plan.narratives.UserStory` MUST use `As a <role>, I want <capability>, so that <outcome>.`
 - ! `plan.items` MUST be non-empty
 - ! executable acceptance MUST live in `plan.items[].narrative.Acceptance`

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -19,6 +19,8 @@ Key `task` commands for working with vBRIEF files:
 - `task issue:ingest -- <N>` / `task issue:ingest -- --all [--label L] [--status S] [--dry-run]` — Ingest GitHub issues as scope vBRIEFs in `vbrief/proposed/` (deduplicates via existing references)
 - `task vbrief:validate` — Validate schema, filenames, folder/status consistency (part of `task check`)
 - `task scope:promote|activate|complete|cancel|restore|block|unblock <file>` — Lifecycle transitions
+- `task scope:decompose -- <parent.vbrief.json> --draft <decomposition.json>` — Apply an approved phase/epic to story decomposition
+- `task swarm:readiness -- vbrief/active/*.vbrief.json` — Report whether candidate stories are safe for concurrent swarm allocation
 
 For interactive creation workflows, use `run` commands (`.deft/core/run bootstrap`, `.deft/core/run spec`). See [commands.md](../commands.md) for the full command lifecycle.
 
@@ -159,9 +161,61 @@ Cross-references: [`../meta/security.md`](../meta/security.md) `### 2. Cognitive
 Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Linking is bidirectional:
 
 - ! All `uri` and `planRef` path values in scope vBRIEF JSON are **relative to the `vbrief/` directory** — not relative to the containing file's location
-- ! Epic `references` array MUST list child story file paths (type: `x-vbrief/plan`)
+- ! Epic `references` array MUST list child story file paths (type: `x-vbrief/plan`, `TrustLevel: internal`)
 - ! Story vBRIEFs MUST carry `planRef` back to their parent epic
 - ~ The decision to create an epic vs. a standalone story is made collaboratively between user and agent
+
+### Scope Kinds and Swarm Semantics
+
+Directive uses `plan.metadata.kind` to distinguish broad planning scopes from executable swarm units:
+
+- `kind = "epic"` or `kind = "phase"` — broad implementation scope. MAY use `plan.narratives.Acceptance` for parent-level acceptance context and MAY have `plan.items: []`.
+- `kind = "story"` — executable implementation unit. MUST use non-empty `plan.items` for executable acceptance.
+
+- ! Story vBRIEFs are the only valid inputs for concurrent swarm worker allocation.
+- ! Epic/phase vBRIEFs MUST be decomposed before swarm allocation unless explicitly marked as a single-story scope.
+- ! Swarm allocation MUST NOT treat broad acceptance in `plan.narratives.Acceptance` as executable story acceptance.
+- ~ Phase 4 speckit output SHOULD use `kind = "phase"` or `kind = "epic"`; Phase 4.5 decomposition emits `kind = "story"` children.
+
+### Swarm-Ready Story Contract
+
+Swarm-ready story metadata lives under `plan.metadata.swarm` so the v0.6 schema remains compatible:
+
+```json
+{
+  "plan": {
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": ["src/foo.ts", "tests/foo.test.ts"],
+        "verify_commands": ["npm test -- foo"],
+        "expected_outputs": ["focused tests pass"],
+        "depends_on": ["story-id"],
+        "conflict_group": "backend-api",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    }
+  }
+}
+```
+
+For `kind = "story"` and `swarm.readiness = "ready"`:
+
+- ! `plan.items` MUST be non-empty
+- ! executable acceptance MUST live in `plan.items[].narrative.Acceptance`
+- ! dependency IDs MUST live in `plan.metadata.swarm.depends_on`
+- ! `file_scope` MUST be non-empty
+- ! `verify_commands` MUST be non-empty
+- ! `expected_outputs` SHOULD describe the evidence the worker is expected to produce
+- ! traces MUST exist through item/story `Traces`, `x-vbrief/spec-section` references, or an explicit `missing_traces_justification`
+- ! `planRef` MUST point to the parent phase/epic when the story was decomposed from one
+- ! parent phase/epic `references` MUST include child story paths with `type: x-vbrief/plan` and `TrustLevel: internal`
+- ⊗ Set `parallel_safe: true` on a `size: "large"` story
+- ⊗ Treat `file_scope_confidence: "low"` as parallel-safe by default
 
 **Epic → Stories** (via `references`):
 ```json
@@ -171,8 +225,8 @@ Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Link
     "title": "Auth system overhaul",
     "status": "running",
     "references": [
-      { "type": "x-vbrief/plan", "uri": "./active/2026-04-12-oauth-flow.vbrief.json" },
-      { "type": "x-vbrief/plan", "uri": "./active/2026-04-12-session-mgmt.vbrief.json" }
+      { "type": "x-vbrief/plan", "uri": "./active/2026-04-12-oauth-flow.vbrief.json", "TrustLevel": "internal" },
+      { "type": "x-vbrief/plan", "uri": "./active/2026-04-12-session-mgmt.vbrief.json", "TrustLevel": "internal" }
     ]
   }
 }
@@ -207,13 +261,15 @@ When a scope grows too large, the parent vBRIEF becomes an epic and children are
 
 1. Agent identifies the scope is too large (collaboratively with user)
 2. Parent vBRIEF promoted to epic
-3. Child story vBRIEFs created with `planRef` back to parent
-4. Parent epic's `references` updated to list all child paths
-5. Update `plan.vbrief.json` (and `continue.vbrief.json` if present) `planRef` to reference child scope vBRIEFs
-6. Acceptance criteria redistributed by agent with user approval
-7. Origin provenance stays on the parent epic; children inherit via epic relationship
+3. Agent drafts a decomposition proposal and gets explicit user approval
+4. `task scope:decompose -- <parent> --draft <draft.json>` creates child story vBRIEFs with `planRef` back to parent
+5. Parent epic's `references` updated to list all child paths
+6. Update `plan.vbrief.json` (and `continue.vbrief.json` if present) `planRef` to reference child scope vBRIEFs
+7. Acceptance criteria redistributed by agent with user approval
+8. Origin provenance stays on the parent epic; children inherit via epic relationship
 
-- ! Scope splitting is agent-driven using existing tools — no dedicated split command
+- ! Scope splitting MUST use an approved draft and `task scope:decompose` for child writes
+- ! Run `task swarm:readiness` after decomposition before concurrent worker allocation
 - ~ Uses existing `scope:*` commands for lifecycle transitions after splitting
 
 ### General Rules

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -137,7 +137,7 @@ Additive extension to the source-provenance shape, sourced from the **AI Agent T
     "TrustLevel": "external"
   },
   {
-    "uri": "./completed/2026-05-12-481-patterns-directory-and-llm-app-standards.vbrief.json",
+    "uri": "completed/2026-05-12-481-patterns-directory-and-llm-app-standards.vbrief.json",
     "type": "x-vbrief/plan",
     "title": "Sibling plan #481",
     "TrustLevel": "internal"
@@ -240,8 +240,8 @@ Sequential-safe work MAY use `swarm.readiness = "sequential"` and refinement wor
     "title": "Auth system overhaul",
     "status": "running",
     "references": [
-      { "type": "x-vbrief/plan", "uri": "./active/2026-04-12-oauth-flow.vbrief.json", "TrustLevel": "internal" },
-      { "type": "x-vbrief/plan", "uri": "./active/2026-04-12-session-mgmt.vbrief.json", "TrustLevel": "internal" }
+      { "type": "x-vbrief/plan", "uri": "active/2026-04-12-oauth-flow.vbrief.json", "TrustLevel": "internal" },
+      { "type": "x-vbrief/plan", "uri": "active/2026-04-12-session-mgmt.vbrief.json", "TrustLevel": "internal" }
     ]
   }
 }
@@ -254,7 +254,7 @@ Sequential-safe work MAY use `swarm.readiness = "sequential"` and refinement wor
   "plan": {
     "title": "Implement OAuth flow",
     "status": "running",
-    "planRef": "./active/2026-04-10-auth-system-overhaul.vbrief.json"
+    "planRef": "active/2026-04-10-auth-system-overhaul.vbrief.json"
   }
 }
 ```
@@ -505,7 +505,7 @@ The synthesized project identity — what this project IS right now. Uses the ca
         "title": "Add OAuth flow",
         "status": "running",
         "references": [
-          { "type": "x-vbrief/plan", "uri": "./active/2026-04-12-add-oauth-flow.vbrief.json" }
+          { "type": "x-vbrief/plan", "uri": "active/2026-04-12-add-oauth-flow.vbrief.json" }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

Adds a first-class Directive story decomposition/readiness layer between Speckit Phase 4 and swarm implementation.

Highlights:
- Documents Phase 4.5 Story Decomposition / Swarm Readiness.
- Adds deterministic `task scope:decompose` and `task swarm:readiness` commands.
- Defines the canonical `plan.metadata.kind` / `plan.metadata.swarm` story contract.
- Updates swarm allocation to require readiness reports before worker dispatch.
- Adds `deft-directive-decompose` skill and fixes Speckit/template v0.6 reference patterns.
- Preserves epic acceptance and story acceptance in spec rendering.
- Rebases onto current `master` and aligns generated in-repo references with the new `TrustLevel` provenance contract.
- Tightens the story-quality contract: product-shaped `UserStory`, concrete observable acceptance, narrow file scope, focused verification, and `ready` meaning concurrent-ready only.
- Requires substantive story plans: each ready story needs concrete `Description` and `ImplementationPlan` narratives, not just structurally complete metadata.
- Addresses review feedback for sequential-only stories, cycle reporting, semicolon acceptance rendering, shared TrustLevel defaulting, shared Speckit translation, required swarm metadata enforcement, blocked dependency propagation, explicit story kind enforcement, parent-shape validation, child provenance filtering, vBRIEF-relative URI/planRef emission, intentional Taskfile CLI arg pass-through, and required swarm Taskfile inclusion.

## Related Issues

N/A - user-requested framework change in this session.

## Checklist

- [x] `/deft:change <name>` - scope vBRIEF created, activated, and completed for this work
- [x] `CHANGELOG.md` - added entry under `[Unreleased]`
- [x] `ROADMAP.md` - N/A, no tracked issue state changed
- [x] Tests pass locally: `task check` -> passed

## Verification

- `uv run ruff check scripts/scope_decompose.py scripts/_vbrief_speckit.py scripts/migrate_vbrief.py tests/cli/test_scope_decompose.py` -> passed
- `uv run pytest tests/cli/test_scope_decompose.py tests/cli/test_migrate_vbrief.py tests/content/test_speckit_phase4.py tests/content/test_decomposition_readiness.py -q` -> 239 passed
- `uv run pytest tests/cli/test_scope_decompose.py tests/cli/test_swarm_readiness.py tests/cli/test_migrate_vbrief.py tests/cli/test_spec_render.py tests/content/test_decomposition_readiness.py tests/content/test_speckit_phase4.py tests/content/test_swarm_skill.py tests/content/test_taskfile_cli_args.py tests/content/test_taskfile_uv_project_pin.py tests/content/test_taskfile_paths.py -q` -> 403 passed, 2 deselected
- `task --list-all | rg "swarm:readiness|scope:decompose"` -> both targets resolve
- `task check` -> passed
- `git diff --check` -> clean

## Post-Merge

- [ ] N/A for issue auto-close; no GitHub issue is linked by this PR body.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
