### PR TITLE
fix(triage): batch verify:cache-fresh scope filter so milestone is-open fetches once (#1424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`task verify:cache-fresh` is no longer slow on large triage caches (#1424)** -- when the active subscription used a `milestone {is-open: true}` rule, the cache-freshness gate re-fetched the open-milestones list from GitHub once per cached issue, so a 500-entry cache took ~92 seconds and the cost was paid on every session start and before every agent dispatch. The subscription filter now evaluates the rule set a single time across the whole cache, collapsing those N network round-trips to one and bringing the gate back under a second with identical results. Closes #1424.
 
 ### Removed
 

--- a/scripts/preflight_cache.py
+++ b/scripts/preflight_cache.py
@@ -328,23 +328,70 @@ def _issue_in_scope(
 def _filter_scoped_meta_paths(
     meta_paths: list[Path],
     rules: list[dict[str, Any]] | None,
-    project_root: Path,
+    *,
+    open_milestones_fetcher: Any = None,
 ) -> list[Path]:
-    """Filter ``meta_paths`` to those whose raw.json matches the scope rules."""
+    """Filter ``meta_paths`` to those whose raw.json matches the scope rules.
+
+    #1424: evaluate the rule set ONCE over the whole cache rather than
+    once per cached entry. The per-issue fan-out used to call
+    ``evaluate_rules(rules, [issue])`` N times; because
+    ``evaluate_rules`` builds (and memoizes only within a single call) a
+    fresh open-milestones resolver, a ``milestone {is-open: true}`` rule
+    re-fetched the upstream snapshot once per issue -- an O(N) network
+    fan-out (~92s on a 500-entry cache). Batching collapses that to a
+    single ``evaluate_rules`` call (one milestone fetch) with identical
+    semantics, mirroring the proven fetch-once shape in
+    ``triage_scope_drift.compute_drift``.
+
+    Matched entries are resolved by OBJECT IDENTITY (``id(issue)``), not
+    by issue number: ``evaluate_rules`` dedups via
+    ``matched.setdefault(_issue_number(issue), issue)`` and returns the
+    very issue dicts passed in, so number-keying here would risk
+    collisions or drop entries whose ``number`` is missing/None.
+
+    ``open_milestones_fetcher`` is forwarded to ``evaluate_rules`` for
+    the ``milestone {is-open: true}`` variant; production leaves it
+    ``None`` (the default ``gh api`` fetcher fires once), tests inject a
+    counting closure to assert the at-most-once contract.
+    """
     if not rules:
         return meta_paths
-    out: list[Path] = []
+    mod = _load_triage_scope_module()
+    if mod is None:
+        # Subscription module unavailable -> no filtering (over-include).
+        return meta_paths
+
+    all_issues: list[dict[str, Any]] = []
+    issue_id_to_meta: dict[int, Path] = {}
+    # Entries whose raw.json is missing or unparseable are kept: the
+    # freshness check is the load-bearing signal and we'd rather
+    # over-include than mask a stale cache.
+    keep: set[Path] = set()
     for meta_path in meta_paths:
         raw = _read_raw_issue(meta_path)
-        # When raw.json is missing or unparseable, keep the entry: the
-        # freshness check is the load-bearing signal and we'd rather
-        # over-include than mask a stale cache.
         if raw is None:
-            out.append(meta_path)
+            keep.add(meta_path)
             continue
-        if _issue_in_scope(rules, raw, project_root=project_root):
-            out.append(meta_path)
-    return out
+        all_issues.append(raw)
+        issue_id_to_meta[id(raw)] = meta_path
+
+    if all_issues:
+        try:
+            matched = mod.evaluate_rules(
+                rules, all_issues, open_milestones_fetcher=open_milestones_fetcher
+            )
+        except Exception:  # noqa: BLE001 -- defensive: over-include on failure
+            return meta_paths
+        if not isinstance(matched, list):
+            return meta_paths
+        for issue in matched:
+            meta_path = issue_id_to_meta.get(id(issue))
+            if meta_path is not None:
+                keep.add(meta_path)
+
+    # Preserve the original meta_paths ordering.
+    return [meta_path for meta_path in meta_paths if meta_path in keep]
 
 
 # ---------------------------------------------------------------------------
@@ -517,7 +564,7 @@ def evaluate(
 
     # --- Step 4: subscription filter (#1131) -----------------------------
     scope_rules = _resolve_scope_rules(project_root)
-    scoped_meta_paths = _filter_scoped_meta_paths(meta_paths, scope_rules, project_root)
+    scoped_meta_paths = _filter_scoped_meta_paths(meta_paths, scope_rules)
     # #1245: distinguish a ``backfill-only cache`` state (the cache
     # contains entries but none currently match the active subscription,
     # AND the consumer has emitted at least one triage decision

--- a/tests/cli/test_preflight_cache.py
+++ b/tests/cli/test_preflight_cache.py
@@ -67,6 +67,7 @@ def _write_meta(
     raw_state: str = "open",
     raw_labels: list[str] | None = None,
     raw_title: str = "fixture issue",
+    raw_milestone: str | None = None,
 ) -> Path:
     """Synthesize a single cache entry under ``project_root/.deft-cache/``."""
     owner, name = repo.split("/", 1)
@@ -102,6 +103,7 @@ def _write_meta(
         "title": raw_title,
         "state": raw_state,
         "labels": [{"name": label} for label in (raw_labels or [])],
+        "milestone": {"title": raw_milestone} if raw_milestone else None,
         "body": "",
         "created_at": _utc_iso(fetched_at - timedelta(days=1)),
         "updated_at": _utc_iso(fetched_at),
@@ -1155,3 +1157,192 @@ class TestTaskCheckWiring:
         assert "cache-fresh:" in text
         assert "preflight_cache.py" in text
         assert "--allow-missing-bootstrap" in text
+
+
+# ---------------------------------------------------------------------------
+# Suite 9: #1424 batched subscription filter (one milestone fetch, not N)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchedScopeFilter:
+    """#1424: ``_filter_scoped_meta_paths`` evaluates the rule set ONCE over
+    the whole cache rather than once per cached entry.
+
+    The pre-#1424 implementation fanned out to ``evaluate_rules(rules,
+    [issue])`` N times; because ``evaluate_rules`` builds (and memoizes
+    only within a single call) a fresh open-milestones resolver, a
+    ``milestone {is-open: true}`` scope rule re-fetched the upstream
+    open-milestones snapshot once per issue -- an O(N) ``gh`` fan-out
+    (~92s on a 500-entry cache). Batching collapses that to a single
+    fetch with unchanged matching semantics.
+    """
+
+    MILESTONE_RULE = [{"rule": "milestone", "is-open": True}]
+
+    @staticmethod
+    def _meta_paths(preflight, tmp_path, repo="deftai/directive"):
+        return list(
+            preflight._iter_meta_paths(
+                tmp_path / ".deft-cache", "github-issue", repo
+            )
+        )
+
+    def test_milestone_is_open_fetcher_invoked_at_most_once(
+        self, preflight, tmp_path
+    ):
+        """Primary #1424 DoD: a counting fetcher fires at most once for an
+        N>=3 cache carrying a ``milestone {is-open: true}`` scope rule."""
+        now = datetime(2026, 6, 3, 12, tzinfo=UTC)
+        # N = 4 (>= 3) cached open issues across two milestones.
+        _write_meta(
+            tmp_path, "deftai/directive", 1, now - timedelta(hours=1),
+            raw_milestone="M1",
+        )
+        _write_meta(
+            tmp_path, "deftai/directive", 2, now - timedelta(hours=1),
+            raw_milestone="M2",
+        )
+        _write_meta(
+            tmp_path, "deftai/directive", 3, now - timedelta(hours=1),
+            raw_milestone="M1",
+        )
+        _write_meta(
+            tmp_path, "deftai/directive", 4, now - timedelta(hours=1),
+        )  # no milestone
+        meta_paths = self._meta_paths(preflight, tmp_path)
+        assert len(meta_paths) >= 3
+
+        calls = {"n": 0}
+
+        def counting_fetcher():
+            calls["n"] += 1
+            return {"M1"}
+
+        result = preflight._filter_scoped_meta_paths(
+            meta_paths,
+            self.MILESTONE_RULE,
+            open_milestones_fetcher=counting_fetcher,
+        )
+        # The whole point of #1424: ONE fetch regardless of cache size.
+        assert calls["n"] <= 1, (
+            f"expected at most 1 milestone fetch, got {calls['n']} "
+            f"(per-issue fan-out regressed for {len(meta_paths)} entries)"
+        )
+        # Only issues 1 and 3 (milestone M1, which is open) are retained.
+        retained = {int(p.parent.name) for p in result}
+        assert retained == {1, 3}
+
+    def test_batched_matched_set_equals_per_issue_baseline(
+        self, preflight, tmp_path
+    ):
+        """Semantics are unchanged: the batched matched set equals the
+        pre-#1424 per-issue fan-out baseline."""
+        triage_scope = sys.modules["triage_scope"]
+        now = datetime(2026, 6, 3, 12, tzinfo=UTC)
+        _write_meta(
+            tmp_path, "deftai/directive", 10, now - timedelta(hours=1),
+            raw_milestone="M1",
+        )
+        _write_meta(
+            tmp_path, "deftai/directive", 11, now - timedelta(hours=1),
+            raw_milestone="M2",
+        )
+        _write_meta(
+            tmp_path, "deftai/directive", 12, now - timedelta(hours=1),
+            raw_milestone="M3",
+        )
+        _write_meta(
+            tmp_path, "deftai/directive", 13, now - timedelta(hours=1),
+            raw_milestone="M1", raw_state="closed",
+        )  # closed -> never matches
+        meta_paths = self._meta_paths(preflight, tmp_path)
+        open_set = {"M1", "M3"}
+
+        batched = set(
+            preflight._filter_scoped_meta_paths(
+                meta_paths,
+                self.MILESTONE_RULE,
+                open_milestones_fetcher=lambda: set(open_set),
+            )
+        )
+
+        # Per-issue baseline: emulate the pre-#1424 fan-out exactly.
+        baseline: set = set()
+        for mp in meta_paths:
+            raw = preflight._read_raw_issue(mp)
+            if raw is None:
+                baseline.add(mp)
+                continue
+            matched = triage_scope.evaluate_rules(
+                self.MILESTONE_RULE,
+                [raw],
+                open_milestones_fetcher=lambda: set(open_set),
+            )
+            target = raw.get("number")
+            if any(
+                isinstance(m, dict) and m.get("number") == target
+                for m in matched
+            ):
+                baseline.add(mp)
+
+        assert batched == baseline
+        # Sanity: M1 (10) and M3 (12) open; M2 (11) excluded; closed (13) out.
+        assert {int(p.parent.name) for p in batched} == {10, 12}
+
+    def test_missing_or_unparseable_raw_json_retained(
+        self, preflight, tmp_path
+    ):
+        """Over-include contract preserved: entries whose raw.json is
+        missing or unparseable are retained even under a filtering rule
+        that would otherwise exclude them."""
+        now = datetime(2026, 6, 3, 12, tzinfo=UTC)
+        _write_meta(
+            tmp_path, "deftai/directive", 20, now - timedelta(hours=1),
+            raw_milestone="M1",
+        )  # in open set -> retained via match
+        corrupt = _write_meta(
+            tmp_path, "deftai/directive", 21, now - timedelta(hours=1),
+            raw_milestone="M2",
+        )  # would be filtered, but we corrupt raw.json below
+        removed = _write_meta(
+            tmp_path, "deftai/directive", 22, now - timedelta(hours=1),
+            raw_milestone="M2",
+        )  # would be filtered, but we delete raw.json below
+        _write_meta(
+            tmp_path, "deftai/directive", 23, now - timedelta(hours=1),
+            raw_milestone="M2",
+        )  # parseable + out of open set -> excluded
+        # Corrupt issue 21's raw.json and remove issue 22's entirely.
+        (corrupt / "raw.json").write_text("{not valid json", encoding="utf-8")
+        (removed / "raw.json").unlink()
+
+        meta_paths = self._meta_paths(preflight, tmp_path)
+        result = preflight._filter_scoped_meta_paths(
+            meta_paths,
+            self.MILESTONE_RULE,
+            open_milestones_fetcher=lambda: {"M1"},
+        )
+        retained = {int(p.parent.name) for p in result}
+        # 20 matched, 21 corrupt-kept, 22 missing-kept; 23 excluded.
+        assert retained == {20, 21, 22}
+
+    def test_no_rules_returns_all_meta_paths_unchanged(
+        self, preflight, tmp_path
+    ):
+        """A nil rule list short-circuits: no evaluation, no fetch."""
+        now = datetime(2026, 6, 3, 12, tzinfo=UTC)
+        _write_meta(tmp_path, "deftai/directive", 30, now - timedelta(hours=1))
+        _write_meta(tmp_path, "deftai/directive", 31, now - timedelta(hours=1))
+        meta_paths = self._meta_paths(preflight, tmp_path)
+
+        calls = {"n": 0}
+
+        def counting_fetcher():
+            calls["n"] += 1
+            return {"M1"}
+
+        result = preflight._filter_scoped_meta_paths(
+            meta_paths, None, open_milestones_fetcher=counting_fetcher
+        )
+        assert result == meta_paths
+        assert calls["n"] == 0

--- a/vbrief/completed/2026-06-03-1424-cache-fresh-batch-eval.vbrief.json
+++ b/vbrief/completed/2026-06-03-1424-cache-fresh-batch-eval.vbrief.json
@@ -1,0 +1,47 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1424"
+  },
+  "plan": {
+    "title": "fix(triage): batch verify:cache-fresh scope filter so milestone is-open fetches once, not per-issue (#1424)",
+    "status": "completed",
+    "narratives": {
+      "Description": "fix(triage): batch verify:cache-fresh scope filter so milestone is-open fetches once, not per-issue (#1424)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1424",
+      "Overview": "## Problem\n\n`task verify:cache-fresh` (script `scripts/preflight_cache.py`) takes ~92s on a 500-entry cache because its subscription filter calls `triage_scope.evaluate_rules()` once per cached issue instead of once for the whole batch. When the active `plan.policy.triageScope[]` contains a `{\"rule\": \"milestone\", \"is-open\": true}` rule, each per-issue call re-fetches the upstream open-milestones snapshot, producing an N+1 network fetch (~500 gh round-trips). The gate runs in the session-start ritual (#1149 step 5) and in the pre-`start_agent` gate stack, so the cost is paid on every interactive session start and before every implementation dispatch.\n\n## Root cause\n\n`_filter_scoped_meta_paths` loops over every cached entry and calls `_issue_in_scope -> evaluate_rules(rules, [issue])` with a single-issue list. `evaluate_rules` builds a fresh milestone resolver per call (memoized only within one call), so the `is-open` rule re-fetches the open-milestones snapshot once per issue.\n\n## Proposed fix (Option A -- batch, mirror compute_drift)\n\nRework `_filter_scoped_meta_paths` to evaluate the rule set ONCE over the whole cache, matching `scripts/triage_scope_drift.py::compute_drift`: read every raw.json once into a list of issue dicts plus a `id(issue) -> meta_path` map; call `evaluate_rules(rules, all_issues)` a single time; keep each meta_path whose issue dict is in the returned matched set, resolved by OBJECT IDENTITY (not issue number, which can collide / drop None-number entries); preserve the over-include behavior for entries whose raw.json is missing/unparseable. This collapses N milestone fetches to 1, taking the gate from ~92s to well under a second with unchanged semantics.\n\n## Acceptance criteria\n\n- [ ] `_filter_scoped_meta_paths` calls `evaluate_rules` exactly once over the whole cache.\n- [ ] A `milestone {is-open: true}` scope rule fetches the open-milestones snapshot at most once for an N-entry cache.\n- [ ] Matched meta_paths are resolved by object identity, not issue number.\n- [ ] Entries with missing/unparseable raw.json are still retained (over-include).\n- [ ] Regression test in `tests/cli/test_preflight_cache.py` injects a counting fetcher and asserts at-most-once invocation, baseline equality, and missing-raw retention.\n\n## References\n\n- `scripts/preflight_cache.py` (`_filter_scoped_meta_paths`, `_issue_in_scope`)\n- `scripts/triage_scope.py` (`evaluate_rules`)\n- `scripts/triage_scope_drift.py` (`compute_drift` -- correct fetch-once reference)\n- `scripts/_triage_scope_milestone.py` (`make_open_milestones_resolver`, `default_open_milestones_fetcher`)\n",
+      "Labels": "bug, triage, refactor"
+    },
+    "items": [
+      {
+        "title": "_filter_scoped_meta_paths evaluates the rule set once over the whole cache (single evaluate_rules call).",
+        "status": "proposed"
+      },
+      {
+        "title": "A milestone is-open scope rule fetches the open-milestones snapshot at most once for an N-entry cache.",
+        "status": "proposed"
+      },
+      {
+        "title": "Matched meta_paths are resolved by object identity, not issue number; missing/unparseable raw.json entries are retained.",
+        "status": "proposed"
+      },
+      {
+        "title": "Regression test asserts at-most-once fetcher invocation, batched-equals-baseline matched set, and missing-raw retention.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "triage",
+      "refactor"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1424",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1424: verify:cache-fresh is O(N) gh calls: scope filter runs evaluate_rules per-issue, refetching open milestones (~92s on 500 entries)"
+      }
+    ],
+    "updated": "2026-06-03T16:07:46Z"
+  }
+}


### PR DESCRIPTION
## Summary

`task verify:cache-fresh` (`scripts/preflight_cache.py`) was O(N) `gh` calls: its subscription filter (`_filter_scoped_meta_paths`) called `triage_scope.evaluate_rules()` once per cached issue with a single-issue list. Because `evaluate_rules` builds a fresh open-milestones resolver per call (memoized only within one call), a `{"rule": "milestone", "is-open": true}` scope rule re-fetched the upstream open-milestones snapshot once per issue — ~500 `gh` round-trips, ~92s on a 500-entry cache. The gate runs in the session-start ritual (#1149 step 5) and the pre-`start_agent` gate stack, so the cost was paid on every session start and before every dispatch.

This implements **Option A** from the issue: evaluate the rule set **once** over the whole cache, mirroring the proven fetch-once shape in `scripts/triage_scope_drift.py::compute_drift`.

- Read every `raw.json` once into a list of issue dicts plus an `id(issue) -> meta_path` map.
- Call `evaluate_rules(rules, all_issues)` a **single** time (one milestone fetch).
- Keep each `meta_path` whose issue dict is in the returned matched set, resolved by **object identity** (`id(issue)`), not issue number — `evaluate_rules` dedups via `matched.setdefault(_issue_number(issue), issue)`, so number-keying would risk collisions / drop None-number entries.
- Preserve the existing over-include behavior for entries whose `raw.json` is missing/unparseable.
- `open_milestones_fetcher` is forwarded to `evaluate_rules` so tests can inject a counting closure; production leaves it `None` (default `gh api` fetcher, fires once).

Semantics are unchanged (an issue matches iff it matches any rule); the single batch call also yields one consistent `now` cutoff for `opened-since` / `updated-since` rules.

## Related Issues

Closes #1424

## Checklist

- [x] `/deft:change <name>` — N/A; scope vBRIEF authored + lifecycle-completed (`vbrief/completed/2026-06-03-1424-cache-fresh-batch-eval.vbrief.json`)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [ ] `ROADMAP.md` — N/A (moved at release time)
- [x] Tests pass locally — `pytest tests/cli/test_preflight_cache.py` = 52 passed; `task check` green (6866 passed)

## Test plan

New `TestBatchedScopeFilter` suite in `tests/cli/test_preflight_cache.py`:
- counting `open_milestones_fetcher` invoked **at most once** for an N>=3 cache with a `milestone {is-open: true}` rule;
- batched matched set **equals** the per-issue baseline;
- entries with missing/unparseable `raw.json` are **retained**;
- nil rule list short-circuits (no evaluation, no fetch).
