### PR TITLE
feat(policy): add swarm subagent backend policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Swarm operators can persist a coding sub-agent backend in project policy (#1531a)** -- `task policy:subagent-backend` stores `plan.policy.swarmSubagentBackend` in PROJECT-DEFINITION (shown via `task policy:show`), and `task policy:subagent-backends` probes stable provider ids and role capabilities without spawning a harness. Refs #1531.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Swarm operators can persist a coding sub-agent backend in project policy (#1531a)** -- `task policy:subagent-backend` stores `plan.policy.swarmSubagentBackend` in PROJECT-DEFINITION (shown via `task policy:show`), and `task policy:subagent-backends` probes stable provider ids and role capabilities without spawning a harness. Refs #1531.
+- **Swarm operators can persist a coding sub-agent backend in project policy (#1531a)** -- `task policy:subagent-backend` sets the preferred coding sub-agent provider for swarm leaf workers; `task policy:subagent-backends` lists available providers and their role capabilities without spawning a harness; `task policy:show` surfaces the resolved value. Refs #1531.
 
 ### Changed
 

--- a/scripts/policy.py
+++ b/scripts/policy.py
@@ -2157,6 +2157,12 @@ def resolve_swarm_subagent_backend(
         return SwarmSubagentBackendResult(None, "default", error=None)
 
     raw = policy_block["swarmSubagentBackend"]
+    if raw is None:
+        return SwarmSubagentBackendResult(
+            None,
+            "default-on-error",
+            error="plan.policy.swarmSubagentBackend must be a string; got null",
+        )
     validation_errors = validate_swarm_subagent_backend(raw)
     if validation_errors:
         return SwarmSubagentBackendResult(

--- a/scripts/policy.py
+++ b/scripts/policy.py
@@ -2017,6 +2017,217 @@ def set_policy(
     return changed, audit_entry
 
 
+# ---------------------------------------------------------------------------
+# Swarm sub-agent backend policy (#1531a)
+# ---------------------------------------------------------------------------
+#
+# ``plan.policy.swarmSubagentBackend`` stores the operator-selected coding
+# sub-agent backend for swarm leaf workers. The catalog + probe surface
+# lists stable provider IDs and role capabilities without invoking a real
+# harness -- availability is inferred from lightweight env signals (or
+# ``DEFT_PROBE_<BACKEND>`` overrides for tests).
+
+#: Stable provider IDs for known coding sub-agent backends.
+KNOWN_SUBAGENT_BACKEND_IDS: frozenset[str] = frozenset(
+    {"composer", "grok-build", "cursor-cloud"}
+)
+
+#: Worker roles a backend may advertise for swarm routing (#1531).
+SWARM_WORKER_ROLES: frozenset[str] = frozenset(
+    {
+        "leaf-implementation",
+        "orchestrator",
+        "review-monitor",
+        "merge-release",
+    }
+)
+
+_SUBAGENT_BACKEND_CATALOG: dict[str, dict[str, Any]] = {
+    "composer": {
+        "display_name": "Composer-class coding agent",
+        "roles": ("leaf-implementation",),
+    },
+    "grok-build": {
+        "display_name": "Grok Build (spawn_subagent)",
+        "roles": ("leaf-implementation", "review-monitor"),
+    },
+    "cursor-cloud": {
+        "display_name": "Cursor / cloud agent",
+        "roles": ("leaf-implementation", "orchestrator", "review-monitor"),
+    },
+}
+
+
+@dataclass(frozen=True)
+class SubagentBackendDescriptor:
+    """One catalogued sub-agent backend with probe availability."""
+
+    backend_id: str
+    display_name: str
+    roles: tuple[str, ...]
+    available: bool
+
+
+@dataclass(frozen=True)
+class SwarmSubagentBackendResult:
+    """Resolved ``plan.policy.swarmSubagentBackend`` state."""
+
+    backend_id: str | None
+    source: str  # one of: 'typed', 'default', 'default-on-error'
+    error: str | None = None
+
+
+def _probe_env_truthy(name: str) -> bool:
+    """True when *name* is set to a recognised truthy string."""
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _probe_backend_available(backend_id: str) -> bool:
+    """Lightweight availability probe -- never invokes a real harness.
+
+    Tests (and operators) MAY force availability via
+    ``DEFT_PROBE_<BACKEND>`` where ``<BACKEND>`` is the uppercased id
+    with hyphens replaced by underscores (e.g. ``DEFT_PROBE_GROK_BUILD``).
+    """
+    env_key = f"DEFT_PROBE_{backend_id.upper().replace('-', '_')}"
+    override = os.environ.get(env_key)
+    if override is not None:
+        return override.strip().lower() in _TRUTHY
+
+    if backend_id == "grok-build":
+        runtime = os.environ.get("DEFT_AGENT_RUNTIME", "").strip().lower()
+        return _probe_env_truthy("GROK_BUILD") or runtime == "grok-build"
+    if backend_id == "composer":
+        return _probe_env_truthy("CURSOR_COMPOSER") or _probe_env_truthy(
+            "DEFT_PROBE_COMPOSER"
+        )
+    if backend_id == "cursor-cloud":
+        return _probe_env_truthy("CURSOR_AGENT") or _probe_env_truthy(
+            "DEFT_PROBE_CURSOR_CLOUD"
+        )
+    return False
+
+
+def probe_subagent_backends() -> list[SubagentBackendDescriptor]:
+    """Return the stable backend catalog with per-entry availability.
+
+    Pure-stdlib; does not spawn sub-agents or shell out to a harness.
+    Sorted by ``backend_id`` for deterministic CLI / JSON output.
+    """
+    out: list[SubagentBackendDescriptor] = []
+    for backend_id in sorted(_SUBAGENT_BACKEND_CATALOG):
+        meta = _SUBAGENT_BACKEND_CATALOG[backend_id]
+        out.append(
+            SubagentBackendDescriptor(
+                backend_id=backend_id,
+                display_name=str(meta["display_name"]),
+                roles=tuple(meta["roles"]),
+                available=_probe_backend_available(backend_id),
+            )
+        )
+    return out
+
+
+def validate_swarm_subagent_backend(value: Any) -> list[str]:
+    """Validate a ``plan.policy.swarmSubagentBackend`` payload."""
+    errors: list[str] = []
+    if value is None:
+        return errors
+    if not isinstance(value, str) or not value.strip():
+        errors.append(
+            "plan.policy.swarmSubagentBackend must be a non-empty string; "
+            f"got {type(value).__name__} ({value!r})"
+        )
+        return errors
+    bid = value.strip()
+    if bid not in KNOWN_SUBAGENT_BACKEND_IDS:
+        errors.append(
+            "plan.policy.swarmSubagentBackend must be one of "
+            f"{sorted(KNOWN_SUBAGENT_BACKEND_IDS)}; got {bid!r}"
+        )
+    return errors
+
+
+def resolve_swarm_subagent_backend(
+    project_root: Path | None = None,
+) -> SwarmSubagentBackendResult:
+    """Resolve ``plan.policy.swarmSubagentBackend`` from PROJECT-DEFINITION."""
+    data, err = load_project_definition(project_root)
+    if data is None:
+        return SwarmSubagentBackendResult(None, "default", error=err)
+
+    policy_block = _get_policy_block(data)
+    if "swarmSubagentBackend" not in policy_block:
+        return SwarmSubagentBackendResult(None, "default", error=None)
+
+    raw = policy_block["swarmSubagentBackend"]
+    validation_errors = validate_swarm_subagent_backend(raw)
+    if validation_errors:
+        return SwarmSubagentBackendResult(
+            None,
+            "default-on-error",
+            error=validation_errors[0],
+        )
+    return SwarmSubagentBackendResult(str(raw).strip(), "typed", error=None)
+
+
+def set_swarm_subagent_backend(
+    project_root: Path,
+    *,
+    backend_id: str,
+    actor: str = "agent",
+    note: str = "",
+) -> tuple[bool, str]:
+    """Write ``plan.policy.swarmSubagentBackend`` to PROJECT-DEFINITION."""
+    bid = backend_id.strip()
+    errors = validate_swarm_subagent_backend(bid)
+    if errors:
+        raise ValueError(errors[0])
+
+    path = project_definition_path(project_root)
+    if not path.is_file():
+        raise FileNotFoundError(f"PROJECT-DEFINITION not found at {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    plan = data.setdefault("plan", {})
+    if not isinstance(plan, dict):
+        raise ValueError("PROJECT-DEFINITION 'plan' is not an object")
+    policy_block = plan.setdefault("policy", {})
+    if not isinstance(policy_block, dict):
+        raise ValueError("plan.policy is not an object")
+
+    previous = policy_block.get("swarmSubagentBackend")
+    policy_block["swarmSubagentBackend"] = bid
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    changed = previous != bid
+    parts = [
+        f"actor={actor}",
+        f"swarmSubagentBackend={bid}",
+        f"previous={previous!r}",
+    ]
+    if note:
+        parts.append("note=" + note.replace("\n", " ").replace("\r", " "))
+    audit_entry = " ".join(parts)
+    append_audit_log(project_root, audit_entry)
+    return changed, audit_entry
+
+
+def subagent_backends_to_json(backends: list[SubagentBackendDescriptor]) -> str:
+    """Serialise probe output for ``task policy:subagent-backends --format=json``."""
+    payload = {
+        "backends": [
+            {
+                "id": entry.backend_id,
+                "display_name": entry.display_name,
+                "roles": list(entry.roles),
+                "available": entry.available,
+            }
+            for entry in backends
+        ]
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
 def disclosure_line(result: PolicyResult) -> str:
     """One-liner disclosure phrasing for AGENTS.md / setup interview echo."""
     if result.allow_direct_commits:
@@ -2075,6 +2286,7 @@ FIELD_TRIAGE_SCOPE_IGNORES: str = "plan.policy.triageScopeIgnores"
 FIELD_TRIAGE_RANKING_LABELS: str = "plan.policy.triageRankingLabels"
 FIELD_TRIAGE_AUTO_CLASSIFY: str = "plan.policy.triageAutoClassify"
 FIELD_TRIAGE_HOLD_MARKERS: str = "plan.policy.triageHoldMarkers"
+FIELD_SWARM_SUBAGENT_BACKEND: str = "plan.policy.swarmSubagentBackend"
 
 #: Framework-default literals for the list-shaped policy fields. The
 #: branch / WIP defaults are sourced from existing module constants
@@ -2336,6 +2548,38 @@ def _inspect_triage_hold_markers(
     )
 
 
+def _inspect_swarm_subagent_backend(
+    data: dict | None, project_root: Path
+) -> PolicyField:
+    """Inspect ``plan.policy.swarmSubagentBackend`` (#1531a)."""
+    policy_block = _get_policy_block(data)
+    if "swarmSubagentBackend" not in policy_block:
+        return PolicyField(
+            name=FIELD_SWARM_SUBAGENT_BACKEND,
+            current=None,
+            default=None,
+            source="default",
+        )
+    raw = policy_block["swarmSubagentBackend"]
+    if (
+        isinstance(raw, str)
+        and raw.strip()
+        and raw.strip() in KNOWN_SUBAGENT_BACKEND_IDS
+    ):
+        return PolicyField(
+            name=FIELD_SWARM_SUBAGENT_BACKEND,
+            current=raw.strip(),
+            default=None,
+            source="typed",
+        )
+    return PolicyField(
+        name=FIELD_SWARM_SUBAGENT_BACKEND,
+        current=None,
+        default=None,
+        source="default",
+    )
+
+
 #: Registered typed-policy inspectors. Future typed-flag children append
 #: a new ``_inspect_<field>`` callable here AND its definition above; the
 #: show CLI surfaces it automatically with no other wiring. Append-only
@@ -2358,6 +2602,7 @@ _REGISTERED_POLICIES: tuple[
     _inspect_triage_ranking_labels,
     _inspect_triage_auto_classify,
     _inspect_triage_hold_markers,
+    _inspect_swarm_subagent_backend,
 )
 
 

--- a/scripts/policy.py
+++ b/scripts/policy.py
@@ -2098,13 +2098,9 @@ def _probe_backend_available(backend_id: str) -> bool:
         runtime = os.environ.get("DEFT_AGENT_RUNTIME", "").strip().lower()
         return _probe_env_truthy("GROK_BUILD") or runtime == "grok-build"
     if backend_id == "composer":
-        return _probe_env_truthy("CURSOR_COMPOSER") or _probe_env_truthy(
-            "DEFT_PROBE_COMPOSER"
-        )
+        return _probe_env_truthy("CURSOR_COMPOSER")
     if backend_id == "cursor-cloud":
-        return _probe_env_truthy("CURSOR_AGENT") or _probe_env_truthy(
-            "DEFT_PROBE_CURSOR_CLOUD"
-        )
+        return _probe_env_truthy("CURSOR_AGENT")
     return False
 
 
@@ -2576,7 +2572,7 @@ def _inspect_swarm_subagent_backend(
         name=FIELD_SWARM_SUBAGENT_BACKEND,
         current=None,
         default=None,
-        source="default",
+        source="default-on-error",
     )
 
 

--- a/scripts/policy_set.py
+++ b/scripts/policy_set.py
@@ -29,11 +29,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from policy import (  # noqa: E402
     DEFAULT_WIP_CAP,
+    KNOWN_SUBAGENT_BACKEND_IDS,
     disclosure_line,
+    probe_subagent_backends,
     resolve_policy,
+    resolve_swarm_subagent_backend,
     resolve_wip_cap,
     set_policy,
+    set_swarm_subagent_backend,
     set_wip_cap,
+    subagent_backends_to_json,
 )
 
 CAPABILITY_COST_DISCLOSURE = (
@@ -106,6 +111,39 @@ def _build_parser() -> argparse.ArgumentParser:
     wip.add_argument("--actor", default="task policy:wip-cap")
     wip.add_argument("--note", default="")
     wip.add_argument("--project-root", default=".")
+
+    subagent = sub.add_parser(
+        "subagent-backend",
+        help=(
+            "Set plan.policy.swarmSubagentBackend to a known coding "
+            "sub-agent provider id (#1531a)."
+        ),
+    )
+    subagent.add_argument(
+        "--set",
+        dest="backend_id",
+        required=True,
+        choices=sorted(KNOWN_SUBAGENT_BACKEND_IDS),
+        help="Backend id (composer, grok-build, cursor-cloud).",
+    )
+    subagent.add_argument("--actor", default="task policy:subagent-backend")
+    subagent.add_argument("--note", default="")
+    subagent.add_argument("--project-root", default=".")
+
+    backends = sub.add_parser(
+        "subagent-backends",
+        help=(
+            "List stable sub-agent backend ids, role capabilities, and "
+            "harness availability without invoking a real harness (#1531a)."
+        ),
+    )
+    backends.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    backends.add_argument("--project-root", default=".")
     return parser
 
 
@@ -143,6 +181,10 @@ def main(argv: list[str] | None = None) -> int:
         target = True
     elif args.cmd == "wip-cap":
         return _apply_wip_cap(args, project_root)
+    elif args.cmd == "subagent-backend":
+        return _apply_subagent_backend(args, project_root)
+    elif args.cmd == "subagent-backends":
+        return _apply_subagent_backends(args, project_root)
     else:  # pragma: no cover -- argparse enforces one of the above
         parser.print_help()
         return 2
@@ -225,6 +267,56 @@ def _apply_wip_cap(args, project_root: Path) -> int:
     print(
         f"[deft policy] plan.policy.wipCap={result.cap} (source: {result.source})."
     )
+    return 0
+
+
+def _apply_subagent_backend(args, project_root: Path) -> int:
+    """Handle the ``subagent-backend`` subcommand (#1531a)."""
+    try:
+        changed, audit_entry = set_swarm_subagent_backend(
+            project_root,
+            backend_id=args.backend_id,
+            actor=args.actor,
+            note=args.note,
+        )
+    except FileNotFoundError as exc:
+        print(f"\u274c {exc}", file=sys.stderr)
+        print(
+            "  Recovery: run `task setup` to generate "
+            "vbrief/PROJECT-DEFINITION.vbrief.json.",
+            file=sys.stderr,
+        )
+        return 2
+    except (ValueError, OSError) as exc:
+        print(f"\u274c Config error: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"\u2713 plan.policy.swarmSubagentBackend={args.backend_id}.")
+    if changed:
+        print(f"  audit: meta/policy-changes.log :: {audit_entry}")
+    else:
+        print("  no-op: value already matched (audit entry still appended for trail).")
+    result = resolve_swarm_subagent_backend(project_root)
+    print(
+        "[deft policy] plan.policy.swarmSubagentBackend="
+        f"{result.backend_id!r} (source: {result.source})."
+    )
+    return 0
+
+
+def _apply_subagent_backends(args, project_root: Path) -> int:
+    """Handle the ``subagent-backends`` probe/list subcommand (#1531a)."""
+    _ = project_root  # reserved for future project-scoped adapters
+    entries = probe_subagent_backends()
+    if args.format == "json":
+        print(subagent_backends_to_json(entries))
+        return 0
+    for entry in entries:
+        roles = ", ".join(entry.roles)
+        avail = "available" if entry.available else "unavailable"
+        print(
+            f"{entry.backend_id}\t{entry.display_name}\troles=[{roles}]\t{avail}"
+        )
     return 0
 
 

--- a/tasks/policy.yml
+++ b/tasks/policy.yml
@@ -53,3 +53,19 @@ tasks:
       PYTHONUTF8: "1"
     cmds:
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/policy_set.py" wip-cap {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+
+  subagent-backend:
+    desc: "Set plan.policy.swarmSubagentBackend to a known coding sub-agent provider id (#1531a). -- task policy:subagent-backend -- --set composer|grok-build|cursor-cloud"
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/policy_set.py" subagent-backend {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+
+  subagent-backends:
+    desc: "Probe stable sub-agent backend ids, role capabilities, and harness availability without spawning workers (#1531a). -- task policy:subagent-backends [-- --format=json]"
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/policy_set.py" subagent-backends {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -1013,3 +1013,133 @@ def test_escalate_reviewer_disagreement_no_record_when_not_escalating(
     )
     assert routing.escalates is False
     assert policy_module.count_pending_decisions(project_root) == 0
+
+
+# ---------------------------------------------------------------------------
+# swarm sub-agent backend policy + probe (#1531a)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_swarm_subagent_backend_default_when_unset(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    _write_project_def(project_root, {})
+    result = policy_module.resolve_swarm_subagent_backend(project_root)
+    assert result.backend_id is None
+    assert result.source == "default"
+    assert result.error is None
+
+
+def test_resolve_swarm_subagent_backend_typed_value(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    _write_project_def(
+        project_root, {"policy": {"swarmSubagentBackend": "grok-build"}}
+    )
+    result = policy_module.resolve_swarm_subagent_backend(project_root)
+    assert result.backend_id == "grok-build"
+    assert result.source == "typed"
+
+
+def test_resolve_swarm_subagent_backend_rejects_unknown_id(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    _write_project_def(
+        project_root, {"policy": {"swarmSubagentBackend": "warp-tab"}}
+    )
+    result = policy_module.resolve_swarm_subagent_backend(project_root)
+    assert result.backend_id is None
+    assert result.source == "default-on-error"
+    assert result.error and "warp-tab" in result.error
+
+
+def test_set_swarm_subagent_backend_writes_and_audits(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_COMPOSER", raising=False)
+    _write_project_def(project_root, {})
+    changed, audit = policy_module.set_swarm_subagent_backend(
+        project_root, backend_id="composer", actor="test"
+    )
+    assert changed is True
+    assert "swarmSubagentBackend=composer" in audit
+    data = json.loads(
+        (project_root / "vbrief" / "PROJECT-DEFINITION.vbrief.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert data["plan"]["policy"]["swarmSubagentBackend"] == "composer"
+
+
+def test_set_swarm_subagent_backend_updates_without_vbrief_story_edit(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    _write_project_def(project_root, {})
+    policy_module.set_swarm_subagent_backend(
+        project_root, backend_id="grok-build", actor="test"
+    )
+    changed, _ = policy_module.set_swarm_subagent_backend(
+        project_root, backend_id="composer", actor="test"
+    )
+    assert changed is True
+    resolved = policy_module.resolve_swarm_subagent_backend(project_root)
+    assert resolved.backend_id == "composer"
+    assert resolved.source == "typed"
+
+
+def test_inspect_swarm_subagent_backend_registered_in_policy_show(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    _write_project_def(
+        project_root, {"policy": {"swarmSubagentBackend": "cursor-cloud"}}
+    )
+    field = policy_module.inspect_one_policy(
+        policy_module.FIELD_SWARM_SUBAGENT_BACKEND, project_root
+    )
+    assert field is not None
+    assert field.current == "cursor-cloud"
+    assert field.source == "typed"
+
+
+def test_probe_subagent_backends_returns_stable_catalog(
+    policy_module, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_COMPOSER", raising=False)
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    monkeypatch.delenv("DEFT_PROBE_CURSOR_CLOUD", raising=False)
+    monkeypatch.delenv("GROK_BUILD", raising=False)
+    monkeypatch.delenv("DEFT_AGENT_RUNTIME", raising=False)
+    entries = policy_module.probe_subagent_backends()
+    ids = [entry.backend_id for entry in entries]
+    assert ids == ["composer", "cursor-cloud", "grok-build"]
+    by_id = {entry.backend_id: entry for entry in entries}
+    assert by_id["composer"].roles == ("leaf-implementation",)
+    assert "leaf-implementation" in by_id["grok-build"].roles
+    assert "review-monitor" in by_id["grok-build"].roles
+    assert "orchestrator" in by_id["cursor-cloud"].roles
+
+
+def test_probe_subagent_backends_honours_env_override(
+    policy_module, monkeypatch
+):
+    monkeypatch.setenv("DEFT_PROBE_COMPOSER", "1")
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    entries = policy_module.probe_subagent_backends()
+    by_id = {entry.backend_id: entry for entry in entries}
+    assert by_id["composer"].available is True
+    assert by_id["grok-build"].available is False
+
+
+def test_subagent_backends_json_round_trip(policy_module, monkeypatch):
+    monkeypatch.setenv("DEFT_PROBE_GROK_BUILD", "true")
+    entries = policy_module.probe_subagent_backends()
+    payload = json.loads(policy_module.subagent_backends_to_json(entries))
+    assert len(payload["backends"]) == 3
+    grok = next(b for b in payload["backends"] if b["id"] == "grok-build")
+    assert grok["available"] is True
+    assert "leaf-implementation" in grok["roles"]

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -1144,6 +1144,8 @@ def test_probe_subagent_backends_honours_env_override(
 ):
     monkeypatch.setenv("DEFT_PROBE_COMPOSER", "1")
     monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    monkeypatch.delenv("GROK_BUILD", raising=False)
+    monkeypatch.delenv("DEFT_AGENT_RUNTIME", raising=False)
     entries = policy_module.probe_subagent_backends()
     by_id = {entry.backend_id: entry for entry in entries}
     assert by_id["composer"].available is True

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -1091,6 +1091,21 @@ def test_set_swarm_subagent_backend_updates_without_vbrief_story_edit(
     assert resolved.source == "typed"
 
 
+def test_inspect_swarm_subagent_backend_invalid_value_reports_error_source(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    _write_project_def(
+        project_root, {"policy": {"swarmSubagentBackend": "warp-tab"}}
+    )
+    field = policy_module.inspect_one_policy(
+        policy_module.FIELD_SWARM_SUBAGENT_BACKEND, project_root
+    )
+    assert field is not None
+    assert field.current is None
+    assert field.source == "default-on-error"
+
+
 def test_inspect_swarm_subagent_backend_registered_in_policy_show(
     policy_module, project_root, monkeypatch
 ):

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -1056,6 +1056,19 @@ def test_resolve_swarm_subagent_backend_rejects_unknown_id(
     assert result.error and "warp-tab" in result.error
 
 
+def test_resolve_swarm_subagent_backend_rejects_null_value(
+    policy_module, project_root, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    _write_project_def(
+        project_root, {"policy": {"swarmSubagentBackend": None}}
+    )
+    result = policy_module.resolve_swarm_subagent_backend(project_root)
+    assert result.backend_id is None
+    assert result.source == "default-on-error"
+    assert result.error and "must be a string" in result.error
+
+
 def test_set_swarm_subagent_backend_writes_and_audits(
     policy_module, project_root, monkeypatch
 ):

--- a/tests/cli/test_policy_set.py
+++ b/tests/cli/test_policy_set.py
@@ -105,3 +105,104 @@ def test_missing_project_def_returns_config_error(policy_set_module, tmp_path, c
     assert rc == 2
     assert "not found" in err
     assert "task setup" in err
+
+
+# ---------------------------------------------------------------------------
+# subagent backend policy surface (#1531a)
+# ---------------------------------------------------------------------------
+
+
+def test_subagent_backend_writes_typed_policy(
+    policy_set_module, project_root, capsys, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    rc = policy_set_module.main(
+        [
+            "subagent-backend",
+            "--set",
+            "grok-build",
+            "--project-root",
+            str(project_root),
+            "--actor",
+            "test",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "swarmSubagentBackend=grok-build" in out
+    assert "source: typed" in out
+    data = json.loads(
+        (project_root / "vbrief" / "PROJECT-DEFINITION.vbrief.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert data["plan"]["policy"]["swarmSubagentBackend"] == "grok-build"
+
+
+def test_subagent_backend_rerun_updates_stored_value(
+    policy_set_module, project_root, capsys, monkeypatch
+):
+    monkeypatch.delenv("DEFT_PROBE_COMPOSER", raising=False)
+    policy_set_module.main(
+        [
+            "subagent-backend",
+            "--set",
+            "grok-build",
+            "--project-root",
+            str(project_root),
+        ]
+    )
+    capsys.readouterr()
+    rc = policy_set_module.main(
+        [
+            "subagent-backend",
+            "--set",
+            "composer",
+            "--project-root",
+            str(project_root),
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(
+        (project_root / "vbrief" / "PROJECT-DEFINITION.vbrief.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert data["plan"]["policy"]["swarmSubagentBackend"] == "composer"
+    assert "swarmSubagentBackend='composer'" in out or "swarmSubagentBackend=composer" in out
+
+
+def test_subagent_backends_lists_catalog_without_harness(
+    policy_set_module, project_root, capsys, monkeypatch
+):
+    monkeypatch.setenv("DEFT_PROBE_CURSOR_CLOUD", "yes")
+    monkeypatch.delenv("DEFT_PROBE_COMPOSER", raising=False)
+    monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    rc = policy_set_module.main(
+        ["subagent-backends", "--project-root", str(project_root)]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "composer" in out
+    assert "grok-build" in out
+    assert "cursor-cloud" in out
+    assert "leaf-implementation" in out
+    assert "cursor-cloud" in out and "available" in out
+
+
+def test_subagent_backends_json_format(policy_set_module, project_root, capsys):
+    rc = policy_set_module.main(
+        [
+            "subagent-backends",
+            "--format",
+            "json",
+            "--project-root",
+            str(project_root),
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert len(payload["backends"]) == 3
+    assert all("id" in row and "roles" in row for row in payload["backends"])

--- a/tests/cli/test_policy_set.py
+++ b/tests/cli/test_policy_set.py
@@ -179,6 +179,8 @@ def test_subagent_backends_lists_catalog_without_harness(
     monkeypatch.setenv("DEFT_PROBE_CURSOR_CLOUD", "yes")
     monkeypatch.delenv("DEFT_PROBE_COMPOSER", raising=False)
     monkeypatch.delenv("DEFT_PROBE_GROK_BUILD", raising=False)
+    monkeypatch.delenv("GROK_BUILD", raising=False)
+    monkeypatch.delenv("DEFT_AGENT_RUNTIME", raising=False)
     rc = policy_set_module.main(
         ["subagent-backends", "--project-root", str(project_root)]
     )

--- a/tests/cli/test_policy_set.py
+++ b/tests/cli/test_policy_set.py
@@ -188,7 +188,7 @@ def test_subagent_backends_lists_catalog_without_harness(
     assert "grok-build" in out
     assert "cursor-cloud" in out
     assert "leaf-implementation" in out
-    assert "cursor-cloud" in out and "available" in out
+    assert "cursor-cloud" in out and "\tavailable" in out
 
 
 def test_subagent_backends_json_format(policy_set_module, project_root, capsys):

--- a/tests/test_policy_show.py
+++ b/tests/test_policy_show.py
@@ -74,7 +74,7 @@ def _write_project_def(project_root: Path, plan: dict[str, Any]) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def test_inspect_all_policies_returns_seven_fields(policy_module, project_root):
+def test_inspect_all_policies_returns_eight_fields(policy_module, project_root):
     """Every registered field surfaces in the inspector output."""
     _write_project_def(project_root, {})
     fields = policy_module.inspect_all_policies(project_root)
@@ -87,6 +87,7 @@ def test_inspect_all_policies_returns_seven_fields(policy_module, project_root):
         "plan.policy.triageRankingLabels",
         "plan.policy.triageAutoClassify",
         "plan.policy.triageHoldMarkers",
+        "plan.policy.swarmSubagentBackend",
     ]
     # Every row at default when PROJECT-DEFINITION carries no policy block.
     assert all(f.source == "default" for f in fields)
@@ -98,7 +99,7 @@ def test_inspect_all_policies_missing_project_definition_renders_defaults(
     """Missing PROJECT-DEFINITION yields every default-source row."""
     # tmp_path has no vbrief/ subtree.
     fields = policy_module.inspect_all_policies(tmp_path)
-    assert len(fields) == 7
+    assert len(fields) == 8
     assert all(f.source == "default" for f in fields)
 
 
@@ -113,6 +114,7 @@ def test_registered_policy_names_matches_inspectors(policy_module):
         "plan.policy.triageRankingLabels",
         "plan.policy.triageAutoClassify",
         "plan.policy.triageHoldMarkers",
+        "plan.policy.swarmSubagentBackend",
     ]
 
 
@@ -378,10 +380,11 @@ def test_cli_text_format_renders_every_field(cli_module, project_root):
         "plan.policy.triageRankingLabels",
         "plan.policy.triageAutoClassify",
         "plan.policy.triageHoldMarkers",
+        "plan.policy.swarmSubagentBackend",
     ):
         assert f"[policy] {name}" in out
     # Default source surfaced for every row.
-    assert out.count("source:  default") == 7
+    assert out.count("source:  default") == 8
 
 
 def test_cli_json_format_schema_stability(cli_module, project_root):
@@ -394,7 +397,7 @@ def test_cli_json_format_schema_stability(cli_module, project_root):
     assert set(envelope.keys()) == {"generated_at", "fields"}
     assert envelope["generated_at"].endswith("Z")
     assert isinstance(envelope["fields"], list)
-    assert len(envelope["fields"]) == 7
+    assert len(envelope["fields"]) == 8
     # Each row carries the contracted four keys in order.
     for row in envelope["fields"]:
         assert list(row.keys()) == ["name", "current", "default", "source"]
@@ -533,8 +536,8 @@ def test_cli_missing_project_definition_exits_zero_with_stderr_note(
 ):
     rc, out, err = _run_cli(cli_module, ["--project-root", str(tmp_path)])
     assert rc == 0
-    # All seven rows still render with default sources.
-    assert out.count("source:  default") == 7
+    # All eight rows still render with default sources.
+    assert out.count("source:  default") == 8
     assert "PROJECT-DEFINITION not found" in err
 
 
@@ -544,11 +547,11 @@ def test_cli_missing_project_definition_exits_zero_with_stderr_note(
 # ---------------------------------------------------------------------------
 
 
-def test_registry_contains_seven_callables_in_order(policy_module):
+def test_registry_contains_eight_callables_in_order(policy_module):
     """Append-only registry; reorder/drop changes user-visible output order."""
     registry = policy_module._REGISTERED_POLICIES
     assert isinstance(registry, tuple)
-    assert len(registry) == 7
+    assert len(registry) == 8
     # Every entry is callable -- the show CLI assumes this.
     assert all(callable(insp) for insp in registry)
 

--- a/vbrief/active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
+++ b/vbrief/active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
@@ -55,7 +55,7 @@
         "title": "Issue #1531: swarm: opt-in tiered / heterogeneous dispatch (strong-model orchestrator + cheap high-context leaf code-runners)"
       },
       {
-        "uri": "active/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json",
+        "uri": "completed/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Add persistent sub-agent backend policy and availability gate",
         "TrustLevel": "internal"

--- a/vbrief/completed/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json
+++ b/vbrief/completed/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1531a-subagent-backend-policy-and-probe",
     "title": "Add persistent sub-agent backend policy and availability gate",
-    "status": "running",
+    "status": "completed",
     "planRef": "active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
     "narratives": {
       "Description": "This story gives Deft a durable project-level policy for the user-selected coding sub-agent backend and a runtime capability probe that lists available backends in the current harness. It is independently buildable because it owns the policy/task/probe surface; the later launch story consumes that policy before dispatch.",
@@ -68,7 +68,8 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "high"
-      }
+      },
+      "completedAt": "2026-06-08T01:15:37Z"
     },
     "references": [
       {
@@ -84,6 +85,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-08T00:41:49Z"
+    "updated": "2026-06-08T01:15:37Z"
   }
 }


### PR DESCRIPTION
## Summary

Adds durable project-level policy for the operator-selected coding sub-agent backend (`plan.policy.swarmSubagentBackend`) plus a harness-free availability probe for swarm routing.

- `task policy:subagent-backend -- --set <id>` persists the backend choice in PROJECT-DEFINITION (audited to `meta/policy-changes.log`)
- `task policy:subagent-backends` lists stable provider ids (`composer`, `grok-build`, `cursor-cloud`), role capabilities, and lightweight availability signals
- `task policy:show` surfaces `plan.policy.swarmSubagentBackend` current value and source

Child story for the #1531 heterogeneous dispatch epic; does not wire launch-time enforcement (deferred to 1531e).

## Related Issues

Refs #1531

## Checklist

- [x] `/deft:change <name>` — N/A (<3 unrelated surfaces; scoped policy task surface only)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [ ] `ROADMAP.md` — N/A (child story; umbrella stays open)
- [x] Tests pass locally (`pytest tests/cli/test_policy.py tests/cli/test_policy_set.py -k subagent`; full pytest green; `task check` blocked by pre-existing `vbrief:validate` failures in out-of-scope Wave 2 story `1531e` stale `pending/` references on cohort worktree)

## Test plan

- [x] `pytest tests/cli/test_policy.py tests/cli/test_policy_set.py -k subagent`
- [x] `pytest tests/test_policy_show.py`
- [x] `task policy:subagent-backends`
- [x] `task policy:subagent-backend -- --set grok-build` then `task policy:show --field=plan.policy.swarmSubagentBackend`
