### PR TITLE
fix(triage,cache): autodetect --repo in triage:queue; clarify populate_cache counters (#1246, #1247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- `task triage:queue` (and the sibling `triage:show` / `triage:audit` verbs) now auto-detect `--repo` from the current clone's `origin` remote, so operators inside an unambiguous repository no longer have to repeat the `OWNER/NAME` slug on every invocation. The explicit `--repo` flag and `$DEFT_TRIAGE_REPO` env var still take precedence; an outside-git-tree invocation continues to surface the canonical "--repo required" error. Closes #1246.
+- `cache:fetch-all` now reports per-issue counters under unambiguous noun names (`issues_written`, `already_fresh`, `issues_failed`) instead of the misleading `succeeded` / `failed` / `skipped` triple that made `skipped=396` read as "396 items dropped" on a healthy bootstrap. The JSON output keeps the legacy keys for one release of back-compat; a new `FetchAllReport.summary_line()` renderer produces the unambiguous human-readable recap consumers should adopt. Closes #1247.
 
 ### Removed
 

--- a/scripts/_cache_fetch.py
+++ b/scripts/_cache_fetch.py
@@ -327,7 +327,7 @@ def run_fetch_all(
         raw = _normalise_rest_issue(issue)
         number = raw.get("number")
         if not isinstance(number, int) or number <= 0:
-            report.failed += 1
+            report.issues_failed += 1
             report.failures.append(
                 {"key": f"{repo}/?", "reason": f"invalid 'number' field: {number!r}"}
             )
@@ -336,14 +336,14 @@ def run_fetch_all(
         key = f"{repo}/{number}"
         edir = entry_dir_for(key)
         if is_fresh(edir / "meta.json"):
-            report.skipped += 1
+            report.already_fresh += 1
             continue
 
         try:
             do_put(key, raw)
-            report.succeeded += 1
+            report.issues_written += 1
         except Exception as exc:  # noqa: BLE001 -- caller's CacheError variants
-            report.failed += 1
+            report.issues_failed += 1
             report.failures.append({"key": key, "reason": str(exc)})
 
         # Per-issue delay; batch-size checkpoint adds an extra pause so a

--- a/scripts/_cache_fetch.py
+++ b/scripts/_cache_fetch.py
@@ -146,23 +146,129 @@ def _normalise_rest_issue(raw: dict[str, Any]) -> dict[str, Any]:
 
 @dataclass
 class FetchAllReport:
-    """Aggregate counts returned by :func:`run_fetch_all`."""
+    """Aggregate counts returned by :func:`run_fetch_all`.
 
-    succeeded: int = 0
-    failed: int = 0
-    skipped: int = 0
+    Counter terminology (#1247)
+    ---------------------------
+    Pre-#1247 the report exposed three counters named ``succeeded`` /
+    ``failed`` / ``skipped``. Operators read the recap line
+    ``cache:fetch-all ... succeeded=1 failed=0 skipped=396`` as "1 of
+    397 items processed, 396 dropped" and assumed something was wrong
+    -- when in fact ``succeeded`` counted per-issue cache writes that
+    actually landed on disk (a fresh fetch + put), ``skipped`` counted
+    per-issue entries that were already-fresh in the cache (TTL window
+    still valid, so no re-fetch was needed), and ``failed`` counted
+    per-issue write errors. The terminology was at three different
+    levels of abstraction.
+
+    The canonical attribute names are now ``issues_written`` /
+    ``already_fresh`` / ``issues_failed``. The legacy ``succeeded`` /
+    ``failed`` / ``skipped`` attributes remain as backward-compatible
+    aliases (read-write) so external callers and tests that still
+    reference the old names keep working until they migrate.
+
+    :meth:`to_json` emits the new keys as the primary surface and
+    duplicates them under the legacy keys for one release. The
+    :meth:`summary_line` renderer produces the unambiguous human-
+    readable string the triage:bootstrap recap and ``task
+    cache:fetch-all`` direct invocations consume.
+    """
+
+    #: Per-issue cache writes that landed (fresh fetch + put). Was named
+    #: ``succeeded`` pre-#1247.
+    issues_written: int = 0
+    #: Per-issue cache writes that errored out. Was named ``failed``
+    #: pre-#1247.
+    issues_failed: int = 0
+    #: Per-issue entries skipped because the on-disk cache was still
+    #: within its TTL window (no re-fetch needed). Was named ``skipped``
+    #: pre-#1247 -- the source of the misleading "why are 396 things
+    #: skipped?" first-read.
+    already_fresh: int = 0
     failures: list[dict[str, str]] = field(default_factory=list)
 
+    # ----- Backward-compat property aliases (#1247) -----
+    #
+    # External callers (scripts/triage_bootstrap.py recap line,
+    # tests/test_cache.py, tests/integration/test_cache_*.py) still
+    # read ``report.succeeded`` / ``report.failed`` / ``report.skipped``.
+    # The aliases below preserve that surface so the rename is non-
+    # breaking; new code SHOULD use the canonical names above.
+
+    @property
+    def succeeded(self) -> int:
+        """Legacy alias for :attr:`issues_written` (#1247)."""
+        return self.issues_written
+
+    @succeeded.setter
+    def succeeded(self, value: int) -> None:
+        self.issues_written = value
+
+    @property
+    def failed(self) -> int:
+        """Legacy alias for :attr:`issues_failed` (#1247)."""
+        return self.issues_failed
+
+    @failed.setter
+    def failed(self, value: int) -> None:
+        self.issues_failed = value
+
+    @property
+    def skipped(self) -> int:
+        """Legacy alias for :attr:`already_fresh` (#1247)."""
+        return self.already_fresh
+
+    @skipped.setter
+    def skipped(self, value: int) -> None:
+        self.already_fresh = value
+
     def to_json(self) -> str:
+        """Serialise the report.
+
+        v1 emits both the canonical (#1247) and legacy keys so existing
+        consumers (``tests/test_cache.py::test_partial_failure_exit_shape``
+        asserts ``payload["succeeded"]`` / ``payload["failed"]``) keep
+        passing while the framework completes the rename rollout. The
+        legacy duplicates are removed in a future release once the rest
+        of the consumer tree has migrated.
+        """
         return json.dumps(
             {
-                "succeeded": self.succeeded,
-                "failed": self.failed,
-                "skipped": self.skipped,
+                # Canonical (#1247) -- the unambiguous noun-level surface.
+                "issues_written": self.issues_written,
+                "already_fresh": self.already_fresh,
+                "issues_failed": self.issues_failed,
+                # Legacy aliases preserved one release for back-compat.
+                "succeeded": self.issues_written,
+                "failed": self.issues_failed,
+                "skipped": self.already_fresh,
                 "failures": self.failures,
             },
             ensure_ascii=False,
             sort_keys=True,
+        )
+
+    def summary_line(self, *, source: str, repo: str) -> str:
+        """Render the unambiguous human-readable recap line (#1247).
+
+        Replaces the misleading ``succeeded=1 failed=0 skipped=396``
+        formatting with explicit per-issue counter names so an operator
+        reading the first signal of a bootstrap run does not have to
+        ask "why are 396 things skipped?". The naming follows the GH
+        issue body's 'Expected' suggestion:
+
+            cache:fetch-all source=github-issue repo=owner/name
+            issues_written=1 already_fresh=396 issues_failed=0
+
+        Operators / orchestrators / recap formatters that need a
+        single-line, machine-greppable status string SHOULD prefer this
+        method over hand-formatting against the individual attributes.
+        """
+        return (
+            f"cache:fetch-all source={source} repo={repo} "
+            f"issues_written={self.issues_written} "
+            f"already_fresh={self.already_fresh} "
+            f"issues_failed={self.issues_failed}"
         )
 
 
@@ -251,9 +357,7 @@ def run_fetch_all(
     return report
 
 
-def _list_issues_rest(
-    repo: str, *, state: str, limit: int
-) -> list[dict[str, Any]]:
+def _list_issues_rest(repo: str, *, state: str, limit: int) -> list[dict[str, Any]]:
     """Wrap :func:`rest_issue_list_paginated` with retry on REST 429.
 
     REST's ``core`` bucket has a 5000/hr/user budget -- much larger than
@@ -264,9 +368,7 @@ def _list_issues_rest(
     try:
         return _paginated_lister(repo, state=state, limit=limit)
     except InvalidRepoError as exc:
-        raise CacheFetchError(
-            f"invalid --repo {repo!r} for REST list enumeration: {exc}"
-        ) from exc
+        raise CacheFetchError(f"invalid --repo {repo!r} for REST list enumeration: {exc}") from exc
     except GhRestError as exc:
         is_429, retry_after = detect_rate_limit(str(exc) or exc.stderr or "")
         if not is_429:

--- a/scripts/_triage_queue_cli.py
+++ b/scripts/_triage_queue_cli.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -277,8 +278,6 @@ def _detect_origin_repo_inline(project_root: Path | None) -> str | None:
     url = (result.stdout or "").strip()
     if not url:
         return None
-    import re
-
     match = re.search(
         r"github\.com[:/]([A-Za-z0-9][A-Za-z0-9._-]*)/"
         r"([A-Za-z0-9][A-Za-z0-9._-]*?)(?:\.git)?/?\s*$",

--- a/scripts/_triage_queue_cli.py
+++ b/scripts/_triage_queue_cli.py
@@ -4,6 +4,17 @@ Extracted from ``scripts/triage_queue.py`` so the parent module stays
 under the 1000-line MUST cap documented in ``coding/coding.md``. The
 public surface lives in ``triage_queue``; this module is the argparse
 shim and command dispatcher only.
+
+Repo resolution (#1246)
+-----------------------
+The ``triage:queue`` / ``triage:show`` / ``triage:audit`` CLI surfaces
+resolve ``--repo`` with the precedence: explicit ``--repo`` flag >
+``$DEFT_TRIAGE_REPO`` env var > auto-detection from
+``git remote get-url origin`` (run inside ``--project-root``) > error.
+The auto-detection step removes the most-common-path papercut where an
+operator inside an unambiguous clone had to repeat the repo slug on
+every invocation. Cross-repo invocations remain supported via the
+explicit flag (highest precedence).
 """
 
 from __future__ import annotations
@@ -11,6 +22,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -38,9 +50,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--repo",
         default=os.environ.get("DEFT_TRIAGE_REPO"),
-        help=(
-            "Upstream repo slug 'owner/name'. Falls back to $DEFT_TRIAGE_REPO."
-        ),
+        help=("Upstream repo slug 'owner/name'. Falls back to $DEFT_TRIAGE_REPO."),
     )
     parser.add_argument(
         "--cache-root",
@@ -68,9 +78,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
 def build_parser(default_limit: int) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="triage_queue.py",
-        description=(
-            "Ranked triage queue + per-item show + audit-log surface (#1128)."
-        ),
+        description=("Ranked triage queue + per-item show + audit-log surface (#1128)."),
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
@@ -81,8 +89,7 @@ def build_parser(default_limit: int) -> argparse.ArgumentParser:
         type=int,
         default=default_limit,
         help=(
-            "Cap the number of rows printed (default: "
-            f"{default_limit}). Pass 0 to disable the cap."
+            f"Cap the number of rows printed (default: {default_limit}). Pass 0 to disable the cap."
         ),
     )
 
@@ -213,8 +220,99 @@ def build_parser(default_limit: int) -> argparse.ArgumentParser:
     return parser
 
 
+#: subprocess.run timeout for ``git remote get-url origin`` auto-detection
+#: (#1246). Defensive: a stuck ``git`` proxy (corporate VPN re-auth) would
+#: otherwise hang every ``task triage:queue`` invocation indefinitely.
+_GIT_INFER_TIMEOUT_S: int = 10
+
+
+def _detect_origin_repo(project_root: Path | None) -> str | None:
+    """Return ``owner/name`` parsed from ``git remote get-url origin``, or ``None``.
+
+    Run inside ``project_root`` (or the current working directory when
+    ``project_root`` is ``None``). Returns ``None`` on any of:
+
+    * ``git`` not on PATH.
+    * ``git remote get-url origin`` exits non-zero (outside a git working
+      tree, or no ``origin`` remote configured).
+    * The subprocess hangs past :data:`_GIT_INFER_TIMEOUT_S` seconds --
+      defensive against a wedged credential helper / VPN re-auth.
+    * The origin URL is not a recognised ``github.com`` form (https /
+      ssh / git@ shapes).
+
+    Delegated to ``scripts/_project_context.py::_detect_repo_from_git``
+    where importable so the framework keeps a single origin-detection
+    grammar; falls back to an inline implementation only on slim test
+    checkouts that have not yet rebased onto that module.
+    """
+    try:
+        from _project_context import _detect_repo_from_git
+    except ImportError:  # pragma: no cover -- slim-checkout fallback
+        return _detect_origin_repo_inline(project_root)
+    return _detect_repo_from_git(project_root)
+
+
+def _detect_origin_repo_inline(project_root: Path | None) -> str | None:
+    """Fallback origin-detector used when ``_project_context`` is unimportable.
+
+    Mirrors the precedence + parsing rules of the canonical helper so
+    consumers on a slim test checkout still get the #1246 papercut
+    eliminated. Returns ``None`` when detection fails so the caller can
+    surface the canonical "--repo required" error.
+    """
+    cwd = str(project_root) if project_root is not None else None
+    try:
+        result = subprocess.run(  # noqa: S603 -- argv is a literal
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=cwd,
+            timeout=_GIT_INFER_TIMEOUT_S,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = (result.stdout or "").strip()
+    if not url:
+        return None
+    import re
+
+    match = re.search(
+        r"github\.com[:/]([A-Za-z0-9][A-Za-z0-9._-]*)/"
+        r"([A-Za-z0-9][A-Za-z0-9._-]*?)(?:\.git)?/?\s*$",
+        url,
+    )
+    if not match:
+        return None
+    return f"{match.group(1)}/{match.group(2)}"
+
+
 def _resolve_repo(args: argparse.Namespace) -> str | None:
-    return args.repo or os.environ.get("DEFT_TRIAGE_REPO")
+    """Resolve the effective ``--repo`` slug for triage_queue CLI verbs.
+
+    Precedence (#1246):
+
+    1. ``args.repo`` -- the explicit ``--repo`` flag, which also picks up
+       ``$DEFT_TRIAGE_REPO`` because the argparse default reads the env
+       var. Highest precedence; preserved for cross-repo invocations.
+    2. ``git remote get-url origin`` parsed from inside
+       ``--project-root`` (or the current working directory). Removes
+       the papercut where an operator inside an unambiguous clone had
+       to repeat the repo slug on every ``task triage:queue`` call.
+    3. ``None`` -- the caller emits the canonical
+       ``triage:<verb>: --repo OWNER/NAME (or $DEFT_TRIAGE_REPO) is
+       required.`` error so the operator sees an actionable next step
+       rather than a silent empty-cache walk.
+    """
+    if args.repo:
+        return args.repo
+    project_root: Path | None = None
+    if getattr(args, "project_root", None):
+        with contextlib.suppress(OSError):
+            project_root = Path(args.project_root).resolve()
+    return _detect_origin_repo(project_root)
 
 
 def _override_cache_root(project_root: Path, cache_root: Path) -> None:
@@ -250,21 +348,15 @@ def _cmd_queue(args: argparse.Namespace, tq: Any) -> int:
     # can see closed umbrellas; the queue itself still filters to open
     # children via the QueueBuildOptions.orphan_issue_numbers set.
     issues_for_queue = tq.load_cached_issues(repo, project_root=project_root)
-    issues_with_closed = tq.load_cached_issues(
-        repo, project_root=project_root, include_closed=True
-    )
+    issues_with_closed = tq.load_cached_issues(repo, project_root=project_root, include_closed=True)
     issues_by_number = {i["number"]: i for i in issues_with_closed}
     audit_entries = tq.read_audit_entries(repo, audit_path=args.audit_log)
     ranking_labels = tuple(tq.resolve_ranking_labels(project_root))
     active_refs = frozenset(tq._active_referenced_issue_numbers(project_root))
     orphan_numbers: frozenset[int] = frozenset()
     if slice_audit is not None:
-        records = slice_audit.load_slice_records(
-            tq.slice_record, path=args.slices_log
-        )
-        orphan_numbers = slice_audit.collect_orphan_issue_numbers(
-            records, issues_by_number
-        )
+        records = slice_audit.load_slice_records(tq.slice_record, path=args.slices_log)
+        orphan_numbers = slice_audit.collect_orphan_issue_numbers(records, issues_by_number)
     limit = None if args.limit == 0 else max(0, int(args.limit))
     options = tq.QueueBuildOptions(
         ranking_labels=ranking_labels,
@@ -272,9 +364,7 @@ def _cmd_queue(args: argparse.Namespace, tq: Any) -> int:
         orphan_issue_numbers=orphan_numbers,
         limit=limit,
     )
-    items = tq.build_queue(
-        issues_for_queue, audit_entries, repo=repo, options=options
-    )
+    items = tq.build_queue(issues_for_queue, audit_entries, repo=repo, options=options)
     print(
         tq.render_queue(
             items,
@@ -299,18 +389,12 @@ def _cmd_show(args: argparse.Namespace, tq: Any) -> int:
         _override_cache_root(project_root, Path(args.cache_root).resolve())
     issues = {
         i["number"]: i
-        for i in tq.load_cached_issues(
-            repo, project_root=project_root, include_closed=True
-        )
+        for i in tq.load_cached_issues(repo, project_root=project_root, include_closed=True)
     }
     issue = issues.get(int(args.number))
     history: list[dict[str, Any]] = []
     if tq.candidates_log is not None:
-        history = list(
-            tq.candidates_log.find_by_issue(
-                int(args.number), repo, path=args.audit_log
-            )
-        )
+        history = list(tq.candidates_log.find_by_issue(int(args.number), repo, path=args.audit_log))
     history_sorted = sorted(history, key=lambda r: r.get("timestamp", ""))
     latest = history_sorted[-1] if history_sorted else None
     active_refs = tq._active_referenced_issue_numbers(project_root)
@@ -393,11 +477,7 @@ def _cmd_audit(args: argparse.Namespace, tq: Any) -> int:
     if args.vbrief_staleness:
         active_refs = frozenset(tq._active_referenced_issue_numbers(project_root))
         latest = tq.latest_decisions_by_issue(entries)
-        entries = [
-            entry
-            for entry in latest.values()
-            if tq.is_stale_acceptance(entry, active_refs)
-        ]
+        entries = [entry for entry in latest.values() if tq.is_stale_acceptance(entry, active_refs)]
         entries.sort(key=lambda r: r.get("timestamp", ""))
     if args.format == "json":
         print(
@@ -448,12 +528,8 @@ def _slice_inputs(
             file=sys.stderr,
         )
         return None
-    records = slice_audit.load_slice_records(
-        tq.slice_record, path=args.slices_log
-    )
-    issues = tq.load_cached_issues(
-        repo, project_root=project_root, include_closed=True
-    )
+    records = slice_audit.load_slice_records(tq.slice_record, path=args.slices_log)
+    issues = tq.load_cached_issues(repo, project_root=project_root, include_closed=True)
     issues_by_number = {i["number"]: i for i in issues}
     return records, issues_by_number
 

--- a/tests/test_cache_fetch.py
+++ b/tests/test_cache_fetch.py
@@ -1,0 +1,160 @@
+"""Tests for scripts/_cache_fetch.py FetchAllReport rename (#1247).
+
+The pre-#1247 ``succeeded`` / ``failed`` / ``skipped`` counters misled
+operators reading the ``triage:bootstrap step 1`` / ``task
+cache:fetch-all`` recap (they read ``skipped=396`` as "396 items
+dropped" when the value actually counted already-fresh cache entries
+that did NOT need re-fetching). The rename introduces unambiguous
+canonical names while keeping the legacy aliases for one release of
+back-compat.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_cache_fetch = importlib.import_module("_cache_fetch")
+FetchAllReport = _cache_fetch.FetchAllReport
+
+
+# ---------------------------------------------------------------------------
+# Canonical attribute names (#1247)
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_attributes_default_to_zero():
+    report = FetchAllReport()
+    assert report.issues_written == 0
+    assert report.already_fresh == 0
+    assert report.issues_failed == 0
+    assert report.failures == []
+
+
+def test_canonical_attributes_assignable_directly():
+    report = FetchAllReport()
+    report.issues_written = 5
+    report.already_fresh = 10
+    report.issues_failed = 1
+    assert report.issues_written == 5
+    assert report.already_fresh == 10
+    assert report.issues_failed == 1
+
+
+# ---------------------------------------------------------------------------
+# Legacy alias back-compat (#1247)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_aliases_read_through_to_canonical():
+    report = FetchAllReport(issues_written=7, already_fresh=3, issues_failed=1)
+    # Legacy alias accessors must read through to the canonical fields
+    # so external callers (triage_bootstrap recap formatter,
+    # tests/test_cache.py, tests/integration/test_cache_*.py) keep
+    # working without modification.
+    assert report.succeeded == 7
+    assert report.skipped == 3
+    assert report.failed == 1
+
+
+def test_legacy_aliases_write_through_to_canonical():
+    report = FetchAllReport()
+    report.succeeded = 4
+    report.failed = 2
+    report.skipped = 8
+    # Setters update the canonical attributes.
+    assert report.issues_written == 4
+    assert report.issues_failed == 2
+    assert report.already_fresh == 8
+
+
+def test_legacy_increments_compose_with_canonical_reads():
+    """`report.succeeded += 1` must increment via the property setter.
+
+    This is the exact pattern :func:`run_fetch_all` uses internally;
+    breaking it would silently zero the counters on every run.
+    """
+    report = FetchAllReport()
+    report.succeeded += 1
+    report.succeeded += 1
+    report.failed += 1
+    report.skipped += 3
+    assert report.issues_written == 2
+    assert report.issues_failed == 1
+    assert report.already_fresh == 3
+
+
+# ---------------------------------------------------------------------------
+# to_json() emits both canonical and legacy keys (#1247)
+# ---------------------------------------------------------------------------
+
+
+def test_to_json_includes_canonical_keys():
+    report = FetchAllReport(issues_written=1, already_fresh=396, issues_failed=0)
+    payload = json.loads(report.to_json())
+    # Canonical keys present and carry the right values.
+    assert payload["issues_written"] == 1
+    assert payload["already_fresh"] == 396
+    assert payload["issues_failed"] == 0
+
+
+def test_to_json_preserves_legacy_keys_for_back_compat():
+    """Legacy aliases survive in to_json() for one release of back-compat.
+
+    Existing consumers (``tests/test_cache.py::test_partial_failure_exit_shape``
+    reads ``payload['succeeded']`` / ``payload['failed']``) keep working.
+    """
+    report = FetchAllReport(issues_written=1, already_fresh=396, issues_failed=2)
+    payload = json.loads(report.to_json())
+    assert payload["succeeded"] == 1
+    assert payload["skipped"] == 396
+    assert payload["failed"] == 2
+
+
+def test_to_json_emits_failures_list_unchanged():
+    failures = [{"key": "owner/repo/42", "reason": "boom"}]
+    report = FetchAllReport(issues_written=0, issues_failed=1, failures=list(failures))
+    payload = json.loads(report.to_json())
+    assert payload["failures"] == failures
+
+
+# ---------------------------------------------------------------------------
+# summary_line() renders the unambiguous human-readable recap (#1247)
+# ---------------------------------------------------------------------------
+
+
+def test_summary_line_uses_unambiguous_noun_names():
+    report = FetchAllReport(issues_written=1, already_fresh=396, issues_failed=0)
+    line = report.summary_line(source="github-issue", repo="deftai/directive")
+    # The unambiguous counter names are present.
+    assert "issues_written=1" in line
+    assert "already_fresh=396" in line
+    assert "issues_failed=0" in line
+    # And the misleading legacy nouns are NOT in the user-visible line.
+    assert "succeeded=" not in line
+    assert "skipped=" not in line
+    # The "skipped" suffix appears only inside "already_fresh" never as
+    # a standalone token -- check exact word boundary by re-asserting.
+    assert " skipped " not in f" {line} "
+
+
+def test_summary_line_includes_source_and_repo():
+    report = FetchAllReport()
+    line = report.summary_line(source="github-issue", repo="owner/name")
+    assert "source=github-issue" in line
+    assert "repo=owner/name" in line
+    assert line.startswith("cache:fetch-all ")
+
+
+def test_summary_line_renders_when_all_three_counters_nonzero():
+    report = FetchAllReport(issues_written=10, already_fresh=20, issues_failed=2)
+    line = report.summary_line(source="github-issue", repo="o/r")
+    assert "issues_written=10" in line
+    assert "already_fresh=20" in line
+    assert "issues_failed=2" in line

--- a/tests/test_triage_queue.py
+++ b/tests/test_triage_queue.py
@@ -1160,8 +1160,12 @@ def test_cli_queue_outside_git_tree_still_errors(monkeypatch, capsys, tmp_path: 
 def test_detect_origin_repo_returns_none_on_missing_git(monkeypatch):
     """`_detect_origin_repo` returns None when git is absent / blows up."""
     # Force the canonical helper to return None via a monkeypatched
-    # _project_context._detect_repo_from_git.
-    import _project_context  # type: ignore[import-not-found]
+    # _project_context._detect_repo_from_git. Use ``pytest.importorskip``
+    # so a slim test checkout that does not vendor _project_context skips
+    # cleanly instead of raising ``ModuleNotFoundError`` at collection
+    # time (Greptile P2 on PR #1254 -- mirrors the ``except ImportError``
+    # guard the production code already carries on the same import).
+    _project_context = pytest.importorskip("_project_context")
 
     monkeypatch.setattr(
         _project_context,

--- a/tests/test_triage_queue.py
+++ b/tests/test_triage_queue.py
@@ -16,8 +16,10 @@ Covers the read-only triage queue + show + audit surface:
 
 from __future__ import annotations
 
+import argparse
 import importlib
 import json
+import subprocess
 import sys
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -109,9 +111,7 @@ def _write_cached_issue(
     # Emulate the unified-cache labels shape: list of {name: ...} dicts.
     raw = dict(issue)
     raw["labels"] = [{"name": label} for label in issue.get("labels", [])]
-    (edir / "raw.json").write_text(
-        json.dumps(raw, sort_keys=True), encoding="utf-8"
-    )
+    (edir / "raw.json").write_text(json.dumps(raw, sort_keys=True), encoding="utf-8")
     return edir
 
 
@@ -152,9 +152,7 @@ def test_validate_ranking_labels_rejects_empty_entry():
 
 
 def test_validate_ranking_labels_warns_duplicate():
-    _errors, warnings = triage_queue.validate_ranking_labels(
-        ["urgent", "urgent"]
-    )
+    _errors, warnings = triage_queue.validate_ranking_labels(["urgent", "urgent"])
     assert any("duplicate label" in w for w in warnings)
 
 
@@ -366,9 +364,7 @@ def test_load_cached_issues_walks_repo_dir(tmp_path: Path):
     cache_root = tmp_path / ".deft-cache"
     _write_cached_issue(cache_root, REPO, _issue(1, title="First"))
     _write_cached_issue(cache_root, REPO, _issue(2, title="Second"))
-    _write_cached_issue(
-        cache_root, REPO, _issue(3, title="Closed", state="closed")
-    )
+    _write_cached_issue(cache_root, REPO, _issue(3, title="Closed", state="closed"))
     issues = triage_queue.load_cached_issues(REPO, project_root=tmp_path)
     # Closed excluded by default; sort by number for assertion stability.
     nums = sorted(i["number"] for i in issues)
@@ -383,9 +379,7 @@ def test_load_cached_issues_include_closed(tmp_path: Path):
     cache_root = tmp_path / ".deft-cache"
     _write_cached_issue(cache_root, REPO, _issue(1, state="open"))
     _write_cached_issue(cache_root, REPO, _issue(2, state="closed"))
-    issues = triage_queue.load_cached_issues(
-        REPO, project_root=tmp_path, include_closed=True
-    )
+    issues = triage_queue.load_cached_issues(REPO, project_root=tmp_path, include_closed=True)
     assert sorted(i["number"] for i in issues) == [1, 2]
 
 
@@ -656,9 +650,7 @@ def test_cli_audit_json_emits_stable_schema(capsys, tmp_path: Path):
     assert payload["repo"] == REPO
 
 
-def test_cli_audit_vbrief_staleness_filters_to_stale_accepts(
-    capsys, tmp_path: Path
-):
+def test_cli_audit_vbrief_staleness_filters_to_stale_accepts(capsys, tmp_path: Path):
     audit_path = tmp_path / "vbrief" / ".eval" / "candidates.jsonl"
     entries = [
         _audit_entry(200, "accept", timestamp="2026-05-15T10:00:00Z"),  # stale
@@ -746,9 +738,7 @@ def test_cli_show_returns_0_with_decision_history(capsys, tmp_path: Path):
 
 def test_cli_queue_requires_repo(capsys, tmp_path: Path, monkeypatch):
     monkeypatch.delenv("DEFT_TRIAGE_REPO", raising=False)
-    rc = triage_queue.main(
-        ["queue", "--project-root", str(tmp_path)]
-    )
+    rc = triage_queue.main(["queue", "--project-root", str(tmp_path)])
     assert rc == 2
     assert "--repo" in capsys.readouterr().err
 
@@ -1069,3 +1059,113 @@ def test_cli_audit_no_flags_preserves_d11_behaviour(capsys, tmp_path: Path):
     payload = json.loads(capsys.readouterr().out)
     # _seed_cache_and_log writes two entries; both should pass.
     assert payload["entry_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Repo auto-detection (#1246)
+# ---------------------------------------------------------------------------
+
+
+def _init_fake_git_origin(tmp_path: Path, url: str) -> None:
+    """Initialise a bare-bones git working tree in ``tmp_path`` with ``origin=url``.
+
+    Used by the #1246 autodetect tests so we can exercise the
+    ``git remote get-url origin`` path without depending on the host
+    working copy's remote configuration.
+    """
+    subprocess.run(
+        ["git", "init", "--quiet", str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "remote", "add", "origin", url],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_args(*, repo: str | None = None, project_root: str = ".") -> argparse.Namespace:
+    return argparse.Namespace(repo=repo, project_root=project_root)
+
+
+def test_resolve_repo_returns_explicit_flag_first(monkeypatch, tmp_path: Path):
+    # Explicit flag wins even when the env var is set and origin is detectable.
+    monkeypatch.setenv("DEFT_TRIAGE_REPO", "env/repo")
+    _init_fake_git_origin(tmp_path, "https://github.com/auto/detect.git")
+    args = _make_args(repo="explicit/win", project_root=str(tmp_path))
+    assert triage_queue_cli._resolve_repo(args) == "explicit/win"
+
+
+def test_resolve_repo_falls_back_to_env_var(monkeypatch, tmp_path: Path):
+    # No explicit flag -> DEFT_TRIAGE_REPO is captured by argparse default,
+    # so args.repo carries the env var value; autodetect is not consulted.
+    monkeypatch.setenv("DEFT_TRIAGE_REPO", "env/wins")
+    _init_fake_git_origin(tmp_path, "https://github.com/auto/detect.git")
+    # argparse parses the queue subcommand with the env default applied.
+    parser = triage_queue_cli.build_parser(default_limit=25)
+    args = parser.parse_args(["queue", "--project-root", str(tmp_path)])
+    assert triage_queue_cli._resolve_repo(args) == "env/wins"
+
+
+def test_resolve_repo_autodetects_from_origin_https(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("DEFT_TRIAGE_REPO", raising=False)
+    _init_fake_git_origin(tmp_path, "https://github.com/deftai/directive.git")
+    args = _make_args(repo=None, project_root=str(tmp_path))
+    assert triage_queue_cli._resolve_repo(args) == "deftai/directive"
+
+
+def test_resolve_repo_autodetects_from_origin_ssh(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("DEFT_TRIAGE_REPO", raising=False)
+    _init_fake_git_origin(tmp_path, "git@github.com:owner/with.dots.git")
+    args = _make_args(repo=None, project_root=str(tmp_path))
+    # The name component preserves dots (Greptile P1 on #562 lesson).
+    assert triage_queue_cli._resolve_repo(args) == "owner/with.dots"
+
+
+def test_resolve_repo_returns_none_outside_git_tree(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("DEFT_TRIAGE_REPO", raising=False)
+    # tmp_path has no .git/ and no origin remote -- detection must fail
+    # so the caller can surface the canonical --repo error.
+    args = _make_args(repo=None, project_root=str(tmp_path))
+    assert triage_queue_cli._resolve_repo(args) is None
+
+
+def test_cli_queue_autodetects_repo_no_flag_no_env(monkeypatch, capsys, tmp_path: Path):
+    """`task triage:queue` without --repo / env var must succeed when origin resolves.
+
+    Acceptance criterion (a) from the issue body: the most-common-path
+    papercut is gone. Cache is empty so the queue prints the bootstrap
+    hint; the load-bearing assertion is `rc == 0` (no --repo error).
+    """
+    monkeypatch.delenv("DEFT_TRIAGE_REPO", raising=False)
+    _init_fake_git_origin(tmp_path, "https://github.com/deftai/directive.git")
+    rc = triage_queue.main(["queue", "--project-root", str(tmp_path)])
+    out = capsys.readouterr()
+    assert rc == 0, f"stdout={out.out!r} stderr={out.err!r}"
+    # The render_queue header names the auto-detected repo.
+    assert "deftai/directive" in out.out
+
+
+def test_cli_queue_outside_git_tree_still_errors(monkeypatch, capsys, tmp_path: Path):
+    """Acceptance criterion (d): no --repo + outside-git-repo -> error preserved."""
+    monkeypatch.delenv("DEFT_TRIAGE_REPO", raising=False)
+    rc = triage_queue.main(["queue", "--project-root", str(tmp_path)])
+    assert rc == 2
+    assert "--repo" in capsys.readouterr().err
+
+
+def test_detect_origin_repo_returns_none_on_missing_git(monkeypatch):
+    """`_detect_origin_repo` returns None when git is absent / blows up."""
+    # Force the canonical helper to return None via a monkeypatched
+    # _project_context._detect_repo_from_git.
+    import _project_context  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(
+        _project_context,
+        "_detect_repo_from_git",
+        lambda _root: None,
+    )
+    assert triage_queue_cli._detect_origin_repo(None) is None


### PR DESCRIPTION
## Summary

Two small, surgical fixes batched into a single PR per the wave-dispatch plan.

### #1246 — autodetect `--repo` from `origin` remote

`task triage:queue` (and the sibling `triage:show` / `triage:audit` verbs)
previously refused to run when `--repo OWNER/NAME` was omitted, even inside
a git clone whose `origin` remote unambiguously identified the repo. New
resolution chain in `scripts/_triage_queue_cli.py::_resolve_repo`:

1. `--repo` flag (also picks up `$DEFT_TRIAGE_REPO` via the argparse default).
2. `git remote get-url origin` parsed from inside `--project-root`.
3. Canonical `"--repo OWNER/NAME ... is required."` error.

Delegates to the canonical helper `_project_context._detect_repo_from_git`
when importable so the framework keeps a single origin-detection grammar;
falls back to an inline parser on slim test checkouts.

### #1247 — unambiguous `cache:fetch-all` counter names

`scripts/_cache_fetch.py::FetchAllReport` exposed three counters
(`succeeded` / `failed` / `skipped`) at three different levels of
abstraction. Operators read the recap line
`cache:fetch-all ... succeeded=1 failed=0 skipped=396` as
"1 of 397 items processed, 396 dropped" — when in fact `skipped` counted
already-fresh cache entries the orchestrator legitimately did not need
to re-fetch.

The canonical attribute names are now `issues_written` /
`already_fresh` / `issues_failed`. The legacy `succeeded` / `failed` /
`skipped` attributes remain as read/write `@property` aliases for one
release of back-compat (the bootstrap recap formatter, `tests/test_cache.py`,
and the integration suites all read the legacy names and keep working
without modification). `to_json()` emits both naming conventions and a new
`FetchAllReport.summary_line(source=..., repo=...)` renderer produces the
unambiguous human-readable recap callers should adopt.

## Acceptance criteria

**#1246**
- ✅ `task triage:queue -- --limit=10` works inside an unambiguous clone.
- ✅ Explicit `--repo` and `$DEFT_TRIAGE_REPO` still override autodetection.
- ✅ Outside-git-tree invocation still surfaces the canonical error.
- ✅ Tests cover (a) autodetect happy path (https + ssh), (b) flag override,
  (c) env override via argparse default, (d) outside-git-tree error path.

**#1247**
- ✅ Canonical counter names available on the `FetchAllReport` dataclass.
- ✅ `to_json()` emits `issues_written` / `already_fresh` / `issues_failed`
  alongside the legacy keys (one-release back-compat for downstream consumers).
- ✅ New `summary_line()` renderer produces the unambiguous human-readable
  string downstream consumers should adopt.
- ✅ Tests cover canonical fields, legacy alias read/write contract,
  `to_json()` dual-key emission, and `summary_line()` rendering.

## Follow-up (#1247 partial fix — surfaced as a separate concern)

The `task triage:bootstrap step 1/5 populate_cache -- done (...)` recap
line is hand-formatted inside `scripts/triage_bootstrap.py:496-505` via
`getattr(report, "succeeded", None)` etc. — that file is **not owned by
this agent** per the dispatch envelope's file-scope manifest, so the
recap line continues to print the legacy field names even though the
underlying dataclass and the `task cache:fetch-all` JSON output both
expose the unambiguous names.

The minimal follow-up edit is:

```python path=null start=null
# scripts/triage_bootstrap.py, replace lines 496-505 with:
return StepOutcome(
    name="populate_cache",
    ok=True,
    message=report.summary_line(source=_CACHE_SOURCE, repo=effective_repo),
    details={
        "repo": effective_repo,
        "source": _CACHE_SOURCE,
        "issues_written": report.issues_written,
        "already_fresh": report.already_fresh,
        "issues_failed": report.issues_failed,
        "elapsed_s": round(elapsed, 3),
        "fetch_timeout_s": effective_timeout,
    },
)
```

`scripts/cache.py::_cmd_fetch_all` (Line 939) already prints
`report.to_json()` to stdout, so the direct `task cache:fetch-all`
invocation already shows the unambiguous keys after this PR lands. The
follow-up only changes the `triage:bootstrap` recap line.

## Validation

- `task lint` — clean (ruff + mypy)
- `task verify:encoding` — clean (1169 files, no mojibake)
- `python -m pytest tests/test_cache_fetch.py tests/test_triage_queue.py
  tests/test_cache.py tests/test_triage_bootstrap.py` — 175 passed
- `python -m pytest tests/` (excluding pre-existing failures unrelated to
  this PR) — 6043 passed, 3 skipped, 1 xfailed
- 19 new tests covering both fixes (7 for #1246 autodetect, 12 for #1247
  FetchAllReport rename)

## Closes

- Closes #1246
- Closes #1247
