### PR TITLE
chore(vbrief): move 7 dogfood scopes to completed/ (cycle 1244-1251)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -406,4 +406,11 @@
 - **#1239** -- perf(cache): triage:bootstrap is GraphQL-heavy; #954 mandates REST-first -- `[completed]`
 - **#1240** -- bug(verify:cache-fresh): still reports 'bootstrap state' after a successful triage:bootstrap -- `[completed]`
 - **#1242** -- docs(changelog): entries MUST be brief release-notes, not implementation detail (v0.32.0 release-blocker) -- `[completed]`
+- **#1244** -- bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent -- `[completed]`
+- **#1245** -- bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state -- `[completed]`
+- **#1246** -- enhancement(triage): triage:queue should auto-detect --repo from origin remote -- `[completed]`
+- **#1247** -- bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators -- `[completed]`
+- **#1248** -- enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items) -- `[completed]`
+- **#1250** -- bug(triage,policy): task triage:welcome materializes plan.policy.wipCap, violating #1186 Deliverable 1 -- `[completed]`
+- **#1251** -- bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy -- `[completed]`
 

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-05-20T13:37:35Z"
+    "updated": "2026-05-20T19:24:51Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -894,102 +894,6 @@
               "uri": "https://github.com/deftai/directive/pull/1125",
               "type": "x-vbrief/github-pr",
               "title": "PR #1125: feat(skills): add deft-directive-gh-arch (re-land of #442) -- merged predecessor"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap",
-        "title": "bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1244",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1244: bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi",
-        "title": "bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1245",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1245: bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o",
-        "title": "enhancement(triage): triage:queue should auto-detect --repo from origin remote",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1246",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1246: enhancement(triage): triage:queue should auto-detect --repo from origin remote"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee",
-        "title": "bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1247",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1247: bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only",
-        "title": "enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1248",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1248: enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe",
-        "title": "bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/1251",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #1251: bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy"
             }
           ]
         }
@@ -8514,6 +8418,118 @@
             }
           ]
         }
+      },
+      {
+        "id": "2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap",
+        "title": "bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1244",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1244: bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi",
+        "title": "bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1245",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1245: bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o",
+        "title": "enhancement(triage): triage:queue should auto-detect --repo from origin remote",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1246",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1246: enhancement(triage): triage:queue should auto-detect --repo from origin remote"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee",
+        "title": "bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1247",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1247: bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only",
+        "title": "enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1248",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1248: enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-20-1250-bugtriagepolicy-task-triagewelcome-materializes-planpolicywi",
+        "title": "bug(triage,policy): task triage:welcome materializes plan.policy.wipCap, violating #1186 Deliverable 1",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-20-1250-bugtriagepolicy-task-triagewelcome-materializes-planpolicywi.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1250",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1250: bug(triage,policy): task triage:welcome materializes plan.policy.wipCap, violating #1186 Deliverable 1"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe",
+        "title": "bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/1251",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #1251: bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy"
+            }
+          ]
+        }
       }
     ],
     "metadata": {
@@ -8536,6 +8552,7 @@
         "Narrative 'OpenQuestions' may be stale: completed scope 'feat(triage-scope): milestone rule any-of + is-open variants (#1181)' shares topics (open)",
         "Narrative 'OpenQuestions' may be stale: completed scope 'fix(scripts/reconcile_issues.py, scripts/release.py): vBRIEF-lifecycle-sync gate false-positives on repos with >200 open issues' shares topics (open)",
         "Narrative 'Overview' may be stale: completed scope 'bug(refinement,ingest): `task issue:ingest` produces stub vBRIEFs without `plan.narratives.Overview` or `plan.items` -- ingested items are not swarm-ready' shares topics (overview)",
+        "Narrative 'Overview' may be stale: completed scope 'enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)' shares topics (overview)",
         "Narrative 'Overview' may be stale: completed scope 'fix(scripts): migrate_vbrief produces PROJECT-DEFINITION without required 'overview' narrative key' shares topics (overview)",
         "Narrative 'ProjectConfig' may be stale: completed scope 'Automatically check for updates to cloned repos in a project -- detect stale cloned dependencies, notify user; part of future `deft doctor`/`deft update` (new CLI tooling)' shares topics (project)",
         "Narrative 'ProjectConfig' may be stale: completed scope 'Branching requirement too prescriptive -- context-aware solo-project qualifier' shares topics (project)",

--- a/vbrief/completed/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json
+++ b/vbrief/completed/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1244",
@@ -58,6 +58,6 @@
         "title": "Issue #1244: bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent"
       }
     ],
-    "updated": "2026-05-20T13:14:45Z"
+    "updated": "2026-05-20T19:24:32Z"
   }
 }

--- a/vbrief/completed/2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi.vbrief.json
+++ b/vbrief/completed/2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1245",
@@ -25,6 +25,6 @@
         "title": "Issue #1245: bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state"
       }
     ],
-    "updated": "2026-05-20T13:14:45Z"
+    "updated": "2026-05-20T19:24:32Z"
   }
 }

--- a/vbrief/completed/2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o.vbrief.json
+++ b/vbrief/completed/2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "enhancement(triage): triage:queue should auto-detect --repo from origin remote",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "enhancement(triage): triage:queue should auto-detect --repo from origin remote",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1246",
@@ -23,6 +23,6 @@
         "title": "Issue #1246: enhancement(triage): triage:queue should auto-detect --repo from origin remote"
       }
     ],
-    "updated": "2026-05-20T13:14:56Z"
+    "updated": "2026-05-20T19:24:33Z"
   }
 }

--- a/vbrief/completed/2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee.vbrief.json
+++ b/vbrief/completed/2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1247",
@@ -23,6 +23,6 @@
         "title": "Issue #1247: bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators"
       }
     ],
-    "updated": "2026-05-20T13:14:56Z"
+    "updated": "2026-05-20T19:24:33Z"
   }
 }

--- a/vbrief/completed/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json
+++ b/vbrief/completed/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1248",
@@ -73,6 +73,6 @@
         "title": "Issue #1248: enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)"
       }
     ],
-    "updated": "2026-05-20T13:14:57Z"
+    "updated": "2026-05-20T19:24:33Z"
   }
 }

--- a/vbrief/completed/2026-05-20-1250-bugtriagepolicy-task-triagewelcome-materializes-planpolicywi.vbrief.json
+++ b/vbrief/completed/2026-05-20-1250-bugtriagepolicy-task-triagewelcome-materializes-planpolicywi.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage,policy): task triage:welcome materializes plan.policy.wipCap, violating #1186 Deliverable 1",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage,policy): task triage:welcome materializes plan.policy.wipCap, violating #1186 Deliverable 1",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1250",
@@ -25,6 +25,6 @@
         "title": "Issue #1250: bug(triage,policy): task triage:welcome materializes plan.policy.wipCap, violating #1186 Deliverable 1"
       }
     ],
-    "updated": "2026-05-20T14:37:52Z"
+    "updated": "2026-05-20T19:24:34Z"
   }
 }

--- a/vbrief/completed/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json
+++ b/vbrief/completed/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1251",
@@ -82,6 +82,6 @@
         "title": "Issue #1251: bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy"
       }
     ],
-    "updated": "2026-05-20T13:37:34Z"
+    "updated": "2026-05-20T19:24:34Z"
   }
 }


### PR DESCRIPTION
## Summary

Post-merge lifecycle hygiene for the cache/triage dogfood cycle that just landed. All seven dogfood scope vBRIEFs are moved from `vbrief/active/` to `vbrief/completed/` via `task scope:complete`, and the project + roadmap are re-rendered against the new state.

## Scopes moved

| Issue | PR     | Scope vBRIEF                                                                                                                  |
| ----- | ------ | ----------------------------------------------------------------------------------------------------------------------------- |
| #1244 | #1262  | `2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json`                                     |
| #1245 | #1264  | `2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi.vbrief.json`                                    |
| #1246 | #1263  | `2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o.vbrief.json`                                    |
| #1247 | #1263  | `2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee.vbrief.json`                                    |
| #1248 | #1261  | `2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json`                                     |
| #1250 | #1257  | `2026-05-20-1250-bugtriagepolicy-task-triagewelcome-materializes-planpolicywi.vbrief.json`                                    |
| #1251 | #1265  | `2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json`                                    |

Each transition was driven by `uv run python scripts/scope_lifecycle.py complete <path>` so `plan.status` is `completed` on every moved file.

## Re-rendered artifacts

- `vbrief/PROJECT-DEFINITION.vbrief.json` — 453 scope items registered; the seven scopes now report `lifecycle_folder = "completed"`.
- `ROADMAP.md` — re-rendered against the updated lifecycle state.

## Validation

- `task check` passes: 6264 passed / 3 skipped / 9 deselected / 1 xfailed. Final line: `All checks passed`.
- Pre-existing 62 staleness flags on the project render are unrelated to this PR (the project render surfaces them on every run independent of this cycle).

## Out of scope

- Issues filed during the same session but not yet implemented: #1258 (session-start PR summary), #1259 (review-cycle partial-Greptile exit gap), #1260 (PROJECT-DEFINITION mutation lock generalization). These are tracked separately.
- The pre-existing `vbrief/active/2026-05-13-1125-followup-scope-complete-and-spec-render.vbrief.json` is unrelated to this cycle and remains active.

Refs #1249, #1262, #1264, #1261, #1263, #1265, #1257.
