### PR TITLE
feat(vbrief): task vbrief:reconcile:graph cascade-unblock walker (#1287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Blocked vBRIEFs now auto-promote once their dependencies finish, so cascades advance without manual bookkeeping (#1287)** -- a new `task vbrief:reconcile:graph` walks `vbrief/proposed/` and promotes any candidate whose `swarm.depends_on[]` entries have all resolved to completed or cancelled work. It is forge-agnostic, respects the WIP cap (with a `--force` override), detects dependency cycles, and is idempotent so a second run is a no-op. Supports `--dry-run` and `--json`. Part of the #1284 vBRIEF-as-canonical epic. Closes #1287.
 
 ### Changed
 

--- a/scripts/vbrief_reconcile_graph.py
+++ b/scripts/vbrief_reconcile_graph.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""vbrief_reconcile_graph.py -- cascade-unblock walker (#1287).
+
+A pure-vBRIEF, forge-agnostic verb (``task vbrief:reconcile:graph``) that
+walks ``vbrief/proposed/``, resolves each candidate's
+``plan.metadata.swarm.depends_on[]`` against current lifecycle state, and
+promotes (``proposed/ -> pending/`` via the existing
+``scope_lifecycle.run_transition`` path) every candidate whose
+dependencies ALL resolve to a brief living in ``vbrief/completed/`` or
+``vbrief/cancelled/``.
+
+Design contract:
+
+* **Cascade-unblock only.** A candidate with an empty ``depends_on`` is
+  left in ``proposed/`` -- the backlog is the operator's, not the
+  walker's. Only candidates that WERE blocked on dependencies and are now
+  unblocked get promoted.
+* **WIP-cap aware.** Promotions stop once ``pending/ + active/`` reaches
+  the configured cap (``plan.policy.wipCap``, default 10). ``--force``
+  overrides the cap (each forced promote is logged by the underlying
+  scope-lifecycle audit path).
+* **Cycle-safe.** Dependency cycles among proposed candidates are detected
+  via the ``swarm_readiness`` dep-graph machinery and never promoted; a
+  cycle is reported and yields exit 1.
+* **Idempotent.** A second run is a no-op: promoted candidates have left
+  ``proposed/``, so nothing further resolves.
+
+Reuses the dependency-graph resolution machinery in
+``scripts/swarm_readiness.py`` (``_candidate``, ``_all_scope_ids``,
+``_candidate_dep_graph``, ``_mark_cycles``) and the promote surface in
+``scripts/scope_lifecycle.py`` (``run_transition``) rather than
+reinventing either.
+
+Exit codes (three-state):
+    0 -- ran successfully (promoted >= 0 candidates; WIP-cap deferral and
+         not-yet-resolved candidates are normal, idempotent outcomes).
+    1 -- a dependency cycle was detected among proposed candidates.
+    2 -- usage / config error (no ``vbrief/proposed/`` directory, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from scope_lifecycle import run_transition  # noqa: E402
+from swarm_readiness import (  # noqa: E402
+    Candidate,
+    _all_scope_ids,
+    _as_str_list,
+    _candidate,
+    _candidate_dep_graph,
+    _mark_cycles,
+)
+
+reconfigure_stdio()
+
+# A dependency "resolves" (no longer blocks its dependent) when the brief
+# it names lives in one of these terminal lifecycle folders.
+RESOLVED_FOLDERS = ("completed", "cancelled")
+_CYCLE_MARKER = "dependency cycle:"
+
+
+@dataclass
+class ReconcileOutcome:
+    """Result of a single reconcile walk."""
+
+    promoted: list[str] = field(default_factory=list)
+    deferred_wip: list[str] = field(default_factory=list)
+    waiting: list[tuple[str, list[str]]] = field(default_factory=list)
+    cycles: list[str] = field(default_factory=list)
+    errors: list[tuple[str, str]] = field(default_factory=list)
+    cap: int = 0
+    count: int = 0
+    dry_run: bool = False
+    forced: bool = False
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "promoted": list(self.promoted),
+            "deferred_wip": list(self.deferred_wip),
+            "waiting": [{"story_id": sid, "unresolved": deps} for sid, deps in self.waiting],
+            "cycles": list(self.cycles),
+            "errors": [{"story_id": sid, "message": msg} for sid, msg in self.errors],
+            "cap": self.cap,
+            "count": self.count,
+            "dry_run": self.dry_run,
+            "forced": self.forced,
+        }
+
+
+def _resolve_wip_state(project_root: Path) -> tuple[int, int]:
+    """Return ``(cap, current_count)`` for the WIP cap.
+
+    Deferred-import of ``scripts.policy`` so a tree that pre-dates the D4
+    WIP-cap schema (#1124) degrades to "no cap" (a very large cap) rather
+    than raising.
+    """
+    try:
+        from policy import count_vbrief_wip, resolve_wip_cap
+    except ImportError:  # pragma: no cover -- D4 not present
+        return sys.maxsize, 0
+    cap = resolve_wip_cap(project_root).cap
+    count = count_vbrief_wip(project_root)
+    return cap, count
+
+
+def _dep_resolved(dep: str, known_ids: dict[str, tuple[Path, str]]) -> bool:
+    """True when *dep* names a brief in a terminal (completed/cancelled) folder."""
+    known = known_ids.get(dep)
+    if known is None:
+        return False
+    path, _status = known
+    return path.parent.name in RESOLVED_FOLDERS
+
+
+def _unresolved_deps(
+    candidate: Candidate,
+    known_ids: dict[str, tuple[Path, str]],
+) -> list[str]:
+    """Return the dependency ids that have NOT resolved to a terminal folder."""
+    return [
+        dep
+        for dep in _as_str_list(candidate.swarm.get("depends_on"))
+        if not _dep_resolved(dep, known_ids)
+    ]
+
+
+def _candidate_in_cycle(candidate: Candidate) -> bool:
+    return any(reason.startswith(_CYCLE_MARKER) for reason in candidate.blocked)
+
+
+def reconcile_graph(
+    project_root: Path,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> tuple[int, ReconcileOutcome]:
+    """Walk proposed/, promote cascade-unblocked candidates, return (exit, outcome).
+
+    The promote order is deterministic (sorted by story id) so the WIP-cap
+    cut-off is stable across runs.
+    """
+    proposed_dir = project_root / "vbrief" / "proposed"
+    if not proposed_dir.is_dir():
+        return 2, ReconcileOutcome()
+
+    candidate_paths = sorted(proposed_dir.glob("*.vbrief.json"))
+    candidates = [c for path in candidate_paths if (c := _candidate(path, project_root))]
+
+    known_ids = _all_scope_ids(project_root)
+    for candidate in candidates:
+        known_ids.setdefault(candidate.story_id, (candidate.path, candidate.status))
+
+    # Reuse the swarm_readiness dep-graph + cycle machinery. ``_candidate_dep_graph``
+    # builds edges only between proposed candidates; ``_mark_cycles`` then appends a
+    # ``dependency cycle: ...`` marker to every candidate that participates in one.
+    graph = _candidate_dep_graph(candidates, known_ids)
+    _mark_cycles(candidates, graph)
+
+    cap, count = _resolve_wip_state(project_root)
+    outcome = ReconcileOutcome(cap=cap, count=count, dry_run=dry_run, forced=force)
+
+    eligible: list[Candidate] = []
+    for candidate in sorted(candidates, key=lambda c: c.story_id):
+        if _candidate_in_cycle(candidate):
+            cycle_reason = next(
+                reason for reason in candidate.blocked if reason.startswith(_CYCLE_MARKER)
+            )
+            outcome.cycles.append(f"{candidate.story_id}: {cycle_reason}")
+            continue
+        deps = _as_str_list(candidate.swarm.get("depends_on"))
+        if not deps:
+            # Cascade-unblock only: a dependency-free brief is operator backlog,
+            # not the walker's to promote.
+            continue
+        unresolved = _unresolved_deps(candidate, known_ids)
+        if unresolved:
+            outcome.waiting.append((candidate.story_id, unresolved))
+            continue
+        eligible.append(candidate)
+
+    running_count = count
+    for candidate in eligible:
+        if running_count >= cap and not force:
+            outcome.deferred_wip.append(candidate.story_id)
+            continue
+        if dry_run:
+            outcome.promoted.append(candidate.story_id)
+            running_count += 1
+            continue
+        ok, message = run_transition("promote", candidate.path)
+        if not ok:
+            outcome.errors.append((candidate.story_id, message))
+            continue
+        outcome.promoted.append(candidate.story_id)
+        running_count += 1
+
+    outcome.count = running_count
+    exit_code = 1 if outcome.cycles else 0
+    return exit_code, outcome
+
+
+def _render_report(outcome: ReconcileOutcome) -> str:
+    lines: list[str] = ["vBRIEF reconcile graph", ""]
+    suffix = " (dry-run)" if outcome.dry_run else ""
+
+    lines.append(f"Promoted{suffix}:")
+    if outcome.promoted:
+        lines.extend(f"- {story_id}" for story_id in outcome.promoted)
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append(f"Deferred (WIP cap {outcome.count}/{outcome.cap}):")
+    if outcome.deferred_wip:
+        lines.extend(f"- {story_id}" for story_id in outcome.deferred_wip)
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Waiting (deps unresolved):")
+    if outcome.waiting:
+        lines.extend(
+            f"- {story_id}: needs {', '.join(deps)}" for story_id, deps in outcome.waiting
+        )
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Cycles:")
+    if outcome.cycles:
+        lines.extend(f"- {entry}" for entry in outcome.cycles)
+    else:
+        lines.append("- none")
+
+    if outcome.errors:
+        lines.append("")
+        lines.append("Errors:")
+        lines.extend(f"- {story_id}: {message}" for story_id, message in outcome.errors)
+
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cascade-unblock walker: promote proposed/ vBRIEFs whose "
+            "swarm.depends_on[] all resolve to completed/ or cancelled/."
+        )
+    )
+    parser.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing vbrief/ (default: current directory).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Override the WIP cap when promoting (each forced promote is audited).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report which candidates WOULD be promoted without moving any files.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON summary instead of the text report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    project_root = Path(args.project_root).resolve()
+    exit_code, outcome = reconcile_graph(
+        project_root,
+        force=args.force,
+        dry_run=args.dry_run,
+    )
+    if exit_code == 2:
+        if args.json:
+            print(json.dumps({"error": "no vbrief/proposed/ directory found"}))
+        else:
+            print(
+                f"Error: no vbrief/proposed/ directory found under {project_root}",
+                file=sys.stderr,
+            )
+        return 2
+    if args.json:
+        print(json.dumps(outcome.to_json(), indent=2))
+    else:
+        print(_render_report(outcome))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/vbrief.yml
+++ b/tasks/vbrief.yml
@@ -74,6 +74,33 @@ tasks:
         resolved=$(uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/_resolve_preflight_path.py" --project-root "{{.USER_WORKING_DIR}}") || exit $?
         uv --project "{{.DEFT_ROOT}}" run python "$resolved" --project-root "{{.USER_WORKING_DIR}}" --vbrief-path {{.CLI_ARGS}}
 
+  reconcile:graph:
+    # Cascade-unblock walker (#1287). Walks vbrief/proposed/, resolves each
+    # candidate's plan.metadata.swarm.depends_on[] against current lifecycle
+    # state, and promotes (proposed/ -> pending/ via scope_lifecycle) every
+    # candidate whose dependencies ALL resolve to a brief in completed/ or
+    # cancelled/. Pure-vBRIEF / forge-agnostic: reuses the swarm_readiness.py
+    # dep-graph + cycle machinery and the scope_lifecycle promote surface.
+    # WIP-cap aware, cycle-safe (exit 1 on a detected cycle), and idempotent
+    # (a second run is a no-op). Pass-through flags: --force (override the WIP
+    # cap, audited), --dry-run (report without moving), --json (machine
+    # summary).
+    #
+    # CLI_ARGS forwarding (#577): bare ``{{.CLI_ARGS}}`` -- DO NOT wrap in
+    # Taskfile-level double quotes. go-task already shell-escapes CLI_ARGS
+    # with single quotes; double-wrapping breaks Windows argv. See the
+    # preflight task below for the full rationale.
+    #
+    # NOTE: NO ``sources:`` / ``generates:`` per ``conventions/task-caching.md``
+    # because the walk reads/writes lifecycle folders that go-task does not
+    # track, so a cached skip would silently swallow real promotions.
+    desc: "Reconcile dep graph: promote proposed/ vBRIEFs whose swarm.depends_on[] all resolve to completed/ or cancelled/ (#1287). Flags: --force --dry-run --json."
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/vbrief_reconcile_graph.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+
   activate:
     # Implementation-intent activation gate companion (#810). Idempotent:
     # already-active vBRIEFs print a no-op message and exit 0; pending/

--- a/tests/cli/test_vbrief_reconcile_graph.py
+++ b/tests/cli/test_vbrief_reconcile_graph.py
@@ -1,0 +1,241 @@
+"""Acceptance tests for ``task vbrief:reconcile:graph`` (#1287).
+
+The cascade-unblock walker promotes proposed/ candidates whose
+``plan.metadata.swarm.depends_on[]`` entries ALL resolve to a dependency
+living in ``vbrief/completed/`` or ``vbrief/cancelled/``. It respects the
+WIP cap, detects dependency cycles, and is idempotent (a second run is a
+no-op).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "vbrief_reconcile_graph.py"
+
+LIFECYCLE_FOLDERS = ("proposed", "pending", "active", "completed", "cancelled")
+
+_STATUS_FOR_FOLDER = {
+    "proposed": "proposed",
+    "pending": "pending",
+    "active": "running",
+    "completed": "completed",
+    "cancelled": "cancelled",
+}
+
+
+def _write_brief(
+    project: Path,
+    story_id: str,
+    *,
+    folder: str = "proposed",
+    depends_on: list[str] | None = None,
+) -> Path:
+    """Write a minimal but schema-plausible story vBRIEF into *folder*."""
+    path = project / "vbrief" / folder / f"2026-05-21-{story_id}.vbrief.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "vBRIEFInfo": {"version": "0.6"},
+        "plan": {
+            "id": story_id,
+            "title": story_id,
+            "status": _STATUS_FOR_FOLDER[folder],
+            "narratives": {
+                "Description": f"{story_id} description.",
+                "ImplementationPlan": f"1. Do {story_id}.",
+                "UserStory": f"As a user, I want {story_id}.",
+                "Traces": "FR-1",
+            },
+            "items": [
+                {
+                    "id": f"{story_id}-a1",
+                    "title": "Acceptance item 1",
+                    "status": "pending",
+                    "narrative": {"Acceptance": f"Given X when {story_id} then Y."},
+                }
+            ],
+            "metadata": {
+                "kind": "story",
+                "swarm": {
+                    "readiness": "ready",
+                    "parallel_safe": True,
+                    "file_scope": [f"src/{story_id}.py"],
+                    "verify_commands": [f"pytest {story_id}"],
+                    "expected_outputs": ["tests pass"],
+                    "depends_on": depends_on or [],
+                    "conflict_group": "reconcile-suite",
+                    "size": "small",
+                    "file_scope_confidence": "high",
+                    "model_tier": "standard",
+                },
+            },
+        },
+    }
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _write_project_definition(project: Path, *, wip_cap: int | None = None) -> None:
+    plan: dict = {"id": "proj", "title": "Project", "status": "active"}
+    if wip_cap is not None:
+        plan["policy"] = {"wipCap": wip_cap}
+    path = project / "vbrief" / "PROJECT-DEFINITION.vbrief.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"vBRIEFInfo": {"version": "0.6"}, "plan": plan}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _run(project: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--project-root", str(project), *extra],
+        cwd=project,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _folder_of(project: Path, story_id: str) -> str | None:
+    name = f"2026-05-21-{story_id}.vbrief.json"
+    for folder in LIFECYCLE_FOLDERS:
+        if (project / "vbrief" / folder / name).is_file():
+            return folder
+    return None
+
+
+def test_single_dep_resolved_promotes(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a"])
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "child-b") == "pending"
+    assert "child-b" in result.stdout
+
+
+def test_single_dep_unresolved_skips(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "dep-a", folder="pending")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a"])
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "child-b") == "proposed"
+
+
+def test_multi_dep_all_resolved_promotes(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "dep-c", folder="cancelled")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a", "dep-c"])
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "child-b") == "pending"
+
+
+def test_multi_dep_partial_unresolved_skips(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "dep-c", folder="proposed")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a", "dep-c"])
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "child-b") == "proposed"
+
+
+def test_depfree_candidate_not_promoted(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "loner", folder="proposed", depends_on=[])
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "loner") == "proposed"
+
+
+def test_cycle_detected_exit1(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "cyc-x", folder="proposed", depends_on=["cyc-y"])
+    _write_brief(tmp_path, "cyc-y", folder="proposed", depends_on=["cyc-x"])
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "cyc-x") == "proposed"
+    assert _folder_of(tmp_path, "cyc-y") == "proposed"
+    assert "cycle" in result.stdout.lower()
+
+
+def test_wip_cap_blocks_promotion(tmp_path: Path) -> None:
+    _write_project_definition(tmp_path, wip_cap=1)
+    # One brief already in pending/ fills the cap (count == 1, cap == 1).
+    _write_brief(tmp_path, "occupant", folder="pending")
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a"])
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "child-b") == "proposed"
+
+
+def test_wip_cap_force_overrides(tmp_path: Path) -> None:
+    _write_project_definition(tmp_path, wip_cap=1)
+    _write_brief(tmp_path, "occupant", folder="pending")
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a"])
+
+    result = _run(tmp_path, "--force")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "child-b") == "pending"
+
+
+def test_idempotent_second_run_noop(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a"])
+
+    first = _run(tmp_path)
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert _folder_of(tmp_path, "child-b") == "pending"
+
+    second = _run(tmp_path)
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert _folder_of(tmp_path, "child-b") == "pending"
+    assert "child-b" not in second.stdout.split("Promoted", 1)[-1].split("\n\n", 1)[0]
+
+
+def test_dry_run_does_not_move(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a"])
+
+    result = _run(tmp_path, "--dry-run")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _folder_of(tmp_path, "child-b") == "proposed"
+    assert "child-b" in result.stdout
+
+
+def test_json_output_lists_promotions(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "dep-a", folder="completed")
+    _write_brief(tmp_path, "child-b", folder="proposed", depends_on=["dep-a"])
+
+    result = _run(tmp_path, "--json")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert "child-b" in payload["promoted"]
+
+
+def test_missing_proposed_dir_exit2(tmp_path: Path) -> None:
+    # No vbrief/ tree at all -> usage/config error.
+    result = _run(tmp_path)
+
+    assert result.returncode == 2, result.stdout + result.stderr

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -855,10 +855,10 @@
       {
         "id": "2026-05-21-1287-vbrief-reconcile-graph",
         "title": "task vbrief:reconcile:graph -- cascade-unblock walker",
-        "status": "proposed",
+        "status": "completed",
         "metadata": {
-          "source_path": "proposed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json",
-          "lifecycle_folder": "proposed",
+          "source_path": "completed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json",
+          "lifecycle_folder": "completed",
           "references": [
             {
               "uri": "https://github.com/deftai/directive/issues/1287",

--- a/vbrief/completed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json
+++ b/vbrief/completed/2026-05-21-1287-vbrief-reconcile-graph.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1287-vbrief-reconcile-graph",
     "title": "task vbrief:reconcile:graph -- cascade-unblock walker",
-    "status": "proposed",
+    "status": "completed",
     "planRef": "#1287",
     "narratives": {
       "Description": "Build the cascade-unblock walker: a verb that promotes vBRIEFs whose swarm.depends_on[] all resolve to completed/ or cancelled/. The walker is pure-vBRIEF and forge-agnostic, and composes with the existing scripts/swarm_readiness.py dependency-graph machinery so the decomposition advances without manual promotion.",
@@ -66,7 +66,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-15T00:34:27Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -79,6 +81,7 @@
         "type": "x-vbrief/github-issue",
         "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
       }
-    ]
+    ],
+    "updated": "2026-06-15T00:34:27Z"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `task vbrief:reconcile:graph` (`scripts/vbrief_reconcile_graph.py`): a pure-vBRIEF, forge-agnostic cascade-unblock walker. It walks `vbrief/proposed/`, resolves each candidate's `plan.metadata.swarm.depends_on[]` against current lifecycle state, and promotes (proposed/ -> pending/ via the existing `scope_lifecycle` promote path) every candidate whose dependencies have ALL resolved to `completed/` or `cancelled/`.
- Reuses the dependency-graph machinery in `scripts/swarm_readiness.py` (`_candidate`, `_all_scope_ids`, `_candidate_dep_graph`, `_mark_cycles`) and the promote surface in `scripts/scope_lifecycle.py` rather than reinventing.
- WIP-cap aware (stops promoting at the configured `plan.policy.wipCap`; `--force` overrides, audited via the scope-lifecycle path), cycle-safe (dependency cycles among proposed candidates are detected and never promoted, exit 1), and idempotent (a second run is a no-op). Supports `--dry-run` and `--json`.
- Cascade-unblock semantics: dependency-free proposed briefs are left in the backlog -- only candidates that were blocked on deps and are now unblocked get promoted.

Part of the #1284 vBRIEF-as-canonical epic. Closes #1287.

## Test plan
- New `tests/cli/test_vbrief_reconcile_graph.py` (12 tests): single-dep cascade promote, multi-dep all-resolved promote, multi-dep partial-unresolved skip, single-dep unresolved skip, dep-free skip, cycle detection (exit 1, no promote), WIP-cap blocks promotion, `--force` override, idempotent second-run no-op, `--dry-run` no move, `--json` output, missing `vbrief/proposed/` -> exit 2.
- Deterministic gates green: `task core:lint` (ruff + mypy, 270 files), `task core:validate`, `task verify:encoding`, `task vbrief:validate`.
- Full suite green with isolated basetemp: `pytest tests/ --basetemp=...` -> 7790 passed, 5 skipped, 1 xfailed, 0 errors.

> Note: the default `task check` pytest lane shows a pre-existing, environment-only flake unrelated to this change -- a shared `/tmp/pytest-of-msadams` base-temp dir gets cleaned up mid-run (Python 3.14 + `tmp_path_retention_count = 0`), cascading FileNotFound errors. Removing this PR's test file reproduces it identically on the merge-base, and running with a dedicated `--basetemp` is fully green.

## Exit codes
- `0` ran successfully (promoted >= 0; WIP-cap deferral and not-yet-resolved candidates are normal idempotent outcomes)
- `1` a dependency cycle was detected among proposed candidates
- `2` usage/config error (no `vbrief/proposed/` directory)

Made with [Cursor](https://cursor.com)