### PR TITLE
feat(preamble): first-class ## Allocation context dispatch-envelope schema (#1378 Story A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Dispatch envelopes now carry a structured `## Allocation context` section (#1378, Story A)** -- swarm-cohort dispatches declare operator approval through a small set of canonical fields instead of free-form prose, so downstream skills and the Story Start Gate can recognise the #1371 batching consent token mechanically rather than by pattern-matching. The canonical orchestrator preamble now documents the frozen schema, a worked swarm-cohort example, and the recognition contract: a `swarm-cohort` dispatch with a non-null allocation-plan id and rationale satisfies the consent token, while an absent section falls back to the existing #1371 prose carve-out. Refs #1378, #1371.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Dispatch envelopes now carry a structured `## Allocation context` section (#1378, Story A)** -- swarm-cohort dispatches declare operator approval through a small set of canonical fields instead of free-form prose, so downstream skills and the Story Start Gate can recognise the #1371 batching consent token mechanically rather than by pattern-matching. The canonical orchestrator preamble now documents the frozen schema, a worked swarm-cohort example, and the recognition contract: a `swarm-cohort` dispatch with a non-null allocation-plan id and rationale satisfies the consent token, while an absent section falls back to the existing #1371 prose carve-out. Refs #1378, #1371.
+- **Dispatch envelopes now carry a structured `## Allocation context` section (#1378, Story A)** -- swarm-cohort dispatches declare operator approval through five canonical fields instead of free-form prose, so downstream skills and the Story Start Gate can recognise the #1371 batching consent token mechanically rather than by pattern-matching. An absent section falls back to the existing #1371 prose carve-out. Refs #1378, #1371.
 
 ### Changed
 

--- a/templates/agent-prompt-preamble.md
+++ b/templates/agent-prompt-preamble.md
@@ -23,6 +23,32 @@ Anti-pattern: editing files before activating the vBRIEF, then activating "to ma
 
 The gate also requires an explicit action-verb directive from the user (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`). Affirmative continuation phrases ("yes", "go", "proceed") are NOT authorisation unless the prior turn explicitly proposed implementation.
 
+## 2.5 Allocation context -- swarm-cohort consent token (#1378)
+
+Every dispatch envelope MUST carry a `## Allocation context` section so any downstream skill (the build SKILL Story Start Gate, the `task vbrief:preflight` gate) or deterministic gate can decide whether batched work was operator-approved by reading structured fields instead of pattern-matching free-form prose. The section has exactly five fields, in this order:
+
+- `dispatch_kind`: `solo` | `swarm-cohort` -- whether this worker is a lone dispatch or one member of an operator-approved swarm cohort.
+- `allocation_plan_id`: <swarm-monitor session id, or path to the Phase 5 allocation-plan snapshot> | null -- the stable handle for the allocation plan that authorized this dispatch.
+- `batching_rationale`: <one-line rationale from the Phase 5 allocation plan> | null -- the one-line reason the cohort was batched together.
+- `cohort_vbriefs`: [<vbrief-path>, ...] -- the full cohort vBRIEF list; a `solo` dispatch lists just its one vBRIEF.
+- `operator_approval_evidence`: <Phase 5 approval timestamp or session reference> -- the audit handle proving the operator approved the allocation plan.
+
+**Recognition contract:** a section reporting `dispatch_kind: swarm-cohort` with a NON-NULL `allocation_plan_id` AND a NON-NULL `batching_rationale` satisfies the Story Start Gate consent-token requirement (the #1371 carve-out) -- the worker does NOT re-prompt the operator for batching approval mid-cohort. When the `## Allocation context` section is ABSENT (pre-#1378 dispatches, solo-interactive sessions), fall back to the #1371 prose carve-out in the Story Start Gate.
+
+Worked example (a swarm-cohort member):
+
+```markdown path=null start=null
+## Allocation context
+
+- dispatch_kind: swarm-cohort
+- allocation_plan_id: orchestrator-run-019e80bd-7328-7636-b283-a2f818243dd9
+- batching_rationale: Three disjoint-file-scope stories from #1378; Story A freezes the schema, Stories B and C build against it in parallel.
+- cohort_vbriefs: [vbrief/active/2026-06-01-1378a-allocation-context-schema.vbrief.json, vbrief/active/2026-06-01-1378b-skill-allocation-context-recognition.vbrief.json, vbrief/active/2026-06-01-1378c-preflight-story-start-gate.vbrief.json]
+- operator_approval_evidence: user directive "swarm 1378 per option a" 2026-06-01T02:26Z
+```
+
+A `solo` dispatch sets `dispatch_kind: solo`, MAY leave `allocation_plan_id` / `batching_rationale` null, and lists only its own vBRIEF in `cohort_vbriefs`; such a section does NOT by itself satisfy the consent token, so the Story Start Gate falls through to the #1371 prose carve-out for a lone interactive dispatch.
+
 ## 3. PowerShell 5.1 non-ASCII rule (#798)
 
 If your shell is `pwsh 5.x` on Windows AND you are editing a file containing any non-ASCII glyph (em dashes, en dashes, arrows, smart quotes, ⊗, ✓, ellipses, emoji, ...), you MUST route the read AND write through Python `pathlib`:

--- a/templates/agent-prompt-preamble.md
+++ b/templates/agent-prompt-preamble.md
@@ -31,13 +31,13 @@ Every dispatch envelope MUST carry a `## Allocation context` section so any down
 - `allocation_plan_id`: <swarm-monitor session id, or path to the Phase 5 allocation-plan snapshot> | null -- the stable handle for the allocation plan that authorized this dispatch.
 - `batching_rationale`: <one-line rationale from the Phase 5 allocation plan> | null -- the one-line reason the cohort was batched together.
 - `cohort_vbriefs`: [<vbrief-path>, ...] -- the full cohort vBRIEF list; a `solo` dispatch lists just its one vBRIEF.
-- `operator_approval_evidence`: <Phase 5 approval timestamp or session reference> -- the audit handle proving the operator approved the allocation plan.
+- `operator_approval_evidence`: <Phase 5 approval timestamp or session reference> -- the audit handle proving the operator approved the allocation plan (advisory / audit-only -- it is NOT part of the recognition-contract gate below).
 
 **Recognition contract:** a section reporting `dispatch_kind: swarm-cohort` with a NON-NULL `allocation_plan_id` AND a NON-NULL `batching_rationale` satisfies the Story Start Gate consent-token requirement (the #1371 carve-out) -- the worker does NOT re-prompt the operator for batching approval mid-cohort. When the `## Allocation context` section is ABSENT (pre-#1378 dispatches, solo-interactive sessions), fall back to the #1371 prose carve-out in the Story Start Gate.
 
 Worked example (a swarm-cohort member):
 
-```markdown path=null start=null
+```markdown
 ## Allocation context
 
 - dispatch_kind: swarm-cohort

--- a/tests/content/test_allocation_context_schema.py
+++ b/tests/content/test_allocation_context_schema.py
@@ -1,0 +1,139 @@
+"""Content tests for the ``## Allocation context`` schema (#1378 Story A).
+
+Story A freezes the canonical ``## Allocation context`` dispatch-envelope
+schema in ``templates/agent-prompt-preamble.md`` so downstream stories build
+against a stable contract: Story B (skill recognition of the consent token)
+and Story C (the deterministic Story Start Gate) both read the five fields and
+the recognition contract pinned here. These tests are the frozen-schema guard
+-- a future edit that renames a field, drops the recognition contract, or
+deletes the worked example MUST fail CI.
+
+The sibling ``test_agent_prompt_preamble_template.py`` pins the rest of the
+preamble; this file owns only the #1378 allocation-context section.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "templates" / "agent-prompt-preamble.md"
+
+# The five canonical fields, in their frozen order. Story B / Story C read
+# these names verbatim; renaming one here is a breaking change to the cohort.
+FROZEN_FIELDS = (
+    "dispatch_kind",
+    "allocation_plan_id",
+    "batching_rationale",
+    "cohort_vbriefs",
+    "operator_approval_evidence",
+)
+
+
+@pytest.fixture(scope="module")
+def template_text() -> str:
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_template_exists() -> None:
+    assert TEMPLATE.is_file(), (
+        f"templates/agent-prompt-preamble.md must exist at {TEMPLATE}"
+    )
+
+
+def test_allocation_context_heading_present(template_text: str) -> None:
+    """A markdown heading naming the allocation-context section must exist."""
+    assert re.search(r"^##\s+.*Allocation context", template_text, re.MULTILINE), (
+        "preamble must carry a `## ... Allocation context` section heading"
+    )
+
+
+def test_section_references_1378(template_text: str) -> None:
+    """The section self-identifies as #1378 scope for traceability."""
+    assert "#1378" in template_text
+
+
+@pytest.mark.parametrize("field", FROZEN_FIELDS)
+def test_all_five_fields_documented(template_text: str, field: str) -> None:
+    """Each of the five frozen field names must appear in the template."""
+    assert field in template_text, (
+        f"allocation-context schema missing required field: {field!r}"
+    )
+
+
+def test_fields_documented_in_frozen_order(template_text: str) -> None:
+    """The five fields must be documented in the frozen contract order.
+
+    Story B / Story C depend on this ordering being stable; a reorder is a
+    breaking schema change and must fail CI.
+    """
+    positions = [template_text.index(field) for field in FROZEN_FIELDS]
+    assert positions == sorted(positions), (
+        "allocation-context fields must be documented in the frozen order: "
+        f"{FROZEN_FIELDS}"
+    )
+
+
+def test_dispatch_kind_enumerates_both_values(template_text: str) -> None:
+    """dispatch_kind documents both the solo and swarm-cohort values."""
+    assert "solo" in template_text
+    assert "swarm-cohort" in template_text
+
+
+def test_recognition_contract_sentence_present(template_text: str) -> None:
+    """The recognition-contract sentence pins the consent-token semantics.
+
+    A ``swarm-cohort`` dispatch with a NON-NULL allocation_plan_id AND a
+    NON-NULL batching_rationale satisfies the Story Start Gate consent token
+    (the #1371 carve-out). This is the exact sentence Story C's gate keys off.
+    """
+    assert "Recognition contract" in template_text
+    assert "NON-NULL" in template_text
+    assert "#1371" in template_text
+    assert re.search(
+        r"dispatch_kind:\s*swarm-cohort.*NON-NULL.*allocation_plan_id.*"
+        r"batching_rationale",
+        template_text,
+        re.IGNORECASE | re.DOTALL,
+    ), "recognition-contract sentence must tie swarm-cohort + non-null fields to the consent token"
+    assert "consent-token" in template_text or "consent token" in template_text
+
+
+def test_absent_section_falls_back_to_1371_prose(template_text: str) -> None:
+    """When the section is ABSENT, fall back to the #1371 prose carve-out."""
+    assert "ABSENT" in template_text
+    assert re.search(
+        r"ABSENT.*fall back to the #1371 prose carve-out",
+        template_text,
+        re.IGNORECASE | re.DOTALL,
+    ), "absent-section fallback to the #1371 prose carve-out must be documented"
+
+
+def test_worked_example_present(template_text: str) -> None:
+    """A populated swarm-cohort worked example must be present.
+
+    The example shows every field populated with realistic values so an
+    orchestrator copying the section into a dispatch envelope has a template.
+    """
+    assert "Worked example" in template_text
+    # The example block embeds a literal `## Allocation context` data block.
+    assert "## Allocation context" in template_text
+    assert "dispatch_kind: swarm-cohort" in template_text
+    # Every field appears in the worked example as a populated bullet.
+    assert "- allocation_plan_id: orchestrator-run-" in template_text
+    assert "- batching_rationale: " in template_text
+    assert "- cohort_vbriefs: [" in template_text
+    assert "- operator_approval_evidence: " in template_text
+
+
+def test_worked_example_lists_full_cohort(template_text: str) -> None:
+    """The swarm-cohort example lists more than one vBRIEF in cohort_vbriefs."""
+    match = re.search(r"- cohort_vbriefs: \[(.+?)\]", template_text, re.DOTALL)
+    assert match, "worked example must include a cohort_vbriefs list"
+    entries = [e for e in match.group(1).split(",") if ".vbrief.json" in e]
+    assert len(entries) >= 2, (
+        "a swarm-cohort worked example must list the full cohort (>= 2 vBRIEFs)"
+    )

--- a/tests/content/test_allocation_context_schema.py
+++ b/tests/content/test_allocation_context_schema.py
@@ -38,6 +38,22 @@ def template_text() -> str:
     return TEMPLATE.read_text(encoding="utf-8")
 
 
+def _allocation_section(text: str) -> str:
+    """Return only the body of the ``## Allocation context`` section.
+
+    Scopes position-sensitive probes to the text between the
+    ``## ... Allocation context`` heading and the next top-level ``## ``
+    heading, so field-name positions are not skewed by an earlier preamble
+    section that happens to mention a field name.
+    """
+    match = re.search(r"^##\s+.*Allocation context.*$", text, re.MULTILINE)
+    assert match, "allocation-context section heading not found"
+    start = match.end()
+    nxt = re.search(r"^##\s+", text[start:], re.MULTILINE)
+    end = start + nxt.start() if nxt else len(text)
+    return text[start:end]
+
+
 def test_template_exists() -> None:
     assert TEMPLATE.is_file(), (
         f"templates/agent-prompt-preamble.md must exist at {TEMPLATE}"
@@ -68,9 +84,12 @@ def test_fields_documented_in_frozen_order(template_text: str) -> None:
     """The five fields must be documented in the frozen contract order.
 
     Story B / Story C depend on this ordering being stable; a reorder is a
-    breaking schema change and must fail CI.
+    breaking schema change and must fail CI. The search is scoped to the
+    allocation-context section so a field name appearing in an earlier
+    preamble section cannot skew the recorded positions.
     """
-    positions = [template_text.index(field) for field in FROZEN_FIELDS]
+    section = _allocation_section(template_text)
+    positions = [section.index(field) for field in FROZEN_FIELDS]
     assert positions == sorted(positions), (
         "allocation-context fields must be documented in the frozen order: "
         f"{FROZEN_FIELDS}"

--- a/vbrief/completed/2026-06-01-1378a-allocation-context-schema.vbrief.json
+++ b/vbrief/completed/2026-06-01-1378a-allocation-context-schema.vbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "feat(preamble): first-class ## Allocation context dispatch-envelope schema (#1378 Story A)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Add a structured `## Allocation context` section to the canonical dispatch envelope (templates/agent-prompt-preamble.md) so downstream skills (#1378 Story B) and the deterministic gate (#1378 Story C) can read the swarm-cohort consent token mechanically instead of inferring it from free-form prose. Foundation story: B and C build against the schema this story freezes.",
       "Origin": "Decomposed from https://github.com/deftai/directive/issues/1378 (Story A of A/B/C).",
@@ -32,7 +32,12 @@
         }
       }
     ],
-    "tags": ["swarm", "agent-experience", "preamble", "cluster:1378-allocation-context"],
+    "tags": [
+      "swarm",
+      "agent-experience",
+      "preamble",
+      "cluster:1378-allocation-context"
+    ],
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/1378",
@@ -65,6 +70,7 @@
         "file_scope_confidence": "high",
         "model_tier": "standard"
       }
-    }
+    },
+    "updated": "2026-06-01T02:48:16Z"
   }
 }


### PR DESCRIPTION
## Summary

Story A (foundation) of #1378. Adds the canonical `## Allocation context` section to the dispatch envelope (`templates/agent-prompt-preamble.md`) so downstream skills (Story B) and the deterministic Story Start Gate (Story C) can read the swarm-cohort consent token from structured fields instead of pattern-matching free-form prose.

This story **freezes the schema contract**; Stories B and C build against it.

## Changes

- **`templates/agent-prompt-preamble.md`** -- new section `## 2.5 Allocation context -- swarm-cohort consent token (#1378)` documenting:
  - the five frozen fields, in order: `dispatch_kind`, `allocation_plan_id`, `batching_rationale`, `cohort_vbriefs`, `operator_approval_evidence`
  - the recognition contract: a `swarm-cohort` dispatch with a NON-NULL `allocation_plan_id` AND a NON-NULL `batching_rationale` satisfies the Story Start Gate consent-token requirement (the #1371 carve-out)
  - the absent-section fallback to the #1371 prose carve-out
  - a populated swarm-cohort worked example
  - (placed as a fractional section per the existing 3.5 / 3.6 / 10.5 precedent so the existing numbered sections stay intact)
- **`tests/content/test_allocation_context_schema.py`** -- new content test pinning the section heading, all five field names, the frozen field order, the worked example values (incl. full cohort listing), the recognition-contract sentence, and the absent-section fallback.
- **`CHANGELOG.md`** -- one `[Unreleased]` entry under `### Added`.

## Schema contract (frozen)

Fields, in order:
- `dispatch_kind`: `solo` | `swarm-cohort`
- `allocation_plan_id`: <swarm-monitor session id, or path to the Phase 5 allocation-plan snapshot> | null
- `batching_rationale`: <one-line rationale from the Phase 5 allocation plan> | null
- `cohort_vbriefs`: [<vbrief-path>, ...]
- `operator_approval_evidence`: <Phase 5 approval timestamp or session reference>

## vBRIEF

`vbrief/active/2026-06-01-1378a-allocation-context-schema.vbrief.json` (moves to `completed/` once review-clean).

## Testing

- `uv --project . run pytest tests/content/test_allocation_context_schema.py -v` -- 14 passed
- `task check` -- green (6602 passed, encoding clean, branch-protection OK)

## Related

- Part of #1378 (A/B/C cohort)
- Refs #1371 (swarm-cohort consent-token carve-out)
