### PR TITLE
chore(vbrief): complete swarm cohort lifecycle records

### DIFF
--- a/vbrief/completed/2026-06-12-1187-directive-bound-agents-should-detect-missing-tooling-taskuvp.vbrief.json
+++ b/vbrief/completed/2026-06-12-1187-directive-bound-agents-should-detect-missing-tooling-taskuvp.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1187-missing-tooling-bootstrap",
     "title": "Directive-bound agents should detect missing tooling (task/uv/python/gh) and offer to install on first encounter",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Directive-bound sessions should detect missing required tools before the first command failure and give the operator a clear next step. The first version should cover task, uv, Python, gh, and git with safe install offers or manual fallback instructions.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1187",
@@ -94,7 +94,8 @@
         "size": "L",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-12T15:33:18Z"
     },
     "references": [
       {
@@ -103,6 +104,6 @@
         "title": "Issue #1187: Directive-bound agents should detect missing tooling (task/uv/python/gh) and offer to install on first encounter"
       }
     ],
-    "updated": "2026-06-12T13:22:02Z"
+    "updated": "2026-06-12T15:33:18Z"
   }
 }

--- a/vbrief/completed/2026-06-12-1596-startup-ritual-should-warn-when-the-default-branch-is-out-of.vbrief.json
+++ b/vbrief/completed/2026-06-12-1596-startup-ritual-should-warn-when-the-default-branch-is-out-of.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1596-default-branch-sync-warning",
     "title": "Startup ritual should warn when the default branch is out of sync with remote",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "The startup ritual should surface stale local default-branch state so operators notice before building from an old base. The warning must be concise, non-blocking, and quiet when the default branch and upstream are already in sync.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1596",
@@ -86,7 +86,8 @@
         "size": "M",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-12T15:33:26Z"
     },
     "references": [
       {
@@ -95,6 +96,6 @@
         "title": "Issue #1596: Startup ritual should warn when the default branch is out of sync with remote"
       }
     ],
-    "updated": "2026-06-12T13:04:35Z"
+    "updated": "2026-06-12T15:33:26Z"
   }
 }

--- a/vbrief/completed/2026-06-12-lifecycle-taskfile-commands-should-preserve-reliable-success.vbrief.json
+++ b/vbrief/completed/2026-06-12-lifecycle-taskfile-commands-should-preserve-reliable-success.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1053-powershell-lifecycle-exit-semantics",
     "title": "Lifecycle Taskfile commands should preserve reliable success semantics under Windows PowerShell 5.1",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-12-1053-consumer-swarm-fails-on-greenfield-projects-no-dispatch-mech.vbrief.json",
     "narratives": {
       "Description": "The original recurrence reported successful lifecycle commands being observed as failures under Windows PowerShell 5.1 because progress or stderr handling confused the harness. Current scripts mostly route success to stdout, but there is no direct regression proof for the lifecycle command trio under the affected shell and capture path.",
@@ -68,7 +68,8 @@
         "size": "M",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-12T15:33:26Z"
     },
     "references": [
       {
@@ -78,6 +79,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-12T13:51:11Z"
+    "updated": "2026-06-12T15:33:26Z"
   }
 }

--- a/vbrief/proposed/2026-06-12-1053-consumer-swarm-fails-on-greenfield-projects-no-dispatch-mech.vbrief.json
+++ b/vbrief/proposed/2026-06-12-1053-consumer-swarm-fails-on-greenfield-projects-no-dispatch-mech.vbrief.json
@@ -35,7 +35,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-12-lifecycle-taskfile-commands-should-preserve-reliable-success.vbrief.json",
+        "uri": "completed/2026-06-12-lifecycle-taskfile-commands-should-preserve-reliable-success.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Lifecycle Taskfile commands should preserve reliable success semantics under Windows PowerShell 5.1",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
Lifecycle bookkeeping cleanup after the 8-story swarm cohort merged. Moves the three remaining in-flight stories from `vbrief/active/` to `vbrief/completed/` now that their implementation PRs have landed on `master`:

- **#1187** — missing-tooling bootstrap (merged in PR #1601)
- **#1596** — startup default-branch sync warning (merged in PR #1601)
- **#1053** — PowerShell lifecycle exit semantics story (merged in PR #1602)

`vbrief/active/` is now empty; the proposed #1053 umbrella parent's child-status was updated automatically by `task scope:complete`.

## Test plan
- [x] `task vbrief:validate` passes (607 scope vBRIEFs)
- [x] `task check` green (7663 passed)

Refs #1187 #1596 #1053
