### PR TITLE
feat(triage): demote vBRIEF-status:blocked items in triage:queue (#1286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **`task triage:queue` now hides blocked work so the queue shows only what you can grab next (#1286)** -- items whose linked vBRIEF is parked (status `blocked`) or still waiting on an unresolved dependency are demoted into a new `[BLOCKED]` group at the bottom of the queue by default. Pass `--include-blocked` to bring them back into their natural place when you want the full picture. Closes #1286. Refs #1284.
 
 ### Fixed
 

--- a/scripts/_triage_queue_cli.py
+++ b/scripts/_triage_queue_cli.py
@@ -93,6 +93,16 @@ def build_parser(default_limit: int) -> argparse.ArgumentParser:
             f"Cap the number of rows printed (default: {default_limit}). Pass 0 to disable the cap."
         ),
     )
+    p_queue.add_argument(
+        "--include-blocked",
+        action="store_true",
+        dest="include_blocked",
+        help=(
+            "Re-surface items whose linked vBRIEF is blocked (plan.status:blocked"
+            " or an unresolved swarm.depends_on) into their natural group. By"
+            " default such items are demoted into the [BLOCKED] group (#1286)."
+        ),
+    )
 
     p_show = sub.add_parser(
         "show",
@@ -361,6 +371,7 @@ def _cmd_queue(args: argparse.Namespace, tq: Any) -> int:
         ranking_labels=ranking_labels,
         active_referenced=active_refs,
         orphan_issue_numbers=orphan_numbers,
+        include_blocked=getattr(args, "include_blocked", False),
         limit=limit,
     )
     items = tq.build_queue(issues_for_queue, audit_entries, repo=repo, options=options)

--- a/scripts/triage_help.py
+++ b/scripts/triage_help.py
@@ -400,16 +400,17 @@ REGISTRY: dict[str, VerbHelp] = {
         refs="(D11 / #1128)",
         description=(
             "Print the ranked triage queue from the local cache. Groups "
-            "(display order): [RESUME] -> [URGENT] -> untriaged -> "
-            "other. Within-group default = updated_at desc; consumer "
-            "plan.policy.triageRankingLabels[] re-orders within-group "
-            "by matched-label declared order."
+            "(display order): [ORPHAN] -> [RESUME] -> [URGENT] -> untriaged "
+            "-> other -> [BLOCKED]. Within-group default = updated_at desc; "
+            "consumer plan.policy.triageRankingLabels[] re-orders within-group "
+            "by matched-label declared order. Items whose linked vBRIEF is "
+            "blocked (status:blocked / unresolved depends_on) are demoted into "
+            "[BLOCKED] unless --include-blocked is passed (#1286)."
         ),
-        usage="task triage:queue [-- --limit=N] [--state=<filter>] [--format=json] [--repo=owner/name]",
+        usage="task triage:queue [-- --limit=N] [--include-blocked] [--repo=owner/name]",
         flags=(
             ("--limit N", "10", "Max rows to print."),
-            ("--state FILTER", "(untriaged+resume)", "Filter by latest decision (e.g. accept, defer)."),
-            ("--format json", "text", "JSON output for scripting."),
+            ("--include-blocked", "(off)", "Re-surface blocked items into their natural group (#1286)."),
             ("--repo owner/name", "(git remote)", "Explicit repo override."),
         ),
         examples=(

--- a/scripts/triage_queue.py
+++ b/scripts/triage_queue.py
@@ -164,12 +164,19 @@ DEFAULT_SLICE_STALLED_DAYS: int = 30
 #: Within-group ranking labels (e.g. ``breaking-change``) still apply, so
 #: a ``breaking-change``-labelled orphan tops the queue while a plain
 #: orphan still sits above a resume-eligible item.
+#:
+#: ``BLOCKED`` sits at the BOTTOM (#1286): an item whose linked vBRIEF has
+#: ``plan.status == "blocked"`` or an unresolved
+#: ``plan.metadata.swarm.depends_on`` is demoted there by default so the
+#: ranked list surfaces only grabbable work. The ``--include-blocked``
+#: opt-in re-surfaces such items into their natural group instead.
 GROUP_ORDER: tuple[str, ...] = (
     "ORPHAN",
     "RESUME",
     "URGENT",
     "untriaged",
     "other",
+    "BLOCKED",
 )
 
 #: Display labels per group (left-of-issue marker).
@@ -179,6 +186,7 @@ GROUP_DISPLAY: dict[str, str] = {
     "URGENT": "[URGENT]    ",
     "untriaged": "[untriaged] ",
     "other": "[other]     ",
+    "BLOCKED": "[BLOCKED]   ",
 }
 
 #: Framework default for ``plan.policy.triageRankingLabels[]``. EMPTY per
@@ -263,6 +271,17 @@ class QueueBuildOptions:
     #: True when the in-flight WIP set is at/over ``plan.policy.wipCap``.
     #: Gates the :attr:`finish_before_start` net-new filter above.
     wip_at_cap: bool = False
+    #: Issue numbers whose linked vBRIEF is blocked (#1286): ``plan.status
+    #: == "blocked"`` OR an unresolved ``plan.metadata.swarm.depends_on``.
+    #: Demoted into the ``BLOCKED`` group by default unless
+    #: :attr:`include_blocked` is True. Empty by default; the CLI path
+    #: instead reads the per-issue ``_blocked`` annotation stamped by
+    #: :func:`load_cached_issues`.
+    blocked_issue_numbers: frozenset[int] = field(default_factory=frozenset)
+    #: When True, blocked items (#1286) are re-surfaced into their natural
+    #: group instead of being demoted into the ``BLOCKED`` group. Wired to
+    #: the ``--include-blocked`` CLI opt-in.
+    include_blocked: bool = False
     limit: int | None = None
 
 
@@ -731,6 +750,98 @@ def wip_at_cap(project_root: Path | None = None) -> bool:
     return count >= cap
 
 
+# ---------------------------------------------------------------------------
+# Blocked / unresolved-dependency demotion (#1286)
+# ---------------------------------------------------------------------------
+
+
+def _depends_on_ids(plan: dict[str, Any]) -> list[str]:
+    """Return the non-empty string ids in ``plan.metadata.swarm.depends_on``.
+
+    Tolerant of the absent / non-list / non-string shapes so a malformed
+    swarm block never raises -- it simply contributes no dependency ids.
+    """
+    metadata = plan.get("metadata") if isinstance(plan, dict) else None
+    swarm = metadata.get("swarm") if isinstance(metadata, dict) else None
+    raw = swarm.get("depends_on") if isinstance(swarm, dict) else None
+    if not isinstance(raw, list):
+        return []
+    return [dep.strip() for dep in raw if isinstance(dep, str) and dep.strip()]
+
+
+def _completed_plan_ids(project_root: Path | None) -> set[str]:
+    """Return the set of ``plan.id`` values from ``vbrief/completed/``.
+
+    Used to decide whether a scope's ``depends_on`` entries are resolved:
+    a dependency id is resolved when a completed scope carries that id.
+    """
+    out: set[str] = set()
+    base = (project_root or Path.cwd()) / "vbrief" / "completed"
+    if not base.is_dir():
+        return out
+    for path in sorted(base.glob("*.vbrief.json")):
+        plan = _load_plan(path)
+        if plan is None:
+            continue
+        pid = plan.get("id")
+        if isinstance(pid, str) and pid.strip():
+            out.add(pid.strip())
+    return out
+
+
+def scope_is_blocked(plan: Any, *, completed_ids: set[str]) -> bool:
+    """Return True when a scope's linked vBRIEF is blocked (#1286).
+
+    A scope is blocked when EITHER:
+
+    * ``plan.status == "blocked"`` -- the operator explicitly parked it, OR
+    * ``plan.metadata.swarm.depends_on`` is non-empty and at least one
+      dependency id is unresolved (no completed scope carries that id).
+
+    ``completed_ids`` is the set of ``plan.id`` values from completed
+    scopes (see :func:`_completed_plan_ids`); an empty set treats every
+    declared dependency as unresolved, which is the safe default when the
+    completed lifecycle folder is unavailable.
+    """
+    if not isinstance(plan, dict):
+        return False
+    if plan.get("status") == "blocked":
+        return True
+    deps = _depends_on_ids(plan)
+    return bool(deps) and any(dep not in completed_ids for dep in deps)
+
+
+def blocked_by_issue_number(
+    project_root: Path | None,
+    *,
+    folders: tuple[str, ...] = ("pending", "active"),
+) -> set[int]:
+    """Map referenced issue numbers -> blocked state (#1286).
+
+    Walks the in-flight ``pending`` + ``active`` scopes (the folders the
+    queue ranks), flags each one via :func:`scope_is_blocked`, and returns
+    the set of GitHub issue numbers a blocked scope references. The
+    ``vbrief/completed/`` plan ids are read once up front so unresolved-
+    dependency detection is consistent across the walk.
+    """
+    out: set[int] = set()
+    root = project_root or Path.cwd()
+    completed_ids = _completed_plan_ids(root)
+    base = root / "vbrief"
+    for folder in folders:
+        folder_dir = base / folder
+        if not folder_dir.is_dir():
+            continue
+        for path in sorted(folder_dir.glob("*.vbrief.json")):
+            plan = _load_plan(path)
+            if plan is None:
+                continue
+            if not scope_is_blocked(plan, completed_ids=completed_ids):
+                continue
+            out |= _issue_numbers_from_plan(plan)
+    return out
+
+
 #: Operator-facing pointer surfaced when a scope is refused as under-specified
 #: (#1419 Slice 1 / #987). Names refinement as the canonical next step.
 SPEC_READINESS_REFINEMENT_HINT = (
@@ -919,6 +1030,9 @@ def load_cached_issues(
     # surface without the cli shim threading extra arguments.
     continuation_map = continuation_by_issue_number(project_root)
     deficit_map = bucket_deficit_by_issue_number(project_root)
+    # #1286: flag issues whose linked vBRIEF is blocked (status:blocked or an
+    # unresolved swarm.depends_on) so build_queue can demote them.
+    blocked_set = blocked_by_issue_number(project_root)
     issues: list[dict[str, Any]] = []
     for entry in base.iterdir():
         if not entry.is_dir() or not entry.name.isdigit():
@@ -981,6 +1095,7 @@ def load_cached_issues(
                 "_continuation": int(n) in continuation_map,
                 "_continuation_order": continuation_map.get(int(n), ""),
                 "_bucket_deficit": deficit_map.get(int(n)),
+                "_blocked": int(n) in blocked_set,
             }
         )
     return issues
@@ -1250,6 +1365,24 @@ def _resolve_deficit(
     return float(candidate)
 
 
+def _resolve_blocked(
+    issue: dict[str, Any],
+    number: int,
+    blocked_numbers: frozenset[int] | set[int],
+) -> bool:
+    """Resolve whether a queue row is blocked (#1286).
+
+    Precedence mirrors :func:`_resolve_continuation`: an explicit
+    :attr:`QueueBuildOptions.blocked_issue_numbers` membership (the
+    programmatic surface) wins; otherwise the ``_blocked`` annotation that
+    :func:`load_cached_issues` stamps from the in-flight scope vBRIEFs (the
+    CLI surface) is used.
+    """
+    if number in blocked_numbers:
+        return True
+    return bool(issue.get("_blocked"))
+
+
 def build_queue(
     issues: Iterable[dict[str, Any]],
     audit_entries: Iterable[dict[str, Any]],
@@ -1284,16 +1417,25 @@ def build_queue(
         # operator must still see.
         if drop_net_new and not is_continuation and not is_orphan:
             continue
+        is_blocked = _resolve_blocked(issue, n, opts.blocked_issue_numbers)
         latest = decisions.get(n)
         latest_decision = latest.get("decision") if isinstance(latest, dict) else None
+        # #1286: a blocked item (status:blocked / unresolved depends_on) is
+        # demoted into the BLOCKED group (bottom of GROUP_ORDER) by default
+        # so the queue surfaces only grabbable work. The --include-blocked
+        # opt-in (opts.include_blocked) re-surfaces it into its natural
+        # group instead, so the demotion check runs FIRST.
+        if is_blocked and not opts.include_blocked:
+            group = "BLOCKED"
         # D13 (#1132): ORPHAN takes precedence over every other group --
         # an orphan is work the framework already committed to and risks
         # losing, so it surfaces above RESUME / URGENT / untriaged.
-        if is_orphan:
+        elif is_orphan:
             group = "ORPHAN"
         else:
             group = derive_group(latest_decision, n in opts.active_referenced)
         issue["_latest_decision"] = latest_decision
+        issue["_blocked"] = is_blocked
         issue["_resolved_rank"] = _resolve_rank(issue, n, rank_by_number)
         issue["_continuation"] = is_continuation
         issue["_continuation_order"] = _resolve_continuation_order(

--- a/tests/cli/test_triage_queue.py
+++ b/tests/cli/test_triage_queue.py
@@ -736,3 +736,228 @@ def test_load_cached_issues_annotates_continuation(tmp_path):
     assert by_number[100]["_continuation"] is False
     items = triage_queue.build_queue(issues, [], repo=REPO)
     assert [i.number for i in items] == [200, 100]
+
+
+# ---------------------------------------------------------------------------
+# #1286 -- demote vBRIEF-status:blocked / unresolved-dependency items
+# ---------------------------------------------------------------------------
+#
+# Acceptance criteria from the story vBRIEF:
+#   * Blocked items (linked vBRIEF plan.status == "blocked" OR an unresolved
+#     plan.metadata.swarm.depends_on) are demoted into the [BLOCKED] group by
+#     default.
+#   * Unblocked items surface in their natural group.
+#   * The --include-blocked opt-in re-surfaces blocked items into their
+#     natural group.
+
+
+def _write_status_scope(
+    folder, filename, *, issue_number, status="running", depends_on=None, plan_id=None
+):
+    """Write an in-flight scope with a given status / depends_on / plan id."""
+    folder.mkdir(parents=True, exist_ok=True)
+    plan = {
+        "title": "Scope",
+        "status": status,
+        "references": [
+            {
+                "uri": f"https://github.com/{REPO}/issues/{issue_number}",
+                "type": "x-vbrief/github-issue",
+                "title": f"Issue #{issue_number}",
+            }
+        ],
+    }
+    if plan_id is not None:
+        plan["id"] = plan_id
+    if depends_on is not None:
+        plan["metadata"] = {"swarm": {"depends_on": depends_on}}
+    payload = {"vBRIEFInfo": {"version": "0.6"}, "plan": plan}
+    (folder / filename).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_completed_with_id(folder, filename, *, plan_id):
+    folder.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "vBRIEFInfo": {"version": "0.6"},
+        "plan": {"title": "done", "status": "completed", "id": plan_id},
+    }
+    (folder / filename).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+# --- GROUP_ORDER + scope_is_blocked unit coverage ---------------------------
+
+
+def test_blocked_group_is_last_in_group_order():
+    assert "BLOCKED" in triage_queue.GROUP_ORDER
+    assert triage_queue.GROUP_ORDER[-1] == "BLOCKED"
+    # The display marker is registered so render_queue does not fall back.
+    assert "BLOCKED" in triage_queue.GROUP_DISPLAY
+
+
+def test_scope_is_blocked_status_blocked():
+    assert triage_queue.scope_is_blocked({"status": "blocked"}, completed_ids=set()) is True
+
+
+def test_scope_is_blocked_unresolved_depends_on():
+    plan = {"status": "running", "metadata": {"swarm": {"depends_on": ["dep-a"]}}}
+    assert triage_queue.scope_is_blocked(plan, completed_ids=set()) is True
+
+
+def test_scope_is_blocked_resolved_depends_on_is_not_blocked():
+    plan = {"status": "running", "metadata": {"swarm": {"depends_on": ["dep-a"]}}}
+    assert triage_queue.scope_is_blocked(plan, completed_ids={"dep-a"}) is False
+
+
+def test_scope_is_blocked_partial_unresolved_depends_on():
+    plan = {"status": "running", "metadata": {"swarm": {"depends_on": ["dep-a", "dep-b"]}}}
+    # dep-b still unresolved -> blocked.
+    assert triage_queue.scope_is_blocked(plan, completed_ids={"dep-a"}) is True
+
+
+def test_scope_is_blocked_no_deps_running_is_not_blocked():
+    plan = {"status": "running", "metadata": {"swarm": {"depends_on": []}}}
+    assert triage_queue.scope_is_blocked(plan, completed_ids=set()) is False
+    assert triage_queue.scope_is_blocked({"status": "running"}, completed_ids=set()) is False
+
+
+# --- build_queue: demote by default / surface unblocked / opt-in ------------
+
+
+def test_build_queue_demotes_blocked_into_blocked_group():
+    """Blocked items are demoted into the [BLOCKED] group by default."""
+    issues = [_issue(1), _issue(2)]
+    options = triage_queue.QueueBuildOptions(blocked_issue_numbers=frozenset({1}))
+    items = triage_queue.build_queue(issues, [], repo=REPO, options=options)
+    by_number = {i.number: i for i in items}
+    assert by_number[1].group == "BLOCKED"
+    assert by_number[2].group == "untriaged"
+    # BLOCKED sorts last, so the unblocked item leads.
+    assert [i.number for i in items] == [2, 1]
+
+
+def test_build_queue_unblocked_issue_surfaces_in_natural_group():
+    issues = [_issue(1)]
+    options = triage_queue.QueueBuildOptions(blocked_issue_numbers=frozenset())
+    items = triage_queue.build_queue(issues, [], repo=REPO, options=options)
+    assert items[0].group == "untriaged"
+
+
+def test_build_queue_include_blocked_resurfaces_into_natural_group():
+    """--include-blocked re-surfaces blocked items into their natural group."""
+    issues = [_issue(1), _issue(2)]
+    options = triage_queue.QueueBuildOptions(
+        blocked_issue_numbers=frozenset({1}),
+        include_blocked=True,
+    )
+    items = triage_queue.build_queue(issues, [], repo=REPO, options=options)
+    by_number = {i.number: i for i in items}
+    assert by_number[1].group == "untriaged"
+    assert by_number[2].group == "untriaged"
+
+
+def test_build_queue_blocked_resume_demoted_unless_included():
+    """A blocked item that would otherwise RESUME is still demoted by default."""
+    issues = [_issue(1)]
+    options = triage_queue.QueueBuildOptions(
+        active_referenced=frozenset({1}),
+        blocked_issue_numbers=frozenset({1}),
+    )
+    items = triage_queue.build_queue(issues, [], repo=REPO, options=options)
+    assert items[0].group == "BLOCKED"
+    # With include_blocked the RESUME group is restored.
+    items2 = triage_queue.build_queue(
+        issues,
+        [],
+        repo=REPO,
+        options=triage_queue.QueueBuildOptions(
+            active_referenced=frozenset({1}),
+            blocked_issue_numbers=frozenset({1}),
+            include_blocked=True,
+        ),
+    )
+    assert items2[0].group == "RESUME"
+
+
+# --- blocked_by_issue_number (filesystem-truth) -----------------------------
+
+
+def test_blocked_by_issue_number_detects_status_blocked(tmp_path):
+    vbrief = tmp_path / "vbrief"
+    _write_status_scope(
+        vbrief / "active", "2026-06-04-a.vbrief.json", issue_number=700, status="blocked"
+    )
+    _write_status_scope(
+        vbrief / "active", "2026-06-04-b.vbrief.json", issue_number=701, status="running"
+    )
+    result = triage_queue.blocked_by_issue_number(tmp_path)
+    assert 700 in result
+    assert 701 not in result
+
+
+def test_blocked_by_issue_number_detects_unresolved_depends_on(tmp_path):
+    vbrief = tmp_path / "vbrief"
+    _write_status_scope(
+        vbrief / "pending",
+        "2026-06-04-dep.vbrief.json",
+        issue_number=800,
+        status="pending",
+        depends_on=["story-x"],
+    )
+    result = triage_queue.blocked_by_issue_number(tmp_path)
+    assert 800 in result
+
+
+def test_blocked_by_issue_number_resolved_depends_on_not_blocked(tmp_path):
+    vbrief = tmp_path / "vbrief"
+    _write_completed_with_id(vbrief / "completed", "2026-06-01-x.vbrief.json", plan_id="story-x")
+    _write_status_scope(
+        vbrief / "pending",
+        "2026-06-04-dep.vbrief.json",
+        issue_number=810,
+        status="pending",
+        depends_on=["story-x"],
+    )
+    result = triage_queue.blocked_by_issue_number(tmp_path)
+    assert 810 not in result
+
+
+# --- CLI data path: load_cached_issues stamps _blocked ----------------------
+
+
+def test_load_cached_issues_annotates_blocked(tmp_path):
+    cache_root = tmp_path / ".deft-cache"
+    _write_cached_issue(cache_root, REPO, _issue(700))
+    _write_cached_issue(cache_root, REPO, _issue(701))
+    vbrief = tmp_path / "vbrief"
+    _write_status_scope(
+        vbrief / "active", "2026-06-04-blocked.vbrief.json", issue_number=700, status="blocked"
+    )
+    _write_status_scope(
+        vbrief / "active", "2026-06-04-ok.vbrief.json", issue_number=701, status="running"
+    )
+    issues = triage_queue.load_cached_issues(REPO, project_root=tmp_path)
+    by_number = {i["number"]: i for i in issues}
+    assert by_number[700]["_blocked"] is True
+    assert by_number[701]["_blocked"] is False
+    # End-to-end: build_queue demotes the blocked issue.
+    items = triage_queue.build_queue(issues, [], repo=REPO)
+    by_num = {i.number: i for i in items}
+    assert by_num[700].group == "BLOCKED"
+    assert by_num[701].group == "untriaged"
+
+
+def test_load_cached_issues_blocked_resurfaces_with_include_blocked(tmp_path):
+    cache_root = tmp_path / ".deft-cache"
+    _write_cached_issue(cache_root, REPO, _issue(700))
+    vbrief = tmp_path / "vbrief"
+    _write_status_scope(
+        vbrief / "active", "2026-06-04-blocked.vbrief.json", issue_number=700, status="blocked"
+    )
+    issues = triage_queue.load_cached_issues(REPO, project_root=tmp_path)
+    items = triage_queue.build_queue(
+        issues,
+        [],
+        repo=REPO,
+        options=triage_queue.QueueBuildOptions(include_blocked=True),
+    )
+    assert items[0].group != "BLOCKED"

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -834,10 +834,10 @@
       {
         "id": "2026-05-21-1286-triage-queue-blocked-filter",
         "title": "Demote vBRIEF-status:blocked items in triage:queue",
-        "status": "proposed",
+        "status": "completed",
         "metadata": {
-          "source_path": "proposed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json",
-          "lifecycle_folder": "proposed",
+          "source_path": "completed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json",
+          "lifecycle_folder": "completed",
           "references": [
             {
               "uri": "https://github.com/deftai/directive/issues/1286",

--- a/vbrief/completed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json
+++ b/vbrief/completed/2026-05-21-1286-triage-queue-blocked-filter.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1286-triage-queue-blocked-filter",
     "title": "Demote vBRIEF-status:blocked items in triage:queue",
-    "status": "proposed",
+    "status": "completed",
     "planRef": "#1286",
     "narratives": {
       "Description": "The triage queue (scripts/triage_queue.py) groups items by triage-decision history (ORPHAN / RESUME / URGENT / untriaged / other) and does not consult vBRIEF dependency state, so blocked children pollute the queue. This story extends the queue to read each candidate's linked vBRIEF status and demote status:blocked or unresolved-dependency items so the ranked list surfaces only grabbable work.",
@@ -65,7 +65,9 @@
         "size": "small",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-15T00:43:27Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -78,6 +80,7 @@
         "type": "x-vbrief/github-issue",
         "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
       }
-    ]
+    ],
+    "updated": "2026-06-15T00:43:27Z"
   }
 }


### PR DESCRIPTION
## Summary

Part of the #1284 vBRIEF-as-canonical epic (Wave-1 cohort).

`task triage:queue` grouped items by triage-decision history but ignored each candidate's linked vBRIEF dependency state, so blocked children polluted the ranked list. This change demotes blocked work so the queue surfaces only grabbable items:

- A new `[BLOCKED]` group sits at the bottom of `GROUP_ORDER`. An item whose linked vBRIEF has `plan.status == "blocked"` **or** an unresolved `plan.metadata.swarm.depends_on` (a dependency id not carried by any completed scope's `plan.id`) is demoted there by default.
- `--include-blocked` re-surfaces those items into their natural group (RESUME / URGENT / untriaged / other) for the full picture.
- Blocked state is resolved from the in-flight `pending` + `active` scope vBRIEFs, mirroring the existing `_rank_by_issue_number` / `continuation_by_issue_number` walk patterns. The CLI data path stamps a per-issue `_blocked` annotation in `load_cached_issues`; the programmatic surface accepts `QueueBuildOptions.blocked_issue_numbers` + `include_blocked`.
- New public helpers: `scope_is_blocked`, `blocked_by_issue_number`.

## Test plan

Added to `tests/cli/test_triage_queue.py` (TDD: written first, confirmed red, then green):

- `scope_is_blocked`: status-blocked, unresolved/partially-unresolved/resolved `depends_on`, and the no-deps running case.
- `blocked_by_issue_number`: filesystem-truth detection of status-blocked and unresolved-dependency scopes; resolved deps are not blocked.
- `build_queue`: **blocked-demoted by default**, **unblocked surfaces normally**, **`--include-blocked` re-surfaces** (incl. a blocked-RESUME case), and the BLOCKED group is last in `GROUP_ORDER`.
- `load_cached_issues`: stamps `_blocked` and the end-to-end demotion / opt-in resurfacing through the CLI data path.

`task check` is GREEN (lint + type + full test suite + coverage + encoding + validate; 7793 passed). `--include-blocked` CLI flag smoke-tested.

Closes #1286. Refs #1284.

Made with [Cursor](https://cursor.com)