### PR TITLE
fix(doctor): port redirect stub shape check

### DIFF
--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -36,16 +36,6 @@ from pathlib import Path
 
 HAS_RICH = False
 
-# Safe import of skill-redirect sentinel + window for the bounded exact-header
-# check in _check_skill_paths_resolve. This ports the #1383 / #1321 fix
-# (prevents re-introducing false positives when real skills quote the sentinel
-# in prose/docs after the first 200 chars). Falls back to the literal if the
-# sibling module is not importable in exotic exec contexts.
-try:
-    from _event_detect import DEPRECATED_SKILL_REDIRECT_SENTINEL  # type: ignore[import-not-found]
-except Exception:  # noqa: BLE001 -- graceful fallback
-    DEPRECATED_SKILL_REDIRECT_SENTINEL = "<!-- deft:deprecated-skill-redirect -->"
-_SKILL_SENTINEL_WINDOW = 200
 console = None
 Panel = None
 Markdown = None
@@ -171,14 +161,23 @@ _FULL_GUIDELINES_RE = re.compile(r"Full guidelines:\s+(\S+)/main\.md")
 _SKILL_PATH_RE = re.compile(r"(?P<root>[\w./-]+?)/skills/(?P<name>[a-z][\w-]*)/SKILL\.md")
 
 # Deprecation-redirect sentinels (#411 / cross-PR #1383 alignment for #1321).
-# Both variants are recognized in the *header window only* (first 200 chars)
-# when checking skill paths referenced from AGENTS.md. This prevents
-# false-positive "redirect stub" failures on real skills that merely quote
-# the sentinel string in body prose or examples (the exact failure mode
-# fixed in #1383 and re-introduced by the initial doctor.py port).
+# Both variants are recognized as exact marker lines in the header window when
+# checking skill paths referenced from AGENTS.md. This prevents false-positive
+# "redirect stub" failures on real skills that merely quote the sentinel string
+# in body prose or examples (the exact failure mode fixed in #1383 and
+# re-introduced by the initial doctor.py port).
 # Legacy vbrief-style stubs use the first; real skill deprecation stubs use
 # the second (and must appear early per test_deprecated_skill_redirects.py).
 _DEPRECATED_REDIRECT_SENTINEL = "<!-- deft:deprecated-redirect -->"
+_DEPRECATED_SKILL_REDIRECT_SENTINEL = "<!-- deft:deprecated-skill-redirect -->"
+_REDIRECT_STUB_HEADER_LINES = 8
+
+
+def _is_deprecation_redirect_stub(text: str) -> bool:
+    """Return True when a resolved skill file is an actual redirect stub."""
+    lines = text.replace("\r\n", "\n").lstrip().splitlines()
+    sentinels = {_DEPRECATED_REDIRECT_SENTINEL, _DEPRECATED_SKILL_REDIRECT_SENTINEL}
+    return any(line.strip() in sentinels for line in lines[:_REDIRECT_STUB_HEADER_LINES])
 
 
 @dataclass
@@ -379,16 +378,8 @@ def _check_skill_paths_resolve(project_root: Path, agents_md_text: str) -> Check
             missing.append(rel)
             continue
         text = _read_text_safe(candidate)
-        if text is not None:
-            # Bounded header-window check (first 200 chars) for *either* sentinel.
-            # This is the exact safe behavior ported from #1383 (via _event_detect
-            # + QUICK-START Step 2b) to close the cross-PR regression flagged by
-            # dbcall2 on the 7a0606c head. Real skills quoting the token in body
-            # (after the window) now correctly pass; legacy stubs (even with
-            # preamble before the token) still fail as expected.
-            head = text[:_SKILL_SENTINEL_WINDOW]
-            if _DEPRECATED_REDIRECT_SENTINEL in head or DEPRECATED_SKILL_REDIRECT_SENTINEL in head:
-                redirect_stubs.append(rel)
+        if text is not None and _is_deprecation_redirect_stub(text):
+            redirect_stubs.append(rel)
     if not missing and not redirect_stubs:
         return CheckResult(
             name="skill-paths-resolve",

--- a/tests/cli/test_cmd_doctor.py
+++ b/tests/cli/test_cmd_doctor.py
@@ -38,10 +38,25 @@ Refs: #792, #1272, related #793.
 
 from __future__ import annotations
 
+import importlib.util
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCTOR_SCRIPT = REPO_ROOT / "scripts" / "doctor.py"
+
+
+@pytest.fixture()
+def doctor_module():
+    spec = importlib.util.spec_from_file_location("doctor", DOCTOR_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["doctor"] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _make_fake_which(presence: dict[str, bool]):
@@ -347,7 +362,7 @@ def test_doctor_existing_taskfile_with_include_reports_ok(
 
 
 def test_doctor_session_mode_diagnoses_only_no_prompt_no_mutation(
-    run_command, deft_run_module, monkeypatch, consumer_project
+    run_command, deft_run_module, doctor_module, monkeypatch, consumer_project
 ):
     """--session never prompts and never mutates, even when --fix is also passed."""
     monkeypatch.setattr(deft_run_module, "HAS_RICH", False)
@@ -383,7 +398,7 @@ def test_doctor_session_mode_diagnoses_only_no_prompt_no_mutation(
             "session-safe mode is diagnose-only by contract (#1272)"
         )
 
-    monkeypatch.setattr(deft_run_module, "read_yn", _explode)
+    monkeypatch.setattr(doctor_module, "read_yn", _explode)
 
     result = run_command("cmd_doctor", ["--session", "--fix"])
 
@@ -397,7 +412,7 @@ def test_doctor_session_mode_diagnoses_only_no_prompt_no_mutation(
 
 
 def test_doctor_fix_with_consent_creates_canonical_taskfile(
-    run_command, deft_run_module, monkeypatch, consumer_project
+    run_command, deft_run_module, doctor_module, monkeypatch, consumer_project
 ):
     """--fix + TTY + explicit consent writes the canonical snippet verbatim."""
     monkeypatch.setattr(deft_run_module, "HAS_RICH", False)
@@ -415,9 +430,7 @@ def test_doctor_fix_with_consent_creates_canonical_taskfile(
 
     monkeypatch.setattr(deft_run_module.sys, "stdin", _FakeStdin())
     # Operator approves.
-    monkeypatch.setattr(
-        deft_run_module, "read_yn", lambda *_args, **_kwargs: True
-    )
+    monkeypatch.setattr(doctor_module, "read_yn", lambda *_args, **_kwargs: True)
 
     result = run_command("cmd_doctor", ["--fix"])
 
@@ -429,14 +442,14 @@ def test_doctor_fix_with_consent_creates_canonical_taskfile(
     written = target.read_text(encoding="utf-8")
     # Must match the canonical snippet byte-for-byte so the docs and the
     # write path do not drift over time.
-    assert written == deft_run_module._TASKFILE_INCLUDE_SNIPPET
+    assert written == doctor_module._TASKFILE_INCLUDE_SNIPPET
     # Drift decrement: after a successful in-session repair, the summary
     # should report success rather than 1 error.
     assert "Wrote" in result.stdout
 
 
 def test_doctor_fix_decline_does_not_write(
-    run_command, deft_run_module, monkeypatch, consumer_project
+    run_command, deft_run_module, doctor_module, monkeypatch, consumer_project
 ):
     """--fix + TTY + decline leaves Taskfile.yml absent."""
     monkeypatch.setattr(deft_run_module, "HAS_RICH", False)
@@ -452,9 +465,7 @@ def test_doctor_fix_decline_does_not_write(
             return True
 
     monkeypatch.setattr(deft_run_module.sys, "stdin", _FakeStdin())
-    monkeypatch.setattr(
-        deft_run_module, "read_yn", lambda *_args, **_kwargs: False
-    )
+    monkeypatch.setattr(doctor_module, "read_yn", lambda *_args, **_kwargs: False)
 
     result = run_command("cmd_doctor", ["--fix"])
 
@@ -583,7 +594,7 @@ def test_running_inside_deft_repo_negates_canonical_install_dir(
 
 
 def test_classify_taskfile_include_recognises_legacy_deft_path(
-    deft_run_module, tmp_path
+    doctor_module, tmp_path
 ):
     """_classify_taskfile_include recognises both ``./.deft/core`` and ``./deft`` includes."""
     legacy_form = (
@@ -595,24 +606,24 @@ def test_classify_taskfile_include_recognises_legacy_deft_path(
     )
     (tmp_path / "Taskfile.yml").write_text(legacy_form, encoding="utf-8")
 
-    assert deft_run_module._classify_taskfile_include(tmp_path) == "ok"
+    assert doctor_module._classify_taskfile_include(tmp_path) == "ok"
 
 
-def test_classify_taskfile_include_missing_file_status(deft_run_module, tmp_path):
+def test_classify_taskfile_include_missing_file_status(doctor_module, tmp_path):
     """Missing root Taskfile.yml AND Taskfile.yaml -> missing-file."""
-    assert deft_run_module._classify_taskfile_include(tmp_path) == "missing-file"
+    assert doctor_module._classify_taskfile_include(tmp_path) == "missing-file"
 
 
-def test_classify_taskfile_include_yaml_extension(deft_run_module, tmp_path):
+def test_classify_taskfile_include_yaml_extension(doctor_module, tmp_path):
     """Resolver accepts the ``.yaml`` spelling as well as ``.yml``."""
     (tmp_path / "Taskfile.yaml").write_text(
         "version: '3'\nincludes:\n  deft:\n    taskfile: ./.deft/core/Taskfile.yml\n",
         encoding="utf-8",
     )
-    assert deft_run_module._classify_taskfile_include(tmp_path) == "ok"
+    assert doctor_module._classify_taskfile_include(tmp_path) == "ok"
 
 
-def test_classify_taskfile_include_strips_utf8_bom(deft_run_module, tmp_path):
+def test_classify_taskfile_include_strips_utf8_bom(doctor_module, tmp_path):
     """Taskfile.yml persisted with a UTF-8 BOM must still classify as ``ok``.
 
     Regression guard for the #1303 pass-2 correctness finding: Windows editors
@@ -636,4 +647,4 @@ def test_classify_taskfile_include_strips_utf8_bom(deft_run_module, tmp_path):
     target = tmp_path / "Taskfile.yml"
     target.write_bytes(b"\xef\xbb\xbf" + canonical.encode("utf-8"))
 
-    assert deft_run_module._classify_taskfile_include(tmp_path) == "ok"
+    assert doctor_module._classify_taskfile_include(tmp_path) == "ok"

--- a/tests/cli/test_cmd_doctor.py
+++ b/tests/cli/test_cmd_doctor.py
@@ -51,12 +51,19 @@ DOCTOR_SCRIPT = REPO_ROOT / "scripts" / "doctor.py"
 
 @pytest.fixture()
 def doctor_module():
+    previous = sys.modules.get("doctor")
     spec = importlib.util.spec_from_file_location("doctor", DOCTOR_SCRIPT)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules["doctor"] = module
     spec.loader.exec_module(module)
-    return module
+    try:
+        yield module
+    finally:
+        if previous is None:
+            sys.modules.pop("doctor", None)
+        else:
+            sys.modules["doctor"] = previous
 
 
 def _make_fake_which(presence: dict[str, bool]):

--- a/tests/cli/test_framework_doctor.py
+++ b/tests/cli/test_framework_doctor.py
@@ -207,37 +207,54 @@ class TestSkillPathsResolve:
         assert check["data"]["redirect_stubs"]
 
     def test_legacy_stub_with_preamble_still_detected_as_redirect(self, fd, tmp_path):
-        """Regression: legacy stub with preamble before sentinel (within header window)
-        must still be flagged (covers the 'legacy stub with preamble fails' case
-        from dbcall2 cross-PR note on #1383 behavior).
-        """
         _write_agents_md(tmp_path)
         install = _write_install_tree(tmp_path, skills=("deft-directive-setup",))
         stub_path = install / "skills" / "deft-directive-setup" / "SKILL.md"
-        # Preamble (e.g. heading) then sentinel within first 200 chars.
         stub_path.write_text(
-            "# Legacy\n<!-- deft:deprecated-skill-redirect -->\nRedirecting...\n",
+            "<!-- DEFT-PREAMBLE-V1 -->\n"
+            "<!-- deft:deprecated-redirect -->\n"
+            "# legacy stub\n",
             encoding="utf-8",
         )
         result = fd.run_checks(tmp_path)
         check = next(c for c in result["checks"] if c["name"] == "skill-paths-resolve")
         assert check["status"] == "fail"
-        assert "deft-directive-setup" in str(check["data"].get("redirect_stubs", []))
+        assert check["data"]["redirect_stubs"] == [
+            ".deft/core/skills/deft-directive-setup/SKILL.md"
+        ]
+
+    def test_deprecated_skill_redirect_stub_detected(self, fd, tmp_path):
+        _write_agents_md(tmp_path)
+        install = _write_install_tree(tmp_path, skills=("deft-directive-setup",))
+        stub_path = install / "skills" / "deft-directive-setup" / "SKILL.md"
+        stub_path.write_text(
+            "<!-- DEFT-PREAMBLE-V1 -->\n"
+            "<!-- deft:deprecated-skill-redirect -->\n"
+            "# Deprecated skill path\n"
+            "Read `deft/QUICK-START.md` for current routing.\n",
+            encoding="utf-8",
+        )
+        result = fd.run_checks(tmp_path)
+        check = next(c for c in result["checks"] if c["name"] == "skill-paths-resolve")
+        assert check["status"] == "fail"
+        assert check["data"]["redirect_stubs"] == [
+            ".deft/core/skills/deft-directive-setup/SKILL.md"
+        ]
 
     def test_real_skill_mentioning_sentinel_in_body_passes(self, fd, tmp_path):
-        """Regression: a real (non-stub) skill file that merely quotes a sentinel
-        string deep in its prose (after the 200-char header window) must NOT be
-        flagged as redirect stub (the exact #1321 false-positive case fixed in
-        #1383 and required for safe #1380 landing per dbcall2).
-        """
         _write_agents_md(tmp_path)
         install = _write_install_tree(tmp_path, skills=("deft-directive-setup",))
         real_path = install / "skills" / "deft-directive-setup" / "SKILL.md"
-        # Header (no sentinel) + long prose that includes the token later.
-        # (Split to keep <100 cols per ruff E501.)
-        prefix = "Deft Skill\n\n" + ("x" * 250) + "\nExample: use "
-        body = prefix + "<!-- deft:deprecated-redirect --> only in stubs.\n"
-        real_path.write_text(body, encoding="utf-8")
+        real_path.write_text(
+            "---\n"
+            "name: deft-directive-setup\n"
+            "---\n\n"
+            "# Deft Directive Setup\n\n"
+            "A project is pre-cutover when PROJECT.md contains neither the "
+            "legacy `<!-- deft:deprecated-redirect -->` sentinel nor the "
+            "current Purpose marker.\n",
+            encoding="utf-8",
+        )
         result = fd.run_checks(tmp_path)
         check = next(c for c in result["checks"] if c["name"] == "skill-paths-resolve")
         assert check["status"] == "pass"

--- a/tests/cli/test_framework_doctor.py
+++ b/tests/cli/test_framework_doctor.py
@@ -241,6 +241,33 @@ class TestSkillPathsResolve:
             ".deft/core/skills/deft-directive-setup/SKILL.md"
         ]
 
+    def test_redirect_stub_header_window_boundary(self, fd, tmp_path):
+        _write_agents_md(tmp_path)
+        install = _write_install_tree(tmp_path, skills=("deft-directive-setup",))
+        stub_path = install / "skills" / "deft-directive-setup" / "SKILL.md"
+
+        covered_preamble = "".join(f"<!-- preamble {i} -->\n" for i in range(7))
+        stub_path.write_text(
+            covered_preamble + "<!-- deft:deprecated-redirect -->\n# legacy stub\n",
+            encoding="utf-8",
+        )
+        result = fd.run_checks(tmp_path)
+        check = next(c for c in result["checks"] if c["name"] == "skill-paths-resolve")
+        assert check["status"] == "fail"
+        assert check["data"]["redirect_stubs"] == [
+            ".deft/core/skills/deft-directive-setup/SKILL.md"
+        ]
+
+        uncovered_preamble = "".join(f"<!-- preamble {i} -->\n" for i in range(8))
+        stub_path.write_text(
+            uncovered_preamble + "<!-- deft:deprecated-redirect -->\n# legacy stub\n",
+            encoding="utf-8",
+        )
+        result = fd.run_checks(tmp_path)
+        check = next(c for c in result["checks"] if c["name"] == "skill-paths-resolve")
+        assert check["status"] == "pass"
+        assert not check["data"].get("redirect_stubs")
+
     def test_real_skill_mentioning_sentinel_in_body_passes(self, fd, tmp_path):
         _write_agents_md(tmp_path)
         install = _write_install_tree(tmp_path, skills=("deft-directive-setup",))


### PR DESCRIPTION
## Summary
- Port #1383's exact-line redirect-stub shape check into scripts/doctor.py so #1380 does not reintroduce #1321 after retiring framework_doctor.py.
- Cover legacy stubs with preambles, the new deprecated-skill redirect sentinel, and real skills that quote the legacy sentinel near the top of prose.
- Update doctor extraction tests to patch/call helpers on the canonical scripts/doctor.py module instead of the run shim.

## Tests
- uv --project . run --frozen pytest tests/cli/test_framework_doctor.py tests/cli/test_cmd_doctor.py tests/cli/test_install_manifest_root.py
- UV_FROZEN=1 task check

Refs #1321, #1335, #1336, #1380, #1383