### PR TITLE
Recommend labels when creating issues

### DIFF
--- a/skills/deft-directive-article-review/SKILL.md
+++ b/skills/deft-directive-article-review/SKILL.md
@@ -125,6 +125,7 @@ Allow the user to comment, change framing, merge suggestions, or remove any. Ite
   - Body that describes the suggestion, the source article, and the specific directive files affected
   - A note if the suggestion is speculative/research-grade vs. immediately actionable
   - A reference to any related open issues ("extends #N", "related to #N")
+  - Issue-label hygiene: inspect existing repo labels with `gh label list` or the labels API, choose suitable existing labels when practical, or explicitly note that no label was applied. This is a recommendation, not a gate -- do not block issue creation solely because no label fits, and do not invent ad hoc labels outside the repo's existing label set.
 - ! After creating issues, print the issue URLs
 - ⊗ Create issues without explicit user confirmation
 

--- a/skills/deft-directive-gh-arch/SKILL.md
+++ b/skills/deft-directive-gh-arch/SKILL.md
@@ -100,6 +100,7 @@ Present designs sequentially, then compare in prose. Give your own recommendatio
 ### Step 6: File the GitHub Issue
 
 - ! Create a refactor RFC immediately using `gh issue create` with the template below
+- ~ Issue-label hygiene: before filing, inspect the target repo's existing labels with `gh label list` or the labels API; choose one or more suitable existing labels when practical, or explicitly note that no label was applied. This is a recommendation, not a gate -- do not block issue creation solely because no label fits, and do not invent ad hoc labels outside the repo's existing label set.
 - ! After creating, print the issue URL
 - ! When the RFC is filed as an umbrella with companion child issues (e.g. an interface-extraction RFC plus one child per migrating caller), record the cohort in `vbrief/.eval/slices.jsonl` via `scripts/slice_record.py::write_slice(...)` with `actor="skill:gh-arch"` -- this is the durable production-side record consumed by `task triage:audit --orphans` (#1132 / D13). Same usage pattern as `skills/deft-directive-gh-slice/SKILL.md` Step 6; idempotent on retry. Skip when the RFC is a single-issue "file and forget" with no child cohort.
 - ! Confirm skill exit: "deft-directive-gh-arch complete — RFC filed at <url>."

--- a/skills/deft-directive-gh-slice/SKILL.md
+++ b/skills/deft-directive-gh-slice/SKILL.md
@@ -95,6 +95,7 @@ Iterate until the user approves the breakdown.
 - ! Create issues in dependency order (blockers first) so you can reference real issue numbers
 - ! Use `gh issue create` for each approved slice with the template below
 - ! Trace each issue back to the relevant SPECIFICATION.md phase/task IDs where applicable
+- ~ Issue-label hygiene: before filing, inspect the target repo's existing labels with `gh label list` or the labels API; choose one or more suitable existing labels when practical, or explicitly note that no label was applied. This is a recommendation, not a gate -- do not block issue creation solely because no label fits, and do not invent ad hoc labels outside the repo's existing label set.
 - ⊗ Modify or close any existing parent issue
 
 **Issue template:**

--- a/skills/deft-directive-refinement/SKILL.md
+++ b/skills/deft-directive-refinement/SKILL.md
@@ -312,6 +312,8 @@ The task scans every vBRIEF with a GitHub-backed reference (whether the referenc
 
 ! When the refinement session files a new umbrella issue (or surfaces one whose current-shape comment is missing), file the umbrella then file its `## Current shape (as of pass-N)` comment per `## Umbrella current-shape convention` in `AGENTS.md` (#1152) -- the edit-in-place comment is the canonical surface every subsequent design pass updates.
 
+~ Issue-label hygiene for any umbrella or child issue this skill files: before creating issues, inspect the target repo's existing labels with `gh label list` or the labels API; choose one or more suitable existing labels when practical, or explicitly note that no label was applied. This is a recommendation, not a gate -- do not block issue creation solely because no label fits, and do not invent ad hoc labels outside the repo's existing label set.
+
 ! When a refinement pass produces a slicing event (rare but possible -- e.g. a design pass on an existing umbrella files N additional Wave-N child issues), record the cohort in `vbrief/.eval/slices.jsonl` via `scripts/slice_record.py::write_slice(...)` with `actor="skill:refinement"` immediately after the children are filed (#1132 / D13). Same call shape as `skills/deft-directive-gh-slice/SKILL.md` Step 6. The cohort record is what makes `task triage:audit --orphans` able to detect Wave-2+ children whose umbrella closes prematurely; without it the production-side drift this surface guards against re-fires. Skip when the pass produced no new child cohort (e.g. a pure re-prioritization).
 
 

--- a/skills/deft-directive-triage/SKILL.md
+++ b/skills/deft-directive-triage/SKILL.md
@@ -50,7 +50,9 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 1. ! Run `task triage:classify --list` (D10 / #1129) to render the effective universal + consumer auto-classification rules and the active hold-marker list.
 2. ! Walk recent entries in `vbrief/.eval/candidates.jsonl` for anomalies: classifier disagreements against the operator's prior decisions, repeated `defer` cycles on the same issue, or `needs-ac` records older than the freshness window. Surface anomalies to the operator before Phase 2; do NOT auto-fix.
 3. ~ When the operator wants to widen / narrow the corpus, consult `task triage:scope --list` (D12 / #1131) to see the active `plan.policy.triageScope[]` subscription. Subscription edits belong in PROJECT-DEFINITION.vbrief.json, not in this skill.
-4. ⊗ Re-classify items already terminally decided (accept / reject / mark-duplicate) without explicit operator approval -- the audit log is append-only and supersession runs through Layer 5 (`task triage:reset <N>`), not through silent re-walks.
+4. ~ Issue-label hygiene: labels feed triage queue ranking, issue gauges, hygiene sweeps, and lifecycle reconciliation. When this skill exposes an unlabeled issue or a downstream issue-creation step, recommend choosing one or more suitable labels from the repository's existing label set via `gh label list` or the labels API, or explicitly note that no label was applied. This is a recommendation, not a gate.
+5. ⊗ Re-classify items already terminally decided (accept / reject / mark-duplicate) without explicit operator approval -- the audit log is append-only and supersession runs through Layer 5 (`task triage:reset <N>`), not through silent re-walks.
+6. ⊗ Do not block issue creation because no label was selected, and do not invent ad hoc labels outside the repository's existing label set.
 
 ## Phase 2 -- Present
 

--- a/tests/content/test_issue_creation_label_guidance.py
+++ b/tests/content/test_issue_creation_label_guidance.py
@@ -1,0 +1,81 @@
+"""Content tests for issue-creation label hygiene guidance (#1510)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_ISSUE_CREATION_SKILLS = (
+    "skills/deft-directive-triage/SKILL.md",
+    "skills/deft-directive-refinement/SKILL.md",
+    "skills/deft-directive-gh-slice/SKILL.md",
+    "skills/deft-directive-gh-arch/SKILL.md",
+    "skills/deft-directive-article-review/SKILL.md",
+)
+
+
+def _read(rel_path: str) -> str:
+    return (_REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_issue_creation_guidance_uses_existing_repo_labels() -> None:
+    """Issue-filing guidance SHOULD use the repository's existing labels."""
+    for rel_path in _ISSUE_CREATION_SKILLS:
+        text = _read(rel_path)
+        assert "gh label list" in text or "labels API" in text, (
+            f"{rel_path}: issue-label guidance must fetch existing labels with "
+            "`gh label list` or the labels API (#1510)"
+        )
+        assert "existing label" in text.lower(), (
+            f"{rel_path}: issue-label guidance must choose from the repository's "
+            "existing label set (#1510)"
+        )
+
+
+def test_issue_creation_guidance_allows_explicit_no_label_note() -> None:
+    """No-label issue creation remains allowed when it is deliberate."""
+    for rel_path in _ISSUE_CREATION_SKILLS:
+        text = _read(rel_path)
+        assert "no label was applied" in text.lower(), (
+            f"{rel_path}: guidance must tell agents to explicitly note when no "
+            "label was applied (#1510)"
+        )
+
+
+def test_issue_creation_guidance_is_recommend_not_mandate() -> None:
+    """Label hygiene is a soft nudge, not an issue-creation gate."""
+    for rel_path in _ISSUE_CREATION_SKILLS:
+        text = _read(rel_path).lower()
+        assert "recommendation, not a gate" in text or "not a gate" in text, (
+            f"{rel_path}: guidance must preserve recommend-not-mandate semantics "
+            "(#1510)"
+        )
+        assert "do not block issue creation" in text, (
+            f"{rel_path}: guidance must not hard-gate issue creation when no "
+            "label fits (#1510)"
+        )
+
+
+def test_issue_creation_guidance_forbids_ad_hoc_labels() -> None:
+    """Agents must not mint one-off labels outside the repo label set."""
+    for rel_path in _ISSUE_CREATION_SKILLS:
+        text = _read(rel_path).lower()
+        assert "do not invent ad hoc labels" in text, (
+            f"{rel_path}: guidance must forbid inventing ad hoc labels (#1510)"
+        )
+
+
+def test_triage_skill_documents_label_hygiene_rationale() -> None:
+    """Triage skill should explain why unlabeled issues matter."""
+    text = _read("skills/deft-directive-triage/SKILL.md").lower()
+    for phrase in (
+        "triage queue ranking",
+        "issue gauges",
+        "hygiene sweeps",
+        "lifecycle reconciliation",
+    ):
+        assert phrase in text, (
+            "skills/deft-directive-triage/SKILL.md: label hygiene rationale "
+            f"must mention {phrase!r} (#1510)"
+        )


### PR DESCRIPTION
## Summary
- Adds advisory issue-label hygiene guidance to issue-creation skills.
- Pins that agents choose from existing repository labels, avoid ad hoc labels, and keep the recommendation non-blocking.

## Issues
Closes #1510

## Test plan
- `uv run pytest tests/content/test_triage_skill.py tests/content/test_change_and_skills.py tests/content/test_issue_creation_label_guidance.py`
- `task check`