### PR TITLE
chore: reframe #336 as documentation-tier AXIOM application (#1292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **The "vBRIEF as source of truth for all docs" issue now matches the current architecture (#1292)** -- issue #336 was reframed from its obsolete "five new core vBRIEF content types" mechanism into a documentation-tier application of the Rule Authority [AXIOM]: framework `.md` files are rendered projections of canonical structured source, implemented via the #714 four-tier model and its tier-3 extension packs (#1294 / #1295 / #1296) under the #1284 epic. Contributors reading #336 after the decomposition no longer chase a dropped mechanism. Closes #1292. Refs #336, #1284.
 
 ### Fixed
 

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -939,10 +939,10 @@
       {
         "id": "2026-05-21-1292-issue-336-reframe",
         "title": "Reframe #336: documentation-tier AXIOM application (drop 5 new core content types)",
-        "status": "proposed",
+        "status": "completed",
         "metadata": {
-          "source_path": "proposed/2026-05-21-1292-issue-336-reframe.vbrief.json",
-          "lifecycle_folder": "proposed",
+          "source_path": "completed/2026-05-21-1292-issue-336-reframe.vbrief.json",
+          "lifecycle_folder": "completed",
           "references": [
             {
               "uri": "https://github.com/deftai/directive/issues/1292",

--- a/vbrief/completed/2026-05-21-1292-issue-336-reframe.vbrief.json
+++ b/vbrief/completed/2026-05-21-1292-issue-336-reframe.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1292-issue-336-reframe",
     "title": "Reframe #336: documentation-tier AXIOM application (drop 5 new core content types)",
-    "status": "proposed",
+    "status": "completed",
     "planRef": "#1292",
     "narratives": {
       "Description": "Edit #336's body to drop the obsolete '5 new core content types' mechanism and reframe as documentation-tier AXIOM application with implementation via #714 tier-3 packs. Apply labels: determinism, rfc, design.",
@@ -39,7 +39,9 @@
       },
       "swarm": {
         "readiness": "not-ready"
-      }
+      },
+      "completedAt": "2026-06-15T00:25:15Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -57,6 +59,7 @@
         "type": "x-vbrief/github-issue",
         "title": "Issue #336: migration umbrella (reframe target)"
       }
-    ]
+    ],
+    "updated": "2026-06-15T00:25:15Z"
   }
 }


### PR DESCRIPTION
## Summary

Reframes GitHub issue #336 to match the current vBRIEF-as-canonical architecture, and completes the #1292 story vBRIEF. Docs/vBRIEF-only — no production code.

- **#336 body reframed**: drops the obsolete "five new core vBRIEF content types" (`ruleSet` / `skill` / `strategy` / `referenceGuide` / `changelog`) mechanism, and reframes the issue as a **documentation-tier application of the Rule Authority [AXIOM]** (per `main.md` / ADR-001) — framework `.md` files are rendered projections of canonical structured source. States implementation now happens via the #714 four-tier model + tier-3 extension packs (#1294 lessons-pack / #1295 skills-pack / #1296 rules+strategies-pack) under the #1284 epic, **not** new core content types. A "Reframed (2026-06)" supersession note leads the body and cross-links #1284 / ADR-001 / #714.
- **#336 labels**: added `rfc` + `design` (existing `determinism` retained; `refactor` / `source-of-truth` left intact).
- **vBRIEF lifecycle**: `2026-05-21-1292-issue-336-reframe` promoted → activated → completed.
- **CHANGELOG** `[Unreleased]` entry added (refs #1292 / #336).

Part of the #1284 Wave-1 cohort (allocation `1284-wave1-2026-06-14`).

## Test plan
- [x] `task check` GREEN (7778 passed, 5 skipped, 1 xfailed)
- [x] `gh issue view 336` confirms reframed body + `rfc`/`design`/`determinism` labels
- [x] vBRIEF preflight passed before completion

Closes #1292
Refs #336, #1284

Made with [Cursor](https://cursor.com)