### PR TITLE
Keep consumer task check consumer-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=2f9b53fd04f5 refreshed=2026-06-09T19:28:33Z session=1f5c19b0baa3 -->
+<!-- deft:managed-section v3 sha=5143c83948b0 refreshed=2026-06-09T19:51:23Z session=813ab79252bd -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -392,7 +392,8 @@ The `deft-directive-release` skill is intentionally excluded -- it cuts deft fra
 
 Three consumer-facing surfaces enforce the branch-policy contract (#746 / #747):
 
-- `task deft:verify:branch` -- pre-commit gate wired into the `task deft:check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
+- `task deft:check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `task deft:check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
+- `task deft:verify:branch` -- branch gate wired into the `task deft:check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
 - `.githooks/pre-commit` / `pre-push` -- local hooks installed via `task deft:setup`; verify via `task deft:verify:hooks-installed`.
 - `task deft:policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `task deft:policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Consumer `task deft:check` no longer runs framework source self-tests by default (#1519)** -- vendored `.deft/core` installs now route the aggregate check to consumer-safe install and lifecycle gates, while framework source-repo checks remain available behind an explicit self-check target. Closes #1519.
 - **Completed scopes no longer leave PROJECT-DEFINITION registry rows looking proposed (#1527)** -- `task scope:complete` now keeps the matching local project reference and registry item aligned when it moves a scope into `completed/`, and validation catches stale registry status if a referenced scope and its registry row drift apart. Closes #1527.
 - **Deterministic menus now stay portable across host UIs (#1563)** -- numbered decision flows now require visible numeric labels and strict fallback mapping to the displayed number or exact option text, so agents do not reinterpret alphabetic host affordances like `d` or `b` unless those letters were actually shown. Refs #1563.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -299,7 +299,15 @@ tasks:
 
   # Backward-compatible aliases -- project convention is `task check`, `task test`, etc.
   check:
-    desc: "Run all pre-commit checks (skips @pytest.mark.slow tests via pyproject addopts -- run `task check:slow` for the slow lane, #975)"
+    desc: "Run the context-appropriate pre-commit gate: full framework self-check in this repo, consumer-safe gate from vendored installs (#1519)."
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.TASKFILE_DIR}}" run python "{{.TASKFILE_DIR}}/scripts/_project_context.py" --dispatch-task-check --framework-root "{{.TASKFILE_DIR}}" --project-root "{{.USER_WORKING_DIR}}"
+
+  check:framework-source:
+    desc: "Run all framework source-repo pre-commit checks explicitly (skips @pytest.mark.slow tests via pyproject addopts -- run `task check:slow` for the slow lane, #975)."
     deps:
       - core:validate
       - core:lint
@@ -318,6 +326,19 @@ tasks:
       - verify-strategy-output
     cmds:
       - echo "All checks passed"
+
+  check:consumer:
+    desc: "Run the consumer-safe Deft quality gate for vendored installs (#1519)."
+    deps:
+      - doctor
+      - toolchain:check
+      - verify:branch
+      - verify:cache-fresh
+      - verify:wip-cap
+      - vbrief:validate
+      - verify-strategy-output
+    cmds:
+      - echo "Consumer checks passed"
 
   # D4 (#1124): framework self-check wrapper that passes
   # --allow-over-cap so deft's own landing-day overage (pending/+active/

--- a/scripts/_project_context.py
+++ b/scripts/_project_context.py
@@ -30,6 +30,7 @@ Precedence for ``resolve_project_repo``:
 
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import subprocess
@@ -41,9 +42,7 @@ _PROJECT_ROOT_SENTINELS = ("vbrief", ".git")
 
 def _is_project_root(candidate: Path) -> bool:
     """Return True if *candidate* contains any deft project-root sentinel."""
-    return any(
-        (candidate / sentinel).exists() for sentinel in _PROJECT_ROOT_SENTINELS
-    )
+    return any((candidate / sentinel).exists() for sentinel in _PROJECT_ROOT_SENTINELS)
 
 
 def resolve_project_root(
@@ -150,3 +149,59 @@ def _detect_repo_from_git(project_root: Path | None) -> str | None:
     if result.returncode != 0:
         return None
     return _normalise_repo_slug(result.stdout.strip())
+
+
+def is_framework_source_context(framework_root: Path, project_root: Path) -> bool:
+    """Return True when a task is running from the framework checkout itself.
+
+    Vendored consumer installs execute framework tasks from ``.deft/core`` while
+    the user working directory remains the consumer repo.  Equality of the two
+    resolved roots is the stable distinction: only the source checkout should run
+    source-repo self-tests by default.
+    """
+    return framework_root.resolve() == project_root.resolve()
+
+
+def dispatch_task_check(
+    framework_root: Path,
+    project_root: Path,
+    *,
+    runner=subprocess.run,
+) -> int:
+    """Dispatch ``task check`` to the context-appropriate aggregate target."""
+    target = (
+        "check:framework-source"
+        if is_framework_source_context(framework_root, project_root)
+        else "check:consumer"
+    )
+    result = runner(
+        ["task", "-t", str(framework_root / "Taskfile.yml"), target],
+        cwd=str(project_root),
+    )
+    return int(result.returncode)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dispatch-task-check",
+        action="store_true",
+        help="Dispatch the task check aggregate for the current install context.",
+    )
+    parser.add_argument("--framework-root", type=Path)
+    parser.add_argument("--project-root", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.dispatch_task_check:
+        if args.framework_root is None or args.project_root is None:
+            raise SystemExit("--framework-root and --project-root are required")
+        return dispatch_task_check(args.framework_root, args.project_root)
+    _build_parser().print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/_project_context.py
+++ b/scripts/_project_context.py
@@ -156,10 +156,12 @@ def is_framework_source_context(framework_root: Path, project_root: Path) -> boo
 
     Vendored consumer installs execute framework tasks from ``.deft/core`` while
     the user working directory remains the consumer repo.  Equality of the two
-    resolved roots is the stable distinction: only the source checkout should run
-    source-repo self-tests by default.
+    lexical absolute roots is the stable distinction: only the source checkout
+    should run source-repo self-tests by default.  Do not resolve symlinks here:
+    a consumer project may symlink ``.deft/core`` to a local framework checkout
+    and should still run the consumer-safe gate.
     """
-    return framework_root.resolve() == project_root.resolve()
+    return Path(os.path.abspath(framework_root)) == Path(os.path.abspath(project_root))
 
 
 def dispatch_task_check(
@@ -194,12 +196,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = _build_parser().parse_args(argv)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
     if args.dispatch_task_check:
         if args.framework_root is None or args.project_root is None:
             raise SystemExit("--framework-root and --project-root are required")
         return dispatch_task_check(args.framework_root, args.project_root)
-    _build_parser().print_help()
+    parser.print_help()
     return 0
 
 

--- a/templates/agents-entry.md
+++ b/templates/agents-entry.md
@@ -92,7 +92,8 @@ The `deft-directive-release` skill is intentionally excluded -- it cuts deft fra
 
 Three consumer-facing surfaces enforce the branch-policy contract (#746 / #747):
 
-- `task deft:verify:branch` -- pre-commit gate wired into the `task deft:check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
+- `task deft:check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `task deft:check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
+- `task deft:verify:branch` -- branch gate wired into the `task deft:check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
 - `.githooks/pre-commit` / `pre-push` -- local hooks installed via `task deft:setup`; verify via `task deft:verify:hooks-installed`.
 - `task deft:policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `task deft:policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
 

--- a/tests/cli/test_preflight_cache.py
+++ b/tests/cli/test_preflight_cache.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sys
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -1133,6 +1134,15 @@ class TestTaskCheckWiring:
     Taskfile YAML/text to assert the wiring is in place.
     """
 
+    @staticmethod
+    def _task_block(text: str, task_name: str) -> str:
+        start = re.search(rf"^  {re.escape(task_name)}:\n", text, re.MULTILINE)
+        assert start is not None, f"{task_name} task missing"
+        next_task = re.search(r"^  [^\s#][^:\n]*:\n", text[start.end() :], re.MULTILINE)
+        if next_task is None:
+            return text[start.end() :]
+        return text[start.end() : start.end() + next_task.start()]
+
     def test_taskfile_lists_verify_cache_fresh_in_check_deps(self):
         # Normalize CRLF -> LF so the test is platform-agnostic.
         text = (
@@ -1142,12 +1152,9 @@ class TestTaskCheckWiring:
             "verify:cache-fresh missing from Taskfile.yml -- the gate is not "
             "wired into `task check`"
         )
-        # Pin the sibling ordering so the gate runs alongside the existing
-        # verify:* aggregate, not as a standalone target the operator must
-        # opt into.
-        check_block_idx = text.index("check:\n")
-        cmds_idx = text.index("cmds:", check_block_idx)
-        block = text[check_block_idx:cmds_idx]
+        # `task check` dispatches to the framework-source aggregate in this repo;
+        # pin the gate there so it remains part of the pre-commit path.
+        block = self._task_block(text, "check:framework-source")
         assert "verify:branch" in block
         assert "verify:encoding" in block
         assert "verify:cache-fresh" in block

--- a/tests/cli/test_task_scripts.py
+++ b/tests/cli/test_task_scripts.py
@@ -22,9 +22,7 @@ REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 
 # go-task CLI is not installed in CI (GitHub Actions ubuntu-latest)
 _has_task = shutil.which("task") is not None
-requires_task = pytest.mark.skipif(
-    not _has_task, reason="go-task CLI not available"
-)
+requires_task = pytest.mark.skipif(not _has_task, reason="go-task CLI not available")
 
 _has_all_tools = all(shutil.which(t) for t in ("go", "uv", "task", "git", "gh"))
 requires_all_tools = pytest.mark.skipif(
@@ -35,6 +33,7 @@ requires_all_tools = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
 
 def run_script(
     script_name: str, cwd: Path | None = None, env: dict | None = None
@@ -52,10 +51,45 @@ def run_script(
     )
 
 
-
 # ===========================================================================
 # toolchain-check.py
 # ===========================================================================
+
+
+class TestTaskCheckAggregate:
+    """Static contract tests for the context-aware ``task check`` split."""
+
+    TASKFILE = REPO_ROOT / "Taskfile.yml"
+
+    def test_check_target_dispatches_through_project_context(self):
+        body = self.TASKFILE.read_text(encoding="utf-8")
+        assert "check:framework-source:" in body
+        assert "check:consumer:" in body
+        assert "--dispatch-task-check" in body
+
+    def test_consumer_check_does_not_depend_on_framework_self_tests(self):
+        body = self.TASKFILE.read_text(encoding="utf-8")
+        consumer_block = body.split("\n  check:consumer:\n", 1)[1].split(
+            "\n  verify-wip-cap-framework-self-check:",
+            1,
+        )[0]
+        forbidden_deps = (
+            "core:validate",
+            "core:lint",
+            "core:test",
+            "verify:stubs",
+            "verify:links",
+            "verify:rule-ownership",
+            "verify:encoding",
+            "verify:destructive-gh-verbs",
+            "verify:scm-boundary",
+        )
+        for dep in forbidden_deps:
+            assert dep not in consumer_block
+        assert "doctor" in consumer_block
+        assert "verify:branch" in consumer_block
+        assert "vbrief:validate" in consumer_block
+
 
 class TestToolchainCheck:
     """Tests for scripts/toolchain-check.py."""
@@ -95,6 +129,7 @@ class TestToolchainCheck:
 # ===========================================================================
 # verify-stubs.py
 # ===========================================================================
+
 
 class TestVerifyStubs:
     """Tests for scripts/verify-stubs.py."""
@@ -146,9 +181,7 @@ class TestVerifyStubs:
 
     def test_bare_pass_detected(self, tmp_path):
         """Bare 'pass' after a colon-ending line is flagged as a stub."""
-        (tmp_path / "stub_fn.py").write_text(
-            "def placeholder():\n    pass\n", encoding="utf-8"
-        )
+        (tmp_path / "stub_fn.py").write_text("def placeholder():\n    pass\n", encoding="utf-8")
         result = run_script("verify-stubs.py", cwd=tmp_path)
         assert result.returncode == 1
         assert "bare pass" in result.stdout
@@ -157,6 +190,7 @@ class TestVerifyStubs:
 # ===========================================================================
 # validate-links.py
 # ===========================================================================
+
 
 class TestValidateLinks:
     """Tests for scripts/validate-links.py."""
@@ -176,9 +210,7 @@ class TestValidateLinks:
         (tmp_path / "README.md").write_text(
             "See [missing](nonexistent.md) here.\n", encoding="utf-8"
         )
-        result = run_script(
-            "validate-links.py", cwd=tmp_path, env={"LINK_CHECK_STRICT": "1"}
-        )
+        result = run_script("validate-links.py", cwd=tmp_path, env={"LINK_CHECK_STRICT": "1"})
         assert result.returncode == 1
         assert "broken internal link" in result.stdout.lower()
 
@@ -205,19 +237,13 @@ class TestValidateLinks:
         """Files in history/archive/ are excluded from scanning."""
         archive = tmp_path / "history" / "archive"
         archive.mkdir(parents=True)
-        (archive / "old.md").write_text(
-            "See [gone](deleted.md).\n", encoding="utf-8"
-        )
-        result = run_script(
-            "validate-links.py", cwd=tmp_path, env={"LINK_CHECK_STRICT": "1"}
-        )
+        (archive / "old.md").write_text("See [gone](deleted.md).\n", encoding="utf-8")
+        result = run_script("validate-links.py", cwd=tmp_path, env={"LINK_CHECK_STRICT": "1"})
         assert result.returncode == 0
 
     def test_strict_flag_argv(self, tmp_path):
         """--strict flag via argv triggers non-zero exit on broken links."""
-        (tmp_path / "doc.md").write_text(
-            "See [nope](nope.md).\n", encoding="utf-8"
-        )
+        (tmp_path / "doc.md").write_text("See [nope](nope.md).\n", encoding="utf-8")
         script = REPO_ROOT / "scripts" / "validate-links.py"
         result = subprocess.run(
             [sys.executable, str(script), "--strict"],
@@ -233,6 +259,7 @@ class TestValidateLinks:
 # ===========================================================================
 # change:init via task CLI
 # ===========================================================================
+
 
 @requires_task
 class TestChangeInit:
@@ -343,6 +370,7 @@ class TestChangeInit:
 # commit:lint via task CLI
 # ===========================================================================
 
+
 @requires_task
 class TestCommitLint:
     """Tests for tasks/commit.yml commit:lint task."""
@@ -352,17 +380,23 @@ class TestCommitLint:
         subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True, check=True)
         subprocess.run(
             ["git", "config", "user.email", "test@test.com"],
-            cwd=str(tmp_path), capture_output=True, check=True,
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
         )
         subprocess.run(
             ["git", "config", "user.name", "Test"],
-            cwd=str(tmp_path), capture_output=True, check=True,
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
         )
         (tmp_path / "f.txt").write_text("x", encoding="utf-8")
         subprocess.run(["git", "add", "."], cwd=str(tmp_path), capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", message],
-            cwd=str(tmp_path), capture_output=True, check=True,
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
         )
 
     def _run_commit_lint(self, tmp_path: Path) -> subprocess.CompletedProcess:
@@ -403,8 +437,17 @@ class TestCommitLint:
     def test_all_valid_types_accepted(self, tmp_path):
         """All conventional commit types are accepted."""
         valid_types = (
-            "feat", "fix", "docs", "chore", "refactor",
-            "test", "style", "perf", "ci", "build", "revert",
+            "feat",
+            "fix",
+            "docs",
+            "chore",
+            "refactor",
+            "test",
+            "style",
+            "perf",
+            "ci",
+            "build",
+            "revert",
         )
         for ctype in valid_types:
             self._setup_repo(tmp_path, f"{ctype}: valid message")
@@ -417,7 +460,8 @@ class TestCommitLint:
             subprocess.run(["git", "add", "."], cwd=str(tmp_path), capture_output=True)
             subprocess.run(
                 ["git", "commit", "-m", f"{ctype}: valid message"],
-                cwd=str(tmp_path), capture_output=True,
+                cwd=str(tmp_path),
+                capture_output=True,
             )
 
 

--- a/tests/cli/test_task_scripts.py
+++ b/tests/cli/test_task_scripts.py
@@ -11,6 +11,7 @@ Author: Scott Adams (msadams) -- 2026-04-12
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -61,6 +62,15 @@ class TestTaskCheckAggregate:
 
     TASKFILE = REPO_ROOT / "Taskfile.yml"
 
+    @staticmethod
+    def _task_block(body: str, task_name: str) -> str:
+        start = re.search(rf"^  {re.escape(task_name)}:\n", body, re.MULTILINE)
+        assert start is not None, f"{task_name} task missing"
+        next_task = re.search(r"^  [^\s#][^:\n]*:\n", body[start.end() :], re.MULTILINE)
+        if next_task is None:
+            return body[start.end() :]
+        return body[start.end() : start.end() + next_task.start()]
+
     def test_check_target_dispatches_through_project_context(self):
         body = self.TASKFILE.read_text(encoding="utf-8")
         assert "check:framework-source:" in body
@@ -69,10 +79,7 @@ class TestTaskCheckAggregate:
 
     def test_consumer_check_does_not_depend_on_framework_self_tests(self):
         body = self.TASKFILE.read_text(encoding="utf-8")
-        consumer_block = body.split("\n  check:consumer:\n", 1)[1].split(
-            "\n  verify-wip-cap-framework-self-check:",
-            1,
-        )[0]
+        consumer_block = self._task_block(body, "check:consumer")
         forbidden_deps = (
             "core:validate",
             "core:lint",

--- a/tests/integration/test_consumer_tasks.py
+++ b/tests/integration/test_consumer_tasks.py
@@ -52,9 +52,7 @@ def consumer_root(tmp_path: Path) -> Iterator[Path]:
     ``tempfile.TemporaryDirectory`` under the same parent gives each
     integration test its own root that is not vulnerable to that race.
     """
-    with tempfile.TemporaryDirectory(
-        prefix="deft-consumer-", dir=str(tmp_path)
-    ) as td:
+    with tempfile.TemporaryDirectory(prefix="deft-consumer-", dir=str(tmp_path)) as td:
         yield Path(td)
 
 
@@ -147,6 +145,75 @@ def _load_module(name: str, path: Path):
 
 
 # ---------------------------------------------------------------------------
+# task check aggregate (#1519)
+# ---------------------------------------------------------------------------
+
+
+def test_task_check_dispatches_consumer_safe_gate_for_vendored_install(
+    consumer_project: Path,
+) -> None:
+    """Vendored ``.deft/core`` installs route ``task check`` to consumer gates.
+
+    This simulates the installed shape without running the full nested task
+    graph: the regression was the dispatcher choosing framework self-tests from
+    ``.deft/core`` when the actual project root was the consumer repository.
+    """
+    context = _load_module("project_context_dispatch", SCRIPTS_DIR / "_project_context.py")
+    framework_root = consumer_project / ".deft" / "core"
+    framework_root.mkdir(parents=True)
+    (framework_root / "Taskfile.yml").write_text("version: '3'\n", encoding="utf-8")
+    calls: list[dict[str, object]] = []
+
+    def fake_runner(args, cwd=None):
+        calls.append({"args": args, "cwd": cwd})
+        return subprocess.CompletedProcess(args, 0)
+
+    rc = context.dispatch_task_check(
+        framework_root,
+        consumer_project,
+        runner=fake_runner,
+    )
+
+    assert rc == 0
+    assert calls == [
+        {
+            "args": [
+                "task",
+                "-t",
+                str(framework_root / "Taskfile.yml"),
+                "check:consumer",
+            ],
+            "cwd": str(consumer_project),
+        }
+    ]
+
+
+def test_task_check_dispatches_framework_self_check_in_framework_repo() -> None:
+    """The source checkout still runs the full framework self-check by default."""
+    context = _load_module("project_context_dispatch_source", SCRIPTS_DIR / "_project_context.py")
+    calls: list[dict[str, object]] = []
+
+    def fake_runner(args, cwd=None):
+        calls.append({"args": args, "cwd": cwd})
+        return subprocess.CompletedProcess(args, 0)
+
+    rc = context.dispatch_task_check(REPO_ROOT, REPO_ROOT, runner=fake_runner)
+
+    assert rc == 0
+    assert calls == [
+        {
+            "args": [
+                "task",
+                "-t",
+                str(REPO_ROOT / "Taskfile.yml"),
+                "check:framework-source",
+            ],
+            "cwd": str(REPO_ROOT),
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
 # scope:promote (#535)
 # ---------------------------------------------------------------------------
 
@@ -161,9 +228,7 @@ def test_scope_promote_resolves_against_consumer_root(
     ``vbrief/proposed/X.vbrief.json`` resolved to ``deft/vbrief/...``
     and exit 1 with File-not-found (#535).
     """
-    _write_scope_vbrief(
-        consumer_project, "proposed", "2026-04-22-fixture.vbrief.json"
-    )
+    _write_scope_vbrief(consumer_project, "proposed", "2026-04-22-fixture.vbrief.json")
     # Invoke from a completely unrelated CWD so the only way the script
     # can find the file is via --project-root.
     unrelated_cwd = tmp_path / "elsewhere"
@@ -226,9 +291,7 @@ def test_scope_promote_fails_loudly_when_no_project_root(tmp_path: Path) -> None
 # ---------------------------------------------------------------------------
 
 
-def test_issue_ingest_writes_to_consumer_vbrief(
-    consumer_project: Path, monkeypatch
-) -> None:
+def test_issue_ingest_writes_to_consumer_vbrief(consumer_project: Path, monkeypatch) -> None:
     """issue_ingest.main writes into the consumer's vbrief/ tree.
 
     We monkey-patch the gh / git helpers so no live network call happens.
@@ -237,9 +300,7 @@ def test_issue_ingest_writes_to_consumer_vbrief(
     """
     ingest = _load_module("issue_ingest", SCRIPTS_DIR / "issue_ingest.py")
 
-    monkeypatch.setattr(
-        ingest, "resolve_project_repo", lambda *_a, **_k: "owner/consumer"
-    )
+    monkeypatch.setattr(ingest, "resolve_project_repo", lambda *_a, **_k: "owner/consumer")
     monkeypatch.setattr(
         ingest,
         "_fetch_single_issue",
@@ -286,9 +347,7 @@ def test_issue_ingest_fails_loudly_without_repo(
     through to deft's own origin.
     """
     ingest = _load_module("issue_ingest", SCRIPTS_DIR / "issue_ingest.py")
-    monkeypatch.setattr(
-        ingest, "resolve_project_repo", lambda *_a, **_k: None
-    )
+    monkeypatch.setattr(ingest, "resolve_project_repo", lambda *_a, **_k: None)
     monkeypatch.setattr(ingest, "detect_repo", lambda: None)
     rc = ingest.main(
         [
@@ -318,9 +377,7 @@ def test_reconcile_issues_uses_consumer_repo(consumer_project: Path, monkeypatch
     under test (#538) is unchanged: reconcile_issues MUST resolve to the
     consumer repo, not deft's own origin.
     """
-    reconcile = _load_module(
-        "reconcile_issues_smoke", SCRIPTS_DIR / "reconcile_issues.py"
-    )
+    reconcile = _load_module("reconcile_issues_smoke", SCRIPTS_DIR / "reconcile_issues.py")
     seen: dict[str, object] = {}
 
     def fake_fetch(repo, ids, cwd=None):
@@ -344,9 +401,7 @@ def test_reconcile_issues_uses_consumer_repo(consumer_project: Path, monkeypatch
     )
     rc = reconcile.main()
     assert rc == 0
-    assert seen["repo"] == "owner/consumer", (
-        "reconcile_issues must query the CONSUMER repo (#538)"
-    )
+    assert seen["repo"] == "owner/consumer", "reconcile_issues must query the CONSUMER repo (#538)"
     # cwd kwarg must be the consumer project root, not None / deft/ root.
     assert str(seen["cwd"]).endswith("consumer")
 

--- a/tests/integration/test_consumer_tasks.py
+++ b/tests/integration/test_consumer_tasks.py
@@ -188,6 +188,46 @@ def test_task_check_dispatches_consumer_safe_gate_for_vendored_install(
     ]
 
 
+def test_task_check_dispatches_consumer_safe_gate_for_symlinked_core(
+    consumer_project: Path,
+) -> None:
+    """Symlinked ``.deft/core`` installs remain logical consumer installs."""
+    context = _load_module(
+        "project_context_dispatch_symlink",
+        SCRIPTS_DIR / "_project_context.py",
+    )
+    framework_root = consumer_project / ".deft" / "core"
+    framework_root.parent.mkdir(parents=True)
+    try:
+        framework_root.symlink_to(consumer_project, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"directory symlinks unavailable on this platform: {exc}")
+    calls: list[dict[str, object]] = []
+
+    def fake_runner(args, cwd=None):
+        calls.append({"args": args, "cwd": cwd})
+        return subprocess.CompletedProcess(args, 0)
+
+    rc = context.dispatch_task_check(
+        framework_root,
+        consumer_project,
+        runner=fake_runner,
+    )
+
+    assert rc == 0
+    assert calls == [
+        {
+            "args": [
+                "task",
+                "-t",
+                str(framework_root / "Taskfile.yml"),
+                "check:consumer",
+            ],
+            "cwd": str(consumer_project),
+        }
+    ]
+
+
 def test_task_check_dispatches_framework_self_check_in_framework_repo() -> None:
     """The source checkout still runs the full framework self-check by default."""
     context = _load_module("project_context_dispatch_source", SCRIPTS_DIR / "_project_context.py")

--- a/tests/test_wip_cap.py
+++ b/tests/test_wip_cap.py
@@ -591,12 +591,11 @@ def test_taskfile_check_aggregate_wires_verify_wip_cap() -> None:
     CI re-validation) into the `task check` aggregate").
     """
     taskfile = (_REPO_ROOT / "Taskfile.yml").read_text(encoding="utf-8")
-    # Walk forward from the `check:` task header to the first sibling task
-    # (any line that starts with exactly two spaces, a non-space character,
-    # and ends with a colon). The body in between is the `check:` task
-    # block including its deps list.
-    after = taskfile.split("\n  check:\n", 1)[1]
     import re as _re
+
+    # `task check` dispatches to `check:framework-source` in this repo; inspect
+    # that aggregate so the acceptance test follows the context-aware split.
+    after = taskfile.split("\n  check:framework-source:\n", 1)[1]
     next_sibling = _re.search(r"\n  [^\s][^\n]*:\n", after)
     check_block = after[: next_sibling.start()] if next_sibling else after
     assert (


### PR DESCRIPTION
## Summary
- Scopes consumer `task check` so vendored `.deft/core` installs do not run framework source-repo self-tests by default.
- Keeps framework-source behavior intact and updates generated guidance for the consumer check surface.

## Issues
Closes #1519

## Test plan
- `uv run pytest tests/integration/test_consumer_tasks.py tests/cli/test_task_scripts.py tests/cli/test_framework_doctor.py`
- `uv run ruff check scripts/_project_context.py tests/integration/test_consumer_tasks.py tests/cli/test_task_scripts.py`
- Full `task check` attempted; blocked by unrelated Windows pytest temp-directory failure reported by the worker.