### PR TITLE
chore(vbrief): make #1284 Wave-1 cohort swarm-ready

### DIFF
--- a/vbrief/proposed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "description": "Story vBRIEF for #1286 (feat(triage): demote vBRIEF-status:blocked items in triage:queue); part of the #742 decomposition.",
     "created": "2026-05-21T16:32:24Z",
-    "updated": "2026-05-21T16:32:24Z"
+    "updated": "2026-06-14T23:55:00Z"
   },
   "plan": {
     "id": "1286-triage-queue-blocked-filter",
@@ -11,30 +11,31 @@
     "status": "proposed",
     "planRef": "#1286",
     "narratives": {
-      "Description": "The triage queue (scripts/triage_queue.py) groups items by triage-decision history (ORPHAN / RESUME / URGENT / untriaged / other) and does not consult vBRIEF dependency state, so blocked children pollute the queue. Extend it to consult the linked vBRIEF's status:blocked / unresolved swarm.depends_on and demote those items.",
-      "ImplementationPlan": "Read the linked vBRIEF via existing triage_scope (D12 / #1131). Add a BLOCKED group (or demote into other). Add --include-blocked opt-back-in flag. Cover new behavior with tests.",
-      "UserStory": "As an operator running task triage:queue, I want blocked children to be hidden or demoted so the queue only surfaces grabbable work."
+      "Description": "The triage queue (scripts/triage_queue.py) groups items by triage-decision history (ORPHAN / RESUME / URGENT / untriaged / other) and does not consult vBRIEF dependency state, so blocked children pollute the queue. This story extends the queue to read each candidate's linked vBRIEF status and demote status:blocked or unresolved-dependency items so the ranked list surfaces only grabbable work.",
+      "ImplementationPlan": "Extend scripts/triage_queue.py to resolve each candidate's linked vBRIEF status via scripts/triage_scope.py (D12 / #1131). Add a demote path that moves status:blocked or unresolved swarm.depends_on items into a BLOCKED group, plus an --include-blocked opt-in flag on the CLI. Add tests in tests/cli/test_triage_queue.py covering the blocked-demoted, unblocked-surfaced, and opt-in paths.",
+      "UserStory": "As an operator running task triage:queue, I want blocked children to be hidden or demoted, so that the queue only surfaces grabbable work.",
+      "Traces": "planRef #1286; decomposition_origin #742; epic #1284."
     },
     "items": [
       {
         "title": "Extend triage_queue.py to consult vBRIEF state via triage_scope",
         "status": "pending",
         "narrative": {
-          "Acceptance": "Function exists; returns demote-recommendation per item."
+          "Acceptance": "scripts/triage_queue.py reads each candidate's linked vBRIEF status and returns a demote recommendation per queue item."
         }
       },
       {
         "title": "Add BLOCKED group (or demote into other) + --include-blocked opt-in",
         "status": "pending",
         "narrative": {
-          "Acceptance": "Queue render shows blocked items demoted by default; --include-blocked surfaces them."
+          "Acceptance": "The queue render demotes status:blocked items into a BLOCKED group by default and surfaces them only when --include-blocked is passed."
         }
       },
       {
         "title": "Tests: blocked demoted; unblocked surfaces; opt-in flag",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task check passes; new tests cover all three paths."
+          "Acceptance": "When the suite runs, tests/cli/test_triage_queue.py validates the blocked-demoted, unblocked-surfaced, and --include-blocked opt-in paths."
         }
       }
     ],
@@ -45,7 +46,25 @@
         "decomposition_origin": "#742"
       },
       "swarm": {
-        "readiness": "not-ready"
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/triage_queue.py",
+          "tests/cli/test_triage_queue.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_triage_queue.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "triage_queue.py demotes status:blocked items by default",
+          "--include-blocked flag re-surfaces blocked items"
+        ],
+        "depends_on": [],
+        "conflict_group": "triage-queue",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
       }
     },
     "references": [

--- a/vbrief/proposed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "description": "Story vBRIEF for #1287 (feat(vbrief): task vbrief:reconcile:graph); part of the #742 decomposition.",
     "created": "2026-05-21T16:32:24Z",
-    "updated": "2026-05-21T16:32:24Z"
+    "updated": "2026-06-14T23:55:00Z"
   },
   "plan": {
     "id": "1287-vbrief-reconcile-graph",
@@ -11,30 +11,31 @@
     "status": "proposed",
     "planRef": "#1287",
     "narratives": {
-      "Description": "Build the cascade-unblock walker: a verb that promotes vBRIEFs whose swarm.depends_on[] all resolve to completed/ or cancelled/. Pure vBRIEF; forge-agnostic. Composes with the existing swarm_readiness.py dep-graph machinery.",
-      "ImplementationPlan": "New verb + module under scripts/. Walks vbrief/proposed/, resolves depends_on against current state, runs task scope:promote on eligible candidates (respects WIP cap). Idempotent.",
-      "UserStory": "As the framework, I want blocked children whose upstream resolved to auto-promote so the decomposition operates deterministically."
+      "Description": "Build the cascade-unblock walker: a verb that promotes vBRIEFs whose swarm.depends_on[] all resolve to completed/ or cancelled/. The walker is pure-vBRIEF and forge-agnostic, and composes with the existing scripts/swarm_readiness.py dependency-graph machinery so the decomposition advances without manual promotion.",
+      "ImplementationPlan": "Add a new scripts/vbrief_reconcile_graph.py module and a tasks/vbrief.yml entry. The script walks vbrief/proposed/, resolves each candidate's depends_on against current lifecycle state, and runs scope_lifecycle promote on eligible candidates while respecting the WIP cap, idempotently. Add tests in tests/cli/test_vbrief_reconcile_graph.py covering single-dep, multi-dep, cycle, and WIP-cap interaction to verify the behavior.",
+      "UserStory": "As a framework maintainer, I want blocked children whose upstream dependencies have all resolved to be auto-promoted, so that the decomposition cascade operates deterministically without manual promotion.",
+      "Traces": "planRef #1287; decomposition_origin #742; epic #1284."
     },
     "items": [
       {
         "title": "Define verb interface + Taskfile entry",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task vbrief:reconcile:graph runs; idempotent."
+          "Acceptance": "When run, task vbrief:reconcile:graph creates promotions only for candidates whose swarm.depends_on entries all resolve to completed/ or cancelled/, and re-running creates no further changes."
         }
       },
       {
         "title": "Compose with swarm_readiness.py dep-graph + scope_lifecycle.promote",
         "status": "pending",
         "narrative": {
-          "Acceptance": "Single-dep, multi-dep, cycle, WIP-cap cases all behave per spec."
+          "Acceptance": "Given single-dep, multi-dep, cycle, and WIP-cap inputs, the walker resolves the dependency graph via scripts/swarm_readiness.py and promotes or rejects each candidate per spec."
         }
       },
       {
         "title": "Tests for cascade, cycle detection, WIP cap interaction",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task check passes."
+          "Acceptance": "When the suite runs, tests/cli/test_vbrief_reconcile_graph.py validates cascade promotion, cycle detection, and WIP-cap interaction."
         }
       }
     ],
@@ -45,7 +46,26 @@
         "decomposition_origin": "#742"
       },
       "swarm": {
-        "readiness": "not-ready"
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/vbrief_reconcile_graph.py",
+          "tasks/vbrief.yml",
+          "tests/cli/test_vbrief_reconcile_graph.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_vbrief_reconcile_graph.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "task vbrief:reconcile:graph promotes cascade-unblocked candidates",
+          "re-running the walker is a no-op"
+        ],
+        "depends_on": [],
+        "conflict_group": "reconcile-suite",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
       }
     },
     "references": [

--- a/vbrief/proposed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "description": "Story vBRIEF for #1288 (feat(vbrief,scm): task vbrief:reconcile:labels); part of the #742 decomposition.",
     "created": "2026-05-21T16:32:24Z",
-    "updated": "2026-05-21T16:32:24Z"
+    "updated": "2026-06-14T23:55:00Z"
   },
   "plan": {
     "id": "1288-vbrief-reconcile-labels",
@@ -11,30 +11,31 @@
     "status": "proposed",
     "planRef": "#1288",
     "narratives": {
-      "Description": "Apply/remove SCM labels based on vBRIEF state. Routes through scripts/scm.py (#1145) to stay forge-agnostic. Closes the missing reverse direction of the existing GitHub-state-to-vBRIEF reconciler.",
-      "ImplementationPlan": "New verb + module. Mappings: status=blocked / unresolved depends_on -> status:blocked label; kind=epic -> epic + status:tracker; kind=research -> rfc. Idempotent.",
-      "UserStory": "As the framework, I want the SCM-side label state to mirror canonical vBRIEF state so reviewers don't see drift."
+      "Description": "Apply and remove SCM labels based on canonical vBRIEF state, routing through scripts/scm.py (#1145) to stay forge-agnostic. This closes the missing reverse direction of the existing GitHub-state-to-vBRIEF reconciler so the label surface mirrors lifecycle rather than drifting from it.",
+      "ImplementationPlan": "Add a new scripts/vbrief_reconcile_labels.py module and a tasks/vbrief.yml entry, routing every forge call through scripts/scm.py (#1145). Apply the mapping: status=blocked or unresolved depends_on adds the status:blocked label, kind=epic adds epic plus status:tracker, kind=research adds rfc; the verb is idempotent. Add tests in tests/cli/test_vbrief_reconcile_labels.py for each mapping and idempotency to verify the behavior.",
+      "UserStory": "As a framework maintainer, I want the SCM-side label state to mirror canonical vBRIEF state, so that reviewers do not see drift between labels and lifecycle.",
+      "Traces": "planRef #1288; decomposition_origin #742; epic #1284."
     },
     "items": [
       {
         "title": "Implement label reconciliation per mapping table",
         "status": "pending",
         "narrative": {
-          "Acceptance": "All mappings apply correctly; idempotent."
+          "Acceptance": "When run, task vbrief:reconcile:labels updates SCM labels to match the mapping table and re-running creates no further label changes."
         }
       },
       {
         "title": "Route through scm.call shim (no direct gh calls)",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task verify:scm-boundary passes."
+          "Acceptance": "All forge calls route through scripts/scm.py so that task verify:scm-boundary validates no direct gh invocation remains."
         }
       },
       {
         "title": "Tests for each mapping + idempotency",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task check passes."
+          "Acceptance": "When the suite runs, tests/cli/test_vbrief_reconcile_labels.py validates each label mapping and the idempotent re-run path."
         }
       }
     ],
@@ -45,7 +46,28 @@
         "decomposition_origin": "#742"
       },
       "swarm": {
-        "readiness": "not-ready"
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/vbrief_reconcile_labels.py",
+          "tasks/vbrief.yml",
+          "tests/cli/test_vbrief_reconcile_labels.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_vbrief_reconcile_labels.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "SCM labels mirror vBRIEF status and kind",
+          "re-running reconcile:labels is a no-op"
+        ],
+        "depends_on": [
+          "1287-vbrief-reconcile-graph"
+        ],
+        "conflict_group": "reconcile-suite",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
       }
     },
     "references": [

--- a/vbrief/proposed/2026-05-21-1289-vbrief-reconcile-umbrellas.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1289-vbrief-reconcile-umbrellas.vbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "description": "Story vBRIEF for #1289 (feat(vbrief,scm): task vbrief:reconcile:umbrellas); part of the #742 decomposition.",
     "created": "2026-05-21T16:32:24Z",
-    "updated": "2026-05-21T16:32:24Z"
+    "updated": "2026-06-14T23:55:00Z"
   },
   "plan": {
     "id": "1289-vbrief-reconcile-umbrellas",
@@ -11,30 +11,31 @@
     "status": "proposed",
     "planRef": "#1289",
     "narratives": {
-      "Description": "Auto-update each kind=epic vBRIEF's linked SCM umbrella's current-shape comment per AGENTS.md sec.1152. Edits in place to preserve permalink; amendment trail untouched.",
-      "ImplementationPlan": "New verb + module. Reads each kind=epic vBRIEF, walks children, computes wave structure, builds the canonical body, calls scm shim to edit the current-shape comment in place.",
-      "UserStory": "As a fresh contributor reading an umbrella, I want the current-shape comment to be accurate so I can find the queue without reading the audit trail."
+      "Description": "Auto-update each kind=epic vBRIEF's linked SCM umbrella current-shape comment per AGENTS.md section 1152. The verb edits the comment in place to preserve the permalink and leaves the amendment trail untouched, so a fresh contributor reads one accurate surface instead of reconstructing state from N comments.",
+      "ImplementationPlan": "Add a new scripts/vbrief_reconcile_umbrellas.py module and a tasks/vbrief.yml entry. The script reads each kind=epic vBRIEF, walks its children, computes the wave structure, builds the canonical AGENTS.md section-1152 body, and calls the scripts/scm.py shim to edit the current-shape comment in place so the permalink is preserved. Add tests in tests/cli/test_vbrief_reconcile_umbrellas.py for pass-N bump and child-added/closed cases to verify the rendered body.",
+      "UserStory": "As a fresh contributor reading an umbrella, I want the current-shape comment to be accurate, so that I can find the queue without reading the entire amendment trail.",
+      "Traces": "planRef #1289; decomposition_origin #742; epic #1284."
     },
     "items": [
       {
         "title": "Implement current-shape body generator from epic vBRIEF state",
         "status": "pending",
         "narrative": {
-          "Acceptance": "Output matches sec.1152 canonical body structure."
+          "Acceptance": "The current-shape body generator emits the AGENTS.md section-1152 canonical structure computed from epic vBRIEF state."
         }
       },
       {
         "title": "Edit-in-place via scm shim (preserve permalink)",
         "status": "pending",
         "narrative": {
-          "Acceptance": "Idempotent; second run is a no-op when state unchanged."
+          "Acceptance": "When run, task vbrief:reconcile:umbrellas updates the current-shape comment in place and re-running creates no change when state is unchanged."
         }
       },
       {
         "title": "Tests for pass-N bump + child added/closed cases",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task check passes."
+          "Acceptance": "When the suite runs, tests/cli/test_vbrief_reconcile_umbrellas.py validates the pass-N bump and child-added/closed rendering cases."
         }
       }
     ],
@@ -45,7 +46,28 @@
         "decomposition_origin": "#742"
       },
       "swarm": {
-        "readiness": "not-ready"
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/vbrief_reconcile_umbrellas.py",
+          "tasks/vbrief.yml",
+          "tests/cli/test_vbrief_reconcile_umbrellas.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_vbrief_reconcile_umbrellas.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "umbrella current-shape comment matches epic vBRIEF state",
+          "re-running reconcile:umbrellas is a no-op"
+        ],
+        "depends_on": [
+          "1288-vbrief-reconcile-labels"
+        ],
+        "conflict_group": "reconcile-suite",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
       }
     },
     "references": [

--- a/vbrief/proposed/2026-05-21-1290-reconcile-state-reason.vbrief.json
+++ b/vbrief/proposed/2026-05-21-1290-reconcile-state-reason.vbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "description": "Story vBRIEF for #1290 (feat(vbrief): reconcile_issues.py honors stateReason); part of the #742 decomposition.",
     "created": "2026-05-21T16:32:24Z",
-    "updated": "2026-05-21T16:32:24Z"
+    "updated": "2026-06-14T23:55:00Z"
   },
   "plan": {
     "id": "1290-reconcile-state-reason",
@@ -12,43 +12,44 @@
     "planRef": "#1290",
     "narratives": {
       "Description": "Two coordinated fixes to scripts/reconcile_issues.py --apply-lifecycle-fixes. (1) stateReason routing: consult GitHub's stateReason field so CLOSED+NOT_PLANNED routes to cancelled/, CLOSED+DUPLICATE routes to cancelled/, and CLOSED+COMPLETED routes to completed/ -- removes the manual scope:cancel pre-step that the #742 close required. (2) Axis B primary-reference filter: today the reconciler treats every plan.references[] entry as a lifecycle anchor, so a vBRIEF that merely refs an umbrella gets dragged through the umbrella's terminal state (the #742 close pulled #1283/#1284/#1285/#1291 into completed/ even though their own planRef issues were still open). The fix prefers plan.planRef as the canonical issue for lifecycle resolution and falls back to references[] only when planRef is absent. Both fixes ship together because the #742-class recurrence requires both: without (1) the operator runs scope:cancel by hand; without (2) the reconciler false-positives across the cohort on every umbrella close.",
-      "ImplementationPlan": "Phase A (stateReason): extend the GraphQL query in fetch_issue_states to include stateReason; add the routing mapping (CLOSED+NOT_PLANNED -> cancelled/, CLOSED+DUPLICATE -> cancelled/, CLOSED+COMPLETED -> completed/); preserve idempotency + existing report-only behavior for REOPENED. Phase B (Axis B primary-reference filter): refactor the lifecycle-fix resolver in reconcile_issues.py to read plan.planRef first when determining which issue's state drives the vBRIEF's lifecycle; only fall back to scanning references[] when planRef is unset or unresolvable; emit a structured log line naming which axis (planRef vs references[]) was used for each vBRIEF so the recovery audit is reviewable. Tests cover both phases in one suite.",
-      "UserStory": "As the framework, I want closed-as-not-planned umbrellas to route their dependent vBRIEFs to cancelled/ automatically AND I want the reconciler to follow each vBRIEF's primary plan.planRef instead of dragging unrelated references[] siblings through the umbrella's terminal state, so an umbrella close cannot false-positive across an entire cohort."
+      "ImplementationPlan": "Phase A (stateReason): extend the GraphQL query in fetch_issue_states in scripts/reconcile_issues.py to include stateReason; add the routing mapping (CLOSED+NOT_PLANNED -> cancelled/, CLOSED+DUPLICATE -> cancelled/, CLOSED+COMPLETED -> completed/); preserve idempotency and existing report-only behavior for REOPENED. Phase B (Axis B primary-reference filter): refactor the lifecycle-fix resolver to read plan.planRef first when determining which issue's state drives the vBRIEF's lifecycle, falling back to scanning references[] only when planRef is unset, and emit a structured log line naming which axis was used. Tests in tests/cli/test_reconcile_issues.py cover both phases to verify the routing and the recurrence-record case.",
+      "UserStory": "As a framework maintainer, I want closed-as-not-planned umbrellas to route their dependents to cancelled/ automatically and the reconciler to follow each vBRIEF's primary planRef rather than unrelated references, so that an umbrella close cannot false-positive across an entire cohort.",
+      "Traces": "planRef #1290; decomposition_origin #742; epic #1284; recurrence #1319."
     },
     "items": [
       {
         "title": "Phase A: Add stateReason to the GraphQL query in fetch_issue_states",
         "status": "pending",
         "narrative": {
-          "Acceptance": "Returns dict mapping issue_number -> (state, stateReason)."
+          "Acceptance": "The GraphQL query in fetch_issue_states returns a dict mapping each issue number to its state and stateReason."
         }
       },
       {
         "title": "Phase A: Update --apply-lifecycle-fixes routing per stateReason mapping",
         "status": "pending",
         "narrative": {
-          "Acceptance": "CLOSED+NOT_PLANNED -> cancelled/, CLOSED+DUPLICATE -> cancelled/, CLOSED+COMPLETED -> completed/; REOPENED report-only behavior preserved."
+          "Acceptance": "When --apply-lifecycle-fixes runs, CLOSED+NOT_PLANNED and CLOSED+DUPLICATE route the vBRIEF to cancelled/, CLOSED+COMPLETED routes to completed/, and REOPENED stays report-only."
         }
       },
       {
         "title": "Phase B: Prefer plan.planRef over references[] for canonical lifecycle resolution (Axis B primary-reference filter)",
         "status": "pending",
         "narrative": {
-          "Acceptance": "The lifecycle-fix resolver consults plan.planRef first; references[] is consulted only when planRef is absent or unresolvable. A vBRIEF that merely refs an unrelated closed issue is no longer dragged into that issue's terminal state."
+          "Acceptance": "The resolver consults plan.planRef first and reads references[] only when planRef is absent, so a vBRIEF that merely refs an unrelated closed issue is no longer dragged into that terminal state."
         }
       },
       {
         "title": "Phase B: Structured per-vBRIEF audit log line naming the axis used (planRef vs references[])",
         "status": "pending",
         "narrative": {
-          "Acceptance": "Each lifecycle-fix decision emits a log line carrying the resolved axis so a recovery audit can confirm the reconciler routed off the correct anchor."
+          "Acceptance": "Each lifecycle-fix decision emits a structured log line naming the resolved axis so a recovery audit confirms the reconciler routed off the correct anchor."
         }
       },
       {
         "title": "Tests for both phases; existing tests unchanged",
         "status": "pending",
         "narrative": {
-          "Acceptance": "task check passes; new tests cover stateReason routing AND the planRef-preferred axis; no regression on completed/ path; recurrence-record test pins the #742-class case (vBRIEF refs closed umbrella, planRef points at a still-open issue, vBRIEF stays in its current folder)."
+          "Acceptance": "When the suite runs, tests/cli/test_reconcile_issues.py validates stateReason routing, the planRef-preferred axis, and a recurrence-record case where a vBRIEF refs a closed umbrella but its planRef issue is still open."
         }
       }
     ],
@@ -59,7 +60,25 @@
         "decomposition_origin": "#742"
       },
       "swarm": {
-        "readiness": "not-ready"
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/reconcile_issues.py",
+          "tests/cli/test_reconcile_issues.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_reconcile_issues.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "CLOSED+NOT_PLANNED routes dependents to cancelled/",
+          "lifecycle resolver prefers plan.planRef over references[]"
+        ],
+        "depends_on": [],
+        "conflict_group": "reconcile-suite",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
       }
     },
     "references": [


### PR DESCRIPTION
## Summary

Brings the #1284 Wave-1 child stories to swarm-ready so `task swarm:readiness` exits 0 for the cohort. Prerequisite for implementing #1286/#1287/#1288/#1289/#1290.

- Adds full `plan.metadata.swarm.*` blocks (file_scope, verify_commands, expected_outputs, depends_on, conflict_group, size, file_scope_confidence, model_tier) to the five code stories.
- Fixes UserStory format (`As a ..., so that ...`), concretizes ImplementationPlan code paths + verification evidence, and rewrites acceptance criteria to be observable and >=8 words.
- Chains the reconcile-suite (`1288 -> 1287`, `1289 -> 1288`) so the shared `tasks/vbrief.yml` edits sequence into waves instead of colliding in the file-overlap matrix.

Readiness result: `wave 1: [1286, 1287, 1290]`, `wave 2: [1288]`, `wave 3: [1289]`, no file overlaps.

## Test plan

- [x] `task swarm:readiness -- <5 stories>` exits 0
- [x] `task verify:encoding` clean
- [x] `task validate` clean

Refs #1284, #1286, #1287, #1288, #1289, #1290.

Made with [Cursor](https://cursor.com)