### PR TITLE
fix(triage): filesystem-truth in-flight count with conditional scope-discrepancy line (#1270)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Note: A true UI indicator (e.g. Warp status bar) is deferred to Phase 5. This is
 
 1. **Deft alignment confirmation** -- see `### Deft Alignment Confirmation` above (#134).
 2. **Branch-policy disclosure** -- see the `Branch Policy Disclosure (session start)` block under `## Development Process` (#746 / #747).
-3. **`task triage:summary` one-line state** -- emit the current triage-cache one-liner (D2 / #1122). D2 suppresses repeat emission within 4 hours unless the cache state changed.
+3. **`task triage:summary` one-line state** -- emit the current triage-cache one-liner (D2 / #1122). D2 suppresses repeat emission within 4 hours unless the cache state changed. The headline `in-flight` count is **filesystem-truth** -- a live count of `vbrief/active/*.vbrief.json` files with `plan.status == "running"` (#1270). When that count diverges from the legacy audit-log-derived cache-scoped view, a second `[triage:scope]` line surfaces the gap; the wording distinguishes whether `plan.policy.triageScope[]` is explicitly configured (`outside plan.policy.triageScope[]`) or absent/empty/default (`not configured`).
 4. **`task verify:cache-fresh` warning** -- printed only when the cache is stale (D5 / #1127); silent on a fresh cache.
 
 ⊗ Reorder, skip, or merge the four steps above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **fix(triage): filesystem-truth in-flight count + scope-discrepancy line (#1270)** -- the session-start `task triage:summary` headline now reflects activated work correctly. `in-flight` reads from live `vbrief/active/*.vbrief.json` with `plan.status == "running"` (filesystem-truth) instead of the audit-log-scoped cache view, so activating a vBRIEF moves the count in lockstep with `WIP`. When the filesystem-truth and cache-scoped counts diverge, a second `[triage:scope]` line surfaces the gap and distinguishes whether `plan.policy.triageScope[]` is configured (`outside ...`) or absent/default (`not configured`). Closes #1270.
 
 ### Removed
 

--- a/scripts/triage_summary.py
+++ b/scripts/triage_summary.py
@@ -118,6 +118,20 @@ EMPTY_CACHE_LINE: str = "[triage] cache empty -- run task triage:bootstrap"
 #: D4 / #1124's `pending/ + active/` cap target.
 WIP_LIFECYCLE_DIRS: tuple[str, ...] = ("pending", "active")
 
+#: Lifecycle folder whose ``plan.status == "running"`` vBRIEFs are
+#: counted as the *filesystem-truth* in-flight set (#1270). The active/
+#: folder is the single source of truth for activated work; the
+#: audit-log decision count (``IN_FLIGHT_DECISIONS``) below is retained
+#: only for divergence detection vs. the cache-scoped view.
+FILESYSTEM_IN_FLIGHT_FOLDER: str = "active"
+
+#: ``plan.status`` value that classifies an active/ vBRIEF as in-flight
+#: under the #1270 filesystem-truth contract. The activation verb
+#: (``task vbrief:activate``) flips this field to ``running`` when it
+#: moves a scope into ``vbrief/active/``; any other status (``done``,
+#: ``cancelled``, ``blocked``) MUST NOT count toward the headline.
+FILESYSTEM_IN_FLIGHT_STATUS: str = "running"
+
 #: Glyph appended when the WIP count meets-or-exceeds the cap. Plain
 #: U+26A0 (no variation selector) so the byte width matches the
 #: 120-char contract on every renderer.
@@ -171,6 +185,20 @@ class SummaryResult:
     would join the cache if every currently-detected unsubscribed
     label/milestone were opted into. Suppressed from the one-liner
     when zero; surfaced as ``[scope-drift] N`` when positive.
+
+    ``in_flight`` (#1270) is the *filesystem-truth* count: live
+    ``vbrief/active/*.vbrief.json`` files with ``plan.status ==
+    "running"``. It mirrors :attr:`in_flight_filesystem` and is kept
+    under the historical name so existing call-sites / history
+    records / tests stay green.  :attr:`in_flight_cache_scoped` carries
+    the legacy audit-log-derived count (cached issues whose latest
+    decision is ``accept``) -- retained only so the renderer can
+    detect divergence between the cache view and the filesystem and
+    surface a ``[triage:scope]`` line. :attr:`triage_scope_configured`
+    discriminates the two discrepancy-line variants -- ``True`` means
+    the operator has set a non-empty ``plan.policy.triageScope[]``;
+    ``False`` means the framework default (``[{"rule":"all-open"}]``)
+    is in effect (or no PROJECT-DEFINITION exists).
     """
 
     cache_empty: bool
@@ -189,6 +217,22 @@ class SummaryResult:
     #: backward compatibility with pre-D14 callers / tests that
     #: construct :class:`SummaryResult` directly.
     scope_drift: int = 0
+    #: #1270: filesystem-truth in-flight count (live
+    #: ``vbrief/active/*.vbrief.json`` with ``plan.status == "running"``).
+    #: Defaults to 0 so pre-#1270 :class:`SummaryResult` constructors
+    #: in existing tests continue to work; production callers go
+    #: through :func:`compute_summary` which always sets this.
+    in_flight_filesystem: int = 0
+    #: #1270: legacy audit-log-derived in-flight count (cached issues
+    #: with latest decision ``accept``). Used only for divergence
+    #: detection against :attr:`in_flight_filesystem`.
+    in_flight_cache_scoped: int = 0
+    #: #1270: True iff ``plan.policy.triageScope`` is a non-empty list
+    #: of dict rules on PROJECT-DEFINITION (i.e. the consumer has
+    #: opted past the framework ``all-open`` default). Discriminates
+    #: the ``outside scope`` vs ``not configured`` discrepancy-line
+    #: variant.
+    triage_scope_configured: bool = False
 
     def to_record(self, *, emitted_at: str, line: str) -> dict[str, Any]:
         """Render as the ``summary-history.jsonl`` record shape."""
@@ -200,6 +244,9 @@ class SummaryResult:
             "untriaged": self.untriaged,
             "stale_defer": self.stale_defer,
             "in_flight": self.in_flight,
+            "in_flight_filesystem": self.in_flight_filesystem,
+            "in_flight_cache_scoped": self.in_flight_cache_scoped,
+            "triage_scope_configured": self.triage_scope_configured,
             "wip_count": self.wip_count,
             "wip_cap": self.wip_cap,
             "repos": list(self.repos),
@@ -353,6 +400,96 @@ def count_vbrief_wip(project_root: Path) -> int:
     return total
 
 
+def count_filesystem_in_flight(project_root: Path) -> int:
+    """Count *filesystem-truth* in-flight vBRIEFs (#1270).
+
+    Walks ``vbrief/active/*.vbrief.json``, parses each, and counts
+    those whose ``plan.status`` equals
+    :data:`FILESYSTEM_IN_FLIGHT_STATUS` (``"running"``). Tolerant of:
+
+    * Missing ``vbrief/active/`` folder -- contributes 0.
+    * Malformed JSON files -- skipped (per the D2 "never crash the
+      ritual" contract; mirrors :func:`read_audit_log`).
+    * Files where ``plan`` / ``plan.status`` is absent or a non-string
+      -- counted as NOT running (excluded from the total).
+    * Non-``.vbrief.json`` files in the folder -- ignored (same
+      sidecar-tolerance as :func:`count_vbrief_wip`).
+
+    This is the new primary source of truth for the ritual's
+    ``in-flight`` headline. The legacy audit-log-derived count
+    (cached issues with latest decision ``accept``) is retained in
+    :func:`compute_summary` for divergence detection only.
+    """
+    folder = project_root / "vbrief" / FILESYSTEM_IN_FLIGHT_FOLDER
+    if not folder.is_dir():
+        return 0
+    total = 0
+    for child in folder.iterdir():
+        if not (child.is_file() and child.name.endswith(".vbrief.json")):
+            continue
+        # The whole parse is wrapped so a corrupt vBRIEF (torn write,
+        # bad encoding, OS-level read refusal) does not crash the
+        # ritual. The cost of a missed count is far less than the cost
+        # of a session-start exception.
+        with contextlib.suppress(Exception):
+            data = json.loads(child.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                continue
+            plan = data.get("plan")
+            if not isinstance(plan, dict):
+                continue
+            status = plan.get("status")
+            if isinstance(status, str) and status == FILESYSTEM_IN_FLIGHT_STATUS:
+                total += 1
+    return total
+
+
+def _is_triage_scope_explicitly_configured(project_root: Path) -> bool:
+    """Return ``True`` iff ``plan.policy.triageScope`` is a non-empty
+    list of dict rules on PROJECT-DEFINITION.
+
+    Discriminator for the #1270 discrepancy-line variant:
+
+    * ``True``  -> ``[triage:scope] N in-flight outside
+      plan.policy.triageScope[] (uncounted in queue ranking)``.
+    * ``False`` -> ``[triage:scope] N in-flight; plan.policy.triageScope[]
+      not configured (uncounted in queue ranking)``.
+
+    The framework default (``[{"rule": "all-open"}]``) and the absent /
+    empty / malformed cases all surface as "not configured" -- the
+    operator hasn't tightened scope, so the discrepancy line nudges
+    them toward configuring it rather than implying their explicit
+    config is wrong.
+
+    Tolerant of every failure mode (missing file, malformed JSON,
+    non-dict shapes) -- a config-read failure must NOT crash the
+    ritual; we fall back to ``False`` so the "not configured" wording
+    fires (the conservative reading).
+    """
+    path = project_root / PROJECT_DEFINITION_REL_PATH
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    plan = data.get("plan")
+    if not isinstance(plan, dict):
+        return False
+    policy = plan.get("policy")
+    if not isinstance(policy, dict):
+        return False
+    scope = policy.get("triageScope")
+    if not isinstance(scope, list) or not scope:
+        return False
+    # At least one rule must be a dict for the field to count as
+    # "configured" -- a list of non-dicts is malformed config and
+    # collapses to the same "not configured" path.
+    return any(isinstance(rule, dict) for rule in scope)
+
+
 def resolve_wip_cap(project_root: Path) -> int:
     """Read ``plan.policy.wipCap`` from PROJECT-DEFINITION; fall back to the framework default.
 
@@ -405,26 +542,39 @@ def compute_summary(
     repos = sorted({repo for repo, _n in cached})
     wip_cap = resolve_wip_cap(project_root)
     wip_count = count_vbrief_wip(project_root)
+    # #1270: the filesystem-truth in-flight count is the new headline
+    # source. Computed unconditionally (even on empty cache) so a
+    # consumer who has activated work before bootstrapping the cache
+    # still sees their actual WIP reflected in observability records.
+    in_flight_filesystem = count_filesystem_in_flight(project_root)
+    triage_scope_configured = _is_triage_scope_explicitly_configured(project_root)
 
     if not cached:
-        # Cache empty -- ALL numeric fields are zero, the discriminator
-        # is the boolean. Callers MUST render the empty-cache prompt.
+        # Cache empty -- the renderer emits the canonical empty-cache
+        # prompt regardless of the numeric counts. We still surface
+        # the filesystem count via :attr:`in_flight_filesystem` and
+        # :attr:`in_flight` so downstream observability / JSON
+        # consumers see truthful values; ``in_flight_cache_scoped``
+        # stays at 0 because there's no cache view to disagree with.
         return SummaryResult(
             cache_empty=True,
             untriaged=0,
             stale_defer=0,
-            in_flight=0,
+            in_flight=in_flight_filesystem,
             wip_count=wip_count,
             wip_cap=wip_cap,
             repos=tuple(repos[:8]),
             scope_drift=0,
+            in_flight_filesystem=in_flight_filesystem,
+            in_flight_cache_scoped=0,
+            triage_scope_configured=triage_scope_configured,
         )
 
     entries = read_audit_log(resolved_log_path)
     decisions = latest_decisions(entries)
 
     untriaged = 0
-    in_flight = 0
+    in_flight_cache_scoped = 0
     stale_defer = 0
     for repo, issue_number in cached:
         decision = decisions.get((repo, issue_number))
@@ -434,7 +584,11 @@ def compute_summary(
             # counted in the untriaged bucket.
             untriaged += 1
         elif decision in IN_FLIGHT_DECISIONS:
-            in_flight += 1
+            # #1270: this count is now the *cache-scoped* view, used
+            # only for divergence detection against the
+            # filesystem-truth count above. The headline
+            # :attr:`in_flight` is filesystem-truth.
+            in_flight_cache_scoped += 1
         if decision in STALE_DEFER_DECISIONS:
             # D3 (#1123): cached issues whose latest decision is
             # ``resume-eligible`` ARE the count the one-liner surfaces.
@@ -449,11 +603,17 @@ def compute_summary(
         cache_empty=False,
         untriaged=untriaged,
         stale_defer=stale_defer,
-        in_flight=in_flight,
+        # #1270: ``in_flight`` is now an alias for the filesystem-truth
+        # count. The cache-scoped count surfaces only via
+        # :attr:`in_flight_cache_scoped` and the discrepancy line.
+        in_flight=in_flight_filesystem,
         wip_count=wip_count,
         wip_cap=wip_cap,
         repos=tuple(repos[:8]),
         scope_drift=scope_drift,
+        in_flight_filesystem=in_flight_filesystem,
+        in_flight_cache_scoped=in_flight_cache_scoped,
+        triage_scope_configured=triage_scope_configured,
     )
 
 
@@ -552,6 +712,66 @@ def format_one_liner(result: SummaryResult, *, max_chars: int = MAX_LINE_CHARS) 
             return candidate
 
     return _truncate(candidate, max_chars)
+
+
+def format_scope_discrepancy_line(result: SummaryResult) -> str | None:
+    """Return the ``[triage:scope]`` discrepancy line, or ``None`` if aligned.
+
+    Emitted when the filesystem-truth in-flight count diverges from the
+    cache-scoped audit-log count (#1270). Two wording variants -- the
+    canonical strings are defined inline in the function body below:
+
+    * ``triage_scope_configured = True`` -> ``outside
+      plan.policy.triageScope[]`` wording (operator has set a non-empty
+      ``plan.policy.triageScope[]``).
+    * ``triage_scope_configured = False`` -> ``not configured`` wording
+      (framework default ``all-open`` OR absent / empty / malformed
+      config).
+
+    ``N`` is the *absolute* delta between the two counts. Returns
+    ``None`` (no second line) when the counts agree -- the common case
+    when scope is aligned. Cache-empty summaries also return ``None``
+    because the headline switches to ``EMPTY_CACHE_LINE`` and the
+    discrepancy semantics no longer apply.
+    """
+    if result.cache_empty:
+        return None
+    delta = abs(result.in_flight_filesystem - result.in_flight_cache_scoped)
+    if delta == 0:
+        return None
+    if result.triage_scope_configured:
+        return (
+            f"[triage:scope] {delta} in-flight outside "
+            "plan.policy.triageScope[] (uncounted in queue ranking)"
+        )
+    return (
+        f"[triage:scope] {delta} in-flight; "
+        "plan.policy.triageScope[] not configured "
+        "(uncounted in queue ranking)"
+    )
+
+
+def format_summary(result: SummaryResult, *, max_chars: int = MAX_LINE_CHARS) -> str:
+    """Render the full (possibly multi-line) summary string.
+
+    Composes the headline one-liner (delegated to
+    :func:`format_one_liner`, which retains the original
+    single-physical-line + 120-char-cap contract from #1122) plus,
+    when applicable, a second physical line produced by
+    :func:`format_scope_discrepancy_line` (#1270).
+
+    The 120-char cap is applied per physical line, not to the combined
+    string -- the discrepancy line is informational and intentionally
+    longer than the cap would allow when collapsed into one line. CLI
+    callers print this verbatim; the history-JSONL ``line`` field also
+    receives the full multi-line content so offline replay sees the
+    same view the operator did.
+    """
+    headline = format_one_liner(result, max_chars=max_chars)
+    extra = format_scope_discrepancy_line(result)
+    if extra is None:
+        return headline
+    return f"{headline}\n{extra}"
 
 
 def append_history(
@@ -668,7 +888,11 @@ def main(argv: list[str] | None = None) -> int:
     cache_root = Path(args.cache_root).resolve() if args.cache_root else None
 
     result = compute_summary(project_root, cache_root=cache_root)
-    line = format_one_liner(result)
+    # #1270: ``format_summary`` returns the headline plus, when
+    # filesystem-vs-cache counts diverge, a second ``[triage:scope]``
+    # line. The headline retains the #1122 single-line + 120-char-cap
+    # contract via :func:`format_one_liner`.
+    line = format_summary(result)
     emitted_at = _utc_iso()
 
     if args.json:

--- a/tests/test_resume_conditions.py
+++ b/tests/test_resume_conditions.py
@@ -645,7 +645,15 @@ def test_summary_stale_defer_counts_resume_eligible(tmp_path: Path) -> None:
     result = triage_summary.compute_summary(tmp_path)
     assert result.cache_empty is False
     assert result.stale_defer == 1
-    assert result.in_flight == 1
+    # #1270: ``in_flight`` is now filesystem-truth (live
+    # ``vbrief/active/*.vbrief.json`` with ``plan.status == "running"``);
+    # this fixture seeds no active/ vBRIEFs so the headline count is 0.
+    # The semantic intent of this assertion -- that ``accept`` is
+    # classified into the cache-scoped in-flight bucket (NOT counted as
+    # ``resume-eligible`` or ``defer``) -- now lives on
+    # :attr:`SummaryResult.in_flight_cache_scoped`.
+    assert result.in_flight == 0
+    assert result.in_flight_cache_scoped == 1
     # #2 has a defer decision (not in TRIAGED_DECISIONS' untriaged set);
     # the original summary semantics keep it OUT of "untriaged" because
     # ``defer`` IS in TRIAGED_DECISIONS. So untriaged == 0.

--- a/tests/test_triage_summary.py
+++ b/tests/test_triage_summary.py
@@ -106,6 +106,56 @@ def _set_wip_cap(project_root: Path, cap: int) -> None:
     )
 
 
+def _set_triage_scope(
+    project_root: Path, scope: list[dict[str, Any]] | None
+) -> None:
+    """Write ``plan.policy.triageScope`` on PROJECT-DEFINITION (#1270 helper).
+
+    Passing ``None`` writes a PROJECT-DEFINITION with no ``policy.triageScope``
+    key (i.e. the framework default applies). Passing a list writes that
+    list verbatim. Used by the #1270 discrepancy-line tests to flip
+    between the "configured" and "not configured" wording variants.
+    """
+    pd = project_root / triage_summary.PROJECT_DEFINITION_REL_PATH
+    pd.parent.mkdir(parents=True, exist_ok=True)
+    policy: dict[str, Any] = {}
+    if scope is not None:
+        policy["triageScope"] = scope
+    pd.write_text(
+        json.dumps(
+            {
+                "vBRIEFInfo": {"version": "0.6"},
+                "plan": {"policy": policy},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_active_vbrief(
+    project_root: Path, name: str, *, status: str = "running"
+) -> Path:
+    """Write a minimal ``vbrief/active/<name>.vbrief.json`` (#1270 helper).
+
+    The #1270 filesystem-truth in-flight counter only inspects
+    ``plan.status``; the rest of the vBRIEF shape is irrelevant for the
+    count so we keep the fixture intentionally small.
+    """
+    folder = project_root / "vbrief" / "active"
+    folder.mkdir(parents=True, exist_ok=True)
+    target = folder / f"{name}.vbrief.json"
+    target.write_text(
+        json.dumps(
+            {
+                "vBRIEFInfo": {"version": "0.6"},
+                "plan": {"status": status, "title": name},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
 # ---------------------------------------------------------------------------
 # Empty / missing cache contract
 # ---------------------------------------------------------------------------
@@ -137,6 +187,16 @@ def test_present_but_empty_cache_dir_emits_empty_cache_prompt(tmp_path: Path) ->
 
 
 def test_populated_cache_zero_wip_no_warning(tmp_path: Path) -> None:
+    """Populated cache, 0 WIP, audit-log accepts -- but no active/ vBRIEFs.
+
+    Post-#1270 the headline ``in-flight`` is filesystem-truth, so the 2
+    audit-log ``accept`` decisions surface only via
+    :attr:`SummaryResult.in_flight_cache_scoped` (the divergence-detection
+    field). Filesystem count is 0 because no active/ vBRIEFs exist on
+    tmp_path. The two counts diverge -- the discrepancy line therefore
+    appears in :func:`format_summary`. :func:`format_one_liner` still
+    returns only the headline (single physical line).
+    """
     cache_root = tmp_path / triage_summary.CACHE_DIR_NAME
     _make_cached_issue(cache_root, "deftai/directive", 100)
     _make_cached_issue(cache_root, "deftai/directive", 101)
@@ -165,14 +225,20 @@ def test_populated_cache_zero_wip_no_warning(tmp_path: Path) -> None:
     result = triage_summary.compute_summary(tmp_path)
     assert result.cache_empty is False
     assert result.untriaged == 1
-    assert result.in_flight == 2
+    # #1270: headline `in_flight` == filesystem count (0 active/ vBRIEFs
+    # on tmp_path); the legacy audit-log-derived count (2 accepts) is
+    # preserved on `in_flight_cache_scoped` for divergence detection.
+    assert result.in_flight == 0
+    assert result.in_flight_filesystem == 0
+    assert result.in_flight_cache_scoped == 2
+    assert result.triage_scope_configured is False
     assert result.stale_defer == 0
     assert result.wip_count == 0
     assert result.wip_cap == triage_summary.DEFAULT_WIP_CAP
 
     line = triage_summary.format_one_liner(result)
     assert line.startswith("[triage] 1 untriaged")
-    assert "2 in-flight" in line
+    assert "0 in-flight" in line  # filesystem-truth headline
     assert f"WIP 0/{triage_summary.DEFAULT_WIP_CAP}" in line
     # Stale-defer suppressed when count is 0.
     assert "stale-defer" not in line
@@ -552,6 +618,14 @@ def test_cli_json_mode_emits_record(
 
 
 def test_audit_log_tolerates_malformed_lines(tmp_path: Path) -> None:
+    """Malformed audit-log lines must be skipped while the legitimate
+    ``accept`` still classifies the cached issue.
+
+    Post-#1270 the headline ``in_flight`` is filesystem-truth, so the
+    audit-log-derived count surfaces via
+    :attr:`SummaryResult.in_flight_cache_scoped` -- that's the field
+    this test pins.
+    """
     cache_root = tmp_path / triage_summary.CACHE_DIR_NAME
     _make_cached_issue(cache_root, "deftai/directive", 1000)
     log = tmp_path / triage_summary.CANDIDATES_LOG_REL_PATH
@@ -570,7 +644,7 @@ def test_audit_log_tolerates_malformed_lines(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     result = triage_summary.compute_summary(tmp_path)
-    assert result.in_flight == 1
+    assert result.in_flight_cache_scoped == 1
     assert result.untriaged == 0
 
 
@@ -754,3 +828,378 @@ def test_is_pos_int_dir_predicate_rejects_unicode_digit(tmp_path: Path) -> None:
     # the regression scenario this test guards.
     assert "\u00b2".isdigit() is True
     assert "\u00b2".isdecimal() is False
+
+
+# ---------------------------------------------------------------------------
+# #1270: filesystem-truth in-flight + scope discrepancy line
+# ---------------------------------------------------------------------------
+
+
+def test_count_filesystem_in_flight_counts_only_running_status(
+    tmp_path: Path,
+) -> None:
+    """Only ``plan.status == "running"`` active/ vBRIEFs count."""
+    _write_active_vbrief(tmp_path, "a-running", status="running")
+    _write_active_vbrief(tmp_path, "b-running", status="running")
+    _write_active_vbrief(tmp_path, "c-done", status="done")
+    _write_active_vbrief(tmp_path, "d-cancelled", status="cancelled")
+    _write_active_vbrief(tmp_path, "e-blocked", status="blocked")
+    assert triage_summary.count_filesystem_in_flight(tmp_path) == 2
+
+
+def test_count_filesystem_in_flight_missing_folder_returns_zero(
+    tmp_path: Path,
+) -> None:
+    """A fresh consumer with no ``vbrief/active/`` folder contributes 0."""
+    assert triage_summary.count_filesystem_in_flight(tmp_path) == 0
+
+
+def test_count_filesystem_in_flight_tolerates_malformed_vbriefs(
+    tmp_path: Path,
+) -> None:
+    """Corrupt vBRIEFs MUST NOT crash the ritual; they're just skipped."""
+    folder = tmp_path / "vbrief" / "active"
+    folder.mkdir(parents=True)
+    # Truncated JSON.
+    (folder / "a-torn.vbrief.json").write_text(
+        '{"plan": {"status":', encoding="utf-8"
+    )
+    # Non-dict top level.
+    (folder / "b-list.vbrief.json").write_text("[]", encoding="utf-8")
+    # Missing plan key.
+    (folder / "c-no-plan.vbrief.json").write_text(
+        json.dumps({"vBRIEFInfo": {}}), encoding="utf-8"
+    )
+    # plan.status is a non-string.
+    (folder / "d-status-int.vbrief.json").write_text(
+        json.dumps({"plan": {"status": 42}}), encoding="utf-8"
+    )
+    # Legit running vBRIEF -- this is the only one that counts.
+    _write_active_vbrief(tmp_path, "e-good", status="running")
+    # Non-.vbrief.json file in the folder -- ignored.
+    (folder / "README.md").write_text("scratch", encoding="utf-8")
+    assert triage_summary.count_filesystem_in_flight(tmp_path) == 1
+
+
+def test_is_triage_scope_explicitly_configured_true_for_non_empty_list(
+    tmp_path: Path,
+) -> None:
+    """A non-empty list of dict rules is the "configured" signal."""
+    _set_triage_scope(tmp_path, [{"rule": "labels", "any-of": ["phase-1"]}])
+    assert (
+        triage_summary._is_triage_scope_explicitly_configured(tmp_path) is True
+    )
+
+
+def test_is_triage_scope_explicitly_configured_false_for_default(
+    tmp_path: Path,
+) -> None:
+    """Absent / empty / non-list / list-of-non-dicts all collapse to False.
+
+    The framework default (``[{"rule": "all-open"}]`` applied by
+    :func:`scripts.triage_scope.resolve_scope_rules` when the field is
+    unset) is treated as "not configured" -- the operator hasn't
+    explicitly tightened scope. An explicitly-written ``all-open``
+    rule, by contrast, is treated as configured because the operator
+    wrote it on purpose.
+    """
+    # Case 1: no PROJECT-DEFINITION at all.
+    assert (
+        triage_summary._is_triage_scope_explicitly_configured(tmp_path) is False
+    )
+
+    # Case 2: PROJECT-DEFINITION exists but no triageScope field.
+    _set_triage_scope(tmp_path, None)
+    assert (
+        triage_summary._is_triage_scope_explicitly_configured(tmp_path) is False
+    )
+
+    # Case 3: triageScope is an empty list.
+    _set_triage_scope(tmp_path, [])
+    assert (
+        triage_summary._is_triage_scope_explicitly_configured(tmp_path) is False
+    )
+
+    # Case 4: triageScope is a list of non-dicts (malformed config).
+    pd = tmp_path / triage_summary.PROJECT_DEFINITION_REL_PATH
+    pd.write_text(
+        json.dumps(
+            {
+                "vBRIEFInfo": {"version": "0.6"},
+                "plan": {"policy": {"triageScope": ["all-open", 42]}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        triage_summary._is_triage_scope_explicitly_configured(tmp_path) is False
+    )
+
+
+def test_is_triage_scope_explicitly_configured_tolerates_malformed_json(
+    tmp_path: Path,
+) -> None:
+    """A corrupt PROJECT-DEFINITION must not crash the ritual."""
+    pd = tmp_path / triage_summary.PROJECT_DEFINITION_REL_PATH
+    pd.parent.mkdir(parents=True, exist_ok=True)
+    pd.write_text("{not json", encoding="utf-8")
+    assert (
+        triage_summary._is_triage_scope_explicitly_configured(tmp_path) is False
+    )
+
+
+def test_compute_summary_in_flight_is_filesystem_truth(tmp_path: Path) -> None:
+    """#1270: the headline ``in_flight`` is the filesystem-truth count.
+
+    Setup: 3 cached issues with audit-log accepts on 2 of them (would
+    yield ``in_flight=2`` under the legacy contract). Filesystem has 1
+    active/ vBRIEF with ``status=="running"``. Headline must report 1,
+    cache-scoped must report 2.
+    """
+    cache_root = tmp_path / triage_summary.CACHE_DIR_NAME
+    _make_cached_issue(cache_root, "deftai/directive", 600)
+    _make_cached_issue(cache_root, "deftai/directive", 601)
+    _make_cached_issue(cache_root, "deftai/directive", 602)
+    _write_audit_log(
+        tmp_path,
+        [
+            _make_audit_entry(
+                "deftai/directive", 600, "accept",
+                decision_id="66666666-6666-6666-6666-666666666600",
+            ),
+            _make_audit_entry(
+                "deftai/directive", 601, "accept",
+                decision_id="66666666-6666-6666-6666-666666666601",
+            ),
+        ],
+    )
+    _write_active_vbrief(tmp_path, "only-running", status="running")
+
+    result = triage_summary.compute_summary(tmp_path)
+    assert result.in_flight == 1               # filesystem-truth headline
+    assert result.in_flight_filesystem == 1
+    assert result.in_flight_cache_scoped == 2  # legacy audit-log count
+
+
+def test_format_scope_discrepancy_line_none_when_aligned() -> None:
+    """Aligned counts -> no second line emitted."""
+    result = triage_summary.SummaryResult(
+        cache_empty=False,
+        untriaged=4,
+        stale_defer=0,
+        in_flight=3,
+        wip_count=3,
+        wip_cap=10,
+        in_flight_filesystem=3,
+        in_flight_cache_scoped=3,
+        triage_scope_configured=True,
+    )
+    assert triage_summary.format_scope_discrepancy_line(result) is None
+
+
+def test_format_scope_discrepancy_line_none_on_cache_empty() -> None:
+    """Cache-empty -> no second line (headline switches to EMPTY_CACHE_LINE)."""
+    result = triage_summary.SummaryResult(
+        cache_empty=True,
+        untriaged=0,
+        stale_defer=0,
+        in_flight=2,
+        wip_count=0,
+        wip_cap=10,
+        in_flight_filesystem=2,
+        in_flight_cache_scoped=0,
+        triage_scope_configured=False,
+    )
+    assert triage_summary.format_scope_discrepancy_line(result) is None
+
+
+def test_format_scope_discrepancy_line_configured_wording() -> None:
+    """Configured scope -> "outside plan.policy.triageScope[]" wording."""
+    result = triage_summary.SummaryResult(
+        cache_empty=False,
+        untriaged=4,
+        stale_defer=0,
+        in_flight=3,
+        wip_count=3,
+        wip_cap=10,
+        in_flight_filesystem=3,
+        in_flight_cache_scoped=2,
+        triage_scope_configured=True,
+    )
+    line = triage_summary.format_scope_discrepancy_line(result)
+    assert line is not None
+    assert line == (
+        "[triage:scope] 1 in-flight outside "
+        "plan.policy.triageScope[] (uncounted in queue ranking)"
+    )
+
+
+def test_format_scope_discrepancy_line_not_configured_wording() -> None:
+    """Default / empty scope -> "not configured" wording."""
+    result = triage_summary.SummaryResult(
+        cache_empty=False,
+        untriaged=359,
+        stale_defer=0,
+        in_flight=3,
+        wip_count=3,
+        wip_cap=10,
+        in_flight_filesystem=3,
+        in_flight_cache_scoped=38,
+        triage_scope_configured=False,
+    )
+    line = triage_summary.format_scope_discrepancy_line(result)
+    assert line is not None
+    assert line == (
+        "[triage:scope] 35 in-flight; "
+        "plan.policy.triageScope[] not configured "
+        "(uncounted in queue ranking)"
+    )
+
+
+def test_format_scope_discrepancy_line_uses_absolute_delta() -> None:
+    """The delta is the absolute value -- direction agnostic.
+
+    Either side (filesystem > cache or cache > filesystem) surfaces as
+    a positive ``N``; the operator can investigate further from there.
+    """
+    # filesystem(5) > cache(2): delta = 3
+    fs_high = triage_summary.SummaryResult(
+        cache_empty=False, untriaged=0, stale_defer=0, in_flight=5,
+        wip_count=0, wip_cap=10,
+        in_flight_filesystem=5, in_flight_cache_scoped=2,
+        triage_scope_configured=True,
+    )
+    # cache(38) > filesystem(3): delta = 35
+    cache_high = triage_summary.SummaryResult(
+        cache_empty=False, untriaged=0, stale_defer=0, in_flight=3,
+        wip_count=0, wip_cap=10,
+        in_flight_filesystem=3, in_flight_cache_scoped=38,
+        triage_scope_configured=True,
+    )
+    fs_line = triage_summary.format_scope_discrepancy_line(fs_high)
+    cache_line = triage_summary.format_scope_discrepancy_line(cache_high)
+    assert fs_line is not None and "3 in-flight outside" in fs_line
+    assert cache_line is not None and "35 in-flight outside" in cache_line
+
+
+def test_format_summary_appends_discrepancy_line_when_diverged() -> None:
+    """``format_summary`` returns ``headline\\n[triage:scope] ...`` on divergence."""
+    result = triage_summary.SummaryResult(
+        cache_empty=False,
+        untriaged=359,
+        stale_defer=0,
+        in_flight=3,
+        wip_count=3,
+        wip_cap=10,
+        in_flight_filesystem=3,
+        in_flight_cache_scoped=38,
+        triage_scope_configured=False,
+    )
+    full = triage_summary.format_summary(result)
+    lines = full.split("\n")
+    assert len(lines) == 2
+    assert lines[0].startswith("[triage] 359 untriaged")
+    assert "3 in-flight" in lines[0]
+    assert lines[1].startswith("[triage:scope] 35 in-flight")
+    assert "not configured" in lines[1]
+
+
+def test_format_summary_single_line_when_aligned() -> None:
+    """Aligned counts -> ``format_summary`` returns just the headline."""
+    result = triage_summary.SummaryResult(
+        cache_empty=False,
+        untriaged=4,
+        stale_defer=0,
+        in_flight=2,
+        wip_count=1,
+        wip_cap=10,
+        in_flight_filesystem=2,
+        in_flight_cache_scoped=2,
+        triage_scope_configured=True,
+    )
+    full = triage_summary.format_summary(result)
+    assert "\n" not in full
+    assert "[triage:scope]" not in full
+
+
+def test_format_summary_single_line_when_cache_empty() -> None:
+    """Cache-empty headline always single-line, no discrepancy line."""
+    result = triage_summary.SummaryResult(
+        cache_empty=True,
+        untriaged=0,
+        stale_defer=0,
+        in_flight=2,
+        wip_count=0,
+        wip_cap=10,
+        in_flight_filesystem=2,
+        in_flight_cache_scoped=0,
+        triage_scope_configured=False,
+    )
+    full = triage_summary.format_summary(result)
+    assert full == triage_summary.EMPTY_CACHE_LINE
+    assert "\n" not in full
+
+
+def test_compute_summary_configured_scope_emits_configured_wording(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: a configured scope + divergence -> "outside" wording."""
+    cache_root = tmp_path / triage_summary.CACHE_DIR_NAME
+    _make_cached_issue(cache_root, "deftai/directive", 700)
+    _write_audit_log(
+        tmp_path,
+        [
+            _make_audit_entry(
+                "deftai/directive", 700, "accept",
+                decision_id="77777777-7777-7777-7777-777777777700",
+            ),
+        ],
+    )
+    _set_triage_scope(tmp_path, [{"rule": "labels", "any-of": ["phase-1"]}])
+    _write_active_vbrief(tmp_path, "one-running", status="running")
+    _write_active_vbrief(tmp_path, "two-running", status="running")
+
+    result = triage_summary.compute_summary(tmp_path)
+    assert result.triage_scope_configured is True
+    assert result.in_flight_filesystem == 2
+    assert result.in_flight_cache_scoped == 1
+    full = triage_summary.format_summary(result)
+    assert "outside plan.policy.triageScope[]" in full
+    assert "not configured" not in full
+
+
+def test_to_record_includes_new_in_flight_fields() -> None:
+    """#1270 dataclass fields are persisted in the history JSONL record."""
+    result = triage_summary.SummaryResult(
+        cache_empty=False,
+        untriaged=10,
+        stale_defer=0,
+        in_flight=3,
+        wip_count=3,
+        wip_cap=10,
+        in_flight_filesystem=3,
+        in_flight_cache_scoped=38,
+        triage_scope_configured=True,
+    )
+    rec = result.to_record(emitted_at="2026-05-21T12:00:00Z", line="[triage] ...")
+    assert rec["in_flight_filesystem"] == 3
+    assert rec["in_flight_cache_scoped"] == 38
+    assert rec["triage_scope_configured"] is True
+    # The original alias survives.
+    assert rec["in_flight"] == 3
+
+
+def test_to_record_defaults_for_pre_1270_constructors() -> None:
+    """Constructors that omit the #1270 fields still produce a record."""
+    result = triage_summary.SummaryResult(
+        cache_empty=True,
+        untriaged=0,
+        stale_defer=0,
+        in_flight=0,
+        wip_count=0,
+        wip_cap=10,
+    )
+    rec = result.to_record(emitted_at="2026-05-21T12:00:00Z", line="...")
+    assert rec["in_flight_filesystem"] == 0
+    assert rec["in_flight_cache_scoped"] == 0
+    assert rec["triage_scope_configured"] is False


### PR DESCRIPTION
## Summary

Fixes the session-start `task triage:summary` headline silently disagreeing with the filesystem. The `in-flight` count now reads from live `vbrief/active/*.vbrief.json` files with `plan.status == "running"` (filesystem-truth), in lockstep with `WIP`. When the new headline diverges from the legacy audit-log-derived cache-scoped view, a second `[triage:scope]` line surfaces the gap with two wording variants distinguished by whether `plan.policy.triageScope[]` is explicitly configured.

### Live verification on this clone

```
[triage] 359 untriaged · 3 in-flight · WIP 3/10
[triage:scope] 35 in-flight outside plan.policy.triageScope[] (uncounted in queue ranking)
```

Pre-fix the headline read `... · 38 in-flight · WIP 3/10` — the cache-scoped count (38) didn't move when vBRIEFs were activated. Post-fix the headline (3) tracks `WIP` exactly; the `[triage:scope]` line surfaces the 35-unit divergence (audit-log accepts that no longer correspond to active/ vBRIEFs in this clone's configured scope).

### Scope

MVP per the handoff §5:

1. New `count_filesystem_in_flight(project_root)` helper — globs `vbrief/active/*.vbrief.json`, parses each, counts `plan.status == "running"`. Tolerant of malformed JSON, missing folder, non-string status.
2. New `_is_triage_scope_explicitly_configured(project_root)` — returns `True` iff `plan.policy.triageScope[]` is a non-empty list of dict rules on PROJECT-DEFINITION. Default `all-open` / absent / empty / malformed → `False` (conservative).
3. `SummaryResult` augmented with three new fields (all default `0` / `False`): `in_flight_filesystem`, `in_flight_cache_scoped`, `triage_scope_configured`. Backwards-compatible — existing constructors stay green.
4. `compute_summary()` sets `in_flight = in_flight_filesystem = count_filesystem_in_flight(...)` (the new primary). Computes `in_flight_cache_scoped` via the existing audit-log walk. Populates the configured flag.
5. New `format_summary(result)` composes `format_one_liner(result)` (single-line, 120-char cap — contract preserved) plus, when `in_flight_filesystem != in_flight_cache_scoped`, a second physical line via the new `format_scope_discrepancy_line(result)`:
   - configured → `[triage:scope] N in-flight outside plan.policy.triageScope[] (uncounted in queue ranking)`
   - not configured → `[triage:scope] N in-flight; plan.policy.triageScope[] not configured (uncounted in queue ranking)`
   - `N = abs(in_flight_filesystem - in_flight_cache_scoped)`
6. `main()` switches `print` to `format_summary`; history-JSONL `line` field carries the full multi-line content.
7. `to_record()` surfaces both counts + the configured flag in `summary-history.jsonl`.

### Acceptance criteria coverage (per vBRIEF)

- [x] Item 1: `scripts/triage_summary.py` reads filesystem-truth in-flight.
- [x] Item 2: divergence → `outside plan.policy.triageScope[]` wording.
- [x] Item 3: empty/default `triageScope[]` → `not configured` wording.
- [ ] Item 4: `(cache stale)` vs `(out of scope)` distinction — **deferred to follow-up** (requires correlating with `verify:cache-fresh` state).
- [ ] Item 5: D2 suppression hash-key adjustment — **deferred to follow-up** (D2 throttling lives outside `scripts/triage_summary.py`; the headline-only contract is preserved here so the existing key hash continues to operate against the unchanged primary line, but a future operator may want the discrepancy line to flip without re-triggering the throttle).
- [ ] Item 6: `(degraded)` marker on count-source failure — **deferred to follow-up**.
- [x] Item 7: unit tests for aligned counts, scope-configured divergence, default/empty-`triageScope[]` divergence, `plan.status != "running"` exclusion, malformed-vBRIEF tolerance.
- [x] Item 8: AGENTS.md session-start ritual step 3 updated.
- [x] Item 9: CHANGELOG.md `[Unreleased]` entry (#1242-compliant).
- [x] Item 10: `task check` passes (6288 passed, 0 failures, lint/encoding/branch-policy all clean).

### Tests

- `tests/test_triage_summary.py`: +17 new tests (52 total, up from 35) covering filesystem-truth helper, configured-scope detector, scope-discrepancy line wording variants + `None` cases, absolute-delta direction-agnostic behaviour, `format_summary` composition, end-to-end `compute_summary` filesystem-truth contract, `to_record` field surface.
- `tests/test_resume_conditions.py`: `test_summary_stale_defer_counts_resume_eligible` updated to assert against the new `in_flight_cache_scoped` field (preserves the original semantic intent that `accept` is classified into the cache-scoped in-flight bucket, separately from the new filesystem-truth headline).
- `tests/test_triage_summary.py::test_populated_cache_zero_wip_no_warning`: rewritten to assert the new contract (`in_flight == 0` filesystem-truth, `in_flight_cache_scoped == 2` legacy audit-log count) instead of the old conflated meaning.

## Related Issues

Closes #1270

## Checklist

- [x] `/deft:change <name>` — N/A (scope vBRIEF `vbrief/active/2026-05-20-1270-...vbrief.json` already on master via PR #1271 and `plan.status == "running"`; #810 implementation-intent gate cleared)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [ ] `ROADMAP.md` — N/A (no roadmap change required for this issue)
- [x] Tests pass locally — `task check` clean (6288 passed, 3 skipped, 9 deselected, 1 xfailed)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm #1270 actually closed — `gh issue view 1270 --json state --jq .state`. Squash merges can silently fail to process closing keywords (#167). If still open, close manually: `gh issue close 1270 --comment "Closed by #<PR> (squash merge — auto-close did not trigger)"`
- [ ] File deferred follow-up issues for items 4 / 5 / 6 (cache-stale distinction; D2 hash-key adjustment; `(degraded)` marker)
