### PR TITLE
chore(vbrief): decompose #742 into three homes (#1283, #1284, #1285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **chore(vbrief): decompose #742 (ADR-001 alignment vehicle) into three homes (#1283, #1284, #1285)** -- closed #742 as `not planned` and split into a pack-slicing RFC (#1283), the vBRIEF-as-canonical epic umbrella (#1284), and the deterministic CRUD harness epic (#1285). Filed 17 new GitHub issues + authored 17 matching scope vBRIEFs in `vbrief/proposed/`, including 6 blocked placeholders carrying `plan.metadata.swarm.depends_on` for cascade-unblock semantics. Adopted existing #1274 as Epic-1 Child 1.0b (renderer write-path). Cancelled the obsolete `742-adr-001-empirical-validation` scope vBRIEF (Gates 1+2 dropped per the decomposition). New `status:blocked` label created. Closes #742; refs #1273 (research-strategy lifecycle), #1167 (CRUD-tool architecture), #1119 (operational-state carve-out).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **chore(vbrief): decompose #742 (ADR-001 alignment vehicle) into three homes (#1283, #1284, #1285)** -- closed #742 as `not planned` and split into a pack-slicing RFC (#1283), the vBRIEF-as-canonical epic umbrella (#1284), and the deterministic CRUD harness epic (#1285). Filed 17 new GitHub issues + authored 17 matching scope vBRIEFs in `vbrief/proposed/`, including 6 blocked placeholders carrying `plan.metadata.swarm.depends_on` for cascade-unblock semantics. Adopted existing #1274 as Epic-1 Child 1.0b (renderer write-path). Cancelled the obsolete `742-adr-001-empirical-validation` scope vBRIEF (Gates 1+2 dropped per the decomposition). New `status:blocked` label created. Closes #742; refs #1273 (research-strategy lifecycle), #1167 (CRUD-tool architecture), #1119 (operational-state carve-out).
+- **chore(vbrief): decompose #742 into three homes (#1283, #1284, #1285)** -- split the ADR-001 alignment vehicle into a pack-slicing RFC (#1283), a vBRIEF-as-canonical epic (#1284), and a CRUD-harness epic (#1285); filed 14 new children, adopted #1274, and cancelled the empirical-validation vBRIEF. Closes #742; refs #1273, #1167, #1119.
 
 ### Changed
 

--- a/vbrief/cancelled/2026-05-01-742-adr-001-empirical-validation.vbrief.json
+++ b/vbrief/cancelled/2026-05-01-742-adr-001-empirical-validation.vbrief.json
@@ -3,12 +3,12 @@
     "version": "0.6",
     "description": "Scope vBRIEF (#742 child): Empirical validation of ADR-001 (vBRIEF-as-master). Two-gate evidence pack (comprehension parity + CRUD determinism) addressing Visionik's Apr-30 review concerns. Bench infrastructure lives in deftai/deft-agent-bench (internal); production CRUD tooling lives in deft-directive.",
     "created": "2026-05-01T16:00:00Z",
-    "updated": "2026-05-01T16:00:00Z"
+    "updated": "2026-05-21T16:35:48Z"
   },
   "plan": {
     "id": "742-adr-001-empirical-validation",
     "title": "ADR-001 empirical validation: comprehension parity + CRUD determinism gates",
-    "status": "proposed",
+    "status": "cancelled",
     "planRef": "#742",
     "narratives": {
       "Problem": "ADR-001 (#742) proposes vBRIEF-as-master for the agentic-consumed surface. Visionik's Apr-30 review approved-with-conditions, raising two empirical prerequisites that block final approval: (1) cross-model/harness comprehension validation -- verify that {Opus, ChatGPT, Gemini, etc.} and harnesses {Claude Code, Warp, opencode, pi.dev} consume vBRIEF JSON as well as Markdown; (2) deterministic CRUD tooling as a hard prerequisite -- without typed CRUD operations on vBRIEF JSON, agents 'innovate' within the structure, undermining the reliability claim. Both must be answered empirically before ADR approval and Phase 1 can ship.",
@@ -150,6 +150,7 @@
         "type": "x-vbrief/related-repo",
         "title": "deft-agent-bench (internal): bench infrastructure for this validation effort"
       }
-    ]
+    ],
+    "updated": "2026-05-21T16:33:43Z"
   }
 }

--- a/vbrief/completed/2026-05-20-1270-fixtriage-triagesummary-in-flight-count-should-be-filesystem.vbrief.json
+++ b/vbrief/completed/2026-05-20-1270-fixtriage-triagesummary-in-flight-count-should-be-filesystem.vbrief.json
@@ -2,11 +2,11 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Scope vBRIEF ingested from GitHub issue #1270",
-    "updated": "2026-05-20T21:07:00Z"
+    "updated": "2026-05-21T16:33:43Z"
   },
   "plan": {
     "title": "fix(triage): triage:summary in-flight count should be filesystem-truth with conditional scope-discrepancy line",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "fix(triage): triage:summary in-flight count should be filesystem-truth with conditional scope-discrepancy line",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1270",
@@ -61,6 +61,6 @@
         "title": "Issue #1270: fix(triage): triage:summary in-flight count should be filesystem-truth with conditional scope-discrepancy line"
       }
     ],
-    "updated": "2026-05-20T21:07:00Z"
+    "updated": "2026-05-21T16:33:43Z"
   }
 }

--- a/vbrief/proposed/2026-05-21-1283-pack-slicing-rfc.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1283-pack-slicing-rfc.vbrief.json
@@ -1,0 +1,70 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Research vBRIEF for #1283 (pack-slicing RFC); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:35:48Z"
+  },
+  "plan": {
+    "id": "1283-pack-slicing-rfc",
+    "title": "Pack-aware slice API -- surface, semantics, mechanisms (design RFC)",
+    "status": "proposed",
+    "planRef": "#1283",
+    "narratives": {
+      "Description": "Design RFC for the pack-aware slice mechanism that vBRIEF-as-canonical (Epic 1) depends on for selective-loading. Carved out from #742 (decomposed); this RFC starts fresh because the original section in #742 was unclear in what it presented.",
+      "Overview": "Question-driven RFC. Defines what a pack is (schema-managed bundle), what a slice is (named structured subset; NOT #929 tracer-bullet), the `task <pack>:slice <name> <path>` surface shape, the slice-name registry mechanism, the vBRIEF-source-vs-rendered-output relationship, and the versioning policy. Out of scope: specific pack schemas (per-pack issues), migration order, peripheral content."
+    },
+    "items": [
+      {
+        "title": "Resolve RFC questions and converge on a design",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "All 7 questions in the issue body answered; design proposal posted as a comment; approval or revise-request from reviewers."
+        }
+      },
+      {
+        "title": "Close the RFC with a final design comment + ADR pointer",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Issue closed; if approved, Child 1.2 (lessons-pack pilot) can implement against the design. If rejected, this vBRIEF lands in cancelled/ via the reconciler."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "research",
+      "x-tracking": {
+        "parent_issue": "#1283",
+        "decomposition_origin": "#742",
+        "lifecycle_footgun_ref": "#1273"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1283",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1283: rfc(vbrief,consumption): pack-aware slice API"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/742",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #742: doc(adr): ADR-001 (decomposed)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1273",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1273: UX: research-strategy lifecycle footgun"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1290",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1290: feat(vbrief): reconcile_issues honors stateReason"
+      }
+    ],
+    "updated": "2026-05-21T16:33:43Z"
+  }
+}

--- a/vbrief/proposed/2026-05-21-1284-epic-vbrief-canonical.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1284-epic-vbrief-canonical.vbrief.json
@@ -1,0 +1,144 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Epic umbrella vBRIEF for #1284 (epic(vbrief): vBRIEF-as-canonical for the agentic-consumed surface); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:35:48Z"
+  },
+  "plan": {
+    "id": "1284-epic-vbrief-canonical",
+    "title": "Epic 1 umbrella: vBRIEF-as-canonical for the agentic-consumed surface (approved direction)",
+    "status": "proposed",
+    "planRef": "#1284",
+    "narratives": {
+      "Description": "Approved direction (token-economics rationale; peripheral-content qualifier; defense-in-depth layers A-D). Carved out from #742 (decomposed). The pack rollout proceeds through Phase 1 (lessons-pack-0.1), Phase 2 (skills-pack-0.1), Phase 3 (rules-pack + strategies-pack). Wave-1 children build the supporting mechanisms (queue blocked-awareness, three reconcile verbs, stateReason routing, ADR doc, #336 reframe).",
+      "Overview": "Umbrella tracking the vBRIEF-as-canonical migration. 11 children across 4 waves. Wave-1: #1286, #1274, #1287, #1288, #1289, #1290, #1291, #1292. Wave-2: #1294. Wave-3: #1295. Wave-4: #1296. The §1152 current-shape comment on the SCM issue carries the canonical state."
+    },
+    "items": [
+      {
+        "title": "Decompose to children + maintain current-shape comment",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Children are filed; §1152 current-shape comment is seeded and kept current via task vbrief:reconcile:umbrellas once Child 1.0e lands."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "epic",
+      "x-tracking": {
+        "parent_issue": "#1284",
+        "decomposition_origin": "#742"
+      }
+    },
+    "edges": [
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1286-triage-queue-blocked-filter",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1287-vbrief-reconcile-graph",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1288-vbrief-reconcile-labels",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1289-vbrief-reconcile-umbrellas",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1290-reconcile-state-reason",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1291-adr-001-doc",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1292-issue-336-reframe",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1294-lessons-pack-pilot",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1295-skills-pack",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
+        "to": "1296-rules-and-strategies-pack",
+        "type": "contains"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical for the agentic-consumed surface"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/742",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #742: doc(adr): ADR-001 (decomposed)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1283",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1283: rfc(vbrief,consumption): pack-aware slice API"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1285",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1285: epic(vbrief,crud): CRUD harness epic"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/714",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #714: feat(vbrief): four-tier model"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/715",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #715: feat(vbrief): round-trip preservation"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/748",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #748: rules-classification vocabulary"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1119",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1119: operational-state carve-out"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1273",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1273: research-strategy lifecycle footgun"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1274",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1274: task deft:issue:emit (adopted as Child 1.0b)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/336",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #336: migration umbrella (reframe target)"
+      }
+    ],
+    "updated": "2026-05-21T16:33:43Z"
+  }
+}

--- a/vbrief/proposed/2026-05-21-1284-epic-vbrief-canonical.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1284-epic-vbrief-canonical.vbrief.json
@@ -38,6 +38,11 @@
       },
       {
         "from": "1284-epic-vbrief-canonical",
+        "to": "1274-task-deft-issue-emit",
+        "type": "contains"
+      },
+      {
+        "from": "1284-epic-vbrief-canonical",
         "to": "1287-vbrief-reconcile-graph",
         "type": "contains"
       },

--- a/vbrief/proposed/2026-05-21-1285-epic-crud-harness.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1285-epic-crud-harness.vbrief.json
@@ -1,0 +1,79 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Epic umbrella vBRIEF for #1285 (epic(vbrief,crud): CRUD harness epic); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:35:48Z"
+  },
+  "plan": {
+    "id": "1285-epic-crud-harness",
+    "title": "Epic 2 umbrella: deterministic CRUD harness for vBRIEF JSON (approved, non-gating)",
+    "status": "proposed",
+    "planRef": "#1285",
+    "narratives": {
+      "Description": "Approved, non-gating. The CRUD tool is required infrastructure (per #1167's code-abstraction-over-flat-tools) independent of Gate-2 evidence. Gate 2 (synthetic 3-arm evaluation) is dropped as part of the #742 decomposition.",
+      "Overview": "Umbrella tracking the CRUD-harness work. 4 children across 2 waves. Wave-1: #1293 (core tool). Wave-2: #1297, #1298, #1299. Cascade-unblock for Wave-2 depends on Epic 1 Child #1287 (`task vbrief:reconcile:graph`)."
+    },
+    "items": [
+      {
+        "title": "Decompose to children + maintain current-shape comment",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Children are filed; §1152 current-shape comment is seeded and kept current via task vbrief:reconcile:umbrellas once Child 1.0e lands."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "epic",
+      "x-tracking": {
+        "parent_issue": "#1285",
+        "decomposition_origin": "#742"
+      }
+    },
+    "edges": [
+      {
+        "from": "1285-epic-crud-harness",
+        "to": "1293-vbrief-crud-tool",
+        "type": "contains"
+      },
+      {
+        "from": "1285-epic-crud-harness",
+        "to": "1297-crud-taskfile-wiring",
+        "type": "contains"
+      },
+      {
+        "from": "1285-epic-crud-harness",
+        "to": "1298-crud-migrate-call-sites",
+        "type": "contains"
+      },
+      {
+        "from": "1285-epic-crud-harness",
+        "to": "1299-crud-contributor-doc",
+        "type": "contains"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1285",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1285: epic(vbrief,crud): CRUD harness epic"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/742",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #742: doc(adr): ADR-001 (decomposed)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1167",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1167: code-abstraction-over-flat-tools architecture"
+      }
+    ],
+    "updated": "2026-05-21T16:33:43Z"
+  }
+}

--- a/vbrief/proposed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json
@@ -1,0 +1,64 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1286 (feat(triage): demote vBRIEF-status:blocked items in triage:queue); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1286-triage-queue-blocked-filter",
+    "title": "Demote vBRIEF-status:blocked items in triage:queue",
+    "status": "proposed",
+    "planRef": "#1286",
+    "narratives": {
+      "Description": "The triage queue (scripts/triage_queue.py) groups items by triage-decision history (ORPHAN / RESUME / URGENT / untriaged / other) and does not consult vBRIEF dependency state, so blocked children pollute the queue. Extend it to consult the linked vBRIEF's status:blocked / unresolved swarm.depends_on and demote those items.",
+      "ImplementationPlan": "Read the linked vBRIEF via existing triage_scope (D12 / #1131). Add a BLOCKED group (or demote into other). Add --include-blocked opt-back-in flag. Cover new behavior with tests.",
+      "UserStory": "As an operator running task triage:queue, I want blocked children to be hidden or demoted so the queue only surfaces grabbable work."
+    },
+    "items": [
+      {
+        "title": "Extend triage_queue.py to consult vBRIEF state via triage_scope",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Function exists; returns demote-recommendation per item."
+        }
+      },
+      {
+        "title": "Add BLOCKED group (or demote into other) + --include-blocked opt-in",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Queue render shows blocked items demoted by default; --include-blocked surfaces them."
+        }
+      },
+      {
+        "title": "Tests: blocked demoted; unblocked surfaces; opt-in flag",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes; new tests cover all three paths."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1286",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1286",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1286: feat(triage): demote vBRIEF-status:blocked items in triage:queue"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json
@@ -1,0 +1,64 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1287 (feat(vbrief): task vbrief:reconcile:graph); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1287-vbrief-reconcile-graph",
+    "title": "task vbrief:reconcile:graph -- cascade-unblock walker",
+    "status": "proposed",
+    "planRef": "#1287",
+    "narratives": {
+      "Description": "Build the cascade-unblock walker: a verb that promotes vBRIEFs whose swarm.depends_on[] all resolve to completed/ or cancelled/. Pure vBRIEF; forge-agnostic. Composes with the existing swarm_readiness.py dep-graph machinery.",
+      "ImplementationPlan": "New verb + module under scripts/. Walks vbrief/proposed/, resolves depends_on against current state, runs task scope:promote on eligible candidates (respects WIP cap). Idempotent.",
+      "UserStory": "As the framework, I want blocked children whose upstream resolved to auto-promote so the decomposition operates deterministically."
+    },
+    "items": [
+      {
+        "title": "Define verb interface + Taskfile entry",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task vbrief:reconcile:graph runs; idempotent."
+        }
+      },
+      {
+        "title": "Compose with swarm_readiness.py dep-graph + scope_lifecycle.promote",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Single-dep, multi-dep, cycle, WIP-cap cases all behave per spec."
+        }
+      },
+      {
+        "title": "Tests for cascade, cycle detection, WIP cap interaction",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1287",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1287",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1287: feat(vbrief): task vbrief:reconcile:graph"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json
@@ -1,0 +1,64 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1288 (feat(vbrief,scm): task vbrief:reconcile:labels); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1288-vbrief-reconcile-labels",
+    "title": "task vbrief:reconcile:labels -- SCM label reconciliation",
+    "status": "proposed",
+    "planRef": "#1288",
+    "narratives": {
+      "Description": "Apply/remove SCM labels based on vBRIEF state. Routes through scripts/scm.py (#1145) to stay forge-agnostic. Closes the missing reverse direction of the existing GitHub-state-to-vBRIEF reconciler.",
+      "ImplementationPlan": "New verb + module. Mappings: status=blocked / unresolved depends_on -> status:blocked label; kind=epic -> epic + status:tracker; kind=research -> rfc. Idempotent.",
+      "UserStory": "As the framework, I want the SCM-side label state to mirror canonical vBRIEF state so reviewers don't see drift."
+    },
+    "items": [
+      {
+        "title": "Implement label reconciliation per mapping table",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "All mappings apply correctly; idempotent."
+        }
+      },
+      {
+        "title": "Route through scm.call shim (no direct gh calls)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task verify:scm-boundary passes."
+        }
+      },
+      {
+        "title": "Tests for each mapping + idempotency",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1288",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1288",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1288: feat(vbrief,scm): task vbrief:reconcile:labels"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1289-vbrief-reconcile-umbrellas.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1289-vbrief-reconcile-umbrellas.vbrief.json
@@ -1,0 +1,64 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1289 (feat(vbrief,scm): task vbrief:reconcile:umbrellas); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1289-vbrief-reconcile-umbrellas",
+    "title": "task vbrief:reconcile:umbrellas -- umbrella current-shape auto-update",
+    "status": "proposed",
+    "planRef": "#1289",
+    "narratives": {
+      "Description": "Auto-update each kind=epic vBRIEF's linked SCM umbrella's current-shape comment per AGENTS.md sec.1152. Edits in place to preserve permalink; amendment trail untouched.",
+      "ImplementationPlan": "New verb + module. Reads each kind=epic vBRIEF, walks children, computes wave structure, builds the canonical body, calls scm shim to edit the current-shape comment in place.",
+      "UserStory": "As a fresh contributor reading an umbrella, I want the current-shape comment to be accurate so I can find the queue without reading the audit trail."
+    },
+    "items": [
+      {
+        "title": "Implement current-shape body generator from epic vBRIEF state",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Output matches sec.1152 canonical body structure."
+        }
+      },
+      {
+        "title": "Edit-in-place via scm shim (preserve permalink)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Idempotent; second run is a no-op when state unchanged."
+        }
+      },
+      {
+        "title": "Tests for pass-N bump + child added/closed cases",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1289",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1289",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1289: feat(vbrief,scm): task vbrief:reconcile:umbrellas"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1290-reconcile-state-reason.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1290-reconcile-state-reason.vbrief.json
@@ -1,0 +1,64 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1290 (feat(vbrief): reconcile_issues.py honors stateReason); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1290-reconcile-state-reason",
+    "title": "reconcile_issues.py honors stateReason (NOT_PLANNED -> cancelled/)",
+    "status": "proposed",
+    "planRef": "#1290",
+    "narratives": {
+      "Description": "Extend scripts/reconcile_issues.py --apply-lifecycle-fixes to consult GitHub's stateReason field. Routes CLOSED+NOT_PLANNED to cancelled/ and CLOSED+COMPLETED to completed/. Required for the #742 close to operate deterministically without manual scope:cancel pre-step.",
+      "ImplementationPlan": "Extend the GraphQL query to include stateReason. Add mapping table. Preserve idempotency + existing report-only behavior for REOPENED.",
+      "UserStory": "As the framework, I want closed-as-not-planned umbrellas to route their dependent vBRIEFs to cancelled/ automatically so I don't need a manual pre-step."
+    },
+    "items": [
+      {
+        "title": "Add stateReason to the GraphQL query in fetch_issue_states",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Returns dict mapping issue_number -> (state, stateReason)."
+        }
+      },
+      {
+        "title": "Update --apply-lifecycle-fixes routing per mapping",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "CLOSED+NOT_PLANNED -> cancelled/, CLOSED+DUPLICATE -> cancelled/."
+        }
+      },
+      {
+        "title": "Tests for new mapping; existing tests unchanged",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes; no regression on completed/ path."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1290",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1290",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1290: feat(vbrief): reconcile_issues.py honors stateReason"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1290-reconcile-state-reason.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1290-reconcile-state-reason.vbrief.json
@@ -7,34 +7,48 @@
   },
   "plan": {
     "id": "1290-reconcile-state-reason",
-    "title": "reconcile_issues.py honors stateReason (NOT_PLANNED -> cancelled/)",
+    "title": "reconcile_issues.py honors stateReason + primary-reference filter (NOT_PLANNED -> cancelled/, Axis B canonical-issue resolution)",
     "status": "proposed",
     "planRef": "#1290",
     "narratives": {
-      "Description": "Extend scripts/reconcile_issues.py --apply-lifecycle-fixes to consult GitHub's stateReason field. Routes CLOSED+NOT_PLANNED to cancelled/ and CLOSED+COMPLETED to completed/. Required for the #742 close to operate deterministically without manual scope:cancel pre-step.",
-      "ImplementationPlan": "Extend the GraphQL query to include stateReason. Add mapping table. Preserve idempotency + existing report-only behavior for REOPENED.",
-      "UserStory": "As the framework, I want closed-as-not-planned umbrellas to route their dependent vBRIEFs to cancelled/ automatically so I don't need a manual pre-step."
+      "Description": "Two coordinated fixes to scripts/reconcile_issues.py --apply-lifecycle-fixes. (1) stateReason routing: consult GitHub's stateReason field so CLOSED+NOT_PLANNED routes to cancelled/, CLOSED+DUPLICATE routes to cancelled/, and CLOSED+COMPLETED routes to completed/ -- removes the manual scope:cancel pre-step that the #742 close required. (2) Axis B primary-reference filter: today the reconciler treats every plan.references[] entry as a lifecycle anchor, so a vBRIEF that merely refs an umbrella gets dragged through the umbrella's terminal state (the #742 close pulled #1283/#1284/#1285/#1291 into completed/ even though their own planRef issues were still open). The fix prefers plan.planRef as the canonical issue for lifecycle resolution and falls back to references[] only when planRef is absent. Both fixes ship together because the #742-class recurrence requires both: without (1) the operator runs scope:cancel by hand; without (2) the reconciler false-positives across the cohort on every umbrella close.",
+      "ImplementationPlan": "Phase A (stateReason): extend the GraphQL query in fetch_issue_states to include stateReason; add the routing mapping (CLOSED+NOT_PLANNED -> cancelled/, CLOSED+DUPLICATE -> cancelled/, CLOSED+COMPLETED -> completed/); preserve idempotency + existing report-only behavior for REOPENED. Phase B (Axis B primary-reference filter): refactor the lifecycle-fix resolver in reconcile_issues.py to read plan.planRef first when determining which issue's state drives the vBRIEF's lifecycle; only fall back to scanning references[] when planRef is unset or unresolvable; emit a structured log line naming which axis (planRef vs references[]) was used for each vBRIEF so the recovery audit is reviewable. Tests cover both phases in one suite.",
+      "UserStory": "As the framework, I want closed-as-not-planned umbrellas to route their dependent vBRIEFs to cancelled/ automatically AND I want the reconciler to follow each vBRIEF's primary plan.planRef instead of dragging unrelated references[] siblings through the umbrella's terminal state, so an umbrella close cannot false-positive across an entire cohort."
     },
     "items": [
       {
-        "title": "Add stateReason to the GraphQL query in fetch_issue_states",
+        "title": "Phase A: Add stateReason to the GraphQL query in fetch_issue_states",
         "status": "pending",
         "narrative": {
           "Acceptance": "Returns dict mapping issue_number -> (state, stateReason)."
         }
       },
       {
-        "title": "Update --apply-lifecycle-fixes routing per mapping",
+        "title": "Phase A: Update --apply-lifecycle-fixes routing per stateReason mapping",
         "status": "pending",
         "narrative": {
-          "Acceptance": "CLOSED+NOT_PLANNED -> cancelled/, CLOSED+DUPLICATE -> cancelled/."
+          "Acceptance": "CLOSED+NOT_PLANNED -> cancelled/, CLOSED+DUPLICATE -> cancelled/, CLOSED+COMPLETED -> completed/; REOPENED report-only behavior preserved."
         }
       },
       {
-        "title": "Tests for new mapping; existing tests unchanged",
+        "title": "Phase B: Prefer plan.planRef over references[] for canonical lifecycle resolution (Axis B primary-reference filter)",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task check passes; no regression on completed/ path."
+          "Acceptance": "The lifecycle-fix resolver consults plan.planRef first; references[] is consulted only when planRef is absent or unresolvable. A vBRIEF that merely refs an unrelated closed issue is no longer dragged into that issue's terminal state."
+        }
+      },
+      {
+        "title": "Phase B: Structured per-vBRIEF audit log line naming the axis used (planRef vs references[])",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Each lifecycle-fix decision emits a log line carrying the resolved axis so a recovery audit can confirm the reconciler routed off the correct anchor."
+        }
+      },
+      {
+        "title": "Tests for both phases; existing tests unchanged",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes; new tests cover stateReason routing AND the planRef-preferred axis; no regression on completed/ path; recurrence-record test pins the #742-class case (vBRIEF refs closed umbrella, planRef points at a still-open issue, vBRIEF stays in its current folder)."
         }
       }
     ],

--- a/vbrief/proposed/2026-05-21-1291-adr-001-doc.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1291-adr-001-doc.vbrief.json
@@ -1,0 +1,80 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1291 (doc(adr): ADR-001 -- vBRIEF-as-canonical); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:35:48Z"
+  },
+  "plan": {
+    "id": "1291-adr-001-doc",
+    "title": "ADR-001 doc deliverable: vBRIEF-as-canonical (write the doc)",
+    "status": "proposed",
+    "planRef": "#1291",
+    "narratives": {
+      "Description": "Write docs/decisions/ADR-001.md per the #665 ADR convention. Inherits the approved sections of #742's rationale prose verbatim (token-economics, qualifier, two-axis context, defense-in-depth layers, counter-arguments, operational-state carve-out, strategic positioning).",
+      "ImplementationPlan": "Author the ADR file per the #665 template. Add a cross-reference line to main.md's AXIOM section. Run task check (encoding gate + any doc-link checks).",
+      "UserStory": "As a future reviewer asking 'why is vBRIEF canonical?', I want a single ADR I can cite, so debates don't reopen."
+    },
+    "items": [
+      {
+        "title": "Draft docs/decisions/ADR-001.md per #665 template",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "File exists; template structure followed."
+        }
+      },
+      {
+        "title": "Inherit approved sections from #742 verbatim",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Token-economics, qualifier, two-axis, defense-in-depth, counter-args, operational-state, strategic positioning all present."
+        }
+      },
+      {
+        "title": "Cross-link from main.md AXIOM section",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "main.md gets a 'See ADR-001' line; encoding gate passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1291",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1291",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1291: doc(adr): ADR-001 -- vBRIEF-as-canonical"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/742",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #742: doc(adr): source ADR (decomposed)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/665",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #665: ADR convention"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/401",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #401: AXIOM ship-PR"
+      }
+    ],
+    "updated": "2026-05-21T16:33:43Z"
+  }
+}

--- a/vbrief/proposed/2026-05-21-1292-issue-336-reframe.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1292-issue-336-reframe.vbrief.json
@@ -1,0 +1,62 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1292 (chore: reframe #336); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1292-issue-336-reframe",
+    "title": "Reframe #336: documentation-tier AXIOM application (drop 5 new core content types)",
+    "status": "proposed",
+    "planRef": "#1292",
+    "narratives": {
+      "Description": "Edit #336's body to drop the obsolete '5 new core content types' mechanism and reframe as documentation-tier AXIOM application with implementation via #714 tier-3 packs. Apply labels: determinism, rfc, design.",
+      "ImplementationPlan": "Edit #336 body via gh issue edit --body-file; verify labels; add cross-references to this umbrella + Child 1.4 (rules-pack-0.1 / Phase 3).",
+      "UserStory": "As a contributor reading #336 after the decomposition lands, I want its body to match the current architecture so I don't waste cycles on obsolete mechanisms."
+    },
+    "items": [
+      {
+        "title": "Draft reframed #336 body",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "No '5 new core content types' language; AXIOM framing present."
+        }
+      },
+      {
+        "title": "Apply the edit + verify labels",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "#336 body matches the draft; determinism/rfc/design labels applied."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1292",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1292",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1292: chore: reframe #336"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/336",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #336: migration umbrella (reframe target)"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1293-vbrief-crud-tool.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1293-vbrief-crud-tool.vbrief.json
@@ -1,0 +1,76 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1293 (feat(vbrief): scripts/vbrief_crud.py); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1293-vbrief-crud-tool",
+    "title": "scripts/vbrief_crud.py -- typed CRUD tool for vBRIEF JSON",
+    "status": "proposed",
+    "planRef": "#1293",
+    "narratives": {
+      "Description": "Build the deterministic CRUD tool. Round-trip-preserving writes, schema-validation-on-the-spot, byte-stable output. Foundation of Epic 2; the rest of Epic 2's children depend on it.",
+      "ImplementationPlan": "Typed entry points (create, read, update, delete). Schema-validate via existing vbrief_validate.py. Deterministic JSON encoder configuration. Path-based addressing for nested fields. Architecture per #1167.",
+      "UserStory": "As an agent editing a vBRIEF, I want a typed CRUD surface so I don't 'innovate' within the structure and so writes round-trip cleanly."
+    },
+    "items": [
+      {
+        "title": "Implement create/read/update/delete entry points",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Typed Python functions; path-based addressing works on nested fields."
+        }
+      },
+      {
+        "title": "Round-trip preservation + byte-stable output",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Read-write-read produces identical bytes; no key reordering or whitespace drift."
+        }
+      },
+      {
+        "title": "Schema validation on every write",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Invalid mutations fail at the CRUD boundary, not downstream."
+        }
+      },
+      {
+        "title": "Tests for happy-path, schema-rejection, non-ASCII, large-file, concurrent-edit",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1293",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1293",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1293: feat(vbrief): scripts/vbrief_crud.py"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1285",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1285: epic(vbrief,crud): CRUD harness"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1167",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1167: code-abstraction-over-flat-tools architecture"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1294-lessons-pack-pilot.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1294-lessons-pack-pilot.vbrief.json
@@ -1,0 +1,85 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1294 (feat(packs): lessons-pack-0.1 pilot); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1294-lessons-pack-pilot",
+    "title": "lessons-pack-0.1 pilot -- first tier-3 extension pack",
+    "status": "proposed",
+    "planRef": "#1294",
+    "narratives": {
+      "Description": "Blocked placeholder. Phase 1 of the vBRIEF-as-canonical rollout. Scope finalizes when the pack-slicing RFC and the reconcile suite land. See the GitHub issue body for details.",
+      "ImplementationPlan": "Defer detailed implementation plan until upstream design (#1283) converges and the reconcile suite (#1287/#1288/#1289) lands. Scope-locked at that point; expected items: define lessons-pack schema, build renderer, build slice surface, migrate framework's lessons.md, wire drift detection.",
+      "UserStory": "As an agent loading lessons context, I want structured slice access to lessons by recency / tag / author so I pay only for the slice I query."
+    },
+    "items": [
+      {
+        "title": "Wait for upstream blockers to land",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Pack-slicing RFC closed (approved); reconcile suite shipped."
+        }
+      },
+      {
+        "title": "Define lessons-pack-0.1 schema (per tier-3 model)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Schema vendored; round-trip preservation production-grade."
+        }
+      },
+      {
+        "title": "Build renderer + slice API + drift detection + migrate lessons.md",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes; lessons.md is derivative; task lessons:slice works."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1294",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready",
+        "depends_on": [
+          "1283-pack-slicing-rfc",
+          "1287-vbrief-reconcile-graph",
+          "1288-vbrief-reconcile-labels",
+          "1289-vbrief-reconcile-umbrellas"
+        ]
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1294",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1294: feat(packs): lessons-pack-0.1 pilot"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1274",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1274: task deft:issue:emit (adopted as Child 1.0b; renderer prerequisite)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/714",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #714: tier-3 model"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/715",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #715: round-trip preservation"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1295-skills-pack.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1295-skills-pack.vbrief.json
@@ -1,0 +1,67 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1295 (feat(packs): skills-pack-0.1); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1295-skills-pack",
+    "title": "skills-pack-0.1 -- second tier-3 pack",
+    "status": "proposed",
+    "planRef": "#1295",
+    "narratives": {
+      "Description": "Blocked placeholder. Phase 2 of the vBRIEF-as-canonical rollout. Scope finalizes after Phase 1 (lessons-pack-0.1) closes.",
+      "ImplementationPlan": "Defer detailed implementation plan until Phase 1 closes. Expected items: define schema based on Phase 1 lessons, ship renderer + slice API, migrate ONE skill as proof, iterate.",
+      "UserStory": "As an agent loading skill content, I want structured slice access to phases / anti-patterns / gates / chaining so I pay only for the slice I query."
+    },
+    "items": [
+      {
+        "title": "Wait for Phase 1 (lessons-pack-0.1) to close",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Lessons-pack proves the pattern."
+        }
+      },
+      {
+        "title": "Define skills-pack-0.1 schema",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Schema vendored."
+        }
+      },
+      {
+        "title": "Migrate ONE skill as proof, then iterate",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task skill:slice <name> works on the proof skill."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1295",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready",
+        "depends_on": [
+          "1294-lessons-pack-pilot"
+        ]
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1295",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1295: feat(packs): skills-pack-0.1"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1296-rules-and-strategies-pack.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1296-rules-and-strategies-pack.vbrief.json
@@ -1,0 +1,72 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1296 (feat(packs): rules-pack-0.1 + strategies-pack-0.1); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1296-rules-and-strategies-pack",
+    "title": "rules-pack-0.1 + strategies-pack-0.1",
+    "status": "proposed",
+    "planRef": "#1296",
+    "narratives": {
+      "Description": "Blocked placeholder. Phase 3 of the vBRIEF-as-canonical rollout. Covers main.md, AGENTS.md, coding/*. The classification vocabulary from #748 is the natural schema-design input.",
+      "ImplementationPlan": "Defer detailed implementation plan until Phase 2 (skills-pack-0.1) closes. Expected items: define schemas, ship renderers + slice APIs, migrate main.md / AGENTS.md / coding/* content.",
+      "UserStory": "As an agent loading framework rules, I want structured slice access (MUST-tier / SHOULD-tier / kind / domain) so the slice carries only the rules I need."
+    },
+    "items": [
+      {
+        "title": "Wait for Phase 2 (skills-pack-0.1) to close",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Skills-pack proves the pattern on a larger surface."
+        }
+      },
+      {
+        "title": "Define rules-pack-0.1 schema (input: #748 vocabulary)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Schema vendored; integrates #748 classification vocabulary."
+        }
+      },
+      {
+        "title": "Migrate main.md / AGENTS.md / coding/* content; ship strategies-pack-0.1",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes; rules are queryable via slice."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1296",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready",
+        "depends_on": [
+          "1295-skills-pack"
+        ]
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1296",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1296: feat(packs): rules-pack-0.1 + strategies-pack-0.1"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/748",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #748: rules-classification vocabulary"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1297-crud-taskfile-wiring.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1297-crud-taskfile-wiring.vbrief.json
@@ -1,0 +1,60 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1297 (feat(taskfile): wire vbrief CRUD into task surface); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1297-crud-taskfile-wiring",
+    "title": "Wire vBRIEF CRUD into task surface",
+    "status": "proposed",
+    "planRef": "#1297",
+    "narratives": {
+      "Description": "Blocked placeholder. Operator-facing wrappers for the CRUD tool. Scope finalizes when Child 2.1 lands.",
+      "ImplementationPlan": "Defer detailed plan until 2.1 lands. Expected: task vbrief:create / read / update / delete entries in the Taskfile, with arg passthrough to scripts/vbrief_crud.py.",
+      "UserStory": "As an operator, I want task verbs for CRUD operations so I don't memorize the Python entry-point signature."
+    },
+    "items": [
+      {
+        "title": "Wait for #2.1 to land",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "scripts/vbrief_crud.py shipped."
+        }
+      },
+      {
+        "title": "Add Taskfile entries with arg passthrough",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task vbrief:* verbs work; tests cover passthrough."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1297",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready",
+        "depends_on": [
+          "1293-vbrief-crud-tool"
+        ]
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1297",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1297: feat(taskfile): wire vbrief CRUD into task surface"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1285",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1285: epic(vbrief,crud): CRUD harness"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1298-crud-migrate-call-sites.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1298-crud-migrate-call-sites.vbrief.json
@@ -1,0 +1,67 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1298 (chore: migrate existing free-form vBRIEF edit call sites to CRUD tool); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1298-crud-migrate-call-sites",
+    "title": "Migrate existing free-form vBRIEF edit call sites to CRUD tool",
+    "status": "proposed",
+    "planRef": "#1298",
+    "narratives": {
+      "Description": "Blocked placeholder. Sweep scripts/ for places that read+rewrite vBRIEF JSON inline and replace those call sites with vbrief_crud.py invocations. Removes free-form JSON editing as a maintenance hazard.",
+      "ImplementationPlan": "Defer detailed plan until 2.1 lands. Expected: grep for json.load+json.dump patterns on vBRIEF files; replace each with CRUD calls; test that behavior is preserved.",
+      "UserStory": "As a future maintainer, I want all vBRIEF edits to go through the CRUD tool so the round-trip / schema guarantees hold uniformly."
+    },
+    "items": [
+      {
+        "title": "Wait for #2.1 to land",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "scripts/vbrief_crud.py shipped."
+        }
+      },
+      {
+        "title": "Identify all call sites",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Inventory exists; each site classified (must-migrate vs out-of-scope)."
+        }
+      },
+      {
+        "title": "Migrate each call site; preserve behavior",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "task check passes; existing tests unchanged."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1298",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready",
+        "depends_on": [
+          "1293-vbrief-crud-tool"
+        ]
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1298",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1298: chore: migrate existing free-form vBRIEF edit call sites to CRUD tool"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1285",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1285: epic(vbrief,crud): CRUD harness"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-05-21-1299-crud-contributor-doc.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1299-crud-contributor-doc.vbrief.json
@@ -1,0 +1,60 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1299 (doc(contributing): when to use CRUD tool vs direct vBRIEF authoring); part of the #742 decomposition.",
+    "created": "2026-05-21T16:32:24Z",
+    "updated": "2026-05-21T16:32:24Z"
+  },
+  "plan": {
+    "id": "1299-crud-contributor-doc",
+    "title": "When to use CRUD tool vs direct vBRIEF authoring (contributor doc)",
+    "status": "proposed",
+    "planRef": "#1299",
+    "narratives": {
+      "Description": "Blocked placeholder. Document the boundary: fresh vBRIEF authoring is fine; mutating an existing vBRIEF must go through CRUD. Cross-reference the AGENTS.md Rule Authority section.",
+      "ImplementationPlan": "Defer detailed plan until 2.1 lands. Expected: add a section to CONTRIBUTING.md (or coding/coding.md) with the rule + worked examples; cross-reference from AGENTS.md.",
+      "UserStory": "As a contributor about to edit a vBRIEF, I want clear guidance on which surface to use so I don't accidentally regress the determinism guarantees."
+    },
+    "items": [
+      {
+        "title": "Wait for #2.1 to land",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "scripts/vbrief_crud.py shipped."
+        }
+      },
+      {
+        "title": "Author the contributor section + worked examples",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "CONTRIBUTING / coding doc reflects the rule; cross-refs from AGENTS.md."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1299",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "not-ready",
+        "depends_on": [
+          "1293-vbrief-crud-tool"
+        ]
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1299",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1299: doc(contributing): when to use CRUD tool vs direct vBRIEF authoring"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1285",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1285: epic(vbrief,crud): CRUD harness"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Decomposes #742 (ADR-001 alignment vehicle) into three new homes on GitHub plus 17 matching scope vBRIEFs in `vbrief/proposed/`. #742 is closed as `not planned`.

## What landed

### Three new tracking surfaces

- **#1283** -- `rfc(vbrief,consumption): pack-aware slice API` -- fresh, question-driven RFC for the pack-slicing mechanism (open for design discussion).
- **#1284** -- `epic(vbrief): vBRIEF-as-canonical for the agentic-consumed surface (approved direction)` -- inherits the approved sections of #742's rationale prose.
- **#1285** -- `epic(vbrief,crud): deterministic CRUD harness for vBRIEF JSON (approved, non-gating)` -- ships architecture-driven per #1167.

### 14 children (Epic 1 + Epic 2)

Epic 1 (10 new + #1274 adopted as Child 1.0b):
`#1286 #1287 #1288 #1289 #1290 #1291 #1292 #1294 #1295 #1296`

Epic 2 (4 new):
`#1293 #1297 #1298 #1299`

The 6 blocked children (Wave 2+) carry the new `status:blocked` label + `plan.metadata.swarm.depends_on[]` for cascade-unblock semantics.

### What got dropped

- **Gate 1** (cross-model/harness comprehension parity benchmark).
- **Gate 2** (CRUD-determinism three-arm synthetic evaluation).
- The `2026-05-01-742-adr-001-empirical-validation` scope vBRIEF (scoped around the gates; moved to `vbrief/cancelled/`).

### Reconciler bug surfaced

The existing `reconcile_issues.py --apply-lifecycle-fixes` treats every `references[]` entry as a lifecycle anchor and pulled 4 brand-new vBRIEFs (#1283/#1284/#1285/#1291) into `completed/` on #742 close. They were manually restored. Child #1290's scope was expanded to fix this deterministically via a primary-reference filter (Axis B: prefer `plan.planRef` for canonical issue resolution).

## Changes in this PR

- **Created:** 14 GitHub issues + 1 label (`status:blocked`) + 2 §1152 current-shape comments + 7 cross-reference comments + 17 scope vBRIEFs in `vbrief/proposed/`.
- **Modified:** `CHANGELOG.md` `[Unreleased]`; the empirical-validation vBRIEF (proposed/ -> cancelled/); the `2026-05-20-1270-fixtriage` vBRIEF (active/ -> completed/, a legitimate reconciler-driven move).
- **Closed:** #742 as `not planned`.

## Checks

- `python scripts/vbrief_validate.py --vbrief-dir vbrief` -> OK (472 scope vBRIEFs).
- `python scripts/preflight_branch.py` -> OK (feature branch).
- `python scripts/verify_encoding.py` -> OK (1175 files clean).
- `task check` -> 6,286 passed / 3 skipped / 9 deselected / 1 xfailed; `verify:cache-fresh` (a transient operational signal post-cache refresh of 14 new issues) flagged the cache as stale.

## Operational note

This is bookkeeping + filing only. No script behavior changes. The reconciler bug surfaced during the close-out is documented and tracked under #1290; one-time recovery script lives in `$env:TEMP\decomp-742\recover.py` (NOT committed).

Closes #742; refs #1273 (research-strategy lifecycle), #1167 (CRUD-tool architecture), #1119 (operational-state carve-out), #1274 (adopted as Child 1.0b).
