### PR TITLE
fix(install): scope consumer deft:check, ship executable hooks, refresh core-guard (#1474 #1477 #1478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Consumer `task deft:check` no longer runs the framework's own self-tests (#1474)** -- a vendored install shipped the framework's `.deft/core/tests/` suite and the consumer-facing check executed it, so a clean consumer checkout always went red (14 failed + 6 errors by construction) on framework-repo-only fixtures. The installer now excludes the framework self-test suite from the consumer deposit on every install and upgrade, so those tests are never vendored and the gate reflects real consumer-relevant results. Closes #1474.
+- **Wired git hooks now actually fire on Linux and macOS consumers (#1477)** -- the installer deposited `.githooks/pre-commit` and `.githooks/pre-push` without the executable bit, so git silently skipped them and the branch-protection and destructive-push gates never ran for Unix consumers. The installer now deposits the hooks executable and records mode 100755 in the git index so the exec bit is tracked cross-platform, and `task verify:hooks-installed` now fails instead of reporting green when a wired hook is non-executable. Closes #1477.
+- **Framework-only `deft-install --upgrade` PRs are no longer rejected by `deft-core-guard` (#1478)** -- the deposited guard's allowlist omitted `.githooks/` and the guard was create-if-absent, so existing consumers kept a stale guard and every upgrade PR that deposited the wired hooks alongside `.deft/core/**` was rejected. The installer now refreshes a stale deft-managed guard on upgrade and the allowlist exempts the wired `.githooks/` deposit, so a framework-only upgrade lands as a single green PR. Closes #1478.
 
 ### Removed
 

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -32,6 +32,18 @@ const (
 	coreGuardWorkflowRelPath = ".github/workflows/deft-core-guard.yml"
 )
 
+// frameworkSelfTestRelPath is the framework's own pytest suite as vendored into
+// a consumer install at .deft/core/tests/. Those tests validate the framework
+// inside its OWN repo (deftai/directive) and depend on framework-repo-only
+// fixtures (the framework CI workflows, the framework's vbrief/.eval/README.md,
+// the dev version string), so they fail by construction in any consumer
+// checkout -- the always-red `task deft:check` reported 14 failed + 6 errors
+// (#1474). pruneFrameworkSelfTests excludes the suite from the consumer deposit
+// so the framework-repo-only self-tests are never vendored (and therefore never
+// executed) in a consumer project. The canonical .deft/core/ layout is assumed,
+// mirroring coreGlob.
+const frameworkSelfTestRelPath = ".deft/core/tests"
+
 // installerManagedMatcher classifies a single repo-relative (POSIX-separated)
 // changed path as installer-managed -- i.e. deposited and maintained by
 // deft-install / upgrade outside .deft/core/, not consumer app code. A matcher
@@ -230,9 +242,11 @@ jobs:
 // depositNeutralization performs the #1430 deposit so the vendored framework
 // payload at .deft/core/** is treated as packaged framework assets rather than
 // consumer source by linguist, the Greptile/CodeQL bot reviewers, and an
-// optional CI guard. Every step is best-effort: a deposit failure (e.g. a
-// malformed pre-existing config the installer refuses to rewrite) is logged as a
-// warning and never aborts the install, mirroring WriteInstallManifest.
+// optional CI guard. It also prunes the framework's own self-test suite from the
+// consumer deposit (#1474) so `task deft:check` never runs framework-repo-only
+// tests. Every step is best-effort: a deposit failure (e.g. a malformed
+// pre-existing config the installer refuses to rewrite) is logged as a warning
+// and never aborts the install, mirroring WriteInstallManifest.
 func depositNeutralization(w *Wizard, projectDir string) {
 	if _, err := EnsureGitattributes(w, projectDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not deposit .gitattributes: %v\n", err)
@@ -246,6 +260,38 @@ func depositNeutralization(w *Wizard, projectDir string) {
 	if _, err := EnsureCoreGuardWorkflow(w, projectDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not deposit CI guard workflow: %v\n", err)
 	}
+	if _, err := pruneFrameworkSelfTests(w, projectDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not prune framework self-tests: %v\n", err)
+	}
+}
+
+// pruneFrameworkSelfTests removes the vendored framework self-test suite
+// (.deft/core/tests/) from a consumer install so the framework-repo-only tests
+// are never shipped -- and therefore never executed by the consumer-facing
+// `task deft:check` (#1474). It runs on every install (fresh + upgrade), after
+// the payload deposit, so a re-vendored tree is re-pruned. Returns true when the
+// suite was present and removed; an absent suite is a clean no-op (false, nil).
+// The canonical .deft/core/ layout is assumed, matching the rest of this
+// neutralization deposit (coreGlob). Best-effort by contract: the caller treats
+// a removal failure as non-fatal, mirroring depositNeutralization.
+func pruneFrameworkSelfTests(w *Wizard, projectDir string) (bool, error) {
+	path := filepath.Join(projectDir, filepath.FromSlash(frameworkSelfTestRelPath))
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("could not stat %s: %w", frameworkSelfTestRelPath, err)
+	}
+	if !info.IsDir() {
+		// A regular file at that path is not the framework test suite; leave it.
+		return false, nil
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return false, fmt.Errorf("could not remove %s: %w", frameworkSelfTestRelPath, err)
+	}
+	w.printf("Removed vendored framework self-tests (%s) from the consumer deposit (#1474).\n", frameworkSelfTestRelPath)
+	return true, nil
 }
 
 // EnsureGitattributes appends the linguist generated/vendored markers for
@@ -663,20 +709,60 @@ func insertCodeQLPathsIgnore(content, glob string) (string, bool) {
 	return content, false
 }
 
+// coreGuardWorkflowMarker is the distinctive header every deft-rendered guard
+// carries (coreGuardWorkflowContent always begins `name: deft-core-guard`). It
+// is the recognition token EnsureCoreGuardWorkflow uses to decide whether a
+// pre-existing file at coreGuardWorkflowRelPath is a deft-managed guard (safe to
+// refresh) versus an unrelated consumer file that merely shares the path (#1478).
+const coreGuardWorkflowMarker = "name: deft-core-guard"
+
 // EnsureCoreGuardWorkflow deposits the optional CI guard workflow at
-// coreGuardWorkflowRelPath create-if-absent (#1430). It is never overwritten so
-// a consumer who customised or deleted it keeps their choice. Returns true if
-// the file was created.
+// coreGuardWorkflowRelPath (#1430). It is create-if-absent AND refresh-on-stale:
+//
+//   - absent              -> the current guard is written (fresh install).
+//   - present + current   -> no-op (content already matches).
+//   - present + STALE deft guard -> rewritten to the current content so an
+//     allowlist change (e.g. the #1463 .githooks/ exemption added after the
+//     consumer first installed) reaches the consumer on the next --upgrade
+//     (#1478). Before this, the create-if-absent contract left v0.40.0 consumers
+//     pinned to a guard whose allowlist omitted .githooks/, so every framework
+//     upgrade PR was rejected by construction.
+//   - present + NOT a deft guard -> left untouched, so a consumer file that
+//     happens to share the path is never clobbered (the guard remains safe to
+//     delete or replace).
+//
+// Returns true if the file was created or refreshed.
 func EnsureCoreGuardWorkflow(w *Wizard, projectDir string) (bool, error) {
 	path := filepath.Join(projectDir, filepath.FromSlash(coreGuardWorkflowRelPath))
-	if pathExists(path) {
-		w.printf("%s already present — skipping.\n", coreGuardWorkflowRelPath)
-		return false, nil
+	desired := coreGuardWorkflowContent()
+
+	data, err := os.ReadFile(path)
+	if err == nil {
+		existing := string(data)
+		if existing == desired {
+			w.printf("%s already current — skipping.\n", coreGuardWorkflowRelPath)
+			return false, nil
+		}
+		if !strings.Contains(existing, coreGuardWorkflowMarker) {
+			// Not a deft-managed guard -- never clobber a consumer file that
+			// merely shares the deposit path.
+			w.printf("%s present but not deft-managed — leaving unchanged.\n", coreGuardWorkflowRelPath)
+			return false, nil
+		}
+		if err := os.WriteFile(path, []byte(desired), 0o644); err != nil {
+			return false, fmt.Errorf("could not refresh %s: %w", coreGuardWorkflowRelPath, err)
+		}
+		w.printf("%s refreshed: deft-core-guard allowlist updated (#1478).\n", coreGuardWorkflowRelPath)
+		return true, nil
 	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("could not read %s: %w", coreGuardWorkflowRelPath, err)
+	}
+
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return false, fmt.Errorf("could not create workflows dir: %w", err)
 	}
-	if err := os.WriteFile(path, []byte(coreGuardWorkflowContent()), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(desired), 0o644); err != nil {
 		return false, fmt.Errorf("could not write %s: %w", coreGuardWorkflowRelPath, err)
 	}
 	w.printf("%s created: CI refuses PRs mixing %s with app files.\n", coreGuardWorkflowRelPath, coreGlob)

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -629,3 +629,185 @@ func TestEnsureCodeQLPathsIgnore_ContextBlindAddsExclusion(t *testing.T) {
 		t.Errorf("original paths: include was not preserved:\n%s", content)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Framework self-test pruning (#1474)
+// ---------------------------------------------------------------------------
+
+// TestPruneFrameworkSelfTests_RemovesVendoredSuite pins #1474 acceptance (a2):
+// the consumer deposit excludes the framework's own .deft/core/tests/ suite so
+// the always-red framework-repo-only self-tests are never vendored/executed.
+func TestPruneFrameworkSelfTests_RemovesVendoredSuite(t *testing.T) {
+	tmp := t.TempDir()
+	testsDir := filepath.Join(tmp, filepath.FromSlash(frameworkSelfTestRelPath))
+	if err := os.MkdirAll(filepath.Join(testsDir, "unit"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testsDir, "test_x.py"), []byte("def test_x():\n    assert True\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A non-test framework file MUST survive -- only tests/ is pruned.
+	scriptsDir := filepath.Join(tmp, filepath.FromSlash(".deft/core/scripts"))
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "doctor.py"), []byte("# keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := pruneFrameworkSelfTests(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Error("expected removed=true when the vendored tests/ suite is present")
+	}
+	if pathExists(testsDir) {
+		t.Errorf("%s must be removed from the consumer deposit", frameworkSelfTestRelPath)
+	}
+	if !pathExists(filepath.Join(scriptsDir, "doctor.py")) {
+		t.Error("non-test framework files (.deft/core/scripts/) must be preserved")
+	}
+}
+
+// TestPruneFrameworkSelfTests_NoOpWhenAbsent: a consumer with no vendored tests/
+// is a clean no-op (no error, removed=false).
+func TestPruneFrameworkSelfTests_NoOpWhenAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, filepath.FromSlash(".deft/core")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := pruneFrameworkSelfTests(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatalf("absent suite must not error: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false when there is no vendored tests/ suite")
+	}
+}
+
+// TestPruneFrameworkSelfTests_LeavesRegularFile: a regular file at the tests/
+// path (not a directory) is not the framework suite and must be left intact.
+func TestPruneFrameworkSelfTests_LeavesRegularFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, filepath.FromSlash(frameworkSelfTestRelPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not a dir\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := pruneFrameworkSelfTests(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Error("a regular file at the tests/ path must NOT be treated as the suite")
+	}
+	if !pathExists(path) {
+		t.Error("the regular file must be left intact")
+	}
+}
+
+// TestDepositNeutralization_PrunesFrameworkTests pins #1474 acceptance (a1/a2)
+// at the integration boundary: the full neutralization deposit removes the
+// vendored framework self-tests while leaving the rest of the payload intact.
+func TestDepositNeutralization_PrunesFrameworkTests(t *testing.T) {
+	tmp := t.TempDir()
+	testsDir := filepath.Join(tmp, filepath.FromSlash(frameworkSelfTestRelPath))
+	if err := os.MkdirAll(testsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testsDir, "test_self.py"), []byte("def test():\n    assert False\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	coreFile := filepath.Join(tmp, filepath.FromSlash(".deft/core/main.md"))
+	if err := os.MkdirAll(filepath.Dir(coreFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(coreFile, []byte("# framework\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	depositNeutralization(newDepositWizard(), tmp)
+
+	if pathExists(testsDir) {
+		t.Errorf("depositNeutralization must prune %s", frameworkSelfTestRelPath)
+	}
+	if !pathExists(coreFile) {
+		t.Error("depositNeutralization must NOT remove non-test framework files")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deft-core-guard refresh-on-upgrade + .githooks/ classification (#1478)
+// ---------------------------------------------------------------------------
+
+// TestEnsureCoreGuardWorkflow_RefreshesStaleDeftGuard pins #1478 acceptance
+// (a2): an existing consumer whose deposited guard predates the .githooks/
+// allowlist entry gets the guard REFRESHED on the next install/upgrade rather
+// than skipped, so the framework-only upgrade PR stops being rejected.
+func TestEnsureCoreGuardWorkflow_RefreshesStaleDeftGuard(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, filepath.FromSlash(coreGuardWorkflowRelPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A recognisably deft-managed guard (carries the marker) but STALE: its
+	// allowlist omits the .githooks/ atom the current renderer emits.
+	stale := "name: deft-core-guard\n# old guard rendered before the .githooks/ allowlist entry (#1463)\n"
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCoreGuardWorkflow(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true: a stale deft-managed guard must be refreshed on upgrade")
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != coreGuardWorkflowContent() {
+		t.Errorf("stale guard was not refreshed to the current content:\n%s", string(data))
+	}
+	// The refreshed guard now exempts .githooks/ (the rendered ERE atom).
+	if !strings.Contains(string(data), "^\\.githooks/") {
+		t.Errorf("refreshed guard missing the .githooks/ allowlist atom:\n%s", string(data))
+	}
+}
+
+// TestEnsureCoreGuardWorkflow_CleanReRunIsNoOp: re-running over an already-current
+// guard is a no-op (content already matches the renderer).
+func TestEnsureCoreGuardWorkflow_CleanReRunIsNoOp(t *testing.T) {
+	tmp := t.TempDir()
+	w := newDepositWizard()
+	if _, err := EnsureCoreGuardWorkflow(w, tmp); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureCoreGuardWorkflow(w, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("expected changed=false when the deposited guard already matches the current content")
+	}
+}
+
+// TestCoreGuard_GithooksClassifyInstallerManaged pins #1478 acceptance (a3): the
+// wired .githooks/pre-commit and .githooks/pre-push classify as installer-managed
+// (not app), so a framework-deposit PR carrying them alongside .deft/core/**
+// passes the guard instead of being rejected.
+func TestCoreGuard_GithooksClassifyInstallerManaged(t *testing.T) {
+	changed := []string{".deft/core/VERSION", ".githooks/pre-commit", ".githooks/pre-push"}
+	_, managed, app := classifyChangedPaths(changed)
+	if len(app) != 0 {
+		t.Errorf(".githooks/ hooks must NOT classify as app; got app=%v", app)
+	}
+	if len(managed) != 2 {
+		t.Errorf("expected both .githooks/ hooks installer-managed; got managed=%v", managed)
+	}
+	if guardWouldFail(changed) {
+		t.Error("guard must PASS a framework-deposit PR mixing .deft/core/** with .githooks/* (#1478)")
+	}
+}

--- a/cmd/deft-install/githooks.go
+++ b/cmd/deft-install/githooks.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 // ---------------------------------------------------------------------------
@@ -116,6 +117,7 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 	}
 
 	deposited := false
+	healed := false           // a present hook was non-executable and the chmod repaired it (#1477)
 	var hookRelPaths []string // POSIX repo-relative paths of hooks present on disk
 	for _, name := range hookFilenames {
 		data, err := os.ReadFile(filepath.Join(srcDir, name))
@@ -139,6 +141,17 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 				return false, fmt.Errorf("could not write hook %s: %w", name, err)
 			}
 			deposited = true
+		}
+		// Detect a non-executable hook BEFORE the heal so the caller can report
+		// it -- otherwise a byte-identical 0o644 hook (the precise #1477 bug state
+		// for existing consumers) is silently repaired and the run reports
+		// "already wired -- skipping". The exec bit is meaningless on Windows
+		// (Stat reports no 0o111 bits there), so the probe is POSIX-only to avoid
+		// a spurious heal on every Windows re-run.
+		if runtime.GOOS != "windows" {
+			if info, serr := os.Stat(dst); serr == nil && info.Mode().Perm()&0o111 == 0 {
+				healed = true
+			}
 		}
 		// Enforce the executable bit even on a byte-identical re-deposit:
 		// os.WriteFile applies its perm ONLY when CREATING a file (an O_TRUNC
@@ -174,6 +187,14 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 
 	if deposited || hooksWired {
 		w.printf("✓ git hooks wired: %s/ deposited and core.hooksPath=%s (#1463 branch gate active).\n", consumerHooksDirName, consumerHooksDirName)
+		return true, nil
+	}
+	if healed {
+		// Content was already current but a hook had lost its exec bit; the
+		// chmod above repaired it. Surface the heal rather than reporting a
+		// no-op so a consumer who re-ran the installer to fix dead hooks sees
+		// confirmation (#1477).
+		w.printf("✓ git hooks healed: marked %s/ hooks executable (mode 100755) (#1477).\n", consumerHooksDirName)
 		return true, nil
 	}
 	w.printf("git hooks already wired (%s/ + core.hooksPath) — skipping.\n", consumerHooksDirName)

--- a/cmd/deft-install/githooks.go
+++ b/cmd/deft-install/githooks.go
@@ -36,6 +36,13 @@ import (
 // core.hooksPath and the hardened verify:hooks-installed check (#1463 Option 1).
 const consumerHooksDirName = ".githooks"
 
+// hookFileMode is the permission the deposited hooks are written and chmod'd to.
+// The executable bits (0o755) are REQUIRED for git to run the hooks on POSIX
+// hosts -- a non-executable hook is silently skipped, leaving the #747 / #798 /
+// #1019 gates inert on Unix consumers (#1477). On Windows the exec bit is a
+// no-op (chmod there only toggles the read-only attribute), which is harmless.
+const hookFileMode = 0o755
+
 // hookFilenames is the set of git hook scripts the installer materializes at the
 // consumer root. Only hooks the framework actually ships are copied; git
 // silently ignores any hook name it does not recognise, and a payload that does
@@ -62,6 +69,23 @@ var gitConfigGetHooksPathFunc = func(dir string) (string, error) {
 // it after confirming dir is inside a git work tree).
 var setGitHooksPathFunc = func(dir, value string) error {
 	return exec.Command("git", "-C", dir, "config", "core.hooksPath", value).Run()
+}
+
+// gitIndexChmodExecFunc records the executable bit (git mode 100755) for the
+// given repo-relative paths in the index of the repo at dir, via
+// `git update-index --add --chmod=+x`. Indirected for tests. This is what makes
+// the TRACKED hook deposit executable cross-platform: on Windows the
+// working-tree exec bit is invisible to git, so without this a consumer's
+// `git add` would stage the hooks as mode 100644 and git would silently skip
+// them on Unix checkouts (#1477). Best-effort by contract -- the caller only
+// invokes it after confirming dir is inside a git work tree and treats a
+// failure as non-fatal.
+var gitIndexChmodExecFunc = func(dir string, relPaths ...string) error {
+	if len(relPaths) == 0 {
+		return nil
+	}
+	args := append([]string{"-C", dir, "update-index", "--add", "--chmod=+x"}, relPaths...)
+	return exec.Command("git", args...).Run()
 }
 
 // WriteConsumerGitHooks copies the framework payload's .githooks/ hook scripts
@@ -92,6 +116,7 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 	}
 
 	deposited := false
+	var hookRelPaths []string // POSIX repo-relative paths of hooks present on disk
 	for _, name := range hookFilenames {
 		data, err := os.ReadFile(filepath.Join(srcDir, name))
 		if err != nil {
@@ -101,7 +126,7 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 			return false, fmt.Errorf("could not read hook %s: %w", name, err)
 		}
 		dst := filepath.Join(dstDir, name)
-		// Idempotency probe: skip the write ONLY when the hook is already present
+		// Idempotency probe: skip the WRITE ONLY when the hook is already present
 		// byte-for-byte. A read error (os.ErrNotExist on first deposit, or an
 		// unreadable existing hook) is intentionally folded into upToDate=false so
 		// the canonical hook is (re)written either way; the WriteFile below is the
@@ -109,17 +134,27 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 		// caller, so a failed read here needs no separate handling.
 		existing, rerr := os.ReadFile(dst)
 		upToDate := rerr == nil && bytes.Equal(existing, data)
-		if upToDate {
-			continue // already up-to-date byte-for-byte
+		if !upToDate {
+			if err := os.WriteFile(dst, data, hookFileMode); err != nil {
+				return false, fmt.Errorf("could not write hook %s: %w", name, err)
+			}
+			deposited = true
 		}
-		// 0o755: the hook MUST be executable for git to run it on POSIX hosts.
-		if err := os.WriteFile(dst, data, 0o755); err != nil {
-			return false, fmt.Errorf("could not write hook %s: %w", name, err)
+		// Enforce the executable bit even on a byte-identical re-deposit:
+		// os.WriteFile applies its perm ONLY when CREATING a file (an O_TRUNC
+		// rewrite of a pre-existing 0o644 hook keeps 0o644) and the create-time
+		// perm is subject to umask. An explicit chmod guarantees the on-disk hook
+		// is executable so the #747 / #798 / #1019 gates fire on Unix consumers,
+		// and heals a hook an older installer deposited non-executable (#1477).
+		if err := os.Chmod(dst, hookFileMode); err != nil {
+			w.printf("Warning: could not mark hook %s executable: %v\n", name, err)
 		}
-		deposited = true
+		hookRelPaths = append(hookRelPaths, consumerHooksDirName+"/"+name)
 	}
 
-	// Point core.hooksPath at the consumer-root hooks dir so git runs them.
+	// Point core.hooksPath at the consumer-root hooks dir so git runs them, and
+	// record the hooks' exec bit (mode 100755) in the git index so the tracked
+	// deposit is executable on every platform (#1477).
 	hooksWired := false
 	if _, isRepo, _ := gitPorcelainStatusFunc(projectDir); isRepo {
 		current, _ := gitConfigGetHooksPathFunc(projectDir)
@@ -128,6 +163,11 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 				w.printf("Warning: could not set core.hooksPath: %v\n", err)
 			} else {
 				hooksWired = true
+			}
+		}
+		if len(hookRelPaths) > 0 {
+			if err := gitIndexChmodExecFunc(projectDir, hookRelPaths...); err != nil {
+				w.printf("Warning: could not record hook exec bit in git index: %v\n", err)
 			}
 		}
 	}

--- a/cmd/deft-install/githooks.go
+++ b/cmd/deft-install/githooks.go
@@ -149,7 +149,12 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 		// (Stat reports no 0o111 bits there), so the probe is POSIX-only to avoid
 		// a spurious heal on every Windows re-run.
 		if runtime.GOOS != "windows" {
-			if info, serr := os.Stat(dst); serr == nil && info.Mode().Perm()&0o111 == 0 {
+			if info, serr := os.Stat(dst); serr != nil {
+				// Non-fatal: the chmod below still runs; warn so a transient
+				// stat failure leaves a trace rather than silently skipping the
+				// heal-detection probe.
+				w.printf("Warning: could not stat hook %s to check its exec bit: %v\n", name, serr)
+			} else if info.Mode().Perm()&0o111 == 0 {
 				healed = true
 			}
 		}

--- a/cmd/deft-install/githooks_test.go
+++ b/cmd/deft-install/githooks_test.go
@@ -266,8 +266,14 @@ func TestWriteConsumerGitHooks_HealsNonExecutableExistingHook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := WriteConsumerGitHooks(newGithooksWizard(), proj, deftDir); err != nil {
+	changed, err := WriteConsumerGitHooks(newGithooksWizard(), proj, deftDir)
+	if err != nil {
 		t.Fatalf("WriteConsumerGitHooks: %v", err)
+	}
+	// A heal-only run (content already current, exec bit repaired) must report
+	// changed=true so the consumer sees confirmation rather than a no-op (#1477).
+	if !changed {
+		t.Error("expected changed=true when a non-executable hook is healed")
 	}
 	for _, name := range []string{"pre-commit", "pre-push"} {
 		info, err := os.Stat(filepath.Join(dstDir, name))

--- a/cmd/deft-install/githooks_test.go
+++ b/cmd/deft-install/githooks_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -42,10 +43,12 @@ func TestWriteConsumerGitHooks_DepositsAndConfigures(t *testing.T) {
 	origStatus := gitPorcelainStatusFunc
 	origGet := gitConfigGetHooksPathFunc
 	origSet := setGitHooksPathFunc
+	origIdx := gitIndexChmodExecFunc
 	defer func() {
 		gitPorcelainStatusFunc = origStatus
 		gitConfigGetHooksPathFunc = origGet
 		setGitHooksPathFunc = origSet
+		gitIndexChmodExecFunc = origIdx
 	}()
 
 	proj := t.TempDir()
@@ -59,6 +62,11 @@ func TestWriteConsumerGitHooks_DepositsAndConfigures(t *testing.T) {
 		gotDir, gotVal = dir, value
 		return nil
 	}
+	var gotIdxPaths []string
+	gitIndexChmodExecFunc = func(_ string, relPaths ...string) error {
+		gotIdxPaths = relPaths
+		return nil
+	}
 
 	changed, err := WriteConsumerGitHooks(newGithooksWizard(), proj, deftDir)
 	if err != nil {
@@ -66,6 +74,13 @@ func TestWriteConsumerGitHooks_DepositsAndConfigures(t *testing.T) {
 	}
 	if !changed {
 		t.Error("expected changed=true on a fresh wire")
+	}
+
+	// The tracked hook deposit MUST be git-index-recorded with the exec bit so
+	// it is mode 100755 cross-platform (#1477).
+	wantIdx := []string{".githooks/pre-commit", ".githooks/pre-push"}
+	if strings.Join(gotIdxPaths, ",") != strings.Join(wantIdx, ",") {
+		t.Errorf("git-index chmod called with %v, want %v", gotIdxPaths, wantIdx)
 	}
 
 	// Hooks copied byte-for-byte to the consumer root .githooks/.
@@ -100,10 +115,12 @@ func TestWriteConsumerGitHooks_Idempotent(t *testing.T) {
 	origStatus := gitPorcelainStatusFunc
 	origGet := gitConfigGetHooksPathFunc
 	origSet := setGitHooksPathFunc
+	origIdx := gitIndexChmodExecFunc
 	defer func() {
 		gitPorcelainStatusFunc = origStatus
 		gitConfigGetHooksPathFunc = origGet
 		setGitHooksPathFunc = origSet
+		gitIndexChmodExecFunc = origIdx
 	}()
 
 	proj := t.TempDir()
@@ -115,6 +132,7 @@ func TestWriteConsumerGitHooks_Idempotent(t *testing.T) {
 	gitConfigGetHooksPathFunc = func(string) (string, error) { return consumerHooksDirName, nil }
 	setCalls := 0
 	setGitHooksPathFunc = func(string, string) error { setCalls++; return nil }
+	gitIndexChmodExecFunc = func(string, ...string) error { return nil }
 
 	// First wire deposits the hooks (config already set, so config is skipped).
 	if _, err := WriteConsumerGitHooks(newGithooksWizard(), proj, deftDir); err != nil {
@@ -185,6 +203,80 @@ func TestWriteConsumerGitHooks_MissingSourceSkips(t *testing.T) {
 	}
 	if pathExists(filepath.Join(proj, ".githooks")) {
 		t.Error("no consumer .githooks/ should be created when the source is absent")
+	}
+}
+
+// TestWriteConsumerGitHooks_DepositsExecutableMode pins #1477: the deposited
+// consumer hooks are written executable (the mode carries the 0o111 bits) so
+// git runs them on POSIX hosts. POSIX-only -- Windows has no executable bit.
+func TestWriteConsumerGitHooks_DepositsExecutableMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable-bit semantics are POSIX-only")
+	}
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	// Non-git project: hooks are still deposited on disk; the git-index path is
+	// skipped so no git stub is needed.
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) { return nil, false, nil }
+
+	proj := t.TempDir()
+	deftDir := filepath.Join(proj, ".deft", "core")
+	seedPayloadHooks(t, deftDir)
+
+	if _, err := WriteConsumerGitHooks(newGithooksWizard(), proj, deftDir); err != nil {
+		t.Fatalf("WriteConsumerGitHooks: %v", err)
+	}
+	for _, name := range []string{"pre-commit", "pre-push"} {
+		info, err := os.Stat(filepath.Join(proj, ".githooks", name))
+		if err != nil {
+			t.Fatalf("stat deposited %s: %v", name, err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("deposited hook %s is not executable (mode %o)", name, info.Mode().Perm())
+		}
+	}
+}
+
+// TestWriteConsumerGitHooks_HealsNonExecutableExistingHook pins #1477: when an
+// older installer left a hook non-executable (0o644), a re-run heals the exec
+// bit even though the content is byte-identical -- the WRITE is skipped but the
+// chmod is not. POSIX-only.
+func TestWriteConsumerGitHooks_HealsNonExecutableExistingHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable-bit semantics are POSIX-only")
+	}
+	origStatus := gitPorcelainStatusFunc
+	defer func() { gitPorcelainStatusFunc = origStatus }()
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) { return nil, false, nil }
+
+	proj := t.TempDir()
+	deftDir := filepath.Join(proj, ".deft", "core")
+	preCommit, prePush := seedPayloadHooks(t, deftDir)
+
+	// Pre-existing consumer hooks: identical content, but NON-executable (the
+	// #1477 bug state from an older installer or a Windows-origin commit).
+	dstDir := filepath.Join(proj, ".githooks")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "pre-commit"), []byte(preCommit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "pre-push"), []byte(prePush), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := WriteConsumerGitHooks(newGithooksWizard(), proj, deftDir); err != nil {
+		t.Fatalf("WriteConsumerGitHooks: %v", err)
+	}
+	for _, name := range []string{"pre-commit", "pre-push"} {
+		info, err := os.Stat(filepath.Join(dstDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("byte-identical non-executable hook %s was not healed to executable (mode %o)", name, info.Mode().Perm())
+		}
 	}
 }
 

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -1275,7 +1275,12 @@ func copyFile(src, dst string) (err error) {
 	}
 	defer in.Close()
 	mode := os.FileMode(0o644)
-	if info, serr := in.Stat(); serr == nil {
+	if info, serr := in.Stat(); serr != nil {
+		// Stat failure is non-fatal -- fall back to 0o644 -- but log it so a
+		// transient error leaves a trace rather than silently dropping the
+		// source mode (mirrors copyTree's stat-for-mode handling in upgrade.go).
+		log.Printf("warning: stat %q for mode (using 0o644): %v", src, serr)
+	} else {
 		mode = info.Mode().Perm()
 	}
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -1261,17 +1261,34 @@ func filepathWalk(root string, fn func(string, bool) error) error {
 // the underlying flush at Close() fails) surfaces to the caller rather than
 // being swallowed by a bare `defer out.Close()`. The named return `err` lets
 // the deferred close-error override a nil return when io.Copy succeeded.
+//
+// The source file's permission bits are preserved (#1477): the git-free payload
+// swap (upgrade.go copyTree -> copyFile) and the vbrief schema seed (copyDir ->
+// copyFile) must not strip the executable bit from vendored executables -- the
+// .githooks/ hooks, the `run` launcher, and shebang scripts ship mode 100755 in
+// the framework tarball and were silently flattened to 0o644 before this. Fall
+// back to 0o644 when the source mode cannot be stat'd.
 func copyFile(src, dst string) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	mode := os.FileMode(0o644)
+	if info, serr := in.Stat(); serr == nil {
+		mode = info.Mode().Perm()
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
-	return copyStream(in, out)
+	if err := copyStream(in, out); err != nil {
+		return err
+	}
+	// O_CREATE applies the perm only when the file did not already exist and is
+	// subject to umask; chmod guarantees dst ends with the source's mode
+	// regardless (e.g. a pre-existing 0o644 dst being refreshed). (#1477)
+	return os.Chmod(dst, mode)
 }
 
 // copyStream is the I/O orchestration half of copyFile, split out so the

--- a/scripts/verify_hooks_installed.py
+++ b/scripts/verify_hooks_installed.py
@@ -16,7 +16,10 @@ This gate now asserts the hooks are not merely *configured* but *functional*:
 1. ``core.hooksPath`` is set (non-empty).
 2. The resolved hooks directory exists.
 3. The ``pre-commit`` and ``pre-push`` hooks are present in it.
-4. The gate scripts the hooks reference resolve in THIS layout -- own-repo
+4. On POSIX, those hooks are EXECUTABLE -- git silently skips a non-executable
+   hook, so a present-but-mode-100644 hook is the #1477 inert-gate class (the
+   exec bit is meaningless on Windows, so the check is POSIX-only).
+5. The gate scripts the hooks reference resolve in THIS layout -- own-repo
    ``scripts/``, canonical vendored ``.deft/core/scripts/``, or legacy
    ``deft/scripts/``.
 
@@ -32,6 +35,7 @@ Exit codes (three-state, mirrors ``scripts/preflight_branch.py`` and friends):
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -129,6 +133,21 @@ def evaluate(project_root: Path) -> tuple[int, str]:
             f"{', '.join(missing_hooks)} (#1463 false-green).\n"
             "  Recovery: re-run the deft installer / `task setup`."
         )
+
+    # On POSIX the hooks MUST be executable or git silently skips them, leaving
+    # the branch / encoding / destructive-gh-verb gates inert (#1477). The exec
+    # bit does not exist on Windows, so this check is POSIX-only.
+    if os.name == "posix":
+        non_exec = [h for h in REQUIRED_HOOKS if not os.access(hooks_dir / h, os.X_OK)]
+        if non_exec:
+            return 1, (
+                f"❌ deft hooks wired but NON-FUNCTIONAL: {hooks_dir} hook(s) "
+                f"{', '.join(non_exec)} are not executable (git mode is not "
+                "100755); git silently skips non-executable hooks on Unix "
+                "(#1477).\n"
+                "  Recovery: re-run the deft installer / `task setup`, or "
+                "`chmod +x .githooks/pre-commit .githooks/pre-push`."
+            )
 
     scripts_dir = _resolve_scripts_dir(project_root)
     if scripts_dir is None:

--- a/tests/cli/test_verify_hooks_installed.py
+++ b/tests/cli/test_verify_hooks_installed.py
@@ -17,6 +17,7 @@ pytest's ``tmp_path`` (the Windows cleanup-race concern from #281).
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -53,7 +54,12 @@ def _make_hooks_dir(root: Path, rel: str = ".githooks") -> Path:
     hooks = root / rel
     hooks.mkdir(parents=True, exist_ok=True)
     for name in ("pre-commit", "pre-push"):
-        (hooks / name).write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+        hook = hooks / name
+        hook.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+        # Mark executable so the #1477 POSIX-executability gate sees a
+        # functional hook (chmod is a harmless no-op for the exec bit on
+        # Windows).
+        hook.chmod(0o755)
     return hooks
 
 
@@ -83,6 +89,35 @@ def test_vendored_layout_passes(gate, tmp_path, monkeypatch):
     code, msg = gate.evaluate(tmp_path)
     assert code == 0
     assert "installed and functional" in msg
+
+
+def test_posix_executable_hooks_pass(gate, tmp_path, monkeypatch):
+    """POSIX: present + executable hooks pass the #1477 exec check."""
+    if os.name != "posix":
+        pytest.skip("exec-bit check is POSIX-only")
+    _make_hooks_dir(tmp_path)  # helper chmods 0o755
+    _make_scripts_dir(tmp_path, "scripts")
+    _stub_hooks_path(monkeypatch, gate, ".githooks")
+    code, msg = gate.evaluate(tmp_path)
+    assert code == 0
+    assert "installed and functional" in msg
+
+
+def test_posix_non_executable_hooks_fail(gate, tmp_path, monkeypatch):
+    """POSIX: present but NON-executable hooks are the #1477 inert-gate class."""
+    if os.name != "posix":
+        pytest.skip("exec-bit check is POSIX-only")
+    hooks = tmp_path / ".githooks"
+    hooks.mkdir()
+    for name in ("pre-commit", "pre-push"):
+        hook = hooks / name
+        hook.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+        hook.chmod(0o644)  # NON-executable
+    _make_scripts_dir(tmp_path, "scripts")
+    _stub_hooks_path(monkeypatch, gate, ".githooks")
+    code, msg = gate.evaluate(tmp_path)
+    assert code == 1
+    assert "not executable" in msg
 
 
 def test_hooks_path_unset_is_not_installed(gate, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Installer-conflict-group cohort fixes for three consumer-layout adoption blockers. All changes are confined to the installer (`cmd/deft-install/`), its tests, the hooks health-check script, and a shared-append CHANGELOG entry.

### #1474 — Consumer `task deft:check` no longer runs the framework's own self-tests
A vendored install shipped the framework's `.deft/core/tests/` suite and the consumer-facing check executed it, so a clean consumer checkout always went red (14 failed + 6 errors by construction) on framework-repo-only fixtures. The neutralization deposit now prunes the framework self-test suite from the consumer deposit on every install/upgrade, so the framework-repo-only tests are never vendored or executed in a consumer project.

### #1477 — Wired git hooks now actually fire on Linux/macOS consumers
The installer deposited `.githooks/pre-commit` / `.githooks/pre-push` without the executable bit, so git silently skipped them and the branch-protection and destructive-push gates were inert on Unix consumers. The installer now:
- writes the hooks executable and always `chmod`s them (healing a byte-identical 0o644 redeposit / umask),
- records mode 100755 in the git index via `git update-index --add --chmod=+x` so the exec bit is tracked cross-platform (Windows can't observe the working-tree bit),
- preserves the source exec bit through the git-free payload swap (`copyFile` no longer hard-codes 0o644).

`scripts/verify_hooks_installed.py` now asserts POSIX executability and fails (exit 1) instead of reporting green when a wired hook is non-executable.

### #1478 — Framework-only `deft-install --upgrade` PRs stop being rejected by `deft-core-guard`
`.githooks/` was already in the installer-managed allowlist (#1463), but `EnsureCoreGuardWorkflow` was create-if-absent, so existing consumers kept a stale guard whose regex omitted `.githooks/` and every upgrade PR mixing the wired hooks with `.deft/core/**` was rejected. The guard is now refreshed on upgrade when the deposited file is a stale deft-managed guard (recognised by its `name: deft-core-guard` header); a consumer file that merely shares the path is left untouched.

## Testing
- `go test ./cmd/deft-install/` — pass
- `uv run pytest tests/cli/test_verify_hooks_installed.py` — pass (2 POSIX-only exec tests skip on Windows; run on CI Linux)
- Full `pytest tests/` — 6906 passed, 5 skipped, 1 xfailed (run with an isolated `--basetemp`)
- `task lint`, `task validate`, `verify:encoding`, `verify:stubs`, `verify:links`, `verify:rule-ownership`, `verify:branch`, `verify:destructive-gh-verbs`, `verify:scm-boundary`, `verify-strategy-output`, `toolchain:check`, `verify:cache-fresh`, `verify:wip-cap` (self-check) — all pass

## Notes
- New source paths ship with tests in the same PR (`deposit_test.go`, `githooks_test.go`, `test_verify_hooks_installed.py`).
- CHANGELOG.md touched append-only ([Unreleased] → Fixed); no existing entries edited.

Closes #1474
Closes #1477
Closes #1478
