### PR TITLE
docs(adr): add ADR-001 for vBRIEF-as-canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **A single decision record now explains why the vBRIEF is canonical, so the question stops getting re-litigated (#1291)** -- `docs/decisions/ADR-001.md` documents the accepted direction (vBRIEF is the source of truth for the agentic-consumed surface; rendered `.md` and code headers are projections), leading with a plain-English summary of the end state, and inheriting the token-economics rationale, peripheral-content qualifier, and defense-in-depth adoption ladder from the #742 alignment vehicle. The ADR records the decision while explicitly deferring enforcement behind named triggers, and `main.md`'s AXIOM section now links to it. Closes #1291.
+- **A single decision record now explains why the vBRIEF is canonical, so the question stops getting re-litigated (#1291)** -- directive now has an accepted ADR for treating vBRIEF as the source of truth for agent-consumed framework content, with rendered docs and code-adjacent orientation treated as projections. The record leads with the user-visible end state, preserves the token-economics rationale from the earlier alignment work, and names the trigger-based path from clarity to future enforcement. Closes #1291.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A single decision record now explains why the vBRIEF is canonical, so the question stops getting re-litigated (#1291)** -- `docs/decisions/ADR-001.md` documents the accepted direction (vBRIEF is the source of truth for the agentic-consumed surface; rendered `.md` and code headers are projections), leading with a plain-English summary of the end state, and inheriting the token-economics rationale, peripheral-content qualifier, and defense-in-depth adoption ladder from the #742 alignment vehicle. The ADR records the decision while explicitly deferring enforcement behind named triggers, and `main.md`'s AXIOM section now links to it. Closes #1291.
 
 ### Changed
 

--- a/docs/decisions/ADR-001.md
+++ b/docs/decisions/ADR-001.md
@@ -83,4 +83,8 @@ This ADR records the *decision and direction*; it does **not** decide the typed-
 - #1283 — pack-aware slice API RFC (Layer B surface design).
 - #665 — ADR convention (this document's template).
 - #401 — AXIOM ship-PR (already merged); cross-linked from `main.md`.
+- #714 — directive as the reference consumer of the vBRIEF specification.
+- #1309 — consumer propagation marker discipline for `templates/agents-entry.md`.
+- #1589 — spec reconstruction package; coordinate brownfield extraction paths.
+- deftai/vBRIEF#23 — upstream typed architecture schema-home proposal.
 - #336 — all `.md` as rendered views; #1498 — code/headers as projections; #1492 — system-of-record gate; #602 / #634 / #642 — encoding-form vs detection-strength axes.

--- a/docs/decisions/ADR-001.md
+++ b/docs/decisions/ADR-001.md
@@ -1,0 +1,86 @@
+# ADR-001: vBRIEF-as-canonical for the agentic-consumed surface
+
+**Status**: accepted — decomposed from #742 (the alignment vehicle, closed not-planned); written as the doc deliverable of #1291 under the #1284 epic.
+
+## TL;DR — the net result once fully adopted
+
+Directive finally dogfoods its own thesis: **canonical intent lives in the vBRIEF; everything else is a regenerated, drift-checked projection.** Once the adoption ladder in this ADR is complete:
+
+- **One source of truth.** Skills, rules, lessons, specs, and structural metadata live in canonical vBRIEF JSON. Every `.md` — and, optionally, code headers/maps — is a *generated projection*, validated against canonical, never hand-authored.
+- **Agents load slices, not whole files.** A skill invocation pulls just the anti-patterns or just the phases (~96% fewer tokens than a full `SKILL.md`) — cheaper, sharper, less context pollution.
+- **The principle is enforced, not just declared.** What this ADR records as a decision becomes wired gates (`verify:*` in `task check`, propagated to consumers via #1309), so "code and docs are projections" cannot silently drift back into hand-edited sources.
+
+Net: the framework is **cheaper to consume, harder to drift, and provably consistent.** This ADR is the decision record; the wiring is sequenced (not immediate) via the adoption ladder and triggers in *Consequences* below — so "accepted" means the decision is settled, not that enforcement is already on.
+
+## Context
+
+Directive is primarily consumed by agents, not humans. AGENTS.md, the skills system, `task issue:ingest`, every `deft-directive-*` skill exist to be loaded into agent context windows and acted upon. Human readers (contributors, maintainers) are real but secondary consumers.
+
+Agentic consumption is metered in tokens. Hand-authored prose markdown's smallest atomic unit is the file: an agent loading `skills/foo/SKILL.md` to ask "what are this skill's anti-patterns?" pays the token cost of the entire file. Structured-source-with-renderer supports selective loading: an agent loading `plan.items[]` from a vBRIEF without `plan.narratives.Background` pays only for the slice it queries.
+
+The framework already documents the **encoding-form ladder** (Rule Authority [AXIOM] in `main.md`, shipped with #401):
+
+> deterministic > Taskfile > vBRIEF > RFC2119 > prose
+
+This ADR establishes that the ladder is not a taste hierarchy but a **token-efficiency hierarchy** for an agentic consumer: each step up is more structured and therefore cheaper per load. Deterministic checks cost zero agent tokens; Taskfile entries are queryable; vBRIEF is structured; RFC2119 and prose are unstructured. (This builds on the latent-vs-deterministic framing in #602 and the two-axis model in #634 / #642.)
+
+## Decision
+
+For directive's **agentic-consumed surface**, the vBRIEF is the canonical source of truth; rendered `.md` is a derivative artifact for human and legacy-agent consumption. Taken to its conclusion, **source code and file headers are themselves projections of canonical intent** — a datum that must survive a language rewrite cannot live in a source file; it lives in the vBRIEF or is re-derivable from the AST (the principle #1498 applies to structural metadata).
+
+**Peripheral-content qualifier (load-bearing).** For content that is human-only browsing (`CONTRIBUTING.md`), append-mostly logs (`CHANGELOG.md`), or experimental schemas without stable shape, prose-canonical remains acceptable and compatible with the AXIOM. Without this qualifier the decision overreaches.
+
+## Consequences
+
+### What this enables
+
+- **Selective loading** — load `plan.items[]` without `plan.narratives.Background`; savings scale with query granularity.
+- **De-duplication via references** — shared content referenced once rather than restated across files.
+- **Targeted retrieval** — "show all MUST-tier rules" becomes a structured query, not an NLP inference over prose.
+- **Reliability, provenance, programmatic migration, tooling composability, multi-language portability** — structured source has deterministic shape, carries lineage, migrates programmatically, and is portable across agent runtimes (JSON parsers everywhere; no shared markdown semantic parser).
+- **Strategic positioning** — directive becomes the *reference implementation of vBRIEF-as-master for agentic-consumed framework content*, not merely a consumer of the spec (#714).
+
+### Adoption mechanism — defense in depth
+
+The token argument is hollow if agents do not actually shift consumption. Four layers, increasing in disruption, drive the shift:
+
+- **Layer A — Banner deflection.** Every generated `.md` ships an in-file pointer to the slice surface. Cheapest; no agent-side change.
+- **Layer B — Slice tooling.** A `task <pack>:slice <name> <path>` family returning structured, byte-stable, minimal-token subsets. (Surface design: #1283.)
+- **Layer C — Normative rule.** A `!` rule in `main.md` / `AGENTS.md`: when querying packed content for specific structured information, agents MUST prefer the slice API over reading the rendered `.md`.
+- **Layer D — Eliminate parallel `.md`.** Only for internal-only artifacts humans never read; human-discoverable surfaces (SKILL.md) keep the rendered form.
+
+Recommended sequencing: ship **A + B together**; layer **C** as a hardening step; reserve **D** for specific cases.
+
+### Wiring is deferred — but bound by a trigger (anti-drift discipline)
+
+Per the AXIOM, an un-enforced decision is the weakest tier and will drift. To keep "later" from becoming "never", enforcement is split into two tracks, each gated by an explicit trigger that fires a **go/no-go review** (never an automatic mandate):
+
+- **Narrative-slicing track (Layers C/D over prose: phases, anti-patterns, lessons, MUST-tier rules).** Trigger = *evidence* **or** *backstop*: wire once a defined set of real packs (e.g. skills-pack + rules-pack) are sliced in ≥1 live skill flow, **or** a fixed dogfood window elapses and a go/no-go review is forced. This track has **no dependency** on the typed-architecture schema and MUST stay decoupled from it.
+- **Typed-metadata track (system-of-record #1492, code-structure #1498).** Trigger = *hard prerequisite* `(a)`: the typed schema home must exist (coordinated with upstream `deftai/vBRIEF` PR #23) before any enforcement; then the same evidence/backstop pair governs promotion. A `generator-before-enforcer` rule applies — skeleton/pack generation lands before or with the gate that requires it, never after (avoids the #1492-D1 "unsatisfiable by construction" failure).
+
+**Visibility during the gap.** Before any enforcement lands, an **advisory** drift counter (the `check_render_staleness` pattern, #336 / #1498) reports the violation count so the gap stays bounded and the eventual migration size is known. Consumer propagation (`templates/agents-entry.md` + #1309 markers) is a separate, later gate downstream of a framework dogfood window — it is the true one-way door (#1492 D2).
+
+### Open questions (explicitly NOT decided here)
+
+This ADR records the *decision and direction*; it does **not** decide the typed-metadata schema home. The following are deferred to #1284 / #1492 / #1498 and upstream `deftai/vBRIEF` PR #23:
+
+- Where typed structural / system-of-record metadata lives in the schema (`plan.architecture.*` vs a consumer namespace).
+- Which structural metadata becomes canonical first.
+- Brownfield extraction mechanics (AST-derivable vs agent-assisted; confidence thresholds) — coordinate with the reconstruction package #1589 to avoid two extractors.
+
+## Alternatives considered
+
+- **Generic JSONPath instead of named slices.** Rejected: couples agents to internal schema shape, has no versioning or self-documentation. Named, pack-versioned slices keep a stable API while the schema refactors underneath.
+- **Pre-rendered slice files (`SKILL.phases.md`).** Rejected: file explosion (slices × files), multiplied drift-detection burden, and still prose — loses the JSON-vs-prose token advantage.
+- **Lazy-load runtime support.** Rejected: requires per-runtime loader cooperation; not portable. Slice-as-CLI is portable across agent ecosystems.
+- **Prose-canonical (status quo).** Rejected for the agentic surface on token-economics grounds; retained only for peripheral content per the qualifier above.
+- **Full code-generation of directive's source from the vBRIEF.** Out of scope — a much larger, possibly-never bet. The near-term decision is the *direction of truth* and the projection discipline, not wholesale code-gen.
+
+## References
+
+- #1284 — epic: vBRIEF-as-canonical for the agentic-consumed surface (parent).
+- #742 — source ADR alignment vehicle (closed not-planned; rationale inherited here).
+- #1283 — pack-aware slice API RFC (Layer B surface design).
+- #665 — ADR convention (this document's template).
+- #401 — AXIOM ship-PR (already merged); cross-linked from `main.md`.
+- #336 — all `.md` as rendered views; #1498 — code/headers as projections; #1492 — system-of-record gate; #602 / #634 / #642 — encoding-form vs detection-strength axes.

--- a/main.md
+++ b/main.md
@@ -55,7 +55,7 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 ⊗ Encode a rule in a weaker layer when a stronger applies.
 
-See #634, #642.
+See #634, #642. See [ADR-001](./docs/decisions/ADR-001.md) for the token-economics rationale behind this ordering (vBRIEF-as-canonical for the agentic-consumed surface).
 
 **Decision Making:**
 - ! Follow established patterns in current context

--- a/vbrief/completed/2026-05-21-1291-adr-001-doc.vbrief.json
+++ b/vbrief/completed/2026-05-21-1291-adr-001-doc.vbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "description": "Story vBRIEF for #1291 (doc(adr): ADR-001 -- vBRIEF-as-canonical); part of the #742 decomposition.",
     "created": "2026-05-21T16:32:24Z",
-    "updated": "2026-05-25T22:35:08Z"
+    "updated": "2026-06-12T16:08:11Z"
   },
   "plan": {
     "id": "1291-adr-001-doc",

--- a/vbrief/completed/2026-05-21-1291-adr-001-doc.vbrief.json
+++ b/vbrief/completed/2026-05-21-1291-adr-001-doc.vbrief.json
@@ -18,21 +18,21 @@
     "items": [
       {
         "title": "Draft docs/decisions/ADR-001.md per #665 template",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "File exists; template structure followed."
         }
       },
       {
         "title": "Inherit approved sections from #742 verbatim",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Token-economics, qualifier, two-axis, defense-in-depth, counter-args, operational-state, strategic positioning all present."
         }
       },
       {
         "title": "Cross-link from main.md AXIOM section",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "main.md gets a 'See ADR-001' line; encoding gate passes."
         }
@@ -46,7 +46,8 @@
       },
       "swarm": {
         "readiness": "not-ready"
-      }
+      },
+      "completedAt": "2026-06-12T16:08:11Z"
     },
     "references": [
       {
@@ -75,6 +76,6 @@
         "title": "Issue #401: AXIOM ship-PR"
       }
     ],
-    "updated": "2026-05-25T22:35:08Z"
+    "updated": "2026-06-12T16:08:11Z"
   }
 }


### PR DESCRIPTION
## Summary
- Add `docs/decisions/ADR-001.md` documenting the accepted vBRIEF-as-canonical decision for the agentic-consumed surface.
- Lead with the end-state TL;DR, then capture the #742 token-economics rationale, peripheral-content qualifier, adoption ladder, and deferred wiring triggers.
- Cross-link ADR-001 from `main.md`, add a CHANGELOG entry, and complete the #1291 vBRIEF lifecycle record.

## Related Issues
Closes #1291.

## Checklist
- [x] `/deft:change <name>` — N/A: this is the tracked ADR doc deliverable for #1291, with scope coverage in `vbrief/completed/2026-05-21-1291-adr-001-doc.vbrief.json`; no separate multi-file change proposal was needed.
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`.
- [x] `ROADMAP.md` — N/A: release-time ROADMAP updates only.
- [x] Tests pass locally: `task check` — 7665 passed, 5 skipped, 9 deselected, 1 xfailed.

## Test plan
- `task check` — 7665 passed, 5 skipped, 9 deselected, 1 xfailed.

## Post-Merge
- [ ] Verify issue auto-close for #1291 after squash merge.
- [ ] Enable branch protection on `master` requiring CI status check — N/A: one-time setup, not part of this docs PR.

Made with [Cursor](https://cursor.com)
