### PR TITLE
chore(vbrief): complete #1274 stories (issue:emit tool + strategy hints)

### DIFF
--- a/vbrief/completed/2026-06-15-1274a-issue-emit-tool.vbrief.json
+++ b/vbrief/completed/2026-06-15-1274a-issue-emit-tool.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1274a-issue-emit-tool",
     "title": "task issue:emit -- vBRIEF -> GitHub issue write path",
-    "status": "running",
+    "status": "completed",
     "planRef": "#1274",
     "narratives": {
       "Description": "Ship task issue:emit, the write-direction counterpart to task issue:ingest, so a scope vBRIEF can be filed as a GitHub issue with one command. The verb renders the issue body from the vBRIEF title, Description, Acceptance, and Traces narratives, files the issue through the scripts/scm.py shim, and writes the resulting issue URL back into the source vBRIEF's references[] as an x-vbrief/github-issue entry.",
@@ -66,7 +66,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-15T12:44:22Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -80,6 +82,6 @@
         "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
       }
     ],
-    "updated": "2026-06-15T12:26:44Z"
+    "updated": "2026-06-15T12:44:22Z"
   }
 }

--- a/vbrief/completed/2026-06-15-1274b-strategy-emit-hints.vbrief.json
+++ b/vbrief/completed/2026-06-15-1274b-strategy-emit-hints.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1274b-strategy-emit-hints",
     "title": "Strategy emit-hints: discoverable issue:emit across vBRIEF-producing strategies",
-    "status": "running",
+    "status": "completed",
     "planRef": "#1274",
     "narratives": {
       "Description": "Make GitHub-issue back-references discoverable at the moment every strategy finishes emitting scope vBRIEFs. Add one shared strategies/emit-hints.md helper that prints the none/umbrella/per-vBRIEF choice plus the canonical task issue:emit invocations, and link it from each vBRIEF-producing strategy's emission step the same way those strategies already reference artifact-guards.md. The framework default (vBRIEF-only, no issue) is unchanged; only the silence around it is removed.",
@@ -75,7 +75,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-15T12:44:23Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -89,6 +91,6 @@
         "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
       }
     ],
-    "updated": "2026-06-15T12:26:52Z"
+    "updated": "2026-06-15T12:44:23Z"
   }
 }


### PR DESCRIPTION
## Summary
Moves the two #1274 story vBRIEFs from `active/` to `completed/` now that PR #1634 (issue:emit tool) and PR #1635 (strategy emit-hints) are merged.

## Test plan
- [x] `task scope:complete` succeeded for both

Made with [Cursor](https://cursor.com)