### PR TITLE
fix(doctor): tolerant canonical-first manifest read for .deft/VERSION (#1427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **`deft-install --upgrade` on a tag clone no longer fails with detached-HEAD `git pull` (#1429)** -- migrating a clone payload to vendored runs no git command against the payload or the consumer repo, so the long-standing detached-HEAD `git pull` failure on tag clones can no longer occur. Refs #1428, #1425.
 - **Installer removes an orphaned `.deft/VERSION` on upgrade (#1427)** -- after stamping the canonical manifest at `.deft/core/VERSION`, an `--upgrade` now deletes a stale `.deft/VERSION` left by older installer rails (canonical layout only; the legacy `deft/` layout never touches the consumer's root `VERSION`). Refs #1427, #1428.
+- **`task doctor` now finds a webinstaller-vendored manifest at `.deft/VERSION` (#1427)** -- the doctor locates the install manifest canonical-first (`<install_root>/VERSION`, then `.deft/core/VERSION`, then `.deft/VERSION`, then legacy `deft/VERSION`) across the manifest-agreement, install-path-consistency, and payload-staleness checks, so a webinstaller install whose manifest sits at `.deft/VERSION` is no longer invisible to the doctor (the canonical `.deft/core/VERSION` still wins when both are present). Refs #1428.
 
 ### Removed
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -632,33 +632,38 @@ def _check_install_path_consistency(project_root: Path, install_root: str | None
     # effective install root came from (Greptile P1 on PR #1063 -- prior
     # heuristic compared values, which mislabelled when manifest and
     # AGENTS.md happened to agree).
-    # #1427: locate the manifest canonical-first via the shared helper so a
-    # webinstaller-vendored ``.deft/VERSION`` is considered too (the prior
-    # shape probed only ``.deft/core/VERSION`` and legacy ``deft/VERSION``).
-    # ``_locate_manifest`` returns the first existing manifest, so the
-    # "first manifest found wins" semantics of the old two-path loop are
-    # preserved.
-    manifest_path = _locate_manifest(project_root, install_root)
-    if manifest_path is not None:
+    # #1427: probe the manifest canonical-first via the shared candidate
+    # list so a webinstaller-vendored ``.deft/VERSION`` is considered too
+    # (the prior shape probed only ``.deft/core/VERSION`` and legacy
+    # ``deft/VERSION``). Iterate the candidate list rather than call
+    # ``_locate_manifest`` so an existing-but-unreadable manifest (OSError /
+    # permission denial -> ``_read_text_safe`` returns None) falls through
+    # to the next candidate, preserving the ``continue``-on-unreadable
+    # resilience of the original two-path loop (Greptile P2 on PR #1431).
+    # The first READABLE manifest wins, matching the prior
+    # break-on-first-found semantics.
+    for manifest_path in _manifest_candidate_paths(project_root, install_root):
         manifest_text = _read_text_safe(manifest_path)
-        if manifest_text is not None:
-            manifest = _parse_manifest(manifest_text)
-            manifest_install_root = manifest.get("install_root")
-            if isinstance(manifest_install_root, str) and manifest_install_root.strip():
-                effective_install_root = manifest_install_root.strip()
-                fallback_info_note = ""
-                source = "manifest"
-            else:
-                # Manifest found but missing the #1062 ``install_root`` field
-                # (legacy v0.28 shape, or a webinstaller ``.deft/VERSION``
-                # that omits it). Fall back to the AGENTS.md parse and note
-                # it. ``source`` stays "AGENTS.md" -- the manifest was found
-                # but did not carry the install_root field, so the effective
-                # value still came from the AGENTS.md parse.
-                fallback_info_note = (
-                    f" INFO: manifest at {manifest_path} is missing install_root; "
-                    "fell back to the legacy AGENTS.md install-root parse."
-                )
+        if manifest_text is None:
+            continue
+        manifest = _parse_manifest(manifest_text)
+        manifest_install_root = manifest.get("install_root")
+        if isinstance(manifest_install_root, str) and manifest_install_root.strip():
+            effective_install_root = manifest_install_root.strip()
+            fallback_info_note = ""
+            source = "manifest"
+            break
+        # Manifest found but missing the #1062 ``install_root`` field
+        # (legacy v0.28 shape, or a webinstaller ``.deft/VERSION`` that
+        # omits it). Fall back to the AGENTS.md parse and note it.
+        # ``source`` stays "AGENTS.md" -- the manifest was found but did not
+        # carry the install_root field, so the effective value still came
+        # from the AGENTS.md parse.
+        fallback_info_note = (
+            f" INFO: manifest at {manifest_path} is missing install_root; "
+            "fell back to the legacy AGENTS.md install-root parse."
+        )
+        break
     if effective_install_root is None:
         return CheckResult(
             name="install-path-consistency",

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -303,6 +303,62 @@ def _manifest_tag_to_version(manifest: dict) -> str | None:
     return None
 
 
+def _manifest_candidate_paths(
+    project_root: Path, install_root: str | None
+) -> list[Path]:
+    """Return the canonical-first VERSION-manifest probe order (#1427).
+
+    The install provenance manifest is written to divergent paths by two
+    install rails: the Go installer writes the documented canonical
+    ``<install_root>/VERSION`` (``.deft/core/VERSION`` per #1062), while the
+    webinstaller writes ``.deft/VERSION`` (a 5-field manifest that omits the
+    #1062 ``install_root`` field). The ordering below is **canonical-first**
+    so an existing ``.deft/core/VERSION`` always wins over a stale
+    ``.deft/VERSION``:
+
+      1. ``<install_root>/VERSION`` -- the AGENTS.md / manifest-declared
+         install root, when known (skipped when ``install_root`` is None).
+      2. ``.deft/core/VERSION``    -- the v0.27+ canonical install (#1062).
+      3. ``.deft/VERSION``         -- the webinstaller-vendored location
+         (#1427); restores detection for that population.
+      4. ``deft/VERSION``          -- the pre-v0.27 legacy install.
+
+    Duplicates are removed while preserving order so an ``install_root`` of
+    ``.deft/core`` does not probe the same path twice. Pure -- builds paths
+    only; no filesystem access.
+    """
+    raw: list[Path] = []
+    if install_root:
+        raw.append(project_root / install_root / "VERSION")
+    raw.append(project_root / ".deft" / "core" / "VERSION")
+    raw.append(project_root / ".deft" / "VERSION")
+    raw.append(project_root / "deft" / "VERSION")
+    seen: set[str] = set()
+    ordered: list[Path] = []
+    for candidate in raw:
+        key = str(candidate)
+        if key not in seen:
+            seen.add(key)
+            ordered.append(candidate)
+    return ordered
+
+
+def _locate_manifest(project_root: Path, install_root: str | None) -> Path | None:
+    """Return the first existing VERSION manifest, canonical-first (#1427).
+
+    Walks :func:`_manifest_candidate_paths` in canonical-first order and
+    returns the first candidate that exists on disk, or ``None`` when no
+    manifest is present. Centralises the manifest-location contract so
+    ``_check_manifest_agreement``, ``_check_install_path_consistency``, and
+    the #1339 payload-staleness read path all agree on where a manifest may
+    live -- including the webinstaller's ``.deft/VERSION`` location.
+    """
+    for candidate in _manifest_candidate_paths(project_root, install_root):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _is_deprecation_redirect_stub(text: str) -> bool:
     """Return True when a resolved skill file is an actual redirect stub."""
     lines = text.replace("\r\n", "\n").lstrip().splitlines()
@@ -421,20 +477,30 @@ def _check_skill_paths_resolve(project_root: Path, agents_md_text: str) -> Check
 
 
 def _check_manifest_agreement(project_root: Path, install_root: str | None) -> CheckResult:
-    """Check #3: <install>/VERSION YAML manifest agrees with <root>/.deft-version."""
-    if install_root is None:
-        return CheckResult(
-            name="manifest-agreement",
-            status="skip",
-            detail="No install root declared in AGENTS.md; cannot locate manifest.",
-        )
-    manifest_path = project_root / install_root / "VERSION"
+    """Check #3: <install>/VERSION YAML manifest agrees with <root>/.deft-version.
+
+    The manifest is located via :func:`_locate_manifest` (#1427) so a
+    webinstaller-vendored install whose manifest is at ``.deft/VERSION`` is
+    found, canonical-first. ``install_root`` may be None (the webinstaller
+    population whose manifest omits the #1062 ``install_root`` field and
+    whose AGENTS.md therefore yields no install-root claim) -- the helper
+    still probes the canonical/legacy locations, so detection no longer
+    depends on the AGENTS.md install-root parse.
+    """
+    manifest_path = _locate_manifest(project_root, install_root)
+    # Canonical-first expected location for diagnostics when no manifest is
+    # found on disk (``_manifest_candidate_paths`` always returns >= 1 entry).
+    expected_manifest_path = (
+        manifest_path
+        if manifest_path is not None
+        else _manifest_candidate_paths(project_root, install_root)[0]
+    )
     bare_candidates = [
         project_root / "vbrief" / ".deft-version",
         project_root / ".deft-version",
     ]
     bare_path: Path | None = next((p for p in bare_candidates if p.is_file()), None)
-    manifest_text = _read_text_safe(manifest_path)
+    manifest_text = _read_text_safe(manifest_path) if manifest_path else None
     bare_text = _read_text_safe(bare_path) if bare_path else None
     if manifest_text is None and bare_text is None:
         return CheckResult(
@@ -445,7 +511,7 @@ def _check_manifest_agreement(project_root: Path, install_root: str | None) -> C
                 "nothing to reconcile (greenfield install)."
             ),
             data={
-                "manifest_path": str(manifest_path),
+                "manifest_path": str(manifest_path) if manifest_path else None,
                 "bare_path": str(bare_path) if bare_path else None,
             },
         )
@@ -455,12 +521,13 @@ def _check_manifest_agreement(project_root: Path, install_root: str | None) -> C
             status="fail",
             detail=(
                 f"Bare .deft-version exists at {bare_path} but YAML manifest "
-                f"is missing at {manifest_path}. Run `task upgrade` to write "
+                f"is missing at {expected_manifest_path}. Run `task upgrade` to write "
                 "the canonical manifest (#1046 PR-B AC-4). See UPGRADING.md "
                 "for the v0.27.x -> v0.28 transition walkthrough."
             ),
             data={
-                "manifest_path": str(manifest_path),
+                "manifest_path": str(manifest_path) if manifest_path else None,
+                "expected_manifest_path": str(expected_manifest_path),
                 "bare_path": str(bare_path) if bare_path else None,
                 "bare_value": (bare_text or "").strip() if bare_text else None,
                 "suggested_fix": "task upgrade",
@@ -565,28 +632,33 @@ def _check_install_path_consistency(project_root: Path, install_root: str | None
     # effective install root came from (Greptile P1 on PR #1063 -- prior
     # heuristic compared values, which mislabelled when manifest and
     # AGENTS.md happened to agree).
-    for manifest_path in (
-        project_root / ".deft" / "core" / "VERSION",
-        project_root / "deft" / "VERSION",
-    ):
+    # #1427: locate the manifest canonical-first via the shared helper so a
+    # webinstaller-vendored ``.deft/VERSION`` is considered too (the prior
+    # shape probed only ``.deft/core/VERSION`` and legacy ``deft/VERSION``).
+    # ``_locate_manifest`` returns the first existing manifest, so the
+    # "first manifest found wins" semantics of the old two-path loop are
+    # preserved.
+    manifest_path = _locate_manifest(project_root, install_root)
+    if manifest_path is not None:
         manifest_text = _read_text_safe(manifest_path)
-        if manifest_text is None:
-            continue
-        manifest = _parse_manifest(manifest_text)
-        manifest_install_root = manifest.get("install_root")
-        if isinstance(manifest_install_root, str) and manifest_install_root.strip():
-            effective_install_root = manifest_install_root.strip()
-            fallback_info_note = ""
-            source = "manifest"
-            break
-        fallback_info_note = (
-            f" INFO: manifest at {manifest_path} is missing install_root; "
-            "fell back to the legacy AGENTS.md install-root parse."
-        )
-        # source stays "AGENTS.md" -- the manifest was found but did not
-        # carry the install_root field, so the effective value still came
-        # from the AGENTS.md parse.
-        break
+        if manifest_text is not None:
+            manifest = _parse_manifest(manifest_text)
+            manifest_install_root = manifest.get("install_root")
+            if isinstance(manifest_install_root, str) and manifest_install_root.strip():
+                effective_install_root = manifest_install_root.strip()
+                fallback_info_note = ""
+                source = "manifest"
+            else:
+                # Manifest found but missing the #1062 ``install_root`` field
+                # (legacy v0.28 shape, or a webinstaller ``.deft/VERSION``
+                # that omits it). Fall back to the AGENTS.md parse and note
+                # it. ``source`` stays "AGENTS.md" -- the manifest was found
+                # but did not carry the install_root field, so the effective
+                # value still came from the AGENTS.md parse.
+                fallback_info_note = (
+                    f" INFO: manifest at {manifest_path} is missing install_root; "
+                    "fell back to the legacy AGENTS.md install-root parse."
+                )
     if effective_install_root is None:
         return CheckResult(
             name="install-path-consistency",
@@ -1389,14 +1461,19 @@ def _run_payload_staleness_check(
     except Exception:
         pass
     if manifest_path is None:
-        for cand in [
-            project_root / ".deft" / "core" / "VERSION",
-            project_root / "deft" / "VERSION",
-            project_root / ".deft-version",  # legacy marker, not full manifest
-        ]:
-            if cand.exists():
-                manifest_path = cand
-                break
+        # #1427: probe canonical-first via the shared helper so a
+        # webinstaller-vendored ``.deft/VERSION`` manifest is found too
+        # (the prior list probed only ``.deft/core/VERSION`` and legacy
+        # ``deft/VERSION``).
+        manifest_path = _locate_manifest(project_root, None)
+    if manifest_path is None:
+        # Legacy bare marker -- not a full manifest, but the last-resort
+        # provenance source for a pre-v0.28 install. Kept out of
+        # ``_locate_manifest`` because that helper returns VERSION-manifest
+        # paths only.
+        legacy_marker = project_root / ".deft-version"
+        if legacy_marker.exists():
+            manifest_path = legacy_marker
     if manifest_path is None or not manifest_path.exists():
         emit_info(f"{check_name}: skip -- no install manifest found (pre-v0.28 or legacy state)")
         add_finding("skip", "no manifest", check=check_name, status="skip")

--- a/tests/cli/test_doctor_locate_manifest.py
+++ b/tests/cli/test_doctor_locate_manifest.py
@@ -192,6 +192,37 @@ class TestInstallPathConsistencyDeftVersion:
         assert check.data["effective_install_root"] == ".deft/core"
         assert check.data["effective_install_root_source"] == "manifest"
 
+    def test_unreadable_manifest_falls_through_to_next_candidate(
+        self, doctor_module, tmp_path, monkeypatch
+    ):
+        # An existing-but-unreadable canonical .deft/core/VERSION (OSError /
+        # permission denial -> _read_text_safe returns None) MUST NOT stop
+        # the probe; the check falls through to the next readable candidate
+        # (.deft/VERSION). Regression for the Greptile P2 on PR #1431 that
+        # restored the old two-path loop's continue-on-unreadable behavior.
+        _write(
+            tmp_path / ".deft" / "core" / "VERSION",
+            "tag: 'v0.0.1'\ninstall_root: '.deft/core'\n",
+        )
+        _write(
+            tmp_path / ".deft" / "VERSION",
+            "tag: 'v0.39.2'\ninstall_root: '.deft/legacy'\n",
+        )
+        (tmp_path / ".deft" / "legacy").mkdir(parents=True, exist_ok=True)
+        real_read = doctor_module._read_text_safe
+
+        def _fake_read(path):
+            # Simulate the canonical manifest existing but being unreadable.
+            if str(path).replace("\\", "/").endswith(".deft/core/VERSION"):
+                return None
+            return real_read(path)
+
+        monkeypatch.setattr(doctor_module, "_read_text_safe", _fake_read)
+        check = doctor_module._check_install_path_consistency(tmp_path, None)
+        assert check.status == "pass", check.detail
+        assert check.data["effective_install_root"] == ".deft/legacy"
+        assert check.data["effective_install_root_source"] == "manifest"
+
 
 # ---------------------------------------------------------------------------
 # payload-staleness (#1339) -- .deft/VERSION detection

--- a/tests/cli/test_doctor_locate_manifest.py
+++ b/tests/cli/test_doctor_locate_manifest.py
@@ -1,0 +1,268 @@
+"""tests/cli/test_doctor_locate_manifest.py -- canonical-first manifest probe (#1427).
+
+The install provenance manifest is written to divergent paths by two install
+rails: the Go installer writes the canonical ``.deft/core/VERSION`` (#1062),
+while the webinstaller writes ``.deft/VERSION`` (a 5-field manifest that omits
+the ``install_root`` field). Before #1427 the doctor only read
+``.deft/core/VERSION`` / legacy ``deft/VERSION``, so a webinstaller-vendored
+install was invisible to ``manifest-agreement``, ``install-path-consistency``,
+and the #1339 payload-staleness handoff.
+
+These tests pin:
+  * ``_manifest_candidate_paths`` / ``_locate_manifest`` canonical-first ordering
+    (``<install_root>/VERSION`` > ``.deft/core/VERSION`` > ``.deft/VERSION`` >
+    ``deft/VERSION``), de-duplication, and first-existing-wins.
+  * ``.deft/VERSION`` detection across all three read paths, AND that an
+    existing canonical ``.deft/core/VERSION`` still wins over a stale
+    ``.deft/VERSION``.
+
+The ``doctor_module`` fixture (tests/conftest.py) loads ``scripts/doctor.py``.
+Refs #1427, #1428, #1062, #1339.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(path: Path, body: str) -> None:
+    """Create parents and write ``body`` (UTF-8) to ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _manifest_candidate_paths -- pure ordering / dedup contract
+# ---------------------------------------------------------------------------
+
+
+class TestManifestCandidatePaths:
+    def test_ordering_with_install_root(self, doctor_module, tmp_path):
+        cands = doctor_module._manifest_candidate_paths(tmp_path, "custom/root")
+        assert cands == [
+            tmp_path / "custom" / "root" / "VERSION",
+            tmp_path / ".deft" / "core" / "VERSION",
+            tmp_path / ".deft" / "VERSION",
+            tmp_path / "deft" / "VERSION",
+        ]
+
+    def test_ordering_without_install_root(self, doctor_module, tmp_path):
+        cands = doctor_module._manifest_candidate_paths(tmp_path, None)
+        assert cands == [
+            tmp_path / ".deft" / "core" / "VERSION",
+            tmp_path / ".deft" / "VERSION",
+            tmp_path / "deft" / "VERSION",
+        ]
+
+    def test_dedup_when_install_root_is_canonical(self, doctor_module, tmp_path):
+        # install_root == ".deft/core" must NOT produce a duplicate
+        # .deft/core/VERSION probe entry.
+        cands = doctor_module._manifest_candidate_paths(tmp_path, ".deft/core")
+        assert cands == [
+            tmp_path / ".deft" / "core" / "VERSION",
+            tmp_path / ".deft" / "VERSION",
+            tmp_path / "deft" / "VERSION",
+        ]
+
+    def test_deft_version_precedes_legacy_deft(self, doctor_module, tmp_path):
+        # Canonical-first: .deft/VERSION (webinstaller) is probed before the
+        # pre-v0.27 legacy deft/VERSION.
+        cands = doctor_module._manifest_candidate_paths(tmp_path, None)
+        assert cands.index(tmp_path / ".deft" / "VERSION") < cands.index(
+            tmp_path / "deft" / "VERSION"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _locate_manifest -- first-existing-wins, canonical-first
+# ---------------------------------------------------------------------------
+
+
+class TestLocateManifest:
+    def test_returns_none_when_no_manifest(self, doctor_module, tmp_path):
+        assert doctor_module._locate_manifest(tmp_path, ".deft/core") is None
+
+    def test_finds_deft_version(self, doctor_module, tmp_path):
+        _write(tmp_path / ".deft" / "VERSION", "tag: v0.39.2\n")
+        assert doctor_module._locate_manifest(tmp_path, None) == (
+            tmp_path / ".deft" / "VERSION"
+        )
+
+    def test_canonical_core_wins_over_deft_version(self, doctor_module, tmp_path):
+        _write(tmp_path / ".deft" / "core" / "VERSION", "tag: v0.39.2\n")
+        _write(tmp_path / ".deft" / "VERSION", "tag: v0.0.1\n")
+        assert doctor_module._locate_manifest(tmp_path, None) == (
+            tmp_path / ".deft" / "core" / "VERSION"
+        )
+
+    def test_install_root_manifest_wins_when_present(self, doctor_module, tmp_path):
+        _write(tmp_path / "custom" / "VERSION", "tag: v0.39.2\n")
+        _write(tmp_path / ".deft" / "core" / "VERSION", "tag: v0.0.1\n")
+        assert doctor_module._locate_manifest(tmp_path, "custom") == (
+            tmp_path / "custom" / "VERSION"
+        )
+
+    def test_legacy_deft_version_is_last_resort(self, doctor_module, tmp_path):
+        _write(tmp_path / "deft" / "VERSION", "tag: v0.39.2\n")
+        assert doctor_module._locate_manifest(tmp_path, None) == (
+            tmp_path / "deft" / "VERSION"
+        )
+
+
+# ---------------------------------------------------------------------------
+# manifest-agreement (check #3) -- .deft/VERSION detection
+# ---------------------------------------------------------------------------
+
+
+class TestManifestAgreementDeftVersion:
+    def test_pass_when_deft_version_agrees_with_bare(self, doctor_module, tmp_path):
+        # Webinstaller case: manifest lives at .deft/VERSION and AGENTS.md
+        # declares no install root (install_root=None). Pre-#1427 this
+        # skipped (early install_root-None return); now it is reconciled.
+        _write(
+            tmp_path / ".deft" / "VERSION",
+            "ref: 'v0.39.2'\nsha: 'deadbeef'\ntag: 'v0.39.2'\n",
+        )
+        _write(tmp_path / ".deft-version", "0.39.2\n")
+        check = doctor_module._check_manifest_agreement(tmp_path, None)
+        assert check.status == "pass", check.detail
+        assert check.data["manifest_path"].replace("\\", "/").endswith(
+            ".deft/VERSION"
+        )
+
+    def test_fail_drift_with_deft_version(self, doctor_module, tmp_path):
+        _write(
+            tmp_path / ".deft" / "VERSION",
+            "ref: 'v0.39.2'\nsha: 'deadbeef'\ntag: 'v0.39.2'\n",
+        )
+        _write(tmp_path / ".deft-version", "0.38.0\n")
+        check = doctor_module._check_manifest_agreement(tmp_path, None)
+        assert check.status == "fail", check.detail
+        assert check.data["authoritative"] == "manifest"
+
+    def test_canonical_core_version_wins_over_stale_deft_version(
+        self, doctor_module, tmp_path
+    ):
+        # Both manifests present: the canonical .deft/core/VERSION (0.39.2)
+        # must win over a stale .deft/VERSION (0.0.1). Agreement with the
+        # bare 0.39.2 marker therefore PASSES.
+        _write(tmp_path / ".deft" / "core" / "VERSION", "tag: 'v0.39.2'\n")
+        _write(tmp_path / ".deft" / "VERSION", "tag: 'v0.0.1'\n")
+        _write(tmp_path / ".deft-version", "0.39.2\n")
+        check = doctor_module._check_manifest_agreement(tmp_path, None)
+        assert check.status == "pass", check.detail
+        assert check.data["manifest_path"].replace("\\", "/").endswith(
+            ".deft/core/VERSION"
+        )
+
+
+# ---------------------------------------------------------------------------
+# install-path-consistency (check #4) -- .deft/VERSION detection
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPathConsistencyDeftVersion:
+    def test_reads_install_root_from_deft_version(self, doctor_module, tmp_path):
+        # A webinstaller .deft/VERSION that DOES carry install_root is now
+        # consulted (pre-#1427 only .deft/core/VERSION + deft/VERSION were).
+        _write(
+            tmp_path / ".deft" / "VERSION",
+            "ref: 'v0.39.2'\ntag: 'v0.39.2'\ninstall_root: '.deft/core'\n",
+        )
+        (tmp_path / ".deft" / "core").mkdir(parents=True, exist_ok=True)
+        check = doctor_module._check_install_path_consistency(tmp_path, None)
+        assert check.status == "pass", check.detail
+        assert check.data["effective_install_root"] == ".deft/core"
+        assert check.data["effective_install_root_source"] == "manifest"
+
+    def test_canonical_core_version_wins_over_deft_version(
+        self, doctor_module, tmp_path
+    ):
+        # .deft/core/VERSION (install_root .deft/core) must win over a stale
+        # .deft/VERSION (install_root .deft/legacy).
+        _write(
+            tmp_path / ".deft" / "core" / "VERSION",
+            "tag: 'v0.39.2'\ninstall_root: '.deft/core'\n",
+        )
+        _write(
+            tmp_path / ".deft" / "VERSION",
+            "tag: 'v0.0.1'\ninstall_root: '.deft/legacy'\n",
+        )
+        check = doctor_module._check_install_path_consistency(tmp_path, None)
+        assert check.data["effective_install_root"] == ".deft/core"
+        assert check.data["effective_install_root_source"] == "manifest"
+
+
+# ---------------------------------------------------------------------------
+# payload-staleness (#1339) -- .deft/VERSION detection
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal stand-in for ``subprocess.run`` output (returncode + stdout)."""
+
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def _collect_staleness(doctor_module, project_root: Path):
+    findings: list[dict] = []
+    warnings: list[str] = []
+
+    def _add_finding(severity: str, message: str, **extras: object) -> None:
+        entry: dict[str, object] = {"severity": severity, "message": message}
+        entry.update(extras)
+        findings.append(entry)
+
+    doctor_module._run_payload_staleness_check(
+        project_root,
+        emit_warn=warnings.append,
+        emit_info=lambda _m: None,
+        add_finding=_add_finding,
+    )
+    return warnings, findings
+
+
+class TestPayloadStalenessDeftVersion:
+    def test_stale_detected_from_deft_version(
+        self, doctor_module, tmp_path, monkeypatch
+    ):
+        # Webinstaller manifest at .deft/VERSION (NOT .deft/core/VERSION).
+        _write(
+            tmp_path / ".deft" / "VERSION",
+            "sha: " + "1" * 40 + "\nref: master\ntag: v0.39.2\n",
+        )
+        # Force the "manifest next to doctor.py" probe to miss so the
+        # project-root fallback (which now includes .deft/VERSION) runs.
+        monkeypatch.setattr(
+            doctor_module, "get_script_dir", lambda: tmp_path / "no-such-scripts"
+        )
+        # Remote sha differs -> stale.
+        monkeypatch.setattr(
+            doctor_module.subprocess,
+            "run",
+            lambda *a, **k: _FakeProc("2" * 40 + "\trefs/heads/master\n"),
+        )
+        warnings, findings = _collect_staleness(doctor_module, tmp_path)
+        assert [f for f in findings if f.get("status") == "stale"], findings
+        assert any("deft-install" in w for w in warnings), warnings
+
+    def test_current_from_deft_version_emits_no_stale(
+        self, doctor_module, tmp_path, monkeypatch
+    ):
+        _write(
+            tmp_path / ".deft" / "VERSION",
+            "sha: " + "a" * 40 + "\nref: master\ntag: v0.39.2\n",
+        )
+        monkeypatch.setattr(
+            doctor_module, "get_script_dir", lambda: tmp_path / "no-such-scripts"
+        )
+        # Remote sha matches -> current, not stale.
+        monkeypatch.setattr(
+            doctor_module.subprocess,
+            "run",
+            lambda *a, **k: _FakeProc("a" * 40 + "\trefs/heads/master\n"),
+        )
+        _warnings, findings = _collect_staleness(doctor_module, tmp_path)
+        assert not [f for f in findings if f.get("status") == "stale"], findings

--- a/vbrief/active/2026-06-02-doctor-manifest-tolerant-read-issue-1427.vbrief.json
+++ b/vbrief/active/2026-06-02-doctor-manifest-tolerant-read-issue-1427.vbrief.json
@@ -1,0 +1,59 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "author": "agent-doctor",
+    "description": "Scope vBRIEF for #1427 (doctor half): make scripts/doctor.py a tolerant manifest reader via a centralized canonical-first _locate_manifest helper so webinstaller-vendored installs whose manifest is at .deft/VERSION are detected.",
+    "created": "2026-06-02T22:05:00Z",
+    "updated": "2026-06-02T22:05:00Z"
+  },
+  "plan": {
+    "title": "v0.39.2 doctor manifest tolerant-read (canonical-first _locate_manifest)",
+    "status": "running",
+    "metadata": {
+      "kind": "story",
+      "swarm": true
+    },
+    "narratives": {
+      "Problem": "The install provenance manifest is written to two different paths by two install rails. The Go installer writes the canonical <install>/VERSION (.deft/core/VERSION, #1062); the webinstaller writes .deft/VERSION (omitting install_root). scripts/doctor.py only reads .deft/core/VERSION and legacy deft/VERSION, so a webinstaller-vendored install is invisible to manifest-agreement, install-path-consistency, and the #1339 payload-staleness handoff.",
+      "Action": "Add a single centralized _locate_manifest(project_root, install_root) helper returning the first existing of (canonical-first): <install_root>/VERSION, .deft/core/VERSION, .deft/VERSION, deft/VERSION. Wire it into _check_manifest_agreement, _check_install_path_consistency, and the payload-staleness read path. Canonical-first ordering guarantees an existing .deft/core/VERSION always wins over a stale .deft/VERSION. Back-compat only: restores detection; does not synthesize the missing install_root field (that is the webinstaller fix).",
+      "Constraint": "Scope is the doctor half of #1427 only. Do NOT touch cmd/deft-install/** (the Go-upgrade orphan-removal migration is owned by the sibling agent). Add sibling tests in tests/cli/ for probe ordering and .deft/VERSION detection.",
+      "Test": "task check (ruff + mypy + pytest). New regression tests assert canonical-first probe ordering and that a .deft/VERSION-only manifest is found by all three read paths."
+    },
+    "items": [
+      {
+        "title": "Add _locate_manifest(project_root, install_root) helper with canonical-first probe ordering (<install_root>/VERSION, .deft/core/VERSION, .deft/VERSION, deft/VERSION)",
+        "status": "running"
+      },
+      {
+        "title": "Use _locate_manifest in _check_manifest_agreement (replaces install_root-only path derivation)",
+        "status": "running"
+      },
+      {
+        "title": "Use _locate_manifest in _check_install_path_consistency (replaces 2-path probe)",
+        "status": "running"
+      },
+      {
+        "title": "Use _locate_manifest in the #1339 payload-staleness read path (adds .deft/VERSION)",
+        "status": "running"
+      },
+      {
+        "title": "Add tests in tests/cli/ for probe ordering and .deft/VERSION detection",
+        "status": "running"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1427",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1427: Install manifest path divergence: doctor tolerant-read + Go-upgrade migration of .deft/VERSION -> .deft/core/VERSION"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1428",
+        "type": "x-vbrief/github-issue",
+        "title": "Umbrella #1428: vendored-done-right cohort"
+      }
+    ],
+    "created": "2026-06-02T22:05:00Z",
+    "updated": "2026-06-02T22:04:05Z"
+  }
+}

--- a/vbrief/active/2026-06-02-doctor-manifest-tolerant-read-issue-1427.vbrief.json
+++ b/vbrief/active/2026-06-02-doctor-manifest-tolerant-read-issue-1427.vbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "author": "agent-doctor",
     "description": "Scope vBRIEF for #1427 (doctor half): make scripts/doctor.py a tolerant manifest reader via a centralized canonical-first _locate_manifest helper so webinstaller-vendored installs whose manifest is at .deft/VERSION are detected.",
-    "created": "2026-06-02T22:05:00Z",
+    "created": "2026-06-02T22:00:00Z",
     "updated": "2026-06-02T22:05:00Z"
   },
   "plan": {
@@ -53,7 +53,7 @@
         "title": "Umbrella #1428: vendored-done-right cohort"
       }
     ],
-    "created": "2026-06-02T22:05:00Z",
+    "created": "2026-06-02T22:00:00Z",
     "updated": "2026-06-02T22:04:05Z"
   }
 }


### PR DESCRIPTION
## Summary

Make `scripts/doctor.py` a tolerant, canonical-first manifest reader so a webinstaller-vendored install whose provenance manifest lives at `.deft/VERSION` is detected again. This is the **doctor half** of #1427 only — the Go-installer upgrade migration (orphan removal of `.deft/VERSION`) is owned by the sibling agent and is intentionally **not** touched here (`cmd/deft-install/**` is untouched).

## Background

The install provenance manifest is written to two divergent paths by two install rails:
- **Go installer** writes the documented canonical `<install>/VERSION` → `.deft/core/VERSION` (#1062).
- **Webinstaller** writes `.deft/VERSION` (a 5-field manifest that omits the #1062 `install_root` field).

Before this change the doctor only read `.deft/core/VERSION` and the legacy `deft/VERSION`, so a webinstaller-vendored install was invisible to:
- `manifest-agreement` (check #3) — built `project_root/install_root/VERSION` only, and early-skipped when `install_root` was absent;
- `install-path-consistency` (check #4) — probed only `.deft/core/VERSION` and `deft/VERSION`;
- the #1339 payload-staleness read path.

## Changes

- New centralized helpers in `scripts/doctor.py`:
  - `_manifest_candidate_paths(project_root, install_root)` — canonical-first probe order `<install_root>/VERSION`, `.deft/core/VERSION`, `.deft/VERSION`, `deft/VERSION`, de-duplicated while preserving order.
  - `_locate_manifest(project_root, install_root)` — returns the first existing candidate, or `None`.
- Wired `_locate_manifest` into all three read paths:
  - `_check_manifest_agreement` — locates the manifest canonical-first; now finds `.deft/VERSION` even when AGENTS.md declares no install root (the webinstaller population).
  - `_check_install_path_consistency` — replaces the prior 2-path probe; source-stickiness / `fallback_info_note` / `effective_install_root_source` contracts preserved.
  - `_run_payload_staleness_check` — keeps the installed-layout `<deftDir>/VERSION` preference first, then `_locate_manifest`, then the legacy bare `.deft-version` marker.
- **Canonical-first guarantee:** an existing `.deft/core/VERSION` always wins over a stale `.deft/VERSION`.
- New tests: `tests/cli/test_doctor_locate_manifest.py` — probe ordering, dedup, first-existing-wins, canonical-first wins, and `.deft/VERSION` detection across all three read paths.

Back-compat only: this restores *detection*. It does NOT synthesize the missing `install_root` field (that is the companion `deftai/webinstaller` writer fix).

## Validation

`task check` passed: **6788 passed, 3 skipped, 9 deselected, 1 xfailed**. Existing doctor suites (`test_framework_doctor.py`, `test_install_manifest_root.py`, `test_framework_doctor_prose.py`, `test_doctor_payload_staleness.py`) remain green.

## Story Start Gate (#810)

Scope vBRIEF `vbrief/active/2026-06-02-doctor-manifest-tolerant-read-issue-1427.vbrief.json` created, promoted, activated (`plan.status=running`); `task vbrief:preflight` exits 0.

Closes #1427
Refs #1428, #1062, #1339
