### PR TITLE
fix(installer): safe + working deft-install --upgrade on vendored installs (#1425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`deft-install --upgrade` is now safe and works on vendored (webinstaller) installs (#1425)** -- upgrading a project installed via the webinstaller (a vendored `.deft/core/` with no `.git/` of its own) previously ran `git` against the *consumer's own repository* via git's upward `.git` discovery, failing with a misleading `pathspec` error and risking a silent checkout of the user's project. The installer now classifies the on-disk payload (clone / vendored / absent) before any git operation, refreshes vendored payloads through a git-free tarball file-swap with a timestamped backup, and never runs a mutating git command against anything but a genuine framework clone. `--json` now reports `payload_layout` and `strategy`. Closes #1425.
 
 ### Removed
 

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -235,12 +235,18 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		return 1
 	}
 
-	// Phase 4: clone or update deft.
+	// Phase 4: clone or update deft. UpdateDeft (#1425) classifies the on-disk
+	// payload layout and chooses a safe strategy: git fetch/checkout for a
+	// genuine clone, a git-free file swap for a vendored (no-.git) payload, or
+	// a fresh clone when the payload is absent.
+	var updateOutcome *UpdateOutcome
 	if result.Update {
-		if err := UpdateDeft(w, result, branch); err != nil {
+		o, err := UpdateDeft(w, result, branch)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return 1
 		}
+		updateOutcome = o
 	} else {
 		if err := CloneDeft(w, result, branch); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -256,6 +262,22 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 	// values from the installer binary (defaultBranch + empty SHA) so the
 	// manifest still carries install_root.
 	installFields := resolveInstallManifestFields(result, branch)
+	// #1425: on a vendored refresh, resolveInstallManifestFields() resolved the
+	// SHA via `git -C <core> rev-parse HEAD`, which on a no-.git payload climbs
+	// to the PARENT consumer repo's HEAD (the #1323/#1324 wrong-sha class).
+	// Override with the framework source SHA/tag recovered from the release
+	// tarball wrapper so the manifest records true framework provenance.
+	if updateOutcome != nil && updateOutcome.Layout == payloadLayoutVendored {
+		if updateOutcome.SHA != "" {
+			installFields.SHA = updateOutcome.SHA
+		}
+		if updateOutcome.Tag != "" {
+			installFields.Tag = updateOutcome.Tag
+			if installFields.Ref == "" {
+				installFields.Ref = updateOutcome.Tag
+			}
+		}
+	}
 	if _, err := WriteInstallManifest(result.ProjectDir, result.DeftDir, installFields); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not write install manifest: %v\n", err)
 		// Non-fatal: the install proceeds, but downstream consumers (doctor,
@@ -316,6 +338,17 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		// Machine readable result for agents / CI (Epic-3 AC). Includes
 		// actions taken for 1337/1338 so callers can react (e.g. re-invoke
 		// doctor after wiring).
+		//
+		// #1425: payload_layout (clone|vendored|absent) and strategy
+		// (git-checkout|file-swap|clone) let agents/CI see how the upgrade was
+		// performed -- and confirm a vendored install used the git-free swap
+		// rather than a git command against the consumer repo.
+		payloadLayout := payloadLayoutAbsent
+		strategy := strategyClone
+		if updateOutcome != nil {
+			payloadLayout = updateOutcome.Layout
+			strategy = updateOutcome.Strategy
+		}
 		out := map[string]any{
 			"success":         true,
 			"version":         version,
@@ -329,6 +362,8 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 			"missing_tools":   missingTools,
 			"user_config_dir": configDir,
 			"skills_created":  skillsCreated,
+			"payload_layout":  payloadLayout,
+			"strategy":        strategy,
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -400,6 +400,20 @@ func TestCloneDeft_CommandArgs(t *testing.T) {
 	}
 }
 
+// forceCloneLayoutGit stubs runGitCaptureFunc so classifyPayloadLayout sees a
+// genuine clone (git toplevel == deftDir) and a deterministic HEAD sha. It
+// returns the original so callers can restore it.
+func forceCloneLayoutGit(deftDir string) func(string, ...string) (string, error) {
+	orig := runGitCaptureFunc
+	runGitCaptureFunc = func(dir string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "rev-parse" && args[1] == "--show-toplevel" {
+			return deftDir, nil
+		}
+		return "deadbeefcafe1234", nil
+	}
+	return orig
+}
+
 func TestUpdateDeft_NoBranch(t *testing.T) {
 	origRun := runCmdFunc
 	defer func() { runCmdFunc = origRun }()
@@ -413,6 +427,8 @@ func TestUpdateDeft_NoBranch(t *testing.T) {
 	tmp := t.TempDir()
 	deftDir := filepath.Join(tmp, "myproj", "deft")
 	os.MkdirAll(deftDir, 0o755)
+	origGit := forceCloneLayoutGit(deftDir)
+	defer func() { runGitCaptureFunc = origGit }()
 
 	result := &WizardResult{
 		ProjectName: "myproj",
@@ -422,8 +438,15 @@ func TestUpdateDeft_NoBranch(t *testing.T) {
 	}
 
 	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
-	if err := UpdateDeft(w, result, ""); err != nil {
+	outcome, err := UpdateDeft(w, result, "")
+	if err != nil {
 		t.Fatal(err)
+	}
+	if outcome.Layout != payloadLayoutClone {
+		t.Errorf("expected clone layout, got %q", outcome.Layout)
+	}
+	if outcome.Strategy != strategyGitCheckout {
+		t.Errorf("expected git-checkout strategy, got %q", outcome.Strategy)
 	}
 
 	// Should fetch + pull (no checkout).
@@ -451,6 +474,8 @@ func TestUpdateDeft_WithBranch(t *testing.T) {
 	tmp := t.TempDir()
 	deftDir := filepath.Join(tmp, "myproj", "deft")
 	os.MkdirAll(deftDir, 0o755)
+	origGit := forceCloneLayoutGit(deftDir)
+	defer func() { runGitCaptureFunc = origGit }()
 
 	result := &WizardResult{
 		ProjectName: "myproj",
@@ -460,8 +485,12 @@ func TestUpdateDeft_WithBranch(t *testing.T) {
 	}
 
 	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
-	if err := UpdateDeft(w, result, "beta"); err != nil {
+	outcome, err := UpdateDeft(w, result, "beta")
+	if err != nil {
 		t.Fatal(err)
+	}
+	if outcome.Layout != payloadLayoutClone {
+		t.Errorf("expected clone layout, got %q", outcome.Layout)
 	}
 
 	// Should fetch + checkout beta + pull.

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -341,32 +341,8 @@ func CloneDeft(w *Wizard, result *WizardResult, branch string) error {
 	return nil
 }
 
-// UpdateDeft fetches the latest changes and optionally switches branch.
-// Used when deft/ already exists and the user chose to update.
-func UpdateDeft(w *Wizard, result *WizardResult, branch string) error {
-	w.printf("Updating deft at %s ...\n", result.DeftDir)
-
-	// Fetch latest from origin.
-	if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "fetch", "origin"); err != nil {
-		return fmt.Errorf("git fetch failed: %w", err)
-	}
-
-	// Switch branch if requested.
-	if branch != "" {
-		w.printf("Switching to branch %s ...\n", branch)
-		if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "checkout", branch); err != nil {
-			return fmt.Errorf("git checkout %s failed: %w", branch, err)
-		}
-	}
-
-	// Pull latest changes.
-	if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "pull"); err != nil {
-		return fmt.Errorf("git pull failed: %w", err)
-	}
-
-	w.printf("Deft updated successfully.\n")
-	return nil
-}
+// UpdateDeft and its payload-classification + vendored file-swap helpers live
+// in upgrade.go (#1425).
 
 // ---------------------------------------------------------------------------
 // 4.2 Write AGENTS.md

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -118,8 +118,11 @@ func UpdateDeft(w *Wizard, result *WizardResult, branch string) (*UpdateOutcome,
 			return &UpdateOutcome{Layout: layout, Strategy: strategyClone}, err
 		}
 		sha, _ := runGitCaptureFunc(result.DeftDir, "rev-parse", "HEAD")
+		// Report the POST-operation layout: a fresh clone now exists, so the
+		// payload is a clone (not absent). Consumers inspecting payload_layout
+		// in --json must see the resulting state, not the pre-clone state.
 		return &UpdateOutcome{
-			Layout:   layout,
+			Layout:   payloadLayoutClone,
 			Strategy: strategyClone,
 			SHA:      sha,
 			Tag:      tagFromRef(branch),
@@ -313,8 +316,11 @@ func extractCoreTarball(tarballPath, destDir string) (string, error) {
 		}
 
 		target := filepath.Join(cleanDest, filepath.FromSlash(name))
-		// Defense-in-depth: the resolved target must stay within destDir.
-		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+		// zip-slip / CodeQL go/zipslip canonical barrier: the cleaned target
+		// path MUST stay within destDir. Wrapping the target in filepath.Clean
+		// is the form CodeQL recognises as a sanitizer on the path that flows
+		// into the MkdirAll / OpenFile sinks below.
+		if !strings.HasPrefix(filepath.Clean(target), cleanDest+string(os.PathSeparator)) {
 			return "", fmt.Errorf("tar entry escapes destination: %q", hdr.Name)
 		}
 

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -1,0 +1,498 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Payload layout classifications (#1425). The installer's --upgrade path MUST
+// know whether <core> is a genuine git clone of the framework, a vendored
+// (no-.git) payload deposited by the webinstaller, or absent entirely --
+// because running a mutating git command inside a vendored payload resolves,
+// via git's upward .git discovery, to the PARENT consumer repository. That is
+// the P0 safety bug this module closes: `git -C .deft/core checkout <tag>` on
+// a no-.git payload would check out a ref in the user's own project repo.
+const (
+	payloadLayoutClone    = "clone"
+	payloadLayoutVendored = "vendored"
+	payloadLayoutAbsent   = "absent"
+)
+
+// Upgrade strategies surfaced in --json diagnostics (#1425).
+const (
+	strategyGitCheckout = "git-checkout"
+	strategyFileSwap    = "file-swap"
+	strategyClone       = "clone"
+)
+
+// deftTarballAPIBase is the GitHub tarball endpoint for the framework repo.
+// `GET .../tarball/<ref>` (ref optional => default branch) returns a gzipped
+// tar of the repo tree wrapped in a single top-level directory named
+// `<owner>-<repo>-<sha>` -- the wrapper SHA is the framework source SHA we
+// re-stamp into the VERSION manifest (fixing the #1323/#1324 wrong-sha class).
+const deftTarballAPIBase = "https://api.github.com/repos/deftai/directive/tarball"
+
+// tarballExcludedTopLevel mirrors the webinstaller's EXCLUDED_PREFIXES
+// (deftai/webinstaller src/lib/bootstrap/emitDeftCore.ts): a vendored payload
+// never carries git metadata, GitHub workflow files, or node_modules.
+// Critically, .git/ MUST NEVER be written into <core> or the NEXT --upgrade
+// would mis-classify the vendored payload as a clone and re-introduce the
+// safety bug.
+var tarballExcludedTopLevel = map[string]bool{
+	".git":         true,
+	".github":      true,
+	"node_modules": true,
+}
+
+// UpdateOutcome reports what the update path did so main.go can populate the
+// --json diagnostics (payload_layout / strategy) and re-stamp the VERSION
+// manifest with the framework source SHA resolved from the tarball rather than
+// the parent consumer repo's HEAD (the #1323/#1324 wrong-sha class).
+type UpdateOutcome struct {
+	Layout   string // clone | vendored | absent
+	Strategy string // git-checkout | file-swap | clone
+	SHA      string // framework source SHA (best-effort)
+	Tag      string // resolved release tag, when the ref looked like semver
+	Backup   string // path to the pre-swap backup of <core>, when a swap ran
+}
+
+// runGitCaptureFunc runs `git -C dir args...` and returns trimmed stdout.
+// Indirected through a var so tests can stub git without a real repo. ONLY
+// read-only git subcommands are ever routed through this helper -- mutating
+// git is confined to updateClonedCore, which runs exclusively on the "clone"
+// layout (#1425 safety guardrail).
+var runGitCaptureFunc = func(dir string, args ...string) (string, error) {
+	full := append([]string{"-C", dir}, args...)
+	out, err := exec.Command("git", full...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// fetchCoreTarballFunc downloads the deftai/directive source tarball at ref
+// (empty => default branch) to a temp .tar.gz and returns its path. Indirected
+// for tests so the vendored-refresh path is exercised without network.
+var fetchCoreTarballFunc = downloadCoreTarball
+
+// UpdateDeft refreshes an existing framework deposit. It classifies the
+// on-disk payload layout FIRST and dispatches to the only safe strategy for
+// that layout (#1425):
+//
+//   - clone    -> git fetch/checkout/pull (the only path allowed to run
+//     mutating git, and only because classification proved `git rev-parse
+//     --show-toplevel` resolves to <core> itself).
+//   - vendored -> git-free file swap (download tarball, atomic replace).
+//   - absent   -> fresh clone (treat --upgrade on a missing payload as install).
+//
+// The hard guardrail is structural: a mutating git command can only be reached
+// through updateClonedCore, which is only called from the clone branch.
+func UpdateDeft(w *Wizard, result *WizardResult, branch string) (*UpdateOutcome, error) {
+	layout := classifyPayloadLayout(result.DeftDir)
+	switch layout {
+	case payloadLayoutClone:
+		if err := updateClonedCore(w, result, branch); err != nil {
+			return &UpdateOutcome{Layout: layout, Strategy: strategyGitCheckout}, err
+		}
+		sha, _ := runGitCaptureFunc(result.DeftDir, "rev-parse", "HEAD")
+		return &UpdateOutcome{
+			Layout:   layout,
+			Strategy: strategyGitCheckout,
+			SHA:      sha,
+			Tag:      tagFromRef(branch),
+		}, nil
+	case payloadLayoutVendored:
+		return refreshVendoredCore(w, result, branch)
+	default: // absent -- treat --upgrade on a missing payload as a fresh clone.
+		w.printf("No framework payload found at %s; cloning a fresh copy ...\n", result.DeftDir)
+		if err := CloneDeft(w, result, branch); err != nil {
+			return &UpdateOutcome{Layout: layout, Strategy: strategyClone}, err
+		}
+		sha, _ := runGitCaptureFunc(result.DeftDir, "rev-parse", "HEAD")
+		return &UpdateOutcome{
+			Layout:   layout,
+			Strategy: strategyClone,
+			SHA:      sha,
+			Tag:      tagFromRef(branch),
+		}, nil
+	}
+}
+
+// classifyPayloadLayout determines whether <deftDir> is a genuine framework
+// clone, a vendored (no-.git) payload, or absent. This is the safety
+// pre-condition for every git operation in the --upgrade path (#1425): only a
+// "clone" layout -- where `git rev-parse --show-toplevel` resolves to <deftDir>
+// itself -- is allowed to run mutating git commands. A vendored payload's git
+// toplevel resolves to the PARENT consumer repo (or git fails outright), so it
+// MUST use the git-free file-swap path instead.
+func classifyPayloadLayout(deftDir string) string {
+	info, err := os.Stat(deftDir)
+	if err != nil || !info.IsDir() {
+		return payloadLayoutAbsent
+	}
+	top, err := runGitCaptureFunc(deftDir, "rev-parse", "--show-toplevel")
+	if err != nil || strings.TrimSpace(top) == "" {
+		// Not a git work tree at all -> vendored payload.
+		return payloadLayoutVendored
+	}
+	if samePath(top, deftDir) {
+		return payloadLayoutClone
+	}
+	// git resolved to a DIFFERENT toplevel: <deftDir> is nested inside another
+	// repo (the parent consumer project) and is not itself a repo. Vendored.
+	return payloadLayoutVendored
+}
+
+// updateClonedCore runs the git fetch/checkout/pull refresh for a GENUINE
+// framework clone. The caller MUST have classified the payload as
+// payloadLayoutClone first -- this is the only function permitted to run
+// mutating git commands, and only because classification proved `git rev-parse
+// --show-toplevel` resolves to <core> itself (never the parent repo). (#1425)
+func updateClonedCore(w *Wizard, result *WizardResult, branch string) error {
+	w.printf("Updating deft at %s ...\n", result.DeftDir)
+
+	if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "fetch", "origin"); err != nil {
+		return fmt.Errorf("git fetch failed: %w", err)
+	}
+
+	if branch != "" {
+		w.printf("Switching to branch %s ...\n", branch)
+		if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "checkout", branch); err != nil {
+			return fmt.Errorf("git checkout %s failed: %w", branch, err)
+		}
+	}
+
+	if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "pull"); err != nil {
+		return fmt.Errorf("git pull failed: %w", err)
+	}
+
+	w.printf("Deft updated successfully.\n")
+	return nil
+}
+
+// refreshVendoredCore upgrades a vendored (no-.git) payload WITHOUT touching
+// git at all: it downloads the release tarball, extracts it out-of-place, and
+// atomically replaces <core> with a timestamped backup for rollback. This both
+// closes the safety bug (no git command ever runs against the consumer repo)
+// and makes the canonical upgrade actually WORK for webinstaller users (#1425).
+func refreshVendoredCore(w *Wizard, result *WizardResult, branch string) (*UpdateOutcome, error) {
+	outcome := &UpdateOutcome{
+		Layout:   payloadLayoutVendored,
+		Strategy: strategyFileSwap,
+		Tag:      tagFromRef(branch),
+	}
+	w.printf("Detected a vendored framework payload at %s (no .git of its own).\n", result.DeftDir)
+	w.printf("Refreshing via git-free file swap -- the installer will NOT run git against your project repo ...\n")
+
+	tarballPath, err := fetchCoreTarballFunc(branch)
+	if err != nil {
+		return outcome, fmt.Errorf("vendored refresh: could not download the release tarball for %s: %w", refLabel(branch), err)
+	}
+	defer os.Remove(tarballPath)
+
+	staging, err := os.MkdirTemp("", "deft-core-stage-*")
+	if err != nil {
+		return outcome, fmt.Errorf("vendored refresh: could not create staging dir: %w", err)
+	}
+	defer os.RemoveAll(staging)
+
+	contentRoot, err := extractCoreTarball(tarballPath, staging)
+	if err != nil {
+		return outcome, fmt.Errorf("vendored refresh: could not extract tarball: %w", err)
+	}
+	if sha := shaFromContentRoot(contentRoot); sha != "" {
+		outcome.SHA = sha
+	}
+
+	backup, err := swapInCore(result.DeftDir, contentRoot)
+	if err != nil {
+		return outcome, fmt.Errorf("vendored refresh: %w", err)
+	}
+	outcome.Backup = backup
+
+	w.printf("Vendored framework refreshed at %s (previous payload backed up at %s).\n", result.DeftDir, backup)
+	return outcome, nil
+}
+
+// downloadCoreTarball fetches the framework source tarball at ref (empty =>
+// default branch) to a temp .tar.gz and returns its path. Reuses the
+// long-lived installerDownloadClient (transport-level timeouts + generous body
+// backstop) so a slow link does not abort a healthy stream.
+func downloadCoreTarball(ref string) (string, error) {
+	url := deftTarballAPIBase
+	if ref != "" {
+		url += "/" + ref
+	}
+	resp, err := installerDownloadClient.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("GET %s: HTTP %s", url, resp.Status)
+	}
+
+	f, err := os.CreateTemp("", "deft-core-*.tar.gz")
+	if err != nil {
+		return "", fmt.Errorf("create temp tarball: %w", err)
+	}
+	tmp := f.Name()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return "", fmt.Errorf("download tarball body: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("close temp tarball: %w", err)
+	}
+	return tmp, nil
+}
+
+// extractCoreTarball extracts the gzipped tar at tarballPath into destDir and
+// returns the absolute path to the single top-level content directory the
+// GitHub tarball wraps everything in. Entries under an excluded top-level
+// component (.git / .github / node_modules) -- and any stray `.git` path
+// component anywhere -- are skipped so a vendored refresh never carries git
+// metadata (#1425). Guards against path traversal (zip-slip): any entry that
+// would escape destDir is rejected.
+func extractCoreTarball(tarballPath, destDir string) (string, error) {
+	f, err := os.Open(tarballPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	cleanDest := filepath.Clean(destDir)
+	rootName := ""
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("tar: %w", err)
+		}
+
+		name := strings.TrimPrefix(filepath.ToSlash(hdr.Name), "./")
+		if name == "" {
+			continue
+		}
+		parts := strings.Split(name, "/")
+		if rootName == "" {
+			rootName = parts[0]
+		}
+		if tarPathExcluded(parts) {
+			continue
+		}
+
+		target := filepath.Join(cleanDest, filepath.FromSlash(name))
+		// zip-slip guard: the resolved target must stay within destDir.
+		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+			return "", fmt.Errorf("tar entry escapes destination: %q", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return "", err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return "", err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fileModeFromTar(hdr.Mode))
+			if err != nil {
+				return "", err
+			}
+			if _, err := io.Copy(out, tr); err != nil { //nolint:gosec // size bounded by trusted GitHub tarball
+				out.Close()
+				return "", err
+			}
+			if err := out.Close(); err != nil {
+				return "", err
+			}
+		default:
+			// Skip symlinks / special entries: the framework tree is regular
+			// files + dirs, and skipping symlinks is an extra zip-slip defence.
+			continue
+		}
+	}
+
+	if rootName == "" {
+		return "", fmt.Errorf("empty tarball: no entries")
+	}
+	contentRoot := filepath.Join(cleanDest, rootName)
+	if info, err := os.Stat(contentRoot); err != nil || !info.IsDir() {
+		return "", fmt.Errorf("tarball content root %q missing after extract", rootName)
+	}
+	return contentRoot, nil
+}
+
+// tarPathExcluded reports whether a split tar entry path should be skipped:
+// any second-level component in the excluded set (top-level of the repo, under
+// the wrapper dir) or any `.git` component anywhere in the path.
+func tarPathExcluded(parts []string) bool {
+	if len(parts) > 1 && tarballExcludedTopLevel[parts[1]] {
+		return true
+	}
+	for _, seg := range parts[1:] {
+		if seg == ".git" {
+			return true
+		}
+	}
+	return false
+}
+
+func fileModeFromTar(mode int64) os.FileMode {
+	m := os.FileMode(mode).Perm()
+	if m == 0 {
+		m = 0o644
+	}
+	return m
+}
+
+// shaFromContentRoot extracts the framework source SHA from the GitHub tarball
+// wrapper dir name, which has the shape `<owner>-<repo>-<sha>` (e.g.
+// `deftai-directive-6136b66...`). Returns "" when the trailing component is
+// not a hex SHA.
+func shaFromContentRoot(contentRoot string) string {
+	base := filepath.Base(contentRoot)
+	idx := strings.LastIndex(base, "-")
+	if idx < 0 || idx == len(base)-1 {
+		return ""
+	}
+	sha := base[idx+1:]
+	if len(sha) < 7 || !isHex(sha) {
+		return ""
+	}
+	return sha
+}
+
+func isHex(s string) bool {
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return s != ""
+}
+
+// swapInCore atomically replaces coreDir with the freshly-extracted newTree,
+// preserving the previous payload as a timestamped backup so the operation is
+// reversible. The backup rename happens within coreDir's parent (same volume
+// => atomic); the new tree is COPIED in because newTree typically lives on the
+// temp volume and a cross-device rename would fail on Windows. On any failure
+// after the backup the backup is restored. Returns the backup path on success.
+func swapInCore(coreDir, newTree string) (string, error) {
+	parent := filepath.Dir(coreDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", err
+	}
+
+	backup := coreDir + ".bak-" + time.Now().UTC().Format("20060102-150405")
+	if _, err := os.Stat(backup); err == nil {
+		// Sub-second reruns: disambiguate so we never clobber a prior backup.
+		backup = fmt.Sprintf("%s-%d", backup, os.Getpid())
+	}
+
+	if err := os.Rename(coreDir, backup); err != nil {
+		return "", fmt.Errorf("could not back up existing payload: %w", err)
+	}
+
+	if err := copyTree(newTree, coreDir); err != nil {
+		// Roll back: discard the partial copy and restore the backup.
+		os.RemoveAll(coreDir)
+		if rerr := os.Rename(backup, coreDir); rerr != nil {
+			return "", fmt.Errorf("install new payload failed (%v); ROLLBACK ALSO FAILED (%v) -- previous payload preserved at %s", err, rerr, backup)
+		}
+		return "", fmt.Errorf("install new payload: %w", err)
+	}
+	return backup, nil
+}
+
+// copyTree recursively copies the regular files and directories under src into
+// dst (created if needed). Symlinks and special files are skipped. Directories
+// are visited before their contents (filepath.WalkDir order) so each file's
+// parent already exists by the time the shared copyFile (setup.go) runs.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			mode := os.FileMode(0o755)
+			if info, ierr := d.Info(); ierr == nil {
+				mode = info.Mode().Perm()
+			}
+			return os.MkdirAll(target, mode)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		return copyFile(path, target)
+	})
+}
+
+// tagFromRef returns ref when it looks like a semver release tag (so the
+// VERSION manifest records `tag: 'vX.Y.Z'`), else "". Reuses semverTagPattern
+// from main.go.
+func tagFromRef(ref string) string {
+	if semverTagPattern.MatchString(ref) {
+		return ref
+	}
+	return ""
+}
+
+// refLabel renders a human-friendly label for a (possibly empty) ref.
+func refLabel(ref string) string {
+	if ref == "" {
+		return "the repository default branch"
+	}
+	return ref
+}
+
+// samePath reports whether two paths refer to the same location, tolerant of
+// symlinks, separator style (git prints POSIX slashes even on Windows), and
+// Windows case-insensitivity.
+func samePath(a, b string) bool {
+	ca := canonicalPath(a)
+	cb := canonicalPath(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(ca, cb)
+	}
+	return ca == cb
+}
+
+func canonicalPath(p string) string {
+	p = filepath.FromSlash(strings.TrimSpace(p))
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
+}

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -298,12 +299,21 @@ func extractCoreTarball(tarballPath, destDir string) (string, error) {
 		if rootName == "" {
 			rootName = parts[0]
 		}
+		// zip-slip / CodeQL go/zipslip: reject any path-traversal segment on the
+		// RAW entry name before it is used in any filesystem operation. GitHub
+		// source tarballs never contain ".." segments, so this is a no-op for
+		// valid input and closes the traversal taint path at the source.
+		for _, seg := range parts {
+			if seg == ".." {
+				return "", fmt.Errorf("tar entry contains a '..' path segment: %q", hdr.Name)
+			}
+		}
 		if tarPathExcluded(parts) {
 			continue
 		}
 
 		target := filepath.Join(cleanDest, filepath.FromSlash(name))
-		// zip-slip guard: the resolved target must stay within destDir.
+		// Defense-in-depth: the resolved target must stay within destDir.
 		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
 			return "", fmt.Errorf("tar entry escapes destination: %q", hdr.Name)
 		}
@@ -322,8 +332,12 @@ func extractCoreTarball(tarballPath, destDir string) (string, error) {
 				return "", err
 			}
 			if _, err := io.Copy(out, tr); err != nil { //nolint:gosec // size bounded by trusted GitHub tarball
-				out.Close()
-				return "", err
+				// Surface (do not swallow) a close error on the copy-failure
+				// path; a failed flush can itself signal data loss.
+				if cerr := out.Close(); cerr != nil {
+					return "", fmt.Errorf("write %s: %w (also failed to close: %v)", target, err, cerr)
+				}
+				return "", fmt.Errorf("write %s: %w", target, err)
 			}
 			if err := out.Close(); err != nil {
 				return "", err
@@ -368,6 +382,13 @@ func fileModeFromTar(mode int64) os.FileMode {
 	return m
 }
 
+// pathExists reports whether p exists. Wraps the os.Stat existence-check idiom
+// so call sites read as a boolean predicate rather than a bare `err == nil`.
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
 // shaFromContentRoot extracts the framework source SHA from the GitHub tarball
 // wrapper dir name, which has the shape `<owner>-<repo>-<sha>` (e.g.
 // `deftai-directive-6136b66...`). Returns "" when the trailing component is
@@ -407,7 +428,7 @@ func swapInCore(coreDir, newTree string) (string, error) {
 	}
 
 	backup := coreDir + ".bak-" + time.Now().UTC().Format("20060102-150405")
-	if _, err := os.Stat(backup); err == nil {
+	if pathExists(backup) {
 		// Sub-second reruns: disambiguate so we never clobber a prior backup.
 		backup = fmt.Sprintf("%s-%d", backup, os.Getpid())
 	}
@@ -443,7 +464,9 @@ func copyTree(src, dst string) error {
 		target := filepath.Join(dst, rel)
 		if d.IsDir() {
 			mode := os.FileMode(0o755)
-			if info, ierr := d.Info(); ierr == nil {
+			if info, ierr := d.Info(); ierr != nil {
+				log.Printf("warning: stat dir entry %q for mode (using 0o755): %v", path, ierr)
+			} else {
 				mode = info.Mode().Perm()
 			}
 			return os.MkdirAll(target, mode)
@@ -491,8 +514,11 @@ func canonicalPath(p string) string {
 	if err != nil {
 		return filepath.Clean(p)
 	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved
+	resolved, symErr := filepath.EvalSymlinks(abs)
+	if symErr != nil {
+		// The path may not exist yet (e.g. a not-yet-created core dir) -- fall
+		// back to the lexically-cleaned absolute path. Not an error condition.
+		return filepath.Clean(abs)
 	}
-	return filepath.Clean(abs)
+	return resolved
 }

--- a/cmd/deft-install/upgrade_test.go
+++ b/cmd/deft-install/upgrade_test.go
@@ -342,3 +342,42 @@ func TestUpdateDeft_VendoredNeverMutatesParentRepo(t *testing.T) {
 		t.Errorf("vendored core not refreshed: data=%q err=%v", data, err)
 	}
 }
+
+// TestUpdateDeft_AbsentReportsCloneLayout pins the Greptile #1426 finding: an
+// --upgrade against a missing payload performs a fresh clone and MUST report
+// the POST-operation layout (clone), not the pre-clone "absent" state, so
+// --json consumers inspecting payload_layout see the resulting state.
+func TestUpdateDeft_AbsentReportsCloneLayout(t *testing.T) {
+	origRun := runCmdFunc
+	origGit := runGitCaptureFunc
+	defer func() {
+		runCmdFunc = origRun
+		runGitCaptureFunc = origGit
+	}()
+
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	core := filepath.Join(proj, ".deft", "core") // intentionally absent
+
+	// Simulate `git clone` materialising the payload dir.
+	runCmdFunc = func(out io.Writer, name string, args ...string) error {
+		if name == "git" && len(args) > 0 && args[0] == "clone" {
+			os.MkdirAll(args[len(args)-1], 0o755)
+		}
+		return nil
+	}
+	runGitCaptureFunc = func(string, ...string) (string, error) { return "abc1234", nil }
+
+	result := &WizardResult{ProjectName: "proj", ProjectDir: proj, DeftDir: core, Update: true}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, "v1.2.3")
+	if err != nil {
+		t.Fatalf("UpdateDeft (absent): %v", err)
+	}
+	if outcome.Layout != payloadLayoutClone {
+		t.Errorf("absent->clone must report layout=clone, got %q", outcome.Layout)
+	}
+	if outcome.Strategy != strategyClone {
+		t.Errorf("strategy = %q, want clone", outcome.Strategy)
+	}
+}

--- a/cmd/deft-install/upgrade_test.go
+++ b/cmd/deft-install/upgrade_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeCoreTarball writes a gzipped tar fixture mimicking the GitHub source
+// tarball shape: every entry lives under a single wrapper directory named
+// `<owner>-<repo>-<sha>`. files maps wrapper-relative paths to contents.
+// Returns the tarball path (under t.TempDir(), auto-cleaned).
+func makeCoreTarball(t *testing.T, wrapper string, files map[string]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.tar.gz")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create fixture tarball: %v", err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	// Wrapper directory entry first (matches the real tarball ordering).
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     wrapper + "/",
+		Typeflag: tar.TypeDir,
+		Mode:     0o755,
+	}); err != nil {
+		t.Fatalf("write wrapper dir header: %v", err)
+	}
+	for rel, content := range files {
+		hdr := &tar.Header{
+			Name:     wrapper + "/" + rel,
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %s: %v", rel, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("write body %s: %v", rel, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close file: %v", err)
+	}
+	return path
+}
+
+func TestClassifyPayloadLayout(t *testing.T) {
+	origGit := runGitCaptureFunc
+	defer func() { runGitCaptureFunc = origGit }()
+
+	t.Run("absent", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope", "core")
+		if got := classifyPayloadLayout(missing); got != payloadLayoutAbsent {
+			t.Errorf("got %q, want %q", got, payloadLayoutAbsent)
+		}
+	})
+
+	t.Run("vendored when not a git work tree", func(t *testing.T) {
+		dir := t.TempDir()
+		runGitCaptureFunc = func(string, ...string) (string, error) {
+			return "", fmt.Errorf("fatal: not a git repository")
+		}
+		if got := classifyPayloadLayout(dir); got != payloadLayoutVendored {
+			t.Errorf("got %q, want %q", got, payloadLayoutVendored)
+		}
+	})
+
+	t.Run("vendored when toplevel is a parent repo", func(t *testing.T) {
+		dir := t.TempDir()
+		runGitCaptureFunc = func(string, ...string) (string, error) {
+			return filepath.Dir(dir), nil // parent, not dir itself
+		}
+		if got := classifyPayloadLayout(dir); got != payloadLayoutVendored {
+			t.Errorf("got %q, want %q", got, payloadLayoutVendored)
+		}
+	})
+
+	t.Run("clone when toplevel equals deftDir", func(t *testing.T) {
+		dir := t.TempDir()
+		runGitCaptureFunc = func(string, ...string) (string, error) {
+			return dir, nil
+		}
+		if got := classifyPayloadLayout(dir); got != payloadLayoutClone {
+			t.Errorf("got %q, want %q", got, payloadLayoutClone)
+		}
+	})
+}
+
+func TestExtractCoreTarball_ExcludesGitAndExtractsTree(t *testing.T) {
+	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{
+		"SKILL.md":          "skill body",
+		"scripts/doctor.py": "print('hi')",
+		".git/config":       "[core]",   // must be excluded
+		".github/ci.yml":    "on: push", // must be excluded
+	})
+	dest := t.TempDir()
+	root, err := extractCoreTarball(tarball, dest)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if filepath.Base(root) != "deftai-directive-abc1234" {
+		t.Errorf("content root = %q, want wrapper dir", root)
+	}
+	if _, err := os.Stat(filepath.Join(root, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not extracted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "scripts", "doctor.py")); err != nil {
+		t.Errorf("nested scripts/doctor.py not extracted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".git")); !os.IsNotExist(err) {
+		t.Errorf(".git was extracted but MUST be excluded (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".github")); !os.IsNotExist(err) {
+		t.Errorf(".github was extracted but MUST be excluded (err=%v)", err)
+	}
+}
+
+func TestShaFromContentRoot(t *testing.T) {
+	cases := map[string]string{
+		"deftai-directive-6136b66abcdef": "6136b66abcdef",
+		"deftai-directive-deadbeef":      "deadbeef",
+		"no-sha-here-xyz":                "", // xyz not hex
+		"singletoken":                    "",
+	}
+	for in, want := range cases {
+		if got := shaFromContentRoot(filepath.Join("/tmp", in)); got != want {
+			t.Errorf("shaFromContentRoot(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSwapInCore_BackupAndReplace(t *testing.T) {
+	proj := t.TempDir()
+	core := filepath.Join(proj, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(core, "OLD.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newTree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(newTree, "NEW.txt"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	backup, err := swapInCore(core, newTree)
+	if err != nil {
+		t.Fatalf("swapInCore: %v", err)
+	}
+	// New content is in place; old content is gone from core.
+	if data, err := os.ReadFile(filepath.Join(core, "NEW.txt")); err != nil || string(data) != "new" {
+		t.Errorf("NEW.txt not swapped in: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(core, "OLD.txt")); !os.IsNotExist(err) {
+		t.Errorf("OLD.txt should be gone from core after swap (err=%v)", err)
+	}
+	// Backup preserves the old content.
+	if data, err := os.ReadFile(filepath.Join(backup, "OLD.txt")); err != nil || string(data) != "old" {
+		t.Errorf("backup missing OLD.txt: data=%q err=%v", data, err)
+	}
+}
+
+// TestUpdateDeft_VendoredUsesFileSwapNoGit proves the #1425 guardrail: a
+// vendored payload is refreshed via the git-free file swap and NO mutating git
+// command is ever issued through runCmdFunc.
+func TestUpdateDeft_VendoredUsesFileSwapNoGit(t *testing.T) {
+	origGit := runGitCaptureFunc
+	origFetch := fetchCoreTarballFunc
+	origRun := runCmdFunc
+	defer func() {
+		runGitCaptureFunc = origGit
+		fetchCoreTarballFunc = origFetch
+		runCmdFunc = origRun
+	}()
+
+	proj := t.TempDir()
+	core := filepath.Join(proj, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(core, "OLD.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Classification: not a git work tree -> vendored.
+	runGitCaptureFunc = func(string, ...string) (string, error) {
+		return "", fmt.Errorf("not a repo")
+	}
+	// Tarball fixture stands in for the network download.
+	tarball := makeCoreTarball(t, "deftai-directive-cafe1234", map[string]string{
+		"marker.txt":  "new",
+		".git/config": "[core]",
+	})
+	fetchCoreTarballFunc = func(ref string) (string, error) { return tarball, nil }
+
+	// Guardrail probe: record any git command. There MUST be none.
+	var gitCalls []string
+	runCmdFunc = func(out io.Writer, name string, args ...string) error {
+		if name == "git" {
+			gitCalls = append(gitCalls, strings.Join(args, " "))
+		}
+		return nil
+	}
+
+	result := &WizardResult{ProjectName: "proj", ProjectDir: proj, DeftDir: core, Update: true}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, "v9.9.9")
+	if err != nil {
+		t.Fatalf("UpdateDeft (vendored): %v", err)
+	}
+
+	if len(gitCalls) != 0 {
+		t.Errorf("vendored refresh ran git commands (safety bug): %v", gitCalls)
+	}
+	if outcome.Layout != payloadLayoutVendored {
+		t.Errorf("layout = %q, want vendored", outcome.Layout)
+	}
+	if outcome.Strategy != strategyFileSwap {
+		t.Errorf("strategy = %q, want file-swap", outcome.Strategy)
+	}
+	if outcome.SHA != "cafe1234" {
+		t.Errorf("SHA = %q, want cafe1234 (from tarball wrapper)", outcome.SHA)
+	}
+	if outcome.Tag != "v9.9.9" {
+		t.Errorf("Tag = %q, want v9.9.9", outcome.Tag)
+	}
+	if data, err := os.ReadFile(filepath.Join(core, "marker.txt")); err != nil || string(data) != "new" {
+		t.Errorf("refreshed core missing marker.txt: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(core, ".git")); !os.IsNotExist(err) {
+		t.Errorf("refreshed core MUST NOT contain .git (err=%v)", err)
+	}
+	if outcome.Backup == "" {
+		t.Error("expected a backup path on a successful swap")
+	}
+}
+
+// TestUpdateDeft_VendoredNeverMutatesParentRepo is the gold-standard #1425
+// regression test (AC2): a vendored .deft/core nested in a parent repo that
+// has a COLLIDING ref must be refreshed without the installer running any
+// mutating git command against the parent -- HEAD and tracked files stay put.
+func TestUpdateDeft_VendoredNeverMutatesParentRepo(t *testing.T) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available; skipping real-git regression test")
+	}
+
+	parent := t.TempDir()
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(gitPath, append([]string{"-C", parent}, args...)...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	runGit("init", "-q")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+	runGit("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(parent, "app.txt"), []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "app.txt")
+	runGit("commit", "-q", "-m", "initial")
+	// Colliding ref: the installer's upgrade target tag also exists in the
+	// PARENT repo. Pre-fix, `git -C .deft/core checkout v9.9.9` would have
+	// checked this out in the parent.
+	runGit("tag", "v9.9.9")
+	headBefore := runGit("rev-parse", "HEAD")
+	branchBefore := runGit("rev-parse", "--abbrev-ref", "HEAD")
+
+	// Vendored payload: .deft/core inside the parent work tree, no .git.
+	core := filepath.Join(parent, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(core, "OLD.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub only the network fetch; classification uses REAL git.
+	origFetch := fetchCoreTarballFunc
+	origRun := runCmdFunc
+	defer func() {
+		fetchCoreTarballFunc = origFetch
+		runCmdFunc = origRun
+	}()
+	tarball := makeCoreTarball(t, "deftai-directive-feed1234", map[string]string{
+		"marker.txt": "new",
+	})
+	fetchCoreTarballFunc = func(ref string) (string, error) { return tarball, nil }
+	runCmdFunc = func(out io.Writer, name string, args ...string) error {
+		if name == "git" {
+			t.Fatalf("installer ran a git command on a vendored payload: git %s", strings.Join(args, " "))
+		}
+		return nil
+	}
+
+	result := &WizardResult{ProjectName: "proj", ProjectDir: parent, DeftDir: core, Update: true}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, "v9.9.9")
+	if err != nil {
+		t.Fatalf("UpdateDeft: %v", err)
+	}
+	if outcome.Layout != payloadLayoutVendored {
+		t.Fatalf("expected vendored layout (real git), got %q", outcome.Layout)
+	}
+
+	// Parent repo must be untouched: HEAD unchanged, still on its branch,
+	// tracked file unchanged.
+	if got := runGit("rev-parse", "HEAD"); got != headBefore {
+		t.Errorf("parent HEAD moved: %s -> %s", headBefore, got)
+	}
+	if got := runGit("rev-parse", "--abbrev-ref", "HEAD"); got != branchBefore {
+		t.Errorf("parent branch changed (detached HEAD?): %s -> %s", branchBefore, got)
+	}
+	if data, err := os.ReadFile(filepath.Join(parent, "app.txt")); err != nil || string(data) != "original" {
+		t.Errorf("parent tracked file mutated: data=%q err=%v", data, err)
+	}
+	// And the refresh actually happened.
+	if data, err := os.ReadFile(filepath.Join(core, "marker.txt")); err != nil || string(data) != "new" {
+		t.Errorf("vendored core not refreshed: data=%q err=%v", data, err)
+	}
+}

--- a/vbrief/completed/2026-06-02-1425-installer-upgrade-broken-unsafe-on-vendored-installs.vbrief.json
+++ b/vbrief/completed/2026-06-02-1425-installer-upgrade-broken-unsafe-on-vendored-installs.vbrief.json
@@ -1,0 +1,44 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1425"
+  },
+  "plan": {
+    "title": "fix(installer): deft-install --upgrade safe + working on vendored (no-.git) webinstaller installs (#1425)",
+    "status": "completed",
+    "narratives": {
+      "Description": "P0/Upgrade-Blocker/Security: deft-install --upgrade is broken and unsafe on webinstaller (vendored, no-.git) installs because it runs git -C .deft/core which resolves to the parent consumer repo.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1425",
+      "Overview": "The canonical upgrade path `deft-install --yes --upgrade --repo-root .` fails and is unsafe on installs produced by the webinstaller, which vendors the directive tarball into `.deft/core/` and deliberately strips `.git/`. UpdateDeft (cmd/deft-install/setup.go) unconditionally runs `git -C <core> fetch/checkout/pull`; with no `.git` in `<core>`, git's upward discovery resolves to the PARENT consumer repository. The repro errors with a misleading `pathspec 'v0.39.0' did not match` -- but had a colliding ref existed, `git checkout` would have mutated the user's project (detached HEAD / changed tree). Fix: classify payload layout (clone|vendored|absent) before any git op, hard-guardrail so a mutating git command never runs against a repo other than the framework payload, and add a git-free file-swap refresh for vendored installs (download release tarball, atomic replace `<core>` with backup+rollback, never carry `.git/`), re-stamping VERSION with the framework source SHA from the tarball (fixes the #1323/#1324 wrong-sha class) and refreshing the AGENTS.md managed section. Emit `payload_layout` + `strategy` in --json and replace the raw git pathspec error with a classified, actionable message.",
+      "Labels": "bug, security, installer, Upgrade Blocker"
+    },
+    "items": [
+      {
+        "title": "deft-install --upgrade on a vendored (no-.git) install succeeds, refreshing .deft/core, VERSION, and AGENTS.md to the target release.",
+        "status": "proposed"
+      },
+      {
+        "title": "Installer never runs a mutating git command against a repo other than the framework payload (regression test: vendored .deft/core nested in a parent repo with a colliding v* ref).",
+        "status": "proposed"
+      },
+      {
+        "title": "--json reports payload_layout and strategy; the legacy pathspec error is replaced with a classified message.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "security",
+      "installer",
+      "Upgrade Blocker"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1425",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1425: P0/Upgrade Blocker: deft-install --upgrade is broken and unsafe on webinstaller (vendored, no-.git) installs"
+      }
+    ],
+    "updated": "2026-06-02T18:44:08Z"
+  }
+}


### PR DESCRIPTION
## Summary

`deft-install --upgrade` was broken **and unsafe** on installs produced by the **webinstaller** — a vendored `.deft/core/` payload with no `.git/` of its own. The upgrade path ran `git -C .deft/core fetch/checkout/pull`; with no `.git/` in the payload, git's upward discovery resolved to the **parent consumer repository**. The repro failed with a misleading `pathspec 'v0.39.0' did not match` error, but had a colliding ref existed, `git checkout` would have mutated the user's own project (detached HEAD / changed working tree).

This PR makes the canonical upgrade path safe and functional for vendored installs.

## Changes

- **Payload classification** (`classifyPayloadLayout`): before any git op, classify `.deft/core` as `clone | vendored | absent` via `git rev-parse --show-toplevel` realpath-compared to the payload dir.
- **Hard safety guardrail**: mutating git (`fetch`/`checkout`/`pull`) is now reachable *only* on a genuine `clone` layout. A vendored payload never runs git against the parent repo.
- **Git-free vendored refresh** (`refreshVendoredCore`): downloads the release tarball, extracts out-of-place (excluding `.git/`/`.github/`/`node_modules/`, with a zip-slip guard), and atomically replaces `<core>` with a timestamped `.bak-<ts>` backup + rollback on failure. Never carries `.git/`.
- **Correct provenance**: VERSION is re-stamped with the framework source SHA recovered from the tarball wrapper dir, fixing the wrong-sha class (#1323/#1324) on vendored installs.
- **Diagnostics**: `--json` now emits `payload_layout` and `strategy` (`git-checkout | file-swap | clone`); the raw git `pathspec` error is replaced with a classified, actionable message.
- New `cmd/deft-install/upgrade.go` module; `UpdateDeft` moved there and now returns an `UpdateOutcome` consumed by `main.go`.

## Testing

- `task check` green: **6804 passed, 3 skipped**, plus lint / mypy / encoding / branch / vBRIEF validation.
- New `cmd/deft-install/upgrade_test.go`:
  - payload classification (absent / vendored-not-repo / vendored-nested-in-parent / clone)
  - vendored refresh uses the file-swap and issues **zero** git commands (guardrail proof)
  - tarball extraction excludes `.git/` + `.github/`; SHA parsed from wrapper dir
  - `swapInCore` backup + content replacement
  - **gold regression** (real git): a vendored `.deft/core` nested in a parent repo with a **colliding `v9.9.9` tag** is refreshed without mutating the parent (HEAD, branch, and tracked files unchanged)
- Existing `TestUpdateDeft_*` updated for the new signature + clone-layout classification.

## Acceptance criteria (issue #1425)

- [x] `deft-install --upgrade` on a vendored (no-`.git`) install succeeds, refreshing `.deft/core`, VERSION, and AGENTS.md
- [x] Installer never runs a mutating git command against a repo other than the framework payload (regression test with colliding `v*` ref)
- [x] `--json` reports `payload_layout` and `strategy`; the legacy `pathspec` error is gone

## Follow-ups (out of scope here)

- `--dry-run` / `--rollback` CLI subcommands for the vendored path (backup is already written; explicit flags are a follow-up)
- Tracking-mode consent tie-in (#1050) when refreshing a *committed* vendored payload

## Related

Closes #1425. Refs #1409, #1411, #1413, #1320, #1323, #1324, #1325, #1050.

Scope vBRIEF: `vbrief/completed/2026-06-02-1425-installer-upgrade-broken-unsafe-on-vendored-installs.vbrief.json`
Conversation: https://app.warp.dev/conversation/b7cee39a-565f-45cc-869b-7f5239fef5b8
