### PR TITLE
docs(lessons): record won't-fix decision for #584 (disposable code / decaying negatives)

### DIFF
--- a/meta/lessons.md
+++ b/meta/lessons.md
@@ -594,3 +594,15 @@ The 2026-05-07 session surfaced the `graphql` bucket exhaustion failure mode for
 **Why this lessons entry is a short cross-reference:** per the Rule Authority [AXIOM] in `main.md`, the rule body lives at the strongest layer (coding standard + skill + deterministic gate); this entry exists for discoverability + recurrence-record citation.
 
 **Cross-references:** `coding/debugging.md` (rule body); `skills/deft-directive-debug/SKILL.md` (workflow); `scripts/verify_investigation.py` + `tasks/verify.yml::investigation` (validator gate); `docs/reference/forensic-research/` (vendored design); #1580 (Fact vs Judgment labeling -- shared vocabulary); superseded #659 + #1173.
+
+## Disposable code & decaying negatives: record decisions, not dead-ends (2026-06)
+
+**Source:** #584 -- consumer request to leave intentionally-disabled / sub-optimal code in place so agents don't delete it or "helpfully" re-enable it. Closed won't-fix after a design discussion.
+
+**Decision:** deft will NOT add an in-tree "parked code" mechanism or a project-local negative-results store. The delete-dead-code rule in `coding/hygiene.md` stands; no relaxation.
+
+**Principle (the reusable part):** In an agentic codebase, both *code* and *experiment-level negative results* are cheap to regenerate and decay quickly, so preserving them has low -- often negative -- ROI. A stale "don't try X" note actively misleads future agents away from approaches that later become viable (Chesterton's Fence in reverse). Record *stable design decisions* (ADR-grade), not disposable dead-ends. Genuinely-deferred work belongs in the tracker (a vBRIEF), optionally with a one-line `TODO(#ref)` pointer at the site -- never as commented-out or flag-disabled code.
+
+**Exception (already covered, needs no new machinery):** stable, expensive-to-rediscover, high-stakes negatives (licensing / legal constraints, hard API limits, incident post-mortems) DO warrant durable records -- but ADRs / post-mortems / the issue tracker already serve them.
+
+**Why prose-tier:** a governance / won't-build decision with no code rule to enforce; this entry exists for discoverability so the #584 discussion does not recur. Future duplicates close as duplicate-of-#584.

--- a/packs/lessons/lessons-pack-0.1.json
+++ b/packs/lessons/lessons-pack-0.1.json
@@ -504,6 +504,20 @@
       ],
       "source": "Issue #1621 (consolidates the stale #659 + #1173). Directive had no debugging capability; agents defaulted to guess-and-fix, thrashing on retries and treating the first plausible hypothesis as correct. The design is grounded in the obra/superpowers `systematic-debugging` pattern and the vendored `forensic-research` reference bundle (mandatory falsification, claim ledger, validator).",
       "body": "**Source:** Issue #1621 (consolidates the stale #659 + #1173). Directive had no debugging capability; agents defaulted to guess-and-fix, thrashing on retries and treating the first plausible hypothesis as correct. The design is grounded in the obra/superpowers `systematic-debugging` pattern and the vendored `forensic-research` reference bundle (mandatory falsification, claim ledger, validator).\n\n**Canonical encoding (strongest-applicable layer):** the rule body lives in `coding/debugging.md` (Iron Law, four phases, the 3-fix architecture gate, evidence discipline, Fact vs Hypothesis labeling, observability-gap loop); the sustained multi-agent investigation posture lives in the `deft-directive-debug` skill; the investigation-ledger validator is the deterministic `task verify:investigation` gate (`scripts/verify_investigation.py`). `coding/coding.md` carries the short-form cross-reference + the #1621 anti-pattern entry. The vendored reference design sits under `docs/reference/forensic-research/`.\n\n**Why this lessons entry is a short cross-reference:** per the Rule Authority [AXIOM] in `main.md`, the rule body lives at the strongest layer (coding standard + skill + deterministic gate); this entry exists for discoverability + recurrence-record citation.\n\n**Cross-references:** `coding/debugging.md` (rule body); `skills/deft-directive-debug/SKILL.md` (workflow); `scripts/verify_investigation.py` + `tasks/verify.yml::investigation` (validator gate); `docs/reference/forensic-research/` (vendored design); #1580 (Fact vs Judgment labeling -- shared vocabulary); superseded #659 + #1173."
+    },
+    {
+      "id": "agentic-disposability-decisions-not-deadends-2026-06",
+      "title": "Disposable code & decaying negatives: record decisions, not dead-ends (2026-06)",
+      "date": "2026-06",
+      "issue_refs": [
+        "#584"
+      ],
+      "tags": [
+        "lifecycle",
+        "context"
+      ],
+      "source": "Issue #584 -- consumer request to keep intentionally-disabled / sub-optimal code in place so agents neither remove nor re-enable it. Closed won't-fix.",
+      "body": "**Source:** #584 -- consumer request to leave intentionally-disabled / sub-optimal code in place so agents don't delete it or \"helpfully\" re-enable it. Closed won't-fix after a design discussion.\n\n**Decision:** deft will NOT add an in-tree \"parked code\" mechanism or a project-local negative-results store. The delete-dead-code rule in `coding/hygiene.md` stands; no relaxation.\n\n**Principle (the reusable part):** In an agentic codebase, both *code* and *experiment-level negative results* are cheap to regenerate and decay quickly, so preserving them has low -- often negative -- ROI. A stale \"don't try X\" note actively misleads future agents away from approaches that later become viable (Chesterton's Fence in reverse). Record *stable design decisions* (ADR-grade), not disposable dead-ends. Genuinely-deferred work belongs in the tracker (a vBRIEF), optionally with a one-line `TODO(#ref)` pointer at the site -- never as commented-out or flag-disabled code.\n\n**Exception (already covered, needs no new machinery):** stable, expensive-to-rediscover, high-stakes negatives (licensing / legal constraints, hard API limits, incident post-mortems) DO warrant durable records -- but ADRs / post-mortems / the issue tracker already serve them.\n\n**Why prose-tier:** a governance / won't-build decision with no code rule to enforce; this entry exists for discoverability so the #584 discussion does not recur. Future duplicates close as duplicate-of-#584."
     }
   ]
 }

--- a/vbrief/cancelled/2026-06-16-584-agents-potentially-not-respecting-commented-out-code.vbrief.json
+++ b/vbrief/cancelled/2026-06-16-584-agents-potentially-not-respecting-commented-out-code.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #584"
+  },
+  "plan": {
+    "title": "Agents potentially not \"respecting\" commented out code",
+    "id": "584-respect-disabled-code",
+    "status": "cancelled",
+    "narratives": {
+      "Description": "Operators intentionally leave non-functional or deliberately-disabled modules in place to return to later, but fresh agents repeatedly re-activate that code to fix a thematically-related problem even when comments say not to. This story defines a sanctioned disabled-code marker convention and a respect-disabled rule so a fresh agent treats marked code as off-limits without explicit operator approval.",
+      "ImplementationPlan": "- Add the respect-disabled rule and a canonical marker convention (e.g. `deft:disabled -- do not re-enable; see #N`) to the coding/hygiene.md guideline file, reconciling it with the existing delete-dead-code guidance so the two do not conflict.\n- Mirror the consumer-relevant rule into AGENTS.md and templates/agents-entry.md and run `task agents:refresh` so the consumer managed-section inherits it.\n- Add a content test under tests/content/ that asserts the marker convention and respect-disabled rule text is present in the canonical surface and fails when it is absent.",
+      "UserStory": "As an operator maintaining intentionally-disabled code, I want agents to respect a sanctioned disabled-code marker, so that future agents do not re-activate modules I deliberately turned off.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/584",
+      "Overview": "A behavior I have had surface several times now is I will have a module or variable whose intended purpose doesn't fully pan out (e.g., a re-rank module for my legal query app, designed to more accurately rank case law lists from an external database).  I leave the non-functioning or sub-optimal module in place to potentially return to later, or disable the code via a variable.\n\nThen I switch to a new agent, run tests, and often have to explain the module/variable in question doesn't work.  Even when I have agents put explicit comments in the code to this effect, future agents still want to activate that module/code to fix a thematically-related problem.\n\nMaybe I am missing a best practices way to handle this, but it has happened to me multiple times this week already.",
+      "Labels": "bug, agent-experience"
+    },
+    "items": [
+      {
+        "title": "Respect the sanctioned disabled-code marker",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given source code carrying the sanctioned disabled marker, when a fresh agent works a thematically-related problem, then it leaves the marked code disabled and asks for operator approval before re-enabling."
+        }
+      },
+      {
+        "title": "Reconcile with delete-dead-code guidance",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the new respect-disabled rule and the existing delete-dead-code guidance, when both are read together, then the marker convention is documented as the explicit carve-out so the two rules do not conflict."
+        }
+      },
+      {
+        "title": "Content test guards the documented rule",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the canonical AGENTS.md surface, when the content test runs, then it asserts the marker convention text is present and fails when the rule is missing."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "coding/hygiene.md",
+          "AGENTS.md",
+          "templates/agents-entry.md",
+          "tests/content/test_agents_entry_contract.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/content/test_agents_entry_contract.py",
+          "task agents:refresh"
+        ],
+        "expected_outputs": [
+          "coding/hygiene.md documents the disabled-code marker convention and respect-disabled rule",
+          "AGENTS.md and templates/agents-entry.md carry the mirrored rule",
+          "passing content test asserting the rule text is present"
+        ],
+        "depends_on": [],
+        "conflict_group": "agents-md-harness",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "Bug fix ingested from GitHub issue #584; no spec-section requirement trace applies."
+      }
+    },
+    "tags": [
+      "bug",
+      "agent-experience"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/584",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #584: Agents potentially not \"respecting\" commented out code"
+      }
+    ],
+    "updated": "2026-06-16T18:54:31Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Resolves the design discussion on #584 (request to keep intentionally-disabled / sub-optimal code in place so agents don't remove or re-enable it) as **won't-fix**. The issue is already closed on GitHub; this PR records the decision in-repo so it doesn't recur.
- Adds a lessons-learned entry: in an agentic codebase, both *code* and *experiment-level negative results* are cheap to regenerate and decay quickly, so record **stable design decisions** (ADR-grade), not disposable dead-ends. Stale "don't try X" notes trend toward negative ROI (Chesterton's Fence in reverse).
- Cancels the #584 scope vBRIEF (`active/` -> `cancelled/`).

## Rationale
- The delete-dead-code rule in `coding/hygiene.md` stands; no in-tree "parked code" mechanism and no project-local negative-results store.
- The only durable subset of negatives (licensing/legal constraints, hard API limits, incident post-mortems) is already served by ADRs / post-mortems / the issue tracker, so it needs no new deft machinery.
- Genuinely-deferred work belongs in the tracker (a vBRIEF), optionally with a one-line `TODO(#ref)` pointer at the site.

## Changes
- `packs/lessons/lessons-pack-0.1.json` (source of truth) + `meta/lessons.md` (rendered via `task packs:render`) -- new lesson entry, tagged `lifecycle` / `context`.
- `vbrief/cancelled/2026-06-16-584-...vbrief.json` -- the cancelled scope.

## Test plan
- [x] `task check` passes (exit 0)
- [x] `tests/cli/test_pack_render.py` green -- pack <-> schema <-> render parity
- [x] pre-commit + pre-push hooks pass (branch gate, encoding, vBRIEF conformance)

Refs #584

Made with [Cursor](https://cursor.com)