### PR TITLE
chore(vbrief): complete provider-neutral swarm epic

### DIFF
--- a/vbrief/completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
+++ b/vbrief/completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "swarm: opt-in tiered / heterogeneous dispatch (strong-model orchestrator + cheap high-context leaf code-runners)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "The swarm skill currently frames heterogeneous leaf-agent routing around the Grok Build spawn_subagent path, but the operator-facing capability should be provider-neutral. This story turns the issue discussion into concrete swarm guidance so users can choose Composer-class coding agents, Grok Build agents, Cursor/cloud agents, or future adapters for leaf implementation while preserving strong-model control for orchestration, review, merge, and release gates.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1531",
@@ -109,8 +109,9 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "high"
-      }
+      },
+      "completedAt": "2026-06-08T16:54:49Z"
     },
-    "updated": "2026-06-08T16:03:39Z"
+    "updated": "2026-06-08T16:54:49Z"
   }
 }

--- a/vbrief/completed/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json
+++ b/vbrief/completed/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1531a-subagent-backend-policy-and-probe",
     "title": "Add persistent sub-agent backend policy and availability gate",
     "status": "completed",
-    "planRef": "active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
+    "planRef": "completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
     "narratives": {
       "Description": "This story gives Deft a durable project-level policy for the user-selected coding sub-agent backend and a runtime capability probe that lists available backends in the current harness. It is independently buildable because it owns the policy/task/probe surface; the later launch story consumes that policy before dispatch.",
       "ImplementationPlan": "1. Update the source files scripts/policy.py, scripts/policy_set.py, and tasks/policy.yml so plan.policy.swarmSubagentBackend can be shown, changed, and audited from the normal policy surface.\n2. Add focused tests in tests/cli/test_policy.py and tests/cli/test_policy_set.py that verify backend listing/probe output, user-changeable policy storage, and policy:show evidence without invoking a real harness.",

--- a/vbrief/completed/2026-06-08-add-provider-neutral-worker-metadata-to-the-agent-preamble.vbrief.json
+++ b/vbrief/completed/2026-06-08-add-provider-neutral-worker-metadata-to-the-agent-preamble.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1531c-preamble-provider-metadata",
     "title": "Add provider-neutral worker metadata to the agent preamble",
     "status": "completed",
-    "planRef": "active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
+    "planRef": "completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
     "narratives": {
       "Description": "This story updates the canonical dispatch preamble so implementation workers can see which backend and role they were assigned without relying on Grok Build-specific wording. It is independently buildable because it owns the dispatch-envelope contract text and can preserve existing allocation-context fields while adding provider-neutral metadata guidance.",
       "ImplementationPlan": "1. Update the source file templates/agent-prompt-preamble.md near the allocation context and sub-agent spawn rules to document provider-neutral worker metadata such as dispatch provider, worker role, and selected backend or routing policy.\n2. Verify the preamble contract with tests/content/test_swarm_skill.py assertions that preserve the five-field allocation-context evidence while checking the new backend metadata guidance.",

--- a/vbrief/completed/2026-06-08-document-provider-neutral-sub-agent-routing-in-the-swarm-ski.vbrief.json
+++ b/vbrief/completed/2026-06-08-document-provider-neutral-sub-agent-routing-in-the-swarm-ski.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1531b-swarm-skill-provider-neutral-routing",
     "title": "Document provider-neutral sub-agent routing in the swarm skill",
     "status": "completed",
-    "planRef": "active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
+    "planRef": "completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
     "narratives": {
       "Description": "This story updates the swarm operator guidance so heterogeneous dispatch is described as a provider-neutral capability rather than a Grok Build-only path. It is independently buildable because it owns the swarm skill text and does not need to modify dispatch templates or tests directly.",
       "ImplementationPlan": "1. Update the source file skills/deft-directive-swarm/SKILL.md to separate dispatch provider, worker role, and model or agent selection in the heterogeneous dispatch guidance.\n2. Verify the change with focused content tests in tests/content/test_swarm_skill.py by ensuring the skill text exposes provider-neutral backend evidence and safe role-boundary assertions.",

--- a/vbrief/completed/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
+++ b/vbrief/completed/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1531e-headless-launch-backend-integration",
     "title": "Integrate selected sub-agent backend into headless swarm launch and audit output",
     "status": "completed",
-    "planRef": "active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
+    "planRef": "completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
     "narratives": {
       "Description": "This story makes the stored sub-agent backend policy load-bearing during headless swarm launch. It is independently buildable because it owns the launch-manifest consumption path and fail-loud checks, while depending on the policy/probe story for backend discovery and stored selection.",
       "ImplementationPlan": "1. Update the source files scripts/swarm_launch.py and tasks/swarm.yml so task swarm:launch reads plan.policy.swarmSubagentBackend, checks it against the current harness probe, and refuses headless dispatch when the policy is missing or unavailable.\n2. Add focused tests in tests/cli/test_swarm_launch.py that verify missing-policy failure, unavailable-backend failure with listed alternatives, and successful launch-manifest audit fields for selected backend and worker role.",

--- a/vbrief/completed/2026-06-08-pin-provider-neutral-sub-agent-guidance-with-content-tests.vbrief.json
+++ b/vbrief/completed/2026-06-08-pin-provider-neutral-sub-agent-guidance-with-content-tests.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1531d-provider-guidance-tests",
     "title": "Pin provider-neutral sub-agent guidance with content tests",
     "status": "completed",
-    "planRef": "active/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
+    "planRef": "completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json",
     "narratives": {
       "Description": "This story adds focused content tests for the provider-neutral swarm and preamble guidance after the documentation stories land. It is sequenced after the text updates so the test assertions can pin the final wording without forcing implementation workers to edit the same files concurrently.",
       "ImplementationPlan": "1. Update the source file tests/content/test_swarm_skill.py with test functions that assert the swarm skill names provider-neutral backend choice and includes Composer-class, Grok Build, Cursor/cloud, and future adapter examples.\n2. Verify the test evidence by running pytest tests/content/test_swarm_skill.py -k provider_neutral and confirm the assertions fail on Grok Build-only wording and pass with the updated skill and preamble text.",


### PR DESCRIPTION
## Summary
- Move the #1531 provider-neutral swarm parent epic from active to completed.
- Repoint completed child stories to the completed parent vBRIEF path.

## Test plan
- task vbrief:validate

Made with [Cursor](https://cursor.com)