### PR TITLE
fix(ingest): enrich vBRIEFs from issue body content (#1248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **fix(ingest): `task issue:ingest` enriches vBRIEFs from issue body (#1248)** -- the ingester no longer produces stub-only scope vBRIEFs. `narratives.Overview` continues to carry the issue body verbatim, and `plan.items[]` is now populated from Markdown task-list checkboxes (`- [ ] ...`) or from a numbered / bulleted list under an `Acceptance Criteria` heading. Closing-keyword cross-refs in the body (`Closes #N`, `Refs #N`, `Blocked by #N`) lift into typed `plan.references[]` entries (`x-vbrief/closes`, `x-vbrief/refs`, `x-vbrief/blocks`); code-fenced examples and self-references are skipped. Closes #1248.
 
 ### Removed
 

--- a/scripts/issue_ingest.py
+++ b/scripts/issue_ingest.py
@@ -96,8 +96,234 @@ _STATUS_MAP: dict[str, tuple[str, str]] = {
     "active": ("active", "running"),
 }
 
+# #1248: body-parsing patterns. The ingester previously emitted stub-only
+# vBRIEFs (no ``Overview``, ``plan.items == []``) which forced the
+# refinement workflow to re-read the GitHub issue body by hand. The
+# patterns below extract acceptance-criteria checklists, numbered AC
+# items, and Closes / Refs / Blocked-by cross-references from the issue
+# body so downstream consumers (``deft-directive-refinement``,
+# ``task triage:queue`` dedup) have substantive content to project from.
+
+# GitHub-flavoured Markdown task-list line. Captures the marker (space /
+# x / X) and the trailing title text. The trailing ``$`` anchors against
+# trailing whitespace so a multi-line list item only contributes the
+# first line; deeper nesting / continuation lines are explicitly out of
+# scope for v1 and noted as a follow-up in the issue body.
+_CHECKBOX_RE = re.compile(
+    r"^\s*[-*+]\s+\[([ xX])\]\s+(.+?)\s*$",
+    re.MULTILINE,
+)
+
+# Heading whose text contains "Acceptance Criteria" (case-insensitive).
+# Used as the entry point for the AC-section fallback when the body
+# carries no checkbox-style task list.
+_AC_HEADING_RE = re.compile(
+    r"^(#{1,6})\s+.*\bacceptance\s+criteria\b.*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Bullet- or numbered-list item. Used inside the AC section after the
+# heading match -- both ``- foo`` / ``* foo`` / ``+ foo`` and
+# ``1. foo`` / ``1) foo`` shapes are accepted.
+_LIST_ITEM_RE = re.compile(
+    r"^\s*(?:[-*+]|\d+[.)])\s+(.+?)\s*$",
+    re.MULTILINE,
+)
+
+# Closing / referencing / blocking keyword -> canonical ``x-vbrief/*``
+# reference type. Ordering is significant: ``blocked by`` is matched
+# before ``blocks`` would be (the latter is intentionally absent because
+# ``Blocks #N`` on the source issue has the inverse semantic of the
+# ingested issue being blocked). Patterns are applied against a body
+# stripped of fenced and inline code spans so Markdown examples don't
+# produce spurious cross-refs.
+_CROSS_REF_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "x-vbrief/closes",
+        re.compile(
+            r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "x-vbrief/blocks",
+        re.compile(
+            r"\bblocked[\s\-]+by\s+#(\d+)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "x-vbrief/refs",
+        re.compile(
+            r"\b(?:refs?|references?|see\s+also|related(?:\s+to)?)\s+#(\d+)\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+# Fenced code block (triple-backtick) and inline code span (single
+# backtick, no embedded backtick / newline). Stripped before cross-ref
+# / plan-item extraction so a body that quotes ``Closes #N`` as an
+# illustration does not produce a real cross-ref.
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+
 
 # --- Helpers ----------------------------------------------------------------
+
+
+def _strip_code_blocks(body: str) -> str:
+    """Return ``body`` with Markdown code spans elided (#1248).
+
+    Fenced code blocks (triple-backtick) and inline single-backtick code
+    spans are replaced with the empty string before cross-ref / plan-item
+    extraction. This prevents an issue body that *quotes* ``Closes #N``
+    as a syntax example (the #1248 body is itself an example -- it
+    embeds a JSON block illustrating the stub-only shape) from producing
+    spurious cross-refs or plan-items.
+    """
+    if not body:
+        return ""
+    return _INLINE_CODE_RE.sub("", _CODE_FENCE_RE.sub("", body))
+
+
+def _extract_plan_items(body: str) -> list[dict]:
+    """Extract ``plan.items[]`` entries from a GitHub issue body (#1248).
+
+    Detection ladder:
+
+    1. Markdown task-list checkboxes (``- [ ] foo`` / ``- [x] bar``) --
+       the GitHub-native shape that ``deft-directive-refinement`` and
+       ``task triage:queue`` both project from. Unchecked boxes map to
+       ``status = "proposed"``; checked boxes map to
+       ``status = "completed"`` so an issue that ships partial progress
+       is reflected honestly.
+    2. Bullet- / numbered-list items underneath an ``Acceptance
+       Criteria`` heading -- the second-most-common shape across the
+       2026-05-20 audit cohort. Stops at the next heading at the same
+       or higher level.
+    3. Graceful degradation: when neither shape is present, return an
+       empty list. The vBRIEF still carries ``narratives.Overview`` so
+       refinement can refine *something*; ``plan.items`` is only ever
+       populated when there is structured source material to project
+       from.
+
+    Every emitted item carries the schema-required ``title`` + ``status``
+    keys (``minLength: 1`` on ``title``; ``status`` from the canonical
+    ``Status`` enum). Duplicate titles are de-duped while preserving
+    document order.
+    """
+    if not body:
+        return []
+    text = _strip_code_blocks(body)
+
+    items: list[dict] = []
+    seen: set[str] = set()
+    for match in _CHECKBOX_RE.finditer(text):
+        marker = match.group(1)
+        title_text = match.group(2).strip()
+        if not title_text or title_text in seen:
+            continue
+        seen.add(title_text)
+        status = "completed" if marker.lower() == "x" else "proposed"
+        items.append({"title": title_text, "status": status})
+    if items:
+        return items
+
+    # Fallback: numbered / bulleted list under an Acceptance Criteria heading.
+    return _extract_ac_section_items(text)
+
+
+def _extract_ac_section_items(text: str) -> list[dict]:
+    """Extract list items from an Acceptance Criteria section (#1248 fallback).
+
+    Walks for an ``Acceptance Criteria`` heading (any level 1-6,
+    case-insensitive). When found, slices the body to the section --
+    bounded by the next heading at the same-or-higher level -- and
+    returns each bullet / numbered list item as a PlanItem dict with
+    ``status = "proposed"``.
+    """
+    heading_match = _AC_HEADING_RE.search(text)
+    if not heading_match:
+        return []
+    heading_level = len(heading_match.group(1))
+    section_start = heading_match.end()
+    next_heading_re = re.compile(
+        rf"^#{{1,{heading_level}}}\s+\S",
+        re.MULTILINE,
+    )
+    after = text[section_start:]
+    next_match = next_heading_re.search(after)
+    section_text = after[: next_match.start()] if next_match else after
+
+    items: list[dict] = []
+    seen: set[str] = set()
+    for li in _LIST_ITEM_RE.finditer(section_text):
+        title_text = li.group(1).strip()
+        # Defensive: strip a leftover ``[ ]`` / ``[x]`` checkbox prefix
+        # if a maintainer mixed checkbox + numbered shapes inside the
+        # AC section.
+        cb = re.match(r"\[([ xX])\]\s+(.+)", title_text)
+        if cb:
+            title_text = cb.group(2).strip()
+        if not title_text or title_text in seen:
+            continue
+        seen.add(title_text)
+        items.append({"title": title_text, "status": "proposed"})
+    return items
+
+
+def _extract_cross_refs(
+    body: str,
+    repo_url: str,
+    *,
+    exclude: set[int] | None = None,
+) -> list[dict]:
+    """Extract Closes / Refs / Blocked-by cross-refs from issue body (#1248).
+
+    Returns a list of canonical ``VBriefReference`` dicts (``{uri, type,
+    title}``) ready to append to ``plan.references[]``. Reference types:
+
+    - ``x-vbrief/closes`` for ``Closes / Fixes / Resolves #N`` (inflected
+      forms ``closed`` / ``fixed`` / ``resolved`` accepted).
+    - ``x-vbrief/blocks`` for ``Blocked by #N`` -- the dependency
+      direction the issue body expresses (this scope is blocked by #N).
+    - ``x-vbrief/refs`` for ``Refs / References / See also / Related #N``.
+
+    Skips matches that fall inside fenced or inline code spans (the
+    body is passed through :func:`_strip_code_blocks` first) and any
+    issue number in ``exclude`` -- callers pass the provenance issue
+    number itself so a self-reference (e.g. ``Closes #1248`` in #1248's
+    own body) does not produce a duplicate reference to the canonical
+    ``x-vbrief/github-issue`` origin.
+
+    Returns an empty list when ``repo_url`` is empty -- the canonical
+    ``VBriefReference`` shape requires ``uri``, and synthesising a
+    URL without a repo handle would be dishonest.
+    """
+    if not body or not repo_url:
+        return []
+    text = _strip_code_blocks(body)
+    refs: list[dict] = []
+    seen: set[tuple[str, int]] = set()
+    excluded = exclude or set()
+    for ref_type, pattern in _CROSS_REF_PATTERNS:
+        for match in pattern.finditer(text):
+            number = int(match.group(1))
+            if number in excluded:
+                continue
+            key = (ref_type, number)
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append(
+                {
+                    "uri": f"{repo_url}/issues/{number}",
+                    "type": ref_type,
+                    "title": f"Issue #{number}",
+                }
+            )
+    return refs
 
 
 def _provenance_issue_number(data: dict) -> int | None:
@@ -281,35 +507,56 @@ def _build_issue_vbrief(
     if body_str:
         # #988: carry the issue body verbatim to ``narratives.Overview`` so
         # the swarm Phase 0 "acceptance criteria present" check has source
-        # text to project from. We do NOT parse sections into ``plan.items``
-        # here -- that is explicitly a follow-up per the issue's Non-goals.
+        # text to project from. #1248 widens this surface by ALSO emitting
+        # structured ``plan.items[]`` + ``plan.references[]`` cross-refs
+        # derived from the body, so refinement / triage:queue have more
+        # than just an opaque blob to work with.
         narratives["Overview"] = body_str
     if label_names:
         narratives["Labels"] = ", ".join(label_names)
+
+    # #1248: derive ``plan.items[]`` from the issue body's task-list /
+    # acceptance-criteria checklist (graceful degradation to ``[]`` when
+    # neither shape is present).
+    plan_items = _extract_plan_items(body_str) if body_str else []
 
     plan: dict = {
         "title": title,
         "status": plan_status,
         "narratives": narratives,
-        "items": [],
+        "items": plan_items,
     }
     if label_names:
         # #988: structured-surface mirror of ``narratives.Labels`` so
         # consumers can filter by tag without parsing the freeform string.
         plan["tags"] = list(label_names)
 
-    # #639: canonical v0.6 VBriefReference shape. Only emit when we have a
-    # resolvable URL -- the schema requires ``uri`` and we must not forge
-    # one. Matches ``scripts/_vbrief_build.py::create_scope_vbrief`` and
-    # ``conventions/references.md``.
+    # #639 + #1248: canonical v0.6 VBriefReference shape, with the body-
+    # derived Closes / Refs / Blocked-by cross-refs appended after the
+    # canonical ``x-vbrief/github-issue`` origin. Only emit when we have
+    # a resolvable URL -- the schema requires ``uri`` and we must not
+    # forge one. Matches ``scripts/_vbrief_build.py::create_scope_vbrief``
+    # and ``conventions/references.md``.
     if url:
-        plan["references"] = [
+        references: list[dict] = [
             {
                 "uri": url,
                 "type": "x-vbrief/github-issue",
                 "title": f"Issue #{number}: {title}",
             }
         ]
+        if body_str and repo_url:
+            # Use ``repo_url`` (not ``url``) so cross-refs target sibling
+            # issues under the same repo even when ``url`` already
+            # resolves a specific issue; exclude ``number`` so a
+            # self-referencing ``Closes #N`` in the body does not
+            # duplicate the canonical origin reference above.
+            references.extend(
+                _extract_cross_refs(
+                    body_str, repo_url, exclude={number}
+                )
+            )
+        plan["references"] = references
 
     return {
         "vBRIEFInfo": {

--- a/scripts/issue_ingest.py
+++ b/scripts/issue_ingest.py
@@ -161,11 +161,14 @@ _CROSS_REF_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ),
 )
 
-# Fenced code block (triple-backtick) and inline code span (single
-# backtick, no embedded backtick / newline). Stripped before cross-ref
-# / plan-item extraction so a body that quotes ``Closes #N`` as an
-# illustration does not produce a real cross-ref.
-_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+# Fenced code block (triple-backtick OR tilde-fence) and inline code
+# span (single backtick, no embedded backtick / newline). Stripped
+# before cross-ref / plan-item extraction so a body that quotes
+# ``Closes #N`` as an illustration does not produce a real cross-ref.
+# The capturing group + ``\1`` backreference enforces matching
+# delimiters (a ``~~~`` fence cannot be closed by ``\`\`\``) per the
+# GitHub Flavoured Markdown spec.
+_CODE_FENCE_RE = re.compile(r"(```|~~~).*?\1", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 
 
@@ -262,14 +265,21 @@ def _extract_ac_section_items(text: str) -> list[dict]:
         title_text = li.group(1).strip()
         # Defensive: strip a leftover ``[ ]`` / ``[x]`` checkbox prefix
         # if a maintainer mixed checkbox + numbered shapes inside the
-        # AC section.
+        # AC section. Preserve the checked state so a completed item
+        # in a numbered+checkbox mixed AC list lands as ``completed``
+        # rather than being silently demoted to ``proposed`` (downstream
+        # consumers ``deft-directive-refinement`` / ``task triage:queue``
+        # treat ``status`` as signal for remaining work).
+        status = "proposed"
         cb = re.match(r"\[([ xX])\]\s+(.+)", title_text)
         if cb:
             title_text = cb.group(2).strip()
+            if cb.group(1).lower() == "x":
+                status = "completed"
         if not title_text or title_text in seen:
             continue
         seen.add(title_text)
-        items.append({"title": title_text, "status": "proposed"})
+        items.append({"title": title_text, "status": status})
     return items
 
 

--- a/tests/cli/test_issue_ingest_body_parsing.py
+++ b/tests/cli/test_issue_ingest_body_parsing.py
@@ -1,0 +1,440 @@
+"""test_issue_ingest_body_parsing.py -- Body parsing regression for #1248.
+
+`task issue:ingest` used to emit stub-only scope vBRIEFs (no Overview,
+``plan.items == []``, no cross-refs derived from the body), forcing the
+refinement workflow to re-read the GitHub issue body by hand. The tests
+below pin the four required acceptance criteria from issue #1248:
+
+(a) issue with body + AC checklist -> ``plan.items[]`` populated.
+(b) issue with body but no checklist -> ``plan.items == []`` (graceful
+    degradation); ``narratives.Overview`` still present so refinement
+    has *something* to project from.
+(c) issue with empty body -> no ``Overview``, no ``items``, no body-
+    derived references (canonical ``x-vbrief/github-issue`` origin still
+    present).
+(d) closing-keyword cross-ref extraction -> ``Closes #N`` / ``Refs #N`` /
+    ``Blocked by #N`` land as ``x-vbrief/closes`` / ``x-vbrief/refs`` /
+    ``x-vbrief/blocks`` entries on ``plan.references[]`` alongside the
+    canonical origin reference.
+
+Loaded with the same ``importlib.util`` pattern as the sibling tests
+(``test_issue_ingest.py`` / ``test_issue_ingest_canonical_refs.py``) so
+sibling-module imports (``_vbrief_build``, ``reconcile_issues``) resolve
+without a fresh ``sys.path`` mutation per test.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+
+
+def _load_issue_ingest():
+    """Load ``scripts/issue_ingest.py`` in-process via ``importlib.util``."""
+    scripts_dir = REPO_ROOT / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "issue_ingest_body_parsing",
+        scripts_dir / "issue_ingest.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+issue_ingest = _load_issue_ingest()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _issue(
+    number: int,
+    title: str,
+    *,
+    body: str | None = None,
+    labels: list[str] | None = None,
+) -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://github.com/owner/repo/issues/{number}",
+        "body": body or "",
+        "labels": [{"name": name} for name in (labels or [])],
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) Issue with body + AC checklist -> plan.items[] populated
+# ---------------------------------------------------------------------------
+
+
+class TestBodyWithChecklist:
+    """Checkbox task-list lines become ``plan.items[]`` entries."""
+
+    def test_checkbox_list_becomes_plan_items(self):
+        body = (
+            "## Summary\n"
+            "Add widget support to the dashboard.\n\n"
+            "## Acceptance Criteria\n"
+            "- [ ] Widget renders in the sidebar\n"
+            "- [ ] Widget exposes a click handler\n"
+            "- [x] Spec doc updated\n"
+        )
+        vbrief, folder = issue_ingest._build_issue_vbrief(
+            _issue(500, "Widget support", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        assert folder == "proposed"
+        items = vbrief["plan"]["items"]
+        assert len(items) == 3
+        assert items[0] == {
+            "title": "Widget renders in the sidebar",
+            "status": "proposed",
+        }
+        assert items[1] == {
+            "title": "Widget exposes a click handler",
+            "status": "proposed",
+        }
+        # Checked box maps to ``completed`` so partial progress shows up.
+        assert items[2] == {
+            "title": "Spec doc updated",
+            "status": "completed",
+        }
+        # Overview carries the full body verbatim per #988 / #1248.
+        assert (
+            "Add widget support to the dashboard."
+            in vbrief["plan"]["narratives"]["Overview"]
+        )
+
+    def test_numbered_ac_section_fallback(self):
+        """Numbered list under an ``Acceptance Criteria`` heading lands as items."""
+        body = (
+            "## Overview\n"
+            "Improve the search ranking.\n\n"
+            "## Acceptance criteria\n"
+            "1. Search latency below 200ms p95\n"
+            "2. Result relevance metric improves by 5%\n"
+            "3. Telemetry pinned in dashboards\n\n"
+            "## Out of scope\n"
+            "- Re-training the ranking model\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(501, "Better search ranking", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        items = vbrief["plan"]["items"]
+        titles = [i["title"] for i in items]
+        assert titles == [
+            "Search latency below 200ms p95",
+            "Result relevance metric improves by 5%",
+            "Telemetry pinned in dashboards",
+        ]
+        # The Out-of-scope bullet must NOT leak across the section
+        # boundary into ``plan.items``.
+        assert all("Re-training" not in t for t in titles)
+        for item in items:
+            assert item["status"] == "proposed"
+
+    def test_checkbox_takes_priority_over_ac_section(self):
+        """When both shapes are present, checkbox wins (more specific signal)."""
+        body = (
+            "- [ ] Top-level task A\n"
+            "- [ ] Top-level task B\n\n"
+            "## Acceptance Criteria\n"
+            "1. Different bullet\n"
+            "2. Another bullet\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(502, "Mixed shapes", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        titles = [i["title"] for i in vbrief["plan"]["items"]]
+        assert titles == ["Top-level task A", "Top-level task B"]
+
+
+# ---------------------------------------------------------------------------
+# (b) Issue with body but no checklist -> graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestBodyOnlyNoChecklist:
+    """A body without checkboxes / AC heading degrades to ``items == []``."""
+
+    def test_prose_only_body_yields_empty_items_but_overview_present(self):
+        body = (
+            "## Summary\n"
+            "We saw five users hit a permission error during onboarding.\n"
+            "The error message says `denied by policy` but the user is in\n"
+            "the right group. Investigation needed.\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(600, "Onboarding permission error", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        assert vbrief["plan"]["items"] == []
+        assert vbrief["plan"]["narratives"]["Overview"] == body
+        # Single canonical reference (the github-issue origin).
+        refs = vbrief["plan"]["references"]
+        assert len(refs) == 1
+        assert refs[0]["type"] == "x-vbrief/github-issue"
+
+
+# ---------------------------------------------------------------------------
+# (c) Empty body -> no Overview / no items
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyBody:
+    """An empty / missing body produces no Overview and no items."""
+
+    def test_empty_body_string(self):
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(700, "Empty body", body=""),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        assert "Overview" not in vbrief["plan"]["narratives"]
+        assert vbrief["plan"]["items"] == []
+        refs = vbrief["plan"]["references"]
+        assert len(refs) == 1
+        assert refs[0]["type"] == "x-vbrief/github-issue"
+
+    def test_missing_body_key(self):
+        issue = _issue(701, "No body key at all")
+        issue.pop("body", None)
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            issue,
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        assert "Overview" not in vbrief["plan"]["narratives"]
+        assert vbrief["plan"]["items"] == []
+
+    def test_null_body_field(self):
+        """``gh api`` returns ``"body": null`` for issues opened with no body."""
+        issue = _issue(702, "Null body")
+        issue["body"] = None
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            issue,
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        assert "Overview" not in vbrief["plan"]["narratives"]
+        assert vbrief["plan"]["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# (d) Closing-keyword cross-ref extraction
+# ---------------------------------------------------------------------------
+
+
+class TestCrossRefExtraction:
+    """Closes / Refs / Blocked-by lift into typed ``plan.references[]`` entries."""
+
+    def test_closes_keyword_extracted(self):
+        body = (
+            "## Summary\n"
+            "Fix the off-by-one error in the paginator.\n\n"
+            "Closes #1200\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(800, "Paginator off-by-one", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        refs = vbrief["plan"]["references"]
+        # First ref is the canonical origin; the body-derived close-ref follows.
+        assert refs[0]["type"] == "x-vbrief/github-issue"
+        closes = [r for r in refs if r["type"] == "x-vbrief/closes"]
+        assert len(closes) == 1
+        assert closes[0]["uri"] == "https://github.com/owner/repo/issues/1200"
+        assert closes[0]["title"] == "Issue #1200"
+
+    def test_fixes_resolves_inflections_extracted(self):
+        body = (
+            "Fixes #10. Also resolves #11.\n"
+            "Earlier patch closed #12 (already merged).\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(801, "Inflections", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        closes = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/closes"
+        ]
+        numbers = sorted(int(r["uri"].rsplit("/", 1)[-1]) for r in closes)
+        assert numbers == [10, 11, 12]
+
+    def test_refs_and_related_extracted_as_refs_type(self):
+        body = (
+            "Refs #300.\n"
+            "See also #301.\n"
+            "Related to #302.\n"
+            "References #303.\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(802, "Refs cohort", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        refs_type = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/refs"
+        ]
+        numbers = sorted(int(r["uri"].rsplit("/", 1)[-1]) for r in refs_type)
+        assert numbers == [300, 301, 302, 303]
+
+    def test_blocked_by_extracted_as_blocks_type(self):
+        body = (
+            "## Summary\n"
+            "Add the new dashboard widget.\n\n"
+            "Blocked by #999\n"
+            "Blocked-by #1000\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(803, "Dashboard widget", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        blocks = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/blocks"
+        ]
+        numbers = sorted(int(r["uri"].rsplit("/", 1)[-1]) for r in blocks)
+        assert numbers == [999, 1000]
+
+    def test_self_reference_excluded(self):
+        """``Closes #N`` in #N's own body must not duplicate the origin ref."""
+        body = "This issue is itself. Closes #888."
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(888, "Self-ref", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        closes = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/closes"
+        ]
+        assert closes == []
+        # Origin still emitted.
+        origins = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/github-issue"
+        ]
+        assert len(origins) == 1
+
+    def test_code_block_mentions_ignored(self):
+        """Cross-ref tokens inside fenced code blocks must not match."""
+        body = (
+            "## Summary\n"
+            "Document the closing-keyword grammar.\n\n"
+            "Example body that would auto-close an upstream issue:\n\n"
+            "```\nCloses #2000\nFixes #2001\n```\n\n"
+            "Real cross-ref:\n\nCloses #2002\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(900, "Docs", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        closes = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/closes"
+        ]
+        numbers = sorted(int(r["uri"].rsplit("/", 1)[-1]) for r in closes)
+        # Only the real cross-ref (#2002) lifts; the two inside the fence
+        # are quoted examples and must not auto-create references.
+        assert numbers == [2002]
+
+    def test_inline_code_mentions_ignored(self):
+        body = "Inline `Closes #3000` is an example, not a real ref. Closes #3001."
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(901, "Inline code", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        closes = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/closes"
+        ]
+        numbers = sorted(int(r["uri"].rsplit("/", 1)[-1]) for r in closes)
+        assert numbers == [3001]
+
+    def test_cross_refs_skipped_when_repo_url_unknown(self):
+        """No ``repo_url`` -> no cross-refs (cannot synthesise a honest URI)."""
+        body = "Closes #1. Refs #2. Blocked by #3."
+        issue = _issue(1000, "No repo url", body=body)
+        issue["url"] = ""  # also drop the explicit URL
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            issue,
+            status="proposed",
+            repo_url="",
+        )
+        # No references at all (origin requires URL; cross-refs require
+        # ``repo_url``).
+        assert vbrief["plan"].get("references", []) == []
+
+
+# ---------------------------------------------------------------------------
+# (e) End-to-end smoke through ingest_one for the full path
+# ---------------------------------------------------------------------------
+
+
+class TestIngestOneEndToEnd:
+    """Drive ``ingest_one`` so the on-disk JSON reflects every enrichment."""
+
+    def test_written_vbrief_carries_items_and_cross_refs(self, tmp_path):
+        body = (
+            "## Summary\n"
+            "Refactor the cache layer.\n\n"
+            "## Acceptance Criteria\n"
+            "- [ ] Cache TTL configurable per source\n"
+            "- [ ] Backfill verb exists for cold-start\n\n"
+            "Closes #1200\n"
+            "Refs #883\n"
+        )
+        vbrief_dir = tmp_path / "vbrief"
+        vbrief_dir.mkdir()
+        result, path, _msg = issue_ingest.ingest_one(
+            _issue(1100, "Cache refactor", body=body, labels=["enhancement"]),
+            vbrief_dir=vbrief_dir,
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        assert result == "created"
+        data = json.loads(path.read_text(encoding="utf-8"))
+
+        # Items present and well-shaped.
+        items = data["plan"]["items"]
+        assert len(items) == 2
+        for item in items:
+            assert item["status"] == "proposed"
+            assert isinstance(item["title"], str) and item["title"]
+
+        # References: origin + closes + refs.
+        ref_types = sorted(
+            {r["type"] for r in data["plan"]["references"]}
+        )
+        assert ref_types == [
+            "x-vbrief/closes",
+            "x-vbrief/github-issue",
+            "x-vbrief/refs",
+        ]
+
+        # Overview present; labels mirrored to plan.tags.
+        assert "Refactor the cache layer." in data["plan"]["narratives"]["Overview"]
+        assert data["plan"]["tags"] == ["enhancement"]

--- a/tests/cli/test_issue_ingest_body_parsing.py
+++ b/tests/cli/test_issue_ingest_body_parsing.py
@@ -162,6 +162,35 @@ class TestBodyWithChecklist:
         titles = [i["title"] for i in vbrief["plan"]["items"]]
         assert titles == ["Top-level task A", "Top-level task B"]
 
+    def test_numbered_ac_section_preserves_checked_status_mix(self):
+        """Numbered AC list with ``[x]`` markers preserves the checked state.
+
+        Greptile finding on PR #1252: previously ``_extract_ac_section_items``
+        stripped the ``[x]`` / ``[ ]`` checkbox prefix but always emitted
+        ``status = "proposed"`` even for completed items, silently inflating
+        the refinement / ``triage:queue`` work queue. These items do NOT
+        satisfy ``_CHECKBOX_RE`` (which requires a ``[-*+]`` bullet, not a
+        numbered marker), so they reach the AC-section fallback and exercise
+        the defensive checkbox-prefix strip.
+        """
+        body = (
+            "## Acceptance Criteria\n"
+            "1. [x] First criterion done\n"
+            "2. [ ] Second criterion pending\n"
+            "3. [X] Third criterion also done\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(503, "Mixed AC numbered+checkbox", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        items = vbrief["plan"]["items"]
+        assert items == [
+            {"title": "First criterion done", "status": "completed"},
+            {"title": "Second criterion pending", "status": "proposed"},
+            {"title": "Third criterion also done", "status": "completed"},
+        ]
+
 
 # ---------------------------------------------------------------------------
 # (b) Issue with body but no checklist -> graceful degradation
@@ -373,6 +402,34 @@ class TestCrossRefExtraction:
         ]
         numbers = sorted(int(r["uri"].rsplit("/", 1)[-1]) for r in closes)
         assert numbers == [3001]
+
+    def test_tilde_fenced_code_block_mentions_ignored(self):
+        """``~~~``-fenced code blocks strip identically to triple-backticks.
+
+        Greptile finding on PR #1252: previously ``_CODE_FENCE_RE`` only
+        matched triple-backtick fences, so a body that quoted the closing-
+        keyword grammar inside a tilde-fenced block (a valid GitHub
+        Flavoured Markdown alternative) produced spurious cross-references.
+        """
+        body = (
+            "## Summary\n"
+            "Document the closing-keyword grammar with a tilde fence.\n\n"
+            "~~~\nCloses #4000\nFixes #4001\n~~~\n\n"
+            "Real cross-ref:\n\nCloses #4002\n"
+        )
+        vbrief, _ = issue_ingest._build_issue_vbrief(
+            _issue(902, "Tilde fence docs", body=body),
+            status="proposed",
+            repo_url="https://github.com/owner/repo",
+        )
+        closes = [
+            r for r in vbrief["plan"]["references"]
+            if r["type"] == "x-vbrief/closes"
+        ]
+        numbers = sorted(int(r["uri"].rsplit("/", 1)[-1]) for r in closes)
+        # Only the real cross-ref (#4002) lifts; #4000 + #4001 are inside
+        # the ``~~~`` fence and must be stripped before pattern matching.
+        assert numbers == [4002]
 
     def test_cross_refs_skipped_when_repo_url_unknown(self):
         """No ``repo_url`` -> no cross-refs (cannot synthesise a honest URI)."""

--- a/tests/cli/test_issue_ingest_direct.py
+++ b/tests/cli/test_issue_ingest_direct.py
@@ -490,9 +490,11 @@ class TestBodyFidelityAndTags:
         )
         assert "tags" not in vbrief["plan"]
 
-    def test_plan_items_remains_empty_per_988_non_goals(self):
-        """#988 Non-goals: section-parsing into ``plan.items`` is explicitly a
-        follow-up. ``plan.items`` MUST remain ``[]`` from this fix.
+    def test_plan_items_populated_from_checklist_per_1248(self):
+        """#1248 supersedes the #988 Non-goal: checkbox / AC-section content
+        on the issue body MUST land as ``plan.items[]`` entries so the
+        refinement workflow has structured input to project from instead
+        of having to re-read the GitHub issue body by hand.
         """
         body = (
             "## Acceptance Criteria\n- [ ] thing one\n- [ ] thing two\n"
@@ -502,7 +504,9 @@ class TestBodyFidelityAndTags:
             "proposed",
             "",
         )
-        assert vbrief["plan"]["items"] == []
+        items = vbrief["plan"]["items"]
+        assert [i["title"] for i in items] == ["thing one", "thing two"]
+        assert all(i["status"] == "proposed" for i in items)
 
 
 # ---------------------------------------------------------------------------

--- a/vbrief/active/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json
+++ b/vbrief/active/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json
@@ -12,7 +12,56 @@
       "Overview": "## Summary\r\n\r\n`task issue:ingest` produces vBRIEFs with only three narratives (`Description`, `Origin`, `Labels`) and zero `plan.items` — essentially a structural echo of the GH issue title + labels. The resulting `proposed/*.vbrief.json` files contribute almost nothing to the refinement workflow that's supposed to consume them; an operator running `deft-directive-refinement` must reconstruct the substance from scratch by re-reading the GH issue.\r\n\r\n## Reproduction (audit pass of `vbrief/proposed/` on 2026-05-20)\r\n\r\nOf 46 vBRIEFs in `vbrief/proposed/`, **40 are stub-only** (no `Overview` narrative, `len(plan.items) == 0`). The pattern is uniform:\r\n\r\n```json\r\n{\r\n  \"vBRIEFInfo\": { \"version\": \"0.6\", \"description\": \"Scope vBRIEF ingested from GitHub issue #100\" },\r\n  \"plan\": {\r\n    \"title\": \"[Compliance] Evidence collection automation hooks\",\r\n    \"status\": \"proposed\",\r\n    \"narratives\": {\r\n      \"Description\": \"[Compliance] Evidence collection automation hooks\",\r\n      \"Origin\": \"Ingested from https://api.github.com/repos/deftai/directive/issues/100\",\r\n      \"Labels\": \"enhancement, compliance, soc2\"\r\n    },\r\n    \"items\": [],\r\n    \"references\": [ { ... } ]\r\n  }\r\n}\r\n```\r\n\r\n`Description` is just the issue title verbatim; `Origin` is the API URL; `Labels` is a comma-joined list. None of the issue body content makes it in.\r\n\r\n## Expected\r\n\r\n`task issue:ingest` should at minimum:\r\n- Populate `narratives.Overview` from the issue body's first paragraph (or full body, truncated to a sensible length).\r\n- Surface acceptance criteria / checklists from the issue body as initial `plan.items[]` entries (one item per checkbox or numbered AC).\r\n- Preserve issue body cross-refs (`Closes #N`, `Refs #N`, `Blocked by #N`) as additional `plan.references[]` entries with appropriate types (`x-vbrief/closes`, `x-vbrief/refs`, `x-vbrief/blocks`).\r\n\r\n## Impact\r\n\r\n- Refinement workflow consumes garbage-quality input. Operators effectively re-do the ingest by hand.\r\n- The \"save proposed, refine later\" model loses most of its value because there's nothing to refine FROM.\r\n- `task triage:queue` collision check with existing proposed vBRIEFs (the intended deduplication mechanism) is moot when the proposed files contain no substantive content to compare against.\r\n\r\n## Possibly related\r\n\r\nThis may be the issue tracked elsewhere — search for prior work on `issue_ingest.py` body parsing. If a richer ingester exists behind a flag (e.g. `--full-body`) that should be the default.\r\n\r\n## Suggested investigation\r\n\r\n- `scripts/issue_ingest.py`: does the existing code already fetch issue body via REST? If yes, why is it discarded?\r\n- Are there length/safety concerns blocking a richer ingest? Issue bodies can be large; truncation rules are a legitimate concern.\r\n- Schema check: does `vbrief-core.schema.json` v0.6 support a `narratives.Overview` value of arbitrary length, or are there structural constraints to honor?\r\n",
       "Labels": "enhancement, skills"
     },
-    "items": [],
+    "items": [
+      {
+        "id": "1248.populate-overview",
+        "title": "Populate narratives.Overview from the issue body",
+        "status": "completed",
+        "narrative": {
+          "Description": "Carry the GitHub issue body verbatim into plan.narratives.Overview so the refinement workflow has source text to project from. Already present from the #988 cache-first fix; #1248 preserves the behaviour and widens the surface."
+        }
+      },
+      {
+        "id": "1248.extract-checklist-items",
+        "title": "Derive plan.items[] from issue-body task-list checkboxes",
+        "status": "completed",
+        "narrative": {
+          "Description": "Each `- [ ] ...` line becomes a PlanItem with status `proposed`; `- [x] ...` becomes `completed`. Deduped while preserving document order."
+        }
+      },
+      {
+        "id": "1248.extract-ac-section-items",
+        "title": "Fall back to numbered / bulleted list under an Acceptance Criteria heading",
+        "status": "completed",
+        "narrative": {
+          "Description": "When the body has no checkbox list, parse the Acceptance Criteria section (any heading level, case-insensitive) and emit each bullet / numbered item as a PlanItem with status `proposed`. Section is bounded by the next equal-or-higher-level heading."
+        }
+      },
+      {
+        "id": "1248.extract-cross-refs",
+        "title": "Lift Closes / Refs / Blocked-by cross-refs into plan.references[]",
+        "status": "completed",
+        "narrative": {
+          "Description": "`Closes/Fixes/Resolves #N` -> `x-vbrief/closes`; `Refs/References/See also/Related #N` -> `x-vbrief/refs`; `Blocked by #N` -> `x-vbrief/blocks`. Skips matches inside fenced or inline code spans and excludes the provenance issue itself to avoid self-reference duplication."
+        }
+      },
+      {
+        "id": "1248.graceful-degradation",
+        "title": "Graceful degradation when body has no structured content",
+        "status": "completed",
+        "narrative": {
+          "Description": "An empty body produces no Overview, empty items, and no body-derived references. A prose-only body still emits Overview but leaves items empty so downstream tooling does not consume invented structure."
+        }
+      },
+      {
+        "id": "1248.tests",
+        "title": "Pin the four AC scenarios with regression tests",
+        "status": "completed",
+        "narrative": {
+          "Description": "tests/cli/test_issue_ingest_body_parsing.py covers: (a) body + AC checklist, (b) body only no checklist, (c) empty body, (d) closing-keyword cross-ref extraction. Plus code-block immunity and self-reference exclusion guards."
+        }
+      }
+    ],
     "tags": [
       "enhancement",
       "skills"


### PR DESCRIPTION
# Summary

`task issue:ingest` no longer produces stub-only scope vBRIEFs. The ingester now derives `plan.items[]` and `plan.references[]` cross-refs from the GitHub issue body so the refinement workflow has substantive content to project from instead of having to re-read the upstream issue by hand.

Closes #1248. Refs #988 (cache-first Overview carry-through), #1186 (consumer-config example that consumes the enriched output).

# What changed

`scripts/issue_ingest.py::_build_issue_vbrief`:

- `narratives.Overview` continues to carry the issue body verbatim (the #988 contract is preserved).
- New `_extract_plan_items(body)` populates `plan.items[]` from:
  1. GitHub Flavoured Markdown task-list lines (`- [ ] item` → `proposed`; `- [x] item` → `completed`).
  2. Numbered / bulleted list under an `Acceptance Criteria` heading (any level, case-insensitive), bounded by the next equal-or-higher-level heading.
  3. Graceful degradation to `[]` when neither shape is present.
- New `_extract_cross_refs(body, repo_url, exclude={number})` lifts:
  - `Closes/Fixes/Resolves #N` (inflected forms accepted) → `x-vbrief/closes`
  - `Blocked by #N` → `x-vbrief/blocks`
  - `Refs/References/See also/Related #N` → `x-vbrief/refs`
- Cross-refs skip matches inside fenced or inline code spans (`` ` ``) via a new `_strip_code_blocks` helper -- a body that *quotes* `Closes #N` as a syntax example does not produce a real cross-ref.
- The provenance issue itself is excluded so a self-referencing `Closes #N` in `#N`'s own body does not duplicate the canonical `x-vbrief/github-issue` origin reference.
- When `repo_url` is empty no cross-refs are emitted -- the canonical `VBriefReference` shape requires `uri` and synthesising a URL without a repo handle would be dishonest.

# Tests

`tests/cli/test_issue_ingest_body_parsing.py` (16 new tests) pins the four acceptance criteria from the issue body plus belt-and-braces guards:

- (a) Body + AC checklist → `plan.items[]` populated (checkbox + numbered AC variants).
- (b) Body but no checklist → `plan.items == []`; `narratives.Overview` still emitted.
- (c) Empty body / missing body / null body → no Overview, no items, only canonical origin reference.
- (d) Closing-keyword cross-ref extraction (`Closes` / `Fixes` / `Resolves` + inflections, `Refs` / `References` / `See also` / `Related`, `Blocked by` / `Blocked-by`).
- (e) Code-block immunity: cross-ref tokens inside fenced or inline code spans must NOT produce references.
- (f) Self-reference exclusion: `Closes #N` inside `#N`'s own body must NOT duplicate the canonical origin reference.
- (g) `repo_url` empty → no cross-refs (cannot synthesise an honest URI).
- (h) End-to-end smoke through `ingest_one` so the on-disk JSON reflects every enrichment.

The existing `tests/cli/test_issue_ingest_direct.py::TestBodyFidelityAndTags::test_plan_items_remains_empty_per_988_non_goals` was rewritten to `test_plan_items_populated_from_checklist_per_1248` because #1248 explicitly supersedes the #988 Non-goal (section parsing into `plan.items` was tracked as a follow-up; this PR is that follow-up).

# Suggested investigation findings (from issue body)

- **Does the existing code already fetch the issue body via REST?** Yes -- `_fetch_single_issue` returns the full payload including `body`. The body landed in `narratives.Overview` since #988 but was never parsed into structured items. This PR closes that gap.
- **Length / safety concerns?** No truncation applied. `narratives.Overview` is `type: string` in the schema with no length constraint. Operators reviewing large bodies in the vBRIEF can collapse the section in their editor; downstream consumers (`task triage:queue` dedup, `deft-directive-refinement`) already cope with multi-KB Overviews from the #988 carry-through.
- **Schema support for arbitrary-length narratives?** Confirmed via `vbrief/schemas/vbrief-core.schema.json` -- `Overview` is a plain `{"type": "string"}` field; the only constraint on `PlanItem.title` is `minLength: 1`, which the new helpers honour (empty list items are skipped).

# Validation

- `task core:lint` clean (ruff + mypy).
- `task vbrief:validate` clean (2 pre-existing PROJECT-DEFINITION warnings unrelated to this PR).
- `tests/cli/test_issue_ingest*.py + tests/test_triage_actions.py + tests/test_scm_call.py` -- all 111 tests pass.
- Full `task check` baseline-clean against my changes; 2 pre-existing failures observed on the chore base branch (`test_policy_omits_wip_cap`, `test_gitignore_does_not_blanket_ignore_eval_directory`) are owned by parallel agents on the same chore branch and are unrelated to #1248 (verified by `git stash` + re-run on baseline; same 2 failures persist).

# CHANGELOG

Entry added under `[Unreleased] ### Fixed`, brief release-notes voice per #1242.

# vBRIEF

Enriched `vbrief/active/2026-05-20-1248-...vbrief.json` `plan.items[]` with 6 PlanItems mirroring the acceptance criteria implemented; `narratives.Overview` left untouched (already carried verbatim issue body from auto-ingest).
