### PR TITLE
fix(install): deft-core-guard allowlists installer-managed root files (#1440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`deft-core-guard` no longer rejects `deft-install --upgrade` PRs (#1440)** -- the deposited guard counted every installer-managed root file as consumer "app" code, so a `deft-install --upgrade` could never land as a single green PR. The guard now treats installer-managed deposits (`AGENTS.md`, `.agents/`, `.gitattributes`/`.gitignore`, `greptile.json`, the CodeQL config, the guard workflow itself, and the `vbrief/` scaffolding plus `vbrief/.deft-version`) as part of the framework deposit, so an upgrade-only PR passes. Mixing `.deft/core/**` with genuine app files or consumer vBRIEF data (`vbrief/**/*.vbrief.json`) still fails, and the allowlist is rendered from a single in-installer source so the guard and the installer cannot drift. Closes #1440.
 
 ### Removed
 

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -32,13 +32,150 @@ const (
 	coreGuardWorkflowRelPath = ".github/workflows/deft-core-guard.yml"
 )
 
-// coreGuardWorkflowContent is the optional CI guard deposited at
-// coreGuardWorkflowRelPath (#1430). It fails a PR that mixes changes to the
-// vendored framework payload (.deft/core/**) with changes to the consumer's own
-// files, so a framework update from deft-install/upgrade lands in its own PR and
-// reviewers can treat it as a packaged, machine-managed bump. It is deposited
-// create-if-absent and is safe for consumers to delete.
-const coreGuardWorkflowContent = `name: deft-core-guard
+// installerManagedMatcher classifies a single repo-relative (POSIX-separated)
+// changed path as installer-managed -- i.e. deposited and maintained by
+// deft-install / upgrade outside .deft/core/, not consumer app code. A matcher
+// is either an exact path or a directory prefix (any path beneath it).
+type installerManagedMatcher struct {
+	exact  string // full repo-relative path matched verbatim
+	prefix string // directory prefix (trailing slash) matching any path beneath it
+}
+
+// matches reports whether a repo-relative POSIX path is covered by the matcher.
+func (m installerManagedMatcher) matches(path string) bool {
+	if m.exact != "" {
+		return path == m.exact
+	}
+	return m.prefix != "" && strings.HasPrefix(path, m.prefix)
+}
+
+// ere renders the matcher as one anchored POSIX ERE atom equivalent to
+// matches(): an exact path becomes ^path$ and a prefix becomes ^prefix.
+func (m installerManagedMatcher) ere() string {
+	if m.exact != "" {
+		return "^" + escapeERE(m.exact) + "$"
+	}
+	return "^" + escapeERE(m.prefix)
+}
+
+// escapeERE backslash-escapes the POSIX ERE metacharacters in s so a literal
+// path fragment is matched verbatim by both grep -E and Go's regexp.
+func escapeERE(s string) string {
+	const meta = `.^$*+?()[]{}|\`
+	var b strings.Builder
+	for _, r := range s {
+		if r < 128 && strings.ContainsRune(meta, r) {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// installerManagedMatchers is the single source of truth for the installer's own
+// non-core deposit surface (#1440). It feeds BOTH the deposited deft-core-guard
+// regex (via installerManagedGuardERE) and the Go classifier
+// (classifyChangedPaths), so the guard the installer writes can never drift from
+// what the installer actually manages.
+//
+// CRITICAL: this allowlist MUST NOT cover consumer-authored vBRIEF data
+// (vbrief/PROJECT-DEFINITION.vbrief.json, vbrief/**/*.vbrief.json). Mixing that
+// with a .deft/core/** change MUST still trip the guard -- that separation is
+// the whole point of #1430. The vbrief entries below are scaffolding only
+// (.deft-version, vbrief.md, schemas/, migration/, and the per-lifecycle
+// .gitkeep placeholders), derived from vbriefLifecycleDirs so they stay in
+// lockstep with what WriteConsumerVbrief deposits.
+func installerManagedMatchers() []installerManagedMatcher {
+	matchers := []installerManagedMatcher{
+		{exact: "AGENTS.md"},
+		{prefix: ".agents/"},
+		{exact: ".gitattributes"},
+		{exact: ".gitignore"},
+		{exact: "greptile.json"},
+		{exact: codeqlConfigRelPath},
+		{exact: coreGuardWorkflowRelPath},
+		{exact: "vbrief/.deft-version"},
+		{exact: "vbrief/vbrief.md"},
+		{prefix: "vbrief/schemas/"},
+		{prefix: "vbrief/migration/"},
+	}
+	for _, sub := range vbriefLifecycleDirs {
+		matchers = append(matchers, installerManagedMatcher{exact: "vbrief/" + sub + "/.gitkeep"})
+	}
+	return matchers
+}
+
+// installerManagedGuardERE renders the installer-managed allowlist as one POSIX
+// ERE alternation (atoms joined by "|") suitable for `grep -E`. It is the exact
+// pattern embedded in the deposited guard AND the pattern classifyChangedPaths
+// mirrors, so the two cannot diverge. The atoms contain no single quotes, so the
+// result is safe to embed inside a single-quoted shell string.
+func installerManagedGuardERE() string {
+	matchers := installerManagedMatchers()
+	atoms := make([]string, len(matchers))
+	for i, m := range matchers {
+		atoms[i] = m.ere()
+	}
+	return strings.Join(atoms, "|")
+}
+
+// classifyChangedPaths splits a PR's changed (repo-relative, POSIX) paths into
+// the three buckets the deft-core-guard reasons about: framework payload
+// (.deft/core/**), installer-managed deposits (the #1440 allowlist), and app
+// (everything else -- consumer source AND consumer vBRIEF data). The guard fails
+// iff both core and app are non-empty. Empty strings are ignored. This mirrors
+// the shell logic rendered by coreGuardWorkflowContent so the Go tests can pin
+// the guard's semantics without executing bash.
+func classifyChangedPaths(changed []string) (core, installerManaged, app []string) {
+	matchers := installerManagedMatchers()
+	for _, p := range changed {
+		if p == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(p, ".deft/core/"):
+			core = append(core, p)
+		case matchesAnyInstallerManaged(matchers, p):
+			installerManaged = append(installerManaged, p)
+		default:
+			app = append(app, p)
+		}
+	}
+	return core, installerManaged, app
+}
+
+// matchesAnyInstallerManaged reports whether path is covered by any matcher.
+func matchesAnyInstallerManaged(matchers []installerManagedMatcher, path string) bool {
+	for _, m := range matchers {
+		if m.matches(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// guardWouldFail reports the deposited guard's decision for a set of changed
+// paths: it fails a PR iff the diff mixes the framework payload (.deft/core/**)
+// with genuine app paths (after subtracting the installer-managed allowlist).
+func guardWouldFail(changed []string) bool {
+	core, _, app := classifyChangedPaths(changed)
+	return len(core) > 0 && len(app) > 0
+}
+
+// coreGuardWorkflowContent renders the optional CI guard deposited at
+// coreGuardWorkflowRelPath (#1430, #1440). It fails a PR that mixes changes to
+// the vendored framework payload (.deft/core/**) with changes to the consumer's
+// own files, so a framework update from deft-install/upgrade lands in its own PR
+// and reviewers can treat it as a packaged, machine-managed bump. It is
+// deposited create-if-absent and is safe for consumers to delete.
+//
+// The "app" set subtracts the installer-managed allowlist (#1440) so a
+// `deft-install --upgrade` PR -- which legitimately rewrites root files like
+// AGENTS.md and vbrief scaffolding alongside .deft/core/** -- is no longer
+// rejected by construction. The allowlist regex is rendered from
+// installerManagedGuardERE so the deposited guard and the installer never drift.
+func coreGuardWorkflowContent() string {
+	return `name: deft-core-guard
 
 # Deft framework guard (#1430): a single PR should not mix changes to the
 # vendored framework payload (.deft/core/**) with changes to your own project
@@ -68,7 +205,13 @@ jobs:
           echo "Changed files:"
           echo "$changed"
           core=$(printf '%s\n' "$changed" | grep -E '^\.deft/core/' || true)
-          app=$(printf '%s\n' "$changed" | grep -vE '^\.deft/core/' | grep -v '^$' || true)
+          # Installer-managed deposits (deft-install / upgrade writes these
+          # outside .deft/core/, e.g. AGENTS.md, .agents/, vbrief scaffolding)
+          # are part of the framework deposit, not consumer app code, so they are
+          # subtracted from the "app" set (#1440). Consumer vBRIEF data
+          # (vbrief/**/*.vbrief.json) is intentionally NOT exempt and still trips
+          # the guard when mixed with a .deft/core/** change.
+          app=$(printf '%s\n' "$changed" | grep -vE '^\.deft/core/' | grep -vE '` + installerManagedGuardERE() + `' | grep -v '^$' || true)
           if [ -n "$core" ] && [ -n "$app" ]; then
             echo "::error title=deft-core guard (#1430)::This PR changes the vendored framework payload (.deft/core/**) AND non-framework files. Split the framework update into its own PR."
             echo "--- framework (.deft/core/**) changes ---"; printf '%s\n' "$core"
@@ -77,6 +220,7 @@ jobs:
           fi
           echo "OK: no mixed framework + app changes."
 `
+}
 
 // depositNeutralization performs the #1430 deposit so the vendored framework
 // payload at .deft/core/** is treated as packaged framework assets rather than
@@ -527,7 +671,7 @@ func EnsureCoreGuardWorkflow(w *Wizard, projectDir string) (bool, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return false, fmt.Errorf("could not create workflows dir: %w", err)
 	}
-	if err := os.WriteFile(path, []byte(coreGuardWorkflowContent), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(coreGuardWorkflowContent()), 0o644); err != nil {
 		return false, fmt.Errorf("could not write %s: %w", coreGuardWorkflowRelPath, err)
 	}
 	w.printf("%s created: CI refuses PRs mixing %s with app files.\n", coreGuardWorkflowRelPath, coreGlob)

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -433,6 +434,164 @@ func TestEnsureCodeQLPathsIgnore_InlineListAppends(t *testing.T) {
 	}
 	if changed2 {
 		t.Error("expected changed=false on second invocation")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deft-core-guard installer-managed allowlist (#1440)
+// ---------------------------------------------------------------------------
+
+// upgradeOnlyChangeSet is a representative `deft-install --upgrade` diff: the
+// vendored payload plus every installer-managed root deposit. None of these are
+// consumer app code, so the guard must let the PR through.
+func upgradeOnlyChangeSet() []string {
+	changed := []string{
+		".deft/core/VERSION",
+		".deft/core/skills/deft-directive-setup/SKILL.md",
+		"AGENTS.md",
+		".agents/deft.md",
+		".gitattributes",
+		".gitignore",
+		"greptile.json",
+		codeqlConfigRelPath,
+		coreGuardWorkflowRelPath,
+		"vbrief/.deft-version",
+		"vbrief/vbrief.md",
+		"vbrief/schemas/scope.schema.json",
+		"vbrief/migration/0001-init.md",
+	}
+	for _, sub := range vbriefLifecycleDirs {
+		changed = append(changed, "vbrief/"+sub+"/.gitkeep")
+	}
+	return changed
+}
+
+// TestCoreGuard_UpgradeOnlyChangeSetAllowed pins acceptance criterion (a): an
+// upgrade-only diff (.deft/core/** + the installer-managed allowlist) passes the
+// guard. Without the #1440 allowlist subtraction the installer-managed root
+// files land in "app" and this set is rejected (RED); with it the set is GREEN.
+func TestCoreGuard_UpgradeOnlyChangeSetAllowed(t *testing.T) {
+	changed := upgradeOnlyChangeSet()
+	core, managed, app := classifyChangedPaths(changed)
+	if len(core) == 0 {
+		t.Fatal("expected the change set to include .deft/core/** paths")
+	}
+	if len(app) != 0 {
+		t.Errorf("upgrade-only diff must leave the app set empty; got app=%v", app)
+	}
+	// Every non-core path must be recognised as installer-managed.
+	if want := len(changed) - len(core); len(managed) != want {
+		t.Errorf("expected %d installer-managed paths, got %d (%v)", want, len(managed), managed)
+	}
+	if guardWouldFail(changed) {
+		t.Error("guard must PASS an upgrade-only diff (.deft/core/** + installer-managed root files)")
+	}
+}
+
+// TestCoreGuard_MixedWithAppFails pins acceptance criterion (b): mixing
+// .deft/core/** with a genuine app file still trips the guard.
+func TestCoreGuard_MixedWithAppFails(t *testing.T) {
+	changed := []string{".deft/core/VERSION", "AGENTS.md", "src/main.py"}
+	core, _, app := classifyChangedPaths(changed)
+	if len(core) == 0 || len(app) == 0 {
+		t.Fatalf("expected both core and app non-empty; core=%v app=%v", core, app)
+	}
+	if app[0] != "src/main.py" {
+		t.Errorf("expected src/main.py to classify as app; got app=%v", app)
+	}
+	if !guardWouldFail(changed) {
+		t.Error("guard must FAIL a diff mixing .deft/core/** with a genuine app file")
+	}
+}
+
+// TestCoreGuard_MixedWithConsumerVbriefFails pins acceptance criterion (c):
+// consumer-authored vBRIEF data is NOT allowlisted, so mixing it with a core
+// change still fails. Covers both the project definition and a lifecycle scope
+// vBRIEF that lives right next to an allowlisted .gitkeep.
+func TestCoreGuard_MixedWithConsumerVbriefFails(t *testing.T) {
+	cases := [][]string{
+		{".deft/core/VERSION", "vbrief/PROJECT-DEFINITION.vbrief.json"},
+		{".deft/core/VERSION", "vbrief/active/2026-06-03-1440-fix.vbrief.json"},
+	}
+	for _, changed := range cases {
+		_, managed, app := classifyChangedPaths(changed)
+		if len(managed) != 0 {
+			t.Errorf("consumer vBRIEF data must NOT be installer-managed; got managed=%v for %v", managed, changed)
+		}
+		if len(app) == 0 {
+			t.Errorf("consumer vBRIEF data must classify as app; got empty app for %v", changed)
+		}
+		if !guardWouldFail(changed) {
+			t.Errorf("guard must FAIL when .deft/core/** is mixed with consumer vBRIEF data: %v", changed)
+		}
+	}
+}
+
+// TestCoreGuard_AllowlistAuthoritative pins acceptance criterion (d): the
+// deposited guard template renders its matcher from the SAME allowlist source
+// the Go classifier uses, and the rendered ERE accepts exactly the
+// installer-managed paths the classifier accepts. This is what prevents the
+// guard and the installer from drifting apart.
+func TestCoreGuard_AllowlistAuthoritative(t *testing.T) {
+	ere := installerManagedGuardERE()
+
+	// The deposited workflow must embed the allowlist ERE verbatim in its
+	// app-subtraction step -- proving the template is rendered from the source.
+	content := coreGuardWorkflowContent()
+	wantLine := "grep -vE '" + ere + "'"
+	if !strings.Contains(content, wantLine) {
+		t.Errorf("deposited guard does not embed the allowlist ERE; expected to find:\n%s\nin:\n%s", wantLine, content)
+	}
+
+	// The rendered ERE (what grep -E runs) and the Go classifier
+	// (matchesAnyInstallerManaged) must agree on every probe path, so the bash
+	// guard and the Go logic can never diverge.
+	re := regexp.MustCompile(ere)
+	matchers := installerManagedMatchers()
+
+	managed := []string{
+		"AGENTS.md",
+		".agents/deft.md",
+		".agents/nested/dir/file.md",
+		".gitattributes",
+		".gitignore",
+		"greptile.json",
+		codeqlConfigRelPath,
+		coreGuardWorkflowRelPath,
+		"vbrief/.deft-version",
+		"vbrief/vbrief.md",
+		"vbrief/schemas/scope.schema.json",
+		"vbrief/migration/0001-init.md",
+	}
+	for _, sub := range vbriefLifecycleDirs {
+		managed = append(managed, "vbrief/"+sub+"/.gitkeep")
+	}
+	notManaged := []string{
+		"src/main.py",
+		"README.md",
+		".deft/core/VERSION",
+		"vbrief/PROJECT-DEFINITION.vbrief.json",
+		"vbrief/active/2026-06-03-1440-fix.vbrief.json",
+		"agents.md",       // case-sensitive: must NOT match AGENTS.md
+		"vbrief/schemas",  // the prefix entry requires a trailing slash + child
+		"vbrief/active/x", // a lifecycle file that is not .gitkeep
+	}
+
+	for _, p := range managed {
+		if !matchesAnyInstallerManaged(matchers, p) {
+			t.Errorf("classifier should treat %q as installer-managed", p)
+		}
+		if !re.MatchString(p) {
+			t.Errorf("rendered guard ERE should match installer-managed path %q", p)
+		}
+	}
+	for _, p := range notManaged {
+		if matchesAnyInstallerManaged(matchers, p) {
+			t.Errorf("classifier must NOT treat %q as installer-managed", p)
+		}
+		if re.MatchString(p) {
+			t.Errorf("rendered guard ERE must NOT match %q", p)
+		}
 	}
 }
 


### PR DESCRIPTION
## What & why

The deposited `deft-core-guard` workflow (`#1430`) failed **every** `deft-install --upgrade` PR by construction: it classified anything outside `.deft/core/**` as consumer "app" code and failed when core + app were both non-empty. But `--upgrade` legitimately rewrites installer-managed root files every run (`AGENTS.md`, `vbrief/.deft-version`, etc.), so a steady-state upgrade always looked "mixed" and was rejected.

## Fix

The guard now fails only when `.deft/core/**` is mixed with paths that are **neither core NOR installer-managed**. An installer-managed allowlist is subtracted from the "app" set:

- `AGENTS.md`, `.agents/**`
- `.gitattributes`, `.gitignore`, `greptile.json`
- `.github/codeql/codeql-config.yml`, `.github/workflows/deft-core-guard.yml`
- `vbrief/.deft-version`, `vbrief/vbrief.md`, `vbrief/schemas/**`, `vbrief/migration/**`, `vbrief/<lifecycle>/.gitkeep`

**Consumer-authored vBRIEF data is intentionally NOT exempt** — `vbrief/PROJECT-DEFINITION.vbrief.json` and `vbrief/**/*.vbrief.json` still trip the guard when mixed with a core change (the whole point of `#1430`).

## Authoritative (no drift)

The allowlist lives as a single source in `deposit.go` (`installerManagedMatchers`). It feeds BOTH:
1. the deposited guard's `grep -vE` matcher (via `installerManagedGuardERE`), and
2. the Go classifier (`classifyChangedPaths`),

so the guard the installer writes can never drift from what the installer actually manages. The vbrief lifecycle `.gitkeep` entries are derived from the existing `vbriefLifecycleDirs` source.

## Tests (`deposit_test.go`)

- (a) upgrade-only diff (`.deft/core/**` + allowlisted root files) **passes**
- (b) `.deft/core/**` + a genuine app file (`src/main.py`) **fails**
- (c) `.deft/core/**` + consumer vBRIEF data (`PROJECT-DEFINITION.vbrief.json` and a lifecycle `*.vbrief.json`) **fails**
- (d) allowlist-authoritative: the rendered guard embeds the allowlist ERE verbatim, and the rendered ERE (compiled via Go `regexp`) agrees with the Go classifier on every probe path

### RED → GREEN evidence
With the allowlist temporarily neutered (pre-fix behavior), (a) and (d) fail (installer-managed files counted as app — exactly the `#1440` bug); with the allowlist they pass. (c) passes both ways, confirming consumer vBRIEF data is never exempted.

## Validation

- `go test ./cmd/deft-install/...` → `ok`
- `go vet ./cmd/deft-install/` → clean
- `gofmt -l` on LF-normalized changed files → none

Closes #1440.
