### PR TITLE
fix(installer): ignore ritual runtime sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Session-start runtime files no longer dirty freshly installed consumer repositories (#1609)** -- the installer and relocator now deposit selective `.gitignore` entries for `.deft/ritual-state.json` and `.deft/last-session.json`, keeping the ritual sentinels local while preserving the tracked `.deft/core/` framework payload. Closes #1609.
 
 ### Removed
 

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -1187,7 +1187,7 @@ func TestCanonicalGitignoreRuntimeSentinelsMatchPythonSource(t *testing.T) {
 	}
 	var goEntries []string
 	for _, line := range canonicalGitignoreLines {
-		if strings.HasPrefix(line, ".deft/") && strings.HasSuffix(line, ".json") {
+		if strings.HasPrefix(line, ".deft/") && !strings.HasSuffix(line, "/") && !strings.Contains(line, "*") {
 			goEntries = append(goEntries, line)
 		}
 	}

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -979,6 +979,8 @@ func TestEnsureGitignoreLines_CreatesNew(t *testing.T) {
 	// #1464: selective per-file eval entries, NOT the blanket vbrief/.eval/.
 	for _, want := range []string{
 		".deft-cache/",
+		".deft/ritual-state.json",
+		".deft/last-session.json",
 		"vbrief/.eval/candidates.jsonl",
 		"vbrief/.eval/summary-history.jsonl",
 		"vbrief/.eval/scope-lifecycle.jsonl",
@@ -1013,6 +1015,7 @@ func TestEnsureGitignoreLines_AppendsToExisting(t *testing.T) {
 	}
 	for _, want := range []string{
 		"node_modules/", ".env", ".deft-cache/",
+		".deft/ritual-state.json", ".deft/last-session.json",
 		"vbrief/.eval/candidates.jsonl", "vbrief/.eval/doctor-state.json",
 	} {
 		if !strings.Contains(content, want) {
@@ -1068,6 +1071,33 @@ func TestEnsureGitignoreLines_LeakedArtifactGuards(t *testing.T) {
 	for _, want := range []string{"vbrief/*.lock", ".deft/core.bak-*/", ".deft/*.bak-*", "*.premigrate.*"} {
 		if !strings.Contains(content, want) {
 			t.Errorf(".gitignore deposit missing leaked-artefact guard %q", want)
+		}
+	}
+}
+
+// TestEnsureGitignoreLines_DoesNotIgnoreFrameworkPayload asserts the #1609
+// fix stays selective: consumer repos commit .deft/core/ for reproducibility,
+// while only runtime sentinel files under .deft/ are ignored.
+func TestEnsureGitignoreLines_DoesNotIgnoreFrameworkPayload(t *testing.T) {
+	tmp := t.TempDir()
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+
+	if _, err := EnsureGitignoreLines(w, tmp); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if err != nil {
+		t.Fatalf("missing .gitignore: %v", err)
+	}
+	content := string(data)
+	for _, forbidden := range []string{".deft/", ".deft", ".deft/core/", ".deft/core"} {
+		if n := countWholeLines(content, forbidden); n != 0 {
+			t.Errorf(".gitignore must not contain blanket/framework payload entry %q", forbidden)
+		}
+	}
+	for _, want := range []string{".deft/ritual-state.json", ".deft/last-session.json"} {
+		if countWholeLines(content, want) != 1 {
+			t.Errorf(".gitignore missing selective runtime sentinel %q", want)
 		}
 	}
 }
@@ -1141,6 +1171,31 @@ func TestEnsureGitignoreLines_HealsBareBlanketOnlyFile(t *testing.T) {
 	}
 }
 
+// TestCanonicalGitignoreRuntimeSentinelsMatchPythonSource pins the Go
+// installer's selective .deft runtime sentinel entries to
+// GITIGNORE_DEFT_RUNTIME_SENTINELS in scripts/_triage_bootstrap_gitignore.py
+// (#1609). If the Python source grows, the installer mirror must follow.
+func TestCanonicalGitignoreRuntimeSentinelsMatchPythonSource(t *testing.T) {
+	pyPath := filepath.Join(repoRootFromDeftInstall(t), "scripts", "_triage_bootstrap_gitignore.py")
+	src, err := os.ReadFile(pyPath)
+	if err != nil {
+		t.Fatalf("could not read %s: %v", pyPath, err)
+	}
+	pyEntries := parsePythonRuntimeSentinelEntries(t, string(src))
+	if len(pyEntries) == 0 {
+		t.Fatal("parsed zero GITIGNORE_DEFT_RUNTIME_SENTINELS from Python source -- parser drift?")
+	}
+	var goEntries []string
+	for _, line := range canonicalGitignoreLines {
+		if strings.HasPrefix(line, ".deft/") && strings.HasSuffix(line, ".json") {
+			goEntries = append(goEntries, line)
+		}
+	}
+	if strings.Join(goEntries, "\n") != strings.Join(pyEntries, "\n") {
+		t.Errorf("Go canonicalGitignoreLines .deft runtime subset drifted from Python GITIGNORE_DEFT_RUNTIME_SENTINELS.\n  Go:     %v\n  Python: %v", goEntries, pyEntries)
+	}
+}
+
 // TestCanonicalGitignoreEvalEntriesMatchPythonSource pins the Go installer's
 // selective vbrief/.eval/* entries to GITIGNORE_EVAL_ENTRIES in
 // scripts/_triage_bootstrap_gitignore.py (the single source of truth shared
@@ -1173,10 +1228,21 @@ func TestCanonicalGitignoreEvalEntriesMatchPythonSource(t *testing.T) {
 // typed assignment form so the docstring mention is not matched.
 func parsePythonEvalEntries(t *testing.T, src string) []string {
 	t.Helper()
-	block := regexp.MustCompile(`GITIGNORE_EVAL_ENTRIES:\s*tuple\[str, \.\.\.\]\s*=\s*\(([^)]*)\)`)
+	return parsePythonTupleEntries(t, src, "GITIGNORE_EVAL_ENTRIES")
+}
+
+func parsePythonRuntimeSentinelEntries(t *testing.T, src string) []string {
+	t.Helper()
+	return parsePythonTupleEntries(t, src, "GITIGNORE_DEFT_RUNTIME_SENTINELS")
+}
+
+func parsePythonTupleEntries(t *testing.T, src string, tupleName string) []string {
+	t.Helper()
+	pattern := fmt.Sprintf(`%s:\s*tuple\[str, \.\.\.\]\s*=\s*\(([^)]*)\)`, regexp.QuoteMeta(tupleName))
+	block := regexp.MustCompile(pattern)
 	m := block.FindStringSubmatch(src)
 	if m == nil {
-		t.Fatal("could not locate GITIGNORE_EVAL_ENTRIES tuple in Python source")
+		t.Fatalf("could not locate %s tuple in Python source", tupleName)
 	}
 	quoted := regexp.MustCompile(`"([^"]+)"`)
 	var out []string

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -178,8 +178,8 @@ var agentsMDManagedOpenPattern = regexp.MustCompile(`<!-- deft:managed-section v
 
 // canonicalGitignoreLines is the .gitignore baseline the installer deposits.
 // It mirrors scripts/relocate.py::GITIGNORE_LINES (the F2 canonical default
-// from #1015): the runtime cache directory plus the SELECTIVE per-file
-// vbrief/.eval/* entries.
+// from #1015): the runtime cache directory, the SELECTIVE .deft runtime
+// sentinel files, plus the SELECTIVE per-file vbrief/.eval/* entries.
 //
 // #1251 / #1464: the eval state is gitignored via the selective per-file
 // entries (candidates.jsonl / summary-history.jsonl / scope-lifecycle.jsonl /
@@ -191,6 +191,12 @@ var agentsMDManagedOpenPattern = regexp.MustCompile(`<!-- deft:managed-section v
 // bootstrap + relocator rails consume); the parity test
 // TestCanonicalGitignoreEvalEntriesMatchPythonSource pins the two together,
 // and EnsureGitignoreLines HEALS a pre-existing blanket on upgrade.
+//
+// #1609: session-start writes per-clone runtime sentinels under .deft/. The
+// consumer projection tracks .deft/core/ for reproducible installs, so the
+// installer MUST ignore only the sentinel files (.deft/ritual-state.json and
+// .deft/last-session.json) instead of depositing a blanket .deft/ rule that
+// would hide the framework payload.
 //
 // The three leaked-artefact guards below stop a consumer's `git add -A` from
 // trapping installer/render scratch files:
@@ -218,6 +224,10 @@ var agentsMDManagedOpenPattern = regexp.MustCompile(`<!-- deft:managed-section v
 // itself, only the timestamped backup siblings.
 var canonicalGitignoreLines = []string{
 	".deft-cache/",
+	// Selective .deft runtime sentinels -- MUST equal
+	// GITIGNORE_DEFT_RUNTIME_SENTINELS in scripts/_triage_bootstrap_gitignore.py.
+	".deft/ritual-state.json",
+	".deft/last-session.json",
 	// Selective vbrief/.eval/* entries -- MUST equal GITIGNORE_EVAL_ENTRIES in
 	// scripts/_triage_bootstrap_gitignore.py, in the same order (parity test
 	// TestCanonicalGitignoreEvalEntriesMatchPythonSource pins this).
@@ -653,8 +663,9 @@ func WriteAgentsMD(w *Wizard, projectDir string) error {
 // ---------------------------------------------------------------------------
 
 // EnsureGitignoreLines ensures the canonical baseline (the runtime cache dir +
-// the SELECTIVE vbrief/.eval/* entries + the leaked-artefact guards) is present
-// in the consumer's .gitignore, creating the file when absent. It also HEALS a
+// the SELECTIVE .deft runtime sentinels + the SELECTIVE vbrief/.eval/* entries
+// + the leaked-artefact guards) is present in the consumer's .gitignore,
+// creating the file when absent. It also HEALS a
 // pre-existing forbidden blanket `vbrief/.eval/` (or `vbrief/.eval`) line on
 // upgrade (#1464): pre-#1251 rails deposited that blanket, which hides the
 // tracked vbrief/.eval/slices.jsonl + README.md from git; an upgrade now

--- a/scripts/_triage_bootstrap_gitignore.py
+++ b/scripts/_triage_bootstrap_gitignore.py
@@ -8,13 +8,17 @@
 Extracted from :mod:`triage_bootstrap` under #952 to keep the parent
 module under the 1000-line MUST limit from ``coding/coding.md``. The
 helpers are pure (no module-level state) and operate on the consumer
-project's ``.gitignore``, ``.gitattributes``, and ``vbrief/.eval/``
-scratch directory only; nothing here touches the cache or scope vBRIEF
-state.
+project's ``.gitignore``, ``.gitattributes``, Deft runtime sentinel
+paths, and ``vbrief/.eval/`` scratch directory only; nothing here
+touches the cache or scope vBRIEF state.
 
 Public surface (stable for :mod:`triage_bootstrap` re-exports):
 
 - :data:`GITIGNORE_LINE` -- canonical ``.deft-cache/`` line.
+- :data:`GITIGNORE_DEFT_RUNTIME_SENTINELS` -- canonical selective
+  ``.deft`` runtime sentinel lines (``ritual-state.json`` /
+  ``last-session.json``). Single source of truth mirrored by the
+  installer and imported by the relocator (#1609).
 - :data:`GITIGNORE_EVAL_ENTRIES` -- canonical selective per-file lines
   for the #1144 hybrid policy (``candidates.jsonl`` /
   ``summary-history.jsonl`` / ``scope-lifecycle.jsonl`` /
@@ -66,8 +70,17 @@ def _outcome_cls() -> type:
 
 
 #: Canonical gitignore line. Trailing slash matches the convention in
-#: the existing ``.gitignore`` (e.g. ``dist/``, ``.deft/``).
+#: the existing ``.gitignore`` (e.g. ``dist/``, ``node_modules/``).
 GITIGNORE_LINE: str = ".deft-cache/"
+
+#: Canonical selective gitignore lines for Deft-owned per-clone runtime
+#: sentinels under ``.deft/``. The framework payload at ``.deft/core/``
+#: remains intentionally trackable for reproducible consumer installs, so
+#: these entries MUST stay file-specific and MUST NOT become ``.deft/``.
+GITIGNORE_DEFT_RUNTIME_SENTINELS: tuple[str, ...] = (
+    ".deft/ritual-state.json",
+    ".deft/last-session.json",
+)
 
 #: Canonical selective gitignore lines for the #1144 hybrid policy.
 #: Replaces the pre-#1251 blanket ``vbrief/.eval/`` line. The entries

--- a/scripts/relocate.py
+++ b/scripts/relocate.py
@@ -9,7 +9,7 @@ D AGENTS.md only) to the canonical v0.27 layout::
         .deft/core/      -- read-only packaged framework assets (per #11)
         .deft-cache/     -- gitignored runtime cache
         AGENTS.md        -- managed-section v2 (#768)
-        .gitignore       -- contains `.deft-cache/` and `vbrief/.eval/`
+        .gitignore       -- contains local Deft runtime entries
 
 State detection (A-G) and customization probing live in
 :mod:`scripts._relocate_states`; snapshot tarball logic lives in
@@ -101,6 +101,7 @@ from _relocate_states import (  # noqa: E402
 from _stdio_utf8 import reconfigure_stdio  # noqa: E402
 from _triage_bootstrap_gitignore import (  # noqa: E402
     FORBIDDEN_BLANKET_EVAL_LINES,
+    GITIGNORE_DEFT_RUNTIME_SENTINELS,
     GITIGNORE_EVAL_ENTRIES,
     strip_gitignore_inline_comment,
 )
@@ -198,8 +199,9 @@ VBRIEF_LIFECYCLE_DIRS: tuple[str, ...] = (
 #:
 #: F2 canonical-default decision (#1015): the canonical relocator default
 #: gitignores ``.deft-cache/`` (runtime cache, snapshot tarballs, audit log
-#: -- mirrors the #845 / #883 hidden-namespace gitignore convention) and the
-#: operator-private ``vbrief/.eval/`` audit-log state. The framework deposit
+#: -- mirrors the #845 / #883 hidden-namespace gitignore convention), the
+#: selective ``.deft`` runtime sentinels written by the session ritual, and
+#: the operator-private ``vbrief/.eval/`` audit-log state. The framework deposit
 #: at ``.deft/core/`` is INTENTIONALLY NOT auto-gitignored: per #11 the
 #: ``.deft/core/`` tree is read-only packaged framework assets that ship
 #: with the consumer's repo for reproducibility. Auto-gitignoring it would
@@ -219,6 +221,7 @@ VBRIEF_LIFECYCLE_DIRS: tuple[str, ...] = (
 #: blanket is healed (stripped) by ``_ensure_gitignore_lines`` on upgrade.
 GITIGNORE_LINES: tuple[str, ...] = (
     ".deft-cache/",
+    *GITIGNORE_DEFT_RUNTIME_SENTINELS,
     *GITIGNORE_EVAL_ENTRIES,
 )
 

--- a/scripts/ritual_sentinel.py
+++ b/scripts/ritual_sentinel.py
@@ -82,13 +82,14 @@ LOG = logging.getLogger(__name__)
 SCHEMA_VERSION: int = 1
 
 #: Filesystem-relative location of the per-clone sentinel. Never
-#: committed -- ``.deft/`` is gitignored.
+#: committed -- consumer projections selectively gitignore this file
+#: while preserving the trackable ``.deft/core/`` framework payload.
 SENTINEL_RELPATH: tuple[str, str] = (".deft", "last-session.json")
 
 #: Filesystem-relative location of the fail-closed session ritual state
 #: (#1348). Separate from :data:`SENTINEL_RELPATH` because the existing
 #: last-session sentinel is intentionally fail-open while this verifier
-#: must fail closed.
+#: must fail closed. Also selectively gitignored in consumer projections.
 RITUAL_STATE_RELPATH: tuple[str, str] = (".deft", "ritual-state.json")
 
 #: Schema version emitted by the ritual-state writer and required by the

--- a/tests/relocate/test_self_bootstrap.py
+++ b/tests/relocate/test_self_bootstrap.py
@@ -12,8 +12,10 @@ Owned by the v0.27.1 follow-up issue #1015. Covers four behaviour blocks:
   references is present in ``UPGRADING.md`` under the v0.27 migration section.
 
 - **F2 canonical default** -- the canonical ``.gitignore`` baseline is
-  ``.deft-cache/`` + the SELECTIVE ``vbrief/.eval/*`` entries (#1251 / #1464;
-  NOT the blanket ``vbrief/.eval/`` and NOT ``.deft/core/``). A small
+  ``.deft-cache/`` + the SELECTIVE ``.deft`` runtime sentinels (#1609) +
+  the SELECTIVE ``vbrief/.eval/*`` entries (#1251 / #1464; NOT the blanket
+  ``.deft/``, NOT the blanket ``vbrief/.eval/``, and NOT ``.deft/core/``).
+  A small
   parametrised test pins consistency across the relocator implementation,
   the pre-existing state-matrix fixture assertions, and the relocator-side
   test fixture (``test_state_matrix.py::_assert_canonical_end_state``). The
@@ -290,8 +292,10 @@ class TestF1UpgradingNote:
 
 
 class TestF2GitignoreDefault:
-    """The canonical default is ``.deft-cache/`` + the selective eval entries.
+    """The canonical default is cache + selective runtime/eval entries.
 
+    #1609: session ritual state under ``.deft/`` is ignored via exact files,
+    never via a blanket ``.deft/`` line that would hide ``.deft/core/``.
     #1251 / #1464: the eval state is gitignored via the SELECTIVE per-file
     entries (the single source of truth ``GITIGNORE_EVAL_ENTRIES``), NEVER the
     blanket ``vbrief/.eval/`` line which would hide the tracked
@@ -302,10 +306,19 @@ class TestF2GitignoreDefault:
     """
 
     def test_relocator_constant_pins_canonical_default(self, relocate: Any) -> None:
-        # Single source of truth: GITIGNORE_LINES == .deft-cache/ + the
-        # imported GITIGNORE_EVAL_ENTRIES tuple (#1464).
-        expected = (".deft-cache/", *relocate.GITIGNORE_EVAL_ENTRIES)
+        # Single source of truth: GITIGNORE_LINES == .deft-cache/ + imported
+        # runtime sentinel entries (#1609) + imported eval entries (#1464).
+        expected = (
+            ".deft-cache/",
+            *relocate.GITIGNORE_DEFT_RUNTIME_SENTINELS,
+            *relocate.GITIGNORE_EVAL_ENTRIES,
+        )
         assert expected == relocate.GITIGNORE_LINES
+        # The forbidden .deft blanket is absent; the selective entries replace it.
+        assert ".deft/" not in relocate.GITIGNORE_LINES
+        assert ".deft" not in relocate.GITIGNORE_LINES
+        assert ".deft/ritual-state.json" in relocate.GITIGNORE_LINES
+        assert ".deft/last-session.json" in relocate.GITIGNORE_LINES
         # The forbidden blanket is gone; the selective entries replace it.
         assert "vbrief/.eval/" not in relocate.GITIGNORE_LINES
         assert "vbrief/.eval" not in relocate.GITIGNORE_LINES
@@ -313,9 +326,11 @@ class TestF2GitignoreDefault:
         assert "vbrief/.eval/doctor-state.json" in relocate.GITIGNORE_LINES
 
     def test_dot_deft_core_is_intentionally_absent(self, relocate: Any) -> None:
-        # If a future PR adds .deft/core/ to GITIGNORE_LINES it MUST first
+        # If a future PR adds .deft/ or .deft/core/ to GITIGNORE_LINES it MUST first
         # update the F2 decision rationale comment in scripts/relocate.py
         # AND drop this test (which encodes the inverse contract).
+        assert ".deft/" not in relocate.GITIGNORE_LINES
+        assert ".deft" not in relocate.GITIGNORE_LINES
         assert ".deft/core/" not in relocate.GITIGNORE_LINES
         assert ".deft/core" not in relocate.GITIGNORE_LINES
 
@@ -323,6 +338,8 @@ class TestF2GitignoreDefault:
         "expected_line",
         [
             ".deft-cache/",
+            ".deft/ritual-state.json",
+            ".deft/last-session.json",
             "vbrief/.eval/candidates.jsonl",
         ],
     )
@@ -386,6 +403,8 @@ class TestGitignoreHealBlanket:
             if line.strip() and not line.lstrip().startswith("#")
         ]
         assert "vbrief/.eval" not in active
+        assert ".deft/ritual-state.json" in active
+        assert ".deft/last-session.json" in active
         assert "vbrief/.eval/candidates.jsonl" in active
         # Re-run is a clean no-op (blanket already healed, entries present).
         assert relocate._ensure_gitignore_lines(tmp_path) is False
@@ -400,6 +419,8 @@ class TestGitignoreHealBlanket:
         gi = tmp_path / ".gitignore"
         seeded = (
             ".deft-cache/\n"
+            ".deft/ritual-state.json  # local ritual state\n"
+            ".deft/last-session.json\n"
             "vbrief/.eval/candidates.jsonl  # added manually\n"
             "vbrief/.eval/summary-history.jsonl\n"
             "vbrief/.eval/scope-lifecycle.jsonl\n"
@@ -412,6 +433,9 @@ class TestGitignoreHealBlanket:
         assert relocate._ensure_gitignore_lines(tmp_path) is False
         body = gi.read_text(encoding="utf-8")
         assert body == seeded
+        assert body.count(".deft/ritual-state.json") == 1, (
+            "inline-commented canonical sentinel must not be re-deposited (#1609)"
+        )
         assert body.count("vbrief/.eval/candidates.jsonl") == 1, (
             "inline-commented canonical entry must not be re-deposited (#1464)"
         )

--- a/tests/relocate/test_state_matrix.py
+++ b/tests/relocate/test_state_matrix.py
@@ -295,6 +295,23 @@ def _assert_canonical_end_state(
     assert "<!-- /deft:managed-section -->" in agents, "v2 marker close absent"
     gitignore = (project_root / ".gitignore").read_text(encoding="utf-8")
     assert ".deft-cache/" in gitignore, ".gitignore missing .deft-cache/ entry"
+    assert ".deft/ritual-state.json" in gitignore, (
+        ".gitignore missing selective .deft ritual-state entry"
+    )
+    assert ".deft/last-session.json" in gitignore, (
+        ".gitignore missing selective .deft last-session entry"
+    )
+    active_deft = [
+        line.strip()
+        for line in gitignore.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert ".deft/" not in active_deft, (
+        "relocator must not deposit a blanket .deft/ line; .deft/core/ is tracked"
+    )
+    assert ".deft/core/" not in active_deft, (
+        "relocator must not hide the tracked .deft/core/ framework payload"
+    )
     assert "vbrief/.eval/candidates.jsonl" in gitignore, (
         ".gitignore missing selective vbrief/.eval/ entry"
     )

--- a/vbrief/completed/2026-06-13-1609-installer-ignore-deft-ritual-runtime-sentinels-in-consumer-p.vbrief.json
+++ b/vbrief/completed/2026-06-13-1609-installer-ignore-deft-ritual-runtime-sentinels-in-consumer-p.vbrief.json
@@ -1,0 +1,51 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1609"
+  },
+  "plan": {
+    "title": "installer: ignore .deft ritual runtime sentinels in consumer projects",
+    "status": "completed",
+    "narratives": {
+      "Description": "installer: ignore .deft ritual runtime sentinels in consumer projects",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1609",
+      "Overview": "## Summary\n\nConsumer installs now write Deft session-start runtime state to `.deft/ritual-state.json`, but the installer/projection-managed `.gitignore` does not ignore that file. The result is an expected local sentinel showing up as an untracked dirty file in consumer repos, which then blocks the Deft story-start gate before implementation.\n\n## Observed in consumer repo\n\nIn `deftai/statusreport`, running the session-start ritual created:\n\n- `.deft/ritual-state.json`\n\n`git status --short --branch` then showed:\n\n```text\n## master...origin/master\n?? .deft/ritual-state.json\n```\n\nThe generated file contains worktree/session-specific state such as `git_head`, `worktree_path`, `session_id`, branch-policy output, and triage-welcome output. It is not shareable project state and should not be committed.\n\n## Why this appears to be installer-owned\n\n`ritual_sentinel.py` documents the sentinel as never committed because `.deft/` is assumed to be gitignored. Modern consumer installs track `.deft/core/`, so blanket-ignoring `.deft/` is no longer the actual projection model. The installer/relocator already owns selective `.gitignore` projection for local Deft state, so it should also project ignore entries for the runtime sentinels created by the session ritual.\n\nLikely entries:\n\n```gitignore\n.deft/ritual-state.json\n.deft/last-session.json\n```\n\n## Impact\n\n- Fresh/returning interactive sessions create an untracked file as part of the required ritual.\n- The story-start gate sees a dirty tree and halts implementation.\n- Users and agents must manually decide whether to delete/ignore an internal runtime file before doing unrelated work.\n\n## Expected behavior\n\nInstaller/upgrade/relocator projection should ensure consumer `.gitignore` excludes Deft runtime sentinels while preserving tracked `.deft/core/` payload files.\n\n## Acceptance criteria\n\n- Fresh consumer install includes selective ignore coverage for `.deft/ritual-state.json`.\n- Upgrade/relocator heals existing consumer repos that lack the ignore entry.\n- Consider `.deft/last-session.json` in the same fix, since it is also documented as per-clone runtime state.\n- Add/update parity tests so installer, relocator, and any Python source-of-truth for gitignore projection stay aligned.",
+      "Labels": "bug, adoption-blocker, installer"
+    },
+    "items": [
+      {
+        "title": "Fresh consumer install includes selective ignore coverage for .",
+        "status": "proposed"
+      },
+      {
+        "title": "Upgrade/relocator heals existing consumer repos that lack the ignore entry.",
+        "status": "proposed"
+      },
+      {
+        "title": "Consider  in the same fix, since it is also documented as per-clone runtime state.",
+        "status": "proposed"
+      },
+      {
+        "title": "Add/update parity tests so installer, relocator, and any Python source-of-truth for gitignore projection stay aligned.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "installer"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1609",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1609: installer: ignore .deft ritual runtime sentinels in consumer projects"
+      }
+    ],
+    "updated": "2026-06-13T13:55:03Z",
+    "metadata": {
+      "completedAt": "2026-06-13T13:55:03Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}

--- a/vbrief/completed/2026-06-13-1609-installer-ignore-deft-ritual-runtime-sentinels-in-consumer-p.vbrief.json
+++ b/vbrief/completed/2026-06-13-1609-installer-ignore-deft-ritual-runtime-sentinels-in-consumer-p.vbrief.json
@@ -14,20 +14,20 @@
     },
     "items": [
       {
-        "title": "Fresh consumer install includes selective ignore coverage for .",
-        "status": "proposed"
+        "title": "Fresh consumer install includes selective ignore coverage for `.deft/ritual-state.json`.",
+        "status": "completed"
       },
       {
         "title": "Upgrade/relocator heals existing consumer repos that lack the ignore entry.",
-        "status": "proposed"
+        "status": "completed"
       },
       {
-        "title": "Consider  in the same fix, since it is also documented as per-clone runtime state.",
-        "status": "proposed"
+        "title": "Consider `.deft/last-session.json` in the same fix, since it is also documented as per-clone runtime state.",
+        "status": "completed"
       },
       {
         "title": "Add/update parity tests so installer, relocator, and any Python source-of-truth for gitignore projection stay aligned.",
-        "status": "proposed"
+        "status": "completed"
       }
     ],
     "tags": [
@@ -42,7 +42,7 @@
         "title": "Issue #1609: installer: ignore .deft ritual runtime sentinels in consumer projects"
       }
     ],
-    "updated": "2026-06-13T13:55:03Z",
+    "updated": "2026-06-13T14:27:36Z",
     "metadata": {
       "completedAt": "2026-06-13T13:55:03Z",
       "capacityBucket": "new-capability"


### PR DESCRIPTION
## Summary

- Add selective `.gitignore` coverage for `.deft/ritual-state.json` and `.deft/last-session.json` in the installer and relocator projections.
- Keep `.deft/core/` intentionally trackable so consumer repos do not hide the vendored framework payload.
- Add parity/regression tests across the Go installer and Python relocator sources.

## Related Issues

Closes #1609

## Checklist

- [x] `/deft:change <name>` — N/A; this was an ingested bug scope with an active/completed vBRIEF.
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`.
- [x] `ROADMAP.md` — N/A; release-time roadmap movement only.
- [x] Tests pass locally.

## Testing

- `PATH="$PWD/.venv/bin:$PATH" go test ./cmd/deft-install`
- `.venv/bin/python3 -m pytest tests/relocate/test_self_bootstrap.py tests/relocate/test_state_matrix.py -q`
- `.venv/bin/python3 -m pytest tests/cli/test_session_start.py tests/cli/test_verify_session_ritual.py -q`
- `.venv/bin/python3 scripts/vbrief_validate.py --vbrief-dir vbrief`
- `.venv/bin/python3 -m pytest tests/content/test_pyproject_version_freshness.py -q`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" UV_NO_SYNC=1 task check` — collected 7703 items / 9 deselected / 7694 selected; result: 7688 passed, 5 skipped, 9 deselected, 1 xfailed.

## Review Cycle

- Greptile review on `5b014b0` reported 0 P0, 0 P1, and 2 P2 findings with confidence 4/5.
- Commit `65322de` addresses 2/2 P2 findings in one batch: tightened the runtime-sentinel parity filter and completed the vBRIEF acceptance-criteria items.
- GitHub MCP review tools were unavailable in this session; I used `gh pr view --comments` plus `gh api repos/deftai/directive/pulls/1612/comments` as the two review sources.

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed — `gh issue view 1609 --json state --jq .state`. If still open, close manually: `gh issue close 1609 --comment "Closed by #<PR> (squash merge — auto-close did not trigger)"`
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
