### PR TITLE
chore: complete #1621 debug-skill scope vBRIEF

### DIFF
--- a/vbrief/completed/2026-06-14-1621-featskillscoding-deft-directive-debug-systematic-root-cause.vbrief.json
+++ b/vbrief/completed/2026-06-14-1621-featskillscoding-deft-directive-debug-systematic-root-cause.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(skills,coding): deft-directive-debug — systematic root-cause investigation skill + coding/debugging.md (supersedes #659, #1173)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "feat(skills,coding): deft-directive-debug — systematic root-cause investigation skill + coding/debugging.md (supersedes #659, #1173)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1621",
@@ -26,6 +26,10 @@
         "title": "Issue #1621: feat(skills,coding): deft-directive-debug — systematic root-cause investigation skill + coding/debugging.md (supersedes #659, #1173)"
       }
     ],
-    "updated": "2026-06-14T20:56:47Z"
+    "updated": "2026-06-14T22:54:34Z",
+    "metadata": {
+      "completedAt": "2026-06-14T22:54:34Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
Lifecycle-only: moves the #1621 scope vBRIEF from `active/` to `completed/` now that the debugging capability (D1–D3) shipped in #1623 and the issue is closed.

Refs #1621

Made with [Cursor](https://cursor.com)