### PR TITLE
feat(vbrief,scm): task vbrief:reconcile:labels (#1288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Blocked vBRIEFs now auto-promote once their dependencies finish, so cascades advance without manual bookkeeping (#1287)** -- a new `task vbrief:reconcile:graph` walks `vbrief/proposed/` and promotes any candidate whose `swarm.depends_on[]` entries have all resolved to completed or cancelled work. It is forge-agnostic, respects the WIP cap (with a `--force` override), detects dependency cycles, and is idempotent so a second run is a no-op. Supports `--dry-run` and `--json`. Part of the #1284 vBRIEF-as-canonical epic. Closes #1287.
+- **Issue labels now mirror vBRIEF state, so reviewers stop seeing drift between an issue's labels and its lifecycle (#1288)** -- a new `task vbrief:reconcile:labels` reads each in-flight vBRIEF's linked GitHub issue and applies or removes a managed label set to match canonical state: `status:blocked` for blocked or dependency-blocked work, `epic` + `status:tracker` for epics, and `rfc` for research. It only touches the labels it owns (other labels are left alone), routes every forge call through the SCM shim, and is idempotent so a second run changes nothing. Supports `--repo`, `--dry-run`, and `--json`. Part of the #1284 vBRIEF-as-canonical epic. Closes #1288.
 
 ### Changed
 

--- a/scripts/vbrief_reconcile_labels.py
+++ b/scripts/vbrief_reconcile_labels.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""vbrief_reconcile_labels.py -- SCM label reconciliation (#1288).
+
+The reverse-direction companion to ``task vbrief:reconcile:graph`` (#1287):
+where the graph walker promotes proposed/ vBRIEFs as their dependencies
+clear, this verb (``task vbrief:reconcile:labels``) keeps the *forge*
+label surface in sync with canonical vBRIEF state so reviewers never see
+drift between an issue's labels and its lifecycle.
+
+Mapping table (canonical vBRIEF state -> managed labels):
+
+* ``plan.status == "blocked"`` OR any unresolved
+  ``plan.metadata.swarm.depends_on[]`` entry -> ``status:blocked``
+* ``plan.metadata.kind == "epic"``     -> ``epic`` + ``status:tracker``
+* ``plan.metadata.kind == "research"`` -> ``rfc``
+
+A dependency is *unresolved* when the brief it names does not (yet) live
+in a terminal lifecycle folder (``completed/`` or ``cancelled/``) -- the
+exact same resolution rule the #1287 graph walker uses, reused here via
+:data:`vbrief_reconcile_graph.RESOLVED_FOLDERS` /
+:func:`vbrief_reconcile_graph._dep_resolved`.
+
+Design contract:
+
+* **Mirror, don't accumulate.** The verb manages exactly the four labels
+  in :data:`MANAGED_LABELS`. On each run it ADDS the managed labels the
+  mapping currently demands and REMOVES managed labels that no longer
+  apply. Labels outside the managed set (``bug``, ``priority:high``, ...)
+  are never touched.
+* **Forge-agnostic.** Every forge call routes through ``scripts/scm.py``
+  (#1145) via :func:`scm.call`; ``task verify:scm-boundary`` enforces no
+  direct ``gh`` invocation remains. The default :class:`ScmLabelClient`
+  is the only thing that talks to the forge, and it is injectable so the
+  test suite never makes a live ``gh`` call.
+* **Idempotent.** A second run is a no-op: the first run already brought
+  the label set to the desired state, so the computed add/remove diff is
+  empty and no mutation fires.
+
+Exit codes (three-state, mirrors ``scripts/vbrief_reconcile_graph.py``):
+
+    0 -- ran successfully (zero or more labels reconciled).
+    1 -- one or more per-issue forge calls failed.
+    2 -- usage / config error (no ``vbrief/`` directory under
+         ``--project-root``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from swarm_readiness import _all_scope_ids, _as_str_list  # noqa: E402
+from triage_reconcile import _extract_issue_ref  # noqa: E402
+from vbrief_reconcile_graph import _dep_resolved  # noqa: E402
+
+import scm  # noqa: E402
+
+reconfigure_stdio()
+
+#: Lifecycle folders whose vBRIEFs carry an actionable label state. The
+#: mapping concepts (blocked / epic / research) are all in-flight, so the
+#: terminal folders (completed/cancelled) are not scanned for label
+#: application; they DO participate in dependency resolution via
+#: :func:`_all_scope_ids` below.
+SCAN_FOLDERS = ("proposed", "pending", "active")
+
+#: The complete set of labels this verb owns. Only these are ever added
+#: or removed; everything else on an issue is left untouched.
+MANAGED_LABELS = ("status:blocked", "epic", "status:tracker", "rfc")
+
+#: scm.call source identity (#1145). v1 supports only github-issue.
+SCM_SOURCE = "github-issue"
+
+
+class ScmLabelError(RuntimeError):
+    """Raised when a forge label read / mutation fails."""
+
+
+# ---------------------------------------------------------------------------
+# Mapping
+# ---------------------------------------------------------------------------
+
+
+def compute_desired_labels(plan: dict, *, unresolved_deps: bool) -> set[str]:
+    """Return the managed labels the mapping table demands for *plan*.
+
+    The result is always a subset of :data:`MANAGED_LABELS`. ``epic`` and
+    ``research`` are mutually exclusive ``kind`` values, so the kind arm
+    uses ``elif``; ``status:blocked`` is orthogonal (a blocked epic gets
+    all three).
+    """
+    desired: set[str] = set()
+    status = plan.get("status")
+    metadata = plan.get("metadata") if isinstance(plan.get("metadata"), dict) else {}
+    kind = metadata.get("kind")
+    if status == "blocked" or unresolved_deps:
+        desired.add("status:blocked")
+    if kind == "epic":
+        desired.update(("epic", "status:tracker"))
+    elif kind == "research":
+        desired.add("rfc")
+    return desired
+
+
+# ---------------------------------------------------------------------------
+# Forge client (injectable)
+# ---------------------------------------------------------------------------
+
+
+class LabelClient(Protocol):
+    """The seam the reconciler talks to. Tests inject an in-memory fake."""
+
+    def fetch_labels(self, repo: str, issue_number: int) -> list[str]:
+        ...
+
+    def apply(
+        self,
+        repo: str,
+        issue_number: int,
+        add: Sequence[str],
+        remove: Sequence[str],
+    ) -> None:
+        ...
+
+
+class ScmLabelClient:
+    """Forge-backed label client routing every call through ``scripts/scm.py``.
+
+    Both the read (``issue view --json labels``) and the mutation
+    (``issue edit --add-label/--remove-label``) go through
+    :func:`scm.call` with ``source="github-issue"`` so the #1145 scm
+    boundary is honoured -- ``task verify:scm-boundary`` flags any direct
+    ``gh`` invocation, and this client deliberately has none.
+    """
+
+    def fetch_labels(self, repo: str, issue_number: int) -> list[str]:
+        proc = scm.call(
+            SCM_SOURCE,
+            "issue",
+            ["view", str(issue_number), "--repo", repo, "--json", "labels"],
+        )
+        if proc.returncode != 0:
+            raise ScmLabelError(
+                f"issue view #{issue_number} ({repo}) failed: "
+                f"{(proc.stderr or '').strip()}"
+            )
+        try:
+            data = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise ScmLabelError(
+                f"issue view #{issue_number} ({repo}) returned non-JSON: {exc}"
+            ) from exc
+        labels = data.get("labels") if isinstance(data, dict) else None
+        if not isinstance(labels, list):
+            return []
+        names: list[str] = []
+        for entry in labels:
+            if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+                names.append(entry["name"])
+            elif isinstance(entry, str):
+                names.append(entry)
+        return names
+
+    def apply(
+        self,
+        repo: str,
+        issue_number: int,
+        add: Sequence[str],
+        remove: Sequence[str],
+    ) -> None:
+        args = ["edit", str(issue_number), "--repo", repo]
+        for name in add:
+            args += ["--add-label", name]
+        for name in remove:
+            args += ["--remove-label", name]
+        proc = scm.call(SCM_SOURCE, "issue", args)
+        if proc.returncode != 0:
+            raise ScmLabelError(
+                f"issue edit #{issue_number} ({repo}) failed: "
+                f"{(proc.stderr or '').strip()}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Outcome types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LabelChange:
+    """A single issue's computed (and, unless dry-run, applied) label diff."""
+
+    story_id: str
+    repo: str
+    issue_number: int
+    current: list[str]
+    desired: list[str]
+    add: list[str]
+    remove: list[str]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "story_id": self.story_id,
+            "repo": self.repo,
+            "issue_number": self.issue_number,
+            "current": list(self.current),
+            "desired": list(self.desired),
+            "add": list(self.add),
+            "remove": list(self.remove),
+        }
+
+
+@dataclass
+class ReconcileLabelsOutcome:
+    """Aggregate result of a single label-reconcile run."""
+
+    changed: list[LabelChange] = field(default_factory=list)
+    unchanged: list[LabelChange] = field(default_factory=list)
+    skipped_no_ref: list[str] = field(default_factory=list)
+    errors: list[tuple[str, str]] = field(default_factory=list)
+    dry_run: bool = False
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "changed": [c.to_json() for c in self.changed],
+            "unchanged": [c.to_json() for c in self.unchanged],
+            "skipped_no_ref": list(self.skipped_no_ref),
+            "errors": [{"story_id": sid, "message": msg} for sid, msg in self.errors],
+            "dry_run": self.dry_run,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core reconcile logic
+# ---------------------------------------------------------------------------
+
+
+def _unresolved_deps(
+    swarm: dict,
+    known_ids: dict[str, tuple[Path, str]],
+) -> bool:
+    """True when any ``depends_on`` entry has NOT resolved to a terminal folder.
+
+    Reuses :func:`vbrief_reconcile_graph._dep_resolved` so "resolved"
+    means exactly what the #1287 graph walker means: the named brief
+    lives in ``completed/`` or ``cancelled/``. An unknown dependency id
+    counts as unresolved (the dependent is still blocked on it).
+    """
+    return any(
+        not _dep_resolved(dep, known_ids)
+        for dep in _as_str_list(swarm.get("depends_on"))
+    )
+
+
+def reconcile_labels(
+    project_root: Path,
+    *,
+    repo: str | None = None,
+    dry_run: bool = False,
+    client: LabelClient | None = None,
+) -> tuple[int, ReconcileLabelsOutcome]:
+    """Reconcile managed SCM labels against canonical vBRIEF state.
+
+    Walks :data:`SCAN_FOLDERS`, resolves each brief's linked issue from
+    its ``x-vbrief/github-issue`` reference (falling back to *repo* when
+    the reference URI lacks an owner/name segment), computes the
+    add/remove diff against :data:`MANAGED_LABELS`, and applies it via
+    *client* (unless *dry_run*). Returns ``(exit_code, outcome)``.
+    """
+    vbrief_dir = project_root / "vbrief"
+    if not vbrief_dir.is_dir():
+        return 2, ReconcileLabelsOutcome(dry_run=dry_run)
+
+    if client is None:
+        client = ScmLabelClient()
+
+    known_ids = _all_scope_ids(project_root)
+    outcome = ReconcileLabelsOutcome(dry_run=dry_run)
+    seen_issues: set[tuple[str, int]] = set()
+
+    for folder in SCAN_FOLDERS:
+        folder_path = vbrief_dir / folder
+        if not folder_path.is_dir():
+            continue
+        for path in sorted(folder_path.glob("*.vbrief.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            plan = data.get("plan") if isinstance(data.get("plan"), dict) else {}
+            story_id = str(plan.get("id") or path.name[: -len(".vbrief.json")])
+
+            ref_repo, number = _extract_issue_ref(data)
+            effective_repo = ref_repo or repo
+            if number is None or effective_repo is None:
+                outcome.skipped_no_ref.append(story_id)
+                continue
+            key = (effective_repo, number)
+            if key in seen_issues:
+                continue
+            seen_issues.add(key)
+
+            metadata = plan.get("metadata") if isinstance(plan.get("metadata"), dict) else {}
+            swarm = metadata.get("swarm") if isinstance(metadata.get("swarm"), dict) else {}
+            desired = compute_desired_labels(
+                plan, unresolved_deps=_unresolved_deps(swarm, known_ids)
+            )
+
+            try:
+                current = client.fetch_labels(effective_repo, number)
+            except ScmLabelError as exc:
+                outcome.errors.append((story_id, str(exc)))
+                continue
+
+            current_managed = {name for name in current if name in MANAGED_LABELS}
+            add = sorted(desired - current_managed)
+            remove = sorted(current_managed - desired)
+            change = LabelChange(
+                story_id=story_id,
+                repo=effective_repo,
+                issue_number=number,
+                current=sorted(current),
+                desired=sorted(desired),
+                add=add,
+                remove=remove,
+            )
+
+            if not add and not remove:
+                outcome.unchanged.append(change)
+                continue
+            if dry_run:
+                outcome.changed.append(change)
+                continue
+            try:
+                client.apply(effective_repo, number, add, remove)
+            except ScmLabelError as exc:
+                outcome.errors.append((story_id, str(exc)))
+                continue
+            outcome.changed.append(change)
+
+    exit_code = 1 if outcome.errors else 0
+    return exit_code, outcome
+
+
+# ---------------------------------------------------------------------------
+# Rendering + CLI
+# ---------------------------------------------------------------------------
+
+
+def _render_report(outcome: ReconcileLabelsOutcome) -> str:
+    lines: list[str] = ["vBRIEF reconcile labels", ""]
+    suffix = " (dry-run)" if outcome.dry_run else ""
+
+    lines.append(f"Changed{suffix}:")
+    if outcome.changed:
+        for change in outcome.changed:
+            parts: list[str] = []
+            if change.add:
+                parts.append(f"+{', +'.join(change.add)}")
+            if change.remove:
+                parts.append(f"-{', -'.join(change.remove)}")
+            lines.append(
+                f"- #{change.issue_number} ({change.repo}) "
+                f"[{change.story_id}]: {'; '.join(parts)}"
+            )
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.append("Unchanged:")
+    if outcome.unchanged:
+        lines.extend(
+            f"- #{c.issue_number} ({c.repo}) [{c.story_id}]" for c in outcome.unchanged
+        )
+    else:
+        lines.append("- none")
+
+    if outcome.skipped_no_ref:
+        lines.append("")
+        lines.append("Skipped (no github-issue reference / repo):")
+        lines.extend(f"- {story_id}" for story_id in outcome.skipped_no_ref)
+
+    if outcome.errors:
+        lines.append("")
+        lines.append("Errors:")
+        lines.extend(f"- {story_id}: {message}" for story_id, message in outcome.errors)
+
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reconcile SCM labels to mirror canonical vBRIEF state: "
+            "status:blocked (blocked / unresolved deps), epic + status:tracker "
+            "(kind=epic), rfc (kind=research). Routes through scripts/scm.py "
+            "(#1145). Idempotent."
+        )
+    )
+    parser.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing vbrief/ (default: current directory).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help=(
+            "Fallback repo slug 'owner/name' used ONLY when a vBRIEF's "
+            "github-issue reference URI lacks an owner/repo segment."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report which labels WOULD change without mutating any issue.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON summary instead of the text report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    project_root = Path(args.project_root).resolve()
+    exit_code, outcome = reconcile_labels(
+        project_root,
+        repo=args.repo,
+        dry_run=args.dry_run,
+    )
+    if exit_code == 2:
+        if args.json:
+            print(json.dumps({"error": "no vbrief/ directory found"}))
+        else:
+            print(
+                f"Error: no vbrief/ directory found under {project_root}",
+                file=sys.stderr,
+            )
+        return 2
+    if args.json:
+        print(json.dumps(outcome.to_json(), indent=2))
+    else:
+        print(_render_report(outcome))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/vbrief.yml
+++ b/tasks/vbrief.yml
@@ -101,6 +101,36 @@ tasks:
     cmds:
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/vbrief_reconcile_graph.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
 
+  reconcile:labels:
+    # SCM label reconciliation (#1288). Walks vbrief/proposed/ + pending/ +
+    # active/, resolves each brief's linked GitHub issue from its
+    # x-vbrief/github-issue reference, and applies/removes a fixed set of
+    # managed labels so the forge surface mirrors canonical vBRIEF state:
+    # status=blocked or an unresolved swarm.depends_on[] -> status:blocked;
+    # kind=epic -> epic + status:tracker; kind=research -> rfc. Mirror (not
+    # accumulate): managed labels that no longer apply are removed; labels
+    # outside the managed set are never touched. Every forge call routes
+    # through scripts/scm.py (#1145) so task verify:scm-boundary stays green,
+    # and the verb is idempotent (a second run mutates nothing). Pass-through
+    # flags: --repo OWNER/NAME (fallback when a reference URI lacks owner/
+    # repo), --dry-run (report without mutating), --json (machine summary).
+    #
+    # CLI_ARGS forwarding (#577): bare ``{{.CLI_ARGS}}`` -- DO NOT wrap in
+    # Taskfile-level double quotes. go-task already shell-escapes CLI_ARGS
+    # with single quotes; double-wrapping breaks Windows argv. See the
+    # preflight task above for the full rationale.
+    #
+    # NOTE: NO ``sources:`` / ``generates:`` per ``conventions/task-caching.md``
+    # because the walk reads the lifecycle folders and mutates remote forge
+    # state that go-task does not track, so a cached skip would silently
+    # swallow real label changes.
+    desc: "Reconcile SCM labels to mirror vBRIEF state: status:blocked / epic+status:tracker / rfc (#1288). Routes through scripts/scm.py. Flags: --repo --dry-run --json."
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/vbrief_reconcile_labels.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+
   activate:
     # Implementation-intent activation gate companion (#810). Idempotent:
     # already-active vBRIEFs print a no-op message and exit 0; pending/

--- a/tests/cli/test_vbrief_reconcile_labels.py
+++ b/tests/cli/test_vbrief_reconcile_labels.py
@@ -1,0 +1,344 @@
+"""Acceptance tests for ``task vbrief:reconcile:labels`` (#1288).
+
+The label reconciler walks the in-flight vBRIEF lifecycle folders
+(``proposed/`` / ``pending/`` / ``active/``), resolves each brief's linked
+GitHub issue from its ``x-vbrief/github-issue`` reference, and applies /
+removes a fixed set of *managed* SCM labels so the forge surface mirrors
+canonical vBRIEF state:
+
+- ``plan.status == "blocked"`` OR an unresolved
+  ``plan.metadata.swarm.depends_on[]`` entry -> ``status:blocked``
+- ``plan.metadata.kind == "epic"``     -> ``epic`` + ``status:tracker``
+- ``plan.metadata.kind == "research"`` -> ``rfc``
+
+The verb is idempotent (a second run makes no forge mutation), never
+touches labels outside the managed set, and routes every forge call
+through ``scripts/scm.py`` (#1145). These tests inject a fake SCM label
+client so the suite never makes a live ``gh`` call.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "vbrief_reconcile_labels.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import vbrief_reconcile_labels as mod  # noqa: E402
+
+_STATUS_FOR_FOLDER = {
+    "proposed": "proposed",
+    "pending": "pending",
+    "active": "running",
+    "completed": "completed",
+    "cancelled": "cancelled",
+}
+
+
+class FakeLabelClient:
+    """In-memory stand-in for the scm-backed label client.
+
+    ``labels`` maps ``(repo, issue_number)`` -> current label name list.
+    ``apply`` mutates that state so a second reconcile run is a genuine
+    no-op, exactly as the live forge would behave.
+    """
+
+    def __init__(self, labels: dict[tuple[str, int], list[str]] | None = None) -> None:
+        self.labels: dict[tuple[str, int], list[str]] = {
+            key: list(value) for key, value in (labels or {}).items()
+        }
+        self.apply_calls: list[tuple[str, int, list[str], list[str]]] = []
+
+    def fetch_labels(self, repo: str, issue_number: int) -> list[str]:
+        return list(self.labels.get((repo, issue_number), []))
+
+    def apply(
+        self,
+        repo: str,
+        issue_number: int,
+        add,
+        remove,
+    ) -> None:
+        add = list(add)
+        remove = list(remove)
+        self.apply_calls.append((repo, issue_number, add, remove))
+        current = set(self.labels.get((repo, issue_number), []))
+        current |= set(add)
+        current -= set(remove)
+        self.labels[(repo, issue_number)] = sorted(current)
+
+
+def _write_brief(
+    project: Path,
+    story_id: str,
+    *,
+    folder: str = "active",
+    status: str | None = None,
+    kind: str = "story",
+    depends_on: list[str] | None = None,
+    issue_number: int | None = None,
+    repo: str = "deftai/directive",
+    with_reference: bool = True,
+) -> Path:
+    """Write a minimal but schema-plausible story vBRIEF into *folder*."""
+    path = project / "vbrief" / folder / f"2026-05-21-{story_id}.vbrief.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    references = []
+    if with_reference and issue_number is not None:
+        references.append(
+            {
+                "uri": f"https://github.com/{repo}/issues/{issue_number}",
+                "type": "x-vbrief/github-issue",
+                "title": f"Issue #{issue_number}",
+            }
+        )
+    data = {
+        "vBRIEFInfo": {"version": "0.6"},
+        "plan": {
+            "id": story_id,
+            "title": story_id,
+            "status": status or _STATUS_FOR_FOLDER[folder],
+            "narratives": {
+                "Description": f"{story_id} description.",
+                "ImplementationPlan": f"1. Do {story_id}.",
+                "UserStory": f"As a user, I want {story_id}.",
+                "Traces": "FR-1",
+            },
+            "items": [
+                {
+                    "id": f"{story_id}-a1",
+                    "title": "Acceptance item 1",
+                    "status": "pending",
+                    "narrative": {"Acceptance": f"Given X when {story_id} then Y."},
+                }
+            ],
+            "metadata": {
+                "kind": kind,
+                "swarm": {
+                    "readiness": "ready",
+                    "parallel_safe": True,
+                    "file_scope": [f"src/{story_id}.py"],
+                    "verify_commands": [f"pytest {story_id}"],
+                    "expected_outputs": ["tests pass"],
+                    "depends_on": depends_on or [],
+                    "conflict_group": "reconcile-suite",
+                    "size": "small",
+                    "file_scope_confidence": "high",
+                    "model_tier": "standard",
+                },
+            },
+            "references": references,
+        },
+    }
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _run_cli(project: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--project-root", str(project), *extra],
+        cwd=project,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_desired_labels unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_desired_blocked_status() -> None:
+    plan = {"status": "blocked", "metadata": {"kind": "story"}}
+    assert mod.compute_desired_labels(plan, unresolved_deps=False) == {"status:blocked"}
+
+
+def test_desired_unresolved_deps_blocks() -> None:
+    plan = {"status": "running", "metadata": {"kind": "story"}}
+    assert mod.compute_desired_labels(plan, unresolved_deps=True) == {"status:blocked"}
+
+
+def test_desired_epic() -> None:
+    plan = {"status": "running", "metadata": {"kind": "epic"}}
+    assert mod.compute_desired_labels(plan, unresolved_deps=False) == {
+        "epic",
+        "status:tracker",
+    }
+
+
+def test_desired_research() -> None:
+    plan = {"status": "running", "metadata": {"kind": "research"}}
+    assert mod.compute_desired_labels(plan, unresolved_deps=False) == {"rfc"}
+
+
+def test_desired_plain_story_empty() -> None:
+    plan = {"status": "running", "metadata": {"kind": "story"}}
+    assert mod.compute_desired_labels(plan, unresolved_deps=False) == set()
+
+
+# ---------------------------------------------------------------------------
+# reconcile_labels end-to-end (injected client)
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_status_adds_label(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "blk", folder="active", status="blocked", issue_number=10)
+    client = FakeLabelClient()
+
+    exit_code, outcome = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert ("deftai/directive", 10, ["status:blocked"], []) in client.apply_calls
+    assert client.labels[("deftai/directive", 10)] == ["status:blocked"]
+
+
+def test_unresolved_dep_adds_blocked(tmp_path: Path) -> None:
+    # dep lives in pending/ (not terminal) -> unresolved -> blocked.
+    _write_brief(tmp_path, "dep-a", folder="pending", issue_number=1)
+    _write_brief(
+        tmp_path,
+        "child-b",
+        folder="active",
+        depends_on=["dep-a"],
+        issue_number=20,
+    )
+    client = FakeLabelClient()
+
+    exit_code, _ = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert client.labels[("deftai/directive", 20)] == ["status:blocked"]
+
+
+def test_resolved_dep_no_blocked(tmp_path: Path) -> None:
+    # dep lives in completed/ -> resolved -> NOT blocked.
+    _write_brief(tmp_path, "dep-a", folder="completed", issue_number=1)
+    _write_brief(
+        tmp_path,
+        "child-b",
+        folder="active",
+        depends_on=["dep-a"],
+        issue_number=21,
+    )
+    client = FakeLabelClient()
+
+    exit_code, _ = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert client.apply_calls == []
+    assert ("deftai/directive", 21) not in client.labels
+
+
+def test_epic_adds_epic_and_tracker(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "epic-x", folder="active", kind="epic", issue_number=30)
+    client = FakeLabelClient()
+
+    exit_code, _ = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert client.labels[("deftai/directive", 30)] == ["epic", "status:tracker"]
+
+
+def test_research_adds_rfc(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "rfc-y", folder="active", kind="research", issue_number=40)
+    client = FakeLabelClient()
+
+    exit_code, _ = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert client.labels[("deftai/directive", 40)] == ["rfc"]
+
+
+def test_removes_stale_managed_label(tmp_path: Path) -> None:
+    # Issue currently carries status:blocked but the brief is no longer
+    # blocked -> the stale managed label is removed.
+    _write_brief(tmp_path, "ok", folder="active", status="running", issue_number=50)
+    client = FakeLabelClient({("deftai/directive", 50): ["status:blocked"]})
+
+    exit_code, _ = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert ("deftai/directive", 50, [], ["status:blocked"]) in client.apply_calls
+    assert client.labels[("deftai/directive", 50)] == []
+
+
+def test_preserves_unmanaged_labels(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "blk", folder="active", status="blocked", issue_number=60)
+    client = FakeLabelClient({("deftai/directive", 60): ["bug", "priority:high"]})
+
+    exit_code, _ = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert set(client.labels[("deftai/directive", 60)]) == {
+        "bug",
+        "priority:high",
+        "status:blocked",
+    }
+
+
+def test_idempotent_second_run_noop(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "epic-x", folder="active", kind="epic", issue_number=70)
+    client = FakeLabelClient()
+
+    first_code, _ = mod.reconcile_labels(tmp_path, client=client)
+    assert first_code == 0
+    first_apply_count = len(client.apply_calls)
+    assert first_apply_count == 1
+
+    second_code, outcome = mod.reconcile_labels(tmp_path, client=client)
+    assert second_code == 0
+    # No further mutations on the second pass.
+    assert len(client.apply_calls) == first_apply_count
+    assert outcome.changed == []
+
+
+def test_dry_run_makes_no_mutation(tmp_path: Path) -> None:
+    _write_brief(tmp_path, "blk", folder="active", status="blocked", issue_number=80)
+    client = FakeLabelClient()
+
+    exit_code, outcome = mod.reconcile_labels(tmp_path, client=client, dry_run=True)
+
+    assert exit_code == 0
+    assert client.apply_calls == []
+    assert outcome.dry_run is True
+    assert any(c.issue_number == 80 for c in outcome.changed)
+
+
+def test_brief_without_reference_skipped(tmp_path: Path) -> None:
+    _write_brief(
+        tmp_path,
+        "noref",
+        folder="active",
+        status="blocked",
+        with_reference=False,
+    )
+    client = FakeLabelClient()
+
+    exit_code, outcome = mod.reconcile_labels(tmp_path, client=client)
+
+    assert exit_code == 0
+    assert client.apply_calls == []
+    assert "noref" in outcome.skipped_no_ref
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_missing_vbrief_dir_exit2(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path)
+    assert result.returncode == 2, result.stdout + result.stderr
+
+
+def test_cli_missing_vbrief_dir_json_exit2(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path, "--json")
+    assert result.returncode == 2, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert "error" in payload

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -876,10 +876,10 @@
       {
         "id": "2026-05-21-1288-vbrief-reconcile-labels",
         "title": "task vbrief:reconcile:labels -- SCM label reconciliation",
-        "status": "proposed",
+        "status": "completed",
         "metadata": {
-          "source_path": "proposed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json",
-          "lifecycle_folder": "proposed",
+          "source_path": "completed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json",
+          "lifecycle_folder": "completed",
           "references": [
             {
               "uri": "https://github.com/deftai/directive/issues/1288",

--- a/vbrief/completed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json
+++ b/vbrief/completed/2026-05-21-1288-vbrief-reconcile-labels.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1288-vbrief-reconcile-labels",
     "title": "task vbrief:reconcile:labels -- SCM label reconciliation",
-    "status": "proposed",
+    "status": "completed",
     "planRef": "#1288",
     "narratives": {
       "Description": "Apply and remove SCM labels based on canonical vBRIEF state, routing through scripts/scm.py (#1145) to stay forge-agnostic. This closes the missing reverse direction of the existing GitHub-state-to-vBRIEF reconciler so the label surface mirrors lifecycle rather than drifting from it.",
@@ -68,7 +68,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-15T00:49:36Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -81,6 +83,7 @@
         "type": "x-vbrief/github-issue",
         "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
       }
-    ]
+    ],
+    "updated": "2026-06-15T00:49:36Z"
   }
 }


### PR DESCRIPTION
## Summary
Adds `task vbrief:reconcile:labels`, the reverse-direction companion to `task vbrief:reconcile:graph` (#1287): it keeps the GitHub label surface in sync with canonical vBRIEF state so reviewers never see drift between an issue's labels and its lifecycle. Part of the #1284 vBRIEF-as-canonical epic.

Mapping (managed labels only):
- `plan.status == "blocked"` OR an unresolved `plan.metadata.swarm.depends_on[]` -> `status:blocked`
- `plan.metadata.kind == "epic"` -> `epic` + `status:tracker`
- `plan.metadata.kind == "research"` -> `rfc`

Behavior:
- **Mirror, not accumulate** -- managed labels that no longer apply are removed; labels outside the managed set are never touched.
- **Forge-agnostic** -- every forge call routes through `scripts/scm.py` (#1145), so `task verify:scm-boundary` stays green. The label client is injectable, so tests never make a live `gh` call.
- **Idempotent** -- a second run computes an empty diff and mutates nothing.
- Resolves each brief's linked issue from its `x-vbrief/github-issue` reference; `--repo` is a fallback only when the reference URI lacks an owner/name segment.
- `--dry-run` / `--json`; three-state exit (0 ok / 1 forge error / 2 no `vbrief/` dir), mirroring the #1287 sibling.

Dependency resolution reuses `vbrief_reconcile_graph._dep_resolved` and `swarm_readiness._all_scope_ids`, and issue-ref parsing reuses `triage_reconcile._extract_issue_ref`, for consistency with the existing reconcile suite.

## Files
- NEW `scripts/vbrief_reconcile_labels.py`
- NEW `tests/cli/test_vbrief_reconcile_labels.py` (each mapping, stale-label removal, unmanaged-label preservation, idempotency, dry-run, no-reference skip, CLI exit-2)
- `tasks/vbrief.yml` -- new `reconcile:labels` entry alongside `reconcile:graph`
- `CHANGELOG.md` -- `[Unreleased]` entry

## Test plan
- [x] `task check` GREEN (7807 passed; lint/mypy/validate/encoding/scm-boundary all clean)
- [x] New tests pass in isolation (`uv run pytest tests/cli/test_vbrief_reconcile_labels.py`)
- [x] `task verify:scm-boundary` clean -- no direct `gh` invocation
- [x] Lifecycle gates: scope promote/activate, preflight exit 0, scope complete

Closes #1288
Refs #1284

Made with [Cursor](https://cursor.com)