### PR TITLE
Preserve issue ingest escape text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Issue-ingested vBRIEFs now preserve literal backslash escape text and flag real control characters (#1036)** -- GitHub issue bodies that mention paths like `\vbrief/`, `\task`, or JSON-looking escapes now round-trip through the cache and ingest path as literal Markdown, while decoded upstream control characters surface as warnings and encoding-verifier findings before they silently contaminate vBRIEF narratives. Closes #1036.
 - **Namespaced consumer triage onboarding now calls the right sibling tasks (#1577)** -- `task deft:triage:welcome -- --onboard` now carries the current Taskfile namespace into the welcome script, so bootstrap, WIP relief, and final summary calls resolve as `deft:*` in consumer includes while the maintainer `task triage:welcome -- --onboard` path remains unchanged. Closes #1577.
 - **The directive work queue no longer shows already-finished lifecycle cleanup as active work** -- completed branch-policy and triage/session-ritual scopes now have aligned terminal vBRIEF records, the superseded #1348 planning artifact is cancelled, and the project registry points at the canonical completed records. Refs #1348, #1577.
 

--- a/scripts/issue_ingest.py
+++ b/scripts/issue_ingest.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""
+r"""
 issue_ingest.py -- Ingest GitHub issues into vBRIEF lifecycle folders.
 
 Every post-GA issue would otherwise live only on GitHub and reappear in the
@@ -22,6 +22,11 @@ Exit codes:
     2 -- external error (missing gh, API failure, usage error)
 
 Story: #454 (task issue:ingest).
+
+Issue bodies are opaque upstream Markdown text. Never decode them through
+Python or JSON string-escape semantics after the GitHub JSON payload has been
+parsed; literal substrings such as ``\vbrief``, ``\task``, ``\n``, and
+``\u0041`` must remain literal text in ``plan.narratives.Overview``.
 """
 
 from __future__ import annotations
@@ -171,6 +176,13 @@ _CROSS_REF_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 _CODE_FENCE_RE = re.compile(r"(```|~~~).*?\1", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 
+_CONTROL_CHAR_LABELS: dict[str, str] = {
+    "\b": "U+0008 backspace",
+    "\t": "U+0009 tab",
+    "\v": "U+000B vertical tab",
+    "\f": "U+000C form feed",
+}
+
 
 # --- Helpers ----------------------------------------------------------------
 
@@ -188,6 +200,41 @@ def _strip_code_blocks(body: str) -> str:
     if not body:
         return ""
     return _INLINE_CODE_RE.sub("", _CODE_FENCE_RE.sub("", body))
+
+
+def _has_non_indentation_prefix(text: str, index: int) -> bool:
+    """Return True when a tab at ``index`` follows non-whitespace on its line."""
+    line_start = text.rfind("\n", 0, index) + 1
+    return any(ch not in " \t" for ch in text[line_start:index])
+
+
+def _body_control_character_labels(body: str) -> list[str]:
+    """Return visible labels for unexpected control characters in issue body text."""
+    labels: list[str] = []
+    seen: set[str] = set()
+    for index, char in enumerate(body):
+        if char == "\t" and not _has_non_indentation_prefix(body, index):
+            continue
+        label = _CONTROL_CHAR_LABELS.get(char)
+        if label is None and ord(char) < 32 and char not in {"\n", "\r"}:
+            label = f"U+{ord(char):04X} control character"
+        if label and label not in seen:
+            seen.add(label)
+            labels.append(label)
+    return labels
+
+
+def _warn_body_control_characters(number: int, body: str) -> None:
+    """Surface decoded upstream control characters before writing a vBRIEF."""
+    labels = _body_control_character_labels(body)
+    if not labels:
+        return
+    print(
+        f"Warning: issue #{number} body contains unexpected control characters "
+        f"({', '.join(labels)}); preserving Overview verbatim, but "
+        "verify_encoding will flag the generated vBRIEF narrative.",
+        file=sys.stderr,
+    )
 
 
 def _extract_plan_items(body: str) -> list[dict]:
@@ -521,6 +568,7 @@ def _build_issue_vbrief(
         # structured ``plan.items[]`` + ``plan.references[]`` cross-refs
         # derived from the body, so refinement / triage:queue have more
         # than just an opaque blob to work with.
+        _warn_body_control_characters(number, body_str)
         narratives["Overview"] = body_str
     if label_names:
         narratives["Labels"] = ", ".join(label_names)

--- a/scripts/verify_encoding.py
+++ b/scripts/verify_encoding.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import json
 import re
 import subprocess
 import sys
@@ -110,6 +111,16 @@ UTF8_BOM = b"\xef\xbb\xbf"
 #: File extensions where a leading UTF-8 BOM is non-canonical and should be
 #: flagged. Other extensions (.csv, .ps1, .bat) tolerate or expect a BOM.
 NO_BOM_EXTENSIONS = frozenset({".md", ".json", ".yml", ".yaml", ".txt"})
+
+#: Control characters that must not hide inside decoded vBRIEF narratives.
+#: JSON serializes these as escapes (for example ``\u000b``), so the raw
+#: text scanner below cannot see them until the vBRIEF is parsed.
+VBRIEF_CONTROL_CHAR_LABELS: dict[str, str] = {
+    "\b": "U+0008 backspace in vBRIEF narrative",
+    "\t": "U+0009 tab in vBRIEF narrative",
+    "\v": "U+000B vertical tab in vBRIEF narrative",
+    "\f": "U+000C form feed in vBRIEF narrative",
+}
 
 #: File extensions to scan by default. Conservative -- excludes binary formats
 #: and source files where the cost/benefit of mojibake detection is lower.
@@ -360,6 +371,9 @@ def scan_file(rel_path: str, full_path: Path) -> list[Finding]:
         ):
             findings.extend(_scan_line(rel_path, lineno, stripped, context=orig))
 
+    if _is_vbrief_narrative_control_scope(rel_path):
+        findings.extend(_scan_vbrief_narrative_controls(rel_path, text))
+
     return findings
 
 
@@ -386,6 +400,83 @@ def _scan_line(
         if pattern in line:
             findings.append(Finding(rel_path, lineno, label, ctx))
     return findings
+
+
+def _is_vbrief_narrative_control_scope(rel_path: str) -> bool:
+    """Return True for in-flight vBRIEF files that may receive issue ingest."""
+    if not rel_path.endswith(".vbrief.json"):
+        return False
+    normalized_path = rel_path.replace("\\", "/")
+    normalized = f"/{normalized_path}"
+    return "/vbrief/proposed/" in normalized or "/vbrief/active/" in normalized
+
+
+def _scan_vbrief_narrative_controls(rel_path: str, text: str) -> list[Finding]:
+    """Scan decoded ``plan.narratives`` strings for hidden control chars.
+
+    The general scanner works on raw file text. That catches mojibake and
+    BOMs, but not JSON-escaped controls such as ``"\u000b"`` because the
+    raw bytes are printable. vBRIEF narratives are user-facing Markdown, so
+    decode just that structured surface and flag controls after JSON parsing.
+    """
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, dict):
+        return []
+    plan = data.get("plan")
+    if not isinstance(plan, dict):
+        return []
+    narratives = plan.get("narratives")
+    if not isinstance(narratives, dict):
+        return []
+
+    findings: list[Finding] = []
+    for key, value in narratives.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        key_line = _json_key_line(text, key)
+        for label in _decoded_control_labels(value):
+            findings.append(
+                Finding(
+                    rel_path,
+                    key_line,
+                    label,
+                    f"plan.narratives.{key} contains {label}",
+                )
+            )
+    return findings
+
+
+def _decoded_control_labels(value: str) -> list[str]:
+    """Return unique finding labels for disallowed decoded controls."""
+    labels: list[str] = []
+    seen: set[str] = set()
+    for index, char in enumerate(value):
+        if char == "\t" and not _tab_is_non_indentation(value, index):
+            continue
+        label = VBRIEF_CONTROL_CHAR_LABELS.get(char)
+        if label is None and ord(char) < 32 and char not in {"\n", "\r"}:
+            label = f"U+{ord(char):04X} control character in vBRIEF narrative"
+        if label and label not in seen:
+            seen.add(label)
+            labels.append(label)
+    return labels
+
+
+def _tab_is_non_indentation(value: str, index: int) -> bool:
+    """Treat tabs after prose as suspicious, but allow leading indentation."""
+    line_start = value.rfind("\n", 0, index) + 1
+    return any(ch not in " \t" for ch in value[line_start:index])
+
+
+def _json_key_line(text: str, key: str) -> int:
+    """Best-effort line number for a JSON object key."""
+    match = re.search(rf'"{re.escape(key)}"\s*:', text)
+    if match is None:
+        return 1
+    return text.count("\n", 0, match.start()) + 1
 
 
 def _filter_scannable(

--- a/tests/cli/test_issue_ingest_escape_corruption.py
+++ b/tests/cli/test_issue_ingest_escape_corruption.py
@@ -1,0 +1,109 @@
+"""Regression coverage for issue ingest escape preservation (#1036).
+
+Synthetic GitHub issue bodies that contain literal JSON-escape-looking text
+must stay opaque through cache read/write and vBRIEF construction. Bodies that
+already contain decoded control characters should be preserved, but made
+visible before they silently land in ``plan.narratives.Overview``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cache = _load_module("cache_for_escape_corruption_test", SCRIPTS_DIR / "cache.py")
+issue_ingest = _load_module(
+    "issue_ingest_escape_corruption_test",
+    SCRIPTS_DIR / "issue_ingest.py",
+)
+
+
+def _issue_payload(number: int, body: str) -> dict:
+    return {
+        "number": number,
+        "title": "Escape preservation",
+        "body": body,
+        "url": f"https://github.com/deftai/directive/issues/{number}",
+        "labels": [{"name": "bug"}],
+    }
+
+
+def test_cache_and_ingest_preserve_literal_escape_looking_body(
+    tmp_path: Path,
+) -> None:
+    body = (
+        "Literal paths stay literal: \\vbrief/proposed/ and \\task.\n"
+        "Literal escape-looking sequences stay literal too: "
+        "\\n \\r \\b \\f \\\\ \\\" \\u0041."
+    )
+    assert issue_ingest._body_control_character_labels(body) == []
+
+    cache.cache_put(
+        "github-issue",
+        "deftai/directive/1036",
+        _issue_payload(1036, body),
+        cache_root=tmp_path,
+    )
+
+    cached_issue = issue_ingest._fetch_from_cache(
+        "deftai/directive",
+        1036,
+        cache_root=tmp_path,
+    )
+    assert cached_issue is not None
+    assert cached_issue["body"] == body
+
+    vbrief, _folder = issue_ingest._build_issue_vbrief(
+        cached_issue,
+        "proposed",
+        "https://github.com/deftai/directive",
+    )
+    overview = vbrief["plan"]["narratives"]["Overview"]
+    assert overview == body
+    assert "\\vbrief/proposed/" in overview
+    assert "\\task" in overview
+    assert "\\n" in overview
+    assert "\\u0041" in overview
+    assert "\v" not in overview
+    assert "\t" not in overview
+
+    raw_path = tmp_path / "github-issue" / "deftai" / "directive" / "1036" / "raw.json"
+    raw_on_disk = json.loads(raw_path.read_text(encoding="utf-8"))
+    assert raw_on_disk["body"] == body
+
+
+def test_ingest_warns_when_upstream_body_already_has_control_chars(
+    capsys,
+) -> None:
+    body = "Already corrupted: \vbrief and \task plus \bbackspace and \fform."
+
+    vbrief, _folder = issue_ingest._build_issue_vbrief(
+        _issue_payload(1037, body),
+        "proposed",
+        "https://github.com/deftai/directive",
+    )
+
+    assert vbrief["plan"]["narratives"]["Overview"] == body
+    err = capsys.readouterr().err
+    assert "unexpected control characters" in err
+    assert "U+000B vertical tab" in err
+    assert "U+0009 tab" in err
+    assert "U+0008 backspace" in err
+    assert "U+000C form feed" in err

--- a/tests/cli/test_verify_encoding.py
+++ b/tests/cli/test_verify_encoding.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -140,6 +141,44 @@ def test_replacement_char_u_fffd_is_detected(tmp_path: Path) -> None:
     code, findings, msg = verify_encoding.evaluate(tmp_path, mode="all")
     assert code == 1
     assert any(f.label == "U+FFFD replacement char" for f in findings)
+
+
+def test_vbrief_narrative_control_characters_are_detected_after_json_decode(
+    tmp_path: Path,
+) -> None:
+    """#1036: JSON-escaped controls in vBRIEF narratives must not hide."""
+    _init_git_repo(tmp_path)
+    target = tmp_path / "vbrief" / "proposed" / "2026-06-12-1036-corrupt.vbrief.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "vBRIEFInfo": {"version": "0.6"},
+                "plan": {
+                    "title": "Corrupt overview",
+                    "status": "proposed",
+                    "narratives": {
+                        "Overview": "Bad decoded controls: \vbrief and \task.",
+                    },
+                    "items": [],
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    _git_add(tmp_path, "vbrief/proposed/2026-06-12-1036-corrupt.vbrief.json")
+    _git_commit(tmp_path)
+
+    code, findings, msg = verify_encoding.evaluate(tmp_path, mode="all")
+
+    assert code == 1, msg
+    labels = {f.label for f in findings}
+    assert "U+000B vertical tab in vBRIEF narrative" in labels
+    assert "U+0009 tab in vBRIEF narrative" in labels
+    assert {f.path for f in findings} == {
+        "vbrief/proposed/2026-06-12-1036-corrupt.vbrief.json"
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -244,6 +244,25 @@ class TestCachePut:
         meta = json.loads((edir / "meta.json").read_text(encoding="utf-8"))
         cache.validate_meta(meta)
 
+    def test_raw_json_preserves_literal_escape_looking_body(self, tmp_path: Path) -> None:
+        """#1036: cache serialization must not string-unescape issue body text."""
+        body = (
+            "Literal text: \\vbrief \\task \\n \\r \\b \\f \\\\ \\\" \\u0041."
+        )
+        result = cache.cache_put(
+            "github-issue",
+            "deftai/directive/1036",
+            _good_raw(number=1036, body=body),
+            cache_root=tmp_path,
+        )
+
+        raw_on_disk = json.loads(
+            (result.entry_dir / "raw.json").read_text(encoding="utf-8")
+        )
+        assert raw_on_disk["body"] == body
+        assert "\v" not in raw_on_disk["body"]
+        assert "\t" not in raw_on_disk["body"]
+
     def test_hard_fail_skips_content_md(self, tmp_path: Path) -> None:
         body_with_secret = f"oops: AKIA{'A' * 16}"
         result = cache.cache_put(

--- a/vbrief/completed/2026-06-12-1036-scriptsissue-ingestpy-cache-chain-corrupts-vbrief-overview-w.vbrief.json
+++ b/vbrief/completed/2026-06-12-1036-scriptsissue-ingestpy-cache-chain-corrupts-vbrief-overview-w.vbrief.json
@@ -1,0 +1,87 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1036"
+  },
+  "plan": {
+    "id": "1036-issue-ingest-escape-preservation",
+    "title": "Guard issue ingest/cache against escape-sequence and control-character corruption",
+    "status": "completed",
+    "narratives": {
+      "Description": "Issue ingest should preserve clean upstream issue bodies that contain literal JSON-escape-looking substrings such as `\\vbrief`, `\\task`, `\\n`, and `\\u0041`. It should also make unexpected control characters in upstream bodies visible before they silently become corrupted vBRIEF narratives.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1036",
+      "ImplementationPlan": "Add focused regression coverage around `scripts/cache.py::cache_put`, `scripts/issue_ingest.py::_fetch_issue`, and `scripts/issue_ingest.py::_build_issue_vbrief` using synthetic issue bodies with literal backslash escape sequences. Add verification evidence for upstream bodies that already contain control characters, either by extending narrative/control-character scanning or by documenting and testing the warning path that prevents silent corruption.",
+      "UserStory": "As a Deft operator ingesting GitHub issues, I want issue bodies to preserve literal escape-looking text and flag real control characters, so that generated vBRIEFs remain readable and trustworthy.",
+      "Traces": "Issue #1036; live probe showed clean synthetic cache/ingest input is preserved today, while historical issue #1025 now contains control characters in the live GitHub API body.",
+      "Overview": "## Symptom\r\n\r\n`task issue:ingest` (and the downstream `task triage:accept` path that delegates to `scripts/issue_ingest.py::ingest_single_for_accept`) produces scope vBRIEFs whose `plan.narratives.Overview` contains corrupted bytes when the upstream GitHub issue body carries literal backslash-letter substrings that happen to be valid JSON escape sequences.\r\n\r\nThe two confirmed corruption patterns observed in the wild:\r\n\r\n- `\\vbrief/` → `<U+000B>brief/` (the `\\v` becomes a vertical-tab control char)\r\n- `\\task` → `<U+0009>ask` (the `\\t` becomes a tab control char)\r\n\r\nOther JSON escapes in the same class (`\\b`, `\\f`, `\\n`, `\\r`, `\\\\`, `\\\"`, `\\uXXXX`) are likely affected the same way. `\\u` in particular would silently drop the leading backslash plus four hex chars and substitute the codepoint.\r\n\r\n## Reproduction\r\n\r\nLive evidence (2026-05-11, deftai/directive):\r\n\r\n1. **Upstream issue #1025** body contains paragraphs like:\r\n   ```\r\n   The deft setup skill (deft-directive-setup) deposits scope vBRIEFs in\r\n   \\vbrief/proposed/ after Phase 3. The swarm skill (deft-directive-swarm)\r\n   Phase 0 Step 1 expects vBRIEFs in `\\vbrief/active/`.\r\n   ```\r\n   (the literal `\\vbrief/` and `\\task` substrings come from the issue author's habit of escaping backticks for the dollar-sign-and-other-special-chars markdown shell rendering).\r\n\r\n2. **Accept the issue via the canonical path:**\r\n   ```pwsh\r\n   uv run python scripts/triage_actions.py accept --issue 1025 --repo deftai/directive\r\n   ```\r\n\r\n3. **Read the produced vBRIEF Overview:**\r\n   ```pwsh\r\n   $j = Get-Content vbrief/proposed/2026-05-11-1025-*.vbrief.json -Raw -Encoding UTF8 | ConvertFrom-Json\r\n   $j.plan.narratives.Overview\r\n   ```\r\n\r\n   Result: `\\vbrief/` appears as `<VT>brief/` (U+000B), `\\task` appears as `<TAB>ask` — the body is corrupted at write time, not at read time. The raw JSON file on disk literally contains the control characters.\r\n\r\n4. **Greptile flagged this on PR #1034** (the surfacing event) with confidence 3/5 and a P1-class finding. The corrupted vBRIEF is unreadable as a downstream artifact -- the swarm-dispatch contract documented at `skills/deft-directive-swarm/SKILL.md` Phase 0 Step 0B requires `plan.narratives.Overview` to be the verbatim issue body; corruption silently breaks that contract.\r\n\r\n## Root cause hypothesis\r\n\r\nSomewhere along the `gh api repos/.../issues/<N>` → `scripts/cache.py::cache_put` → raw.json → `scripts/issue_ingest.py::_fetch_from_cache` → `plan.narratives.Overview` chain, the issue body is being parsed as a JSON string (which interprets `\\v` / `\\t` / `\\u....` escape sequences) instead of being kept opaque.\r\n\r\nMost likely candidate: `_fetch_from_cache` reads `raw.json` via `json.loads` (correct -- this decodes the JSON-string escapes back to their character values), but then the value is treated as already-decoded markdown when it should be treated as opaque source-text-that-happens-to-contain-backslashes.\r\n\r\nThe `gh api` output is itself JSON, and the GitHub REST `body` field SHOULD escape `\\v` to `\\\\v` in the JSON serialization. If GitHub is emitting `body: \"...\\\\vbrief/...\"` (correctly escaped), and `cache_put` writes raw.json by re-serializing the parsed dict via `json.dumps(..., ensure_ascii=False)`, then the round-trip should preserve `\\\\vbrief/` in raw.json as `\"\\\\vbrief/\"`. When `issue_ingest` re-reads via `json.loads`, the unescape produces `\\vbrief/` (a literal backslash followed by `vbrief/`) which is correct.\r\n\r\nIf the chain instead writes raw.json by passing the gh stdout bytes through some intermediate path that double-decodes -- e.g. `json.loads(gh_stdout)[\"body\"]` then re-encoding without `ensure_ascii=False`, or any path that interprets the body string as a Python format string -- the second decode flips `\\\\v` → `\\v` (a vertical tab in Python string semantics, which is U+000B). That's the observed corruption shape.\r\n\r\nCross-references: the recurrence pattern matches the same \"double-encoding/decoding\" class as the #798 PS 5.1 chain (different surface: that one was OS-codepage-driven, this one is Python-string-escape-driven).\r\n\r\n## Recommended remediation paths\r\n\r\n1. **Audit the body-extraction path** end-to-end: `gh api` → `cache.cache_put` (raw.json write) → `cache.cache_get` (raw.json read) → `issue_ingest._fetch_from_cache` (Overview extraction). Add a regression test that round-trips a synthetic issue body containing `\\v`, `\\t`, `\\n`, `\\r`, `\\b`, `\\f`, `\\\\`, `\\\"`, `\\uXXXX` through the full chain and asserts the resulting `plan.narratives.Overview` contains the literal bytes verbatim (no control-char substitution).\r\n\r\n2. **Add a `verify_encoding` gate hook** for ingested vBRIEFs: extend `scripts/verify_encoding.py` (#798) to scan `vbrief/proposed/` and `vbrief/active/` files for U+000B / U+0008 / U+000C / U+0009 (when not in indentation context) / other non-printable control chars in narrative fields. Wire into `task check`. Three-state exit consistent with the existing scanner.\r\n\r\n3. **Document the contract** in `scripts/issue_ingest.py` module docstring: \"Issue body MUST be treated as opaque text. Never `format()`, never `eval()`, never re-decode through `json.loads(json.dumps(body))` -- pass the body bytes through unmodified.\"\r\n\r\n## Tests required\r\n\r\n- New `tests/cli/test_issue_ingest_escape_corruption.py` with synthetic gh fixture carrying every JSON-escape class in the issue body. Asserts round-trip preserves all bytes; asserts narrative key Overview contains no control chars.\r\n- Extend `tests/test_cache.py` with a raw.json round-trip test asserting `json.dumps(body, ensure_ascii=False)` survives a `json.loads` decode without flipping `\\\\v` to U+000B.\r\n\r\n## Cross-references\r\n\r\n- PR #1034 (the surfacing event; Greptile P1 finding on the corrupted vBRIEF #1025)\r\n- #798 (PS 5.1 non-ASCII round-trip corruption -- same general class, different surface; the deterministic `verify_encoding.py` gate this issue extends)\r\n- `scripts/issue_ingest.py::_fetch_from_cache` and `scripts/issue_ingest.py::_build_issue_vbrief` (likely root-cause sites)\r\n- `scripts/cache.py::cache_put` (raw.json write site; the round-trip starts here)\r\n- `skills/deft-directive-swarm/SKILL.md` Phase 0 Step 0B (the downstream contract this corruption silently breaks)\r\n",
+      "Labels": "bug"
+    },
+    "items": [
+      {
+        "id": "1036-escape-preservation-a1",
+        "title": "Synthetic clean issue bodies preserve literal escape-looking text",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a synthetic issue body contains literal `\\vbrief`, `\\task`, `\\n`, `\\r`, `\\b`, `\\f`, `\\\\`, `\\\"`, and `\\u0041` substrings, when it round-trips through cache put/get and issue ingest, then the generated Overview contains the same literal substrings and records no substituted control characters.",
+          "Traces": "Issue #1036 remediation path 1"
+        }
+      },
+      {
+        "id": "1036-escape-preservation-a2",
+        "title": "Upstream control characters are made visible",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a GitHub issue body already contains U+000B, U+0008, U+000C, or non-indentation U+0009, when issue ingest or validation processes it, then the command emits a visible warning or verification finding instead of silently treating the narrative as clean text.",
+          "Traces": "Issue #1036; live #1025 API body already contains control characters"
+        }
+      },
+      {
+        "id": "1036-escape-preservation-a3",
+        "title": "Opaque-body contract is documented and tested",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given future maintainers inspect the ingest path, when they read `scripts/issue_ingest.py` tests or module documentation, then they see that GitHub issue bodies are opaque text and must not be re-decoded through JSON/string-escape semantics.",
+          "Traces": "Issue #1036 remediation path 3"
+        }
+      }
+    ],
+    "tags": [
+      "bug"
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/issue_ingest.py",
+          "scripts/cache.py",
+          "scripts/verify_encoding.py",
+          "tests/cli/test_issue_ingest_escape_corruption.py",
+          "tests/test_cache.py",
+          "tests/cli/test_verify_encoding.py"
+        ],
+        "verify_commands": [
+          "uv --project . run pytest tests/cli/test_issue_ingest_escape_corruption.py tests/test_cache.py tests/cli/test_verify_encoding.py -q"
+        ],
+        "expected_outputs": [
+          "Escape-preservation and control-character regression tests pass, proving clean backslash substrings are preserved and upstream control chars are surfaced."
+        ],
+        "depends_on": [],
+        "conflict_group": "issue-ingest-cache-encoding",
+        "size": "M",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard"
+      },
+      "completedAt": "2026-06-12T14:45:52Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1036",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1036: scripts/issue_ingest.py + cache chain corrupts vBRIEF Overview when issue body contains literal JSON-escape substrings (\\v -> U+000B, \\t -> U+0009)"
+      }
+    ],
+    "updated": "2026-06-12T14:45:52Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Preserve literal backslash escape-looking text when GitHub issue bodies become vBRIEF Overview narratives.
- Surface decoded upstream control characters through ingest warnings and the encoding verifier.
- Add regression coverage for cache, issue ingest, and vBRIEF narrative control scanning.

## Test plan
- PYTEST_ADDOPTS="--basetemp=/tmp/deft-task-check-agent1" task check
- uv --project . run pytest tests/cli/test_issue_ingest_escape_corruption.py tests/test_cache.py tests/cli/test_verify_encoding.py -q

Refs #1036
