### PR TITLE
fix(install): gitignore *.premigrate.* migration snapshots in canonical deposit (#1450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`deft-install` now gitignores `*.premigrate.*` migration snapshots so they are not left as an untracked, guard-tripping artefact (#1450)** -- the vBRIEF migration / spec-render step run during install/upgrade writes pre-migration safety snapshots (`ROADMAP.premigrate.md`, `SPECIFICATION.premigrate.md`, `vbrief/specification.premigrate.vbrief.json`) into the consumer working tree, but the installer's canonical `.gitignore` deposit did not cover them -- so `git add -A` swept them in and, mixed with a `.deft/core/**` change, they tripped the deft-core-guard (#1440) as "app" files. The installer deposit now includes the leading-slash-free `*.premigrate.*` glob (matching both the repo-root snapshots and the nested `vbrief/` one at any depth), the same leaked-artefact hygiene class as the `vbrief/*.lock` (#1311) and `.deft/*.bak-*` (#1445) guards. Closes #1450.
 
 ### Removed
 

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -1030,6 +1030,31 @@ func TestEnsureGitignoreLines_Idempotent(t *testing.T) {
 	}
 }
 
+// TestEnsureGitignoreLines_LeakedArtifactGuards asserts the canonical deposit
+// carries every leaked-artefact guard so a consumer's `git add -A` never traps
+// installer/render scratch files (#1311 locks, #1445 backups, #1450 migration
+// snapshots). The `*.premigrate.*` glob is leading-slash-free so it matches
+// both the repo-root snapshots (ROADMAP.premigrate.md) and the nested
+// vbrief/specification.premigrate.vbrief.json at any depth.
+func TestEnsureGitignoreLines_LeakedArtifactGuards(t *testing.T) {
+	tmp := t.TempDir()
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+
+	if _, err := EnsureGitignoreLines(w, tmp); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if err != nil {
+		t.Fatalf("missing .gitignore: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{"vbrief/*.lock", ".deft/core.bak-*/", ".deft/*.bak-*", "*.premigrate.*"} {
+		if !strings.Contains(content, want) {
+			t.Errorf(".gitignore deposit missing leaked-artefact guard %q", want)
+		}
+	}
+}
+
 func TestWriteConsumerVbrief_CreatesNew(t *testing.T) {
 	tmp := t.TempDir()
 	projectDir := filepath.Join(tmp, "proj")

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -179,7 +179,7 @@ var agentsMDManagedOpenPattern = regexp.MustCompile(`<!-- deft:managed-section v
 
 // canonicalGitignoreLines extends scripts/relocate.py::GITIGNORE_LINES (the F2
 // canonical default from #1015) -- the runtime cache directory and the
-// audit-log private state -- with two leaked-artefact guards so a consumer's
+// audit-log private state -- with three leaked-artefact guards so a consumer's
 // `git add -A` never traps installer/render scratch files:
 //
 //   - vbrief/*.lock          -- the PROJECT-DEFINITION mutation-lock sidecar
@@ -189,6 +189,15 @@ var agentsMDManagedOpenPattern = regexp.MustCompile(`<!-- deft:managed-section v
 //   - .deft/core.bak-*/ + .deft/*.bak-* -- pre-swap payload backups. The
 //     installer now writes them OUTSIDE the working tree (#1445), so these
 //     only catch backups left by a pre-#1445 installer already in the tree.
+//   - *.premigrate.* -- pre-migration safety snapshots written by the vBRIEF
+//     migration / spec-render step during install/upgrade (e.g.
+//     ROADMAP.premigrate.md, SPECIFICATION.premigrate.md,
+//     vbrief/specification.premigrate.vbrief.json). The leading-slash-free
+//     glob matches at any depth, so it covers both the repo-root snapshots
+//     and the nested vbrief/ one. Same hygiene class as the lock/backup
+//     guards above (#1450; the migrator already writes this pattern to the
+//     consumer .gitignore on the Python path per #497/#530 -- this closes the
+//     installer-deposit gap for the binary install/upgrade rail).
 //
 // The framework deposit at .deft/core/ is INTENTIONALLY NOT auto-gitignored --
 // per #11 .deft/core/ ships read-only packaged framework assets that consumers
@@ -200,6 +209,7 @@ var canonicalGitignoreLines = []string{
 	"vbrief/*.lock",
 	".deft/core.bak-*/",
 	".deft/*.bak-*",
+	"*.premigrate.*",
 }
 
 // minimalTaskfileContent is the canonical starter Taskfile.yml written (or


### PR DESCRIPTION
## Summary

The vBRIEF migration / spec-render step run during install/upgrade writes `*.premigrate.*` safety snapshots (`ROADMAP.premigrate.md`, `SPECIFICATION.premigrate.md`, `vbrief/specification.premigrate.vbrief.json`) into the consumer working tree, but the installer's canonical `.gitignore` deposit (`canonicalGitignoreLines` in `cmd/deft-install/setup.go`) did not cover them. So `git add -A` swept them in, and mixed with a `.deft/core/**` change they tripped the deft-core-guard (#1440) as "app" files.

Same leaked-artefact hygiene class as #1311 (`vbrief/*.lock`) and #1445 (`.deft/*.bak-*`), both fixed in v0.39.6.

## Fix

Add the leading-slash-free `*.premigrate.*` glob to `canonicalGitignoreLines`. A no-leading-slash gitignore pattern matches at any depth, so the single entry covers both the repo-root snapshots and the nested `vbrief/specification.premigrate.vbrief.json`.

Scoped deliberately to the installer deposit (the binary install/upgrade rail), mirroring the v0.39.6 approach for #1311/#1445. The Python migrator already writes this pattern to the consumer `.gitignore` on its own path (#497/#530); this closes the installer-deposit gap.

## Tests

- `cmd/deft-install/main_test.go::TestEnsureGitignoreLines_LeakedArtifactGuards` (new) asserts the deposit carries all leaked-artefact guards including `*.premigrate.*` (also retroactively covers the v0.39.6 lock/backup patterns that lacked an assertion).
- `go test ./cmd/deft-install/` and `go vet ./cmd/deft-install/`: pass.

## Acceptance criteria

- After an install/upgrade that runs migration/spec-render, no `*.premigrate.*` file is left as an untracked, non-gitignored artifact that `git add -A` would stage. ✓

Closes #1450.
