### PR TITLE
Fix vendored payload version resolution

### DIFF
--- a/run
+++ b/run
@@ -29,13 +29,19 @@ from typing import List, Optional
 # header always prints the correct version with no manual bump step.
 #
 # Resolution priority (first match wins -- mirrors
-# scripts/resolve_version.py and the Taskfile.yml inline `sh:` block):
+# scripts/resolve_version.py):
 #   1. $DEFT_RELEASE_VERSION env var -- set by
 #      scripts/release.py::run_build so the in-flight release version
 #      pins what `run` reports during `task release -- 0.X.Y`.
-#   2. `git describe --tags --abbrev=0` (with leading `v` stripped) --
-#      reflects the latest annotated release tag for ordinary checkouts.
-#   3. `0.0.0-dev` -- fallback for fresh checkouts with no tags or
+#   2. <install-root>/VERSION manifest tag/ref -- canonical for
+#      git-free .deft/core payload installs.
+#   3. <install-root>/.deft-version -- legacy/plain installed marker.
+#   4. <install-root>/pyproject.toml [project].version -- release
+#      metadata shipped with plain-file payloads.
+#   5. `git describe --tags --abbrev=0` (with leading `v` stripped) --
+#      only when <install-root> is itself a Git checkout, so consumer
+#      repo tags are never mistaken for Deft release tags.
+#   6. `0.0.0-dev` -- fallback for fresh checkouts with no tags or
 #      repositories where `git` is unavailable.
 #
 # This logic is intentionally inlined (not a `from scripts.resolve_version
@@ -47,63 +53,139 @@ from typing import List, Optional
 #       you change one, change the other -- regression coverage in
 #       tests/cli/test_run_version.py and tests/cli/test_resolve_version.py
 #       pins both surfaces to the same chain.
-_VERSION_MANIFEST_TAG_RE = re.compile(
-    r"^(?:tag|ref):\s*['\"]?v?([\d.][\w.-]*)['\"]?\s*$",
-    re.MULTILINE,
+_DEV_FALLBACK_VERSION = "0.0.0-dev"
+_VERSION_MANIFEST_LINE_RE = re.compile(
+    r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?P<value>.*?)\s*$"
+)
+_PYPROJECT_VERSION_RE = re.compile(
+    r"^\s*version\s*=\s*['\"](?P<value>[^'\"]+)['\"]\s*$"
 )
 
 
-def _version_from_install_manifest(base_dir: Path) -> Optional[str]:
-    """Return the version from ``<base_dir>/VERSION`` manifest, or None (#1323)."""
-    manifest = base_dir / "VERSION"
-    try:
-        if not manifest.is_file():
-            return None
-        text = manifest.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = _VERSION_MANIFEST_TAG_RE.search(text)
-    if match is None:
-        return None
-    return match.group(1).strip() or None
+def _normalise_resolved_version(raw: str, *, allow_dev: bool = False) -> Optional[str]:
+    """Return a bare version candidate, or None when the value is unusable.
 
-
-def _version_from_deft_version_file(base_dir: Path) -> Optional[str]:
-    """Return the version from ``<base_dir>/.deft-version``, or None (#1323)."""
-    marker = base_dir / ".deft-version"
-    try:
-        if not marker.is_file():
-            return None
-        version = marker.read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    if version.startswith("v"):
-        version = version[1:]
-    return version or None
-
-def _resolve_version() -> str:
-    """Resolve `run`'s VERSION using the documented priority chain.
-
-    Mirrors ``scripts/resolve_version.py::resolve_version()``. Each
-    branch is best-effort: a missing ``git`` binary, a fresh checkout
-    with no tags, or a malformed tag falls through to the next branch
-    rather than raising, so importing ``run`` never fails because of a
-    version-resolution edge case.
+    Durable on-disk metadata must not propagate the dev fallback: once
+    ``0.0.0-dev`` lands in an install manifest or marker it becomes the
+    durable-state corruption this resolver is meant to prevent.
+    The explicit environment override is exempt because the operator or
+    release pipeline deliberately supplied it.
     """
-    env_value = os.environ.get("DEFT_RELEASE_VERSION", "").strip()
-    if env_value:
-        return env_value
-    # Root lookups at the directory containing this script so a vendored
-    # `.deft/core/run` reads `.deft/core/VERSION` rather than consumer repo
-    # metadata.
-    script_dir_path = Path(__file__).parent.absolute()
-    manifest_value = _version_from_install_manifest(script_dir_path)
-    if manifest_value:
-        return manifest_value
-    deft_version_value = _version_from_deft_version_file(script_dir_path)
-    if deft_version_value:
-        return deft_version_value
-    script_dir = str(script_dir_path)
+    candidate = raw.strip().strip("'\"")
+    if candidate.startswith("v"):
+        candidate = candidate[1:]
+    if not candidate:
+        return None
+    if candidate == _DEV_FALLBACK_VERSION and not allow_dev:
+        return None
+    if not allow_dev and not candidate[0].isdigit():
+        return None
+    return candidate
+
+
+def _version_from_install_manifest(install_root: Path) -> Optional[str]:
+    """Read ``<install-root>/VERSION`` tag/ref as installed version."""
+    manifest_path = install_root / "VERSION"
+    if not manifest_path.is_file():
+        return None
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    parsed: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = _VERSION_MANIFEST_LINE_RE.match(stripped)
+        if match is None:
+            continue
+        parsed[match.group("key").lower()] = match.group("value").strip()
+
+    for key in ("tag", "ref"):
+        raw = parsed.get(key)
+        if raw is None:
+            continue
+        value = _normalise_resolved_version(raw)
+        if value:
+            return value
+    return None
+
+
+def _version_from_plain_marker(install_root: Path) -> Optional[str]:
+    """Read ``<install-root>/.deft-version`` when present."""
+    marker_path = install_root / ".deft-version"
+    if not marker_path.is_file():
+        return None
+    try:
+        return _normalise_resolved_version(marker_path.read_text(encoding="utf-8"))
+    except OSError:
+        return None
+
+
+def _version_from_deft_version_file(install_root: Path) -> Optional[str]:
+    """Compatibility alias for the installed-version marker helper."""
+    return _version_from_plain_marker(install_root)
+
+
+def _version_from_pyproject(install_root: Path) -> Optional[str]:
+    """Read ``[project].version`` from a shipped pyproject.toml."""
+    pyproject_path = install_root / "pyproject.toml"
+    if not pyproject_path.is_file():
+        return None
+    try:
+        text = pyproject_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    in_project_section = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        content_line = stripped.split("#", 1)[0].strip()
+        if content_line.startswith("[") and content_line.endswith("]"):
+            in_project_section = content_line == "[project]"
+            continue
+        if not in_project_section:
+            continue
+        match = _PYPROJECT_VERSION_RE.match(content_line)
+        if match is not None:
+            return _normalise_resolved_version(match.group("value"))
+    return None
+
+
+def _git_top_level(install_root: Path) -> Optional[Path]:
+    """Return Git top-level only when git can resolve it from install_root."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            cwd=str(install_root),
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    top_level = (result.stdout or "").strip()
+    if not top_level:
+        return None
+    return Path(top_level)
+
+
+def _version_from_git(install_root: Path) -> Optional[str]:
+    """Return latest Git tag only for standalone Deft checkouts."""
+    top_level = _git_top_level(install_root)
+    try:
+        if top_level is None or top_level.resolve() != install_root.resolve():
+            return None
+    except OSError:
+        return None
+
     try:
         result = subprocess.run(
             ["git", "describe", "--tags", "--abbrev=0"],
@@ -111,18 +193,56 @@ def _resolve_version() -> str:
             text=True,
             timeout=10,
             check=False,
-            cwd=script_dir,
+            cwd=str(install_root),
         )
     except (subprocess.TimeoutExpired, OSError):
-        # OSError covers FileNotFoundError (subclass) raised when `git`
-        # is not on PATH plus other unexpected I/O failures.
-        return "0.0.0-dev"
+        return None
     if result.returncode != 0:
-        return "0.0.0-dev"
-    tag = (result.stdout or "").strip()
-    if tag.startswith("v"):
-        tag = tag[1:]
-    return tag or "0.0.0-dev"
+        return None
+    return _normalise_resolved_version(result.stdout or "")
+
+
+def _resolve_version(install_root: Optional[Path] = None) -> str:
+    """Resolve `run`'s VERSION using the documented priority chain.
+
+    Mirrors ``scripts/resolve_version.py::resolve_version()``. Each
+    branch is best-effort: unreadable manifest files, a missing ``git``
+    binary, a fresh checkout with no tags, or a malformed tag falls
+    through to the next branch rather than raising, so importing ``run``
+    never fails because of a version-resolution edge case.
+    """
+    env_value = os.environ.get("DEFT_RELEASE_VERSION", "").strip()
+    if env_value:
+        return _normalise_resolved_version(env_value, allow_dev=True) or env_value
+
+    root = Path(install_root) if install_root is not None else Path(__file__).parent.absolute()
+    for resolver in (
+        _version_from_install_manifest,
+        _version_from_deft_version_file,
+        _version_from_pyproject,
+        _version_from_git,
+    ):
+        value = resolver(root)
+        if value:
+            return value
+    return _DEV_FALLBACK_VERSION
+
+
+def _dev_fallback_state_writes_allowed(install_root: Optional[Path] = None) -> bool:
+    """Allow durable ``0.0.0-dev`` writes only from standalone checkouts."""
+    root = Path(install_root) if install_root is not None else Path(__file__).parent.absolute()
+    top_level = _git_top_level(root)
+    try:
+        return top_level is not None and top_level.resolve() == root.resolve()
+    except OSError:
+        return False
+
+
+def _version_safe_for_state_write(version: str, install_root: Optional[Path] = None) -> bool:
+    """Return False when a consumer install would persist the dev fallback."""
+    if version.strip() != _DEV_FALLBACK_VERSION:
+        return True
+    return _dev_fallback_state_writes_allowed(install_root)
 
 
 VERSION = _resolve_version()
@@ -721,13 +841,16 @@ def _read_version_marker(project_root: Path) -> Optional[str]:
     return None
 
 
-def _write_version_marker(vbrief_root: Path) -> None:
+def _write_version_marker(vbrief_root: Path) -> bool:
     """Write VERSION into `vbrief/.deft-version` (best-effort, never raises)."""
+    if not _version_safe_for_state_write(VERSION):
+        return False
     try:
         vbrief_root.mkdir(parents=True, exist_ok=True)
         (vbrief_root / ".deft-version").write_text(VERSION + "\n", encoding="utf-8")
     except OSError:
-        pass
+        return False
+    return True
 
 
 def _detect_pre_cutover_legacy(project_root: Path) -> List[str]:
@@ -2221,6 +2344,8 @@ def _write_install_manifest(
     the two stay in sync on every install.
     """
     effective_tag = tag if tag is not None else VERSION
+    if not _version_safe_for_state_write(effective_tag, install_root):
+        return None
     effective_sha = sha if sha is not None else _resolve_framework_sha(install_root)
     effective_fetched_at = fetched_at if fetched_at is not None else _now_utc_iso()
     effective_project_root = project_root if project_root is not None else install_root.parent
@@ -2503,7 +2628,20 @@ def cmd_upgrade(args: List[str]):
 
     vbrief_dir = project_root / "vbrief"
     target_dir = vbrief_dir if vbrief_dir.is_dir() else project_root
-    _write_version_marker(target_dir)
+    if not _version_safe_for_state_write(VERSION):
+        error(
+            "Refusing to record unresolved framework version 0.0.0-dev. "
+            "Check the installed VERSION manifest (.deft/core/VERSION or deft/VERSION) "
+            "before running upgrade."
+        )
+        return 1
+    if not _write_version_marker(target_dir):
+        error(
+            f"Could not write framework version marker at {target_dir / '.deft-version'}. "
+            "Check filesystem permissions and available disk space "
+            "before running upgrade."
+        )
+        return 1
 
     # #1046 PR-B AC-4: write the canonical YAML provenance manifest at
     # ``<install>/VERSION``. The install root is wherever the framework
@@ -2522,6 +2660,8 @@ def cmd_upgrade(args: List[str]):
                 fetched_by="run-upgrade",
                 project_root=project_root,
             )
+            if written_manifest_path is None:
+                warn(f"Could not refresh install manifest at {install_candidate / 'VERSION'}.")
             break
 
     # #1325: a legacy parent-level `.deft/VERSION` left behind after the

--- a/scripts/resolve_version.py
+++ b/scripts/resolve_version.py
@@ -1,42 +1,46 @@
 #!/usr/bin/env python3
-"""resolve_version.py -- Python mirror of the Taskfile VERSION resolver (#723)
+"""resolve_version.py -- Python runtime VERSION resolver
 plus the canonical semver -> PEP 440 normalization helper (#771).
 
-This script is an INDEPENDENT Python mirror of the version-resolution
-priority chain that the canonical Taskfile-side resolver implements
-inline in ``Taskfile.yml`` ``vars: VERSION: { sh: ... }``. The Taskfile
-inline POSIX ``sh:`` block is the ACTUAL resolver consumed by
+This script is the Python runtime resolver for Deft entry points that
+need a framework version outside the Taskfile build pipeline. It began
+as an independent Python mirror of the Taskfile-side release-build
+resolver. The Python/runtime chain reads durable installed version files
+so git-free payload installs can report the release they actually carry
+even when their parent consumer repository has no Deft tags.
+
+This Python module is NOT invoked from ``Taskfile.yml``. The Taskfile
+inline POSIX ``sh:`` block remains the resolver consumed by
 ``task build`` / ``task release`` (run via go-task's embedded
 mvdan/sh interpreter so it works cross-platform without requiring
-``uv`` / Python at parse time).
+``uv`` / Python at parse time). Python callers should use this module
+instead of reimplementing installed-payload detection.
 
-This Python module is NOT invoked from ``Taskfile.yml``. It exists so
-Python callers (regression tests in ``tests/cli/test_resolve_version.py``,
-``scripts/release.py::run_build``, future scripts that need the
-version at import time, etc.) have a single source of truth for the
-same resolution priority -- avoiding silent drift between the Taskfile
-``sh:`` block and ad-hoc Python re-implementations.
-
-Resolution priority (first match wins -- mirrors the Taskfile sh block):
+Resolution priority (first match wins):
     1. ``$DEFT_RELEASE_VERSION`` -- set by ``scripts/release.py::run_build``
        so the in-flight release version (e.g. ``0.21.0``) becomes the
        build artifact filename during ``task release -- 0.21.0``. The
-       Taskfile literal previously hard-coded ``0.20.0``, which produced
-       ``dist/deft-0.20.0.zip`` during the v0.21.0 cut (#723).
-    2. ``git describe --tags --abbrev=0`` (stripped of leading ``v``) --
-       reflects the latest annotated release tag for standalone
-       ``task build`` invocations on a tagged checkout.
-    3. ``0.0.0-dev`` -- fallback for fresh checkouts with no tags or
+       Taskfile literal previously hard-coded ``0.20.0``, which produced an
+       incorrect artifact filename during the next release.
+    2. ``<install-root>/VERSION`` manifest ``tag`` / ``ref`` -- canonical
+       installed version source for git-free payload installs.
+    3. ``<install-root>/.deft-version`` -- legacy/plain installed marker.
+    4. ``<install-root>/pyproject.toml`` ``[project].version`` -- release
+       metadata shipped with plain-file payloads.
+    5. ``git describe --tags --abbrev=0`` (stripped of leading ``v``) --
+       only when ``<install-root>`` is itself a Git checkout, so consumer
+       repo tags are never mistaken for Deft release tags.
+    6. ``0.0.0-dev`` -- fallback for fresh checkouts with no tags or
        repositories where ``git`` is unavailable.
 
 The script writes the resolved version to stdout WITHOUT a trailing
-newline so its output matches the Taskfile inline ``sh:`` block's
-``printf '%s'`` shape byte-for-byte (no trailing whitespace either
-way). ``stderr`` is intentionally silent on the happy path.
+newline so callers receive the same ``printf '%s'`` shape used by the
+Taskfile inline ``sh:`` block. ``stderr`` is intentionally silent on
+the happy path.
 
-If you change the priority chain here, you MUST also update the inline
-``sh:`` block in ``Taskfile.yml`` (and vice versa) -- the two are kept
-in lockstep by convention, not by code reuse.
+If you change the release-build priority chain here, consider whether
+the inline ``sh:`` block in ``Taskfile.yml`` needs the same change. The
+installed-payload branches are intentionally Python-runtime only.
 
 PEP 440 normalization (#771)
 ----------------------------
@@ -76,22 +80,15 @@ from pathlib import Path
 
 DEV_FALLBACK = "0.0.0-dev"
 ENV_VAR = "DEFT_RELEASE_VERSION"
+_MANIFEST_LINE_RE = re.compile(r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?P<value>.*?)\s*$")
+_PYPROJECT_VERSION_RE = re.compile(r"^\s*version\s*=\s*['\"](?P<value>[^'\"]+)['\"]\s*$")
 
-# Framework install root for the vendored-install metadata lookups (#1323).
+# Framework install root for installed version file lookups.
 # This script lives at ``<install>/scripts/resolve_version.py``; its parent's
 # parent is the framework deposit (``<install>``) where the Go installer
 # writes the canonical ``VERSION`` manifest and the bare ``.deft-version``
 # derivative. In framework-self-dev the same path resolves to the repo root.
 _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
-
-# Parses the ``tag``/``ref`` field of the ``<install>/VERSION`` YAML manifest.
-# Multiline so a single ``re.search`` finds whichever of the two lines comes
-# first (they carry the same value in a well-formed manifest). Mirrors the
-# inline regex in ``run::_VERSION_MANIFEST_TAG_RE``.
-_MANIFEST_TAG_RE = re.compile(
-    r"^(?:tag|ref):\s*['\"]?v?([\d.][\w.-]*)['\"]?\s*$",
-    re.MULTILINE,
-)
 
 # ---------------------------------------------------------------------------
 # PEP 440 normalization (#771)
@@ -222,53 +219,136 @@ def _from_env() -> str | None:
     return value or None
 
 
-def _from_manifest(base_dir: Path | None = None) -> str | None:
-    """Return the version from ``<base_dir>/VERSION`` manifest, or None (#1323).
+def _normalise_resolved_version(raw: str, *, allow_dev: bool = False) -> str | None:
+    """Return a bare version candidate, or None when the value is unusable."""
+    candidate = raw.strip().strip("'\"")
+    if candidate.startswith("v"):
+        candidate = candidate[1:]
+    if not candidate:
+        return None
+    if candidate == DEV_FALLBACK and not allow_dev:
+        return None
+    if not allow_dev and not candidate[0].isdigit():
+        return None
+    return candidate
 
-    Reads the canonical install manifest's ``tag``/``ref`` field so a vendored
-    ``.deft/core/`` install (no nested ``.git``) resolves its real version
-    rather than ``0.0.0-dev``. ``base_dir`` defaults to the framework root.
-    """
-    base = base_dir if base_dir is not None else _FRAMEWORK_ROOT
-    manifest = base / "VERSION"
+
+def _default_install_root() -> Path:
+    """Return the framework root for this script in source or install layout."""
+    return _FRAMEWORK_ROOT
+
+
+def _from_install_manifest(install_root: Path) -> str | None:
+    """Return ``<install-root>/VERSION`` tag/ref as installed version."""
+    manifest_path = install_root / "VERSION"
+    if not manifest_path.is_file():
+        return None
     try:
-        if not manifest.is_file():
-            return None
-        text = manifest.read_text(encoding="utf-8")
+        text = manifest_path.read_text(encoding="utf-8")
     except OSError:
         return None
-    match = _MANIFEST_TAG_RE.search(text)
-    if match is None:
+
+    parsed: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = _MANIFEST_LINE_RE.match(stripped)
+        if match is None:
+            continue
+        parsed[match.group("key").lower()] = match.group("value").strip()
+
+    for key in ("tag", "ref"):
+        raw = parsed.get(key)
+        if raw is None:
+            continue
+        value = _normalise_resolved_version(raw)
+        if value:
+            return value
+    return None
+
+
+def _from_manifest(install_root: Path | None = None) -> str | None:
+    """Compatibility alias for the installed manifest resolver."""
+    root = Path(install_root) if install_root is not None else _default_install_root()
+    return _from_install_manifest(root)
+
+
+def _from_plain_marker(install_root: Path) -> str | None:
+    """Return ``<install-root>/.deft-version`` when present."""
+    marker_path = install_root / ".deft-version"
+    if not marker_path.is_file():
         return None
-    return match.group(1).strip() or None
-
-
-def _from_deft_version(base_dir: Path | None = None) -> str | None:
-    """Return the version from ``<base_dir>/.deft-version`` plaintext, or None (#1323).
-
-    Strips a leading ``v`` so the value matches the bare ``X.Y.Z`` shape.
-    ``base_dir`` defaults to the framework root.
-    """
-    base = base_dir if base_dir is not None else _FRAMEWORK_ROOT
-    marker = base / ".deft-version"
     try:
-        if not marker.is_file():
-            return None
-        version = marker.read_text(encoding="utf-8").strip()
+        return _normalise_resolved_version(marker_path.read_text(encoding="utf-8"))
     except OSError:
         return None
-    if version.startswith("v"):
-        version = version[1:]
-    return version or None
 
 
-def _from_git() -> str | None:
-    """Return the latest annotated tag (without leading ``v``) or None.
+def _from_deft_version(install_root: Path | None = None) -> str | None:
+    """Compatibility alias for the installed-version marker helper."""
+    root = Path(install_root) if install_root is not None else _default_install_root()
+    return _from_plain_marker(root)
 
-    Rooted at the framework root so a vendored ``.deft/core/`` install does
-    not pick up the consumer repo's tags (the manifest / ``.deft-version``
-    branches catch that case first; this is the framework-self-dev path).
-    """
+
+def _from_pyproject(install_root: Path) -> str | None:
+    """Return ``[project].version`` from a shipped pyproject.toml."""
+    pyproject_path = install_root / "pyproject.toml"
+    if not pyproject_path.is_file():
+        return None
+    try:
+        text = pyproject_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    in_project_section = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        content_line = stripped.split("#", 1)[0].strip()
+        if content_line.startswith("[") and content_line.endswith("]"):
+            in_project_section = content_line == "[project]"
+            continue
+        if not in_project_section:
+            continue
+        match = _PYPROJECT_VERSION_RE.match(content_line)
+        if match is not None:
+            return _normalise_resolved_version(match.group("value"))
+    return None
+
+
+def _git_top_level(install_root: Path) -> Path | None:
+    """Return Git top-level only when git can resolve it from install_root."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            cwd=str(install_root),
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    top_level = (result.stdout or "").strip()
+    if not top_level:
+        return None
+    return Path(top_level)
+
+
+def _from_git(install_root: Path | None = None) -> str | None:
+    """Return the latest annotated tag only for standalone checkouts."""
+    root = Path(install_root) if install_root is not None else _default_install_root()
+    top_level = _git_top_level(root)
+    try:
+        if top_level is None or top_level.resolve() != root.resolve():
+            return None
+    except OSError:
+        return None
+
     try:
         result = subprocess.run(
             ["git", "describe", "--tags", "--abbrev=0"],
@@ -276,42 +356,31 @@ def _from_git() -> str | None:
             text=True,
             timeout=10,
             check=False,
-            cwd=str(_FRAMEWORK_ROOT),
+            cwd=str(root),
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return None
     if result.returncode != 0:
         return None
-    tag = (result.stdout or "").strip()
-    if not tag:
-        return None
-    if tag.startswith("v"):
-        tag = tag[1:]
-    return tag or None
+    return _normalise_resolved_version(result.stdout or "")
 
 
-def resolve_version() -> str:
-    """Resolve the version using the documented priority chain.
-
-    Priority (first match wins -- mirrors ``run::_resolve_version``):
-        1. ``$DEFT_RELEASE_VERSION`` env override.
-        2. ``<install>/VERSION`` manifest ``tag``/``ref`` field (#1323).
-        3. ``<install>/.deft-version`` plaintext (#1323).
-        4. ``git describe --tags --abbrev=0`` rooted at the framework root.
-        5. ``0.0.0-dev`` fallback.
-    """
+def resolve_version(install_root: Path | None = None) -> str:
+    """Resolve the version using the documented priority chain."""
     env_value = _from_env()
     if env_value:
-        return env_value
-    manifest_value = _from_manifest()
-    if manifest_value:
-        return manifest_value
-    deft_version_value = _from_deft_version()
-    if deft_version_value:
-        return deft_version_value
-    git_value = _from_git()
-    if git_value:
-        return git_value
+        return _normalise_resolved_version(env_value, allow_dev=True) or env_value
+
+    root = Path(install_root) if install_root is not None else _default_install_root()
+    for resolver in (
+        _from_manifest,
+        _from_deft_version,
+        _from_pyproject,
+        _from_git,
+    ):
+        value = resolver(root)
+        if value:
+            return value
     return DEV_FALLBACK
 
 

--- a/tests/cli/test_resolve_version.py
+++ b/tests/cli/test_resolve_version.py
@@ -1,14 +1,15 @@
-"""test_resolve_version.py -- Tests for scripts/resolve_version.py (#723, #771).
+"""test_resolve_version.py -- Tests for scripts/resolve_version.py.
 
-``scripts/resolve_version.py`` is an INDEPENDENT Python mirror of the
-resolution priority chain implemented inline in ``Taskfile.yml``
-``vars: VERSION: { sh: ... }``. The Python module is NOT invoked from
-Taskfile.yml -- these tests pin the Python-side contract so callers
-(``scripts/release.py::run_build``, future Python entry-points) cannot
-silently drift from the canonical Taskfile sh: block.
+``scripts/resolve_version.py`` is the Python runtime resolver for callers
+that need the framework version outside the Taskfile build pipeline. It
+mirrors the Taskfile release-build resolver and extends the runtime chain
+with installed version files so git-free payload installs do not inherit the
+consumer repository's Git version state.
 
-Covers the three resolution branches:
+Covers the resolution branches:
 - ``$DEFT_RELEASE_VERSION`` env override wins over git tag.
+- ``VERSION`` manifest and local marker metadata win over git.
+- ``pyproject.toml`` ``[project].version`` is a durable shipped fallback.
 - ``git describe --tags --abbrev=0`` fallback (stripped of leading ``v``).
 - ``0.0.0-dev`` fallback when neither env nor git produce a value.
 - ``main()`` writes the resolved version to stdout WITHOUT a trailing newline.
@@ -86,57 +87,78 @@ class TestFromEnv:
 
 
 class TestFromGit:
-    def test_strips_leading_v(self, monkeypatch):
+    def test_strips_leading_v(self, monkeypatch, tmp_path):
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="v0.20.2\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version._from_git() == "0.20.2"
+        assert resolve_version._from_git(tmp_path) == "0.20.2"
 
-    def test_returns_unprefixed_tag(self, monkeypatch):
+    def test_returns_unprefixed_tag(self, monkeypatch, tmp_path):
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="0.21.0\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version._from_git() == "0.21.0"
+        assert resolve_version._from_git(tmp_path) == "0.21.0"
 
-    def test_returns_none_when_git_missing(self, monkeypatch):
+    def test_returns_none_when_git_missing(self, monkeypatch, tmp_path):
         def fake_run(cmd, **kwargs):
             raise FileNotFoundError("git")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version._from_git() is None
+        assert resolve_version._from_git(tmp_path) is None
 
-    def test_returns_none_on_timeout(self, monkeypatch):
+    def test_returns_none_on_timeout(self, monkeypatch, tmp_path):
         def fake_run(cmd, **kwargs):
             raise subprocess.TimeoutExpired(cmd, timeout=10)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version._from_git() is None
+        assert resolve_version._from_git(tmp_path) is None
 
-    def test_returns_none_on_nonzero_exit(self, monkeypatch):
+    def test_returns_none_on_nonzero_exit(self, monkeypatch, tmp_path):
         def fake_run(cmd, **kwargs):
-            return SimpleNamespace(
-                stdout="", stderr="No names found", returncode=128
-            )
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
+            return SimpleNamespace(stdout="", stderr="No names found", returncode=128)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version._from_git() is None
+        assert resolve_version._from_git(tmp_path) is None
 
-    def test_returns_none_on_empty_stdout(self, monkeypatch):
+    def test_returns_none_on_empty_stdout(self, monkeypatch, tmp_path):
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version._from_git() is None
+        assert resolve_version._from_git(tmp_path) is None
 
-    def test_returns_none_when_only_v(self, monkeypatch):
+    def test_returns_none_when_only_v(self, monkeypatch, tmp_path):
         # Defensive: a tag that is bare "v" should not become an empty version.
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="v\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version._from_git() is None
+        assert resolve_version._from_git(tmp_path) is None
+
+    def test_returns_none_when_git_root_is_parent_consumer_repo(self, monkeypatch, tmp_path):
+        consumer = tmp_path / "consumer"
+        install_root = consumer / ".deft" / "core"
+        install_root.mkdir(parents=True)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{consumer}\n", stderr="", returncode=0)
+            raise AssertionError("git describe must not run for parent consumer repo")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert resolve_version._from_git(install_root) is None
 
 
 # ---------------------------------------------------------------------------
@@ -154,23 +176,90 @@ class TestResolveVersion:
         monkeypatch.setattr(subprocess, "run", fake_run)
         assert resolve_version.resolve_version() == "0.21.0"
 
-    def test_git_used_when_env_missing(self, monkeypatch):
+    def test_install_manifest_wins_before_git(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        (tmp_path / "VERSION").write_text(
+            "ref: 'v0.39.0'\n" "sha: 'b016dbaa38e1'\n" "tag: 'v0.39.0'\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when manifest resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert resolve_version.resolve_version(tmp_path) == "0.39.0"
+
+    def test_plain_marker_used_after_manifest_missing(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        (tmp_path / ".deft-version").write_text("0.38.0\n", encoding="utf-8")
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when marker resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert resolve_version.resolve_version(tmp_path) == "0.38.0"
+
+    def test_pyproject_used_after_corrupt_dev_manifest(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        (tmp_path / "VERSION").write_text("tag: 'v0.0.0-dev'\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = 'deft-directive'\nversion = \"0.39.0\"\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when pyproject resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert resolve_version.resolve_version(tmp_path) == "0.39.0"
+
+    def test_pyproject_project_header_allows_inline_comment(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        (tmp_path / "VERSION").write_text("tag: 'v0.0.0-dev'\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text(
+            "[project] # package metadata\nname = 'deft-directive'\nversion = \"0.39.0\"\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when pyproject resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert resolve_version.resolve_version(tmp_path) == "0.39.0"
+
+    def test_pyproject_version_line_allows_inline_comment(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        (tmp_path / "VERSION").write_text("tag: 'v0.0.0-dev'\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = 'deft-directive'\nversion = \"0.39.0\" # release metadata\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when pyproject resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert resolve_version.resolve_version(tmp_path) == "0.39.0"
+
+    def test_git_used_when_env_missing(self, monkeypatch, tmp_path):
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
 
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="v0.20.2\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version.resolve_version() == "0.20.2"
+        assert resolve_version.resolve_version(tmp_path) == "0.20.2"
 
-    def test_dev_fallback_when_neither_available(self, monkeypatch):
+    def test_dev_fallback_when_neither_available(self, monkeypatch, tmp_path):
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
 
         def fake_run(cmd, **kwargs):
             raise FileNotFoundError("git")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert resolve_version.resolve_version() == resolve_version.DEV_FALLBACK
+        assert resolve_version.resolve_version(tmp_path) == resolve_version.DEV_FALLBACK
         assert resolve_version.DEV_FALLBACK == "0.0.0-dev"
 
 
@@ -180,9 +269,7 @@ class TestResolveVersion:
 
 
 class TestMain:
-    def test_main_writes_resolved_version_without_trailing_newline(
-        self, monkeypatch, capsys
-    ):
+    def test_main_writes_resolved_version_without_trailing_newline(self, monkeypatch, capsys):
         monkeypatch.setenv("DEFT_RELEASE_VERSION", "0.21.0")
         rc = resolve_version.main([])
         assert rc == 0
@@ -196,6 +283,7 @@ class TestMain:
 
     def test_main_default_is_dev_when_nothing_resolves(self, monkeypatch, capsys):
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        monkeypatch.setattr(resolve_version, "_default_install_root", lambda: Path("/missing"))
 
         def fake_run(cmd, **kwargs):
             raise FileNotFoundError("git")
@@ -322,9 +410,7 @@ class TestToPep440NonPublishable:
     def test_non_publishable_subclasses_value_error(self):
         # Catch-blocks that already trap ``ValueError`` (e.g. argparse
         # error reporting) MUST keep working post-#771.
-        assert issubclass(
-            resolve_version.NonPublishableVersionError, ValueError
-        )
+        assert issubclass(resolve_version.NonPublishableVersionError, ValueError)
 
     def test_non_publishable_message_cites_tag(self):
         # The pipeline embeds the exception message in the operator-readable
@@ -417,8 +503,8 @@ class TestPep440PhaseCExtensionHook:
             "v0.20.0-alpha.1": "0.20.0a1",
         }
         for raw, expected in cases.items():
-            assert resolve_version.to_pep440(raw) == expected, (
-                f"#771 canonical mapping drift: {raw!r} -> {expected!r}"
-            )
+            assert (
+                resolve_version.to_pep440(raw) == expected
+            ), f"canonical mapping drift: {raw!r} -> {expected!r}"
         with pytest.raises(resolve_version.NonPublishableVersionError):
             resolve_version.to_pep440("v0.0.0-test.1")

--- a/tests/cli/test_run_version.py
+++ b/tests/cli/test_run_version.py
@@ -7,14 +7,15 @@ v0.21.0 cut surfaced the resulting drift: ``run --help`` reported
 release pipeline updated the literal.
 
 #741 replaces the literal with an inline priority chain that mirrors
-``scripts/resolve_version.py::resolve_version()`` (and the canonical
-Taskfile ``vars: VERSION: { sh: ... }`` block from #723):
+``scripts/resolve_version.py::resolve_version()``:
 
 1. ``$DEFT_RELEASE_VERSION`` env override -- pinned by
    ``scripts/release.py::run_build`` during ``task release -- 0.X.Y``.
-2. ``git describe --tags --abbrev=0`` (with leading ``v`` stripped) --
+2. Installed version files (``VERSION``, ``.deft-version``, ``pyproject.toml``)
+   for git-free payload installs.
+3. ``git describe --tags --abbrev=0`` (with leading ``v`` stripped) --
    ordinary checkouts on a tagged commit.
-3. ``0.0.0-dev`` -- fresh checkouts with no tags or git unavailable.
+4. ``0.0.0-dev`` -- fresh checkouts with no tags or git unavailable.
 
 These tests pin the priority chain at the ``run`` surface so future
 contributors cannot silently re-introduce the literal-bump pattern. The
@@ -43,6 +44,8 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -54,7 +57,21 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_PATH = REPO_ROOT / "run"
 
 
-def _load_run_module(monkeypatch: pytest.MonkeyPatch | None = None) -> ModuleType:
+def _copy_run_to(directory: Path) -> Path:
+    """Copy the extension-less run script into a temp install root."""
+    directory.mkdir(parents=True, exist_ok=True)
+    target = directory / "run"
+    shutil.copyfile(RUN_PATH, target)
+    scripts_dir = directory / "scripts"
+    scripts_dir.mkdir(exist_ok=True)
+    shutil.copyfile(REPO_ROOT / "scripts" / "_agents_md.py", scripts_dir / "_agents_md.py")
+    return target
+
+
+def _load_run_module(
+    monkeypatch: pytest.MonkeyPatch | None = None,
+    run_path: Path = RUN_PATH,
+) -> ModuleType:
     """Re-load the extension-less ``run`` script as a Python module.
 
     Each test gets its own freshly-loaded copy so module-load-time
@@ -63,15 +80,11 @@ def _load_run_module(monkeypatch: pytest.MonkeyPatch | None = None) -> ModuleTyp
     is deliberately distinct from ``deft_run`` (used by ``run.py``)
     so the production shim is not perturbed.
     """
-    loader = importlib.machinery.SourceFileLoader(
-        "deft_run_test", str(RUN_PATH)
-    )
-    spec = importlib.util.spec_from_loader(
-        "deft_run_test", loader, origin=str(RUN_PATH)
-    )
+    loader = importlib.machinery.SourceFileLoader("deft_run_test", str(run_path))
+    spec = importlib.util.spec_from_loader("deft_run_test", loader, origin=str(run_path))
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
-    module.__file__ = str(RUN_PATH)
+    module.__file__ = str(run_path)
     # Always replace the cached entry so successive calls in a test
     # session get a fresh resolution.
     sys.modules["deft_run_test"] = module
@@ -101,101 +114,112 @@ class TestPriorityChain:
         assert run_mod.VERSION == "9.9.9"
 
     def test_git_describe_used_when_env_missing(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
-            assert cmd[:2] == ["git", "describe"], (
-                f"unexpected subprocess call: {cmd!r}"
-            )
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
+            assert cmd[:2] == ["git", "describe"], f"unexpected subprocess call: {cmd!r}"
             return SimpleNamespace(stdout="v0.21.0\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         # Leading `v` MUST be stripped to match the canonical
         # `scripts/resolve_version.py` contract.
         assert run_mod.VERSION == "0.21.0"
 
     def test_git_describe_unprefixed_tag_passthrough(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="0.21.0\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         assert run_mod.VERSION == "0.21.0"
 
     def test_dev_fallback_when_git_missing(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
             raise FileNotFoundError("git")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         assert run_mod.VERSION == "0.0.0-dev"
 
     def test_dev_fallback_on_git_timeout(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
             raise subprocess.TimeoutExpired(cmd, timeout=10)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         assert run_mod.VERSION == "0.0.0-dev"
 
     def test_dev_fallback_on_git_nonzero_exit(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """A repo without any tags makes ``git describe`` exit 128."""
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
-            return SimpleNamespace(
-                stdout="", stderr="No names found", returncode=128
-            )
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
+            return SimpleNamespace(stdout="", stderr="No names found", returncode=128)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         assert run_mod.VERSION == "0.0.0-dev"
 
     def test_dev_fallback_on_empty_git_stdout(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         assert run_mod.VERSION == "0.0.0-dev"
 
     def test_dev_fallback_on_bare_v_tag(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """A defensive: tag ``v`` (post-strip empty) MUST NOT propagate."""
         monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="v\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         assert run_mod.VERSION == "0.0.0-dev"
 
-    def test_env_takes_priority_even_with_valid_git(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_env_takes_priority_even_with_valid_git(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Env override MUST short-circuit the git probe (priority order)."""
         monkeypatch.setenv("DEFT_RELEASE_VERSION", "0.99.0")
         called: list[list[str]] = []
@@ -208,13 +232,10 @@ class TestPriorityChain:
         run_mod = _load_run_module(monkeypatch)
         assert run_mod.VERSION == "0.99.0"
         assert called == [], (
-            "subprocess.run MUST NOT be called when env override is set; got "
-            f"{called!r}"
+            "subprocess.run MUST NOT be called when env override is set; got " f"{called!r}"
         )
 
-    def test_env_whitespace_stripped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_env_whitespace_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DEFT_RELEASE_VERSION", "  0.21.0\n")
 
         def fake_run(*args, **kwargs):  # pragma: no cover - guard
@@ -225,18 +246,232 @@ class TestPriorityChain:
         assert run_mod.VERSION == "0.21.0"
 
     def test_env_pure_whitespace_falls_through_to_git(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.setenv("DEFT_RELEASE_VERSION", "   \n")
+        run_path = _copy_run_to(tmp_path)
 
         def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+                return SimpleNamespace(stdout=f"{tmp_path}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout="v0.21.0\n", stderr="", returncode=0)
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        run_mod = _load_run_module(monkeypatch)
+        run_mod = _load_run_module(monkeypatch, run_path)
         # Pure-whitespace env value MUST be treated as unset, not as the
         # version literal " " or "".
         assert run_mod.VERSION == "0.21.0"
+
+    def test_install_manifest_wins_before_git(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
+        (tmp_path / "VERSION").write_text(
+            "ref: 'v0.39.0'\n" "sha: 'b016dbaa38e1'\n" "tag: 'v0.39.0'\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when manifest resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        run_mod = _load_run_module(monkeypatch, run_path)
+        assert run_mod.VERSION == "0.39.0"
+
+    def test_pyproject_used_after_corrupt_dev_manifest(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
+        (tmp_path / "VERSION").write_text("tag: 'v0.0.0-dev'\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = 'deft-directive'\nversion = \"0.39.0\"\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when pyproject resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        run_mod = _load_run_module(monkeypatch, run_path)
+        assert run_mod.VERSION == "0.39.0"
+
+    def test_pyproject_project_header_allows_inline_comment(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
+        (tmp_path / "VERSION").write_text("tag: 'v0.0.0-dev'\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text(
+            "[project] # package metadata\nname = 'deft-directive'\nversion = \"0.39.0\"\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when pyproject resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        run_mod = _load_run_module(monkeypatch, run_path)
+        assert run_mod.VERSION == "0.39.0"
+
+    def test_pyproject_version_line_allows_inline_comment(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
+        (tmp_path / "VERSION").write_text("tag: 'v0.0.0-dev'\n", encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = 'deft-directive'\nversion = \"0.39.0\" # release metadata\n",
+            encoding="utf-8",
+        )
+
+        def fake_run(*args, **kwargs):  # pragma: no cover - asserted not called
+            raise AssertionError("git must not be invoked when pyproject resolves")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        run_mod = _load_run_module(monkeypatch, run_path)
+        assert run_mod.VERSION == "0.39.0"
+
+    def test_vendored_payload_ignores_parent_consumer_git_tags(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        consumer = tmp_path / "consumer"
+        core = consumer / ".deft" / "core"
+        run_path = _copy_run_to(core)
+        subprocess.run(["git", "init"], cwd=consumer, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.invalid"],
+            cwd=consumer,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=consumer,
+            check=True,
+            capture_output=True,
+        )
+        (consumer / "README.md").write_text("consumer repo\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=consumer, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "consumer initial"],
+            cwd=consumer,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(["git", "tag", "v9.9.9"], cwd=consumer, check=True, capture_output=True)
+
+        run_mod = _load_run_module(monkeypatch, run_path)
+        assert run_mod.VERSION == "0.0.0-dev"
+
+    def test_vendored_payload_refuses_dev_fallback_state_writes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A consumer install must not persist unresolved VERSION state."""
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        consumer = tmp_path / "consumer"
+        core = consumer / ".deft" / "core"
+        run_path = _copy_run_to(core)
+        (core / "scripts").mkdir(exist_ok=True)
+        shutil.copyfile(
+            REPO_ROOT / "scripts" / "_precutover.py", core / "scripts" / "_precutover.py"
+        )
+        subprocess.run(["git", "init"], cwd=consumer, check=True, capture_output=True)
+
+        run_mod = _load_run_module(monkeypatch, run_path)
+        assert run_mod.VERSION == "0.0.0-dev"
+        assert run_mod._write_version_marker(consumer / "vbrief") is False
+        monkeypatch.setenv("DEFT_RELEASE_VERSION", "0.0.0-dev")
+        assert run_mod._write_version_marker(consumer / "vbrief") is False
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        assert not (consumer / "vbrief" / ".deft-version").exists()
+        assert (
+            run_mod._write_install_manifest(core, fetched_by="test", project_root=consumer) is None
+        )
+        assert not (core / "VERSION").exists()
+
+        env = {k: v for k, v in os.environ.items() if k != "DEFT_RELEASE_VERSION"}
+        upgrade_result = subprocess.run(
+            [sys.executable, str(run_path), "upgrade"],
+            cwd=consumer,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert upgrade_result.returncode == 1
+        assert "Refusing to record unresolved framework version" in (
+            upgrade_result.stdout + upgrade_result.stderr
+        )
+        assert not (consumer / "vbrief" / ".deft-version").exists()
+        assert not (core / "VERSION").exists()
+
+    def test_standalone_dev_checkout_allows_dev_fallback_state_writes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A true standalone dev checkout may still record explicit dev state.
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        run_path = _copy_run_to(tmp_path)
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+
+        run_mod = _load_run_module(monkeypatch, run_path)
+        assert run_mod.VERSION == "0.0.0-dev"
+        assert run_mod._write_version_marker(tmp_path / "vbrief") is True
+        assert (tmp_path / "vbrief" / ".deft-version").read_text(
+            encoding="utf-8"
+        ).strip() == "0.0.0-dev"
+        assert run_mod._write_install_manifest(tmp_path, fetched_by="test") == (
+            tmp_path / "VERSION"
+        )
+        assert "tag: 'v0.0.0-dev'" in (tmp_path / "VERSION").read_text(encoding="utf-8")
+
+    def test_vendored_payload_manifest_drives_version_and_gate(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A vendored payload inside a consumer repo has no Deft Git checkout.
+        monkeypatch.delenv("DEFT_RELEASE_VERSION", raising=False)
+        consumer = tmp_path / "consumer"
+        core = consumer / ".deft" / "core"
+        run_path = _copy_run_to(core)
+        (core / "scripts").mkdir(exist_ok=True)
+        shutil.copyfile(
+            REPO_ROOT / "scripts" / "_precutover.py", core / "scripts" / "_precutover.py"
+        )
+        (core / "VERSION").write_text(
+            "ref: 'v0.39.0'\n"
+            "sha: 'b016dbaa38e1'\n"
+            "tag: 'v0.39.0'\n"
+            "install_root: '.deft/core'\n",
+            encoding="utf-8",
+        )
+        (consumer / "vbrief").mkdir(parents=True)
+        (consumer / "vbrief" / ".deft-version").write_text("0.39.0\n", encoding="utf-8")
+        subprocess.run(["git", "init"], cwd=consumer, check=True, capture_output=True)
+
+        env = {k: v for k, v in os.environ.items() if k != "DEFT_RELEASE_VERSION"}
+        version_result = subprocess.run(
+            [sys.executable, str(run_path), "version"],
+            cwd=consumer,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert version_result.returncode == 0
+        assert version_result.stdout.strip() == "Deft CLI v0.39.0"
+
+        gate_result = subprocess.run(
+            [sys.executable, str(run_path), "gate"],
+            cwd=consumer,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert gate_result.returncode == 0
+        assert gate_result.stdout.strip() == "OK v0.39.0"
 
 
 # ---------------------------------------------------------------------------
@@ -265,14 +500,14 @@ class TestNoLiteralVersion:
                 if stripped.startswith(prefix):
                     offending_lines.append((idx, line))
         assert not offending_lines, (
-            "Static `VERSION = \"X.Y.Z\"` literal forbidden in `run` per "
+            'Static `VERSION = "X.Y.Z"` literal forbidden in `run` per '
             f"#741. Offending lines: {offending_lines}"
         )
 
     def test_resolve_version_helper_present(self) -> None:
         """The dynamic resolver function MUST exist by name in ``run``."""
         text = RUN_PATH.read_text(encoding="utf-8")
-        assert "def _resolve_version()" in text, (
+        assert "def _resolve_version(" in text, (
             "`run` MUST define `_resolve_version()` -- the dynamic "
             "replacement for the removed VERSION literal per #741."
         )

--- a/tests/cli/test_upgrade_gate.py
+++ b/tests/cli/test_upgrade_gate.py
@@ -170,6 +170,20 @@ class TestVersionMarkerHelpers:
         assert (vbrief_root / ".deft-version").is_file()
         assert deft_run_module._read_version_marker(tmp_path) == deft_run_module.VERSION
 
+    def test_write_marker_returns_false_on_write_error(
+        self, tmp_path, deft_run_module, monkeypatch
+    ):
+        original_write_text = Path.write_text
+
+        def fake_write_text(path, *args, **kwargs):
+            if path.name == ".deft-version":
+                raise OSError("cannot write marker")
+            return original_write_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", fake_write_text)
+        assert deft_run_module._write_version_marker(tmp_path / "vbrief") is False
+        assert not (tmp_path / "vbrief" / ".deft-version").exists()
+
     def test_project_root_marker_is_fallback(self, tmp_path, deft_run_module):
         """If vbrief/.deft-version is missing, project-root .deft-version is used."""
         (tmp_path / ".deft-version").write_text("0.18.5\n", encoding="utf-8")
@@ -412,6 +426,41 @@ class TestCmdUpgrade:
             encoding="utf-8"
         ).strip() == deft_run_module.VERSION
         assert "Updated .deft-version" in result.stdout
+
+    def test_reports_marker_write_error_without_unresolved_version_message(
+        self, run_command, isolated_env, deft_run_module, monkeypatch
+    ):
+        monkeypatch.setattr(deft_run_module, "HAS_RICH", False)
+        monkeypatch.setattr(deft_run_module, "VERSION", "0.39.0")
+        (isolated_env / "vbrief").mkdir(exist_ok=True)
+        original_write_text = Path.write_text
+
+        def fake_write_text(path, *args, **kwargs):
+            if path.name == ".deft-version":
+                raise OSError("cannot write marker")
+            return original_write_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", fake_write_text)
+        result = run_command("cmd_upgrade", [])
+
+        combined = result.stdout + result.stderr
+        assert result.return_code == 1
+        assert "Could not write framework version marker" in combined
+        assert ".deft-version" in combined
+        assert "0.0.0-dev" not in combined
+
+    def test_warns_when_install_manifest_refresh_fails(
+        self, run_command, isolated_env, deft_run_module, monkeypatch
+    ):
+        monkeypatch.setattr(deft_run_module, "HAS_RICH", False)
+        (isolated_env / "vbrief").mkdir(exist_ok=True)
+        (isolated_env / ".deft" / "core").mkdir(parents=True)
+        monkeypatch.setattr(deft_run_module, "_write_install_manifest", lambda *a, **k: None)
+        result = run_command("cmd_upgrade", [])
+        assert result.return_code in (0, None)
+        combined = result.stdout + result.stderr
+        assert "Could not refresh install manifest" in combined
+        assert ".deft/core/VERSION" in combined
 
     def test_warns_on_legacy_artifacts(
         self, run_command, isolated_env, deft_run_module, monkeypatch


### PR DESCRIPTION
## Summary
- Prefer installed payload metadata (`VERSION`, `.deft-version`, `pyproject.toml`) before Git when resolving the runtime Deft version.
- Guard Git tag resolution so it only runs when the framework payload is itself the Git top-level, not when `.deft/core` is inside a consumer repo.
- Refuse to persist `0.0.0-dev` into consumer version markers/manifests, while keeping standalone dev checkout behavior.

## Tests
- `uv --project /Users/davidcall/tools/deft/directive run --frozen pytest tests/cli/test_run_version.py tests/cli/test_resolve_version.py tests/cli/test_cmd_gate.py tests/cli/test_upgrade_gate.py tests/cli/test_install_manifest_root.py`
- `task check`

Closes #1323
