### PR TITLE
fix(install): vendored upgrade regenerates root artifacts (AGENTS.md + .deft-version) (#1437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`deft-install --upgrade` no longer leaves a duplicate AGENTS.md managed section (#1437)** -- on a vendored install whose `AGENTS.md` already carried a managed section stamped with provenance attributes (the marker `run agents:refresh` and the relocator write), the upgrade appended a second managed section instead of refreshing the existing one, which left `task doctor` reporting the section as unreadable. The installer now recognises an attributed marker and rewrites it in place, and the rewrite is self-healing: an install already broken with two or more managed sections is collapsed back to exactly one on the next upgrade, with your own prose around the section preserved. Closes #1437.
+- **`deft-install --upgrade` now refreshes `vbrief/.deft-version` so the install stays doctor-clean (#1437)** -- the vendored file-swap upgrade refreshed the framework payload and its version manifest but left the bare `vbrief/.deft-version` marker at its old value, so `task doctor` flagged a version-drift mismatch right after a successful upgrade. The upgrade now regenerates that marker from the manifest as part of the swap, so a fresh `--upgrade` is self-consistent and passes doctor without a manual follow-up step. Closes #1437.
 
 ### Removed
 

--- a/cmd/deft-install/e2e_upgrade_test.go
+++ b/cmd/deft-install/e2e_upgrade_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEndToEnd_VendoredUpgrade_DoctorInvariants is the #1437 end-to-end smoke
+// test. It builds a REALISTIC vendored-install fixture and drives the REAL
+// vendored upgrade code path -- the exact UpdateDeft -> WriteInstallManifest ->
+// WriteAgentsMD sequence main.go runs for a `--upgrade` -- then asserts the two
+// doctor invariants the v0.39.3 vendored upgrade violated:
+//
+//  1. AGENTS.md ends with EXACTLY ONE deft managed section. The duplicate-
+//     managed-section bug appended a SECOND section, which defeated the doctor's
+//     freshness probe (agents-md-managed-section-fresh -> unreadable).
+//  2. The bare vbrief/.deft-version derivative AGREES with the tag recorded in
+//     the canonical .deft/core/VERSION manifest. The file-swap refreshed the
+//     manifest but left the bare derivative stale (manifest-agreement -> fail).
+//
+// The fixture mirrors a webinstaller-origin install: a vendored .deft/core
+// (no .git) carrying an OLD manifest, a root AGENTS.md whose managed section
+// uses the ATTRIBUTED v3 marker (sha=/refreshed=/session=) with operator prose
+// above and below it, and a STALE vbrief/.deft-version (0.0.0-dev). The tarball
+// uses the real GitHub shape (leading pax_global_header + single wrapper dir).
+//
+// Hermetic + fast: no network (fetchCoreTarballFunc stubbed) and no real git
+// (runGitCaptureFunc stubbed so the payload classifies as vendored). The two
+// invariants are asserted directly in Go rather than by invoking
+// scripts/doctor.py -- running the real doctor hermetically would require
+// bundling the entire framework tree into the fixture; the assertions below ARE
+// the invariants those doctor checks enforce.
+//
+// RED->GREEN: this test FAILS on pre-#1437 code (a second managed section is
+// appended AND vbrief/.deft-version stays 0.0.0-dev) and PASSES after the fix.
+func TestEndToEnd_VendoredUpgrade_DoctorInvariants(t *testing.T) {
+	origGit := runGitCaptureFunc
+	origFetch := fetchCoreTarballFunc
+	defer func() {
+		runGitCaptureFunc = origGit
+		fetchCoreTarballFunc = origFetch
+	}()
+
+	proj := t.TempDir()
+	core := filepath.Join(proj, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Old vendored manifest (pre-upgrade payload at v0.39.2).
+	oldManifest := "ref: 'v0.39.2'\nsha: 'oldsha0000'\ntag: 'v0.39.2'\n" +
+		"install_root: '.deft/core'\nfetched_at: '2026-06-01T00:00:00Z'\nfetched_by: 'deft-install'\n"
+	if err := os.WriteFile(filepath.Join(core, "VERSION"), []byte(oldManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Root AGENTS.md with an ATTRIBUTED v3 marker + operator prose around the
+	// managed fence -- the exact shape that defeated the bare-string matcher.
+	const operatorTop = "# My Project — Agent Guide\n\n" +
+		"Hand-written operator notes that MUST survive the upgrade.\n\n"
+	const operatorBottom = "\n## Operator appendix\n\n" +
+		"More hand-written notes below the managed fence.\n"
+	attributedSection := "<!-- deft:managed-section v3 sha=6136b66c42c8 refreshed=2026-06-01T03:08:04Z session=d7bc893a5c2d -->\n" +
+		"# Deft — AI Development Framework\n\n" +
+		"Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md\n\n" +
+		"(stale managed body from an older framework version)\n" +
+		agentsMDFenceClose + "\n"
+	agentsPath := filepath.Join(proj, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte(operatorTop+attributedSection+operatorBottom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale bare derivative left by an earlier rail.
+	vbriefDir := filepath.Join(proj, "vbrief")
+	if err := os.MkdirAll(vbriefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vbriefDir, ".deft-version"), []byte("0.0.0-dev\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Classify as vendored (no git work tree); stand in a real-shaped tarball
+	// for the network download.
+	runGitCaptureFunc = func(string, ...string) (string, error) {
+		return "", fmt.Errorf("not a git repository")
+	}
+	tarball := makeCoreTarballWithPaxHeader(t, "deftai-directive-abc1234def567", map[string]string{
+		"main.md":           "framework main",
+		"scripts/doctor.py": "print('hi')",
+	})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
+
+	const upgradeTag = "v0.39.3"
+
+	// --- Drive the REAL upgrade sequence main.go runs for an --upgrade. ---
+	result := &WizardResult{ProjectName: "myproj", ProjectDir: proj, DeftDir: core, Update: true}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, upgradeTag)
+	if err != nil {
+		t.Fatalf("UpdateDeft (vendored upgrade): %v", err)
+	}
+
+	// main.go overrides the manifest tag with the tarball-resolved tag on a
+	// vendored refresh before stamping .deft/core/VERSION.
+	fields := InstallManifestFields{
+		Ref:         outcome.Tag,
+		SHA:         outcome.SHA,
+		Tag:         outcome.Tag,
+		InstallRoot: ".deft/core",
+		FetchedAt:   "2026-06-03T00:00:00Z",
+		FetchedBy:   "deft-install",
+	}
+	if _, err := WriteInstallManifest(result.ProjectDir, result.DeftDir, fields); err != nil {
+		t.Fatalf("WriteInstallManifest: %v", err)
+	}
+	if err := WriteAgentsMD(w, result.ProjectDir); err != nil {
+		t.Fatalf("WriteAgentsMD: %v", err)
+	}
+
+	// --- Invariant 1: AGENTS.md has EXACTLY ONE managed section. ---
+	got, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(got)
+	if n := strings.Count(content, agentsMDFenceClose); n != 1 {
+		t.Errorf("AGENTS.md has %d managed-section closing fences, want exactly 1 (duplicate-managed-section bug #1437):\n%s", n, content)
+	}
+	if n := strings.Count(content, "<!-- deft:managed-section v"); n != 1 {
+		t.Errorf("AGENTS.md has %d managed-section open markers, want exactly 1:\n%s", n, content)
+	}
+	// Operator prose above and below the fence MUST be preserved.
+	if !strings.Contains(content, "Hand-written operator notes that MUST survive the upgrade.") {
+		t.Errorf("operator prose ABOVE the managed fence was lost:\n%s", content)
+	}
+	if !strings.Contains(content, "More hand-written notes below the managed fence.") {
+		t.Errorf("operator prose BELOW the managed fence was lost:\n%s", content)
+	}
+	// The single section is the refreshed canonical body (the attributed marker
+	// is rewritten in place to the bare canonical marker).
+	if !strings.Contains(content, agentsMDSentinel) {
+		t.Errorf("AGENTS.md missing the canonical bare v3 marker after upgrade:\n%s", content)
+	}
+
+	// --- Invariant 2: bare vbrief/.deft-version agrees with the manifest. ---
+	bareRaw, err := os.ReadFile(filepath.Join(vbriefDir, ".deft-version"))
+	if err != nil {
+		t.Fatalf("vbrief/.deft-version missing after upgrade: %v", err)
+	}
+	bare := strings.TrimSpace(string(bareRaw))
+	manifestRaw, err := os.ReadFile(filepath.Join(core, "VERSION"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	derived := deriveTagFromManifestForTest(t, string(manifestRaw))
+	if bare != derived {
+		t.Errorf("manifest-agreement invariant violated: bare vbrief/.deft-version=%q does NOT agree with manifest tag-derived %q (#1437)", bare, derived)
+	}
+	if bare == "0.0.0-dev" {
+		t.Errorf("vbrief/.deft-version was not regenerated (still the stale 0.0.0-dev)")
+	}
+}
+
+// deriveTagFromManifestForTest extracts the bare semver the doctor's
+// manifest-agreement check derives from a YAML manifest: the tag: value with a
+// single leading 'v' stripped. Test-local so this smoke test does not depend on
+// any installer-side helper -- it must compile + run against pre-fix code to
+// prove the RED state.
+func deriveTagFromManifestForTest(t *testing.T, manifest string) string {
+	t.Helper()
+	for _, line := range strings.Split(manifest, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "tag:") {
+			v := strings.TrimSpace(strings.TrimPrefix(line, "tag:"))
+			v = strings.Trim(v, "'\"")
+			return strings.TrimPrefix(v, "v")
+		}
+	}
+	t.Fatalf("no tag: line in manifest:\n%s", manifest)
+	return ""
+}

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -49,12 +49,11 @@ const (
 	// elsewhere in AGENTS.md (#1060 cross-layout rewrite).
 	agentsMDFenceClose = "<!-- /deft:managed-section -->"
 
-	// agentsMDV2Sentinel is the v0.27 marker form retained for one release
-	// cycle (v0.28 only; v0.29 deprecates v2). #1046 PR-B AC-5 bumps the
-	// canonical marker to v3 with refresh provenance attributes; the v2 form
-	// is still recognised here so a fresh canonical install on top of a
-	// v0.27 AGENTS.md still recognises the deft entry.
-	agentsMDV2Sentinel = "<!-- deft:managed-section v2 -->"
+	// The v0.27 v2 marker form (`<!-- deft:managed-section v2 -->`) is still
+	// recognised during detection so a fresh canonical install on top of a
+	// v0.27 AGENTS.md rewrites the deft entry rather than appending. It is
+	// matched (attribute-tolerantly, alongside v3) by agentsMDManagedOpenPattern
+	// below rather than via a dedicated constant (#1046 PR-B AC-5, #1437).
 
 	// agentsMDLegacySentinel is the pre-v0.27 idempotency marker. It still
 	// participates in detection so a fresh canonical install on top of a
@@ -166,6 +165,17 @@ description: >-
 Read and follow: .deft/core/skills/deft-directive-sync/SKILL.md
 `
 )
+
+// agentsMDManagedOpenPattern matches a deft managed-section OPEN marker for
+// either the v2 or v3 layout, WITH OR WITHOUT the provenance attributes
+// (sha=/refreshed=/session=) that `run agents:refresh` and the relocator stamp
+// onto the open marker (#1046 PR-B AC-5). Detection MUST be attribute-tolerant:
+// keying on the exact bare marker string made WriteAgentsMD miss an attributed
+// marker and APPEND a second managed section instead of rewriting the existing
+// one (the v0.39.3 duplicate-managed-section bug, #1437). The installer still
+// EMITS the bare canonical marker (agentsMDSentinel); only the MATCHING here is
+// attribute-tolerant. The closing marker (agentsMDFenceClose) is unchanged.
+var agentsMDManagedOpenPattern = regexp.MustCompile(`<!-- deft:managed-section v[23][^>]*-->`)
 
 // canonicalGitignoreLines mirrors scripts/relocate.py::GITIGNORE_LINES (the F2
 // canonical default from #1015): the runtime cache directory and the audit-log
@@ -375,80 +385,118 @@ func detectAgentsMDLayoutLabel(body string) string {
 	return "unknown"
 }
 
-// agentsMDManagedSlice returns the substring of body between the first v3 or
-// v2 open marker and the matching closing fence (inclusive of the close fence
-// bytes). Returns (slice, true) when a fenced managed section is found, or
-// ("", false) when no fenced block is detected (pre-v0.27 unfenced legacy
-// body, or no deft sentinel at all). Used by WriteAgentsMD to scope the
-// idempotency probe to the managed slice ONLY (Greptile P1 #1066: file-wide
-// claim check could produce a false skip when operator-authored prose
-// outside the fence contains the layout claim while the managed block stays
-// stale).
-func agentsMDManagedSlice(body string) (string, bool) {
-	for _, openMarker := range []string{agentsMDSentinel, agentsMDV2Sentinel} {
-		idx := strings.Index(body, openMarker)
-		if idx < 0 {
-			continue
-		}
-		closeOff := strings.Index(body[idx:], agentsMDFenceClose)
-		if closeOff < 0 {
-			continue
-		}
-		closeIdx := idx + closeOff + len(agentsMDFenceClose)
-		return body[idx:closeIdx], true
-	}
-	return "", false
+// agentsMDSpan is a half-open byte range [Start, End) covering one fenced deft
+// managed section -- the open marker through the matching closing fence,
+// inclusive of the close-fence bytes -- inside an AGENTS.md body.
+type agentsMDSpan struct {
+	Start int
+	End   int
 }
 
-// rewriteAgentsMDBlock replaces the deft-managed section inside body with the
-// rendered replacement and returns (newBody, surgical). When the section is
-// fenced by a v2/v3 open marker AND the closing marker, only the fenced range
-// is rewritten (`surgical=true`) so any operator prose outside the managed
-// section is preserved verbatim. The pre-v0.27 layout has no closing fence,
-// so when only the unfenced legacy sentinel is present the entire file is
-// replaced with the replacement (`surgical=false`); the legacy body has no
-// reliable terminator the installer can detect, and leaving stale legacy
-// prose alongside the new canonical body would itself produce the kind of
-// cross-layout drift #1060 closes.
+// agentsMDManagedSpans returns the byte ranges of EVERY deft managed section in
+// body: each v2/v3 open marker (attributed or bare, matched by
+// agentsMDManagedOpenPattern) paired with the next closing fence. An open
+// marker with no following closing fence terminates the scan (it cannot be
+// surgically bounded). Returns nil when no fenced section is present. Used by
+// agentsMDManagedSlice (idempotency probe scope) and rewriteAgentsMDBlock
+// (self-heal collapse to a single section, #1437).
+func agentsMDManagedSpans(body string) []agentsMDSpan {
+	var spans []agentsMDSpan
+	from := 0
+	for from <= len(body) {
+		loc := agentsMDManagedOpenPattern.FindStringIndex(body[from:])
+		if loc == nil {
+			break
+		}
+		openStart := from + loc[0]
+		closeOff := strings.Index(body[openStart:], agentsMDFenceClose)
+		if closeOff < 0 {
+			break
+		}
+		closeEnd := openStart + closeOff + len(agentsMDFenceClose)
+		spans = append(spans, agentsMDSpan{Start: openStart, End: closeEnd})
+		from = closeEnd
+	}
+	return spans
+}
+
+// agentsMDManagedSlice returns the substring of body covering the FIRST fenced
+// managed section (inclusive of the close-fence bytes). Returns (slice, true)
+// when a fenced managed section is found, or ("", false) when no fenced block
+// is detected (pre-v0.27 unfenced legacy body, or no deft sentinel at all).
+// The open marker is matched attribute-tolerantly (#1437). Used by
+// WriteAgentsMD to scope the idempotency probe to the managed slice ONLY
+// (Greptile P1 #1066: a file-wide claim check could produce a false skip when
+// operator-authored prose outside the fence contains the layout claim while
+// the managed block stays stale).
+func agentsMDManagedSlice(body string) (string, bool) {
+	spans := agentsMDManagedSpans(body)
+	if len(spans) == 0 {
+		return "", false
+	}
+	return body[spans[0].Start:spans[0].End], true
+}
+
+// rewriteAgentsMDBlock replaces the deft-managed section(s) inside body with a
+// SINGLE rendered replacement and returns (newBody, surgical). When at least
+// one fenced section (v2/v3, attributed or bare) is present the rewrite is
+// surgical (`surgical=true`): the FIRST section is replaced in place with
+// replacement and EVERY subsequent managed section is removed, so any number of
+// existing managed sections converges to exactly one (the #1437 self-heal --
+// installs already broken with duplicate sections are cleaned up on the next
+// upgrade). Operator prose before, between, and after the fences is preserved
+// verbatim. The pre-v0.27 layout has no closing fence, so when no fenced
+// section is present the entire file is replaced with the replacement
+// (`surgical=false`); the legacy body has no reliable terminator the installer
+// can detect, and leaving stale legacy prose alongside the new canonical body
+// would itself produce the kind of cross-layout drift #1060 closes.
 //
 // When the replacement already ends in a newline AND the byte immediately
-// after the closing fence is also a newline, one trailing newline is
-// consumed from body so repeated surgical rewrites don't accumulate blank
-// lines at the boundary (Greptile P1 #1066: cosmetic drift across upgrades).
+// after the first section's closing fence is also a newline, one trailing
+// newline is consumed from body so repeated surgical rewrites don't accumulate
+// blank lines at the boundary (Greptile P1 #1066: cosmetic drift across
+// upgrades).
 func rewriteAgentsMDBlock(body, replacement string) (string, bool) {
-	for _, openMarker := range []string{agentsMDSentinel, agentsMDV2Sentinel} {
-		idx := strings.Index(body, openMarker)
-		if idx < 0 {
-			continue
-		}
-		closeOff := strings.Index(body[idx:], agentsMDFenceClose)
-		if closeOff < 0 {
-			continue
-		}
-		closeIdx := idx + closeOff + len(agentsMDFenceClose)
-		if strings.HasSuffix(replacement, "\n") && closeIdx < len(body) && body[closeIdx] == '\n' {
-			closeIdx++
-		}
-		return body[:idx] + replacement + body[closeIdx:], true
+	spans := agentsMDManagedSpans(body)
+	if len(spans) == 0 {
+		return replacement, false
 	}
-	return replacement, false
+	var b strings.Builder
+	// Operator prose before the first managed section is preserved verbatim.
+	b.WriteString(body[:spans[0].Start])
+	// Exactly one canonical managed section replaces the first one.
+	b.WriteString(replacement)
+	prevEnd := spans[0].End
+	if strings.HasSuffix(replacement, "\n") && prevEnd < len(body) && body[prevEnd] == '\n' {
+		prevEnd++
+	}
+	// Drop every SUBSEQUENT managed section (converge N -> 1) while preserving
+	// any operator prose BETWEEN the fences.
+	for _, sp := range spans[1:] {
+		b.WriteString(body[prevEnd:sp.Start])
+		prevEnd = sp.End
+	}
+	b.WriteString(body[prevEnd:])
+	return b.String(), true
 }
 
 // WriteAgentsMD creates, rewrites, or appends the deft managed section in
 // AGENTS.md so the file always advertises the install root the installer is
-// depositing at. Layout-aware sentinel logic (#1060):
+// depositing at. Layout-aware sentinel logic (#1060, #1437):
 //
-//   - AGENTS.md absent              -> write the layout-correct v3 body.
-//   - v3 marker AND matching claim  -> skip (file is up-to-date).
-//   - v3 marker but foreign layout  -> surgically rewrite the managed block
-//     to the layout-correct v3 body (preserving operator prose outside the
-//     fence).
-//   - v2 marker (pre-v0.28)         -> surgically rewrite to v3.
-//   - pre-v0.27 legacy sentinel     -> rewrite the entire file to the
+//   - AGENTS.md absent                  -> write the layout-correct v3 body.
+//   - exactly ONE bare-marker section
+//     AND matching claim                -> skip (file is up-to-date).
+//   - any managed section(s), attributed
+//     or bare (v2/v3), stale / foreign
+//     layout / duplicated               -> rewrite to a SINGLE layout-correct
+//     v3 body, collapsing duplicates and preserving operator prose outside
+//     the fences (the #1437 self-heal: converges 0/1/N sections to one).
+//   - pre-v0.27 legacy sentinel only    -> rewrite the entire file to the
 //     layout-correct v3 body (the legacy body is unfenced so a surgical
 //     replacement is not safe -- see rewriteAgentsMDBlock).
-//   - no deft sentinel at all       -> append the layout-correct v3 body to
-//     the existing file (preserves the operator's pre-existing AGENTS.md).
+//   - no deft sentinel at all           -> append the layout-correct v3 body
+//     to the existing file (preserves the operator's pre-existing AGENTS.md).
 //
 // The install root is derived from the Wizard's selected framework subdir
 // (the same value the deposit path uses) and normalised to POSIX form so the
@@ -473,8 +521,14 @@ func WriteAgentsMD(w *Wizard, projectDir string) error {
 
 	s := string(existing)
 	expectedClaim := agentsMDLayoutClaim(installRoot)
-	hasV3 := strings.Contains(s, agentsMDSentinel)
-	hasV2 := strings.Contains(s, agentsMDV2Sentinel)
+
+	// Locate EVERY deft managed section (v2/v3, attributed or bare). The open
+	// marker is matched attribute-tolerantly so a marker carrying provenance
+	// attributes (sha=/refreshed=/session=, emitted by `run agents:refresh` /
+	// the relocator) is recognised -- keying on the bare marker string made
+	// WriteAgentsMD fall through and APPEND a second managed section instead of
+	// rewriting the existing one (#1437).
+	managedSpans := agentsMDManagedSpans(s)
 	hasLegacy := strings.Contains(s, agentsMDLegacySentinel)
 
 	// Scope the layout-claim probe to the fenced managed slice when one
@@ -492,19 +546,25 @@ func WriteAgentsMD(w *Wizard, projectDir string) error {
 	}
 	hasClaim := strings.Contains(probe, expectedClaim)
 
-	// Up-to-date: v3 marker AND body advertises the install root we are
-	// depositing at. This is the only happy-path that may legitimately skip
-	// the rewrite per the #1060 layout-aware contract.
-	if hasV3 && hasClaim {
+	// Up-to-date happy path: EXACTLY ONE managed section, emitted in the BARE
+	// canonical marker form the installer itself writes (agentsMDSentinel), and
+	// already advertising the install root we are depositing at. Gating the
+	// skip on the bare marker -- rather than the attribute-tolerant match used
+	// for detection above -- means an ATTRIBUTED marker is rewritten in place
+	// to the canonical body (#1437) while a re-run on the installer's own
+	// output stays a byte-for-byte no-op. A file carrying MULTIPLE managed
+	// sections (the duplicate bug) also falls through so it self-heals to one.
+	if strings.Contains(s, agentsMDSentinel) && hasClaim && len(managedSpans) == 1 {
 		w.printf("AGENTS.md already advertises install root %s — skipping.\n", installRoot)
 		return nil
 	}
 
-	// Any deft sentinel present but body is stale (older marker) or pointing
-	// at a foreign layout: rewrite to the layout-correct v3 body so the
-	// installer never leaves the consumer in the cross-layout drift the
-	// framework:doctor probe would flag (#1060).
-	if hasV3 || hasV2 || hasLegacy {
+	// Any deft managed section (v2/v3, attributed or bare) OR a pre-v0.27
+	// legacy sentinel: rewrite to a SINGLE layout-correct v3 body, collapsing
+	// any duplicates and preserving operator prose outside the fences, so the
+	// installer never leaves the consumer in the cross-layout drift or the
+	// duplicate-section state the doctor would flag (#1060, #1437 self-heal).
+	if len(managedSpans) > 0 || hasLegacy {
 		newBody, surgical := rewriteAgentsMDBlock(s, body)
 		if err := os.WriteFile(path, []byte(newBody), 0o644); err != nil {
 			return fmt.Errorf("could not rewrite AGENTS.md: %w", err)

--- a/cmd/deft-install/setup_test.go
+++ b/cmd/deft-install/setup_test.go
@@ -531,6 +531,163 @@ func TestWriteAgentsMD_StaleCanonicalAGENTSMD_RewrittenByLegacyInstall(t *testin
 	}
 }
 
+// ---------------------------------------------------------------------------
+// #1437: attributed-marker recognition + self-heal collapse to one section
+// ---------------------------------------------------------------------------
+
+// countManagedSections reports how many deft managed-section closing fences a
+// body carries -- one per managed section. A correct AGENTS.md has exactly one.
+func countManagedSections(body string) int {
+	return strings.Count(body, agentsMDFenceClose)
+}
+
+// TestWriteAgentsMD_AttributedV3Marker_RewritesInPlaceToSingleSection is the
+// #1437 regression (a): an AGENTS.md whose open marker carries the v3
+// provenance attributes (sha=/refreshed=/session=) -- the form `agents:refresh`
+// / the relocator emit -- is RECOGNISED and rewritten in place to a single
+// canonical managed section. Pre-fix the bare-string matcher missed it and
+// APPENDED a second section. Operator prose around the fence is preserved.
+func TestWriteAgentsMD_AttributedV3Marker_RewritesInPlaceToSingleSection(t *testing.T) {
+	tmp := t.TempDir()
+	operatorTop := "# Project AGENTS\n\nOperator notes above the fence.\n\n"
+	operatorBottom := "\n## Appendix\n\nOperator notes below the fence.\n"
+	attributed := "<!-- deft:managed-section v3 sha=6136b66c42c8 refreshed=2026-06-01T03:08:04Z session=d7bc893a5c2d -->\n" +
+		"Deft is installed in .deft/core/. (older managed body)\n" +
+		agentsMDFenceClose + "\n"
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte(operatorTop+attributed+operatorBottom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	w := NewWizard(strings.NewReader(""), &out, false)
+	if err := WriteAgentsMD(w, tmp); err != nil {
+		t.Fatalf("WriteAgentsMD: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmp, "AGENTS.md"))
+	content := string(data)
+	if n := countManagedSections(content); n != 1 {
+		t.Errorf("attributed marker produced %d managed sections, want exactly 1 (append-instead-of-rewrite bug #1437):\n%s", n, content)
+	}
+	if n := strings.Count(content, "<!-- deft:managed-section v"); n != 1 {
+		t.Errorf("want exactly 1 managed-section open marker, got %d:\n%s", n, content)
+	}
+	if !strings.Contains(content, agentsMDSentinel) {
+		t.Errorf("attributed marker was not rewritten to the bare canonical marker:\n%s", content)
+	}
+	if strings.Contains(content, "sha=6136b66c42c8") {
+		t.Errorf("stale attributed-marker provenance survived the rewrite:\n%s", content)
+	}
+	for _, prose := range []string{"Operator notes above the fence.", "Operator notes below the fence."} {
+		if !strings.Contains(content, prose) {
+			t.Errorf("operator prose %q was lost during the rewrite:\n%s", prose, content)
+		}
+	}
+	if !strings.Contains(out.String(), "rewriting AGENTS.md") {
+		t.Errorf("installer did not log the in-place rewrite; got log:\n%s", out.String())
+	}
+}
+
+// TestWriteAgentsMD_TwoManagedSections_CollapseToOne is the #1437 regression
+// (b): an AGENTS.md that already carries TWO managed sections (the state this
+// bug produced) is collapsed to exactly one canonical section on the next
+// upgrade, preserving operator prose before, between, and after the fences.
+func TestWriteAgentsMD_TwoManagedSections_CollapseToOne(t *testing.T) {
+	tmp := t.TempDir()
+	top := "# Project AGENTS\n\nTop operator prose.\n\n"
+	first := "<!-- deft:managed-section v3 sha=aaa111 refreshed=2026-06-01T00:00:00Z session=s1 -->\n" +
+		"Deft is installed in .deft/core/. (old body 1)\n" + agentsMDFenceClose + "\n"
+	middle := "\nMiddle operator prose between two managed sections.\n\n"
+	second := agentsMDSentinel + "\n" +
+		"Deft is installed in .deft/core/. (old body 2)\n" + agentsMDFenceClose + "\n"
+	bottom := "\nBottom operator prose.\n"
+	if err := os.WriteFile(filepath.Join(tmp, "AGENTS.md"), []byte(top+first+middle+second+bottom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	w := NewWizard(strings.NewReader(""), &out, false)
+	if err := WriteAgentsMD(w, tmp); err != nil {
+		t.Fatalf("WriteAgentsMD: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmp, "AGENTS.md"))
+	content := string(data)
+	if n := countManagedSections(content); n != 1 {
+		t.Errorf("two managed sections did not collapse to one; got %d:\n%s", n, content)
+	}
+	if n := strings.Count(content, "<!-- deft:managed-section v"); n != 1 {
+		t.Errorf("want exactly 1 open marker after collapse, got %d:\n%s", n, content)
+	}
+	for _, prose := range []string{"Top operator prose.", "Middle operator prose between two managed sections.", "Bottom operator prose."} {
+		if !strings.Contains(content, prose) {
+			t.Errorf("operator prose %q was lost during the collapse:\n%s", prose, content)
+		}
+	}
+	if strings.Contains(content, "old body 1") || strings.Contains(content, "old body 2") {
+		t.Errorf("stale managed bodies survived the collapse:\n%s", content)
+	}
+}
+
+// TestWriteAgentsMD_CleanSingleSection_StaysSingleIdempotent is the #1437
+// regression (c): a clean single-section file (the installer's own output)
+// stays a single section and is a byte-for-byte no-op on a re-run.
+func TestWriteAgentsMD_CleanSingleSection_StaysSingleIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	w1 := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	if err := WriteAgentsMD(w1, tmp); err != nil { // fresh install -> one canonical section
+		t.Fatal(err)
+	}
+	path := filepath.Join(tmp, "AGENTS.md")
+	first, _ := os.ReadFile(path)
+	if n := countManagedSections(string(first)); n != 1 {
+		t.Fatalf("fresh install did not produce exactly one managed section; got %d:\n%s", n, first)
+	}
+
+	var out bytes.Buffer
+	w2 := NewWizard(strings.NewReader(""), &out, false)
+	if err := WriteAgentsMD(w2, tmp); err != nil {
+		t.Fatalf("WriteAgentsMD (re-run): %v", err)
+	}
+	second, _ := os.ReadFile(path)
+	if string(first) != string(second) {
+		t.Errorf("re-run changed a clean single-section file (not idempotent)")
+	}
+	if n := countManagedSections(string(second)); n != 1 {
+		t.Errorf("clean single-section file did not stay single; got %d", n)
+	}
+	if !strings.Contains(out.String(), "skipping") {
+		t.Errorf("expected the idempotent re-run to skip; got log:\n%s", out.String())
+	}
+}
+
+// TestRewriteAgentsMDBlock_CollapsesAllSectionsToOne unit-tests the self-heal
+// directly: N managed sections (v3 attributed + bare) converge to exactly one
+// replacement, with operator prose before/between/after preserved (#1437).
+func TestRewriteAgentsMDBlock_CollapsesAllSectionsToOne(t *testing.T) {
+	replacement := agentsMDSentinel + "\nNEW CANONICAL BODY\n" + agentsMDFenceClose + "\n"
+	body := "A\n" +
+		agentsMDSentinel + "\nold1\n" + agentsMDFenceClose + "\n" +
+		"B\n" +
+		"<!-- deft:managed-section v3 sha=xyz -->\nold2\n" + agentsMDFenceClose + "\n" +
+		"C\n"
+	got, surgical := rewriteAgentsMDBlock(body, replacement)
+	if !surgical {
+		t.Fatal("expected surgical=true when fenced sections exist")
+	}
+	if n := countManagedSections(got); n != 1 {
+		t.Errorf("want exactly 1 managed section after collapse, got %d:\n%s", n, got)
+	}
+	for _, want := range []string{"A\n", "B\n", "C\n", "NEW CANONICAL BODY"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q preserved/inserted, missing from:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "old1") || strings.Contains(got, "old2") {
+		t.Errorf("stale managed bodies survived the collapse:\n%s", got)
+	}
+}
+
 // TestWriteAgentsMD_ClaimScopedToManagedSlice_NoFalseSkip pins the
 // Greptile P1 #1066 issue 1 fix: the `hasClaim` idempotency probe is
 // scoped to the fenced managed slice, NOT the full file. An operator-

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -267,8 +267,59 @@ func refreshVendoredCore(w *Wizard, result *WizardResult, branch string) (*Updat
 	}
 	outcome.Backup = backup
 
+	// #1437: the vendored file-swap owns .deft/core/** only. Regenerate the
+	// bare vbrief/.deft-version derivative from the resolved release tag -- the
+	// same tag the caller stamps into .deft/core/VERSION -- so the upgrade
+	// leaves the install self-consistent. Without this a stale derivative left
+	// by an earlier rail (e.g. "0.0.0-dev") fails the doctor's manifest-
+	// agreement check. Best-effort: a write failure warns but never fails the
+	// refresh.
+	if marker, mErr := regenerateBareVersionMarker(result.ProjectDir, outcome.Tag); mErr != nil {
+		w.printf("warning: refreshed payload but could not regenerate vbrief/.deft-version: %v\n", mErr)
+	} else if marker != "" {
+		w.printf("Regenerated %s to %s (agrees with the refreshed manifest).\n", marker, bareVersionFromTag(outcome.Tag))
+	}
+
 	w.printf("Vendored framework refreshed at %s (previous payload backed up at %s).\n", result.DeftDir, backup)
 	return outcome, nil
+}
+
+// bareVersionFromTag converts a manifest tag/ref ("v0.39.3" or "0.39.3") to the
+// bare vbrief/.deft-version derivative value ("0.39.3") by stripping a single
+// leading "v". Mirrors run::_install_manifest_tag_to_version and the doctor's
+// _manifest_tag_to_version (which lstrip("v") before comparing). Returns "" for
+// an empty tag so callers skip writing a meaningless derivative (e.g. a branch
+// upgrade whose manifest carries no semver tag).
+func bareVersionFromTag(tag string) string {
+	t := strings.TrimSpace(tag)
+	if t == "" {
+		return ""
+	}
+	return strings.TrimPrefix(t, "v")
+}
+
+// regenerateBareVersionMarker (re)writes the bare vbrief/.deft-version
+// derivative from the resolved release tag so it agrees with the canonical
+// <core>/VERSION manifest the installer stamps after a vendored swap (#1437).
+// The file holds the BARE semver plus a trailing newline, mirroring
+// run::_write_version_marker and the doctor's preferred bare-derivative
+// location (vbrief/.deft-version). Returns the written path, or "" when tag
+// carries no semver (nothing to regenerate). The parent vbrief/ directory is
+// created if absent.
+func regenerateBareVersionMarker(projectDir, tag string) (string, error) {
+	bare := bareVersionFromTag(tag)
+	if bare == "" {
+		return "", nil
+	}
+	vbriefDir := filepath.Join(projectDir, "vbrief")
+	if err := os.MkdirAll(vbriefDir, 0o755); err != nil {
+		return "", fmt.Errorf("could not create vbrief/ for .deft-version: %w", err)
+	}
+	path := filepath.Join(vbriefDir, ".deft-version")
+	if err := os.WriteFile(path, []byte(bare+"\n"), 0o644); err != nil {
+		return "", fmt.Errorf("could not write vbrief/.deft-version: %w", err)
+	}
+	return path, nil
 }
 
 // downloadAndExtractCore downloads the framework source tarball at ref (empty

--- a/cmd/deft-install/upgrade_test.go
+++ b/cmd/deft-install/upgrade_test.go
@@ -617,3 +617,110 @@ func TestUpdateDeft_CloneTagDetachedHeadMigratesWithoutGit(t *testing.T) {
 		t.Errorf("migrated core MUST NOT contain .git (err=%v)", err)
 	}
 }
+
+// TestBareVersionFromTag pins the tag -> bare-derivative mapping used to keep
+// vbrief/.deft-version in agreement with the YAML manifest tag (#1437). Mirrors
+// the doctor's _manifest_tag_to_version lstrip("v").
+func TestBareVersionFromTag(t *testing.T) {
+	cases := map[string]string{
+		"v0.39.3":     "0.39.3",
+		"0.39.3":      "0.39.3",
+		"v1.2.3-rc.1": "1.2.3-rc.1",
+		"  v0.40.0  ": "0.40.0",
+		"":            "",
+	}
+	for in, want := range cases {
+		if got := bareVersionFromTag(in); got != want {
+			t.Errorf("bareVersionFromTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestRegenerateBareVersionMarker covers the #1437 derivative writer directly:
+// it writes the BARE semver (no leading v) plus a trailing newline at
+// vbrief/.deft-version, creates the parent vbrief/ dir when absent, and is a
+// no-op for an empty (non-semver) tag.
+func TestRegenerateBareVersionMarker(t *testing.T) {
+	t.Run("writes bare semver and creates vbrief dir", func(t *testing.T) {
+		proj := t.TempDir()
+		path, err := regenerateBareVersionMarker(proj, "v0.39.3")
+		if err != nil {
+			t.Fatalf("regenerateBareVersionMarker: %v", err)
+		}
+		want := filepath.Join(proj, "vbrief", ".deft-version")
+		if path != want {
+			t.Errorf("path = %q, want %q", path, want)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "0.39.3\n" {
+			t.Errorf("content = %q, want %q (bare semver + trailing newline)", string(data), "0.39.3\n")
+		}
+	})
+	t.Run("empty tag is a no-op", func(t *testing.T) {
+		proj := t.TempDir()
+		path, err := regenerateBareVersionMarker(proj, "")
+		if err != nil {
+			t.Fatalf("regenerateBareVersionMarker: %v", err)
+		}
+		if path != "" {
+			t.Errorf("expected empty path for an empty tag, got %q", path)
+		}
+		if _, statErr := os.Stat(filepath.Join(proj, "vbrief", ".deft-version")); !os.IsNotExist(statErr) {
+			t.Errorf("empty tag must not create .deft-version (err=%v)", statErr)
+		}
+	})
+}
+
+// TestRefreshVendoredCore_RegeneratesBareVersionMarker is the #1437 Bug B
+// regression: the vendored file-swap upgrade refreshes .deft/core/** AND now
+// regenerates the bare vbrief/.deft-version derivative from the resolved tag, so
+// a stale derivative left by an earlier rail (here "0.0.0-dev") is brought into
+// agreement with the manifest the installer stamps. Drives the REAL UpdateDeft
+// vendored path against a real-shaped (pax-header) tarball, hermetically.
+func TestRefreshVendoredCore_RegeneratesBareVersionMarker(t *testing.T) {
+	origGit := runGitCaptureFunc
+	origFetch := fetchCoreTarballFunc
+	defer func() {
+		runGitCaptureFunc = origGit
+		fetchCoreTarballFunc = origFetch
+	}()
+
+	proj := t.TempDir()
+	core := filepath.Join(proj, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Stale bare derivative left by an earlier rail (the #1437 observed state).
+	vbriefDir := filepath.Join(proj, "vbrief")
+	if err := os.MkdirAll(vbriefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vbriefDir, ".deft-version"), []byte("0.0.0-dev\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Classify as vendored (no git work tree); stand in a real-shaped tarball.
+	runGitCaptureFunc = func(string, ...string) (string, error) { return "", fmt.Errorf("not a repo") }
+	tarball := makeCoreTarballWithPaxHeader(t, "deftai-directive-cafef00d1234", map[string]string{"main.md": "framework"})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
+
+	result := &WizardResult{ProjectName: "proj", ProjectDir: proj, DeftDir: core, Update: true}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, "v0.39.3")
+	if err != nil {
+		t.Fatalf("UpdateDeft (vendored refresh): %v", err)
+	}
+	if outcome.Strategy != strategyFileSwap {
+		t.Fatalf("strategy = %q, want %q", outcome.Strategy, strategyFileSwap)
+	}
+	got, err := os.ReadFile(filepath.Join(vbriefDir, ".deft-version"))
+	if err != nil {
+		t.Fatalf("vbrief/.deft-version missing after refresh: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "0.39.3" {
+		t.Errorf("vbrief/.deft-version = %q, want %q (regenerated from the resolved tag)", strings.TrimSpace(string(got)), "0.39.3")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1437.

On a vendored (no-`.git`) install, `deft-install --upgrade` succeeded (post #1433) but left a doctor-failing state: the file-swap only owned `.deft/core/**` and skipped two project-root derived artifacts. This PR fixes both, adds unit regressions, and adds an end-to-end smoke test to stop this recurrence class (#1425 → #1433 → #1437 all escaped fixture-only unit tests).

## A — Duplicate `AGENTS.md` managed section (`cmd/deft-install/setup.go`)

The managed-section matchers keyed on the exact, attribute-less marker `<!-- deft:managed-section v3 -->`. A real `AGENTS.md` whose open marker carries provenance attributes (`sha=`/`refreshed=`/`session=`, emitted by `run agents:refresh` / the relocator) was not matched, so `WriteAgentsMD` fell through and **appended a second managed section** (doctor: `agents-md-managed-section-fresh: unreadable`).

- Detection (`agentsMDManagedSlice`, the rewrite trigger, and the new `agentsMDManagedSpans` helper) now matches the open marker attribute-tolerantly via a package-level regex (`<!-- deft:managed-section v[23][^>]*-->`), covering both v2 and v3, attributed or bare. The installer still **emits** the bare canonical marker; only matching changed.
- The rewrite is **self-healing**: it removes *every* existing managed section and re-emits **exactly one** canonical section, converging 0/1/N → 1, preserving operator prose before/between/after the fences. Installs already broken with duplicate sections are cleaned up on the next `--upgrade`.
- The happy-path skip is gated on the bare canonical marker, so an attributed marker is rewritten in place while a re-run on the installer's own output stays a byte-for-byte no-op.

## B — Bare `vbrief/.deft-version` not regenerated (`cmd/deft-install/upgrade.go`)

The vendored file-swap refreshed `.deft/core/VERSION` but not the bare `vbrief/.deft-version` derivative (doctor: `manifest-agreement: fail`, manifest tag vs `.deft-version='0.0.0-dev'`). The vendored refresh path now regenerates `vbrief/.deft-version` (bare semver, no leading `v`) from the resolved release tag as part of the swap, so a fresh `--upgrade` is self-consistent and doctor-clean without a manual `task upgrade`.

## Tests

- Unit regressions (`setup_test.go` / `upgrade_test.go`): attributed-marker rewrite → single section in place; a pre-existing two-section file collapses to one; a clean single-section file stays single (idempotent); direct `rewriteAgentsMDBlock` N→1 collapse; `bareVersionFromTag` / `regenerateBareVersionMarker`; and the vendored refresh regenerating `vbrief/.deft-version`.
- **End-to-end smoke test** (`e2e_upgrade_test.go`): builds a realistic vendored-install fixture (old manifest, root `AGENTS.md` with an attributed v3 marker + operator prose, stale `vbrief/.deft-version`), drives the real vendored upgrade path against a real-shaped (pax-header) tarball, and asserts the doctor invariants hold post-upgrade: **exactly one** managed section **and** `vbrief/.deft-version` agrees with `.deft/core/VERSION`. It is hermetic (no network, no real git). Verified **RED on pre-fix code** (second section appended; `.deft-version` stays `0.0.0-dev`) and **GREEN after** the fix.

## Validation

- `go test ./cmd/deft-install/...` — all green (incl. new tests).
- `go vet ./cmd/deft-install/` — clean.
- `gofmt -l` on the changed `.go` files — none listed (files LF-normalized; the repo's `core.autocrlf=true` re-applies CRLF in the working tree on checkout, committed blobs are LF).
