### PR TITLE
chore(vbrief): complete #1643 packs discoverability

### DIFF
--- a/vbrief/completed/2026-06-15-1643-packs-discoverability.vbrief.json
+++ b/vbrief/completed/2026-06-15-1643-packs-discoverability.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1643-packs-discoverability",
     "title": "Pack discovery (--list-packs) + consumer discoverability wiring for packs:slice",
-    "status": "running",
+    "status": "completed",
     "planRef": "#1643",
     "narratives": {
       "Description": "Make the content-pack slice surface discoverable end-to-end so a consumer agent actually knows to use it. First add a pack-level discovery affordance (task packs:slice --list-packs) so the surface is self-describing: --list-packs to find packs, then <pack> --list to find slices. Then wire that discovery path into the surfaces a consumer agent loads -- the managed AGENTS.md section, main.md, and skill routing -- so the agent loads lessons via the slice instead of reading the whole 100KB file or never loading them at all. Every wiring surface references the discovery commands (--list-packs / --list), never hardcoded pack or slice names, so the v2 expansion (#1637) adds packs and slices without churning this wiring.",
@@ -77,7 +77,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-15T15:06:09Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -101,6 +103,6 @@
         "title": "Issue #1284: epic(vbrief): vBRIEF-as-canonical"
       }
     ],
-    "updated": "2026-06-15T14:50:07Z"
+    "updated": "2026-06-15T15:06:09Z"
   }
 }


### PR DESCRIPTION
Moves the #1643 vBRIEF active -> completed now that PR #1644 merged.

## Test plan
- [x] task scope:complete succeeded

Made with [Cursor](https://cursor.com)