### PR TITLE
feat(skills): swarm Phase 3 Step 2d grok-build launch adapter + Phase 4 platform-agnostic monitoring (#1331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **feat(skills): swarm skill natively supports Grok Build / non-Warp environments via Phase 3 Step 2d (#1331)** -- The deft-directive-swarm skill now includes a concrete launch adapter (Step 2d) for Grok Build and other non-Warp agent runtimes: when spawn_subagent is detected (no start_agent, no WARP_*), the monitor dispatches workers via spawn_subagent with the canonical preamble and standard STEP 1-6 prompt. Phase 3 Step 1 detection order is updated so spawn_subagent is probed before the decision tree, and grok-build routes to Step 2d explicitly rather than falling through to the manual-terminal fallback. Phase 4 pre-spawn verification language is now platform-agnostic (worktree state + sub-agent lifecycle signals instead of Warp-tab observations), with a grok-build parenthetical for get_command_or_subagent_output polling. A quick-start section documents the minimal runtime contract for non-Warp swarms. Refs #1331, #1342.
 
 ### Changed
 

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -39,6 +39,17 @@ or invoke `task verify:branch`. The swarm skill creates branches per agent so th
 - Multiple independent story-level vBRIEFs in `vbrief/active/` need to be worked on simultaneously
 - A batch of stories are ready and have no mutual dependencies
 
+## Running Swarms in Grok Build / Non-Warp Environments
+
+Minimal runtime contract for running swarms outside Warp:
+
+- One isolated git worktree per agent (identical to the Warp path — see Phase 2)
+- Workers launched via `spawn_subagent` dispatch (Phase 3 Step 2d)
+- Monitor coordination via worktree-state polling (`git status`, `git log`) and `get_command_or_subagent_output`
+- Review-cycle sub-agents spawned via `spawn_subagent` (not `start_agent`)
+
+This path became first-class in #1342 (platform adapter slices 1-3) and is fully documented in Phase 3 Step 2d and Phase 4. Grok Build + Windows users should also see #1353 (§3.5 in `templates/agent-prompt-preamble.md`) for shell output capture limitations that affect `get_command_or_subagent_output` in PowerShell 5.1 contexts. Refs #1342, #1331.
+
 ## Prerequisites
 
 - ! `vbrief/active/` contains one or more story-level vBRIEFs with status `running`
@@ -264,11 +275,12 @@ git worktree add <path> -b <branch-name> <configured-base-branch>
 
 1. ! **Probe for `start_agent` tool** — check the available tool set for `start_agent` (or equivalent agent-orchestration tool). Its presence indicates a Warp environment with native orchestration support.
 2. ! **Probe for Warp environment** — if `start_agent` is not available, check for `WARP_*` environment variables (e.g. `WARP_TERMINAL_SESSION`, `WARP_IS_WARP_TERMINAL`). Their presence indicates Warp without orchestration.
-3. ! **Select launch path automatically** based on detection results — do NOT present static options:
+3. ! **Probe for `spawn_subagent` tool** — when neither `start_agent` nor `WARP_*` is present, check for `spawn_subagent` (Grok Build / non-Warp TUI launch adapter, #1342 slice 2). Its presence indicates the grok-build platform.
+4. ! **Select launch path automatically** based on detection results — do NOT present static options:
    - **`start_agent` available** → Orchestrated launch (Step 2a) — preferred path, fully automated, no manual tab management
    - **`start_agent` unavailable, Warp detected** → Interactive Warp tabs (Step 2b) — full MCP, global rules, warm index; requires manual tab management
-   - **No Warp detected** → Manual terminal launch (Step 2b fallback) — paste prompt into any terminal with access to the worktree
-4. ! **Probe for `spawn_subagent` tool** — when neither `start_agent` nor `WARP_*` is present, check for `spawn_subagent` (Grok Build / non-Warp TUI launch adapter, #1342 slice 2). Its presence indicates the grok-build platform.
+   - **`grok-build` (`spawn_subagent` available, no `start_agent`, no `WARP_*`)** → Grok Build launch (Step 2d) — first-class non-Warp path
+   - **No orchestration primitive detected** → Manual terminal launch (Step 2b fallback) — paste prompt into any terminal with access to the worktree
 5. ! **Return a stable platform descriptor** for downstream phases — one of `warp-orchestrated` (start_agent available), `warp-manual` (Warp without start_agent), `grok-build` (spawn_subagent available, non-Warp), or `generic-terminal` (no orchestration primitives). The detection matrix MUST include explicit absence checks for `start_agent` and `WARP_*` so the four descriptors are unambiguous. Phase 4 monitoring and Phase 6 sub-agent dispatch read this stable platform descriptor as a single source of truth instead of re-running detection per call.
 6. ? **Cloud escape hatch** — use `oz agent run-cloud` (Step 2c) ONLY if the user explicitly requests cloud execution. Never default to cloud.
 
@@ -320,6 +332,15 @@ Agents execute on remote VMs without local MCP servers, codebase indexing, or Wa
 ⊗ Default to cloud launch — it is an escape hatch, not a default path.
 ⊗ Use `oz agent run-cloud` when the user expects local execution — `run-cloud` routes to remote VMs with no local context.
 
+### Step 2d: Grok Build Launch (spawn_subagent available)
+
+! When the platform descriptor is `grok-build` (spawn_subagent detected, no start_agent, no WARP_*), dispatch each worker via `spawn_subagent` with:
+1. The canonical `templates/agent-prompt-preamble.md` content as the preamble
+2. The standard worktree prompt (STEP 1-6 from the Prompt Template below), adapted to use `get_command_or_subagent_output` for polling rather than `start_agent` lifecycle events
+3. The worktree path set to the agent's isolated git worktree
+
+~ This is the first-class non-Warp path. Workers use worktree state polling (`git status`, `git log`) and `get_command_or_subagent_output` as their coordination channel instead of Warp tab state.
+
 ## Phase 4 — Monitor
 
 ### Polling Cadence
@@ -341,7 +362,7 @@ Track each agent through these stages:
 
 ### Takeover Triggers
 
-! **Pre-spawn verification:** Before spawning a replacement agent, verify the original is truly unresponsive by waiting for an idle/blocked lifecycle event (e.g. the agent's Warp tab shows no tool calls in progress, no pending shell commands, and no recent output). Do NOT spawn a replacement based solely on message timing, absence of recent commits, or a perceived delay — original Warp tabs can resume after apparent failure, and spawning a new agent creates two concurrent agents on the same worktree (see Duplicate-Tab Failure Mode below).
+! **Pre-spawn verification:** Before spawning a replacement agent, verify the original is truly unresponsive by waiting for an idle/blocked lifecycle event — verified via worktree state (`git status`, `git log --oneline -3`) and sub-agent lifecycle signals showing no in-flight work (for grok-build / spawn_subagent agents: polling is via worktree state + `get_command_or_subagent_output` rather than tab observation). Do NOT spawn a replacement based solely on message timing, absence of recent commits, or a perceived delay — original agents (Warp tabs or spawn_subagent processes) can resume after apparent failure, and spawning a new agent creates two concurrent agents on the same worktree (see Duplicate-Tab Failure Mode below).
 
 ! Take over an agent's workflow if ANY of these occur:
 
@@ -706,3 +727,4 @@ CONSTRAINTS:
 - ⊗ Run `git checkout` (any branch) -- including the brief `cd <other-worktree>; git checkout master --quiet` shape -- in a worktree the merging agent does not own during Phase 6 Step 3 (Update Master) or Step 4 (Clean Up). Post-merge state-update semantics MUST be performed via `git fetch origin <base-branch>` from the merger's OWN worktree, never by switching HEAD on a sibling worktree another agent is actively using. Recurrence record: PR #797 merge session (2026-05-01); companion to the Sub-Agent Role Separation rules (#727) -- this anti-pattern extends the same boundary discipline from sub-agent spawn shape to worktree HEAD operations (#800)
 - ⊗ Skip the Phase 0 Step 0.5 lifecycle bridge (#1025) and let the Step 1 preflight gate reject candidate scope vBRIEFs wholesale. The setup skill deposits scope vBRIEFs in `vbrief/proposed/` and the refinement skill leaves them in `vbrief/pending/`; the swarm Phase 0 Step 1 preflight only accepts `vbrief/active/` with `plan.status == "running"`. The bridge step (`task scope:promote -- <path>` then `task scope:activate -- <path>`) is the contract that converts proposed/pending candidates to active before allocation -- bypassing it re-surfaces the originating 2026-05-10 first-session consumer-swarm failure mode (`Invalid transition: 'activate' requires file in pending/`)
 - ⊗ Auto-promote + activate every candidate in `vbrief/proposed/` or `vbrief/pending/` during the Phase 0 Step 0.5 bridge without explicit user approval (#1025). Proposed-stage vBRIEFs may be in a deliberate refinement queue (`skills/deft-directive-refinement/SKILL.md` Phase 4); silent promotion bypasses the user's lifecycle intent and may flip `plan.status` to `running` on scopes the user has not yet refined. Broad affirmatives (`proceed`, `do it`, `go ahead`) do NOT satisfy the bridge approval gate -- require an explicit `yes` / `confirmed` / `approve`
+- ⊗ Fall through to the manual-terminal fallback (Step 2b) when spawn_subagent is available -- Step 2d is the first-class grok-build launch path; manual terminal is for environments with no orchestration primitive at all (#1331)

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -50,6 +50,8 @@ Minimal runtime contract for running swarms outside Warp:
 
 This path became first-class in #1342 (platform adapter slices 1-3) and is fully documented in Phase 3 Step 2d and Phase 4. Grok Build + Windows users should also see #1353 (§3.5 in `templates/agent-prompt-preamble.md`) for shell output capture limitations that affect `get_command_or_subagent_output` in PowerShell 5.1 contexts. Refs #1342, #1331.
 
+~ **Windows + Grok Build (#1353):** When issuing shell commands via `run_terminal_command` on this platform, avoid `|`, `>`, or `2>&1` in the command string — use Python `pathlib`/`subprocess` or plain `task` targets instead to avoid wrapper leakage. See `templates/agent-prompt-preamble.md` §3.5 for the full escape hatch list.
+
 ## Prerequisites
 
 - ! `vbrief/active/` contains one or more story-level vBRIEFs with status `running`

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -378,9 +378,9 @@ When taking over: read the agent's current state (git log, diff, PR comments), c
 ⚠️ **Root cause of #261 and #263 (generalized for #1342 slice 3):** This is the **Duplicate-Agent Failure Mode** -- it fires on every platform descriptor, not just Warp tabs. Original Warp agent tabs may resume after apparent failure (network hiccup, temporary Warp UI freeze, context window pressure); the same failure mode applies to `spawn_subagent`-launched grok-build sub-agents that appear stalled but later resume. If the monitor spawns a new agent for the same worktree, two concurrent agents execute on the same branch simultaneously. This corrupts the `tool_use`/`tool_result` message chain — both agents issue tool calls, but responses are interleaved unpredictably, causing one or both agents to act on stale or incorrect state.
 
 **Recovery guidance:**
-- ! Keep original agent tabs open until their PR is merged — do not close tabs that appear stalled
-- ! If an agent appears stalled, go to its original Warp tab and tell it to resume (e.g. "continue from where you left off") rather than spawning a replacement
-- ! If the original tab is truly unrecoverable (Warp crash, tab closed), only then create a new agent — and first verify the worktree state (`git status`, `git log`, `gh pr list`) to avoid conflicting with any in-flight work
+- ! Keep original agents active until their PR is merged — do not terminate agent processes that appear stalled (for Warp tabs: keep the tab open; for grok-build / spawn_subagent agents: verify via `get_command_or_subagent_output` before replacing)
+- ! If an agent appears stalled, attempt to resume it in its original context (for Warp: go to the original Warp tab and say "continue from where you left off"; for grok-build: re-query via `get_command_or_subagent_output` or send a resume message) rather than spawning a replacement
+- ! If the original agent is truly unrecoverable (Warp crash, tab closed, or spawn_subagent process terminated), only then create a new agent — and first verify the worktree state (`git status`, `git log`, `gh pr list`) to avoid conflicting with any in-flight work
 
 ### Context-Length Warning
 

--- a/vbrief/active/2026-05-26-1331-deft-directive-swarm-is-tightly-coupled-to-the-warp-runtime.vbrief.json
+++ b/vbrief/active/2026-05-26-1331-deft-directive-swarm-is-tightly-coupled-to-the-warp-runtime.vbrief.json
@@ -1,11 +1,12 @@
 {
   "vBRIEFInfo": {
     "version": "0.6",
-    "description": "Scope vBRIEF ingested from GitHub issue #1331"
+    "description": "Scope vBRIEF ingested from GitHub issue #1331",
+    "updated": "2026-05-26T12:56:03Z"
   },
   "plan": {
     "title": "deft-directive-swarm is tightly coupled to the Warp runtime, making it hard to use in other agent environments (Grok Build, etc.)",
-    "status": "pending",
+    "status": "running",
     "narratives": {
       "Description": "deft-directive-swarm is tightly coupled to the Warp runtime, making it hard to use in other agent environments (Grok Build, etc.)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1331",

--- a/vbrief/active/2026-05-26-1331-deft-directive-swarm-is-tightly-coupled-to-the-warp-runtime.vbrief.json
+++ b/vbrief/active/2026-05-26-1331-deft-directive-swarm-is-tightly-coupled-to-the-warp-runtime.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Scope vBRIEF ingested from GitHub issue #1331",
-    "updated": "2026-05-26T12:56:03Z"
+    "updated": "2026-05-26T13:30:00Z"
   },
   "plan": {
     "title": "deft-directive-swarm is tightly coupled to the Warp runtime, making it hard to use in other agent environments (Grok Build, etc.)",
@@ -19,25 +19,25 @@
         "id": "item-1",
         "title": "Add Phase 3 Step 2d: Grok Build launch adapter (spawn_subagent)",
         "description": "In skills/deft-directive-swarm/SKILL.md Phase 3, add a concrete Step 2d block for the grok-build platform descriptor. When spawn_subagent is the detected primitive, the skill dispatches each worker agent via spawn_subagent with: the canonical agent-prompt-preamble + the standard worktree prompt. Update the Step 1 detection decision tree so 'grok-build' routes to Step 2d explicitly (not fall-through to the manual terminal path). Note: spawn_subagent check in Step 1 must be elevated so it is evaluated before the 'No Warp detected -> manual fallback' branch.",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "id": "item-2",
         "title": "Update Phase 4 monitoring language to be platform-agnostic",
         "description": "In Phase 4 (Monitor), replace Warp-tab-specific language in takeover triggers and pre-spawn verification with platform-agnostic equivalents. Specifically: 'original Warp tab shows no tool calls in progress' -> reference worktree state polling (git status, git log) and sub-agent lifecycle signals as the primary signals for both Warp and grok-build. Add a parenthetical for grok-build: polling is via worktree state + get_command_or_subagent_output rather than tab observation.",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "id": "item-3",
         "title": "Add Grok Build quick-start note to skill preamble or Phase 3",
         "description": "Add a short 'Running swarms in Grok Build / non-Warp environments' note to the skill. Document the minimal runtime contract: one worktree per agent, spawn_subagent dispatch, worktree-state polling for monitoring, review-cycle sub-agents via spawn_subagent. Cross-reference #1342 as the originating platform work. This closes the documentation gap called out in #1331 item 4.",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "id": "item-4",
         "title": "Run task check and add CHANGELOG entry",
         "description": "Run task check. All gates must pass. Add CHANGELOG.md [Unreleased] entry per #1242 style: user-visible benefit (swarm skill now works natively in Grok Build / non-Warp environments), mechanism (Phase 3 Step 2d + Phase 4 platform-agnostic monitoring), refs #1331, #1342.",
-        "status": "proposed"
+        "status": "completed"
       }
     ],
     "tags": [
@@ -53,6 +53,6 @@
         "title": "Issue #1331: deft-directive-swarm is tightly coupled to the Warp runtime, making it hard to use in other agent environments (Grok Build, etc.)"
       }
     ],
-    "updated": "2026-05-26T12:09:43Z"
+    "updated": "2026-05-26T13:30:00Z"
   }
 }


### PR DESCRIPTION
## Summary

Adds a concrete Grok Build / non-Warp launch adapter to the deft-directive-swarm skill and makes Phase 4 monitoring language platform-agnostic. Previously, the swarm skill had no first-class launch path for environments with `spawn_subagent` but no `start_agent` or `WARP_*`, causing operators to hit a dead end at Phase 3 and build custom swarms instead.

**Changes:**
- **Phase 3 Step 1**: Moves `spawn_subagent` probe to point 3 (before the decision tree) so the detection order is unambiguous: `start_agent` -> `WARP_*` -> `spawn_subagent` -> `generic-terminal`. Updates the decision tree to explicitly route `grok-build` to Step 2d.
- **Phase 3 Step 2d** (new): Concrete launch adapter for Grok Build. When `grok-build` is the platform descriptor, dispatches workers via `spawn_subagent` with the canonical `templates/agent-prompt-preamble.md` preamble and the standard STEP 1-6 worktree prompt, adapted to use `get_command_or_subagent_output` for coordination instead of `start_agent` lifecycle events.
- **Phase 4 Takeover Triggers**: Replaces Warp-tab-specific pre-spawn verification language with platform-agnostic equivalent: worktree state (`git status`, `git log --oneline -3`) + sub-agent lifecycle signals, with a `grok-build` parenthetical for `get_command_or_subagent_output`.
- **Quick-start section**: New `## Running Swarms in Grok Build / Non-Warp Environments` section documents the minimal runtime contract (one worktree per agent, `spawn_subagent` dispatch, worktree-state polling), cross-references #1342 and #1353.
- **Anti-pattern**: Added to anti-patterns block -- do not fall through to manual-terminal fallback when `spawn_subagent` is available.

## Related Issues

Refs #1331, #1342. See #1353 for the companion shell-capture limitation note in agent-prompt-preamble.md.

## Checklist

- [x] `/deft:change <name>` -- N/A (skill-only, non-cross-cutting doc change; dispatched as part of #1331 swarm)
- [x] `CHANGELOG.md` -- added entry under `[Unreleased]`
- [x] `ROADMAP.md` -- N/A (no tracked roadmap item for this skill patch)
- [x] Tests pass locally -- `task check` passed: 6405 passed, 3 skipped, 9 deselected, 1 xfailed

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed -- `gh issue view 1331 --json state --jq .state`. Squash merges can silently fail to process closing keywords (#167). If still open, close manually.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
