### PR TITLE
docs(upgrade): big-jump triage + combined Case G+H (one session) (#1114, #1115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **UPGRADING.md now opens with a big-jump triage entry point for multi-version upgrades (#1115)** -- a consumer jumping several minor versions no longer has to read every section to work out which ones apply. A new top-of-file triage maps version-range buckets to the sections that apply and the order to run them in (oldest applicable first), flags each bucket as auto-handled or manual, and points you at QUICK-START.md and the canonical `deft-install` + `task doctor` finish line. Closes #1115.
+- **QUICK-START.md can now finish a stale-AGENTS.md refresh and a pre-cutover migration in one agent session (#1114)** -- on a big-jump upgrade that trips both Case G (stale AGENTS.md) and Case H (pre-cutover artifacts), the agent used to stop and force a second session between the two. A new combined Case G+H path refreshes AGENTS.md first, runs the migration second, and emits a single restart at the end, removing the wasted session round-trip while producing the same end state. Closes #1114.
 
 ### Changed
 

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -37,6 +37,8 @@ Three checks here, in this order. The first match wins; later checks only run wh
 
 Priority ordering: Case G (byte-different content) always wins over Case K (install-path mismatch) because the refresh path is the higher-priority remediation -- when the template content has moved on, the refresh closes BOTH the content drift and any incidental install-path mismatch that the new content might re-introduce. Case K only fires when the content is byte-current AND the path is unresolved -- the exact "refresh would be a no-op" failure class issue #1046 documents.
 
+**Big-jump joint check (Case G+H gate).** Before acting on ANY Case G routing above (a byte-different managed section, or an unresolved / redirect-stub legacy skill path), first ALSO evaluate the 2c pre-cutover check below against `../`. ! If 2c ALSO holds (real pre-v0.20 `SPECIFICATION.md` / `PROJECT.md` present), the project is in the **joint big-jump state** where both the AGENTS.md refresh (Case G) and the pre-cutover migration (Case H) are due — jump to **Case G+H** (combined single-session remediation) in Step 3 instead of Case G. The combined path runs the refresh and the migration in one session and emits a single restart, avoiding the wasted Case G → restart → Case H round-trip. If 2c does not hold, route to Case G as usual.
+
 ### 2c. Are there pre-v0.20 artifacts at the user's project root?
 
 Check both of these files at `../` (the user's project root), using the same
@@ -86,6 +88,18 @@ Pick exactly one case from Step 2 and follow its instructions. Do not mix cases.
 7. After migration completes, re-run Step 2 of this QUICK-START — the project state has changed. Most likely you land in Case G (AGENTS.md still references old paths) or Case J.
 8. When AGENTS.md is refreshed, ! instruct the user: **"Framework updated. Start a new agent session to pick up the changes. The current session has stale context."**
 
+### Case G+H — Combined stale AGENTS.md + pre-cutover migration (big-jump, one session)
+
+Reached only via the **Big-jump joint check** in 2b: the managed section in `../AGENTS.md` is stale (Case G) AND pre-v0.20 artifacts are present at `../` (Case H). This is the typical shape of a multi-version "big jump" that crossed both the AGENTS.md managed-section refresh and the pre-v0.20 document-model cutover. Running Case G and Case H as two separate sessions wastes an agent-session round-trip, because `task migrate:vbrief` re-reads filesystem state directly and does NOT depend on the refreshed `AGENTS.md` being in the current agent's context. Both remediations therefore complete safely in **one session**.
+
+! Run the two remediations in this exact order — **AGENTS.md refresh first, migration second** — then emit a **single** restart instruction at the very end:
+
+1. **Refresh AGENTS.md first (Case G work).** Perform Case G steps 1-4 verbatim: identify the managed section, append when the sentinel is absent or byte-replace it when present, and preserve everything outside the managed region. ⊗ Do NOT emit the Case G step-5 restart instruction here — the combined path defers the single restart to step 3.
+2. **Run migration second (Case H work).** Perform Case H steps 1-6 verbatim: run the environment preflight, report each result, ask for explicit approval, and on approval run `task migrate:vbrief` (or the `task -t ./deft/Taskfile.yml migrate:vbrief` fallback) from the project root. ⊗ Do NOT perform Case H step 7 (re-run Step 2) or step 8 (restart): the AGENTS.md refresh is already done in step 1, and the single restart is emitted in step 3. The migration reads filesystem state directly, so refreshing AGENTS.md first does not change its inputs — the ordering is safe.
+3. **Single restart, exactly once.** Only after BOTH the refresh and the migration have completed, ! instruct the user EXACTLY ONCE: **"Framework updated and project migrated. Start a new agent session to pick up the changes. The current session has stale context."** ⊗ Do NOT emit a second restart instruction — the deferred Case G restart and the Case H restart collapse into this one.
+
+The end state is byte-identical to running Case G and Case H separately: the same managed-section refresh against `./templates/agents-entry.md` and the same `task migrate:vbrief` output (deprecation-redirect stubs plus the five `vbrief/` lifecycle folders). The only thing removed is the wasted intermediate session restart. For the version-by-version context of a big jump, see the [big-jump triage entry point](./UPGRADING.md#big-jump-triage--multi-version-upgrades-start-here) in UPGRADING.md.
+
 ### Case I — Partial migration repair
 
 1. Tell the user: "Your project has a partial vBRIEF layout. Missing lifecycle folders: <list the absent ones>. Shall I complete the migration by running `task migrate:vbrief`? It is idempotent and safe to re-run."
@@ -112,7 +126,7 @@ Read and follow `../AGENTS.md`. This starts the normal first-session flow (user 
 
 **Brownfield pointer:** For users retrofitting Deft onto an existing project (existing code, existing docs, or pre-v0.20 Deft layout), the authoritative adoption guide is [docs/BROWNFIELD.md](./docs/BROWNFIELD.md). It covers install options, migration, post-migration checks, and troubleshooting in more depth than the Case H flow above.
 
-**Upgrade pointer:** Users moving between framework versions should also read [UPGRADING.md](./UPGRADING.md) in the repo root for the version-by-version guide.
+**Upgrade pointer:** Users moving between framework versions should also read [UPGRADING.md](./UPGRADING.md) in the repo root for the version-by-version guide. For a multi-version "big jump", start at its [big-jump triage entry point](./UPGRADING.md#big-jump-triage--multi-version-upgrades-start-here), which names which version buckets apply and in what order. An agent on a big jump that hits both a stale AGENTS.md and pre-cutover artifacts should follow [Case G+H](#case-gh--combined-stale-agentsmd--pre-cutover-migration-big-jump-one-session) above to complete both in one session.
 
 ## Update notifications
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,35 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 ---
 
+## Big-jump triage — multi-version upgrades (start here)
+
+> **Multi-version jump?** Start here. This guide is ordered newest-first, so a consumer jumping several minor versions otherwise has to read every section to infer which ones apply and in what order. This entry point maps **version-range buckets** to the sections that apply and the **apply-order** to run them in.
+
+**How to use this triage:**
+
+1. Find the bucket for the version you are upgrading **from** (your current `.deft-version`, or the `tag` field in `<install>/VERSION`).
+2. Apply the listed transitions in **apply-order: oldest applicable first**, working forward to the newest. Because the sections in this file are ordered newest-first, that means working **bottom-up** through the file.
+3. Each bucket is flagged **auto-handled** (the canonical installer / `task doctor` / `task upgrade` does it for you) or **manual** (you run a migration / relocate / cache step yourself).
+
+**Version-range buckets (apply-order, oldest applicable first):**
+
+- **From pre-v0.20 (very old) — manual.** Run the pre-cutover migration, then refresh AGENTS.md: [From any pre-v0.20 version → v0.20.0](#from-any-pre-v020-version--v0200) and [From pre-#768 AGENTS.md → managed-section AGENTS.md](#from-pre-768-agentsmd--managed-section-agentsmd). Agents: when the project shows BOTH a stale AGENTS.md and pre-cutover artifacts, follow [QUICK-START.md Case G+H](./QUICK-START.md#case-gh--combined-stale-agentsmd--pre-cutover-migration-big-jump-one-session) to complete both in one session instead of two.
+- **From v0.20–v0.24 — auto-handled (opt-in).** Triage v1 is purely additive; nothing breaks if you skip it: [Migration to triage v1](#migration-to-triage-v1).
+- **From v0.25.x — manual (breaking).** The deft-cache on-disk layout changed: [From v0.25.x → v0.26.0](#from-v025x--v0260-deft-cache-unified-layer-breaking).
+- **From v0.26.x — auto-handled (interactive).** Run the triage adoption ritual: [From v0.26.x → v0.27](#from-v026x---v027-triage-adoption-via-task-triagewelcome).
+- **From v0.27.x — mostly auto-handled.** Pick up the install manifest and the `deft/` → `.deft/core/` layout: [From v0.27.x → v0.28](#from-v027x---v028-canonical-install-manifest-at-installversion), [From deft/ → .deft/core/](#from-deft---deftcore), and [From drifted AGENTS.md → current install](#from-drifted-agentsmd---current-install-task-upgrade-repair-path-1061).
+- **From v0.28–v0.36 (and the final hop to current) — auto-handled.** The canonical installer + doctor handoff is the single supported path: [Canonical installer + doctor handoff](#canonical-installer--doctor-handoff-v037--epic-56-1339-1340-1409).
+
+**Final step for every bucket.** Finish on the canonical headless upgrade command, then let the doctor confirm you are current:
+
+```bash
+deft-install --yes --upgrade --repo-root . --json
+```
+
+Then run `task doctor` (or `run doctor`): it reads `<install>/VERSION`, compares against the remote ref, and tells you whether any further hop is still due. See [Canonical installer + doctor handoff](#canonical-installer--doctor-handoff-v037--epic-56-1339-1340-1409) for the full handoff contract.
+
+---
+
 ## Canonical installer + doctor handoff (v0.37+ / Epic-5+6 #1339 #1340, #1409)
 
 **The single supported path for humans and agents:**

--- a/tests/content/test_quickstart_combined_remediation.py
+++ b/tests/content/test_quickstart_combined_remediation.py
@@ -1,0 +1,201 @@
+"""tests/content/test_quickstart_combined_remediation.py -- Case G+H (#1114).
+
+Contract test asserting QUICK-START.md documents the combined Case G+H
+remediation path for a big-jump upgrade where AGENTS.md is stale (Case G)
+AND pre-cutover artifacts are present (Case H):
+
+- a 2b "Big-jump joint check" gate that detects the joint condition and
+  routes to Case G+H instead of Case G;
+- a "### Case G+H" section that orders the AGENTS.md refresh ahead of the
+  migration and emits exactly ONE restart instruction;
+- the documented byte-identical-to-running-separately guarantee; and
+- a cross-reference into UPGRADING.md's big-jump triage entry point that
+  resolves to a real heading anchor (kept consistent with #1115).
+
+Story: #1114 (combine QUICK-START Case G + Case H into one session).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_QUICK_START = _REPO_ROOT / "QUICK-START.md"
+_UPGRADING = _REPO_ROOT / "UPGRADING.md"
+
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+
+
+def _github_slug(heading_text: str) -> str:
+    """Mirror GitHub's heading-anchor slug algorithm.
+
+    Lowercase, drop everything that is not a word char / whitespace /
+    hyphen, then map each whitespace char to a hyphen (no collapsing).
+    """
+    s = heading_text.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s, flags=re.UNICODE)
+    return re.sub(r"\s", "-", s)
+
+
+def _anchor_set(text: str) -> set[str]:
+    """Compute the set of GitHub heading anchors for a markdown document.
+
+    Skips fenced code blocks so ``# comment`` lines inside ```` ``` ````
+    blocks are not mistaken for headings, and applies github-slugger's
+    duplicate-suffix rule (``slug``, ``slug-1``, ``slug-2`` ...).
+    """
+    anchors: set[str] = set()
+    counts: dict[str, int] = {}
+    in_fence = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _HEADING_RE.match(line)
+        if not m:
+            continue
+        base = _github_slug(m.group(2))
+        if base not in counts:
+            counts[base] = 0
+            anchors.add(base)
+        else:
+            counts[base] += 1
+            anchors.add(f"{base}-{counts[base]}")
+    return anchors
+
+
+def _section_body(text: str, heading_substr: str, max_level: int) -> str:
+    """Return the body of the first heading whose text contains heading_substr.
+
+    The body runs until the next heading at level <= max_level.
+    """
+    lines = text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        m = _HEADING_RE.match(line)
+        if m and heading_substr in m.group(2):
+            start = idx
+            break
+    assert start is not None, f"heading containing {heading_substr!r} not found"
+    body: list[str] = []
+    for line in lines[start + 1:]:
+        m = _HEADING_RE.match(line)
+        if m and len(m.group(1)) <= max_level:
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def test_quick_start_exists() -> None:
+    assert _QUICK_START.is_file(), f"Expected {_QUICK_START} (#1114)"
+
+
+def test_joint_check_gate_present_in_detection() -> None:
+    """Step 2 detection MUST document the joint big-jump check that routes
+    a stale-AGENTS.md + pre-cutover project to Case G+H (a1)."""
+    text = _QUICK_START.read_text(encoding="utf-8")
+    step3_idx = text.find("## Step 3")
+    assert step3_idx != -1, "QUICK-START.md must retain its Step 3 heading"
+    gate_idx = text.find("Big-jump joint check")
+    assert gate_idx != -1, (
+        "QUICK-START.md Step 2 must document a 'Big-jump joint check' that "
+        "detects the joint stale-AGENTS.md + pre-cutover condition (#1114)."
+    )
+    assert gate_idx < step3_idx, (
+        "The joint check must live in the Step 2 detection phase, before Step 3."
+    )
+    gate_window = text[gate_idx:step3_idx]
+    for token in ("Case G+H", "pre-cutover", "Case G", "Case H"):
+        assert token in gate_window, (
+            f"Joint-check gate is missing required token {token!r} (#1114)."
+        )
+    assert "jump to **Case G+H**" in gate_window or "Case G+H" in gate_window, (
+        "The joint check must route to Case G+H (#1114)."
+    )
+
+
+def test_combined_case_section_present() -> None:
+    text = _QUICK_START.read_text(encoding="utf-8")
+    assert "### Case G+H" in text, (
+        "QUICK-START.md must document a '### Case G+H' combined remediation "
+        "section (#1114)."
+    )
+
+
+def test_combined_case_orders_refresh_before_migration() -> None:
+    """The combined path MUST run the AGENTS.md refresh before the migration (a1)."""
+    text = _QUICK_START.read_text(encoding="utf-8")
+    body = _section_body(text, "Case G+H", max_level=3)
+    assert "AGENTS.md refresh first, migration second" in body, (
+        "Case G+H must state the canonical ordering "
+        "'AGENTS.md refresh first, migration second' (#1114)."
+    )
+    refresh_idx = body.find("Refresh AGENTS.md first")
+    migration_idx = body.find("Run migration second")
+    assert refresh_idx != -1 and migration_idx != -1, (
+        "Case G+H must contain a refresh step and a migration step (#1114)."
+    )
+    assert refresh_idx < migration_idx, (
+        "Case G+H must order the AGENTS.md refresh step before the migration "
+        "step (#1114)."
+    )
+
+
+def test_combined_case_emits_single_restart() -> None:
+    """The combined path MUST collapse the two restarts into exactly one (a1)."""
+    text = _QUICK_START.read_text(encoding="utf-8")
+    body = _section_body(text, "Case G+H", max_level=3)
+    assert "EXACTLY ONCE" in body, (
+        "Case G+H must instruct the single restart EXACTLY ONCE (#1114)."
+    )
+    assert "Do NOT emit a second restart" in body, (
+        "Case G+H must forbid emitting a second restart instruction (#1114)."
+    )
+    # Defers the per-case restarts so only one is emitted.
+    assert "step-5 restart" in body and "step 8 (restart)" in body, (
+        "Case G+H must defer the Case G and Case H restart instructions so a "
+        "single restart is emitted at the end (#1114)."
+    )
+
+
+def test_combined_case_documents_equivalent_end_state() -> None:
+    """The combined path MUST document the byte-identical-to-separate guarantee (a2)."""
+    text = _QUICK_START.read_text(encoding="utf-8")
+    body = _section_body(text, "Case G+H", max_level=3)
+    assert "byte-identical" in body, (
+        "Case G+H must state the end state is byte-identical to running the "
+        "cases separately (#1114, acceptance a2)."
+    )
+    assert "separately" in body, (
+        "Case G+H must compare against running Case G and Case H separately "
+        "(#1114, acceptance a2)."
+    )
+
+
+def test_combined_case_cross_reference_resolves() -> None:
+    """The Case G+H cross-reference into UPGRADING.md must resolve to a real
+    anchor, keeping the QUICK-START <-> UPGRADING references consistent (#1114/#1115)."""
+    qs_text = _QUICK_START.read_text(encoding="utf-8")
+    up_text = _UPGRADING.read_text(encoding="utf-8")
+    up_anchors = _anchor_set(up_text)
+    body = _section_body(qs_text, "Case G+H", max_level=3)
+
+    upgrading_links = [
+        target
+        for _label, target in _LINK_RE.findall(body)
+        if "UPGRADING.md#" in target
+    ]
+    assert upgrading_links, (
+        "Case G+H must cross-reference UPGRADING.md's big-jump triage entry "
+        "point (#1114)."
+    )
+    for target in upgrading_links:
+        anchor = target.split("#", 1)[1]
+        assert anchor in up_anchors, (
+            f"Case G+H links to UPGRADING.md#{anchor}, which does not resolve "
+            f"to any heading in UPGRADING.md (#1114)."
+        )

--- a/tests/content/test_upgrading_bigjump_triage.py
+++ b/tests/content/test_upgrading_bigjump_triage.py
@@ -1,0 +1,200 @@
+"""tests/content/test_upgrading_bigjump_triage.py -- big-jump triage (#1115).
+
+Contract test asserting UPGRADING.md exposes a discoverable top-of-file
+big-jump triage entry point for multi-version upgrades:
+
+- a `## Big-jump triage` section that appears before the first version
+  section (so a multi-version upgrader sees it first);
+- version-range buckets that name which sections apply, their apply-order
+  (oldest applicable first), and whether each is auto-handled or manual;
+- cross-references to QUICK-START.md and the canonical installer + doctor
+  command surface that resolve to real heading anchors (kept consistent
+  with #1114).
+
+Story: #1115 (add a big-jump triage / entry point for multi-version upgrades).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_UPGRADING = _REPO_ROOT / "UPGRADING.md"
+_QUICK_START = _REPO_ROOT / "QUICK-START.md"
+
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+
+_TRIAGE_HEADING = "Big-jump triage"
+_DOCTOR_ANCHOR = "canonical-installer--doctor-handoff-v037--epic-56-1339-1340-1409"
+
+
+def _github_slug(heading_text: str) -> str:
+    """Mirror GitHub's heading-anchor slug algorithm."""
+    s = heading_text.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s, flags=re.UNICODE)
+    return re.sub(r"\s", "-", s)
+
+
+def _anchor_set(text: str) -> set[str]:
+    """Compute the GitHub heading-anchor set for a markdown document.
+
+    Skips fenced code blocks and applies github-slugger's duplicate-suffix
+    rule (``slug``, ``slug-1``, ``slug-2`` ...).
+    """
+    anchors: set[str] = set()
+    counts: dict[str, int] = {}
+    in_fence = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _HEADING_RE.match(line)
+        if not m:
+            continue
+        base = _github_slug(m.group(2))
+        if base not in counts:
+            counts[base] = 0
+            anchors.add(base)
+        else:
+            counts[base] += 1
+            anchors.add(f"{base}-{counts[base]}")
+    return anchors
+
+
+def _section_body(text: str, heading_substr: str, max_level: int) -> str:
+    """Return the body of the first heading containing heading_substr."""
+    lines = text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        m = _HEADING_RE.match(line)
+        if m and heading_substr in m.group(2):
+            start = idx
+            break
+    assert start is not None, f"heading containing {heading_substr!r} not found"
+    body: list[str] = []
+    for line in lines[start + 1:]:
+        m = _HEADING_RE.match(line)
+        if m and len(m.group(1)) <= max_level:
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def test_upgrading_exists() -> None:
+    assert _UPGRADING.is_file(), f"Expected {_UPGRADING} (#1115)"
+
+
+def test_big_jump_entry_point_is_discoverable() -> None:
+    """The triage entry point MUST appear before the first version section so a
+    multi-version upgrader self-routes without reading every section (a1)."""
+    text = _UPGRADING.read_text(encoding="utf-8")
+    triage_idx = text.find(f"## {_TRIAGE_HEADING}")
+    assert triage_idx != -1, (
+        "UPGRADING.md must expose a '## Big-jump triage' entry point (#1115)."
+    )
+    first_from_idx = text.find("\n## From ")
+    canonical_idx = text.find("\n## Canonical installer")
+    section_idxs = [i for i in (first_from_idx, canonical_idx) if i != -1]
+    assert section_idxs, "UPGRADING.md must contain at least one version section"
+    assert triage_idx < min(section_idxs), (
+        "The big-jump triage entry point must appear before the first version "
+        "section so it is the first thing a multi-version upgrader reads (#1115)."
+    )
+
+
+def test_triage_lists_version_buckets_with_apply_order() -> None:
+    """The triage MUST map version-range buckets to apply-order (a1)."""
+    text = _UPGRADING.read_text(encoding="utf-8")
+    body = _section_body(text, _TRIAGE_HEADING, max_level=2)
+    buckets = [ln for ln in body.splitlines() if ln.startswith("- **From")]
+    assert len(buckets) >= 5, (
+        f"The triage must enumerate the version-range buckets; found "
+        f"{len(buckets)} (#1115)."
+    )
+    assert "apply-order" in body, (
+        "The triage must spell out an explicit apply-order (#1115)."
+    )
+    assert "oldest" in body.lower(), (
+        "The triage apply-order must name the oldest-applicable-first ordering "
+        "(#1115)."
+    )
+
+
+def test_triage_flags_auto_vs_manual() -> None:
+    """Each bucket MUST be flagged auto-handled vs manual (a1)."""
+    text = _UPGRADING.read_text(encoding="utf-8")
+    body = _section_body(text, _TRIAGE_HEADING, max_level=2)
+    assert "auto-handled" in body, (
+        "The triage must flag which buckets are auto-handled (#1115)."
+    )
+    assert "manual" in body, (
+        "The triage must flag which buckets require manual steps (#1115)."
+    )
+
+
+def test_triage_references_quickstart_and_doctor_surface() -> None:
+    """The triage MUST reference QUICK-START.md and the doctor command surface (a2)."""
+    text = _UPGRADING.read_text(encoding="utf-8")
+    body = _section_body(text, _TRIAGE_HEADING, max_level=2)
+    assert "QUICK-START.md#" in body, (
+        "The triage must cross-reference QUICK-START.md (#1115)."
+    )
+    assert "task doctor" in body, (
+        "The triage must point multi-version upgraders at the doctor command "
+        "surface (#1115)."
+    )
+    assert "deft-install --yes --upgrade --repo-root . --json" in body, (
+        "The triage must name the canonical headless upgrade command as the "
+        "final step (#1115)."
+    )
+    assert f"#{_DOCTOR_ANCHOR}" in body, (
+        "The triage must link to the canonical installer + doctor handoff "
+        "section (#1115)."
+    )
+
+
+def test_triage_cross_references_resolve() -> None:
+    """Every anchor cross-reference in the triage MUST resolve to a real heading
+    anchor in its target file (a2, a3)."""
+    up_text = _UPGRADING.read_text(encoding="utf-8")
+    qs_text = _QUICK_START.read_text(encoding="utf-8")
+    up_anchors = _anchor_set(up_text)
+    qs_anchors = _anchor_set(qs_text)
+    body = _section_body(up_text, _TRIAGE_HEADING, max_level=2)
+
+    checked = 0
+    for _label, target in _LINK_RE.findall(body):
+        if target.startswith(("http://", "https://", "mailto:")):
+            continue
+        if "#" not in target:
+            continue
+        file_part, anchor = target.split("#", 1)
+        file_part = file_part.lstrip("./")
+        if file_part == "" or file_part.endswith("UPGRADING.md"):
+            target_set, where = up_anchors, "UPGRADING.md"
+        elif file_part.endswith("QUICK-START.md"):
+            target_set, where = qs_anchors, "QUICK-START.md"
+        else:
+            continue
+        assert anchor in target_set, (
+            f"Big-jump triage links to {where}#{anchor}, which does not "
+            f"resolve to any heading in {where} (#1115)."
+        )
+        checked += 1
+    assert checked >= 7, (
+        f"The triage should cross-link the version buckets and the QUICK-START "
+        f"+ doctor surfaces; only {checked} anchor links were validated (#1115)."
+    )
+
+
+def test_doctor_anchor_actually_exists() -> None:
+    """Guard the doctor-surface anchor token used by the triage (#1115)."""
+    up_text = _UPGRADING.read_text(encoding="utf-8")
+    assert _DOCTOR_ANCHOR in _anchor_set(up_text), (
+        "The canonical installer + doctor handoff heading must exist so the "
+        "triage's doctor-surface link resolves (#1115)."
+    )


### PR DESCRIPTION
## Summary

Documentation upgrade-path improvements for multi-version ("big jump") upgrades, across two swarm-ready stories.

### #1115 — UPGRADING.md big-jump triage entry point
`UPGRADING.md` is ordered newest-first with no top-of-file triage, so a consumer jumping several minor versions had to read every section to infer which apply and in what order. This adds a discoverable **Big-jump triage** section at the top that:
- maps **version-range buckets** to the sections that apply and their **apply-order** (oldest applicable first; i.e. bottom-up through the newest-first file),
- flags each bucket **auto-handled** vs **manual**, and
- finishes every path on the canonical `deft-install --yes --upgrade --repo-root . --json` command + `task doctor`, cross-linking `QUICK-START.md` and the canonical installer + doctor handoff section.

### #1114 — QUICK-START.md combined Case G+H (one session)
On a big-jump upgrade that trips both **Case G** (stale `AGENTS.md`) and **Case H** (pre-cutover artifacts), QUICK-START previously halted after the Case G refresh and forced a second agent session for the Case H migration. This adds:
- a **2b joint-detection gate** that routes the joint condition to a new combined case, and
- a **Case G+H** section that refreshes `AGENTS.md` first, runs `task migrate:vbrief` second, and emits a **single** restart at the end.

The migration re-reads filesystem state and does not depend on the refreshed `AGENTS.md` in agent context, so the combined end state is byte-identical to running the two cases separately — minus the wasted session round-trip.

The QUICK-START and UPGRADING cross-references are kept mutually consistent and resolve to real heading anchors.

## Tests
- `tests/content/test_quickstart_combined_remediation.py` — Case G+H section, joint-detection gate, refresh-before-migration ordering, single-restart, byte-identical guarantee, and UPGRADING anchor resolution.
- `tests/content/test_upgrading_bigjump_triage.py` — discoverable entry point, version buckets + apply-order, auto-vs-manual flags, and GitHub-anchor resolution for every QUICK-START / same-file / doctor cross-reference.
- `task check`: lint (ruff + mypy), encoding, links, and the full content suite pass. The only `task check` failure is the known, cohort-wide `vbrief:validate` D4 parent/child linkage issue (already repaired on the integration base, inherited at merge; `vbrief:validate` is a local-only gate not run in CI) and is outside this PR's owned files.

## Owned files
`QUICK-START.md`, `UPGRADING.md`, `tests/content/test_quickstart_combined_remediation.py`, `tests/content/test_upgrading_bigjump_triage.py`, plus an append-only `CHANGELOG.md` entry.

Closes #1114
Closes #1115

---
- Conversation: https://app.warp.dev/conversation/58381bf9-5652-46d7-b469-f98d8512d66e
- Run: https://oz.warp.dev/runs/019e8f04-3bdb-7120-9bc0-cce64d265f3b
