### PR TITLE
fix(render,installer): stop leaking vbrief .lock and .deft/core.bak backups (#1311, #1445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`task project:render` (and triage mutations) no longer leak a `vbrief/PROJECT-DEFINITION.vbrief.json.lock` file (#1311)** -- the PROJECT-DEFINITION mutation lock created its sidecar `.lock` file on acquisition but never removed it, so a clean render or policy mutation left an untracked 1-byte file in `vbrief/` that `git add -A` trapped on the next chore commit. The lock context manager now deletes the sidecar on exit (happy path and on exception), and the same cleanup discipline is applied to the `vbrief/.eval/*.lock` audit-log sidecars (candidates / slices / scope-lifecycle). The installer's canonical `.gitignore` deposit also gains `vbrief/*.lock` as a belt-and-suspenders guard so consumers are protected even on an interrupted render. Closes #1311.
+- **`deft-install --upgrade` no longer leaves a `.deft/core.bak-*` backup inside the consumer working tree (#1445)** -- the vendored file-swap upgrade wrote its pre-swap payload backup to `.deft/core.bak-<timestamp>/` next to the payload, which escaped the `.deft/core/`-only gitignore policy and was trapped by `git add -A`, staging thousands of backup files outside the #1430 neutralization scope. The backup is now written OUTSIDE the working tree (under the user cache dir, OS temp as a fallback) and its path is printed for rollback, so an upgrade leaves no untracked artefact in the repo and repeated upgrades do not accumulate copies in the tree. The installer's canonical `.gitignore` deposit also gains `.deft/core.bak-*/` and `.deft/*.bak-*` to neutralize any in-tree backup left by an older installer. Closes #1445.
 
 ### Removed
 

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -177,14 +177,29 @@ Read and follow: .deft/core/skills/deft-directive-sync/SKILL.md
 // attribute-tolerant. The closing marker (agentsMDFenceClose) is unchanged.
 var agentsMDManagedOpenPattern = regexp.MustCompile(`<!-- deft:managed-section v[23][^>]*-->`)
 
-// canonicalGitignoreLines mirrors scripts/relocate.py::GITIGNORE_LINES (the F2
-// canonical default from #1015): the runtime cache directory and the audit-log
-// private state. The framework deposit at .deft/core/ is INTENTIONALLY NOT
-// auto-gitignored -- per #11 .deft/core/ ships read-only packaged framework
-// assets that consumers commit for reproducibility.
+// canonicalGitignoreLines extends scripts/relocate.py::GITIGNORE_LINES (the F2
+// canonical default from #1015) -- the runtime cache directory and the
+// audit-log private state -- with two leaked-artefact guards so a consumer's
+// `git add -A` never traps installer/render scratch files:
+//
+//   - vbrief/*.lock          -- the PROJECT-DEFINITION mutation-lock sidecar
+//     (vbrief/PROJECT-DEFINITION.vbrief.json.lock) and any sibling vbrief-root
+//     lock. The framework now deletes these on a clean exit (#1311), so this
+//     is belt-and-suspenders for an interrupted render / an older payload.
+//   - .deft/core.bak-*/ + .deft/*.bak-* -- pre-swap payload backups. The
+//     installer now writes them OUTSIDE the working tree (#1445), so these
+//     only catch backups left by a pre-#1445 installer already in the tree.
+//
+// The framework deposit at .deft/core/ is INTENTIONALLY NOT auto-gitignored --
+// per #11 .deft/core/ ships read-only packaged framework assets that consumers
+// commit for reproducibility; the .bak globs above never match .deft/core
+// itself, only the timestamped backup siblings.
 var canonicalGitignoreLines = []string{
 	".deft-cache/",
 	"vbrief/.eval/",
+	"vbrief/*.lock",
+	".deft/core.bak-*/",
+	".deft/*.bak-*",
 }
 
 // minimalTaskfileContent is the canonical starter Taskfile.yml written (or

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -553,37 +553,105 @@ func isHex(s string) bool {
 	return s != ""
 }
 
-// swapInCore atomically replaces coreDir with the freshly-extracted newTree,
-// preserving the previous payload as a timestamped backup so the operation is
-// reversible. The backup rename happens within coreDir's parent (same volume
-// => atomic); the new tree is COPIED in because newTree typically lives on the
-// temp volume and a cross-device rename would fail on Windows. On any failure
-// after the backup the backup is restored. Returns the backup path on success.
+// swapInCore replaces coreDir with the freshly-extracted newTree, preserving
+// the previous payload as a timestamped backup so the operation is reversible.
+//
+// #1445: the backup is staged OUTSIDE the consumer working tree (under the
+// user cache dir, OS temp as a fallback) rather than at the in-tree
+// `<coreDir>.bak-<ts>` it used to use. An in-tree backup escaped the
+// `.deft/core/`-only gitignore policy (consumers commit .deft/core/ for
+// reproducibility, so .deft/ is NOT blanket-ignored) and was trapped by
+// `git add -A`, staging thousands of backup files. Writing it out-of-tree
+// means the upgrade never leaves an untracked artefact in the repo.
+//
+// The previous payload is MOVED to the backup via movePayload, which is
+// cross-device-safe (rename when same-volume, copy+remove otherwise -- the
+// usual case for a cache/temp backup). The new tree is then COPIED in. On any
+// failure after the backup the previous payload is restored from it. Returns
+// the (out-of-tree) backup path on success so the caller can print it for
+// rollback discoverability.
 func swapInCore(coreDir, newTree string) (string, error) {
 	parent := filepath.Dir(coreDir)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return "", err
 	}
 
-	backup := coreDir + ".bak-" + time.Now().UTC().Format("20060102-150405")
-	if pathExists(backup) {
-		// Sub-second reruns: disambiguate so we never clobber a prior backup.
-		backup = fmt.Sprintf("%s-%d", backup, os.Getpid())
+	backup, err := backupDirOutsideTree()
+	if err != nil {
+		return "", fmt.Errorf("could not allocate out-of-tree backup dir: %w", err)
 	}
 
-	if err := os.Rename(coreDir, backup); err != nil {
+	if err := movePayload(coreDir, backup); err != nil {
 		return "", fmt.Errorf("could not back up existing payload: %w", err)
 	}
 
 	if err := copyTree(newTree, coreDir); err != nil {
-		// Roll back: discard the partial copy and restore the backup.
+		// Roll back: discard the partial copy and restore from the backup.
 		os.RemoveAll(coreDir)
-		if rerr := os.Rename(backup, coreDir); rerr != nil {
+		if rerr := movePayload(backup, coreDir); rerr != nil {
 			return "", fmt.Errorf("install new payload failed (%v); ROLLBACK ALSO FAILED (%v) -- previous payload preserved at %s", err, rerr, backup)
 		}
 		return "", fmt.Errorf("install new payload: %w", err)
 	}
 	return backup, nil
+}
+
+// backupRootDirFunc resolves the base directory under which swapInCore stages
+// the out-of-tree payload backup (#1445). Indirected through a var so tests
+// can redirect it to a hermetic temp dir instead of polluting the real user
+// cache dir.
+var backupRootDirFunc = defaultBackupRootDir
+
+// defaultBackupRootDir returns ``<user-cache>/deft/backups`` (e.g.
+// ``%LocalAppData%\deft\backups`` on Windows, ``~/.cache/deft/backups`` on
+// Linux), falling back to the OS temp dir when the user cache dir cannot be
+// resolved. The directory is created on demand by backupDirOutsideTree.
+func defaultBackupRootDir() string {
+	base, err := os.UserCacheDir()
+	if err != nil || strings.TrimSpace(base) == "" {
+		base = os.TempDir()
+	}
+	return filepath.Join(base, "deft", "backups")
+}
+
+// backupDirOutsideTree returns a not-yet-existing directory path -- OUTSIDE the
+// consumer working tree -- where swapInCore stages the pre-swap payload backup
+// (#1445). The path is timestamped and pid-disambiguated for sub-second
+// reruns. The parent backup root is created here; if the resolved root is not
+// writable the OS temp dir is used as a last resort.
+func backupDirOutsideTree() (string, error) {
+	dir := backupRootDirFunc()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		dir = filepath.Join(os.TempDir(), "deft-backups")
+		if err2 := os.MkdirAll(dir, 0o755); err2 != nil {
+			return "", err2
+		}
+	}
+	backup := filepath.Join(dir, "core.bak-"+time.Now().UTC().Format("20060102-150405"))
+	if pathExists(backup) {
+		backup = fmt.Sprintf("%s-%d", backup, os.Getpid())
+	}
+	return backup, nil
+}
+
+// movePayload moves src to dst, tolerant of a cross-device boundary. It tries
+// an atomic os.Rename first (fast, same-volume); when that fails -- the usual
+// case when dst lives on the OS cache/temp volume, where os.Rename returns
+// EXDEV/ERROR_NOT_SAME_DEVICE -- it falls back to a recursive copy followed by
+// removing the source. The destination parent is created on demand. On the
+// copy-fallback path the source is left intact if the copy fails, so a
+// caller's rollback message can still point at a preserved backup.
+func movePayload(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	if err := copyTree(src, dst); err != nil {
+		return err
+	}
+	return os.RemoveAll(src)
 }
 
 // copyTree recursively copies the regular files and directories under src into

--- a/cmd/deft-install/upgrade_backup_test.go
+++ b/cmd/deft-install/upgrade_backup_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMain redirects the out-of-tree backup root (#1445) to a hermetic temp
+// dir for the whole package test run so swapInCore-exercising tests never
+// write into the real user cache dir. Individual tests may override
+// backupRootDirFunc further for precise per-test assertions.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "deft-install-backups-*")
+	if err != nil {
+		panic(err)
+	}
+	backupRootDirFunc = func() string { return tmp }
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
+// isInsideTree reports whether child resolves to a path inside parent.
+func isInsideTree(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// assertNoInTreeBackup walks root and fails if any `*.bak-*` artefact (the
+// historical in-tree `.deft/core.bak-<ts>` shape) survives -- such a file
+// would be staged by `git add -A` (#1445).
+func assertNoInTreeBackup(t *testing.T, root string) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.Contains(d.Name(), ".bak-") {
+			t.Errorf("untracked backup artefact left in working tree: %s (git add -A would trap it) -- see #1445", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+}
+
+// TestSwapInCore_BackupIsOutsideWorkingTree is the #1445 unit-level regression:
+// the pre-swap payload backup is staged OUTSIDE the consumer working tree, so
+// (a) no `*.bak-*` artefact is left under the project, and (b) the returned
+// backup path is outside projectDir and carries the previous payload.
+func TestSwapInCore_BackupIsOutsideWorkingTree(t *testing.T) {
+	backupRoot := t.TempDir()
+	orig := backupRootDirFunc
+	backupRootDirFunc = func() string { return backupRoot }
+	defer func() { backupRootDirFunc = orig }()
+
+	proj := t.TempDir()
+	core := filepath.Join(proj, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(core, "OLD.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newTree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(newTree, "NEW.txt"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	backup, err := swapInCore(core, newTree)
+	if err != nil {
+		t.Fatalf("swapInCore: %v", err)
+	}
+
+	// New payload swapped in; old content gone from core.
+	if data, err := os.ReadFile(filepath.Join(core, "NEW.txt")); err != nil || string(data) != "new" {
+		t.Errorf("NEW.txt not swapped in: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(core, "OLD.txt")); !os.IsNotExist(err) {
+		t.Errorf("OLD.txt should be gone from core after swap (err=%v)", err)
+	}
+
+	// The backup is OUTSIDE the project tree and preserves the old payload.
+	if isInsideTree(proj, backup) {
+		t.Errorf("backup %q is INSIDE the project tree %q (git add -A would trap it) -- see #1445", backup, proj)
+	}
+	if data, err := os.ReadFile(filepath.Join(backup, "OLD.txt")); err != nil || string(data) != "old" {
+		t.Errorf("out-of-tree backup missing OLD.txt: data=%q err=%v", data, err)
+	}
+
+	// No in-tree backup artefact survived.
+	assertNoInTreeBackup(t, proj)
+}
+
+// TestRefreshVendoredCore_NoInTreeBackup proves the end-to-end #1445 behavior:
+// a vendored `--upgrade` leaves NO untracked backup anywhere under the consumer
+// project tree, and reports the backup at an out-of-tree path.
+func TestRefreshVendoredCore_NoInTreeBackup(t *testing.T) {
+	backupRoot := t.TempDir()
+	origBackup := backupRootDirFunc
+	origGit := runGitCaptureFunc
+	origFetch := fetchCoreTarballFunc
+	backupRootDirFunc = func() string { return backupRoot }
+	defer func() {
+		backupRootDirFunc = origBackup
+		runGitCaptureFunc = origGit
+		fetchCoreTarballFunc = origFetch
+	}()
+
+	proj := t.TempDir()
+	core := filepath.Join(proj, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(core, "OLD.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Classify as vendored (not a git work tree) and stand in a tarball.
+	runGitCaptureFunc = func(string, ...string) (string, error) {
+		return "", fmt.Errorf("not a repo")
+	}
+	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{"marker.txt": "new"})
+	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
+
+	result := &WizardResult{ProjectName: "proj", ProjectDir: proj, DeftDir: core, Update: true}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+	outcome, err := UpdateDeft(w, result, "v1.2.3")
+	if err != nil {
+		t.Fatalf("UpdateDeft (vendored refresh): %v", err)
+	}
+
+	if outcome.Backup == "" {
+		t.Fatal("expected a backup path on a successful refresh")
+	}
+	if isInsideTree(proj, outcome.Backup) {
+		t.Errorf("reported backup %q is inside the project tree (#1445)", outcome.Backup)
+	}
+	// The refresh actually happened.
+	if data, err := os.ReadFile(filepath.Join(core, "marker.txt")); err != nil || string(data) != "new" {
+		t.Errorf("vendored core not refreshed: data=%q err=%v", data, err)
+	}
+	// And nothing `*.bak-*` was left in the working tree.
+	assertNoInTreeBackup(t, proj)
+}

--- a/scripts/_project_definition_io.py
+++ b/scripts/_project_definition_io.py
@@ -40,44 +40,65 @@ def project_definition_path(project_root: Path) -> Path:
 
 @contextlib.contextmanager
 def project_definition_mutation_lock(project_root: Path) -> Iterator[None]:
-    """Serialise PROJECT-DEFINITION read-modify-write critical sections."""
+    """Serialise PROJECT-DEFINITION read-modify-write critical sections.
+
+    The sidecar ``<file>.lock`` is removed on exit -- on the happy path AND
+    on an exception -- so a clean mutation never leaves
+    ``vbrief/PROJECT-DEFINITION.vbrief.json.lock`` behind for ``git add -A``
+    to trap on the next chore commit (#1311). The unlink runs in a
+    ``finally`` while the in-process ``_mutation_thread_lock`` is still held,
+    so no concurrent in-process acquirer can race it, and is best-effort: a
+    cross-process holder (Windows keeps the open file locked) or a benign
+    POSIX unlink race simply leaves the (gitignored) sidecar in place rather
+    than raising.
+    """
     path = project_definition_path(project_root)
     lock_path = path.parent / (path.name + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with _mutation_thread_lock, open(lock_path, "a+b") as fh:
-        if not lock_path.stat().st_size:
-            fh.write(b"\0")
-            fh.flush()
-        fh.seek(0)
-        if sys.platform == "win32":
-            import msvcrt
+    with _mutation_thread_lock:
+        try:
+            with open(lock_path, "a+b") as fh:
+                if not lock_path.stat().st_size:
+                    fh.write(b"\0")
+                    fh.flush()
+                fh.seek(0)
+                if sys.platform == "win32":
+                    import msvcrt
 
-            acquired = False
-            deadline = time.monotonic() + 30.0
-            while True:
-                try:
-                    msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
-                    acquired = True
-                    break
-                except OSError:
-                    if time.monotonic() > deadline:
-                        raise
-                    time.sleep(0.02)
-            try:
-                yield
-            finally:
-                if acquired:
-                    fh.seek(0)
-                    with contextlib.suppress(OSError):
-                        msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
+                    acquired = False
+                    deadline = time.monotonic() + 30.0
+                    while True:
+                        try:
+                            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+                            acquired = True
+                            break
+                        except OSError:
+                            if time.monotonic() > deadline:
+                                raise
+                            time.sleep(0.02)
+                    try:
+                        yield
+                    finally:
+                        if acquired:
+                            fh.seek(0)
+                            with contextlib.suppress(OSError):
+                                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
 
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                    try:
+                        yield
+                    finally:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            # The sidecar handle is closed by the `with open(...)` block above
+            # BEFORE this unlink (Windows refuses to delete an open file); the
+            # unlink is held under _mutation_thread_lock so it cannot race an
+            # in-process re-acquire, and is best-effort across processes
+            # (#1311 -- do not leave PROJECT-DEFINITION.vbrief.json.lock behind).
+            with contextlib.suppress(OSError):
+                lock_path.unlink()
 
 
 def load_project_definition_for_mutation(

--- a/scripts/candidates_log.py
+++ b/scripts/candidates_log.py
@@ -239,49 +239,60 @@ def _append_lock(log_path: Path) -> Iterator[None]:
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # ``a+b`` opens for read+write+create without truncating -- needed because
     # msvcrt.locking requires the byte range to exist.
-    with _thread_lock, open(lock_path, "a+b") as fh:
-        if not lock_path.stat().st_size:
-            fh.write(b"\0")
-            fh.flush()
-        fh.seek(0)
-        if sys.platform == "win32":
-            import msvcrt
+    with _thread_lock:
+        try:
+            with open(lock_path, "a+b") as fh:
+                if not lock_path.stat().st_size:
+                    fh.write(b"\0")
+                    fh.flush()
+                fh.seek(0)
+                if sys.platform == "win32":
+                    import msvcrt
 
-            # Spin on LK_NBLCK -- the LK_LOCK retry loop is fixed at 10x
-            # 1s and would block the test suite on bursty contention. The
-            # acquire spin is INTENTIONALLY outside the post-acquire try/
-            # finally so a deadline-driven raise does NOT trigger the
-            # release path on a never-acquired lock; the explicit
-            # ``acquired`` flag makes that invariant load-bearing for
-            # future readers (Slizard #876 P2).
-            acquired = False
-            deadline = time.monotonic() + 30.0
-            while True:
-                try:
-                    msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
-                    acquired = True
-                    break
-                except OSError:
-                    if time.monotonic() > deadline:
-                        raise
-                    time.sleep(0.02)
-            try:
-                yield
-            finally:
-                if acquired:
-                    fh.seek(0)
-                    # Best-effort release: the lock may already be gone if
-                    # the process is mid-shutdown; that is not an error.
-                    with suppress(OSError):
-                        msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
+                    # Spin on LK_NBLCK -- the LK_LOCK retry loop is fixed at 10x
+                    # 1s and would block the test suite on bursty contention.
+                    # The acquire spin is INTENTIONALLY outside the post-acquire
+                    # try/finally so a deadline-driven raise does NOT trigger
+                    # the release path on a never-acquired lock; the explicit
+                    # ``acquired`` flag makes that invariant load-bearing for
+                    # future readers (Slizard #876 P2).
+                    acquired = False
+                    deadline = time.monotonic() + 30.0
+                    while True:
+                        try:
+                            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+                            acquired = True
+                            break
+                        except OSError:
+                            if time.monotonic() > deadline:
+                                raise
+                            time.sleep(0.02)
+                    try:
+                        yield
+                    finally:
+                        if acquired:
+                            fh.seek(0)
+                            # Best-effort release: the lock may already be gone
+                            # if the process is mid-shutdown; not an error.
+                            with suppress(OSError):
+                                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
 
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                    try:
+                        yield
+                    finally:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            # Remove the sidecar ``<log>.lock`` so a clean append never leaves
+            # an untracked lock file behind (#1311 discipline). The handle is
+            # closed by the `with open(...)` block above BEFORE this unlink
+            # (Windows refuses to delete an open file); held under
+            # ``_thread_lock`` so the unlink cannot race an in-process
+            # re-acquire. Best-effort across processes.
+            with suppress(OSError):
+                lock_path.unlink()
 
 
 def _resolve_path(path: Path | str | None) -> Path:

--- a/scripts/scope_audit_log.py
+++ b/scripts/scope_audit_log.py
@@ -233,40 +233,51 @@ def _append_lock(log_path: Path) -> Iterator[None]:
     """
     lock_path = log_path.parent / (log_path.name + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with _thread_lock, open(lock_path, "a+b") as fh:
-        if not lock_path.stat().st_size:
-            fh.write(b"\0")
-            fh.flush()
-        fh.seek(0)
-        if sys.platform == "win32":
-            import msvcrt
+    with _thread_lock:
+        try:
+            with open(lock_path, "a+b") as fh:
+                if not lock_path.stat().st_size:
+                    fh.write(b"\0")
+                    fh.flush()
+                fh.seek(0)
+                if sys.platform == "win32":
+                    import msvcrt
 
-            acquired = False
-            deadline = time.monotonic() + 30.0
-            while True:
-                try:
-                    msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
-                    acquired = True
-                    break
-                except OSError:
-                    if time.monotonic() > deadline:
-                        raise
-                    time.sleep(0.02)
-            try:
-                yield
-            finally:
-                if acquired:
-                    fh.seek(0)
-                    with suppress(OSError):
-                        msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
+                    acquired = False
+                    deadline = time.monotonic() + 30.0
+                    while True:
+                        try:
+                            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+                            acquired = True
+                            break
+                        except OSError:
+                            if time.monotonic() > deadline:
+                                raise
+                            time.sleep(0.02)
+                    try:
+                        yield
+                    finally:
+                        if acquired:
+                            fh.seek(0)
+                            with suppress(OSError):
+                                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
 
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                    try:
+                        yield
+                    finally:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            # Remove the sidecar ``<log>.lock`` so a clean append never leaves
+            # an untracked lock file behind (#1311 discipline). The handle is
+            # closed by the `with open(...)` block above BEFORE this unlink
+            # (Windows refuses to delete an open file); held under
+            # ``_thread_lock`` so the unlink cannot race an in-process
+            # re-acquire. Best-effort across processes.
+            with suppress(OSError):
+                lock_path.unlink()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/slice_record.py
+++ b/scripts/slice_record.py
@@ -248,40 +248,51 @@ def _append_lock(log_path: Path) -> Iterator[None]:
     """
     lock_path = log_path.parent / (log_path.name + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with _thread_lock, open(lock_path, "a+b") as fh:
-        if not lock_path.stat().st_size:
-            fh.write(b"\0")
-            fh.flush()
-        fh.seek(0)
-        if sys.platform == "win32":
-            import msvcrt
+    with _thread_lock:
+        try:
+            with open(lock_path, "a+b") as fh:
+                if not lock_path.stat().st_size:
+                    fh.write(b"\0")
+                    fh.flush()
+                fh.seek(0)
+                if sys.platform == "win32":
+                    import msvcrt
 
-            acquired = False
-            deadline = time.monotonic() + 30.0
-            while True:
-                try:
-                    msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
-                    acquired = True
-                    break
-                except OSError:
-                    if time.monotonic() > deadline:
-                        raise
-                    time.sleep(0.02)
-            try:
-                yield
-            finally:
-                if acquired:
-                    fh.seek(0)
-                    with suppress(OSError):
-                        msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
+                    acquired = False
+                    deadline = time.monotonic() + 30.0
+                    while True:
+                        try:
+                            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+                            acquired = True
+                            break
+                        except OSError:
+                            if time.monotonic() > deadline:
+                                raise
+                            time.sleep(0.02)
+                    try:
+                        yield
+                    finally:
+                        if acquired:
+                            fh.seek(0)
+                            with suppress(OSError):
+                                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
 
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                    try:
+                        yield
+                    finally:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            # Remove the sidecar ``<log>.lock`` so a clean append never leaves
+            # an untracked lock file behind (#1311 discipline). The handle is
+            # closed by the `with open(...)` block above BEFORE this unlink
+            # (Windows refuses to delete an open file); held under
+            # ``_thread_lock`` so the unlink cannot race an in-process
+            # re-acquire. Best-effort across processes.
+            with suppress(OSError):
+                lock_path.unlink()
 
 
 def _resolve_path(path: Path | str | None) -> Path:

--- a/tests/cli/test_project_render.py
+++ b/tests/cli/test_project_render.py
@@ -582,3 +582,42 @@ class TestCLI:
 
         result = run_project_render(str(vbrief_dir))
         assert "2 scope items" in result.stdout
+
+
+# ===========================================================================
+# Lock-leak regression (#1311)
+# ===========================================================================
+
+
+class TestNoLockLeak:
+    """`task project:render` must not leave a .lock sidecar in vbrief/.
+
+    The mutation-lock sidecar (vbrief/PROJECT-DEFINITION.vbrief.json.lock)
+    used to be created and never cleaned up, so `git add -A` trapped it on
+    the next chore commit (#1311). These deterministic gates assert no
+    `*.lock` artefact survives a successful render -- on first creation and
+    on a subsequent update of an existing PROJECT-DEFINITION.
+    """
+
+    def test_no_lock_file_after_skeleton_creation(self, tmp_path):
+        """A fresh skeleton render leaves no .lock behind."""
+        vbrief_dir = tmp_path / "vbrief"
+        vbrief_dir.mkdir()
+
+        result = run_project_render(str(vbrief_dir))
+        assert result.returncode == 0
+        assert list(vbrief_dir.glob("*.lock")) == []
+
+    def test_no_lock_file_after_update(self, tmp_path):
+        """Re-rendering an existing PROJECT-DEFINITION leaves no .lock behind."""
+        vbrief_dir = tmp_path / "vbrief"
+        write_vbrief(
+            vbrief_dir / "active" / "2026-04-13-a.vbrief.json",
+            title="Task A",
+            status="running",
+        )
+
+        run_project_render(str(vbrief_dir))
+        run_project_render(str(vbrief_dir))
+
+        assert list(vbrief_dir.glob("*.lock")) == []

--- a/tests/test_project_definition_io_lock.py
+++ b/tests/test_project_definition_io_lock.py
@@ -1,0 +1,58 @@
+"""#1311 regressions: the PROJECT-DEFINITION mutation lock must not leak its
+sidecar ``vbrief/PROJECT-DEFINITION.vbrief.json.lock`` file.
+
+The lock file was created on acquisition but never removed, so a clean
+``task project:render`` / triage mutation left an untracked 1-byte file in
+``vbrief/`` that ``git add -A`` trapped on the next chore commit. These tests
+pin the deterministic gate: after the mutation-lock context exits -- on the
+happy path AND on an exception -- no ``.lock`` file remains.
+"""
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from _project_definition_io import project_definition_mutation_lock
+
+
+def _lock_path(project_root: Path) -> Path:
+    return project_root / "vbrief" / "PROJECT-DEFINITION.vbrief.json.lock"
+
+
+def test_mutation_lock_removes_sidecar_on_clean_exit(tmp_path: Path) -> None:
+    """A successful critical section leaves NO .lock behind (#1311)."""
+    with project_definition_mutation_lock(tmp_path):
+        # The lock is held here; the sidecar exists while acquired.
+        assert _lock_path(tmp_path).exists()
+
+    assert not _lock_path(tmp_path).exists(), (
+        "PROJECT-DEFINITION.vbrief.json.lock leaked after a clean mutation "
+        "(git add -A would trap it) -- see #1311"
+    )
+
+
+def test_mutation_lock_removes_sidecar_on_exception(tmp_path: Path) -> None:
+    """An exception inside the critical section still cleans up the lock."""
+    with pytest.raises(RuntimeError), project_definition_mutation_lock(tmp_path):
+        raise RuntimeError("boom")
+
+    assert not _lock_path(tmp_path).exists(), (
+        "lock sidecar leaked after the critical section raised -- cleanup "
+        "must run in a finally (#1311)"
+    )
+
+
+def test_no_lock_files_remain_under_vbrief(tmp_path: Path) -> None:
+    """Defensive: no ``*.lock`` artefact survives a mutation cycle."""
+    with project_definition_mutation_lock(tmp_path):
+        pass
+
+    leaked = list((tmp_path / "vbrief").glob("*.lock"))
+    assert leaked == [], f"unexpected leaked lock files under vbrief/: {leaked}"


### PR DESCRIPTION
# Stop leaking `vbrief/*.lock` and `.deft/core.bak-*` into the consumer repo

Two leaked-file footguns where a clean framework operation left an untracked
artefact that `git add -A` traps on the next chore commit.

Closes #1311
Closes #1445

## #1311 — `task project:render` / triage mutations leaked `vbrief/PROJECT-DEFINITION.vbrief.json.lock`

The PROJECT-DEFINITION mutation lock (`scripts/_project_definition_io.py::project_definition_mutation_lock`,
used by the triage policy writers) created its sidecar `.lock` file on
acquisition but never removed it. A clean render or policy mutation left an
untracked 1-byte file in `vbrief/` that `git add -A` trapped.

- The lock context manager now deletes the sidecar on exit — happy path **and**
  on an exception — via a `finally` held under the in-process thread lock
  (close-before-unlink so Windows can delete it; best-effort across processes).
- Applied the same cleanup discipline to the `vbrief/.eval/*.lock` audit-log
  sidecars (`candidates_log.py`, `slice_record.py`, `scope_audit_log.py`) so all
  four sidecar-lock helpers self-clean.
- Belt-and-suspenders: the installer's canonical `.gitignore` deposit
  (`canonicalGitignoreLines`) gains `vbrief/*.lock` so consumers are protected
  even on an interrupted render.

## #1445 — vendored `--upgrade` left `.deft/core.bak-<ts>/` backups inside the working tree

The vendored file-swap upgrade wrote its pre-swap payload backup to
`.deft/core.bak-<timestamp>/` next to the payload. Because consumers commit
`.deft/core/` (so `.deft/` is **not** blanket-ignored), the backup escaped the
gitignore policy and was trapped by `git add -A`, staging thousands of files
outside the #1430 neutralization scope.

- **Preferred fix:** `swapInCore` now stages the backup **outside** the working
  tree — under the user cache dir (`os.UserCacheDir()/deft/backups`), OS temp as
  a fallback — via a cross-device-safe `movePayload` (atomic rename when
  same-volume, copy+remove otherwise). The path is returned/printed for rollback
  discoverability, so an upgrade leaves **no** untracked artefact in the repo and
  repeated upgrades do not accumulate copies in the tree.
- Belt-and-suspenders: `canonicalGitignoreLines` also gains `.deft/core.bak-*/`
  and `.deft/*.bak-*` to neutralize any in-tree backup left by a pre-#1445
  installer already in the tree.

## Tests (RED → GREEN)

- `tests/test_project_definition_io_lock.py` (new) — fails on the old code
  (lock sidecar survives); passes after the cleanup. Covers clean exit,
  exception path, and a no-`*.lock`-under-`vbrief/` sweep.
- `tests/cli/test_project_render.py::TestNoLockLeak` (new) — asserts no `.lock`
  remains after a successful `project:render` (skeleton + update).
- `cmd/deft-install/upgrade_backup_test.go` (new) — asserts `swapInCore` /
  `UpdateDeft` write the backup outside the project tree and leave no `*.bak-*`
  artefact in the working tree. Adds a package `TestMain` that redirects the
  backup root to a hermetic temp dir so the suite never writes to the real cache.

## Validation

- `uv run ruff check` (touched files): clean
- `uv run mypy tests/`: success, no issues (239 source files)
- `uv run pytest` (lock + render + `.eval` helper suites): all pass
- `go test ./cmd/deft-install/`: ok
- `go vet ./cmd/deft-install/`: clean
