### PR TITLE
fix(triage): repopulate candidates.jsonl reliably on triage:welcome step 3 (#1244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- **fix(triage): `task triage:welcome` now reliably populates `vbrief/.eval/candidates.jsonl` (#1244)** -- the welcome ritual no longer silently skips Phase 3 bootstrap when a partially-populated `.deft-cache/` exists from a prior run. Phase 3 now keys off the canonical audit log (`vbrief/.eval/candidates.jsonl`) -- the same signal `task triage:queue` and `task verify:cache-fresh` consume -- so the first-session onboarding contract holds. Dry-mode runs (`--no-subprocess`) loudly surface that the cache will remain absent, and operators can explicitly decline bootstrap via a new `--skip-bootstrap` flag that emits a visible audit message. Closes #1244.
+- **fix(triage): `task triage:welcome` no longer silently skips bootstrap (#1244)** -- the welcome ritual now reliably populates the triage cache on first-session runs. Phase 3 keys off the canonical "bootstrap finished" audit log the same way downstream verbs (`task triage:queue`, `task verify:cache-fresh`) do, so a partial cache from a prior run cannot trick the ritual into reporting completion while the cache is empty. Dry-mode runs loudly surface the cache gap, and operators can explicitly decline bootstrap with a new opt-out flag that records a persistent audit trail. Closes #1244.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **fix(triage): `task triage:welcome` now reliably populates `vbrief/.eval/candidates.jsonl` (#1244)** -- the welcome ritual no longer silently skips Phase 3 bootstrap when a partially-populated `.deft-cache/` exists from a prior run. Phase 3 now keys off the canonical audit log (`vbrief/.eval/candidates.jsonl`) -- the same signal `task triage:queue` and `task verify:cache-fresh` consume -- so the first-session onboarding contract holds. Dry-mode runs (`--no-subprocess`) loudly surface that the cache will remain absent, and operators can explicitly decline bootstrap via a new `--skip-bootstrap` flag that emits a visible audit message. Closes #1244.
 
 ### Removed
 

--- a/scripts/_triage_welcome_cli.py
+++ b/scripts/_triage_welcome_cli.py
@@ -178,6 +178,18 @@ def build_parser() -> argparse.ArgumentParser:
             "in production runs."
         ),
     )
+    parser.add_argument(
+        "--skip-bootstrap",
+        action="store_true",
+        help=(
+            "Explicitly decline the Phase 3 `task triage:bootstrap` "
+            "invocation (#1244). The ritual still completes but emits a "
+            "visible audit message AND records the decline in "
+            "`meta/policy-changes.log`; downstream verbs that depend on "
+            "`vbrief/.eval/candidates.jsonl` will refuse to run until "
+            "bootstrap is invoked separately."
+        ),
+    )
     return parser
 
 
@@ -199,5 +211,6 @@ def run_cli(argv: list[str] | None, tw_module: Any) -> int:
     outcome = tw_module.run_welcome(
         project_root,
         run_subprocess=not args.no_subprocess,
+        skip_bootstrap=args.skip_bootstrap,
     )
     return outcome.exit_code

--- a/scripts/triage_welcome.py
+++ b/scripts/triage_welcome.py
@@ -77,6 +77,14 @@ PROJECT_DEFINITION_REL_PATH = "vbrief/PROJECT-DEFINITION.vbrief.json"
 CACHE_DIR_NAME: str = ".deft-cache"
 CACHE_SOURCE: str = "github-issue"
 
+#: Canonical "bootstrap finished" audit log (#1244). Mirrors
+#: :data:`scripts.preflight_cache.CANDIDATES_RELPATH` and
+#: :data:`scripts.triage_bootstrap.AUDIT_LOG_RELPATH`. Downstream verbs
+#: (`task triage:queue`, `task verify:cache-fresh`) all key off this
+#: file's presence rather than the raw ``.deft-cache/`` entry count, so
+#: welcome's Phase 3 idempotency probe MUST use the same signal.
+CANDIDATES_RELPATH: tuple[str, ...] = ("vbrief", ".eval", "candidates.jsonl")
+
 #: vBRIEF lifecycle folders that contribute to the WIP count.
 WIP_LIFECYCLE_DIRS: tuple[str, ...] = ("pending", "active")
 
@@ -132,7 +140,11 @@ WELCOME_AUDIT_TAG: str = "triage-welcome"
 
 @dataclass(frozen=True)
 class PriorState:
-    """Snapshot of the four state probes Phase 1 needs."""
+    """Snapshot of the state probes Phase 1 needs.
+
+    ``audit_log_present`` is the canonical "bootstrap finished" signal
+    (#1244); the raw ``.deft-cache/`` entry count is diagnostic only.
+    """
 
     triage_scope_set: bool
     triage_scope_summary: str  # human-readable label (e.g. "unset" / "Mid")
@@ -141,6 +153,7 @@ class PriorState:
     wip_cap_set: bool
     wip_cap: int  # current value OR the DEFAULT_WIP_CAP fallback
     wip_count: int  # pending/ + active/
+    audit_log_present: bool  # vbrief/.eval/candidates.jsonl exists (#1244)
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +225,16 @@ def _count_cache_entries(project_root: Path) -> int:
     return count
 
 
+def candidates_log_path(project_root: Path) -> Path:
+    """Absolute path to ``vbrief/.eval/candidates.jsonl`` (#1244)."""
+    return project_root.joinpath(*CANDIDATES_RELPATH)
+
+
+def _audit_log_present(project_root: Path) -> bool:
+    """True iff ``vbrief/.eval/candidates.jsonl`` exists (zero-length OK)."""
+    return candidates_log_path(project_root).is_file()
+
+
 def _count_wip(project_root: Path) -> int:
     total = 0
     root = project_root / "vbrief"
@@ -274,6 +297,7 @@ def detect_prior_state(project_root: Path) -> PriorState:
         wip_cap_set=wip_cap_set,
         wip_cap=wip_cap,
         wip_count=_count_wip(project_root),
+        audit_log_present=_audit_log_present(project_root),
     )
 
 
@@ -514,6 +538,7 @@ __all__ = [
     "AUDIT_LOG_REL_PATH",
     "CACHE_DIR_NAME",
     "CACHE_SOURCE",
+    "CANDIDATES_RELPATH",
     "TRIAGE_SKILL_PATH",
     "WELCOME_AUDIT_TAG",
     "PROJECT_DEFINITION_REL_PATH",
@@ -531,6 +556,7 @@ __all__ = [
     "default_output",
     "append_audit_entry",
     "project_definition_path",
+    "candidates_log_path",
 ]
 
 # Backward-compatible private aliases kept for any future call site.
@@ -543,9 +569,23 @@ _default_output = default_output
 # ---------------------------------------------------------------------------
 
 
+#: ``WelcomeOutcome.bootstrap_action`` tokens (#1244). Compare via these
+#: constants -- a rename then surfaces as a NameError at import time.
+BOOTSTRAP_ACTION_RAN = "ran"
+BOOTSTRAP_ACTION_SKIPPED_ALREADY_BOOTSTRAPPED = "skipped:already-bootstrapped"
+BOOTSTRAP_ACTION_SKIPPED_DECLINED = "skipped:declined"
+BOOTSTRAP_ACTION_SKIPPED_DRY_MODE = "skipped:dry-mode"
+
+
 @dataclass
 class WelcomeOutcome:
-    """End-of-run summary for tests / dispatcher consumers."""
+    """End-of-run summary for tests / dispatcher consumers.
+
+    ``bootstrap_action`` (#1244) surfaces whether Phase 3 invoked
+    ``task triage:bootstrap`` or skipped it (and why). One of the
+    ``BOOTSTRAP_ACTION_*`` constants above, or ``None`` if the ritual
+    exited before Phase 3 (e.g. Discuss / Back at Phase 2).
+    """
 
     phases_run: list[int] = field(default_factory=list)
     phases_skipped: list[int] = field(default_factory=list)
@@ -555,6 +595,7 @@ class WelcomeOutcome:
     relief_confirmed: bool = False
     discussed_at_phase: int | None = None
     exit_code: int = 0
+    bootstrap_action: str | None = None
 
 
 def run_welcome(
@@ -563,18 +604,25 @@ def run_welcome(
     input_fn: Callable[[str], str] | None = None,
     output_fn: Callable[[str], None] | None = None,
     run_subprocess: bool = True,
+    skip_bootstrap: bool = False,
 ) -> WelcomeOutcome:
     """Execute the 6-phase ritual. Returns a structured outcome.
 
-    Phases 1-6 run inside a single ``while True`` loop driven by a
-    ``phase`` counter so the deterministic-questions ``Back`` semantic
-    ("re-render the prior question") works correctly: a Back selection
-    at Phase 4 rewinds to Phase 2 and the loop re-enters the interactive
-    menu (the ``force_re_prompt_*`` flags override the
-    already-set-skip on the rewind iteration). A Discuss selection halts
-    the loop and returns immediately. Subprocess failures in Phases 3
-    and 5 set ``outcome.exit_code = 2`` so callers learn the ritual
-    encountered a problem, matching Phase 2 / Phase 4 writer semantics.
+    Phases 1-6 run inside a single ``while True`` loop so the
+    deterministic-questions ``Back`` semantic re-renders the prior
+    question (a Back at Phase 4 rewinds to Phase 2 with
+    ``force_re_prompt_*`` overriding the already-set-skip). A Discuss
+    selection returns immediately. Subprocess failures in Phases 3 and
+    5 set ``outcome.exit_code = 2``.
+
+    Phase 3 bootstrap-skip semantics (#1244): the canonical "bootstrap
+    already finished" signal is ``vbrief/.eval/candidates.jsonl`` (the
+    audit log seeded by ``task triage:bootstrap`` step 5), NOT the raw
+    ``.deft-cache/`` entry count. When the audit log is absent the
+    ritual MUST (a) run bootstrap (the default, idempotent), (b) loudly
+    surface dry-mode suppression when ``run_subprocess=False``, or
+    (c) record an explicit operator decline via ``skip_bootstrap=True``
+    and append a visible audit entry.
     """
     in_fn = input_fn or default_input
     out_fn = output_fn or default_output
@@ -608,8 +656,13 @@ def run_welcome(
             state = detect_prior_state(project_root)
             out_fn(f"  triageScope: {state.triage_scope_summary}")
             out_fn(
-                f"  cache: {state.cache_entry_count} entry/entries "
+                f"  cache: {state.cache_entry_count} raw entry/entries "
                 f"({'empty' if state.cache_empty else 'populated'})"
+            )
+            out_fn(
+                f"  candidates.jsonl: "
+                f"{'present' if state.audit_log_present else 'absent'} "
+                f"({'/'.join(CANDIDATES_RELPATH)})"
             )
             if state.wip_cap_set:
                 out_fn(f"  wipCap: set ({state.wip_cap})")
@@ -685,31 +738,77 @@ def run_welcome(
             continue
 
         if phase == 3:
+            # #1244: audit log presence (NOT raw cache count) is the
+            # canonical "bootstrap finished" signal; see run_welcome
+            # docstring for the full rationale.
             refreshed = detect_prior_state(project_root)
-            if not refreshed.cache_empty:
+            audit_rel = "/".join(CANDIDATES_RELPATH)
+            if refreshed.audit_log_present:
                 out_fn(
-                    f"[3/6] Cache already populated "
-                    f"({refreshed.cache_entry_count} entries); "
-                    "skipping bootstrap."
+                    f"[3/6] Bootstrap audit log already present "
+                    f"({audit_rel}, {refreshed.cache_entry_count} raw cache "
+                    "entry/entries); skipping `task triage:bootstrap`."
+                )
+                outcome.bootstrap_action = (
+                    BOOTSTRAP_ACTION_SKIPPED_ALREADY_BOOTSTRAPPED
                 )
                 _record_skipped(3)
+            elif skip_bootstrap:
+                out_fn(
+                    "[3/6] `task triage:bootstrap` explicitly declined "
+                    "via --skip-bootstrap."
+                )
+                out_fn(
+                    f"  ! {audit_rel} remains absent; downstream verbs "
+                    "(`task triage:queue`, `task verify:cache-fresh`) "
+                    "will refuse to run."
+                )
+                out_fn(
+                    "  ! Run `task triage:bootstrap` separately when "
+                    "ready to populate the cache."
+                )
+                append_audit_entry(
+                    project_root,
+                    (
+                        f"actor={WELCOME_AUDIT_TAG} "
+                        "action=bootstrap-declined "
+                        "reason=explicit-skip-flag "
+                        f"audit_log={audit_rel} "
+                        "audit_log_present=false"
+                    ),
+                )
+                outcome.bootstrap_action = BOOTSTRAP_ACTION_SKIPPED_DECLINED
+                _record_skipped(3)
+            elif not run_subprocess:
+                # Test-mode -- loudly surface the cache gap so dispatchers
+                # don't mistake dry-mode for a populated cache (#1244).
+                out_fn(
+                    "[3/6] `task triage:bootstrap` suppressed by "
+                    "--no-subprocess (test-mode)."
+                )
+                out_fn(
+                    f"  ! {audit_rel} remains absent; downstream verbs "
+                    "(`task triage:queue`, `task verify:cache-fresh`) "
+                    "will refuse to run until bootstrap is invoked."
+                )
+                outcome.bootstrap_action = BOOTSTRAP_ACTION_SKIPPED_DRY_MODE
+                _record_skipped(3)
             else:
+                # Audit log absent, no decline, subprocess enabled.
+                # Bootstrap is idempotent so re-running over a
+                # partially-populated `.deft-cache/` is safe.
                 out_fn("[3/6] Running `task triage:bootstrap`...")
-                if run_subprocess:
-                    rc = _run_task(["triage:bootstrap"], cwd=project_root)
-                    if rc != 0:
-                        out_fn(
-                            f"  ! `task triage:bootstrap` exited {rc}; "
-                            "see stderr above. Setting outcome.exit_code=2 "
-                            "so the dispatcher learns the ritual hit a "
-                            "downstream failure (re-run welcome after "
-                            "fixing bootstrap to resume)."
-                        )
-                        outcome.exit_code = 2
-                else:
+                rc = _run_task(["triage:bootstrap"], cwd=project_root)
+                if rc != 0:
                     out_fn(
-                        "  [dry-mode] bootstrap subprocess suppressed by caller."
+                        f"  ! `task triage:bootstrap` exited {rc}; "
+                        "see stderr above. Setting outcome.exit_code=2 "
+                        "so the dispatcher learns the ritual hit a "
+                        "downstream failure (re-run welcome after "
+                        "fixing bootstrap to resume)."
                     )
+                    outcome.exit_code = 2
+                outcome.bootstrap_action = BOOTSTRAP_ACTION_RAN
                 _record_run(3)
             phase = 4
             continue
@@ -853,16 +952,9 @@ def run_welcome(
             out_fn("[6/6] Final state:")
             if run_subprocess:
                 _run_task(["triage:summary"], cwd=project_root)
-                # TODO(#1148 / N8): wire `task policy:show --changed-only`
-                # here as the canonical consolidated typed-policy
-                # inspector for the post-ritual summary. The inspector
-                # landed on master via N8 (#1148) but this Phase 6 hop
-                # is intentionally NOT updated in that same PR because
-                # N3 (#1143) was already merged when N8 shipped -- a
-                # follow-up amendment PR (or operator) closes the loop
-                # by adding ``_run_task(["policy:show", "--",
-                # "--changed-only"], cwd=project_root)`` immediately
-                # after the triage:summary call above.
+                # TODO(#1148 / N8): follow-up to add `_run_task(["policy:show",
+                # "--", "--changed-only"])` here once N3's PR has shipped --
+                # the inspector landed via N8 after N3 merged.
             else:
                 out_fn(
                     "  [dry-mode] triage:summary subprocess suppressed by caller."

--- a/tests/test_triage_welcome.py
+++ b/tests/test_triage_welcome.py
@@ -74,6 +74,19 @@ def _seed_cache_entry(root: Path, owner: str, repo: str, issue: int) -> Path:
     return path
 
 
+def _seed_candidates_log(root: Path) -> Path:
+    """Create a zero-length ``vbrief/.eval/candidates.jsonl`` audit log (#1244).
+
+    Mirrors :func:`scripts.triage_bootstrap.step_seed_candidates_log`: the
+    file's presence (not its contents) is the canonical "bootstrap
+    finished" signal welcome's Phase 3 keys off.
+    """
+    path = root.joinpath(*triage_welcome.CANDIDATES_RELPATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    return path
+
+
 def _seed_vbrief(root: Path, folder: str, slug: str, *, age_days: int = 0) -> Path:
     """Create a synthetic vBRIEF file in ``vbrief/<folder>/``."""
     d = root / "vbrief" / folder
@@ -127,6 +140,16 @@ def test_detect_prior_state_empty_project(tmp_path: Path) -> None:
     assert state.wip_cap_set is False
     assert state.wip_cap == triage_welcome.DEFAULT_WIP_CAP
     assert state.wip_count == 0
+    assert state.audit_log_present is False
+
+
+def test_detect_prior_state_audit_log_present(tmp_path: Path) -> None:
+    """#1244: PriorState surfaces candidates.jsonl independent of cache state."""
+    _seed_candidates_log(tmp_path)
+    state = triage_welcome.detect_prior_state(tmp_path)
+    assert state.audit_log_present is True
+    # Cache stays empty -- audit log is a separate, canonical signal.
+    assert state.cache_empty is True
 
 
 def test_detect_prior_state_populated(tmp_path: Path) -> None:
@@ -278,7 +301,12 @@ def test_clean_install_runs_all_phases(tmp_path: Path) -> None:
     assert outcome.discussed_at_phase is None
     assert 1 in outcome.phases_run
     assert 2 in outcome.phases_run
-    assert 3 in outcome.phases_run
+    # #1244: Phase 3 skipped in dry-mode (candidates.jsonl absent).
+    assert 3 in outcome.phases_skipped
+    assert (
+        outcome.bootstrap_action
+        == triage_welcome.BOOTSTRAP_ACTION_SKIPPED_DRY_MODE
+    )
     assert 4 in outcome.phases_run
     assert 5 in outcome.phases_skipped  # WIP 0 <= cap 10
     assert 6 in outcome.phases_run
@@ -295,13 +323,15 @@ def test_clean_install_runs_all_phases(tmp_path: Path) -> None:
 
 
 def test_partial_install_skips_completed_phases(tmp_path: Path) -> None:
-    """Pre-set scope + cap + cache => phases 2/3/4 all skipped on re-run."""
+    """Pre-set scope + cap + cache + audit log => phases 2/3/4 all skipped."""
     _seed_project_definition(
         tmp_path,
         triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
         wip_cap=10,
     )
     _seed_cache_entry(tmp_path, "deftai", "directive", 1)
+    # #1244: audit log presence is the canonical "bootstrap finished" signal.
+    _seed_candidates_log(tmp_path)
     output = _CapturedOutput()
     outcome = triage_welcome.run_welcome(
         tmp_path,
@@ -314,6 +344,10 @@ def test_partial_install_skips_completed_phases(tmp_path: Path) -> None:
     assert outcome.phases_skipped == [2, 3, 4, 5]
     assert outcome.subscription_choice is None
     assert outcome.wip_cap_choice is None
+    assert (
+        outcome.bootstrap_action
+        == triage_welcome.BOOTSTRAP_ACTION_SKIPPED_ALREADY_BOOTSTRAPPED
+    )
 
 
 def test_wip_exceeds_cap_offers_relief_dry_run_first(tmp_path: Path) -> None:
@@ -324,6 +358,7 @@ def test_wip_exceeds_cap_offers_relief_dry_run_first(tmp_path: Path) -> None:
         wip_cap=2,
     )
     _seed_cache_entry(tmp_path, "deftai", "directive", 42)
+    _seed_candidates_log(tmp_path)  # #1244: skip Phase 3 cleanly
     # WIP=3 (1 pending old + 2 active) > cap=2
     _seed_vbrief(tmp_path, "pending", "2026-03-01-old", age_days=60)
     _seed_vbrief(tmp_path, "active", "2026-05-18-foo")
@@ -353,6 +388,7 @@ def test_wip_exceeds_cap_relief_confirmed(tmp_path: Path) -> None:
         wip_cap=1,
     )
     _seed_cache_entry(tmp_path, "deftai", "directive", 99)
+    _seed_candidates_log(tmp_path)  # #1244: skip Phase 3 cleanly
     _seed_vbrief(tmp_path, "pending", "2026-03-01-old", age_days=60)
     _seed_vbrief(tmp_path, "active", "2026-05-18-a")
     _seed_vbrief(tmp_path, "active", "2026-05-18-b")
@@ -532,7 +568,7 @@ def test_phase_3_bootstrap_failure_propagates_exit_code(
         triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
         wip_cap=10,
     )
-    # Cache empty so Phase 3 actually runs.
+    # Cache empty + audit log absent so Phase 3 actually runs (#1244).
     monkeypatch.setattr(triage_welcome, "_run_task", lambda *a, **kw: 17)
     output = _CapturedOutput()
     outcome = triage_welcome.run_welcome(
@@ -543,6 +579,7 @@ def test_phase_3_bootstrap_failure_propagates_exit_code(
     )
     assert outcome.exit_code == 2
     assert "`task triage:bootstrap` exited 17" in output.joined()
+    assert outcome.bootstrap_action == triage_welcome.BOOTSTRAP_ACTION_RAN
 
 
 def test_phase_5_scope_demote_failure_propagates_exit_code(
@@ -559,6 +596,9 @@ def test_phase_5_scope_demote_failure_propagates_exit_code(
         wip_cap=1,
     )
     _seed_cache_entry(tmp_path, "deftai", "directive", 42)
+    # #1244: seed audit log so Phase 3 cleanly skips; we want to isolate
+    # the Phase 5 scope:demote failure surface.
+    _seed_candidates_log(tmp_path)
     _seed_vbrief(tmp_path, "pending", "2026-03-01-old", age_days=60)
     _seed_vbrief(tmp_path, "active", "2026-05-18-a")
     _seed_vbrief(tmp_path, "active", "2026-05-18-b")
@@ -630,9 +670,198 @@ def test_main_runs_no_subprocess_mode(tmp_path: Path, monkeypatch: pytest.Monkey
         wip_cap=10,
     )
     _seed_cache_entry(tmp_path, "deftai", "directive", 1)
+    # #1244: seed audit log so Phase 3 skips cleanly without needing the
+    # subprocess hop; otherwise dry-mode would still surface the cache gap.
+    _seed_candidates_log(tmp_path)
     # All phases are skipped via state detection -> no input needed.
     monkeypatch.setattr("builtins.input", lambda _prompt="": "")
     rc = triage_welcome.main(
         ["--project-root", str(tmp_path), "--no-subprocess"]
     )
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# #1244 -- Phase 3 candidates.jsonl-aware bootstrap-skip semantics
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_runs_when_audit_log_absent_even_with_cache_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1244 (a): the non-interactive bootstrap path MUST run even when
+    ``.deft-cache/`` has raw entries -- so long as ``candidates.jsonl``
+    is absent. This is the exact failure mode in the bug report
+    reproduction: a partially-populated cache from a prior run made
+    Phase 3 skip bootstrap while ``candidates.jsonl`` (the downstream
+    contract) remained absent.
+    """
+    _seed_project_definition(
+        tmp_path,
+        triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
+        wip_cap=10,
+    )
+    # Raw cache present (1 issue) but audit log ABSENT -- the bug-report
+    # repro state. Pre-#1244 the welcome ritual skipped Phase 3 here.
+    _seed_cache_entry(tmp_path, "deftai", "directive", 7)
+    invocations: list[list[str]] = []
+
+    def _stub_run_task(args: list[str], *, cwd: Path) -> int:
+        invocations.append(list(args))
+        # Simulate a real bootstrap by seeding the audit log so Phase 6's
+        # summary call (also routed through _run_task) sees fresh state.
+        if args == ["triage:bootstrap"]:
+            _seed_candidates_log(tmp_path)
+        return 0
+
+    monkeypatch.setattr(triage_welcome, "_run_task", _stub_run_task)
+    output = _CapturedOutput()
+    outcome = triage_welcome.run_welcome(
+        tmp_path,
+        input_fn=_ScriptedInput([]),
+        output_fn=output,
+        run_subprocess=True,
+    )
+    assert outcome.exit_code == 0
+    assert outcome.bootstrap_action == triage_welcome.BOOTSTRAP_ACTION_RAN
+    assert ["triage:bootstrap"] in invocations
+    assert 3 in outcome.phases_run
+    # Post-condition the bug report demands: the canonical audit log is
+    # populated (the test stub seeds it as the subprocess would).
+    assert (tmp_path / "vbrief" / ".eval" / "candidates.jsonl").is_file()
+
+
+def test_skip_bootstrap_emits_visible_audit_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1244 (b): the explicit-decline path skips bootstrap with a clearly
+    visible audit message AND records the decline in
+    ``meta/policy-changes.log``.
+    """
+    _seed_project_definition(
+        tmp_path,
+        triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
+        wip_cap=10,
+    )
+    # Audit log absent; operator passes --skip-bootstrap (skip_bootstrap=True).
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        triage_welcome,
+        "_run_task",
+        lambda args, *, cwd: calls.append(list(args)) or 0,
+    )
+    output = _CapturedOutput()
+    outcome = triage_welcome.run_welcome(
+        tmp_path,
+        input_fn=_ScriptedInput([]),
+        output_fn=output,
+        run_subprocess=True,
+        skip_bootstrap=True,
+    )
+    assert outcome.exit_code == 0
+    assert (
+        outcome.bootstrap_action
+        == triage_welcome.BOOTSTRAP_ACTION_SKIPPED_DECLINED
+    )
+    assert 3 in outcome.phases_skipped
+    # _run_task was NOT called for bootstrap (only Phase 6's summary).
+    assert ["triage:bootstrap"] not in calls
+    joined = output.joined()
+    # Operator-facing visible audit message surfaces the decline AND
+    # explains the cache-impact for downstream verbs.
+    assert "explicitly declined" in joined
+    assert "--skip-bootstrap" in joined
+    assert "vbrief/.eval/candidates.jsonl" in joined
+    assert "task triage:queue" in joined
+    # Persistent audit entry written to meta/policy-changes.log.
+    audit_log = (tmp_path / triage_welcome.AUDIT_LOG_REL_PATH).read_text(
+        encoding="utf-8"
+    )
+    assert "action=bootstrap-declined" in audit_log
+    assert "reason=explicit-skip-flag" in audit_log
+    assert "actor=triage-welcome" in audit_log
+
+
+def test_no_subprocess_surfaces_cache_gap_loudly(tmp_path: Path) -> None:
+    """#1244: ``--no-subprocess`` MUST loudly surface that
+    ``candidates.jsonl`` will remain absent -- the bug report's exact
+    failure mode was that dry-mode emitted a soft "suppressed" line that
+    let dispatchers mistake the run for a populated cache.
+    """
+    _seed_project_definition(
+        tmp_path,
+        triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
+        wip_cap=10,
+    )
+    output = _CapturedOutput()
+    outcome = triage_welcome.run_welcome(
+        tmp_path,
+        input_fn=_ScriptedInput([]),
+        output_fn=output,
+        run_subprocess=False,
+    )
+    assert outcome.exit_code == 0
+    assert (
+        outcome.bootstrap_action
+        == triage_welcome.BOOTSTRAP_ACTION_SKIPPED_DRY_MODE
+    )
+    assert 3 in outcome.phases_skipped
+    joined = output.joined()
+    assert "--no-subprocess" in joined
+    assert "vbrief/.eval/candidates.jsonl" in joined
+    assert "refuse to run" in joined  # downstream-verb warning surfaces
+
+
+def test_phase_1_readout_surfaces_audit_log_state(tmp_path: Path) -> None:
+    """#1244: Phase 1's detection readout MUST include the
+    ``candidates.jsonl`` presence so operators see the canonical
+    "bootstrap finished" signal alongside the raw cache count.
+    """
+    _seed_project_definition(
+        tmp_path,
+        triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
+        wip_cap=10,
+    )
+    _seed_candidates_log(tmp_path)
+    output = _CapturedOutput()
+    triage_welcome.run_welcome(
+        tmp_path,
+        input_fn=_ScriptedInput([]),
+        output_fn=output,
+        run_subprocess=False,
+    )
+    joined = output.joined()
+    assert "candidates.jsonl: present" in joined
+    assert "vbrief/.eval/candidates.jsonl" in joined
+
+
+def test_cli_skip_bootstrap_flag_threads_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1244: the CLI ``--skip-bootstrap`` flag reaches
+    :func:`run_welcome` and is honoured.
+    """
+    _seed_project_definition(
+        tmp_path,
+        triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
+        wip_cap=10,
+    )
+    captured: dict[str, object] = {}
+    real_run = triage_welcome.run_welcome
+
+    def _spy(*args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(triage_welcome, "run_welcome", _spy)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+    rc = triage_welcome.main(
+        [
+            "--project-root",
+            str(tmp_path),
+            "--no-subprocess",
+            "--skip-bootstrap",
+        ]
+    )
+    assert rc == 0
+    assert captured.get("skip_bootstrap") is True

--- a/tests/test_triage_welcome.py
+++ b/tests/test_triage_welcome.py
@@ -745,11 +745,12 @@ def test_skip_bootstrap_emits_visible_audit_message(
     )
     # Audit log absent; operator passes --skip-bootstrap (skip_bootstrap=True).
     calls: list[list[str]] = []
-    monkeypatch.setattr(
-        triage_welcome,
-        "_run_task",
-        lambda args, *, cwd: calls.append(list(args)) or 0,
-    )
+
+    def _record_run_task(args: list[str], *, cwd: Path) -> int:
+        calls.append(list(args))
+        return 0
+
+    monkeypatch.setattr(triage_welcome, "_run_task", _record_run_task)
     output = _CapturedOutput()
     outcome = triage_welcome.run_welcome(
         tmp_path,

--- a/vbrief/active/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json
+++ b/vbrief/active/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json
@@ -12,7 +12,40 @@
       "Overview": "## Summary\r\n\r\n`task triage:welcome` claims to execute its bootstrap phase (step 3 of the 6-phase ritual per N3/#1143), but in practice `candidates.jsonl` remains absent on exit. The ritual exits 0 with a \"completed\" status while the cache is empty, so the next step in the operator workflow (`task triage:queue`) silently has nothing to rank.\r\n\r\n## Reproduction (2026-05-20 session, master @ pre-#1143 follow-up)\r\n\r\nStarting state: fresh checkout, `vbrief/.eval/candidates.jsonl` absent.\r\n\r\n```\r\n$ task verify:cache-fresh\r\n✓ deft cache-fresh: vbrief\\.eval\\candidates.jsonl absent and --allow-missing-bootstrap was passed -- treating as bootstrap state.\r\n\r\n$ task triage:welcome -- --no-subprocess\r\n[6-phase ritual completes, exit 0]\r\n\r\n$ if (Test-Path vbrief\\.eval\\candidates.jsonl) { ... } else { Write-Host \"NOT PRESENT\" }\r\nNOT PRESENT\r\n\r\n$ task triage:bootstrap   # the same step welcome SHOULD have run\r\ntriage:bootstrap step 1/5 populate_cache -- starting (repo=deftai/directive; fetch_timeout_s=3600)\r\ntriage:bootstrap step 1/5 populate_cache -- done (cache:fetch-all source=github-issue repo=deftai/directive succeeded=1 failed=0 skipped=396)\r\n[populates candidates.jsonl]\r\n```\r\n\r\n## Expected\r\n\r\n`task triage:welcome` step 3 either:\r\n- runs `task triage:bootstrap` unconditionally (it is documented as idempotent) and produces a populated cache, OR\r\n- announces clearly that bootstrap was skipped (and why), so the operator does not assume the cache is hot.\r\n\r\n## Actual\r\n\r\nWelcome ritual finishes \"successfully\" without populating the cache and without surfacing that bootstrap was skipped. The operator has to discover the gap by independently invoking `verify:cache-fresh` or by `Test-Path vbrief\\.eval\\candidates.jsonl`.\r\n\r\n## Impact\r\n\r\n- Breaks the documented onboarding contract for first-session operators.\r\n- Composability of the pre-`start_agent` gate stack (#1149) silently breaks: `verify:cache-fresh` later fails because the cache was never populated, but the operator believes welcome completed its job.\r\n- Wastes the most important user-trust window — the first interactive session.\r\n\r\n## Suggested investigation\r\n\r\n- `scripts/triage_welcome.py` step 3: does the bootstrap subprocess invocation suppress non-zero exit codes? Does an interactive prompt default to \"decline bootstrap\" when no TTY?\r\n- Cross-check against the `--no-subprocess` flag — does it short-circuit step 3?\r\n- Consider making bootstrap unconditional (it is idempotent per its docstring); the only reason to skip is if the operator explicitly declines.\r\n\r\n## Workaround\r\n\r\n```\r\ntask triage:bootstrap\r\n```\r\n\r\nRun explicitly after `triage:welcome` until fixed.\r\n",
       "Labels": "bug, skills, adoption-blocker"
     },
-    "items": [],
+    "items": [
+      {
+        "id": "1244-1",
+        "title": "Audit-log-aware Phase 3 idempotency probe",
+        "status": "completed",
+        "narrative": {
+          "Description": "scripts/triage_welcome.py uses vbrief/.eval/candidates.jsonl (the canonical 'bootstrap finished' signal that downstream verbs key off) instead of raw .deft-cache/<source>/.../<N>/ entry count to decide whether Phase 3 should skip task triage:bootstrap. Pre-fix, a partially-populated .deft-cache from a prior run made Phase 3 skip while candidates.jsonl remained absent, silently breaking the contract task triage:queue / task verify:cache-fresh assume."
+        }
+      },
+      {
+        "id": "1244-2",
+        "title": "Loud dry-mode + explicit-decline paths",
+        "status": "completed",
+        "narrative": {
+          "Description": "When --no-subprocess suppresses bootstrap, Phase 3 emits a clearly visible warning naming vbrief/.eval/candidates.jsonl and downstream verbs that will refuse to run. New --skip-bootstrap CLI flag records an explicit operator decline with a persistent audit entry on meta/policy-changes.log AND a visible operator-facing message."
+        }
+      },
+      {
+        "id": "1244-3",
+        "title": "PriorState.audit_log_present + WelcomeOutcome.bootstrap_action surfaces",
+        "status": "completed",
+        "narrative": {
+          "Description": "PriorState gains audit_log_present so the Phase 1 readout surfaces candidates.jsonl state alongside the raw cache count. WelcomeOutcome gains bootstrap_action with four canonical tokens (ran / skipped:already-bootstrapped / skipped:declined / skipped:dry-mode) so dispatchers can distinguish the four Phase 3 paths programmatically."
+        }
+      },
+      {
+        "id": "1244-4",
+        "title": "Test coverage: bug-repro state + explicit-decline + dry-mode + Phase 1 readout + CLI flag",
+        "status": "completed",
+        "narrative": {
+          "Description": "tests/test_triage_welcome.py adds five #1244 regression tests: (a) bootstrap MUST run when audit log absent even with .deft-cache populated; (b) --skip-bootstrap emits visible audit message + persists to meta/policy-changes.log; (c) --no-subprocess loudly surfaces the cache gap; (d) Phase 1 readout includes candidates.jsonl line; (e) CLI flag threads through to run_welcome."
+        }
+      }
+    ],
     "tags": [
       "bug",
       "skills",


### PR DESCRIPTION
## Summary

Closes #1244.

`task triage:welcome` step 3 was silently skipping `task triage:bootstrap` whenever a partially-populated `.deft-cache/` existed from a prior run, while `vbrief/.eval/candidates.jsonl` remained absent. The ritual exited 0 with a "completed" status while the downstream contract was broken — `task triage:queue` had nothing to rank and `task verify:cache-fresh` failed on the very next session.

## Root cause

`scripts/triage_welcome.py` Phase 3 used `state.cache_empty` (raw `.deft-cache/<source>/<owner>/<repo>/<N>/` directory count) as its idempotency probe. But the canonical "bootstrap finished" signal that every downstream verb keys off is `vbrief/.eval/candidates.jsonl` (the audit log seeded by `task triage:bootstrap` step 5 / #1240). The two are independent — raw cache entries can exist from a partial earlier run while the audit log is absent.

## Fix

1. **Audit-log-aware Phase 3 idempotency probe** — `PriorState` gains `audit_log_present`; `detect_prior_state` populates it via the new `candidates_log_path()` helper. Phase 3 now skips bootstrap only when the audit log is present, not when raw cache entries exist.
2. **Loud dry-mode warning** — `--no-subprocess` (test-mode) now emits a clearly visible cache-gap warning naming `vbrief/.eval/candidates.jsonl` and the downstream verbs that will refuse to run. Pre-fix it emitted a single "suppressed" line that let dispatchers mistake dry-mode for a populated cache.
3. **Explicit-decline path** — new `--skip-bootstrap` CLI flag records an operator-visible audit message AND a persistent entry on `meta/policy-changes.log` (`action=bootstrap-declined reason=explicit-skip-flag`).
4. **Phase 1 readout surfaces audit log state** — operators see `candidates.jsonl: present|absent` alongside the raw cache count.
5. **`WelcomeOutcome.bootstrap_action` field** — dispatchers can programmatically distinguish the four Phase 3 paths via canonical tokens: `ran` / `skipped:already-bootstrapped` / `skipped:declined` / `skipped:dry-mode`.

## Suggested investigation (from the issue body) — answered

- **"Does the bootstrap subprocess invocation suppress non-zero exit codes?"** No — the prior code propagated rc != 0 via `outcome.exit_code = 2`. That part was correct.
- **"Does an interactive prompt default to 'decline bootstrap' when no TTY?"** No — Phase 3 was not interactive. The root cause was the cache-empty probe, not a prompt default.
- **"Does the `--no-subprocess` flag short-circuit step 3?"** Yes — and it still does (it's a test-mode flag). But now it loudly surfaces the cache gap rather than silently passing the run as completed.
- **"Consider making bootstrap unconditional (it is idempotent per its docstring); the only reason to skip is if the operator explicitly declines."** Done. Bootstrap is now invoked whenever `candidates.jsonl` is absent, except in the two explicit-skip paths: `--no-subprocess` (test-mode, loudly warned) and `--skip-bootstrap` (operator decline, audit-trailed).

## Tests

`tests/test_triage_welcome.py` adds 5 new #1244 regression tests:
1. `test_bootstrap_runs_when_audit_log_absent_even_with_cache_entries` — the bug-report repro state (raw `.deft-cache/` populated, `candidates.jsonl` absent) now invokes `task triage:bootstrap`.
2. `test_skip_bootstrap_emits_visible_audit_message` — `--skip-bootstrap` path emits operator-visible audit message AND persists to `meta/policy-changes.log`.
3. `test_no_subprocess_surfaces_cache_gap_loudly` — `--no-subprocess` warning includes the canonical "downstream verbs will refuse to run" phrasing.
4. `test_phase_1_readout_surfaces_audit_log_state` — Phase 1 readout includes the `candidates.jsonl: present` line.
5. `test_cli_skip_bootstrap_flag_threads_through` — CLI `--skip-bootstrap` flag reaches `run_welcome`.

All 31 tests in `tests/test_triage_welcome.py` pass locally (`uv run pytest tests/test_triage_welcome.py`).

## Definition of done — verified

- ✅ `task triage:welcome` (default path) produces a populated `vbrief/.eval/candidates.jsonl` on exit when the audit log is absent.
- ✅ The ritual surfaces clearly whether step 3 bootstrap was executed or skipped (and why if skipped).
- ✅ New tests cover (a) the non-interactive path where bootstrap MUST run, (b) the explicit-decline path with visible audit message.
- ✅ The GH issue's "Suggested investigation" bullets are answered above.

## `task check` — pre-existing failures (NOT introduced by this PR)

Two failures pre-exist on the `chore/demote-pre-cache-pending` base branch HEAD and are unrelated to this fix:

1. `tests/content/test_consumer_config_example.py::test_policy_omits_wip_cap` — `vbrief/PROJECT-DEFINITION.vbrief.json` already had `wipCap` set before this PR's first commit (`git --no-pager log --oneline -1 vbrief/PROJECT-DEFINITION.vbrief.json` shows commit `ea5bbee` is the most recent toucher, predates my work).
2. `tests/test_eval_governance.py::test_gitignore_does_not_blanket_ignore_eval_directory` — `.gitignore` already blanket-ignores `vbrief/.eval/`; I did not touch `.gitignore` (verified via `git diff .gitignore` is empty).

Both fail when my changes are stashed. The base branch carries this drift; this PR's scope is strictly #1244.

## Scope notes

- Touched only the files I own per the dispatch envelope: `scripts/triage_welcome.py`, `scripts/_triage_welcome_cli.py`, `tests/test_triage_welcome.py`, `CHANGELOG.md`, and the assigned vBRIEF.
- Imported from (but did NOT modify) `scripts/triage_bootstrap.py` — Phase 3 still delegates to `task triage:bootstrap` via the existing subprocess hop. The fix lives in the orchestration layer per the dispatch constraint.
- `scripts/triage_welcome.py` line count: 999 (under the AGENTS.md `<1000 line` MUST ceiling).

## Checklist

- [x] Tests added for new code paths
- [x] CHANGELOG.md entry under `[Unreleased]` (#1242 style, ~700 chars, ends `Closes #1244`)
- [x] vBRIEF Overview enriched with plan.items[]
- [x] `uv run pytest tests/test_triage_welcome.py` passes (31/31)
- [x] `uv run python scripts/vbrief_validate.py` exits 0
