### PR TITLE
feat(install): vendor framework git-free + deposit neutralization (#1429, #1430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Installer deposits the framework-payload neutralization on every install (#1430)** -- the Go installer now writes (idempotently, create-if-absent, preserving existing entries) `.gitattributes` linguist `generated`/`vendored` markers for `.deft/core/**`, a Greptile `ignorePatterns` entry in `greptile.json`, a CodeQL `paths-ignore` entry in `.github/codeql/codeql-config.yml`, and an optional `.github/workflows/deft-core-guard.yml` CI guard that fails a PR mixing `.deft/core/**` with non-framework paths. Consumers' language stats, bot reviewers, and CI now treat the vendored framework payload as packaged, machine-managed assets rather than consumer source. Closes #1430. Refs #1428.
 
 ### Changed
+- **Fresh installs vendor the framework via a git-free tarball; `--upgrade` migrates clone payloads to vendored (#1429)** -- `deft-install` no longer `git clone`s the framework on a fresh install. It downloads the release tarball at the resolved ref and extracts it into `.deft/core/` (excluding `.git`/`.github`/`node_modules`), so a fresh deposit never carries a nested `.git`. On `--upgrade`, a legacy git-clone payload is now migrated to vendored via an atomic file swap (timestamped backup, nested `.git` removed) instead of `git fetch`/`checkout`/`pull`. The `--json` `payload_layout`/`strategy` fields report `vendored` with the `vendor` or `clone-to-vendored` strategy. Closes #1429. Refs #1428.
 
 ### Fixed
+- **`deft-install --upgrade` on a tag clone no longer fails with detached-HEAD `git pull` (#1429)** -- migrating a clone payload to vendored runs no git command against the payload or the consumer repo, so the long-standing detached-HEAD `git pull` failure on tag clones can no longer occur. Refs #1428, #1425.
+- **Installer removes an orphaned `.deft/VERSION` on upgrade (#1427)** -- after stamping the canonical manifest at `.deft/core/VERSION`, an `--upgrade` now deletes a stale `.deft/VERSION` left by older installer rails (canonical layout only; the legacy `deft/` layout never touches the consumer's root `VERSION`). Refs #1427, #1428.
 
 ### Removed
 

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -105,17 +105,20 @@ func depositNeutralization(w *Wizard, projectDir string) {
 // Mirrors EnsureGitignoreLines (#1430). Returns true if the file was modified.
 func EnsureGitattributes(w *Wizard, projectDir string) (bool, error) {
 	path := filepath.Join(projectDir, ".gitattributes")
-	existing := ""
-	if data, err := os.ReadFile(path); err == nil {
-		existing = string(data)
-	} else if !errors.Is(err, os.ErrNotExist) {
+	data, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return false, fmt.Errorf("could not read .gitattributes: %w", err)
 	}
+	existing := ""
+	if err == nil {
+		existing = string(data)
+	}
 
+	// Build the set of existing lines via strings.Split (not bufio.Scanner) so
+	// an over-long line can never silently truncate the idempotency probe.
 	present := map[string]bool{}
-	scanner := bufio.NewScanner(strings.NewReader(existing))
-	for scanner.Scan() {
-		present[strings.TrimSpace(scanner.Text())] = true
+	for _, line := range strings.Split(existing, "\n") {
+		present[strings.TrimSpace(line)] = true
 	}
 
 	var additions []string
@@ -187,7 +190,7 @@ func EnsureGreptileIgnore(w *Wizard, projectDir string) (bool, error) {
 	patterns := ""
 	if raw, ok := obj["ignorePatterns"]; ok {
 		if err := json.Unmarshal(raw, &patterns); err != nil {
-			return false, fmt.Errorf("greptile.json ignorePatterns is not a newline-separated string; leaving it unchanged")
+			return false, fmt.Errorf("greptile.json ignorePatterns is not a newline-separated string (%w); leaving it unchanged", err)
 		}
 	}
 	if exists && greptilePatternPresent(patterns, coreGlob) {
@@ -200,13 +203,23 @@ func EnsureGreptileIgnore(w *Wizard, projectDir string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("could not encode ignorePatterns: %w", err)
 	}
+
+	// Preserve the consumer's original top-level key order. A Go map emits keys
+	// sorted, which would shuffle the file on first deposit and create diff
+	// noise in consumer repos.
+	orderedKeys, err := orderedTopLevelKeys(data)
+	if err != nil {
+		return false, fmt.Errorf("could not parse greptile.json key order (leaving it unchanged): %w", err)
+	}
+	if _, existed := obj["ignorePatterns"]; !existed {
+		orderedKeys = append(orderedKeys, "ignorePatterns")
+	}
 	obj["ignorePatterns"] = encoded
 
-	out, err := json.MarshalIndent(obj, "", "  ")
+	out, err := marshalObjectOrdered(obj, orderedKeys)
 	if err != nil {
 		return false, fmt.Errorf("could not encode greptile.json: %w", err)
 	}
-	out = append(out, '\n')
 	if err := os.WriteFile(path, out, 0o644); err != nil {
 		return false, fmt.Errorf("could not write greptile.json: %w", err)
 	}
@@ -239,6 +252,96 @@ func appendGreptilePattern(patterns, glob string) string {
 		return patterns + glob
 	}
 	return patterns + "\n" + glob
+}
+
+// orderedTopLevelKeys returns the top-level object keys of a JSON document in
+// document order (encoding/json maps lose order). Used so EnsureGreptileIgnore
+// rewrites greptile.json without reshuffling the consumer's existing fields.
+func orderedTopLevelKeys(data []byte) ([]string, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("expected a JSON object")
+	}
+	var keys []string
+	for dec.More() {
+		kt, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := kt.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected a string object key")
+		}
+		keys = append(keys, key)
+		if err := skipJSONValue(dec); err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
+}
+
+// skipJSONValue consumes exactly one JSON value (scalar, object, or array) from
+// dec, tracking nesting depth so nested structures are skipped whole.
+func skipJSONValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if d, ok := tok.(json.Delim); ok && (d == '{' || d == '[') {
+		depth := 1
+		for depth > 0 {
+			t, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			if dd, ok := t.(json.Delim); ok {
+				if dd == '{' || dd == '[' {
+					depth++
+				} else {
+					depth--
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// marshalObjectOrdered serialises obj as indented JSON with keys emitted in the
+// given order (keys absent from obj are skipped). Values are written verbatim
+// from their json.RawMessage, then the whole document is normalised via
+// json.Indent so indentation is consistent.
+func marshalObjectOrdered(obj map[string]json.RawMessage, keys []string) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+	for _, k := range keys {
+		v, ok := obj[k]
+		if !ok {
+			continue
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(kb)
+		buf.WriteByte(':')
+		buf.Write(v)
+	}
+	buf.WriteByte('}')
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, buf.Bytes(), "", "  "); err != nil {
+		return nil, err
+	}
+	pretty.WriteByte('\n')
+	return pretty.Bytes(), nil
 }
 
 // EnsureCodeQLPathsIgnore ensures a CodeQL config at
@@ -296,30 +399,84 @@ func codeqlConfigDefault() string {
 		"  - '" + coreGlob + "'\n"
 }
 
-// codeqlPathsIgnorePresent reports whether content already lists glob as a YAML
-// list item (quoted with either quote style, or bare).
+// codeqlPathsIgnorePresent reports whether glob is already excluded under a
+// top-level `paths-ignore:` key -- either as a YAML list item in a block or as
+// an element of an inline array (`paths-ignore: ['x', 'y']`). A match under any
+// OTHER key (e.g. CodeQL's `paths:` include list) does NOT count, so the
+// idempotency probe never skips adding the exclusion just because the glob
+// happens to appear in an unrelated section of the config.
 func codeqlPathsIgnorePresent(content, glob string) bool {
+	norm := strings.ReplaceAll(strings.ReplaceAll(content, "\r\n", "\n"), "\r", "\n")
 	candidates := []string{
 		"- '" + glob + "'",
 		"- \"" + glob + "\"",
 		"- " + glob,
 	}
-	for _, line := range strings.Split(content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		for _, c := range candidates {
-			if trimmed == c {
-				return true
+	inBlock := false
+	for _, line := range strings.Split(norm, "\n") {
+		// A top-level key (indent 0) opens or closes the paths-ignore context.
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+			trimmed := strings.TrimRight(line, " \t")
+			if trimmed == "paths-ignore:" {
+				inBlock = true
+				continue
+			}
+			if strings.HasPrefix(trimmed, "paths-ignore:") {
+				// Inline form: paths-ignore: [ ... ] on the same line.
+				rest := strings.TrimSpace(trimmed[len("paths-ignore:"):])
+				if inlineArrayHasGlob(rest, glob) {
+					return true
+				}
+				inBlock = false
+				continue
+			}
+			// Any other top-level key ends the paths-ignore block.
+			inBlock = false
+			continue
+		}
+		if inBlock {
+			t := strings.TrimSpace(line)
+			for _, c := range candidates {
+				if t == c {
+					return true
+				}
 			}
 		}
 	}
 	return false
 }
 
-// insertCodeQLPathsIgnore inserts the glob as the FIRST child of an existing
-// top-level (indent-0) `paths-ignore:` block, returning (newContent, true). When
-// no such block exists it returns (content, false) so the caller can append a
-// fresh block. Mirrors insertDeftIncludeAfterIncludesLine (setup.go): CR-LF is
-// normalised to LF for the scan and LF is written back.
+// inlineArrayHasGlob reports whether a YAML inline array literal (e.g.
+// `['dist/**', '.deft/core/**']`) contains glob as one of its elements.
+func inlineArrayHasGlob(literal, glob string) bool {
+	literal = strings.TrimSpace(literal)
+	if !strings.HasPrefix(literal, "[") || !strings.HasSuffix(literal, "]") {
+		return false
+	}
+	inner := literal[1 : len(literal)-1]
+	for _, part := range strings.Split(inner, ",") {
+		item := strings.Trim(strings.TrimSpace(part), "'\"")
+		if item == glob {
+			return true
+		}
+	}
+	return false
+}
+
+// insertCodeQLPathsIgnore adds glob to an existing top-level `paths-ignore:` key
+// without creating a duplicate key, returning (newContent, true) on success.
+// Two existing shapes are handled:
+//
+//   - Block form (`paths-ignore:` on its own line) -> insert `  - '<glob>'` as
+//     the first child.
+//   - Inline form (`paths-ignore: ['a', 'b']`) -> append `'<glob>'` to the
+//     inline array, preserving the existing entries. (A second top-level
+//     `paths-ignore:` key would shadow them under YAML last-key-wins, silently
+//     dropping the consumer's existing exclusions.)
+//
+// When no top-level `paths-ignore:` key exists it returns (content, false) so
+// the caller appends a fresh block. Mirrors insertDeftIncludeAfterIncludesLine
+// (setup.go): CR-LF is normalised to LF for the scan and LF is written back.
 func insertCodeQLPathsIgnore(content, glob string) (string, bool) {
 	norm := strings.ReplaceAll(strings.ReplaceAll(content, "\r\n", "\n"), "\r", "\n")
 	lines := strings.Split(norm, "\n")
@@ -328,12 +485,30 @@ func insertCodeQLPathsIgnore(content, glob string) (string, bool) {
 		if len(line) == 0 || line[0] == ' ' || line[0] == '\t' {
 			continue
 		}
-		if strings.TrimRight(line, " \t") == "paths-ignore:" {
+		trimmed := strings.TrimRight(line, " \t")
+		if trimmed == "paths-ignore:" {
+			// Block form -> insert as the first child of the block.
 			out := make([]string, 0, len(lines)+1)
 			out = append(out, lines[:i+1]...)
 			out = append(out, entry)
 			out = append(out, lines[i+1:]...)
 			return strings.Join(out, "\n"), true
+		}
+		if strings.HasPrefix(trimmed, "paths-ignore:") {
+			rest := strings.TrimSpace(trimmed[len("paths-ignore:"):])
+			if strings.HasPrefix(rest, "[") && strings.HasSuffix(rest, "]") {
+				// Inline array form -> append the glob into the existing array.
+				inner := strings.TrimSpace(rest[1 : len(rest)-1])
+				item := "'" + glob + "'"
+				if inner == "" {
+					lines[i] = "paths-ignore: [" + item + "]"
+				} else {
+					lines[i] = "paths-ignore: [" + inner + ", " + item + "]"
+				}
+				return strings.Join(lines, "\n"), true
+			}
+			// Unrecognised inline shape (e.g. trailing comment) -> let the
+			// caller fall back rather than risk corrupting the file.
 		}
 	}
 	return content, false

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// coreGlob is the gitignore/linguist/CodeQL-style glob that matches every file
+// under the vendored framework payload. The payload at .deft/core/ is packaged,
+// machine-managed framework code (#1428) -- not consumer source -- so the
+// neutralization deposit (#1430) tells linguist, bot reviewers, and CI to treat
+// it as such.
+const coreGlob = ".deft/core/**"
+
+// coreGitattributesLines mark the vendored payload as generated AND vendored so
+// GitHub's linguist excludes it from language statistics and collapses it in
+// diffs. Mirrors the line-based, idempotent contract of EnsureGitignoreLines.
+var coreGitattributesLines = []string{
+	coreGlob + " linguist-generated=true",
+	coreGlob + " linguist-vendored=true",
+}
+
+// codeqlConfigRelPath / coreGuardWorkflowRelPath are the POSIX-relative deposit
+// locations (converted to OS-native separators at use sites).
+const (
+	codeqlConfigRelPath      = ".github/codeql/codeql-config.yml"
+	coreGuardWorkflowRelPath = ".github/workflows/deft-core-guard.yml"
+)
+
+// coreGuardWorkflowContent is the optional CI guard deposited at
+// coreGuardWorkflowRelPath (#1430). It fails a PR that mixes changes to the
+// vendored framework payload (.deft/core/**) with changes to the consumer's own
+// files, so a framework update from deft-install/upgrade lands in its own PR and
+// reviewers can treat it as a packaged, machine-managed bump. It is deposited
+// create-if-absent and is safe for consumers to delete.
+const coreGuardWorkflowContent = `name: deft-core-guard
+
+# Deft framework guard (#1430): a single PR should not mix changes to the
+# vendored framework payload (.deft/core/**) with changes to your own project
+# files. Framework updates come from ` + "`deft-install`" + ` / upgrade and should
+# land in their own PR so reviewers (and bot reviewers) can treat them as
+# packaged, machine-managed assets. Delete this file if you do not want the guard.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  no-mixed-core-and-app:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Refuse PRs that mix .deft/core/** with non-framework paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+          core=$(printf '%s\n' "$changed" | grep -E '^\.deft/core/' || true)
+          app=$(printf '%s\n' "$changed" | grep -vE '^\.deft/core/' | grep -v '^$' || true)
+          if [ -n "$core" ] && [ -n "$app" ]; then
+            echo "::error title=deft-core guard (#1430)::This PR changes the vendored framework payload (.deft/core/**) AND non-framework files. Split the framework update into its own PR."
+            echo "--- framework (.deft/core/**) changes ---"; printf '%s\n' "$core"
+            echo "--- non-framework changes ---"; printf '%s\n' "$app"
+            exit 1
+          fi
+          echo "OK: no mixed framework + app changes."
+`
+
+// depositNeutralization performs the #1430 deposit so the vendored framework
+// payload at .deft/core/** is treated as packaged framework assets rather than
+// consumer source by linguist, the Greptile/CodeQL bot reviewers, and an
+// optional CI guard. Every step is best-effort: a deposit failure (e.g. a
+// malformed pre-existing config the installer refuses to rewrite) is logged as a
+// warning and never aborts the install, mirroring WriteInstallManifest.
+func depositNeutralization(w *Wizard, projectDir string) {
+	if _, err := EnsureGitattributes(w, projectDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not deposit .gitattributes: %v\n", err)
+	}
+	if _, err := EnsureGreptileIgnore(w, projectDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not deposit Greptile ignore: %v\n", err)
+	}
+	if _, err := EnsureCodeQLPathsIgnore(w, projectDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not deposit CodeQL paths-ignore: %v\n", err)
+	}
+	if _, err := EnsureCoreGuardWorkflow(w, projectDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not deposit CI guard workflow: %v\n", err)
+	}
+}
+
+// EnsureGitattributes appends the linguist generated/vendored markers for
+// .deft/core/** to the consumer's .gitattributes if any line is missing. The
+// file is created when absent; pre-existing lines are preserved byte-for-byte.
+// Mirrors EnsureGitignoreLines (#1430). Returns true if the file was modified.
+func EnsureGitattributes(w *Wizard, projectDir string) (bool, error) {
+	path := filepath.Join(projectDir, ".gitattributes")
+	existing := ""
+	if data, err := os.ReadFile(path); err == nil {
+		existing = string(data)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("could not read .gitattributes: %w", err)
+	}
+
+	present := map[string]bool{}
+	scanner := bufio.NewScanner(strings.NewReader(existing))
+	for scanner.Scan() {
+		present[strings.TrimSpace(scanner.Text())] = true
+	}
+
+	var additions []string
+	for _, line := range coreGitattributesLines {
+		if !present[line] {
+			additions = append(additions, line)
+		}
+	}
+	if len(additions) == 0 {
+		w.printf(".gitattributes already marks %s as generated/vendored — skipping.\n", coreGlob)
+		return false, nil
+	}
+
+	var body strings.Builder
+	body.WriteString(existing)
+	if existing != "" && !strings.HasSuffix(existing, "\n") {
+		body.WriteString("\n")
+	}
+	if existing != "" && !strings.HasSuffix(existing, "\n\n") {
+		body.WriteString("\n")
+	}
+	body.WriteString("# Deft framework: the vendored payload is packaged framework code, not\n")
+	body.WriteString("# consumer source. Mark it generated + vendored so language stats and\n")
+	body.WriteString("# diffs treat .deft/core/** as machine-managed (#1430).\n")
+	for _, add := range additions {
+		body.WriteString(add)
+		body.WriteString("\n")
+	}
+
+	if err := os.WriteFile(path, []byte(body.String()), 0o644); err != nil {
+		return false, fmt.Errorf("could not write .gitattributes: %w", err)
+	}
+	w.printf(".gitattributes updated with linguist markers: %s\n", strings.Join(additions, ", "))
+	return true, nil
+}
+
+// EnsureGreptileIgnore ensures the consumer's greptile.json ignores
+// .deft/core/** during bot review (#1430). The file is created when absent. When
+// present, only the newline-separated `ignorePatterns` string is touched --
+// every other field is preserved verbatim via json.RawMessage. If
+// `ignorePatterns` exists but is not a string (a shape the documented Greptile
+// schema does not use), the file is left unchanged and an error is returned so
+// the installer never corrupts a config it does not understand. Returns true if
+// the file was created or modified.
+func EnsureGreptileIgnore(w *Wizard, projectDir string) (bool, error) {
+	path := filepath.Join(projectDir, "greptile.json")
+	data, readErr := os.ReadFile(path)
+	exists := true
+	if readErr != nil {
+		if !errors.Is(readErr, os.ErrNotExist) {
+			return false, fmt.Errorf("could not read greptile.json: %w", readErr)
+		}
+		exists = false
+	}
+	// Treat an empty (or whitespace-only) existing file as an empty object so
+	// json.Unmarshal does not fail on a 0-byte greptile.json.
+	if !exists || strings.TrimSpace(string(data)) == "" {
+		data = []byte("{}")
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return false, fmt.Errorf("could not parse greptile.json (leaving it unchanged): %w", err)
+	}
+	if obj == nil {
+		obj = map[string]json.RawMessage{}
+	}
+
+	patterns := ""
+	if raw, ok := obj["ignorePatterns"]; ok {
+		if err := json.Unmarshal(raw, &patterns); err != nil {
+			return false, fmt.Errorf("greptile.json ignorePatterns is not a newline-separated string; leaving it unchanged")
+		}
+	}
+	if exists && greptilePatternPresent(patterns, coreGlob) {
+		w.printf("greptile.json already ignores %s — skipping.\n", coreGlob)
+		return false, nil
+	}
+
+	patterns = appendGreptilePattern(patterns, coreGlob)
+	encoded, err := json.Marshal(patterns)
+	if err != nil {
+		return false, fmt.Errorf("could not encode ignorePatterns: %w", err)
+	}
+	obj["ignorePatterns"] = encoded
+
+	out, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("could not encode greptile.json: %w", err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return false, fmt.Errorf("could not write greptile.json: %w", err)
+	}
+	if exists {
+		w.printf("greptile.json updated: bot review now ignores %s.\n", coreGlob)
+	} else {
+		w.printf("greptile.json created: bot review ignores %s.\n", coreGlob)
+	}
+	return true, nil
+}
+
+// greptilePatternPresent reports whether the newline-separated patterns string
+// already contains the glob as a standalone line.
+func greptilePatternPresent(patterns, glob string) bool {
+	for _, line := range strings.Split(patterns, "\n") {
+		if strings.TrimSpace(line) == glob {
+			return true
+		}
+	}
+	return false
+}
+
+// appendGreptilePattern appends glob to the newline-separated patterns string,
+// inserting a separating newline only when the existing value is non-empty.
+func appendGreptilePattern(patterns, glob string) string {
+	if strings.TrimSpace(patterns) == "" {
+		return glob
+	}
+	if strings.HasSuffix(patterns, "\n") {
+		return patterns + glob
+	}
+	return patterns + "\n" + glob
+}
+
+// EnsureCodeQLPathsIgnore ensures a CodeQL config at
+// .github/codeql/codeql-config.yml excludes .deft/core/** from analysis (#1430).
+// The file (and its parent dir) is created when absent. When present and the
+// glob is already excluded it is a no-op; otherwise the entry is inserted as the
+// first child of an existing top-level `paths-ignore:` block, or a fresh
+// `paths-ignore:` block is appended when none exists. Returns true if the file
+// was created or modified.
+func EnsureCodeQLPathsIgnore(w *Wizard, projectDir string) (bool, error) {
+	path := filepath.Join(projectDir, filepath.FromSlash(codeqlConfigRelPath))
+	data, readErr := os.ReadFile(path)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return false, fmt.Errorf("could not read %s: %w", codeqlConfigRelPath, readErr)
+	}
+	if errors.Is(readErr, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return false, fmt.Errorf("could not create CodeQL config dir: %w", err)
+		}
+		if err := os.WriteFile(path, []byte(codeqlConfigDefault()), 0o644); err != nil {
+			return false, fmt.Errorf("could not write %s: %w", codeqlConfigRelPath, err)
+		}
+		w.printf("%s created: CodeQL ignores %s.\n", codeqlConfigRelPath, coreGlob)
+		return true, nil
+	}
+
+	existing := string(data)
+	if codeqlPathsIgnorePresent(existing, coreGlob) {
+		w.printf("%s already ignores %s — skipping.\n", codeqlConfigRelPath, coreGlob)
+		return false, nil
+	}
+	updated, inserted := insertCodeQLPathsIgnore(existing, coreGlob)
+	if !inserted {
+		// No top-level `paths-ignore:` key -> append a fresh block.
+		if existing != "" && !strings.HasSuffix(existing, "\n") {
+			existing += "\n"
+		}
+		updated = existing + "paths-ignore:\n  - '" + coreGlob + "'\n"
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		return false, fmt.Errorf("could not write %s: %w", codeqlConfigRelPath, err)
+	}
+	w.printf("%s updated: CodeQL now ignores %s.\n", codeqlConfigRelPath, coreGlob)
+	return true, nil
+}
+
+// codeqlConfigDefault is the standalone CodeQL config deposited when none
+// exists. It carries a name (so the file is self-describing in the Actions UI)
+// and a single paths-ignore entry for the vendored payload.
+func codeqlConfigDefault() string {
+	return "# Deft framework: exclude the vendored payload from CodeQL analysis (#1430).\n" +
+		"# .deft/core/** is packaged framework code, not consumer source.\n" +
+		"name: \"CodeQL config (deft)\"\n" +
+		"paths-ignore:\n" +
+		"  - '" + coreGlob + "'\n"
+}
+
+// codeqlPathsIgnorePresent reports whether content already lists glob as a YAML
+// list item (quoted with either quote style, or bare).
+func codeqlPathsIgnorePresent(content, glob string) bool {
+	candidates := []string{
+		"- '" + glob + "'",
+		"- \"" + glob + "\"",
+		"- " + glob,
+	}
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		for _, c := range candidates {
+			if trimmed == c {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// insertCodeQLPathsIgnore inserts the glob as the FIRST child of an existing
+// top-level (indent-0) `paths-ignore:` block, returning (newContent, true). When
+// no such block exists it returns (content, false) so the caller can append a
+// fresh block. Mirrors insertDeftIncludeAfterIncludesLine (setup.go): CR-LF is
+// normalised to LF for the scan and LF is written back.
+func insertCodeQLPathsIgnore(content, glob string) (string, bool) {
+	norm := strings.ReplaceAll(strings.ReplaceAll(content, "\r\n", "\n"), "\r", "\n")
+	lines := strings.Split(norm, "\n")
+	entry := "  - '" + glob + "'"
+	for i, line := range lines {
+		if len(line) == 0 || line[0] == ' ' || line[0] == '\t' {
+			continue
+		}
+		if strings.TrimRight(line, " \t") == "paths-ignore:" {
+			out := make([]string, 0, len(lines)+1)
+			out = append(out, lines[:i+1]...)
+			out = append(out, entry)
+			out = append(out, lines[i+1:]...)
+			return strings.Join(out, "\n"), true
+		}
+	}
+	return content, false
+}
+
+// EnsureCoreGuardWorkflow deposits the optional CI guard workflow at
+// coreGuardWorkflowRelPath create-if-absent (#1430). It is never overwritten so
+// a consumer who customised or deleted it keeps their choice. Returns true if
+// the file was created.
+func EnsureCoreGuardWorkflow(w *Wizard, projectDir string) (bool, error) {
+	path := filepath.Join(projectDir, filepath.FromSlash(coreGuardWorkflowRelPath))
+	if pathExists(path) {
+		w.printf("%s already present — skipping.\n", coreGuardWorkflowRelPath)
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, fmt.Errorf("could not create workflows dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(coreGuardWorkflowContent), 0o644); err != nil {
+		return false, fmt.Errorf("could not write %s: %w", coreGuardWorkflowRelPath, err)
+	}
+	w.printf("%s created: CI refuses PRs mixing %s with app files.\n", coreGuardWorkflowRelPath, coreGlob)
+	return true, nil
+}

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newDepositWizard() *Wizard {
+	return NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+}
+
+// ---------------------------------------------------------------------------
+// EnsureGitattributes (#1430)
+// ---------------------------------------------------------------------------
+
+func TestEnsureGitattributes_CreatesNew(t *testing.T) {
+	tmp := t.TempDir()
+	changed, err := EnsureGitattributes(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true on greenfield consumer")
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".gitattributes"))
+	if err != nil {
+		t.Fatalf("missing .gitattributes: %v", err)
+	}
+	for _, want := range coreGitattributesLines {
+		if !strings.Contains(string(data), want) {
+			t.Errorf(".gitattributes missing marker %q", want)
+		}
+	}
+}
+
+func TestEnsureGitattributes_AppendsPreservesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	pre := "# consumer attrs\nvbrief/.eval/*.jsonl  merge=union\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".gitattributes"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureGitattributes(newDepositWizard(), tmp); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".gitattributes"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	// Pre-existing content MUST be preserved byte-for-byte at the start.
+	if !strings.HasPrefix(content, pre) {
+		t.Errorf(".gitattributes preamble lost; got:\n%s", content)
+	}
+	for _, want := range append([]string{"merge=union"}, coreGitattributesLines...) {
+		if !strings.Contains(content, want) {
+			t.Errorf(".gitattributes missing %q after augment", want)
+		}
+	}
+}
+
+func TestEnsureGitattributes_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	w := newDepositWizard()
+	if _, err := EnsureGitattributes(w, tmp); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureGitattributes(w, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("expected changed=false on second invocation")
+	}
+	data, _ := os.ReadFile(filepath.Join(tmp, ".gitattributes"))
+	if got := strings.Count(string(data), "linguist-generated=true"); got != 1 {
+		t.Errorf("expected exactly one linguist-generated line, got %d", got)
+	}
+	if got := strings.Count(string(data), "linguist-vendored=true"); got != 1 {
+		t.Errorf("expected exactly one linguist-vendored line, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnsureGreptileIgnore (#1430)
+// ---------------------------------------------------------------------------
+
+func TestEnsureGreptileIgnore_CreatesNew(t *testing.T) {
+	tmp := t.TempDir()
+	changed, err := EnsureGreptileIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true on greenfield consumer")
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, "greptile.json"))
+	if err != nil {
+		t.Fatalf("missing greptile.json: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("greptile.json is not valid JSON: %v", err)
+	}
+	patterns, _ := obj["ignorePatterns"].(string)
+	if !strings.Contains(patterns, coreGlob) {
+		t.Errorf("greptile.json ignorePatterns missing %q: %q", coreGlob, patterns)
+	}
+}
+
+func TestEnsureGreptileIgnore_MergesPreservingFields(t *testing.T) {
+	tmp := t.TempDir()
+	pre := `{
+  "strictness": 2,
+  "ignorePatterns": "*.md"
+}
+`
+	if err := os.WriteFile(filepath.Join(tmp, "greptile.json"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureGreptileIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true when the glob is missing")
+	}
+	data, _ := os.ReadFile(filepath.Join(tmp, "greptile.json"))
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("greptile.json no longer valid JSON: %v", err)
+	}
+	// Other fields preserved.
+	if got, ok := obj["strictness"].(float64); !ok || got != 2 {
+		t.Errorf("strictness not preserved: %v", obj["strictness"])
+	}
+	patterns, _ := obj["ignorePatterns"].(string)
+	if !strings.Contains(patterns, "*.md") {
+		t.Errorf("pre-existing ignore pattern *.md lost: %q", patterns)
+	}
+	if !strings.Contains(patterns, coreGlob) {
+		t.Errorf("ignorePatterns missing %q after merge: %q", coreGlob, patterns)
+	}
+}
+
+func TestEnsureGreptileIgnore_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	w := newDepositWizard()
+	if _, err := EnsureGreptileIgnore(w, tmp); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureGreptileIgnore(w, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("expected changed=false on second invocation")
+	}
+	data, _ := os.ReadFile(filepath.Join(tmp, "greptile.json"))
+	if got := strings.Count(string(data), coreGlob); got != 1 {
+		t.Errorf("expected exactly one %q entry, got %d", coreGlob, got)
+	}
+}
+
+func TestEnsureGreptileIgnore_RefusesNonStringPatterns(t *testing.T) {
+	tmp := t.TempDir()
+	// ignorePatterns as an array is a shape the installer must not rewrite.
+	pre := `{"ignorePatterns": ["*.md"]}`
+	if err := os.WriteFile(filepath.Join(tmp, "greptile.json"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureGreptileIgnore(newDepositWizard(), tmp)
+	if err == nil {
+		t.Error("expected an error when ignorePatterns is not a string")
+	}
+	if changed {
+		t.Error("expected changed=false when refusing to rewrite")
+	}
+	// The original file MUST be left untouched.
+	data, _ := os.ReadFile(filepath.Join(tmp, "greptile.json"))
+	if string(data) != pre {
+		t.Errorf("greptile.json was modified despite refusal: %q", string(data))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnsureCodeQLPathsIgnore (#1430)
+// ---------------------------------------------------------------------------
+
+func TestEnsureCodeQLPathsIgnore_CreatesNew(t *testing.T) {
+	tmp := t.TempDir()
+	changed, err := EnsureCodeQLPathsIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true on greenfield consumer")
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, filepath.FromSlash(codeqlConfigRelPath)))
+	if err != nil {
+		t.Fatalf("missing CodeQL config: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "paths-ignore:") {
+		t.Error("CodeQL config missing paths-ignore key")
+	}
+	if !strings.Contains(content, coreGlob) {
+		t.Errorf("CodeQL config missing %q", coreGlob)
+	}
+}
+
+func TestEnsureCodeQLPathsIgnore_InsertsIntoExisting(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, filepath.FromSlash(".github/codeql"))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pre := "name: \"app codeql\"\npaths-ignore:\n  - 'dist/**'\n"
+	path := filepath.Join(tmp, filepath.FromSlash(codeqlConfigRelPath))
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureCodeQLPathsIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true when the glob is missing")
+	}
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "dist/**") {
+		t.Errorf("pre-existing paths-ignore entry lost: %q", content)
+	}
+	if !strings.Contains(content, coreGlob) {
+		t.Errorf("CodeQL config missing %q after insert: %q", coreGlob, content)
+	}
+	// Exactly one paths-ignore: key (the entry was inserted into the existing
+	// block, not appended as a duplicate top-level key).
+	if got := strings.Count(content, "paths-ignore:"); got != 1 {
+		t.Errorf("expected a single paths-ignore block, found %d", got)
+	}
+
+	// Idempotent second pass.
+	changed2, err := EnsureCodeQLPathsIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed2 {
+		t.Error("expected changed=false on second invocation")
+	}
+	data2, _ := os.ReadFile(path)
+	if got := strings.Count(string(data2), coreGlob); got != 1 {
+		t.Errorf("expected exactly one %q entry, got %d", coreGlob, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnsureCoreGuardWorkflow (#1430)
+// ---------------------------------------------------------------------------
+
+func TestEnsureCoreGuardWorkflow_CreateIfAbsentIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	w := newDepositWizard()
+	changed, err := EnsureCoreGuardWorkflow(w, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true on first deposit")
+	}
+	path := filepath.Join(tmp, filepath.FromSlash(coreGuardWorkflowRelPath))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("missing guard workflow: %v", err)
+	}
+	if !strings.Contains(string(data), "deft-core-guard") {
+		t.Error("guard workflow missing its name")
+	}
+
+	// Customise the file, then re-run: it MUST NOT be overwritten.
+	if err := os.WriteFile(path, []byte("# customised\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed2, err := EnsureCoreGuardWorkflow(w, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed2 {
+		t.Error("expected changed=false when the workflow already exists")
+	}
+	data2, _ := os.ReadFile(path)
+	if string(data2) != "# customised\n" {
+		t.Error("guard workflow was overwritten (must be create-if-absent only)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Orphan .deft/VERSION removal (#1427)
+// ---------------------------------------------------------------------------
+
+func TestRemoveOrphanDeftVersion_CanonicalRemovesOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	deftDir := filepath.Join(tmp, ".deft", "core")
+	if err := os.MkdirAll(deftDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Canonical manifest + orphan one level up.
+	manifest := filepath.Join(deftDir, installManifestFilename)
+	orphan := filepath.Join(tmp, ".deft", installManifestFilename)
+	if err := os.WriteFile(manifest, []byte("ref: 'v1'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(orphan, []byte("ref: 'stale'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := &WizardResult{ProjectDir: tmp, DeftDir: deftDir, Update: true}
+	removeOrphanDeftVersion(newDepositWizard(), result)
+
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("orphaned .deft/VERSION should be removed (err=%v)", err)
+	}
+	if _, err := os.Stat(manifest); err != nil {
+		t.Errorf("canonical .deft/core/VERSION must be preserved: %v", err)
+	}
+}
+
+func TestRemoveOrphanDeftVersion_LegacyLayoutLeavesRootVersion(t *testing.T) {
+	tmp := t.TempDir()
+	// Legacy layout: deftDir = <project>/deft, so the parent is the project
+	// root and <project>/VERSION belongs to the CONSUMER -- it must NOT be
+	// removed.
+	deftDir := filepath.Join(tmp, "deft")
+	if err := os.MkdirAll(deftDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootVersion := filepath.Join(tmp, installManifestFilename)
+	if err := os.WriteFile(rootVersion, []byte("consumer's own VERSION\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := &WizardResult{ProjectDir: tmp, DeftDir: deftDir, Update: true, LegacyLayout: true}
+	removeOrphanDeftVersion(newDepositWizard(), result)
+
+	if _, err := os.Stat(rootVersion); err != nil {
+		t.Errorf("legacy layout MUST NOT remove the consumer's root VERSION: %v", err)
+	}
+}
+
+func TestRemoveOrphanDeftVersion_NoOpWhenAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	deftDir := filepath.Join(tmp, ".deft", "core")
+	if err := os.MkdirAll(deftDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No orphan present -> a silent no-op (must not panic or error).
+	result := &WizardResult{ProjectDir: tmp, DeftDir: deftDir, Update: true}
+	removeOrphanDeftVersion(newDepositWizard(), result)
+}

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -361,3 +361,112 @@ func TestRemoveOrphanDeftVersion_NoOpWhenAbsent(t *testing.T) {
 	result := &WizardResult{ProjectDir: tmp, DeftDir: deftDir, Update: true}
 	removeOrphanDeftVersion(newDepositWizard(), result)
 }
+
+// ---------------------------------------------------------------------------
+// Review-cycle regression fixes (#1432)
+// ---------------------------------------------------------------------------
+
+// TestEnsureGreptileIgnore_PreservesKeyOrder pins the fix for the JSON key-order
+// finding: the merge MUST keep the consumer's original top-level key order
+// rather than the alphabetical order a Go map emits (which created diff noise).
+func TestEnsureGreptileIgnore_PreservesKeyOrder(t *testing.T) {
+	tmp := t.TempDir()
+	// Keys deliberately NOT in alphabetical order; ignorePatterns absent so it
+	// is appended last.
+	pre := "{\n  \"strictness\": 2,\n  \"commentTypes\": [\"logic\"]\n}\n"
+	if err := os.WriteFile(filepath.Join(tmp, "greptile.json"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureGreptileIgnore(newDepositWizard(), tmp); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(filepath.Join(tmp, "greptile.json"))
+	content := string(data)
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("greptile.json no longer valid JSON: %v", err)
+	}
+	iStrict := strings.Index(content, "\"strictness\"")
+	iComment := strings.Index(content, "\"commentTypes\"")
+	iIgnore := strings.Index(content, "\"ignorePatterns\"")
+	if !(iStrict >= 0 && iComment > iStrict && iIgnore > iComment) {
+		t.Errorf("expected key order strictness < commentTypes < ignorePatterns; got positions %d/%d/%d in:\n%s", iStrict, iComment, iIgnore, content)
+	}
+}
+
+// TestEnsureCodeQLPathsIgnore_InlineListAppends pins the fix for the inline-YAML
+// finding: an existing INLINE paths-ignore array is appended to in place (no
+// duplicate top-level key that would shadow the consumer's existing exclusions
+// under YAML last-key-wins).
+func TestEnsureCodeQLPathsIgnore_InlineListAppends(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, filepath.FromSlash(".github/codeql")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(tmp, filepath.FromSlash(codeqlConfigRelPath))
+	pre := "name: \"app\"\npaths-ignore: ['dist/**']\n"
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureCodeQLPathsIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true when the glob is missing from the inline array")
+	}
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "dist/**") {
+		t.Errorf("pre-existing inline exclusion dropped: %q", content)
+	}
+	if !strings.Contains(content, coreGlob) {
+		t.Errorf("CodeQL config missing %q after inline append: %q", coreGlob, content)
+	}
+	if got := strings.Count(content, "paths-ignore:"); got != 1 {
+		t.Errorf("expected a single paths-ignore key (no duplicate), found %d in:\n%s", got, content)
+	}
+	// Idempotent second pass (the inline glob is now recognised as present).
+	changed2, err := EnsureCodeQLPathsIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed2 {
+		t.Error("expected changed=false on second invocation")
+	}
+}
+
+// TestEnsureCodeQLPathsIgnore_ContextBlindAddsExclusion pins the fix for the
+// context-blind presence finding: the glob appearing under an UNRELATED key
+// (CodeQL's `paths:` include) must NOT be treated as already-excluded; the
+// exclusion is still added under paths-ignore.
+func TestEnsureCodeQLPathsIgnore_ContextBlindAddsExclusion(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, filepath.FromSlash(".github/codeql")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(tmp, filepath.FromSlash(codeqlConfigRelPath))
+	// The glob is listed under `paths:` (an INCLUDE), not paths-ignore.
+	pre := "name: \"app\"\npaths:\n  - '" + coreGlob + "'\n"
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if codeqlPathsIgnorePresent(pre, coreGlob) {
+		t.Fatal("context-blind: glob under paths: must NOT count as paths-ignore presence")
+	}
+	changed, err := EnsureCodeQLPathsIgnore(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true: exclusion must be added even though glob appears under paths:")
+	}
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "paths-ignore:") {
+		t.Errorf("expected a paths-ignore block to be added; got:\n%s", content)
+	}
+	if !strings.Contains(content, "paths:\n  - '"+coreGlob+"'") {
+		t.Errorf("original paths: include was not preserved:\n%s", content)
+	}
+}

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -235,10 +235,11 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		return 1
 	}
 
-	// Phase 4: clone or update deft. UpdateDeft (#1425) classifies the on-disk
-	// payload layout and chooses a safe strategy: git fetch/checkout for a
-	// genuine clone, a git-free file swap for a vendored (no-.git) payload, or
-	// a fresh clone when the payload is absent.
+	// Phase 4: vendor or update deft. Every deposit is git-free (#1428): a fresh
+	// install vendors the release tarball (VendorDeft); an --upgrade dispatches
+	// via UpdateDeft, which migrates a git-clone payload to vendored, refreshes
+	// an existing vendored payload via file swap, or vendors a fresh copy when
+	// the payload is absent.
 	var updateOutcome *UpdateOutcome
 	if result.Update {
 		o, err := UpdateDeft(w, result, branch)
@@ -248,17 +249,19 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		}
 		updateOutcome = o
 	} else {
-		if err := CloneDeft(w, result, branch); err != nil {
+		o, err := VendorDeft(w, result, branch)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return 1
 		}
+		updateOutcome = o
 	}
 
 	// #1062: stamp the canonical YAML install manifest at <deftDir>/VERSION
-	// alongside CloneDeft / UpdateDeft so the framework records the
+	// alongside VendorDeft / UpdateDeft so the framework records the
 	// install_root field as the single source of truth for the install-
 	// layout contract. Best-effort: a failure to resolve git provenance
-	// (fresh shallow clone, git unavailable) falls back to the resolved
+	// (vendored payload, git unavailable) falls back to the resolved
 	// values from the installer binary (defaultBranch + empty SHA) so the
 	// manifest still carries install_root.
 	installFields := resolveInstallManifestFields(result, branch)
@@ -284,6 +287,14 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		// sync skill) will fall back to the AGENTS.md parse for install_root.
 	}
 
+	// #1427: on an upgrade, remove an orphaned .deft/VERSION left by older
+	// installer rails that wrote the manifest one level ABOVE .deft/core/. The
+	// canonical manifest now lives at .deft/core/VERSION (written above), so a
+	// stale .deft/VERSION would shadow it for consumers that read the parent.
+	if result.Update {
+		removeOrphanDeftVersion(w, result)
+	}
+
 	if err := WriteAgentsMD(w, result.ProjectDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
@@ -302,6 +313,14 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
 	}
+
+	// Phase 4b2 (#1430): deposit the neutralization so the vendored framework
+	// payload at .deft/core/** is treated as packaged framework assets -- not
+	// consumer source -- by linguist (language stats), bot reviewers
+	// (Greptile/CodeQL), and an optional CI guard. Best-effort: a deposit
+	// failure (e.g. a malformed pre-existing config) warns but never aborts the
+	// install, mirroring the WriteInstallManifest contract above.
+	depositNeutralization(w, result.ProjectDir)
 
 	// Phase 4c: consumer-root vbrief/ deposit (canonical contract: scope
 	// vBRIEFs live at the consumer root, not inside the framework copy).
@@ -344,7 +363,7 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		// performed -- and confirm a vendored install used the git-free swap
 		// rather than a git command against the consumer repo.
 		payloadLayout := payloadLayoutAbsent
-		strategy := strategyClone
+		strategy := strategyVendor
 		if updateOutcome != nil {
 			payloadLayout = updateOutcome.Layout
 			strategy = updateOutcome.Strategy
@@ -496,6 +515,34 @@ func resolveDeftHeadSHA(deftDir string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// removeOrphanDeftVersion deletes an orphaned <project>/.deft/VERSION left by
+// older installer rails that stamped the manifest one level ABOVE the canonical
+// .deft/core/VERSION (#1427). It runs ONLY for the canonical layout -- i.e.
+// when the framework parent dir is named ".deft" -- so the legacy `deft/`
+// layout (whose parent is the project root) can never cause the consumer's own
+// root VERSION file to be removed. Best-effort: a stat miss or non-regular
+// entry is a silent no-op; a removal error is surfaced as a warning only.
+func removeOrphanDeftVersion(w *Wizard, result *WizardResult) {
+	parent := filepath.Dir(result.DeftDir)
+	if filepath.Base(parent) != ".deft" {
+		return
+	}
+	orphan := filepath.Join(parent, installManifestFilename)
+	// Never touch the manifest the installer just wrote at .deft/core/VERSION.
+	if samePath(orphan, filepath.Join(result.DeftDir, installManifestFilename)) {
+		return
+	}
+	info, err := os.Stat(orphan)
+	if err != nil || !info.Mode().IsRegular() {
+		return
+	}
+	if err := os.Remove(orphan); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not remove orphaned %s: %v\n", orphan, err)
+		return
+	}
+	w.printf("Removed orphaned %s (the install manifest now lives at %s).\n", orphan, filepath.Join(result.DeftDir, installManifestFilename))
 }
 
 // pressEnterToExit waits for the user to press Enter before the process exits.

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -361,44 +361,8 @@ func TestEnsureGit_PostInstallReCheck(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 4 — clone and setup
+// Phase 4 — vendor and update
 // ---------------------------------------------------------------------------
-
-func TestCloneDeft_CommandArgs(t *testing.T) {
-	origRun := runCmdFunc
-	defer func() { runCmdFunc = origRun }()
-
-	var gotName string
-	var gotArgs []string
-	runCmdFunc = func(out io.Writer, name string, args ...string) error {
-		gotName = name
-		gotArgs = args
-		return nil
-	}
-
-	tmp := t.TempDir()
-	result := &WizardResult{
-		ProjectName: "myproj",
-		ProjectDir:  filepath.Join(tmp, "myproj"),
-		DeftDir:     filepath.Join(tmp, "myproj", "deft"),
-	}
-
-	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
-	if err := CloneDeft(w, result, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if gotName != "git" {
-		t.Errorf("expected command 'git', got %q", gotName)
-	}
-	if len(gotArgs) != 3 || gotArgs[0] != "clone" || gotArgs[1] != deftRepoURL || gotArgs[2] != result.DeftDir {
-		t.Errorf("unexpected args: %v", gotArgs)
-	}
-	// Project dir should have been created.
-	if _, err := os.Stat(result.ProjectDir); err != nil {
-		t.Errorf("project dir was not created: %v", err)
-	}
-}
 
 // forceCloneLayoutGit stubs runGitCaptureFunc so classifyPayloadLayout sees a
 // genuine clone (git toplevel == deftDir) and a deterministic HEAD sha. It
@@ -414,131 +378,86 @@ func forceCloneLayoutGit(deftDir string) func(string, ...string) (string, error)
 	return orig
 }
 
-func TestUpdateDeft_NoBranch(t *testing.T) {
+// TestUpdateDeft_CloneMigratesToVendored proves the #1428 behavior change: an
+// --upgrade against a genuine git-clone payload MIGRATES it to a vendored
+// (git-free) payload via file swap. NO mutating git command runs, the result
+// carries no .git, the old payload is gone, and the outcome reports the
+// post-migration vendored layout + clone-to-vendored strategy.
+func TestUpdateDeft_CloneMigratesToVendored(t *testing.T) {
 	origRun := runCmdFunc
-	defer func() { runCmdFunc = origRun }()
-
-	var cmds []string
-	runCmdFunc = func(out io.Writer, name string, args ...string) error {
-		cmds = append(cmds, name+" "+strings.Join(args, " "))
-		return nil
-	}
+	origFetch := fetchCoreTarballFunc
+	defer func() {
+		runCmdFunc = origRun
+		fetchCoreTarballFunc = origFetch
+	}()
 
 	tmp := t.TempDir()
-	deftDir := filepath.Join(tmp, "myproj", "deft")
-	os.MkdirAll(deftDir, 0o755)
+	deftDir := filepath.Join(tmp, "myproj", ".deft", "core")
+	if err := os.MkdirAll(deftDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Seed an old payload + a nested .git so we can assert both are gone after.
+	if err := os.WriteFile(filepath.Join(deftDir, "OLD.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(deftDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	origGit := forceCloneLayoutGit(deftDir)
 	defer func() { runGitCaptureFunc = origGit }()
 
-	result := &WizardResult{
-		ProjectName: "myproj",
-		ProjectDir:  filepath.Join(tmp, "myproj"),
-		DeftDir:     deftDir,
-		Update:      true,
-	}
+	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{"marker.txt": "new"})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
 
-	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
-	outcome, err := UpdateDeft(w, result, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if outcome.Layout != payloadLayoutClone {
-		t.Errorf("expected clone layout, got %q", outcome.Layout)
-	}
-	if outcome.Strategy != strategyGitCheckout {
-		t.Errorf("expected git-checkout strategy, got %q", outcome.Strategy)
-	}
-
-	// Should fetch + pull (no checkout).
-	if len(cmds) != 2 {
-		t.Fatalf("expected 2 commands, got %d: %v", len(cmds), cmds)
-	}
-	if !strings.Contains(cmds[0], "fetch origin") {
-		t.Errorf("expected fetch, got: %s", cmds[0])
-	}
-	if !strings.Contains(cmds[1], "pull") {
-		t.Errorf("expected pull, got: %s", cmds[1])
-	}
-}
-
-func TestUpdateDeft_WithBranch(t *testing.T) {
-	origRun := runCmdFunc
-	defer func() { runCmdFunc = origRun }()
-
-	var cmds []string
+	// Guardrail: record any git command. There MUST be none on the migration.
+	var gitCalls []string
 	runCmdFunc = func(out io.Writer, name string, args ...string) error {
-		cmds = append(cmds, name+" "+strings.Join(args, " "))
-		return nil
-	}
-
-	tmp := t.TempDir()
-	deftDir := filepath.Join(tmp, "myproj", "deft")
-	os.MkdirAll(deftDir, 0o755)
-	origGit := forceCloneLayoutGit(deftDir)
-	defer func() { runGitCaptureFunc = origGit }()
-
-	result := &WizardResult{
-		ProjectName: "myproj",
-		ProjectDir:  filepath.Join(tmp, "myproj"),
-		DeftDir:     deftDir,
-		Update:      true,
-	}
-
-	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
-	outcome, err := UpdateDeft(w, result, "beta")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if outcome.Layout != payloadLayoutClone {
-		t.Errorf("expected clone layout, got %q", outcome.Layout)
-	}
-
-	// Should fetch + checkout beta + pull.
-	if len(cmds) != 3 {
-		t.Fatalf("expected 3 commands, got %d: %v", len(cmds), cmds)
-	}
-	if !strings.Contains(cmds[0], "fetch origin") {
-		t.Errorf("expected fetch, got: %s", cmds[0])
-	}
-	if !strings.Contains(cmds[1], "checkout beta") {
-		t.Errorf("expected checkout beta, got: %s", cmds[1])
-	}
-	if !strings.Contains(cmds[2], "pull") {
-		t.Errorf("expected pull, got: %s", cmds[2])
-	}
-}
-
-func TestCloneDeft_WithBranch(t *testing.T) {
-	origRun := runCmdFunc
-	defer func() { runCmdFunc = origRun }()
-
-	var gotArgs []string
-	runCmdFunc = func(out io.Writer, name string, args ...string) error {
-		gotArgs = args
-		return nil
-	}
-
-	tmp := t.TempDir()
-	result := &WizardResult{
-		ProjectName: "myproj",
-		ProjectDir:  filepath.Join(tmp, "myproj"),
-		DeftDir:     filepath.Join(tmp, "myproj", "deft"),
-	}
-
-	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
-	if err := CloneDeft(w, result, "beta"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Expect: clone --branch beta <url> <dir>
-	expected := []string{"clone", "--branch", "beta", deftRepoURL, result.DeftDir}
-	if len(gotArgs) != len(expected) {
-		t.Fatalf("expected %d args, got %d: %v", len(expected), len(gotArgs), gotArgs)
-	}
-	for i, want := range expected {
-		if gotArgs[i] != want {
-			t.Errorf("arg[%d] = %q, want %q", i, gotArgs[i], want)
+		if name == "git" {
+			gitCalls = append(gitCalls, strings.Join(args, " "))
 		}
+		return nil
+	}
+
+	result := &WizardResult{
+		ProjectName: "myproj",
+		ProjectDir:  filepath.Join(tmp, "myproj"),
+		DeftDir:     deftDir,
+		Update:      true,
+	}
+
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, "v9.9.9")
+	if err != nil {
+		t.Fatalf("UpdateDeft (clone->vendored): %v", err)
+	}
+
+	if len(gitCalls) != 0 {
+		t.Errorf("migration ran git commands (safety bug): %v", gitCalls)
+	}
+	if outcome.Layout != payloadLayoutVendored {
+		t.Errorf("layout = %q, want vendored (post-migration)", outcome.Layout)
+	}
+	if outcome.Strategy != strategyMigrate {
+		t.Errorf("strategy = %q, want %q", outcome.Strategy, strategyMigrate)
+	}
+	if outcome.Tag != "v9.9.9" {
+		t.Errorf("tag = %q, want v9.9.9", outcome.Tag)
+	}
+	if outcome.SHA != "abc1234" {
+		t.Errorf("SHA = %q, want abc1234 (from tarball wrapper)", outcome.SHA)
+	}
+	if outcome.Backup == "" {
+		t.Error("expected a backup path on a successful migration")
+	}
+	if data, err := os.ReadFile(filepath.Join(deftDir, "marker.txt")); err != nil || string(data) != "new" {
+		t.Errorf("migrated core missing marker.txt: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(deftDir, "OLD.txt")); !os.IsNotExist(err) {
+		t.Errorf("old payload file should be gone after migration (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(deftDir, ".git")); !os.IsNotExist(err) {
+		t.Errorf("migrated core MUST NOT contain .git (err=%v)", err)
 	}
 }
 
@@ -820,16 +739,13 @@ func TestInstallPathConsistency_SkillPointersUseCanonicalPrefix(t *testing.T) {
 // workflow creates only AGENTS.md, .agents/, .gitignore, vbrief/, and the
 // canonical .deft/ framework parent at the project root.
 func TestInstallPathConsistency_OnlyExpectedRootFiles(t *testing.T) {
-	origRun := runCmdFunc
-	defer func() { runCmdFunc = origRun }()
+	origFetch := fetchCoreTarballFunc
+	defer func() { fetchCoreTarballFunc = origFetch }()
 
-	// Stub git clone to materialise the framework dir at result.DeftDir.
-	runCmdFunc = func(out io.Writer, name string, args ...string) error {
-		if len(args) > 0 && args[0] == "clone" {
-			os.MkdirAll(args[len(args)-1], 0o755)
-		}
-		return nil
-	}
+	// Vendor a tarball fixture into result.DeftDir (.deft/core) -- git-free, so
+	// the deposit leaves no .git and no stray root files of its own.
+	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{"SKILL.md": "skill"})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
 
 	tmp := t.TempDir()
 	projectDir := filepath.Join(tmp, "myproj")
@@ -843,7 +759,7 @@ func TestInstallPathConsistency_OnlyExpectedRootFiles(t *testing.T) {
 
 	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
 
-	if err := CloneDeft(w, result, ""); err != nil {
+	if _, err := VendorDeft(w, result, ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := WriteAgentsMD(w, result.ProjectDir); err != nil {

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -35,8 +35,6 @@ var bareSemverPattern = regexp.MustCompile(`^\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?$
 var agentsMDEntry = templates.AgentsEntry
 
 const (
-	deftRepoURL = "https://github.com/deftai/directive"
-
 	// agentsMDSentinel detects an existing deft entry in AGENTS.md for the
 	// idempotency probe in WriteAgentsMD. We use the v0.28 marker open token
 	// (the same marker the relocator and `run agents:refresh` use) because it
@@ -313,36 +311,14 @@ func WriteInstallManifest(projectDir, deftDir string, fields InstallManifestFiel
 }
 
 // ---------------------------------------------------------------------------
-// 4.1 Clone deft
+// 4.1 Framework deposit
 // ---------------------------------------------------------------------------
-
-// CloneDeft clones the deft repository into deftDir.
-// The parent directory (projectDir) is created if it does not exist.
-// If branch is non-empty the clone checks out that branch.
-func CloneDeft(w *Wizard, result *WizardResult, branch string) error {
-	// Ensure the project directory exists.
-	if err := os.MkdirAll(result.ProjectDir, 0o755); err != nil {
-		return fmt.Errorf("could not create project directory: %w", err)
-	}
-
-	args := []string{"clone"}
-	if branch != "" {
-		args = append(args, "--branch", branch)
-		w.printf("Cloning deft (branch %s) into %s ...\n", branch, result.DeftDir)
-	} else {
-		w.printf("Cloning deft into %s ...\n", result.DeftDir)
-	}
-	args = append(args, deftRepoURL, result.DeftDir)
-
-	if err := runCmdFunc(w.out, "git", args...); err != nil {
-		w.printf("\nClone failed. Please check your internet connection and try again.\n")
-		return fmt.Errorf("git clone failed: %w", err)
-	}
-	return nil
-}
-
-// UpdateDeft and its payload-classification + vendored file-swap helpers live
-// in upgrade.go (#1425).
+//
+// The framework deposit is git-free (#1428): VendorDeft (fresh tarball vendor
+// install), UpdateDeft (upgrade dispatch), migrateCloneToVendored,
+// refreshVendoredCore, and the payload-layout classification helpers all live
+// in upgrade.go (#1425, #1428). The neutralization deposit (.gitattributes,
+// Greptile/CodeQL bot-ignore, CI guard) lives in deposit.go (#1430).
 
 // ---------------------------------------------------------------------------
 // 4.2 Write AGENTS.md

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -27,11 +27,14 @@ const (
 	payloadLayoutAbsent   = "absent"
 )
 
-// Upgrade strategies surfaced in --json diagnostics (#1425).
+// Install/upgrade strategies surfaced in --json diagnostics. Every payload the
+// installer deposits is now git-free (#1428 "vendored-done-right"): a fresh
+// install vendors a tarball, an existing vendored payload is refreshed via file
+// swap, and a legacy git-clone payload is migrated to vendored.
 const (
-	strategyGitCheckout = "git-checkout"
-	strategyFileSwap    = "file-swap"
-	strategyClone       = "clone"
+	strategyFileSwap = "file-swap"
+	strategyVendor   = "vendor"
+	strategyMigrate  = "clone-to-vendored"
 )
 
 // deftTarballAPIBase is the GitHub tarball endpoint for the framework repo.
@@ -59,7 +62,7 @@ var tarballExcludedTopLevel = map[string]bool{
 // the parent consumer repo's HEAD (the #1323/#1324 wrong-sha class).
 type UpdateOutcome struct {
 	Layout   string // clone | vendored | absent
-	Strategy string // git-checkout | file-swap | clone
+	Strategy string // file-swap | vendor | clone-to-vendored
 	SHA      string // framework source SHA (best-effort)
 	Tag      string // resolved release tag, when the ref looked like semver
 	Backup   string // path to the pre-swap backup of <core>, when a swap ran
@@ -67,9 +70,10 @@ type UpdateOutcome struct {
 
 // runGitCaptureFunc runs `git -C dir args...` and returns trimmed stdout.
 // Indirected through a var so tests can stub git without a real repo. ONLY
-// read-only git subcommands are ever routed through this helper -- mutating
-// git is confined to updateClonedCore, which runs exclusively on the "clone"
-// layout (#1425 safety guardrail).
+// read-only git subcommands are ever routed through this helper (it is used
+// solely by classifyPayloadLayout to read `git rev-parse --show-toplevel`).
+// No installer code path runs a mutating git command against the payload or
+// the parent consumer repo (#1428 safety guardrail).
 var runGitCaptureFunc = func(dir string, args ...string) (string, error) {
 	full := append([]string{"-C", dir}, args...)
 	out, err := exec.Command("git", full...).Output()
@@ -86,47 +90,27 @@ var fetchCoreTarballFunc = downloadCoreTarball
 
 // UpdateDeft refreshes an existing framework deposit. It classifies the
 // on-disk payload layout FIRST and dispatches to the only safe strategy for
-// that layout (#1425):
+// that layout. Every strategy is now git-free against the consumer repo (#1428
+// "vendored-done-right"):
 //
-//   - clone    -> git fetch/checkout/pull (the only path allowed to run
-//     mutating git, and only because classification proved `git rev-parse
-//     --show-toplevel` resolves to <core> itself).
+//   - clone    -> migrate to vendored (download tarball, atomic swap, drop the
+//     nested .git). This removes the #1425 mutating-git surface and fixes the
+//     detached-HEAD `git pull` failure on tag clones.
 //   - vendored -> git-free file swap (download tarball, atomic replace).
-//   - absent   -> fresh clone (treat --upgrade on a missing payload as install).
+//   - absent   -> fresh git-free vendor (treat --upgrade on a missing payload
+//     as a vendor install).
 //
-// The hard guardrail is structural: a mutating git command can only be reached
-// through updateClonedCore, which is only called from the clone branch.
+// The hard guardrail is structural: no branch runs a mutating git command
+// against the payload or the parent consumer repo.
 func UpdateDeft(w *Wizard, result *WizardResult, branch string) (*UpdateOutcome, error) {
-	layout := classifyPayloadLayout(result.DeftDir)
-	switch layout {
+	switch classifyPayloadLayout(result.DeftDir) {
 	case payloadLayoutClone:
-		if err := updateClonedCore(w, result, branch); err != nil {
-			return &UpdateOutcome{Layout: layout, Strategy: strategyGitCheckout}, err
-		}
-		sha, _ := runGitCaptureFunc(result.DeftDir, "rev-parse", "HEAD")
-		return &UpdateOutcome{
-			Layout:   layout,
-			Strategy: strategyGitCheckout,
-			SHA:      sha,
-			Tag:      tagFromRef(branch),
-		}, nil
+		return migrateCloneToVendored(w, result, branch)
 	case payloadLayoutVendored:
 		return refreshVendoredCore(w, result, branch)
-	default: // absent -- treat --upgrade on a missing payload as a fresh clone.
-		w.printf("No framework payload found at %s; cloning a fresh copy ...\n", result.DeftDir)
-		if err := CloneDeft(w, result, branch); err != nil {
-			return &UpdateOutcome{Layout: layout, Strategy: strategyClone}, err
-		}
-		sha, _ := runGitCaptureFunc(result.DeftDir, "rev-parse", "HEAD")
-		// Report the POST-operation layout: a fresh clone now exists, so the
-		// payload is a clone (not absent). Consumers inspecting payload_layout
-		// in --json must see the resulting state, not the pre-clone state.
-		return &UpdateOutcome{
-			Layout:   payloadLayoutClone,
-			Strategy: strategyClone,
-			SHA:      sha,
-			Tag:      tagFromRef(branch),
-		}, nil
+	default: // absent -- treat --upgrade on a missing payload as a fresh vendor.
+		w.printf("No framework payload found at %s; vendoring a fresh copy ...\n", result.DeftDir)
+		return VendorDeft(w, result, branch)
 	}
 }
 
@@ -155,31 +139,103 @@ func classifyPayloadLayout(deftDir string) string {
 	return payloadLayoutVendored
 }
 
-// updateClonedCore runs the git fetch/checkout/pull refresh for a GENUINE
-// framework clone. The caller MUST have classified the payload as
-// payloadLayoutClone first -- this is the only function permitted to run
-// mutating git commands, and only because classification proved `git rev-parse
-// --show-toplevel` resolves to <core> itself (never the parent repo). (#1425)
-func updateClonedCore(w *Wizard, result *WizardResult, branch string) error {
-	w.printf("Updating deft at %s ...\n", result.DeftDir)
+// VendorDeft performs a fresh, git-free vendor install of the framework: it
+// downloads the release tarball at ref, extracts it (excluding
+// .git/.github/node_modules), and deposits the tree at <core> with NO git
+// metadata of its own (#1428). This replaces the historical `git clone`
+// install so a fresh deposit can never (a) leave a nested .deft/core/.git that
+// re-introduces the #1425 mutating-git surface, nor (b) hit the detached-HEAD
+// `git pull` failure a tag clone produces on the next upgrade.
+//
+// On a greenfield project <core> does not exist yet, so the extracted tree is
+// copied straight in. If a stray payload is already present it is swapped in
+// with a timestamped backup for safety/idempotency. The framework source SHA
+// recovered from the tarball wrapper is reported so the caller can stamp true
+// framework provenance into the VERSION manifest (the #1323/#1324 wrong-sha
+// class).
+func VendorDeft(w *Wizard, result *WizardResult, branch string) (*UpdateOutcome, error) {
+	outcome := &UpdateOutcome{
+		Layout:   payloadLayoutVendored,
+		Strategy: strategyVendor,
+		Tag:      tagFromRef(branch),
+	}
+	if err := os.MkdirAll(result.ProjectDir, 0o755); err != nil {
+		return outcome, fmt.Errorf("vendor install: could not create project directory: %w", err)
+	}
+	w.printf("Vendoring deft into %s (git-free tarball install) ...\n", result.DeftDir)
 
-	if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "fetch", "origin"); err != nil {
-		return fmt.Errorf("git fetch failed: %w", err)
+	contentRoot, sha, cleanup, err := downloadAndExtractCore(branch)
+	if err != nil {
+		return outcome, fmt.Errorf("vendor install: %w", err)
+	}
+	defer cleanup()
+	if sha != "" {
+		outcome.SHA = sha
 	}
 
-	if branch != "" {
-		w.printf("Switching to branch %s ...\n", branch)
-		if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "checkout", branch); err != nil {
-			return fmt.Errorf("git checkout %s failed: %w", branch, err)
+	if pathExists(result.DeftDir) {
+		// A previous payload is present (re-run / stray dir): swap it out with a
+		// timestamped backup rather than merging the new tree into the old one.
+		backup, swErr := swapInCore(result.DeftDir, contentRoot)
+		if swErr != nil {
+			return outcome, fmt.Errorf("vendor install: %w", swErr)
+		}
+		outcome.Backup = backup
+	} else {
+		if err := os.MkdirAll(filepath.Dir(result.DeftDir), 0o755); err != nil {
+			return outcome, fmt.Errorf("vendor install: could not create framework parent dir: %w", err)
+		}
+		if err := copyTree(contentRoot, result.DeftDir); err != nil {
+			return outcome, fmt.Errorf("vendor install: %w", err)
 		}
 	}
 
-	if err := runCmdFunc(w.out, "git", "-C", result.DeftDir, "pull"); err != nil {
-		return fmt.Errorf("git pull failed: %w", err)
+	w.printf("Deft vendored at %s.\n", result.DeftDir)
+	return outcome, nil
+}
+
+// migrateCloneToVendored converts a legacy git-clone payload into a vendored
+// (git-free) payload WITHOUT running any git command (#1428). It downloads the
+// release tarball, atomically swaps it in over <core> with a timestamped
+// backup of the old clone, then removes any nested .git so the next --upgrade
+// classifies the payload as vendored (not clone). This fixes the live
+// detached-HEAD `git pull` failure on tag clones the previous git
+// fetch/checkout/pull path hit, and removes the #1425 mutating-git surface.
+func migrateCloneToVendored(w *Wizard, result *WizardResult, branch string) (*UpdateOutcome, error) {
+	outcome := &UpdateOutcome{
+		Layout:   payloadLayoutVendored, // POST-migration layout (#1426 report-resulting-state precedent)
+		Strategy: strategyMigrate,
+		Tag:      tagFromRef(branch),
+	}
+	w.printf("Detected a git-clone framework payload at %s; migrating to a vendored (git-free) payload ...\n", result.DeftDir)
+
+	contentRoot, sha, cleanup, err := downloadAndExtractCore(branch)
+	if err != nil {
+		return outcome, fmt.Errorf("clone->vendored migration: %w", err)
+	}
+	defer cleanup()
+	if sha != "" {
+		outcome.SHA = sha
 	}
 
-	w.printf("Deft updated successfully.\n")
-	return nil
+	backup, err := swapInCore(result.DeftDir, contentRoot)
+	if err != nil {
+		return outcome, fmt.Errorf("clone->vendored migration: %w", err)
+	}
+	outcome.Backup = backup
+
+	// Defensive: extractCoreTarball already excludes .git, so the swapped-in
+	// tree carries none -- but a nested .deft/core/.git left by any other rail
+	// would re-trigger the clone classification (and the #1425 safety bug) on
+	// the next run, so remove it explicitly.
+	if gitDir := filepath.Join(result.DeftDir, ".git"); pathExists(gitDir) {
+		if rmErr := os.RemoveAll(gitDir); rmErr != nil {
+			w.printf("warning: migrated payload but could not remove nested .git at %s: %v\n", gitDir, rmErr)
+		}
+	}
+
+	w.printf("Framework payload migrated to vendored at %s (previous clone backed up at %s).\n", result.DeftDir, backup)
+	return outcome, nil
 }
 
 // refreshVendoredCore upgrades a vendored (no-.git) payload WITHOUT touching
@@ -196,23 +252,12 @@ func refreshVendoredCore(w *Wizard, result *WizardResult, branch string) (*Updat
 	w.printf("Detected a vendored framework payload at %s (no .git of its own).\n", result.DeftDir)
 	w.printf("Refreshing via git-free file swap -- the installer will NOT run git against your project repo ...\n")
 
-	tarballPath, err := fetchCoreTarballFunc(branch)
+	contentRoot, sha, cleanup, err := downloadAndExtractCore(branch)
 	if err != nil {
-		return outcome, fmt.Errorf("vendored refresh: could not download the release tarball for %s: %w", refLabel(branch), err)
+		return outcome, fmt.Errorf("vendored refresh: %w", err)
 	}
-	defer os.Remove(tarballPath)
-
-	staging, err := os.MkdirTemp("", "deft-core-stage-*")
-	if err != nil {
-		return outcome, fmt.Errorf("vendored refresh: could not create staging dir: %w", err)
-	}
-	defer os.RemoveAll(staging)
-
-	contentRoot, err := extractCoreTarball(tarballPath, staging)
-	if err != nil {
-		return outcome, fmt.Errorf("vendored refresh: could not extract tarball: %w", err)
-	}
-	if sha := shaFromContentRoot(contentRoot); sha != "" {
+	defer cleanup()
+	if sha != "" {
 		outcome.SHA = sha
 	}
 
@@ -224,6 +269,35 @@ func refreshVendoredCore(w *Wizard, result *WizardResult, branch string) (*Updat
 
 	w.printf("Vendored framework refreshed at %s (previous payload backed up at %s).\n", result.DeftDir, backup)
 	return outcome, nil
+}
+
+// downloadAndExtractCore downloads the framework source tarball at ref (empty
+// => default branch) and extracts it into a fresh temp staging dir, returning
+// the extracted content root, the framework source SHA recovered from the
+// tarball wrapper (best-effort, may be ""), and a cleanup func the caller MUST
+// defer to remove the tarball + staging dir. On error the cleanup has already
+// run and a no-op func is returned so callers can defer unconditionally.
+func downloadAndExtractCore(ref string) (contentRoot, sha string, cleanup func(), err error) {
+	noop := func() {}
+	tarballPath, err := fetchCoreTarballFunc(ref)
+	if err != nil {
+		return "", "", noop, fmt.Errorf("could not download the release tarball for %s: %w", refLabel(ref), err)
+	}
+	staging, err := os.MkdirTemp("", "deft-core-stage-*")
+	if err != nil {
+		os.Remove(tarballPath)
+		return "", "", noop, fmt.Errorf("could not create staging dir: %w", err)
+	}
+	cleanup = func() {
+		os.Remove(tarballPath)
+		os.RemoveAll(staging)
+	}
+	root, err := extractCoreTarball(tarballPath, staging)
+	if err != nil {
+		cleanup()
+		return "", "", noop, fmt.Errorf("could not extract tarball: %w", err)
+	}
+	return root, shaFromContentRoot(root), cleanup, nil
 }
 
 // downloadCoreTarball fetches the framework source tarball at ref (empty =>

--- a/cmd/deft-install/upgrade_test.go
+++ b/cmd/deft-install/upgrade_test.go
@@ -343,30 +343,35 @@ func TestUpdateDeft_VendoredNeverMutatesParentRepo(t *testing.T) {
 	}
 }
 
-// TestUpdateDeft_AbsentReportsCloneLayout pins the Greptile #1426 finding: an
-// --upgrade against a missing payload performs a fresh clone and MUST report
-// the POST-operation layout (clone), not the pre-clone "absent" state, so
-// --json consumers inspecting payload_layout see the resulting state.
-func TestUpdateDeft_AbsentReportsCloneLayout(t *testing.T) {
+// TestUpdateDeft_AbsentVendorsFreshCopy pins the #1428 behavior: an --upgrade
+// against a MISSING payload performs a git-free vendor install (not a clone)
+// and reports the post-operation vendored layout + vendor strategy.
+func TestUpdateDeft_AbsentVendorsFreshCopy(t *testing.T) {
 	origRun := runCmdFunc
 	origGit := runGitCaptureFunc
+	origFetch := fetchCoreTarballFunc
 	defer func() {
 		runCmdFunc = origRun
 		runGitCaptureFunc = origGit
+		fetchCoreTarballFunc = origFetch
 	}()
 
 	tmp := t.TempDir()
 	proj := filepath.Join(tmp, "proj")
 	core := filepath.Join(proj, ".deft", "core") // intentionally absent
 
-	// Simulate `git clone` materialising the payload dir.
+	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{"marker.txt": "new"})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
+
+	// Guardrail: there must be NO git command on a vendored fresh install.
+	var gitCalls []string
 	runCmdFunc = func(out io.Writer, name string, args ...string) error {
-		if name == "git" && len(args) > 0 && args[0] == "clone" {
-			os.MkdirAll(args[len(args)-1], 0o755)
+		if name == "git" {
+			gitCalls = append(gitCalls, strings.Join(args, " "))
 		}
 		return nil
 	}
-	runGitCaptureFunc = func(string, ...string) (string, error) { return "abc1234", nil }
+	runGitCaptureFunc = func(string, ...string) (string, error) { return "", fmt.Errorf("not a repo") }
 
 	result := &WizardResult{ProjectName: "proj", ProjectDir: proj, DeftDir: core, Update: true}
 	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
@@ -374,10 +379,151 @@ func TestUpdateDeft_AbsentReportsCloneLayout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpdateDeft (absent): %v", err)
 	}
-	if outcome.Layout != payloadLayoutClone {
-		t.Errorf("absent->clone must report layout=clone, got %q", outcome.Layout)
+	if len(gitCalls) != 0 {
+		t.Errorf("vendored fresh install ran git commands (safety bug): %v", gitCalls)
 	}
-	if outcome.Strategy != strategyClone {
-		t.Errorf("strategy = %q, want clone", outcome.Strategy)
+	if outcome.Layout != payloadLayoutVendored {
+		t.Errorf("absent->vendor must report layout=vendored, got %q", outcome.Layout)
+	}
+	if outcome.Strategy != strategyVendor {
+		t.Errorf("strategy = %q, want %q", outcome.Strategy, strategyVendor)
+	}
+	if data, err := os.ReadFile(filepath.Join(core, "marker.txt")); err != nil || string(data) != "new" {
+		t.Errorf("vendored core missing marker.txt: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(core, ".git")); !os.IsNotExist(err) {
+		t.Errorf("vendored core MUST NOT contain .git (err=%v)", err)
+	}
+}
+
+// TestVendorDeft_FreshInstallNoGit proves the headline #1429 behavior: a fresh
+// install vendors the release tarball into a greenfield .deft/core/ WITHOUT any
+// git command and WITHOUT leaving .git, and re-stamps the framework source SHA
+// recovered from the tarball wrapper.
+func TestVendorDeft_FreshInstallNoGit(t *testing.T) {
+	origFetch := fetchCoreTarballFunc
+	origRun := runCmdFunc
+	defer func() {
+		fetchCoreTarballFunc = origFetch
+		runCmdFunc = origRun
+	}()
+
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	core := filepath.Join(proj, ".deft", "core") // greenfield: absent
+
+	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{
+		"SKILL.md":    "skill body",
+		".git/config": "[core]", // must be excluded by extraction
+	})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
+
+	var gitCalls []string
+	runCmdFunc = func(out io.Writer, name string, args ...string) error {
+		if name == "git" {
+			gitCalls = append(gitCalls, strings.Join(args, " "))
+		}
+		return nil
+	}
+
+	result := &WizardResult{ProjectName: "proj", ProjectDir: proj, DeftDir: core}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := VendorDeft(w, result, "v1.2.3")
+	if err != nil {
+		t.Fatalf("VendorDeft: %v", err)
+	}
+	if len(gitCalls) != 0 {
+		t.Errorf("fresh vendor ran git commands (safety bug): %v", gitCalls)
+	}
+	if outcome.Layout != payloadLayoutVendored || outcome.Strategy != strategyVendor {
+		t.Errorf("outcome layout/strategy = %q/%q, want vendored/%q", outcome.Layout, outcome.Strategy, strategyVendor)
+	}
+	if outcome.SHA != "abc1234" {
+		t.Errorf("SHA = %q, want abc1234 (from tarball wrapper)", outcome.SHA)
+	}
+	if outcome.Tag != "v1.2.3" {
+		t.Errorf("Tag = %q, want v1.2.3", outcome.Tag)
+	}
+	if outcome.Backup != "" {
+		t.Errorf("greenfield vendor should not back up (no prior payload), got %q", outcome.Backup)
+	}
+	if data, err := os.ReadFile(filepath.Join(core, "SKILL.md")); err != nil || string(data) != "skill body" {
+		t.Errorf("vendored core missing SKILL.md: data=%q err=%v", data, err)
+	}
+	// Critical: a vendored payload carries NO .git (the #1428/#1425 invariant).
+	if _, err := os.Stat(filepath.Join(core, ".git")); !os.IsNotExist(err) {
+		t.Errorf("vendored core MUST NOT contain .git (err=%v)", err)
+	}
+}
+
+// TestUpdateDeft_CloneTagDetachedHeadMigratesWithoutGit is the gold-standard
+// #1428 regression: a REAL git clone checked out at a tag (detached HEAD) -- the
+// exact state whose `git pull` failed before this change -- is migrated to a
+// vendored payload via file swap, with NO git command run and no .git left.
+func TestUpdateDeft_CloneTagDetachedHeadMigratesWithoutGit(t *testing.T) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available; skipping real-git migration test")
+	}
+
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	core := filepath.Join(proj, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(gitPath, append([]string{"-C", core}, args...)...)
+		if out, gerr := cmd.CombinedOutput(); gerr != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), gerr, out)
+		}
+	}
+	// Build a genuine clone-layout payload: core is itself a git work tree
+	// (toplevel == core) checked out at a TAG -> detached HEAD.
+	runGit("init", "-q")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+	runGit("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(core, "OLD.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "-A")
+	runGit("commit", "-q", "-m", "seed")
+	runGit("tag", "v9.9.9")
+	runGit("checkout", "-q", "v9.9.9") // detached HEAD
+
+	origFetch := fetchCoreTarballFunc
+	origRun := runCmdFunc
+	defer func() {
+		fetchCoreTarballFunc = origFetch
+		runCmdFunc = origRun
+	}()
+	tarball := makeCoreTarball(t, "deftai-directive-feed1234", map[string]string{"marker.txt": "new"})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
+	runCmdFunc = func(out io.Writer, name string, args ...string) error {
+		if name == "git" {
+			t.Fatalf("migration ran a git command (safety/regression): git %s", strings.Join(args, " "))
+		}
+		return nil
+	}
+
+	result := &WizardResult{ProjectName: "proj", ProjectDir: proj, DeftDir: core, Update: true}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, "v9.9.9")
+	if err != nil {
+		t.Fatalf("UpdateDeft (detached-HEAD clone migration): %v", err)
+	}
+	if outcome.Layout != payloadLayoutVendored {
+		t.Fatalf("expected vendored layout post-migration, got %q", outcome.Layout)
+	}
+	if outcome.Strategy != strategyMigrate {
+		t.Errorf("strategy = %q, want %q", outcome.Strategy, strategyMigrate)
+	}
+	if data, err := os.ReadFile(filepath.Join(core, "marker.txt")); err != nil || string(data) != "new" {
+		t.Errorf("migrated core missing marker.txt: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(core, ".git")); !os.IsNotExist(err) {
+		t.Errorf("migrated core MUST NOT contain .git (err=%v)", err)
 	}
 }

--- a/vbrief/active/2026-06-02-v0-39-2-installer-vendoring-neutralization-deposit.vbrief.json
+++ b/vbrief/active/2026-06-02-v0-39-2-installer-vendoring-neutralization-deposit.vbrief.json
@@ -1,0 +1,86 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for the v0.39.2 Go-installer vendoring + neutralization deposit (Closes #1429, #1430; Refs #1428, #1427). Part of the #1428 vendored-done-right cohort.",
+    "created": "2026-06-02T22:05:00Z",
+    "updated": "2026-06-02T22:05:00Z"
+  },
+  "plan": {
+    "id": "v0-39-2-installer-vendoring-neutralization-deposit",
+    "title": "v0.39.2 Go-installer vendoring + neutralization deposit",
+    "status": "running",
+    "planRef": "#1429",
+    "narratives": {
+      "Overview": "Make the Go installer (cmd/deft-install) vendor the framework as a git-free tarball payload on fresh install and migrate existing git-clone payloads to vendored on --upgrade, then deposit the neutralization (.gitattributes linguist markers + Greptile/CodeQL bot-ignore + CI guard) so consumers treat .deft/core/** as packaged framework assets.",
+      "Problem": "Fresh installs git-clone the framework, leaving a nested .deft/core/.git that (a) re-introduces the #1425 detached-HEAD `git pull` failure on tag clones and (b) makes the vendored payload mis-classify. The vendored framework payload is also surfaced to linguist language stats and bot reviewers (Greptile/CodeQL) as if it were consumer code.",
+      "ImplementationPlan": "Slice A (#1429): replace fresh-install CloneDeft with a git-free tarball vendor (reuse #1425 helpers downloadCoreTarball/extractCoreTarball/swapInCore/tarPathExcluded); on --upgrade migrate a clone layout to vendored via atomic swap + remove nested .git instead of git fetch/checkout/pull. Slice B (#1430): deposit.go with EnsureGitattributes (linguist-generated/vendored), Greptile ignore + CodeQL paths-ignore, and a CI-guard workflow; wire into the install flow. Orphan (#1427): after WriteInstallManifest on upgrade, remove an orphaned .deft/VERSION.",
+      "Constraint": "Only modify cmd/deft-install/** and the deposit content + CI-guard workflow file. Do NOT touch scripts/doctor.py or tests/cli/test_*doctor*.py (agent-doctor owns them). CHANGELOG additions under [Unreleased] only. Do NOT run project:render / roadmap:render. New source files require sibling tests in the same PR.",
+      "Test": "Go tests: fresh-install-vendors (asserts no .git), clone->vendored migration (incl. detached-HEAD tag clone no longer fails, nested .git removed, parent repo untouched), EnsureGitattributes idempotency, orphan .deft/VERSION removal, Greptile/CodeQL/guard deposits. `task check` green before each commit.",
+      "UserStory": "As a consumer installing or upgrading deft, I want the framework vendored without git so the installer never runs git against my project repo and my language stats / bot reviewers ignore the packaged framework payload."
+    },
+    "items": [
+      {
+        "title": "Slice A: vendor on fresh install + clone->vendored upgrade migration (#1429)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Fresh install vendors via tarball (no .git under .deft/core/); --upgrade on a clone layout migrates to vendored via atomic swap with timestamped backup and removes the nested .git; no mutating git runs against the consumer repo."
+        }
+      },
+      {
+        "title": "Slice B: deposit the neutralization (#1430)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "EnsureGitattributes deposits .deft/core/** linguist-generated/vendored idempotently; Greptile ignore entry + CodeQL paths-ignore + CI-guard workflow deposited; deposit calls wired into the install flow."
+        }
+      },
+      {
+        "title": "Orphan: remove .deft/VERSION on upgrade (#1427 Go part)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "After WriteInstallManifest writes .deft/core/VERSION on an upgrade, an orphaned .deft/VERSION (canonical layout only) is removed if present."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1428",
+        "closes": [
+          "#1429",
+          "#1430"
+        ],
+        "refs": [
+          "#1428",
+          "#1427"
+        ]
+      },
+      "swarm": {
+        "readiness": "ready",
+        "agent": "agent-installer"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1429",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1429: installer vendor on fresh install + clone->vendored upgrade migration (Slice A)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1430",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1430: deposit the neutralization (.gitattributes + bot-ignore + CI guard) (Slice B)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1428",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1428: umbrella - vendored-done-right cohort"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1427",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1427: orphan .deft/VERSION removal (Go installer part)"
+      }
+    ],
+    "updated": "2026-06-02T22:06:13Z"
+  }
+}


### PR DESCRIPTION
## Summary

v0.39.2 "vendored-done-right" cohort (umbrella #1428): make the Go installer (`cmd/deft-install`) vendor the framework as a **git-free** tarball payload, migrate existing git-clone payloads to vendored on `--upgrade`, and deposit the neutralization so consumers treat `.deft/core/**` as packaged framework assets.

Closes #1429
Closes #1430
Refs #1428
Refs #1427

## Changes

### Slice A — vendor on fresh install + clone→vendored migration (#1429)
- **Fresh install no longer `git clone`s.** New `VendorDeft` downloads the release tarball at the resolved ref and extracts it into `.deft/core/` (excluding `.git`/`.github`/`node_modules`), reusing the merged #1425 helpers (`downloadCoreTarball`, `extractCoreTarball`, `swapInCore`, `tarPathExcluded`) via a shared `downloadAndExtractCore`. A fresh deposit never carries a nested `.git`. `.deft/core/VERSION`, the AGENTS.md managed section, and `.agents/skills` pointers are written exactly as before; the framework source SHA is recovered from the tarball wrapper so the manifest records true provenance.
- **`--upgrade` on a clone layout migrates to vendored.** `migrateCloneToVendored` performs an atomic `swapInCore` (timestamped backup of the old clone) and removes any nested `.deft/core/.git`, instead of `updateClonedCore`'s `git fetch`/`checkout`/`pull`. This removes the last mutating-git surface and **fixes the live detached-HEAD `git pull` failure on tag clones**.
- The absent-on-upgrade path also vendors (no git clone anywhere). Removed the now-dead `CloneDeft`, `deftRepoURL`, `updateClonedCore`, and the `git-checkout` / `clone` strategy constants.
- `--json` reports `payload_layout: vendored` with `strategy` `vendor` (fresh) or `clone-to-vendored` (migration).

### Slice B — deposit the neutralization (#1430)
New `cmd/deft-install/deposit.go`, wired into the install flow after `EnsureGitignoreLines` (best-effort: warns, never aborts the install). All deposits are idempotent, create-if-absent, and preserve existing entries:
- **`EnsureGitattributes`** — `.deft/core/** linguist-generated=true` + `linguist-vendored=true` (mirrors `EnsureGitignoreLines`).
- **Greptile ignore** — merges `.deft/core/**` into `greptile.json` `ignorePatterns` (JSON-merge via `json.RawMessage`, preserving every other field; refuses to rewrite a non-string `ignorePatterns`).
- **CodeQL paths-ignore** — `.github/codeql/codeql-config.yml` `paths-ignore: ['.deft/core/**']` (insert-into-existing-block or create).
- **CI guard (optional)** — `.github/workflows/deft-core-guard.yml` fails a PR that mixes `.deft/core/**` with non-framework paths (create-if-absent, never overwritten).

### Orphan removal (#1427, Go part)
After `WriteInstallManifest` writes `.deft/core/VERSION` on an upgrade, a stale `.deft/VERSION` left by older installer rails is removed (canonical layout only — the legacy `deft/` layout never touches the consumer's root `VERSION`).

## Testing
- `go build` / `go vet` / `go test ./cmd/deft-install/` — all pass.
- New Go tests: fresh-vendor-no-git (asserts no `.git`), real-git **detached-HEAD tag-clone** migration (no git command, no `.git` left, parent untouched), clone→vendored + absent→vendor outcomes, `EnsureGitattributes` / Greptile / CodeQL idempotency + field preservation + non-string refusal, CI-guard create-if-absent, orphan `.deft/VERSION` removal (canonical + legacy guard + no-op).
- `task check` green: 6772 passed, 3 skipped, 1 xfailed.

## Scope / constraints
- Only `cmd/deft-install/**` (incl. new `deposit.go` + `*_test.go`) plus the deposited content/CI-guard strings were modified. `scripts/doctor.py` and `tests/cli/test_*doctor*.py` were **not** touched (agent-doctor owns them). CHANGELOG additions under `[Unreleased]` only.

## Story Start Gate (#810)
`vbrief/active/2026-06-02-v0-39-2-installer-vendoring-neutralization-deposit.vbrief.json` (schema v0.6, `plan.status: running`); `task vbrief:preflight` exits 0.

---
- Conversation: https://app.warp.dev/conversation/fd0cebb0-1863-4a1a-8e97-18a770cd6d03
- Run: https://oz.warp.dev/runs/019e8a5d-3ab2-74ed-aec9-f28d5110645f
