### PR TITLE
fix(policy): enforce branch protection

### DIFF
--- a/meta/policy-changes.log
+++ b/meta/policy-changes.log
@@ -13,3 +13,4 @@
 2026-05-22T19:16:30Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True
 2026-05-22T19:48:49Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=True
 2026-06-05T15:44:19Z actor=triage-welcome field=plan.policy.wipCap value=15 previous=None changed=true
+2026-06-07T20:59:00Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -10688,7 +10688,7 @@
           "label": "duplicate"
         }
       ],
-      "allowDirectCommitsToMaster": true
+      "allowDirectCommitsToMaster": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- Re-enables the typed branch-protection policy by setting `allowDirectCommitsToMaster=false`.
- Adds the matching policy audit-log entry so the transition is visible.

## Test plan
- [x] `task triage:bootstrap`
- [x] `task verify:cache-fresh`
- [x] `task check`

Made with [Cursor](https://cursor.com)