### PR TITLE
feat(install): dirty-tree advisory at --upgrade + scoped framework staging (#1453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`deft-install --upgrade` now warns about a dirty working tree up front and stages only the framework deposit for you (#1453)** -- the deposited `deft-core-guard` CI check (#1430/#1440) was the only thing stopping a consumer from committing a `.deft/core/**` framework bump mixed with their own files, and it is a late, PR-time, GitHub-only, deletable backstop. The installer now gives proactive, local guidance. Before an `--upgrade` payload swap it checks `git status --porcelain` and, if the tree is dirty, prints an actionable advisory (commit/stash your own work first; land the framework deposit on its own branch; a mixed PR is rejected by the guard); the default is warn-and-proceed so the initial install and the `--yes` non-interactive agent/CI path are never blocked. A new opt-in `--require-clean` turns the advisory into a hard refusal (escapable via `--force` / `--allow-dirty`), surfaced as a machine-readable `dirty_tree_require_clean` error under `--json` with no interactive hang. After the swap the installer prints the exact scoped `git add <framework + installer-managed paths>` command (explicitly warning against `git add -A`) and best-effort stages ONLY those framework-owned paths -- never consumer app files -- reusing the same installer-managed allowlist the guard exempts. `--json` output gains `dirty_tree`, `dirty_files`, and `staged_paths`. Closes #1453.
 
 ### Changed
 

--- a/cmd/deft-install/hygiene.go
+++ b/cmd/deft-install/hygiene.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// commit-hygiene (#1453) gives the installer a PROACTIVE counterpart to the
+// deposited deft-core-guard CI check (#1430/#1440). The guard is a late,
+// PR-time, GitHub-only, consumer-deletable backstop that rejects a PR mixing
+// the vendored framework payload (.deft/core/**) with the consumer's own files.
+// Before this change the installer gave no advance warning, so a consumer would
+// only discover the rule after pushing. The two layers below close that gap:
+//
+//   - Layer 1: a dirty-working-tree advisory BEFORE an --upgrade payload swap.
+//   - Layer 2: scoped staging + an exact, copy-pasteable scoped commit command
+//     AFTER the deposit (reusing installerManagedMatchers so the installer only
+//     ever stages framework-owned paths, never consumer app files).
+
+// dirtyTreeBlockCode is the stable machine-readable error code surfaced in
+// --json mode when --require-clean refuses an upgrade against a dirty tree, so
+// agents / CI can branch on it deterministically (no interactive hang, no
+// silent abort).
+const dirtyTreeBlockCode = "dirty_tree_require_clean"
+
+// dirtyTreeBlockMessage is the human-readable counterpart to dirtyTreeBlockCode.
+const dirtyTreeBlockMessage = "working tree has uncommitted changes and --require-clean was set; commit/stash first or re-run with --force / --allow-dirty"
+
+// dirtyTreePreviewLimit bounds how many porcelain status lines the prose
+// advisory prints so a large dirty tree does not flood the terminal.
+const dirtyTreePreviewLimit = 20
+
+// commitHygieneOptions carries the #1453 flag state into the dirty-tree
+// advisory. requireClean (--require-clean) turns the default warn-and-proceed
+// advisory into a hard refusal; force (--force / --allow-dirty) escapes that
+// refusal.
+type commitHygieneOptions struct {
+	requireClean bool
+	force        bool
+}
+
+// dirtyTreeAdvisory is the result of the pre-swap working-tree probe (#1453).
+type dirtyTreeAdvisory struct {
+	checked bool     // the probe actually ran (an upgrade inside a git work tree)
+	dirty   bool     // the working tree had uncommitted changes
+	files   []string // `git status --porcelain` lines (verbatim)
+	blocked bool     // --require-clean refused the upgrade (dirty && requireClean && !force)
+}
+
+// gitPorcelainStatusFunc returns the `git status --porcelain` lines for the
+// repo containing dir, whether dir is inside a git work tree at all, and any
+// hard error. Indirected through a var so tests can drive the advisory without
+// a real repo. Best-effort by contract: a non-git project (or a missing git
+// binary) yields (nil, false, nil) so callers simply skip the advisory.
+var gitPorcelainStatusFunc = defaultGitPorcelainStatus
+
+// defaultGitPorcelainStatus is the production gitPorcelainStatusFunc. It is the
+// installer's only working-tree READ against the consumer repo; it runs no
+// mutating git command. It first confirms dir is inside a work tree, then reads
+// the porcelain status. Output is split on newlines with the trailing newline
+// trimmed but the per-line XY status prefix preserved (so the advisory can show
+// the verbatim status), and blank lines dropped.
+func defaultGitPorcelainStatus(dir string) ([]string, bool, error) {
+	inside, err := exec.Command("git", "-C", dir, "rev-parse", "--is-inside-work-tree").Output()
+	if err != nil || strings.TrimSpace(string(inside)) != "true" {
+		return nil, false, nil
+	}
+	out, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	if err != nil {
+		return nil, true, err
+	}
+	var lines []string
+	for _, ln := range strings.Split(strings.TrimRight(string(out), "\r\n"), "\n") {
+		ln = strings.TrimRight(ln, "\r")
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		lines = append(lines, ln)
+	}
+	return lines, true, nil
+}
+
+// runGitStageFunc runs `git -C dir add -- <paths...>`. This is the ONLY
+// mutating git command the installer ever issues against the consumer repo, and
+// it is strictly scoped (#1453): callers pass only framework + installer-managed
+// paths, never `git add -A` and never consumer app files. Indirected for tests.
+var runGitStageFunc = func(dir string, paths ...string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	args := append([]string{"-C", dir, "add", "--"}, paths...)
+	return exec.Command("git", args...).Run()
+}
+
+// dirtyTreeGate is the Layer-1 entry point. It enforces the CRITICAL #1453
+// invariant that the dirty-tree advisory is an UPGRADE-only concern: an initial
+// install never probes the tree and can never be blocked. For an upgrade it
+// delegates to checkDirtyTree.
+func dirtyTreeGate(isUpgrade bool, projectDir string, opts commitHygieneOptions) dirtyTreeAdvisory {
+	if !isUpgrade {
+		return dirtyTreeAdvisory{}
+	}
+	return checkDirtyTree(projectDir, opts)
+}
+
+// checkDirtyTree probes the consumer working tree before an --upgrade payload
+// swap (#1453). It is a silent no-op for a clean tree, a non-git project, or
+// when git is unavailable. The DEFAULT is warn-and-proceed (dirty reported,
+// never blocked); --require-clean turns a dirty tree into a hard refusal, which
+// --force / --allow-dirty escapes. It NEVER prompts, so the --yes /
+// non-interactive agent/CI path can never hang.
+func checkDirtyTree(projectDir string, opts commitHygieneOptions) dirtyTreeAdvisory {
+	lines, isRepo, err := gitPorcelainStatusFunc(projectDir)
+	if err != nil || !isRepo {
+		// Best-effort: a git error or non-repo simply skips the advisory.
+		return dirtyTreeAdvisory{}
+	}
+	if len(lines) == 0 {
+		return dirtyTreeAdvisory{checked: true}
+	}
+	adv := dirtyTreeAdvisory{checked: true, dirty: true, files: lines}
+	if opts.requireClean && !opts.force {
+		adv.blocked = true
+	}
+	return adv
+}
+
+// printDirtyTreeAdvisory writes the human-readable commit-hygiene advisory for
+// a dirty working tree (#1453). It frames the message as either a hard refusal
+// (blocked, via --require-clean) or a warn-and-proceed notice, and always
+// explains WHY (the deft-core-guard rejects a mixed PR) and WHAT to do
+// (commit/stash first; land the framework deposit on its own branch/PR).
+func printDirtyTreeAdvisory(w *Wizard, adv dirtyTreeAdvisory) {
+	if !adv.dirty {
+		return
+	}
+	w.printf("\n")
+	if adv.blocked {
+		w.printf("Refusing to upgrade: your working tree has uncommitted changes (--require-clean).\n")
+	} else {
+		w.printf("Warning: your working tree has uncommitted changes before this upgrade.\n")
+	}
+	w.printf("This upgrade rewrites the framework payload (.deft/core/**) and installer-managed\n")
+	w.printf("files. Committing those together with your own work trips the deft-core-guard CI\n")
+	w.printf("check, which rejects a PR that mixes .deft/core/** with your project files.\n\n")
+	w.printf("Recommended before upgrading:\n")
+	w.printf("  1. Commit or stash your own work first (git stash  /  git commit).\n")
+	w.printf("  2. Run the upgrade, then commit the framework deposit on its OWN branch.\n")
+	w.printf("  3. Open the framework bump as a separate PR from your app changes.\n\n")
+	w.printf("Uncommitted changes:\n")
+	for i, ln := range adv.files {
+		if i >= dirtyTreePreviewLimit {
+			w.printf("  ... and %d more\n", len(adv.files)-dirtyTreePreviewLimit)
+			break
+		}
+		w.printf("  %s\n", ln)
+	}
+	if adv.blocked {
+		w.printf("\nRe-run with --force (or --allow-dirty) to upgrade anyway, or drop --require-clean.\n")
+	}
+	w.printf("\n")
+}
+
+// dirtyTreeBlockResult builds the single machine-readable JSON object emitted on
+// stdout when --require-clean refuses an upgrade in --json mode (#1453). The
+// shape mirrors the success object's dirty_* fields so a consumer parses one
+// schema either way. dirty_files is always a non-nil slice for stable JSON.
+func dirtyTreeBlockResult(adv dirtyTreeAdvisory) map[string]any {
+	files := adv.files
+	if files == nil {
+		files = []string{}
+	}
+	return map[string]any{
+		"success":     false,
+		"error":       dirtyTreeBlockMessage,
+		"error_code":  dirtyTreeBlockCode,
+		"dirty_tree":  true,
+		"dirty_files": files,
+	}
+}
+
+// frameworkStagePaths returns the ordered, repo-relative (POSIX) set of paths
+// the installer may stage after a deposit (#1453 Layer 2): the framework
+// payload dir (result.DeftDir, relative to the project root) followed by the
+// installer-managed deposit surface (installerManagedMatchers -- the SAME
+// allowlist the deft-core-guard exempts). Only paths that EXIST under
+// projectDir are returned, so the set names what is actually on disk and
+// `git add` never errors on an absent pathspec. Crucially this NEVER includes
+// consumer app code or consumer vBRIEF data: those are not in the allowlist, so
+// they fall through to the guard's "app" bucket and must stay out of the
+// framework commit.
+func frameworkStagePaths(projectDir, deftDir string) []string {
+	var paths []string
+	seen := map[string]bool{}
+	add := func(rel string) {
+		rel = filepath.ToSlash(rel)
+		if rel == "" || rel == "." || seen[rel] {
+			return
+		}
+		if !pathExists(filepath.Join(projectDir, filepath.FromSlash(rel))) {
+			return
+		}
+		seen[rel] = true
+		paths = append(paths, rel)
+	}
+
+	// Framework payload dir first (relative to the project root). Skip it if it
+	// resolves outside the project tree (defensive; should not happen).
+	if rel, err := filepath.Rel(projectDir, deftDir); err == nil && !strings.HasPrefix(rel, "..") {
+		add(rel)
+	}
+
+	// Installer-managed deposit surface: exact paths verbatim, directory
+	// prefixes as their (trailing-slash-trimmed) dir so `git add <dir>` stages
+	// everything beneath it.
+	for _, m := range installerManagedMatchers() {
+		if m.exact != "" {
+			add(m.exact)
+		} else if m.prefix != "" {
+			add(strings.TrimSuffix(m.prefix, "/"))
+		}
+	}
+	return paths
+}
+
+// stageFrameworkPaths best-effort stages ONLY the supplied framework +
+// installer-managed paths (#1453 Layer 2b). It NEVER runs `git add -A`. Best-
+// effort means: a non-git project (or missing git) is a silent no-op, and a
+// `git add` error is returned for optional debug logging but must NEVER fail
+// the install. Returns whether anything was staged.
+func stageFrameworkPaths(projectDir string, paths []string) (bool, error) {
+	if len(paths) == 0 {
+		return false, nil
+	}
+	if _, isRepo, _ := gitPorcelainStatusFunc(projectDir); !isRepo {
+		return false, nil
+	}
+	if err := runGitStageFunc(projectDir, paths...); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// printCommitGuidance prints the scoped next-steps commit guidance after a
+// deposit (#1453 Layer 2a): the exact scoped command naming only the framework
+// + installer-managed paths, and an explicit warning against `git add -A`
+// (which would sweep consumer app files into the framework commit and trip the
+// deft-core-guard). staged reports whether the installer already staged those
+// paths so the guidance reads correctly either way.
+func printCommitGuidance(w *Wizard, paths []string, staged bool) {
+	if len(paths) == 0 {
+		return
+	}
+	addCmd := "git add " + strings.Join(paths, " ")
+	w.printf("\nCommit hygiene (#1453): keep the framework deposit in its OWN commit/PR.\n")
+	w.printf("Do NOT use `git add -A` -- mixing the payload with your own files trips the\n")
+	w.printf("deft-core-guard CI check.\n")
+	if staged {
+		w.printf("The installer already staged ONLY these framework + installer-managed paths:\n")
+		w.printf("  %s\n", addCmd)
+		w.printf("Review them, then commit on a framework-only branch:\n")
+		w.printf("  git commit -m \"chore(deft): update framework payload\"\n")
+	} else {
+		w.printf("Stage ONLY these framework + installer-managed paths, then commit:\n")
+		w.printf("  %s\n", addCmd)
+		w.printf("  git commit -m \"chore(deft): update framework payload\"\n")
+	}
+}

--- a/cmd/deft-install/hygiene_test.go
+++ b/cmd/deft-install/hygiene_test.go
@@ -1,0 +1,412 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #1453 -- installer commit-hygiene: Layer 1 dirty-tree advisory at --upgrade
+// ---------------------------------------------------------------------------
+
+// TestCheckDirtyTree_WarnDefaultProceeds is the default warn-and-proceed path:
+// a dirty working tree on an --upgrade is reported (dirty=true) but NEVER
+// blocked when --require-clean was not set, so the upgrade proceeds.
+func TestCheckDirtyTree_WarnDefaultProceeds(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	want := []string{" M app.go", "?? new.txt"}
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) {
+		return want, true, nil
+	}
+
+	adv := checkDirtyTree("/proj", commitHygieneOptions{})
+	if !adv.checked {
+		t.Error("expected checked=true when the probe ran in a git work tree")
+	}
+	if !adv.dirty {
+		t.Error("expected dirty=true for a non-empty porcelain status")
+	}
+	if adv.blocked {
+		t.Error("default (no --require-clean) must warn-and-proceed, not block")
+	}
+	if strings.Join(adv.files, "\n") != strings.Join(want, "\n") {
+		t.Errorf("files = %v, want %v", adv.files, want)
+	}
+}
+
+// TestCheckDirtyTree_RequireCleanBlocks pins the opt-in hard-refusal: with
+// --require-clean and no escape flag, a dirty tree is blocked.
+func TestCheckDirtyTree_RequireCleanBlocks(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) {
+		return []string{" M app.go"}, true, nil
+	}
+
+	adv := checkDirtyTree("/proj", commitHygieneOptions{requireClean: true})
+	if !adv.dirty {
+		t.Fatal("expected dirty=true")
+	}
+	if !adv.blocked {
+		t.Error("expected blocked=true with --require-clean on a dirty tree")
+	}
+}
+
+// TestCheckDirtyTree_ForceEscapes proves --force / --allow-dirty escapes the
+// --require-clean refusal: dirty is still reported but the upgrade is allowed.
+func TestCheckDirtyTree_ForceEscapes(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) {
+		return []string{" M app.go"}, true, nil
+	}
+
+	adv := checkDirtyTree("/proj", commitHygieneOptions{requireClean: true, force: true})
+	if !adv.dirty {
+		t.Fatal("expected dirty=true")
+	}
+	if adv.blocked {
+		t.Error("--force / --allow-dirty must escape the --require-clean refusal")
+	}
+}
+
+// TestCheckDirtyTree_CleanIsNoop: a clean tree is checked but not dirty/blocked.
+func TestCheckDirtyTree_CleanIsNoop(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) {
+		return nil, true, nil
+	}
+
+	adv := checkDirtyTree("/proj", commitHygieneOptions{requireClean: true})
+	if !adv.checked {
+		t.Error("expected checked=true for a clean git work tree")
+	}
+	if adv.dirty || adv.blocked {
+		t.Errorf("clean tree must not be dirty/blocked, got %+v", adv)
+	}
+}
+
+// TestCheckDirtyTree_NonRepoSkips: a non-git project (or git absent) is a
+// silent no-op -- never checked, never dirty, never blocked.
+func TestCheckDirtyTree_NonRepoSkips(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) {
+		return nil, false, nil
+	}
+
+	adv := checkDirtyTree("/proj", commitHygieneOptions{requireClean: true})
+	if adv.checked || adv.dirty || adv.blocked {
+		t.Errorf("non-repo must be a no-op, got %+v", adv)
+	}
+}
+
+// TestDirtyTreeGate_InitialInstallNeverBlocks is the CRITICAL #1453 invariant:
+// an INITIAL install (not an upgrade) must NEVER probe the tree or block, even
+// with a dirty tree and --require-clean set.
+func TestDirtyTreeGate_InitialInstallNeverBlocks(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	probed := false
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) {
+		probed = true
+		return []string{" M app.go"}, true, nil
+	}
+
+	adv := dirtyTreeGate(false /* isUpgrade */, "/proj", commitHygieneOptions{requireClean: true})
+	if probed {
+		t.Error("an initial install must NOT probe the working tree")
+	}
+	if adv.checked || adv.dirty || adv.blocked {
+		t.Errorf("initial install must never block, got %+v", adv)
+	}
+}
+
+// TestDirtyTreeGate_UpgradeRunsProbe: an upgrade runs the probe and honours
+// the advisory result.
+func TestDirtyTreeGate_UpgradeRunsProbe(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	probed := false
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) {
+		probed = true
+		return []string{" M app.go"}, true, nil
+	}
+
+	adv := dirtyTreeGate(true /* isUpgrade */, "/proj", commitHygieneOptions{requireClean: true})
+	if !probed {
+		t.Error("an upgrade must probe the working tree")
+	}
+	if !adv.dirty || !adv.blocked {
+		t.Errorf("upgrade with dirty tree + --require-clean must block, got %+v", adv)
+	}
+}
+
+// TestDirtyTreeBlockResult_JSON pins the machine-readable refusal surfaced in
+// --json mode for the --yes/CI path (no interactive hang, no silent abort).
+func TestDirtyTreeBlockResult_JSON(t *testing.T) {
+	adv := dirtyTreeAdvisory{checked: true, dirty: true, blocked: true, files: []string{" M app.go"}}
+	res := dirtyTreeBlockResult(adv)
+
+	if res["success"] != false {
+		t.Errorf("success = %v, want false", res["success"])
+	}
+	if res["error_code"] != dirtyTreeBlockCode {
+		t.Errorf("error_code = %v, want %q", res["error_code"], dirtyTreeBlockCode)
+	}
+	if res["dirty_tree"] != true {
+		t.Errorf("dirty_tree = %v, want true", res["dirty_tree"])
+	}
+	// Must marshal to a single valid JSON object (the --json contract).
+	if _, err := json.Marshal(res); err != nil {
+		t.Fatalf("block result is not JSON-marshalable: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1453 -- Layer 2: scoped staging path set + best-effort staging
+// ---------------------------------------------------------------------------
+
+// TestFrameworkStagePaths_OnlyFrameworkAndManaged is the gold-standard scoped
+// path set test: only the framework payload (.deft/core) and installer-managed
+// deposits are returned. Consumer app code AND consumer vBRIEF data MUST be
+// excluded (the whole point of the deft-core-guard separation).
+func TestFrameworkStagePaths_OnlyFrameworkAndManaged(t *testing.T) {
+	proj := t.TempDir()
+	mustMkdir := func(rel string) {
+		if err := os.MkdirAll(filepath.Join(proj, filepath.FromSlash(rel)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite := func(rel, body string) {
+		p := filepath.Join(proj, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Framework payload + installer-managed deposits.
+	mustWrite(".deft/core/main.md", "framework")
+	mustWrite("AGENTS.md", "agents")
+	mustWrite(".agents/skills/deft/SKILL.md", "skill")
+	mustWrite(".gitattributes", "x")
+	mustWrite(".gitignore", "x")
+	mustWrite("vbrief/vbrief.md", "tmpl")
+	mustWrite("vbrief/schemas/scope.schema.json", "{}")
+	mustMkdir("vbrief/active")
+	mustWrite("vbrief/active/.gitkeep", "")
+
+	// Consumer app code + consumer vBRIEF data -- MUST be excluded.
+	mustWrite("src/main.go", "package main")
+	mustWrite("README.md", "consumer readme")
+	mustWrite("vbrief/PROJECT-DEFINITION.vbrief.json", "{}")
+	mustWrite("vbrief/active/2026-issue-1.vbrief.json", "{}")
+
+	deftDir := filepath.Join(proj, ".deft", "core")
+	got := frameworkStagePaths(proj, deftDir)
+	gotSet := map[string]bool{}
+	for _, p := range got {
+		gotSet[p] = true
+	}
+
+	// Framework + a sample of installer-managed paths must be present.
+	for _, want := range []string{".deft/core", "AGENTS.md", ".agents", ".gitattributes", ".gitignore", "vbrief/vbrief.md", "vbrief/schemas"} {
+		if !gotSet[want] {
+			t.Errorf("expected staged path %q in %v", want, got)
+		}
+	}
+	// Consumer files MUST NOT appear, neither directly nor via a parent dir.
+	for _, banned := range []string{"src/main.go", "src", "README.md", "vbrief", "vbrief/PROJECT-DEFINITION.vbrief.json"} {
+		if gotSet[banned] {
+			t.Errorf("consumer path %q must NEVER be staged (got %v)", banned, got)
+		}
+	}
+	// Defensive: no returned path may be a bare consumer file.
+	for _, p := range got {
+		if p == "vbrief/active/2026-issue-1.vbrief.json" {
+			t.Errorf("consumer vBRIEF data leaked into stage set: %q", p)
+		}
+	}
+}
+
+// TestFrameworkStagePaths_SkipsMissing: only paths that actually exist on disk
+// are returned (so `git add` never errors on an absent pathspec).
+func TestFrameworkStagePaths_SkipsMissing(t *testing.T) {
+	proj := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(proj, ".deft", "core"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	deftDir := filepath.Join(proj, ".deft", "core")
+	got := frameworkStagePaths(proj, deftDir)
+	// .deft/core exists; AGENTS.md etc. do not.
+	for _, p := range got {
+		full := filepath.Join(proj, filepath.FromSlash(p))
+		if !pathExists(full) {
+			t.Errorf("returned non-existent path %q", p)
+		}
+	}
+	if len(got) != 1 || got[0] != ".deft/core" {
+		t.Errorf("expected only .deft/core, got %v", got)
+	}
+}
+
+// TestStageFrameworkPaths_StagesOnlyGivenPaths: staging routes EXACTLY the
+// provided paths through git add (never `git add -A`).
+func TestStageFrameworkPaths_StagesOnlyGivenPaths(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	origStage := runGitStageFunc
+	defer func() {
+		gitPorcelainStatusFunc = origStatus
+		runGitStageFunc = origStage
+	}()
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) { return nil, true, nil }
+	var gotDir string
+	var gotPaths []string
+	runGitStageFunc = func(dir string, paths ...string) error {
+		gotDir = dir
+		gotPaths = paths
+		return nil
+	}
+
+	in := []string{".deft/core", "AGENTS.md"}
+	staged, err := stageFrameworkPaths("/proj", in)
+	if err != nil {
+		t.Fatalf("stageFrameworkPaths: %v", err)
+	}
+	if !staged {
+		t.Error("expected staged=true on a successful git add")
+	}
+	if gotDir != "/proj" {
+		t.Errorf("staged dir = %q, want /proj", gotDir)
+	}
+	if strings.Join(gotPaths, " ") != strings.Join(in, " ") {
+		t.Errorf("staged paths = %v, want %v (never git add -A)", gotPaths, in)
+	}
+}
+
+// TestStageFrameworkPaths_NonRepoNoStage: a non-git project is a best-effort
+// no-op -- runGitStageFunc is never invoked and staged=false.
+func TestStageFrameworkPaths_NonRepoNoStage(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	origStage := runGitStageFunc
+	defer func() {
+		gitPorcelainStatusFunc = origStatus
+		runGitStageFunc = origStage
+	}()
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) { return nil, false, nil }
+	called := false
+	runGitStageFunc = func(string, ...string) error {
+		called = true
+		return nil
+	}
+
+	staged, err := stageFrameworkPaths("/proj", []string{".deft/core"})
+	if err != nil {
+		t.Fatalf("stageFrameworkPaths: %v", err)
+	}
+	if staged {
+		t.Error("non-repo must not report staged=true")
+	}
+	if called {
+		t.Error("non-repo must never call git add")
+	}
+}
+
+// TestDirtyTreeAndStaging_RealGit exercises the REAL git probe + scoped staging
+// end to end: a dirty consumer file is detected, and only framework +
+// installer-managed paths are staged -- the consumer app file stays UNSTAGED.
+func TestDirtyTreeAndStaging_RealGit(t *testing.T) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available; skipping real-git commit-hygiene test")
+	}
+	proj := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(gitPath, append([]string{"-C", proj}, args...)...)
+		if out, gerr := cmd.CombinedOutput(); gerr != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), gerr, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+	runGit("config", "commit.gpgsign", "false")
+
+	// Framework + installer-managed deposit, plus a consumer app file.
+	write := func(rel, body string) {
+		p := filepath.Join(proj, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".deft/core/main.md", "framework")
+	write("AGENTS.md", "agents")
+	write("app/server.go", "package app") // consumer app code
+
+	// Layer 1: the real probe sees a dirty tree.
+	lines, isRepo, perr := gitPorcelainStatusFunc(proj)
+	if perr != nil {
+		t.Fatalf("gitPorcelainStatusFunc: %v", perr)
+	}
+	if !isRepo {
+		t.Fatal("expected isRepo=true for a real git work tree")
+	}
+	if len(lines) == 0 {
+		t.Fatal("expected a dirty porcelain status")
+	}
+
+	// Layer 2: stage ONLY framework + installer-managed paths.
+	paths := frameworkStagePaths(proj, filepath.Join(proj, ".deft", "core"))
+	staged, serr := stageFrameworkPaths(proj, paths)
+	if serr != nil {
+		t.Fatalf("stageFrameworkPaths: %v", serr)
+	}
+	if !staged {
+		t.Fatal("expected staged=true in a real git repo")
+	}
+
+	// Inspect the index: framework paths staged, consumer app file NOT staged.
+	cmd := exec.Command(gitPath, "-C", proj, "diff", "--cached", "--name-only")
+	out, derr := cmd.Output()
+	if derr != nil {
+		t.Fatalf("git diff --cached: %v", derr)
+	}
+	stagedSet := map[string]bool{}
+	for _, ln := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if ln != "" {
+			stagedSet[ln] = true
+		}
+	}
+	if !stagedSet[".deft/core/main.md"] {
+		t.Errorf(".deft/core/main.md should be staged; staged=%v", keysSorted(stagedSet))
+	}
+	if !stagedSet["AGENTS.md"] {
+		t.Errorf("AGENTS.md should be staged; staged=%v", keysSorted(stagedSet))
+	}
+	if stagedSet["app/server.go"] {
+		t.Errorf("consumer app/server.go MUST NOT be staged; staged=%v", keysSorted(stagedSet))
+	}
+}
+
+func keysSorted(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -66,6 +66,9 @@ Options:
                             --repo-root for target dir (or uses CWD); auto-confirms
                             updates and installs; ideal for CI/agents
   --upgrade                 Force update/upgrade path even if framework dir exists
+  --require-clean           On --upgrade, refuse to proceed if the working tree has
+                            uncommitted changes (default: warn and proceed)
+  --force, --allow-dirty    Escape --require-clean and upgrade a dirty working tree
   --repo-root <path>        Target project directory (enables fully non-interactive
                             installs when combined with --yes)
   --json                    Emit structured JSON result to stdout (success, paths,
@@ -79,6 +82,8 @@ Windows-style aliases:
   /legacy-layout            Same as --legacy-layout
   /yes, /non-interactive    Same as --yes
   /upgrade                  Same as --upgrade
+  /require-clean            Same as --require-clean
+  /force, /allow-dirty      Same as --force
   /repo-root <path>         Same as --repo-root
   /json                     Same as --json
   /debug                    Same as --debug
@@ -114,6 +119,9 @@ func normalizeArgs(args []string) []string {
 		"/yes":             "--yes",
 		"/non-interactive": "--non-interactive",
 		"/upgrade":         "--upgrade",
+		"/require-clean":   "--require-clean",
+		"/force":           "--force",
+		"/allow-dirty":     "--allow-dirty",
 		"/repo-root":       "--repo-root",
 		"/json":            "--json",
 	}
@@ -139,6 +147,9 @@ func main() {
 	yes := flag.Bool("yes", false, "non-interactive mode (no prompts; combine with --repo-root)")
 	nonInteractive := flag.Bool("non-interactive", false, "alias for --yes")
 	upgrade := flag.Bool("upgrade", false, "force update/upgrade of existing install")
+	requireClean := flag.Bool("require-clean", false, "on --upgrade, refuse a dirty working tree (default: warn and proceed)")
+	force := flag.Bool("force", false, "escape --require-clean and upgrade a dirty working tree")
+	allowDirty := flag.Bool("allow-dirty", false, "alias for --force")
 	repoRoot := flag.String("repo-root", "", "target project dir for non-interactive installs")
 	jsonOut := flag.Bool("json", false, "emit JSON result instead of (or with) prose for agents")
 	flag.Usage = printUsage
@@ -154,7 +165,10 @@ func main() {
 	effectiveBranch := resolveBranch(*branch, defaultBranch)
 
 	nonInt := *yes || *nonInteractive
-	code := install(*debug, effectiveBranch, *legacyLayout, nonInt, *upgrade, *repoRoot, *jsonOut)
+	// --force and --allow-dirty are synonyms: either escapes the #1453
+	// --require-clean refusal of a dirty working tree on --upgrade.
+	forceDirty := *force || *allowDirty
+	code := install(*debug, effectiveBranch, *legacyLayout, nonInt, *upgrade, *repoRoot, *jsonOut, *requireClean, forceDirty)
 	if runtime.GOOS == "windows" && !nonInt {
 		pressEnterToExit()
 	}
@@ -164,7 +178,9 @@ func main() {
 }
 
 // install runs the full install/update workflow and returns an exit code.
-func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgrade bool, repoRoot string, jsonOut bool) int {
+// requireClean / force carry the #1453 commit-hygiene flag state
+// (--require-clean and --force / --allow-dirty respectively).
+func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgrade bool, repoRoot string, jsonOut, requireClean, force bool) int {
 	if debug {
 		fmt.Printf("[debug] OS=%s ARCH=%s\n", runtime.GOOS, runtime.GOARCH)
 		fmt.Printf("[debug] defaultBranch=%s branch=%s legacyLayout=%v nonInteractive=%v upgrade=%v repoRoot=%s json=%v\n", defaultBranch, branch, legacyLayout, nonInteractive, upgrade, repoRoot, jsonOut)
@@ -232,6 +248,30 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 	// Phase 3: ensure git is available.
 	if err := EnsureGit(w); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	// #1453 Layer 1: dirty-working-tree advisory BEFORE an --upgrade payload
+	// swap. Gated on result.Update so an INITIAL install is never probed or
+	// blocked. Default is warn-and-proceed; --require-clean turns a dirty tree
+	// into a hard refusal that --force / --allow-dirty escapes. The probe never
+	// prompts, so the --yes / CI path can never hang. In --json mode the prose
+	// advisory is routed to stderr (stdout stays single-JSON-clean) and a
+	// refusal emits one machine-readable error object on stdout.
+	dirtyAdv := dirtyTreeGate(result.Update, result.ProjectDir, commitHygieneOptions{requireClean: requireClean, force: force})
+	advWriter := w
+	if jsonOut {
+		advWriter = NewWizardWithLayout(strings.NewReader(""), os.Stderr, debug, legacyLayout)
+	}
+	printDirtyTreeAdvisory(advWriter, dirtyAdv)
+	if dirtyAdv.blocked {
+		if jsonOut {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if encErr := enc.Encode(dirtyTreeBlockResult(dirtyAdv)); encErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: JSON encode failed: %v\n", encErr)
+			}
+		}
 		return 1
 	}
 
@@ -353,6 +393,16 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		return 1
 	}
 
+	// #1453 Layer 2: scoped staging + commit guidance. After every deposit,
+	// best-effort stage ONLY the framework + installer-managed paths (never
+	// `git add -A`, never consumer app files) and (below) print the exact scoped
+	// commit command. A staging failure is best-effort and never fails install.
+	stagePaths := frameworkStagePaths(result.ProjectDir, result.DeftDir)
+	staged, stageErr := stageFrameworkPaths(result.ProjectDir, stagePaths)
+	if stageErr != nil && debug {
+		fmt.Fprintf(os.Stderr, "[debug] scoped staging best-effort error: %v\n", stageErr)
+	}
+
 	if jsonOut {
 		// Machine readable result for agents / CI (Epic-3 AC). Includes
 		// actions taken for 1337/1338 so callers can react (e.g. re-invoke
@@ -367,6 +417,16 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		if updateOutcome != nil {
 			payloadLayout = updateOutcome.Layout
 			strategy = updateOutcome.Strategy
+		}
+		// #1453: surface the commit-hygiene advisory + scoped staging so agents /
+		// CI can react. Slices are non-nil for a stable JSON schema (never null).
+		dirtyFiles := dirtyAdv.files
+		if dirtyFiles == nil {
+			dirtyFiles = []string{}
+		}
+		stagedOut := []string{}
+		if staged {
+			stagedOut = stagePaths
 		}
 		out := map[string]any{
 			"success":         true,
@@ -383,6 +443,9 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 			"skills_created":  skillsCreated,
 			"payload_layout":  payloadLayout,
 			"strategy":        strategy,
+			"dirty_tree":      dirtyAdv.dirty,
+			"dirty_files":     dirtyFiles,
+			"staged_paths":    stagedOut,
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -407,11 +470,13 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		// stderr (which agents commonly capture alongside stdout).
 		wErr := NewWizardWithLayout(strings.NewReader(""), os.Stderr, debug, legacyLayout)
 		PrintNextSteps(wErr, result, configDir, skillsCreated)
+		printCommitGuidance(wErr, stagePaths, staged)
 		doHandoffToDoctor(wErr, result, jsonOut)
 		return 0
 	}
 
 	PrintNextSteps(w, result, configDir, skillsCreated)
+	printCommitGuidance(w, stagePaths, staged)
 
 	// #1339 (Epic-5): Installer → Doctor handoff + payload staleness detection.
 	// The installer invokes the canonical doctor (scripts/doctor.py) with


### PR DESCRIPTION
## Summary

Gives `deft-install` a **proactive** commit-hygiene counterpart to the deposited `deft-core-guard` CI check (#1430/#1440). The guard is the only thing stopping a consumer from committing a `.deft/core/**` framework bump mixed with their own files — but it is a late, PR-time, GitHub-only, consumer-deletable backstop. The installer now warns and guides locally, before a push ever happens.

Implements **Layers 1 and 2** of #1453. Layer 3 (a local git pre-commit hook) is intentionally **deferred** as a follow-up.

## Layer 1 — dirty-tree advisory at `--upgrade`

- Before the payload swap, on an `--upgrade` only, the installer runs `git status --porcelain`. If the tree is dirty it prints a clear, actionable advisory: commit/stash your own work first; commit the framework deposit on its own branch; a mixed PR is rejected by the `deft-core-guard`.
- **Default = warn-and-proceed** (never hard-blocks).
- New opt-in `--require-clean` turns it into a hard refusal, escapable via `--force` / `--allow-dirty`.
- **Never blocks the initial install** (gated on the upgrade path only) and **never breaks the `--yes` non-interactive agent/CI path**: under `--yes` it warns-and-proceeds by default, or with `--require-clean` fails with a machine-readable `dirty_tree_require_clean` error surfaced in `--json` (no interactive hang, no silent abort). The probe never prompts.
- The advisory is surfaced in `--json` (`dirty_tree`, `dirty_files`).

## Layer 2 — scoped staging + commit guidance

- After the swap, prints the exact scoped commit command (`git add <.deft/core + installer-managed paths> && git commit ...`) and explicitly warns against `git add -A`.
- Best-effort stages **ONLY** the framework payload + installer-managed paths, reusing the existing `installerManagedMatchers` allowlist (the same set the guard exempts). Skips silently when not a git repo / git is absent; **never** fails the install over a staging error; **never** stages consumer app files or consumer vBRIEF data.
- `--json` gains `staged_paths`.

## Implementation notes

- New `cmd/deft-install/hygiene.go` reuses `installerManagedMatchers` / `pathExists` from `deposit.go`. The only mutating git command is a strictly-scoped `git add -- <paths>` (`runGitStageFunc`); the working-tree read is `git status --porcelain` (`gitPorcelainStatusFunc`). Both are indirected through vars for testing.
- New flags `--require-clean`, `--force`, `--allow-dirty` (plus `/`-style Windows aliases) wired through `main.go` `install(...)`.

## Tests (TDD, RED → GREEN)

New `cmd/deft-install/hygiene_test.go` (RED first: build failed on undefined symbols; GREEN after implementation):

- dirty-tree warn (default, proceeds) vs `--require-clean` block (+ `--force` escape)
- clean-tree no-op, non-repo no-op
- `dirtyTreeGate` **initial-install-never-blocks** (no probe, no block) + upgrade-runs-probe
- `dirtyTreeBlockResult` machine-readable `--json` refusal
- scoped-staging path set returns only framework + installer-managed paths (consumer app code AND consumer vBRIEF data excluded)
- staging routes exactly the given paths (never `git add -A`); non-repo no-op
- real-git integration: dirty tree detected, only framework/installer-managed paths staged, consumer app file left unstaged

## Validation

- `go test ./cmd/deft-install/` → **158 passed, 0 failed, 1 skipped**
- `go vet ./cmd/deft-install/` → clean
- `go build ./cmd/deft-install/` → clean

Closes #1453
