### PR TITLE
Warn before running stale installer binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
   # -----------------------------------------------------------------------
   smoke-test:
     needs: [build, universal-macos]
+    env:
+      DEFT_NO_UPDATE_CHECK: "1"
     strategy:
       matrix:
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Session-start ritual completion is now machine-verifiable before implementation dispatch (#1348)** -- `task session:start` records quick-tier ritual state in `.deft/ritual-state.json`, while `task verify:session-ritual -- --tier=gated` fails closed when that state is missing, stale, from another worktree, or tied to an older HEAD. The gated verifier lazily records `task doctor` and `task verify:cache-fresh`, honors explicit deferrals, and supports `DEFT_SESSION_RITUAL_SKIP=1` for CI and dispatched headless workers with an audit warning when the bypass hides a failure. Closes #1348.
+- **Downloaded installer binaries now warn before using stale releases (#689)** -- `deft-install` checks the latest published release before changing a project, confirms when it is current, and defaults to abort when the local binary is older or cannot verify currency. Offline and CI runs can opt out with `--no-update-check` or `DEFT_NO_UPDATE_CHECK=1`. Closes #689.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Download the installer for your platform from [GitHub Releases](https://github.c
 
 The installer guides you through choosing a project directory, installs git if needed, vendors the deft framework payload into `.deft/core/` (as of v0.39.2 a git-free deposit with no nested `.git` of its own; older installs and manual `git clone` origins instead carry a framework clone that keeps its own `.git`), wires it into your project's `AGENTS.md`, and creates your user config directory. Either layout is upgraded in place by `deft-install --upgrade`, which auto-detects the payload and never runs git against your own repository.
 
+On startup, `deft-install` checks the latest GitHub release and warns if the downloaded binary on disk is stale before it changes your project. Offline and CI runs can skip that check with `--no-update-check` or `DEFT_NO_UPDATE_CHECK=1`.
+
 **Building from source (developers only):** requires Go 1.22+
 
 ```bash

--- a/cmd/deft-install/githooks_test.go
+++ b/cmd/deft-install/githooks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +13,7 @@ import (
 // newGithooksWizard returns a Wizard whose output is discarded -- the hook
 // tests assert on filesystem + git state, not on printed prose.
 func newGithooksWizard() *Wizard {
-	return NewWizard(strings.NewReader(""), os.NewFile(0, os.DevNull), false)
+	return NewWizard(strings.NewReader(""), io.Discard, false)
 }
 
 // seedPayloadHooks writes minimal stand-in hook scripts into

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -78,6 +78,7 @@ Options:
                             installs when combined with --yes)
   --json                    Emit structured JSON result to stdout (success, paths,
                             actions taken, warnings); suppresses some prose
+  --no-update-check         Skip the startup version-currency check (offline/CI)
   --debug                   Print build target and diagnostic info
   --version                 Print version and exit
   --help                    Show this help message
@@ -92,6 +93,7 @@ Windows-style aliases:
   /maintainer               Same as --maintainer
   /repo-root <path>         Same as --repo-root
   /json                     Same as --json
+  /no-update-check          Same as --no-update-check
   /debug                    Same as --debug
   /v, /version              Same as --version
   /?, /h, /help             Same as --help
@@ -133,6 +135,7 @@ func normalizeArgs(args []string) []string {
 		"/maintainer":      "--maintainer",
 		"/repo-root":       "--repo-root",
 		"/json":            "--json",
+		"/no-update-check": "--no-update-check",
 	}
 	out := make([]string, 0, len(args))
 	for _, a := range args {
@@ -162,6 +165,7 @@ func main() {
 	maintainer := flag.Bool("maintainer", false, "maintainer checkout mode: bootstrap/report tools without consumer file projections")
 	repoRoot := flag.String("repo-root", "", "target project dir for non-interactive installs")
 	jsonOut := flag.Bool("json", false, "emit JSON result instead of (or with) prose for agents")
+	noUpdateCheck := flag.Bool("no-update-check", false, "skip startup version-currency check")
 	flag.Usage = printUsage
 	flag.Parse()
 
@@ -178,7 +182,7 @@ func main() {
 	// --force and --allow-dirty are synonyms: either bypasses the #1458
 	// default dirty-tree refusal of a dirty working tree on --upgrade.
 	forceDirty := *force || *allowDirty
-	code := install(*debug, effectiveBranch, *legacyLayout, nonInt, *upgrade, *repoRoot, *jsonOut, *requireClean, forceDirty, *maintainer)
+	code := install(*debug, effectiveBranch, *legacyLayout, nonInt, *upgrade, *repoRoot, *jsonOut, *requireClean, forceDirty, *maintainer, *noUpdateCheck)
 	if runtime.GOOS == "windows" && !nonInt {
 		pressEnterToExit()
 	}
@@ -195,7 +199,7 @@ func main() {
 // --repo-root points at this repository's source tree, reports maintainer tools,
 // and skips every consumer projection so AGENTS.md / .gitignore / workflows stay
 // maintainer-owned.
-func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgrade bool, repoRoot string, jsonOut, requireClean, force, maintainer bool) int {
+func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgrade bool, repoRoot string, jsonOut, requireClean, force, maintainer, noUpdateCheck bool) int {
 	if debug {
 		fmt.Printf("[debug] OS=%s ARCH=%s\n", runtime.GOOS, runtime.GOARCH)
 		fmt.Printf("[debug] defaultBranch=%s branch=%s legacyLayout=%v nonInteractive=%v upgrade=%v repoRoot=%s json=%v maintainer=%v\n", defaultBranch, branch, legacyLayout, nonInteractive, upgrade, repoRoot, jsonOut, maintainer)
@@ -204,6 +208,12 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 	var result *WizardResult
 	var err error
 	if nonInteractive && repoRoot != "" {
+		if !updateCheckBypassed(noUpdateCheck) {
+			w := NewWizardWithLayout(strings.NewReader(""), os.Stdout, debug, legacyLayout)
+			if code := runInstallerUpdateCheck(w, false); code != 0 {
+				return code
+			}
+		}
 		// Fast path for agents/CI: construct result directly from --repo-root
 		// without any interactive prompts. Derive project name from basename.
 		absRoot, absErr := filepath.Abs(repoRoot)
@@ -216,6 +226,12 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 			fmt.Printf("[debug] non-interactive fast-path: project=%s deft=%s update=%v\n", result.ProjectDir, result.DeftDir, result.Update)
 		}
 	} else if nonInteractive {
+		if !updateCheckBypassed(noUpdateCheck) {
+			w := NewWizardWithLayout(strings.NewReader(""), os.Stdout, debug, legacyLayout)
+			if code := runInstallerUpdateCheck(w, false); code != 0 {
+				return code
+			}
+		}
 		// --yes without --repo-root: fall back to CWD as repo root (common for
 		// agents running inside an existing project dir).
 		cwd, getErr := os.Getwd()
@@ -234,7 +250,13 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		}
 	} else {
 		w := NewWizardWithLayout(os.Stdin, os.Stdout, debug, legacyLayout)
-		result, err = w.Run()
+		w.printBanner()
+		if !updateCheckBypassed(noUpdateCheck) {
+			if code := runInstallerUpdateCheck(w, stdinAllowsUpdateCheckPrompt()); code != 0 {
+				return code
+			}
+		}
+		result, err = w.runAfterBanner()
 		if err != nil {
 			if err == errUserExit {
 				fmt.Println("\nGoodbye!")

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -1515,7 +1515,7 @@ func TestInstall_DirtyTreeUpgradeFailsLoudNonInteractive(t *testing.T) {
 	}
 	t.Setenv("DEFT_USER_PATH", filepath.Join(t.TempDir(), "cfg"))
 
-	code := install(false, "", false, true, true, proj, false, false, false, false)
+	code := install(false, "", false, true, true, proj, false, false, false, false, true)
 	if code == 0 {
 		t.Error("dirty-tree --upgrade --yes must exit non-zero (fail loud), got 0")
 	}
@@ -1552,7 +1552,7 @@ func TestInstall_DirtyTreeUpgradeJSONStructuredObject(t *testing.T) {
 		t.Fatalf("os.Pipe: %v", perr)
 	}
 	os.Stdout = wPipe
-	code := install(false, "", false, true, true, proj, true, false, false, false)
+	code := install(false, "", false, true, true, proj, true, false, false, false, true)
 	_ = wPipe.Close()
 	os.Stdout = oldStdout
 	stdout, _ := io.ReadAll(r)
@@ -1611,7 +1611,7 @@ func TestInstall_ForceUpgradesDirtyTree(t *testing.T) {
 	fetchCoreTarballFunc = func(string) (string, error) { return tarball, nil }
 	t.Setenv("DEFT_USER_PATH", filepath.Join(t.TempDir(), "cfg"))
 
-	code := install(false, "", false, true, true, proj, false, false, true, false)
+	code := install(false, "", false, true, true, proj, false, false, true, false, true)
 	if code != 0 {
 		t.Fatalf("--force upgrade of a dirty tree must succeed (exit 0), got %d", code)
 	}

--- a/cmd/deft-install/update_check.go
+++ b/cmd/deft-install/update_check.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const installerUpdateCheckTimeout = 1500 * time.Millisecond
+
+var (
+	installerUpdateCheckClient  = &http.Client{Timeout: installerUpdateCheckTimeout}
+	latestInstallerReleaseURL   = "https://api.github.com/repos/deftai/directive/releases/latest"
+	fetchLatestInstallerRelease = fetchLatestInstallerReleaseFromGitHub
+)
+
+type installerRelease struct {
+	TagName     string `json:"tag_name"`
+	PublishedAt string `json:"published_at"`
+	HTMLURL     string `json:"html_url"`
+}
+
+func updateCheckBypassed(flagValue bool) bool {
+	return flagValue || osEnvEquals("DEFT_NO_UPDATE_CHECK", "1")
+}
+
+func stdinAllowsUpdateCheckPrompt() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+func osEnvEquals(key, value string) bool {
+	return strings.TrimSpace(os.Getenv(key)) == value
+}
+
+func runInstallerUpdateCheck(w *Wizard, promptAllowed bool) int {
+	release, err := fetchLatestInstallerRelease(version)
+	if err != nil {
+		return handleUnverifiedInstallerVersion(w, promptAllowed, err)
+	}
+
+	cmp, err := compareInstallerSemver(version, release.TagName)
+	if err != nil {
+		return handleUnverifiedInstallerVersion(w, promptAllowed, err)
+	}
+	if cmp == 0 {
+		w.printf("Checking for updates...\n")
+		w.printf("[ok] Running latest (%s)\n\n", displayInstallerVersion(version))
+		return 0
+	}
+	if cmp > 0 {
+		// Locally built or unpublished binaries should not warn just because
+		// their embedded version is ahead of the latest public release.
+		return 0
+	}
+
+	w.printf("Checking for updates...\n")
+	w.printf("[!] You are running deft-install %s\n", displayInstallerVersion(version))
+	w.printf("    Latest release is %s (published %s)\n", displayInstallerVersion(release.TagName), formatInstallerReleaseDate(release.PublishedAt))
+	w.printf("    Download: %s\n\n", installerReleaseDownloadURL(release))
+	if !promptAllowed {
+		w.printf("Installer version is stale and stdin is non-interactive. Re-run with --no-update-check or DEFT_NO_UPDATE_CHECK=1 to bypass.\n")
+		return 1
+	}
+	if promptYesNo(w, fmt.Sprintf("Continue with %s anyway? [y/N]: ", displayInstallerVersion(version))) {
+		return 0
+	}
+	w.printf("Aborted.\n")
+	return 1
+}
+
+func handleUnverifiedInstallerVersion(w *Wizard, promptAllowed bool, cause error) int {
+	w.printf("Checking for updates...\n")
+	w.printf("[?] Could not verify version (%v)\n", cause)
+	w.printf("    You are running %s. Latest version unknown.\n\n", displayInstallerVersion(version))
+	if !promptAllowed {
+		w.printf("Installer version could not be verified and stdin is non-interactive. Re-run with --no-update-check or DEFT_NO_UPDATE_CHECK=1 to bypass.\n")
+		return 1
+	}
+	if promptYesNo(w, "Continue without verification? [y/N]: ") {
+		return 0
+	}
+	w.printf("Aborted.\n")
+	return 1
+}
+
+func promptYesNo(w *Wizard, prompt string) bool {
+	w.printf("%s", prompt)
+	input, err := w.readLine()
+	if err != nil {
+		return false
+	}
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "y" || input == "yes"
+}
+
+func fetchLatestInstallerReleaseFromGitHub(installerVersion string) (installerRelease, error) {
+	req, err := http.NewRequest(http.MethodGet, latestInstallerReleaseURL, nil)
+	if err != nil {
+		return installerRelease{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "deft-install/"+displayInstallerVersion(installerVersion))
+
+	resp, err := installerUpdateCheckClient.Do(req)
+	if err != nil {
+		return installerRelease{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return installerRelease{}, fmt.Errorf("latest release API returned HTTP %s", resp.Status)
+	}
+
+	var release installerRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return installerRelease{}, err
+	}
+	if strings.TrimSpace(release.TagName) == "" {
+		return installerRelease{}, errors.New("latest release response did not include tag_name")
+	}
+	return release, nil
+}
+
+func installerReleaseDownloadURL(release installerRelease) string {
+	if strings.TrimSpace(release.HTMLURL) != "" {
+		return release.HTMLURL
+	}
+	return "https://github.com/deftai/directive/releases/latest"
+}
+
+func formatInstallerReleaseDate(value string) string {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		if strings.TrimSpace(value) == "" {
+			return "unknown"
+		}
+		return value
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+func displayInstallerVersion(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	if strings.HasPrefix(value, "v") {
+		return value
+	}
+	return "v" + value
+}
+
+type installerSemver struct {
+	major int
+	minor int
+	patch int
+	pre   []string
+}
+
+var installerSemverPattern = regexp.MustCompile(`^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$`)
+
+func compareInstallerSemver(left, right string) (int, error) {
+	lv, err := parseInstallerSemver(left)
+	if err != nil {
+		return 0, err
+	}
+	rv, err := parseInstallerSemver(right)
+	if err != nil {
+		return 0, err
+	}
+	return lv.compare(rv), nil
+}
+
+func parseInstallerSemver(value string) (installerSemver, error) {
+	m := installerSemverPattern.FindStringSubmatch(strings.TrimSpace(value))
+	if m == nil {
+		return installerSemver{}, fmt.Errorf("version %q is not SemVer", value)
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	patch, _ := strconv.Atoi(m[3])
+	var pre []string
+	if m[4] != "" {
+		pre = strings.Split(m[4], ".")
+	}
+	return installerSemver{major: major, minor: minor, patch: patch, pre: pre}, nil
+}
+
+func (v installerSemver) compare(other installerSemver) int {
+	for _, pair := range [][2]int{{v.major, other.major}, {v.minor, other.minor}, {v.patch, other.patch}} {
+		if pair[0] < pair[1] {
+			return -1
+		}
+		if pair[0] > pair[1] {
+			return 1
+		}
+	}
+	return compareInstallerPrerelease(v.pre, other.pre)
+}
+
+func compareInstallerPrerelease(left, right []string) int {
+	if len(left) == 0 && len(right) == 0 {
+		return 0
+	}
+	if len(left) == 0 {
+		return 1
+	}
+	if len(right) == 0 {
+		return -1
+	}
+	for i := 0; i < len(left) && i < len(right); i++ {
+		li, lnum := numericPrereleaseIdentifier(left[i])
+		ri, rnum := numericPrereleaseIdentifier(right[i])
+		switch {
+		case lnum && rnum:
+			if li < ri {
+				return -1
+			}
+			if li > ri {
+				return 1
+			}
+		case lnum:
+			return -1
+		case rnum:
+			return 1
+		default:
+			if left[i] < right[i] {
+				return -1
+			}
+			if left[i] > right[i] {
+				return 1
+			}
+		}
+	}
+	if len(left) < len(right) {
+		return -1
+	}
+	if len(left) > len(right) {
+		return 1
+	}
+	return 0
+}
+
+func numericPrereleaseIdentifier(value string) (int, bool) {
+	if value == "" {
+		return 0, false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(value)
+	return n, err == nil
+}

--- a/cmd/deft-install/update_check_test.go
+++ b/cmd/deft-install/update_check_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func withInstallerUpdateCheckStub(t *testing.T, embedded string, fetch func(string) (installerRelease, error)) {
+	t.Helper()
+	origVersion := version
+	origFetch := fetchLatestInstallerRelease
+	version = embedded
+	fetchLatestInstallerRelease = fetch
+	t.Cleanup(func() {
+		version = origVersion
+		fetchLatestInstallerRelease = origFetch
+	})
+}
+
+func TestInstallerUpdateCheck_MatchPrintsLatestConfirmation(t *testing.T) {
+	withInstallerUpdateCheckStub(t, "v0.45.1", func(gotVersion string) (installerRelease, error) {
+		if gotVersion != "v0.45.1" {
+			t.Fatalf("fetch saw version %q, want v0.45.1", gotVersion)
+		}
+		return installerRelease{TagName: "v0.45.1", PublishedAt: "2026-06-12T12:00:00Z"}, nil
+	})
+	var out bytes.Buffer
+	w := NewWizard(strings.NewReader(""), &out, false)
+
+	if code := runInstallerUpdateCheck(w, true); code != 0 {
+		t.Fatalf("match path returned %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "[ok] Running latest (v0.45.1)") {
+		t.Fatalf("match path did not print latest confirmation:\n%s", out.String())
+	}
+}
+
+func TestInstallerUpdateCheck_MismatchDefaultsToAbort(t *testing.T) {
+	withInstallerUpdateCheckStub(t, "v0.20.0-rc.1", func(string) (installerRelease, error) {
+		return installerRelease{
+			TagName:     "v0.20.2",
+			PublishedAt: "2026-04-24T09:30:00Z",
+			HTMLURL:     "https://github.com/deftai/directive/releases/tag/v0.20.2",
+		}, nil
+	})
+	var out bytes.Buffer
+	w := NewWizard(strings.NewReader("\n"), &out, false)
+
+	if code := runInstallerUpdateCheck(w, true); code != 1 {
+		t.Fatalf("empty response should abort stale installer, got code %d", code)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"You are running deft-install v0.20.0-rc.1",
+		"Latest release is v0.20.2 (published 2026-04-24)",
+		"Continue with v0.20.0-rc.1 anyway? [y/N]: ",
+		"Aborted.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("mismatch output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestInstallerUpdateCheck_MismatchCanContinue(t *testing.T) {
+	withInstallerUpdateCheckStub(t, "v0.20.0", func(string) (installerRelease, error) {
+		return installerRelease{TagName: "v0.20.2", PublishedAt: "2026-04-24T09:30:00Z"}, nil
+	})
+	var out bytes.Buffer
+	w := NewWizard(strings.NewReader("y\n"), &out, false)
+
+	if code := runInstallerUpdateCheck(w, true); code != 0 {
+		t.Fatalf("explicit y should continue stale installer, got code %d", code)
+	}
+}
+
+func TestInstallerUpdateCheck_UnverifiedPromptsAndCanContinue(t *testing.T) {
+	withInstallerUpdateCheckStub(t, "v0.45.1", func(string) (installerRelease, error) {
+		return installerRelease{}, errors.New("timeout after 1.5s")
+	})
+	var out bytes.Buffer
+	w := NewWizard(strings.NewReader("yes\n"), &out, false)
+
+	if code := runInstallerUpdateCheck(w, true); code != 0 {
+		t.Fatalf("explicit yes should continue after unverified check, got code %d", code)
+	}
+	if !strings.Contains(out.String(), "Could not verify version (timeout after 1.5s)") {
+		t.Fatalf("unverified output missing timeout reason:\n%s", out.String())
+	}
+}
+
+func TestInstallerUpdateCheck_NonTTYStaleFailsWithoutPrompt(t *testing.T) {
+	withInstallerUpdateCheckStub(t, "v0.20.0", func(string) (installerRelease, error) {
+		return installerRelease{TagName: "v0.20.2", PublishedAt: "2026-04-24T09:30:00Z"}, nil
+	})
+	var out bytes.Buffer
+	w := NewWizard(strings.NewReader("y\n"), &out, false)
+
+	if code := runInstallerUpdateCheck(w, false); code != 1 {
+		t.Fatalf("non-TTY stale installer must fail, got code %d", code)
+	}
+	if strings.Contains(out.String(), "anyway? [y/N]") {
+		t.Fatalf("non-TTY stale path must not prompt:\n%s", out.String())
+	}
+}
+
+func TestInstallerUpdateCheck_BypassSources(t *testing.T) {
+	t.Setenv("DEFT_NO_UPDATE_CHECK", "")
+	if updateCheckBypassed(false) {
+		t.Fatal("empty env and false flag should not bypass")
+	}
+	if !updateCheckBypassed(true) {
+		t.Fatal("--no-update-check flag should bypass")
+	}
+	t.Setenv("DEFT_NO_UPDATE_CHECK", "1")
+	if !updateCheckBypassed(false) {
+		t.Fatal("DEFT_NO_UPDATE_CHECK=1 should bypass")
+	}
+}
+
+func TestInstallerUpdateCheck_HelpAndVersionFlagsNormalizeWithoutNetworkFlag(t *testing.T) {
+	got := normalizeArgs([]string{"/version", "/help", "/no-update-check"})
+	want := []string{"--version", "--help", "--no-update-check"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("normalizeArgs = %v, want %v", got, want)
+	}
+}
+
+func TestCompareInstallerSemverPrereleaseOrdering(t *testing.T) {
+	tests := []struct {
+		left  string
+		right string
+		want  int
+	}{
+		{"v0.20.0-rc.1", "v0.20.0", -1},
+		{"v0.20.2", "v0.20.0", 1},
+		{"0.20.2+build.1", "v0.20.2", 0},
+		{"v0.20.0-rc.2", "v0.20.0-rc.10", -1},
+	}
+	for _, tc := range tests {
+		got, err := compareInstallerSemver(tc.left, tc.right)
+		if err != nil {
+			t.Fatalf("compareInstallerSemver(%q, %q): %v", tc.left, tc.right, err)
+		}
+		if got != tc.want {
+			t.Fatalf("compareInstallerSemver(%q, %q) = %d, want %d", tc.left, tc.right, got, tc.want)
+		}
+	}
+}
+
+func TestFetchLatestInstallerRelease_SendsUserAgent(t *testing.T) {
+	origURL := latestInstallerReleaseURL
+	origClient := installerUpdateCheckClient
+	t.Cleanup(func() {
+		latestInstallerReleaseURL = origURL
+		installerUpdateCheckClient = origClient
+	})
+
+	var userAgent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name":"v0.45.1","published_at":"2026-06-12T12:00:00Z","html_url":"https://example.test/release"}`))
+	}))
+	defer server.Close()
+	latestInstallerReleaseURL = server.URL
+	installerUpdateCheckClient = server.Client()
+
+	release, err := fetchLatestInstallerReleaseFromGitHub("v0.45.1")
+	if err != nil {
+		t.Fatalf("fetchLatestInstallerReleaseFromGitHub: %v", err)
+	}
+	if release.TagName != "v0.45.1" {
+		t.Fatalf("tag = %q, want v0.45.1", release.TagName)
+	}
+	if userAgent != "deft-install/v0.45.1" {
+		t.Fatalf("User-Agent = %q, want deft-install/v0.45.1", userAgent)
+	}
+}

--- a/cmd/deft-install/wizard.go
+++ b/cmd/deft-install/wizard.go
@@ -33,10 +33,10 @@ const LegacyFrameworkSubdir = "deft"
 
 // Wizard guides the user through choosing an install location.
 type Wizard struct {
-	scanner       *bufio.Scanner
-	out           io.Writer
-	debug         bool
-	legacyLayout  bool
+	scanner      *bufio.Scanner
+	out          io.Writer
+	debug        bool
+	legacyLayout bool
 }
 
 // WizardResult holds the chosen paths after the wizard completes.
@@ -76,7 +76,10 @@ func NewWizardWithLayout(in io.Reader, out io.Writer, debug, legacyLayout bool) 
 // Run executes the full install wizard and returns the chosen paths.
 func (w *Wizard) Run() (*WizardResult, error) {
 	w.printBanner()
+	return w.runAfterBanner()
+}
 
+func (w *Wizard) runAfterBanner() (*WizardResult, error) {
 	projectName, err := w.askProjectName()
 	if err != nil {
 		return nil, err

--- a/tools/installer.md
+++ b/tools/installer.md
@@ -1,0 +1,23 @@
+# Installer
+
+Legend: !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+## Version Currency
+
+! `deft-install` MUST query the GitHub Releases API (`GET /repos/deftai/directive/releases/latest`) after the welcome banner and before the project-name prompt, with a 1.5s combined connect/read timeout. The `User-Agent` header MUST be `deft-install/<version>`.
+
+! On version match, `deft-install` MUST print a one-line confirmation (`Running latest (<version>)`) and proceed without prompting.
+
+! On version mismatch, `deft-install` MUST print the embedded version, latest version, publish date, and download URL, then prompt `[y/N]` with default abort.
+
+! On network error or timeout, `deft-install` MUST print a "could not verify" message and prompt `[y/N]` with default abort.
+
+! On non-TTY stdin, `deft-install` MUST exit 1 for any non-match outcome unless `DEFT_NO_UPDATE_CHECK=1` is set or `--no-update-check` is passed.
+
+⊗ Run the version check for `--version` or `--help` invocations.
+
+⊗ Suppress the prompt for any class of drift: rc-vs-GA, patch, and minor drift all use the same confirmation rule.
+
+⊗ Warn when the embedded version is ahead of latest. Locally built development binaries must proceed without update-check noise in that case.
+
+Comparison rule: warn iff `embedded < latest` under SemVer ordering. Pre-release identifiers sort below their corresponding GA per SemVer, so `v0.20.0-rc.1 < v0.20.0` without special-casing release candidates.

--- a/vbrief/completed/2026-06-12-689-featinstaller-version-currency-self-check-at-startup.vbrief.json
+++ b/vbrief/completed/2026-06-12-689-featinstaller-version-currency-self-check-at-startup.vbrief.json
@@ -1,0 +1,105 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #689"
+  },
+  "plan": {
+    "id": "689-installer-version-currency",
+    "title": "feat(installer): version-currency self-check at startup",
+    "status": "completed",
+    "narratives": {
+      "Description": "The standalone installer should warn users when they are running an old downloaded binary before it starts changing a project. The check should be fast, skippable for CI/offline use, and silent for help/version introspection.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/689",
+      "ImplementationPlan": "Add a version-currency check to `cmd/deft-install` that calls the GitHub latest-release API after the banner, compares SemVer versions, and prompts on stale or unverifiable versions. Document the installer directive and offline bypasses, update release smoke tests to opt out in non-TTY mode, and add Go tests for match, mismatch, timeout, non-TTY, bypass, and help/version paths.",
+      "UserStory": "As a Deft user re-running a downloaded installer, I want to know when the binary is stale before setup proceeds, so that I do not bootstrap a project with an outdated installer.",
+      "Traces": "Issue #689; stale rc installer binary rerun after newer GA release.",
+      "Overview": "## Motivation\r\n\r\nA user re-ran a previously-downloaded `deft-install` binary. The binary printed `deft-install v0.20.0-rc.1` while the latest published release was `v0.20.2`. Nothing in the installer signalled the staleness; the user noticed only because the wizard banner version looked off.\r\n\r\nInvestigation confirmed:\r\n\r\n- `releases/latest/download/install-macos-universal` and `install-linux-amd64` both correctly redirect to and serve v0.20.2 (verified: embedded version string `v0.20.2`, sha matches the v0.20.2 release asset).\r\n- The release pipeline (`.github/workflows/release.yml`) correctly stamps `-X main.version=${{ github.ref_name }}`.\r\n- README links exclusively use `releases/latest/download/...` — no stale direct links to old tags anywhere in the codebase.\r\n\r\nThe root cause was the user's local copy of the installer being a previously-downloaded rc.1 binary. There is currently no mechanism for `deft-install` to detect and surface this drift to the user.\r\n\r\n## Proposed change\r\n\r\nAdd a version-currency self-check to `deft-install`. On startup, after the welcome banner and before the project-name prompt, query the GitHub Releases API for the latest tag and compare it to the embedded `version`. Surface drift to the user with a prompt to confirm before proceeding.\r\n\r\n## Directive (new file: `tools/installer.md`)\r\n\r\n```\r\n## Version currency\r\n\r\n! deft-install MUST query the GitHub Releases API\r\n  (GET /repos/deftai/directive/releases/latest) after the welcome banner\r\n  and before the project-name prompt, with a 1.5s combined connect+read\r\n  timeout. The User-Agent header MUST be `deft-install/<version>`.\r\n\r\n! On version match, deft-install MUST print a one-line confirmation\r\n  (`Running latest (<version>)`) and proceed without prompting.\r\n\r\n! On version mismatch, deft-install MUST print embedded version, latest\r\n  version, publish date, and download URL, then prompt `[y/N]`\r\n  (default abort).\r\n\r\n! On network error or timeout, deft-install MUST print a \"could not\r\n  verify\" message and prompt `[y/N]` (default abort).\r\n\r\n! On non-TTY stdin, deft-install MUST exit 1 for any non-match outcome\r\n  unless `DEFT_NO_UPDATE_CHECK=1` is set or `--no-update-check` is passed.\r\n\r\n⊗ Run the version check for `--version` or `--help` invocations.\r\n\r\n⊗ Suppress the prompt for any class of drift (rc-vs-GA, patch, minor —\r\n  all equal under this rule).\r\n\r\n⊗ Warn when embedded version is *ahead* of latest (locally built dev\r\n  binaries must not generate noise).\r\n\r\nComparison rule: warn iff `embedded < latest` under SemVer ordering.\r\nPre-release identifiers sort below their corresponding GA per SemVer\r\n(e.g. `v0.20.0-rc.1 < v0.20.0`), so this single rule covers all cases\r\nwithout special-casing pre-releases.\r\n```\r\n\r\n## UX strawman\r\n\r\nMatch:\r\n\r\n```\r\n[banner]\r\n\r\nChecking for updates...\r\n[ok] Running latest (v0.20.2)\r\n\r\nWhat is the name of your project?\r\n```\r\n\r\nMismatch:\r\n\r\n```\r\n[banner]\r\n\r\nChecking for updates...\r\n[!] You are running deft-install v0.20.0-rc.1\r\n    Latest release is v0.20.2 (published 2026-04-24)\r\n    Download: https://github.com/deftai/directive/releases/latest\r\n\r\nContinue with v0.20.0-rc.1 anyway? [y/N]:\r\n```\r\n\r\nTimeout / network error:\r\n\r\n```\r\n[banner]\r\n\r\nChecking for updates...\r\n[?] Could not verify version (network error / timeout after 1.5s)\r\n    You are running v0.20.x. Latest version unknown.\r\n\r\nContinue without verification? [y/N]:\r\n```\r\n\r\n## Decisions baked in\r\n\r\nThese are pre-decided in the design discussion to keep the eventual scope-vBRIEF interview from re-litigating them:\r\n\r\n- **Source of truth:** GitHub Releases API only. No deft-owned static manifest in v1. Revisit only if rate-limiting becomes a real problem in practice.\r\n- **Time budget:** 1.5s combined connect+read timeout. Synchronous, executed after the banner is printed.\r\n- **Output policy:** always print the check result. Match prints a confirmation; mismatch and timeout print details and prompt.\r\n- **Default polarity:** `[y/N]` (default abort) for both mismatch and timeout. Prevents accidental click-through.\r\n- **Non-TTY behavior:** strict. Exit 1 on any non-match outcome unless `--no-update-check` flag or `DEFT_NO_UPDATE_CHECK=1` env var is set.\r\n- **Bypass for introspection:** `--version` and `--help` MUST NOT trigger the check.\r\n- **Comparison:** SemVer-aware `embedded < latest`. One rule covers rc/patch/minor drift uniformly.\r\n- **No \"ahead-of-latest\" warning:** locally built dev binaries with `embedded > latest` proceed silently.\r\n\r\n## Acceptance criteria\r\n\r\n- [ ] `tools/installer.md` directive added with the language above.\r\n- [ ] `cmd/deft-install/` implements the check, both prompts, both escape hatches, the non-TTY exit-1 path, and the `--version` / `--help` bypass.\r\n- [ ] Unit tests cover: match path, mismatch + abort, mismatch + continue, timeout path, non-TTY path with and without env var, `--version` / `--help` bypass.\r\n- [ ] Smoke-test workflow (`.github/workflows/release.yml`) updated to set `DEFT_NO_UPDATE_CHECK=1` so post-build smoke tests don't fail on non-TTY without bypass.\r\n- [ ] CHANGELOG.md `[Unreleased]` entry added.\r\n- [ ] README.md updated with a short note about `--no-update-check` / `DEFT_NO_UPDATE_CHECK` for offline / CI contexts.\r\n\r\n## Known cost worth naming\r\n\r\nUsers on hotel wifi, captive portals, or slow-but-working connections will occasionally hit the 1.5s timeout and see the timeout prompt. This is acceptable cost for the staleness guarantee. Users who know they're offline have `--no-update-check` and `DEFT_NO_UPDATE_CHECK=1` as documented escape hatches.\r\n\r\n## Out of scope (explicit non-goals)\r\n\r\n- `deft/run` and `task` commands. Cloned-repo drift detection is `skills/deft-directive-sync/SKILL.md`'s responsibility; this rule is installer-only because the installer is the only deft surface that runs as a frozen binary disconnected from the cloned repo.\r\n- Code signing (tracked elsewhere on the roadmap).\r\n- Auto-update / self-replace behavior. v1 only warns + prompts; the user redownloads manually.\r\n\r\n## Related\r\n\r\n- Reproducer: rc.1 binary on disk re-run after v0.20.2 GA, no signal of staleness.\r\n- Sister issue (deferred until decisions resolve): introducing `area/*` label convention.\r\n",
+      "Labels": "enhancement, adoption-blocker"
+    },
+    "items": [
+      {
+        "id": "689-installer-currency-a1",
+        "title": "Add the installer version-currency directive.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given maintainers inspect installer rules, when they read `tools/installer.md`, then it states the latest-release API check, timeout, prompt behavior, bypasses, non-TTY behavior, and SemVer comparison rule.",
+          "Traces": "Issue #689 acceptance criterion 1"
+        }
+      },
+      {
+        "id": "689-installer-currency-a2",
+        "title": "Implement the installer update check and prompt behavior.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given `deft-install` starts normally, when the embedded version is older than the latest release or the check cannot verify currency, then it prints the required details and defaults to abort unless the operator explicitly continues or uses a documented bypass.",
+          "Traces": "Issue #689 acceptance criterion 2"
+        }
+      },
+      {
+        "id": "689-installer-currency-a3",
+        "title": "Cover match, mismatch, timeout, non-TTY, bypass, help, and version paths with tests.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the installer test suite runs, when version-currency cases are exercised, then match, mismatch-abort, mismatch-continue, timeout, non-TTY with and without bypass, `--version`, and `--help` behavior are covered.",
+          "Traces": "Issue #689 acceptance criterion 3"
+        }
+      },
+      {
+        "id": "689-installer-currency-a4",
+        "title": "Update release smoke tests to opt out of the update check in non-TTY mode.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the release workflow smoke-tests a freshly built installer non-interactively, when it runs, then `DEFT_NO_UPDATE_CHECK=1` or an equivalent bypass prevents update-check prompts from failing the smoke test.",
+          "Traces": "Issue #689 acceptance criterion 4"
+        }
+      },
+      {
+        "id": "689-installer-currency-a5",
+        "title": "Document the installer currency warning, bypasses, and release note.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given this story lands, when users read `README.md` and `CHANGELOG.md`, then the docs explain `--no-update-check` / `DEFT_NO_UPDATE_CHECK=1` for offline or CI use and the `[Unreleased]` entry describes the stale-binary warning in user-facing language.",
+          "Traces": "Issue #689 acceptance criteria 5 and 6"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "adoption-blocker"
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "cmd/deft-install",
+          "tools/installer.md",
+          ".github/workflows/release.yml",
+          "README.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "go test ./cmd/deft-install/..."
+        ],
+        "expected_outputs": [
+          "Installer tests cover stale, current, unavailable, non-TTY, bypass, help, and version-check behavior."
+        ],
+        "depends_on": [],
+        "conflict_group": "installer-version-currency",
+        "size": "L",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard"
+      },
+      "completedAt": "2026-06-12T14:50:28Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/689",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #689: feat(installer): version-currency self-check at startup"
+      }
+    ],
+    "updated": "2026-06-12T14:50:28Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a startup version-currency check to the standalone installer before project changes begin.
- Prompt on stale or unverifiable binaries, with documented no-update-check bypasses for offline and CI runs.
- Update release smoke tests and installer documentation for the new behavior.

## Test plan
- go test ./cmd/deft-install/...
- PYTEST_ADDOPTS="--basetemp=/tmp/deft-task-check-agent3" task check

Refs #689
