### PR TITLE
feat(codebase): add provider contract layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Codebase structure now has a provider-ready contract layer (#1595)** -- Directive can emit a dependency-free `codebase-map.v1` artifact, validate an external `codebase-provider.v1` response, and fall back to the default extractor when no conformant provider is configured. The codeStructure validator now dogfoods PR3 discipline checks that keep authored metadata free of derived facts while the projection registry keeps canonical entries command-agnostic. Refs #1498 #1530 #1659.
 
 ### Changed
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -340,6 +340,7 @@ tasks:
       - verify:pack-drift
       - verify-wip-cap-framework-self-check
       - vbrief:validate
+      - codebase:validate-structure
       - verify-strategy-output
     cmds:
       - echo "All checks passed"

--- a/docs/code-structure-profile.md
+++ b/docs/code-structure-profile.md
@@ -1,6 +1,6 @@
 # CodeStructure Profile
 
-Status: accepted for #1595 PR 2
+Status: accepted for #1595 PR 2; extended by #1595 PR 3
 
 Related: [#1595](https://github.com/deftai/directive/issues/1595), [#1498](https://github.com/deftai/directive/issues/1498), [#1618](https://github.com/deftai/directive/issues/1618), [#1379](https://github.com/deftai/directive/issues/1379)
 
@@ -10,9 +10,12 @@ Related: [#1595](https://github.com/deftai/directive/issues/1595), [#1498](https
 maintainers a stable module/path/pattern record without making source comments,
 generated MAPs, or local indexes authoritative.
 
-The PR 2 profile is intentionally limited to metadata shape and validation.
-Brownfield extraction, MAP generation, generated headers, local indexes, and
-consumer propagation are later slices of #1595.
+The PR 2 profile was intentionally limited to metadata shape and validation.
+PR 3 adds the contract layer between authored metadata and later projections:
+a dependency-free default extractor, a provider artifact handshake, a
+projection-kind registry, and discipline checks that keep authored
+`codeStructure` focused on canonical intent. MAP rendering, generated headers,
+local indexes, and consumer propagation are still later slices of #1595.
 
 ## Physical Home
 
@@ -75,5 +78,68 @@ task codebase:validate-structure
 
 The validator checks stable ids, safe repository-relative globs and paths,
 module references, duplicate ownership conflicts, projection manifest entries,
-and unknown-key tolerance. It does not extract metadata from code and does not
-generate projections.
+unknown-key tolerance, and PR 3 source-of-truth discipline. It hard-blocks known
+derived-fact keys such as imports, coupling, file counts, languages, symbols, or
+entry points from authored metadata. It also rejects multiple codeStructure
+homes in one file, rejects codeStructure-bearing vBRIEF siblings during default
+project discovery, verifies existing generated projections carry a generated
+banner/source pointer, and checks glossary URIs when a project root is known.
+
+Boundedness findings such as unusually large `filePurposeOverrides[]` are
+warnings by default. Pass `--strict` through the task when a caller wants those
+warnings to fail:
+
+```bash
+task codebase:validate-structure -- --strict
+```
+
+## Extraction Contract
+
+Run:
+
+```bash
+task codebase:extract-default
+```
+
+The default extractor emits a `codebase-map.v1` JSON artifact to stdout. It
+uses `codeStructure.modules[].pathGlobs` when available and falls back to
+top-level repository directories when no authored metadata exists. Coupling,
+entry points, and language distribution are derived with deterministic
+repository walking and import-line or filename heuristics only; no network,
+model, parser, or AST dependency is used. The artifact carries provenance and
+degraded markers so later MAP rendering can distinguish authored intent from
+heuristic facts.
+
+Run:
+
+```bash
+task codebase:provider-map -- --provider-command "<provider argv>"
+```
+
+External providers may replace the default artifact only when they emit a JSON
+object with `formatVersion: "codebase-map.v1"`,
+`contractVersion: "codebase-provider.v1"`, `kind: "codebase-map"`, provider
+metadata, source metadata, a non-empty `modules[]` array whose entries carry
+`id`, `files`, and `derivedFrom`, and the tier-1 arrays `coupling[]`,
+`entryPoints[]`, `languageDistribution[]`, and `degraded[]`. The
+language-neutral JSON Schema at `vbrief/schemas/codebase-map.schema.json` is
+the normative contract: `scripts/codebase_provider.py` validates provider
+artifacts by interpreting that schema with a dependency-free local subset
+validator, so the contract survives a future host-language rewrite instead of
+living only in Python field checks. `tests/fixtures/codebase-map.v1.golden.json`
+is the canonical example and regression fixture. Missing, failing, or
+mismatched providers fall back to the default extractor instead of failing the
+metadata validation path.
+
+## Projection Registry
+
+`projectionManifest[].kind` remains invocation-agnostic. For the first kind,
+`codebase-map`, Directive owns the format and provider contract in
+`scripts/codebase_projection_registry.py` and exposes it with:
+
+```bash
+task codebase:projection-registry -- --kind codebase-map
+```
+
+The registry stores semantic actions, not literal `task ...` command strings,
+so canonical metadata stays portable across task-runner follow-ups.

--- a/docs/codebase-map-source-of-truth.md
+++ b/docs/codebase-map-source-of-truth.md
@@ -135,9 +135,22 @@ constraints:
 - full source-code generation from vBRIEF metadata
 - AST support for every language in the first implementation slice
 
-## PR 2 Hand-Off
+## PR 3 Contract Layer
 
-The next PR should define the first concrete `codeStructure` schema/profile and
-its validation behavior at `PROJECT-DEFINITION.plan.architecture.codeStructure`.
-It should remain focused on canonical-intent shape and validation, not
-extraction or MAP rendering.
+PR 2 defined and dogfooded the first concrete `codeStructure` profile at
+`PROJECT-DEFINITION.plan.architecture.codeStructure`.
+
+PR 3 adds the contract layer needed before MAP rendering: a deterministic
+dependency-free default extractor, a provider artifact handshake, a
+projection-kind registry, and stricter discipline checks that keep derived facts
+out of authored metadata. The provider artifact contract is published as the
+language-neutral JSON Schema `vbrief/schemas/codebase-map.schema.json`. That
+schema is the normative contract, and `scripts/codebase_provider.py` validates
+provider artifacts by interpreting the schema with a dependency-free local
+subset validator rather than maintaining a second hand-written Python contract.
+`tests/fixtures/codebase-map.v1.golden.json` is the canonical example output
+and regression anchor, so out-of-process providers do not have to
+reverse-engineer the Python extractor. This keeps the durable contract on the
+schema side of the #1530 host-language rewrite boundary. This is still pre-MAP:
+`.planning/codebase/MAP.md` generation and freshness checks remain the next
+slice.

--- a/scripts/code_structure_validate.py
+++ b/scripts/code_structure_validate.py
@@ -14,7 +14,7 @@ import argparse
 import json
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -22,6 +22,25 @@ STABLE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 CODE_STRUCTURE_VERSION = "0.1"
 DIRECTIVE_HOME = "x-directive/architecture.codeStructure"
 PLAN_HOME = "plan.architecture.codeStructure"
+PROJECT_DEFINITION_PATH = Path("vbrief/PROJECT-DEFINITION.vbrief.json")
+GENERATED_PROJECTION_MARKERS = ("generated", "do not edit", "source of truth")
+DERIVED_FACT_KEYS = {
+    "callgraph",
+    "classes",
+    "coupling",
+    "dependencies",
+    "dependencygraph",
+    "entrypoints",
+    "exports",
+    "filecount",
+    "files",
+    "functions",
+    "imports",
+    "language",
+    "languages",
+    "loc",
+    "symbols",
+}
 
 
 class CodeStructureConfigError(RuntimeError):
@@ -42,6 +61,7 @@ class ValidationResult:
     """Validation result for one codeStructure record."""
 
     errors: list[Finding]
+    warnings: list[Finding] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -86,23 +106,59 @@ def _safe_relative_path(value: object) -> bool:
     return ".." not in parts
 
 
-def extract_code_structure(data: dict[str, Any]) -> ExtractedCodeStructure | None:
-    """Return a codeStructure record from the canonical home or consumer fallback."""
+def _normal_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _project_relative(path: Path, project_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(project_root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def extract_code_structure_homes(data: dict[str, Any]) -> list[ExtractedCodeStructure]:
+    """Return every recognized codeStructure home in deterministic priority order."""
+    homes: list[ExtractedCodeStructure] = []
     plan = data.get("plan")
     if isinstance(plan, dict):
         architecture = plan.get("architecture")
         if isinstance(architecture, dict):
             record = architecture.get("codeStructure")
             if isinstance(record, dict):
-                return ExtractedCodeStructure(record=record, home=PLAN_HOME)
+                homes.append(ExtractedCodeStructure(record=record, home=PLAN_HOME))
 
     extension = data.get("x-directive/architecture")
     if isinstance(extension, dict):
         record = extension.get("codeStructure")
         if isinstance(record, dict):
-            return ExtractedCodeStructure(record=record, home=DIRECTIVE_HOME)
+            homes.append(ExtractedCodeStructure(record=record, home=DIRECTIVE_HOME))
+    return homes
 
-    return None
+
+def extract_code_structure(data: dict[str, Any]) -> ExtractedCodeStructure | None:
+    """Return a codeStructure record from the canonical home or consumer fallback."""
+    homes = extract_code_structure_homes(data)
+    return homes[0] if homes else None
+
+
+def _scan_for_derived_fact_keys(value: object, errors: list[Finding], location: str) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_location = f"{location}.{key}" if location else str(key)
+            if _normal_key(str(key)) in DERIVED_FACT_KEYS:
+                errors.append(
+                    _finding(
+                        "CS-DERIVED-FACT",
+                        f"codeStructure must not author derived fact key {key!r}",
+                        key_location,
+                    )
+                )
+            _scan_for_derived_fact_keys(nested, errors, key_location)
+        return
+    if isinstance(value, list):
+        for index, nested in enumerate(value):
+            _scan_for_derived_fact_keys(nested, errors, f"{location}[{index}]")
 
 
 def _validate_required_arrays(record: dict[str, Any], errors: list[Finding], source: str) -> None:
@@ -285,7 +341,17 @@ def _validate_allowed_patterns(
                 )
 
 
-def _validate_projection_manifest(entries: list[Any], errors: list[Finding]) -> None:
+def _projection_has_generated_banner(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")[:2048].lower()
+    except OSError:
+        return False
+    return all(marker in text for marker in GENERATED_PROJECTION_MARKERS)
+
+
+def _validate_projection_manifest(
+    entries: list[Any], errors: list[Finding], project_root: Path | None
+) -> None:
     seen_paths: set[str] = set()
     for index, entry in enumerate(entries):
         location = f"projectionManifest[{index}]"
@@ -313,6 +379,14 @@ def _validate_projection_manifest(entries: list[Any], errors: list[Finding]) -> 
             errors.append(
                 _finding("CS-PROJECTION", "projection source must be non-empty", location)
             )
+        elif entry.get("source") not in {PLAN_HOME, DIRECTIVE_HOME}:
+            errors.append(
+                _finding(
+                    "CS-PROJECTION-SOURCE",
+                    f"projection source must be {PLAN_HOME!r} or {DIRECTIVE_HOME!r}",
+                    f"{location}.source",
+                )
+            )
         generated = entry.get("generated")
         if not isinstance(generated, bool):
             errors.append(
@@ -333,6 +407,20 @@ def _validate_projection_manifest(entries: list[Any], errors: list[Finding]) -> 
                         "CS-PROJECTION-COMMAND",
                         f"projectionManifest must not store runner-specific {command_key}",
                         f"{location}.{command_key}",
+                    )
+                )
+        if (
+            project_root is not None
+            and isinstance(path_value, str)
+            and _safe_relative_path(path_value)
+        ):
+            projection_path = project_root / path_value
+            if projection_path.exists() and not _projection_has_generated_banner(projection_path):
+                errors.append(
+                    _finding(
+                        "CS-PROJECTION-BANNER",
+                        "existing projection path must carry a generated banner and source pointer",
+                        f"{location}.path",
                     )
                 )
 
@@ -374,7 +462,9 @@ def _validate_file_purpose_overrides(
             _validate_module_ref(entry.get("module"), module_ids, f"{location}.module", errors)
 
 
-def _validate_glossary_refs(entries: object, errors: list[Finding]) -> None:
+def _validate_glossary_refs(
+    entries: object, errors: list[Finding], project_root: Path | None
+) -> None:
     if entries is None:
         return
     if not isinstance(entries, list):
@@ -387,16 +477,83 @@ def _validate_glossary_refs(entries: object, errors: list[Finding]) -> None:
             continue
         if not _non_empty_string(entry.get("term")):
             errors.append(_finding("CS-GLOSSARY", "glossary ref needs term", location))
-        if "uri" in entry and not _safe_relative_path(entry.get("uri")):
+        uri = entry.get("uri")
+        if "uri" in entry and not _safe_relative_path(uri):
             errors.append(
                 _finding("CS-PATH", "glossary ref uri must be repository-relative", location)
             )
+        elif project_root is not None and isinstance(uri, str):
+            target = project_root / uri
+            if not target.exists():
+                errors.append(
+                    _finding(
+                        "CS-GLOSSARY-URI",
+                        f"glossary ref uri does not exist: {uri!r}",
+                        f"{location}.uri",
+                    )
+                )
 
 
-def validate_code_structure(record: dict[str, Any], source: str = "<memory>") -> ValidationResult:
+def _validate_boundedness(record: dict[str, Any], warnings: list[Finding]) -> None:
+    modules = _as_list(record.get("modules"))
+    overrides = _as_list(record.get("filePurposeOverrides"))
+    if overrides and len(overrides) > max(10, len(modules) * 2):
+        warnings.append(
+            _finding(
+                "CS-BOUNDEDNESS",
+                (
+                    "filePurposeOverrides should stay bounded to human overrides, "
+                    "not become a per-file registry"
+                ),
+                "filePurposeOverrides",
+            )
+        )
+
+    ownership = _as_list(record.get("pathOwnership"))
+    if ownership and len(ownership) > max(12, len(modules) * 3):
+        warnings.append(
+            _finding(
+                "CS-BOUNDEDNESS",
+                (
+                    "pathOwnership is large relative to module count; "
+                    "prefer module globs where possible"
+                ),
+                "pathOwnership",
+            )
+        )
+
+    for index, module in enumerate(modules):
+        if not isinstance(module, dict):
+            continue
+        globs = module.get("pathGlobs")
+        if not isinstance(globs, list) or len(globs) != 1 or not isinstance(globs[0], str):
+            continue
+        glob_value = globs[0]
+        if not _has_glob_magic(glob_value := str(glob_value)):
+            warnings.append(
+                _finding(
+                    "CS-SINGLE-FILE-MODULE",
+                    (
+                        "module has a single non-glob path; ensure this is intentional "
+                        "and not per-file metadata"
+                    ),
+                    f"modules[{index}].pathGlobs[0]",
+                )
+            )
+
+
+def _has_glob_magic(value: str) -> bool:
+    return any(char in value for char in "*?[")
+
+
+def validate_code_structure(
+    record: dict[str, Any], source: str = "<memory>", project_root: Path | None = None
+) -> ValidationResult:
     """Validate one codeStructure record."""
     errors: list[Finding] = []
+    warnings: list[Finding] = []
     _validate_required_arrays(record, errors, source)
+    _scan_for_derived_fact_keys(record, errors, "codeStructure")
 
     glob_owner: dict[str, str] = {}
     module_ids: set[str] = set()
@@ -414,10 +571,11 @@ def validate_code_structure(record: dict[str, Any], source: str = "<memory>") ->
 
     _validate_path_ownership(_as_list(record.get("pathOwnership")), module_ids, errors)
     _validate_allowed_patterns(_as_list(record.get("allowedPatterns")), module_ids, errors)
-    _validate_projection_manifest(_as_list(record.get("projectionManifest")), errors)
+    _validate_projection_manifest(_as_list(record.get("projectionManifest")), errors, project_root)
     _validate_file_purpose_overrides(record.get("filePurposeOverrides"), module_ids, errors)
-    _validate_glossary_refs(record.get("glossaryRefs"), errors)
-    return ValidationResult(errors=errors)
+    _validate_glossary_refs(record.get("glossaryRefs"), errors, project_root)
+    _validate_boundedness(record, warnings)
+    return ValidationResult(errors=errors, warnings=warnings)
 
 
 def load_json_file(path: Path) -> dict[str, Any]:
@@ -435,11 +593,40 @@ def load_json_file(path: Path) -> dict[str, Any]:
     return data
 
 
-def validate_file(path: Path) -> ValidationResult:
+def validate_file(
+    path: Path, *, project_root: Path | None = None, allow_standalone: bool = True
+) -> ValidationResult:
     """Load and validate the codeStructure record in *path*."""
     data = load_json_file(path)
-    extracted = extract_code_structure(data)
-    if extracted is None:
+    homes = extract_code_structure_homes(data)
+    errors: list[Finding] = []
+    if len(homes) > 1:
+        errors.append(
+            _finding(
+                "CS-HOME-CONFLICT",
+                (
+                    "only one codeStructure home is allowed; found "
+                    f"{', '.join(home.home for home in homes)}"
+                ),
+                str(path),
+            )
+        )
+    if project_root is not None and not allow_standalone:
+        rel_path = _project_relative(path, project_root)
+        if rel_path != PROJECT_DEFINITION_PATH.as_posix() and homes:
+            errors.append(
+                _finding(
+                    "CS-HOME",
+                    (
+                        "canonical codeStructure metadata must live in "
+                        "vbrief/PROJECT-DEFINITION.vbrief.json; sibling files "
+                        "must be generated projections"
+                    ),
+                    str(path),
+                )
+            )
+
+    if not homes:
         return ValidationResult(
             errors=[
                 _finding(
@@ -449,22 +636,41 @@ def validate_file(path: Path) -> ValidationResult:
                 )
             ]
         )
-    return validate_code_structure(extracted.record, source=f"{path}:{extracted.home}")
+
+    extracted = homes[0]
+    result = validate_code_structure(
+        extracted.record,
+        source=f"{path}:{extracted.home}",
+        project_root=project_root,
+    )
+    return ValidationResult(errors=errors + result.errors, warnings=result.warnings)
 
 
 def discover_code_structure_paths(project_root: Path) -> list[Path]:
     """Discover codeStructure-bearing vBRIEFs for a project root."""
-    paths: list[Path] = []
+    paths: dict[str, Path] = {}
     project_def = project_root / "vbrief" / "PROJECT-DEFINITION.vbrief.json"
     if project_def.exists():
         try:
             data = load_json_file(project_def)
         except CodeStructureConfigError:
-            paths.append(project_def)
+            paths[project_def.as_posix()] = project_def
         else:
             if extract_code_structure(data) is not None:
-                paths.append(project_def)
-    return paths
+                paths[project_def.as_posix()] = project_def
+
+    vbrief_root = project_root / "vbrief"
+    if vbrief_root.exists():
+        for vbrief_path in sorted(vbrief_root.rglob("*.vbrief.json")):
+            if vbrief_path == project_def:
+                continue
+            try:
+                data = load_json_file(vbrief_path)
+            except CodeStructureConfigError:
+                continue
+            if extract_code_structure(data) is not None:
+                paths[vbrief_path.as_posix()] = vbrief_path
+    return [paths[key] for key in sorted(paths)]
 
 
 def _result_to_dict(path: Path, result: ValidationResult) -> dict[str, Any]:
@@ -475,6 +681,10 @@ def _result_to_dict(path: Path, result: ValidationResult) -> dict[str, Any]:
             {"code": finding.code, "message": finding.message, "location": finding.location}
             for finding in result.errors
         ],
+        "warnings": [
+            {"code": finding.code, "message": finding.message, "location": finding.location}
+            for finding in result.warnings
+        ],
     }
 
 
@@ -483,6 +693,7 @@ def _config_error_to_dict(path: Path, error: CodeStructureConfigError) -> dict[s
         "path": str(path),
         "ok": False,
         "errors": [{"code": "CS-CONFIG", "message": str(error), "location": str(path)}],
+        "warnings": [],
     }
 
 
@@ -492,11 +703,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--project-root", default=".", help="Project root for default discovery.")
     parser.add_argument("--path", action="append", help="Explicit codeStructure vBRIEF path.")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON summary.")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as failures.")
     args = parser.parse_args(argv)
 
     project_root = Path(args.project_root)
+    explicit_paths = bool(args.path)
     paths = (
-        [Path(p) for p in args.path] if args.path else discover_code_structure_paths(project_root)
+        [Path(p) for p in args.path]
+        if explicit_paths
+        else discover_code_structure_paths(project_root)
     )
 
     if not paths:
@@ -510,13 +725,17 @@ def main(argv: list[str] | None = None) -> int:
     exit_code = 0
     for path in paths:
         try:
-            result = validate_file(path)
+            result = validate_file(
+                path,
+                project_root=None if explicit_paths else project_root,
+                allow_standalone=explicit_paths,
+            )
         except CodeStructureConfigError as exc:
             summaries.append(_config_error_to_dict(path, exc))
             exit_code = 2
             continue
         summaries.append(_result_to_dict(path, result))
-        if not result.ok and exit_code == 0:
+        if exit_code == 0 and (not result.ok or (args.strict and result.warnings)):
             exit_code = 1
 
     if args.json:
@@ -524,9 +743,6 @@ def main(argv: list[str] | None = None) -> int:
     else:
         for summary in summaries:
             path = summary["path"]
-            if summary["ok"]:
-                print(f"OK: {path}")
-                continue
             for finding in summary["errors"]:
                 prefix = "ERROR" if finding["code"] == "CS-CONFIG" else "FAIL"
                 output = sys.stderr if prefix == "ERROR" else sys.stdout
@@ -535,6 +751,13 @@ def main(argv: list[str] | None = None) -> int:
                     f"{finding['location']}: {finding['message']}",
                     file=output,
                 )
+            for finding in summary["warnings"]:
+                print(
+                    f"WARN: {path}: {finding['code']}: "
+                    f"{finding['location']}: {finding['message']}"
+                )
+            if summary["ok"] and (not args.strict or not summary["warnings"]):
+                print(f"OK: {path}")
     return exit_code
 
 

--- a/scripts/codebase_default_extractor.py
+++ b/scripts/codebase_default_extractor.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Dependency-free default extractor for #1595 codebase-map artifacts.
+
+The default path is intentionally modest: it walks the repository, applies the
+authored ``codeStructure`` module globs when available, and uses import-line
+heuristics for coarse coupling. It does not parse ASTs, call the network, or
+ask a model to summarize code. Richer providers can replace this artifact via
+``scripts/codebase_provider.py`` once they satisfy the provider contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import code_structure_validate
+from codebase_projection_registry import (
+    CODEBASE_MAP_FORMAT_VERSION,
+    CODEBASE_MAP_KIND,
+    CODEBASE_PROVIDER_CONTRACT_VERSION,
+)
+
+DEFAULT_PROVIDER_NAME = "directive-default-extractor"
+DEFAULT_PROVIDER_VERSION = "0.1"
+MAX_IMPORT_SCAN_BYTES = 262_144
+MAX_FILES_PER_MODULE = 100
+MAX_EVIDENCE_PER_EDGE = 5
+
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "swarm-worktrees",
+}
+
+LANGUAGE_BY_SUFFIX = {
+    ".go": "Go",
+    ".js": "JavaScript",
+    ".jsx": "JavaScript",
+    ".json": "JSON",
+    ".md": "Markdown",
+    ".py": "Python",
+    ".sh": "Shell",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".yaml": "YAML",
+    ".yml": "YAML",
+}
+
+ENTRYPOINT_NAMES = {
+    "__main__.py",
+    "cli.py",
+    "cmd.py",
+    "index.js",
+    "index.ts",
+    "main.go",
+    "main.py",
+    "run",
+    "run.py",
+}
+
+IMPORT_PATTERNS = [
+    re.compile(r"^\s*import\s+([A-Za-z_][\w.]*)"),
+    re.compile(r"^\s*from\s+([A-Za-z_][\w.]*)\s+import\s+"),
+    re.compile(r"^\s*import\s+.*?\s+from\s+[\"']([^\"']+)[\"']"),
+    re.compile(r"^\s*(?:const|let|var)\s+.*?=\s*require\([\"']([^\"']+)[\"']\)"),
+    re.compile(r"^\s*import\s+[\"']([^\"']+)[\"']"),
+]
+
+
+def _posix(path: Path) -> str:
+    return path.as_posix()
+
+
+def _relative_file(path: Path, project_root: Path) -> str:
+    return _posix(path.relative_to(project_root))
+
+
+def default_code_structure_path(project_root: Path, code_structure_path: Path | None) -> Path:
+    """Return the authored codeStructure source path used by the default extractor."""
+    return code_structure_path or project_root / "vbrief" / "PROJECT-DEFINITION.vbrief.json"
+
+
+def _stable_id(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "root"
+
+
+def _repo_files(project_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(project_root):
+        dirnames[:] = [dirname for dirname in dirnames if dirname not in SKIP_DIRS]
+        for filename in filenames:
+            files.append(Path(dirpath) / filename)
+    return sorted(files, key=lambda item: _relative_file(item, project_root))
+
+
+def _glob_files(project_root: Path, globs: list[str]) -> list[Path]:
+    files: dict[str, Path] = {}
+    for glob_value in globs:
+        for match in project_root.glob(glob_value):
+            if not match.is_file():
+                continue
+            rel_parts = match.relative_to(project_root).parts
+            if any(part in SKIP_DIRS for part in rel_parts):
+                continue
+            files[_relative_file(match, project_root)] = match
+    return [files[key] for key in sorted(files)]
+
+
+def _load_authored_code_structure(
+    project_root: Path, code_structure_path: Path | None
+) -> tuple[dict[str, Any] | None, str | None]:
+    path = default_code_structure_path(project_root, code_structure_path)
+    if not path.exists():
+        return None, None
+    data = code_structure_validate.load_json_file(path)
+    extracted = code_structure_validate.extract_code_structure(data)
+    if extracted is None:
+        return None, None
+    return extracted.record, extracted.home
+
+
+def _module_prefixes(module: dict[str, Any], files: list[Path], project_root: Path) -> set[str]:
+    prefixes: set[str] = set()
+    for glob_value in module.get("pathGlobs", []):
+        if not isinstance(glob_value, str):
+            continue
+        first = glob_value.split("/", maxsplit=1)[0]
+        if (
+            first
+            and not code_structure_validate._has_glob_magic(first)
+            and first not in {".", "**"}
+        ):
+            prefixes.add(first.removesuffix(".py"))
+    for file_path in files:
+        rel_parts = file_path.relative_to(project_root).parts
+        if len(rel_parts) > 1:
+            prefixes.add(rel_parts[0])
+        elif file_path.suffix == ".py":
+            prefixes.add(file_path.stem)
+    return {prefix for prefix in prefixes if prefix}
+
+
+def _curated_modules(
+    project_root: Path, code_structure: dict[str, Any]
+) -> tuple[list[dict[str, Any]], dict[str, str], dict[str, set[str]], list[dict[str, str]]]:
+    artifacts: list[dict[str, Any]] = []
+    file_to_module: dict[str, str] = {}
+    prefixes_by_module: dict[str, set[str]] = {}
+    degraded: list[dict[str, str]] = []
+
+    for raw_module in code_structure.get("modules", []):
+        if not isinstance(raw_module, dict):
+            continue
+        module_id = str(raw_module.get("id", "unknown"))
+        globs = [value for value in raw_module.get("pathGlobs", []) if isinstance(value, str)]
+        files = _glob_files(project_root, globs)
+        rel_files = [_relative_file(path, project_root) for path in files]
+        for rel_path in rel_files:
+            file_to_module.setdefault(rel_path, module_id)
+        if len(rel_files) > MAX_FILES_PER_MODULE:
+            degraded.append(
+                {
+                    "code": "MODULE-FILES-TRUNCATED",
+                    "module": module_id,
+                    "message": (
+                        f"Module file list was truncated to {MAX_FILES_PER_MODULE} "
+                        "deterministic entries."
+                    ),
+                }
+            )
+        artifacts.append(
+            {
+                "id": module_id,
+                "name": raw_module.get("name"),
+                "purpose": raw_module.get("purpose"),
+                "pathGlobs": globs,
+                "fileCount": len(rel_files),
+                "files": rel_files[:MAX_FILES_PER_MODULE],
+                "derivedFrom": {
+                    "intent": "codeStructure.modules[]",
+                    "files": "repository-glob-walk",
+                },
+            }
+        )
+        prefixes_by_module[module_id] = _module_prefixes(raw_module, files, project_root)
+    return artifacts, file_to_module, prefixes_by_module, degraded
+
+
+def _directory_modules(
+    project_root: Path,
+) -> tuple[list[dict[str, Any]], dict[str, str], dict[str, set[str]], list[dict[str, str]]]:
+    grouped: dict[str, list[Path]] = defaultdict(list)
+    for file_path in _repo_files(project_root):
+        parts = file_path.relative_to(project_root).parts
+        if not parts:
+            continue
+        top = parts[0] if len(parts) > 1 else "root-files"
+        grouped[top].append(file_path)
+
+    modules: list[dict[str, Any]] = []
+    file_to_module: dict[str, str] = {}
+    prefixes_by_module: dict[str, set[str]] = {}
+    degraded_markers: list[dict[str, str]] = [
+        {
+            "code": "NO-CODESTRUCTURE",
+            "message": (
+                "No authored codeStructure metadata was found; modules were derived from "
+                "top-level repository paths."
+            ),
+        }
+    ]
+    for top in sorted(grouped):
+        module_id = _stable_id(top)
+        rel_files = [_relative_file(path, project_root) for path in sorted(grouped[top])]
+        for rel_path in rel_files:
+            file_to_module.setdefault(rel_path, module_id)
+        if len(rel_files) > MAX_FILES_PER_MODULE:
+            degraded_markers.append(
+                {
+                    "code": "MODULE-FILES-TRUNCATED",
+                    "module": module_id,
+                    "message": (
+                        f"Module file list was truncated to {MAX_FILES_PER_MODULE} "
+                        "deterministic entries."
+                    ),
+                }
+            )
+        modules.append(
+            {
+                "id": module_id,
+                "name": top,
+                "purpose": None,
+                "pathGlobs": [f"{top}/**/*" if top != "root-files" else "*"],
+                "fileCount": len(rel_files),
+                "files": rel_files[:MAX_FILES_PER_MODULE],
+                "derivedFrom": {
+                    "intent": "directory-derived-fallback",
+                    "files": "repository-tree-walk",
+                },
+            }
+        )
+        prefixes_by_module[module_id] = {top} if top != "root-files" else set()
+
+    return modules, file_to_module, prefixes_by_module, degraded_markers
+
+
+def _read_imports(path: Path) -> list[tuple[int, str]]:
+    if path.suffix not in {".go", ".js", ".jsx", ".py", ".ts", ".tsx"}:
+        return []
+    try:
+        if path.stat().st_size > MAX_IMPORT_SCAN_BYTES:
+            return []
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+
+    imports: list[tuple[int, str]] = []
+    in_go_import_block = False
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if path.suffix == ".go":
+            if stripped == "import (":
+                in_go_import_block = True
+                continue
+            if in_go_import_block and stripped == ")":
+                in_go_import_block = False
+                continue
+            if in_go_import_block:
+                match = re.search(r'"([^"]+)"', stripped)
+                if match:
+                    imports.append((line_number, match.group(1)))
+                continue
+            match = re.match(r'^\s*import\s+"([^"]+)"', line)
+            if match:
+                imports.append((line_number, match.group(1)))
+            continue
+
+        for pattern in IMPORT_PATTERNS:
+            match = pattern.match(line)
+            if match:
+                imports.append((line_number, match.group(1)))
+                break
+    return imports
+
+
+def _import_targets(ref: str, prefixes_by_module: dict[str, set[str]]) -> set[str]:
+    if ref.startswith("."):
+        return set()
+    normalized = ref.removeprefix("@")
+    first_segment = re.split(r"[/.]", normalized, maxsplit=1)[0]
+    targets: set[str] = set()
+    for module_id, prefixes in prefixes_by_module.items():
+        if first_segment in prefixes or ref in prefixes:
+            targets.add(module_id)
+    return targets
+
+
+def _coupling_edges(
+    project_root: Path, file_to_module: dict[str, str], prefixes_by_module: dict[str, set[str]]
+) -> list[dict[str, Any]]:
+    edges: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for rel_path, source_module in sorted(file_to_module.items()):
+        path = project_root / rel_path
+        for line_number, import_ref in _read_imports(path):
+            for target_module in _import_targets(import_ref, prefixes_by_module):
+                if target_module == source_module:
+                    continue
+                evidence = edges[(source_module, target_module)]
+                if len(evidence) < MAX_EVIDENCE_PER_EDGE:
+                    evidence.append(
+                        {"path": rel_path, "line": line_number, "import": import_ref}
+                    )
+
+    return [
+        {
+            "from": source,
+            "to": target,
+            "derivedFrom": "import-line-heuristic",
+            "confidence": "heuristic",
+            "evidence": evidence,
+        }
+        for (source, target), evidence in sorted(edges.items())
+    ]
+
+
+def _entry_points(file_to_module: dict[str, str]) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for rel_path, module_id in sorted(file_to_module.items()):
+        path = Path(rel_path)
+        if path.name in ENTRYPOINT_NAMES or path.parts[:1] == ("cmd",):
+            entries.append(
+                {
+                    "path": rel_path,
+                    "module": module_id,
+                    "derivedFrom": "filename-heuristic",
+                    "confidence": "heuristic",
+                }
+            )
+    return entries
+
+
+def _language_distribution(file_to_module: dict[str, str]) -> list[dict[str, Any]]:
+    counts = Counter(
+        LANGUAGE_BY_SUFFIX.get(Path(rel_path).suffix, "Other") for rel_path in file_to_module
+    )
+    return [
+        {"language": language, "files": count, "derivedFrom": "extension-heuristic"}
+        for language, count in sorted(counts.items())
+    ]
+
+
+def build_codebase_map(
+    project_root: Path,
+    *,
+    code_structure_path: Path | None = None,
+    fallback_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic tier-1 codebase-map artifact."""
+    project_root = project_root.resolve()
+    code_structure, source_home = _load_authored_code_structure(project_root, code_structure_path)
+    source_path = default_code_structure_path(project_root, code_structure_path)
+
+    if code_structure is not None:
+        modules, file_to_module, prefixes_by_module, degraded = _curated_modules(
+            project_root, code_structure
+        )
+    else:
+        modules, file_to_module, prefixes_by_module, degraded = _directory_modules(project_root)
+
+    degraded.append(
+        {
+            "code": "AST-FREE-HEURISTICS",
+            "message": (
+                "Default extractor uses repository walking and import-line heuristics only; "
+                "no AST or language parser provider was configured."
+            ),
+        }
+    )
+    if fallback_reason:
+        degraded.append({"code": "PROVIDER-FALLBACK", "message": fallback_reason})
+
+    return {
+        "formatVersion": CODEBASE_MAP_FORMAT_VERSION,
+        "contractVersion": CODEBASE_PROVIDER_CONTRACT_VERSION,
+        "kind": CODEBASE_MAP_KIND,
+        "provider": {
+            "name": DEFAULT_PROVIDER_NAME,
+            "version": DEFAULT_PROVIDER_VERSION,
+            "mode": "default",
+            "degraded": True,
+            **({"fallbackReason": fallback_reason} if fallback_reason else {}),
+        },
+        "source": {
+            "projectRoot": str(project_root),
+            "codeStructurePath": str(source_path),
+            "codeStructureHome": source_home,
+        },
+        "modules": modules,
+        "coupling": _coupling_edges(project_root, file_to_module, prefixes_by_module),
+        "entryPoints": _entry_points(file_to_module),
+        "languageDistribution": _language_distribution(file_to_module),
+        "degraded": degraded,
+    }
+
+
+def config_error_to_dict(
+    path: Path, error: code_structure_validate.CodeStructureConfigError
+) -> dict[str, Any]:
+    """Return the structured config-error shape shared by codebase CLIs."""
+    return {
+        "path": str(path),
+        "ok": False,
+        "errors": [{"code": "CS-CONFIG", "message": str(error), "location": str(path)}],
+        "warnings": [],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Emit the default codebase-map artifact.")
+    parser.add_argument("--project-root", default=".", help="Repository root to inspect.")
+    parser.add_argument("--path", help="Explicit vBRIEF containing codeStructure metadata.")
+    args = parser.parse_args(argv)
+
+    project_root = Path(args.project_root)
+    code_structure_path = Path(args.path) if args.path else None
+    try:
+        artifact = build_codebase_map(project_root, code_structure_path=code_structure_path)
+    except code_structure_validate.CodeStructureConfigError as exc:
+        print(
+            json.dumps(
+                config_error_to_dict(
+                    default_code_structure_path(project_root, code_structure_path), exc
+                ),
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(artifact, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codebase_projection_registry.py
+++ b/scripts/codebase_projection_registry.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Projection-kind registry for #1595 codebase structure artifacts.
+
+The authored ``codeStructure.projectionManifest[]`` record stores intent:
+``kind``, ``path``, ``source``, and ``generated``. Runner-specific commands stay
+out of that canonical metadata. This registry is the framework-owned bridge
+from a stable projection kind to the contract details later task wrappers can
+use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+
+CODEBASE_MAP_KIND = "codebase-map"
+CODEBASE_MAP_FORMAT_VERSION = "codebase-map.v1"
+CODEBASE_PROVIDER_CONTRACT_VERSION = "codebase-provider.v1"
+
+
+@dataclass(frozen=True)
+class ProjectionKind:
+    """Framework-owned behavior for one ``projectionManifest[].kind`` value."""
+
+    kind: str
+    artifact_format_version: str
+    provider_contract_version: str
+    output_role: str
+    generate_action: str
+    freshness_action: str
+    description: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+_REGISTRY: tuple[ProjectionKind, ...] = (
+    ProjectionKind(
+        kind=CODEBASE_MAP_KIND,
+        artifact_format_version=CODEBASE_MAP_FORMAT_VERSION,
+        provider_contract_version=CODEBASE_PROVIDER_CONTRACT_VERSION,
+        output_role="architecture-map",
+        generate_action="generate-codebase-map",
+        freshness_action="verify-codebase-map-freshness",
+        description=(
+            "Generated codebase orientation map derived from authored "
+            "codeStructure metadata plus code-derived facts."
+        ),
+    ),
+)
+
+
+def list_projection_kinds() -> list[ProjectionKind]:
+    """Return registered projection kinds in deterministic order."""
+    return sorted(_REGISTRY, key=lambda entry: entry.kind)
+
+
+def resolve_projection_kind(kind: str) -> ProjectionKind:
+    """Resolve one projection kind or raise ``KeyError`` with a useful message."""
+    for entry in _REGISTRY:
+        if entry.kind == kind:
+            return entry
+    known = ", ".join(entry.kind for entry in list_projection_kinds()) or "<none>"
+    raise KeyError(f"unknown projection kind {kind!r}; known kinds: {known}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for registry inspection."""
+    parser = argparse.ArgumentParser(description="Inspect codebase projection kinds.")
+    parser.add_argument("--kind", help="Projection kind to resolve.")
+    parser.add_argument("--list", action="store_true", help="List all projection kinds.")
+    args = parser.parse_args(argv)
+
+    if args.list:
+        payload: object = [entry.to_dict() for entry in list_projection_kinds()]
+    elif args.kind:
+        try:
+            payload = resolve_projection_kind(args.kind).to_dict()
+        except KeyError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+    else:
+        parser.print_help()
+        return 0
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codebase_provider.py
+++ b/scripts/codebase_provider.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Provider selection and validation for #1595 codebase-map artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shlex
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import code_structure_validate
+from _safe_subprocess import run_text
+from codebase_default_extractor import (
+    build_codebase_map,
+    config_error_to_dict,
+    default_code_structure_path,
+)
+from codebase_projection_registry import CODEBASE_MAP_KIND
+
+CODEBASE_MAP_SCHEMA_PATH = Path("vbrief/schemas/codebase-map.schema.json")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCHEMA_ANNOTATION_KEYS = frozenset({"$schema", "$id", "title", "description"})
+_SUPPORTED_SCHEMA_KEYS = _SCHEMA_ANNOTATION_KEYS | frozenset(
+    {
+        "additionalProperties",
+        "const",
+        "items",
+        "minItems",
+        "minimum",
+        "minLength",
+        "properties",
+        "required",
+        "type",
+    }
+)
+
+
+@dataclass
+class ProviderSelection:
+    """Result of selecting either an external provider or the default extractor."""
+
+    artifact: dict[str, Any]
+    used_external_provider: bool
+    fallback_reason: str | None = None
+
+
+@lru_cache(maxsize=1)
+def _load_codebase_map_schema() -> dict[str, Any]:
+    schema_path = _REPO_ROOT / CODEBASE_MAP_SCHEMA_PATH
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    if not isinstance(schema, dict):
+        raise ValueError(f"{CODEBASE_MAP_SCHEMA_PATH} must contain a JSON object")
+    return schema
+
+
+def _schema_for_expected_kind(expected_kind: str) -> dict[str, Any]:
+    schema = _load_codebase_map_schema()
+    if expected_kind == CODEBASE_MAP_KIND:
+        return schema
+    schema = copy.deepcopy(schema)
+    schema["properties"]["kind"]["const"] = expected_kind
+    return schema
+
+
+def _schema_path(path: str, field: str) -> str:
+    return f"{path}.{field}" if path else field
+
+
+def _schema_error_path(path: str) -> str:
+    return path or "<root>"
+
+
+def _type_names(schema_type: object) -> tuple[str, ...]:
+    if isinstance(schema_type, str):
+        return (schema_type,)
+    if isinstance(schema_type, list) and all(isinstance(item, str) for item in schema_type):
+        return tuple(schema_type)
+    return ()
+
+
+def _matches_json_type(value: object, schema_type: str) -> bool:
+    if schema_type == "array":
+        return isinstance(value, list)
+    if schema_type == "boolean":
+        return isinstance(value, bool)
+    if schema_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if schema_type == "null":
+        return value is None
+    if schema_type == "object":
+        return isinstance(value, dict)
+    if schema_type == "string":
+        return isinstance(value, str)
+    return False
+
+
+def _type_label(schema_type: str) -> str:
+    if schema_type == "array":
+        return "an array"
+    if schema_type == "integer":
+        return "an integer"
+    if schema_type == "object":
+        return "an object"
+    return f"a {schema_type}"
+
+
+def _schema_type_error(path: str, schema_types: tuple[str, ...]) -> str:
+    if len(schema_types) == 1:
+        return f"{_schema_error_path(path)} must be {_type_label(schema_types[0])}"
+    return f"{_schema_error_path(path)} must be one of: {', '.join(schema_types)}"
+
+
+def _validate_schema_shape(schema: object, path: str) -> list[str]:
+    if not isinstance(schema, dict):
+        return [f"schema at {_schema_error_path(path)} must be an object"]
+
+    errors: list[str] = []
+    unknown = sorted(set(schema) - _SUPPORTED_SCHEMA_KEYS)
+    for keyword in unknown:
+        errors.append(
+            f"schema at {_schema_error_path(path)} uses unsupported keyword {keyword!r}"
+        )
+
+    schema_types = _type_names(schema.get("type"))
+    if "type" in schema and not schema_types:
+        errors.append(f"schema at {_schema_error_path(path)} has unsupported type")
+
+    required = schema.get("required")
+    if required is not None and (
+        not isinstance(required, list) or any(not isinstance(item, str) for item in required)
+    ):
+        errors.append(f"schema at {_schema_error_path(path)} has invalid required[]")
+
+    properties = schema.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict):
+            errors.append(f"schema at {_schema_error_path(path)} has invalid properties")
+        else:
+            for field, child_schema in properties.items():
+                errors.extend(_validate_schema_shape(child_schema, _schema_path(path, field)))
+
+    if "items" in schema:
+        errors.extend(_validate_schema_shape(schema["items"], f"{path}[]"))
+
+    additional = schema.get("additionalProperties")
+    if additional is not None and not isinstance(additional, bool):
+        errors.append(
+            f"schema at {_schema_error_path(path)} has unsupported additionalProperties"
+        )
+
+    return errors
+
+
+def _validate_json_schema_subset(
+    value: object, schema: dict[str, Any], path: str = ""
+) -> list[str]:
+    schema_errors = _validate_schema_shape(schema, path)
+    if schema_errors:
+        return schema_errors
+
+    errors: list[str] = []
+    schema_types = _type_names(schema.get("type"))
+    if schema_types and not any(
+        _matches_json_type(value, schema_type) for schema_type in schema_types
+    ):
+        return [_schema_type_error(path, schema_types)]
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{_schema_error_path(path)} must be {schema['const']!r}")
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for field in required:
+            if field not in value:
+                errors.append(f"{_schema_path(path, field)} must be present")
+
+        properties = schema.get("properties", {})
+        if isinstance(properties, dict):
+            for field, child_schema in properties.items():
+                if field in value:
+                    errors.extend(
+                        _validate_json_schema_subset(
+                            value[field],
+                            child_schema,
+                            _schema_path(path, field),
+                        )
+                    )
+
+        if schema.get("additionalProperties") is False and isinstance(properties, dict):
+            for field in sorted(set(value) - set(properties)):
+                errors.append(f"{_schema_path(path, field)} is not allowed")
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            if min_items == 1:
+                errors.append(f"{_schema_error_path(path)} must be a non-empty array")
+            else:
+                errors.append(f"{_schema_error_path(path)} must contain at least {min_items} items")
+        if "items" in schema:
+            for index, item in enumerate(value):
+                errors.extend(
+                    _validate_json_schema_subset(item, schema["items"], f"{path}[{index}]")
+                )
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        if isinstance(min_length, int) and len(value) < min_length:
+            if min_length == 1:
+                errors.append(f"{_schema_error_path(path)} must be a non-empty string")
+            else:
+                errors.append(
+                    f"{_schema_error_path(path)} must contain at least {min_length} characters"
+                )
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        if isinstance(minimum, (int, float)) and value < minimum:
+            errors.append(f"{_schema_error_path(path)} must be >= {minimum}")
+
+    return errors
+
+
+def validate_provider_artifact(
+    artifact: object, *, expected_kind: str = CODEBASE_MAP_KIND
+) -> list[str]:
+    """Return deterministic JSON Schema contract errors for a provider artifact."""
+    if not isinstance(artifact, dict):
+        return ["artifact must be a JSON object"]
+
+    return _validate_json_schema_subset(artifact, _schema_for_expected_kind(expected_kind))
+
+
+def _fallback(project_root: Path, reason: str) -> ProviderSelection:
+    return ProviderSelection(
+        artifact=build_codebase_map(project_root, fallback_reason=reason),
+        used_external_provider=False,
+        fallback_reason=reason,
+    )
+
+
+def select_codebase_map(
+    project_root: Path, provider_command: str | list[str] | None = None
+) -> ProviderSelection:
+    """Return an external provider artifact when valid, else the default artifact."""
+    if provider_command is None or provider_command == "":
+        return _fallback(project_root, "no external codebase-map provider configured")
+
+    try:
+        command = (
+            shlex.split(provider_command) if isinstance(provider_command, str) else provider_command
+        )
+    except ValueError as exc:
+        return _fallback(project_root, f"provider command could not be parsed: {exc}")
+    if not command:
+        return _fallback(project_root, "provider command was empty")
+
+    try:
+        completed = run_text(command, cwd=str(project_root), timeout=60)
+    except Exception as exc:  # noqa: BLE001 -- provider failure is intentionally non-fatal.
+        return _fallback(project_root, f"provider command failed before output: {exc}")
+
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no provider output"
+        return _fallback(
+            project_root,
+            f"provider command exited {completed.returncode}: {detail}",
+        )
+
+    try:
+        artifact = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return _fallback(project_root, f"provider output was not valid JSON: {exc.msg}")
+
+    errors = validate_provider_artifact(artifact)
+    if errors:
+        return _fallback(project_root, "provider artifact contract mismatch: " + "; ".join(errors))
+
+    return ProviderSelection(artifact=artifact, used_external_provider=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Select a codebase-map provider artifact.")
+    parser.add_argument("--project-root", default=".", help="Repository root to inspect.")
+    parser.add_argument("--provider-command", help="External provider argv string.")
+    args = parser.parse_args(argv)
+
+    project_root = Path(args.project_root)
+    try:
+        selection = select_codebase_map(project_root, args.provider_command)
+    except code_structure_validate.CodeStructureConfigError as exc:
+        print(
+            json.dumps(
+                config_error_to_dict(default_code_structure_path(project_root, None), exc),
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(selection.artifact, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/codebase.yml
+++ b/tasks/codebase.yml
@@ -5,7 +5,7 @@ vars:
 
 tasks:
   validate-structure:
-    desc: "Validate authored codeStructure metadata (#1595 PR2)."
+    desc: "Validate authored codeStructure metadata and PR3 discipline rules (#1595)."
     dir: '{{.USER_WORKING_DIR}}'
     env:
       PYTHONUTF8: "1"
@@ -13,3 +13,27 @@ tasks:
     # forwards user-supplied paths and project-root flags via CLI_ARGS.
     cmds:
       - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/code_structure_validate.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+
+  extract-default:
+    desc: "Emit the dependency-free default codebase-map artifact to stdout (#1595 PR3)."
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/codebase_default_extractor.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+
+  provider-map:
+    desc: "Select an external codebase-map provider or fall back to the default artifact (#1595 PR3)."
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/codebase_provider.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+
+  projection-registry:
+    desc: "Inspect registered codebase projection kinds (#1595 PR3)."
+    dir: '{{.USER_WORKING_DIR}}'
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/codebase_projection_registry.py" {{.CLI_ARGS}}

--- a/tests/cli/test_code_structure_validate.py
+++ b/tests/cli/test_code_structure_validate.py
@@ -98,6 +98,10 @@ def _codes(result: csv_validate.ValidationResult) -> set[str]:
     return {finding.code for finding in result.errors}
 
 
+def _warning_codes(result: csv_validate.ValidationResult) -> set[str]:
+    return {finding.code for finding in result.warnings}
+
+
 class TestValidateCodeStructure:
     def test_valid_record_passes(self) -> None:
         result = csv_validate.validate_code_structure(_record(), source="fixture")
@@ -118,6 +122,21 @@ class TestValidateCodeStructure:
         )
         result = csv_validate.validate_code_structure(data, source="fixture")
         assert result.ok
+
+    def test_derived_fact_keys_are_rejected(self) -> None:
+        data = _record(
+            modules=[
+                {
+                    "id": "cli",
+                    "name": "CLI",
+                    "purpose": "Command-line entry points.",
+                    "pathGlobs": ["scripts/*.py"],
+                    "imports": ["tests.helpers"],
+                }
+            ]
+        )
+        result = csv_validate.validate_code_structure(data, source="fixture")
+        assert "CS-DERIVED-FACT" in _codes(result)
 
     def test_bad_module_id_fails(self) -> None:
         data = _record(
@@ -240,6 +259,36 @@ class TestValidateCodeStructure:
         assert "CS-PROJECTION" in codes
         assert "CS-PROJECTION-COMMAND" in codes
 
+    def test_existing_projection_requires_generated_banner(self, tmp_path: Path) -> None:
+        projection = tmp_path / ".planning" / "codebase" / "MAP.md"
+        projection.parent.mkdir(parents=True)
+        projection.write_text("# Hand-authored map\n", encoding="utf-8")
+
+        result = csv_validate.validate_code_structure(
+            _record(glossaryRefs=[]), source="fixture", project_root=tmp_path
+        )
+
+        assert "CS-PROJECTION-BANNER" in _codes(result)
+
+    def test_glossary_ref_uri_must_exist_when_project_root_is_known(self, tmp_path: Path) -> None:
+        result = csv_validate.validate_code_structure(
+            _record(glossaryRefs=[{"term": "missing", "uri": "docs/missing.md"}]),
+            source="fixture",
+            project_root=tmp_path,
+        )
+        assert "CS-GLOSSARY-URI" in _codes(result)
+
+    def test_boundedness_findings_warn_without_failing(self) -> None:
+        overrides = [
+            {"path": f"scripts/file_{index}.py", "purpose": "Fixture override."}
+            for index in range(11)
+        ]
+        result = csv_validate.validate_code_structure(
+            _record(filePurposeOverrides=overrides), source="fixture"
+        )
+        assert result.ok
+        assert "CS-BOUNDEDNESS" in _warning_codes(result)
+
 
 class TestExtractionAndCli:
     def test_extracts_from_plan_architecture(self) -> None:
@@ -252,6 +301,16 @@ class TestExtractionAndCli:
         extracted = csv_validate.extract_code_structure(_fallback_vbrief(_record()))
         assert extracted is not None
         assert extracted.home == csv_validate.DIRECTIVE_HOME
+
+    def test_file_with_both_homes_fails(self, tmp_path: Path) -> None:
+        path = tmp_path / "code-structure.vbrief.json"
+        payload = _vbrief(_record())
+        payload["x-directive/architecture"] = {"codeStructure": _record()}
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        result = csv_validate.validate_file(path)
+
+        assert "CS-HOME-CONFLICT" in _codes(result)
 
     def test_cli_validates_explicit_path(self, tmp_path: Path) -> None:
         path = tmp_path / "code-structure.vbrief.json"
@@ -289,10 +348,20 @@ class TestExtractionAndCli:
         found = csv_validate.discover_code_structure_paths(tmp_path)
         assert found == [project_def]
 
-    def test_default_discovery_ignores_architecture_sibling(self, tmp_path: Path) -> None:
+    def test_default_discovery_finds_architecture_sibling_for_home_gate(
+        self, tmp_path: Path
+    ) -> None:
         arch = tmp_path / "vbrief" / "architecture"
         arch.mkdir(parents=True)
         path = arch / "code-structure.vbrief.json"
-        path.write_text(json.dumps(_fallback_vbrief(_record())), encoding="utf-8")
+        path.write_text(json.dumps(_fallback_vbrief(_record(glossaryRefs=[]))), encoding="utf-8")
         found = csv_validate.discover_code_structure_paths(tmp_path)
-        assert found == []
+        assert found == [path]
+
+    def test_default_validation_rejects_architecture_sibling(self, tmp_path: Path) -> None:
+        arch = tmp_path / "vbrief" / "architecture"
+        arch.mkdir(parents=True)
+        path = arch / "code-structure.vbrief.json"
+        path.write_text(json.dumps(_fallback_vbrief(_record(glossaryRefs=[]))), encoding="utf-8")
+
+        assert csv_validate.main(["--project-root", str(tmp_path)]) == 1

--- a/tests/cli/test_codebase_default_extractor.py
+++ b/tests/cli/test_codebase_default_extractor.py
@@ -1,0 +1,139 @@
+"""Tests for the #1595 default codebase-map extractor."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import codebase_default_extractor as extractor  # noqa: E402
+
+
+def _write_project_definition(project_root: Path) -> None:
+    project_def = project_root / "vbrief" / "PROJECT-DEFINITION.vbrief.json"
+    project_def.parent.mkdir(parents=True)
+    project_def.write_text(
+        json.dumps(
+            {
+                "vBRIEFInfo": {"version": "0.6"},
+                "plan": {
+                    "title": "Fixture",
+                    "status": "running",
+                    "architecture": {
+                        "codeStructure": {
+                            "version": "0.1",
+                            "modules": [
+                                {
+                                    "id": "app",
+                                    "name": "App",
+                                    "purpose": "Application entry points.",
+                                    "pathGlobs": ["app/**/*.py"],
+                                },
+                                {
+                                    "id": "lib",
+                                    "name": "Library",
+                                    "purpose": "Shared helpers.",
+                                    "pathGlobs": ["lib/**/*.py"],
+                                },
+                            ],
+                            "pathOwnership": [],
+                            "allowedPatterns": [],
+                            "projectionManifest": [
+                                {
+                                    "path": ".planning/codebase/MAP.md",
+                                    "kind": "codebase-map",
+                                    "source": "plan.architecture.codeStructure",
+                                    "generated": True,
+                                }
+                            ],
+                        }
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_curated_extractor_emits_modules_coupling_entrypoints_and_languages(
+    tmp_path: Path,
+) -> None:
+    _write_project_definition(tmp_path)
+    app = tmp_path / "app"
+    lib = tmp_path / "lib"
+    app.mkdir()
+    lib.mkdir()
+    (app / "main.py").write_text("from lib.util import thing\nthing()\n", encoding="utf-8")
+    (lib / "util.py").write_text("def thing():\n    return 1\n", encoding="utf-8")
+
+    artifact = extractor.build_codebase_map(tmp_path)
+
+    assert artifact["formatVersion"] == "codebase-map.v1"
+    assert artifact["contractVersion"] == "codebase-provider.v1"
+    assert artifact["kind"] == "codebase-map"
+    assert [module["id"] for module in artifact["modules"]] == ["app", "lib"]
+    assert artifact["coupling"][0]["from"] == "app"
+    assert artifact["coupling"][0]["to"] == "lib"
+    assert artifact["entryPoints"][0]["path"] == "app/main.py"
+    assert artifact["languageDistribution"] == [
+        {"language": "Python", "files": 2, "derivedFrom": "extension-heuristic"}
+    ]
+    assert {entry["code"] for entry in artifact["degraded"]} == {"AST-FREE-HEURISTICS"}
+
+
+def test_extractor_without_code_structure_derives_directory_modules(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+    (tmp_path / "node_modules" / "pkg").mkdir(parents=True)
+    (tmp_path / "node_modules" / "pkg" / "index.js").write_text("", encoding="utf-8")
+
+    artifact = extractor.build_codebase_map(tmp_path)
+
+    assert artifact["modules"][0]["id"] == "src"
+    assert {module["id"] for module in artifact["modules"]} == {"src"}
+    degraded_codes = {entry["code"] for entry in artifact["degraded"]}
+    assert "NO-CODESTRUCTURE" in degraded_codes
+    assert "AST-FREE-HEURISTICS" in degraded_codes
+
+
+def test_directory_fallback_marks_truncated_module_file_lists(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    for index in range(extractor.MAX_FILES_PER_MODULE + 1):
+        (src / f"file_{index:03}.py").write_text("", encoding="utf-8")
+
+    artifact = extractor.build_codebase_map(tmp_path)
+
+    src_module = artifact["modules"][0]
+    assert src_module["fileCount"] == extractor.MAX_FILES_PER_MODULE + 1
+    assert len(src_module["files"]) == extractor.MAX_FILES_PER_MODULE
+    assert {
+        (entry["code"], entry.get("module")) for entry in artifact["degraded"]
+    } >= {("MODULE-FILES-TRUNCATED", "src")}
+
+
+def test_main_reports_config_error_without_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad_path = tmp_path / "bad.vbrief.json"
+    bad_path.write_text("{not-json", encoding="utf-8")
+
+    exit_code = extractor.main(
+        ["--project-root", str(tmp_path), "--path", str(bad_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["ok"] is False
+    assert payload["path"] == str(bad_path)
+    assert payload["errors"][0]["code"] == "CS-CONFIG"
+    assert "not valid JSON" in payload["errors"][0]["message"]

--- a/tests/cli/test_codebase_projection_registry.py
+++ b/tests/cli/test_codebase_projection_registry.py
@@ -1,0 +1,42 @@
+"""Tests for the #1595 projection-kind registry."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import codebase_projection_registry as registry  # noqa: E402
+
+
+def test_codebase_map_kind_resolves_contract_versions() -> None:
+    projection = registry.resolve_projection_kind("codebase-map")
+    assert projection.artifact_format_version == "codebase-map.v1"
+    assert projection.provider_contract_version == "codebase-provider.v1"
+    assert projection.generate_action == "generate-codebase-map"
+    assert not projection.generate_action.startswith("task ")
+
+
+def test_unknown_kind_fails() -> None:
+    with pytest.raises(KeyError):
+        registry.resolve_projection_kind("unknown-map")
+
+
+def test_cli_lists_registered_kinds(capsys: pytest.CaptureFixture[str]) -> None:
+    assert registry.main(["--list"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["kind"] == "codebase-map"
+
+
+def test_cli_list_takes_precedence_over_kind(capsys: pytest.CaptureFixture[str]) -> None:
+    assert registry.main(["--list", "--kind", "codebase-map"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload, list)
+    assert payload[0]["kind"] == "codebase-map"

--- a/tests/cli/test_codebase_provider.py
+++ b/tests/cli/test_codebase_provider.py
@@ -1,0 +1,222 @@
+"""Tests for the #1595 codebase-map provider contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import codebase_provider as provider  # noqa: E402
+
+
+def _valid_artifact() -> dict:
+    return {
+        "formatVersion": "codebase-map.v1",
+        "contractVersion": "codebase-provider.v1",
+        "kind": "codebase-map",
+        "provider": {"name": "fixture-provider", "version": "1.0"},
+        "source": {"projectRoot": "/fixture"},
+        "modules": [
+            {
+                "id": "app",
+                "files": ["app/main.py"],
+                "derivedFrom": {"files": "provider", "intent": "provider"},
+            }
+        ],
+        "coupling": [],
+        "entryPoints": [],
+        "languageDistribution": [
+            {"language": "Python", "files": 1, "derivedFrom": "extension-heuristic"}
+        ],
+        "degraded": [],
+    }
+
+
+def test_validate_provider_artifact_accepts_contract() -> None:
+    assert provider.validate_provider_artifact(_valid_artifact()) == []
+
+
+def test_validate_provider_artifact_reports_contract_mismatch() -> None:
+    artifact = _valid_artifact()
+    artifact["contractVersion"] = "wrong"
+    artifact["modules"] = []
+
+    errors = provider.validate_provider_artifact(artifact)
+
+    assert "contractVersion must be 'codebase-provider.v1'" in errors
+    assert "modules must be a non-empty array" in errors
+
+
+def test_validate_provider_artifact_rejects_missing_tier1_skeleton() -> None:
+    artifact = _valid_artifact()
+    del artifact["coupling"]
+    del artifact["entryPoints"]
+    del artifact["languageDistribution"]
+
+    errors = provider.validate_provider_artifact(artifact)
+
+    assert "coupling must be present" in errors
+    assert "entryPoints must be present" in errors
+    assert "languageDistribution must be present" in errors
+
+
+def test_validate_provider_artifact_rejects_degenerate_modules() -> None:
+    artifact = _valid_artifact()
+    artifact["modules"] = [{}]
+
+    errors = provider.validate_provider_artifact(artifact)
+
+    assert "modules[0].id must be present" in errors
+    assert "modules[0].files must be present" in errors
+    assert "modules[0].derivedFrom must be present" in errors
+
+
+def test_validate_provider_artifact_rejects_module_field_type_mismatch() -> None:
+    artifact = _valid_artifact()
+    artifact["modules"][0]["derivedFrom"] = "provider"
+    artifact["modules"][0]["files"] = [""]
+    artifact["languageDistribution"][0]["files"] = "one"
+
+    errors = provider.validate_provider_artifact(artifact)
+
+    assert "modules[0].derivedFrom must be an object" in errors
+    assert "modules[0].files[0] must be a non-empty string" in errors
+    assert "languageDistribution[0].files must be an integer" in errors
+
+
+def test_codebase_map_schema_and_golden_fixture_are_published() -> None:
+    schema_path = _REPO_ROOT / provider.CODEBASE_MAP_SCHEMA_PATH
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    assert schema["$id"].endswith("codebase-map.v1.schema.json")
+    assert schema["required"] == [
+        "formatVersion",
+        "contractVersion",
+        "kind",
+        "provider",
+        "source",
+        "modules",
+        "coupling",
+        "entryPoints",
+        "languageDistribution",
+        "degraded",
+    ]
+    assert schema["properties"]["formatVersion"]["const"] == "codebase-map.v1"
+    assert schema["properties"]["contractVersion"]["const"] == "codebase-provider.v1"
+
+    golden = json.loads(
+        (_REPO_ROOT / "tests/fixtures/codebase-map.v1.golden.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert provider.validate_provider_artifact(golden) == []
+
+
+def test_validate_provider_artifact_uses_published_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema = json.loads(
+        (_REPO_ROOT / provider.CODEBASE_MAP_SCHEMA_PATH).read_text(encoding="utf-8")
+    )
+    schema["required"].append("schemaOnly")
+    monkeypatch.setattr(provider, "_load_codebase_map_schema", lambda: schema)
+
+    errors = provider.validate_provider_artifact(_valid_artifact())
+
+    assert "schemaOnly must be present" in errors
+
+
+def test_validate_provider_artifact_fails_closed_on_unsupported_schema_keyword(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        provider,
+        "_load_codebase_map_schema",
+        lambda: {"type": "object", "patternProperties": {}},
+    )
+
+    errors = provider.validate_provider_artifact(_valid_artifact())
+
+    assert "schema at <root> uses unsupported keyword 'patternProperties'" in errors
+
+
+def test_select_provider_accepts_conformant_external_artifact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    completed = type(
+        "Completed",
+        (),
+        {"returncode": 0, "stdout": json.dumps(_valid_artifact()), "stderr": ""},
+    )()
+    monkeypatch.setattr(provider, "run_text", lambda *args, **kwargs: completed)
+
+    selection = provider.select_codebase_map(tmp_path, "fixture-provider --json")
+
+    assert selection.used_external_provider is True
+    assert selection.artifact["provider"]["name"] == "fixture-provider"
+
+
+def test_select_provider_falls_back_on_invalid_artifact(tmp_path: Path, monkeypatch) -> None:
+    completed = type(
+        "Completed",
+        (),
+        {"returncode": 0, "stdout": json.dumps({"formatVersion": "wrong"}), "stderr": ""},
+    )()
+    monkeypatch.setattr(provider, "run_text", lambda *args, **kwargs: completed)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+
+    selection = provider.select_codebase_map(tmp_path, "fixture-provider --json")
+
+    assert selection.used_external_provider is False
+    assert selection.fallback_reason is not None
+    assert selection.artifact["provider"]["name"] == "directive-default-extractor"
+    assert "provider artifact contract mismatch" in selection.fallback_reason
+
+
+def test_select_provider_falls_back_when_no_provider_is_configured(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+
+    selection = provider.select_codebase_map(tmp_path)
+
+    assert selection.used_external_provider is False
+    assert selection.artifact["provider"]["fallbackReason"] == (
+        "no external codebase-map provider configured"
+    )
+
+
+def test_select_provider_falls_back_when_provider_command_is_malformed(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+
+    selection = provider.select_codebase_map(tmp_path, '"unterminated')
+
+    assert selection.used_external_provider is False
+    assert selection.fallback_reason is not None
+    assert "provider command could not be parsed" in selection.fallback_reason
+
+
+def test_provider_main_reports_default_extractor_config_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    vbrief_path = tmp_path / "vbrief" / "PROJECT-DEFINITION.vbrief.json"
+    vbrief_path.parent.mkdir()
+    vbrief_path.write_text("{not-json", encoding="utf-8")
+
+    exit_code = provider.main(["--project-root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["ok"] is False
+    assert payload["path"] == str(vbrief_path)
+    assert payload["errors"][0]["code"] == "CS-CONFIG"
+    assert "not valid JSON" in payload["errors"][0]["message"]

--- a/tests/content/test_code_structure_profile.py
+++ b/tests/content/test_code_structure_profile.py
@@ -41,7 +41,9 @@ def test_directive_dogfood_code_structure_validates() -> None:
     data = json.loads(path.read_text(encoding="utf-8"))
     assert "codeStructure" in data["plan"]["architecture"]
     assert csv_validate.DIRECTIVE_HOME.split(".", maxsplit=1)[0] not in data
-    result = csv_validate.validate_file(path)
+    result = csv_validate.validate_file(
+        path, project_root=_REPO_ROOT, allow_standalone=False
+    )
     assert result.ok, [finding.message for finding in result.errors]
 
 
@@ -51,6 +53,9 @@ def test_codebase_task_is_registered() -> None:
     assert "codebase:" in taskfile
     assert "tasks/codebase.yml" in taskfile
     assert "validate-structure:" in codebase_tasks
+    assert "extract-default:" in codebase_tasks
+    assert "provider-map:" in codebase_tasks
+    assert "projection-registry:" in codebase_tasks
     assert "code_structure_validate.py" in codebase_tasks
 
 
@@ -60,4 +65,8 @@ def test_profile_doc_names_physical_home_and_later_slices() -> None:
     assert "plan.architecture.codeStructure" in doc
     assert "vbrief-core.schema.json" in doc
     assert "No standalone canonical" in doc
-    assert "Brownfield extraction, MAP generation, generated headers" in doc
+    assert "vbrief/schemas/codebase-map.schema.json" in doc
+    assert "tests/fixtures/codebase-map.v1.golden.json" in doc
+    assert "normative contract" in doc
+    assert "codebase-provider.v1" in doc
+    assert "MAP rendering, generated headers" in doc

--- a/tests/fixtures/codebase-map.v1.golden.json
+++ b/tests/fixtures/codebase-map.v1.golden.json
@@ -1,0 +1,86 @@
+{
+  "contractVersion": "codebase-provider.v1",
+  "coupling": [
+    {
+      "confidence": "heuristic",
+      "derivedFrom": "import-line-heuristic",
+      "evidence": [
+        {
+          "import": "lib.util",
+          "line": 1,
+          "path": "app/main.py"
+        }
+      ],
+      "from": "app",
+      "to": "lib"
+    }
+  ],
+  "degraded": [
+    {
+      "code": "AST-FREE-HEURISTICS",
+      "message": "Default extractor uses repository walking and import-line heuristics only; no AST or language parser provider was configured."
+    }
+  ],
+  "entryPoints": [
+    {
+      "confidence": "heuristic",
+      "derivedFrom": "filename-heuristic",
+      "module": "app",
+      "path": "app/main.py"
+    }
+  ],
+  "formatVersion": "codebase-map.v1",
+  "kind": "codebase-map",
+  "languageDistribution": [
+    {
+      "derivedFrom": "extension-heuristic",
+      "files": 2,
+      "language": "Python"
+    }
+  ],
+  "modules": [
+    {
+      "derivedFrom": {
+        "files": "repository-glob-walk",
+        "intent": "codeStructure.modules[]"
+      },
+      "fileCount": 1,
+      "files": [
+        "app/main.py"
+      ],
+      "id": "app",
+      "name": "App",
+      "pathGlobs": [
+        "app/**/*.py"
+      ],
+      "purpose": "Application entry points."
+    },
+    {
+      "derivedFrom": {
+        "files": "repository-glob-walk",
+        "intent": "codeStructure.modules[]"
+      },
+      "fileCount": 1,
+      "files": [
+        "lib/util.py"
+      ],
+      "id": "lib",
+      "name": "Library",
+      "pathGlobs": [
+        "lib/**/*.py"
+      ],
+      "purpose": "Shared helpers."
+    }
+  ],
+  "provider": {
+    "degraded": true,
+    "mode": "default",
+    "name": "directive-default-extractor",
+    "version": "0.1"
+  },
+  "source": {
+    "codeStructureHome": "plan.architecture.codeStructure",
+    "codeStructurePath": "vbrief/PROJECT-DEFINITION.vbrief.json",
+    "projectRoot": "/fixture"
+  }
+}

--- a/vbrief/active/2026-06-16-1595-pr3-extractor-provider-discipline-gate.vbrief.json
+++ b/vbrief/active/2026-06-16-1595-pr3-extractor-provider-discipline-gate.vbrief.json
@@ -1,0 +1,123 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1595 PR3 deterministic extractor, provider contract, and discipline gate.",
+    "created": "2026-06-16T19:03:00Z",
+    "updated": "2026-06-16T20:20:00Z"
+  },
+  "plan": {
+    "id": "1595-pr3-extractor-provider-discipline-gate",
+    "title": "Add codebase extractor provider contract and discipline gate",
+    "status": "running",
+    "narratives": {
+      "Description": "PR3 for #1595 adds the contract layer between authored codeStructure metadata and the later MAP projection: a deterministic dependency-free default extractor, an out-of-process provider handshake, an architecture-map artifact format, a kind-to-command registry, and the PR3 discipline gate. This preserves the current-shape decision that directive owns contracts and a safe default path, not a heavy in-repo map engine.",
+      "ImplementationPlan": "1. Define the tier-1 architecture-map output format and provider handshake with independent formatVersion and contractVersion fields. 2. Implement an AST-free default extractor that uses repository tree walking and import-line heuristics only, with no network, model, or parser dependency. 3. Add provider selection/validation that accepts a conformant external provider artifact when configured and falls back to the default extractor on absence, mismatch, or provider failure. 4. Add a projection-kind registry for codebase-map so canonical projectionManifest entries remain invocation-agnostic. 5. Extend task codebase:validate-structure with PR3 discipline checks: hard-block derived-fact keys and undeclared canonical siblings, warn on boundedness heuristics, and validate deterministic referential integrity where possible. 6. Add focused tests, docs, and a brief CHANGELOG entry.",
+      "UserStory": "As a maintainer, I want directive to own the codebase-map contract and safe default extraction path before MAP rendering lands, so future providers can enrich the map without moving authority out of vBRIEF-owned metadata.",
+      "NonGoals": "No generated .planning/codebase/MAP.md output, no codebase-map-fresh freshness check, no generated source headers, no consumer AGENTS/template propagation, no heavy crawl/summarize engine, no network/model dependency, and no parser/AST dependency in the default path."
+    },
+    "items": [
+      {
+        "title": "Tier-1 architecture-map artifact format and provider handshake are defined and tested.",
+        "status": "completed"
+      },
+      {
+        "title": "Default extractor emits a non-empty AST-free structural skeleton with provenance and degraded markers.",
+        "status": "completed"
+      },
+      {
+        "title": "Provider selection validates conformant artifacts and gracefully falls back to the default extractor.",
+        "status": "completed"
+      },
+      {
+        "title": "Projection kind registry resolves codebase-map behavior without storing runner commands in canonical data.",
+        "status": "completed"
+      },
+      {
+        "title": "codeStructure discipline gate enforces canonical/derived boundaries and reports boundedness warnings.",
+        "status": "completed"
+      },
+      {
+        "title": "Docs, tests, and CHANGELOG describe PR3 without implying MAP rendering has shipped.",
+        "status": "completed"
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "context-engineering",
+      "source-of-truth"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1595",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1595: feat(codebase): generate codebase MAP from vBRIEF-owned codeStructure metadata"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/pull/1642",
+        "type": "x-vbrief/github-pr",
+        "title": "PR #1642: feat(codebase): add codeStructure profile validator"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1498",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1498: RFC: Directive must dogfood vBRIEF-as-source-of-truth"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1530: RFC: Migrate Deft Directive's implementation from Python to TypeScript"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1659",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1659: Decouple framework runtime + guidance from the task runner"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1595",
+        "series_pr": "PR3"
+      },
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "scripts/code_structure_validate.py",
+          "scripts/codebase_default_extractor.py",
+          "scripts/codebase_provider.py",
+          "scripts/codebase_projection_registry.py",
+          "tests/cli/test_code_structure_validate.py",
+          "tests/cli/test_codebase_default_extractor.py",
+          "tests/cli/test_codebase_provider.py",
+          "tests/cli/test_codebase_projection_registry.py",
+          "docs/code-structure-profile.md",
+          "docs/codebase-map-source-of-truth.md",
+          "vbrief/PROJECT-DEFINITION.vbrief.json",
+          "vbrief/schemas/vbrief-core.schema.json",
+          "tasks/codebase.yml",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task codebase:validate-structure",
+          "uv run pytest tests/cli/test_code_structure_validate.py tests/cli/test_codebase_default_extractor.py tests/cli/test_codebase_provider.py tests/cli/test_codebase_projection_registry.py tests/content/test_code_structure_profile.py -q",
+          "task vbrief:validate",
+          "task check"
+        ],
+        "expected_outputs": [
+          "PR3 contract layer exists before MAP rendering",
+          "default extraction is AST-free and offline",
+          "provider mismatch or absence gracefully falls back",
+          "discipline checks keep codeStructure canonical-intent only"
+        ],
+        "depends_on": [],
+        "conflict_group": "code-structure-pr3",
+        "size": "large",
+        "file_scope_confidence": "medium",
+        "model_tier": "advanced"
+      },
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-06-16T20:20:00Z"
+  }
+}

--- a/vbrief/schemas/codebase-map.schema.json
+++ b/vbrief/schemas/codebase-map.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deft.dev/schemas/codebase-map.v1.schema.json",
+  "title": "Codebase Map Artifact v1",
+  "description": "Language-neutral contract for a provider-emitted codebase-map.v1 artifact. Out-of-process providers may be written in any language, but must emit this JSON object on stdout for Directive to accept it instead of falling back to the default extractor.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "formatVersion",
+    "contractVersion",
+    "kind",
+    "provider",
+    "source",
+    "modules",
+    "coupling",
+    "entryPoints",
+    "languageDistribution",
+    "degraded"
+  ],
+  "properties": {
+    "formatVersion": {
+      "const": "codebase-map.v1",
+      "description": "Artifact format version owned by Directive."
+    },
+    "contractVersion": {
+      "const": "codebase-provider.v1",
+      "description": "Provider handshake contract version accepted by Directive."
+    },
+    "kind": {
+      "const": "codebase-map",
+      "description": "Projection kind."
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "degraded": {
+          "type": "boolean"
+        },
+        "fallbackReason": {
+          "type": "string"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["projectRoot"],
+      "properties": {
+        "projectRoot": {
+          "type": "string",
+          "minLength": 1
+        },
+        "codeStructurePath": {
+          "type": "string"
+        },
+        "codeStructureHome": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "modules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "files", "derivedFrom"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": ["string", "null"]
+          },
+          "purpose": {
+            "type": ["string", "null"]
+          },
+          "pathGlobs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "fileCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "derivedFrom": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "coupling": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["from", "to", "derivedFrom"],
+        "properties": {
+          "from": {
+            "type": "string",
+            "minLength": 1
+          },
+          "to": {
+            "type": "string",
+            "minLength": 1
+          },
+          "derivedFrom": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence": {
+            "type": "string"
+          },
+          "evidence": {
+            "type": "array"
+          }
+        }
+      }
+    },
+    "entryPoints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["path", "module", "derivedFrom"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "module": {
+            "type": "string",
+            "minLength": 1
+          },
+          "derivedFrom": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "languageDistribution": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["language", "files", "derivedFrom"],
+        "properties": {
+          "language": {
+            "type": "string",
+            "minLength": 1
+          },
+          "files": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "derivedFrom": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "degraded": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          },
+          "module": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the #1595 PR3 codebase-map contract layer: projection-kind registry, dependency-free default extractor, and provider validation/fallback path
- extend codeStructure validation with PR3 discipline checks for derived facts, canonical home boundaries, generated projection banners, glossary URI integrity, and boundedness warnings
- wire codebase task entrypoints, docs, changelog, and focused coverage for the extractor/provider/registry behavior

## Tests
- .venv/bin/python -m pytest tests/cli/test_code_structure_validate.py tests/cli/test_codebase_default_extractor.py tests/cli/test_codebase_provider.py tests/cli/test_codebase_projection_registry.py tests/content/test_code_structure_profile.py -q
- .venv/bin/ruff check scripts/code_structure_validate.py scripts/codebase_default_extractor.py scripts/codebase_provider.py scripts/codebase_projection_registry.py tests/cli/test_code_structure_validate.py tests/cli/test_codebase_default_extractor.py tests/cli/test_codebase_provider.py tests/cli/test_codebase_projection_registry.py tests/content/test_code_structure_profile.py
- task codebase:validate-structure
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/deftai/directive.git.insteadOf GIT_CONFIG_VALUE_0=git@github.com:dbcall2/directive.git task check

Refs #1595. Refs #1498 #1530 #1659.