### PR TITLE
fix(review): classify informal Greptile clean replies (#1543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Greptile informal clean replies without canonical fields now fail loud with a recovery path (#1543)** -- when Greptile posts a separate "diff is clean" comment but omits `Last reviewed commit:` and `Confidence Score: X/5`, merge gates still block (prose alone is not merge-ready) yet `task pr:merge-ready`, the review-cycle skill, and swarm pollers now classify the `informal-clean missing-canonical-fields` state and route operators to retrigger Greptile, wait for canonical evidence, or document an override instead of silent polling. Closes #1543.
 - **`deft-install` archive extraction adopts CodeQL's recognized zip-slip barrier shape (#1525, #1528)** -- the framework tarball extractor was already guarded against path traversal, but not in the form CodeQL's `go/zipslip` model recognizes, so alert #6 stayed open. The extractor now rejects any tar entry whose raw `hdr.Name` contains `..` at the source and validates the exact extraction target against the destination directory before any write (symlink entries still skipped as defense-in-depth), with a regression test. Closes #1528. Refs #1525, code-scanning alert #6.
 
 ### Removed

--- a/scripts/pr_merge_readiness.py
+++ b/scripts/pr_merge_readiness.py
@@ -156,7 +156,6 @@ _SECTION_RE = re.compile(
 # review that is still writing or a malformed partial summary.
 _INFORMAL_CLEAN_SIGNAL_RE = re.compile(
     r"(?:"
-    r"current diff is clean|"
     r"diff is clean|"
     r"(?:prior |previously flagged )?issues? (?:are )?now resolved|"
     r"all prior issues resolved|"

--- a/scripts/pr_merge_readiness.py
+++ b/scripts/pr_merge_readiness.py
@@ -150,6 +150,38 @@ _SECTION_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Informal-clean prose signals (#1543). Greptile sometimes posts a separate
+# human-readable "all resolved / diff is clean" comment without the canonical
+# rolling-summary fields. These patterns distinguish that state from a
+# review that is still writing or a malformed partial summary.
+_INFORMAL_CLEAN_SIGNAL_RE = re.compile(
+    r"(?:"
+    r"current diff is clean|"
+    r"diff is clean|"
+    r"(?:prior |previously flagged )?issues? (?:are )?now resolved|"
+    r"all prior issues resolved|"
+    r"no new issues(?: to flag)?|"
+    r"looks solid|"
+    r"good to proceed"
+    r")",
+    re.IGNORECASE,
+)
+
+_INFORMAL_CLEAN_STATE = "informal-clean missing-canonical-fields"
+
+_INFORMAL_CLEAN_DIAGNOSTIC = (
+    f"Greptile {_INFORMAL_CLEAN_STATE} state (#1543): the latest Greptile bot "
+    "comment says the diff is clean / prior issues are resolved, but omits the "
+    "canonical rolling-summary fields `Last reviewed commit:` and "
+    "`Confidence Score: X/5` that merge gates require. Prose alone cannot "
+    "prove review currency or confidence. Recovery: (1) comment "
+    "`@greptileai review` on the PR to retrigger a canonical rolling summary, "
+    "(2) wait for Greptile to edit its primary summary comment with both "
+    "canonical fields on the current HEAD, or (3) document an explicit "
+    "operator override per skills/deft-directive-swarm/SKILL.md Phase 6 "
+    "Step 1. Do NOT keep polling -- this is not 'review still writing'."
+)
+
 
 @dataclass
 class GreptileVerdict:
@@ -161,7 +193,26 @@ class GreptileVerdict:
     p0_count: int
     p1_count: int
     p2_count: int
+    informal_clean: bool = False        # clean prose but missing canonical fields (#1543)
     raw_body_excerpt: str = ""          # first ~200 chars for debugging
+
+
+def is_informal_clean_missing_canonical_fields(
+    verdict: GreptileVerdict, body: str,
+) -> bool:
+    """Return True when Greptile posted informal clean prose without canonical fields.
+
+    Mirrors the detection contract in
+    ``templates/swarm-greptile-poller-prompt.md`` and
+    ``skills/deft-directive-review-cycle/SKILL.md`` (#1543).
+    """
+    if not verdict.found or verdict.errored:
+        return False
+    if verdict.last_reviewed_sha is not None or verdict.confidence is not None:
+        return False
+    if verdict.p0_count > 0 or verdict.p1_count > 0:
+        return False
+    return _INFORMAL_CLEAN_SIGNAL_RE.search(body) is not None
 
 
 def parse_greptile_body(body: str) -> GreptileVerdict:
@@ -248,7 +299,7 @@ def parse_greptile_body(body: str) -> GreptileVerdict:
                 # -- preserves badge-source-of-truth when both surfaces emit.
                 p2_count = count
 
-    return GreptileVerdict(
+    verdict = GreptileVerdict(
         found=True,
         errored=errored,
         last_reviewed_sha=last_reviewed_sha,
@@ -258,6 +309,9 @@ def parse_greptile_body(body: str) -> GreptileVerdict:
         p2_count=p2_count,
         raw_body_excerpt=body[:200],
     )
+    if is_informal_clean_missing_canonical_fields(verdict, body):
+        verdict.informal_clean = True
+    return verdict
 
 
 # ---- gh wrappers ------------------------------------------------------------
@@ -426,6 +480,10 @@ def evaluate_gates(pr_number: int, head_sha: str | None, verdict: GreptileVerdic
             "Retry via @greptileai or escalate per "
             "skills/deft-directive-swarm/SKILL.md Phase 6 Step 1."
         )
+
+    if verdict.informal_clean:
+        failures.append(_INFORMAL_CLEAN_DIAGNOSTIC)
+        return failures
 
     if verdict.last_reviewed_sha is None:
         failures.append(

--- a/skills/deft-directive-review-cycle/SKILL.md
+++ b/skills/deft-directive-review-cycle/SKILL.md
@@ -270,6 +270,24 @@ Both commands extract the "Comments Outside Diff" section with surrounding conte
 
 If the exit condition is not met, go back to Step 2.
 
+### Informal-clean missing canonical fields (#1543)
+
+Greptile can post a **separate** informal clean reply that says prior issues are resolved and the current diff is clean while omitting the canonical rolling-summary fields Directive merge gates require: `Last reviewed commit:` and `Confidence Score: X/5`. `task pr:merge-ready` and `task swarm:verify-review-clean` correctly refuse merge-ready in this state -- prose alone cannot prove review currency or confidence.
+
+! When the latest Greptile bot comment is found, reports P0=0 and P1=0, but BOTH canonical fields are unparsed, classify the state as **`informal-clean missing-canonical-fields`** (see `scripts/pr_merge_readiness.py`) instead of treating it as "review still writing" or silently polling.
+
+! Recovery for informal-clean missing canonical fields -- route to ONE of these operator actions; do NOT keep polling:
+
+1. Comment `@greptileai review` on the PR to retrigger a canonical rolling summary on the current HEAD.
+2. Wait for Greptile to edit its primary rolling-summary comment with both canonical fields, then re-run `task pr:merge-ready -- <N>`.
+3. Document an explicit operator override per `skills/deft-directive-swarm/SKILL.md` Phase 6 Step 1 (merge with rationale in the merge commit body).
+
+⊗ Treat informal clean Greptile prose (`current diff is clean`, `looks solid`, `no new issues`) as merge-ready without canonical `Last reviewed commit:` and `Confidence Score: X/5` evidence.
+
+⊗ Keep polling silently when `task pr:merge-ready` reports the informal-clean missing-canonical-fields diagnostic -- this is a blocked recovery state, not a late-arriving review.
+
+~ Swarm pollers MUST surface this state via the `### (6) INFORMAL-CLEAN` terminal exit in `templates/swarm-greptile-poller-prompt.md` instead of falling through to generic `(4) TIMEOUT` or `(5) STALL`.
+
 ## Submitting GitHub Reviews
 
 ! When submitting PR reviews via the GitHub MCP tool, always use `pull_request_review_write` with method `create` and the appropriate event:

--- a/templates/swarm-greptile-poller-prompt.md
+++ b/templates/swarm-greptile-poller-prompt.md
@@ -43,7 +43,7 @@ placeholders below are the ONLY single-braced tokens.
 
 TASK: You are a review-cycle agent for PR #{pr_number} in {repo}. Embody `skills/deft-directive-review-cycle/SKILL.md` end-to-end as a single coherent role -- you handle BOTH polling Greptile for review state AND fixing any P0/P1 findings. Do NOT split into separate "poll" and "fix" agents. Do NOT exit until the exit condition is met OR you hit a terminal error / timeout.
 
-DO NOT STOP until ONE of the five terminal exit conditions below fires.
+DO NOT STOP until ONE of the six terminal exit conditions below fires.
 
 ## Role posture
 
@@ -248,6 +248,43 @@ confidence = int(m.group(1)) if m else None
 
 The clean threshold is `confidence > 3`, i.e. 4/5 or 5/5. Lower scores indicate Greptile is uncertain -- do NOT exit clean.
 
+### Informal-clean missing canonical fields (#1543)
+
+Greptile sometimes posts a separate informal clean reply (`current diff is clean`, `prior issues are now resolved`, `no new issues`, `looks solid`) without the canonical rolling-summary fields `Last reviewed commit:` and `Confidence Score: X/5`. This is NOT "review still writing" and MUST NOT fall through to silent polling or generic `(5) STALL`.
+
+```python
+import re
+
+_INFORMAL_CLEAN_SIGNAL_RE = re.compile(
+    r"(?:"
+    r"current diff is clean|"
+    r"diff is clean|"
+    r"(?:prior |previously flagged )?issues? (?:are )?now resolved|"
+    r"all prior issues resolved|"
+    r"no new issues(?: to flag)?|"
+    r"looks solid|"
+    r"good to proceed"
+    r")",
+    re.IGNORECASE,
+)
+
+def is_informal_clean_missing_canonical_fields(
+    body: str,
+    last_reviewed_sha,
+    confidence,
+    has_blocking: bool,
+) -> bool:
+    if last_reviewed_sha is not None or confidence is not None:
+        return False
+    if has_blocking:
+        return False
+    if body.strip().startswith("Greptile encountered an error while reviewing this PR"):
+        return False
+    return _INFORMAL_CLEAN_SIGNAL_RE.search(body) is not None
+```
+
+When `is_informal_clean_missing_canonical_fields(...)` is True on the current poll, exit immediately via `### (6) INFORMAL-CLEAN` below. Do NOT increment `stall_streak` toward `(5) STALL` -- the recovery path is retrigger / canonical evidence / documented override, not more polling.
+
 ## CLEAN gate evaluation, `clean_gate_holdout`, and per-poll instrumentation (#1039)
 
 The (1) CLEAN terminal exit is an AND of the five conditions enumerated under `### (1) CLEAN` below. A parse failure in ANY of the five (regex doesn't match Greptile's actual rendering / parse silently returns None / a `CI / *` check is `pending` rather than `completed`) keeps both `has_blocking = False` AND `is_clean = False` simultaneously, dropping the poller into the fall-through path that polls until the `{poll_cap_minutes}`-minute cap (PR #1038 recurrence, 2026-05-11; #1039). The gate evaluator below names the FIRST failing condition (in (1)/(2)/(3)/(4)/(5) order) as `clean_gate_holdout` so the per-poll log AND the (4) TIMEOUT / (5) STALL exit messages surface WHICH of the five conditions held the gate -- the operator MUST NEVER have to ask "which condition failed?" (Tier 3 per-condition fail-loud, #1039).
@@ -308,7 +345,7 @@ Also track a `stall_streak` counter across polls: increment when `has_blocking i
 
 ## Terminal exit conditions
 
-When ANY of the five conditions below fires, send the corresponding message to `{parent_agent_id}` and exit. Each message body MUST end with the exact line `-- no more polling, exiting now` so the parent can detect the exit unambiguously.
+When ANY of the six conditions below fires, send the corresponding message to `{parent_agent_id}` and exit. Each message body MUST end with the exact line `-- no more polling, exiting now` so the parent can detect the exit unambiguously.
 
 ### (1) CLEAN
 
@@ -330,7 +367,7 @@ Send to parent:
       Last reviewed commit: <sha>
       -- no more polling, exiting now
 
-**Swarm-orchestrated terminal contract (#1364):** when this poller is dispatched as part of a swarm cohort (parent monitor is running `skills/deft-directive-swarm/SKILL.md` Phase 6), this exact subject line -- `PR #{pr_number} CLEAN -- ready for merge` -- with `confidence > 3` recorded on the **current HEAD** is the ONLY acceptable "review complete" signal the swarm monitor accepts toward the Phase 5 -> 6 merge-gate transition. The four other terminal exits below ((2) NEW P0/P1 FINDINGS escalation, (3) ERRORED, (4) TIMEOUT, (5) STALL) are NOT "review complete" signals for swarm purposes: each one MUST force either fresh poller re-dispatch on the same PR or explicit user escalation BEFORE the monitor surfaces the Phase 5 -> 6 gate. The monitor enforces this structurally via `task swarm:verify-review-clean` (#1364); see `skills/deft-directive-swarm/SKILL.md` Phase 5 Exit Condition for the cohort verifier mandate. A poller that has terminated lifecycle-clean (i.e. the sub-agent process exited normally) but with `clean_gate_holdout != None` HAS NOT "reported review-clean" for swarm-cycle purposes -- the verifier picks the gap up and the monitor re-dispatches.
+**Swarm-orchestrated terminal contract (#1364):** when this poller is dispatched as part of a swarm cohort (parent monitor is running `skills/deft-directive-swarm/SKILL.md` Phase 6), this exact subject line -- `PR #{pr_number} CLEAN -- ready for merge` -- with `confidence > 3` recorded on the **current HEAD** is the ONLY acceptable "review complete" signal the swarm monitor accepts toward the Phase 5 -> 6 merge-gate transition. The five other terminal exits below ((2) NEW P0/P1 FINDINGS escalation, (3) ERRORED, (4) TIMEOUT, (5) STALL, (6) INFORMAL-CLEAN) are NOT "review complete" signals for swarm purposes: each one MUST force either fresh poller re-dispatch on the same PR or explicit user escalation BEFORE the monitor surfaces the Phase 5 -> 6 gate. The monitor enforces this structurally via `task swarm:verify-review-clean` (#1364); see `skills/deft-directive-swarm/SKILL.md` Phase 5 Exit Condition for the cohort verifier mandate. A poller that has terminated lifecycle-clean (i.e. the sub-agent process exited normally) but with `clean_gate_holdout != None` HAS NOT "reported review-clean" for swarm-cycle purposes -- the verifier picks the gap up and the monitor re-dispatches.
 
 ### (2) NEW P0/P1 FINDINGS
 
@@ -403,6 +440,30 @@ Increment the `stall_streak` counter introduced under `## CLEAN gate evaluation,
         clean_gate_holdout: <which-of-the-five-conditions-failed>
       Parent should diagnose via Tier 1 instrumentation log.
       -- no more polling, exiting now
+
+### (6) INFORMAL-CLEAN
+
+`is_informal_clean_missing_canonical_fields(...)` is True on the current poll: Greptile posted informal clean prose but omitted BOTH canonical fields `Last reviewed commit:` and `Confidence Score: X/5`. This is the **`informal-clean missing-canonical-fields`** blocked recovery state (#1543). Do NOT keep polling.
+
+Send:
+
+    Subject: PR #{pr_number} informal-clean missing canonical fields -- recovery required
+    Body:
+      Greptile informal-clean missing-canonical-fields state (#1543).
+      Latest Greptile comment says the diff is clean / prior issues resolved,
+      but lacks canonical `Last reviewed commit:` and `Confidence Score: X/5`.
+      Recovery options:
+        (1) comment `@greptileai review` to retrigger a canonical rolling summary
+        (2) wait for Greptile to edit its primary summary with both canonical fields
+        (3) document an explicit operator override per swarm SKILL Phase 6 Step 1
+      Latest state:
+        last_reviewed_sha: unparsed
+        head_sha: <sha>
+        confidence: unparsed
+        has_blocking: False
+      -- no more polling, exiting now
+
+**Swarm-orchestrated terminal contract (#1543):** like `(3) ERRORED`, `(4) TIMEOUT`, and `(5) STALL`, this exit is NOT a "review complete" signal for `task swarm:verify-review-clean`. The monitor MUST re-dispatch or escalate; do NOT surface the Phase 5 -> 6 merge gate until canonical evidence or a documented override resolves the state.
 
 ## Constraints (non-negotiable)
 

--- a/templates/swarm-greptile-poller-prompt.md
+++ b/templates/swarm-greptile-poller-prompt.md
@@ -257,7 +257,6 @@ import re
 
 _INFORMAL_CLEAN_SIGNAL_RE = re.compile(
     r"(?:"
-    r"current diff is clean|"
     r"diff is clean|"
     r"(?:prior |previously flagged )?issues? (?:are )?now resolved|"
     r"all prior issues resolved|"

--- a/tests/cli/test_pr_merge_readiness.py
+++ b/tests/cli/test_pr_merge_readiness.py
@@ -355,7 +355,11 @@ class TestEvaluateGates:
         assert any("P1" in f for f in failures)
 
     def test_informal_clean_emits_targeted_diagnostic(self):
-        v = self._verdict(informal_clean=True)
+        v = self._verdict(
+            informal_clean=True,
+            last_reviewed_sha=None,
+            confidence=None,
+        )
         failures = merge_readiness.evaluate_gates(
             1, "abc1234567890def1234567890abcdef12345678", v,
         )
@@ -366,7 +370,11 @@ class TestEvaluateGates:
         assert "Could not parse `Last reviewed commit:`" not in failures[0]
 
     def test_informal_clean_refuses_merge_ready(self):
-        v = self._verdict(informal_clean=True)
+        v = self._verdict(
+            informal_clean=True,
+            last_reviewed_sha=None,
+            confidence=None,
+        )
         failures = merge_readiness.evaluate_gates(1, "abc1234", v)
         assert failures != []
 

--- a/tests/cli/test_pr_merge_readiness.py
+++ b/tests/cli/test_pr_merge_readiness.py
@@ -87,6 +87,18 @@ def _section_body(sha: str, confidence: int, p0: int, p1: int, p2: int) -> str:
     )
 
 
+def _informal_clean_body() -> str:
+    """Synthetic informal clean reply patterned on PR #1541 (#1543)."""
+    return (
+        "The review on `ac9f42a` has completed — no stall on my end. "
+        "Both previously flagged issues are now resolved:\n\n"
+        "- **P1** (resolved): inspector consistency fixed.\n"
+        "- **P2** (resolved/outdated): redundant fallback clauses removed.\n\n"
+        "The current diff is clean. No new issues to flag — the implementation "
+        "looks solid. Good to proceed to the confidence exit gate.\n"
+    )
+
+
 # ---------------------------------------------------------------------------
 # parse_greptile_body
 # ---------------------------------------------------------------------------
@@ -234,6 +246,26 @@ class TestParseGreptileBody:
         assert v.confidence == 5
         assert v.last_reviewed_sha == "85c0b1de994a"
 
+    def test_informal_clean_missing_canonical_fields_detected(self):
+        body = _informal_clean_body()
+        v = merge_readiness.parse_greptile_body(body)
+        assert v.found is True
+        assert v.informal_clean is True
+        assert v.last_reviewed_sha is None
+        assert v.confidence is None
+        assert v.p0_count == 0
+        assert v.p1_count == 0
+
+    def test_informal_clean_helper_false_when_canonical_fields_present(self):
+        body = _clean_body()
+        v = merge_readiness.parse_greptile_body(body)
+        assert v.informal_clean is False
+
+    def test_informal_clean_not_confused_with_still_writing(self):
+        body = "## Greptile Summary\n\nStill analyzing your changes...\n"
+        v = merge_readiness.parse_greptile_body(body)
+        assert v.informal_clean is False
+
 
 # ---------------------------------------------------------------------------
 # evaluate_gates
@@ -322,6 +354,22 @@ class TestEvaluateGates:
         assert any("confidence" in f.lower() for f in failures)
         assert any("P1" in f for f in failures)
 
+    def test_informal_clean_emits_targeted_diagnostic(self):
+        v = self._verdict(informal_clean=True)
+        failures = merge_readiness.evaluate_gates(
+            1, "abc1234567890def1234567890abcdef12345678", v,
+        )
+        assert len(failures) == 1
+        assert "informal-clean missing-canonical-fields" in failures[0]
+        assert "@greptileai review" in failures[0]
+        assert "documented override" in failures[0] or "operator override" in failures[0]
+        assert "Could not parse `Last reviewed commit:`" not in failures[0]
+
+    def test_informal_clean_refuses_merge_ready(self):
+        v = self._verdict(informal_clean=True)
+        failures = merge_readiness.evaluate_gates(1, "abc1234", v)
+        assert failures != []
+
 
 # ---------------------------------------------------------------------------
 # main / CLI
@@ -409,3 +457,28 @@ class TestMain:
         payload = json.loads(out)
         assert payload["merge_ready"] is True
         assert payload["pr_number"] == 1
+
+    def test_informal_clean_exits_1_with_recovery_path(self, monkeypatch, capsys):
+        sha = "abc1234567890def1234567890abcdef12345678"
+        self._patch_gh(monkeypatch, sha, _informal_clean_body())
+        rc = merge_readiness.main(["1541", "--repo", "deftai/directive"])
+        assert rc == merge_readiness.EXIT_MERGE_BLOCKED
+        out = capsys.readouterr().out
+        assert "MERGE-BLOCKED" in out
+        assert "informal-clean missing-canonical-fields" in out
+        assert "@greptileai review" in out
+
+    def test_informal_clean_json_payload(self, monkeypatch, capsys):
+        sha = "abc1234567890def1234567890abcdef12345678"
+        self._patch_gh(monkeypatch, sha, _informal_clean_body())
+        rc = merge_readiness.main(
+            ["1541", "--repo", "deftai/directive", "--json"],
+        )
+        assert rc == merge_readiness.EXIT_MERGE_BLOCKED
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["merge_ready"] is False
+        assert payload["verdict"]["informal_clean"] is True
+        assert any(
+            "informal-clean missing-canonical-fields" in f
+            for f in payload["failures"]
+        )

--- a/tests/cli/test_pr_merge_readiness_fallbacks.py
+++ b/tests/cli/test_pr_merge_readiness_fallbacks.py
@@ -139,6 +139,25 @@ def _greptile_rest_payload(sha: str = _HEAD_SHA, confidence: int = 5) -> str:
     ])
 
 
+def _informal_clean_jq_body() -> str:
+    """Synthetic informal clean body patterned on PR #1541 (#1543)."""
+    return (
+        "The review on `ac9f42a` has completed — no stall on my end. "
+        "Both previously flagged issues are now resolved.\n\n"
+        "The current diff is clean. No new issues to flag — the implementation "
+        "looks solid. Good to proceed to the confidence exit gate.\n"
+    )
+
+
+def _informal_clean_rest_payload() -> str:
+    return json.dumps([
+        {
+            "user": {"login": "greptile-apps[bot]"},
+            "body": _informal_clean_jq_body(),
+        },
+    ])
+
+
 def _pr_rest_payload(
     sha: str = _HEAD_SHA, state: str = "open", merged: bool = False,
 ) -> str:
@@ -209,6 +228,41 @@ class TestPrimaryPath:
         assert result.via == pr_merge_readiness.VIA_PRIMARY
         assert result.merge_ready is False
         assert any("No Greptile rolling-summary" in f for f in result.failures)
+
+
+class TestInformalCleanFallbacks:
+    def test_primary_informal_clean_blocked_with_targeted_diagnostic(self, monkeypatch):
+        install_fake_gh(monkeypatch, {
+            "head-sha": _ns(stdout=_HEAD_SHA + "\n"),
+            "comments-jq": _ns(stdout=_informal_clean_jq_body()),
+        })
+        result = pr_merge_readiness.compute_gate_result(
+            pr_number=1541, repo="deftai/directive",
+        )
+        assert result.via == pr_merge_readiness.VIA_PRIMARY
+        assert result.merge_ready is False
+        assert result.verdict.informal_clean is True
+        assert any(
+            "informal-clean missing-canonical-fields" in f
+            for f in result.failures
+        )
+
+    def test_fallback1_informal_clean_blocked_with_targeted_diagnostic(self, monkeypatch):
+        install_fake_gh(monkeypatch, {
+            "head-sha": _ns(stdout=_HEAD_SHA + "\n"),
+            "comments-jq": _ns(stderr="gh rate-limited", returncode=1),
+            "comments-rest": _ns(stdout=_informal_clean_rest_payload()),
+        })
+        result = pr_merge_readiness.compute_gate_result(
+            pr_number=1541, repo="deftai/directive",
+        )
+        assert result.via == pr_merge_readiness.VIA_FALLBACK1
+        assert result.merge_ready is False
+        assert result.verdict.informal_clean is True
+        assert any(
+            "informal-clean missing-canonical-fields" in f
+            for f in result.failures
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/content/test_review_cycle_skill.py
+++ b/tests/content/test_review_cycle_skill.py
@@ -173,6 +173,57 @@ def test_phase2_step1_late_arriving_references_poller_template() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _informal_clean_section() -> str:
+    """Return the #1543 informal-clean guidance section from the skill."""
+    text = _read_skill()
+    start = text.find("### Informal-clean missing canonical fields (#1543)")
+    assert start != -1, (
+        f"{_REVIEW_CYCLE_PATH}: must document informal-clean missing "
+        "canonical fields (#1543)"
+    )
+    # Section runs until the next top-level Phase heading or Submitting block.
+    end_markers = [
+        text.find("## Submitting GitHub Reviews", start),
+        text.find("## Anti-Patterns", start),
+    ]
+    end = min(i for i in end_markers if i != -1)
+    return text[start:end]
+
+
+def test_greptile_informal_clean_section_present() -> None:
+    """Review-cycle skill must document informal-clean missing canonical fields (#1543)."""
+    section = _informal_clean_section()
+    assert "informal-clean missing-canonical-fields" in section
+
+
+def test_greptile_informal_clean_recovery_path_tokens() -> None:
+    """Informal-clean guidance must route to retrigger, canonical evidence, or override."""
+    section = _informal_clean_section()
+    assert "@greptileai review" in section
+    assert "documented override" in section or "operator override" in section
+    assert "Do NOT keep polling" in section or "do not keep polling" in section.lower()
+
+
+def test_greptile_informal_clean_must_not_accept_prose_alone() -> None:
+    """Informal-clean guidance must forbid treating prose alone as merge-ready."""
+    section = _informal_clean_section()
+    pattern = re.compile(
+        r"^\u2297 Treat informal clean Greptile prose",
+        re.MULTILINE,
+    )
+    assert pattern.search(section), (
+        f"{_REVIEW_CYCLE_PATH}: informal-clean section must contain a "
+        "`\u2297 Treat informal clean Greptile prose...` MUST NOT rule (#1543)"
+    )
+
+
+def test_greptile_informal_clean_references_poller_template() -> None:
+    """Informal-clean guidance must cross-reference the poller template terminal exit."""
+    section = _informal_clean_section()
+    assert "templates/swarm-greptile-poller-prompt.md" in section
+    assert "(6) INFORMAL-CLEAN" in section
+
+
 def test_phase2_step1_no_cp1252_mojibake() -> None:
     """The newly-added rules MUST NOT contain the cp1252 mojibake form of
     \u2297 (e.g. `\u0393\u00E8\u00F9` -- the Windows-1252 round-trip

--- a/tests/content/test_swarm_poller_template.py
+++ b/tests/content/test_swarm_poller_template.py
@@ -1143,14 +1143,14 @@ def test_ac4_regression_clean_exit_unchanged_on_pre_1039_bodies() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_template_section_intro_says_five_terminal_exits(template_text: str) -> None:
-    """Template MUST advertise FIVE terminal exit conditions (#1039 AC-2)."""
-    assert "five terminal exit conditions" in template_text, (
-        "template intro must say `five terminal exit conditions` (#1039)"
+def test_template_section_intro_says_six_terminal_exits(template_text: str) -> None:
+    """Template MUST advertise SIX terminal exit conditions (#1039 + #1543)."""
+    assert "six terminal exit conditions" in template_text, (
+        "template intro must say `six terminal exit conditions` (#1543)"
     )
     assert (
-        "When ANY of the five conditions below fires" in template_text
-    ), "`## Terminal exit conditions` intro must enumerate five conditions (#1039)"
+        "When ANY of the six conditions below fires" in template_text
+    ), "`## Terminal exit conditions` intro must enumerate six conditions (#1543)"
 
 
 def test_template_contains_evaluate_clean_gate_function(template_text: str) -> None:
@@ -1293,6 +1293,36 @@ def test_template_recurrence_record_cites_1039(template_text: str) -> None:
     assert "5794b0e7" in template_text, (
         "template must cite the wedged poller agent id `5794b0e7-...` (#1039)"
     )
+
+
+def test_greptile_informal_clean_detector_in_template(template_text: str) -> None:
+    """Template MUST encode informal-clean missing canonical fields detection (#1543)."""
+    assert "is_informal_clean_missing_canonical_fields" in template_text
+    assert "informal-clean missing-canonical-fields" in template_text
+    assert "current diff is clean" in template_text
+
+
+def test_greptile_informal_clean_terminal_exit_in_template(template_text: str) -> None:
+    """Template MUST contain the `### (6) INFORMAL-CLEAN` terminal exit (#1543)."""
+    assert "### (6) INFORMAL-CLEAN" in template_text
+    assert (
+        "informal-clean missing canonical fields -- recovery required"
+        in template_text
+    )
+    informal_idx = template_text.index(
+        "Subject: PR #{pr_number} informal-clean missing canonical fields"
+    )
+    informal_block = template_text[informal_idx : informal_idx + 1500]
+    assert "@greptileai review" in informal_block
+    assert "-- no more polling, exiting now" in informal_block
+    assert "swarm:verify-review-clean" not in informal_block or (
+        "NOT a \"review complete\" signal" in informal_block
+    )
+
+
+def test_greptile_informal_clean_not_stall_fallback(template_text: str) -> None:
+    """Informal-clean guidance must route away from generic STALL polling (#1543)."""
+    assert "Do NOT increment `stall_streak` toward `(5) STALL`" in template_text
 
 
 def test_template_platform_adapter_unification_1342_phase6(template_text: str) -> None:

--- a/vbrief/active/2026-06-08-1543-review-cycle-handle-greptile-informal-clean-replies-without.vbrief.json
+++ b/vbrief/active/2026-06-08-1543-review-cycle-handle-greptile-informal-clean-replies-without.vbrief.json
@@ -1,0 +1,100 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1543"
+  },
+  "plan": {
+    "id": "1543-review-cycle-greptile-informal-clean-fields",
+    "title": "review-cycle: handle Greptile informal clean replies without canonical fields",
+    "status": "running",
+    "narratives": {
+      "Description": "Greptile can post an informal clean reply that says a PR diff is clean while omitting the canonical rolling-summary fields Directive needs for deterministic merge gating. This story preserves the strict gate while making the review-cycle skill, poller prompt, and parser diagnostics recognize the state and route operators to a targeted recovery or documented override.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1543",
+      "Overview": "## Summary\nPR #1541 exposed a review-cycle gap: Greptile can post an informal clean reply that says the diff is clean, while omitting the canonical rolling-summary fields that Directive's merge gates require: `Last reviewed commit:` and `Confidence Score: X/5`.\n\nThe deterministic gates are correct to block in this state because they cannot prove the review is current or confidence is above the threshold. However, the review-cycle skill, poller prompt, and merge-readiness diagnostics should recognize this specific state and route it cleanly instead of leaving the swarm monitor in an ambiguous stall.\n\n## Observed\n- `task pr:merge-ready -- 1541` reports P0=0 and P1=0 but fails because it cannot parse `Last reviewed commit:` or `Confidence Score` from the Greptile body.\n- `task swarm:verify-review-clean -- 1540 1541` blocks the cohort for the same reason.\n- The latest Greptile bot comment on PR #1541 is human-readable and clean, but not the canonical rolling-summary format.\n\n## Expected\nDirective should fail loud with a targeted recovery path when Greptile posts an informal clean response without canonical fields.\n\nThe fix should not loosen the merge gate to accept prose such as \"looks solid\". It should preserve the requirement for current reviewed SHA and confidence evidence, or require an explicit documented override.\n\n## Proposed scope\n- Update `skills/deft-directive-review-cycle/SKILL.md` to document the \"informal clean but missing canonical fields\" state and the operator choices.\n- Update `templates/swarm-greptile-poller-prompt.md` so pollers report this as a distinct terminal/blocked state instead of generic timeout/stall.\n- Update `scripts/pr_merge_readiness.py` diagnostics to distinguish informal-clean missing fields from a review that is still writing or absent.\n- Add focused tests for the parser/diagnostics and content guidance.\n\n## Acceptance criteria\n- Given a Greptile bot comment that says prior issues are resolved / current diff is clean but omits `Last reviewed commit:` and `Confidence Score`, `task pr:merge-ready` exits non-zero with a diagnostic that names the informal-clean missing-canonical-fields state and gives a recovery path.\n- Given a swarm cohort hits this state, the review-cycle guidance routes to either requesting a canonical Greptile summary/retrigger or a documented override, not silent polling.\n- The merge gate still refuses to treat informal clean prose alone as merge-ready.\n- Tests pin the parser behavior and the review-cycle/poller guidance.\n\n## References\n- PR #1541: provider backend policy story blocked by missing canonical Greptile fields\n- PR #1540/#1541 Wave 1 swarm verifier: `task swarm:verify-review-clean -- 1540 1541`\n- Related gates: `scripts/pr_merge_readiness.py`, `scripts/swarm_verify_review_clean.py`",
+      "ImplementationPlan": "1. Update scripts/pr_merge_readiness.py so missing canonical Greptile fields in an informal clean reply produce a distinct non-clean diagnostic with a targeted recovery path, while preserving the strict SHA and confidence requirements for CLEAN.\n2. Add parser tests in tests/cli/test_pr_merge_readiness.py for informal-clean missing-field comments and any necessary fallback coverage in tests/cli/test_pr_merge_readiness_fallbacks.py.\n3. Update skills/deft-directive-review-cycle/SKILL.md and templates/swarm-greptile-poller-prompt.md so review-cycle agents and swarm pollers classify this as a blocked recovery state instead of generic stall/timeout.\n4. Add or update content tests in tests/content/test_review_cycle_skill.py and tests/content/test_swarm_poller_template.py to pin the guidance.",
+      "UserStory": "As a swarm monitor, I want informal clean Greptile replies without canonical fields to fail loud with a recovery path, so that I do not merge without reviewed-SHA and confidence evidence or keep polling indefinitely.",
+      "Labels": "bug, swarm, skills"
+    },
+    "items": [
+      {
+        "id": "1543-review-cycle-greptile-informal-clean-fields-a1",
+        "title": "Given a Greptile bot comment says prior issues are resolved and the current diff is clean but omits canonical fields, task pr:merge-ready exits non-zero with an informal-clean missing-canonical-fields diagnostic and recovery path.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a Greptile bot comment says prior issues are resolved and the current diff is clean but omits `Last reviewed commit:` and `Confidence Score`, `task pr:merge-ready` exits non-zero with a diagnostic that names the informal-clean missing-canonical-fields state and gives a recovery path.",
+          "Traces": "https://github.com/deftai/directive/issues/1543"
+        }
+      },
+      {
+        "id": "1543-review-cycle-greptile-informal-clean-fields-a2",
+        "title": "Given a swarm cohort hits this state, review-cycle and poller guidance routes to requesting canonical evidence, retriggering, or a documented override instead of silent polling.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a swarm cohort hits this state, the review-cycle guidance routes to either requesting a canonical Greptile summary/retrigger or a documented override, not silent polling.",
+          "Traces": "https://github.com/deftai/directive/issues/1543"
+        }
+      },
+      {
+        "id": "1543-review-cycle-greptile-informal-clean-fields-a3",
+        "title": "Given an informal clean Greptile comment lacks reviewed-SHA and confidence fields, when task pr:merge-ready evaluates the PR, then the deterministic merge gate refuses to report merge-ready.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an informal clean Greptile comment lacks reviewed-SHA and confidence fields, when task pr:merge-ready evaluates the PR, then the deterministic merge gate refuses to report merge-ready.",
+          "Traces": "https://github.com/deftai/directive/issues/1543"
+        }
+      },
+      {
+        "id": "1543-review-cycle-greptile-informal-clean-fields-a4",
+        "title": "Given the focused parser and content tests run, then they fail before the informal-clean diagnostic and guidance exist and pass after the parser and docs are updated.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the focused parser and content tests run, then they fail before the informal-clean diagnostic and guidance exist and pass after the parser and docs are updated.",
+          "Traces": "https://github.com/deftai/directive/issues/1543"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "swarm",
+      "skills"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1543",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1543: review-cycle: handle Greptile informal clean replies without canonical fields"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/pr_merge_readiness.py",
+          "tests/cli/test_pr_merge_readiness.py",
+          "tests/cli/test_pr_merge_readiness_fallbacks.py",
+          "skills/deft-directive-review-cycle/SKILL.md",
+          "templates/swarm-greptile-poller-prompt.md",
+          "tests/content/test_review_cycle_skill.py",
+          "tests/content/test_swarm_poller_template.py"
+        ],
+        "verify_commands": [
+          "pytest tests/cli/test_pr_merge_readiness.py tests/cli/test_pr_merge_readiness_fallbacks.py -k informal",
+          "pytest tests/content/test_review_cycle_skill.py tests/content/test_swarm_poller_template.py -k greptile",
+          "task check"
+        ],
+        "expected_outputs": [
+          "merge-readiness parser reports informal-clean missing canonical fields as a distinct non-clean state",
+          "review-cycle and poller guidance document recovery without weakening the merge gate"
+        ],
+        "depends_on": [],
+        "conflict_group": "review-cycle-greptile-parser-guidance",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "updated": "2026-06-08T13:59:10Z"
+  }
+}

--- a/vbrief/completed/2026-06-08-1543-review-cycle-handle-greptile-informal-clean-replies-without.vbrief.json
+++ b/vbrief/completed/2026-06-08-1543-review-cycle-handle-greptile-informal-clean-replies-without.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1543-review-cycle-greptile-informal-clean-fields",
     "title": "review-cycle: handle Greptile informal clean replies without canonical fields",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Greptile can post an informal clean reply that says a PR diff is clean while omitting the canonical rolling-summary fields Directive needs for deterministic merge gating. This story preserves the strict gate while making the review-cycle skill, poller prompt, and parser diagnostics recognize the state and route operators to a targeted recovery or documented override.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1543",
@@ -19,7 +19,7 @@
       {
         "id": "1543-review-cycle-greptile-informal-clean-fields-a1",
         "title": "Given a Greptile bot comment says prior issues are resolved and the current diff is clean but omits canonical fields, task pr:merge-ready exits non-zero with an informal-clean missing-canonical-fields diagnostic and recovery path.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a Greptile bot comment says prior issues are resolved and the current diff is clean but omits `Last reviewed commit:` and `Confidence Score`, `task pr:merge-ready` exits non-zero with a diagnostic that names the informal-clean missing-canonical-fields state and gives a recovery path.",
           "Traces": "https://github.com/deftai/directive/issues/1543"
@@ -28,7 +28,7 @@
       {
         "id": "1543-review-cycle-greptile-informal-clean-fields-a2",
         "title": "Given a swarm cohort hits this state, review-cycle and poller guidance routes to requesting canonical evidence, retriggering, or a documented override instead of silent polling.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a swarm cohort hits this state, the review-cycle guidance routes to either requesting a canonical Greptile summary/retrigger or a documented override, not silent polling.",
           "Traces": "https://github.com/deftai/directive/issues/1543"
@@ -37,7 +37,7 @@
       {
         "id": "1543-review-cycle-greptile-informal-clean-fields-a3",
         "title": "Given an informal clean Greptile comment lacks reviewed-SHA and confidence fields, when task pr:merge-ready evaluates the PR, then the deterministic merge gate refuses to report merge-ready.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given an informal clean Greptile comment lacks reviewed-SHA and confidence fields, when task pr:merge-ready evaluates the PR, then the deterministic merge gate refuses to report merge-ready.",
           "Traces": "https://github.com/deftai/directive/issues/1543"
@@ -46,7 +46,7 @@
       {
         "id": "1543-review-cycle-greptile-informal-clean-fields-a4",
         "title": "Given the focused parser and content tests run, then they fail before the informal-clean diagnostic and guidance exist and pass after the parser and docs are updated.",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the focused parser and content tests run, then they fail before the informal-clean diagnostic and guidance exist and pass after the parser and docs are updated.",
           "Traces": "https://github.com/deftai/directive/issues/1543"
@@ -93,8 +93,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-08T14:25:10Z"
     },
-    "updated": "2026-06-08T13:59:10Z"
+    "updated": "2026-06-08T14:25:10Z"
   }
 }


### PR DESCRIPTION
## Summary
- Classify Greptile informal-clean missing-canonical-fields state when a bot comment says the diff is clean but omits Last reviewed commit: and Confidence Score: X/5.
- 	ask pr:merge-ready now emits a targeted recovery diagnostic (retrigger Greptile, wait for canonical evidence, or documented override) instead of generic parse failures or silent polling.
- Review-cycle skill and swarm poller template route this blocked state via (6) INFORMAL-CLEAN terminal exit.

## Test plan
- [x] pytest tests/cli/test_pr_merge_readiness.py tests/cli/test_pr_merge_readiness_fallbacks.py -k informal
- [x] pytest tests/content/test_review_cycle_skill.py tests/content/test_swarm_poller_template.py -k greptile
- [x] 	ask check (7298 tests passed; unrelated vbrief:validate failures from sibling active vBRIEFs in worktree)

Closes #1543
