### PR TITLE
fix: flag SemVer pre-release tags as GitHub pre-releases (#425)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,13 @@ jobs:
           # or set it to false; `task release:publish` is the only path
           # authorised to flip draft -> public.
           draft: true
+          # #425: flag SemVer pre-release tags (-rc.N / -beta.N / -alpha.N)
+          # as GitHub pre-releases automatically. The hyphen is SemVer's
+          # canonical pre-release marker, so `contains(github.ref_name, '-')`
+          # catches every qualifier without a maintained suffix list. Mirrors
+          # the tag-derived `--prerelease` flag in scripts/release.py so both
+          # release-creation paths agree.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
           files: |
             artifacts/install-windows-amd64.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Pre-release tags are now flagged as GitHub pre-releases automatically (#425)** -- release-candidate, beta, and alpha tags (any tag whose version carries a SemVer pre-release suffix like `-rc.1`) are now marked as GitHub pre-releases at creation time, so operators no longer have to run a manual `gh release edit --prerelease` correction after every RC cut. Both release-creation paths agree: the release workflow sets `prerelease` from the tag name and `scripts/release.py` passes a tag-derived `--prerelease` to `gh release create`. Closes #425.
 
 ### Removed
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -345,6 +345,35 @@ def _validate_version(version: str) -> None:
         )
 
 
+def is_prerelease_tag(version: str) -> bool:
+    """Return True when ``version`` carries a SemVer pre-release suffix (#425).
+
+    A SemVer pre-release is everything after the first ``-`` that follows the
+    core ``X.Y.Z`` version (``-rc.N``, ``-beta.N``, ``-alpha.N``, ...). This
+    pure tag-based decision drives the ``--prerelease`` flag passed to
+    ``gh release create`` so RC / beta / alpha cuts are flagged as GitHub
+    pre-releases automatically instead of requiring a manual
+    ``gh release edit --prerelease`` after every cut. It mirrors the
+    workflow-side ``prerelease: ${{ contains(github.ref_name, '-') }}`` so
+    both release-creation paths agree.
+
+    A leading ``v`` is tolerated so callers may pass either the tag
+    (``v0.20.0-rc.1``) or the bare version (``0.20.0-rc.1``).
+
+    Examples
+    --------
+        ``v0.20.0-rc.1``    -> True
+        ``v1.0.0-alpha.3``  -> True
+        ``0.20.0-beta.2``   -> True
+        ``v0.20.0``         -> False
+        ``0.20.0``          -> False
+    """
+    candidate = version.strip()
+    if candidate.startswith("v"):
+        candidate = candidate[1:]
+    return "-" in candidate
+
+
 def _today_iso() -> str:
     return _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%d")
 
@@ -1218,6 +1247,7 @@ def create_github_release(
     notes: str,
     *,
     draft: bool = True,
+    prerelease: bool = False,
 ) -> tuple[bool, str]:
     """Create the GitHub release tagged ``v<version>``.
 
@@ -1225,6 +1255,12 @@ def create_github_release(
     created in draft state so binaries upload via release.yml CI but the
     artifact is not yet visible to consumers. ``task release:publish --
     <version>`` flips the draft to public after manual review.
+
+    ``prerelease`` defaults to False; when True the release is created
+    with ``--prerelease`` so SemVer pre-release tags (``-rc.N`` / ``-beta.N``
+    / ``-alpha.N``) are flagged as GitHub pre-releases automatically (#425).
+    Callers derive the boolean from the tag via ``is_prerelease_tag`` so this
+    path agrees with the workflow-side ``prerelease: ${{ contains(...) }}``.
 
     Notes-file path (#731): when ``notes`` is non-empty we materialise
     it to a UTF-8 temp file and pass ``--notes-file <path>`` to ``gh``
@@ -1249,6 +1285,8 @@ def create_github_release(
     ]
     if draft:
         cmd.append("--draft")
+    if prerelease:
+        cmd.append("--prerelease")
 
     # Materialise notes to a UTF-8 temp file when non-empty so the
     # gh release create command line stays well under the OS argv cap
@@ -1309,7 +1347,12 @@ def create_github_release(
             return False, "gh CLI not found on PATH"
         if result.returncode != 0:
             return False, f"gh release create failed: {result.stderr.strip()}"
-        suffix = " (draft)" if draft else ""
+        flags = [
+            label
+            for label, enabled in (("draft", draft), ("prerelease", prerelease))
+            if enabled
+        ]
+        suffix = f" ({', '.join(flags)})" if flags else ""
         return True, f"created GitHub release {tag}{suffix}"
     finally:
         if notes_file is not None:
@@ -1912,20 +1955,27 @@ def run_pipeline(config: ReleaseConfig) -> int:
             _emit(11, label, f"FAIL ({reason})")
             return EXIT_VIOLATION
 
-    # Step 12: GitHub release.
+    # Step 12: GitHub release. #425: flag SemVer pre-release tags
+    # (``-rc.N`` / ``-beta.N`` / ``-alpha.N``) as GitHub pre-releases
+    # automatically so RC cuts no longer require a manual
+    # ``gh release edit --prerelease``. The decision mirrors the
+    # workflow-side ``prerelease: ${{ contains(github.ref_name, '-') }}``.
+    prerelease = is_prerelease_tag(version)
     draft_suffix = " (draft)" if config.draft else " (PUBLIC)"
-    label = f"GitHub release v{version}{draft_suffix}"
+    prerelease_suffix = " (prerelease)" if prerelease else ""
+    label = f"GitHub release v{version}{draft_suffix}{prerelease_suffix}"
     create_succeeded = False
     if config.skip_release:
         _emit(12, label, "SKIP (--skip-release)")
     elif config.dry_run:
         draft_flag = " --draft" if config.draft else ""
+        prerelease_flag = " --prerelease" if prerelease else ""
         _emit(
             12,
             label,
             (
                 f"DRYRUN (would run `gh release create v{version} "
-                f"--repo {config.repo}{draft_flag} ...`)"
+                f"--repo {config.repo}{draft_flag}{prerelease_flag} ...`)"
             ),
         )
     else:
@@ -1936,7 +1986,12 @@ def run_pipeline(config: ReleaseConfig) -> int:
         # repos and when the template is absent (graceful degradation).
         notes = _prepend_upgrade_banner(notes, config.repo, project_root)
         ok, reason = create_github_release(
-            project_root, version, config.repo, notes, draft=config.draft
+            project_root,
+            version,
+            config.repo,
+            notes,
+            draft=config.draft,
+            prerelease=prerelease,
         )
         if ok:
             _emit(12, label, f"OK ({reason})")

--- a/tests/cli/test_release_prerelease.py
+++ b/tests/cli/test_release_prerelease.py
@@ -1,0 +1,173 @@
+"""test_release_prerelease.py -- #425 pre-release tag flagging tests.
+
+Split from tests/cli/test_release.py to keep that file under the
+1000-line MUST limit (AGENTS.md). Covers the #425 change that flags
+SemVer pre-release tags (``-rc.N`` / ``-beta.N`` / ``-alpha.N``) as
+GitHub pre-releases automatically so RC cuts no longer require a manual
+``gh release edit --prerelease`` after the workflow completes.
+
+Coverage:
+- ``is_prerelease_tag`` returns True for ``-rc`` / ``-alpha`` / ``-beta``
+  tags (with and without a leading ``v``) and False for stable tags.
+- ``create_github_release`` appends ``--prerelease`` to the gh argv when
+  ``prerelease=True`` and omits it otherwise; the prerelease state is
+  surfaced in the operator-readable reason string.
+
+Refs #425, #716, #74.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module():
+    scripts_dir = REPO_ROOT / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "release", scripts_dir / "release.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["release"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+release = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# is_prerelease_tag -- pure tag-based decision (#425)
+# ---------------------------------------------------------------------------
+
+
+class TestIsPrereleaseTag:
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "v0.20.0-rc.1",
+            "0.20.0-rc.1",
+            "v1.0.0-alpha.3",
+            "1.0.0-alpha.3",
+            "v0.20.0-beta.2",
+            "0.20.0-beta.7",
+        ],
+    )
+    def test_prerelease_tags_return_true(self, version: str):
+        assert release.is_prerelease_tag(version) is True
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "v0.20.0",
+            "0.20.0",
+            "v1.0.0",
+            "10.20.30",
+        ],
+    )
+    def test_stable_tags_return_false(self, version: str):
+        assert release.is_prerelease_tag(version) is False
+
+    def test_leading_v_is_tolerated(self):
+        # The leading ``v`` itself must not be treated as a pre-release
+        # marker -- only a ``-`` after the core version counts.
+        assert release.is_prerelease_tag("v0.20.0") is False
+        assert release.is_prerelease_tag("v0.20.0-rc.1") is True
+
+
+# ---------------------------------------------------------------------------
+# create_github_release -- --prerelease flag plumbing (#425)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGithubReleasePrerelease:
+    def test_prerelease_true_appends_flag(self, monkeypatch, tmp_path):
+        captured = {}
+
+        monkeypatch.setattr(release.shutil, "which", lambda _: "/usr/bin/gh")
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, reason = release.create_github_release(
+            tmp_path, "0.20.0-rc.1", "deftai/directive", "", prerelease=True
+        )
+        assert ok is True
+        assert "--prerelease" in captured["cmd"], (
+            "#425: gh release create MUST pass --prerelease when "
+            f"prerelease=True; observed argv: {captured['cmd']}"
+        )
+        assert "prerelease" in reason
+
+    def test_prerelease_false_omits_flag(self, monkeypatch, tmp_path):
+        captured = {}
+
+        monkeypatch.setattr(release.shutil, "which", lambda _: "/usr/bin/gh")
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, reason = release.create_github_release(
+            tmp_path, "0.20.0", "deftai/directive", "", prerelease=False
+        )
+        assert ok is True
+        assert "--prerelease" not in captured["cmd"], (
+            "--prerelease MUST NOT appear in argv when prerelease=False; "
+            f"observed: {captured['cmd']}"
+        )
+        assert "prerelease" not in reason
+
+    def test_default_omits_prerelease_flag(self, monkeypatch, tmp_path):
+        # The default (no prerelease kwarg) preserves pre-#425 behaviour:
+        # stable releases are never flagged pre-release.
+        captured = {}
+
+        monkeypatch.setattr(release.shutil, "which", lambda _: "/usr/bin/gh")
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, _reason = release.create_github_release(
+            tmp_path, "0.20.0", "deftai/directive", ""
+        )
+        assert ok is True
+        assert "--prerelease" not in captured["cmd"]
+
+    def test_draft_and_prerelease_both_appear(self, monkeypatch, tmp_path):
+        captured = {}
+
+        monkeypatch.setattr(release.shutil, "which", lambda _: "/usr/bin/gh")
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, reason = release.create_github_release(
+            tmp_path,
+            "0.20.0-rc.1",
+            "deftai/directive",
+            "",
+            draft=True,
+            prerelease=True,
+        )
+        assert ok is True
+        assert "--draft" in captured["cmd"]
+        assert "--prerelease" in captured["cmd"]
+        assert "(draft, prerelease)" in reason

--- a/tests/cli/test_release_upgrade_banner.py
+++ b/tests/cli/test_release_upgrade_banner.py
@@ -265,7 +265,9 @@ class TestPipelineBannerWiring:
         _stub_pipeline(monkeypatch)
         captured: dict = {}
 
-        def fake_create(project_root, version, repo, notes, *, draft=True):
+        def fake_create(
+            project_root, version, repo, notes, *, draft=True, prerelease=False
+        ):
             captured["notes"] = notes
             return True, "created GitHub release v0.21.0 (draft)"
 
@@ -289,7 +291,9 @@ class TestPipelineBannerWiring:
         _stub_pipeline(monkeypatch)
         captured: dict = {}
 
-        def fake_create(project_root, version, repo, notes, *, draft=True):
+        def fake_create(
+            project_root, version, repo, notes, *, draft=True, prerelease=False
+        ):
             captured["notes"] = notes
             return True, "created GitHub release v0.21.0 (draft)"
 

--- a/vbrief/completed/2026-06-16-425-cirelease-explicitly-flag-pre-release-tags-auto-detection-no.vbrief.json
+++ b/vbrief/completed/2026-06-16-425-cirelease-explicitly-flag-pre-release-tags-auto-detection-no.vbrief.json
@@ -1,0 +1,84 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #425"
+  },
+  "plan": {
+    "title": "ci(release): explicitly flag pre-release tags -- auto-detection not working for -rc.N suffix",
+    "id": "425-prerelease-tag-flag",
+    "status": "completed",
+    "narratives": {
+      "Description": "The release pipeline does not mark SemVer pre-release tags (-rc.N, -beta.N, -alpha.N) as GitHub pre-releases, so RC tags publish as normal releases and require a manual `gh release edit --prerelease` correction after every cut. This story makes the pre-release flag explicit and driven by the tag name's SemVer pre-release marker so RC, beta, and alpha cuts are flagged automatically.",
+      "ImplementationPlan": "- In the scripts/release.py module, compute a prerelease boolean from the tag name (true when the version after 'v' contains a '-') and pass it to the `gh release create` call via a `--prerelease` flag.\n- Mirror the same flag in the .github/workflows/release.yml softprops/action-gh-release step using `prerelease: ${{ contains(github.ref_name, '-') }}` so both creation paths agree.\n- Add a unit test in tests/ that verifies the prerelease-decision helper returns true for v0.20.0-rc.1 and v1.0.0-alpha.3 and false for v0.20.0.",
+      "UserStory": "As a release operator, I want pre-release tags flagged automatically, so that I no longer have to manually correct RC releases after every cut.",
+      "Approach": "2026-06-16 codebase verification: still valid/unfixed, but the workflow has been restructured since the issue was filed. .github/workflows/release.yml no longer has a `Create release` step -- it now uploads to a draft via softprops/action-gh-release@v3.0.0 (`Upload binaries to draft release`, draft: true), and the actual `gh release create --draft` happens in scripts/release.py with publish in scripts/release_publish.py. No `prerelease` field exists anywhere in the workflow and no rc/pre-release detection exists in release.py. Fix both create paths so they agree: set `prerelease: ${{ contains(github.ref_name, '-') }}` on the workflow softprops step AND pass a tag-derived `--prerelease` to the `gh release create` in scripts/release.py. (The publish step keeps prerelease as set; it only flips draft.)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/425",
+      "Overview": "## Summary\r\n\r\n`softprops/action-gh-release@v2` as currently configured in `.github/workflows/release.yml` does not automatically flag releases as pre-release when the tag has a SemVer pre-release suffix (`-rc.N`, `-beta.N`, etc.). Both `v0.20.0-rc.1` and `v0.20.0-rc.2` were published as regular releases (`isPrerelease: false`) and required manual `gh release edit --prerelease` intervention after the workflow completed.\r\n\r\nThis is low-cost operational friction now but will compound every time we cut an RC, alpha, or beta going forward.\r\n\r\n## Current state\r\n\r\n`.github/workflows/release.yml` (release job, around line 154-163):\r\n\r\n```yaml\r\n      - name: Create release\r\n        uses: softprops/action-gh-release@v2\r\n        with:\r\n          generate_release_notes: true\r\n          files: |\r\n            artifacts/install-windows-amd64.exe\r\n            artifacts/install-windows-arm64.exe\r\n            artifacts/install-macos-universal\r\n            artifacts/install-linux-amd64\r\n            artifacts/install-linux-arm64\r\n```\r\n\r\nNo `prerelease` field is specified, so the action falls back to its internal heuristic. Whatever that heuristic is, it has missed two rc tags in a row.\r\n\r\n## Evidence\r\n\r\nBoth RC tags required manual correction:\r\n\r\n- `v0.20.0-rc.1`: created as regular release, `gh release edit v0.20.0-rc.1 --prerelease` required\r\n- `v0.20.0-rc.2`: same, `gh release edit v0.20.0-rc.2 --prerelease` required\r\n\r\nBoth tags contain the hyphen-suffix that SemVer defines as pre-release (`-rc.1`, `-rc.2`).\r\n\r\n## Proposed fix\r\n\r\nAdd an explicit `prerelease` field driven by whether the tag name contains a hyphen (SemVer's canonical pre-release marker):\r\n\r\n```yaml\r\n      - name: Create release\r\n        uses: softprops/action-gh-release@v2\r\n        with:\r\n          generate_release_notes: true\r\n          prerelease: ${{ contains(github.ref_name, '-') }}\r\n          files: |\r\n            artifacts/install-windows-amd64.exe\r\n            artifacts/install-windows-arm64.exe\r\n            artifacts/install-macos-universal\r\n            artifacts/install-linux-amd64\r\n            artifacts/install-linux-arm64\r\n```\r\n\r\nBehavior after the fix:\r\n\r\n- `v0.20.0` → `prerelease: false` (no hyphen)\r\n- `v0.20.0-rc.1` → `prerelease: true`\r\n- `v0.20.0-beta.1` → `prerelease: true`\r\n- `v1.0.0-alpha.3` → `prerelease: true`\r\n\r\nCatches every SemVer pre-release qualifier without requiring a maintained list of suffixes.\r\n\r\n## Testing\r\n\r\nBecause the workflow only runs on tag push or `workflow_dispatch`, testing the change safely requires a disposable test tag. Recommend:\r\n\r\n1. Tag `v0.0.0-rc.test` from a throwaway commit.\r\n2. Push → workflow runs → verify release is flagged pre-release in `gh release view`.\r\n3. Delete tag + release.\r\n\r\nAlternatively, the fix can ship bundled with the next real RC (v0.20.1-rc.1 or similar) and will be validated there.\r\n\r\n## Severity / scheduling\r\n\r\n- **P3** — operational polish, not a correctness issue.\r\n- Small enough to land with any other release-workflow touch.\r\n- Not urgent for v0.20.0 final, but nice to have before future RCs.\r\n\r\n## Discovered\r\n\r\nDuring v0.20.0-rc.1 and rc.2 release cuts; manual `--prerelease` correction required both times.\r\n",
+      "Labels": "bug, github-actions"
+    },
+    "items": [
+      {
+        "title": "Flag pre-release tags at create time",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a tag like v0.20.0-rc.1, when the release pipeline creates the GitHub release, then the release is marked prerelease=true with no manual gh release edit."
+        }
+      },
+      {
+        "title": "Leave stable tags as full releases",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a stable tag like v0.20.0 with no hyphen, when the release pipeline creates the release, then it is marked prerelease=false."
+        }
+      },
+      {
+        "title": "Unit-test the prerelease decision helper",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the prerelease-decision helper, when the test suite runs, then it returns true for -rc, -beta, and -alpha tags and false for stable tags."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/release.py",
+          ".github/workflows/release.yml",
+          "tests/cli/test_release.py"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/cli/test_release.py",
+          "uv run python scripts/release.py --help"
+        ],
+        "expected_outputs": [
+          "scripts/release.py passes a prerelease flag to gh release create derived from the tag name",
+          "release.yml softprops step sets prerelease via contains(github.ref_name, '-')",
+          "passing unit test covering rc/beta/alpha/stable tag inputs"
+        ],
+        "depends_on": [],
+        "conflict_group": "release-pipeline",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "Bug fix ingested from GitHub issue #425; no spec-section requirement trace applies."
+      },
+      "completedAt": "2026-06-16T20:12:33Z",
+      "capacityBucket": "new-capability"
+    },
+    "tags": [
+      "bug",
+      "github-actions"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/425",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #425: ci(release): explicitly flag pre-release tags -- auto-detection not working for -rc.N suffix"
+      }
+    ],
+    "updated": "2026-06-16T20:12:33Z"
+  }
+}


### PR DESCRIPTION
## Summary

Pre-release tags (`-rc.N`, `-beta.N`, `-alpha.N`) were not being flagged as GitHub pre-releases, so RC cuts published as normal releases and required a manual `gh release edit --prerelease` correction after every cut. This makes the pre-release flag explicit and tag-driven across both release-creation paths.

- Add `is_prerelease_tag()` to `scripts/release.py` — a pure tag-based decision (true when the version after an optional `v` contains a `-`).
- Pipeline Step 12 derives the boolean and passes `--prerelease` to `gh release create` (the maintainer `task release` path).
- The `release.yml` `softprops/action-gh-release` draft-upload step now sets `prerelease: ${{ contains(github.ref_name, '-') }}` so the workflow path agrees.
- New `tests/cli/test_release_prerelease.py` covers `-rc` / `-alpha` / `-beta` → true and stable → false, plus the `--prerelease` argv plumbing. Two banner-wiring stubs updated for the new `create_github_release` kwarg.

Behavior after the fix:
- `v0.20.0` → `prerelease: false`
- `v0.20.0-rc.1` / `v0.20.0-beta.1` / `v1.0.0-alpha.3` → `prerelease: true`

Note: `_validate_version` deliberately remains strict `X.Y.Z` (existing test asserts pre-release versions are rejected by the orchestrated pipeline), so the helper + flag are scoped additions; the workflow path is the one that fires for RC tag pushes today.

## Test plan

- [x] `uv run pytest tests/cli/test_release_prerelease.py tests/cli/test_release.py` — 105 passed
- [x] `uv run python scripts/release.py --help`
- [x] `task check` — 8290 passed, 5 skipped

Closes #425

## Allocation context
- dispatch_kind: swarm-cohort
- allocation_plan_id: swarm-2026-06-16-onboarding-hardening
- batching_rationale: 4 independent ready stories, distinct conflict groups, zero file overlap per `task swarm:readiness`; one story per agent.
- cohort_vbriefs: vbrief/active/2026-06-16-1668-installer-should-validate-python-311-and-python3-availabilit.vbrief.json, vbrief/active/2026-06-16-425-cirelease-explicitly-flag-pre-release-tags-auto-detection-no.vbrief.json, vbrief/active/2026-06-16-670-task-migratevbrief-produces-non-prettier-clean-output-breaks.vbrief.json, vbrief/active/2026-06-16-696-fixharness-enforce-usermd-content-read-on-returning-sessions.vbrief.json
- operator_approval_evidence: Operator approved parallel swarm dispatch on 2026-06-16 (Cursor; base=master, worker-carries-vBRIEF).

Made with [Cursor](https://cursor.com)