### PR TITLE
feat(swarm): enforce selected subagent backend for headless launch (#1531e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Swarm operators can persist a coding sub-agent backend in project policy (#1531a)** -- `task policy:subagent-backend` sets the preferred coding sub-agent provider for swarm leaf workers; `task policy:subagent-backends` lists available providers and their role capabilities without spawning a harness; `task policy:show` surfaces the resolved value. Refs #1531.
+- **Headless swarm launch enforces selected sub-agent backend (#1531e)** -- `task swarm:launch` now refuses to emit a manifest when `plan.policy.swarmSubagentBackend` is missing or probe-unavailable, listing detected alternatives and the policy command to choose one; successful launches include audit-visible backend, dispatch provider, and worker-role metadata on each manifest entry without altering the #1378 allocation-context contract. Refs #1531.
 
 ### Changed
 

--- a/scripts/swarm_launch.py
+++ b/scripts/swarm_launch.py
@@ -135,6 +135,13 @@ LEAF_CODING_WORKER_ROLE = "leaf-implementation"
 #: Recovery command surfaced when backend policy is missing or unavailable.
 SUBAGENT_BACKEND_SET_CMD = "task policy:subagent-backend -- --set {backend_id}"
 
+#: Provider-neutral dispatch routing ids keyed by backend catalog id (#1531e).
+_DISPATCH_PROVIDER_BY_BACKEND: dict[str, str] = {
+    "composer": "cursor",
+    "grok-build": "grok",
+    "cursor-cloud": "cursor",
+}
+
 # An x-vbrief/github-issue URI of the form
 # ``https://github.com/<owner>/<repo>/issues/<N>``.
 _ISSUE_URI_RE = re.compile(r"/issues/(\d+)")
@@ -495,7 +502,22 @@ def enforce_subagent_backend_policy(
             f"{SUBAGENT_BACKEND_SET_CMD.format(backend_id='<id>')}"
         )
 
+    if LEAF_CODING_WORKER_ROLE not in selected.roles:
+        roles_text = ", ".join(selected.roles) if selected.roles else "(none)"
+        return None, (
+            f"plan.policy.swarmSubagentBackend={result.backend_id!r} does not "
+            f"support worker role {LEAF_CODING_WORKER_ROLE!r} "
+            f"(roles=[{roles_text}]).\n"
+            f"Choose a leaf-implementation backend: "
+            f"{SUBAGENT_BACKEND_SET_CMD.format(backend_id='<id>')}"
+        )
+
     return selected, None
+
+
+def dispatch_provider_for(backend_id: str) -> str:
+    """Map a catalog backend id to its provider-neutral dispatch provider."""
+    return _DISPATCH_PROVIDER_BY_BACKEND.get(backend_id, backend_id)
 
 
 # ---------------------------------------------------------------------------
@@ -1053,7 +1075,9 @@ def main(argv: list[str] | None = None) -> int:
         operator_approval_evidence=operator_approval,
         gate_clearances=gate_clearances,
         subagent_backend=backend.backend_id if backend is not None else None,
-        dispatch_provider=backend.backend_id if backend is not None else None,
+        dispatch_provider=(
+            dispatch_provider_for(backend.backend_id) if backend is not None else None
+        ),
         worker_role=LEAF_CODING_WORKER_ROLE if backend is not None else None,
     )
 

--- a/scripts/swarm_launch.py
+++ b/scripts/swarm_launch.py
@@ -100,6 +100,19 @@ try:  # pragma: no cover -- core sibling in this repo
 except Exception:  # noqa: BLE001
     append_authority_event = None  # type: ignore[assignment]
 
+# Sub-agent backend policy + probe (#1531a / #1531e). Guarded so tests can
+# stub the seams when the policy module is unavailable.
+try:  # pragma: no cover -- core sibling in this repo
+    from policy import (  # type: ignore  # noqa: E402
+        SubagentBackendDescriptor,
+        probe_subagent_backends,
+        resolve_swarm_subagent_backend,
+    )
+except Exception:  # noqa: BLE001
+    SubagentBackendDescriptor = None  # type: ignore[assignment,misc]
+    probe_subagent_backends = None  # type: ignore[assignment]
+    resolve_swarm_subagent_backend = None  # type: ignore[assignment]
+
 EXIT_OK = 0
 EXIT_GATE_FAILED = 1
 EXIT_CONFIG_ERROR = 2
@@ -115,6 +128,12 @@ GATE_ENFORCE = "enforce"
 #: Durable authority-event log file (under vbrief/.audit/) -- allocation
 #: approvals + consumed gate clearances per RFC #1419 Receipts & Audit.
 AUTHORITY_LOG_NAME = "authority-events.jsonl"
+
+#: Default worker role for headless coding-worker dispatch (#1531e).
+LEAF_CODING_WORKER_ROLE = "leaf-implementation"
+
+#: Recovery command surfaced when backend policy is missing or unavailable.
+SUBAGENT_BACKEND_SET_CMD = "task policy:subagent-backend -- --set {backend_id}"
 
 # An x-vbrief/github-issue URI of the form
 # ``https://github.com/<owner>/<repo>/issues/<N>``.
@@ -413,6 +432,73 @@ def enforce_gates(
 
 
 # ---------------------------------------------------------------------------
+# Sub-agent backend policy (#1531e)
+# ---------------------------------------------------------------------------
+
+
+def _format_probed_backends(backends: list[Any]) -> str:
+    """Human-readable probe listing for fail-loud stderr."""
+    lines: list[str] = []
+    for entry in backends:
+        avail = "available" if entry.available else "unavailable"
+        roles = ", ".join(entry.roles)
+        lines.append(f"  {entry.backend_id} ({avail}; roles=[{roles}])")
+    return "\n".join(lines)
+
+
+def enforce_subagent_backend_policy(
+    project_root: Path,
+) -> tuple[SubagentBackendDescriptor | None, str | None]:
+    """Validate ``plan.policy.swarmSubagentBackend`` before headless dispatch.
+
+    Returns ``(descriptor, None)`` when the stored backend is present and
+    probe-available, or ``(None, reason)`` on the first failure. Never
+    prompts -- ``--autonomous`` and interactive launches share this path.
+    """
+    if resolve_swarm_subagent_backend is None or probe_subagent_backends is None:
+        return None, (
+            "sub-agent backend policy module is not importable "
+            "(scripts/policy.py)."
+        )
+
+    result = resolve_swarm_subagent_backend(project_root)
+    probed = probe_subagent_backends()
+
+    if result.backend_id is None:
+        detail = result.error or "plan.policy.swarmSubagentBackend is not set."
+        listing = _format_probed_backends(probed)
+        return None, (
+            f"{detail}\n"
+            "Select a coding sub-agent backend before headless dispatch:\n"
+            f"{listing}\n"
+            "Probe harness availability: task policy:subagent-backends\n"
+            f"Persist a choice: {SUBAGENT_BACKEND_SET_CMD.format(backend_id='<id>')}"
+        )
+
+    selected = next((e for e in probed if e.backend_id == result.backend_id), None)
+    if selected is None:
+        known = ", ".join(e.backend_id for e in probed)
+        return None, (
+            f"plan.policy.swarmSubagentBackend={result.backend_id!r} is not a "
+            f"known backend id (known: {known}).\n"
+            f"Persist a valid choice: {SUBAGENT_BACKEND_SET_CMD.format(backend_id='<id>')}"
+        )
+
+    if not selected.available:
+        available_ids = [e.backend_id for e in probed if e.available]
+        avail_text = ", ".join(available_ids) if available_ids else "(none)"
+        return None, (
+            f"plan.policy.swarmSubagentBackend={result.backend_id!r} is "
+            f"unavailable in the current harness.\n"
+            f"Available backend ids: {avail_text}\n"
+            f"Choose a different backend: "
+            f"{SUBAGENT_BACKEND_SET_CMD.format(backend_id='<id>')}"
+        )
+
+    return selected, None
+
+
+# ---------------------------------------------------------------------------
 # Gate-clearance integration (#1419 Slice 7)
 # ---------------------------------------------------------------------------
 
@@ -634,6 +720,9 @@ def build_manifest(
     batching_rationale: str | None,
     operator_approval_evidence: str | None,
     gate_clearances: list[dict] | None = None,
+    subagent_backend: str | None = None,
+    dispatch_provider: str | None = None,
+    worker_role: str | None = None,
 ) -> list[dict]:
     """Build the C2 launch-manifest array (one envelope per story).
 
@@ -642,6 +731,10 @@ def build_manifest(
     7) so the dispatched worker's Gate 0 can recognise the pre-recorded
     clearance. The field is OMITTED when there are no clearances so the
     historical five-field #1378 consent token is unchanged for the common case.
+
+    Top-level ``subagent_backend``, ``dispatch_provider``, and ``worker_role``
+    fields (#1531e) carry audit-visible routing metadata without altering the
+    #1378 allocation-context recognition contract.
     """
     cohort_vbriefs = [story.relpath for story in resolved]
     manifest: list[dict] = []
@@ -660,15 +753,20 @@ def build_manifest(
         }
         if gate_clearances:
             allocation_context["gate_clearances"] = gate_clearances
-        manifest.append(
-            {
-                "story_id": story.story_id,
-                "vbrief_path": story.relpath,
-                "worktree_path": worktree_path,
-                "branch": _derive_branch(group, story.story_id),
-                "allocation_context": allocation_context,
-            }
-        )
+        entry: dict[str, Any] = {
+            "story_id": story.story_id,
+            "vbrief_path": story.relpath,
+            "worktree_path": worktree_path,
+            "branch": _derive_branch(group, story.story_id),
+            "allocation_context": allocation_context,
+        }
+        if subagent_backend is not None:
+            entry["subagent_backend"] = subagent_backend
+        if dispatch_provider is not None:
+            entry["dispatch_provider"] = dispatch_provider
+        if worker_role is not None:
+            entry["worker_role"] = worker_role
+        manifest.append(entry)
     return manifest
 
 
@@ -867,6 +965,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         return EXIT_GATE_FAILED
 
+    backend, backend_error = enforce_subagent_backend_policy(project_root)
+    if backend_error is not None:
+        print(f"Error: {backend_error}", file=sys.stderr)
+        return EXIT_GATE_FAILED
+
     # Cohort-fill ordering (#1419 Slice 2 / #987): continuation-first,
     # deficit-biased among net-new, then rank/date. Reorders the dispatch
     # manifest (and each envelope's cohort_vbriefs list) so finishing started
@@ -949,6 +1052,9 @@ def main(argv: list[str] | None = None) -> int:
         batching_rationale=batching_rationale,
         operator_approval_evidence=operator_approval,
         gate_clearances=gate_clearances,
+        subagent_backend=backend.backend_id if backend is not None else None,
+        dispatch_provider=backend.backend_id if backend is not None else None,
+        worker_role=LEAF_CODING_WORKER_ROLE if backend is not None else None,
     )
 
     rendered = json.dumps(manifest, indent=2)

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -27,7 +27,7 @@ tasks:
   # Companion script: scripts/swarm_launch.py
   # Companion test:   tests/cli/test_swarm_launch.py
   launch:
-    desc: "Resolve a pre-approved cohort, enforce the #810 + swarm:readiness gates per story, and emit the launch-manifest JSON (#1387)"
+    desc: "Resolve a pre-approved cohort, enforce the #810 + swarm:readiness gates and sub-agent backend policy per story, and emit the launch-manifest JSON (#1387, #1531e)"
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"

--- a/tests/cli/test_swarm_launch.py
+++ b/tests/cli/test_swarm_launch.py
@@ -101,6 +101,28 @@ def gates_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sl, "run_readiness_gate", lambda path, root: (0, "OK"))
 
 
+def _write_project_def(project: Path, policy: dict) -> None:
+    """Write a minimal PROJECT-DEFINITION with the given plan.policy block."""
+    payload = {
+        "vBRIEFInfo": {"version": "0.6"},
+        "plan": {"policy": policy},
+    }
+    path = project / "vbrief" / "PROJECT-DEFINITION.vbrief.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture
+def backend_ready(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure a valid, probe-available sub-agent backend policy (#1531e)."""
+    _write_project_def(project, {"swarmSubagentBackend": "grok-build"})
+    monkeypatch.setenv("DEFT_PROBE_GROK_BUILD", "yes")
+
+
+@pytest.fixture
+def launch_ready(gates_pass, backend_ready) -> None:
+    """Gates pass and sub-agent backend policy is ready for manifest emission."""
+
+
 # ---------------------------------------------------------------------------
 # a1 -- story resolution
 # ---------------------------------------------------------------------------
@@ -218,7 +240,7 @@ class TestGateEnforcement:
         assert "sA" in err
         assert "readiness" in err
 
-    def test_all_gates_pass_exits_ok(self, project: Path, gates_pass, capsys) -> None:
+    def test_all_gates_pass_exits_ok(self, project: Path, launch_ready, capsys) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         rc = sl.main(["--stories", "100", "--project-root", str(project)])
         assert rc == sl.EXIT_OK
@@ -232,7 +254,7 @@ class TestGateEnforcement:
 
 
 class TestManifestShape:
-    def test_manifest_object_has_c2_fields(self, project: Path, gates_pass, capsys) -> None:
+    def test_manifest_object_has_c2_fields(self, project: Path, launch_ready, capsys) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         rc = sl.main(["--stories", "100", "--project-root", str(project)])
         assert rc == sl.EXIT_OK
@@ -243,12 +265,15 @@ class TestManifestShape:
             "worktree_path",
             "branch",
             "allocation_context",
+            "subagent_backend",
+            "dispatch_provider",
+            "worker_role",
         }
         assert entry["story_id"] == "sA"
         assert entry["vbrief_path"].endswith("a.vbrief.json")
         assert entry["branch"] == "swarm/sA"
 
-    def test_allocation_context_has_1378_fields(self, project: Path, gates_pass, capsys) -> None:
+    def test_allocation_context_has_1378_fields(self, project: Path, launch_ready, capsys) -> None:
         active = project / "vbrief" / "active"
         _write_story(active, "a.vbrief.json", story_id="sA", issues=[100])
         _write_story(active, "b.vbrief.json", story_id="sB", issues=[200])
@@ -274,21 +299,21 @@ class TestManifestShape:
         assert manifest[0]["branch"] == "swarm/cohort-x/sA"
 
     def test_solo_dispatch_kind_for_single_story_without_group(
-        self, project: Path, gates_pass, capsys
+        self, project: Path, launch_ready, capsys
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         sl.main(["--stories", "100", "--project-root", str(project)])
         ctx = json.loads(capsys.readouterr().out)[0]["allocation_context"]
         assert ctx["dispatch_kind"] == "solo"
 
-    def test_default_worktree_path_when_no_map(self, project: Path, gates_pass, capsys) -> None:
+    def test_default_worktree_path_when_no_map(self, project: Path, launch_ready, capsys) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         sl.main(["--stories", "100", "--project-root", str(project)])
         entry = json.loads(capsys.readouterr().out)[0]
         assert ".deft-scratch/worktrees/sA" in entry["worktree_path"]
 
     def test_worktree_map_consumed_via_injected_resolver(
-        self, project: Path, gates_pass, monkeypatch, capsys, tmp_path: Path
+        self, project: Path, launch_ready, monkeypatch, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         map_path = tmp_path / "wt-map.json"
@@ -324,7 +349,7 @@ class TestManifestShape:
         assert captured["create_missing"] is True
 
     def test_no_create_worktrees_flag_forwarded(
-        self, project: Path, gates_pass, monkeypatch, capsys, tmp_path: Path
+        self, project: Path, launch_ready, monkeypatch, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         map_path = tmp_path / "wt-map.json"
@@ -353,7 +378,7 @@ class TestManifestShape:
         assert captured["create_missing"] is False
 
     def test_worktree_map_without_resolver_exits_config_error(
-        self, project: Path, gates_pass, monkeypatch, capsys, tmp_path: Path
+        self, project: Path, launch_ready, monkeypatch, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         map_path = tmp_path / "wt-map.json"
@@ -366,7 +391,7 @@ class TestManifestShape:
         assert "resolver" in capsys.readouterr().err
 
     def test_worktree_map_resolver_raising_exits_config_error(
-        self, project: Path, gates_pass, monkeypatch, capsys, tmp_path: Path
+        self, project: Path, launch_ready, monkeypatch, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         map_path = tmp_path / "wt-map.json"
@@ -382,7 +407,7 @@ class TestManifestShape:
         assert rc == sl.EXIT_CONFIG_ERROR
         assert "collision" in capsys.readouterr().err
 
-    def test_output_file_written(self, project: Path, gates_pass, capsys, tmp_path: Path) -> None:
+    def test_output_file_written(self, project: Path, launch_ready, capsys, tmp_path: Path) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         out_path = tmp_path / "manifest.json"
         rc = sl.main(
@@ -393,7 +418,7 @@ class TestManifestShape:
         assert written[0]["story_id"] == "sA"
 
     def test_output_write_failure_exits_config_error(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         # --output points at an existing directory, so write_text raises OSError.
@@ -407,7 +432,7 @@ class TestManifestShape:
         assert captured.out.strip() == ""
 
     def test_worktree_map_duplicate_story_id_exits_config_error(
-        self, project: Path, gates_pass, monkeypatch, capsys, tmp_path: Path
+        self, project: Path, launch_ready, monkeypatch, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         map_path = tmp_path / "wt-map.json"
@@ -433,7 +458,9 @@ class TestManifestShape:
 
 
 class TestAutonomousMode:
-    def test_autonomous_records_batching_rationale(self, project: Path, gates_pass, capsys) -> None:
+    def test_autonomous_records_batching_rationale(
+        self, project: Path, launch_ready, capsys
+    ) -> None:
         active = project / "vbrief" / "active"
         _write_story(active, "a.vbrief.json", story_id="sA", issues=[100])
         _write_story(active, "b.vbrief.json", story_id="sB", issues=[200])
@@ -445,13 +472,15 @@ class TestAutonomousMode:
             assert rationale is not None
             assert rationale.strip() != ""
 
-    def test_non_autonomous_leaves_rationale_null(self, project: Path, gates_pass, capsys) -> None:
+    def test_non_autonomous_leaves_rationale_null(
+        self, project: Path, launch_ready, capsys
+    ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         sl.main(["--stories", "100", "--project-root", str(project)])
         ctx = json.loads(capsys.readouterr().out)[0]["allocation_context"]
         assert ctx["batching_rationale"] is None
 
-    def test_explicit_batching_rationale_honored(self, project: Path, gates_pass, capsys) -> None:
+    def test_explicit_batching_rationale_honored(self, project: Path, launch_ready, capsys) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         sl.main(
             [
@@ -501,7 +530,7 @@ class TestConfigErrors:
 
 class TestCohortOrdering:
     def test_continuation_orders_first(
-        self, project: Path, gates_pass, monkeypatch, capsys
+        self, project: Path, launch_ready, monkeypatch, capsys
     ) -> None:
         active = project / "vbrief" / "active"
         _write_story(active, "a.vbrief.json", story_id="sA", issues=[100])  # net-new
@@ -516,7 +545,7 @@ class TestCohortOrdering:
         assert [m["story_id"] for m in manifest] == ["sB", "sA"]
 
     def test_deficit_orders_most_under_target_first(
-        self, project: Path, gates_pass, monkeypatch, capsys
+        self, project: Path, launch_ready, monkeypatch, capsys
     ) -> None:
         active = project / "vbrief" / "active"
         _write_story(active, "a.vbrief.json", story_id="sA", issues=[100])
@@ -533,7 +562,7 @@ class TestCohortOrdering:
         assert [m["story_id"] for m in manifest] == ["sB", "sA"]
 
     def test_continuation_beats_deficit(
-        self, project: Path, gates_pass, monkeypatch, capsys
+        self, project: Path, launch_ready, monkeypatch, capsys
     ) -> None:
         active = project / "vbrief" / "active"
         _write_story(active, "a.vbrief.json", story_id="sA", issues=[100])  # net-new, big deficit
@@ -549,7 +578,7 @@ class TestCohortOrdering:
         assert [m["story_id"] for m in manifest] == ["sB", "sA"]
 
     def test_neutral_orders_by_filename_proxy(
-        self, project: Path, gates_pass, monkeypatch, capsys
+        self, project: Path, launch_ready, monkeypatch, capsys
     ) -> None:
         # No continuation / deficit signal -> the date_key (relpath) proxy
         # orders deterministically by date-prefixed filename, regardless of
@@ -564,7 +593,7 @@ class TestCohortOrdering:
         assert [m["story_id"] for m in manifest] == ["sA", "sB"]
 
     def test_cohort_vbriefs_reflects_ordering(
-        self, project: Path, gates_pass, monkeypatch, capsys
+        self, project: Path, launch_ready, monkeypatch, capsys
     ) -> None:
         active = project / "vbrief" / "active"
         _write_story(active, "a.vbrief.json", story_id="sA", issues=[100])
@@ -638,7 +667,7 @@ def _clearance_file(tmp_path: Path, project: Path, *, paths: list[str]) -> Path:
 
 class TestGateClearanceEnforcement:
     def test_enforce_uncleared_block_gate_aborts(
-        self, project: Path, gates_pass, capsys
+        self, project: Path, launch_ready, capsys
     ) -> None:
         _engine()
         _write_story(
@@ -654,7 +683,7 @@ class TestGateClearanceEnforcement:
         assert "block-gated" in err
 
     def test_enforce_cleared_block_gate_launches(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         """a2: a recorded clearance permits the gated (solo) story to launch."""
         _write_story(
@@ -675,7 +704,7 @@ class TestGateClearanceEnforcement:
         assert [m["story_id"] for m in manifest] == ["sA"]
 
     def test_advise_default_launches_uncleared_gated_story(
-        self, project: Path, gates_pass, capsys
+        self, project: Path, launch_ready, capsys
     ) -> None:
         """Advisory default surfaces the uncleared block gate but still launches."""
         _engine()
@@ -690,7 +719,7 @@ class TestGateClearanceEnforcement:
         assert "advisory" in captured.err.lower()
 
     def test_enforce_block_gated_story_in_cohort_must_ship_solo(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         """A cleared block-gated story still cannot ride a multi-story cohort (v1)."""
         active = project / "vbrief" / "active"
@@ -712,7 +741,7 @@ class TestGateClearanceEnforcement:
         assert "solo" in capsys.readouterr().err.lower()
 
     def test_envelope_carries_gate_clearances(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         """The consent token gains a gate_clearances field when clearances are supplied."""
         _write_story(
@@ -732,7 +761,7 @@ class TestGateClearanceEnforcement:
         assert ctx["gate_clearances"][0]["gate_id"] == GATE_ID
 
     def test_malformed_gate_clearances_file_exits_config_error(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         bad = tmp_path / "bad.json"
@@ -744,7 +773,7 @@ class TestGateClearanceEnforcement:
         assert "gate-clearances" in capsys.readouterr().err
 
     def test_non_array_gate_clearances_file_exits_config_error(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         bad = tmp_path / "obj.json"
@@ -773,7 +802,7 @@ class TestAuthorityAudit:
         ]
 
     def test_successful_launch_appends_allocation_approved(
-        self, project: Path, gates_pass, capsys
+        self, project: Path, launch_ready, capsys
     ) -> None:
         """a3: a successful launch appends an allocation:approved authority event."""
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
@@ -786,7 +815,7 @@ class TestAuthorityAudit:
         assert "event_id" in approval and "timestamp" in approval
 
     def test_consumed_clearance_appends_gate_cleared(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         _write_story(
             project / "vbrief" / "active", "a.vbrief.json",
@@ -807,7 +836,7 @@ class TestAuthorityAudit:
         assert cleared[0]["gate_id"] == GATE_ID
 
     def test_no_audit_flag_suppresses_audit(
-        self, project: Path, gates_pass, capsys
+        self, project: Path, launch_ready, capsys
     ) -> None:
         _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
         rc = sl.main(["--stories", "100", "--no-audit", "--project-root", str(project)])
@@ -815,7 +844,7 @@ class TestAuthorityAudit:
         assert self._audit_records(project) == []
 
     def test_unconsumed_clearance_is_not_logged(
-        self, project: Path, gates_pass, capsys, tmp_path: Path
+        self, project: Path, launch_ready, capsys, tmp_path: Path
     ) -> None:
         """A supplied clearance whose gate never matched is NOT recorded as consumed.
 
@@ -836,3 +865,83 @@ class TestAuthorityAudit:
         records = self._audit_records(project)
         assert any(r["event_type"] == "allocation:approved" for r in records)
         assert not any(r["event_type"] == "gate:cleared" for r in records)
+
+
+# ---------------------------------------------------------------------------
+# #1531e -- sub-agent backend policy enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentBackendPolicy:
+    def test_missing_policy_exits_before_manifest(
+        self, project: Path, gates_pass, capsys
+    ) -> None:
+        _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
+        rc = sl.main(["--stories", "100", "--project-root", str(project)])
+        assert rc == sl.EXIT_GATE_FAILED
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+        err = captured.err
+        assert "Select a coding sub-agent backend" in err
+        assert "composer" in err
+        assert "grok-build" in err
+        assert "task policy:subagent-backend" in err
+
+    def test_unavailable_backend_lists_alternatives(
+        self, project: Path, gates_pass, capsys, monkeypatch
+    ) -> None:
+        _write_project_def(project, {"swarmSubagentBackend": "composer"})
+        monkeypatch.delenv("DEFT_PROBE_COMPOSER", raising=False)
+        monkeypatch.setenv("DEFT_PROBE_GROK_BUILD", "yes")
+        _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
+        rc = sl.main(["--stories", "100", "--project-root", str(project)])
+        assert rc == sl.EXIT_GATE_FAILED
+        err = capsys.readouterr().err
+        assert "composer" in err
+        assert "unavailable" in err
+        assert "grok-build" in err
+        assert "task policy:subagent-backend" in err
+
+    def test_available_backend_adds_audit_metadata(
+        self, project: Path, launch_ready, capsys
+    ) -> None:
+        _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
+        rc = sl.main(["--stories", "100", "--project-root", str(project)])
+        assert rc == sl.EXIT_OK
+        entry = json.loads(capsys.readouterr().out)[0]
+        assert entry["subagent_backend"] == "grok-build"
+        assert entry["dispatch_provider"] == "grok-build"
+        assert entry["worker_role"] == sl.LEAF_CODING_WORKER_ROLE
+        ctx = entry["allocation_context"]
+        assert set(ctx) == {
+            "dispatch_kind",
+            "allocation_plan_id",
+            "batching_rationale",
+            "cohort_vbriefs",
+            "operator_approval_evidence",
+        }
+
+    def test_autonomous_missing_policy_fails_non_interactively(
+        self, project: Path, gates_pass, capsys
+    ) -> None:
+        _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
+        rc = sl.main(
+            ["--stories", "100", "--autonomous", "--project-root", str(project)]
+        )
+        assert rc == sl.EXIT_GATE_FAILED
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_autonomous_unavailable_backend_fails_non_interactively(
+        self, project: Path, gates_pass, capsys, monkeypatch
+    ) -> None:
+        _write_project_def(project, {"swarmSubagentBackend": "cursor-cloud"})
+        monkeypatch.delenv("DEFT_PROBE_CURSOR_CLOUD", raising=False)
+        monkeypatch.delenv("CURSOR_AGENT", raising=False)
+        _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
+        rc = sl.main(
+            ["--stories", "100", "--autonomous", "--project-root", str(project)]
+        )
+        assert rc == sl.EXIT_GATE_FAILED
+        err = capsys.readouterr().err
+        assert "cursor-cloud" in err
+        assert "task policy:subagent-backend" in err

--- a/tests/cli/test_swarm_launch.py
+++ b/tests/cli/test_swarm_launch.py
@@ -910,7 +910,7 @@ class TestSubagentBackendPolicy:
         assert rc == sl.EXIT_OK
         entry = json.loads(capsys.readouterr().out)[0]
         assert entry["subagent_backend"] == "grok-build"
-        assert entry["dispatch_provider"] == "grok-build"
+        assert entry["dispatch_provider"] == "grok"
         assert entry["worker_role"] == sl.LEAF_CODING_WORKER_ROLE
         ctx = entry["allocation_context"]
         assert set(ctx) == {
@@ -945,3 +945,37 @@ class TestSubagentBackendPolicy:
         err = capsys.readouterr().err
         assert "cursor-cloud" in err
         assert "task policy:subagent-backend" in err
+
+    def test_backend_without_leaf_role_fails(
+        self, project: Path, gates_pass, capsys, monkeypatch
+    ) -> None:
+        fake_result = type(
+            "Result",
+            (),
+            {"backend_id": "review-only", "source": "typed", "error": None},
+        )()
+        monkeypatch.setattr(
+            sl, "resolve_swarm_subagent_backend", lambda root: fake_result
+        )
+        monkeypatch.setattr(
+            sl,
+            "probe_subagent_backends",
+            lambda: [
+                type(
+                    "Desc",
+                    (),
+                    {
+                        "backend_id": "review-only",
+                        "display_name": "Review only",
+                        "roles": ("review-monitor",),
+                        "available": True,
+                    },
+                )()
+            ],
+        )
+        _write_story(project / "vbrief" / "active", "a.vbrief.json", story_id="sA", issues=[100])
+        rc = sl.main(["--stories", "100", "--project-root", str(project)])
+        assert rc == sl.EXIT_GATE_FAILED
+        err = capsys.readouterr().err
+        assert "leaf-implementation" in err
+        assert "review-only" in err

--- a/vbrief/active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
+++ b/vbrief/active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
@@ -79,7 +79,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json",
+        "uri": "completed/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Integrate selected sub-agent backend into headless swarm launch and audit output",
         "TrustLevel": "internal"

--- a/vbrief/active/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
+++ b/vbrief/active/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
@@ -87,30 +87,6 @@
         "TrustLevel": "external"
       },
       {
-        "uri": "pending/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json",
-        "type": "x-vbrief/plan",
-        "title": "Add persistent sub-agent backend policy and availability gate",
-        "TrustLevel": "internal"
-      },
-      {
-        "uri": "pending/2026-06-08-document-provider-neutral-sub-agent-routing-in-the-swarm-ski.vbrief.json",
-        "type": "x-vbrief/plan",
-        "title": "Document provider-neutral sub-agent routing in the swarm skill",
-        "TrustLevel": "internal"
-      },
-      {
-        "uri": "pending/2026-06-08-add-provider-neutral-worker-metadata-to-the-agent-preamble.vbrief.json",
-        "type": "x-vbrief/plan",
-        "title": "Add provider-neutral worker metadata to the agent preamble",
-        "TrustLevel": "internal"
-      },
-      {
-        "uri": "pending/2026-06-08-pin-provider-neutral-sub-agent-guidance-with-content-tests.vbrief.json",
-        "type": "x-vbrief/plan",
-        "title": "Pin provider-neutral sub-agent guidance with content tests",
-        "TrustLevel": "internal"
-      },
-      {
         "uri": "https://github.com/deftai/directive/issues/1531",
         "type": "x-vbrief/github-issue",
         "title": "Issue #1531: swarm: opt-in tiered / heterogeneous dispatch",

--- a/vbrief/completed/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
+++ b/vbrief/completed/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1531e-headless-launch-backend-integration",
     "title": "Integrate selected sub-agent backend into headless swarm launch and audit output",
-    "status": "running",
+    "status": "completed",
     "planRef": "active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
     "narratives": {
       "Description": "This story makes the stored sub-agent backend policy load-bearing during headless swarm launch. It is independently buildable because it owns the launch-manifest consumption path and fail-loud checks, while depending on the policy/probe story for backend discovery and stored selection.",
@@ -77,7 +77,8 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "high"
-      }
+      },
+      "completedAt": "2026-06-08T15:50:53Z"
     },
     "references": [
       {
@@ -93,6 +94,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-08T00:41:53Z"
+    "updated": "2026-06-08T15:50:53Z"
   }
 }


### PR DESCRIPTION
## Summary
- `task swarm:launch` now validates `plan.policy.swarmSubagentBackend` against the probe catalog before emitting a manifest.
- Missing or probe-unavailable backend policy fails loud with detected alternatives and `task policy:subagent-backend` recovery guidance (including under `--autonomous`).
- Successful manifests add audit-visible `subagent_backend`, `dispatch_provider`, and `worker_role` fields without altering the #1378 five-field allocation-context contract.

## Test plan
- [x] `pytest tests/cli/test_swarm_launch.py -k subagent`
- [x] `task check`

Refs #1531

Made with [Cursor](https://cursor.com)