### PR TITLE
fix(scripts/resolve_changelog_unreleased): dedup truncated orphan headers (#1003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Cascading rebases no longer accumulate duplicate CHANGELOG stubs (#1003)** -- the `task changelog:resolve-unreleased` union-merge helper could not deduplicate a truncated orphan header (one that opens `**` but never closes it and carries no `(#NNN)`), so each swarm-cascade rebase re-prepended a fresh copy -- two stray `gh_rest.py` stubs shipped in v0.26.2 this way. The helper now drops orphan stubs from both sides with a stderr warning and adds a content-prefix fallback that collapses issue-numberless duplicates. Closes #1003.
 - **`task triage:bootstrap` no longer crashes a reader thread on non-ASCII command output on Windows (#1002)** -- when bootstrap inferred your repo slug from `git remote get-url origin`, it captured the subprocess output without forcing UTF-8, so on a Windows codepage (cp1252) any non-ASCII byte in git's output raised a `UnicodeDecodeError` deep in Python's subprocess reader thread. The capture now routes through the shared UTF-8-safe helper (`encoding="utf-8", errors="replace"`), so localized or non-ASCII git output decodes cleanly instead of crashing the read. Closes #1002.
 
 ### Removed

--- a/scripts/resolve_changelog_unreleased.py
+++ b/scripts/resolve_changelog_unreleased.py
@@ -316,12 +316,17 @@ def content_prefix(entry_text: str) -> str:
     Entries that carry no ``(#NNN)`` reference have no issue-number dedup key.
     To stop issue-numberless duplicates from accumulating across cascade
     rebases, the helper falls back to a normalized content prefix: the first
-    line with its bullet marker and bold markers stripped, whitespace
-    collapsed, lowercased, and truncated to :data:`CONTENT_PREFIX_LEN` chars.
+    line with its bullet marker, bold markers, and any ``(#NNN)`` references
+    stripped, whitespace collapsed, lowercased, and truncated to
+    :data:`CONTENT_PREFIX_LEN` chars. Dropping the ``(#NNN)`` token lets a
+    cross-parity duplicate collapse -- a HEAD entry that carries the issue
+    reference and an otherwise-identical branch entry that does not still
+    share a prefix.
     """
     first_line = entry_text.split("\n", 1)[0]
     stripped = re.sub(r"^\s*[-*]\s+", "", first_line, count=1)
     stripped = stripped.replace("**", "")
+    stripped = ISSUE_NUM_RE.sub("", stripped)
     stripped = " ".join(stripped.split())
     return stripped[:CONTENT_PREFIX_LEN].lower()
 
@@ -352,7 +357,7 @@ def union_merge(
       ``warnings`` (when supplied) so the caller can surface a stderr WARN.
     - **Content-prefix fallback.** A branch entry with NO ``(#NNN)``
       reference is deduplicated against HEAD by a normalized content prefix
-      (see :func:`content_prefix`) when no HEAD entry shares its prefix it is
+      (see :func:`content_prefix`); when no HEAD entry shares its prefix it is
       still prepended, so a genuinely new issue-numberless entry survives.
     """
 

--- a/scripts/resolve_changelog_unreleased.py
+++ b/scripts/resolve_changelog_unreleased.py
@@ -90,6 +90,16 @@ ENTRY_BULLET_RE = re.compile(r"^\s*-\s")
 #: considered duplicates iff their sets share at least one number.
 ISSUE_NUM_RE = re.compile(r"\(#(\d+)\)")
 
+#: Entry-start with an opening bold marker (``- **`` / ``* **``). A deft
+#: CHANGELOG entry canonically opens ``- **<conventional-commit subject>** --``;
+#: a *truncated* header keeps the opening ``**`` but loses the closing ``**``
+#: (and the trailing ``(#NNN)``), which is the orphan-stub shape #1003 fixes.
+ENTRY_BOLD_OPEN_RE = re.compile(r"^\s*[-*]\s+\*\*")
+
+#: Number of normalized leading characters used by the content-prefix dedup
+#: fallback for entries that carry no ``(#NNN)`` reference (#1003).
+CONTENT_PREFIX_LEN = 60
+
 #: Conflict markers (the three-state union of git's standard merge markers).
 CONFLICT_HEAD_PREFIX = "<<<<<<< "
 CONFLICT_SEP = "======="
@@ -273,9 +283,54 @@ def issue_numbers(entry_text: str) -> set[str]:
     return set(ISSUE_NUM_RE.findall(entry_text))
 
 
+def is_orphan_header(entry_text: str) -> bool:
+    """Return ``True`` when ``entry_text`` is a truncated orphan header (#1003).
+
+    A deft CHANGELOG entry canonically opens
+    ``- **<subject>** -- <body> (#NNN)``. A cascade rebase can splice a
+    *truncated* header that keeps the opening ``**`` but loses the closing
+    ``**`` AND the ``(#NNN)`` reference, e.g.::
+
+        - **feat(scripts): `gh_rest.py` REST-fallback helpers
+
+    Such a stub has no ``(#NNN)`` dedup key, so the union-merge helper used to
+    preserve a fresh copy on every rebase -- two duplicate stubs shipped in
+    v0.26.2. An orphan header is detected as an entry whose first line opens a
+    bold span (``- **`` / ``* **``) but does NOT close it on that line
+    (fewer than two ``**`` markers), AND carries no ``(#NNN)`` reference
+    anywhere in the entry.
+    """
+    first_line = entry_text.split("\n", 1)[0]
+    if not ENTRY_BOLD_OPEN_RE.match(first_line):
+        return False
+    # A well-formed header closes its bold span on the same line (>= 2 ``**``).
+    if first_line.count("**") >= 2:
+        return False
+    # A trailing issue reference is a valid dedup key -- not an orphan.
+    return not issue_numbers(entry_text)
+
+
+def content_prefix(entry_text: str) -> str:
+    """Return a normalized leading-content key for prefix-based dedup (#1003).
+
+    Entries that carry no ``(#NNN)`` reference have no issue-number dedup key.
+    To stop issue-numberless duplicates from accumulating across cascade
+    rebases, the helper falls back to a normalized content prefix: the first
+    line with its bullet marker and bold markers stripped, whitespace
+    collapsed, lowercased, and truncated to :data:`CONTENT_PREFIX_LEN` chars.
+    """
+    first_line = entry_text.split("\n", 1)[0]
+    stripped = re.sub(r"^\s*[-*]\s+", "", first_line, count=1)
+    stripped = stripped.replace("**", "")
+    stripped = " ".join(stripped.split())
+    return stripped[:CONTENT_PREFIX_LEN].lower()
+
+
 def union_merge(
     head_sections: list[tuple[str, list[str]]],
     branch_sections: list[tuple[str, list[str]]],
+    *,
+    warnings: list[str] | None = None,
 ) -> list[tuple[str, list[str]]]:
     """Union-merge branch entries into HEAD's section structure.
 
@@ -287,18 +342,43 @@ def union_merge(
     - Subsections that exist only in the branch side are appended after
       all HEAD subsections in the order they first appear in the branch.
 
-    The dedup heuristic is intentionally conservative: an entry with NO
-    issue numbers is treated as unique (no overlap possible), so it is
-    always prepended -- this avoids dropping a branch's first commit-time
-    CHANGELOG line that may not yet carry a closing reference.
+    Two #1003 safeguards stop truncated / issue-numberless stubs from
+    accumulating across cascade rebases:
+
+    - **Orphan-header drop.** A truncated orphan header (see
+      :func:`is_orphan_header`) has no dedup key, so it used to be prepended
+      fresh on every rebase. Such stubs are now DROPPED from BOTH sides and
+      never dedup against valid entries; each drop is recorded in
+      ``warnings`` (when supplied) so the caller can surface a stderr WARN.
+    - **Content-prefix fallback.** A branch entry with NO ``(#NNN)``
+      reference is deduplicated against HEAD by a normalized content prefix
+      (see :func:`content_prefix`) when no HEAD entry shares its prefix it is
+      still prepended, so a genuinely new issue-numberless entry survives.
     """
+
+    def _warn(side: str, name: str, entry_text: str) -> None:
+        if warnings is None:
+            return
+        first_line = entry_text.split("\n", 1)[0]
+        subsection = name or "(ambient)"
+        warnings.append(
+            f"dropped truncated orphan header from {side} side under "
+            f"'{subsection}': {first_line!r}"
+        )
+
     head_dict: dict[str, list[str]] = {}
     head_order: list[str] = []
     for name, entries in head_sections:
+        kept: list[str] = []
+        for e in entries:
+            if is_orphan_header(e):
+                _warn("HEAD", name, e)
+                continue
+            kept.append(e)
         if name in head_dict:
-            head_dict[name].extend(entries)
+            head_dict[name].extend(kept)
         else:
-            head_dict[name] = list(entries)
+            head_dict[name] = list(kept)
             head_order.append(name)
 
     for name, entries in branch_sections:
@@ -306,15 +386,25 @@ def union_merge(
             head_dict[name] = []
             head_order.append(name)
         existing_nums: set[str] = set()
+        existing_prefixes: set[str] = set()
         for e in head_dict[name]:
             existing_nums |= issue_numbers(e)
+            existing_prefixes.add(content_prefix(e))
         new_entries: list[str] = []
         for e in entries:
+            if is_orphan_header(e):
+                _warn("branch", name, e)
+                continue
             nums = issue_numbers(e)
             if nums and nums & existing_nums:
                 continue
+            if not nums and content_prefix(e) in existing_prefixes:
+                # Content-prefix fallback: an issue-numberless entry whose
+                # normalized prefix already exists in HEAD is a duplicate.
+                continue
             new_entries.append(e)
             existing_nums |= nums
+            existing_prefixes.add(content_prefix(e))
         # Prepend in branch-side order so the leftmost branch entry ends up
         # at the top of the resolved section.
         head_dict[name] = new_entries + head_dict[name]
@@ -411,6 +501,7 @@ def resolve_changelog(content: str) -> tuple[str | None, str]:
     # Resolve each conflict block, walking back-to-front so earlier indices
     # remain valid as we splice replacement lines in.
     new_lines = list(lines)
+    warnings: list[str] = []
     for head_idx, sep_idx, tail_idx in reversed(blocks):
         # Sides are sliced exclusive of the markers themselves.
         head_side = new_lines[head_idx + 1 : sep_idx]
@@ -418,7 +509,7 @@ def resolve_changelog(content: str) -> tuple[str | None, str]:
         ambient = find_ambient_subsection(new_lines, head_idx, unreleased_start)
         head_parsed = parse_side(head_side, ambient)
         branch_parsed = parse_side(branch_side, ambient)
-        merged = union_merge(head_parsed, branch_parsed)
+        merged = union_merge(head_parsed, branch_parsed, warnings=warnings)
         rendered = render_resolved(merged, ambient)
         new_lines[head_idx : tail_idx + 1] = rendered
 
@@ -437,6 +528,11 @@ def resolve_changelog(content: str) -> tuple[str | None, str]:
                 "unresolvable: conflict markers remain after resolve "
                 "(internal error -- please file an issue)"
             )
+
+    # Surface any dropped orphan stubs on stderr so the operator can recover
+    # the canonical entry manually if the drop was unexpected (#1003 AC-1).
+    for warning in warnings:
+        print(f"WARN resolve_changelog: {warning}", file=sys.stderr)
 
     new_content = "\n".join(new_lines)
     if had_trailing_newline:

--- a/tests/cli/test_resolve_changelog_unreleased.py
+++ b/tests/cli/test_resolve_changelog_unreleased.py
@@ -17,7 +17,18 @@ Coverage (per the #911 vBRIEF acceptance criteria):
 - Conflicts outside [Unreleased] -> exit 1.
 - Path errors -> exit 2.
 
-Story: #911. Pure stdlib; tests use ``tmp_path`` for isolation.
+#1003 follow-up coverage (truncated orphan-header dedup gap):
+
+- Orphan-header detection (``is_orphan_header``) and content-prefix
+  normalization (``content_prefix``) unit coverage.
+- Orphan stubs on the HEAD side, the branch side, and BOTH sides collapse
+  instead of accumulating; a stderr WARN is emitted on every drop.
+- Content-prefix dedup fallback collapses issue-numberless duplicates.
+- A four-rebase cascade synthetic and a v0.26.2-shaped fixture assert the
+  truncated ``gh_rest.py`` stubs collapse to a single canonical entry.
+
+Story: #911 (base) + #1003 (orphan-stub follow-up). Pure stdlib; tests use
+``tmp_path`` for isolation.
 """
 
 from __future__ import annotations
@@ -516,3 +527,273 @@ class TestIssueNumbers:
 
     def test_no_issue_returns_empty(self):
         assert resolver.issue_numbers("- entry without issue") == set()
+
+
+# ---------------------------------------------------------------------------
+# #1003 -- truncated orphan-header dedup gap
+# ---------------------------------------------------------------------------
+
+
+#: The truncated orphan header shape that shipped twice in v0.26.2: an
+#: entry-start that opens a bold span but never closes it and carries no
+#: ``(#NNN)`` reference. It is a strict text prefix of ``VALID_GH_REST``.
+ORPHAN_STUB = "- **feat(scripts): `gh_rest.py` REST-fallback helpers"
+
+#: The canonical, well-formed entry the orphan stubs partially duplicate
+#: (released line 30 of the v0.26.2 CHANGELOG).
+VALID_GH_REST = (
+    "- **feat(scripts): `gh_rest.py` REST-fallback helpers for "
+    "`gh` mutations and reads (#961)** -- REST helpers for gh."
+)
+
+
+class TestOrphanHeaderDetection:
+    def test_truncated_header_is_orphan(self):
+        assert resolver.is_orphan_header(ORPHAN_STUB) is True
+
+    def test_full_entry_with_close_and_issue_is_not_orphan(self):
+        assert resolver.is_orphan_header(VALID_GH_REST) is False
+
+    def test_closed_bold_without_issue_is_not_orphan(self):
+        # A closing ``**`` means the header is not truncated, even with no
+        # ``(#NNN)`` -- such an entry is handled by the content-prefix path.
+        assert (
+            resolver.is_orphan_header("- **feat: shipped a thing** -- did it")
+            is False
+        )
+
+    def test_plain_bullet_without_bold_is_not_orphan(self):
+        assert resolver.is_orphan_header("- plain entry without bold") is False
+
+    def test_open_bold_with_issue_is_not_orphan(self):
+        # An issue number is a valid dedup key, so an unclosed bold span that
+        # still carries ``(#NNN)`` is NOT treated as an orphan.
+        assert resolver.is_orphan_header("- **feat: thing (#42)") is False
+
+    def test_content_prefix_strips_bullet_and_bold(self):
+        assert (
+            resolver.content_prefix("- **feat: cool thing** -- body (#5)")
+            == "feat: cool thing -- body (#5)"
+        )
+
+    def test_content_prefix_collapses_whitespace_and_lowercases(self):
+        assert (
+            resolver.content_prefix("-   **FEAT:   Spaced   Out**")
+            == "feat: spaced out"
+        )
+
+
+class TestOrphanStubDedup:
+    def test_orphan_on_head_side_dropped(self):
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            + ORPHAN_STUB + "\n"
+            + VALID_GH_REST + "\n"
+            "=======\n"
+            "- branch new entry (#999)\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        lines = new.split("\n")
+        # The standalone truncated header line is gone ...
+        assert ORPHAN_STUB not in lines
+        # ... but the canonical full entry and the branch entry survive.
+        assert VALID_GH_REST in lines
+        assert "- branch new entry (#999)" in new
+        # The truncated prefix now appears only inside the full entry.
+        assert new.count(ORPHAN_STUB) == 1
+
+    def test_orphan_on_branch_side_dropped(self):
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            + VALID_GH_REST + "\n"
+            "=======\n"
+            + ORPHAN_STUB + "\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        assert ORPHAN_STUB not in new.split("\n")
+        assert VALID_GH_REST in new.split("\n")
+        assert new.count(ORPHAN_STUB) == 1
+
+    def test_orphan_on_both_sides_collapse_to_single_header(self):
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            + ORPHAN_STUB + "\n"
+            + VALID_GH_REST + "\n"
+            "=======\n"
+            + ORPHAN_STUB + "\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        # At most one occurrence of the header prefix remains.
+        assert new.count(ORPHAN_STUB) == 1
+        assert ORPHAN_STUB not in new.split("\n")
+        assert VALID_GH_REST in new.split("\n")
+
+    def test_orphan_drop_emits_stderr_warning(self, capsys):
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            + ORPHAN_STUB + "\n"
+            + VALID_GH_REST + "\n"
+            "=======\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        err = capsys.readouterr().err
+        assert "WARN" in err
+        assert "orphan" in err.lower()
+
+    def test_clean_resolve_emits_no_warning(self, capsys):
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            "- master (#100)\n"
+            "=======\n"
+            "- branch (#911)\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        assert "WARN" not in capsys.readouterr().err
+
+
+class TestContentPrefixFallback:
+    def test_issue_numberless_duplicate_collapsed(self):
+        entry = "- **chore: tidy up the build pipeline** -- housekeeping"
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            + entry + "\n"
+            "=======\n"
+            + entry + "\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        # The duplicate issue-numberless entry collapses to a single copy.
+        assert new.count(entry) == 1
+
+    def test_distinct_issue_numberless_entries_both_kept(self):
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            "- **chore: alpha task** -- first\n"
+            "=======\n"
+            "- **chore: beta task** -- second\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        assert "alpha task" in new
+        assert "beta task" in new
+
+
+class TestUnionMergeOrphanAndPrefix:
+    def test_orphan_dropped_from_head_with_warning(self):
+        head = [("Added", [ORPHAN_STUB, VALID_GH_REST])]
+        warnings: list[str] = []
+        merged = resolver.union_merge(head, [], warnings=warnings)
+        assert merged == [("Added", [VALID_GH_REST])]
+        assert len(warnings) == 1
+        assert "HEAD" in warnings[0]
+
+    def test_orphan_dropped_from_branch_with_warning(self):
+        head = [("Added", [VALID_GH_REST])]
+        branch = [("Added", [ORPHAN_STUB])]
+        warnings: list[str] = []
+        merged = resolver.union_merge(head, branch, warnings=warnings)
+        assert merged == [("Added", [VALID_GH_REST])]
+        assert len(warnings) == 1
+        assert "branch" in warnings[0]
+
+    def test_content_prefix_dedup_in_union_merge(self):
+        entry = "- **chore: same** -- body"
+        merged = resolver.union_merge([("Added", [entry])], [("Added", [entry])])
+        assert merged == [("Added", [entry])]
+
+    def test_warnings_optional_when_not_supplied(self):
+        # No ``warnings`` kwarg -> orphans still dropped, no crash.
+        merged = resolver.union_merge([("Added", [ORPHAN_STUB])], [])
+        assert merged == [("Added", [])]
+
+
+class TestCascadingRebaseSynthetic:
+    @staticmethod
+    def _extract_added_block(changelog: str) -> str:
+        """Return the body of the resolved ``### Added`` subsection."""
+        out: list[str] = []
+        in_added = False
+        for ln in changelog.split("\n"):
+            if ln.strip() == "### Added":
+                in_added = True
+                continue
+            if in_added:
+                if ln.startswith(("## ", "### ")):
+                    break
+                out.append(ln)
+        block = "\n".join(out).strip("\n")
+        return block + "\n" if block else ""
+
+    def test_four_rebase_cascade_collapses_orphans(self):
+        # Round 0 master state: just the canonical full entry.
+        head_block = VALID_GH_REST + "\n"
+        for _ in range(4):
+            # Each rebase re-introduces a truncated orphan stub on the branch.
+            body = (
+                "### Added\n"
+                "<<<<<<< HEAD\n"
+                + head_block
+                + "=======\n"
+                + ORPHAN_STUB + "\n"
+                + ">>>>>>> sha\n"
+            )
+            new, _ = resolver.resolve_changelog(_build_changelog(body))
+            assert new is not None
+            # Orphans never accumulate: no standalone stub line, and the
+            # prefix appears only inside the single canonical entry.
+            assert ORPHAN_STUB not in new.split("\n")
+            assert new.count(ORPHAN_STUB) == 1
+            head_block = self._extract_added_block(new)
+        # After the cascade the resolved Added block holds exactly one entry.
+        assert head_block.strip() == VALID_GH_REST
+
+
+class TestV0262PublishedFixture:
+    def test_v0262_orphan_stubs_collapse(self):
+        # Mirrors the v0.26.2 published shape: two truncated gh_rest.py stubs
+        # (released lines 26 and 28) interleaved with valid entries plus the
+        # canonical full entry (line 30), wrapped in a conflict so the helper
+        # processes the section (AC-4).
+        head_block = (
+            ORPHAN_STUB + "\n"  # line-26 orphan
+            "- **perf(tests,tasks): mark watchdog tests slow (#975)** -- slow.\n"
+            + ORPHAN_STUB + "\n"  # line-28 orphan
+            "- **feat(scripts): CHANGELOG union-merge helper (#911)** -- helper.\n"
+            + VALID_GH_REST + "\n"  # line-30 canonical full entry
+        )
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            + head_block
+            + "=======\n"
+            "- **feat(scripts): rebasing branch entry (#1001)** -- new work.\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        # Both truncated stubs collapse: no standalone orphan line remains.
+        assert ORPHAN_STUB not in new.split("\n")
+        # The prefix survives only inside the single canonical full entry.
+        assert new.count(ORPHAN_STUB) == 1
+        # Every valid entry is preserved.
+        for ref in ("(#975)", "(#911)", "(#961)", "(#1001)"):
+            assert ref in new

--- a/tests/cli/test_resolve_changelog_unreleased.py
+++ b/tests/cli/test_resolve_changelog_unreleased.py
@@ -570,10 +570,12 @@ class TestOrphanHeaderDetection:
         # still carries ``(#NNN)`` is NOT treated as an orphan.
         assert resolver.is_orphan_header("- **feat: thing (#42)") is False
 
-    def test_content_prefix_strips_bullet_and_bold(self):
+    def test_content_prefix_strips_bullet_bold_and_issue_ref(self):
+        # The ``(#5)`` token is stripped so a cross-parity duplicate (HEAD with
+        # the ref, branch without) still shares a prefix.
         assert (
             resolver.content_prefix("- **feat: cool thing** -- body (#5)")
-            == "feat: cool thing -- body (#5)"
+            == "feat: cool thing -- body"
         )
 
     def test_content_prefix_collapses_whitespace_and_lowercases(self):
@@ -695,6 +697,22 @@ class TestContentPrefixFallback:
         assert new is not None
         assert "alpha task" in new
         assert "beta task" in new
+
+    def test_cross_parity_duplicate_collapsed(self):
+        # HEAD carries the issue ref; the branch re-adds the same entry without
+        # it. Stripping ``(#NNN)`` from the prefix lets the numberless branch
+        # near-duplicate collapse against the HEAD entry (Greptile P2 / AC-2).
+        body = (
+            "### Added\n"
+            "<<<<<<< HEAD\n"
+            "- **chore: tidy build** -- cleanup (#123)\n"
+            "=======\n"
+            "- **chore: tidy build** -- cleanup\n"
+            ">>>>>>> sha\n"
+        )
+        new, _ = resolver.resolve_changelog(_build_changelog(body))
+        assert new is not None
+        assert new.count("chore: tidy build") == 1
 
 
 class TestUnionMergeOrphanAndPrefix:


### PR DESCRIPTION
## Summary

Fixes the dedup gap in the `task changelog:resolve-unreleased` union-merge helper (#911 follow-up). The helper deduplicated entries only by their `(#NNN)` issue number, so a **truncated orphan header** — an entry-start that opens a bold span (`- **…`) but never closes it and carries no `(#NNN)` — had no dedup key and was preserved as a distinct entry. Across the v0.26.2 cohort cascade (5 PRs, 4 sequential rebases) this compounded into **two duplicate `gh_rest.py` stubs** in the published `CHANGELOG.md`.

Closes #1003.

## Changes

- **`scripts/resolve_changelog_unreleased.py`**
  - `is_orphan_header()` — detects truncated orphan headers (bold-open with fewer than two `**` on the first line AND no `(#NNN)` anywhere in the entry).
  - `union_merge()` now **drops orphan stubs from both the HEAD and branch sides** (they never dedup against valid entries) and records each drop in an optional `warnings` list.
  - `content_prefix()` + a **content-prefix dedup fallback**: an issue-numberless branch entry whose normalized leading content already exists in HEAD is collapsed instead of re-prepended.
  - `resolve_changelog()` surfaces every dropped stub as a `WARN ...` line on stderr (AC-1), so an unexpected drop is recoverable.
- **`tests/cli/test_resolve_changelog_unreleased.py`** — new regression coverage:
  - orphan-header detection + content-prefix unit tests;
  - orphan stubs on the HEAD side, the branch side, and BOTH sides collapse (≤ 1 occurrence of the header prefix), plus stderr-WARN assertions;
  - content-prefix fallback collapses issue-numberless duplicates / keeps distinct ones;
  - a **four-rebase cascade synthetic** that asserts orphans never accumulate;
  - a **v0.26.2-shaped fixture** (AC-4) asserting the line-26/28 stubs collapse to the single canonical entry.
- **`CHANGELOG.md`** — `[Unreleased]` / `### Fixed` entry.

## Acceptance criteria

- AC-1 orphan-header detection + stderr WARN — done.
- AC-2 content-prefix dedup fallback — done.
- AC-3 regression tests (orphan on HEAD / branch / both; cascade synthetic) — done.
- AC-4 v0.26.2-shaped fixture asserts the stubs would have collapsed — done.
- AC-6 CHANGELOG entry — done.
- AC-5 (optional master cleanup of the existing `[0.26.2]` stubs) is intentionally **out of scope** for this PR per the vBRIEF (file_scope is the helper + its tests).

## Validation

`task check` from the worktree: **7276 passed, 5 skipped, 9 deselected, 1 xfailed** with ruff/mypy/validate green.

The single failure is **pre-existing and unrelated** to this change:
`tests/content/test_consumer_config_example.py::test_policy_omits_wip_cap` — the known **#1250 / #1186** `wipCap` content-drift bug. It reproduces identically on the base `master` commit (`2d75516`) with no changes applied, reads a docs example file, and is entirely outside this PR's file scope. Not fixed here per the pre-existing-failure carve-out in `skills/deft-directive-review-cycle`.

Scoped tests: `uv run pytest tests/cli/test_resolve_changelog_unreleased.py` → **53 passed**.

## Notes

- Do **not** merge — left for the swarm monitor.
- Artifacts: [conversation](https://app.warp.dev/conversation/d3b65da5-52be-4bb1-9878-08cad293b6b7) · [run](https://oz.warp.dev/runs/019e988d-852e-726e-9c40-feb6667a9a5f)
