### PR TITLE
chore(vbrief): swarm-ready split of #1274 (issue:emit tool + strategy hints)

### DIFF
--- a/vbrief/proposed/2026-06-15-1274a-issue-emit-tool.vbrief.json
+++ b/vbrief/proposed/2026-06-15-1274a-issue-emit-tool.vbrief.json
@@ -1,0 +1,84 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1274 Change 2 (task issue:emit -- the vBRIEF -> GitHub issue write path); split-A of the #1274 decomposition under epic #1284.",
+    "created": "2026-06-15T12:00:00Z",
+    "updated": "2026-06-15T12:00:00Z"
+  },
+  "plan": {
+    "id": "1274a-issue-emit-tool",
+    "title": "task issue:emit -- vBRIEF -> GitHub issue write path",
+    "status": "proposed",
+    "planRef": "#1274",
+    "narratives": {
+      "Description": "Ship task issue:emit, the write-direction counterpart to task issue:ingest, so a scope vBRIEF can be filed as a GitHub issue with one command. The verb renders the issue body from the vBRIEF title, Description, Acceptance, and Traces narratives, files the issue through the scripts/scm.py shim, and writes the resulting issue URL back into the source vBRIEF's references[] as an x-vbrief/github-issue entry.",
+      "ImplementationPlan": "1. Add scripts/issue_emit.py mirroring scripts/issue_ingest.py in reverse: parse args (single <path>, --umbrella, --per-vbrief, --dry-run, --json), render an issue body from the vBRIEF narratives, and file via scm.call(\"github-issue\", \"issue\", [\"create\", ...]) so the #1145 scm boundary holds. 2. Update each emitted source vBRIEF's references[] with {type: x-vbrief/github-issue, uri, TrustLevel: external} using pathlib UTF-8 writes. 3. Add a reconcile:umbrellas-style task entry to tasks/issue.yml (dir USER_WORKING_DIR, DEFT_ROOT dispatch, bare CLI_ARGS). 4. Add tests/cli/test_issue_emit.py covering single/umbrella/per-vbrief modes, dry-run, DEFT_NO_NETWORK, and references[] write-back with an injected fake scm client (no live gh).",
+      "UserStory": "As a framework maintainer, I want a task issue:emit verb that files GitHub issues from scope vBRIEFs and records the issue URL back into references[], so that vBRIEF-producing strategies have a one-command SCM-tracking path symmetric with task issue:ingest.",
+      "Traces": "planRef #1274; decomposition_origin #742; epic #1284; symmetric counterpart of scripts/issue_ingest.py."
+    },
+    "items": [
+      {
+        "title": "issue:emit single + umbrella + per-vbrief modes via scm shim",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running task issue:emit creates a GitHub issue for a single vBRIEF, while --umbrella creates one checklist issue and --per-vbrief creates one issue per matched vBRIEF, all routed through scripts/scm.py."
+        }
+      },
+      {
+        "title": "references[] write-back with external TrustLevel",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "After a successful emit, each source vBRIEF records an x-vbrief/github-issue reference with the issue URL and TrustLevel external, and a re-run detects the existing reference instead of creating a duplicate."
+        }
+      },
+      {
+        "title": "Dry-run and DEFT_NO_NETWORK print a plan without calling the forge",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When --dry-run or DEFT_NO_NETWORK=1 is set, task issue:emit emits a plan of the issues it would file and persists no change to any source vBRIEF on disk."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1274",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/issue_emit.py",
+          "tasks/issue.yml",
+          "tests/cli/test_issue_emit.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_issue_emit.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "task issue:emit files an issue and writes back an x-vbrief/github-issue reference",
+          "dry-run and DEFT_NO_NETWORK make no forge write"
+        ],
+        "depends_on": [],
+        "conflict_group": "issue-emit-tool",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1274",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1274: discoverable issue emission + task issue:emit"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-15-1274b-strategy-emit-hints.vbrief.json
+++ b/vbrief/proposed/2026-06-15-1274b-strategy-emit-hints.vbrief.json
@@ -1,0 +1,93 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1274 Change 1 (discoverable issue-emit hints across all vBRIEF-producing strategies); split-B of the #1274 decomposition under epic #1284.",
+    "created": "2026-06-15T12:00:00Z",
+    "updated": "2026-06-15T12:00:00Z"
+  },
+  "plan": {
+    "id": "1274b-strategy-emit-hints",
+    "title": "Strategy emit-hints: discoverable issue:emit across vBRIEF-producing strategies",
+    "status": "proposed",
+    "planRef": "#1274",
+    "narratives": {
+      "Description": "Make GitHub-issue back-references discoverable at the moment every strategy finishes emitting scope vBRIEFs. Add one shared strategies/emit-hints.md helper that prints the none/umbrella/per-vBRIEF choice plus the canonical task issue:emit invocations, and link it from each vBRIEF-producing strategy's emission step the same way those strategies already reference artifact-guards.md. The framework default (vBRIEF-only, no issue) is unchanged; only the silence around it is removed.",
+      "ImplementationPlan": "1. Add strategies/emit-hints.md containing the shared hint block (names the three patterns and the task issue:emit --umbrella / --per-vbrief / single invocations, plus the no-action default). 2. Add a one-line reference to strategies/emit-hints.md at the emission step of each vBRIEF-producing strategy doc: bdd.md, discuss.md, research.md, map.md, probe.md, interview.md, yolo.md, rapid.md, enterprise.md, and speckit.md (Phase 4 and Phase 4.5). 3. Add tests/strategies/test_emit_hints.py asserting the helper exists, names the three patterns, and that each listed strategy doc references emit-hints.md at its emission step.",
+      "UserStory": "As a directive user running a vBRIEF-producing strategy, I want a printed hint naming the none/umbrella/per-vBRIEF issue-emit choices at the emission step, so that I discover the task issue:emit escape hatch instead of the default staying silent.",
+      "Traces": "planRef #1274; decomposition_origin #742; epic #1284; shared-reference shape mirrors strategies/artifact-guards.md."
+    },
+    "items": [
+      {
+        "title": "Shared strategies/emit-hints.md helper",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "strategies/emit-hints.md renders all three patterns (none, --umbrella, --per-vbrief) with the canonical task issue:emit invocations and the no-action default."
+        }
+      },
+      {
+        "title": "Every vBRIEF-producing strategy links the hint at its emission step",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Each listed strategy doc (bdd, discuss, research, map, probe, interview, yolo, rapid, enterprise, speckit) displays the emit-hints.md reference at the step where it creates scope vBRIEFs."
+        }
+      },
+      {
+        "title": "Default emission behavior is unchanged",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "No strategy creates a GitHub issue automatically; the hint renders as informational text only and the default vBRIEF-only emission path requires no further user action."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1274",
+        "decomposition_origin": "#742"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "strategies/emit-hints.md",
+          "strategies/bdd.md",
+          "strategies/discuss.md",
+          "strategies/research.md",
+          "strategies/map.md",
+          "strategies/probe.md",
+          "strategies/interview.md",
+          "strategies/yolo.md",
+          "strategies/rapid.md",
+          "strategies/enterprise.md",
+          "strategies/speckit.md",
+          "tests/strategies/test_emit_hints.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/strategies/test_emit_hints.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "strategies/emit-hints.md names the three issue-emit patterns",
+          "each vBRIEF-producing strategy references emit-hints.md at its emission step"
+        ],
+        "depends_on": [],
+        "conflict_group": "strategy-emit-hints",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1274",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1274: discoverable issue emission + task issue:emit"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1284",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Decomposes #1274 into two disjoint, parallel-safe story vBRIEFs under epic #1284.
- `1274a-issue-emit-tool` — `task issue:emit` write-path (`scripts/issue_emit.py`, `tasks/issue.yml`, tests).
- `1274b-strategy-emit-hints` — shared `strategies/emit-hints.md` + emit-hint references across all vBRIEF-producing strategies (docs+tests).

`task swarm:readiness` exits 0: both ready, no file overlap, wave 1, distinct conflict groups.

## Test plan
- [x] `task swarm:readiness` exit 0

Made with [Cursor](https://cursor.com)