### PR TITLE
fix(triage,bootstrap): replace blanket .gitignore with selective #1144 hybrid entries (#1251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **fix(triage,bootstrap): selective `vbrief/.eval/` entries replace the blanket gitignore line (#1251)** -- `task triage:bootstrap` no longer appends a blanket `vbrief/.eval/` line that silently hid the tracked team-shared `slices.jsonl` cohort record from git. Step 4 now writes the three operator-private selective entries (`candidates.jsonl`, `summary-history.jsonl`, `scope-lifecycle.jsonl`), adds the `vbrief/.eval/*.jsonl  merge=union` rule to `.gitattributes`, and seeds `vbrief/.eval/README.md` on a fresh clone; re-runs against an already-configured repo are no-ops so `task check` stays green. Renamed the step from `ensure_gitignore_eval_dir` to `ensure_gitignore_eval_entries` to reflect the per-file semantics. Closes #1251. Refs #1144, #1132.
 
 ### Removed
 

--- a/scripts/_triage_bootstrap_gitignore.py
+++ b/scripts/_triage_bootstrap_gitignore.py
@@ -125,19 +125,52 @@ _EVAL_ENTRIES_RATIONALE: str = (
     "# rebase note.\n"
 )
 _GITATTRIBUTES_EVAL_RATIONALE: str = (
-    "# Append-only JSON-lines logs under vbrief/.eval/ use the union merge driver\n"
+    "\n# Append-only JSON-lines logs under vbrief/.eval/ use the union merge driver\n"
     "# (#1144, N4 of #1119). Both branches' appended lines are concatenated on\n"
     "# auto-merge so single-operator rebases of two append branches resolve\n"
     "# without manual conflict surgery. Note: merge=union does NOT dedupe; see\n"
     "# vbrief/.eval/README.md for the operator-facing semantics.\n"
 )
 
+#: First line of ``_EVAL_ENTRIES_RATIONALE`` used as the dedup sentinel
+#: when deciding whether to prepend the comment block on partial re-runs
+#: (Greptile P2 finding on PR #1256 -- a partial-state .gitignore that
+#: already carries the rationale block but is missing one or more
+#: selective entries should not get a duplicated comment block).
+_EVAL_ENTRIES_RATIONALE_SENTINEL: str = (
+    "# vbrief/.eval/ tracking governance (#1144, N4 of #1119)."
+)
+
+
+def _strip_gitignore_inline_comment(line: str) -> str:
+    """Strip an inline ``# ...`` comment from a gitignore line.
+
+    Returns the line content with any trailing comment removed and
+    surrounding whitespace stripped. A line whose entire content is a
+    comment (after leading whitespace) returns an empty string. Used
+    to detect forbidden blanket lines like ``vbrief/.eval/  # legacy``
+    that would otherwise slip past the set-membership check (SLizard
+    P1 finding on PR #1256).
+    """
+    stripped = line.strip()
+    if not stripped:
+        return ""
+    if stripped.startswith("#"):
+        return ""
+    comment_idx = stripped.find("#")
+    if comment_idx == -1:
+        return stripped
+    return stripped[:comment_idx].rstrip()
+
 
 def _gitignore_already_covers(gitignore_text: str, line: str) -> bool:
     """Return True when ``gitignore_text`` already includes ``line``."""
 
     target = line.strip()
-    return any(raw.strip() == target for raw in gitignore_text.splitlines())
+    return any(
+        _strip_gitignore_inline_comment(raw) == target
+        for raw in gitignore_text.splitlines()
+    )
 
 
 def _is_commented_gitignore_line(raw: str, gitignore_line: str) -> bool:
@@ -354,6 +387,13 @@ def step_ensure_gitignore_eval_entries(project_root: Path) -> StepOutcome:
         if created_readme:
             parts.append("vbrief/.eval/README.md")
         message = "wrote " + " + ".join(parts) + " per #1144 hybrid policy"
+    # Greptile P1 on PR #1256: propagate the stale-blanket warning
+    # through to the outer step's message so it reaches
+    # ``run_bootstrap``'s progress emit + the recap (the sub-step's
+    # message was discarded by the aggregator before this fix).
+    message = message + _format_blanket_warning(
+        bool(details.get("blanket_present", False))
+    )
     return outcome_cls(
         name=step_name,
         ok=True,
@@ -406,22 +446,39 @@ def _ensure_gitignore_selective_entries(
             details={"gitignore_appended_lines": 0},
         )
 
-    existing_lines = {line.strip() for line in existing.splitlines()}
+    # SLizard P1 finding on PR #1256: the previous detector used the
+    # whole stripped line (including inline comments) for set
+    # membership, so a blanket entry like ``vbrief/.eval/  # legacy``
+    # slipped past the forbidden check. Now strip the inline comment
+    # before building the membership set + scanning for forbidden
+    # blanket lines.
+    existing_lines = {
+        stripped
+        for raw in existing.splitlines()
+        if (stripped := _strip_gitignore_inline_comment(raw))
+    }
     blanket_present = any(
         forbidden in existing_lines
         for forbidden in _FORBIDDEN_BLANKET_EVAL_LINES
     )
+    # Greptile P2 finding on PR #1256: dedup the rationale comment
+    # block across partial re-runs (operator deleted one of the three
+    # entries manually; re-run should append the missing entry without
+    # re-prepending the rationale).
+    rationale_already_present = _EVAL_ENTRIES_RATIONALE_SENTINEL in existing
 
     missing = [
         entry for entry in GITIGNORE_EVAL_ENTRIES
         if entry not in existing_lines
     ]
+    blanket_warning = _format_blanket_warning(blanket_present)
     if not missing:
         return outcome_cls(
             name=step_name,
             ok=True,
             message=(
                 "all #1144 selective entries already in .gitignore (no-op)"
+                + blanket_warning
             ),
             details={
                 "gitignore_appended_lines": 0,
@@ -431,7 +488,10 @@ def _ensure_gitignore_selective_entries(
         )
 
     suffix = "" if existing.endswith("\n") or existing == "" else "\n"
-    appended_block = _EVAL_ENTRIES_RATIONALE + "\n".join(missing) + "\n"
+    if rationale_already_present:
+        appended_block = "\n".join(missing) + "\n"
+    else:
+        appended_block = _EVAL_ENTRIES_RATIONALE + "\n".join(missing) + "\n"
     new_content = existing + suffix + appended_block
     try:
         gitignore_path.write_text(new_content, encoding="utf-8")
@@ -449,12 +509,35 @@ def _ensure_gitignore_selective_entries(
         message=(
             f"appended {len(missing)} selective .gitignore "
             f"entr{'y' if len(missing) == 1 else 'ies'}"
+            + blanket_warning
         ),
         details={
             "gitignore_appended_lines": len(missing),
             "gitignore_appended_entries": list(missing),
             "blanket_present": blanket_present,
+            "rationale_already_present": rationale_already_present,
         },
+    )
+
+
+def _format_blanket_warning(blanket_present: bool) -> str:
+    """Return the operator-visible warning suffix when a blanket line is detected.
+
+    Greptile P1 finding on PR #1256: when an operator who ran the
+    pre-#1251 bootstrap upgrades, their ``.gitignore`` still carries
+    the stale ``vbrief/.eval/`` blanket line that hides ``slices.jsonl``
+    from git. Detecting it but reporting only ``hybrid policy
+    satisfied; no-op`` left the operator unaware their repo was still
+    broken. The warning surfaces in ``StepOutcome.message`` so it
+    flows through ``run_bootstrap`` 's progress emit AND the recap.
+    The forbidden line is NEVER auto-rewritten (concurrency safety);
+    the operator removes it manually per the #1251 workaround.
+    """
+    if not blanket_present:
+        return ""
+    return (
+        " WARNING: stale blanket vbrief/.eval/ line detected in .gitignore -- "
+        "remove it manually (it hides tracked slices.jsonl from git per #1251)"
     )
 
 

--- a/scripts/_triage_bootstrap_gitignore.py
+++ b/scripts/_triage_bootstrap_gitignore.py
@@ -1,17 +1,30 @@
+# ruff: noqa: E501  -- the canonical README literal at the bottom of this
+# file contains markdown table rows that intentionally run past the 100-char
+# ceiling so the rendered README is byte-identical to the on-disk
+# `vbrief/.eval/README.md`. Splitting the table cells across lines breaks
+# Markdown rendering. The rest of the module respects the project ceiling.
 """_triage_bootstrap_gitignore.py -- gitignore-ensure + audit-log seed helpers.
 
 Extracted from :mod:`triage_bootstrap` under #952 to keep the parent
 module under the 1000-line MUST limit from ``coding/coding.md``. The
 helpers are pure (no module-level state) and operate on the consumer
-project's ``.gitignore`` and ``vbrief/.eval/`` scratch directory only;
-nothing here touches the cache or scope vBRIEF state.
+project's ``.gitignore``, ``.gitattributes``, and ``vbrief/.eval/``
+scratch directory only; nothing here touches the cache or scope vBRIEF
+state.
 
 Public surface (stable for :mod:`triage_bootstrap` re-exports):
 
 - :data:`GITIGNORE_LINE` -- canonical ``.deft-cache/`` line.
-- :data:`GITIGNORE_EVAL_LINE` -- canonical ``vbrief/.eval/`` line.
+- :data:`GITIGNORE_EVAL_ENTRIES` -- canonical selective per-file lines
+  for the #1144 hybrid policy (``candidates.jsonl`` /
+  ``summary-history.jsonl`` / ``scope-lifecycle.jsonl``).
+- :data:`GITATTRIBUTES_EVAL_RULE` -- canonical
+  ``vbrief/.eval/*.jsonl  merge=union`` line for #1144.
 - :func:`step_ensure_gitignore_entry` -- bootstrap step 3.
-- :func:`step_ensure_gitignore_eval_dir` -- bootstrap step 4.
+- :func:`step_ensure_gitignore_eval_entries` -- bootstrap step 4.
+  Replaces the pre-#1251 ``step_ensure_gitignore_eval_dir`` which
+  appended a blanket ``vbrief/.eval/`` line that violated the
+  hybrid-policy decision recorded on #1144.
 - :func:`step_seed_candidates_log` -- bootstrap step 5 (#1240).
 
 Internal helpers (underscore-prefixed) MUST NOT be imported from
@@ -48,9 +61,35 @@ def _outcome_cls() -> type:
 #: the existing ``.gitignore`` (e.g. ``dist/``, ``.deft/``).
 GITIGNORE_LINE: str = ".deft-cache/"
 
-#: Canonical gitignore line for the per-machine triage audit / eval
-#: scratch directory (#915).
-GITIGNORE_EVAL_LINE: str = "vbrief/.eval/"
+#: Canonical selective gitignore lines for the #1144 hybrid policy.
+#: Replaces the pre-#1251 blanket ``vbrief/.eval/`` line. The three
+#: files below are operator-private; ``slices.jsonl`` is intentionally
+#: omitted from this tuple because it is TRACKED team-shared cohort
+#: state per #1132 / D13.
+GITIGNORE_EVAL_ENTRIES: tuple[str, ...] = (
+    "vbrief/.eval/candidates.jsonl",
+    "vbrief/.eval/summary-history.jsonl",
+    "vbrief/.eval/scope-lifecycle.jsonl",
+)
+
+#: Canonical ``.gitattributes`` line for the #1144 merge=union rule on
+#: append-only JSONL files under ``vbrief/.eval/``. Two spaces between
+#: the glob and the attribute mirrors the existing repo convention.
+GITATTRIBUTES_EVAL_RULE: str = "vbrief/.eval/*.jsonl  merge=union"
+
+#: Glob the merge=union rule must apply to. Used by the idempotency
+#: detector so we don't append a duplicate rule when an operator has
+#: hand-edited the attribute spacing or trailing comments.
+_GITATTRIBUTES_EVAL_GLOB: str = "vbrief/.eval/*.jsonl"
+
+#: Forbidden blanket gitignore lines. The pre-#1251 step appended
+#: ``vbrief/.eval/`` (or ``vbrief/.eval``) which silently hid the
+#: tracked ``slices.jsonl`` from git. Detected so we can warn loudly if
+#: a re-run encounters a stale entry left behind by a prior bootstrap.
+_FORBIDDEN_BLANKET_EVAL_LINES: tuple[str, ...] = (
+    "vbrief/.eval/",
+    "vbrief/.eval",
+)
 
 
 _DEFT_CACHE_RATIONALE: str = (
@@ -59,11 +98,38 @@ _DEFT_CACHE_RATIONALE: str = (
     "# docs/privacy-nfr.md for the gitignore-default + opt-in-commit-cache\n"
     "# contract. Comment this line out to opt in to committing the cache.\n"
 )
-_EVAL_DIR_RATIONALE: str = (
-    "\n# Triage v1 audit/eval scratch (#915). Holds candidates.jsonl + transient\n"
-    "# evaluation artefacts written by triage actions. Per-machine operator state;\n"
-    "# never versioned (would leak triage timing/identity). Comment this line out\n"
-    "# to opt in to committing the audit log.\n"
+#: Comment block written above the selective eval entries on a fresh
+#: clone. Captures the #1144 hybrid policy in-line so an operator
+#: reading ``.gitignore`` sees why ``slices.jsonl`` is intentionally
+#: NOT listed (it is TRACKED team-shared cohort state).
+_EVAL_ENTRIES_RATIONALE: str = (
+    "\n# vbrief/.eval/ tracking governance (#1144, N4 of #1119).\n"
+    "# Hybrid policy from the Current Shape comment on #1144:\n"
+    "#   - candidates.jsonl       -> gitignored (operator-private triage\n"
+    "#                               decisions; re-derive via\n"
+    "#                               `task triage:bootstrap` on a fresh\n"
+    "#                               clone). #845 Story 2 + #915.\n"
+    "#   - summary-history.jsonl  -> gitignored (operator-private\n"
+    "#                               observability; not load-bearing for\n"
+    "#                               any decision).\n"
+    "#   - scope-lifecycle.jsonl  -> gitignored (operator-private\n"
+    "#                               scope-lifecycle audit decisions;\n"
+    "#                               D1 / #1121). Per-operator demote\n"
+    "#                               stream; sharing would conflate\n"
+    "#                               operators' demote timing across the\n"
+    "#                               team.\n"
+    "#   - slices.jsonl           -> TRACKED (team-shared cohort records\n"
+    "#                               produced by slicing skills; see\n"
+    "#                               #1132 / D13).\n"
+    "# See vbrief/.eval/README.md for the full policy + merge=union\n"
+    "# rebase note.\n"
+)
+_GITATTRIBUTES_EVAL_RATIONALE: str = (
+    "# Append-only JSON-lines logs under vbrief/.eval/ use the union merge driver\n"
+    "# (#1144, N4 of #1119). Both branches' appended lines are concatenated on\n"
+    "# auto-merge so single-operator rebases of two append branches resolve\n"
+    "# without manual conflict surgery. Note: merge=union does NOT dedupe; see\n"
+    "# vbrief/.eval/README.md for the operator-facing semantics.\n"
 )
 
 
@@ -192,20 +258,447 @@ def step_ensure_gitignore_entry(project_root: Path) -> StepOutcome:
     )
 
 
-def step_ensure_gitignore_eval_dir(project_root: Path) -> StepOutcome:
-    """Append ``vbrief/.eval/`` to ``.gitignore`` when absent (#915)."""
+def step_ensure_gitignore_eval_entries(project_root: Path) -> StepOutcome:
+    """Ensure the #1144 hybrid policy is encoded in the repo (idempotent).
 
-    return _ensure_gitignore_line(
-        project_root / ".gitignore",
-        GITIGNORE_EVAL_LINE,
-        step_name="ensure_gitignore_eval_dir",
-        create_if_missing=False,
-        rationale_block=_EVAL_DIR_RATIONALE,
-        opt_in_message=(
-            f"{GITIGNORE_EVAL_LINE} is commented out (operator opt-in to "
-            "commit triage audit/eval scratch; not re-adding)"
-        ),
+    Three sub-operations run unconditionally; each is independently
+    idempotent and the aggregate StepOutcome reports the union of work
+    done:
+
+    1. ``.gitignore`` -- append the three selective entries
+       (``candidates.jsonl`` / ``summary-history.jsonl`` /
+       ``scope-lifecycle.jsonl``) when any are missing. NEVER appends
+       the blanket ``vbrief/.eval/`` line that violated #1144 -- the
+       pre-#1251 behaviour. Refuses to create ``.gitignore`` from
+       scratch; step 3 owns that responsibility.
+    2. ``.gitattributes`` -- append the ``vbrief/.eval/*.jsonl
+       merge=union`` rule when absent. Creates the file on a fresh
+       clone.
+    3. ``vbrief/.eval/README.md`` -- write the canonical hybrid-policy
+       README when absent so operators reading the directory in
+       isolation discover the tracking contract.
+
+    All three operations are no-ops when the surface is already
+    correctly configured (the framework's own repo case). The step is
+    safe to re-run on every ``task triage:bootstrap`` invocation.
+    """
+    outcome_cls = _outcome_cls()
+    gitignore_path = project_root / ".gitignore"
+    gitattributes_path = project_root / ".gitattributes"
+    readme_path = project_root / "vbrief" / ".eval" / "README.md"
+    step_name = "ensure_gitignore_eval_entries"
+
+    details: dict[str, object] = {}
+
+    # Sub-op 1 -- .gitignore selective entries.
+    gi_result = _ensure_gitignore_selective_entries(
+        gitignore_path, step_name=step_name,
     )
+    if not gi_result.ok:
+        details.update(gi_result.details)
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message=gi_result.message,
+            error=gi_result.error,
+            details=details,
+        )
+    details.update(gi_result.details)
+
+    # Sub-op 2 -- .gitattributes merge=union rule.
+    ga_result = _ensure_gitattributes_merge_union(
+        gitattributes_path, step_name=step_name,
+    )
+    if not ga_result.ok:
+        details.update(ga_result.details)
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message=ga_result.message,
+            error=ga_result.error,
+            details=details,
+        )
+    details.update(ga_result.details)
+
+    # Sub-op 3 -- README documents the policy.
+    rd_result = _ensure_eval_readme(readme_path, step_name=step_name)
+    if not rd_result.ok:
+        details.update(rd_result.details)
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message=rd_result.message,
+            error=rd_result.error,
+            details=details,
+        )
+    details.update(rd_result.details)
+
+    appended_lines = int(details.get("gitignore_appended_lines", 0))
+    appended_attr = bool(details.get("gitattributes_appended", False))
+    created_readme = bool(details.get("readme_created", False))
+    if not appended_lines and not appended_attr and not created_readme:
+        message = (
+            ".gitignore selective entries, .gitattributes merge=union, "
+            "and vbrief/.eval/README.md already present (#1144 hybrid "
+            "policy satisfied; no-op)"
+        )
+    else:
+        parts: list[str] = []
+        if appended_lines:
+            parts.append(
+                f"{appended_lines} selective .gitignore "
+                f"entr{'y' if appended_lines == 1 else 'ies'}"
+            )
+        if appended_attr:
+            parts.append(".gitattributes merge=union rule")
+        if created_readme:
+            parts.append("vbrief/.eval/README.md")
+        message = "wrote " + " + ".join(parts) + " per #1144 hybrid policy"
+    return outcome_cls(
+        name=step_name,
+        ok=True,
+        message=message,
+        details=details,
+    )
+
+
+def _ensure_gitignore_selective_entries(
+    gitignore_path: Path,
+    *,
+    step_name: str,
+) -> StepOutcome:
+    """Append any missing #1144 selective entries to ``.gitignore``.
+
+    Idempotent: when every selective entry is already present, the
+    file is left untouched. When the ``.gitignore`` itself is absent
+    we refuse (step 3 owns creation) so an out-of-order call surfaces
+    loudly. The forbidden blanket line ``vbrief/.eval/`` is never
+    appended and a warning is logged in ``details`` when an operator
+    has left one behind manually (the bootstrap does NOT rewrite it --
+    the workaround documented on #1251 is for the operator to remove
+    it; auto-rewriting risks racing with concurrent edits).
+    """
+    outcome_cls = _outcome_cls()
+
+    if not gitignore_path.exists():
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message=(
+                ".gitignore not present after the prior gitignore step; "
+                "selective eval entries not written -- re-run bootstrap"
+            ),
+            error="prior gitignore step did not create .gitignore",
+            details={
+                "gitignore_appended_lines": 0,
+                "skipped": "no-gitignore",
+            },
+        )
+
+    try:
+        existing = gitignore_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message="could not read .gitignore",
+            error=str(exc),
+            details={"gitignore_appended_lines": 0},
+        )
+
+    existing_lines = {line.strip() for line in existing.splitlines()}
+    blanket_present = any(
+        forbidden in existing_lines
+        for forbidden in _FORBIDDEN_BLANKET_EVAL_LINES
+    )
+
+    missing = [
+        entry for entry in GITIGNORE_EVAL_ENTRIES
+        if entry not in existing_lines
+    ]
+    if not missing:
+        return outcome_cls(
+            name=step_name,
+            ok=True,
+            message=(
+                "all #1144 selective entries already in .gitignore (no-op)"
+            ),
+            details={
+                "gitignore_appended_lines": 0,
+                "gitignore_already_selective": True,
+                "blanket_present": blanket_present,
+            },
+        )
+
+    suffix = "" if existing.endswith("\n") or existing == "" else "\n"
+    appended_block = _EVAL_ENTRIES_RATIONALE + "\n".join(missing) + "\n"
+    new_content = existing + suffix + appended_block
+    try:
+        gitignore_path.write_text(new_content, encoding="utf-8")
+    except OSError as exc:
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message="could not write .gitignore",
+            error=str(exc),
+            details={"gitignore_appended_lines": 0},
+        )
+    return outcome_cls(
+        name=step_name,
+        ok=True,
+        message=(
+            f"appended {len(missing)} selective .gitignore "
+            f"entr{'y' if len(missing) == 1 else 'ies'}"
+        ),
+        details={
+            "gitignore_appended_lines": len(missing),
+            "gitignore_appended_entries": list(missing),
+            "blanket_present": blanket_present,
+        },
+    )
+
+
+def _ensure_gitattributes_merge_union(
+    gitattributes_path: Path,
+    *,
+    step_name: str,
+) -> StepOutcome:
+    """Ensure the ``vbrief/.eval/*.jsonl  merge=union`` rule is present.
+
+    Idempotent. Detects an existing rule that targets the canonical
+    glob ``vbrief/.eval/*.jsonl`` with ``merge=union`` (regardless of
+    whitespace between the glob and the attribute) so a hand-edited
+    file with single-space spacing or trailing comments is recognised
+    as already-satisfied. Creates the file on a fresh clone.
+    """
+    outcome_cls = _outcome_cls()
+
+    if gitattributes_path.exists():
+        try:
+            existing = gitattributes_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return outcome_cls(
+                name=step_name,
+                ok=False,
+                message="could not read .gitattributes",
+                error=str(exc),
+                details={"gitattributes_appended": False},
+            )
+        if _gitattributes_has_eval_merge_union(existing):
+            return outcome_cls(
+                name=step_name,
+                ok=True,
+                message=(
+                    "vbrief/.eval/*.jsonl merge=union already in "
+                    ".gitattributes (no-op)"
+                ),
+                details={
+                    "gitattributes_appended": False,
+                    "gitattributes_already_present": True,
+                },
+            )
+        suffix = "" if existing.endswith("\n") or existing == "" else "\n"
+        new_content = (
+            existing
+            + suffix
+            + _GITATTRIBUTES_EVAL_RATIONALE
+            + GITATTRIBUTES_EVAL_RULE
+            + "\n"
+        )
+        try:
+            gitattributes_path.write_text(new_content, encoding="utf-8")
+        except OSError as exc:
+            return outcome_cls(
+                name=step_name,
+                ok=False,
+                message="could not write .gitattributes",
+                error=str(exc),
+                details={"gitattributes_appended": False},
+            )
+        return outcome_cls(
+            name=step_name,
+            ok=True,
+            message=(
+                "appended vbrief/.eval/*.jsonl merge=union to .gitattributes"
+            ),
+            details={
+                "gitattributes_appended": True,
+                "gitattributes_created": False,
+            },
+        )
+
+    new_content = (
+        _GITATTRIBUTES_EVAL_RATIONALE + GITATTRIBUTES_EVAL_RULE + "\n"
+    )
+    try:
+        gitattributes_path.write_text(new_content, encoding="utf-8")
+    except OSError as exc:
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message="could not create .gitattributes",
+            error=str(exc),
+            details={"gitattributes_appended": False},
+        )
+    return outcome_cls(
+        name=step_name,
+        ok=True,
+        message=(
+            "created .gitattributes with vbrief/.eval/*.jsonl merge=union"
+        ),
+        details={
+            "gitattributes_appended": True,
+            "gitattributes_created": True,
+        },
+    )
+
+
+def _gitattributes_has_eval_merge_union(body: str) -> bool:
+    """Return True when ``body`` already carries the merge=union rule.
+
+    Tolerant of arbitrary whitespace between the glob and the attribute
+    plus trailing comments / extra attributes on the same line. A
+    line beginning with ``#`` does not satisfy the rule.
+    """
+    for raw in body.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # Tokenise on whitespace; first token is the pattern.
+        parts = stripped.split()
+        if not parts:
+            continue
+        if parts[0] != _GITATTRIBUTES_EVAL_GLOB:
+            continue
+        if "merge=union" in parts[1:]:
+            return True
+    return False
+
+
+def _ensure_eval_readme(
+    readme_path: Path,
+    *,
+    step_name: str,
+) -> StepOutcome:
+    """Write ``vbrief/.eval/README.md`` when absent.
+
+    Idempotent: a pre-existing README (operator-edited or framework-
+    shipped) is left untouched. The bootstrap is intentionally
+    non-destructive here -- if the framework's canonical README drifts
+    relative to a consumer's edited copy, that's an upgrade-time
+    concern, not a bootstrap-time concern.
+    """
+    outcome_cls = _outcome_cls()
+    if readme_path.exists():
+        return outcome_cls(
+            name=step_name,
+            ok=True,
+            message="vbrief/.eval/README.md already present (no-op)",
+            details={
+                "readme_created": False,
+                "readme_already_present": True,
+            },
+        )
+    try:
+        readme_path.parent.mkdir(parents=True, exist_ok=True)
+        readme_path.write_text(_EVAL_README_BODY, encoding="utf-8")
+    except OSError as exc:
+        return outcome_cls(
+            name=step_name,
+            ok=False,
+            message=f"could not create {readme_path}",
+            error=str(exc),
+            details={"readme_created": False},
+        )
+    return outcome_cls(
+        name=step_name,
+        ok=True,
+        message="created vbrief/.eval/README.md (#1144 hybrid policy)",
+        details={"readme_created": True},
+    )
+
+
+#: Canonical README body written on a fresh clone. Mirrors the on-disk
+#: copy at ``vbrief/.eval/README.md`` so the framework's own repo and
+#: a consumer's fresh clone produce byte-identical files. The content
+#: satisfies the deterministic gates in
+#: ``tests/test_eval_governance.py::test_eval_readme_documents_policy``
+#: (the three filenames, the ``task triage:bootstrap`` regen command,
+#: the ``merge=union`` policy, and the no-dedupe qualifier). The
+#: markdown table rows below intentionally run past the 100-char
+#: ceiling so the rendered README mirrors the canonical on-disk file;
+#: see the module-level lint exemption at the top of this file for
+#: the rationale.
+_EVAL_README_BODY: str = """# `vbrief/.eval/` -- triage + slicing evaluation artefacts
+
+This directory holds the append-only JSON-lines logs that the triage and
+slicing skills emit. The framework governs which files in here are tracked
+by git versus gitignored using a **hybrid policy** (#1144, child of #1119).
+
+## Tracking policy
+
+| File | Tracked? | Why |
+| --- | --- | --- |
+| `slices.jsonl` | Yes -- **committed** | Team-shared cohort records produced by slicing skills (D13 / #1132). New operators joining the team need to see prior cohort outputs to detect orphans and avoid re-slicing the same scope. |
+| `candidates.jsonl` | No -- **gitignored** | Operator-private triage decisions (#845 Story 2). Each operator's local accept / defer / reject stream is per-machine state; sharing it would conflate operators' timing + identity across the team. Re-derive on a fresh clone via `task triage:bootstrap`. |
+| `summary-history.jsonl` | No -- **gitignored** | Operator-private observability for `task triage:summary` output time-series. Not load-bearing for any decision. |
+| `scope-lifecycle.jsonl` | No -- **gitignored** | Operator-private scope-lifecycle audit decisions (D1 / #1121). Each demote (`task scope:demote`) appends one entry including a `demote_meta` block (`was_promoted`, `original_promotion_decision_id`, `days_in_pending`, `demote_reason`, `demoted_from`). Per-operator stream; sharing would conflate operators' demote timing across the team. Lightweight metrics over this log are tracked separately at #1180. |
+
+The gitignore lines live in the repo-root `.gitignore` (`vbrief/.eval/candidates.jsonl`,
+`vbrief/.eval/summary-history.jsonl`, and `vbrief/.eval/scope-lifecycle.jsonl`);
+everything else under `vbrief/.eval/` is committed by default.
+
+## Fresh-clone regeneration
+
+On a fresh clone (or any machine that has never run triage), `candidates.jsonl`
+is absent. Regenerate it with:
+
+```
+task triage:bootstrap
+```
+
+The bootstrap path detects the missing file, runs the auto-classifier, and
+writes a fresh `vbrief/.eval/candidates.jsonl`. It does NOT touch the tracked
+`slices.jsonl`; cohort records remain a team-shared resource.
+
+## `merge=union` policy for `*.jsonl`
+
+The repo-root `.gitattributes` declares:
+
+```
+vbrief/.eval/*.jsonl  merge=union
+```
+
+The `union` merge driver concatenates both sides' appended lines on
+auto-merge, so two branches that each appended a different record to the
+same JSON-lines file rebase cleanly without operator surgery. Two things
+operators should know:
+
+- **Concatenation, not set-union.** When two branches append DIFFERENT
+  records to the file, the merge driver concatenates both sides' lines
+  -- there is no smart deduplication of "semantically similar" records.
+  (Identical line-for-line appends collapse because git's three-way
+  merge sees them as the same change, but distinct records always
+  survive verbatim, even if a downstream reader would consider them
+  redundant.) The append-only writers in `scripts/candidates_log.py`
+  mint a fresh `decision_id` per call, so genuinely duplicate records
+  are not the expected case, but downstream readers MUST tolerate
+  multiple records describing the same logical decision.
+- **Single-operator scope only.** This is the foundational rebase
+  ergonomic for the single-operator case (operator A rebases their
+  feature branch onto a master that grew while they were AFK).
+  Multi-operator merge-conflict resolution is explicitly out of scope per
+  #1119 R4 (tracked separately as M1-M4 in #1183).
+
+## See also
+
+- Current Shape comment on #1144 for the canonical decisions (the source
+  of truth this README documents).
+- `.gitignore` -- selective gitignore entries for the operator-private
+  files.
+- `.gitattributes` -- the `merge=union` rule.
+- `scripts/candidates_log.py` -- the writer for `candidates.jsonl`.
+"""
 
 
 #: Canonical relative location of the audit log; mirrors

--- a/scripts/triage_bootstrap.py
+++ b/scripts/triage_bootstrap.py
@@ -26,8 +26,15 @@ Steps (in order):
 3. ``ensure_gitignore_entry`` -- append ``.deft-cache/`` to
    ``.gitignore`` when absent.
 
-4. ``ensure_gitignore_eval_dir`` -- append ``vbrief/.eval/`` to
-   ``.gitignore`` when absent (#915 audit-log scratch directory).
+4. ``ensure_gitignore_eval_entries`` -- ensure the #1144 hybrid policy
+   is encoded: append the selective ``candidates.jsonl`` /
+   ``summary-history.jsonl`` / ``scope-lifecycle.jsonl`` entries to
+   ``.gitignore`` when missing, add the
+   ``vbrief/.eval/*.jsonl  merge=union`` rule to ``.gitattributes``,
+   and write the canonical ``vbrief/.eval/README.md``. Replaces the
+   pre-#1251 ``ensure_gitignore_eval_dir`` which appended a blanket
+   ``vbrief/.eval/`` line that silently ignored the tracked
+   ``slices.jsonl`` (#1132 / D13).
 
 5. ``seed_candidates_log`` -- ensure ``vbrief/.eval/candidates.jsonl``
    exists as a zero-length file so ``task verify:cache-fresh`` can
@@ -493,16 +500,35 @@ def step_populate_cache(
             },
         )
 
+    # #1247: FetchAllReport's counter names are being renamed to
+    # ``issues_written`` / ``already_fresh`` / ``issues_failed`` (PR
+    # #1254). When the new ``summary_line()`` renderer is available we
+    # delegate so the recap stays unambiguous; otherwise we fall back
+    # to the legacy hand-formatted string. The compatibility shim lets
+    # this PR land before or after #1254 without an ordering coupling.
     succeeded = getattr(report, "succeeded", None)
     failed = getattr(report, "failed", None)
     skipped = getattr(report, "skipped", None)
+    summary_line = getattr(report, "summary_line", None)
+    if callable(summary_line):
+        try:
+            message = summary_line(source=_CACHE_SOURCE, repo=effective_repo)
+        except TypeError:
+            # The signature may evolve; fall through to the legacy form
+            # rather than crash the recap if the kwargs change shape.
+            message = (
+                f"cache:fetch-all source={_CACHE_SOURCE} repo={effective_repo} "
+                f"succeeded={succeeded} failed={failed} skipped={skipped}"
+            )
+    else:
+        message = (
+            f"cache:fetch-all source={_CACHE_SOURCE} repo={effective_repo} "
+            f"succeeded={succeeded} failed={failed} skipped={skipped}"
+        )
     return StepOutcome(
         name="populate_cache",
         ok=True,
-        message=(
-            f"cache:fetch-all source={_CACHE_SOURCE} repo={effective_repo} "
-            f"succeeded={succeeded} failed={failed} skipped={skipped}"
-        ),
+        message=message,
         details={
             "repo": effective_repo,
             "source": _CACHE_SOURCE,
@@ -724,15 +750,18 @@ def step_backfill_audit_log(project_root: Path, repo: str | None) -> StepOutcome
 # ``...eval_dir``) stays exactly as Story 3 shipped.
 
 # Re-export the gitignore step functions and the canonical line
-# constants. ``GITIGNORE_LINE`` and ``GITIGNORE_EVAL_LINE`` are part of
-# the module's public surface (consumers / tests reference
-# ``triage_bootstrap.GITIGNORE_LINE``); the ``__all__``-style guard
-# below keeps ruff F401 silent without losing the re-export.
+# constants. ``GITIGNORE_LINE`` / ``GITIGNORE_EVAL_ENTRIES`` /
+# ``GITATTRIBUTES_EVAL_RULE`` are part of the module's public surface
+# (consumers / tests reference ``triage_bootstrap.GITIGNORE_LINE``);
+# the ``__all__``-style guard below keeps ruff F401 silent without
+# losing the re-export. ``step_ensure_gitignore_eval_entries`` is the
+# #1251 rename of the pre-existing ``step_ensure_gitignore_eval_dir``.
 from _triage_bootstrap_gitignore import (  # noqa: E402, F401 -- re-exported public surface
-    GITIGNORE_EVAL_LINE,
+    GITATTRIBUTES_EVAL_RULE,
+    GITIGNORE_EVAL_ENTRIES,
     GITIGNORE_LINE,
     step_ensure_gitignore_entry,
-    step_ensure_gitignore_eval_dir,
+    step_ensure_gitignore_eval_entries,
     step_seed_candidates_log,
 )
 
@@ -764,9 +793,9 @@ def run_bootstrap(
 
     Dispatches the five mutating steps documented in the module
     docstring (populate_cache, backfill_audit_log,
-    ensure_gitignore_entry, ensure_gitignore_eval_dir, seed_eval_dir)
-    and appends one :class:`StepOutcome` per step. ``len(result.steps)
-    == 5`` is the expected post-condition.
+    ensure_gitignore_entry, ensure_gitignore_eval_entries,
+    seed_candidates_log) and appends one :class:`StepOutcome` per
+    step. ``len(result.steps) == 5`` is the expected post-condition.
 
     Repo resolution (#1237): the explicit ``repo`` argument takes
     priority. When ``None``, the dispatcher infers from ``git remote
@@ -847,11 +876,11 @@ def run_bootstrap(
         "done" if gi_cache.ok else "error", gi_cache.message,
     )
 
-    _emit_progress(progress_sink, 4, "ensure_gitignore_eval_dir", "starting")
-    gi_eval = step_ensure_gitignore_eval_dir(project_root)
+    _emit_progress(progress_sink, 4, "ensure_gitignore_eval_entries", "starting")
+    gi_eval = step_ensure_gitignore_eval_entries(project_root)
     result.steps.append(gi_eval)
     _emit_progress(
-        progress_sink, 4, "ensure_gitignore_eval_dir",
+        progress_sink, 4, "ensure_gitignore_eval_entries",
         "done" if gi_eval.ok else "error", gi_eval.message,
     )
 

--- a/scripts/triage_bootstrap.py
+++ b/scripts/triage_bootstrap.py
@@ -510,21 +510,33 @@ def step_populate_cache(
     failed = getattr(report, "failed", None)
     skipped = getattr(report, "skipped", None)
     summary_line = getattr(report, "summary_line", None)
+    legacy_message = (
+        f"cache:fetch-all source={_CACHE_SOURCE} repo={effective_repo} "
+        f"succeeded={succeeded} failed={failed} skipped={skipped}"
+    )
+    message = legacy_message
     if callable(summary_line):
+        # Greptile P2 finding on PR #1256: pre-flight the kwarg shape
+        # via ``inspect.signature(...).bind(...)`` so a future
+        # signature change is the ONLY thing that re-routes us to the
+        # legacy path. A ``TypeError`` from inside ``summary_line()``
+        # itself (post-#1254 implementation bug) now propagates rather
+        # than silently falling back to a cryptic
+        # ``succeeded=None failed=None skipped=None`` recap.
+        import inspect
+
         try:
+            sig = inspect.signature(summary_line)
+        except (TypeError, ValueError):
+            sig = None
+        kwargs_ok = True
+        if sig is not None:
+            try:
+                sig.bind(source=_CACHE_SOURCE, repo=effective_repo)
+            except TypeError:
+                kwargs_ok = False
+        if kwargs_ok:
             message = summary_line(source=_CACHE_SOURCE, repo=effective_repo)
-        except TypeError:
-            # The signature may evolve; fall through to the legacy form
-            # rather than crash the recap if the kwargs change shape.
-            message = (
-                f"cache:fetch-all source={_CACHE_SOURCE} repo={effective_repo} "
-                f"succeeded={succeeded} failed={failed} skipped={skipped}"
-            )
-    else:
-        message = (
-            f"cache:fetch-all source={_CACHE_SOURCE} repo={effective_repo} "
-            f"succeeded={succeeded} failed={failed} skipped={skipped}"
-        )
     return StepOutcome(
         name="populate_cache",
         ok=True,

--- a/tests/integration/test_triage_bootstrap_at_scale.py
+++ b/tests/integration/test_triage_bootstrap_at_scale.py
@@ -151,7 +151,7 @@ def test_run_bootstrap_completes_within_wall_clock_cap(
         "populate_cache",
         "backfill_audit_log",
         "ensure_gitignore_entry",
-        "ensure_gitignore_eval_dir",
+        "ensure_gitignore_eval_entries",
         "seed_candidates_log",
     ]
     assert all(s.ok for s in result.steps), (
@@ -173,10 +173,21 @@ def test_run_bootstrap_completes_within_wall_clock_cap(
     cached = sorted(int(p.name) for p in base.iterdir() if p.is_dir())
     assert cached == list(range(1, SCALE_ISSUE_COUNT + 1))
 
-    # Gitignore lines were written.
+    # Gitignore lines were written. #1251: the eval step now writes the
+    # three selective entries (NOT a blanket `vbrief/.eval/` line).
     gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
     assert ".deft-cache/" in gitignore
-    assert "vbrief/.eval/" in gitignore
+    assert "vbrief/.eval/candidates.jsonl" in gitignore
+    assert "vbrief/.eval/summary-history.jsonl" in gitignore
+    assert "vbrief/.eval/scope-lifecycle.jsonl" in gitignore
+    active_gitignore = [
+        line.strip()
+        for line in gitignore.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert "vbrief/.eval/" not in active_gitignore, (
+        "#1251 forbids the blanket vbrief/.eval/ line in .gitignore"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -208,14 +219,14 @@ def test_run_bootstrap_emits_per_step_progress(
         "triage:bootstrap step 1/5 populate_cache -- starting",
         "triage:bootstrap step 2/5 backfill_audit_log -- starting",
         "triage:bootstrap step 3/5 ensure_gitignore_entry -- starting",
-        "triage:bootstrap step 4/5 ensure_gitignore_eval_dir -- starting",
+        "triage:bootstrap step 4/5 ensure_gitignore_eval_entries -- starting",
         "triage:bootstrap step 5/5 seed_candidates_log -- starting",
     ]
     expected_dones = [
         "triage:bootstrap step 1/5 populate_cache -- done",
         "triage:bootstrap step 2/5 backfill_audit_log -- done",
         "triage:bootstrap step 3/5 ensure_gitignore_entry -- done",
-        "triage:bootstrap step 4/5 ensure_gitignore_eval_dir -- done",
+        "triage:bootstrap step 4/5 ensure_gitignore_eval_entries -- done",
         "triage:bootstrap step 5/5 seed_candidates_log -- done",
     ]
     for stem in expected_starts + expected_dones:
@@ -382,7 +393,7 @@ def test_run_bootstrap_watchdog_emits_timeout_progress_and_structured_exit(
     # still succeed (gitignore is purely local); otherwise the
     # ``partial bootstrap`` invariant from the #952 fix is broken.
     assert result.steps[2].ok is True  # ensure_gitignore_entry
-    assert result.steps[3].ok is True  # ensure_gitignore_eval_dir
+    assert result.steps[3].ok is True  # ensure_gitignore_eval_entries
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_triage_bootstrap.py
+++ b/tests/test_triage_bootstrap.py
@@ -1,6 +1,6 @@
 """Tests for scripts/triage_bootstrap.py (#883 Story 3 rebind).
 
-Covers the four-step orchestration:
+Covers the five-step orchestration:
 
 1. ``populate_cache`` invokes :func:`cache.cache_fetch_all` with
    ``--source=github-issue`` (or skips with a friendly message when the
@@ -8,7 +8,14 @@ Covers the four-step orchestration:
 2. ``backfill_audit_log`` writes one ``accept`` entry per scope vBRIEF
    in ``proposed/`` / ``pending/`` / ``active/`` (skips ``cancelled/``).
 3. ``ensure_gitignore_entry`` adds ``.deft-cache/`` to ``.gitignore``.
-4. ``ensure_gitignore_eval_dir`` adds ``vbrief/.eval/`` to ``.gitignore``.
+4. ``ensure_gitignore_eval_entries`` writes the #1144 selective entries
+   (``candidates.jsonl`` / ``summary-history.jsonl`` /
+   ``scope-lifecycle.jsonl``) to ``.gitignore``, ensures the
+   ``vbrief/.eval/*.jsonl  merge=union`` rule lives in
+   ``.gitattributes``, and writes ``vbrief/.eval/README.md`` when
+   absent. Renamed from ``ensure_gitignore_eval_dir`` under #1251.
+5. ``seed_candidates_log`` ensures ``vbrief/.eval/candidates.jsonl``
+   exists as a zero-length file (#1240).
 
 The pipeline is idempotent: a second invocation produces no new audit
 entries and adds no duplicate ``.gitignore`` lines.
@@ -218,7 +225,7 @@ def test_backfill_audit_log_skips_when_no_vbrief_dir(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# step_ensure_gitignore_entry / step_ensure_gitignore_eval_dir
+# step_ensure_gitignore_entry / step_ensure_gitignore_eval_entries (#1251)
 # ---------------------------------------------------------------------------
 
 
@@ -237,23 +244,185 @@ def test_ensure_gitignore_entry_idempotent(tmp_path: Path) -> None:
     assert first == second
 
 
-def test_ensure_gitignore_eval_dir_appends_when_present(tmp_path: Path) -> None:
-    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
-    outcome = triage_bootstrap.step_ensure_gitignore_eval_dir(tmp_path)
-    assert outcome.ok is True
-    text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
-    assert "vbrief/.eval/" in text
-    assert ".deft-cache/" in text
-
-
-def test_ensure_gitignore_eval_dir_fails_without_existing_gitignore(
+def test_ensure_gitignore_eval_entries_writes_selective_lines(
     tmp_path: Path,
 ) -> None:
-    """The eval-dir step refuses to create .gitignore on its own."""
+    """#1251: step writes the three selective #1144 entries."""
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    # All three selective lines present.
+    assert "vbrief/.eval/candidates.jsonl" in text
+    assert "vbrief/.eval/summary-history.jsonl" in text
+    assert "vbrief/.eval/scope-lifecycle.jsonl" in text
+    # The .deft-cache/ line from step 3 is preserved.
+    assert ".deft-cache/" in text
+    # The pre-#1251 blanket line MUST NOT be appended.
+    lines = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert "vbrief/.eval/" not in lines, (
+        "#1251 forbids the blanket vbrief/.eval/ line; the selective "
+        "entries replace it"
+    )
+    assert "vbrief/.eval" not in lines
+    assert outcome.details.get("gitignore_appended_lines") == 3
 
-    outcome = triage_bootstrap.step_ensure_gitignore_eval_dir(tmp_path)
+
+def test_ensure_gitignore_eval_entries_idempotent_when_selective_present(
+    tmp_path: Path,
+) -> None:
+    """#1251: no-op when the three selective entries are already present."""
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    # Seed the selective entries by hand so the step sees them on entry.
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        gitignore.read_text(encoding="utf-8")
+        + "\nvbrief/.eval/candidates.jsonl\n"
+        + "vbrief/.eval/summary-history.jsonl\n"
+        + "vbrief/.eval/scope-lifecycle.jsonl\n",
+        encoding="utf-8",
+    )
+    # Also seed the .gitattributes rule + README so all three sub-ops
+    # are individually no-op for a true byte-identity check.
+    (tmp_path / ".gitattributes").write_text(
+        "vbrief/.eval/*.jsonl  merge=union\n", encoding="utf-8"
+    )
+    eval_dir = tmp_path / "vbrief" / ".eval"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "README.md").write_text("pre-existing", encoding="utf-8")
+
+    before_gi = gitignore.read_text(encoding="utf-8")
+    before_ga = (tmp_path / ".gitattributes").read_text(encoding="utf-8")
+    before_readme = (eval_dir / "README.md").read_text(encoding="utf-8")
+
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    assert outcome.details.get("gitignore_appended_lines") == 0
+    assert outcome.details.get("gitignore_already_selective") is True
+    assert outcome.details.get("gitattributes_appended") is False
+    assert outcome.details.get("gitattributes_already_present") is True
+    assert outcome.details.get("readme_created") is False
+    assert outcome.details.get("readme_already_present") is True
+
+    # Byte-identical files after the no-op call.
+    assert gitignore.read_text(encoding="utf-8") == before_gi
+    assert (tmp_path / ".gitattributes").read_text(encoding="utf-8") == before_ga
+    assert (eval_dir / "README.md").read_text(encoding="utf-8") == before_readme
+
+
+def test_ensure_gitignore_eval_entries_never_appends_blanket(
+    tmp_path: Path,
+) -> None:
+    """#1251 root-cause: no run shape may append the blanket line."""
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    # Run a few times against different starting states; the blanket
+    # line MUST never appear as an active (non-comment) entry.
+    triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    active = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert "vbrief/.eval/" not in active
+    assert "vbrief/.eval" not in active
+
+
+def test_ensure_gitignore_eval_entries_adds_gitattributes_when_missing(
+    tmp_path: Path,
+) -> None:
+    """#1251: missing `.gitattributes` is created with merge=union."""
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    assert not (tmp_path / ".gitattributes").exists()
+
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    ga = (tmp_path / ".gitattributes").read_text(encoding="utf-8")
+    assert "vbrief/.eval/*.jsonl" in ga
+    assert "merge=union" in ga
+    assert outcome.details.get("gitattributes_appended") is True
+    assert outcome.details.get("gitattributes_created") is True
+
+
+def test_ensure_gitignore_eval_entries_appends_gitattributes_rule_when_absent(
+    tmp_path: Path,
+) -> None:
+    """#1251: pre-existing .gitattributes without the rule gets it appended."""
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    (tmp_path / ".gitattributes").write_text(
+        "*.go diff=golang\n", encoding="utf-8"
+    )
+
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    ga = (tmp_path / ".gitattributes").read_text(encoding="utf-8")
+    # The pre-existing rule is preserved.
+    assert "*.go diff=golang" in ga
+    # The merge=union rule is appended.
+    assert "vbrief/.eval/*.jsonl" in ga
+    assert "merge=union" in ga
+    assert outcome.details.get("gitattributes_appended") is True
+    assert outcome.details.get("gitattributes_created") is False
+
+
+def test_ensure_gitignore_eval_entries_writes_readme_when_missing(
+    tmp_path: Path,
+) -> None:
+    """#1251: missing `vbrief/.eval/README.md` is created with #1144 policy body."""
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    readme = tmp_path / "vbrief" / ".eval" / "README.md"
+    assert readme.is_file()
+    body = readme.read_text(encoding="utf-8")
+    # Mirrors tests/test_eval_governance.py contract for the README.
+    assert "slices.jsonl" in body
+    assert "candidates.jsonl" in body
+    assert "summary-history.jsonl" in body
+    assert "task triage:bootstrap" in body
+    assert "merge=union" in body
+    assert "dedup" in body.lower()
+    assert outcome.details.get("readme_created") is True
+
+
+def test_ensure_gitignore_eval_entries_fails_without_existing_gitignore(
+    tmp_path: Path,
+) -> None:
+    """#1251: the eval-entries step refuses to create .gitignore on its own."""
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
     assert outcome.ok is False
     assert outcome.details.get("skipped") == "no-gitignore"
+
+
+def test_ensure_gitignore_eval_entries_flags_pre_existing_blanket(
+    tmp_path: Path,
+) -> None:
+    """#1251: surface (but do NOT auto-rewrite) a stale blanket line.
+
+    The step's documented behaviour is to add the selective entries
+    and report ``blanket_present=True`` in ``details`` so the operator
+    can act on the workaround (manual removal of the trailing blanket).
+    Auto-rewriting the file is intentionally out of scope -- it races
+    with concurrent operator edits.
+    """
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        gitignore.read_text(encoding="utf-8") + "\nvbrief/.eval/\n",
+        encoding="utf-8",
+    )
+
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    assert outcome.details.get("blanket_present") is True
+    # Selective entries were still added.
+    text = gitignore.read_text(encoding="utf-8")
+    assert "vbrief/.eval/candidates.jsonl" in text
 
 
 def test_ensure_gitignore_respects_commented_opt_in(tmp_path: Path) -> None:
@@ -292,7 +461,7 @@ def test_run_bootstrap_appends_five_step_outcomes(tmp_path: Path) -> None:
         "populate_cache",
         "backfill_audit_log",
         "ensure_gitignore_entry",
-        "ensure_gitignore_eval_dir",
+        "ensure_gitignore_eval_entries",
         "seed_candidates_log",
     ]
     assert result.exit_code == 0

--- a/tests/test_triage_bootstrap.py
+++ b/tests/test_triage_bootstrap.py
@@ -425,6 +425,111 @@ def test_ensure_gitignore_eval_entries_flags_pre_existing_blanket(
     assert "vbrief/.eval/candidates.jsonl" in text
 
 
+def test_ensure_gitignore_eval_entries_blanket_warning_in_message(
+    tmp_path: Path,
+) -> None:
+    """#1256 Greptile P1: blanket_present surfaces in StepOutcome.message.
+
+    When all three selective entries are already present BUT a stale
+    blanket line is detected, the step previously reported
+    ``hybrid policy satisfied; no-op`` -- silently leaving the
+    operator's repo broken because git honours the blanket pattern
+    for the entire directory. The warning must reach
+    ``StepOutcome.message`` so it flows through ``run_bootstrap``'s
+    progress emit AND the recap.
+    """
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    gitignore = tmp_path / ".gitignore"
+    # Seed all three selective entries AND a stale blanket line.
+    gitignore.write_text(
+        gitignore.read_text(encoding="utf-8")
+        + "\nvbrief/.eval/candidates.jsonl\n"
+        + "vbrief/.eval/summary-history.jsonl\n"
+        + "vbrief/.eval/scope-lifecycle.jsonl\n"
+        + "vbrief/.eval/\n",
+        encoding="utf-8",
+    )
+
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    assert outcome.details.get("blanket_present") is True
+    # Warning surfaces in the message, not just in details.
+    assert "WARNING" in outcome.message
+    assert "blanket" in outcome.message.lower()
+    assert "slices.jsonl" in outcome.message
+    assert "#1251" in outcome.message
+
+
+def test_ensure_gitignore_eval_entries_blanket_detection_robust_to_inline_comment(
+    tmp_path: Path,
+) -> None:
+    """#1256 SLizard P1: forbidden-blanket detector strips inline comments.
+
+    The pre-#1256 detector used ``line.strip()`` as the set-membership
+    key, so a blanket entry like ``vbrief/.eval/  # legacy`` slipped
+    past the forbidden check. The post-fix detector strips the inline
+    comment before checking, so the operator gets the warning AND the
+    selective entries are still added.
+    """
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        gitignore.read_text(encoding="utf-8")
+        + "\nvbrief/.eval/  # legacy entry from old bootstrap\n",
+        encoding="utf-8",
+    )
+
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    assert outcome.details.get("blanket_present") is True, (
+        "the detector must strip inline comments before the membership "
+        "check; pre-#1256 the trailing comment hid the forbidden line"
+    )
+    assert "WARNING" in outcome.message
+
+
+def test_ensure_gitignore_eval_entries_no_rationale_duplication_on_partial_re_run(
+    tmp_path: Path,
+) -> None:
+    """#1256 Greptile P2: rationale comment block is not duplicated.
+
+    An operator who runs bootstrap, then manually deletes ONE of the
+    three selective entries, then re-runs bootstrap. The re-run should
+    add only the missing entry, NOT a second copy of the multi-line
+    rationale comment block.
+    """
+    triage_bootstrap.step_ensure_gitignore_entry(tmp_path)
+    # First run: writes all three entries + rationale.
+    triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    after_first = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    rationale_count_first = after_first.count(
+        "# vbrief/.eval/ tracking governance"
+    )
+    assert rationale_count_first == 1
+
+    # Operator manually deletes one of the selective entries.
+    perturbed = after_first.replace(
+        "vbrief/.eval/summary-history.jsonl\n", ""
+    )
+    (tmp_path / ".gitignore").write_text(perturbed, encoding="utf-8")
+
+    # Re-run: should re-add the missing entry but NOT a duplicate rationale.
+    outcome = triage_bootstrap.step_ensure_gitignore_eval_entries(tmp_path)
+    assert outcome.ok is True
+    assert outcome.details.get("gitignore_appended_lines") == 1
+    assert outcome.details.get("rationale_already_present") is True
+    after_second = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    rationale_count_second = after_second.count(
+        "# vbrief/.eval/ tracking governance"
+    )
+    assert rationale_count_second == 1, (
+        "rationale comment block was duplicated on partial re-run; "
+        "#1256 Greptile P2"
+    )
+    # And the missing selective entry is back.
+    assert "vbrief/.eval/summary-history.jsonl" in after_second
+
+
 def test_ensure_gitignore_respects_commented_opt_in(tmp_path: Path) -> None:
     """Commented-out form is the operator opt-in to commit the cache."""
 

--- a/vbrief/active/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json
+++ b/vbrief/active/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json
@@ -12,7 +12,64 @@
       "Overview": "## Summary\r\n\r\n`task triage:bootstrap` step 4 (`ensure_gitignore_eval_dir`) appends a blanket `vbrief/.eval/` line to `.gitignore`, ignoring the entire eval directory. This directly violates the #1144 hybrid policy (\"vbrief/.eval/ tracking governance\"), which specifies that selective files (`candidates.jsonl`, `summary-history.jsonl`, `scope-lifecycle.jsonl`) are gitignored while `slices.jsonl` is TRACKED. The blanket ignore defeats the hybrid policy and breaks the maintainer-design test `tests/test_eval_governance.py::test_gitignore_does_not_blanket_ignore_eval_directory`.\r\n\r\n## Reproduction (2026-05-20 dogfood session)\r\n\r\n1. Fresh `.gitignore` with the proper #1144 selective entries in place:\r\n```\r\nvbrief/.eval/candidates.jsonl\r\nvbrief/.eval/summary-history.jsonl\r\nvbrief/.eval/scope-lifecycle.jsonl\r\n```\r\n2. Run `task triage:bootstrap` (any path; step 4 fires unconditionally on first bootstrap).\r\n3. Observe `.gitignore` diff:\r\n```\r\n+# Triage v1 audit/eval scratch (#915). Holds candidates.jsonl + transient\r\n+# evaluation artefacts written by triage actions. Per-machine operator state;\r\n+# never versioned (would leak triage timing/identity). Comment this line out\r\n+# to opt in to committing the audit log.\r\n+vbrief/.eval/\r\n```\r\n4. Run `task check` (or `pytest tests/test_eval_governance.py::test_gitignore_does_not_blanket_ignore_eval_directory`). Result:\r\n\r\n```\r\nAssertionError: blanket gitignore of vbrief/.eval/ defeats the hybrid policy (#1144)\r\n```\r\n\r\nThe PR carrying this change (#1249) is unmergeable until the blanket ignore is removed.\r\n\r\n## Expected\r\n\r\n`task triage:bootstrap` step 4 should be idempotent w.r.t. the #1144 hybrid policy:\r\n- Check whether `.gitignore` already carries the three selective entries (`candidates.jsonl`, `summary-history.jsonl`, `scope-lifecycle.jsonl`).\r\n- If yes: no-op. The policy is already satisfied.\r\n- If no: append the SELECTIVE entries (not a blanket `vbrief/.eval/`), plus the `.gitattributes merge=union` rule for any tracked-but-mergeable eval files, plus a `vbrief/.eval/README.md` documenting the policy.\r\n- Step name should be renamed from `ensure_gitignore_eval_dir` to `ensure_gitignore_eval_entries` to reflect the per-file semantics.\r\n\r\n## Actual\r\n\r\nStep 4 appends a blanket `vbrief/.eval/` line regardless of whether the selective entries are already present. This:\r\n- Ignores tracked eval files (e.g. `slices.jsonl` per #1132 / D13) that the hybrid policy explicitly requires to be team-shared.\r\n- Creates `.gitignore` precedence ambiguity (more-specific selective entries above + less-specific blanket below — git resolves to blanket).\r\n- Breaks the `task check` deterministic gate against #1144 violations.\r\n\r\n## Impact\r\n\r\n- Breaks `task check` on any session that runs `task triage:bootstrap` against the framework's own repo (the dogfood case).\r\n- Defeats the #1144 hybrid policy: tracked eval files become invisible to git.\r\n- Companion bug to #1250 (`triage:welcome wipCap` materialization). Both surfaced in the same dogfood walk when the test suite caught the contract violations on PR #1249.\r\n\r\n## Suggested investigation\r\n\r\n- `scripts/triage_bootstrap.py` step 4 (`ensure_gitignore_eval_dir`): replace the blanket-line append with the per-file convention from #1144 Current Shape v3.\r\n- Check whether step 4 is supposed to be a no-op when `.gitignore` already has the #1144 entries (likely yes; this is the consumer-clone case).\r\n- Verify the step also adds `.gitattributes merge=union vbrief/.eval/*.jsonl` for the tracked-and-mergeable case if missing.\r\n\r\n## Related\r\n\r\n- #1144: original hybrid policy + Current Shape comment (canonical decision).\r\n- #1132 / D13: `slices.jsonl` is the TRACKED team-shared cohort record that the blanket ignore would silently hide.\r\n- #1244 / #1245 / #1246 / #1247 / #1248 / #1250: companion bugs filed in the same dogfood walk; this is #7 of 7.\r\n\r\n## Workaround\r\n\r\nAfter running `task triage:bootstrap`, manually edit `.gitignore` to remove the trailing `# Triage v1 audit/eval scratch ... vbrief/.eval/` block. The selective entries higher in the file already cover the #1144 hybrid policy.\r\n",
       "Labels": "bug, determinism, adoption-blocker"
     },
-    "items": [],
+    "items": [
+      {
+        "id": "1251-ac-1-selective-gitignore",
+        "title": "Replace blanket vbrief/.eval/ append with three selective entries",
+        "status": "completed",
+        "narratives": {
+          "Action": "scripts/_triage_bootstrap_gitignore.py exposes GITIGNORE_EVAL_ENTRIES tuple (candidates.jsonl, summary-history.jsonl, scope-lifecycle.jsonl) and _ensure_gitignore_selective_entries() appends only the missing entries with a #1144 rationale comment block. The blanket vbrief/.eval/ line is never appended; if an operator left one behind manually the step reports details.blanket_present=True without auto-rewriting (concurrency safety)."
+        }
+      },
+      {
+        "id": "1251-ac-2-rename-step",
+        "title": "Rename step_ensure_gitignore_eval_dir -> step_ensure_gitignore_eval_entries",
+        "status": "completed",
+        "narratives": {
+          "Action": "Renamed the step function, removed the legacy GITIGNORE_EVAL_LINE blanket constant, updated all consumers (triage_bootstrap.py module docstring, run_bootstrap dispatcher, progress-emit step labels) and tests (tests/test_triage_bootstrap.py + tests/integration/test_triage_bootstrap_at_scale.py)."
+        }
+      },
+      {
+        "id": "1251-ac-3-gitattributes-merge-union",
+        "title": "Add .gitattributes vbrief/.eval/*.jsonl merge=union rule when missing",
+        "status": "completed",
+        "narratives": {
+          "Action": "_ensure_gitattributes_merge_union() creates .gitattributes on a fresh clone with the canonical rule + rationale comment block, OR appends the rule to a pre-existing file that lacks it. Idempotent: a file with the rule already present (any whitespace between glob and attribute, plus trailing comments) is a no-op via _gitattributes_has_eval_merge_union() tokenizer."
+        }
+      },
+      {
+        "id": "1251-ac-4-readme-write",
+        "title": "Write canonical vbrief/.eval/README.md on fresh clone",
+        "status": "completed",
+        "narratives": {
+          "Action": "_ensure_eval_readme() writes the canonical #1144 hybrid-policy README when absent. Body matches the on-disk vbrief/.eval/README.md byte-for-byte and satisfies the deterministic gates in tests/test_eval_governance.py::test_eval_readme_documents_policy (the three filenames, task triage:bootstrap regen command, merge=union policy, no-dedupe qualifier). Existing READMEs are left untouched."
+        }
+      },
+      {
+        "id": "1251-ac-5-idempotent-no-op",
+        "title": "Re-run against already-configured repo is a true no-op",
+        "status": "completed",
+        "narratives": {
+          "Action": "All three sub-operations short-circuit when their target state is satisfied. test_ensure_gitignore_eval_entries_idempotent_when_selective_present pins byte-identity on .gitignore + .gitattributes + README after a no-op re-run. The framework's own task check stays green when the bootstrap runs against its own repo."
+        }
+      },
+      {
+        "id": "1251-ac-6-unit-tests",
+        "title": "Unit tests cover fresh-clone, idempotent, and never-blanket paths",
+        "status": "completed",
+        "narratives": {
+          "Action": "tests/test_triage_bootstrap.py grows nine new tests under TestEnsureGitignoreEvalEntries: writes_selective_lines, idempotent_when_selective_present, never_appends_blanket, adds_gitattributes_when_missing, appends_gitattributes_rule_when_absent, writes_readme_when_missing, fails_without_existing_gitignore, flags_pre_existing_blanket. tests/test_eval_governance.py::test_gitignore_does_not_blanket_ignore_eval_directory + test_gitignore_has_selective_eval_entries both pass."
+        }
+      },
+      {
+        "id": "1251-ac-7-summary-line-shim",
+        "title": "Addendum: FetchAllReport.summary_line() compatibility shim",
+        "status": "completed",
+        "narratives": {
+          "Action": "scripts/triage_bootstrap.py step_populate_cache recap line now delegates to report.summary_line(source=..., repo=...) when available (PR #1254 counter rename) and falls back to the legacy succeeded/failed/skipped hand-formatted string otherwise. Single-line getattr/hasattr check; lands safely regardless of #1254 merge order."
+        }
+      }
+    ],
     "tags": [
       "bug",
       "determinism",


### PR DESCRIPTION
## Summary

`task triage:bootstrap` step 4 (`ensure_gitignore_eval_dir`) appended a blanket `vbrief/.eval/` line to `.gitignore` on every fresh run, silently hiding the tracked team-shared `slices.jsonl` cohort record (#1132 / D13) and violating the #1144 hybrid policy. This PR fixes the root cause in `scripts/triage_bootstrap.py` so the bootstrap no longer re-introduces the violation on the next run (PR #1249 already reverted the symptom via commit `b00f1d2`).

The step is renamed to `ensure_gitignore_eval_entries` to reflect the per-file semantics and now performs three idempotent sub-operations:

1. Append the three selective `.gitignore` entries (`vbrief/.eval/candidates.jsonl`, `vbrief/.eval/summary-history.jsonl`, `vbrief/.eval/scope-lifecycle.jsonl`) when missing. **NEVER** appends the blanket `vbrief/.eval/` line.
2. Ensure `.gitattributes` carries `vbrief/.eval/*.jsonl  merge=union` (create on fresh clone, append on existing file without the rule).
3. Write the canonical `vbrief/.eval/README.md` documenting the #1144 hybrid policy when absent (matches the on-disk repo copy byte-for-byte).

All three operations are no-ops on the framework's own repo (the dogfood case that surfaced the bug), so `task check` stays green when bootstrap re-runs.

## Suggested investigation -- answered

The GH issue body's `## Suggested investigation` bullets, answered in-line:

- ✅ **`scripts/triage_bootstrap.py` step 4: replace the blanket-line append with the per-file convention from #1144 Current Shape v3.** Implemented via the rename + new `_ensure_gitignore_selective_entries()` helper. The `GITIGNORE_EVAL_LINE = "vbrief/.eval/"` constant is removed; `GITIGNORE_EVAL_ENTRIES` tuple is the new public surface.
- ✅ **Is step 4 supposed to be a no-op when `.gitignore` already has the #1144 entries?** Yes. `_ensure_gitignore_selective_entries()` short-circuits with `details.gitignore_already_selective=True` when all three selective lines are present. Combined with the .gitattributes + README no-op paths, the whole step is byte-identical on re-run (pinned by `test_ensure_gitignore_eval_entries_idempotent_when_selective_present`).
- ✅ **Verify the step also adds `.gitattributes merge=union vbrief/.eval/*.jsonl` for the tracked-and-mergeable case if missing.** Implemented via `_ensure_gitattributes_merge_union()`. Tolerant idempotency: `_gitattributes_has_eval_merge_union()` tokenises the file so any whitespace between the glob and the attribute + trailing comments still recognise the rule as present.

## Addendum (PR #1254 follow-up)

Per orchestrator addendum, this PR also folds in the `FetchAllReport.summary_line()` compatibility shim for the `scripts/triage_bootstrap.py:496-505` recap line. When PR #1254's new `summary_line()` renderer is available on `report`, the recap delegates to it; otherwise it falls back to the legacy `succeeded/failed/skipped` hand-formatted string. Single `getattr` + `callable` check; lands safely regardless of PR #1254 merge order.

## Acceptance criteria

- ✅ `task triage:bootstrap` against a fresh clone (no `.gitignore` selective entries yet) produces the three selective entries + `.gitattributes merge=union` rule + `vbrief/.eval/README.md`, but NO blanket line. Pinned by `test_ensure_gitignore_eval_entries_writes_selective_lines` + `test_ensure_gitignore_eval_entries_adds_gitattributes_when_missing` + `test_ensure_gitignore_eval_entries_writes_readme_when_missing` + `test_ensure_gitignore_eval_entries_never_appends_blanket`.
- ✅ `task triage:bootstrap` against the framework's own repo (already-configured) is a true no-op on `.gitignore`, `.gitattributes`, and `vbrief/.eval/README.md`. Pinned by `test_ensure_gitignore_eval_entries_idempotent_when_selective_present`.
- ✅ `tests/test_eval_governance.py::test_gitignore_does_not_blanket_ignore_eval_directory` passes.
- ✅ `tests/test_eval_governance.py::test_gitignore_has_selective_eval_entries` passes.
- ✅ New `triage_bootstrap` unit tests cover idempotent + fresh-clone + never-blanket + .gitattributes-create + .gitattributes-append + README + flag-stale-blanket paths (9 new tests in `tests/test_triage_bootstrap.py::TestEnsureGitignoreEvalEntries`).

## Validation

- `task check`: **6196 passed, 3 skipped, 9 deselected, 1 xfailed.** All gates green (validate, lint, mypy, pytest, rule-ownership, vbrief:validate, branch, encoding, scm-boundary).

## File scope

Files owned by this PR (disjoint from in-flight agents on #1244 / #1245 / #1246 / #1247 / #1248):

- `scripts/triage_bootstrap.py` -- step rename + new import + `summary_line()` shim.
- `scripts/_triage_bootstrap_gitignore.py` -- new selective implementation, .gitattributes helper, README helper.
- `tests/test_triage_bootstrap.py` -- 9 new tests, renamed step references.
- `tests/integration/test_triage_bootstrap_at_scale.py` -- step-name + selective-entry assertions.
- `CHANGELOG.md` -- one `[Unreleased]` entry.
- `vbrief/active/2026-05-20-1251-...vbrief.json` -- enriched Overview + 7 plan.items[].

## Related

- Closes #1251.
- Refs #1144 (canonical hybrid-policy decision -- source of truth this PR encodes).
- Refs #1132 / D13 (slices.jsonl tracked team-shared cohort record -- the line the blanket was hiding).
- Refs #1247 / PR #1254 (FetchAllReport counter rename -- compatibility shim folded in per orchestrator addendum).
- Refs PR #1249 (orchestrator-side revert of the symptom; this PR closes the root cause).
