### PR TITLE
fix(install): adopt CodeQL-recognized zip-slip barrier in extractCoreTarball (#1525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`deft-install` archive extraction now uses the CodeQL-recognized zip-slip barrier, clearing a high-severity code-scanning false positive (#1525)** -- the framework tarball extractor was already guarded against path traversal, but the guard shape was not the one CodeQL's `go/zipslip` model recognizes, so alert #6 stayed open. The extractor now rejects any tar entry whose name contains `..` via `strings.Contains` (keeping the cleaned-target containment check as defense-in-depth), with a regression test. Closes #1525. Refs code-scanning alert #6.
 
 ### Removed
 

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -434,14 +434,15 @@ func extractCoreTarball(tarballPath, destDir string) (string, error) {
 		if rootName == "" {
 			rootName = parts[0]
 		}
-		// zip-slip / CodeQL go/zipslip: reject any path-traversal segment on the
-		// RAW entry name before it is used in any filesystem operation. GitHub
-		// source tarballs never contain ".." segments, so this is a no-op for
-		// valid input and closes the traversal taint path at the source.
-		for _, seg := range parts {
-			if seg == ".." {
-				return "", fmt.Errorf("tar entry contains a '..' path segment: %q", hdr.Name)
-			}
+		// zip-slip / CodeQL go/zipslip: reject any path-traversal element on the
+		// RAW entry name before it is used in any filesystem operation. This is
+		// the exact barrier shape CodeQL's go/zipslip sanitizer model recognises
+		// -- strings.Contains(name, "..") on the entry name, dominating the
+		// MkdirAll / OpenFile sinks below. GitHub source tarballs never contain
+		// ".." elements, so this is a no-op for valid input and closes the
+		// traversal taint path at the source.
+		if strings.Contains(name, "..") {
+			return "", fmt.Errorf("tar entry contains a '..' path element: %q", hdr.Name)
 		}
 		if tarPathExcluded(parts) {
 			continue

--- a/cmd/deft-install/upgrade_test.go
+++ b/cmd/deft-install/upgrade_test.go
@@ -222,6 +222,29 @@ func TestExtractCoreTarball_SkipsPaxGlobalHeader(t *testing.T) {
 	}
 }
 
+// TestExtractCoreTarball_RejectsPathTraversal is the go/zipslip (code-scanning
+// alert #6) regression: a tar entry whose name contains a ".." path element
+// MUST be rejected before any filesystem write, and nothing may escape the
+// destination directory. Exercises the CodeQL-recognized strings.Contains(name,
+// "..") barrier in extractCoreTarball.
+func TestExtractCoreTarball_RejectsPathTraversal(t *testing.T) {
+	// makeCoreTarball prefixes the wrapper dir, so "../evil.txt" becomes the
+	// entry "deftai-directive-abc1234/../evil.txt" -- a ".." element.
+	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{
+		"../evil.txt": "pwned",
+	})
+	dest := t.TempDir()
+	if _, err := extractCoreTarball(tarball, dest); err == nil {
+		t.Fatal("expected extractCoreTarball to reject a '..' traversal entry, got nil error")
+	} else if !strings.Contains(err.Error(), "..") {
+		t.Errorf("error should name the rejected '..' entry, got: %v", err)
+	}
+	// The traversal target MUST NOT have been written outside the destination.
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(dest), "evil.txt")); !os.IsNotExist(statErr) {
+		t.Errorf("traversal entry escaped the destination dir (stat err=%v)", statErr)
+	}
+}
+
 func TestShaFromContentRoot(t *testing.T) {
 	cases := map[string]string{
 		"deftai-directive-6136b66abcdef": "6136b66abcdef",

--- a/vbrief/active/2026-06-05-1525-fixinstall-adopt-codeql-recognized-zip-slip-barrier-in-extra.vbrief.json
+++ b/vbrief/active/2026-06-05-1525-fixinstall-adopt-codeql-recognized-zip-slip-barrier-in-extra.vbrief.json
@@ -1,0 +1,41 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1525"
+  },
+  "plan": {
+    "title": "fix(install): adopt CodeQL-recognized zip-slip barrier in extractCoreTarball (clears go/zipslip alert #6)",
+    "status": "running",
+    "narratives": {
+      "Description": "fix(install): adopt CodeQL-recognized zip-slip barrier in extractCoreTarball (clears go/zipslip alert #6)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1525",
+      "Overview": "## Summary\r\n\r\nCodeQL code-scanning alert #6 (`go/zipslip`, security severity HIGH) flags `extractCoreTarball` in `cmd/deft-install/upgrade.go` even though the extractor is already guarded against path traversal. The finding is a **false positive caused by an unrecognized sanitizer shape**, not a real vulnerability — but we want a green scan rather than a standing dismissal.\r\n\r\n## Why CodeQL still flags it\r\n\r\nThe current guards are correct but not the form CodeQL's `go/zipslip` model recognizes:\r\n- Traversal is rejected with a per-segment loop (`seg == \"..\"`), not `strings.Contains(name, \"..\")`.\r\n- The containment barrier checks `filepath.Clean(target)`, while the `os.MkdirAll` / `os.OpenFile` sinks consume the raw `target` value — so CodeQL does not propagate the barrier to the sink.\r\n\r\nCodeQL's documented \"GOOD\" sanitizer (rule help for `go/zipslip`) is `strings.Contains(name, \"..\")` on the entry name, dominating the filesystem sinks.\r\n\r\n## Fix\r\n\r\nIn `extractCoreTarball`, replace the per-segment `..` loop with the CodeQL-recognized barrier on the raw entry name:\r\n\r\n```go\r\nif strings.Contains(name, \"..\") {\r\n    return \"\", fmt.Errorf(\"tar entry contains a '..' path element: %q\", hdr.Name)\r\n}\r\n```\r\n\r\nKeep the existing `HasPrefix(filepath.Clean(target), dest+sep)` check and symlink-skip as defense-in-depth. Add a regression test that a `..`-containing tar entry is rejected and nothing escapes the destination.\r\n\r\n## Acceptance criteria\r\n\r\n- AC-1: `extractCoreTarball` rejects any tar entry whose name contains `..`, with a regression test in `cmd/deft-install/upgrade_test.go`.\r\n- AC-2: existing extractor tests still pass; `task check` green.\r\n- AC-3: after merge, CodeQL re-scan resolves `go/zipslip` alert #6 (or, if it persists, dismiss as confirmed false positive).\r\n- AC-4: CHANGELOG `[Unreleased]` entry.\r\n\r\n## Notes\r\n\r\nThe input is a trusted GitHub source tarball (`codeload` for `deftai/directive`), so real-world exploitability was already near-zero; this change is to satisfy the scanner's recognized-barrier shape. Refs code-scanning alert #6.\r\n"
+    },
+    "items": [
+      {
+        "title": "AC-1:  rejects any tar entry whose name contains , with a regression test in .",
+        "status": "proposed"
+      },
+      {
+        "title": "AC-2: existing extractor tests still pass;  green.",
+        "status": "proposed"
+      },
+      {
+        "title": "AC-3: after merge, CodeQL re-scan resolves  alert #6 (or, if it persists, dismiss as confirmed false positive).",
+        "status": "proposed"
+      },
+      {
+        "title": "AC-4: CHANGELOG  entry.",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1525",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1525: fix(install): adopt CodeQL-recognized zip-slip barrier in extractCoreTarball (clears go/zipslip alert #6)"
+      }
+    ],
+    "updated": "2026-06-05T21:00:34Z"
+  }
+}


### PR DESCRIPTION
## What
Adopt the CodeQL-recognized zip-slip barrier in `extractCoreTarball` (`cmd/deft-install/upgrade.go`) to clear code-scanning alert #6 (`go/zipslip`, security severity HIGH).

## Why
The extractor was already guarded against path traversal, but the guard shape — a per-segment `seg == ".."` loop plus `HasPrefix(filepath.Clean(target), dest+sep)` — is not the form CodeQL's `go/zipslip` model recognizes (and the sinks consume the raw `target`, not the cleaned value), so the alert stayed open. CodeQL's documented "GOOD" sanitizer is `strings.Contains(name, "..")` on the entry name, dominating the filesystem sinks.

## Change
- Replace the per-segment loop with `if strings.Contains(name, "..") { return error }` — the recognized barrier on the raw entry name.
- Keep the cleaned-target containment check and the symlink skip as defense-in-depth.
- Add `TestExtractCoreTarball_RejectsPathTraversal` (a `..`-containing entry is rejected and nothing escapes the destination).
- CHANGELOG `[Unreleased]` entry.

## Validation
- `go test ./cmd/deft-install/ -run TestExtractCoreTarball` — all pass (incl. the new test).
- `task check` green (7336 passed).

## Notes
- The extraction input is a trusted GitHub source tarball (`codeload` for `deftai/directive`), so real-world exploitability was already near-zero; this change exists to satisfy the scanner's recognized barrier shape, not to fix an exploitable bug.
- The real confirmation is the CodeQL re-scan on this PR: if `go/zipslip` clears, alert #6 auto-resolves; if it persists despite the recognized barrier, that's strong evidence to dismiss it as a confirmed false positive.

Closes #1525
Refs code-scanning alert #6.
