### PR TITLE
fix(install): strengthen zip-slip barrier at source + sink to clear go/zipslip alert #6 (#1528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- **`deft-install` archive extraction now uses the CodeQL-recognized zip-slip barrier, clearing a high-severity code-scanning false positive (#1525)** -- the framework tarball extractor was already guarded against path traversal, but the guard shape was not the one CodeQL's `go/zipslip` model recognizes, so alert #6 stayed open. The extractor now rejects any tar entry whose name contains `..` via `strings.Contains` (keeping the cleaned-target containment check as defense-in-depth), with a regression test. Closes #1525. Refs code-scanning alert #6.
+- **`deft-install` archive extraction adopts CodeQL's recognized zip-slip barrier shape (#1525, #1528)** -- the framework tarball extractor was already guarded against path traversal, but not in the form CodeQL's `go/zipslip` model recognizes, so alert #6 stayed open. The extractor now rejects any tar entry whose raw `hdr.Name` contains `..` at the source and validates the exact extraction target against the destination directory before any write (symlink entries still skipped as defense-in-depth), with a regression test. Closes #1528. Refs #1525, code-scanning alert #6.
 
 ### Removed
 

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -419,6 +419,17 @@ func extractCoreTarball(tarballPath, destDir string) (string, error) {
 			return "", fmt.Errorf("tar: %w", err)
 		}
 
+		// zip-slip / CodeQL go/zipslip: sanitize the RAW archive entry name --
+		// the taint source from tr.Next() -- before any filesystem path is
+		// derived from it. strings.Contains(hdr.Name, "..") on the original
+		// header name is the barrier shape CodeQL's go/zipslip model recognises,
+		// and rejecting at the source cuts every downstream MkdirAll / OpenFile
+		// path. GitHub source tarballs never contain ".." entries, so this is a
+		// no-op for valid input.
+		if strings.Contains(hdr.Name, "..") {
+			return "", fmt.Errorf("tar entry contains a '..' path element: %q", hdr.Name)
+		}
+
 		name := strings.TrimPrefix(filepath.ToSlash(hdr.Name), "./")
 		if name == "" {
 			continue
@@ -434,26 +445,16 @@ func extractCoreTarball(tarballPath, destDir string) (string, error) {
 		if rootName == "" {
 			rootName = parts[0]
 		}
-		// zip-slip / CodeQL go/zipslip: reject any path-traversal element on the
-		// RAW entry name before it is used in any filesystem operation. This is
-		// the exact barrier shape CodeQL's go/zipslip sanitizer model recognises
-		// -- strings.Contains(name, "..") on the entry name, dominating the
-		// MkdirAll / OpenFile sinks below. GitHub source tarballs never contain
-		// ".." elements, so this is a no-op for valid input and closes the
-		// traversal taint path at the source.
-		if strings.Contains(name, "..") {
-			return "", fmt.Errorf("tar entry contains a '..' path element: %q", hdr.Name)
-		}
 		if tarPathExcluded(parts) {
 			continue
 		}
 
+		// filepath.Join cleans its result, so target is already lexically clean;
+		// validate THAT exact value (not a separate filepath.Clean copy) so the
+		// checked path is the one that flows into the MkdirAll / OpenFile sinks
+		// below -- the containment barrier CodeQL go/zipslip recognises.
 		target := filepath.Join(cleanDest, filepath.FromSlash(name))
-		// zip-slip / CodeQL go/zipslip canonical barrier: the cleaned target
-		// path MUST stay within destDir. Wrapping the target in filepath.Clean
-		// is the form CodeQL recognises as a sanitizer on the path that flows
-		// into the MkdirAll / OpenFile sinks below.
-		if !strings.HasPrefix(filepath.Clean(target), cleanDest+string(os.PathSeparator)) {
+		if !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
 			return "", fmt.Errorf("tar entry escapes destination: %q", hdr.Name)
 		}
 

--- a/vbrief/active/2026-06-05-1528-fixinstall-strengthen-zip-slip-barrier-at-source-sink-to-cle.vbrief.json
+++ b/vbrief/active/2026-06-05-1528-fixinstall-strengthen-zip-slip-barrier-at-source-sink-to-cle.vbrief.json
@@ -1,0 +1,46 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1528"
+  },
+  "plan": {
+    "title": "fix(install): strengthen zip-slip barrier at source + sink to clear go/zipslip alert #6 (follow-up to #1525)",
+    "status": "running",
+    "narratives": {
+      "Description": "fix(install): strengthen zip-slip barrier at source + sink to clear go/zipslip alert #6 (follow-up to #1525)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1528",
+      "Overview": "## Summary\r\n\r\nFollow-up to #1525 / PR #1526. That change adopted `strings.Contains(name, \"..\")` (on the derived `name`) to clear CodeQL `go/zipslip` alert #6, but the post-merge `master` CodeQL re-scan still reports the alert OPEN at `cmd/deft-install/upgrade.go:414` — verified via the code-scanning instances API (`refs/heads/master 5b4b680 state=open`). The PR-ref check that suggested \"cleared\" was misleading: CodeQL PR analysis does not re-list a pre-existing alert per PR ref, so the authoritative signal is the default-branch re-scan, which still flags it.\r\n\r\n## Why the first attempt missed\r\n\r\n- The barrier checked the *derived* `name`, not the original taint source `hdr.Name` (the value CodeQL tracks from `tr.Next()` at line 414).\r\n- The containment check validated `filepath.Clean(target)` while the `os.MkdirAll` / `os.OpenFile` sinks consumed the raw `target` — so CodeQL's dataflow never saw the validated value reach the sink.\r\n\r\n## Fix (iteration 2)\r\n\r\n1. Sanitize the **raw `hdr.Name`** at the source: `if strings.Contains(hdr.Name, \"..\") { return error }` immediately after the header read, before any path derivation.\r\n2. Validate the **exact `target`** that flows to the sinks: `filepath.Join` already returns a cleaned path, so check `strings.HasPrefix(target, cleanDest+sep)` on `target` itself (drop the separate `filepath.Clean(target)` copy).\r\n3. Remove the now-redundant `name`-based barrier.\r\n\r\nThe existing `TestExtractCoreTarball_RejectsPathTraversal` still covers rejection.\r\n\r\n## Acceptance criteria\r\n\r\n- AC-1: barrier sanitizes `hdr.Name` at the source; sink consumes the validated `target`.\r\n- AC-2: `task check` green; extractor tests pass.\r\n- AC-3: after merge, the `master` CodeQL re-scan resolves `go/zipslip` alert #6 to \"fixed\". If it STILL persists despite this, dismiss alert #6 as a confirmed false positive (the extractor is provably safe).\r\n- AC-4: CHANGELOG `[Unreleased]` entry.\r\n\r\nRefs #1525, code-scanning alert #6.\r\n"
+    },
+    "items": [
+      {
+        "title": "AC-1: barrier sanitizes  at the source; sink consumes the validated .",
+        "status": "proposed"
+      },
+      {
+        "title": "AC-2:  green; extractor tests pass.",
+        "status": "proposed"
+      },
+      {
+        "title": "AC-3: after merge, the  CodeQL re-scan resolves  alert #6 to \"fixed\". If it STILL persists despite this, dismiss alert #6 as a confirmed false positive (the extractor is provably safe).",
+        "status": "proposed"
+      },
+      {
+        "title": "AC-4: CHANGELOG  entry.",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1528",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1528: fix(install): strengthen zip-slip barrier at source + sink to clear go/zipslip alert #6 (follow-up to #1525)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1525",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1525"
+      }
+    ],
+    "updated": "2026-06-05T22:00:31Z"
+  }
+}


### PR DESCRIPTION
## What
Strengthen the zip-slip barrier in `extractCoreTarball` (`cmd/deft-install/upgrade.go`) so CodeQL's `go/zipslip` recognizes it. Follow-up to #1525 / PR #1526.

## Why
PR #1526 adopted `strings.Contains(name, "..")` on the *derived* `name`, but the post-merge **master** CodeQL re-scan still reported alert #6 OPEN at `upgrade.go:414` (verified via the code-scanning instances API: `refs/heads/master 5b4b680 state=open`). The PR-ref "no instance" signal that looked clean was misleading — CodeQL PR analysis doesn't re-list a pre-existing alert per PR ref; the authoritative signal is the default-branch re-scan.

Two gaps in the first attempt:
1. The barrier checked the derived `name`, not the original taint source `hdr.Name` (what CodeQL tracks from `tr.Next()` at line 414).
2. The containment check validated `filepath.Clean(target)` while the `os.MkdirAll` / `os.OpenFile` sinks consumed the raw `target`, so the validated value never reached the sink in CodeQL's dataflow.

## Change
- **Source barrier:** `if strings.Contains(hdr.Name, "..") { return error }` immediately after the header read, before any path is derived — sanitizes the taint at its source.
- **Sink barrier:** validate the exact `target` (`filepath.Join` already returns a clean path) with `strings.HasPrefix(target, cleanDest+sep)` — the checked value is the one written.
- Removed the now-redundant `name`-based barrier.
- Symlink/special entries still skipped (defense-in-depth). Existing `TestExtractCoreTarball_RejectsPathTraversal` still covers rejection.

## Validation
- `go test ./cmd/deft-install/ -run TestExtractCoreTarball` — all pass.
- `task check` green (7336 passed).

## Verification plan
The decisive check is the **post-merge `master` CodeQL re-scan** (not the PR ref). If alert #6 transitions to "fixed" after merge, done. If it STILL persists despite barriers at both the source and the sink, that's conclusive evidence to dismiss alert #6 as a false positive (the extractor is provably safe + the input is a trusted GitHub tarball).

Closes #1528
Refs #1525, code-scanning alert #6.
