### PR TITLE
feat(triage): rank bug-labeled issues above feature/RFC work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Bug-labelled issues now rank ahead of feature and RFC work in the triage queue (#1657)** -- `bug` is now a triage ranking label, appended after the existing escalation labels (`blocks-merge`, `blocks-release-tag`, `adoption-blocker`, `breaking-change`, `urgent`). Explicit release-blockers still win, but an open bug now surfaces above the large mass of unlabelled / feature / RFC items instead of sorting purely by recency. The change is also reflected in the consumer-example default so downstream projects inherit bug-prioritisation as the recommended baseline. Closes #1657. Refs #1128 #1186.
 
 ### Fixed
 

--- a/docs/example-project-definition.md
+++ b/docs/example-project-definition.md
@@ -38,7 +38,8 @@ The values below are what deft itself ships on `vbrief/PROJECT-DEFINITION.vbrief
             "skills",
             "adoption-blocker",
             "blocks-merge",
-            "blocks-release-tag"
+            "blocks-release-tag",
+            "bug"
           ]
         },
         {"rule": "milestone", "is-open": true}
@@ -92,11 +93,12 @@ Note on the `triageScopeIgnores` shape: D14c / #1182 supports two ignore-entry s
 ## 3. Side-by-side annotation column
 For each non-empty value, this column explains whether it is deft-specific (your repo would substitute its own) or a common convention (works for most repos that follow the umbrella).
 ### triageScope[]
-- `labels.any-of [enhancement, epic, meta, skills, adoption-blocker, blocks-merge, blocks-release-tag]` -- mixed:
+- `labels.any-of [enhancement, epic, meta, skills, adoption-blocker, blocks-merge, blocks-release-tag, bug]` -- mixed:
   - `enhancement`, `epic`, `meta`, `skills` -- common convention. Most GitHub repos using a similar labelling hygiene will recognise these as the high-signal buckets (`enhancement` is a GitHub default, `epic` / `meta` / `skills` are commonly used as cross-cutting tags).
   - `adoption-blocker` -- common convention (mid-tier adoption tracking; substitute with your own onboarding-friction label).
   - `blocks-merge` -- deft-specific. Deft uses this label to gate merges on cohort-level reviews; your repo may not have this concept. If your repo uses a different gating label (`blocking`, `priority:p0`, `release-blocker`, ...) substitute it here.
   - `blocks-release-tag` -- deft-specific. Deft uses this label to surface issues that must clear before a release tag cuts; substitute with your own release-gating label or omit.
+  - `bug` -- common convention. Subscribing to `bug` keeps open defects in the triage cache so they can be ranked; it pairs with the `bug` ranking label below (a ranking label only takes effect on issues that are in scope). `bug` is a GitHub default label; substitute with `defect` / `regression` as your repo uses.
 - `milestone.is-open: true` -- common convention. Once D14b / #1181 landed this rule type subscribes to every currently-open upstream milestone at sync time. Most consumers benefit from this -- if you maintain milestones at all, the currently-open set is naturally your active-work envelope.
 ### triageRankingLabels[]
 Highest-priority first; matched labels rank within their group ahead of unmatched ones, with `updated_at` desc as the tiebreaker.

--- a/docs/example-project-definition.md
+++ b/docs/example-project-definition.md
@@ -48,7 +48,8 @@ The values below are what deft itself ships on `vbrief/PROJECT-DEFINITION.vbrief
         "blocks-release-tag",
         "adoption-blocker",
         "breaking-change",
-        "urgent"
+        "urgent",
+        "bug"
       ],
       "triageAutoClassify": [
         {
@@ -104,6 +105,7 @@ Highest-priority first; matched labels rank within their group ahead of unmatche
 - `adoption-blocker` -- common convention.
 - `breaking-change` -- common convention. Works for most repos that follow Conventional Commits or any semantic-versioning discipline; signal is "a release containing this needs operator attention before it ships".
 - `urgent` -- common convention. Many repos use `urgent` / `priority:high` / `p0`; substitute with whichever label your team uses for "drop everything".
+- `bug` -- common convention. Ranked last among the priority labels so the explicit escalation labels above still win, but a `bug`-labelled issue still ranks ahead of the large mass of unlabelled / feature / RFC work. `bug` is a GitHub default label; substitute with `defect` / `regression` / whichever label your team uses for "something is broken".
 ### triageAutoClassify[]
 First-match-wins after the four framework universal rules.
 - `{labels.any-of [status:superseded-pending], action: defer, reason: awaiting umbrella deliverable}` -- deft-specific. Deft uses `status:superseded-pending` for child issues whose work is folded into a larger umbrella deliverable; deferring keeps them out of the active queue without losing the audit trail. If your repo does not have an umbrella-driven planning model, omit this rule or substitute with your own deferred-by-design label.

--- a/tests/content/test_consumer_config_example.py
+++ b/tests/content/test_consumer_config_example.py
@@ -208,9 +208,10 @@ def test_triage_ranking_labels_in_declared_priority_order(policy: dict) -> None:
         "adoption-blocker",
         "breaking-change",
         "urgent",
+        "bug",
     ], (
-        "triageRankingLabels order must match #1186 Deliverable 1: "
-        "[blocks-merge, blocks-release-tag, adoption-blocker, breaking-change, urgent]"
+        "triageRankingLabels order must match #1186 Deliverable 1 + #1657: "
+        "[blocks-merge, blocks-release-tag, adoption-blocker, breaking-change, urgent, bug]"
     )
 
 

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -10683,7 +10683,8 @@
         "blocks-release-tag",
         "adoption-blocker",
         "breaking-change",
-        "urgent"
+        "urgent",
+        "bug"
       ],
       "triageAutoClassify": [
         {

--- a/vbrief/completed/2026-06-15-1657-triage-rank-bug-label.vbrief.json
+++ b/vbrief/completed/2026-06-15-1657-triage-rank-bug-label.vbrief.json
@@ -1,0 +1,81 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1657: rank bug-labeled issues in the triage queue by adding 'bug' to triageRankingLabels (deft's PROJECT-DEFINITION + the consumer-example default).",
+    "created": "2026-06-15T19:15:00Z",
+    "updated": "2026-06-15T19:15:00Z"
+  },
+  "plan": {
+    "id": "1657-triage-rank-bug-label",
+    "title": "Rank bug-labeled issues above feature/RFC work in the triage queue",
+    "status": "completed",
+    "narratives": {
+      "Description": "bug-labeled issues are not prioritized in the triage queue. 'bug' is in plan.policy.triageScope[] (subscribed) but absent from plan.policy.triageRankingLabels[], so a bug issue gets no within-group rank boost and sorts only by updated_at desc -- identical to an unlabeled feature. Append 'bug' to triageRankingLabels after 'urgent' so the explicit escalation labels still win but bugs rank above the large mass of unlabeled / feature / RFC work. Propagate the same change to the consumer-example default (docs/example-project-definition.md) so consumers inherit bug-prioritization as the recommended baseline, and update the priority-order contract test.",
+      "ImplementationPlan": "1. vbrief/PROJECT-DEFINITION.vbrief.json: append 'bug' after 'urgent' in plan.policy.triageRankingLabels. 2. docs/example-project-definition.md: add 'bug' to the triageRankingLabels JSON example (after 'urgent') and add a 'bug -- common convention' entry to the ### triageRankingLabels[] annotation column. 3. tests/content/test_consumer_config_example.py: update test_triage_ranking_labels_in_declared_priority_order to expect the 6-label list ending in 'bug'. 4. CHANGELOG.md [Unreleased]: add a brief user-facing entry. 5. task check.",
+      "UserStory": "As an operator running 'what's next', I want bug-labeled issues to rank above feature/RFC work in the triage queue, so that open defects surface ahead of nice-to-haves without me re-ranking by hand.",
+      "Traces": "planRef #1657; ranking surface #1128 (D11); consumer-example #1186; triageRankingLabels boundary per umbrella #1119 section 12."
+    },
+    "items": [
+      {
+        "title": "Append 'bug' to deft's triageRankingLabels",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "plan.policy.triageRankingLabels in vbrief/PROJECT-DEFINITION.vbrief.json is [blocks-merge, blocks-release-tag, adoption-blocker, breaking-change, urgent, bug], and task triage:queue ranks a bug-labeled untriaged issue above unlabeled/feature peers and below the four higher escalation labels."
+        }
+      },
+      {
+        "title": "Propagate to the consumer-example default + annotation",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "docs/example-project-definition.md JSON example includes 'bug' after 'urgent' in triageRankingLabels, and the ### triageRankingLabels[] annotation column documents 'bug' as a common convention."
+        }
+      },
+      {
+        "title": "Update the priority-order contract test",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "test_consumer_config_example.py::test_triage_ranking_labels_in_declared_priority_order expects the 6-label list ending in 'bug', and task check passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1657"
+      },
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "vbrief/PROJECT-DEFINITION.vbrief.json",
+          "docs/example-project-definition.md",
+          "tests/content/test_consumer_config_example.py",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/content/test_consumer_config_example.py",
+          "task check"
+        ],
+        "expected_outputs": [
+          "triage:queue ranks bug-labeled issues above feature/RFC peers",
+          "consumer-example documents bug as a ranking label"
+        ],
+        "depends_on": [],
+        "conflict_group": "triage-ranking",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "completedAt": "2026-06-15T19:25:59Z",
+      "capacityBucket": "new-capability"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1657",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1657: rank bug-labeled issues in the triage queue"
+      }
+    ],
+    "updated": "2026-06-15T19:25:59Z"
+  }
+}


### PR DESCRIPTION
## Summary

Ranks `bug`-labeled issues in the triage queue. `bug` was in `triageScope[]` (subscribed) but absent from `triageRankingLabels[]`, so a bug got no within-group rank boost and sorted purely by `updated_at` desc — letting stale RFCs/features sit above open bugs.

- Append `bug` to `plan.policy.triageRankingLabels` **after `urgent`** in `vbrief/PROJECT-DEFINITION.vbrief.json`. The four explicit escalation labels (`blocks-merge`, `blocks-release-tag`, `adoption-blocker`, `breaking-change`, `urgent`) still rank higher; `bug` ranks above the large mass of unlabeled / feature / RFC work.
- Propagate to the consumer-example default (`docs/example-project-definition.md`) — JSON example + a `bug` annotation entry (documented as a common convention) — so downstream projects inherit bug-prioritization as the recommended baseline.
- Update the `test_consumer_config_example.py` priority-order contract to expect the 6-label list.
- CHANGELOG `[Unreleased]` entry.

## Test plan

- [x] `uv run pytest tests/content/test_consumer_config_example.py` — 26 passed
- [x] `task check` — 8186 passed, 5 skipped
- [ ] After merge: `task triage:queue` ranks a `bug`-labeled untriaged issue above unlabeled/feature peers and below the four higher escalation labels

Closes #1657. Refs #1128 #1186.
