### PR TITLE
Ask for swarm backend during interactive setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Interactive swarm setup asks for the intended sub-agent backend before launch (#1568)** -- swarm operators now see a numbered Composer/local, Cursor cloud, or Grok Build choice before headless launch planning when no backend policy is set. The prompt separates operator preference from probe availability, so a probe-available cloud backend is not treated as the default. Closes #1568.
 
 ### Fixed
 

--- a/contracts/deterministic-questions.md
+++ b/contracts/deterministic-questions.md
@@ -22,6 +22,12 @@ Host-native structured question tools are allowed only when they preserve the de
 - ! Agents MUST accept fallback chat replies only when they match the displayed number or the exact displayed option text, after trimming surrounding whitespace and ignoring case for text labels.
 - ⊗ Infer deterministic choices from alphabetic host UI affordances, keyboard shortcuts, or semantic guesses unless those letters were actually displayed as part of the canonical menu labels.
 - ⊗ Treat a bare letter such as `d` or `b` as `Defer`, `Discuss`, or `Back` when the rendered deterministic menu was numbered and did not display those letters as choices.
+## Backend-selection prompts (#1568)
+Backend-selection prompts are deterministic questions. They ask for operator preference and MAY show probe availability as context, but availability is not a default or recommendation.
+- ! A backend-selection prompt MUST render visible numbered options for each stable backend choice before `Discuss` and `Back`.
+- ! The backend options MUST appear before the final two entries, with `Discuss` and `Back` remaining the final two numbered options in that order.
+- ! Probe availability MUST be presented as status beside each backend choice, not as the ordering, recommendation, or default.
+- ⊗ Treat `cursor-cloud` as the implicit default merely because it is probe-available.
 ## Discuss-pause semantic (verbatim)
 Documented here as the single normative source so skill prose, tests, and downstream tooling all read the same words.
 - ! When the user selects `Discuss`, the agent MUST pause IMMEDIATELY.

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -135,7 +135,7 @@ Loop body, per candidate (top-of-queue first):
 
 #### Phase 0d -- Cohort dispatch
 
-- ! After the promote-fill loop exits (cap reached, queue empty, or operator `stop`), `vbrief/pending/` now holds the cohort. The existing Step 0.5 (Lifecycle Bridge -- Promote and Activate Proposed Scope vBRIEFs, #1025) below moves the cohort `pending/ -> active/`, and Steps 1-5 (readiness report, blockers, allocation, present, approval) proceed against the activated set. Existing swarm Phase 1+ (Select, Setup, Launch, Monitor, Review, Close) proceeds unchanged.
+- ! After the promote-fill loop exits (cap reached, queue empty, or operator `stop`), `vbrief/pending/` now holds the cohort. On the interactive path, Phase 0e below captures the intended sub-agent backend before Step 0.5 hardens lifecycle state. Then the existing Step 0.5 (Lifecycle Bridge -- Promote and Activate Proposed Scope vBRIEFs, #1025) moves the cohort `pending/ -> active/`, and Steps 1-5 (readiness report, blockers, allocation, present, approval) proceed against the activated set. Existing swarm Phase 1+ (Select, Setup, Launch, Monitor, Review, Close) proceeds unchanged.
 
 #### Phase 0e -- Interactive sub-agent backend selection (#1568)
 
@@ -158,7 +158,7 @@ Render the backend-selection prompt as a deterministic numbered menu in chat (or
 3. Discuss
 4. Back
 
-! If the operator chooses a backend whose probe status is unavailable, surface the remediation needed for that backend (for example, switch runtime, enable `spawn_subagent`, or inject cloud credentials) and stop before launch planning unless the operator explicitly records a per-run launch-context choice for a later environment where that backend will be available.
+! If the operator chooses a backend whose probe status is unavailable or unknown, surface the remediation or uncertainty for that backend (for example, switch runtime, enable `spawn_subagent`, inject cloud credentials, or rerun the probe in the target environment) and stop before launch planning unless the operator explicitly records a per-run launch-context choice for a later environment where that backend will be available or verifiable.
 
 ⊗ Treat probe availability as operator intent. A single probe-available backend is not a recommendation, default, or consent token; the operator must choose the intended backend in the interactive path when policy is unset.
 

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -151,7 +151,12 @@ Render the backend-selection prompt as a deterministic numbered menu in chat (or
 4. Discuss
 5. Back
 
-! After the operator selects a backend, ask whether to persist it to project policy with `task policy:subagent-backend -- <id>` or record it as a per-run launch-context choice for this swarm only. The persistence/per-run follow-up is also a deterministic numbered menu with `Discuss` and `Back` as the final two options.
+! After the operator selects a backend, ask whether to persist it to project policy with `task policy:subagent-backend -- <id>` or record it as a per-run launch-context choice for this swarm only. Render the persistence/per-run follow-up as a deterministic numbered menu with `Discuss` and `Back` as the final two options:
+
+1. Persist backend to project policy with `task policy:subagent-backend -- <id>` -- use this backend for future swarms.
+2. Record backend as a per-run launch-context choice for this swarm only -- do not change project policy.
+3. Discuss
+4. Back
 
 ! If the operator chooses a backend whose probe status is unavailable, surface the remediation needed for that backend (for example, switch runtime, enable `spawn_subagent`, or inject cloud credentials) and stop before launch planning unless the operator explicitly records a per-run launch-context choice for a later environment where that backend will be available.
 

--- a/skills/deft-directive-swarm/SKILL.md
+++ b/skills/deft-directive-swarm/SKILL.md
@@ -137,6 +137,28 @@ Loop body, per candidate (top-of-queue first):
 
 - ! After the promote-fill loop exits (cap reached, queue empty, or operator `stop`), `vbrief/pending/` now holds the cohort. The existing Step 0.5 (Lifecycle Bridge -- Promote and Activate Proposed Scope vBRIEFs, #1025) below moves the cohort `pending/ -> active/`, and Steps 1-5 (readiness report, blockers, allocation, present, approval) proceed against the activated set. Existing swarm Phase 1+ (Select, Setup, Launch, Monitor, Review, Close) proceeds unchanged.
 
+#### Phase 0e -- Interactive sub-agent backend selection (#1568)
+
+! On the **interactive** swarm path, before Step 0.5 hardens lifecycle state and before any `task swarm:launch` / headless launch-manifest handoff is attempted, run `task policy:subagent-backends` and inspect `plan.policy.swarmSubagentBackend`.
+
+! If `plan.policy.swarmSubagentBackend` is unset, ask the operator which subagent backend they intend to use. This question captures operator preference; probe availability is supporting evidence only. Display all stable backend choices with their probed status, but do NOT rank the menu by availability and do NOT imply `cursor-cloud` is the default just because it is probe-available.
+
+Render the backend-selection prompt as a deterministic numbered menu in chat (or via a host UI that visibly preserves the same numeric option labels and exact displayed option text) with `Discuss` and `Back` final per [`../../contracts/deterministic-questions.md`](../../contracts/deterministic-questions.md):
+
+1. Local Composer/Cursor subagents (`composer`) -- intended local Composer-class coding agents; probe status: `<available|unavailable|unknown>`.
+2. Cursor cloud agents (`cursor-cloud`) -- intended remote/cloud agents; probe status: `<available|unavailable|unknown>`.
+3. Grok Build subagents (`grok-build`) -- intended `spawn_subagent` workers; probe status: `<available|unavailable|unknown>`.
+4. Discuss
+5. Back
+
+! After the operator selects a backend, ask whether to persist it to project policy with `task policy:subagent-backend -- <id>` or record it as a per-run launch-context choice for this swarm only. The persistence/per-run follow-up is also a deterministic numbered menu with `Discuss` and `Back` as the final two options.
+
+! If the operator chooses a backend whose probe status is unavailable, surface the remediation needed for that backend (for example, switch runtime, enable `spawn_subagent`, or inject cloud credentials) and stop before launch planning unless the operator explicitly records a per-run launch-context choice for a later environment where that backend will be available.
+
+⊗ Treat probe availability as operator intent. A single probe-available backend is not a recommendation, default, or consent token; the operator must choose the intended backend in the interactive path when policy is unset.
+
+⊗ Add an interactive prompt to the headless / autonomous `task swarm:launch` path. Autonomous/headless launch remains fail-closed when neither `plan.policy.swarmSubagentBackend` nor an explicit launch-context backend choice is present; `scripts/swarm_launch.py` is the guardrail, not a prompt surface.
+
 #### Manual / GitHub-issue escape hatch
 
 ? When the operator explicitly opts out of the queue (e.g. a one-off ad-hoc cohort that has not been ingested into the triage cache yet, or a swarm batch driven from a hand-supplied list of issue numbers), the monitor MAY fall back to the legacy GitHub-issue path:

--- a/tests/content/test_deterministic_questions.py
+++ b/tests/content/test_deterministic_questions.py
@@ -100,6 +100,17 @@ def test_contract_documents_host_ui_portability_rule():
     assert "bare letter such as `d` or `b`" in text
 
 
+def test_contract_documents_backend_selection_prompt_rule():
+    """Issue #1568 -- backend prompts are deterministic numbered menus."""
+    text = CONTRACT_PATH.read_text(encoding="utf-8")
+    assert "## Backend-selection prompts (#1568)" in text
+    assert "operator preference" in text
+    assert "probe availability" in text
+    assert "visible numbered options" in text
+    assert "`Discuss` and `Back` remaining the final two numbered options" in text
+    assert "Treat `cursor-cloud` as the implicit default" in text
+
+
 def test_host_portable_skills_pin_visible_number_mapping():
     missing = []
     for rel in HOST_PORTABLE_SKILLS:

--- a/tests/content/test_swarm_skill.py
+++ b/tests/content/test_swarm_skill.py
@@ -702,3 +702,86 @@ def test_swarm_anti_patterns_1557_token_present(token: str) -> None:
         f"{_SWARM_PATH}: Anti-Patterns missing #1557 token "
         f"{token!r} -- must forbid sandbox auth regressions"
     )
+
+
+# ---------------------------------------------------------------------------
+# 8. #1568 -- interactive backend selection before launch
+# ---------------------------------------------------------------------------
+
+_PHASE0_BACKEND_HEADER = "#### Phase 0e -- Interactive sub-agent backend selection (#1568)"
+_PHASE0_BACKEND_END = "#### Manual / GitHub-issue escape hatch"
+
+_INTERACTIVE_BACKEND_TOKENS = (
+    "task policy:subagent-backends",
+    "plan.policy.swarmSubagentBackend",
+    "before any `task swarm:launch`",
+    "operator preference",
+    "probe availability is supporting evidence only",
+    "do NOT imply `cursor-cloud` is the default just because it is probe-available",
+    "Local Composer/Cursor subagents (`composer`)",
+    "Cursor cloud agents (`cursor-cloud`)",
+    "Grok Build subagents (`grok-build`)",
+    "task policy:subagent-backend -- <id>",
+    "per-run launch-context choice",
+    "Autonomous/headless launch remains fail-closed",
+    "scripts/swarm_launch.py",
+)
+
+
+def _phase0_backend_block(text: str) -> str:
+    """Return the #1568 interactive backend-selection block."""
+    start = text.find(_PHASE0_BACKEND_HEADER)
+    assert start != -1, (
+        f"{_SWARM_PATH}: missing '{_PHASE0_BACKEND_HEADER}' heading -- "
+        "interactive swarms must ask for backend intent before launch"
+    )
+    end = text.find(_PHASE0_BACKEND_END, start)
+    assert end != -1 and end > start, (
+        f"{_SWARM_PATH}: '{_PHASE0_BACKEND_END}' heading not found after "
+        "the #1568 backend-selection block"
+    )
+    return text[start:end]
+
+
+@pytest.mark.parametrize("token", _INTERACTIVE_BACKEND_TOKENS)
+def test_swarm_phase0_backend_selection_token_present(token: str) -> None:
+    """The interactive path must ask for backend intent before headless launch."""
+    block = _phase0_backend_block(_read_swarm())
+    assert token in block, (
+        f"{_SWARM_PATH}: Phase 0 backend-selection block missing token "
+        f"{token!r} -- see issue #1568 acceptance criteria"
+    )
+
+
+def test_swarm_phase0_backend_menu_uses_visible_numbered_options() -> None:
+    """Backend menu must use visible numbering with Discuss and Back final."""
+    block = _phase0_backend_block(_read_swarm())
+    options = (
+        "1. Local Composer/Cursor subagents (`composer`)",
+        "2. Cursor cloud agents (`cursor-cloud`)",
+        "3. Grok Build subagents (`grok-build`)",
+        "4. Discuss",
+        "5. Back",
+    )
+    positions = [block.find(option) for option in options]
+    assert all(position != -1 for position in positions), (
+        f"{_SWARM_PATH}: backend menu missing one or more visible numbered "
+        f"options; positions={dict(zip(options, positions, strict=True))}"
+    )
+    assert positions == sorted(positions), (
+        f"{_SWARM_PATH}: backend menu options must appear in canonical order; "
+        f"positions={dict(zip(options, positions, strict=True))}"
+    )
+
+
+def test_swarm_phase0_backend_menu_keeps_discuss_back_final() -> None:
+    """Discuss and Back must be the final two backend prompt choices."""
+    block = _phase0_backend_block(_read_swarm())
+    discuss = block.find("4. Discuss")
+    back = block.find("5. Back")
+    assert discuss != -1 and back != -1 and discuss < back, (
+        f"{_SWARM_PATH}: backend-selection menu must end with Discuss then Back"
+    )
+    assert "6." not in block[back:], (
+        f"{_SWARM_PATH}: backend-selection menu must not add options after Back"
+    )

--- a/tests/content/test_swarm_skill.py
+++ b/tests/content/test_swarm_skill.py
@@ -774,6 +774,26 @@ def test_swarm_phase0_backend_menu_uses_visible_numbered_options() -> None:
     )
 
 
+def test_swarm_phase0_backend_followup_menu_uses_visible_numbered_options() -> None:
+    """Persistence follow-up menu must also render explicit numbered choices."""
+    block = _phase0_backend_block(_read_swarm())
+    options = (
+        "1. Persist backend to project policy with `task policy:subagent-backend -- <id>`",
+        "2. Record backend as a per-run launch-context choice for this swarm only",
+        "3. Discuss",
+        "4. Back",
+    )
+    positions = [block.find(option) for option in options]
+    assert all(position != -1 for position in positions), (
+        f"{_SWARM_PATH}: backend follow-up menu missing one or more visible "
+        f"numbered options; positions={dict(zip(options, positions, strict=True))}"
+    )
+    assert positions == sorted(positions), (
+        f"{_SWARM_PATH}: backend follow-up menu options must appear in "
+        f"canonical order; positions={dict(zip(options, positions, strict=True))}"
+    )
+
+
 def test_swarm_phase0_backend_menu_keeps_discuss_back_final() -> None:
     """Discuss and Back must be the final two backend prompt choices."""
     block = _phase0_backend_block(_read_swarm())
@@ -782,6 +802,6 @@ def test_swarm_phase0_backend_menu_keeps_discuss_back_final() -> None:
     assert discuss != -1 and back != -1 and discuss < back, (
         f"{_SWARM_PATH}: backend-selection menu must end with Discuss then Back"
     )
-    assert "6." not in block[back:], (
+    assert "6. " not in block[back:], (
         f"{_SWARM_PATH}: backend-selection menu must not add options after Back"
     )

--- a/tests/content/test_swarm_skill.py
+++ b/tests/content/test_swarm_skill.py
@@ -723,6 +723,8 @@ _INTERACTIVE_BACKEND_TOKENS = (
     "Grok Build subagents (`grok-build`)",
     "task policy:subagent-backend -- <id>",
     "per-run launch-context choice",
+    "unavailable or unknown",
+    "rerun the probe in the target environment",
     "Autonomous/headless launch remains fail-closed",
     "scripts/swarm_launch.py",
 )
@@ -751,6 +753,19 @@ def test_swarm_phase0_backend_selection_token_present(token: str) -> None:
         f"{_SWARM_PATH}: Phase 0 backend-selection block missing token "
         f"{token!r} -- see issue #1568 acceptance criteria"
     )
+
+
+def test_swarm_phase0d_routes_through_backend_selection_before_bridge() -> None:
+    """Phase 0d must hand interactive swarms to Phase 0e before Step 0.5."""
+    text = _read_swarm()
+    phase0d = text.find("#### Phase 0d -- Cohort dispatch")
+    phase0e = text.find(_PHASE0_BACKEND_HEADER)
+    assert phase0d != -1 and phase0e != -1 and phase0d < phase0e, (
+        f"{_SWARM_PATH}: Phase 0d must precede the #1568 backend-selection block"
+    )
+    block = text[phase0d:phase0e]
+    assert "Phase 0e below captures the intended sub-agent backend" in block
+    assert "before Step 0.5 hardens lifecycle state" in block
 
 
 def test_swarm_phase0_backend_menu_uses_visible_numbered_options() -> None:


### PR DESCRIPTION
## Summary
- Adds interactive swarm guidance to ask the operator for their intended subagent backend before headless launch.
- Distinguishes operator preference from probe availability and keeps headless/autonomous launch fail-closed.

## Issues
Closes #1568

## Test plan
- `task vbrief:preflight -- vbrief/active/2026-06-09-1568-swarm-ask-operator-for-subagent-backend-during-interactive-s.vbrief.json`
- `uv run pytest tests/content/test_swarm_skill.py tests/content/test_deterministic_questions.py`
- `task check`
- Prior stacked PR review was clean before base branch deletion; this replacement branch is cherry-picked onto current master.