### PR TITLE
feat(capacity): capacity:backfill tool + cold-start discoverability (#1606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A one-time `task capacity:backfill` now activates capacity accounting from your completed history, and `capacity:show` / session start tell you when to run it (#1606)** -- a new offline-first command classifies past completed work into capacity buckets (inferred from each item's origin-issue labels) and stamps the completion date from git, so the engine crosses its minimum-sample threshold and leaves advisory-only mode. It is dry-run by default, idempotent, and never touches cost. When buckets are configured but history is unclassified, `task capacity:show` and the session-start nudge now point you at the backfill. Closes #1606.
 - **A single decision record now explains why the vBRIEF is canonical, so the question stops getting re-litigated (#1291)** -- directive now has an accepted ADR for treating vBRIEF as the source of truth for agent-consumed framework content, with rendered docs and code-adjacent orientation treated as projections. The record leads with the user-visible end state, preserves the token-economics rationale from the earlier alignment work, and names the trigger-based path from clarity to future enforcement. Closes #1291.
 
 ### Changed

--- a/scripts/_lifecycle_hygiene.py
+++ b/scripts/_lifecycle_hygiene.py
@@ -86,6 +86,12 @@ TECH_DEBT_LEDGER_RELPATH: tuple[str, ...] = (
 #: Session-start nudge tiers (rate-of-harm ranking, #1419 Nudge Budgeting).
 TIER_STRANDED: int = 1
 TIER_STALE_EPIC: int = 2
+#: Capacity classification cold-start (#1606) -- lowest rate-of-harm: the data
+#: exists, accounting is just dormant until a one-time backfill runs.
+TIER_CAPACITY_COLDSTART: int = 3
+
+#: Stable nudge id for the singleton capacity cold-start nudge.
+CAPACITY_COLDSTART_NUDGE_ID: str = "capacity-coldstart"
 
 #: Default actor recorded in the tech-debt ledger.
 DEFAULT_ACTOR: str = "lifecycle-hygiene"
@@ -376,6 +382,15 @@ def _render_stale_epic(*, title: str, dormant: int, threshold: int) -> str:
     )
 
 
+def _render_capacity_coldstart(*, unclassified: int, classified: int, minimum: int) -> str:
+    return (
+        f"[TIER-3] capacity cold-start: {unclassified} completed vBRIEF(s) "
+        f"unclassified (classified {classified}/{minimum} in window) -- run "
+        "`task capacity:backfill --apply` to classify history and activate "
+        "capacity accounting (#1606)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Detector
 # ---------------------------------------------------------------------------
@@ -420,8 +435,60 @@ def detect_lifecycle_nudges(
         if nudge is not None:
             nudges.append(nudge)
 
+    capacity_nudge = detect_capacity_coldstart_nudge(project_root, now=now_dt)
+    if capacity_nudge is not None:
+        nudges.append(capacity_nudge)
+
     nudges.sort(key=lambda n: (n.tier, -n.magnitude, n.nudge_id))
     return nudges
+
+
+def detect_capacity_coldstart_nudge(
+    project_root: Path, *, now: datetime | None = None
+) -> LifecycleNudge | None:
+    """Capacity classification cold-start (Tier 3) nudge (#1606).
+
+    Fires only when capacity buckets ARE configured yet the completed history
+    is classification-cold: ``classified_completions`` is below
+    ``minSampleSize`` AND at least one completed vBRIEF carries no explicit
+    ``capacityBucket``. In that state ``task capacity:backfill`` is the one-time
+    action that crosses ``minSampleSize`` and lifts the engine out of advisory
+    mode. Suppressed when capacity is unconfigured (nothing to classify
+    against) or already classified past the sample floor (no cold-start).
+
+    ``capacity_show`` is imported lazily so the common nudge path (epic
+    hygiene only) does not pay the import cost, and so this module stays
+    import-cycle-free for callers that only need the epic detectors.
+    """
+    allocation = policy.resolve_capacity_allocation(project_root)
+    if not allocation.configured:
+        return None
+
+    import capacity_show  # noqa: PLC0415 -- lazy; avoids import cost / cycle
+
+    report = capacity_show.compute_report(project_root, now=now, allocation=allocation)
+    if report.classified_completions >= report.min_sample_size:
+        return None
+    if report.unclassified_completions <= 0:
+        return None
+
+    message = _render_capacity_coldstart(
+        unclassified=report.unclassified_completions,
+        classified=report.classified_completions,
+        minimum=report.min_sample_size,
+    )
+    return LifecycleNudge(
+        nudge_id=CAPACITY_COLDSTART_NUDGE_ID,
+        kind="capacity-coldstart",
+        tier=TIER_CAPACITY_COLDSTART,
+        title="capacity cold-start",
+        epic_rel_path="",
+        dormant_days=0,
+        completed_children=0,
+        total_children=0,
+        magnitude=report.unclassified_completions,
+        message=message,
+    )
 
 
 def _stranded_nudge(

--- a/scripts/capacity_backfill.py
+++ b/scripts/capacity_backfill.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""capacity_backfill.py -- one-time capacity-bucket classifier for completed vBRIEFs (#1606).
+
+The capacity engine (``scripts/capacity_show.py``, #1419 Slice 4) counts a
+completed vBRIEF toward a bucket only when it carries an explicit
+``plan.metadata.capacityBucket`` (and a ``plan.metadata.completedAt`` inside
+the trailing window). ``task scope:complete`` stamps both fields going
+FORWARD -- but only from ``defaultBucket`` -- so a pre-adoption tree
+(directive itself included) has completed work that is *classification
+cold-start*: the history exists, but every completion is unclassified, so the
+``minSampleSize`` guard pins capacity in advisory mode forever.
+
+This module is the deferred ``task capacity:backfill`` migration the #1419 RFC
+("Brownfield Backfill") specified: a one-time, dry-run-default, git-reversible
+pass that derives the two missing facts onto ``completed/`` vBRIEFs:
+
+* ``plan.metadata.completedAt`` -- the git landing time of the file (the most
+  recent commit that touched it), when not already present. Deterministic,
+  zero human input.
+* ``plan.metadata.capacityBucket`` (+ ``plan.metadata.capacityBucketSource``)
+  -- inferred from the vBRIEF's origin-issue labels (its ``x-vbrief/github-issue``
+  reference) matched against the declared ``capacityAllocation.buckets[].match.labels``
+  predicates. A label match yields ``source="match"`` (high confidence); no
+  match (or no cached issue / no issue reference) falls to ``defaultBucket``
+  with ``source="default"`` and is surfaced in the low-confidence batch for
+  human review.
+
+Guarantees:
+
+* **Dry-run by default.** Writes only with ``--apply``.
+* **Idempotent.** An explicit existing ``capacityBucket`` / ``completedAt`` is
+  preserved; a re-run is a no-op for already-stamped files.
+* **Never mutates ``cost``** -- historical cost actuals are not backfillable
+  (no telemetry exists for past runs); ``cost`` accrues forward only.
+* **Offline.** Reads cached issue labels from ``.deft-cache/github-issue/``;
+  no ``gh`` / network calls. Git is the only subprocess (landing time).
+
+Exit codes (three-state, mirrors ``scripts/triage_reconcile.py``):
+
+* ``0`` -- backfill completed (or was a no-op on a re-run / dry-run).
+* ``1`` -- a runtime step failed (e.g. a write raised).
+* ``2`` -- config error: ``--project-root`` missing, or
+  ``plan.policy.capacityAllocation`` is not configured (nothing to classify
+  against).
+
+Refs: #1606 (this tool), #1419 (parent RFC -- Brownfield Backfill), #1511
+(flip gates advisory -> enforce; backfill is its prerequisite).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Make sibling ``scripts`` modules importable when invoked as
+# ``python scripts/capacity_backfill.py`` from the project root.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _safe_subprocess import run_text  # noqa: E402
+from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from policy import (  # noqa: E402
+    load_project_definition,
+    resolve_capacity_allocation,
+)
+
+reconfigure_stdio()
+
+#: Lifecycle folder the backfill operates on (the backward / completed view).
+COMPLETED_FOLDER: str = "completed"
+
+#: Default location of the github-issue label cache (offline label source).
+CACHE_RELPATH: tuple[str, ...] = (".deft-cache", "github-issue")
+
+#: ``capacityBucketSource`` values this tool records.
+SOURCE_MATCH: str = "match"  # a bucket match.labels predicate matched
+SOURCE_DEFAULT: str = "default"  # no match -> defaultBucket (low confidence)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BucketMatcher:
+    """A bucket id paired with its ``match.labels.any-of`` label set."""
+
+    bucket_id: str
+    labels: frozenset[str]
+
+
+@dataclass(frozen=True)
+class BackfillItem:
+    """One completed vBRIEF's resolved backfill facts."""
+
+    rel_path: str
+    issue_number: int | None
+    bucket: str
+    source: str  # SOURCE_MATCH | SOURCE_DEFAULT
+    set_bucket: bool  # capacityBucket was absent and will be / was stamped
+    set_completed_at: bool  # completedAt was absent and will be / was stamped
+
+
+@dataclass
+class BackfillResult:
+    """Aggregate result returned by :func:`backfill`."""
+
+    project_root: Path
+    dry_run: bool
+    scanned: int = 0
+    stamped_bucket: int = 0
+    stamped_completed_at: int = 0
+    already_classified: int = 0
+    matched: int = 0
+    defaulted: int = 0
+    fetched: int = 0
+    skipped_out_of_window: int = 0
+    window_only: bool = False
+    window_days: int = 0
+    items: list[BackfillItem] = field(default_factory=list)
+    low_confidence: list[BackfillItem] = field(default_factory=list)
+    error: str | None = None
+    exit_code: int = 0
+
+    def summary(self) -> str:
+        """Render the human-readable recap the operator sees."""
+        verb = "would stamp" if self.dry_run else "stamped"
+        mark = "✓" if self.exit_code == 0 else "✗"
+        lines = ["", "Capacity backfill recap:"]
+        lines.append(
+            f"  {mark} scanned {self.scanned} completed vBRIEF(s); "
+            f"{verb} capacityBucket on {self.stamped_bucket} "
+            f"(matched {self.matched}, defaulted {self.defaulted}); "
+            f"{verb} completedAt on {self.stamped_completed_at}; "
+            f"{self.already_classified} already classified"
+        )
+        if self.fetched:
+            lines.append(
+                f"      fetched labels for {self.fetched} uncached issue(s) via REST"
+            )
+        if self.window_only:
+            lines.append(
+                f"      window-only: skipped {self.skipped_out_of_window} "
+                f"completion(s) outside the trailing {self.window_days}d window"
+            )
+        if self.error:
+            lines.append(f"      error: {self.error}")
+        if self.low_confidence:
+            lines.append("")
+            lines.append(
+                f"  Low-confidence batch ({len(self.low_confidence)}) -- "
+                "no label match, fell to defaultBucket; review + re-bucket as needed:"
+            )
+            for item in self.low_confidence:
+                issue = f"#{item.issue_number}" if item.issue_number else "(no issue ref)"
+                lines.append(f"    {issue} -> {item.bucket}  [{item.rel_path}]")
+        if self.dry_run and self.exit_code == 0:
+            lines.append("")
+            lines.append("  Dry-run -- re-run with --apply to write these changes.")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Bucket-matcher resolution (reads the RAW match.labels the policy resolver drops)
+# ---------------------------------------------------------------------------
+
+
+def load_bucket_matchers(project_root: Path) -> tuple[list[BucketMatcher], str]:
+    """Return ``(ordered matchers, default_bucket)`` from PROJECT-DEFINITION.
+
+    ``resolve_capacity_allocation`` intentionally exposes only ``id`` + ``target``
+    per bucket, so the raw ``match.labels.any-of`` predicate is read directly
+    here (mirrors ``_lifecycle_hygiene.resolve_epic_thresholds`` reading the raw
+    block for ``epicStrandedDays``). Matchers preserve declaration order so the
+    first bucket whose label set intersects wins.
+    """
+    data, _err = load_project_definition(project_root)
+    matchers: list[BucketMatcher] = []
+    if not isinstance(data, dict):
+        return matchers, ""
+    plan = data.get("plan")
+    policy = plan.get("policy") if isinstance(plan, dict) else None
+    cap = policy.get("capacityAllocation") if isinstance(policy, dict) else None
+    if not isinstance(cap, dict):
+        return matchers, ""
+    buckets = cap.get("buckets")
+    if isinstance(buckets, list):
+        for bucket in buckets:
+            if not isinstance(bucket, dict):
+                continue
+            bucket_id = bucket.get("id")
+            if not isinstance(bucket_id, str) or not bucket_id.strip():
+                continue
+            labels = _match_labels(bucket.get("match"))
+            matchers.append(
+                BucketMatcher(bucket_id=bucket_id.strip(), labels=frozenset(labels))
+            )
+    default_bucket = cap.get("defaultBucket")
+    return matchers, default_bucket if isinstance(default_bucket, str) else ""
+
+
+def _match_labels(match: Any) -> set[str]:
+    """Extract the ``match.labels.any-of`` string set from a bucket block."""
+    if not isinstance(match, dict):
+        return set()
+    labels = match.get("labels")
+    if not isinstance(labels, dict):
+        return set()
+    any_of = labels.get("any-of")
+    if not isinstance(any_of, list):
+        return set()
+    return {x for x in any_of if isinstance(x, str) and x}
+
+
+def classify_bucket(
+    issue_labels: set[str], matchers: list[BucketMatcher], default_bucket: str
+) -> tuple[str, str]:
+    """Return ``(bucket_id, source)`` for an issue's label set.
+
+    First matcher (declaration order) whose ``labels`` intersect *issue_labels*
+    wins with ``source="match"``. No intersection -> ``(default_bucket, "default")``.
+    """
+    for matcher in matchers:
+        if matcher.labels & issue_labels:
+            return matcher.bucket_id, SOURCE_MATCH
+    return default_bucket, SOURCE_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# vBRIEF + cache + git helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp (``...Z`` or offset form) to aware UTC."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _to_iso_z(dt: datetime) -> str:
+    """Render an aware datetime as the canonical ``...Z`` form used on disk."""
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def extract_issue_ref(plan: dict[str, Any]) -> tuple[str | None, int | None]:
+    """Pull ``(repo, issue_number)`` from a vBRIEF plan's ``x-vbrief/github-issue`` ref."""
+    refs = plan.get("references")
+    if not isinstance(refs, list):
+        return None, None
+    for ref in refs:
+        if not isinstance(ref, dict) or ref.get("type") != "x-vbrief/github-issue":
+            continue
+        uri = ref.get("uri")
+        if not isinstance(uri, str):
+            continue
+        cleaned = uri.strip().rstrip("/")
+        parts = [p for p in cleaned.split("://", 1)[-1].split("/") if p]
+        if len(parts) >= 4 and parts[-2] == "issues" and parts[-1].isdigit():
+            return f"{parts[-4]}/{parts[-3]}", int(parts[-1])
+    return None, None
+
+
+def cached_issue_labels(
+    project_root: Path, repo: str, issue_number: int, *, cache_dir: Path | None = None
+) -> set[str] | None:
+    """Return the cached label set for ``repo#issue_number`` (offline), or None.
+
+    None means the issue is not in the cache (a label match cannot be attempted);
+    an empty set means the issue is cached but carries no labels.
+    """
+    base = cache_dir or project_root.joinpath(*CACHE_RELPATH)
+    raw_path = base / repo / str(issue_number) / "raw.json"
+    if not raw_path.is_file():
+        return None
+    try:
+        data = json.loads(raw_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    labels = data.get("labels") if isinstance(data, dict) else None
+    if not isinstance(labels, list):
+        return set()
+    out: set[str] = set()
+    for label in labels:
+        if isinstance(label, str) and label:
+            out.add(label)
+        elif isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str) and name:
+                out.add(name)
+    return out
+
+
+def git_landing_time(repo_rel_path: str, project_root: Path) -> str | None:
+    """Return the most recent commit timestamp touching *repo_rel_path*, as ``...Z``.
+
+    *repo_rel_path* MUST be relative to the git repository root (e.g.
+    ``vbrief/completed/<name>``), not the lifecycle folder. Uses
+    ``git log -1 --format=%cI -- <path>`` (committer date, ISO-8601 strict) as a
+    deterministic proxy for when the vBRIEF landed in ``completed/``. Returns None
+    when git is unavailable or the file is untracked.
+    """
+    try:
+        result = run_text(
+            ["git", "log", "-1", "--format=%cI", "--", repo_rel_path],
+            cwd=str(project_root),
+        )
+    except (OSError, ValueError):
+        return None
+    if result.returncode != 0:
+        return None
+    parsed = _parse_iso(result.stdout.strip())
+    return _to_iso_z(parsed) if parsed is not None else None
+
+
+def fetch_issue_labels(repo: str, issue_number: int) -> set[str] | None:
+    """Fetch an issue's label set via the REST shim (closed-issue-safe), or None.
+
+    Routes through ``scripts/gh_rest.rest_issue_view`` (REST, never GraphQL --
+    respects the #954 bucket-hygiene rule and the #1145 scm-boundary). Imported
+    lazily so the offline default path has no ``gh`` dependency and the unit
+    tests need no network. Any failure (no gh, network error, malformed
+    response) returns None so the caller falls back to the default bucket.
+    """
+    try:
+        from gh_rest import rest_issue_view  # noqa: PLC0415 -- lazy, opt-in only
+
+        issue = rest_issue_view(repo, issue_number)
+    except Exception:  # noqa: BLE001 -- any fetch failure degrades to default
+        return None
+    labels = issue.get("labels") if isinstance(issue, dict) else None
+    if not isinstance(labels, list):
+        return set()
+    out: set[str] = set()
+    for label in labels:
+        if isinstance(label, str) and label:
+            out.add(label)
+        elif isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str) and name:
+                out.add(name)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic
+# ---------------------------------------------------------------------------
+
+
+def backfill(
+    project_root: Path,
+    *,
+    cache_dir: Path | None = None,
+    dry_run: bool = True,
+    window_only: bool = False,
+    fetch: bool = False,
+    now: datetime | None = None,
+) -> BackfillResult:
+    """Backfill ``capacityBucket`` / ``completedAt`` on completed vBRIEFs.
+
+    Idempotent: explicit existing values are preserved. ``cost`` is never
+    touched. When *window_only* is set, completions whose effective
+    ``completedAt`` falls outside the trailing ``capacityAllocation.window``
+    are skipped (the activation-critical subset is exactly the in-window one).
+    When *fetch* is set, origin-issue labels missing from the local cache are
+    pulled via the REST shim (the one-time online opt-in for brownfield history
+    whose closed issues are not in the open-issue-scoped triage cache).
+    """
+    now_dt = now or datetime.now(UTC)
+    allocation = resolve_capacity_allocation(project_root)
+    result = BackfillResult(
+        project_root=project_root,
+        dry_run=dry_run,
+        window_only=window_only,
+        window_days=allocation.window_days,
+    )
+    if not allocation.configured:
+        result.error = (
+            "plan.policy.capacityAllocation is not configured -- configure "
+            "buckets before backfilling (see #1419 / task capacity:show)"
+        )
+        result.exit_code = 2
+        return result
+
+    matchers, default_bucket = load_bucket_matchers(project_root)
+    if not default_bucket:
+        # resolve_capacity_allocation validated the block, but a missing
+        # defaultBucket means unmatched work has nowhere to go -- fail loud.
+        result.error = (
+            "capacityAllocation.defaultBucket is required for backfill "
+            "(unmatched completions must have a fallback bucket)"
+        )
+        result.exit_code = 2
+        return result
+
+    completed_dir = project_root / "vbrief" / COMPLETED_FOLDER
+    if not completed_dir.is_dir():
+        return result
+
+    for path in sorted(completed_dir.glob("*.vbrief.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        plan = data.get("plan") if isinstance(data, dict) else None
+        if not isinstance(plan, dict):
+            continue
+        result.scanned += 1
+        rel_path = f"{COMPLETED_FOLDER}/{path.name}"
+        git_rel_path = f"vbrief/{rel_path}"
+
+        metadata = plan.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        existing_bucket = metadata.get("capacityBucket")
+        has_bucket = isinstance(existing_bucket, str) and bool(existing_bucket.strip())
+        existing_completed_at = metadata.get("completedAt")
+        has_completed_at = (
+            isinstance(existing_completed_at, str) and bool(existing_completed_at.strip())
+        )
+
+        # Resolve the effective completedAt (existing, else git landing time)
+        # so the window filter and the stamp share one value.
+        effective_completed_at = existing_completed_at if has_completed_at else None
+        git_completed_at: str | None = None
+        if not has_completed_at:
+            git_completed_at = git_landing_time(git_rel_path, project_root)
+            effective_completed_at = git_completed_at
+
+        if window_only and not _in_window(effective_completed_at, allocation.window_days, now_dt):
+            result.skipped_out_of_window += 1
+            continue
+
+        repo, issue_number = extract_issue_ref(plan)
+        if has_bucket:
+            result.already_classified += 1
+            bucket = existing_bucket.strip()
+            source = "preserved"
+        else:
+            labels: set[str] | None = None
+            if repo and issue_number is not None:
+                labels = cached_issue_labels(
+                    project_root, repo, issue_number, cache_dir=cache_dir
+                )
+                if labels is None and fetch:
+                    labels = fetch_issue_labels(repo, issue_number)
+                    if labels is not None:
+                        result.fetched += 1
+            bucket, source = classify_bucket(labels or set(), matchers, default_bucket)
+
+        set_bucket = not has_bucket
+        set_completed_at = not has_completed_at and git_completed_at is not None
+
+        item = BackfillItem(
+            rel_path=rel_path,
+            issue_number=issue_number,
+            bucket=bucket,
+            source=source,
+            set_bucket=set_bucket,
+            set_completed_at=set_completed_at,
+        )
+        result.items.append(item)
+
+        if set_bucket:
+            result.stamped_bucket += 1
+            if source == SOURCE_MATCH:
+                result.matched += 1
+            else:
+                result.defaulted += 1
+                result.low_confidence.append(item)
+        if set_completed_at:
+            result.stamped_completed_at += 1
+
+        if not dry_run and (set_bucket or set_completed_at):
+            try:
+                _write_metadata(
+                    path,
+                    data,
+                    plan,
+                    metadata,
+                    bucket=bucket if set_bucket else None,
+                    source=source if set_bucket else None,
+                    completed_at=git_completed_at if set_completed_at else None,
+                )
+            except OSError as exc:
+                result.error = f"{type(exc).__name__}: {exc} ({rel_path})"
+                result.exit_code = 1
+                return result
+
+    return result
+
+
+def _in_window(completed_at: str | None, window_days: int, now: datetime) -> bool:
+    """True when *completed_at* parses and falls within ``[0, window_days]`` of now."""
+    parsed = _parse_iso(completed_at)
+    if parsed is None:
+        return False
+    age_days = (now - parsed).total_seconds() / 86400.0
+    return 0 <= age_days <= window_days
+
+
+def _write_metadata(
+    path: Path,
+    data: dict[str, Any],
+    plan: dict[str, Any],
+    metadata: dict[str, Any],
+    *,
+    bucket: str | None,
+    source: str | None,
+    completed_at: str | None,
+) -> None:
+    """Stamp the resolved fields onto *plan.metadata* and write the file.
+
+    ``cost`` is never read or written here. Mirrors the JSON write style of
+    ``scripts/scope_lifecycle.py`` (2-space indent, ensure_ascii=False, trailing
+    newline) so the diff stays minimal and encoding-clean.
+    """
+    if not isinstance(plan.get("metadata"), dict):
+        plan["metadata"] = metadata
+    if completed_at is not None:
+        metadata["completedAt"] = completed_at
+    if bucket is not None:
+        metadata["capacityBucket"] = bucket
+        if source is not None:
+            metadata["capacityBucketSource"] = source
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _emit_json(result: BackfillResult) -> str:
+    payload = {
+        "project_root": str(result.project_root),
+        "dry_run": result.dry_run,
+        "scanned": result.scanned,
+        "stamped_bucket": result.stamped_bucket,
+        "stamped_completed_at": result.stamped_completed_at,
+        "already_classified": result.already_classified,
+        "matched": result.matched,
+        "defaulted": result.defaulted,
+        "fetched": result.fetched,
+        "skipped_out_of_window": result.skipped_out_of_window,
+        "window_only": result.window_only,
+        "window_days": result.window_days,
+        "exit_code": result.exit_code,
+        "error": result.error,
+        "low_confidence": [
+            {"issue_number": it.issue_number, "bucket": it.bucket, "rel_path": it.rel_path}
+            for it in result.low_confidence
+        ],
+    }
+    return json.dumps(payload, sort_keys=True)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="capacity_backfill.py",
+        description=(
+            "One-time capacity-bucket classifier for completed vBRIEFs (#1606). "
+            "Stamps plan.metadata.capacityBucket (inferred from origin-issue "
+            "labels via the configured bucket match rules) and completedAt "
+            "(git landing time) onto completed/ vBRIEFs that lack them. "
+            "Dry-run by default; idempotent; never touches cost."
+        ),
+    )
+    parser.add_argument(
+        "--project-root",
+        default=os.environ.get("DEFT_PROJECT_ROOT", "."),
+        help="Path to the project root (default: $DEFT_PROJECT_ROOT or cwd).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the changes. Without this flag the tool is a dry-run.",
+    )
+    parser.add_argument(
+        "--window-only",
+        action="store_true",
+        dest="window_only",
+        help=(
+            "Only backfill completions whose completedAt falls within the "
+            "trailing capacityAllocation.window -- the activation-critical "
+            "subset capacity:show actually counts."
+        ),
+    )
+    parser.add_argument(
+        "--fetch",
+        action="store_true",
+        help=(
+            "Pull origin-issue labels via the REST shim for issues missing from "
+            "the local cache (a one-time online opt-in for brownfield history; "
+            "closed issues are not in the open-issue-scoped triage cache). "
+            "Without this flag the tool is fully offline."
+        ),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help=(
+            "Override the github-issue label cache directory "
+            "(default: <project-root>/.deft-cache/github-issue)."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit a structured JSON payload instead of the human recap.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    project_root = Path(args.project_root).resolve()
+    if not project_root.exists() or not project_root.is_dir():
+        print(
+            f"❌ capacity:backfill: --project-root {project_root} does not exist "
+            "or is not a directory.",
+            file=sys.stderr,
+        )
+        return 2
+
+    cache_dir = Path(args.cache_dir).resolve() if args.cache_dir else None
+    result = backfill(
+        project_root,
+        cache_dir=cache_dir,
+        dry_run=not args.apply,
+        window_only=args.window_only,
+        fetch=args.fetch,
+    )
+
+    if args.emit_json:
+        print(_emit_json(result))
+    else:
+        print(result.summary(), file=sys.stderr if result.exit_code else sys.stdout)
+
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capacity_backfill.py
+++ b/scripts/capacity_backfill.py
@@ -121,6 +121,7 @@ class BackfillResult:
     defaulted: int = 0
     fetched: int = 0
     skipped_out_of_window: int = 0
+    skipped_unreadable: int = 0
     window_only: bool = False
     window_days: int = 0
     items: list[BackfillItem] = field(default_factory=list)
@@ -148,6 +149,11 @@ class BackfillResult:
             lines.append(
                 f"      window-only: skipped {self.skipped_out_of_window} "
                 f"completion(s) outside the trailing {self.window_days}d window"
+            )
+        if self.skipped_unreadable:
+            lines.append(
+                f"      skipped {self.skipped_unreadable} unreadable/malformed "
+                "completed vBRIEF file(s) (not counted in scanned)"
             )
         if self.error:
             lines.append(f"      error: {self.error}")
@@ -416,6 +422,10 @@ def backfill(
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
+            # Corrupted / non-UTF-8 / malformed-JSON files are skipped, but the
+            # skip is now counted so the summary's ``scanned`` figure is not
+            # silently lower than the actual file count (#1606 review).
+            result.skipped_unreadable += 1
             continue
         plan = data.get("plan") if isinstance(data, dict) else None
         if not isinstance(plan, dict):
@@ -477,16 +487,10 @@ def backfill(
         )
         result.items.append(item)
 
-        if set_bucket:
-            result.stamped_bucket += 1
-            if source == SOURCE_MATCH:
-                result.matched += 1
-            else:
-                result.defaulted += 1
-                result.low_confidence.append(item)
-        if set_completed_at:
-            result.stamped_completed_at += 1
-
+        # Write FIRST (apply mode), then tally -- so an OSError mid-run leaves
+        # the summary counting only what actually reached disk, not the failed
+        # item (#1606 review). Dry-run performs no write and falls straight to
+        # the tally so it reports what it WOULD stamp.
         if not dry_run and (set_bucket or set_completed_at):
             try:
                 _write_metadata(
@@ -502,6 +506,16 @@ def backfill(
                 result.error = f"{type(exc).__name__}: {exc} ({rel_path})"
                 result.exit_code = 1
                 return result
+
+        if set_bucket:
+            result.stamped_bucket += 1
+            if source == SOURCE_MATCH:
+                result.matched += 1
+            else:
+                result.defaulted += 1
+                result.low_confidence.append(item)
+        if set_completed_at:
+            result.stamped_completed_at += 1
 
     return result
 
@@ -561,6 +575,7 @@ def _emit_json(result: BackfillResult) -> str:
         "defaulted": result.defaulted,
         "fetched": result.fetched,
         "skipped_out_of_window": result.skipped_out_of_window,
+        "skipped_unreadable": result.skipped_unreadable,
         "window_only": result.window_only,
         "window_days": result.window_days,
         "exit_code": result.exit_code,

--- a/scripts/capacity_show.py
+++ b/scripts/capacity_show.py
@@ -145,6 +145,7 @@ class CapacityReport:
     window_days: int
     min_sample_size: int
     classified_completions: int
+    unclassified_completions: int
     advisory_mode: bool
     advisory_reasons: list[str] = field(default_factory=list)
     buckets: list[BucketTally] = field(default_factory=list)
@@ -331,6 +332,14 @@ def compute_report(
             tallies[record.bucket] = BucketTally(bucket_id=record.bucket, target=0.0)
 
     classified_completions = 0
+    # Completed vBRIEFs (any age) that carry no explicit capacityBucket -- the
+    # backfill-able set (#1606). A positive count while sample-short means
+    # `task capacity:backfill` can classify history and cross minSampleSize.
+    unclassified_completions = sum(
+        1
+        for record in records
+        if record.folder == BACKWARD_FOLDER and not record.classified
+    )
     cost_eligible = 0  # classified completions in window
     cost_with_actual = 0
     for record in records:
@@ -377,6 +386,15 @@ def compute_report(
             f"only {classified_completions} classified completion(s) in window "
             f"(< minSampleSize={allocation.min_sample_size}) -- deferring to ordering"
         )
+        # Actionable discoverability hint (#1606): when buckets ARE configured
+        # but completed history is unclassified, point the operator at the
+        # one-time backfill that crosses minSampleSize.
+        if allocation.configured and unclassified_completions > 0:
+            advisory_reasons.append(
+                f"{unclassified_completions} completed vBRIEF(s) are unclassified "
+                "-- run `task capacity:backfill --apply` (one-time) to classify "
+                "history and activate capacity accounting"
+            )
     if cost_fallback and cost_reason:
         advisory_reasons.append(cost_reason)
 
@@ -417,6 +435,7 @@ def compute_report(
         window_days=allocation.window_days,
         min_sample_size=allocation.min_sample_size,
         classified_completions=classified_completions,
+        unclassified_completions=unclassified_completions,
         advisory_mode=sample_short or not allocation.configured,
         advisory_reasons=advisory_reasons,
         buckets=ordered,

--- a/scripts/capacity_show.py
+++ b/scripts/capacity_show.py
@@ -116,6 +116,7 @@ class VbriefRecord:
     folder: str
     classified: bool  # carried an explicit capacityBucket
     in_window: bool  # completed within the trailing window (backward only)
+    completed_at_present: bool  # a non-empty completedAt string is on disk
     is_rework: bool
     cost: float | None
 
@@ -232,8 +233,15 @@ def classify_record(
     weight = _record_weight(kind, plan, metadata, allocation)
 
     in_window = False
+    # Mirror capacity_backfill's ``has_completed_at`` semantics: a non-empty
+    # string counts as present even if it does not parse (backfill preserves it
+    # and never re-stamps, so such an item can never enter the window).
+    raw_completed_at = metadata.get("completedAt")
+    completed_at_present = isinstance(raw_completed_at, str) and bool(
+        raw_completed_at.strip()
+    )
     if folder == BACKWARD_FOLDER:
-        completed_at = _parse_iso(metadata.get("completedAt"))
+        completed_at = _parse_iso(raw_completed_at)
         if completed_at is not None:
             age_days = (now - completed_at).total_seconds() / 86400.0
             in_window = 0 <= age_days <= allocation.window_days
@@ -250,6 +258,7 @@ def classify_record(
         folder=folder,
         classified=classified,
         in_window=in_window,
+        completed_at_present=completed_at_present,
         is_rework=is_rework,
         cost=_coerce_cost(metadata.get("cost")),
     )
@@ -332,13 +341,21 @@ def compute_report(
             tallies[record.bucket] = BucketTally(bucket_id=record.bucket, target=0.0)
 
     classified_completions = 0
-    # Completed vBRIEFs (any age) that carry no explicit capacityBucket -- the
-    # backfill-able set (#1606). A positive count while sample-short means
+    # Completed vBRIEFs that carry no explicit capacityBucket AND that a backfill
+    # could actually pull into the window-scoped classified set (#1606). An
+    # unclassified completion with an explicit completedAt OUTSIDE the trailing
+    # window is EXCLUDED: backfill would stamp its bucket but leave completedAt
+    # out of window, so classified_completions never rises and advisory mode
+    # would persist silently -- promising such a migration is misleading. An
+    # absent completedAt is included: backfill stamps the git landing time,
+    # which may land in window. A positive count while sample-short means
     # `task capacity:backfill` can classify history and cross minSampleSize.
     unclassified_completions = sum(
         1
         for record in records
-        if record.folder == BACKWARD_FOLDER and not record.classified
+        if record.folder == BACKWARD_FOLDER
+        and not record.classified
+        and (record.in_window or not record.completed_at_present)
     )
     cost_eligible = 0  # classified completions in window
     cost_with_actual = 0

--- a/tasks/capacity.yml
+++ b/tasks/capacity.yml
@@ -29,3 +29,11 @@ tasks:
       PYTHONUTF8: "1"
     cmds:
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/capacity_show.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+
+  backfill:
+    desc: "One-time capacity-bucket backfill for completed vBRIEFs (#1606): infer capacityBucket from origin-issue labels + stamp completedAt from git. Dry-run by default; idempotent; never touches cost. -- task capacity:backfill [-- --apply] [--window-only] [--cache-dir <path>] [--json]"
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/capacity_backfill.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tests/cli/test_capacity_backfill.py
+++ b/tests/cli/test_capacity_backfill.py
@@ -1,0 +1,344 @@
+"""Tests for scripts/capacity_backfill.py + the capacity cold-start nudge (#1606).
+
+Covers the brownfield-backfill story's acceptance surface:
+
+* Bucket classification from origin-issue labels (declaration-order match wins;
+  no match -> defaultBucket / low-confidence batch).
+* Dry-run default (no writes) vs --apply (stamps capacityBucket +
+  capacityBucketSource + git-derived completedAt).
+* Idempotency (a re-run preserves explicit values and is a no-op).
+* cost is never mutated.
+* --window-only restricts to the activation-critical trailing-window subset.
+* config error (capacityAllocation absent) -> exit 2.
+* --fetch fallback for issues missing from the offline cache.
+* The Tier-3 capacity cold-start nudge fires only in the cold-start state.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import capacity_backfill  # noqa: E402
+from capacity_backfill import (  # noqa: E402, I001
+    BucketMatcher,
+    backfill,
+    classify_bucket,
+    load_bucket_matchers,
+)
+
+NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+
+LIFECYCLE = ("proposed", "pending", "active", "completed", "cancelled")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _capacity(**overrides: object) -> dict:
+    base: dict = {
+        "unit": "vbrief-count",
+        "window": 30,
+        "enforcement": "advise",
+        "minSampleSize": 2,
+        "defaultBucket": "new-capability",
+        "buckets": [
+            {
+                "id": "technical-debt",
+                "target": 0.3,
+                "match": {"labels": {"any-of": ["bug", "refactor"]}},
+            },
+            {
+                "id": "new-capability",
+                "target": 0.7,
+                "match": {"labels": {"any-of": ["enhancement", "beta"]}},
+            },
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_project(tmp_path: Path, capacity: dict | None) -> Path:
+    vbrief = tmp_path / "vbrief"
+    for folder in LIFECYCLE:
+        (vbrief / folder).mkdir(parents=True, exist_ok=True)
+    plan: dict = {"title": "Capacity backfill test", "status": "running", "items": []}
+    if capacity is not None:
+        plan["policy"] = {"capacityAllocation": capacity}
+    (vbrief / "PROJECT-DEFINITION.vbrief.json").write_text(
+        json.dumps({"vBRIEFInfo": {"version": "0.6"}, "plan": plan}),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _completed_at(days_ago: int) -> str:
+    return (NOW - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _write_completed(
+    tmp_path: Path,
+    name: str,
+    *,
+    issue: int | None = None,
+    repo: str = "deftai/directive",
+    metadata: dict | None = None,
+) -> Path:
+    plan: dict = {"title": name, "status": "completed", "items": []}
+    if metadata is not None:
+        plan["metadata"] = metadata
+    if issue is not None:
+        plan["references"] = [
+            {
+                "type": "x-vbrief/github-issue",
+                "uri": f"https://github.com/{repo}/issues/{issue}",
+            }
+        ]
+    path = tmp_path / "vbrief" / "completed" / f"{name}.vbrief.json"
+    path.write_text(
+        json.dumps({"vBRIEFInfo": {"version": "0.6"}, "plan": plan}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_cache_labels(
+    tmp_path: Path, repo: str, issue: int, labels: list[str]
+) -> None:
+    raw = tmp_path / ".deft-cache" / "github-issue" / repo / str(issue) / "raw.json"
+    raw.parent.mkdir(parents=True, exist_ok=True)
+    raw.write_text(json.dumps({"number": issue, "labels": labels}), encoding="utf-8")
+
+
+def _read_metadata(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data["plan"].get("metadata", {})
+
+
+def _fixed_landing(_rel: str, _root: Path) -> str:
+    return _completed_at(5)
+
+
+# ---------------------------------------------------------------------------
+# Bucket classification
+# ---------------------------------------------------------------------------
+
+
+def test_load_bucket_matchers_reads_raw_match_labels(tmp_path):
+    root = _make_project(tmp_path, _capacity())
+    matchers, default_bucket = load_bucket_matchers(root)
+    assert default_bucket == "new-capability"
+    assert matchers[0].bucket_id == "technical-debt"
+    assert matchers[0].labels == frozenset({"bug", "refactor"})
+    assert matchers[1].labels == frozenset({"enhancement", "beta"})
+
+
+def test_classify_match_wins_by_declaration_order():
+    matchers = [
+        BucketMatcher("technical-debt", frozenset({"bug"})),
+        BucketMatcher("new-capability", frozenset({"enhancement"})),
+    ]
+    # An issue carrying BOTH labels resolves to the first declared matcher.
+    bucket, source = classify_bucket({"bug", "enhancement"}, matchers, "new-capability")
+    assert (bucket, source) == ("technical-debt", "match")
+
+
+def test_classify_no_match_falls_to_default():
+    matchers = [BucketMatcher("technical-debt", frozenset({"bug"}))]
+    bucket, source = classify_bucket({"docs"}, matchers, "new-capability")
+    assert (bucket, source) == ("new-capability", "default")
+
+
+# ---------------------------------------------------------------------------
+# Dry-run / apply / idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_write(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    path = _write_completed(tmp_path, "x", issue=10, metadata={"completedAt": _completed_at(3)})
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    result = backfill(root, dry_run=True, now=NOW)
+
+    assert result.dry_run is True
+    assert result.stamped_bucket == 1
+    assert result.matched == 1
+    assert "capacityBucket" not in _read_metadata(path)
+
+
+def test_apply_stamps_bucket_source_and_completed_at(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    # No completedAt on disk -> git landing time is used.
+    path = _write_completed(tmp_path, "x", issue=10)
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    result = backfill(root, dry_run=False, now=NOW)
+
+    assert result.stamped_bucket == 1
+    assert result.stamped_completed_at == 1
+    md = _read_metadata(path)
+    assert md["capacityBucket"] == "technical-debt"
+    assert md["capacityBucketSource"] == "match"
+    assert md["completedAt"] == _completed_at(5)
+
+
+def test_idempotent_rerun_is_noop(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    _write_completed(tmp_path, "x", issue=10)
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    backfill(root, dry_run=False, now=NOW)
+    second = backfill(root, dry_run=False, now=NOW)
+
+    assert second.stamped_bucket == 0
+    assert second.already_classified == 1
+
+
+def test_existing_bucket_is_preserved(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    path = _write_completed(
+        tmp_path,
+        "x",
+        issue=10,
+        metadata={"completedAt": _completed_at(3), "capacityBucket": "agentic-debt"},
+    )
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    result = backfill(root, dry_run=False, now=NOW)
+
+    assert result.already_classified == 1
+    assert result.stamped_bucket == 0
+    assert _read_metadata(path)["capacityBucket"] == "agentic-debt"
+
+
+def test_cost_is_never_mutated(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    path = _write_completed(tmp_path, "x", issue=10, metadata={"cost": 12.5})
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    backfill(root, dry_run=False, now=NOW)
+
+    assert _read_metadata(path)["cost"] == 12.5
+
+
+# ---------------------------------------------------------------------------
+# Low-confidence batch / window-only / config error / fetch
+# ---------------------------------------------------------------------------
+
+
+def test_unmatched_issue_lands_in_low_confidence_batch(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    _write_completed(tmp_path, "x", issue=10, metadata={"completedAt": _completed_at(3)})
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["docs"])  # no bucket match
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    result = backfill(root, dry_run=True, now=NOW)
+
+    assert result.defaulted == 1
+    assert len(result.low_confidence) == 1
+    assert result.low_confidence[0].bucket == "new-capability"
+    assert result.low_confidence[0].source == "default"
+
+
+def test_window_only_skips_out_of_window(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity(window=30))
+    _write_completed(tmp_path, "old", issue=10, metadata={"completedAt": _completed_at(100)})
+    _write_completed(tmp_path, "new", issue=11, metadata={"completedAt": _completed_at(3)})
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    _write_cache_labels(tmp_path, "deftai/directive", 11, ["bug"])
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    result = backfill(root, dry_run=True, window_only=True, now=NOW)
+
+    assert result.skipped_out_of_window == 1
+    assert result.stamped_bucket == 1
+
+
+def test_not_configured_is_config_error(tmp_path):
+    root = _make_project(tmp_path, None)
+    result = backfill(root, dry_run=True, now=NOW)
+    assert result.exit_code == 2
+    assert result.error and "not configured" in result.error
+
+
+def test_fetch_fallback_for_uncached_issue(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    _write_completed(tmp_path, "x", issue=99, metadata={"completedAt": _completed_at(3)})
+    # No cache entry for #99 -> offline classification would default.
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+    monkeypatch.setattr(
+        capacity_backfill, "fetch_issue_labels", lambda repo, n: {"refactor"}
+    )
+
+    result = backfill(root, dry_run=True, fetch=True, now=NOW)
+
+    assert result.fetched == 1
+    assert result.matched == 1
+    assert result.low_confidence == []
+
+
+def test_fetch_disabled_defaults_uncached_issue(tmp_path, monkeypatch):
+    root = _make_project(tmp_path, _capacity())
+    _write_completed(tmp_path, "x", issue=99, metadata={"completedAt": _completed_at(3)})
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    result = backfill(root, dry_run=True, fetch=False, now=NOW)
+
+    assert result.fetched == 0
+    assert result.defaulted == 1
+
+
+# ---------------------------------------------------------------------------
+# Capacity cold-start nudge (#1606)
+# ---------------------------------------------------------------------------
+
+
+def _detect_nudge(root: Path):
+    from _lifecycle_hygiene import detect_capacity_coldstart_nudge
+
+    return detect_capacity_coldstart_nudge(root, now=NOW)
+
+
+def test_coldstart_nudge_fires_when_configured_and_unclassified(tmp_path):
+    root = _make_project(tmp_path, _capacity(minSampleSize=5))
+    for i in range(3):
+        _write_completed(
+            tmp_path, f"c{i}", issue=10 + i, metadata={"completedAt": _completed_at(3)}
+        )
+    nudge = _detect_nudge(root)
+    assert nudge is not None
+    assert nudge.tier == 3
+    assert "capacity:backfill" in nudge.message
+
+
+def test_coldstart_nudge_suppressed_when_unconfigured(tmp_path):
+    root = _make_project(tmp_path, None)
+    _write_completed(tmp_path, "c", issue=10, metadata={"completedAt": _completed_at(3)})
+    assert _detect_nudge(root) is None
+
+
+def test_coldstart_nudge_suppressed_when_already_classified(tmp_path):
+    root = _make_project(tmp_path, _capacity(minSampleSize=2))
+    for i in range(3):
+        _write_completed(
+            tmp_path,
+            f"c{i}",
+            issue=10 + i,
+            metadata={"completedAt": _completed_at(3), "capacityBucket": "technical-debt"},
+        )
+    # 3 classified >= minSampleSize=2 and nothing unclassified -> no cold-start.
+    assert _detect_nudge(root) is None

--- a/tests/cli/test_capacity_backfill.py
+++ b/tests/cli/test_capacity_backfill.py
@@ -342,3 +342,92 @@ def test_coldstart_nudge_suppressed_when_already_classified(tmp_path):
         )
     # 3 classified >= minSampleSize=2 and nothing unclassified -> no cold-start.
     assert _detect_nudge(root) is None
+
+
+def test_coldstart_nudge_suppressed_when_unclassified_out_of_window(tmp_path):
+    # Unclassified completions whose explicit completedAt predates the window
+    # are NOT backfill-actionable: stamping a bucket leaves completedAt out of
+    # window, so classified_completions never rises. The hint/nudge must not
+    # promise a no-op migration (#1606 Greptile review).
+    root = _make_project(tmp_path, _capacity(window=30, minSampleSize=5))
+    for i in range(3):
+        _write_completed(
+            tmp_path, f"old{i}", issue=10 + i, metadata={"completedAt": _completed_at(100)}
+        )
+    assert _detect_nudge(root) is None
+
+
+def test_coldstart_nudge_fires_for_undated_unclassified(tmp_path):
+    # A completion with NO completedAt IS backfill-actionable: the tool stamps
+    # the git landing time, which may land in window -- so the nudge fires.
+    root = _make_project(tmp_path, _capacity(window=30, minSampleSize=5))
+    for i in range(3):
+        _write_completed(tmp_path, f"u{i}", issue=10 + i)
+    nudge = _detect_nudge(root)
+    assert nudge is not None
+    assert nudge.tier == 3
+
+
+def test_unclassified_completions_excludes_out_of_window(tmp_path):
+    # Direct compute_report coverage of the window-aware backfill-actionable
+    # count: in-window + undated unclassified count; out-of-window does not.
+    import capacity_show
+
+    root = _make_project(tmp_path, _capacity(window=30, minSampleSize=5))
+    _write_completed(tmp_path, "in", issue=10, metadata={"completedAt": _completed_at(3)})
+    _write_completed(tmp_path, "undated", issue=11)
+    _write_completed(tmp_path, "old", issue=12, metadata={"completedAt": _completed_at(100)})
+    report = capacity_show.compute_report(root, now=NOW)
+    assert report.unclassified_completions == 2
+
+
+# ---------------------------------------------------------------------------
+# Write-failure accounting + unreadable-file accounting (#1606 review)
+# ---------------------------------------------------------------------------
+
+
+def test_write_failure_does_not_overstate_stamped_count(tmp_path, monkeypatch):
+    # On an OSError mid-run the summary must count only items that actually
+    # reached disk, not the failing one (#1606 Greptile review, issue 2).
+    root = _make_project(tmp_path, _capacity())
+    _write_completed(tmp_path, "a", issue=10)
+    _write_completed(tmp_path, "b", issue=11)
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    _write_cache_labels(tmp_path, "deftai/directive", 11, ["bug"])
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    calls = {"n": 0}
+    real_write = capacity_backfill._write_metadata
+
+    def _flaky_write(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:  # second item (sorted: a then b) fails to write
+            raise OSError("disk full")
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(capacity_backfill, "_write_metadata", _flaky_write)
+
+    result = backfill(root, dry_run=False, now=NOW)
+
+    assert result.exit_code == 1
+    assert result.error is not None
+    # Only the first item was written, so the summary must report 1, not 2.
+    assert result.stamped_bucket == 1
+    assert result.stamped_completed_at == 1
+
+
+def test_unreadable_completed_file_is_counted(tmp_path, monkeypatch):
+    # A corrupted / non-parseable completed vBRIEF is skipped but counted so
+    # the summary's scanned figure is not silently short (#1606 review, issue 3).
+    root = _make_project(tmp_path, _capacity())
+    _write_completed(tmp_path, "good", issue=10, metadata={"completedAt": _completed_at(3)})
+    _write_cache_labels(tmp_path, "deftai/directive", 10, ["bug"])
+    bad = tmp_path / "vbrief" / "completed" / "bad.vbrief.json"
+    bad.write_text("{ this is not valid json", encoding="utf-8")
+    monkeypatch.setattr(capacity_backfill, "git_landing_time", _fixed_landing)
+
+    result = backfill(root, dry_run=True, now=NOW)
+
+    assert result.skipped_unreadable == 1
+    assert result.scanned == 1
+    assert "unreadable/malformed" in result.summary()

--- a/vbrief/active/2026-06-12-1606-featcapacity-ship-the-deferred-capacitybackfill-tool-1419-hi.vbrief.json
+++ b/vbrief/active/2026-06-12-1606-featcapacity-ship-the-deferred-capacitybackfill-tool-1419-hi.vbrief.json
@@ -1,0 +1,67 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1606"
+  },
+  "plan": {
+    "title": "feat(capacity): ship the deferred capacity:backfill tool (#1419 history classifier)",
+    "status": "running",
+    "narratives": {
+      "Description": "feat(capacity): ship the deferred capacity:backfill tool (#1419 history classifier)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1606",
+      "Overview": "## Summary\n\nShip the deferred `task capacity:backfill` tool — the one-time history classifier specified in the #1419 RFC (\"Brownfield Backfill\") but **not** included in the merged delivery slices (#1503 capacity engine, #1506 selection, #1507 gate integration, etc.). Today only `scripts/capacity_show.py` and `scripts/verify_capacity.py` shipped; there is no way to classify pre-adoption completed vBRIEFs.\n\n## Why now (concrete gap)\n\nDirective just configured `plan.policy.capacityAllocation` (4 buckets: `new-capability` 45% / `technical-debt` 20% / `agentic-debt` 20% / `cognitive-debt` 15%). With buckets typed, `task capacity:show` reveals the cold-start problem:\n\n- The completed vBRIEFs in the trailing window **all dump into `defaultBucket` (`new-capability`)** because none carry an explicit `plan.metadata.capacityBucket`.\n- `classified completions: 0` — every completion is *unclassified*, so the `minSampleSize=20` guard keeps the engine pinned in **ADVISORY** mode indefinitely.\n- `task scope:complete` stamps `completedAt` + `capacityBucket` going forward, but **only from `defaultBucket`** — it does not per-item label-match, so forward stamping alone never produces a correct historical mix.\n\nNet: without backfill, capacity allocation can never leave advisory mode on a pre-adoption tree (including directive itself). This is *classification cold-start, not volume cold-start* — the history exists, it's just unclassified.\n\n## Proposed contract (from #1419 \"Brownfield Backfill\")\n\n`task capacity:backfill` — a one-time migration, same shape/safety as `task migrate:vbrief` (window-first, dry-run-default, git-reversible):\n\n- `completedAt` ← git landing time of the file in `completed/` (deterministic, zero human).\n- `capacityBucket` ← bucket `match` rules (the `labels.any-of` predicates already declared per bucket) evaluated against each vBRIEF's origin-issue labels (via its `x-vbrief/github-issue` reference) → agent inference for ambiguous → **human reviews only the low-confidence batch**. Records `capacityBucketSource` (`match` | `agent` | `human`).\n- In-flight epic `estimatedChildren` ← agent-proposed in the same pass.\n- Note: historical **cost** actuals are NOT backfillable (no telemetry for past runs) — `cost` accrues forward only.\n\n## Acceptance criteria\n\n- [ ] `task capacity:backfill` exists (Taskfile target + `scripts/capacity_backfill.py`), dry-run by default, with `--apply` to write.\n- [ ] Stamps `completedAt` (git-derived) + `capacityBucket` + `capacityBucketSource` onto `completed/` vBRIEFs that lack them; preserves any explicit existing value.\n- [ ] Bucket inference reuses the declared `capacityAllocation.buckets[].match.labels` predicates; surfaces a low-confidence batch for human confirmation.\n- [ ] Idempotent + git-reversible; never mutates `cost`.\n- [ ] New tests under `tests/` exercise classification, dry-run vs apply, and the idempotency contract.\n- [ ] After running on directive, `task capacity:show` reports a non-trivial `classified completions` count and a realistic per-bucket backward mix (no longer 100% `new-capability`).\n\n## Discoverability (brownfield cold-start)\n\nConfiguring buckets is not self-announcing, and the backfill is even less so. Audit of current surfaces (2026-06-12) found **no proactive surface** tells a consumer they need to backfill:\n\n- `task capacity:show` only passively prints `capacityAllocation not configured` / advisory-mode lines — and the consumer has to already know to run it.\n- The session-start nudge surface (`scripts/triage_welcome.py`) + lifecycle nudges (`scripts/_lifecycle_hygiene.py`) cover stranded-slice / stale-epic / skew, but those only fire **after** buckets are configured AND there is classified completion data. The **cold-start** state (buckets set, `classified == 0`, stuck in advisory) — the exact moment a backfill nudge would matter — is invisible.\n- `task doctor` has zero capacity awareness.\n\nThis issue must close the **brownfield** half of that gap (the greenfield onboarding prompt is tracked separately):\n\n- [ ] **Cold-start → backfill nudge.** When `capacityAllocation` IS configured but classified completions == 0 (or `completed/` vBRIEFs exist that lack `capacityBucket`), emit an actionable session-start nudge (`scripts/triage_welcome.py` / `_lifecycle_hygiene.py`) pointing at `task capacity:backfill`. Suppress once `classified >= minSampleSize` or no unclassified completed work remains. Respects the #1419 nudge-budget (Tier-3 informational, single line + overflow pointer).\n- [ ] **Actionable `capacity:show` hint.** Replace the bare `capacityAllocation not configured` / cold-start advisory lines with an actionable next-step (`run task capacity:backfill` when configured-but-unclassified; point at bucket setup when fully unconfigured).\n- [ ] Tests assert the cold-start nudge fires in the configured-but-unclassified state and is suppressed once classified work crosses the threshold.\n\n## References\n\n- Sibling discoverability issue (greenfield): capacity-bucket setup step in `task triage:welcome --onboard` / the setup skill — filed separately (see issue link in this thread).\n- Parent RFC: #1419 (Agentic Prioritization & Coordination Model) — \"Brownfield Backfill\" + \"Adoption Experience\" + \"Session-Start Nudge Budgeting\" sections.\n- Sibling open follow-up: #1511 (flip gates advisory → enforce) — backfill is a prerequisite for capacity enforcement to be meaningful.\n- Shipped engine this builds on: `scripts/capacity_show.py`, `scripts/policy.py::resolve_capacity_allocation`, `scripts/scope_lifecycle.py::_stamp_completion_metadata`.\n- Migration pattern to mirror: `task migrate:vbrief`.\n",
+      "Labels": "enhancement, process, tooling"
+    },
+    "items": [
+      {
+        "title": "exists (Taskfile target + ), dry-run by default, with  to write.",
+        "status": "proposed"
+      },
+      {
+        "title": "Stamps  (git-derived) +  +  onto  vBRIEFs that lack them; preserves any explicit existing value.",
+        "status": "proposed"
+      },
+      {
+        "title": "Bucket inference reuses the declared  predicates; surfaces a low-confidence batch for human confirmation.",
+        "status": "proposed"
+      },
+      {
+        "title": "Idempotent + git-reversible; never mutates .",
+        "status": "proposed"
+      },
+      {
+        "title": "New tests under  exercise classification, dry-run vs apply, and the idempotency contract.",
+        "status": "proposed"
+      },
+      {
+        "title": "After running on directive,  reports a non-trivial  count and a realistic per-bucket backward mix (no longer 100% ).",
+        "status": "proposed"
+      },
+      {
+        "title": "**Cold-start → backfill nudge.** When  IS configured but classified completions == 0 (or  vBRIEFs exist that lack ), emit an actionable session-start nudge ( / ) pointing at . Suppress once  or no unclassified completed work remains. Respects the #1419 nudge-budget (Tier-3 informational, single line + overflow pointer).",
+        "status": "proposed"
+      },
+      {
+        "title": "**Actionable  hint.** Replace the bare  / cold-start advisory lines with an actionable next-step ( when configured-but-unclassified; point at bucket setup when fully unconfigured).",
+        "status": "proposed"
+      },
+      {
+        "title": "Tests assert the cold-start nudge fires in the configured-but-unclassified state and is suppressed once classified work crosses the threshold.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "process",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1606",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1606: feat(capacity): ship the deferred capacity:backfill tool (#1419 history classifier)"
+      }
+    ],
+    "updated": "2026-06-12T20:47:54Z"
+  }
+}

--- a/vbrief/completed/2026-05-01-742-adr-001-empirical-validation.vbrief.json
+++ b/vbrief/completed/2026-05-01-742-adr-001-empirical-validation.vbrief.json
@@ -107,7 +107,10 @@
           "execution": "operations/2026-05-01-adr-001-execution-plan.md",
           "risks": "operations/2026-05-01-adr-001-risks.md"
         }
-      }
+      },
+      "completedAt": "2026-05-22T19:16:28Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
+++ b/vbrief/completed/2026-05-12-directive-decomposition-readiness.vbrief.json
@@ -81,7 +81,10 @@
         "file_scope_confidence": "medium",
         "model_tier": "high",
         "missing_traces_justification": "User-provided change request in this conversation is the source scope; no external issue was supplied."
-      }
+      },
+      "completedAt": "2026-05-17T17:06:42Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "references": [
       {

--- a/vbrief/completed/2026-05-13-1125-followup-scope-complete-and-spec-render.vbrief.json
+++ b/vbrief/completed/2026-05-13-1125-followup-scope-complete-and-spec-render.vbrief.json
@@ -20,6 +20,11 @@
         "title": "PR #1125: feat(skills): add deft-directive-gh-arch (re-land of #442) -- merged predecessor"
       }
     ],
-    "updated": "2026-06-01T17:16:28Z"
+    "updated": "2026-06-01T17:16:28Z",
+    "metadata": {
+      "completedAt": "2026-06-01T17:17:44Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1121-d1-scope-demote.vbrief.json
+++ b/vbrief/completed/2026-05-17-1121-d1-scope-demote.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1122-d2-triage-summary.vbrief.json
+++ b/vbrief/completed/2026-05-17-1122-d2-triage-summary.vbrief.json
@@ -30,6 +30,11 @@
         "title": "Sibling D11: task triage:audit --format=json (planned wrap-up consumer)"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1127-d5-cache-fresh.vbrief.json
+++ b/vbrief/completed/2026-05-17-1127-d5-cache-fresh.vbrief.json
@@ -31,6 +31,11 @@
         "title": "D12 #1131: subscription surface (scripts/triage_scope.py)"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1128-d11-triage-queue.vbrief.json
+++ b/vbrief/completed/2026-05-17-1128-d11-triage-queue.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1129-d10-auto-classify.vbrief.json
+++ b/vbrief/completed/2026-05-17-1129-d10-auto-classify.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1131-d12-triage-scope.vbrief.json
+++ b/vbrief/completed/2026-05-17-1131-d12-triage-scope.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1144-n4-eval-governance.vbrief.json
+++ b/vbrief/completed/2026-05-17-1144-n4-eval-governance.vbrief.json
@@ -30,6 +30,11 @@
         "title": "Umbrella #1119: Wave-0 triage-eval governance swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-17-1149-n9-agents-md-consolidation.vbrief.json
+++ b/vbrief/completed/2026-05-17-1149-n9-agents-md-consolidation.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1123-d3-resume-conditions.vbrief.json
+++ b/vbrief/completed/2026-05-18-1123-d3-resume-conditions.vbrief.json
@@ -35,6 +35,11 @@
         "title": "Sibling D11 (consumer of [RESUME] surface): task triage:queue + audit"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1124-d4-wip-cap.vbrief.json
+++ b/vbrief/completed/2026-05-18-1124-d4-wip-cap.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-2a swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1132-d13-slices-writer.vbrief.json
+++ b/vbrief/completed/2026-05-18-1132-d13-slices-writer.vbrief.json
@@ -35,6 +35,11 @@
         "title": "Sibling D3 (resume-condition grammar): scripts/resume_conditions.py"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1133-d14-scope-drift.vbrief.json
+++ b/vbrief/completed/2026-05-18-1133-d14-scope-drift.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1/2 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1134-d15-scope-undo.vbrief.json
+++ b/vbrief/completed/2026-05-18-1134-d15-scope-undo.vbrief.json
@@ -30,6 +30,11 @@
         "title": "Issue #1121: D1 -- task scope:demote (audit-log surface consumed)"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1141-n1-refinement-phase0.vbrief.json
+++ b/vbrief/completed/2026-05-18-1141-n1-refinement-phase0.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: triage-eval governance swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1142-n2-swarm-phase0-queue-driven.vbrief.json
+++ b/vbrief/completed/2026-05-18-1142-n2-swarm-phase0-queue-driven.vbrief.json
@@ -30,6 +30,11 @@
         "title": "Issue #1136: D18 -- task scope:promote --from-issue=<N> (future integration point)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1143-n3-triage-welcome.vbrief.json
+++ b/vbrief/completed/2026-05-18-1143-n3-triage-welcome.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: triage-eval governance swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1146-n6-triage-smoketest.vbrief.json
+++ b/vbrief/completed/2026-05-18-1146-n6-triage-smoketest.vbrief.json
@@ -60,6 +60,11 @@
         "title": "D18: scope:promote --from-issue (future integration)"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1148-n8-policy-show.vbrief.json
+++ b/vbrief/completed/2026-05-18-1148-n8-policy-show.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: triage-eval governance swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1152-n12-umbrella-current-shape-convention.vbrief.json
+++ b/vbrief/completed/2026-05-18-1152-n12-umbrella-current-shape-convention.vbrief.json
@@ -30,6 +30,11 @@
         "title": "Meta-umbrella #1140: design-pass churn"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1180-lightweight-triage-metrics.vbrief.json
+++ b/vbrief/completed/2026-05-18-1180-lightweight-triage-metrics.vbrief.json
@@ -30,6 +30,11 @@
         "title": "Issue #1128: D11 task triage:queue + audit + show (base verb)"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1181-d14b-milestone-any-of-is-open.vbrief.json
+++ b/vbrief/completed/2026-05-18-1181-d14b-milestone-any-of-is-open.vbrief.json
@@ -30,6 +30,11 @@
         "title": "D14 -- scope-drift + milestone rule v1"
       }
     ],
-    "updated": "2026-05-19T21:22:20Z"
+    "updated": "2026-05-19T21:22:20Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1182-d14c-ignore-list.vbrief.json
+++ b/vbrief/completed/2026-05-18-1182-d14c-ignore-list.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1/2 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-18-1186-consumer-example.vbrief.json
+++ b/vbrief/completed/2026-05-18-1186-consumer-example.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Umbrella #1119: Wave-0/1/2 swarm"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1145-source-agnostic-verb-boundary-scaffold-partial-445935-down-p.vbrief.json
+++ b/vbrief/completed/2026-05-19-1145-source-agnostic-verb-boundary-scaffold-partial-445935-down-p.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Issue #1145: Source-agnostic verb boundary scaffold (partial #445/#935 down-payment) (N5 of #1119)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1147-task-slicerecord-existing-backfill-slice-records-for-hand-fi.vbrief.json
+++ b/vbrief/completed/2026-05-19-1147-task-slicerecord-existing-backfill-slice-records-for-hand-fi.vbrief.json
@@ -24,6 +24,11 @@
         "title": "Issue #1147: task slice:record-existing — backfill slice records for hand-filed cohorts (N7 of #1119)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1150-categorized-verb-help-surface-for-task-triage-task-scope-n10.vbrief.json
+++ b/vbrief/completed/2026-05-19-1150-categorized-verb-help-surface-for-task-triage-task-scope-n10.vbrief.json
@@ -24,6 +24,11 @@
         "title": "Issue #1150: Categorized verb help surface for task triage / task scope (N10 of #1119)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1228-teststriage-help-add-scope-namespace-coverage-document-triag.vbrief.json
+++ b/vbrief/completed/2026-05-19-1228-teststriage-help-add-scope-namespace-coverage-document-triag.vbrief.json
@@ -20,6 +20,11 @@
         "title": "Issue #1228: tests(triage_help): add scope-namespace coverage + document triage_subscribe __default__ fallback (#1150 follow-up)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1230-fixslice-address-p2-greptile-findings-on-slice-record-existi.vbrief.json
+++ b/vbrief/completed/2026-05-19-1230-fixslice-address-p2-greptile-findings-on-slice-record-existi.vbrief.json
@@ -20,6 +20,11 @@
         "title": "Issue #1230: fix(slice): address P2 Greptile findings on slice_record_existing (#1147 follow-up)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1231-fixslice-atomic-idempotency-windows-quoting-1147-follow-up.vbrief.json
+++ b/vbrief/completed/2026-05-19-1231-fixslice-atomic-idempotency-windows-quoting-1147-follow-up.vbrief.json
@@ -20,6 +20,11 @@
         "title": "Issue #1231: fix(slice): atomic idempotency + Windows quoting (#1147 follow-up)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1236-bugtriage-triagequeue-returns-zero-items-after-bootstrap-cas.vbrief.json
+++ b/vbrief/completed/2026-05-19-1236-bugtriage-triagequeue-returns-zero-items-after-bootstrap-cas.vbrief.json
@@ -20,6 +20,11 @@
         "title": "Issue #1236: bug(triage): triage:queue returns zero items after bootstrap (case mismatch on cached state field)"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1237-bugtriagebootstrap-backfill-audit-log-skips-with-no-repo-pro.vbrief.json
+++ b/vbrief/completed/2026-05-19-1237-bugtriagebootstrap-backfill-audit-log-skips-with-no-repo-pro.vbrief.json
@@ -20,6 +20,11 @@
         "title": "Issue #1237: bug(triage:bootstrap): backfill_audit_log skips with 'no --repo provided' while step 1 inferred the repo"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1239-perfcache-triagebootstrap-is-graphql-heavy-954-mandates-rest.vbrief.json
+++ b/vbrief/completed/2026-05-19-1239-perfcache-triagebootstrap-is-graphql-heavy-954-mandates-rest.vbrief.json
@@ -20,6 +20,11 @@
         "title": "Issue #1239: perf(cache): triage:bootstrap is GraphQL-heavy; #954 mandates REST-first"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1240-bugverifycache-fresh-still-reports-bootstrap-state-after-a-s.vbrief.json
+++ b/vbrief/completed/2026-05-19-1240-bugverifycache-fresh-still-reports-bootstrap-state-after-a-s.vbrief.json
@@ -20,6 +20,11 @@
         "title": "Issue #1240: bug(verify:cache-fresh): still reports 'bootstrap state' after a successful triage:bootstrap"
       }
     ],
-    "updated": "2026-05-19T21:22:21Z"
+    "updated": "2026-05-19T21:22:21Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:23:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-19-1242-docschangelog-entries-must-be-brief-release-notes-not-implem.vbrief.json
+++ b/vbrief/completed/2026-05-19-1242-docschangelog-entries-must-be-brief-release-notes-not-implem.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Issue #1242: docs(changelog): entries MUST be brief release-notes, not implementation detail (v0.32.0 release-blocker)"
       }
     ],
-    "updated": "2026-05-19T21:56:30Z"
+    "updated": "2026-05-19T21:56:30Z",
+    "metadata": {
+      "completedAt": "2026-05-19T21:57:12Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json
+++ b/vbrief/completed/2026-05-20-1244-bugtriageskills-task-triagewelcome-silently-skips-bootstrap.vbrief.json
@@ -58,6 +58,11 @@
         "title": "Issue #1244: bug(triage,skills): task triage:welcome silently skips bootstrap; candidates.jsonl remains absent"
       }
     ],
-    "updated": "2026-05-20T19:24:32Z"
+    "updated": "2026-05-20T19:24:32Z",
+    "metadata": {
+      "completedAt": "2026-05-20T19:35:34Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi.vbrief.json
+++ b/vbrief/completed/2026-05-20-1245-bugtriagedeterminism-verifycache-fresh-false-fails-on-backfi.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Issue #1245: bug(triage,determinism): verify:cache-fresh false-fails on backfill-only cache state"
       }
     ],
-    "updated": "2026-05-20T19:24:32Z"
+    "updated": "2026-05-20T19:24:32Z",
+    "metadata": {
+      "completedAt": "2026-05-20T19:35:34Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o.vbrief.json
+++ b/vbrief/completed/2026-05-20-1246-enhancementtriage-triagequeue-should-auto-detect-repo-from-o.vbrief.json
@@ -23,6 +23,11 @@
         "title": "Issue #1246: enhancement(triage): triage:queue should auto-detect --repo from origin remote"
       }
     ],
-    "updated": "2026-05-20T19:24:33Z"
+    "updated": "2026-05-20T19:24:33Z",
+    "metadata": {
+      "completedAt": "2026-05-20T19:35:34Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee.vbrief.json
+++ b/vbrief/completed/2026-05-20-1247-bugtriagebootstrap-populate-cache-counter-terminology-succee.vbrief.json
@@ -23,6 +23,11 @@
         "title": "Issue #1247: bug(triage,bootstrap): populate_cache counter terminology (succeeded=1 skipped=396) misleads operators"
       }
     ],
-    "updated": "2026-05-20T19:24:33Z"
+    "updated": "2026-05-20T19:24:33Z",
+    "metadata": {
+      "completedAt": "2026-05-20T19:35:34Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json
+++ b/vbrief/completed/2026-05-20-1248-enhancementingestskills-task-issueingest-produces-stub-only.vbrief.json
@@ -73,6 +73,11 @@
         "title": "Issue #1248: enhancement(ingest,skills): task issue:ingest produces stub-only vBRIEFs (no Overview, no items)"
       }
     ],
-    "updated": "2026-05-20T19:24:33Z"
+    "updated": "2026-05-20T19:24:33Z",
+    "metadata": {
+      "completedAt": "2026-05-20T19:35:34Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1250-bugtriagepolicy-task-triagewelcome-materializes-planpolicywi.vbrief.json
+++ b/vbrief/completed/2026-05-20-1250-bugtriagepolicy-task-triagewelcome-materializes-planpolicywi.vbrief.json
@@ -25,6 +25,11 @@
         "title": "Issue #1250: bug(triage,policy): task triage:welcome materializes plan.policy.wipCap, violating #1186 Deliverable 1"
       }
     ],
-    "updated": "2026-05-20T19:24:34Z"
+    "updated": "2026-05-20T19:24:34Z",
+    "metadata": {
+      "completedAt": "2026-05-20T19:35:34Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json
+++ b/vbrief/completed/2026-05-20-1251-bugtriagepolicy-task-triagebootstrap-blanket-ignores-vbriefe.vbrief.json
@@ -82,6 +82,11 @@
         "title": "Issue #1251: bug(triage,policy): task triage:bootstrap blanket-ignores vbrief/.eval/, violating #1144 hybrid policy"
       }
     ],
-    "updated": "2026-05-20T19:24:34Z"
+    "updated": "2026-05-20T19:24:34Z",
+    "metadata": {
+      "completedAt": "2026-05-20T19:35:34Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-20-1269-featritual-session-sentinel-version-aware-welcome-back-banne.vbrief.json
+++ b/vbrief/completed/2026-05-20-1269-featritual-session-sentinel-version-aware-welcome-back-banne.vbrief.json
@@ -94,7 +94,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-22T19:13:17Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-05-20-1270-fixtriage-triagesummary-in-flight-count-should-be-filesystem.vbrief.json
+++ b/vbrief/completed/2026-05-20-1270-fixtriage-triagesummary-in-flight-count-should-be-filesystem.vbrief.json
@@ -61,6 +61,11 @@
         "title": "Issue #1270: fix(triage): triage:summary in-flight count should be filesystem-truth with conditional scope-discrepancy line"
       }
     ],
-    "updated": "2026-05-21T16:33:43Z"
+    "updated": "2026-05-21T16:33:43Z",
+    "metadata": {
+      "completedAt": "2026-05-21T17:15:08Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-21-1179-installer-leaves-vbrief-in-partial-state-agentsmd-pre-cutove.vbrief.json
+++ b/vbrief/completed/2026-05-21-1179-installer-leaves-vbrief-in-partial-state-agentsmd-pre-cutove.vbrief.json
@@ -77,7 +77,10 @@
         "file_scope_confidence": "high",
         "model_tier": "standard",
         "depends_on": []
-      }
+      },
+      "completedAt": "2026-05-22T16:03:38Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-21-1272-onboarding-detect-missing-root-taskfileyml-include-and-eithe.vbrief.json
+++ b/vbrief/completed/2026-05-21-1272-onboarding-detect-missing-root-taskfileyml-include-and-eithe.vbrief.json
@@ -89,7 +89,10 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard",
         "depends_on": []
-      }
+      },
+      "completedAt": "2026-05-22T16:03:38Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-21-1281-deft-install-go-19-p1-defects-in-cmddeft-install-and-support.vbrief.json
+++ b/vbrief/completed/2026-05-21-1281-deft-install-go-19-p1-defects-in-cmddeft-install-and-support.vbrief.json
@@ -92,7 +92,10 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard",
         "depends_on": []
-      }
+      },
+      "completedAt": "2026-05-22T16:03:38Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-21-1283-pack-slicing-rfc.vbrief.json
+++ b/vbrief/completed/2026-05-21-1283-pack-slicing-rfc.vbrief.json
@@ -36,7 +36,10 @@
         "parent_issue": "#1283",
         "decomposition_origin": "#742",
         "lifecycle_footgun_ref": "#1273"
-      }
+      },
+      "completedAt": "2026-05-25T22:36:03Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-05-21-1284-epic-vbrief-canonical.vbrief.json
+++ b/vbrief/completed/2026-05-21-1284-epic-vbrief-canonical.vbrief.json
@@ -28,7 +28,10 @@
       "x-tracking": {
         "parent_issue": "#1284",
         "decomposition_origin": "#742"
-      }
+      },
+      "completedAt": "2026-05-25T22:36:03Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     },
     "edges": [
       {

--- a/vbrief/completed/2026-05-21-1285-epic-crud-harness.vbrief.json
+++ b/vbrief/completed/2026-05-21-1285-epic-crud-harness.vbrief.json
@@ -28,7 +28,10 @@
       "x-tracking": {
         "parent_issue": "#1285",
         "decomposition_origin": "#742"
-      }
+      },
+      "completedAt": "2026-05-25T22:36:03Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     },
     "edges": [
       {

--- a/vbrief/completed/2026-05-21-1291-adr-001-doc.vbrief.json
+++ b/vbrief/completed/2026-05-21-1291-adr-001-doc.vbrief.json
@@ -47,7 +47,9 @@
       "swarm": {
         "readiness": "not-ready"
       },
-      "completedAt": "2026-06-12T16:08:11Z"
+      "completedAt": "2026-06-12T16:08:11Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-05-21-1300-directive-rule-always-confirm-a-cancellation-came-from-the-u.vbrief.json
+++ b/vbrief/completed/2026-05-21-1300-directive-rule-always-confirm-a-cancellation-came-from-the-u.vbrief.json
@@ -80,7 +80,10 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard",
         "depends_on": []
-      }
+      },
+      "completedAt": "2026-05-22T16:03:38Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-22-1308-featrunscriptsskills-consolidate-doctor-run-doctor-absorbs-f.vbrief.json
+++ b/vbrief/completed/2026-05-22-1308-featrunscriptsskills-consolidate-doctor-run-doctor-absorbs-f.vbrief.json
@@ -103,7 +103,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-22T19:13:17Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-22-1309-fixtemplatesagents-mdtests-propagate-welcome-wip-cap-session.vbrief.json
+++ b/vbrief/completed/2026-05-22-1309-fixtemplatesagents-mdtests-propagate-welcome-wip-cap-session.vbrief.json
@@ -102,7 +102,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-22T19:13:17Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-25-1349-remove-gh-triage-reclaim-triage-verb.vbrief.json
+++ b/vbrief/completed/2026-05-25-1349-remove-gh-triage-reclaim-triage-verb.vbrief.json
@@ -87,7 +87,10 @@
       "swarm": {
         "readiness": "ready",
         "rationale": "Single PR, isolated scope (one skill directory + one routing block + catalog sweep + tests). No depends_on. Good candidate for a focused worker."
-      }
+      },
+      "completedAt": "2026-05-25T22:36:03Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-05-25-swarm-1342-launch-adapter.vbrief.json
+++ b/vbrief/completed/2026-05-25-swarm-1342-launch-adapter.vbrief.json
@@ -49,6 +49,11 @@
         "uri": "https://github.com/deftai/directive/issues/1342"
       }
     ],
-    "updated": "2026-05-25T20:03:08Z"
+    "updated": "2026-05-25T20:03:08Z",
+    "metadata": {
+      "completedAt": "2026-05-25T22:42:12Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-25-swarm-1342-monitoring-takeover.vbrief.json
+++ b/vbrief/completed/2026-05-25-swarm-1342-monitoring-takeover.vbrief.json
@@ -49,6 +49,11 @@
         "uri": "https://github.com/deftai/directive/issues/1342"
       }
     ],
-    "updated": "2026-05-25T20:03:12Z"
+    "updated": "2026-05-25T20:03:12Z",
+    "metadata": {
+      "completedAt": "2026-05-25T22:42:12Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-25-swarm-1342-phase6-unification-tests.vbrief.json
+++ b/vbrief/completed/2026-05-25-swarm-1342-phase6-unification-tests.vbrief.json
@@ -49,6 +49,11 @@
         "uri": "https://github.com/deftai/directive/issues/1342"
       }
     ],
-    "updated": "2026-05-25T20:03:15Z"
+    "updated": "2026-05-25T20:03:15Z",
+    "metadata": {
+      "completedAt": "2026-05-25T22:42:12Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-25-swarm-1342-runtime-detection.vbrief.json
+++ b/vbrief/completed/2026-05-25-swarm-1342-runtime-detection.vbrief.json
@@ -49,6 +49,11 @@
         "uri": "https://github.com/deftai/directive/issues/1342"
       }
     ],
-    "updated": "2026-05-25T20:03:05Z"
+    "updated": "2026-05-25T20:03:05Z",
+    "metadata": {
+      "completedAt": "2026-05-25T22:42:12Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-05-26-1331-deft-directive-swarm-is-tightly-coupled-to-the-warp-runtime.vbrief.json
+++ b/vbrief/completed/2026-05-26-1331-deft-directive-swarm-is-tightly-coupled-to-the-warp-runtime.vbrief.json
@@ -53,6 +53,11 @@
         "title": "Issue #1331: deft-directive-swarm is tightly coupled to the Warp runtime, making it hard to use in other agent environments (Grok Build, etc.)"
       }
     ],
-    "updated": "2026-05-26T14:01:30Z"
+    "updated": "2026-05-26T14:01:30Z",
+    "metadata": {
+      "completedAt": "2026-05-26T14:13:16Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-26-1353-grok-build-windows-run-terminal-command-leaks-get-content-wr.vbrief.json
+++ b/vbrief/completed/2026-05-26-1353-grok-build-windows-run-terminal-command-leaks-get-content-wr.vbrief.json
@@ -58,6 +58,11 @@
         "title": "Issue #1353: grok-build (Windows): run_terminal_command leaks Get-Content / wrapper noise on any pipeline or redirection (pwsh 7+)"
       }
     ],
-    "updated": "2026-05-26T14:01:29Z"
+    "updated": "2026-05-26T14:01:29Z",
+    "metadata": {
+      "completedAt": "2026-05-26T14:13:16Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-26-1364-swarm-skill-poller-completion-can-surface-phase-56-merge-gat.vbrief.json
+++ b/vbrief/completed/2026-05-26-1364-swarm-skill-poller-completion-can-surface-phase-56-merge-gat.vbrief.json
@@ -100,7 +100,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-28T18:46:12Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-26-1365-swarm-spawn-subagent-review-cycle-sub-agents-can-go-complete.vbrief.json
+++ b/vbrief/completed/2026-05-26-1365-swarm-spawn-subagent-review-cycle-sub-agents-can-go-complete.vbrief.json
@@ -105,7 +105,10 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-28T20:57:23Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-26-1366-harness-python-subprocess-gh-calls-frequently-trigger-unicod.vbrief.json
+++ b/vbrief/completed/2026-05-26-1366-harness-python-subprocess-gh-calls-frequently-trigger-unicod.vbrief.json
@@ -96,7 +96,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-28T18:46:12Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-26-1368-monitoring-long-running-monitors-using-pr-merge-readiness-ar.vbrief.json
+++ b/vbrief/completed/2026-05-26-1368-monitoring-long-running-monitors-using-pr-merge-readiness-ar.vbrief.json
@@ -109,7 +109,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-28T20:57:23Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-26-1369-swarm-improve-reliability-and-tooling-for-long-running-merge.vbrief.json
+++ b/vbrief/completed/2026-05-26-1369-swarm-improve-reliability-and-tooling-for-long-running-merge.vbrief.json
@@ -106,7 +106,10 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-05-28T22:32:18Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-05-27-story-start-gate-lifecycle-implementation-contract.vbrief.json
+++ b/vbrief/completed/2026-05-27-story-start-gate-lifecycle-implementation-contract.vbrief.json
@@ -83,7 +83,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T02:18:20Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "updated": "2026-05-27T02:50:46Z"
   }

--- a/vbrief/completed/2026-05-29-1334-epic-unified-installer-single-doctor-surface-agent-first-boo.vbrief.json
+++ b/vbrief/completed/2026-05-29-1334-epic-unified-installer-single-doctor-surface-agent-first-boo.vbrief.json
@@ -54,6 +54,11 @@
         "title": "Issue #1334: Epic: Unified Installer + Single Doctor Surface (Agent-First Bootstrap & Upgrade)"
       }
     ],
-    "updated": "2026-06-01T05:00:00Z"
+    "updated": "2026-06-01T05:00:00Z",
+    "metadata": {
+      "completedAt": "2026-06-01T05:00:49Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-29-1335-epic-1-extract-scriptsdoctorpy-as-the-single-doctor-implemen.vbrief.json
+++ b/vbrief/completed/2026-05-29-1335-epic-1-extract-scriptsdoctorpy-as-the-single-doctor-implemen.vbrief.json
@@ -46,6 +46,11 @@
         "title": "Issue #1335: Epic-1: Extract scripts/doctor.py as the single doctor implementation"
       }
     ],
-    "updated": "2026-05-31T02:24:34Z"
+    "updated": "2026-05-31T02:24:34Z",
+    "metadata": {
+      "completedAt": "2026-05-31T02:24:59Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-29-1336-epic-2-retire-framework-doctorpy-and-legacy-doctor-surfaces.vbrief.json
+++ b/vbrief/completed/2026-05-29-1336-epic-2-retire-framework-doctorpy-and-legacy-doctor-surfaces.vbrief.json
@@ -42,6 +42,11 @@
         "title": "Issue #1336: Epic-2: Retire framework_doctor.py and legacy doctor surfaces"
       }
     ],
-    "updated": "2026-05-31T02:24:34Z"
+    "updated": "2026-05-31T02:24:34Z",
+    "metadata": {
+      "completedAt": "2026-05-31T02:24:59Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-29-1337-epic-3-harden-go-installer-for-non-interactive-agent-use.vbrief.json
+++ b/vbrief/completed/2026-05-29-1337-epic-3-harden-go-installer-for-non-interactive-agent-use.vbrief.json
@@ -42,6 +42,11 @@
         "title": "Issue #1337: Epic-3: Harden Go installer for non-interactive agent use"
       }
     ],
-    "updated": "2026-05-31T02:24:35Z"
+    "updated": "2026-05-31T02:24:35Z",
+    "metadata": {
+      "completedAt": "2026-05-31T02:24:59Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-29-1338-epic-4-installer-automatic-taskfile-wiring-tool-installation.vbrief.json
+++ b/vbrief/completed/2026-05-29-1338-epic-4-installer-automatic-taskfile-wiring-tool-installation.vbrief.json
@@ -42,6 +42,11 @@
         "title": "Issue #1338: Epic-4: Installer – Automatic Taskfile wiring + tool installation"
       }
     ],
-    "updated": "2026-05-31T02:24:35Z"
+    "updated": "2026-05-31T02:24:35Z",
+    "metadata": {
+      "completedAt": "2026-05-31T02:24:59Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-29-1339-epic-5-installer-doctor-handoff-payload-staleness-detection.vbrief.json
+++ b/vbrief/completed/2026-05-29-1339-epic-5-installer-doctor-handoff-payload-staleness-detection.vbrief.json
@@ -43,6 +43,11 @@
         "title": "Issue #1339: Epic-5: Installer → Doctor handoff + payload staleness detection"
       }
     ],
-    "updated": "2026-05-31T02:24:35Z"
+    "updated": "2026-05-31T02:24:35Z",
+    "metadata": {
+      "completedAt": "2026-05-31T02:24:59Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-05-29-1340-epic-6-documentation-skills-and-agent-guidance-collapse.vbrief.json
+++ b/vbrief/completed/2026-05-29-1340-epic-6-documentation-skills-and-agent-guidance-collapse.vbrief.json
@@ -38,6 +38,11 @@
         "title": "Issue #1340: Epic-6: Documentation, skills, and agent guidance collapse"
       }
     ],
-    "updated": "2026-05-31T02:24:35Z"
+    "updated": "2026-05-31T02:24:35Z",
+    "metadata": {
+      "completedAt": "2026-05-31T02:24:59Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-01-1000-docsagents-wire-refinement-skills-full-trigger-word-set-into.vbrief.json
+++ b/vbrief/completed/2026-06-01-1000-docsagents-wire-refinement-skills-full-trigger-word-set-into.vbrief.json
@@ -53,7 +53,10 @@
         "conflict_group": "agents-md",
         "size": "small",
         "file_scope_confidence": "high"
-      }
+      },
+      "completedAt": "2026-06-03T23:23:54Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-01-1378-p2-cleanup.vbrief.json
+++ b/vbrief/completed/2026-06-01-1378-p2-cleanup.vbrief.json
@@ -78,7 +78,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T03:18:12Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-01T03:06:14Z"
   }

--- a/vbrief/completed/2026-06-01-1378a-allocation-context-schema.vbrief.json
+++ b/vbrief/completed/2026-06-01-1378a-allocation-context-schema.vbrief.json
@@ -69,7 +69,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T02:53:57Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-01T02:48:16Z"
   }

--- a/vbrief/completed/2026-06-01-1378b-skill-allocation-context-recognition.vbrief.json
+++ b/vbrief/completed/2026-06-01-1378b-skill-allocation-context-recognition.vbrief.json
@@ -81,7 +81,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T02:54:49Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-01T02:39:41Z"
   }

--- a/vbrief/completed/2026-06-01-1378c-preflight-story-start-gate.vbrief.json
+++ b/vbrief/completed/2026-06-01-1378c-preflight-story-start-gate.vbrief.json
@@ -85,7 +85,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T02:55:25Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-01T02:47:54Z"
   }

--- a/vbrief/completed/2026-06-01-1387-headless-swarm-launch.vbrief.json
+++ b/vbrief/completed/2026-06-01-1387-headless-swarm-launch.vbrief.json
@@ -47,7 +47,10 @@
       }
     ],
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-01T05:00:49Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-01T05:00:00Z"
   }

--- a/vbrief/completed/2026-06-01-document-the-headless-low-ceremony-launch-path-in-the-swarm.vbrief.json
+++ b/vbrief/completed/2026-06-01-document-the-headless-low-ceremony-launch-path-in-the-swarm.vbrief.json
@@ -75,7 +75,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T05:00:49Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-01-headless-swarm-launch-engine-task-swarmlaunch-deterministic.vbrief.json
+++ b/vbrief/completed/2026-06-01-headless-swarm-launch-engine-task-swarmlaunch-deterministic.vbrief.json
@@ -77,7 +77,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T05:00:49Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-01-pre-created-worktree-resolver-for-swarm-cohorts.vbrief.json
+++ b/vbrief/completed/2026-06-01-pre-created-worktree-resolver-for-swarm-cohorts.vbrief.json
@@ -74,7 +74,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-01T05:00:49Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-02-1413-always-include-upgrade-guidance-section-at-the-top-of-direct.vbrief.json
+++ b/vbrief/completed/2026-06-02-1413-always-include-upgrade-guidance-section-at-the-top-of-direct.vbrief.json
@@ -7,7 +7,10 @@
     "title": "Always include upgrade guidance section at the top of directive release notes",
     "status": "completed",
     "metadata": {
-      "kind": "story"
+      "kind": "story",
+      "completedAt": "2026-06-02T23:30:27Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "narratives": {
       "Description": "Always include upgrade guidance section at the top of directive release notes",

--- a/vbrief/completed/2026-06-02-1425-installer-upgrade-broken-unsafe-on-vendored-installs.vbrief.json
+++ b/vbrief/completed/2026-06-02-1425-installer-upgrade-broken-unsafe-on-vendored-installs.vbrief.json
@@ -39,6 +39,11 @@
         "title": "Issue #1425: P0/Upgrade Blocker: deft-install --upgrade is broken and unsafe on webinstaller (vendored, no-.git) installs"
       }
     ],
-    "updated": "2026-06-02T18:44:08Z"
+    "updated": "2026-06-02T18:44:08Z",
+    "metadata": {
+      "completedAt": "2026-06-02T19:11:23Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-02-1433-v0392-vendored-refresh-aborts-extractor-treats-github-tarbal.vbrief.json
+++ b/vbrief/completed/2026-06-02-1433-v0392-vendored-refresh-aborts-extractor-treats-github-tarbal.vbrief.json
@@ -7,7 +7,10 @@
     "title": "v0.39.2 vendored refresh aborts: extractor treats GitHub tarball pax_global_header as content root; README still says installer clones",
     "status": "completed",
     "metadata": {
-      "kind": "story"
+      "kind": "story",
+      "completedAt": "2026-06-02T23:30:27Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "narratives": {
       "Description": "v0.39.2 vendored refresh aborts: extractor treats GitHub tarball pax_global_header as content root; README still says installer clones",

--- a/vbrief/completed/2026-06-02-doctor-manifest-tolerant-read-issue-1427.vbrief.json
+++ b/vbrief/completed/2026-06-02-doctor-manifest-tolerant-read-issue-1427.vbrief.json
@@ -11,7 +11,10 @@
     "status": "completed",
     "metadata": {
       "kind": "story",
-      "swarm": true
+      "swarm": true,
+      "completedAt": "2026-06-02T22:57:47Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "narratives": {
       "Problem": "The install provenance manifest is written to two different paths by two install rails. The Go installer writes the canonical <install>/VERSION (.deft/core/VERSION, #1062); the webinstaller writes .deft/VERSION (omitting install_root). scripts/doctor.py only reads .deft/core/VERSION and legacy deft/VERSION, so a webinstaller-vendored install is invisible to manifest-agreement, install-path-consistency, and the #1339 payload-staleness handoff.",

--- a/vbrief/completed/2026-06-02-v0-39-2-installer-vendoring-neutralization-deposit.vbrief.json
+++ b/vbrief/completed/2026-06-02-v0-39-2-installer-vendoring-neutralization-deposit.vbrief.json
@@ -57,7 +57,10 @@
       "swarm": {
         "readiness": "ready",
         "agent": "agent-installer"
-      }
+      },
+      "completedAt": "2026-06-02T22:57:47Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-1114-enhancementquick-start-combine-case-g-case-h-into-one-sessio.vbrief.json
+++ b/vbrief/completed/2026-06-03-1114-enhancementquick-start-combine-case-g-case-h-into-one-sessio.vbrief.json
@@ -54,7 +54,10 @@
     ],
     "updated": "2026-06-03T21:38:03Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1115-docsupgrading-add-big-jump-triage-entry-point-for-multi-vers.vbrief.json
+++ b/vbrief/completed/2026-06-03-1115-docsupgrading-add-big-jump-triage-entry-point-for-multi-vers.vbrief.json
@@ -58,7 +58,10 @@
     ],
     "updated": "2026-06-03T21:38:03Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1311-bugscriptsproject-render-task-projectrender-leaks-vbriefproj.vbrief.json
+++ b/vbrief/completed/2026-06-03-1311-bugscriptsproject-render-task-projectrender-leaks-vbriefproj.vbrief.json
@@ -40,6 +40,11 @@
         "title": "Issue #1311: bug(scripts/project_render): task project:render leaks vbrief/PROJECT-DEFINITION.vbrief.json.lock; trapped by git add -A on every chore commit"
       }
     ],
-    "updated": "2026-06-03T02:43:23Z"
+    "updated": "2026-06-03T02:43:23Z",
+    "metadata": {
+      "completedAt": "2026-06-03T02:43:35Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1320-frameworkcheck-updates-probes-consumer-origin-statusreportgi.vbrief.json
+++ b/vbrief/completed/2026-06-03-1320-frameworkcheck-updates-probes-consumer-origin-statusreportgi.vbrief.json
@@ -23,6 +23,11 @@
         "title": "Issue #1320: framework:check-updates probes consumer origin (statusreport.git) on vendored installs; never detects framework drift"
       }
     ],
-    "updated": "2026-06-03T02:43:24Z"
+    "updated": "2026-06-03T02:43:24Z",
+    "metadata": {
+      "completedAt": "2026-06-03T02:43:35Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1323-version-resolver-returns-000-dev-on-vendored-installs-deftco.vbrief.json
+++ b/vbrief/completed/2026-06-03-1323-version-resolver-returns-000-dev-on-vendored-installs-deftco.vbrief.json
@@ -23,6 +23,11 @@
         "title": "Issue #1323: Version resolver returns 0.0.0-dev on vendored installs (.deft/core/ without .git): every framework surface reports wrong version"
       }
     ],
-    "updated": "2026-06-03T02:43:24Z"
+    "updated": "2026-06-03T02:43:24Z",
+    "metadata": {
+      "completedAt": "2026-06-03T02:43:35Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1325-version-manifest-moved-from-deftversion-to-deftcoreversion-w.vbrief.json
+++ b/vbrief/completed/2026-06-03-1325-version-manifest-moved-from-deftversion-to-deftcoreversion-w.vbrief.json
@@ -23,6 +23,11 @@
         "title": "Issue #1325: VERSION manifest moved from .deft/VERSION to .deft/core/VERSION without migration; legacy file persists as stale source-of-truth"
       }
     ],
-    "updated": "2026-06-03T02:43:24Z"
+    "updated": "2026-06-03T02:43:24Z",
+    "metadata": {
+      "completedAt": "2026-06-03T02:43:35Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1332-v0330-canonical-plain-file-installs-resolve-consumer-repo-ve.vbrief.json
+++ b/vbrief/completed/2026-06-03-1332-v0330-canonical-plain-file-installs-resolve-consumer-repo-ve.vbrief.json
@@ -19,6 +19,11 @@
         "title": "Issue #1332: v0.33.0 canonical plain-file installs resolve consumer repo version and false-positive skill redirect stubs"
       }
     ],
-    "updated": "2026-06-03T02:43:24Z"
+    "updated": "2026-06-03T02:43:24Z",
+    "metadata": {
+      "completedAt": "2026-06-03T02:43:35Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1389-doctor-agents-refresh-plan-interim-stub-emits-spurious-unrea.vbrief.json
+++ b/vbrief/completed/2026-06-03-1389-doctor-agents-refresh-plan-interim-stub-emits-spurious-unrea.vbrief.json
@@ -7,7 +7,10 @@
     "title": "doctor: _agents_refresh_plan interim stub emits spurious 'unreadable' AGENTS.md-freshness warning on every consumer task doctor run",
     "status": "completed",
     "metadata": {
-      "kind": "story"
+      "kind": "story",
+      "completedAt": "2026-06-03T01:11:52Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "narratives": {
       "Description": "doctor: _agents_refresh_plan interim stub emits spurious 'unreadable' AGENTS.md-freshness warning on every consumer task doctor run",

--- a/vbrief/completed/2026-06-03-1420-triagereject-fails-when-triage-rejected-label-does-not-exist.vbrief.json
+++ b/vbrief/completed/2026-06-03-1420-triagereject-fails-when-triage-rejected-label-does-not-exist.vbrief.json
@@ -32,7 +32,10 @@
     ],
     "updated": "2026-06-03T21:38:04Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1424-cache-fresh-batch-eval.vbrief.json
+++ b/vbrief/completed/2026-06-03-1424-cache-fresh-batch-eval.vbrief.json
@@ -42,6 +42,11 @@
         "title": "Issue #1424: verify:cache-fresh is O(N) gh calls: scope filter runs evaluate_rules per-issue, refetching open milestones (~92s on 500 entries)"
       }
     ],
-    "updated": "2026-06-03T16:07:46Z"
+    "updated": "2026-06-03T16:07:46Z",
+    "metadata": {
+      "completedAt": "2026-06-03T16:29:24Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1437-v0393-vendored-upgrade-leaves-root-artifacts-stale-duplicate.vbrief.json
+++ b/vbrief/completed/2026-06-03-1437-v0393-vendored-upgrade-leaves-root-artifacts-stale-duplicate.vbrief.json
@@ -7,7 +7,10 @@
     "title": "v0.39.3 vendored upgrade leaves root artifacts stale: duplicate AGENTS.md managed-section (attributed v3 marker not matched) + bare .deft-version not regenerated",
     "status": "completed",
     "metadata": {
-      "kind": "story"
+      "kind": "story",
+      "completedAt": "2026-06-03T00:14:24Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "narratives": {
       "Description": "v0.39.3 vendored upgrade leaves root artifacts stale: duplicate AGENTS.md managed-section (attributed v3 marker not matched) + bare .deft-version not regenerated",

--- a/vbrief/completed/2026-06-03-1440-deft-core-guard-rejects-every-deft-install-upgrade-pr-instal.vbrief.json
+++ b/vbrief/completed/2026-06-03-1440-deft-core-guard-rejects-every-deft-install-upgrade-pr-instal.vbrief.json
@@ -7,7 +7,10 @@
     "title": "deft-core-guard rejects every deft-install --upgrade PR: installer-managed root files (AGENTS.md, .agents/, vbrief scaffolding, ...) counted as 'app'",
     "status": "completed",
     "metadata": {
-      "kind": "story"
+      "kind": "story",
+      "completedAt": "2026-06-03T01:11:52Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "narratives": {
       "Description": "deft-core-guard rejects every deft-install --upgrade PR: installer-managed root files (AGENTS.md, .agents/, vbrief scaffolding, ...) counted as 'app'",

--- a/vbrief/completed/2026-06-03-1441-windows-installer-binary-auto-triggers-uac-elevation-install.vbrief.json
+++ b/vbrief/completed/2026-06-03-1441-windows-installer-binary-auto-triggers-uac-elevation-install.vbrief.json
@@ -7,7 +7,10 @@
     "title": "Windows installer binary auto-triggers UAC elevation (install-* filename heuristic + no asInvoker manifest); breaks headless --yes installs/upgrades",
     "status": "completed",
     "metadata": {
-      "kind": "story"
+      "kind": "story",
+      "completedAt": "2026-06-03T01:11:52Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "narratives": {
       "Description": "Windows installer binary auto-triggers UAC elevation (install-* filename heuristic + no asInvoker manifest); breaks headless --yes installs/upgrades",

--- a/vbrief/completed/2026-06-03-1445-vendored-upgrade-leaves-deftcorebak-ts-backups-in-the-workin.vbrief.json
+++ b/vbrief/completed/2026-06-03-1445-vendored-upgrade-leaves-deftcorebak-ts-backups-in-the-workin.vbrief.json
@@ -41,6 +41,11 @@
         "title": "Issue #1445: Vendored --upgrade leaves .deft/core.bak-<ts>/ backups in the working tree: not gitignored, accumulate, escape neutralization (accidental-commit footgun)"
       }
     ],
-    "updated": "2026-06-03T02:43:25Z"
+    "updated": "2026-06-03T02:43:25Z",
+    "metadata": {
+      "completedAt": "2026-06-03T02:43:35Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1450-migration-leaves-premigrate-snapshots-untracked-at-repo-root.vbrief.json
+++ b/vbrief/completed/2026-06-03-1450-migration-leaves-premigrate-snapshots-untracked-at-repo-root.vbrief.json
@@ -33,6 +33,11 @@
         "title": "Issue #1450: Migration leaves *.premigrate.* snapshots untracked at repo root (not gitignored, not allowlisted) -- git add -A + deft-core-guard footgun"
       }
     ],
-    "updated": "2026-06-03T13:21:37Z"
+    "updated": "2026-06-03T13:21:37Z",
+    "metadata": {
+      "completedAt": "2026-06-03T13:21:46Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1453-installer-commit-hygiene-warn-prevent-mixing-the-framework-d.vbrief.json
+++ b/vbrief/completed/2026-06-03-1453-installer-commit-hygiene-warn-prevent-mixing-the-framework-d.vbrief.json
@@ -50,6 +50,11 @@
         "title": "Issue #1453: Installer commit-hygiene: warn + prevent mixing the framework deposit with consumer files (scoped staging + dirty-tree advisory + optional local guard hook)"
       }
     ],
-    "updated": "2026-06-03T14:37:53Z"
+    "updated": "2026-06-03T14:37:53Z",
+    "metadata": {
+      "completedAt": "2026-06-03T14:38:10Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1454-harden-vendored-version-resolution-guard-git-to-the-payloads.vbrief.json
+++ b/vbrief/completed/2026-06-03-1454-harden-vendored-version-resolution-guard-git-to-the-payloads.vbrief.json
@@ -46,6 +46,11 @@
         "title": "Issue #1323"
       }
     ],
-    "updated": "2026-06-03T14:37:53Z"
+    "updated": "2026-06-03T14:37:53Z",
+    "metadata": {
+      "completedAt": "2026-06-03T14:38:10Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1458-install-dirty-tree-fail-loud.vbrief.json
+++ b/vbrief/completed/2026-06-03-1458-install-dirty-tree-fail-loud.vbrief.json
@@ -45,6 +45,11 @@
         "title": "Issue #1458: deft-install: fail loudly on a dirty working tree by default for --upgrade (--force to bypass) + structured signals in --json"
       }
     ],
-    "updated": "2026-06-03T16:13:47Z"
+    "updated": "2026-06-03T16:13:47Z",
+    "metadata": {
+      "completedAt": "2026-06-03T16:42:46Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1463-consumer-git-hooks.vbrief.json
+++ b/vbrief/completed/2026-06-03-1463-consumer-git-hooks.vbrief.json
@@ -43,6 +43,11 @@
         "title": "Issue #1463: Installer: git hooks never active in vendored consumer projects (branch/encoding/gh gates silently inert)"
       }
     ],
-    "updated": "2026-06-03T16:48:21Z"
+    "updated": "2026-06-03T16:48:21Z",
+    "metadata": {
+      "completedAt": "2026-06-03T17:52:12Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1464-eval-gitignore-selective.vbrief.json
+++ b/vbrief/completed/2026-06-03-1464-eval-gitignore-selective.vbrief.json
@@ -47,6 +47,11 @@
         "title": "Issue #1452: superseded by #1464"
       }
     ],
-    "updated": "2026-06-03T16:54:32Z"
+    "updated": "2026-06-03T16:54:32Z",
+    "metadata": {
+      "completedAt": "2026-06-03T17:38:39Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1465-events-log-gitignore.vbrief.json
+++ b/vbrief/completed/2026-06-03-1465-events-log-gitignore.vbrief.json
@@ -41,6 +41,11 @@
         "title": "Issue #1465: events: .deft/events.jsonl leaks untracked in consumers (stale .deft/-gitignored assumption in _events.py)"
       }
     ],
-    "updated": "2026-06-03T16:55:17Z"
+    "updated": "2026-06-03T16:55:17Z",
+    "metadata": {
+      "completedAt": "2026-06-03T17:08:13Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1468-triage-audit-reconcile.vbrief.json
+++ b/vbrief/completed/2026-06-03-1468-triage-audit-reconcile.vbrief.json
@@ -38,6 +38,11 @@
         "title": "Issue #1468: triage audit log can desync from proposed/ vBRIEFs with no self-heal"
       }
     ],
-    "updated": "2026-06-03T17:23:47Z"
+    "updated": "2026-06-03T17:23:47Z",
+    "metadata": {
+      "completedAt": "2026-06-03T18:11:25Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-1474-deftcheck-runs-framework-self-tests-in-consumers-always-red.vbrief.json
+++ b/vbrief/completed/2026-06-03-1474-deftcheck-runs-framework-self-tests-in-consumers-always-red.vbrief.json
@@ -50,7 +50,10 @@
     ],
     "updated": "2026-06-03T21:38:04Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1475-task-check-type-check-parity-with-ci-run-mypy-over-tests-not.vbrief.json
+++ b/vbrief/completed/2026-06-03-1475-task-check-type-check-parity-with-ci-run-mypy-over-tests-not.vbrief.json
@@ -48,7 +48,10 @@
     ],
     "updated": "2026-06-03T21:38:05Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1476-bugtriagecache-closed-upstream-issues-remain-in-triagequeue.vbrief.json
+++ b/vbrief/completed/2026-06-03-1476-bugtriagecache-closed-upstream-issues-remain-in-triagequeue.vbrief.json
@@ -56,7 +56,10 @@
     ],
     "updated": "2026-06-03T21:38:05Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1477-wired-git-hooks-ship-non-executable-mode-100644-silently-ine.vbrief.json
+++ b/vbrief/completed/2026-06-03-1477-wired-git-hooks-ship-non-executable-mode-100644-silently-ine.vbrief.json
@@ -45,7 +45,10 @@
     ],
     "updated": "2026-06-03T21:38:06Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1478-deft-core-guard-allowlist-omits-githooks-blocks-every-consum.vbrief.json
+++ b/vbrief/completed/2026-06-03-1478-deft-core-guard-allowlist-omits-githooks-blocks-every-consum.vbrief.json
@@ -46,7 +46,10 @@
     ],
     "updated": "2026-06-03T21:37:54Z",
     "metadata": {
-      "kind": "epic"
+      "kind": "epic",
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1485-bugscope-scopeactivatescopecomplete-do-not-update-decomposed.vbrief.json
+++ b/vbrief/completed/2026-06-03-1485-bugscope-scopeactivatescopecomplete-do-not-update-decomposed.vbrief.json
@@ -58,7 +58,10 @@
         "conflict_group": "scope-lifecycle",
         "size": "medium",
         "file_scope_confidence": "high"
-      }
+      },
+      "completedAt": "2026-06-03T23:01:11Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1487-swarm-deft-directive-swarm-must-complete-the-cohort-vbrief-l.vbrief.json
+++ b/vbrief/completed/2026-06-03-1487-swarm-deft-directive-swarm-must-complete-the-cohort-vbrief-l.vbrief.json
@@ -64,7 +64,10 @@
         "conflict_group": "swarm",
         "size": "medium",
         "file_scope_confidence": "medium"
-      }
+      },
+      "completedAt": "2026-06-04T00:03:01Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-06-03-1488-rfc-demote-the-1000-line-file-cap-from-must-to-should-unenfo.vbrief.json
+++ b/vbrief/completed/2026-06-03-1488-rfc-demote-the-1000-line-file-cap-from-must-to-should-unenfo.vbrief.json
@@ -38,6 +38,11 @@
         "title": "Issue #1488: RFC: demote the 1000-line file cap from MUST to SHOULD (unenforced, self-violated, anti-deep-modules)"
       }
     ],
-    "updated": "2026-06-03T21:46:02Z"
+    "updated": "2026-06-03T21:46:02Z",
+    "metadata": {
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
+    }
   }
 }

--- a/vbrief/completed/2026-06-03-add-a-big-jump-triage-entry-point-to-upgradingmd-for-multi-v.vbrief.json
+++ b/vbrief/completed/2026-06-03-add-a-big-jump-triage-entry-point-to-upgradingmd-for-multi-v.vbrief.json
@@ -66,7 +66,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-add-githooks-to-deft-core-guard-allowlist-and-refresh-the-de.vbrief.json
+++ b/vbrief/completed/2026-06-03-add-githooks-to-deft-core-guard-allowlist-and-refresh-the-de.vbrief.json
@@ -68,7 +68,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-bring-task-check-mypy-scope-to-parity-with-ci-cover-tests.vbrief.json
+++ b/vbrief/completed/2026-06-03-bring-task-check-mypy-scope-to-parity-with-ci-cover-tests.vbrief.json
@@ -67,7 +67,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-combine-quick-start-case-g-and-case-h-into-one-session-for-b.vbrief.json
+++ b/vbrief/completed/2026-06-03-combine-quick-start-case-g-and-case-h-into-one-session-for-b.vbrief.json
@@ -66,7 +66,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-deposit-wired-git-hooks-with-mode-100755-so-they-fire-on-uni.vbrief.json
+++ b/vbrief/completed/2026-06-03-deposit-wired-git-hooks-with-mode-100755-so-they-fire-on-uni.vbrief.json
@@ -69,7 +69,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-exclude-upstream-closed-issues-from-triagequeue-when-cached.vbrief.json
+++ b/vbrief/completed/2026-06-03-exclude-upstream-closed-issues-from-triagequeue-when-cached.vbrief.json
@@ -69,7 +69,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-make-triagereject-tolerate-a-missing-triage-rejected-label.vbrief.json
+++ b/vbrief/completed/2026-06-03-make-triagereject-tolerate-a-missing-triage-rejected-label.vbrief.json
@@ -66,7 +66,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-03-scope-consumer-deftcheck-so-it-does-not-run-framework-self-t.vbrief.json
+++ b/vbrief/completed/2026-06-03-scope-consumer-deftcheck-so-it-does-not-run-framework-self-t.vbrief.json
@@ -66,7 +66,10 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-03T22:21:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-04-1419-rfc-agentic-prioritization-coordination-model-for-deft-direc.vbrief.json
+++ b/vbrief/completed/2026-06-04-1419-rfc-agentic-prioritization-coordination-model-for-deft-direc.vbrief.json
@@ -76,7 +76,9 @@
     ],
     "metadata": {
       "kind": "epic",
-      "completedAt": "2026-06-05T01:04:27Z"
+      "completedAt": "2026-06-05T01:04:27Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-05T01:04:27Z"
   }

--- a/vbrief/completed/2026-06-04-add-capacity-allocation-accounting-with-buckets-windows-and.vbrief.json
+++ b/vbrief/completed/2026-06-04-add-capacity-allocation-accounting-with-buckets-windows-and.vbrief.json
@@ -87,7 +87,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-04T22:12:21Z"
+      "completedAt": "2026-06-04T22:12:21Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-04-add-continuation-precedence-and-deficit-biased-selection-to.vbrief.json
+++ b/vbrief/completed/2026-06-04-add-continuation-precedence-and-deficit-biased-selection-to.vbrief.json
@@ -70,7 +70,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-05T00:18:24Z"
+      "completedAt": "2026-06-05T00:18:24Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-04-add-epic-staleness-and-stranded-slice-lifecycle-nudges-with.vbrief.json
+++ b/vbrief/completed/2026-06-04-add-epic-staleness-and-stranded-slice-lifecycle-nudges-with.vbrief.json
@@ -67,7 +67,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-05T01:04:06Z"
+      "completedAt": "2026-06-05T01:04:06Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-04-build-the-risk-tiered-judgment-gate-engine-and-verifyjudgmen.vbrief.json
+++ b/vbrief/completed/2026-06-04-build-the-risk-tiered-judgment-gate-engine-and-verifyjudgmen.vbrief.json
@@ -76,7 +76,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-04T23:28:14Z"
+      "completedAt": "2026-06-04T23:28:14Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-04-integrate-gate-clearances-and-capacity-blocks-into-gate-0-an.vbrief.json
+++ b/vbrief/completed/2026-06-04-integrate-gate-clearances-and-capacity-blocks-into-gate-0-an.vbrief.json
@@ -71,7 +71,9 @@
         "file_scope_confidence": "low",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-05T01:04:06Z"
+      "completedAt": "2026-06-05T01:04:06Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-04-surface-human-clearance-backlog-and-the-earned-autonomy-dial.vbrief.json
+++ b/vbrief/completed/2026-06-04-surface-human-clearance-backlog-and-the-earned-autonomy-dial.vbrief.json
@@ -80,7 +80,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-05T01:04:07Z"
+      "completedAt": "2026-06-05T01:04:07Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-04-wire-planmetadatarank-into-selection-ordering-and-roadmap-re.vbrief.json
+++ b/vbrief/completed/2026-06-04-wire-planmetadatarank-into-selection-ordering-and-roadmap-re.vbrief.json
@@ -76,7 +76,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-05T01:19:29Z",
+      "capacityBucket": "cognitive-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-05-1001-fixrelease-publish-rest-releasestagstag-404s-on-draft-releas.vbrief.json
+++ b/vbrief/completed/2026-06-05-1001-fixrelease-publish-rest-releasestagstag-404s-on-draft-releas.vbrief.json
@@ -78,7 +78,10 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-08T17:41:02Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-06-05-1002-fixtriage-bootstrap-cp1252-decode-unicodedecodeerror-in-subp.vbrief.json
+++ b/vbrief/completed/2026-06-05-1002-fixtriage-bootstrap-cp1252-decode-unicodedecodeerror-in-subp.vbrief.json
@@ -79,7 +79,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-05T17:49:35Z"
+      "completedAt": "2026-06-05T17:49:35Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-06-05-1003-fixscriptsresolve-changelog-unreleased-dedup-gap-on-truncate.vbrief.json
+++ b/vbrief/completed/2026-06-05-1003-fixscriptsresolve-changelog-unreleased-dedup-gap-on-truncate.vbrief.json
@@ -77,7 +77,9 @@
         "file_scope_confidence": "high",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-05T17:49:35Z"
+      "completedAt": "2026-06-05T17:49:35Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-06-05-1027-coverage-threshold-blind-spot-pygametkinter-event-loops-cant.vbrief.json
+++ b/vbrief/completed/2026-06-05-1027-coverage-threshold-blind-spot-pygametkinter-event-loops-cant.vbrief.json
@@ -76,7 +76,9 @@
         "file_scope_confidence": "high",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-05T17:49:35Z"
+      "completedAt": "2026-06-05T17:49:35Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-05-1525-fixinstall-adopt-codeql-recognized-zip-slip-barrier-in-extra.vbrief.json
+++ b/vbrief/completed/2026-06-05-1525-fixinstall-adopt-codeql-recognized-zip-slip-barrier-in-extra.vbrief.json
@@ -38,7 +38,9 @@
     ],
     "updated": "2026-06-05T21:26:44Z",
     "metadata": {
-      "completedAt": "2026-06-05T21:26:44Z"
+      "completedAt": "2026-06-05T21:26:44Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-06-05-1528-fixinstall-strengthen-zip-slip-barrier-at-source-sink-to-cle.vbrief.json
+++ b/vbrief/completed/2026-06-05-1528-fixinstall-strengthen-zip-slip-barrier-at-source-sink-to-cle.vbrief.json
@@ -43,7 +43,9 @@
     ],
     "updated": "2026-06-05T22:40:18Z",
     "metadata": {
-      "completedAt": "2026-06-05T22:40:18Z"
+      "completedAt": "2026-06-05T22:40:18Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     }
   }
 }

--- a/vbrief/completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
+++ b/vbrief/completed/2026-06-08-1531-swarm-opt-in-tiered-heterogeneous-dispatch-strong-model-orch.vbrief.json
@@ -110,7 +110,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-08T16:54:49Z"
+      "completedAt": "2026-06-08T16:54:49Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-08T16:54:49Z"
   }

--- a/vbrief/completed/2026-06-08-1538-linux-installer-yes-reports-missing-core-tools-instead-of-bo.vbrief.json
+++ b/vbrief/completed/2026-06-08-1538-linux-installer-yes-reports-missing-core-tools-instead-of-bo.vbrief.json
@@ -76,7 +76,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-08T01:11:03Z"
+      "completedAt": "2026-06-08T01:11:03Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-08T01:11:03Z",
     "id": "1538-linux-installer-core-tool-bootstrap"

--- a/vbrief/completed/2026-06-08-1543-review-cycle-handle-greptile-informal-clean-replies-without.vbrief.json
+++ b/vbrief/completed/2026-06-08-1543-review-cycle-handle-greptile-informal-clean-replies-without.vbrief.json
@@ -94,7 +94,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-08T14:25:10Z"
+      "completedAt": "2026-06-08T14:25:10Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-08T14:25:10Z"
   }

--- a/vbrief/completed/2026-06-08-1554-installer-add-maintainer-mode-to-avoid-consumer-file-project.vbrief.json
+++ b/vbrief/completed/2026-06-08-1554-installer-add-maintainer-mode-to-avoid-consumer-file-project.vbrief.json
@@ -81,7 +81,9 @@
         "model_tier": "high",
         "missing_traces_justification": "Issue #1554 and its follow-up comments define the maintainer-mode installer scope and acceptance refinements."
       },
-      "completedAt": "2026-06-08T19:58:11Z"
+      "completedAt": "2026-06-08T19:58:11Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-08-1555-tooling-make-github-markdown-body-posting-safe-from-shell-su.vbrief.json
+++ b/vbrief/completed/2026-06-08-1555-tooling-make-github-markdown-body-posting-safe-from-shell-su.vbrief.json
@@ -79,7 +79,9 @@
         "model_tier": "medium",
         "missing_traces_justification": "Issue #1555 was created from the observed WSL GitHub comment mutation failure and references #1554 as the triggering incident."
       },
-      "completedAt": "2026-06-08T19:53:17Z"
+      "completedAt": "2026-06-08T19:53:17Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json
+++ b/vbrief/completed/2026-06-08-add-persistent-sub-agent-backend-policy-and-availability-gat.vbrief.json
@@ -69,7 +69,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-08T01:15:37Z"
+      "completedAt": "2026-06-08T01:15:37Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-08-add-provider-neutral-worker-metadata-to-the-agent-preamble.vbrief.json
+++ b/vbrief/completed/2026-06-08-add-provider-neutral-worker-metadata-to-the-agent-preamble.vbrief.json
@@ -65,7 +65,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-08T16:03:39Z"
+      "completedAt": "2026-06-08T16:03:39Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-08-document-provider-neutral-sub-agent-routing-in-the-swarm-ski.vbrief.json
+++ b/vbrief/completed/2026-06-08-document-provider-neutral-sub-agent-routing-in-the-swarm-ski.vbrief.json
@@ -65,7 +65,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-08T15:35:43Z"
+      "completedAt": "2026-06-08T15:35:43Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-08-enforce-deft-local-branch-policy.vbrief.json
+++ b/vbrief/completed/2026-06-08-enforce-deft-local-branch-policy.vbrief.json
@@ -53,7 +53,9 @@
         "model_tier": "medium",
         "missing_traces_justification": "User requested re-enabling Deft branch policy during the WSL swarm-readiness session."
       },
-      "completedAt": "2026-06-11T18:04:30Z"
+      "completedAt": "2026-06-11T18:04:30Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
+++ b/vbrief/completed/2026-06-08-integrate-selected-sub-agent-backend-into-headless-swarm-lau.vbrief.json
@@ -78,7 +78,9 @@
         "file_scope_confidence": "high",
         "model_tier": "high"
       },
-      "completedAt": "2026-06-08T15:50:53Z"
+      "completedAt": "2026-06-08T15:50:53Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-08-pin-provider-neutral-sub-agent-guidance-with-content-tests.vbrief.json
+++ b/vbrief/completed/2026-06-08-pin-provider-neutral-sub-agent-guidance-with-content-tests.vbrief.json
@@ -67,7 +67,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-08T16:44:25Z"
+      "completedAt": "2026-06-08T16:44:25Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-1348-session-ritual-verifier-implementation.vbrief.json
+++ b/vbrief/completed/2026-06-09-1348-session-ritual-verifier-implementation.vbrief.json
@@ -100,7 +100,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "high",
         "missing_traces_justification": "Issue #1348 already carries the detailed trace set; this active iteration exists to satisfy the current implementation gate after stale completed lifecycle metadata was discovered."
-      }
+      },
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-1382-v0370-released-framework-tree-fails-verifyencoding-in-consum.vbrief.json
+++ b/vbrief/completed/2026-06-09-1382-v0370-released-framework-tree-fails-verifyencoding-in-consum.vbrief.json
@@ -85,7 +85,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T23:08:13Z"
+      "completedAt": "2026-06-09T23:08:13Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T23:08:13Z"
   }

--- a/vbrief/completed/2026-06-09-1510-recommend-adding-labels-to-every-issue-created-consumer-or-m.vbrief.json
+++ b/vbrief/completed/2026-06-09-1510-recommend-adding-labels-to-every-issue-created-consumer-or-m.vbrief.json
@@ -95,7 +95,10 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-09T22:10:47Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T22:09:39Z"
   }

--- a/vbrief/completed/2026-06-09-1518-composer-specific-lessons-learned.vbrief.json
+++ b/vbrief/completed/2026-06-09-1518-composer-specific-lessons-learned.vbrief.json
@@ -39,7 +39,9 @@
     ],
     "metadata": {
       "kind": "epic",
-      "completedAt": "2026-06-09T18:42:29Z"
+      "completedAt": "2026-06-09T18:42:29Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T18:42:29Z"
   }

--- a/vbrief/completed/2026-06-09-1519-bugcheck-consumer-task-check-runs-vendored-framework-self-te.vbrief.json
+++ b/vbrief/completed/2026-06-09-1519-bugcheck-consumer-task-check-runs-vendored-framework-self-te.vbrief.json
@@ -89,7 +89,10 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-09T22:10:47Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T22:09:39Z"
   }

--- a/vbrief/completed/2026-06-09-1523-bugdocstemplates-agentsmd-ritual-mainmd-instruct-bare-task-n.vbrief.json
+++ b/vbrief/completed/2026-06-09-1523-bugdocstemplates-agentsmd-ritual-mainmd-instruct-bare-task-n.vbrief.json
@@ -81,7 +81,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T19:43:16Z"
+      "completedAt": "2026-06-09T19:43:16Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T19:43:16Z"
   }

--- a/vbrief/completed/2026-06-09-1524-bugreleasetriage-lifecycle-sync-gate-reconcile-treat-cancell.vbrief.json
+++ b/vbrief/completed/2026-06-09-1524-bugreleasetriage-lifecycle-sync-gate-reconcile-treat-cancell.vbrief.json
@@ -79,7 +79,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T19:43:18Z"
+      "completedAt": "2026-06-09T19:43:18Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T19:43:18Z"
   }

--- a/vbrief/completed/2026-06-09-1527-scopecomplete-updates-project-definition-references-but-leav.vbrief.json
+++ b/vbrief/completed/2026-06-09-1527-scopecomplete-updates-project-definition-references-but-leav.vbrief.json
@@ -81,7 +81,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T19:43:19Z"
+      "completedAt": "2026-06-09T19:43:19Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T19:43:19Z"
   }

--- a/vbrief/completed/2026-06-09-1553-release-document-default-branch-env-bypass-leak-into-nested.vbrief.json
+++ b/vbrief/completed/2026-06-09-1553-release-document-default-branch-env-bypass-leak-into-nested.vbrief.json
@@ -67,7 +67,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:22:57Z"
+      "completedAt": "2026-06-09T15:22:57Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "tags": [
       "bug",

--- a/vbrief/completed/2026-06-09-1557-swarm-make-github-credential-policy-runtime-aware-for-local.vbrief.json
+++ b/vbrief/completed/2026-06-09-1557-swarm-make-github-credential-policy-runtime-aware-for-local.vbrief.json
@@ -33,7 +33,9 @@
     ],
     "metadata": {
       "kind": "epic",
-      "completedAt": "2026-06-09T18:45:34Z"
+      "completedAt": "2026-06-09T18:45:34Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "tags": [
       "swarm",

--- a/vbrief/completed/2026-06-09-1562-bugtriage-rest-batched-cache-bootstrap-still-spends-minutes.vbrief.json
+++ b/vbrief/completed/2026-06-09-1562-bugtriage-rest-batched-cache-bootstrap-still-spends-minutes.vbrief.json
@@ -77,7 +77,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:22:59Z"
+      "completedAt": "2026-06-09T15:22:59Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "tags": [
       "bug",

--- a/vbrief/completed/2026-06-09-1563-deterministic-questions-break-when-host-ui-renders-structure.vbrief.json
+++ b/vbrief/completed/2026-06-09-1563-deterministic-questions-break-when-host-ui-renders-structure.vbrief.json
@@ -97,7 +97,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T19:43:21Z"
+      "completedAt": "2026-06-09T19:43:21Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T19:43:21Z"
   }

--- a/vbrief/completed/2026-06-09-1564-task-check-pyproject-version-freshness-fails-on-master-after.vbrief.json
+++ b/vbrief/completed/2026-06-09-1564-task-check-pyproject-version-freshness-fails-on-master-after.vbrief.json
@@ -79,7 +79,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T19:43:22Z"
+      "completedAt": "2026-06-09T19:43:22Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T19:43:22Z"
   }

--- a/vbrief/completed/2026-06-09-1568-swarm-ask-operator-for-subagent-backend-during-interactive-s.vbrief.json
+++ b/vbrief/completed/2026-06-09-1568-swarm-ask-operator-for-subagent-backend-during-interactive-s.vbrief.json
@@ -90,7 +90,10 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-09T22:10:47Z",
+      "capacityBucket": "agentic-debt",
+      "capacityBucketSource": "match"
     },
     "updated": "2026-06-09T22:09:39Z"
   }

--- a/vbrief/completed/2026-06-09-add-a-discoverable-composer-facing-probe-skill.vbrief.json
+++ b/vbrief/completed/2026-06-09-add-a-discoverable-composer-facing-probe-skill.vbrief.json
@@ -76,7 +76,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:22:54Z"
+      "completedAt": "2026-06-09T15:22:54Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-add-mechanical-guardrails-against-premature-probe-completion.vbrief.json
+++ b/vbrief/completed/2026-06-09-add-mechanical-guardrails-against-premature-probe-completion.vbrief.json
@@ -77,7 +77,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:30:51Z"
+      "completedAt": "2026-06-09T15:30:51Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-add-read-only-runtime-capability-probe-for-worker-environmen.vbrief.json
+++ b/vbrief/completed/2026-06-09-add-read-only-runtime-capability-probe-for-worker-environmen.vbrief.json
@@ -64,7 +64,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:22:58Z"
+      "completedAt": "2026-06-09T15:22:58Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-document-composer-skill-porting-rules-for-warp-tuned-workflo.vbrief.json
+++ b/vbrief/completed/2026-06-09-document-composer-skill-porting-rules-for-warp-tuned-workflo.vbrief.json
@@ -75,7 +75,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:22:56Z"
+      "completedAt": "2026-06-09T15:22:56Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-document-sandbox-credential-remediation-and-regression-cover.vbrief.json
+++ b/vbrief/completed/2026-06-09-document-sandbox-credential-remediation-and-regression-cover.vbrief.json
@@ -69,7 +69,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:38:50Z"
+      "completedAt": "2026-06-09T15:38:50Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-thread-runtime-and-github-auth-modes-through-swarm-dispatch.vbrief.json
+++ b/vbrief/completed/2026-06-09-thread-runtime-and-github-auth-modes-through-swarm-dispatch.vbrief.json
@@ -69,7 +69,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:38:49Z"
+      "completedAt": "2026-06-09T15:38:49Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-09-validate-github-auth-mode-inside-the-actual-worker-environme.vbrief.json
+++ b/vbrief/completed/2026-06-09-validate-github-auth-mode-inside-the-actual-worker-environme.vbrief.json
@@ -66,7 +66,9 @@
         "file_scope_confidence": "high",
         "model_tier": "medium"
       },
-      "completedAt": "2026-06-09T15:29:36Z"
+      "completedAt": "2026-06-09T15:29:36Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-11-1577-triagewelcome-uses-unprefixed-task-names-and-fails-in-consum.vbrief.json
+++ b/vbrief/completed/2026-06-11-1577-triagewelcome-uses-unprefixed-task-names-and-fails-in-consum.vbrief.json
@@ -45,7 +45,9 @@
     ],
     "updated": "2026-06-11T18:08:00Z",
     "metadata": {
-      "completedAt": "2026-06-11T14:24:25Z"
+      "completedAt": "2026-06-11T14:24:25Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     }
   }
 }

--- a/vbrief/completed/2026-06-12-1036-scriptsissue-ingestpy-cache-chain-corrupts-vbrief-overview-w.vbrief.json
+++ b/vbrief/completed/2026-06-12-1036-scriptsissue-ingestpy-cache-chain-corrupts-vbrief-overview-w.vbrief.json
@@ -73,7 +73,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T14:45:52Z"
+      "completedAt": "2026-06-12T14:45:52Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-12-1187-directive-bound-agents-should-detect-missing-tooling-taskuvp.vbrief.json
+++ b/vbrief/completed/2026-06-12-1187-directive-bound-agents-should-detect-missing-tooling-taskuvp.vbrief.json
@@ -95,7 +95,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T15:33:18Z"
+      "completedAt": "2026-06-12T15:33:18Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-12-1596-startup-ritual-should-warn-when-the-default-branch-is-out-of.vbrief.json
+++ b/vbrief/completed/2026-06-12-1596-startup-ritual-should-warn-when-the-default-branch-is-out-of.vbrief.json
@@ -87,7 +87,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T15:33:26Z"
+      "completedAt": "2026-06-12T15:33:26Z",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-12-1606-featcapacity-ship-the-deferred-capacitybackfill-tool-1419-hi.vbrief.json
+++ b/vbrief/completed/2026-06-12-1606-featcapacity-ship-the-deferred-capacitybackfill-tool-1419-hi.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(capacity): ship the deferred capacity:backfill tool (#1419 history classifier)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "feat(capacity): ship the deferred capacity:backfill tool (#1419 history classifier)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1606",
@@ -62,6 +62,10 @@
         "title": "Issue #1606: feat(capacity): ship the deferred capacity:backfill tool (#1419 history classifier)"
       }
     ],
-    "updated": "2026-06-12T20:47:54Z"
+    "updated": "2026-06-12T21:05:56Z",
+    "metadata": {
+      "completedAt": "2026-06-12T21:05:56Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/vbrief/completed/2026-06-12-689-featinstaller-version-currency-self-check-at-startup.vbrief.json
+++ b/vbrief/completed/2026-06-12-689-featinstaller-version-currency-self-check-at-startup.vbrief.json
@@ -91,7 +91,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T14:50:28Z"
+      "completedAt": "2026-06-12T14:50:28Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "match"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-12-generic-terminal-swarm-fallback-should-offer-serial-self-exe.vbrief.json
+++ b/vbrief/completed/2026-06-12-generic-terminal-swarm-fallback-should-offer-serial-self-exe.vbrief.json
@@ -64,7 +64,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T14:43:26Z"
+      "completedAt": "2026-06-12T14:43:26Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-12-greenfield-setup-should-produce-or-offer-a-swarm-ready-proje.vbrief.json
+++ b/vbrief/completed/2026-06-12-greenfield-setup-should-produce-or-offer-a-swarm-ready-proje.vbrief.json
@@ -75,7 +75,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T14:43:26Z"
+      "completedAt": "2026-06-12T14:43:26Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-12-interactive-swarm-worktrees-should-default-to-deterministic.vbrief.json
+++ b/vbrief/completed/2026-06-12-interactive-swarm-worktrees-should-default-to-deterministic.vbrief.json
@@ -66,7 +66,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T14:43:26Z"
+      "completedAt": "2026-06-12T14:43:26Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "references": [
       {

--- a/vbrief/completed/2026-06-12-lifecycle-taskfile-commands-should-preserve-reliable-success.vbrief.json
+++ b/vbrief/completed/2026-06-12-lifecycle-taskfile-commands-should-preserve-reliable-success.vbrief.json
@@ -69,7 +69,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "standard"
       },
-      "completedAt": "2026-06-12T15:33:26Z"
+      "completedAt": "2026-06-12T15:33:26Z",
+      "capacityBucket": "new-capability",
+      "capacityBucketSource": "default"
     },
     "references": [
       {


### PR DESCRIPTION
## Summary

Ships the deferred `task capacity:backfill` tool (#1419 "Brownfield Backfill") and closes the discoverability gap that left capacity accounting silently dormant on pre-adoption trees.

- **`scripts/capacity_backfill.py`** — one-time classifier for `completed/` vBRIEFs. Infers `capacityBucket` from each item's origin-issue labels via the configured `capacityAllocation.buckets[].match.labels` rules (declaration-order match wins; no match falls to `defaultBucket` and is surfaced in a low-confidence batch), and stamps `completedAt` from git landing time. **Dry-run by default**, **idempotent** (explicit values preserved), and **never touches `cost`**. Offline cache-first with an opt-in `--fetch` (REST shim, never GraphQL) for closed issues absent from the open-issue-scoped triage cache, plus `--window-only` to restrict to the activation-critical trailing window.
- **`task capacity:backfill`** Taskfile surface.
- **Discoverability** — `capacity:show` now emits an actionable hint when buckets are configured but history is unclassified, and a Tier-3 session-start cold-start nudge points the operator at the one-time backfill. Both self-suppress once `minSampleSize` is crossed.
- **Ran it on directive** (second commit, data-only): 183 in-window completions classified (152 by label, 31 defaulted), 132 got git-derived `completedAt`. Capacity is now **out of advisory mode** (183 ≥ minSampleSize 20) with a real 4-bucket mix and actionable deficits.

Commits are split: logic + tests (reviewable) / data migration (mechanical) / lifecycle completion.

## Test plan

- [x] `task check` green (7681 passed)
- [x] New `tests/cli/test_capacity_backfill.py` (16 tests): classification, dry-run/apply/idempotency, cost-preservation, `--window-only`, config-error exit 2, `--fetch` fallback, cold-start nudge fire/suppress
- [x] Existing capacity / lifecycle suites still pass (225)
- [x] `capacity:show` post-backfill reports 183 classified completions, advisory mode cleared
- [x] Cold-start nudge suppresses post-backfill

Refs #1419. Closes #1606.
