### PR TITLE
chore(vbrief): complete branch policy lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Triage WIP counts no longer include the completed branch-policy story (#1559)** -- the stale active vBRIEF for the local branch-protection cleanup has been moved to the completed lifecycle, so session-start triage now reports the framework repo with zero in-scope WIP after the policy work has already landed. Refs #1559.
 
 ### Removed
 

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-06-04T00:03:01Z"
+    "updated": "2026-06-11T21:15:58Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -10514,6 +10514,23 @@
               "type": "x-vbrief/github-issue",
               "title": "Issue #1474: deft:check runs framework self-tests in consumers (always-red gate; 14 failed + 6 errors by construction)",
               "TrustLevel": "external"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-06-08-enforce-deft-local-branch-policy",
+        "title": "Enforce Deft local branch policy",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-06-08-enforce-deft-local-branch-policy.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "urn:deft:user-request:2026-06-08-enforce-local-branch-policy",
+              "type": "x-vbrief/user-request",
+              "title": "User request: flip local Deft branch policy back on during branch work",
+              "TrustLevel": "internal"
             }
           ]
         }

--- a/vbrief/completed/2026-06-08-enforce-deft-local-branch-policy.vbrief.json
+++ b/vbrief/completed/2026-06-08-enforce-deft-local-branch-policy.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "enforce-deft-local-branch-policy",
     "title": "Enforce Deft local branch policy",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Re-enable the Deft local branch-policy gate for the directive framework repository so local hooks and checks no longer permit default-branch commits by project policy. This is a narrow governance change that should be handled independently from the installer and GitHub-body tooling stories.",
       "ImplementationPlan": "Update `vbrief/PROJECT-DEFINITION.vbrief.json` so `plan.policy.allowDirectCommitsToMaster` resolves to `false`. Verify the policy rendering and branch gate behavior through the existing task surfaces without changing unrelated project configuration.",
@@ -52,7 +52,8 @@
         "file_scope_confidence": "high",
         "model_tier": "medium",
         "missing_traces_justification": "User requested re-enabling Deft branch policy during the WSL swarm-readiness session."
-      }
+      },
+      "completedAt": "2026-06-11T21:13:49Z"
     },
     "references": [
       {
@@ -62,6 +63,6 @@
         "TrustLevel": "internal"
       }
     ],
-    "updated": "2026-06-08T19:22:19Z"
+    "updated": "2026-06-11T21:13:49Z"
   }
 }


### PR DESCRIPTION
## Summary
- Move the stale branch-policy vBRIEF from active to completed so triage WIP returns to zero.
- Register the completed lifecycle item in the project definition and add the required changelog note.

## Test plan
- `task verify:story-ready -- --vbrief-path vbrief/active/2026-06-08-enforce-deft-local-branch-policy.vbrief.json`
- `task vbrief:preflight -- vbrief/active/2026-06-08-enforce-deft-local-branch-policy.vbrief.json`
- `task policy:show -- --field=plan.policy.allowDirectCommitsToMaster`
- `task verify:branch`
- `task triage:summary`
- `task check`

Refs #1559.

Made with [Cursor](https://cursor.com)