### PR TITLE
Fix vendored encoding verifier payload exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Vendored encoding checks no longer fail on framework-owned history after upgrade (#1382)** -- consumer installs now omit non-runtime framework history from the packaged payload, and the encoding verifier recognizes its own documented exception files when they live under `.deft/core/`. Consumer-owned mojibake still fails the gate, but packaged Deft artifacts no longer block `task deft:verify:encoding` immediately after upgrade. Closes #1382.
 
 ### Removed
 

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -56,6 +56,15 @@ var tarballExcludedTopLevel = map[string]bool{
 	"node_modules": true,
 }
 
+// tarballExcludedRepoPrefixes are repo-relative content prefixes that should
+// not be deposited into consumer .deft/core payloads. These are source-repo
+// forensic/project-management artifacts, not runtime framework files.
+var tarballExcludedRepoPrefixes = []string{
+	"history/archive",
+	"vbrief/completed",
+	"vbrief/cancelled",
+}
+
 // UpdateOutcome reports what the update path did so main.go can populate the
 // --json diagnostics (payload_layout / strategy) and re-stamp the VERSION
 // manifest with the framework source SHA resolved from the tarball rather than
@@ -505,6 +514,14 @@ func extractCoreTarball(tarballPath, destDir string) (string, error) {
 func tarPathExcluded(parts []string) bool {
 	if len(parts) > 1 && tarballExcludedTopLevel[parts[1]] {
 		return true
+	}
+	if len(parts) > 1 {
+		repoRel := strings.Join(parts[1:], "/")
+		for _, prefix := range tarballExcludedRepoPrefixes {
+			if repoRel == prefix || strings.HasPrefix(repoRel, prefix+"/") {
+				return true
+			}
+		}
 	}
 	for _, seg := range parts[1:] {
 		if seg == ".git" {

--- a/cmd/deft-install/upgrade_test.go
+++ b/cmd/deft-install/upgrade_test.go
@@ -105,10 +105,15 @@ func TestClassifyPayloadLayout(t *testing.T) {
 
 func TestExtractCoreTarball_ExcludesGitAndExtractsTree(t *testing.T) {
 	tarball := makeCoreTarball(t, "deftai-directive-abc1234", map[string]string{
-		"SKILL.md":          "skill body",
-		"scripts/doctor.py": "print('hi')",
-		".git/config":       "[core]",   // must be excluded
-		".github/ci.yml":    "on: push", // must be excluded
+		"SKILL.md":                                              "skill body",
+		"scripts/doctor.py":                                     "print('hi')",
+		"scripts/verify_encoding.py":                            "MOJIBAKE_PATTERNS = {}",
+		"vbrief/schemas/vbrief-core.schema.json":                "{}",
+		"history/archive/2026-03-20/tasks.vbrief.json":          "{}",
+		"vbrief/completed/2026-05-01-798-detect.vbrief.json":    "{}",
+		"vbrief/cancelled/2026-05-01-old-cancelled.vbrief.json": "{}",
+		".git/config":                                           "[core]",   // must be excluded
+		".github/ci.yml":                                        "on: push", // must be excluded
 	})
 	dest := t.TempDir()
 	root, err := extractCoreTarball(tarball, dest)
@@ -124,11 +129,27 @@ func TestExtractCoreTarball_ExcludesGitAndExtractsTree(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, "scripts", "doctor.py")); err != nil {
 		t.Errorf("nested scripts/doctor.py not extracted: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(root, "scripts", "verify_encoding.py")); err != nil {
+		t.Errorf("runtime verifier script not extracted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "vbrief", "schemas", "vbrief-core.schema.json")); err != nil {
+		t.Errorf("runtime vBRIEF schema not extracted: %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(root, ".git")); !os.IsNotExist(err) {
 		t.Errorf(".git was extracted but MUST be excluded (err=%v)", err)
 	}
 	if _, err := os.Stat(filepath.Join(root, ".github")); !os.IsNotExist(err) {
 		t.Errorf(".github was extracted but MUST be excluded (err=%v)", err)
+	}
+	excludedPaths := []string{
+		filepath.Join(root, "history", "archive", "2026-03-20", "tasks.vbrief.json"),
+		filepath.Join(root, "vbrief", "completed", "2026-05-01-798-detect.vbrief.json"),
+		filepath.Join(root, "vbrief", "cancelled", "2026-05-01-old-cancelled.vbrief.json"),
+	}
+	for _, path := range excludedPaths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("%s was extracted but MUST be excluded (err=%v)", path, err)
+		}
 	}
 }
 

--- a/scripts/build_dist.py
+++ b/scripts/build_dist.py
@@ -133,7 +133,7 @@ def _iter_source_files(
     produced archive is reproducible across runs and across platforms
     (the task contract ``test_idempotent_rerun`` depends on this).
 
-    Two pruning paths apply:
+    Three pruning paths apply:
 
     1. Directory pruning -- ``dirnames`` is mutated in place so any
        directory whose basename matches an exclude is skipped along with
@@ -146,12 +146,28 @@ def _iter_source_files(
        this branch the directory-only prune would silently fail to honor
        the documented intent for file-shaped artifacts (Greptile P1
        review on PR #773).
+    3. Path-prefix pruning -- directories and files whose repo-relative POSIX
+       path starts with an entry in ``excluded_prefixes`` are dropped, keeping
+       consumer archives free of source-repo forensic history while preserving
+       runtime siblings such as ``vbrief/schemas/**``.
     """
     entries: list[tuple[Path, str]] = []
     for dirpath, dirnames, filenames in os.walk(root):
         # Mutate dirnames in place to prune the walk -- canonical os.walk
         # idiom. Sort for determinism.
-        dirnames[:] = sorted(d for d in dirnames if d not in excludes)
+        kept_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            if dirname in excludes:
+                continue
+            child = Path(dirpath) / dirname
+            try:
+                child_rel = child.relative_to(root).as_posix()
+            except ValueError:
+                continue
+            if _matches_excluded_prefix(child_rel, excluded_prefixes):
+                continue
+            kept_dirnames.append(dirname)
+        dirnames[:] = kept_dirnames
         for fname in sorted(filenames):
             if fname in excludes:
                 # File-level pruning -- catches single-file artifacts

--- a/scripts/build_dist.py
+++ b/scripts/build_dist.py
@@ -96,6 +96,16 @@ DEFAULT_EXCLUDES: tuple[str, ...] = (
     ".coverage",
 )
 
+# Repo-relative prefixes that should not be shipped in consumer framework
+# payloads. These are project-management / forensic artifacts for this source
+# repository, not runtime framework files. Keep vbrief/schemas/** and other
+# runtime surfaces by pruning only the historical lifecycle folders.
+DEFAULT_EXCLUDED_PATH_PREFIXES: tuple[str, ...] = (
+    "history/archive",
+    "vbrief/completed",
+    "vbrief/cancelled",
+)
+
 EXIT_OK = 0
 EXIT_RUNTIME_ERROR = 1
 EXIT_CONFIG_ERROR = 2
@@ -112,7 +122,9 @@ ARCHIVE_ROOT = "deft"
 
 
 def _iter_source_files(
-    root: Path, excludes: frozenset[str]
+    root: Path,
+    excludes: frozenset[str],
+    excluded_prefixes: tuple[str, ...] = DEFAULT_EXCLUDED_PATH_PREFIXES,
 ) -> list[tuple[Path, str]]:
     """Return a sorted list of ``(absolute_path, archive_relative_posix)``.
 
@@ -153,16 +165,22 @@ def _iter_source_files(
                 # Defensive: os.walk should never yield a path outside
                 # root, but symlinked traversals can in theory.
                 continue
-            entries.append((abs_path, rel.as_posix()))
+            rel_posix = rel.as_posix()
+            if _matches_excluded_prefix(rel_posix, excluded_prefixes):
+                continue
+            entries.append((abs_path, rel_posix))
     return entries
+
+
+def _matches_excluded_prefix(rel_posix: str, prefixes: tuple[str, ...]) -> bool:
+    """Return True when ``rel_posix`` is at or below an excluded path prefix."""
+    return any(rel_posix == prefix or rel_posix.startswith(f"{prefix}/") for prefix in prefixes)
 
 
 # ---- Archive writers --------------------------------------------------------
 
 
-def _write_tar_gz(
-    root: Path, output: Path, entries: list[tuple[Path, str]]
-) -> int:
+def _write_tar_gz(root: Path, output: Path, entries: list[tuple[Path, str]]) -> int:
     """Write a gzipped tar archive of ``entries`` to ``output``.
 
     Each entry is added under the ``ARCHIVE_ROOT`` prefix so extraction
@@ -177,9 +195,7 @@ def _write_tar_gz(
     return count
 
 
-def _write_zip(
-    root: Path, output: Path, entries: list[tuple[Path, str]]
-) -> int:
+def _write_zip(root: Path, output: Path, entries: list[tuple[Path, str]]) -> int:
     """Write a deflate-compressed zip archive of ``entries`` to ``output``."""
     output.parent.mkdir(parents=True, exist_ok=True)
     count = 0
@@ -277,10 +293,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--root",
         type=Path,
         default=None,
-        help=(
-            "Repository root to package (default: parent of the scripts/ "
-            "directory)."
-        ),
+        help=("Repository root to package (default: parent of the scripts/ directory)."),
     )
     parser.add_argument(
         "--exclude-extra",

--- a/scripts/verify_encoding.py
+++ b/scripts/verify_encoding.py
@@ -113,10 +113,20 @@ NO_BOM_EXTENSIONS = frozenset({".md", ".json", ".yml", ".yaml", ".txt"})
 
 #: File extensions to scan by default. Conservative -- excludes binary formats
 #: and source files where the cost/benefit of mojibake detection is lower.
-SCANNABLE_EXTENSIONS = frozenset({
-    ".md", ".json", ".yml", ".yaml", ".txt",
-    ".py", ".sh", ".ps1", ".toml", ".cfg",
-})
+SCANNABLE_EXTENSIONS = frozenset(
+    {
+        ".md",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".txt",
+        ".py",
+        ".sh",
+        ".ps1",
+        ".toml",
+        ".cfg",
+    }
+)
 
 #: Path-glob patterns auto-skipped because the file legitimately contains
 #: mojibake byte sequences as part of its purpose. Each entry is matched
@@ -131,11 +141,25 @@ BUILTIN_ALLOW_LIST: tuple[str, ...] = (
     "vbrief/cancelled/*-798-*.vbrief.json",
     "vbrief/pending/*-798-*.vbrief.json",
     "vbrief/proposed/*-798-*.vbrief.json",
+    ".deft/core/vbrief/active/*-798-*.vbrief.json",
+    ".deft/core/vbrief/completed/*-798-*.vbrief.json",
+    ".deft/core/vbrief/cancelled/*-798-*.vbrief.json",
+    ".deft/core/vbrief/pending/*-798-*.vbrief.json",
+    ".deft/core/vbrief/proposed/*-798-*.vbrief.json",
+    "deft/vbrief/active/*-798-*.vbrief.json",
+    "deft/vbrief/completed/*-798-*.vbrief.json",
+    "deft/vbrief/cancelled/*-798-*.vbrief.json",
+    "deft/vbrief/pending/*-798-*.vbrief.json",
+    "deft/vbrief/proposed/*-798-*.vbrief.json",
     # history/archive/ preserves historical task / vbrief state byte-for-byte.
     # Pre-existing mojibake in archived artifacts (e.g. v0.20 migration residue)
     # is intentionally retained as a forensic record and MUST NOT be rewritten.
     "history/archive/**",
     "history/archive/**/*",
+    ".deft/core/history/archive/**",
+    ".deft/core/history/archive/**/*",
+    "deft/history/archive/**",
+    "deft/history/archive/**/*",
     # Self-skip: this script and its test file are the canonical catalog of
     # the bigrams being detected. Scanning them would flag every entry in
     # MOJIBAKE_PATTERNS as a hit against the file that defines it. The
@@ -143,6 +167,10 @@ BUILTIN_ALLOW_LIST: tuple[str, ...] = (
     # (parametrized over MOJIBAKE_PATTERNS), not by the gate scanning itself.
     "scripts/verify_encoding.py",
     "tests/cli/test_verify_encoding.py",
+    ".deft/core/scripts/verify_encoding.py",
+    ".deft/core/tests/cli/test_verify_encoding.py",
+    "deft/scripts/verify_encoding.py",
+    "deft/tests/cli/test_verify_encoding.py",
 )
 
 #: Markdown inline-code span: single backtick to single backtick on one line,
@@ -157,9 +185,7 @@ _MD_INLINE_CODE = re.compile(r"`[^`\r\n]*`")
 #: ``$`` matches *before* ``\n``, which on CRLF lines leaves the prior ``\r``
 #: needing to be absorbed by the trailing whitespace class). The opening
 #: fence allows a language tag (e.g. ``` ```python ```) before the newline.
-_MD_FENCED_BLOCK = re.compile(
-    r"(?ms)^[ \t]*(```|~~~)[^\n]*\n.*?^[ \t]*\1[ \t\r]*$"
-)
+_MD_FENCED_BLOCK = re.compile(r"(?ms)^[ \t]*(```|~~~)[^\n]*\n.*?^[ \t]*\1[ \t\r]*$")
 
 
 class Finding:
@@ -250,9 +276,7 @@ def _git_tracked_files(project_root: Path) -> list[str]:
         check=False,
     )
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"git ls-files failed (rc={proc.returncode}): {proc.stderr.strip()}"
-        )
+        raise RuntimeError(f"git ls-files failed (rc={proc.returncode}): {proc.stderr.strip()}")
     return [line for line in proc.stdout.splitlines() if line.strip()]
 
 
@@ -289,12 +313,14 @@ def scan_file(rel_path: str, full_path: Path) -> list[Finding]:
         return findings
 
     if suffix in NO_BOM_EXTENSIONS and raw.startswith(UTF8_BOM):
-        findings.append(Finding(
-            rel_path,
-            1,
-            "unexpected UTF-8 BOM",
-            "leading bytes EF BB BF on a format where BOM is non-canonical",
-        ))
+        findings.append(
+            Finding(
+                rel_path,
+                1,
+                "unexpected UTF-8 BOM",
+                "leading bytes EF BB BF on a format where BOM is non-canonical",
+            )
+        )
 
     try:
         text = raw.decode("utf-8", errors="replace")
@@ -328,9 +354,7 @@ def scan_file(rel_path: str, full_path: Path) -> list[Finding]:
         # Pad stripped to original length defensively so a regex edge-case
         # (e.g. trailing newline mismatch) doesn't drop late findings.
         if len(stripped_lines) < len(original_lines):
-            stripped_lines = stripped_lines + [""] * (
-                len(original_lines) - len(stripped_lines)
-            )
+            stripped_lines = stripped_lines + [""] * (len(original_lines) - len(stripped_lines))
         for lineno, (orig, stripped) in enumerate(
             zip(original_lines, stripped_lines, strict=False), 1
         ):
@@ -350,12 +374,14 @@ def _scan_line(
     findings: list[Finding] = []
     ctx = context if context is not None else line
     if REPLACEMENT_CHAR in line:
-        findings.append(Finding(
-            rel_path,
-            lineno,
-            "U+FFFD replacement char",
-            ctx,
-        ))
+        findings.append(
+            Finding(
+                rel_path,
+                lineno,
+                "U+FFFD replacement char",
+                ctx,
+            )
+        )
     for pattern, label in MOJIBAKE_PATTERNS.items():
         if pattern in line:
             findings.append(Finding(rel_path, lineno, label, ctx))
@@ -412,22 +438,31 @@ def evaluate(
     ``capsys`` plumbing or env-var leak.
     """
     if mode not in {"all", "staged"}:
-        return 2, [], (
-            f"❌ verify_encoding: unrecognised mode '{mode}' "
-            "(expected 'all' or 'staged')."
+        return (
+            2,
+            [],
+            (f"❌ verify_encoding: unrecognised mode '{mode}' (expected 'all' or 'staged')."),
         )
 
     try:
         custom_globs = _load_allow_list(allow_list_path)
     except FileNotFoundError as exc:
-        return 2, [], (
-            f"❌ verify_encoding: --allow-list file not found: {exc}\n"
-            "  Recovery: pass an existing path or omit the flag."
+        return (
+            2,
+            [],
+            (
+                f"❌ verify_encoding: --allow-list file not found: {exc}\n"
+                "  Recovery: pass an existing path or omit the flag."
+            ),
         )
     except OSError as exc:
-        return 2, [], (
-            f"❌ verify_encoding: --allow-list unreadable: {exc}\n"
-            "  Recovery: check file permissions."
+        return (
+            2,
+            [],
+            (
+                f"❌ verify_encoding: --allow-list unreadable: {exc}\n"
+                "  Recovery: check file permissions."
+            ),
         )
 
     allow_globs = list(BUILTIN_ALLOW_LIST) + custom_globs
@@ -438,15 +473,23 @@ def evaluate(
         else:
             rel_paths = _git_tracked_files(project_root)
     except FileNotFoundError:
-        return 2, [], (
-            "❌ verify_encoding: 'git' executable not found on PATH.\n"
-            "  Recovery: install git or set DEFT_PYTHON to a python that "
-            "can spawn git."
+        return (
+            2,
+            [],
+            (
+                "❌ verify_encoding: 'git' executable not found on PATH.\n"
+                "  Recovery: install git or set DEFT_PYTHON to a python that "
+                "can spawn git."
+            ),
         )
     except RuntimeError as exc:
-        return 2, [], (
-            f"❌ verify_encoding: git failed -- {exc}\n"
-            "  Recovery: ensure --project-root points at a git working tree."
+        return (
+            2,
+            [],
+            (
+                f"❌ verify_encoding: git failed -- {exc}\n"
+                "  Recovery: ensure --project-root points at a git working tree."
+            ),
         )
 
     candidates = _filter_scannable(rel_paths, project_root, allow_globs)

--- a/tests/cli/test_build_dist.py
+++ b/tests/cli/test_build_dist.py
@@ -87,6 +87,9 @@ def fake_project(tmp_path: Path) -> Path:
             scripts/build_dist.py
             skills/foo/SKILL.md
             tasks/core.yml
+            vbrief/schemas/vbrief-core.schema.json
+            vbrief/completed/old.vbrief.json       <- excluded
+            history/archive/old/tasks.vbrief.json  <- excluded
             .git/HEAD                    <- excluded
             backup/old.md                <- excluded
             node_modules/lib/index.js    <- excluded
@@ -101,11 +104,24 @@ def fake_project(tmp_path: Path) -> Path:
     (root / "scripts").mkdir()
     (root / "scripts" / "build_dist.py").write_text("# stub\n", encoding="utf-8")
     (root / "skills" / "foo").mkdir(parents=True)
-    (root / "skills" / "foo" / "SKILL.md").write_text(
-        "# Test skill\n", encoding="utf-8"
-    )
+    (root / "skills" / "foo" / "SKILL.md").write_text("# Test skill\n", encoding="utf-8")
     (root / "tasks").mkdir()
     (root / "tasks" / "core.yml").write_text("version: '3'\n", encoding="utf-8")
+    (root / "vbrief" / "schemas").mkdir(parents=True)
+    (root / "vbrief" / "schemas" / "vbrief-core.schema.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (root / "vbrief" / "completed").mkdir(parents=True)
+    (root / "vbrief" / "completed" / "old.vbrief.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (root / "history" / "archive" / "old").mkdir(parents=True)
+    (root / "history" / "archive" / "old" / "tasks.vbrief.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
     # Excluded directories with marker files
     (root / ".git").mkdir()
     (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
@@ -212,9 +228,7 @@ class TestOutputPath:
     ids=["linux-tar", "windows-zip", "macos-tar"],
 )
 class TestBuildParity:
-    def test_excluded_paths_absent(
-        self, fake_project: Path, platform_label: str, fmt: str
-    ):
+    def test_excluded_paths_absent(self, fake_project: Path, platform_label: str, fmt: str):
         """The 4 canonical excludes (.git, dist, backup, node_modules) MUST
         be absent from the produced artifact regardless of format."""
         artifact = build_dist.build(fake_project, "0.22.0", fmt)
@@ -226,9 +240,7 @@ class TestBuildParity:
                 f"{[m for m in members if excluded in m.split('/')][:5]}"
             )
 
-    def test_expected_core_paths_present(
-        self, fake_project: Path, platform_label: str, fmt: str
-    ):
+    def test_expected_core_paths_present(self, fake_project: Path, platform_label: str, fmt: str):
         """Expected top-level project content lives under the deft/ prefix."""
         artifact = build_dist.build(fake_project, "0.22.0", fmt)
         members = _list_archive_paths(artifact, fmt)
@@ -237,15 +249,31 @@ class TestBuildParity:
             "deft/scripts/build_dist.py",
             "deft/skills/foo/SKILL.md",
             "deft/tasks/core.yml",
+            "deft/vbrief/schemas/vbrief-core.schema.json",
         ):
             assert expected in members, (
                 f"[{platform_label}-{fmt}] expected member {expected!r} "
                 f"not present. Archive contains: {sorted(members)[:10]} ..."
             )
 
-    def test_artifact_size_below_ceiling(
+    def test_consumer_payload_history_paths_absent(
         self, fake_project: Path, platform_label: str, fmt: str
     ):
+        """Consumer archives omit source-repo history while keeping runtime schema files."""
+        artifact = build_dist.build(fake_project, "0.45.1", fmt)
+        members = _list_archive_paths(artifact, fmt)
+
+        excluded_members = [
+            "deft/history/archive/old/tasks.vbrief.json",
+            "deft/vbrief/completed/old.vbrief.json",
+        ]
+        for excluded in excluded_members:
+            assert excluded not in members, (
+                f"[{platform_label}-{fmt}] non-runtime history leaked into archive: {excluded}"
+            )
+        assert "deft/vbrief/schemas/vbrief-core.schema.json" in members
+
+    def test_artifact_size_below_ceiling(self, fake_project: Path, platform_label: str, fmt: str):
         """Sanity ceiling: artifact MUST stay below 50 MB.
 
         On the synthetic fixture this is overwhelmingly true (a few KB).
@@ -264,9 +292,7 @@ class TestBuildParity:
             f"archive."
         )
 
-    def test_idempotent_rerun(
-        self, fake_project: Path, platform_label: str, fmt: str
-    ):
+    def test_idempotent_rerun(self, fake_project: Path, platform_label: str, fmt: str):
         """Re-running build twice MUST NOT ingest the prior dist/ artifact.
 
         The first run produces an artifact in dist/. The second run, given
@@ -520,9 +546,7 @@ def test_task_build_smoke(tmp_path: Path):
             env=env,
         )
         assert result.returncode == 0, (
-            f"task build exited non-zero:\n"
-            f"stdout=\n{result.stdout}\n"
-            f"stderr=\n{result.stderr}\n"
+            f"task build exited non-zero:\nstdout=\n{result.stdout}\nstderr=\n{result.stderr}\n"
         )
         # On Windows the helper writes a zip; everywhere else a tar.gz. The
         # smoke test accepts whichever is produced for the host so the same
@@ -537,8 +561,7 @@ def test_task_build_smoke(tmp_path: Path):
         # stdout, proving the Python helper actually ran (rather than some
         # legacy tar/Compress-Archive command).
         assert "Created" in result.stdout, (
-            f"task build stdout did not contain Python helper banner; "
-            f"output:\n{result.stdout}"
+            f"task build stdout did not contain Python helper banner; output:\n{result.stdout}"
         )
     finally:
         for stale in (artifact, artifact_zip):

--- a/tests/cli/test_verify_encoding.py
+++ b/tests/cli/test_verify_encoding.py
@@ -167,9 +167,7 @@ def test_bom_flagged_on_no_bom_extensions(ext: str, tmp_path: Path) -> None:
 def test_bom_not_flagged_on_ps1_extension(tmp_path: Path) -> None:
     """PS1 / CSV / BAT files tolerate a BOM; the gate MUST NOT flag those."""
     _init_git_repo(tmp_path)
-    (tmp_path / "script.ps1").write_bytes(
-        b"\xef\xbb\xbfWrite-Host 'hello'\n"
-    )
+    (tmp_path / "script.ps1").write_bytes(b"\xef\xbb\xbfWrite-Host 'hello'\n")
     _git_add(tmp_path, "script.ps1")
     _git_commit(tmp_path)
 
@@ -254,15 +252,15 @@ def test_markdown_mojibake_after_fenced_block_reports_correct_line(
     """
     _init_git_repo(tmp_path)
     (tmp_path / "after_fence.md").write_text(
-        "# Title\n"            # line 1
-        "\n"                   # line 2
-        "```\n"                # line 3 (fence open)
+        "# Title\n"  # line 1
+        "\n"  # line 2
+        "```\n"  # line 3 (fence open)
         "safe content here\n"  # line 4 (inside fence; not scanned)
-        "```\n"                # line 5 (fence close)
-        "\n"                   # line 6
+        "```\n"  # line 5 (fence close)
+        "\n"  # line 6
         "Real corruption \u0393\u00e8\u00f9 here.\n"  # line 7
-        "\n"                   # line 8
-        "Tail.\n",             # line 9
+        "\n"  # line 8
+        "Tail.\n",  # line 9
         encoding="utf-8",
     )
     _git_add(tmp_path, "after_fence.md")
@@ -274,8 +272,7 @@ def test_markdown_mojibake_after_fenced_block_reports_correct_line(
     assert u2297_findings, f"expected U+2297 finding; got {[f.label for f in findings]}"
     hit = u2297_findings[0]
     assert hit.line == 7, (
-        f"fenced-block alignment bug: expected line 7, got {hit.line}. "
-        f"context={hit.context!r}"
+        f"fenced-block alignment bug: expected line 7, got {hit.line}. context={hit.context!r}"
     )
     assert "\u0393\u00e8\u00f9" in hit.context, (
         f"context should be the original bare-mojibake line, not a "
@@ -337,12 +334,71 @@ def test_builtin_allow_list_globs_match_798_brief_pattern() -> None:
     }
     builtin = set(verify_encoding.BUILTIN_ALLOW_LIST)
     missing = expected_brief_globs - builtin
-    assert not missing, (
-        f"BUILTIN_ALLOW_LIST is missing #798 brief globs: {missing}"
+    assert not missing, f"BUILTIN_ALLOW_LIST is missing #798 brief globs: {missing}"
+    assert any(glob.startswith("history/archive/") for glob in builtin), (
+        "BUILTIN_ALLOW_LIST must skip history/archive/** for preserved historical state"
     )
-    assert any(
-        glob.startswith("history/archive/") for glob in builtin
-    ), "BUILTIN_ALLOW_LIST must skip history/archive/** for preserved historical state"
+
+
+def test_builtin_allow_list_covers_vendored_framework_exception_paths(
+    tmp_path: Path,
+) -> None:
+    """Vendored consumer installs track framework files under `.deft/core/**`.
+
+    The same documented exception files that are skipped in the source repo
+    must be skipped under the consumer install prefix too.
+    """
+    _init_git_repo(tmp_path)
+    fixtures = {
+        ".deft/core/scripts/verify_encoding.py": 'MOJIBAKE_PATTERNS = {"Â§": "fixture"}\n',
+        ".deft/core/history/archive/old/tasks.vbrief.json": '{"x": "â€”"}\n',
+        ".deft/core/vbrief/completed/2026-05-01-798-detect-ps-51.vbrief.json": '{"x": "â†’"}\n',
+    }
+    for rel, text in fixtures.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    _git_add(tmp_path, *fixtures)
+    _git_commit(tmp_path)
+
+    code, findings, msg = verify_encoding.evaluate(tmp_path, mode="all")
+    assert code == 0, msg
+    assert findings == []
+
+
+def test_builtin_allow_list_covers_legacy_vendored_framework_exception_paths(
+    tmp_path: Path,
+) -> None:
+    """Legacy `deft/` installs get the same narrow framework exception treatment."""
+    _init_git_repo(tmp_path)
+    rel = "deft/scripts/verify_encoding.py"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('MOJIBAKE_PATTERNS = {"Â§": "fixture"}\n', encoding="utf-8")
+    _git_add(tmp_path, rel)
+    _git_commit(tmp_path)
+
+    code, findings, msg = verify_encoding.evaluate(tmp_path, mode="all")
+    assert code == 0, msg
+    assert findings == []
+
+
+def test_vendored_allow_list_does_not_hide_consumer_owned_corruption(
+    tmp_path: Path,
+) -> None:
+    """Only documented framework exceptions are skipped; app files still fail."""
+    _init_git_repo(tmp_path)
+    vendored = tmp_path / ".deft/core/scripts/verify_encoding.py"
+    vendored.parent.mkdir(parents=True, exist_ok=True)
+    vendored.write_text('MOJIBAKE_PATTERNS = {"Â§": "fixture"}\n', encoding="utf-8")
+    bad = tmp_path / "app.json"
+    bad.write_text('{"x": "Â§"}\n', encoding="utf-8")
+    _git_add(tmp_path, ".deft/core/scripts/verify_encoding.py", "app.json")
+    _git_commit(tmp_path)
+
+    code, findings, msg = verify_encoding.evaluate(tmp_path, mode="all")
+    assert code == 1, msg
+    assert {f.path for f in findings} == {"app.json"}
 
 
 # ---------------------------------------------------------------------------
@@ -389,9 +445,7 @@ def test_staged_mode_clean_when_nothing_staged(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_main_exit_0_on_clean_repo(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_main_exit_0_on_clean_repo(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _init_git_repo(tmp_path)
     (tmp_path / "ok.txt").write_text("hello\n", encoding="utf-8")
     _git_add(tmp_path, "ok.txt")
@@ -401,15 +455,11 @@ def test_main_exit_0_on_clean_repo(
     assert rc == 0
     captured = capsys.readouterr()
     assert (
-        "clean" in captured.out.lower()
-        or captured.out == ""
-        or "verify_encoding" in captured.out
+        "clean" in captured.out.lower() or captured.out == "" or "verify_encoding" in captured.out
     )
 
 
-def test_main_exit_1_on_corruption(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_main_exit_1_on_corruption(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _init_git_repo(tmp_path)
     (tmp_path / "bad.json").write_text(
         '{"x": "\u00c2\u00a7"}\n',
@@ -434,11 +484,15 @@ def test_main_exit_2_on_unreadable_allow_list(
     _git_add(tmp_path, "ok.txt")
     _git_commit(tmp_path)
 
-    rc = verify_encoding.main([
-        "--all",
-        "--project-root", str(tmp_path),
-        "--allow-list", str(tmp_path / "no-such.txt"),
-    ])
+    rc = verify_encoding.main(
+        [
+            "--all",
+            "--project-root",
+            str(tmp_path),
+            "--allow-list",
+            str(tmp_path / "no-such.txt"),
+        ]
+    )
     assert rc == 2
     captured = capsys.readouterr()
     assert "allow-list" in captured.err.lower()
@@ -482,10 +536,16 @@ def test_main_self_reconfigures_stdout_to_utf8_under_cp1252(
     fake_out_buf = io.BytesIO()
     fake_err_buf = io.BytesIO()
     fake_stdout = io.TextIOWrapper(
-        fake_out_buf, encoding="cp1252", errors="strict", write_through=True,
+        fake_out_buf,
+        encoding="cp1252",
+        errors="strict",
+        write_through=True,
     )
     fake_stderr = io.TextIOWrapper(
-        fake_err_buf, encoding="cp1252", errors="strict", write_through=True,
+        fake_err_buf,
+        encoding="cp1252",
+        errors="strict",
+        write_through=True,
     )
     monkeypatch.setattr(sys, "stdout", fake_stdout)
     monkeypatch.setattr(sys, "stderr", fake_stderr)

--- a/vbrief/completed/2026-06-09-1382-v0370-released-framework-tree-fails-verifyencoding-in-consum.vbrief.json
+++ b/vbrief/completed/2026-06-09-1382-v0370-released-framework-tree-fails-verifyencoding-in-consum.vbrief.json
@@ -20,7 +20,7 @@
       {
         "id": "1382-a1",
         "title": "Vendored framework exception paths are allowlisted",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the installer or local archive builder packages the framework for a consumer deposit, when the payload is extracted, then `history/archive/**` and completed vBRIEF history are absent while runtime files such as `scripts/verify_encoding.py` and `vbrief/schemas/**` are preserved.",
           "Traces": "Issue #1382 v0.45.0 reproduction list."
@@ -29,7 +29,7 @@
       {
         "id": "1382-a2",
         "title": "Consumer-owned corruption still fails",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the same consumer repo also tracks a non-framework file containing mojibake or an unexpected BOM, when the encoding verifier runs, then it exits 1 and reports the consumer-owned file.",
           "Traces": "Issue #798 detection invariant."
@@ -38,7 +38,7 @@
       {
         "id": "1382-a3",
         "title": "Regression test covers direct vendored verify command shape",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given tests/cli/test_verify_encoding.py runs, then it pins the `.deft/core/` allow-list behavior so future package-layout changes do not regress #1382.",
           "Traces": "Issue #1382 direct `task deft:verify:encoding` path."

--- a/vbrief/completed/2026-06-09-1382-v0370-released-framework-tree-fails-verifyencoding-in-consum.vbrief.json
+++ b/vbrief/completed/2026-06-09-1382-v0370-released-framework-tree-fails-verifyencoding-in-consum.vbrief.json
@@ -1,0 +1,92 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1382",
+    "updated": "2026-06-09T22:53:00Z"
+  },
+  "plan": {
+    "title": "v0.37.0 released framework tree fails verify:encoding in consumer task check",
+    "status": "completed",
+    "narratives": {
+      "Description": "Consumer repos can still reproduce #1382 after v0.45.0: `task deft:verify:encoding` scans vendored `.deft/core/**` files and flags framework-owned exception files that the verifier already allowlists at repo-root paths. This patch should prune non-runtime historical artifacts from consumer deposits and make the remaining built-in exception contract layout-aware without hiding consumer-owned corruption.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1382",
+      "Overview": "## Summary\n\nAfter applying the v0.37.0 release tree to a consumer project and running the documented upgrade marker path, `DEFT_RELEASE_VERSION=0.37.0 task check` fails `verify:encoding` against files inside `.deft/core`. These are release-tree files, not local consumer edits.\n\n## Observed\n\n`DEFT_RELEASE_VERSION=0.37.0 task verify:encoding` reports 48 hits across 5 files, including:\n\n```\n.deft/core/history/archive/2026-03-20-agent-auto-alignment/tasks.vbrief.json:1 [unexpected UTF-8 BOM]\n.deft/core/history/archive/2026-03-20-agent-auto-alignment/tasks.vbrief.json:82 [U+2014 (—) corrupted via cp1252 read]\n.deft/core/history/archive/2026-03-20-agents-md-onboarding/tasks.vbrief.json:17 [U+2192 (→) corrupted via cp1252 read]\n.deft/core/scripts/verify_encoding.py:25 [U+2019 (’) corrupted via cp1252 read]\n.deft/core/tests/cli/test_verify_encoding.py:189 [U+2297 (⊗) corrupted via cp437 read]\n.deft/core/vbrief/completed/2026-05-01-798-detect-ps-51-non-ascii-round-trip-corruption-in-pre-commit-t.vbrief.json:30 [multiple cp1252 hits]\n```\n\nThe script appears to flag known mojibake pattern literals in `verify_encoding.py` / tests, plus historical framework fixtures and completed vBRIEFs included in the release tree.\n\n## Expected\n\nA released Deft tree should not make consumer `task check` fail immediately after a framework upgrade. Either the release content should be normalized, or `verify:encoding` should exclude/allow documented test fixtures and historical framework artifacts.\n\n## Impact\n\nConsumers upgrading to v0.37.0 cannot get a green `task check` without locally patching Deft internals or maintaining consumer-local allowlists for framework-owned files. That conflicts with upgrade best practices.\n\n## Environment\n\n- Upgrade target: Deft v0.37.0\n- Commands: `DEFT_RELEASE_VERSION=0.37.0 task check`, `DEFT_RELEASE_VERSION=0.37.0 task verify:encoding`\n",
+      "Labels": "bug, Upgrade Blocker",
+      "ImplementationPlan": "1. Update cmd/deft-install/upgrade.go so tarball extraction skips non-runtime framework history and lifecycle artifacts that should not be deposited into consumer `.deft/core/`, especially `history/archive/**` and completed vBRIEF history, while preserving runtime files such as scripts/verify_encoding.py and vbrief/schemas/**.\n2. Update scripts/build_dist.py with matching archive path pruning so local release archives and installer tarball deposits do not drift.\n3. Update scripts/verify_encoding.py so built-in allow-list patterns cover both framework-source paths and vendored consumer paths under `.deft/core/` (and legacy `deft/`) for the remaining shipped verifier self-catalog file.\n4. Keep detection strict for consumer-owned files outside documented framework exceptions; do not broadly skip all `.deft/core/**` content.\n5. Add regression coverage in cmd/deft-install/upgrade_test.go, tests/cli/test_build_dist.py, and tests/cli/test_verify_encoding.py. Run targeted Go/Python tests, then `task check` before PR/release.",
+      "UserStory": "As a consumer upgrading Deft, I want `task deft:verify:encoding` to ignore documented framework-owned exception files inside the vendored payload, so that upgrade verification catches my project corruption instead of failing on packaged framework history.",
+      "Traces": "Issue #1382 latest v0.45.0 statusreport comment; issue #1519 removed vendored tests from consumer check but did not address direct verify:encoding failures; issue #798 built-in allow-list contract; v0.45.1 patch release."
+    },
+    "items": [
+      {
+        "id": "1382-a1",
+        "title": "Vendored framework exception paths are allowlisted",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the installer or local archive builder packages the framework for a consumer deposit, when the payload is extracted, then `history/archive/**` and completed vBRIEF history are absent while runtime files such as `scripts/verify_encoding.py` and `vbrief/schemas/**` are preserved.",
+          "Traces": "Issue #1382 v0.45.0 reproduction list."
+        }
+      },
+      {
+        "id": "1382-a2",
+        "title": "Consumer-owned corruption still fails",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the same consumer repo also tracks a non-framework file containing mojibake or an unexpected BOM, when the encoding verifier runs, then it exits 1 and reports the consumer-owned file.",
+          "Traces": "Issue #798 detection invariant."
+        }
+      },
+      {
+        "id": "1382-a3",
+        "title": "Regression test covers direct vendored verify command shape",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given tests/cli/test_verify_encoding.py runs, then it pins the `.deft/core/` allow-list behavior so future package-layout changes do not regress #1382.",
+          "Traces": "Issue #1382 direct `task deft:verify:encoding` path."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "Upgrade Blocker"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1382",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1382: v0.37.0 released framework tree fails verify:encoding in consumer task check"
+      }
+    ],
+    "id": "1382-vendored-verify-encoding-allowlist",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "cmd/deft-install/upgrade.go",
+          "cmd/deft-install/upgrade_test.go",
+          "scripts/build_dist.py",
+          "scripts/verify_encoding.py",
+          "tests/cli/test_build_dist.py",
+          "tests/cli/test_verify_encoding.py"
+        ],
+        "verify_commands": [
+          "go test ./cmd/deft-install/...",
+          "uv run pytest tests/cli/test_build_dist.py tests/cli/test_verify_encoding.py",
+          "uv run pytest tests/cli/test_verify_encoding.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "vendored `.deft/core/` framework-owned exceptions are ignored while consumer-owned mojibake still fails"
+        ],
+        "depends_on": [],
+        "conflict_group": "verify-encoding",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completedAt": "2026-06-09T23:08:13Z"
+    },
+    "updated": "2026-06-09T23:08:13Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Prune non-runtime framework history from consumer framework payload archives and installer tarball extraction.
- Keep `verify:encoding` strict for consumer-owned files while recognizing documented framework self-exception paths under `.deft/core/` and legacy `deft/`.
- Complete #1382 lifecycle metadata and add focused regression coverage.

## Test plan
- `go test ./cmd/deft-install/...`
- `uv run pytest tests/cli/test_build_dist.py tests/cli/test_verify_encoding.py`
- `uv run ruff check scripts/build_dist.py scripts/verify_encoding.py tests/cli/test_build_dist.py tests/cli/test_verify_encoding.py`
- `task check`