### PR TITLE
fix(installer): de-duplicate gitignore deposit when a covering glob exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`deft-install` no longer deposits a redundant `vbrief/.eval/` line when your `.gitignore` already covers it with a `**/vbrief/.eval/` glob (#1452)** -- the installer-managed `.gitignore` block added the bare `vbrief/.eval/` entry unconditionally, which is pure noise when a covering `**/vbrief/.eval/` glob (matching the same path at the repo root and every nested depth) is already present -- the only finding in an otherwise clean review on a real upgrade. The deposit now skips a canonical line when an equivalent `**/`-prefixed glob already covers it, and still adds `vbrief/.eval/` when no such glob exists. Closes #1452.
 
 ### Removed
 

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -1055,6 +1055,121 @@ func TestEnsureGitignoreLines_LeakedArtifactGuards(t *testing.T) {
 	}
 }
 
+// gitignoreHasExactLine reports whether content has a line that, once trimmed,
+// exactly equals want. Substring checks are insufficient for the #1452 dedup
+// assertions because `**/vbrief/.eval/` contains the substring `vbrief/.eval/`.
+func gitignoreHasExactLine(content, want string) bool {
+	for _, ln := range strings.Split(content, "\n") {
+		if strings.TrimSpace(ln) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEnsureGitignoreLines_SkipsRedundantWhenGlobCovers asserts the #1452 fix:
+// when the consumer .gitignore already carries a covering `**/vbrief/.eval/`
+// glob, the installer MUST NOT deposit the redundant bare `vbrief/.eval/`
+// line, while the covering glob and every other canonical line are preserved /
+// added as usual.
+func TestEnsureGitignoreLines_SkipsRedundantWhenGlobCovers(t *testing.T) {
+	tmp := t.TempDir()
+	pre := "# consumer pre-existing\n**/vbrief/.eval/\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".gitignore"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+
+	changed, err := EnsureGitignoreLines(w, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Other canonical lines (.deft-cache/, vbrief/*.lock, ...) are still
+	// missing, so the deposit is expected to modify the file.
+	if !changed {
+		t.Error("expected changed=true (non-eval canonical lines still need depositing)")
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	// The redundant bare line MUST NOT be deposited.
+	if gitignoreHasExactLine(content, "vbrief/.eval/") {
+		t.Errorf("redundant bare vbrief/.eval/ line was deposited despite covering **/vbrief/.eval/ glob:\n%s", content)
+	}
+	// The covering glob MUST be preserved.
+	if !gitignoreHasExactLine(content, "**/vbrief/.eval/") {
+		t.Errorf(".gitignore lost the covering **/vbrief/.eval/ glob:\n%s", content)
+	}
+	// Every OTHER canonical line MUST still be deposited.
+	for _, want := range []string{".deft-cache/", "vbrief/*.lock", ".deft/core.bak-*/", ".deft/*.bak-*", "*.premigrate.*"} {
+		if !gitignoreHasExactLine(content, want) {
+			t.Errorf(".gitignore missing canonical line %q after deposit:\n%s", want, content)
+		}
+	}
+}
+
+// TestEnsureGitignoreLines_AddsBareWhenNoGlob asserts the current behavior is
+// preserved when NO covering glob is present: the bare `vbrief/.eval/` line is
+// still deposited (#1452 must not regress the default deposit).
+func TestEnsureGitignoreLines_AddsBareWhenNoGlob(t *testing.T) {
+	tmp := t.TempDir()
+	pre := "# consumer pre-existing\nnode_modules/\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".gitignore"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+
+	if _, err := EnsureGitignoreLines(w, tmp); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !gitignoreHasExactLine(content, "vbrief/.eval/") {
+		t.Errorf("bare vbrief/.eval/ line not deposited when no covering glob present:\n%s", content)
+	}
+}
+
+// TestGitignoreEntryCovers exercises the coverage predicate directly: a
+// `**/<x>` glob covers the bare `<x>`, and nothing else does (#1452).
+func TestGitignoreEntryCovers(t *testing.T) {
+	cases := []struct {
+		existing  string
+		canonical string
+		want      bool
+	}{
+		{"**/vbrief/.eval/", "vbrief/.eval/", true},
+		{"**/.deft-cache/", ".deft-cache/", true},
+		{"vbrief/.eval/", "vbrief/.eval/", false},   // exact, not a `**/` cover
+		{"vbrief/.eval", "vbrief/.eval/", false},    // trailing-slash mismatch
+		{"**/other/", "vbrief/.eval/", false},       // unrelated glob
+		{"**vbrief/.eval/", "vbrief/.eval/", false}, // missing slash after **
+	}
+	for _, c := range cases {
+		if got := gitignoreEntryCovers(c.existing, c.canonical); got != c.want {
+			t.Errorf("gitignoreEntryCovers(%q, %q) = %v, want %v", c.existing, c.canonical, got, c.want)
+		}
+	}
+}
+
+// TestGitignoreLineCovered checks the set-level helper against a presence map.
+func TestGitignoreLineCovered(t *testing.T) {
+	present := map[string]bool{
+		"**/vbrief/.eval/": true,
+		"node_modules/":    true,
+	}
+	if !gitignoreLineCovered("vbrief/.eval/", present) {
+		t.Error("expected vbrief/.eval/ to be covered by present **/vbrief/.eval/ glob")
+	}
+	if gitignoreLineCovered(".deft-cache/", present) {
+		t.Error("did not expect .deft-cache/ to be covered (no **/.deft-cache/ present)")
+	}
+}
+
 func TestWriteConsumerVbrief_CreatesNew(t *testing.T) {
 	tmp := t.TempDir()
 	projectDir := filepath.Join(tmp, "proj")

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -620,12 +620,42 @@ func WriteAgentsMD(w *Wizard, projectDir string) error {
 // 4.2b .gitignore upkeep -- canonical F2 default (#1015, #1020)
 // ---------------------------------------------------------------------------
 
+// gitignoreEntryCovers reports whether a pre-existing .gitignore entry
+// (`existing`) already covers a canonical bare entry (`canonical`) via an
+// equivalent leading-`**/` glob. gitignore semantics make a leading `**/`
+// match in EVERY directory, so `**/vbrief/.eval/` matches `vbrief/.eval/` at
+// the repo root (and at every nested depth) -- the glob is a strict superset
+// of the bare form. When the consumer already carries that covering glob the
+// bare line the installer would otherwise deposit is pure noise (#1452). The
+// check is intentionally narrow: only the exact `**/<canonical>` shape counts
+// as a cover, so unrelated globs never silently suppress a canonical deposit.
+func gitignoreEntryCovers(existing, canonical string) bool {
+	return existing == "**/"+canonical
+}
+
+// gitignoreLineCovered reports whether any pre-existing .gitignore entry in
+// `present` already covers the canonical bare `line` via an equivalent
+// leading-`**/` glob (see gitignoreEntryCovers). Used by EnsureGitignoreLines
+// to skip depositing a line that an existing covering glob makes redundant
+// (#1452).
+func gitignoreLineCovered(line string, present map[string]bool) bool {
+	for entry := range present {
+		if gitignoreEntryCovers(entry, line) {
+			return true
+		}
+	}
+	return false
+}
+
 // EnsureGitignoreLines appends the canonical baseline (`.deft-cache/`,
 // `vbrief/.eval/`) to the consumer's .gitignore if any line is missing. The
 // file is created when absent. Pre-existing lines are preserved byte-for-byte.
-// Mirrors scripts/relocate.py::_ensure_gitignore_lines for parity with the
-// relocator (#1015 F2 canonical default). Returns true if the file was
-// modified, false when no additions were needed.
+// A canonical line is also skipped when an existing entry already covers it
+// via an equivalent leading-`**/` glob (e.g. an existing `**/vbrief/.eval/`
+// makes the bare `vbrief/.eval/` deposit redundant, #1452) -- see
+// gitignoreLineCovered. Mirrors scripts/relocate.py::_ensure_gitignore_lines
+// for parity with the relocator (#1015 F2 canonical default). Returns true if
+// the file was modified, false when no additions were needed.
 func EnsureGitignoreLines(w *Wizard, projectDir string) (bool, error) {
 	path := filepath.Join(projectDir, ".gitignore")
 	existing := ""
@@ -643,9 +673,15 @@ func EnsureGitignoreLines(w *Wizard, projectDir string) (bool, error) {
 
 	var additions []string
 	for _, line := range canonicalGitignoreLines {
-		if !present[line] {
-			additions = append(additions, line)
+		if present[line] {
+			continue
 		}
+		// Skip a bare canonical line that an existing `**/<line>` glob
+		// already covers -- depositing it would be redundant noise (#1452).
+		if gitignoreLineCovered(line, present) {
+			continue
+		}
+		additions = append(additions, line)
 	}
 	if len(additions) == 0 {
 		w.printf(".gitignore already covers deft-cache + vbrief eval lines — skipping.\n")

--- a/vbrief/completed/2026-06-03-1452-gitignore-dedup.vbrief.json
+++ b/vbrief/completed/2026-06-03-1452-gitignore-dedup.vbrief.json
@@ -1,0 +1,42 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1452"
+  },
+  "plan": {
+    "title": "fix(installer): de-duplicate gitignore deposit when a covering **/ glob already exists (#1452)",
+    "status": "completed",
+    "narratives": {
+      "Description": "fix(installer): skip the redundant bare vbrief/.eval/ gitignore line when the consumer .gitignore already carries a covering **/vbrief/.eval/ glob (#1452)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1452",
+      "Overview": "The installer's EnsureGitignoreLines in cmd/deft-install/setup.go deposits canonicalGitignoreLines (which includes the non-globbed vbrief/.eval/). When the consumer .gitignore already contains a covering glob such as **/vbrief/.eval/, the deposited bare vbrief/.eval/ line is strictly redundant noise -- gitignore semantics make a leading **/ match at the repo root and every nested depth, so the **/<x> glob is a superset of bare <x>. This was the only finding in an otherwise clean Greptile review on a real upgrade PR. Fix: add a small coverage helper so the deposit logic treats a present **/<x> glob as covering the bare <x> canonical line and skips the redundant addition, while preserving current behavior (still add vbrief/.eval/) when no covering glob is present. All other canonical lines and the byte-for-byte preservation of pre-existing lines are unchanged.",
+      "Labels": "bug, installer"
+    },
+    "items": [
+      {
+        "title": "Add a coverage helper so a present **/<x> glob is treated as covering the bare <x> canonical line during gitignore deposit.",
+        "status": "proposed"
+      },
+      {
+        "title": "A .gitignore already containing **/vbrief/.eval/ does NOT gain a redundant vbrief/.eval/ line after deposit.",
+        "status": "proposed"
+      },
+      {
+        "title": "A .gitignore WITHOUT the covering glob still gets vbrief/.eval/ deposited (current behavior preserved).",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "installer"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1452",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1452: Installer-deposited .gitignore has redundant vbrief/.eval/ entry (duplicate of **/vbrief/.eval/)"
+      }
+    ],
+    "updated": "2026-06-03T16:08:06Z"
+  }
+}


### PR DESCRIPTION
## Summary

The installer-deposited `.gitignore` block added the bare `vbrief/.eval/`
entry unconditionally. When the consumer `.gitignore` already carries a
covering `**/vbrief/.eval/` glob (which matches the same path at the repo
root and at every nested depth), the bare line is strict noise -- the only
finding in an otherwise clean Greptile review on a real upgrade PR.

`EnsureGitignoreLines` now skips a bare canonical line when an existing
entry already covers it via an equivalent leading-`**/` glob, and still
deposits `vbrief/.eval/` when no covering glob is present. All other
canonical lines and the byte-for-byte preservation of pre-existing lines
are unchanged.

## Changes

- Add `gitignoreEntryCovers` / `gitignoreLineCovered` helpers in
  `cmd/deft-install/setup.go` (a `**/<x>` glob covers the bare `<x>`).
- Wire the coverage check into the deposit loop in `EnsureGitignoreLines`.
- Add tests in `cmd/deft-install/main_test.go`: a `.gitignore` with
  `**/vbrief/.eval/` does NOT gain a redundant `vbrief/.eval/` line; a
  `.gitignore` without the glob still gets `vbrief/.eval/`; plus direct
  unit tests for both helpers.

## Related Issues

Closes #1452

## Checklist

- [x] `/deft:change <name>` — N/A (single-purpose source change; scoped vBRIEF authored + completed)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (rendered from lifecycle folders; completed vBRIEF included)
- [x] Tests pass locally (`task check` green; `go test ./cmd/deft-install/...` green)

## Validation

- `go test ./cmd/deft-install/...` — passed
- `task check` — passed (markdown + vBRIEF + encoding + lint + mypy + 6862 pytest)

## Artifacts

- Conversation: https://app.warp.dev/conversation/ae0f6490-1388-44e6-960b-9cf3d577fb62
- Run: https://oz.warp.dev/runs/019e8e39-8d92-727f-b92b-a7471f6449a5
