### PR TITLE
fix(events): fix mypy variable-type collision in #1465 regression test

### DIFF
--- a/tests/cli/test_behavioral_events.py
+++ b/tests/cli/test_behavioral_events.py
@@ -748,8 +748,10 @@ class TestDefaultEventLogGitignored:
         # directory to `!! .deft-cache/`, so match the `!!` prefix tolerantly
         # instead of pinning the exact path.
         status = _git(["status", "--porcelain", "--ignored"], repo)
-        ignored = [ln for ln in status.stdout.splitlines() if ln.startswith("!!")]
-        assert any(".deft-cache" in ln for ln in ignored), (
+        ignored_lines = [
+            ln for ln in status.stdout.splitlines() if ln.startswith("!!")
+        ]
+        assert any(".deft-cache" in ln for ln in ignored_lines), (
             f"relocated event log MUST be reported ignored; got {status.stdout!r}"
         )
         assert "?? .deft-cache/events.jsonl" not in status.stdout


### PR DESCRIPTION
## Summary

Hotfix for a `master` CI breakage introduced by the #1465 fix (PR #1466). PR #1466 was squash-merged at a commit that carried a mypy error, so `master`'s **Python (lint + type-check + test)** check is currently **red**.

In `tests/cli/test_behavioral_events.py::TestDefaultEventLogGitignored.test_default_path_ignored_in_vendored_consumer_layout`, the strengthened `--ignored` assertion reused the local name `ignored`, which was already bound earlier in the same function to a `subprocess.CompletedProcess` (the `git check-ignore` result). Reassigning it to a `list[str]` is an `[assignment]` / `[attr-defined]` mypy error:

```
tests/cli/test_behavioral_events.py:751: error: Incompatible types in assignment (expression has type "list[str]", variable has type "CompletedProcess[str]")  [assignment]
tests/cli/test_behavioral_events.py:752: error: "CompletedProcess[str]" has no attribute "__iter__" (not iterable)  [attr-defined]
```

This is caught by CI's `mypy tests/` step but **not** by local `task check` (which only runs `mypy run.py`), which is why it slipped through pre-merge. A follow-up issue will bring `mypy tests/` (or the full tree) into `task check` so this class of gap is caught locally rather than in CI.

## Change

- Rename the list-comprehension target from `ignored` to `ignored_lines`. No behavior change — the regression test still asserts the relocated `.deft-cache` log is reported ignored and never surfaced as untracked.

## Why a separate PR

#1465 / #1466 are already merged and closed. This is a focused follow-up hotfix to restore a green `master`.

## Validation

- `uv run mypy tests/` — Success: no issues found in 240 source files (the exact CI step that was failing).
- `uv run ruff check` — All checks passed.
- `task check` — green (6869 passed, 3 skipped, 1 xfailed).

## Related Issues

Refs #1465, #1466

## Checklist

- [x] `CHANGELOG.md` — N/A (test-only fix; no user-visible behavior change)
- [ ] `ROADMAP.md` — N/A
- [x] Tests pass locally (`task check` green; `mypy tests/` clean)

## Post-Merge

- [ ] Confirm `master`'s **Python (lint + type-check + test)** check returns green after merge.

---
Conversation: https://app.warp.dev/conversation/eb96f941-b823-4a23-8ed6-ff2fd8c97606
Run: https://oz.warp.dev/runs/019e8e5c-f20c-7663-8b00-5d9c236cd0b6
