### PR TITLE
docs: canonical fetch-and-run install one-liner (#1661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A copy-pasteable install one-liner for "download from GitHub and install here" (#1661)** -- the README install section and QUICK-START now carry a canonical per-platform fetch-and-run one-liner that downloads the correct release binary from `releases/latest/download`, makes it executable, and runs it headless (`--yes --repo-root . --json`). This gives agents asked to install Deft from GitHub a deterministic path so they stop fabricating a non-existent source-checkout `go build` and failing. A content test guards the guidance against regression. Closes #1661.
 
 ### Changed
 

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -4,6 +4,30 @@ You are reading this because a user told you to, or because a stale `AGENTS.md` 
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
+## Installing Deft from GitHub (fetch-and-run one-liner)
+
+! If Deft is **not yet installed** and you were told to "download and install Deft from GitHub into this directory," do NOT build from a source checkout and do NOT guess a path. Run the canonical per-platform fetch-and-run one-liner below. Each downloads the correct release binary from `https://github.com/deftai/directive/releases/latest/download/<asset>`, makes it executable, then runs it headless against the current directory (`--yes --repo-root . --json`).
+
+**macOS (Intel + Apple Silicon):**
+
+```bash
+curl -fsSL -o /tmp/deft-install https://github.com/deftai/directive/releases/latest/download/install-macos-universal && chmod +x /tmp/deft-install && /tmp/deft-install --yes --repo-root . --json
+```
+
+**Linux** (amd64; use `install-linux-arm64` on Raspberry Pi / ARM):
+
+```bash
+curl -fsSL -o /tmp/deft-install https://github.com/deftai/directive/releases/latest/download/install-linux-amd64 && chmod +x /tmp/deft-install && /tmp/deft-install --yes --repo-root . --json
+```
+
+**Windows** (PowerShell; use `install-windows-arm64.exe` on Surface / Copilot+ PCs):
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/deftai/directive/releases/latest/download/install-windows-amd64.exe -OutFile $env:TEMP\deft-install.exe; & $env:TEMP\deft-install.exe --yes --repo-root . --json
+```
+
+⊗ Do NOT `go build` from a source checkout or a developer-specific path (e.g. a hardcoded `/Users/<name>/...` clone) — the canonical fetch path above never assumes a local clone. Once the installer finishes, continue with Step 1 below.
+
 ## Step 1 — Who are you?
 
 Ask the user: **"Are you (1) using deft in your project, or (2) working on deft itself?"**

--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ The installer guides you through choosing a project directory, installs git if n
 
 On startup, `deft-install` checks the latest GitHub release and warns if the downloaded binary on disk is stale before it changes your project. Offline and CI runs can skip that check with `--no-update-check` or `DEFT_NO_UPDATE_CHECK=1`.
 
+#### Agent / headless one-liner (fetch the release binary and run)
+
+Asked to **"download and install Deft from GitHub into this directory"** — for example by an AI agent or a CI job? Use the canonical per-platform fetch-and-run one-liner below. It downloads the correct release binary from `https://github.com/deftai/directive/releases/latest/download/<asset>`, makes it executable, then runs it headless against the current directory (`--yes --repo-root . --json`). ⊗ Do NOT `go build` from a source checkout or guess a developer-specific path (e.g. a hardcoded `/Users/<name>/...` clone) — the canonical fetch path never assumes a local clone.
+
+**macOS (Intel + Apple Silicon):**
+
+```bash
+curl -fsSL -o /tmp/deft-install https://github.com/deftai/directive/releases/latest/download/install-macos-universal && chmod +x /tmp/deft-install && /tmp/deft-install --yes --repo-root . --json
+```
+
+**Linux** (amd64; use `install-linux-arm64` on Raspberry Pi / ARM):
+
+```bash
+curl -fsSL -o /tmp/deft-install https://github.com/deftai/directive/releases/latest/download/install-linux-amd64 && chmod +x /tmp/deft-install && /tmp/deft-install --yes --repo-root . --json
+```
+
+**Windows** (PowerShell; use `install-windows-arm64.exe` on Surface / Copilot+ PCs):
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/deftai/directive/releases/latest/download/install-windows-amd64.exe -OutFile $env:TEMP\deft-install.exe; & $env:TEMP\deft-install.exe --yes --repo-root . --json
+```
+
 **Building from source (developers only):** requires Go 1.22+
 
 ```bash

--- a/tests/content/test_install_oneliner.py
+++ b/tests/content/test_install_oneliner.py
@@ -1,0 +1,83 @@
+"""test_install_oneliner.py -- Content tests for #1661.
+
+Guards the canonical agent/headless fetch-and-run install one-liner so the
+guidance cannot silently regress. An agent told to "download and install Deft
+from GitHub into this directory" must find a copy-pasteable per-platform
+one-liner that fetches the release binary from `releases/latest/download` and
+runs it headless (`--yes --repo-root . --json`) instead of fabricating a
+source-checkout `go build` path.
+
+Story: #1661
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Release assets published by .github/workflows/release.yml.
+_RELEASE_ASSETS = (
+    "install-macos-universal",
+    "install-linux-amd64",
+    "install-windows-amd64.exe",
+)
+
+_DOC_FILES = ("README.md", "QUICK-START.md")
+
+
+def _doc(name: str) -> str:
+    return (_REPO_ROOT / name).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", _DOC_FILES)
+class TestFetchAndRunOneLiner:
+    """README + QUICK-START must carry the canonical fetch-and-run one-liner."""
+
+    def test_references_releases_latest_download(self, name: str):
+        content = _doc(name)
+        assert "releases/latest/download" in content, (
+            f"{name} must document the fetch-and-run one-liner that downloads "
+            "from releases/latest/download (#1661)."
+        )
+
+    def test_runs_headless_flags(self, name: str):
+        content = _doc(name)
+        assert "--yes --repo-root . --json" in content, (
+            f"{name} one-liner must run the binary headless with "
+            "`--yes --repo-root . --json` (#1661)."
+        )
+
+    def test_covers_each_platform_asset(self, name: str):
+        content = _doc(name)
+        for asset in _RELEASE_ASSETS:
+            assert f"releases/latest/download/{asset}" in content, (
+                f"{name} must reference the {asset} release binary via "
+                f"releases/latest/download/{asset} (#1661)."
+            )
+
+    def test_no_source_build_in_oneliner(self, name: str):
+        """The fetch-and-run command lines must not invoke go build.
+
+        Inspect only lines that reference a concrete release asset
+        (`releases/latest/download/install-...`) -- those are the actual
+        copy-pasteable commands. Prose guidance that *warns against* `go build`
+        is intentionally excluded.
+        """
+        content = _doc(name)
+        command_lines = [
+            line
+            for line in content.splitlines()
+            if "releases/latest/download/install-" in line
+        ]
+        assert command_lines, (
+            f"{name} must contain at least one concrete fetch command "
+            "referencing a release asset (#1661)."
+        )
+        for line in command_lines:
+            assert "go build" not in line, (
+                f"{name}: the fetch-and-run command must not invoke "
+                "`go build` -- it fetches the release binary (#1661)."
+            )


### PR DESCRIPTION
## Summary

An AI agent told to "download and install Deft from GitHub into this directory" had no deterministic fetch-and-run path documented, so it improvised a source `go build` from a fabricated checkout path (a non-existent `/Users/tao/...`) and failed. This adds a canonical, copy-pasteable per-platform one-liner that fetches the correct release binary and runs it headless.

- Adds an **Agent / headless one-liner** section to the README install flow and a top-of-file **Installing Deft from GitHub** section to `QUICK-START.md`.
- Each one-liner downloads the correct asset from `https://github.com/deftai/directive/releases/latest/download/<asset>`, `chmod +x` (where applicable), then runs `--yes --repo-root . --json`.
- Covers macOS (`install-macos-universal`), Linux (`install-linux-amd64` / `install-linux-arm64`), and Windows (`install-windows-amd64.exe` / `install-windows-arm64.exe`) — asset names verified against `.github/workflows/release.yml`.
- The canonical path is source-checkout-free: it never references `go build` or a developer-specific clone path.
- New content test `tests/content/test_install_oneliner.py` asserts the one-liner is present in both docs and references `releases/latest/download`, failing if removed.

Scope was limited to `README.md`, `QUICK-START.md`, and the new content test (plus an append-only CHANGELOG entry). `AGENTS.md` / `templates/` were intentionally not touched (owned by another in-flight agent; QUICK-START already routes agents).

## Test plan

- [x] `uv run pytest tests/content/test_install_oneliner.py` — 8 passed
- [x] `task check` — green (8283 passed, 5 skipped)
- [x] `task verify:encoding` — clean (no mojibake / BOM)

Closes #1661

## Allocation context (#1378)
- dispatch_kind: swarm-cohort
- allocation_plan_id: swarm-2026-06-16-onboarding-hardening
- batching_rationale: Operator rolled #1661 into the active cohort; it is conflict-group `install-docs` with zero file overlap against the in-flight cohort per `task swarm:readiness`. Solo addition to the running swarm.
- cohort_vbriefs: vbrief/active/2026-06-16-1661-installer-agent-told-to-download-and-install-from-github-fab.vbrief.json
- operator_approval_evidence: Operator approved dispatching #1661 now on 2026-06-16 (Cursor; base=master, worker-carries-vBRIEF, "Dispatch #1661 now").

Made with [Cursor](https://cursor.com)