### PR TITLE
fix: namespace triage welcome sibling tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Namespaced consumer triage onboarding now calls the right sibling tasks (#1577)** -- `task deft:triage:welcome -- --onboard` now carries the current Taskfile namespace into the welcome script, so bootstrap, WIP relief, and final summary calls resolve as `deft:*` in consumer includes while the maintainer `task triage:welcome -- --onboard` path remains unchanged. Closes #1577.
 
 ### Removed
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -837,6 +837,15 @@ tasks:
       - task: triage-welcome:welcome
         vars:
           CLI_ARGS: "{{.CLI_ARGS}}"
+          DEFT_TASK_PREFIX:
+            sh: |
+              task_name='{{.TASK}}'
+              suffix='triage:welcome'
+              prefix="${task_name%$suffix}"
+              if [ "$prefix" = "$task_name" ]; then
+                prefix=''
+              fi
+              printf '%s' "$prefix"
 
   triage:smoketest:
     desc: "Run the N6 (#1146) end-to-end smoketest against the hermetic 20-issue fixture; exits 0 on PASS / 1 on first failure. -- task triage:smoketest [-- --verbose] [--keep-tempdir] [--cache-only]"

--- a/scripts/_triage_welcome_cli.py
+++ b/scripts/_triage_welcome_cli.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:  # pragma: no cover -- import-time-only typing alias
 # Default-mode (non-onboard) nudge strings (#1309)
 # ---------------------------------------------------------------------------
 
+#: Environment variable used by Taskfile wrappers to tell the Python CLI which
+#: namespace prefix exposes sibling tasks in the caller's project.
+TASK_PREFIX_ENV_VAR: str = "DEFT_TASK_PREFIX"
+
 #: Default-mode nudge string emitted by :func:`run_default_mode` when the
 #: operator has never run ``task triage:welcome --onboard``. Kept as a
 #: module-level constant so tests can pin the exact byte-shape and so
@@ -217,6 +221,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--task-prefix",
+        default=os.environ.get(TASK_PREFIX_ENV_VAR, ""),
+        help=(
+            "Optional Taskfile namespace prefix for sibling task dispatches "
+            "(for example `deft:` in consumer includes). Defaults to "
+            f"${TASK_PREFIX_ENV_VAR}."
+        ),
+    )
+    parser.add_argument(
         "--skip-bootstrap",
         action="store_true",
         help=(
@@ -266,11 +279,13 @@ def run_cli(argv: list[str] | None, tw_module: Any) -> int:
             project_root,
             run_subprocess=not args.no_subprocess,
             skip_bootstrap=args.skip_bootstrap,
+            task_prefix=args.task_prefix,
         )
     else:
         outcome = tw_module.run_default_mode(
             project_root,
             write_history=not args.no_history,
+            task_prefix=args.task_prefix,
         )
     return outcome.exit_code
 
@@ -355,6 +370,7 @@ def run_default_mode(
     *,
     output_fn: Callable[[str], None] | None = None,
     write_history: bool = True,
+    task_prefix: str | None = None,
 ) -> WelcomeOutcome:
     """Non-interactive default mode for ``task triage:welcome`` (#1309).
 
@@ -381,13 +397,20 @@ def run_default_mode(
     emit_oneliner(project_root, output_fn=out_fn, write_history=write_history)
     state = triage_welcome.detect_prior_state(project_root)
     label, missing = _classify_onboarding(state)
+    onboard_command = triage_welcome.format_task_command(
+        ["triage:welcome", "--onboard"],
+        task_prefix=task_prefix,
+    )
     if label == "first-time":
-        out_fn(FIRST_TIME_NUDGE)
+        out_fn(f"[welcome] First-time? Run `{onboard_command}` to set up triage.")
     elif label == "incomplete":
         # Stable, deterministic ordering for the missing-piece list so
         # tests can pin the byte-shape across runs.
         joined = " + ".join(missing)
-        out_fn(INCOMPLETE_NUDGE_TEMPLATE.format(missing=joined))
+        out_fn(
+            f"[welcome] Onboarding incomplete: {joined}. Run "
+            f"`{onboard_command}` to resume."
+        )
     # ``fully-set-up`` is silent -- the summary line alone is enough.
     outcome.exit_code = 0
     return outcome

--- a/scripts/_triage_welcome_cli.py
+++ b/scripts/_triage_welcome_cli.py
@@ -397,19 +397,24 @@ def run_default_mode(
     emit_oneliner(project_root, output_fn=out_fn, write_history=write_history)
     state = triage_welcome.detect_prior_state(project_root)
     label, missing = _classify_onboarding(state)
+    canonical_onboard_command = triage_welcome.format_task_command(
+        ["triage:welcome", "--onboard"]
+    )
     onboard_command = triage_welcome.format_task_command(
         ["triage:welcome", "--onboard"],
         task_prefix=task_prefix,
     )
     if label == "first-time":
-        out_fn(f"[welcome] First-time? Run `{onboard_command}` to set up triage.")
+        out_fn(FIRST_TIME_NUDGE.replace(canonical_onboard_command, onboard_command))
     elif label == "incomplete":
         # Stable, deterministic ordering for the missing-piece list so
         # tests can pin the byte-shape across runs.
         joined = " + ".join(missing)
         out_fn(
-            f"[welcome] Onboarding incomplete: {joined}. Run "
-            f"`{onboard_command}` to resume."
+            INCOMPLETE_NUDGE_TEMPLATE.format(missing=joined).replace(
+                canonical_onboard_command,
+                onboard_command,
+            )
         )
     # ``fully-set-up`` is silent -- the summary line alone is enough.
     outcome.exit_code = 0

--- a/scripts/triage_welcome.py
+++ b/scripts/triage_welcome.py
@@ -513,9 +513,30 @@ def _days_in_pending(path: Path, now: datetime) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _run_task(args: list[str], *, cwd: Path) -> int:
+def normalize_task_prefix(task_prefix: str | None) -> str:
+    """Normalize an optional Taskfile include prefix (``deft`` -> ``deft:``)."""
+    prefix = (task_prefix or "").strip()
+    if prefix and not prefix.endswith(":"):
+        prefix = f"{prefix}:"
+    return prefix
+
+
+def task_command_args(args: list[str], *, task_prefix: str | None = None) -> list[str]:
+    """Return task argv with *task_prefix* applied to the task name only."""
+    if not args:
+        return []
+    prefix = normalize_task_prefix(task_prefix)
+    return [f"{prefix}{args[0]}", *args[1:]]
+
+
+def format_task_command(args: list[str], *, task_prefix: str | None = None) -> str:
+    """Render an operator-facing ``task ...`` command string."""
+    return " ".join(["task", *task_command_args(args, task_prefix=task_prefix)])
+
+
+def _run_task(args: list[str], *, cwd: Path, task_prefix: str | None = None) -> int:
     """Run ``task <args...>``. Returns exit code; never raises on non-zero."""
-    cmd = ["task", *args]
+    cmd = ["task", *task_command_args(args, task_prefix=task_prefix)]
     try:
         result = subprocess.run(cmd, cwd=str(cwd), check=False)
         return result.returncode
@@ -623,6 +644,7 @@ def run_default_mode(
     output_fn: Callable[[str], None] | None = None,
     write_history: bool = True,
     now: datetime | None = None,
+    task_prefix: str | None = None,
 ) -> WelcomeOutcome:
     """Default-mode session-start surface (#1309) + budgeted nudges (#1419 S6).
 
@@ -637,7 +659,10 @@ def run_default_mode(
     """
     out_fn = output_fn or default_output
     outcome = _cli_run_default_mode(
-        project_root, output_fn=out_fn, write_history=write_history
+        project_root,
+        output_fn=out_fn,
+        write_history=write_history,
+        task_prefix=task_prefix,
     )
     for line in session_start_nudge_lines(project_root, now=now):
         out_fn(line)
@@ -661,7 +686,8 @@ __all__ = (
     "pending_decisions_oneliner", "preview_wip_relief",
     "project_definition_path", "prompt_int", "prompt_menu", "prompt_yes_no",
     "record_tech_debt_acceptance", "resolve_epic_thresholds",
-    "run_default_mode", "run_welcome", "session_start_nudge_lines",
+    "format_task_command", "normalize_task_prefix", "run_default_mode",
+    "run_welcome", "session_start_nudge_lines", "task_command_args",
     "write_triage_scope", "write_wip_cap",
 )
 
@@ -707,6 +733,7 @@ def run_welcome(
     output_fn: Callable[[str], None] | None = None,
     run_subprocess: bool = True,
     skip_bootstrap: bool = False,
+    task_prefix: str | None = None,
 ) -> WelcomeOutcome:
     """Execute the 6-phase ritual. Returns a structured outcome.
 
@@ -729,6 +756,15 @@ def run_welcome(
     in_fn = input_fn or default_input
     out_fn = output_fn or default_output
     outcome = WelcomeOutcome()
+    normalized_task_prefix = normalize_task_prefix(task_prefix)
+
+    def _display_task(args: list[str]) -> str:
+        return format_task_command(args, task_prefix=normalized_task_prefix)
+
+    def _run_welcome_task(args: list[str]) -> int:
+        if normalized_task_prefix:
+            return _run_task(args, cwd=project_root, task_prefix=normalized_task_prefix)
+        return _run_task(args, cwd=project_root)
 
     # ``Back`` overrides the "already set, skip" rule for ONE iteration so
     # the operator can re-answer the question they rewound to. Consumed at
@@ -859,7 +895,7 @@ def run_welcome(
                 out_fn(
                     f"[3/6] Bootstrap audit log already present "
                     f"({audit_rel}, {refreshed.cache_entry_count} raw cache "
-                    "entry/entries); skipping `task triage:bootstrap`."
+                    f"entry/entries); skipping `{_display_task(['triage:bootstrap'])}`."
                 )
                 outcome.bootstrap_action = (
                     BOOTSTRAP_ACTION_SKIPPED_ALREADY_BOOTSTRAPPED
@@ -867,16 +903,17 @@ def run_welcome(
                 _record_skipped(3)
             elif skip_bootstrap:
                 out_fn(
-                    "[3/6] `task triage:bootstrap` explicitly declined "
-                    "via --skip-bootstrap."
+                    f"[3/6] `{_display_task(['triage:bootstrap'])}` "
+                    "explicitly declined via --skip-bootstrap."
                 )
                 out_fn(
                     f"  ! {audit_rel} remains absent; downstream verbs "
-                    "(`task triage:queue`, `task verify:cache-fresh`) "
+                    f"(`{_display_task(['triage:queue'])}`, "
+                    f"`{_display_task(['verify:cache-fresh'])}`) "
                     "will refuse to run."
                 )
                 out_fn(
-                    "  ! Run `task triage:bootstrap` separately when "
+                    f"  ! Run `{_display_task(['triage:bootstrap'])}` separately when "
                     "ready to populate the cache."
                 )
                 append_audit_entry(
@@ -895,12 +932,13 @@ def run_welcome(
                 # Test-mode -- loudly surface the cache gap so dispatchers
                 # don't mistake dry-mode for a populated cache (#1244).
                 out_fn(
-                    "[3/6] `task triage:bootstrap` suppressed by "
+                    f"[3/6] `{_display_task(['triage:bootstrap'])}` suppressed by "
                     "--no-subprocess (test-mode)."
                 )
                 out_fn(
                     f"  ! {audit_rel} remains absent; downstream verbs "
-                    "(`task triage:queue`, `task verify:cache-fresh`) "
+                    f"(`{_display_task(['triage:queue'])}`, "
+                    f"`{_display_task(['verify:cache-fresh'])}`) "
                     "will refuse to run until bootstrap is invoked."
                 )
                 outcome.bootstrap_action = BOOTSTRAP_ACTION_SKIPPED_DRY_MODE
@@ -909,11 +947,11 @@ def run_welcome(
                 # Audit log absent, no decline, subprocess enabled.
                 # Bootstrap is idempotent so re-running over a
                 # partially-populated `.deft-cache/` is safe.
-                out_fn("[3/6] Running `task triage:bootstrap`...")
-                rc = _run_task(["triage:bootstrap"], cwd=project_root)
+                out_fn(f"[3/6] Running `{_display_task(['triage:bootstrap'])}`...")
+                rc = _run_welcome_task(["triage:bootstrap"])
                 if rc != 0:
                     out_fn(
-                        f"  ! `task triage:bootstrap` exited {rc}; "
+                        f"  ! `{_display_task(['triage:bootstrap'])}` exited {rc}; "
                         "see stderr above. Setting outcome.exit_code=2 "
                         "so the dispatcher learns the ritual hit a "
                         "downstream failure (re-run welcome after "
@@ -1017,9 +1055,14 @@ def run_welcome(
             )
             preview = preview_wip_relief(project_root)
             outcome.relief_offered = True
-            cmd_str = (
-                f"task scope:demote -- --batch --older-than-days "
-                f"{preview.older_than_days}"
+            cmd_str = _display_task(
+                [
+                    "scope:demote",
+                    "--",
+                    "--batch",
+                    "--older-than-days",
+                    str(preview.older_than_days),
+                ]
             )
             out_fn("  Planned invocation (dry-run preview):")
             out_fn(f"    {cmd_str}")
@@ -1041,7 +1084,7 @@ def run_welcome(
             if confirm and preview.eligible_count > 0:
                 outcome.relief_confirmed = True
                 if run_subprocess:
-                    rc = _run_task(
+                    rc = _run_welcome_task(
                         [
                             "scope:demote",
                             "--",
@@ -1049,18 +1092,18 @@ def run_welcome(
                             "--older-than-days",
                             str(preview.older_than_days),
                         ],
-                        cwd=project_root,
                     )
                     if rc != 0:
                         out_fn(
-                            f"  ! `task scope:demote` exited {rc}. Setting "
+                            f"  ! `{_display_task(['scope:demote'])}` exited {rc}. Setting "
                             "outcome.exit_code=2 so the dispatcher learns "
                             "the relief hop hit a downstream failure."
                         )
                         outcome.exit_code = 2
                 else:
                     out_fn(
-                        "  [dry-mode] scope:demote subprocess suppressed by caller."
+                        f"  [dry-mode] {_display_task(['scope:demote'])} "
+                        "subprocess suppressed by caller."
                     )
             else:
                 out_fn(
@@ -1074,13 +1117,14 @@ def run_welcome(
         if phase == 6:
             out_fn("[6/6] Final state:")
             if run_subprocess:
-                _run_task(["triage:summary"], cwd=project_root)
+                _run_welcome_task(["triage:summary"])
                 # TODO(#1148 / N8): follow-up to add `_run_task(["policy:show",
                 # "--", "--changed-only"])` here once N3's PR has shipped --
                 # the inspector landed via N8 after N3 merged.
             else:
                 out_fn(
-                    "  [dry-mode] triage:summary subprocess suppressed by caller."
+                    f"  [dry-mode] {_display_task(['triage:summary'])} "
+                    "subprocess suppressed by caller."
                 )
             out_fn(
                 f"  Next: {TRIAGE_SKILL_PATH}  "

--- a/tasks/triage-welcome.yml
+++ b/tasks/triage-welcome.yml
@@ -27,5 +27,6 @@ tasks:
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
+      DEFT_TASK_PREFIX: '{{.DEFT_TASK_PREFIX | default ""}}'
     cmds:
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_welcome.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tests/test_triage_welcome.py
+++ b/tests/test_triage_welcome.py
@@ -17,10 +17,14 @@ hops fire. Suites:
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import sys
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -126,6 +130,190 @@ class _CapturedOutput:
 
     def joined(self) -> str:
         return "\n".join(self.lines)
+
+
+# ---------------------------------------------------------------------------
+# Task namespace prefix helpers (#1577)
+# ---------------------------------------------------------------------------
+
+
+def test_task_command_args_prefixes_task_name_only() -> None:
+    assert triage_welcome.normalize_task_prefix(None) == ""
+    assert triage_welcome.normalize_task_prefix("") == ""
+    assert triage_welcome.normalize_task_prefix("deft") == "deft:"
+    assert triage_welcome.normalize_task_prefix("deft:") == "deft:"
+    assert triage_welcome.task_command_args(
+        ["scope:demote", "--", "--batch"],
+        task_prefix="deft:",
+    ) == ["deft:scope:demote", "--", "--batch"]
+    assert (
+        triage_welcome.format_task_command(
+            ["triage:welcome", "--onboard"],
+            task_prefix="deft",
+        )
+        == "task deft:triage:welcome --onboard"
+    )
+
+
+def test_run_task_uses_prefixed_argv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd: list[str], *, cwd: str, check: bool) -> SimpleNamespace:
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["check"] = check
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(triage_welcome.subprocess, "run", _fake_run)
+    rc = triage_welcome._run_task(
+        ["scope:demote", "--", "--batch"],
+        cwd=tmp_path,
+        task_prefix="deft:",
+    )
+
+    assert rc == 0
+    assert captured == {
+        "cmd": ["task", "deft:scope:demote", "--", "--batch"],
+        "cwd": str(tmp_path),
+        "check": False,
+    }
+
+
+def test_run_default_mode_uses_prefixed_onboard_nudge(tmp_path: Path) -> None:
+    _seed_oneliner_environment(tmp_path)
+    output = _CapturedOutput()
+    outcome = triage_welcome.run_default_mode(
+        tmp_path,
+        output_fn=output,
+        write_history=False,
+        task_prefix="deft:",
+    )
+
+    assert outcome.exit_code == 0
+    assert "task deft:triage:welcome --onboard" in output.joined()
+
+
+def test_cli_task_prefix_flag_threads_to_run_welcome(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_project_definition(
+        tmp_path,
+        triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
+        wip_cap=10,
+    )
+    _seed_candidates_log(tmp_path)
+    captured: dict[str, object] = {}
+    real_run = triage_welcome.run_welcome
+
+    def _spy(*args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(triage_welcome, "run_welcome", _spy)
+    rc = triage_welcome.main(
+        [
+            "--project-root",
+            str(tmp_path),
+            "--onboard",
+            "--no-subprocess",
+            "--task-prefix",
+            "deft",
+        ]
+    )
+
+    assert rc == 0
+    assert captured.get("task_prefix") == "deft"
+
+
+def _write_fake_task_binary(bin_dir: Path, log_path: Path) -> Path:
+    task_path = bin_dir / "task"
+    task_path.write_text(
+        """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+with Path(os.environ["FAKE_TASK_LOG"]).open("a", encoding="utf-8") as handle:
+    handle.write(" ".join(args) + "\\n")
+if args and args[0].endswith("triage:bootstrap"):
+    candidates = Path.cwd() / "vbrief" / ".eval" / "candidates.jsonl"
+    candidates.parent.mkdir(parents=True, exist_ok=True)
+    candidates.touch()
+raise SystemExit(0)
+""",
+        encoding="utf-8",
+    )
+    task_path.chmod(0o755)
+    return task_path
+
+
+@pytest.mark.parametrize(
+    ("namespaced_include", "expected_prefix"),
+    [
+        pytest.param(False, "", id="direct-framework-taskfile"),
+        pytest.param(True, "deft:", id="consumer-namespaced-include"),
+    ],
+)
+def test_taskfile_welcome_dispatches_sibling_tasks_with_current_namespace(
+    tmp_path: Path,
+    namespaced_include: bool,
+    expected_prefix: str,
+) -> None:
+    real_task = shutil.which("task")
+    if real_task is None:
+        pytest.skip("go-task is not installed")
+
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    _seed_project_definition(
+        consumer,
+        triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
+        wip_cap=10,
+    )
+    if namespaced_include:
+        (consumer / "Taskfile.yml").write_text(
+            "version: '3'\n"
+            "includes:\n"
+            "  deft:\n"
+            f"    taskfile: {_REPO_ROOT / 'Taskfile.yml'}\n",
+            encoding="utf-8",
+        )
+        task_args = [real_task, "deft:triage:welcome"]
+    else:
+        task_args = [
+            real_task,
+            "-t",
+            str(_REPO_ROOT / "Taskfile.yml"),
+            "triage:welcome",
+        ]
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "fake-task.log"
+    _write_fake_task_binary(fake_bin, log_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["FAKE_TASK_LOG"] = str(log_path)
+    env["UV_FROZEN"] = "1"
+
+    result = subprocess.run(
+        [*task_args, "--", "--onboard"],
+        cwd=consumer,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert 'Task "triage:' not in combined
+    invocations = log_path.read_text(encoding="utf-8").splitlines()
+    assert f"{expected_prefix}triage:bootstrap" in invocations
+    assert f"{expected_prefix}triage:summary" in invocations
+    assert "triage:bootstrap" not in invocations or expected_prefix == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_triage_welcome.py
+++ b/tests/test_triage_welcome.py
@@ -311,9 +311,17 @@ def test_taskfile_welcome_dispatches_sibling_tasks_with_current_namespace(
     combined = result.stdout + result.stderr
     assert 'Task "triage:' not in combined
     invocations = log_path.read_text(encoding="utf-8").splitlines()
-    assert f"{expected_prefix}triage:bootstrap" in invocations
-    assert f"{expected_prefix}triage:summary" in invocations
-    assert "triage:bootstrap" not in invocations or expected_prefix == ""
+    expected_invocations = {
+        f"{expected_prefix}triage:bootstrap",
+        f"{expected_prefix}triage:summary",
+    }
+    assert expected_invocations <= set(invocations)
+    if expected_prefix:
+        assert "triage:bootstrap" not in invocations
+        assert "triage:summary" not in invocations
+    else:
+        assert "deft:triage:bootstrap" not in invocations
+        assert "deft:triage:summary" not in invocations
 
 
 # ---------------------------------------------------------------------------

--- a/vbrief/completed/2026-06-11-1577-triagewelcome-uses-unprefixed-task-names-and-fails-in-consum.vbrief.json
+++ b/vbrief/completed/2026-06-11-1577-triagewelcome-uses-unprefixed-task-names-and-fails-in-consum.vbrief.json
@@ -1,0 +1,50 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1577"
+  },
+  "plan": {
+    "title": "triage:welcome uses unprefixed task names and fails in consumer Taskfile namespace",
+    "status": "completed",
+    "narratives": {
+      "Description": "triage:welcome uses unprefixed task names and fails in consumer Taskfile namespace",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1577",
+      "Overview": "## Summary\n\n`task triage:welcome -- --onboard` fails in a consumer install when the framework Taskfile is included under a namespace (for example `deft:`). The welcome script shells out to unprefixed task names, but the consumer-visible tasks are namespaced.\n\nObserved in `deftai/cartograph` after upgrading to Deft Directive `v0.44.0`.\n\n## Observed\n\nFrom the consumer repo root, the documented/onboarded command was run via the installed include surface:\n\n```bash\ntask deft:triage:welcome -- --onboard\n```\n\nThe flow reached phase 3, then failed because the Python script invoked an unprefixed task:\n\n```text\n[3/6] Running `task triage:bootstrap`...\ntask: Task \"triage:bootstrap\" does not exist\n  ! `task triage:bootstrap` exited 200; see stderr above.\n```\n\nIt later reached phase 6 and failed similarly:\n\n```text\n[6/6] Final state:\ntask: Task \"triage:summary\" does not exist\ntask: Failed to run task \"deft:triage:welcome\": task: Failed to run task \"deft:triage-welcome:welcome\": exit status 2\n```\n\nIn this consumer layout, the available task names are:\n\n```bash\ntask deft:triage:bootstrap\ntask deft:triage:summary\n```\n\nThe unprefixed names do not exist at the project root.\n\n## Impact\n\nThis is first-run friction for the new session-start/onboarding flow:\n\n- The command partially mutates policy state before failing.\n- The operator is left with an incomplete bootstrap and no final summary.\n- In the Cartograph run, the scope/cap choices had to be corrected manually, then `task deft:triage:bootstrap` and `task deft:triage:summary` had to be run directly.\n\n## Expected\n\n`triage:welcome` should resolve and call sibling tasks correctly from both framework-maintainer and consumer-installed layouts.\n\nPossible fixes:\n\n- In `scripts/triage_welcome.py`, call the currently exposed namespace when running inside a consumer include, e.g. `task deft:triage:bootstrap` / `task deft:triage:summary`.\n- Or avoid shelling out through `task` for sibling phases and call the underlying Python functions/modules directly.\n- Or pass the task namespace into the script from the Taskfile wrapper and use that consistently.\n\n## Acceptance criteria\n\n- In a consumer project where `.deft/core/Taskfile.yml` is included under `deft:`, `task deft:triage:welcome -- --onboard` completes all six phases without `task: Task \"triage:*\" does not exist`.\n- In the Directive maintainer repo, the existing unprefixed `task triage:welcome -- --onboard` behavior continues to work.\n- Tests cover both direct/framework and consumer-namespaced Taskfile layouts.\n- The welcome flow does not partially mutate policy state and then fail solely because a sibling task was addressed through the wrong namespace.\n\n## Related\n\n- #1309 -- welcome/session-start propagation and consumer template work.\n- #1119 -- cache-as-operator-working-set umbrella.",
+      "Labels": "bug, adoption-blocker, triage"
+    },
+    "items": [
+      {
+        "title": "In a consumer project where  is included under ,  completes all six phases without .",
+        "status": "proposed"
+      },
+      {
+        "title": "In the Directive maintainer repo, the existing unprefixed  behavior continues to work.",
+        "status": "proposed"
+      },
+      {
+        "title": "Tests cover both direct/framework and consumer-namespaced Taskfile layouts.",
+        "status": "proposed"
+      },
+      {
+        "title": "The welcome flow does not partially mutate policy state and then fail solely because a sibling task was addressed through the wrong namespace.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "triage"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1577",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1577: triage:welcome uses unprefixed task names and fails in consumer Taskfile namespace"
+      }
+    ],
+    "updated": "2026-06-11T14:24:25Z",
+    "metadata": {
+      "completedAt": "2026-06-11T14:24:25Z"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Carries the current Taskfile namespace into `triage:welcome` so consumer includes under `deft:` resolve sibling tasks through `deft:*`.
- Keeps maintainer `task triage:welcome -- --onboard` behavior unprefixed.
- Adds regression coverage for direct framework and consumer-namespaced Taskfile layouts.

## Related Issues

Closes #1577

## Checklist

- [x] `/deft:change <name>` — N/A: single issue-scoped bugfix with active/completed vBRIEF coverage, explicit user approval, and full `task check`.
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`.
- [x] `ROADMAP.md` — N/A: no ROADMAP entry for #1577; lifecycle coverage is in `vbrief/completed/2026-06-11-1577-triagewelcome-uses-unprefixed-task-names-and-fails-in-consum.vbrief.json`.
- [x] Tests pass locally: `UV_FROZEN=1 task check` collected 7561 selected tests; 7555 passed, 5 skipped, 9 deselected, 1 xfailed.

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed — `gh issue view 1577 --json state --jq .state`. If still open, close manually.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
