### PR TITLE
fix(runtime): decouple Deft commands from go-task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,7 +312,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=92e1c020680d refreshed=2026-06-16T20:15:19Z session=355a1ea06529 -->
+<!-- deft:managed-section v3 sha=8f010c664a2c refreshed=2026-06-17T12:39:17Z session=90e3a65c4ce4 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -329,7 +329,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 - ./PROJECT.md exists and is not a deprecation redirect (`<!-- deft:deprecated-redirect -->` or `<!-- Purpose: deprecation redirect -->`).
 - ./vbrief/ exists but any of the five lifecycle subfolders (proposed/, pending/, active/, completed/, cancelled/) is missing
 
-→ On detection: read .deft/core/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "task deft:migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
+→ On detection: read .deft/core/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "deft migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
 
 ⊗ Start Phase 1, Phase 2, or a Returning-Sessions workflow while pre-cutover artifacts are present — run migration first.
 
@@ -368,18 +368,18 @@ Check what exists before doing anything else:
 
 ## Session-start ritual (#1149)
 
-! On every interactive session start, run `task deft:session:start` after loading AGENTS.md. This records the quick-tier ritual in `.deft/ritual-state.json`: Deft alignment confirmation, branch-policy disclosure, required-tool guidance from `task deft:verify:tools`, default-branch sync warnings, and `task deft:triage:welcome` one-line state/nudge. The state is worktree- and HEAD-bound, and becomes stale after `plan.policy.sessionRitualStalenessHours` hours (default: 4).
+! On every interactive session start, run `deft session:start` after loading AGENTS.md. This records the quick-tier ritual in `.deft/ritual-state.json`: Deft alignment confirmation, branch-policy disclosure, required-tool guidance from `deft verify:tools`, default-branch sync warnings, and `deft triage:welcome` one-line state/nudge. The state is worktree- and HEAD-bound, and becomes stale after `plan.policy.sessionRitualStalenessHours` hours (default: 4).
 
-! Before any code-writing tool call or `start_agent` implementation dispatch, run `task deft:verify:session-ritual -- --tier=gated`. The gated tier fails closed unless the quick-tier state is fresh, then lazily records the doctor and cache-fresh Python entrypoints (the checks exposed to operators as `task deft:doctor` and `task deft:verify:cache-fresh`) in the same ritual state. The verifier is now step 0 of the pre-`start_agent` gate stack; any non-zero exit aborts dispatch.
+! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. The gated tier fails closed unless the quick-tier state is fresh, then lazily records the doctor and cache-fresh Python entrypoints (the checks exposed to operators as `deft doctor` and `deft verify:cache-fresh`) in the same ritual state. The verifier is now step 0 of the pre-`start_agent` gate stack; any non-zero exit aborts dispatch.
 
-? If a quick or gated step must be intentionally postponed, record the decision with `task deft:session:start -- --defer step=reason` using one of `alignment`, `branch_policy`, `triage_welcome`, `doctor`, or `cache_fresh`. Deferred steps satisfy the verifier but remain auditable in `.deft/ritual-state.json`.
+? If a quick or gated step must be intentionally postponed, record the decision with `deft session:start -- --defer step=reason` using one of `alignment`, `branch_policy`, `triage_welcome`, `doctor`, or `cache_fresh`. Deferred steps satisfy the verifier but remain auditable in `.deft/ritual-state.json`.
 
-⊗ Self-report the session-start ritual as complete without a fresh `task deft:session:start` state, or bypass `task deft:verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
+⊗ Self-report the session-start ritual as complete without a fresh `deft session:start` state, or bypass `deft verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
 
-`task deft:doctor` remains the install-integrity + toolchain + AGENTS.md managed-section freshness probe (#1308). When the managed-section is stale, the doctor points the operator at `task deft:agents:refresh` to regenerate AGENTS.md from `templates/agents-entry.md`. The canonical `scripts/doctor.py` (single owner post #1335/#1336) also detects payload staleness from the `<install>/VERSION` manifest and, when behind, emits the canonical headless upgrade command `deft-install --yes --upgrade --repo-root . --json` (#1339 / #1409). The installer itself calls `scripts/doctor.py --session --json` at the end of every run for the unified handoff.
+`deft doctor` remains the install-integrity + toolchain + AGENTS.md managed-section freshness probe (#1308). When the managed-section is stale, the doctor points the operator at `deft agents:refresh` to regenerate AGENTS.md from `templates/agents-entry.md`. The canonical `scripts/doctor.py` (single owner post #1335/#1336) also detects payload staleness from the `<install>/VERSION` manifest and, when behind, emits the canonical headless upgrade command `deft-install --yes --upgrade --repo-root . --json` (#1339 / #1409). The installer itself calls `scripts/doctor.py --session --json` at the end of every run for the unified handoff.
 
-**Canonical bootstrap / update path (#1339 #1340 #1409 Epic-5/6):** Use the published platform installer binary (from GitHub Releases) as the single deterministic entrypoint. For an existing install, the canonical headless refresh is `deft-install --yes --upgrade --repo-root . --json` (drop `--json` for human-readable output) -- it replaces the payload + manifest + AGENTS.md in one shot. Legacy `task deft:upgrade` / `run upgrade` are metadata-only acknowledgment (they do NOT replace the payload) and `task deft:relocate -- --confirm` is back-compat only; git-clone / submodule / legacy doctor surfaces are de-emphasized in UPGRADING.md / README / skills. Agent example: after running the installer command, start your session; the doctor output (or `task deft:doctor`) tells you the exact state and whether a re-install is needed for freshness.
-`task deft:triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `task deft:triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual.
+**Canonical bootstrap / update path (#1339 #1340 #1409 Epic-5/6):** Use the published platform installer binary (from GitHub Releases) as the single deterministic entrypoint. For an existing install, the canonical headless refresh is `deft-install --yes --upgrade --repo-root . --json` (drop `--json` for human-readable output) -- it replaces the payload + manifest + AGENTS.md in one shot. Legacy `deft upgrade` / `run upgrade` are metadata-only acknowledgment (they do NOT replace the payload) and `deft relocate -- --confirm` is back-compat only; git-clone / submodule / legacy doctor surfaces are de-emphasized in UPGRADING.md / README / skills. Agent example: after running the installer command, start your session; the doctor output (or `deft doctor`) tells you the exact state and whether a re-install is needed for freshness.
+`deft triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `deft triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual.
 
 ## Resume nudge (conditional, #1269)
 
@@ -389,23 +389,23 @@ Reserved placement for the optional 6th conditional step (resume nudge from the 
 
 ## WIP cap
 
-The `plan.policy.wipCap` field caps the number of in-flight scope vBRIEFs (`vbrief/pending/` + `vbrief/active/`). The framework default is 10 (per umbrella #1119 Current Shape v3). When the cap is reached, `task deft:scope:promote` refuses with a relief hint pointing at `task deft:scope:demote --batch --older-than-days 30` (D1 / #1121). Operators can override the cap from the consumer side via `task deft:triage:welcome --onboard` (the Phase 4 wipCap prompt) or by inspecting / editing the typed field via `task deft:policy:show --field=wipCap`.
+The `plan.policy.wipCap` field caps the number of in-flight scope vBRIEFs (`vbrief/pending/` + `vbrief/active/`). The framework default is 10 (per umbrella #1119 Current Shape v3). When the cap is reached, `deft scope:promote` refuses with a relief hint pointing at `deft scope:demote --batch --older-than-days 30` (D1 / #1121). Operators can override the cap from the consumer side via `deft triage:welcome --onboard` (the Phase 4 wipCap prompt) or by inspecting / editing the typed field via `deft policy:show --field=wipCap`.
 
 ## Cache-as-authoritative work selection (#1149)
 
-! When the operator asks "what should I work on next?" / "build a cohort" / "what's the queue?", run `task deft:triage:queue --limit=10` (D11 / #1128) and present the ranked list before suggesting anything else. The agent MUST NOT recommend work from memory or open-GitHub-issue intuition. This is the consumer-side mirror of the maintainer rule of the same name; the triage queue is the source of truth for what to work on next.
+! When the operator asks "what should I work on next?" / "build a cohort" / "what's the queue?", run `deft triage:queue --limit=10` (D11 / #1128) and present the ranked list before suggesting anything else. The agent MUST NOT recommend work from memory or open-GitHub-issue intuition. This is the consumer-side mirror of the maintainer rule of the same name; the triage queue is the source of truth for what to work on next.
 
-⊗ Recommend a specific issue or vBRIEF without consulting `task deft:triage:queue` (or showing the operator the result of the consultation).
+⊗ Recommend a specific issue or vBRIEF without consulting `deft triage:queue` (or showing the operator the result of the consultation).
 
 ## Content packs
 
 Deft ships versioned content packs (e.g. lessons learned from prior work) under `.deft/core/packs/`. Discover and LOAD pack content via the slice surface instead of reading whole pack files into context:
 
-- `task deft:packs:slice --list-packs` -- discover which packs exist (short-name + version + one-line description). Registry-driven, so new packs appear automatically with no edit here.
-- `task deft:packs:slice <pack> --list` -- discover the named slices a pack exposes.
-- `task deft:packs:slice <pack> <slice> [-- <filters>]` -- load just the slice you need; read the slice, not the whole file.
+- `deft packs:slice --list-packs` -- discover which packs exist (short-name + version + one-line description). Registry-driven, so new packs appear automatically with no edit here.
+- `deft packs:slice <pack> --list` -- discover the named slices a pack exposes.
+- `deft packs:slice <pack> <slice> [-- <filters>]` -- load just the slice you need; read the slice, not the whole file.
 
-! Before improvising on a problem, discover packs with `task deft:packs:slice --list-packs`, then load the relevant slice. This wiring references the discovery commands on purpose -- it never enumerates pack or slice names, so new packs/slices need no change here.
+! Before improvising on a problem, discover packs with `deft packs:slice --list-packs`, then load the relevant slice. This wiring references the discovery commands on purpose -- it never enumerates pack or slice names, so new packs/slices need no change here.
 
 ## Skill Routing
 
@@ -428,8 +428,8 @@ When user input matches a trigger keyword, read the corresponding skill (paths a
 - "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/skills/deft-directive-debug/SKILL.md`
 - "triage hygiene" / "work the cache" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
 - "what's next" / "queue" / "build a cohort" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
-- "welcome" / "onboard triage" -> invokes `task deft:triage:welcome --onboard` (N3 / #1143)
-- "lessons" / "prior art" / "what have we learned about X" -> discover packs with `task deft:packs:slice --list-packs`, then `task deft:packs:slice <pack> --list` and load the relevant slice before improvising (see Content packs above)
+- "welcome" / "onboard triage" -> invokes `deft triage:welcome --onboard` (N3 / #1143)
+- "lessons" / "prior art" / "what have we learned about X" -> discover packs with `deft packs:slice --list-packs`, then `deft packs:slice <pack> --list` and load the relevant slice before improvising (see Content packs above)
 
 The `deft-directive-release` skill is intentionally excluded -- it cuts deft framework releases against a temp clone of `deftai/directive` and is not a consumer-facing surface.
 
@@ -437,10 +437,10 @@ The `deft-directive-release` skill is intentionally excluded -- it cuts deft fra
 
 Three consumer-facing surfaces enforce the branch-policy contract (#746 / #747):
 
-- `task deft:check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `task deft:check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
-- `task deft:verify:branch` -- branch gate wired into the `task deft:check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
-- `.githooks/pre-commit` / `pre-push` -- local hooks installed via `task deft:setup`; verify via `task deft:verify:hooks-installed`.
-- `task deft:policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `task deft:policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
+- `deft check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `deft check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
+- `deft verify:branch` -- branch gate wired into the `deft check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
+- `.githooks/pre-commit` / `pre-push` -- local hooks installed via `deft setup`; verify via `deft verify:hooks-installed`.
+- `deft policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `deft policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
 
 ## Branch Policy Disclosure (#746)
 
@@ -451,9 +451,9 @@ When the active project's `vbrief/PROJECT-DEFINITION.vbrief.json` has `plan.poli
 This phrasing comes from `.deft/core/scripts/policy.py::disclosure_line` and stays in lockstep with the typed surface (#746). When the policy is OFF (default; `allowDirectCommitsToMaster=false`), no session-start disclosure is required -- the absence of the disclosure line itself signals the default-enforcing state.
 
 Override paths the user may invoke:
-- `task deft:policy:show` -- inspect resolved policy
-- `task deft:policy:enforce-branches` -- re-enable branch protection
-- `task deft:policy:allow-direct-commits -- --confirm` -- re-confirm opt-out (audited)
+- `deft policy:show` -- inspect resolved policy
+- `deft policy:enforce-branches` -- re-enable branch protection
+- `deft policy:allow-direct-commits -- --confirm` -- re-confirm opt-out (audited)
 - `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` -- emergency env-var bypass
 
 ⊗ Begin a session that will commit/push without surfacing the policy state when allowDirectCommitsToMaster=true.
@@ -471,12 +471,12 @@ Cross-reference: `.deft/core/docs/analysis/2026-05-26-issue-1353-grok-windows-ca
 
 ### Implementation Intent Gate (#810)
 
-- ! Run `task deft:vbrief:preflight -- <path>` before any code-writing tool call or `start_agent` dispatch -- the gate exits 0 only when the candidate vBRIEF lives in `vbrief/active/` AND `plan.status == "running"`. The Taskfile target resolves the wrapped script via `.deft/core/scripts/_resolve_preflight_path.py` (which probes the canonical, legacy, and in-repo install layouts in priority order) and fails closed with a structured `gate misconfigured` error pointing at `task deft:framework:doctor` if no candidate resolves -- the gate cannot silently fail open on a misconfigured install (#1046 / #1047). The helper names `task deft:vbrief:activate <path>` as its idempotent activation companion; story workflows should use the Story Start Gate below to bridge proposed/pending scope through `task deft:scope:promote` and `task deft:scope:activate` before invoking preflight.
+- ! Run `deft vbrief:preflight -- <path>` before any code-writing tool call or `start_agent` dispatch -- the gate exits 0 only when the candidate vBRIEF lives in `vbrief/active/` AND `plan.status == "running"`. The Taskfile target resolves the wrapped script via `.deft/core/scripts/_resolve_preflight_path.py` (which probes the canonical, legacy, and in-repo install layouts in priority order) and fails closed with a structured `gate misconfigured` error pointing at `deft framework:doctor` if no candidate resolves -- the gate cannot silently fail open on a misconfigured install (#1046 / #1047). The helper names `deft vbrief:activate <path>` as its idempotent activation companion; story workflows should use the Story Start Gate below to bridge proposed/pending scope through `deft scope:promote` and `deft scope:activate` before invoking preflight.
 - ! Require an explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) from the user before invoking the preflight gate or `start_agent` for implementation. When intent is ambiguous, ask one targeted question instead of inferring.
 - ⊗ Infer implementation intent from lifecycle vocabulary ("do the full PR process", "start the work", "poller agents"), branching language, or workflow shape. Workflow-shape vocabulary is NOT authorization to spawn an implementation agent.
 - ⊗ Treat affirmative continuation phrases (`yes`, `go`, `proceed`, `do it`) as implementation authorization unless the prior turn explicitly proposed implementation. Broad approval is not a substitute for an explicit action-verb directive.
 
-**Pre-`start_agent` gate stack (#1149/#1348):** Before dispatching an implementation sub-agent via `start_agent`, run the gates in the canonical order: (0) session ritual gate (#1348, `task deft:verify:session-ritual -- --tier=gated`) -> (1) story-start Gate 0 (#1378, `task deft:verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]`) -> (2) vBRIEF implementation-intent gate (#810, `task deft:vbrief:preflight -- <path>`) -> (3) `task deft:verify:cache-fresh` (D5 / #1127) -> (4) branch-policy gate (`task deft:verify:branch` and the `.githooks/pre-commit` / `pre-push` hooks) -> (5) `start_agent`. Any non-zero exit aborts dispatch.
+**Pre-`start_agent` gate stack (#1149/#1348):** Before dispatching an implementation sub-agent via `start_agent`, run the gates in the canonical order: (0) session ritual gate (#1348, `deft verify:session-ritual -- --tier=gated`) -> (1) story-start Gate 0 (#1378, `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]`) -> (2) vBRIEF implementation-intent gate (#810, `deft vbrief:preflight -- <path>`) -> (3) `deft verify:cache-fresh` (D5 / #1127) -> (4) branch-policy gate (`deft verify:branch` and the `.githooks/pre-commit` / `pre-push` hooks) -> (5) `start_agent`. Any non-zero exit aborts dispatch.
 
 ### Story Start Gate
 
@@ -485,11 +485,11 @@ Cross-reference: `.deft/core/docs/analysis/2026-05-26-issue-1353-grok-windows-ca
 - ⊗ Begin a new story while unrelated dirty work is present without explicit operator approval.
 - ! Resolve exactly one target story vBRIEF path by default. Batching multiple stories requires explicit operator approval and a short rationale.
 - ! When invoked as part of a swarm cohort dispatch, the approved Phase 5 allocation plan satisfies the "explicit operator approval and a short rationale" requirement above -- the dispatched paths and allocation rationale ARE the consent token. Do NOT re-prompt the parent for batching approval mid-cohort; the all-or-nothing dispatch envelope rule (#954) forbids mid-scope user-approval gates.
-- ! Within a swarm cohort, between stories, the working tree MUST be clean (a checkpoint commit + `task deft:scope:complete` just landed). If `git status --short` shows uncommitted state between stories, checkpoint-commit it and proceed -- do NOT pause to ask the operator. The dirty-tree "ask the operator" branch above applies only at the FIRST story-start of a fresh branch.
-- ! If the target story is in `vbrief/proposed/`, run `task deft:scope:promote -- <path>` first; if it is in `vbrief/pending/`, run `task deft:scope:activate -- <path>`. After activation, run `task deft:vbrief:preflight -- <active-story-path>` before code-writing.
+- ! Within a swarm cohort, between stories, the working tree MUST be clean (a checkpoint commit + `deft scope:complete` just landed). If `git status --short` shows uncommitted state between stories, checkpoint-commit it and proceed -- do NOT pause to ask the operator. The dirty-tree "ask the operator" branch above applies only at the FIRST story-start of a fresh branch.
+- ! If the target story is in `vbrief/proposed/`, run `deft scope:promote -- <path>` first; if it is in `vbrief/pending/`, run `deft scope:activate -- <path>`. After activation, run `deft vbrief:preflight -- <active-story-path>` before code-writing.
 - ! Default to one story per branch/PR. Create a checkpoint commit after each completed story before beginning another story, unless the operator explicitly approved batching.
-- ! After checks pass for the story, complete the lifecycle with `task deft:scope:complete -- <active-story-path>` before final PR handoff.
-- ! Before dispatching an implementation sub-agent, run the deterministic Gate 0 `task deft:verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]` ahead of `task deft:vbrief:preflight`. It machine-checks a clean working tree (or `--allow-dirty`), the target vBRIEF in `vbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token; three-state exit (0 ready / 1 not ready / 2 config error). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null; an absent section is the solo path. Any non-zero exit aborts dispatch.
+- ! After checks pass for the story, complete the lifecycle with `deft scope:complete -- <active-story-path>` before final PR handoff.
+- ! Before dispatching an implementation sub-agent, run the deterministic Gate 0 `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]` ahead of `deft vbrief:preflight`. It machine-checks a clean working tree (or `--allow-dirty`), the target vBRIEF in `vbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token; three-state exit (0 ready / 1 not ready / 2 config error). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null; an absent section is the solo path. Any non-zero exit aborts dispatch.
 
 ## Commands
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -336,6 +336,7 @@ tasks:
       - verify:vbrief-conformance
       - verify:destructive-gh-verbs
       - verify:scm-boundary
+      - verify:no-task-runtime
       - verify:cache-fresh
       - verify:pack-drift
       - verify-wip-cap-framework-self-check
@@ -401,6 +402,13 @@ tasks:
       - task: packs:verify-drift
         vars:
           CLI_ARGS: "{{.CLI_ARGS}}"
+
+  verify:no-task-runtime:
+    desc: "Fail when runtime Python code hard-depends on go-task (#1659)."
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - uv --project "{{.TASKFILE_DIR}}" run python "{{.TASKFILE_DIR}}/scripts/verify_no_task_runtime.py"
 
   # `task check:slow` runs the @pytest.mark.slow lane that the default
   # `task check` skips (#975). The slow lane is dominated by the

--- a/run
+++ b/run
@@ -5333,6 +5333,45 @@ def main():
         return 1
 
     args = sys.argv[2:]
+
+    # #1659: package-manager installs cannot assume go-task is on PATH. Route
+    # framework verbs through the shared Python dispatcher before falling back
+    # to the legacy bootstrap command table below. ``check`` is context-aware:
+    # the framework source checkout runs the source aggregate, while vendored
+    # installs run the consumer-safe aggregate.
+    scripts_dir = Path(__file__).resolve().parent / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    try:
+        from framework_commands import has_command, run_framework_command
+        from _project_context import is_framework_source_context
+
+        framework_root = Path(__file__).resolve().parent
+        project_root = Path.cwd().resolve()
+        if command == "check":
+            target = (
+                "check:framework-source"
+                if is_framework_source_context(framework_root, project_root)
+                else "check:consumer"
+            )
+            result = run_framework_command(
+                target,
+                args,
+                project_root=project_root,
+                framework_root=framework_root,
+            )
+            return result.code
+        if has_command(command):
+            result = run_framework_command(
+                command,
+                args,
+                project_root=project_root,
+                framework_root=framework_root,
+            )
+            return result.code
+    except Exception as exc:
+        error(f"Framework command dispatch failed: {exc}")
+        return 1
     
     commands = {
         'bootstrap': cmd_bootstrap,

--- a/scripts/_project_context.py
+++ b/scripts/_project_context.py
@@ -171,7 +171,11 @@ def dispatch_task_check(
     framework_root: Path,
     project_root: Path,
     *,
-    runner: Callable[[str, Path, Path], CommandResult] | None = None,
+    runner: Callable[
+        [str, Path, Path],
+        CommandResult | subprocess.CompletedProcess[str],
+    ]
+    | None = None,
 ) -> int:
     """Dispatch ``check`` to the context-appropriate aggregate target."""
     target = (
@@ -187,7 +191,10 @@ def dispatch_task_check(
         )
     )
     result = command_runner(target, project_root, framework_root)
-    return int(result.code)
+    code = getattr(result, "code", None)
+    if code is None:
+        code = result.returncode
+    return int(code)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/_project_context.py
+++ b/scripts/_project_context.py
@@ -34,7 +34,10 @@ import argparse
 import os
 import re
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+
+from framework_commands import CommandResult, run_framework_command
 
 # Sentinel directories that mark a deft project root.
 _PROJECT_ROOT_SENTINELS = ("vbrief", ".git")
@@ -168,19 +171,23 @@ def dispatch_task_check(
     framework_root: Path,
     project_root: Path,
     *,
-    runner=subprocess.run,
+    runner: Callable[[str, Path, Path], CommandResult] | None = None,
 ) -> int:
-    """Dispatch ``task check`` to the context-appropriate aggregate target."""
+    """Dispatch ``check`` to the context-appropriate aggregate target."""
     target = (
         "check:framework-source"
         if is_framework_source_context(framework_root, project_root)
         else "check:consumer"
     )
-    result = runner(
-        ["task", "-t", str(framework_root / "Taskfile.yml"), target],
-        cwd=str(project_root),
+    command_runner = runner or (
+        lambda command, root, framework: run_framework_command(
+            command,
+            project_root=root,
+            framework_root=framework,
+        )
     )
-    return int(result.returncode)
+    result = command_runner(target, project_root, framework_root)
+    return int(result.code)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -188,7 +195,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dispatch-task-check",
         action="store_true",
-        help="Dispatch the task check aggregate for the current install context.",
+        help="Dispatch the check aggregate for the current install context.",
     )
     parser.add_argument("--framework-root", type=Path)
     parser.add_argument("--project-root", type=Path)

--- a/scripts/_triage_welcome_cli.py
+++ b/scripts/_triage_welcome_cli.py
@@ -32,11 +32,11 @@ if TYPE_CHECKING:  # pragma: no cover -- import-time-only typing alias
 TASK_PREFIX_ENV_VAR: str = "DEFT_TASK_PREFIX"
 
 #: Default-mode nudge string emitted by :func:`run_default_mode` when the
-#: operator has never run ``task triage:welcome --onboard``. Kept as a
+#: operator has never run ``deft triage:welcome --onboard``. Kept as a
 #: module-level constant so tests can pin the exact byte-shape and so
 #: future copy edits land in one place.
 FIRST_TIME_NUDGE: str = (
-    "[welcome] First-time? Run `task triage:welcome --onboard` "
+    "[welcome] First-time? Run `deft triage:welcome --onboard` "
     "to set up triage."
 )
 
@@ -45,7 +45,7 @@ FIRST_TIME_NUDGE: str = (
 #: :func:`_classify_onboarding`).
 INCOMPLETE_NUDGE_TEMPLATE: str = (
     "[welcome] Onboarding incomplete: {missing}. Run "
-    "`task triage:welcome --onboard` to resume."
+    "`deft triage:welcome --onboard` to resume."
 )
 
 
@@ -118,7 +118,7 @@ def prompt_menu(
         if n == discuss_idx:
             output_fn(
                 "  [discuss] Pausing the ritual. Re-run "
-                "`task triage:welcome` after the discussion to resume."
+                "`deft triage:welcome` after the discussion to resume."
             )
             return PromptOutcome(discuss=True)
         if n == back_idx:
@@ -188,7 +188,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="triage_welcome.py",
         description=(
-            "Emit the `task triage:welcome` session-start status surface "
+            "Emit the `deft triage:welcome` session-start status surface "
             "(#1309 default mode -- summary one-liner plus a state-conditional "
             "first-time / incomplete-onboarding nudge), or run the full "
             "6-phase interactive onboarding ritual (#1143) under --onboard. "
@@ -205,7 +205,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Run the interactive 6-phase onboarding ritual (#1143). "
-            "Without this flag (the default), `task triage:welcome` emits "
+            "Without this flag (the default), `deft triage:welcome` emits "
             "the non-interactive summary one-liner plus a state-conditional "
             "nudge pointing at `--onboard` when state is missing or partial "
             "(#1309)."
@@ -215,8 +215,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-subprocess",
         action="store_true",
         help=(
-            "Skip the `task triage:bootstrap` / `scope:demote` / "
-            "`triage:summary` subprocess hops. Test-mode flag for the "
+            "Skip the `deft triage:bootstrap` / `deft scope:demote` / "
+            "`deft triage:summary` follow-up hops. Test-mode flag for the "
             "--onboard ritual; never set in production runs."
         ),
     )
@@ -233,7 +233,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--skip-bootstrap",
         action="store_true",
         help=(
-            "Explicitly decline the --onboard Phase 3 `task triage:bootstrap` "
+            "Explicitly decline the --onboard Phase 3 `deft triage:bootstrap` "
             "invocation (#1244). The ritual still completes but emits a "
             "visible audit message AND records the decline in "
             "`meta/policy-changes.log`; downstream verbs that depend on "
@@ -309,7 +309,7 @@ def _classify_onboarding(state: PriorState) -> tuple[str, list[str]]:
     - ``"first-time"`` -- NONE of the three signals present: no
       ``vbrief/.eval/candidates.jsonl``, no ``plan.policy.triageScope``,
       no ``plan.policy.wipCap``. The operator has never run
-      ``task triage:welcome --onboard``.
+      ``deft triage:welcome --onboard``.
     - ``"incomplete"`` -- a strict subset (1 or 2) of the three signals
       present; ``missing_pieces`` names the absent piece(s) so the
       operator-facing nudge can be specific.
@@ -337,7 +337,7 @@ def emit_oneliner(
     output_fn: Callable[[str], None] | None = None,
     write_history: bool = True,
 ) -> str:
-    """Emit the ``task triage:summary`` one-liner via internal Python call.
+    """Emit the ``deft triage:summary`` one-liner via internal Python call.
 
     Mirrors the byte-shape produced by
     ``scripts/triage_summary.py::main`` (the headline plus, when
@@ -345,7 +345,7 @@ def emit_oneliner(
     spawning a subprocess. ``write_history`` controls whether the
     rolling ``vbrief/.eval/summary-history.jsonl`` sidecar is appended
     to; default-mode welcome runs DO append so observability stays
-    aligned with direct ``task triage:summary`` invocations.
+    aligned with direct ``deft triage:summary`` invocations.
 
     Returns the rendered line(s) so callers can compose with downstream
     state without re-rendering.
@@ -372,13 +372,13 @@ def run_default_mode(
     write_history: bool = True,
     task_prefix: str | None = None,
 ) -> WelcomeOutcome:
-    """Non-interactive default mode for ``task triage:welcome`` (#1309).
+    """Non-interactive default mode for ``deft triage:welcome`` (#1309).
 
     Subsumes the prior session-start step of running
-    ``task triage:summary`` plus a state-conditional first-time /
+    ``deft triage:summary`` plus a state-conditional first-time /
     incomplete-onboarding nudge so a fresh consumer sees one
     actionable line. The interactive 6-phase ritual now lives behind
-    ``task triage:welcome --onboard`` (see :func:`run_cli`).
+    ``deft triage:welcome --onboard`` (see :func:`run_cli`).
 
     No interactive prompts; the function never reads from stdin and is
     safe to invoke from any non-tty surface (CI, cloud agents, etc.).
@@ -397,10 +397,10 @@ def run_default_mode(
     emit_oneliner(project_root, output_fn=out_fn, write_history=write_history)
     state = triage_welcome.detect_prior_state(project_root)
     label, missing = _classify_onboarding(state)
-    canonical_onboard_command = triage_welcome.format_task_command(
+    canonical_onboard_command = triage_welcome.format_welcome_command(
         ["triage:welcome", "--onboard"]
     )
-    onboard_command = triage_welcome.format_task_command(
+    onboard_command = triage_welcome.format_welcome_command(
         ["triage:welcome", "--onboard"],
         task_prefix=task_prefix,
     )

--- a/scripts/ci_local.py
+++ b/scripts/ci_local.py
@@ -12,17 +12,17 @@ catch CI failures before pushing. The workflow defines three jobs:
    traversal, ``scope:promote`` end-to-end, etc.) that only run on a
    Windows host when ``--matrix=windows`` is requested.
 
-In addition, this script exercises the existing local task surface that
-the CI workflow expects to remain green:
+In addition, this script exercises the existing local framework command
+surface that the CI workflow expects to remain green:
 
-- ``task toolchain:check``
-- ``task verify:stubs``
-- ``task verify:links``
-- ``task verify:rule-ownership`` (#705)
-- ``task vbrief:validate``
-- ``task build`` (skipped with ``--skip-build``)
-- ``task build:verify`` (graceful absence -- it's a sibling pending #233
-  item; if the task is missing from ``task --list`` we skip it with an
+- ``deft toolchain:check``
+- ``deft verify:stubs``
+- ``deft verify:links``
+- ``deft verify:rule-ownership`` (#705)
+- ``deft vbrief:validate``
+- ``deft build`` (skipped with ``--skip-build``)
+- ``deft build:verify`` (graceful absence -- it's a sibling pending #233
+  item; if the command is missing from the no-task registry we skip it with an
   informational message rather than failing).
 
 Platform notes
@@ -60,8 +60,7 @@ Exit codes
     0 -- every applicable step succeeded (skipped steps do not count as
          failures)
     1 -- at least one step failed
-    2 -- configuration error (invalid arguments, missing required tool,
-         malformed Taskfile.yml when probing for ``build:verify``)
+    2 -- configuration error (invalid arguments, missing required tool)
 
 Refs #233 (umbrella; this resolves the ``task-ci-local`` plan.item),
 #642 (workflow umbrella), #635 (epic anchor), #633 (pre-PR
@@ -85,6 +84,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from framework_commands import has_command, run_framework_command  # noqa: E402
 
 reconfigure_stdio()
 
@@ -199,37 +199,20 @@ def _has_executable(name: str) -> bool:
     return shutil.which(name) is not None
 
 
-def _build_verify_available(root: Path) -> bool:
-    """Return True iff ``task build:verify`` is defined in the project.
+def _framework_command_available(name: str) -> bool:
+    """Return True iff the no-task framework command registry exposes *name*."""
+    return has_command(name)
 
-    Probes ``task --list`` and looks for a ``* build:verify`` line. When
-    ``task`` itself is missing we return ``False`` -- the caller will
-    print an informational skip message instead of failing.
 
-    When ``task --list`` exits non-zero for an unrelated reason (e.g. a
-    malformed ``Taskfile.yml``), we still return ``False`` but emit a
-    warning to stderr so the underlying error is not silently swallowed
-    behind the "build:verify not yet implemented" skip message (Greptile
-    P2 #713).
-    """
-    if not _has_executable("task"):
-        return False
-    rc, stdout, stderr = _run_command(["task", "--list"], cwd=root)
-    if rc != 0:
-        diagnostic = stderr.strip() or stdout.strip() or "(no output)"
-        print(
-            f"warning: `task --list` exited {rc} while probing for "
-            f"`build:verify`; treating as absent. Underlying error: "
-            f"{diagnostic}",
-            file=sys.stderr,
-        )
-        return False
-    for line in stdout.splitlines():
-        stripped = line.strip()
-        # ``task --list`` prints rows like ``* build:verify: <desc>``.
-        if stripped.startswith("* build:verify:") or stripped == "* build:verify":
-            return True
-    return False
+def _run_framework_command(name: str, root: Path) -> tuple[int, str, str]:
+    """Run a framework command in-process."""
+    result = run_framework_command(
+        name,
+        project_root=root,
+        framework_root=root,
+        capture=True,
+    )
+    return result.code, result.stdout, result.stderr
 
 
 # ---- Step constructors ------------------------------------------------------
@@ -316,60 +299,47 @@ def _make_go_steps(root: Path, *, skip_build: bool) -> list[Step]:
     return [test_step, *cross_steps]
 
 
-def _make_task_steps(root: Path, *, skip_build: bool) -> list[Step]:
-    if not _has_executable("task"):
-        return [
-            Step(
-                name="task: toolchain probe",
-                run_fn=lambda _root: (0, "", ""),
-                applies_fn=lambda: False,
-                skip_reason_fn=lambda: (
-                    "task not on PATH; install go-task "
-                    "(https://taskfile.dev/installation/) to run the Taskfile-level "
-                    "verifications."
-                ),
-            )
-        ]
+def _make_framework_steps(root: Path, *, skip_build: bool) -> list[Step]:
     steps: list[Step] = [
         Step(
-            name="task toolchain:check",
-            run_fn=lambda r: _run_command(["task", "toolchain:check"], cwd=r),
+            name="framework toolchain:check",
+            run_fn=lambda r: _run_framework_command("toolchain:check", r),
         ),
         Step(
-            name="task verify:stubs",
-            run_fn=lambda r: _run_command(["task", "verify:stubs"], cwd=r),
+            name="framework verify:stubs",
+            run_fn=lambda r: _run_framework_command("verify:stubs", r),
         ),
         Step(
-            name="task verify:links",
-            run_fn=lambda r: _run_command(["task", "verify:links"], cwd=r),
+            name="framework verify:links",
+            run_fn=lambda r: _run_framework_command("verify:links", r),
         ),
         Step(
-            name="task verify:rule-ownership",
-            run_fn=lambda r: _run_command(["task", "verify:rule-ownership"], cwd=r),
+            name="framework verify:rule-ownership",
+            run_fn=lambda r: _run_framework_command("verify:rule-ownership", r),
         ),
         Step(
-            name="task vbrief:validate",
-            run_fn=lambda r: _run_command(["task", "vbrief:validate"], cwd=r),
+            name="framework vbrief:validate",
+            run_fn=lambda r: _run_framework_command("vbrief:validate", r),
         ),
     ]
     if not skip_build:
         steps.append(
             Step(
-                name="task build",
-                run_fn=lambda r: _run_command(["task", "build"], cwd=r),
+                name="framework build",
+                run_fn=lambda r: _run_framework_command("build", r),
             )
         )
-        # build:verify is a sibling pending #233 plan.item; detect via
-        # `task --list` and skip with an informational message rather
-        # than failing when it isn't yet implemented.
-        build_verify_present = _build_verify_available(root)
+        # build:verify is a sibling pending #233 plan.item; detect via the
+        # no-task registry and skip with an informational message rather than
+        # failing when it isn't yet implemented.
+        build_verify_present = _framework_command_available("build:verify")
         steps.append(
             Step(
-                name="task build:verify",
-                run_fn=lambda r: _run_command(["task", "build:verify"], cwd=r),
+                name="framework build:verify",
+                run_fn=lambda r: _run_framework_command("build:verify", r),
                 applies_fn=lambda: build_verify_present,
                 skip_reason_fn=lambda: (
-                    "`task build:verify` not yet implemented; skipping -- "
+                    "`deft build:verify` not yet implemented; skipping -- "
                     "see #233 pending vBRIEF for the sibling plan.item."
                 ),
             )
@@ -441,7 +411,7 @@ def build_pipeline(
     steps: list[Step] = []
     steps.extend(_make_python_steps(root))
     steps.extend(_make_go_steps(root, skip_build=skip_build))
-    steps.extend(_make_task_steps(root, skip_build=skip_build))
+    steps.extend(_make_framework_steps(root, skip_build=skip_build))
     steps.extend(_make_windows_dispatch_steps(matrix))
     return steps
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -1215,7 +1215,7 @@ def _agents_refresh_plan(project_root: Path) -> dict:
     unconditionally returned ``{"state": "unreadable"}`` and produced a
     spurious warning on every ``task doctor`` run. Genuinely stale sections
     report ``stale`` (the freshness check then points the operator at
-    ``task agents:refresh``); a genuinely unreadable / template-missing
+    ``deft agents:refresh``); a genuinely unreadable / template-missing
     state still surfaces a warning.
     """
     return _load_agents_md_module()._agents_refresh_plan(project_root)
@@ -1294,7 +1294,7 @@ def _render_doctor_status_line(decision) -> str:
         warn_phrase = f"{warns} warning{'s' if warns != 1 else ''}"
         return (
             f"[doctor] ran {age_h}h ago, {err_phrase} / {warn_phrase} "
-            "-- UNRESOLVED; run `task doctor --full` to re-probe or "
+            "-- UNRESOLVED; run `deft doctor --full` to re-probe or "
             "address findings."
         )
     remaining = decision.next_eligible_at - _now_utc()
@@ -1308,7 +1308,7 @@ def _render_doctor_status_line(decision) -> str:
 def _emit_doctor_throttle_skip(decision, *, json_mode: bool) -> int:
     """Print the throttle-skip surface and return the gated exit code (#1308)."""
     hint = (
-        "run `task doctor --full` to re-probe or address findings"
+        "run `deft doctor --full` to re-probe or address findings"
         if decision.dirty
         else "--full forces"
     )
@@ -1464,7 +1464,7 @@ def _run_agents_md_freshness_check(
     if state in ("stale", "missing", "absent"):
         message = (
             f"AGENTS.md managed section is {state} -- "
-            "run `task agents:refresh` to bring it to the current template."
+            "run `deft agents:refresh` to bring it to the current template."
         )
         emit_warn(message)
         add_finding(
@@ -1472,7 +1472,7 @@ def _run_agents_md_freshness_check(
             message,
             check=check_name,
             status=state,
-            suggestion="task agents:refresh",
+            suggestion="deft agents:refresh",
         )
         return
     message = (
@@ -1869,7 +1869,6 @@ def cmd_doctor(args: list[str]):
         required=True,
         install_url=UV_INSTALL_URL,
     )
-    check_command("task", "task (Taskfile)")
     check_command("git", "git", required=True)
     check_command("python3", "python3")
     check_command("go", "go")
@@ -1896,7 +1895,7 @@ def cmd_doctor(args: list[str]):
     # emits a skip finding with reason "no managed-section markers
     # (likely maintainer repo)" when AGENTS.md carries no v3 markers.
     # Stale templates surface as a warning (zero exit) -- the operator
-    # runs `task agents:refresh` to bring them current.
+    # runs `deft agents:refresh` to bring them current.
     if not json_mode:
         print()
     _emit_info("Checking AGENTS.md managed-section freshness...")
@@ -1970,7 +1969,7 @@ def cmd_doctor(args: list[str]):
     # need (and must not declare) a `deft:` include to itself.
     if not json_mode:
         print()
-    _emit_info("Checking root Taskfile.yml include...")
+    _emit_info("Checking optional root Taskfile.yml include...")
     if _running_inside_deft_repo(project_root):
         _emit_info(
             "Skipping Taskfile include check -- running inside the deft "
@@ -1987,11 +1986,11 @@ def cmd_doctor(args: list[str]):
             include_missing = True
             target = project_root / "Taskfile.yml"
             message = (
-                "Root Taskfile.yml missing -- the `task X` surface "
-                "(task vbrief:preflight / task spec:render / task check) "
-                f"will not resolve until you add one. Paste this into {target}:"
+                "Root Taskfile.yml missing. This is OK for package-manager "
+                "installs that use the `deft X` surface directly. To also "
+                f"enable the optional `task deft:X` surface, paste this into {target}:"
             )
-            _emit_error(message)
+            _emit_info(message)
             if not json_mode:
                 print()
                 print(_TASKFILE_INCLUDE_SNIPPET)
@@ -2042,8 +2041,8 @@ def cmd_doctor(args: list[str]):
                     )
             if include_missing:
                 _add_finding(
-                    "error",
-                    "Root Taskfile.yml missing",
+                    "warning",
+                    "Root Taskfile.yml missing; optional Taskfile include unavailable",
                     check="taskfile-include",
                     file=str(target),
                     suggestion=_TASKFILE_INCLUDE_SNIPPET,
@@ -2051,16 +2050,18 @@ def cmd_doctor(args: list[str]):
         elif include_status == "missing-include":
             message = (
                 "Root Taskfile.yml exists but does not include the deft "
-                "framework. Add this to its `includes:` block (doctor "
-                "NEVER mutates an existing user-owned Taskfile):"
+                "framework. The `deft X` surface still works; add this to "
+                "the Taskfile `includes:` block only if you want the optional "
+                "`task deft:X` surface (doctor NEVER mutates an existing "
+                "user-owned Taskfile):"
             )
-            _emit_error(message)
+            _emit_warn(message)
             if not json_mode:
                 print()
                 print(_format_missing_include_snippet())
             taskfile_path = _resolve_consumer_taskfile(project_root)
             _add_finding(
-                "error",
+                "warning",
                 "Root Taskfile.yml does not include the deft framework",
                 check="taskfile-include",
                 file=str(taskfile_path) if taskfile_path else None,

--- a/scripts/framework_commands.py
+++ b/scripts/framework_commands.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Shared no-task dispatcher for Deft framework verbs (#1659).
+
+This module is the compatibility rail between the old Taskfile verb names
+(``triage:bootstrap``, ``verify:cache-fresh``, etc.) and the Python entrypoints
+that actually implement them. Package-manager installs can route ``deft
+<verb>`` through this module without requiring go-task on PATH, while Taskfile
+consumers can keep using ``task deft:<verb>`` as a thin wrapper.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import importlib.util
+import inspect
+import io
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Literal
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+FRAMEWORK_ROOT = SCRIPT_DIR.parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+RootMode = Literal["project", "framework"]
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    code: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    name: str
+    entrypoint: str | None = None
+    default_args: tuple[str, ...] = ()
+    project_root_arg: str | None = None
+    framework_root_arg: str | None = None
+    vbrief_dir_arg: str | None = None
+    root_arg: str | None = None
+    cwd: RootMode = "project"
+    no_argv: bool = False
+    aggregate: tuple[str, ...] = ()
+    description: str = ""
+
+
+def _spec(
+    name: str,
+    entrypoint: str,
+    *,
+    default_args: Sequence[str] = (),
+    project_root_arg: str | None = None,
+    framework_root_arg: str | None = None,
+    vbrief_dir_arg: str | None = None,
+    root_arg: str | None = None,
+    cwd: RootMode = "project",
+    no_argv: bool = False,
+    description: str = "",
+) -> CommandSpec:
+    return CommandSpec(
+        name=name,
+        entrypoint=entrypoint,
+        default_args=tuple(default_args),
+        project_root_arg=project_root_arg,
+        framework_root_arg=framework_root_arg,
+        vbrief_dir_arg=vbrief_dir_arg,
+        root_arg=root_arg,
+        cwd=cwd,
+        no_argv=no_argv,
+        description=description,
+    )
+
+
+def _aggregate(name: str, commands: Sequence[str], *, description: str = "") -> CommandSpec:
+    return CommandSpec(name=name, aggregate=tuple(commands), description=description)
+
+
+COMMANDS: dict[str, CommandSpec] = {
+    "core:validate": _spec(
+        "core:validate", "framework_commands:_cmd_core_validate", cwd="framework"
+    ),
+    "core:lint": _spec("core:lint", "framework_commands:_cmd_core_lint", cwd="framework"),
+    "core:test": _spec("core:test", "framework_commands:_cmd_core_test", cwd="framework"),
+    "doctor": _spec("doctor", "doctor:cmd_doctor"),
+    "session:start": _spec(
+        "session:start", "session_start:main", project_root_arg="--project-root"
+    ),
+    "triage:welcome": _spec(
+        "triage:welcome", "triage_welcome:main", project_root_arg="--project-root"
+    ),
+    "triage:bootstrap": _spec(
+        "triage:bootstrap", "triage_bootstrap:main", project_root_arg="--project-root"
+    ),
+    "triage:summary": _spec(
+        "triage:summary", "triage_summary:main", project_root_arg="--project-root"
+    ),
+    "triage:accept": _spec("triage:accept", "triage_actions:main", default_args=("accept",)),
+    "triage:status": _spec("triage:status", "triage_actions:main", default_args=("status",)),
+    "triage:scope": _spec("triage:scope", "triage_scope:main"),
+    "cache:fetch-all": _spec("cache:fetch-all", "cache:main", default_args=("fetch-all",)),
+    "capacity:show": _spec(
+        "capacity:show", "capacity_show:main", project_root_arg="--project-root"
+    ),
+    "scope:demote": _spec("scope:demote", "scope_demote:main", project_root_arg="--project-root"),
+    "toolchain:check": _spec("toolchain:check", "toolchain-check.py:main", no_argv=True),
+    "verify:stubs": _spec("verify:stubs", "verify-stubs.py:main", no_argv=True),
+    "verify:links": _spec("verify:links", "validate-links.py:main", no_argv=True),
+    "verify:rule-ownership": _spec(
+        "verify:rule-ownership",
+        "rule_ownership_lint:main",
+        root_arg="--root",
+        cwd="framework",
+    ),
+    "verify:branch": _spec(
+        "verify:branch",
+        "preflight_branch:main",
+        default_args=("--allow-missing-project-definition",),
+        project_root_arg="--project-root",
+    ),
+    "verify:encoding": _spec(
+        "verify:encoding", "verify_encoding:main", project_root_arg="--project-root"
+    ),
+    "verify:vbrief-conformance": _spec(
+        "verify:vbrief-conformance",
+        "verify_vbrief_conformance:main",
+        project_root_arg="--project-root",
+    ),
+    "verify:destructive-gh-verbs": _spec(
+        "verify:destructive-gh-verbs",
+        "preflight_gh:main",
+        default_args=("--self-test",),
+        project_root_arg="--project-root",
+    ),
+    "verify:scm-boundary": _spec(
+        "verify:scm-boundary",
+        "verify_scm_boundary:main",
+        project_root_arg="--project-root",
+    ),
+    "verify:no-task-runtime": _spec(
+        "verify:no-task-runtime",
+        "verify_no_task_runtime:main",
+        no_argv=True,
+        cwd="framework",
+    ),
+    "verify:cache-fresh": _spec(
+        "verify:cache-fresh",
+        "preflight_cache:main",
+        default_args=("--allow-missing-bootstrap",),
+        project_root_arg="--project-root",
+    ),
+    "verify:wip-cap": _spec(
+        "verify:wip-cap", "preflight_wip_cap:main", project_root_arg="--project-root"
+    ),
+    "verify:pack-drift": _spec(
+        "verify:pack-drift", "pack_render:main", default_args=("--check",), cwd="framework"
+    ),
+    "verify-strategy-output": _spec(
+        "verify-strategy-output",
+        "validate_strategy_output:main",
+        project_root_arg="--project-root",
+    ),
+    "vbrief:validate": _spec(
+        "vbrief:validate", "vbrief_validate:main", vbrief_dir_arg="--vbrief-dir"
+    ),
+    "build": _spec(
+        "build",
+        "build_dist:main",
+        default_args=("--version", "__DEFT_VERSION__"),
+        cwd="framework",
+    ),
+    "check:consumer": _aggregate(
+        "check:consumer",
+        (
+            "doctor",
+            "toolchain:check",
+            "verify:branch",
+            "verify:cache-fresh",
+            "verify:wip-cap",
+            "vbrief:validate",
+            "verify-strategy-output",
+        ),
+    ),
+    "check:framework-source": _aggregate(
+        "check:framework-source",
+        (
+            "core:validate",
+            "core:lint",
+            "core:test",
+            "toolchain:check",
+            "verify:stubs",
+            "verify:links",
+            "verify:rule-ownership",
+            "verify:branch",
+            "verify:encoding",
+            "verify:vbrief-conformance",
+            "verify:destructive-gh-verbs",
+            "verify:scm-boundary",
+            "verify:no-task-runtime",
+            "verify:cache-fresh",
+            "verify:pack-drift",
+            "verify:wip-cap",
+            "vbrief:validate",
+            "verify-strategy-output",
+        ),
+    ),
+}
+
+
+def available_commands() -> tuple[str, ...]:
+    return tuple(sorted(COMMANDS))
+
+
+def has_command(name: str) -> bool:
+    return name in COMMANDS
+
+
+def normalize_task_separator(argv: Sequence[str]) -> list[str]:
+    """Tolerate Taskfile-style pass-through: ``deft verb -- --flag``."""
+    args = list(argv)
+    if args[:1] == ["--"]:
+        return args[1:]
+    return args
+
+
+def format_framework_command(
+    args: Sequence[str],
+    *,
+    surface: str = "deft",
+    task_prefix: str | None = None,
+) -> str:
+    """Render an operator-facing command for the selected invocation surface."""
+    parts = list(args)
+    if surface == "task":
+        prefix = (task_prefix or "").strip()
+        if prefix and not prefix.endswith(":"):
+            prefix = f"{prefix}:"
+        if parts:
+            parts[0] = f"{prefix}{parts[0]}"
+        return " ".join(["task", *parts])
+    return " ".join([surface, *parts])
+
+
+def _version() -> str:
+    try:
+        import resolve_version  # noqa: PLC0415
+
+        return resolve_version.resolve_version()
+    except Exception:  # noqa: BLE001 -- build should still produce a dev artifact
+        return "0.0.0-dev"
+
+
+def _load_module(module_ref: str) -> ModuleType:
+    if module_ref.endswith(".py"):
+        path = SCRIPT_DIR / module_ref
+        module_name = f"_deft_command_{path.stem.replace('-', '_')}"
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+    return importlib.import_module(module_ref)
+
+
+def _reject_args(argv: Sequence[str], command: str) -> int:
+    if argv:
+        print(
+            f"error: {command} does not accept arguments: {' '.join(argv)}",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+def _cmd_core_validate(argv: list[str] | None = None) -> int:
+    if _reject_args(argv or [], "core:validate") != 0:
+        return 2
+    files = [
+        path
+        for path in sorted(Path(".").rglob("*.md"))
+        if ".git" not in path.parts and "backup" not in path.parts
+    ]
+    for path in files:
+        print(f"✓ {path}")
+    print(f"✓ All {len(files)} markdown files validated")
+    return 0
+
+
+def _run_uv(args: Sequence[str]) -> int:
+    return subprocess.run(["uv", "--project", str(FRAMEWORK_ROOT), "run", *args]).returncode
+
+
+def _cmd_core_lint(argv: list[str] | None = None) -> int:
+    if _reject_args(argv or [], "core:lint") != 0:
+        return 2
+    ruff_code = _run_uv(["ruff", "check", "."])
+    if ruff_code != 0:
+        return ruff_code
+    targets = ["run.py"]
+    if Path("tests").exists():
+        targets.append("tests")
+    return _run_uv(["python", "-m", "mypy", *targets])
+
+
+def _cmd_core_test(argv: list[str] | None = None) -> int:
+    if _reject_args(argv or [], "core:test") != 0:
+        return 2
+    if not Path("tests").exists():
+        print("no tests/ (vendored consumer) -- skipping")
+        return 0
+    return subprocess.run([sys.executable, "-m", "pytest", "tests"]).returncode
+
+
+def _load_callable(entrypoint: str) -> Callable[..., int | None]:
+    module_ref, _, func_name = entrypoint.partition(":")
+    if not module_ref or not func_name:
+        raise ValueError(f"invalid framework entrypoint: {entrypoint!r}")
+    module = _load_module(module_ref)
+    func = getattr(module, func_name)
+    if not callable(func):
+        raise TypeError(f"framework entrypoint is not callable: {entrypoint}")
+    return func
+
+
+def _argv_for_spec(
+    spec: CommandSpec,
+    argv: Sequence[str],
+    *,
+    project_root: Path,
+    framework_root: Path,
+) -> list[str]:
+    resolved: list[str] = []
+    for item in spec.default_args:
+        resolved.append(_version() if item == "__DEFT_VERSION__" else item)
+    if spec.project_root_arg:
+        resolved.extend((spec.project_root_arg, str(project_root)))
+    if spec.framework_root_arg:
+        resolved.extend((spec.framework_root_arg, str(framework_root)))
+    if spec.vbrief_dir_arg:
+        resolved.extend((spec.vbrief_dir_arg, str(project_root / "vbrief")))
+    if spec.root_arg:
+        resolved.extend((spec.root_arg, str(framework_root)))
+    resolved.extend(normalize_task_separator(argv))
+    return resolved
+
+
+def _invoke(func: Callable[..., int | None], argv: list[str], *, no_argv: bool) -> int:
+    try:
+        if no_argv:
+            if argv:
+                print(
+                    f"error: this framework command does not accept arguments: {' '.join(argv)}",
+                    file=sys.stderr,
+                )
+                return 2
+            code = func()
+        else:
+            signature = inspect.signature(func)
+            code = func() if len(signature.parameters) == 0 else func(argv)
+    except SystemExit as exc:
+        raw = exc.code
+        return raw if isinstance(raw, int) else (0 if raw is None else 1)
+    return int(code or 0)
+
+
+def run_framework_command(
+    name: str,
+    argv: Sequence[str] = (),
+    *,
+    project_root: Path | None = None,
+    framework_root: Path | None = None,
+    capture: bool = False,
+    output_fn: Callable[[str], None] | None = None,
+) -> CommandResult:
+    root = (project_root or Path.cwd()).resolve()
+    framework = (framework_root or FRAMEWORK_ROOT).resolve()
+    spec = COMMANDS.get(name)
+    if spec is None:
+        return CommandResult(2, "", f"unknown framework command: {name}")
+
+    if spec.aggregate:
+        stdout_parts: list[str] = []
+        stderr_parts: list[str] = []
+        for child in spec.aggregate:
+            if output_fn is not None:
+                output_fn(f"[deft] {child}")
+            result = run_framework_command(
+                child,
+                (),
+                project_root=root,
+                framework_root=framework,
+                capture=capture,
+                output_fn=output_fn,
+            )
+            stdout_parts.append(result.stdout)
+            stderr_parts.append(result.stderr)
+            if result.code != 0:
+                return CommandResult(
+                    result.code,
+                    "".join(stdout_parts),
+                    "".join(stderr_parts),
+                )
+        return CommandResult(0, "".join(stdout_parts), "".join(stderr_parts))
+
+    if spec.entrypoint is None:
+        return CommandResult(2, "", f"framework command has no entrypoint: {name}")
+
+    try:
+        func = _load_callable(spec.entrypoint)
+        command_argv = _argv_for_spec(
+            spec,
+            argv,
+            project_root=root,
+            framework_root=framework,
+        )
+    except Exception as exc:  # noqa: BLE001 -- produce CLI-shaped failure
+        return CommandResult(2, "", f"{type(exc).__name__}: {exc}")
+
+    previous_cwd = Path.cwd()
+    cwd = root if spec.cwd == "project" else framework
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    try:
+        os.chdir(cwd)
+        if capture:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = _invoke(func, command_argv, no_argv=spec.no_argv)
+        else:
+            code = _invoke(func, command_argv, no_argv=spec.no_argv)
+    except Exception as exc:  # noqa: BLE001 -- dispatcher is a command boundary
+        print(f"{type(exc).__name__}: {exc}", file=stderr)
+        code = 2
+    finally:
+        os.chdir(previous_cwd)
+    return CommandResult(code, stdout.getvalue(), stderr.getvalue())
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in {"-h", "--help", "help"}:
+        print("Usage: framework_commands.py <verb> [args...]")
+        print()
+        print("Available framework verbs:")
+        for name in available_commands():
+            print(f"  {name}")
+        return 0
+    command, *rest = args
+    result = run_framework_command(command, rest)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    return result.code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/framework_commands.py
+++ b/scripts/framework_commands.py
@@ -104,6 +104,24 @@ COMMANDS: dict[str, CommandSpec] = {
     "triage:summary": _spec(
         "triage:summary", "triage_summary:main", project_root_arg="--project-root"
     ),
+    "triage:queue": _spec(
+        "triage:queue",
+        "triage_queue:main",
+        default_args=("queue",),
+        project_root_arg="--project-root",
+    ),
+    "triage:show": _spec(
+        "triage:show",
+        "triage_queue:main",
+        default_args=("show",),
+        project_root_arg="--project-root",
+    ),
+    "triage:audit": _spec(
+        "triage:audit",
+        "triage_queue:main",
+        default_args=("audit",),
+        project_root_arg="--project-root",
+    ),
     "triage:accept": _spec("triage:accept", "triage_actions:main", default_args=("accept",)),
     "triage:status": _spec("triage:status", "triage_actions:main", default_args=("status",)),
     "triage:scope": _spec("triage:scope", "triage_scope:main"),

--- a/scripts/framework_commands.py
+++ b/scripts/framework_commands.py
@@ -107,6 +107,7 @@ COMMANDS: dict[str, CommandSpec] = {
     "triage:accept": _spec("triage:accept", "triage_actions:main", default_args=("accept",)),
     "triage:status": _spec("triage:status", "triage_actions:main", default_args=("status",)),
     "triage:scope": _spec("triage:scope", "triage_scope:main"),
+    "migrate:vbrief": _spec("migrate:vbrief", "framework_commands:_cmd_migrate_vbrief"),
     "cache:fetch-all": _spec("cache:fetch-all", "cache:main", default_args=("fetch-all",)),
     "capacity:show": _spec(
         "capacity:show", "capacity_show:main", project_root_arg="--project-root"
@@ -320,6 +321,24 @@ def _cmd_core_test(argv: list[str] | None = None) -> int:
         print("no tests/ (vendored consumer) -- skipping")
         return 0
     return subprocess.run([sys.executable, "-m", "pytest", "tests"]).returncode
+
+
+def _cmd_migrate_vbrief(argv: list[str] | None = None) -> int:
+    import migrate_preflight  # noqa: PLC0415
+    import migrate_vbrief  # noqa: PLC0415
+
+    project_root = Path.cwd().resolve()
+    preflight_code = migrate_preflight.main(
+        [
+            "--project-root",
+            str(project_root),
+            "--deft-root",
+            str(FRAMEWORK_ROOT),
+        ]
+    )
+    if preflight_code != 0:
+        return preflight_code
+    return migrate_vbrief.main([str(project_root), *(argv or [])])
 
 
 def _load_callable(entrypoint: str) -> Callable[..., int | None]:

--- a/scripts/preflight_cache.py
+++ b/scripts/preflight_cache.py
@@ -3,9 +3,9 @@
 
 Pure stdlib, cross-platform. Invoked from:
 
-- ``task verify:cache-fresh`` (aggregated into ``task check``)
+- ``deft verify:cache-fresh`` (aggregated into ``task check``)
 - Dispatcher pre-``start_agent`` invocations -- the dispatcher MUST run
-  ``task verify:cache-fresh --for-issue <N>`` before any ``start_agent``
+  ``deft verify:cache-fresh --for-issue <N>`` before any ``start_agent``
   and refuse dispatch on any non-zero exit (see
   ``templates/agent-prompt-preamble.md`` § 12).
 
@@ -17,24 +17,24 @@ Exit codes (three-state):
 
 - ``0`` -- cache fresh AND no blocking defer conditions.
 - ``1`` -- cache stale OR blocking conditions found; prints remediation
-  to stderr (names ``task triage:bootstrap`` and ``task cache:fetch-all``
+  to stderr (names ``deft triage:bootstrap`` and ``deft cache:fetch-all``
   per the issue body).
 - ``2`` -- config error: ``.deft-cache/`` missing entirely, or
   ``vbrief/.eval/candidates.jsonl`` missing. The config-error class is
   distinct from "cache stale" so a dispatcher can distinguish a never-
-  -bootstrapped project (operator runs ``task triage:bootstrap``) from
-  a stale-cache project (operator runs ``task cache:fetch-all``).
+  -bootstrapped project (operator runs ``deft triage:bootstrap``) from
+  a stale-cache project (operator runs ``deft cache:fetch-all``).
 
 State machine (#1240):
 
 Three user-visible states the OK message must distinguish post-#1240
-because ``task triage:bootstrap`` now seeds an empty audit log:
+because ``deft triage:bootstrap`` now seeds an empty audit log:
 
 1. **No cache yet** -- ``.deft-cache/<source>/`` absent. This is the
    never-bootstrapped state; the gate exits 2 (or 0 + bootstrap-state
    message when ``--allow-missing-bootstrap`` is passed).
 2. **Cache present + audit log empty** -- consumer just ran
-   ``task triage:bootstrap`` but has not yet executed any triage
+   ``deft triage:bootstrap`` but has not yet executed any triage
    action. The gate exits 0 with a ``fresh bootstrap, no triage
    actions yet`` message. Pre-#1240 this state was unreachable because
    bootstrap left the audit log absent -- the gate fell through to
@@ -51,7 +51,7 @@ The freshness check is scoped to the consumer's
 gated by stale entries the operator has explicitly chosen not to track.
 When ``--for-issue <N>`` is given the gate ALSO verifies the issue is
 in scope; an out-of-scope issue exits 1 with a pointer to
-``task triage:scope``.
+``deft triage:scope``.
 
 Override paths:
 
@@ -497,8 +497,8 @@ def is_fetched_at_stale(
 
 _REMEDIATION_STALE = (
     "  Remediation:\n"
-    "    task triage:bootstrap         # full re-populate, or\n"
-    "    task cache:fetch-all -- --source github-issue --repo <OWNER/NAME>\n"
+    "    deft triage:bootstrap         # full re-populate, or\n"
+    "    deft cache:fetch-all -- --source github-issue --repo <OWNER/NAME>\n"
     "  Override (audited): --allow-stale (or DEFT_CACHE_MAX_AGE_HOURS=<N>)."
 )
 
@@ -524,7 +524,7 @@ def evaluate(
     ``.deft-cache/`` or ``vbrief/.eval/candidates.jsonl`` is missing the
     gate returns exit 0 with a friendly info message instead of exit 2.
     The framework repo's own ``task check`` uses this so a fresh
-    checkout that has not yet run ``task triage:bootstrap`` is not
+    checkout that has not yet run ``deft triage:bootstrap`` is not
     gated by its own cache-freshness verb. Consumers leave the flag
     OFF so the gate fails loudly when their cache is missing.
     """
@@ -542,15 +542,15 @@ def evaluate(
                 (
                     f"✓ deft cache-fresh: .deft-cache/{source}/ absent and "
                     "--allow-missing-bootstrap was passed -- treating as "
-                    "bootstrap state (consumer runs `task triage:bootstrap` "
+                    "bootstrap state (consumer runs `deft triage:bootstrap` "
                     "to opt in)."
                 ),
             )
         msg = (
             f"❌ deft cache-fresh: .deft-cache/{source}/ not present under "
             f"{project_root}. The triage cache has not been populated.\n"
-            "  Recovery: run `task triage:bootstrap` (idempotent installer)\n"
-            "             or `task cache:fetch-all -- --source "
+            "  Recovery: run `deft triage:bootstrap` (idempotent installer)\n"
+            "             or `deft cache:fetch-all -- --source "
             f"{source} --repo OWNER/NAME`."
         )
         return GateResult(2, msg)
@@ -568,9 +568,9 @@ def evaluate(
             )
         msg = (
             f"❌ deft cache-fresh: {candidates} missing.\n"
-            "  Recovery: run `task triage:bootstrap` to backfill the audit\n"
+            "  Recovery: run `deft triage:bootstrap` to backfill the audit\n"
             "             log, or accept at least one candidate via\n"
-            "             `task triage:accept`."
+            "             `deft triage:accept`."
         )
         return GateResult(2, msg)
 
@@ -589,7 +589,7 @@ def evaluate(
         msg = (
             "❌ deft cache-fresh: no cached entries under "
             f".deft-cache/{source}/{resolved_repo}/.\n"
-            "  Recovery: `task cache:fetch-all -- --source "
+            "  Recovery: `deft cache:fetch-all -- --source "
             f"{source} --repo {resolved_repo}`."
         )
         return GateResult(2, msg)
@@ -626,9 +626,9 @@ def evaluate(
                 "plan.policy.triageScope[] subscription, and the audit log "
                 "is empty (no triage decisions yet).\n"
                 "  Recovery: widen the subscription (see "
-                "`task triage:scope --list`), repopulate via "
-                "`task cache:fetch-all`, or accept at least one candidate "
-                "via `task triage:accept` once the cache has matching entries."
+                "`deft triage:scope --list`), repopulate via "
+                "`deft cache:fetch-all`, or accept at least one candidate "
+                "via `deft triage:accept` once the cache has matching entries."
             )
             if allow_stale:
                 # Mirror the Step 5 stale-cache pattern: --allow-stale
@@ -680,7 +680,7 @@ def evaluate(
         msg = (
             "❌ deft cache-fresh: no parseable `fetched_at` in any cached "
             "meta.json. The cache may be corrupted.\n"
-            "  Recovery: `task cache:fetch-all -- --source "
+            "  Recovery: `deft cache:fetch-all -- --source "
             f"{source} --repo {resolved_repo}`."
         )
         return GateResult(2, msg)
@@ -737,7 +737,7 @@ def evaluate(
 
     # #1240: distinguish "fresh bootstrap, no triage actions yet" from
     # "actively triaging". A zero-length audit log indicates the consumer
-    # just ran ``task triage:bootstrap`` (step 5 seeded the empty file)
+    # just ran ``deft triage:bootstrap`` (step 5 seeded the empty file)
     # but has not yet emitted any triage decision; the gate is still
     # clean but the language acknowledges the operator's mental state.
     # #1245: the ``backfill_only_cache`` flag set during Step 4 supplies
@@ -814,18 +814,18 @@ def _gate_for_issue(
                 f"❌ deft cache-fresh: issue #{issue_number} is OUTSIDE the "
                 "active plan.policy.triageScope[] subscription.\n"
                 "  Recovery: widen the subscription (see "
-                "`task triage:scope --list`) or open it via "
-                "`task triage:accept -- --repo OWNER/NAME --issue "
+                "`deft triage:scope --list`) or open it via "
+                "`deft triage:accept -- --repo OWNER/NAME --issue "
                 f"{issue_number}` after confirming the scope rule covers it."
             )
             return GateResult(1, msg)
     elif scope_rules and raw is None:
         # We couldn't read the raw payload but rules are set; refuse so
-        # the operator must `task cache:fetch-all` first.
+        # the operator must `deft cache:fetch-all` first.
         msg = (
             f"❌ deft cache-fresh: issue #{issue_number} is not present in "
             f".deft-cache/{DEFAULT_SOURCE}/{repo}/ (cannot verify subscription).\n"
-            f"  Recovery: `task cache:fetch-all -- --source {DEFAULT_SOURCE} "
+            f"  Recovery: `deft cache:fetch-all -- --source {DEFAULT_SOURCE} "
             f"--repo {repo}` and retry."
         )
         return GateResult(1, msg)
@@ -838,7 +838,7 @@ def _gate_for_issue(
         msg = (
             f"❌ deft cache-fresh: issue #{issue_number} has no triage decision "
             f"in {candidates.relative_to(project_root)}.\n"
-            "  Recovery: `task triage:accept -- --repo "
+            "  Recovery: `deft triage:accept -- --repo "
             f"{repo} --issue {issue_number}` "
             "before dispatching an implementation agent."
         )
@@ -849,8 +849,8 @@ def _gate_for_issue(
         msg = (
             f"❌ deft cache-fresh: issue #{issue_number} latest decision "
             f"is {verdict!r}, not {REQUIRED_DECISION!r} -- dispatch refused.\n"
-            f"  Recovery: re-evaluate via `task triage:status -- --repo {repo} "
-            f"--issue {issue_number}` and run `task triage:accept` once the "
+            f"  Recovery: re-evaluate via `deft triage:status -- --repo {repo} "
+            f"--issue {issue_number}` and run `deft triage:accept` once the "
             "item is ready, or pick a different issue."
         )
         return GateResult(1, msg)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -925,14 +925,13 @@ def refresh_roadmap(project_root: Path) -> tuple[bool, str]:
     """
     import roadmap_render  # noqa: PLC0415
 
-    old_cwd = Path.cwd()
-    try:
-        os.chdir(project_root)
-        code = roadmap_render.main()
-    finally:
-        os.chdir(old_cwd)
-    if code != 0:
-        return False, f"roadmap:render failed (exit {code})"
+    ok, msg = roadmap_render.render_roadmap(
+        str(project_root / "vbrief" / "pending"),
+        str(project_root / "ROADMAP.md"),
+        completed_dir=str(project_root / "vbrief" / "completed"),
+    )
+    if not ok:
+        return False, f"roadmap:render failed: {msg}"
     return True, "ROADMAP.md re-rendered"
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -84,6 +84,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _stdio_utf8 import reconfigure_stdio  # noqa: E402
+from framework_commands import run_framework_command  # noqa: E402
 from resolve_version import (  # noqa: E402
     NonPublishableVersionError,
     to_pep440,
@@ -697,60 +698,14 @@ def check_tag_available(
 # ---- Step 5 -- CI ----------------------------------------------------------
 
 
-def task_binary_available() -> bool:
-    return shutil.which("task") is not None
-
-
-def task_has_target(target: str, *, cwd: Path) -> bool:
-    """Return True if ``task --list-all`` reports the given target.
-
-    Uses ``--list-all`` (which surfaces tasks regardless of ``desc:`` presence)
-    so a target can be discovered even if it lacks documentation.
-    """
-    if not task_binary_available():
-        return False
-    try:
-        result = subprocess.run(
-            ["task", "--list-all"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            cwd=str(cwd),
-            check=False,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return False
-    if result.returncode != 0:
-        return False
-    pattern = re.compile(rf"^\*?\s*{re.escape(target)}:", re.MULTILINE)
-    return bool(pattern.search(result.stdout))
-
-
 def run_ci(project_root: Path) -> tuple[bool, str]:
-    """Run ``task ci:local`` if available, else fall back to ``task check``.
+    """Run the local CI entrypoint without requiring go-task (#1659)."""
+    import ci_local  # noqa: PLC0415
 
-    Returns ``(ok, reason)`` -- ``reason`` describes which target ran (or why
-    nothing did, when a fallback is also unavailable).
-    """
-    if not task_binary_available():
-        return False, "task binary not found on PATH"
-    if task_has_target("ci:local", cwd=project_root):
-        target = "ci:local"
-    else:
-        target = "check"
-        if not task_has_target("check", cwd=project_root):
-            return False, "neither task ci:local nor task check is defined"
-    try:
-        result = subprocess.run(
-            ["task", target],
-            cwd=str(project_root),
-            check=False,
-        )
-    except FileNotFoundError:
-        return False, "task binary not found on PATH"
-    if result.returncode != 0:
-        return False, f"task {target} failed (exit {result.returncode})"
-    return True, f"ran task {target}"
+    code = ci_local.main(["--root", str(project_root)])
+    if code != 0:
+        return False, f"ci:local failed (exit {code})"
+    return True, "ran ci:local"
 
 
 # ---- Step 4 -- CHANGELOG promotion -----------------------------------------
@@ -960,7 +915,7 @@ def _prepend_upgrade_banner(notes: str, repo: str, project_root: Path) -> str:
 
 
 def refresh_roadmap(project_root: Path) -> tuple[bool, str]:
-    """Re-render ROADMAP.md via ``task roadmap:render``.
+    """Re-render ROADMAP.md via the Python roadmap renderer.
 
     ``scripts/roadmap_render.py`` already aggregates ``vbrief/pending/``
     (Active) and ``vbrief/completed/`` (Completed) idempotently, so the
@@ -968,20 +923,16 @@ def refresh_roadmap(project_root: Path) -> tuple[bool, str]:
     directly. vBRIEFs that should appear in ``## Completed`` are expected
     to have been moved via ``task scope:complete`` in advance.
     """
-    if not task_binary_available():
-        return False, "task binary not found on PATH"
-    if not task_has_target("roadmap:render", cwd=project_root):
-        return True, "task roadmap:render not defined; skipping"
+    import roadmap_render  # noqa: PLC0415
+
+    old_cwd = Path.cwd()
     try:
-        result = subprocess.run(
-            ["task", "roadmap:render"],
-            cwd=str(project_root),
-            check=False,
-        )
-    except FileNotFoundError:
-        return False, "task binary not found on PATH"
-    if result.returncode != 0:
-        return False, f"task roadmap:render failed (exit {result.returncode})"
+        os.chdir(project_root)
+        code = roadmap_render.main()
+    finally:
+        os.chdir(old_cwd)
+    if code != 0:
+        return False, f"roadmap:render failed (exit {code})"
     return True, "ROADMAP.md re-rendered"
 
 
@@ -989,7 +940,7 @@ def refresh_roadmap(project_root: Path) -> tuple[bool, str]:
 
 
 def run_build(project_root: Path, version: str | None = None) -> tuple[bool, str]:
-    """Run ``task build`` for the release, pinning the artifact version (#723).
+    """Run ``deft build`` for the release, pinning the artifact version (#723).
 
     The Taskfile resolves its ``VERSION`` variable via the inline POSIX
     ``sh:`` block in ``Taskfile.yml`` ``vars: VERSION``, which honors
@@ -1015,31 +966,29 @@ def run_build(project_root: Path, version: str | None = None) -> tuple[bool, str
         - ``version`` falsy / ``None``: subprocess env carries NO
           ``DEFT_RELEASE_VERSION`` (any inherited value is removed).
     """
-    if not task_binary_available():
-        return False, "task binary not found on PATH"
-    if not task_has_target("build", cwd=project_root):
-        return True, "task build not defined; skipping"
-    env = os.environ.copy()
     if version:
-        env["DEFT_RELEASE_VERSION"] = version
+        previous = os.environ.get("DEFT_RELEASE_VERSION")
+        os.environ["DEFT_RELEASE_VERSION"] = version
     else:
-        # Strip any inherited value so version=None means "let the
-        # Taskfile resolver decide" (git tag -> dev fallback) and never
+        previous = os.environ.pop("DEFT_RELEASE_VERSION", None)
+        # Strip any inherited value so version=None means "let the resolver
+        # decide" (git tag -> dev fallback) and never
         # "use whatever leaked from the parent shell" -- see #723.
-        env.pop("DEFT_RELEASE_VERSION", None)
     try:
-        result = subprocess.run(
-            ["task", "build"],
-            cwd=str(project_root),
-            env=env,
-            check=False,
+        result = run_framework_command(
+            "build",
+            project_root=project_root,
+            framework_root=project_root,
         )
-    except FileNotFoundError:
-        return False, "task binary not found on PATH"
-    if result.returncode != 0:
-        return False, f"task build failed (exit {result.returncode})"
+    finally:
+        if previous is None:
+            os.environ.pop("DEFT_RELEASE_VERSION", None)
+        else:
+            os.environ["DEFT_RELEASE_VERSION"] = previous
+    if result.code != 0:
+        return False, f"build failed (exit {result.code})"
     suffix = f" (DEFT_RELEASE_VERSION={version})" if version else ""
-    return True, f"task build ran clean{suffix}"
+    return True, f"build ran clean{suffix}"
 
 
 # ---- Step 5 -- pyproject.toml [project].version sync (#771) ----------------

--- a/scripts/release_e2e.py
+++ b/scripts/release_e2e.py
@@ -104,6 +104,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TextIO
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -404,6 +405,29 @@ def _call_release_entrypoint(
             else:
                 os.environ["DEFT_PROJECT_ROOT"] = old_project_root
 
+    @contextlib.contextmanager
+    def _redirect_entrypoint_stdio(stdout: io.StringIO, stderr: io.StringIO):
+        previous_stdout: TextIO | None = None
+        previous_stderr: TextIO | None = None
+        active = False
+        with _ENTRYPOINT_PROCESS_STATE_LOCK:
+            if _ENTRYPOINT_ACTIVE_RESTORE_OWNER is restore_owner:
+                previous_stdout = sys.stdout
+                previous_stderr = sys.stderr
+                sys.stdout, sys.stderr = stdout, stderr
+                active = True
+        try:
+            yield active
+        finally:
+            if active:
+                with _ENTRYPOINT_PROCESS_STATE_LOCK:
+                    if (
+                        _ENTRYPOINT_ACTIVE_RESTORE_OWNER is restore_owner
+                        and previous_stdout is not None
+                        and previous_stderr is not None
+                    ):
+                        sys.stdout, sys.stderr = previous_stdout, previous_stderr
+
     def _timeout_process_state() -> None:
         global _ENTRYPOINT_ACTIVE_RESTORE_OWNER  # noqa: PLW0603
 
@@ -413,15 +437,13 @@ def _call_release_entrypoint(
                 return
             _ENTRYPOINT_ACTIVE_RESTORE_OWNER = None
             # Own cleanup after timeout; the daemon's later finally block must
-            # not restore over any subsequent release entrypoint.
+            # not restore over any subsequent release entrypoint or capture.
+            sys.stdout, sys.stderr = real_stdout, real_stderr
             os.chdir(old_cwd)
             if old_project_root is None:
                 os.environ.pop("DEFT_PROJECT_ROOT", None)
             else:
                 os.environ["DEFT_PROJECT_ROOT"] = old_project_root
-
-    def _restore_stdio() -> None:
-        sys.stdout, sys.stderr = real_stdout, real_stderr
 
     def _worker() -> None:
         stdout = io.StringIO()
@@ -429,7 +451,9 @@ def _call_release_entrypoint(
         try:
             if not _activate_process_state():
                 return
-            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            with _redirect_entrypoint_stdio(stdout, stderr) as stdio_active:
+                if not stdio_active:
+                    return
                 code = entrypoint(argv)
         except SystemExit as exc:
             raw = exc.code
@@ -450,8 +474,8 @@ def _call_release_entrypoint(
     worker.join(timeout)
     if worker.is_alive():
         # A hung worker may still hold process-global stdout/stderr redirects.
-        # Restore real streams and claim root-state cleanup before fail-closed.
-        _restore_stdio()
+        # Claim cleanup before fail-closed; the daemon's later context exit is
+        # owner-aware and will not restore over a subsequent capture.
         _timeout_process_state()
         label = getattr(entrypoint, "__name__", "entrypoint")
         return ENTRYPOINT_TIMEOUT_EXIT_CODE, f"{label} timed out after {timeout:g}s"

--- a/scripts/release_e2e.py
+++ b/scripts/release_e2e.py
@@ -90,7 +90,9 @@ helper re-used here), #725 (forward-revert + normal push in rollback),
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as _dt
+import io
 import json
 import os
 import shutil  # noqa: F401  -- kept for tests that monkeypatch release_e2e.shutil.which
@@ -109,6 +111,7 @@ from _stdio_utf8 import reconfigure_stdio  # noqa: E402
 reconfigure_stdio()
 
 import release  # noqa: E402
+import release_rollback  # noqa: E402
 
 EXIT_OK = release.EXIT_OK
 EXIT_VIOLATION = release.EXIT_VIOLATION
@@ -349,14 +352,42 @@ def push_mirror(clone_dir: Path) -> tuple[bool, str]:
     return True, "pushed heads + tags to temp origin"
 
 
+def _call_release_entrypoint(
+    entrypoint: Callable[[list[str] | None], int],
+    argv: list[str],
+    *,
+    clone_dir: Path,
+) -> tuple[int, str]:
+    old_cwd = Path.cwd()
+    old_project_root = os.environ.get("DEFT_PROJECT_ROOT")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    os.environ["DEFT_PROJECT_ROOT"] = str(clone_dir)
+    try:
+        os.chdir(clone_dir)
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            code = entrypoint(argv)
+    except SystemExit as exc:
+        raw = exc.code
+        code = raw if isinstance(raw, int) else (0 if raw is None else 1)
+    finally:
+        os.chdir(old_cwd)
+        if old_project_root is None:
+            os.environ.pop("DEFT_PROJECT_ROOT", None)
+        else:
+            os.environ["DEFT_PROJECT_ROOT"] = old_project_root
+    output = stderr.getvalue() or stdout.getvalue()
+    return int(code or 0), output
+
+
 def dispatch_task_release(
     clone_dir: Path, version: str, repo: str
 ) -> tuple[bool, str]:
-    """Invoke ``task release`` inside the clone with skip flags and the
+    """Invoke release.py inside the clone with skip flags and the
     vBRIEF-drift override (#720, #728, post-#754 harness fix).
 
     The full dispatched argv is
-    ``task release -- <version> --repo <repo> --skip-ci --skip-build --allow-vbrief-drift``.
+    ``release.py <version> --repo <repo> --skip-ci --skip-build --allow-vbrief-drift``.
 
     Skipping CI + build keeps the rehearsal wall-clock manageable; both
     are covered by the unit-test suite. The 10-step pipeline still
@@ -387,36 +418,24 @@ def dispatch_task_release(
     fully gated. Without this flag, every ``task release:e2e`` invocation
     since #734 landed has failed at the inner Step 3 lifecycle gate.
     """
-    if shutil.which("task") is None:
-        return False, "task binary not found on PATH"
-    cmd = [
-        "task", "release",
-        "--", version,
+    argv = [
+        version,
         "--repo", repo,
         "--skip-ci",
         "--skip-build",
         "--allow-vbrief-drift",
     ]
-    env = os.environ.copy()
-    env["DEFT_PROJECT_ROOT"] = str(clone_dir)
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=str(clone_dir),
-            capture_output=True,
-            text=True,
-            timeout=600,
-            check=False,
-            env=env,
-        )
-    except FileNotFoundError:
-        return False, "task binary not found on PATH"
-    if result.returncode != 0:
+    code, output = _call_release_entrypoint(
+        release.main,
+        argv,
+        clone_dir=clone_dir,
+    )
+    if code != 0:
         return False, (
-            f"task release failed (exit {result.returncode}): "
-            f"{(result.stderr or result.stdout).strip()}"
+            f"release.py failed (exit {code}): "
+            f"{output.strip()}"
         )
-    return True, f"task release -- {version} --repo {repo} (draft) ran clean"
+    return True, f"release.py {version} --repo {repo} (draft) ran clean"
 
 
 def verify_draft_release(
@@ -489,7 +508,7 @@ def verify_tag(clone_dir: Path, version: str) -> tuple[bool, str]:
 def dispatch_task_release_rollback(
     clone_dir: Path, version: str, repo: str
 ) -> tuple[bool, str]:
-    """Invoke ``task release:rollback -- <version> --repo <repo>`` (#720, #728).
+    """Invoke release_rollback.py ``<version> --repo <repo>`` (#720, #728).
 
     Exercises the rollback path against the temp repo so a regression in
     the state-aware unwind (states 1-3) surfaces in the e2e job rather
@@ -502,33 +521,18 @@ def dispatch_task_release_rollback(
     either a false VIOLATION (release-prep SHA cannot be resolved) or
     -- worse -- mutating the real repo's history.
     """
-    if shutil.which("task") is None:
-        return False, "task binary not found on PATH"
-    cmd = [
-        "task", "release:rollback",
-        "--", version,
-        "--repo", repo,
-    ]
-    env = os.environ.copy()
-    env["DEFT_PROJECT_ROOT"] = str(clone_dir)
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=str(clone_dir),
-            capture_output=True,
-            text=True,
-            timeout=300,
-            check=False,
-            env=env,
-        )
-    except FileNotFoundError:
-        return False, "task binary not found on PATH"
-    if result.returncode != 0:
+    argv = [version, "--repo", repo]
+    code, output = _call_release_entrypoint(
+        release_rollback.main,
+        argv,
+        clone_dir=clone_dir,
+    )
+    if code != 0:
         return False, (
-            f"task release:rollback failed (exit {result.returncode}): "
-            f"{(result.stderr or result.stdout).strip()}"
+            f"release_rollback.py failed (exit {code}): "
+            f"{output.strip()}"
         )
-    return True, f"task release:rollback -- {version} --repo {repo} ran clean"
+    return True, f"release_rollback.py {version} --repo {repo} ran clean"
 
 
 def run_rehearsal(

--- a/scripts/release_e2e.py
+++ b/scripts/release_e2e.py
@@ -99,6 +99,7 @@ import shutil  # noqa: F401  -- kept for tests that monkeypatch release_e2e.shut
 import subprocess
 import sys
 import tempfile
+import threading
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -126,6 +127,9 @@ REPO_SLUG_PREFIX = "deftai-release-test-"
 # as a rehearsal artefact -- and ``X.Y.Z`` matches the strict semver
 # regex enforced by ``release._validate_version``.
 REHEARSAL_VERSION = "0.0.1"
+RELEASE_ENTRYPOINT_TIMEOUT_SECONDS = 600.0
+ROLLBACK_ENTRYPOINT_TIMEOUT_SECONDS = 300.0
+ENTRYPOINT_TIMEOUT_EXIT_CODE = 124
 
 
 # ---- Data classes -----------------------------------------------------------
@@ -357,27 +361,61 @@ def _call_release_entrypoint(
     argv: list[str],
     *,
     clone_dir: Path,
+    timeout: float | None = None,
 ) -> tuple[int, str]:
+    """Run a release entrypoint in-process with subprocess-style bounds.
+
+    The original task-backed dispatch capped release at 600s and rollback at
+    300s. In-process calls need the same fail-closed behavior so a hung release
+    command cannot block the e2e rehearsal forever.
+    """
+    if timeout is None:
+        timeout = RELEASE_ENTRYPOINT_TIMEOUT_SECONDS
     old_cwd = Path.cwd()
     old_project_root = os.environ.get("DEFT_PROJECT_ROOT")
-    stdout = io.StringIO()
-    stderr = io.StringIO()
-    os.environ["DEFT_PROJECT_ROOT"] = str(clone_dir)
-    try:
-        os.chdir(clone_dir)
-        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-            code = entrypoint(argv)
-    except SystemExit as exc:
-        raw = exc.code
-        code = raw if isinstance(raw, int) else (0 if raw is None else 1)
-    finally:
+    real_stdout, real_stderr = sys.stdout, sys.stderr
+    result: dict[str, tuple[int, str]] = {}
+
+    def _restore_process_state() -> None:
         os.chdir(old_cwd)
         if old_project_root is None:
             os.environ.pop("DEFT_PROJECT_ROOT", None)
         else:
             os.environ["DEFT_PROJECT_ROOT"] = old_project_root
-    output = stderr.getvalue() or stdout.getvalue()
-    return int(code or 0), output
+
+    def _worker() -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        os.environ["DEFT_PROJECT_ROOT"] = str(clone_dir)
+        try:
+            os.chdir(clone_dir)
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = entrypoint(argv)
+        except SystemExit as exc:
+            raw = exc.code
+            code = raw if isinstance(raw, int) else (0 if raw is None else 1)
+        except Exception as exc:  # noqa: BLE001 -- e2e diagnostics must record failures
+            message = f"{type(exc).__name__}: {exc}"
+            captured_stderr = stderr.getvalue()
+            stderr_value = f"{captured_stderr}\n{message}" if captured_stderr else message
+            result["value"] = (EXIT_VIOLATION, stderr_value or stdout.getvalue())
+            return
+        finally:
+            _restore_process_state()
+        output = stderr.getvalue() or stdout.getvalue()
+        result["value"] = (int(code or 0), output)
+
+    worker = threading.Thread(target=_worker, name="deft-release-entrypoint", daemon=True)
+    worker.start()
+    worker.join(timeout)
+    if worker.is_alive():
+        # A hung worker may still hold process-global stdout/stderr redirects.
+        # Restore the real streams and root env before returning fail-closed.
+        sys.stdout, sys.stderr = real_stdout, real_stderr
+        _restore_process_state()
+        label = getattr(entrypoint, "__name__", "entrypoint")
+        return ENTRYPOINT_TIMEOUT_EXIT_CODE, f"{label} timed out after {timeout:g}s"
+    return result.get("value", (EXIT_VIOLATION, "entrypoint produced no result"))
 
 
 def dispatch_task_release(
@@ -429,6 +467,7 @@ def dispatch_task_release(
         release.main,
         argv,
         clone_dir=clone_dir,
+        timeout=RELEASE_ENTRYPOINT_TIMEOUT_SECONDS,
     )
     if code != 0:
         return False, (
@@ -526,6 +565,7 @@ def dispatch_task_release_rollback(
         release_rollback.main,
         argv,
         clone_dir=clone_dir,
+        timeout=ROLLBACK_ENTRYPOINT_TIMEOUT_SECONDS,
     )
     if code != 0:
         return False, (

--- a/scripts/release_e2e.py
+++ b/scripts/release_e2e.py
@@ -130,6 +130,8 @@ REHEARSAL_VERSION = "0.0.1"
 RELEASE_ENTRYPOINT_TIMEOUT_SECONDS = 600.0
 ROLLBACK_ENTRYPOINT_TIMEOUT_SECONDS = 300.0
 ENTRYPOINT_TIMEOUT_EXIT_CODE = 124
+_ENTRYPOINT_PROCESS_STATE_LOCK = threading.Lock()
+_ENTRYPOINT_ACTIVE_RESTORE_OWNER: object | None = None
 
 
 # ---- Data classes -----------------------------------------------------------
@@ -375,20 +377,58 @@ def _call_release_entrypoint(
     old_project_root = os.environ.get("DEFT_PROJECT_ROOT")
     real_stdout, real_stderr = sys.stdout, sys.stderr
     result: dict[str, tuple[int, str]] = {}
+    restore_owner = object()
+    timed_out = threading.Event()
+
+    def _activate_process_state() -> bool:
+        global _ENTRYPOINT_ACTIVE_RESTORE_OWNER  # noqa: PLW0603
+
+        with _ENTRYPOINT_PROCESS_STATE_LOCK:
+            if timed_out.is_set():
+                return False
+            _ENTRYPOINT_ACTIVE_RESTORE_OWNER = restore_owner
+            os.environ["DEFT_PROJECT_ROOT"] = str(clone_dir)
+            os.chdir(clone_dir)
+            return True
 
     def _restore_process_state() -> None:
-        os.chdir(old_cwd)
-        if old_project_root is None:
-            os.environ.pop("DEFT_PROJECT_ROOT", None)
-        else:
-            os.environ["DEFT_PROJECT_ROOT"] = old_project_root
+        global _ENTRYPOINT_ACTIVE_RESTORE_OWNER  # noqa: PLW0603
+
+        with _ENTRYPOINT_PROCESS_STATE_LOCK:
+            if _ENTRYPOINT_ACTIVE_RESTORE_OWNER is not restore_owner:
+                return
+            _ENTRYPOINT_ACTIVE_RESTORE_OWNER = None
+            os.chdir(old_cwd)
+            if old_project_root is None:
+                os.environ.pop("DEFT_PROJECT_ROOT", None)
+            else:
+                os.environ["DEFT_PROJECT_ROOT"] = old_project_root
+
+    def _timeout_process_state() -> None:
+        global _ENTRYPOINT_ACTIVE_RESTORE_OWNER  # noqa: PLW0603
+
+        with _ENTRYPOINT_PROCESS_STATE_LOCK:
+            timed_out.set()
+            if _ENTRYPOINT_ACTIVE_RESTORE_OWNER is not restore_owner:
+                return
+            _ENTRYPOINT_ACTIVE_RESTORE_OWNER = None
+            # Own cleanup after timeout; the daemon's later finally block must
+            # not restore over any subsequent release entrypoint.
+            os.chdir(old_cwd)
+            if old_project_root is None:
+                os.environ.pop("DEFT_PROJECT_ROOT", None)
+            else:
+                os.environ["DEFT_PROJECT_ROOT"] = old_project_root
+
+    def _restore_stdio() -> None:
+        sys.stdout, sys.stderr = real_stdout, real_stderr
 
     def _worker() -> None:
         stdout = io.StringIO()
         stderr = io.StringIO()
-        os.environ["DEFT_PROJECT_ROOT"] = str(clone_dir)
         try:
-            os.chdir(clone_dir)
+            if not _activate_process_state():
+                return
             with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
                 code = entrypoint(argv)
         except SystemExit as exc:
@@ -410,9 +450,9 @@ def _call_release_entrypoint(
     worker.join(timeout)
     if worker.is_alive():
         # A hung worker may still hold process-global stdout/stderr redirects.
-        # Restore the real streams and root env before returning fail-closed.
-        sys.stdout, sys.stderr = real_stdout, real_stderr
-        _restore_process_state()
+        # Restore real streams and claim root-state cleanup before fail-closed.
+        _restore_stdio()
+        _timeout_process_state()
         label = getattr(entrypoint, "__name__", "entrypoint")
         return ENTRYPOINT_TIMEOUT_EXIT_CODE, f"{label} timed out after {timeout:g}s"
     return result.get("value", (EXIT_VIOLATION, "entrypoint produced no result"))

--- a/scripts/toolchain-check.py
+++ b/scripts/toolchain-check.py
@@ -1,4 +1,4 @@
-"""Verify required toolchain is installed (go, uv, task, git, gh)."""
+"""Verify required source-repo toolchain is installed (go, uv, git, gh)."""
 
 import subprocess
 import sys
@@ -6,7 +6,6 @@ import sys
 TOOLS = [
     ("go", ["go", "version"]),
     ("uv", ["uv", "--version"]),
-    ("task", ["task", "--version"]),
     ("git", ["git", "--version"]),
     ("gh", ["gh", "--version"]),
 ]

--- a/scripts/triage_welcome.py
+++ b/scripts/triage_welcome.py
@@ -11,9 +11,6 @@ from __future__ import annotations
 
 import contextlib
 import json
-import os
-import shutil
-import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -33,6 +30,10 @@ from _lifecycle_hygiene import (  # noqa: E402  (sibling import after sys.path t
 from _project_definition_io import (  # noqa: E402  (after sys.path tweak)
     atomic_write_project_definition,
     project_definition_mutation_lock,
+)
+from framework_commands import (  # noqa: E402
+    format_framework_command,
+    run_framework_command,
 )
 from policy import (  # noqa: E402  (sibling import after sys.path tweak)
     count_pending_decisions,
@@ -536,24 +537,26 @@ def format_task_command(args: list[str], *, task_prefix: str | None = None) -> s
     return " ".join(["task", *task_command_args(args, task_prefix=task_prefix)])
 
 
+def format_welcome_command(args: list[str], *, task_prefix: str | None = None) -> str:
+    """Render the preferred command for welcome guidance (#1659)."""
+    prefix = normalize_task_prefix(task_prefix)
+    if prefix:
+        return format_framework_command(args, surface="task", task_prefix=prefix)
+    return format_framework_command(args, surface="deft")
+
+
 def _run_task(args: list[str], *, cwd: Path, task_prefix: str | None = None) -> int:
-    """Run ``task <args...>``. Returns exit code; never raises on non-zero."""
-    task_binary = shutil.which("task") or "task"
-    task_args = task_command_args(args, task_prefix=task_prefix)
-    if os.name == "nt" and Path(task_binary).suffix.lower() in {".bat", ".cmd"}:
-        cmd = ["cmd.exe", "/c", task_binary, *task_args]
-    else:
-        cmd = [task_binary, *task_args]
-    try:
-        result = subprocess.run(cmd, cwd=str(cwd), check=False)
-        return result.returncode
-    except FileNotFoundError:
-        sys.stderr.write(
-            "  [triage:welcome] WARN: `task` not on PATH -- skipping the "
-            f"subprocess hop ({' '.join(cmd)}). Re-run with the deft "
-            "toolchain available to chain the remaining phases.\n"
-        )
-        return 127
+    """Run a Deft framework verb in-process. Returns exit code; never raises."""
+    _ = task_prefix  # The no-task rail ignores Taskfile namespaces at runtime.
+    if not args:
+        return 2
+    command, *argv = args
+    result = run_framework_command(command, argv, project_root=cwd)
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    return result.code
 
 
 # ---------------------------------------------------------------------------
@@ -583,7 +586,7 @@ from _triage_welcome_cli import (  # noqa: E402,F401  (after sys.path tweak; _cl
 # ---------------------------------------------------------------------------
 
 #: Overflow pointer appended when the budget hides additional ranked nudges.
-NUDGE_OVERFLOW_POINTER: str = "`task capacity:show`"
+NUDGE_OVERFLOW_POINTER: str = "`deft capacity:show`"
 
 #: Default session-start nudge budget (RFC #1419 Nudge Budgeting: budget 1).
 DEFAULT_NUDGE_BUDGET: int = 1
@@ -614,7 +617,7 @@ def session_start_nudge_lines(
     Slice-6 lifecycle-hygiene nudges (stranded-slice Tier-1, stale-epic
     Tier-2) into one ranked list -- ``(tier, -magnitude, id)`` -- and returns
     at most *budget* headline lines plus a single ``+N more`` overflow pointer
-    at ``task capacity:show`` when more nudges remain. This is the budgeted
+    at ``deft capacity:show`` when more nudges remain. This is the budgeted
     default-mode surface; the full ranked list lives in ``capacity:show``.
     """
     ranked: list[tuple[int, int, str, str]] = []
@@ -631,7 +634,7 @@ def session_start_nudge_lines(
     # dormancy-days while the backlog's is a decision count, so dormancy-days
     # effectively dominates same-tier ordering. That is acceptable because the
     # budgeted surface only shows the single top headline plus a `+N more`
-    # pointer; the full, separately-grouped list lives in `task capacity:show`.
+    # pointer; the full, separately-grouped list lives in `deft capacity:show`.
     ranked.sort(key=lambda item: (item[0], -item[1], item[2]))
 
     budget = max(0, budget)
@@ -693,7 +696,7 @@ __all__ = (
     "pending_decisions_oneliner", "preview_wip_relief",
     "project_definition_path", "prompt_int", "prompt_menu", "prompt_yes_no",
     "record_tech_debt_acceptance", "resolve_epic_thresholds",
-    "format_task_command", "normalize_task_prefix", "run_default_mode",
+    "format_task_command", "format_welcome_command", "normalize_task_prefix", "run_default_mode",
     "run_welcome", "session_start_nudge_lines", "task_command_args",
     "write_triage_scope", "write_wip_cap",
 )
@@ -717,7 +720,7 @@ class WelcomeOutcome:
     """End-of-run summary for tests / dispatcher consumers.
 
     ``bootstrap_action`` (#1244) surfaces whether Phase 3 invoked
-    ``task triage:bootstrap`` or skipped it (and why). One of the
+    ``deft triage:bootstrap`` or skipped it (and why). One of the
     ``BOOTSTRAP_ACTION_*`` constants above, or ``None`` if the ritual
     exited before Phase 3 (e.g. Discuss / Back at Phase 2).
     """
@@ -753,7 +756,7 @@ def run_welcome(
 
     Phase 3 bootstrap-skip semantics (#1244): the canonical "bootstrap
     already finished" signal is ``vbrief/.eval/candidates.jsonl`` (the
-    audit log seeded by ``task triage:bootstrap`` step 5), NOT the raw
+    audit log seeded by ``deft triage:bootstrap`` step 5), NOT the raw
     ``.deft-cache/`` entry count. When the audit log is absent the
     ritual MUST (a) run bootstrap (the default, idempotent), (b) loudly
     surface dry-mode suppression when ``run_subprocess=False``, or
@@ -766,11 +769,9 @@ def run_welcome(
     normalized_task_prefix = normalize_task_prefix(task_prefix)
 
     def _display_task(args: list[str]) -> str:
-        return format_task_command(args, task_prefix=normalized_task_prefix)
+        return format_welcome_command(args, task_prefix=normalized_task_prefix)
 
     def _run_welcome_task(args: list[str]) -> int:
-        if normalized_task_prefix:
-            return _run_task(args, cwd=project_root, task_prefix=normalized_task_prefix)
         return _run_task(args, cwd=project_root)
 
     # ``Back`` overrides the "already set, skip" rule for ONE iteration so

--- a/scripts/verify_no_task_runtime.py
+++ b/scripts/verify_no_task_runtime.py
@@ -52,12 +52,36 @@ class Visitor(ast.NodeVisitor):
     def __init__(self, path: Path) -> None:
         self.path = path
         self.findings: list[Finding] = []
+        self.subprocess_names = {"subprocess"}
+        self.subprocess_func_names: set[str] = set()
+        self.shutil_names = {"shutil"}
+        self.shutil_which_names: set[str] = set()
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            local_name = alias.asname or alias.name
+            if alias.name == "subprocess":
+                self.subprocess_names.add(local_name)
+            if alias.name == "shutil":
+                self.shutil_names.add(local_name)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        if node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in SUBPROCESS_FUNCS:
+                    self.subprocess_func_names.add(alias.asname or alias.name)
+        if node.module == "shutil":
+            for alias in node.names:
+                if alias.name == "which":
+                    self.shutil_which_names.add(alias.asname or alias.name)
+        self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
         if isinstance(node.func, ast.Attribute):
             if (
                 isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "subprocess"
+                and node.func.value.id in self.subprocess_names
                 and node.func.attr in SUBPROCESS_FUNCS
                 and _literal_first_arg(node) == "task"
             ):
@@ -70,9 +94,32 @@ class Visitor(ast.NodeVisitor):
                 )
             if (
                 node.func.attr == "which"
-                and _is_name_or_attr(node.func.value, "shutil")
+                and (
+                    _is_name_or_attr(node.func.value, "shutil")
+                    or (
+                        isinstance(node.func.value, ast.Name)
+                        and node.func.value.id in self.shutil_names
+                    )
+                )
                 and _literal_first_arg(node) == "task"
             ):
+                self.findings.append(
+                    Finding(
+                        self.path,
+                        node.lineno,
+                        "runtime go-task PATH probe is forbidden",
+                    )
+                )
+        if isinstance(node.func, ast.Name):
+            if node.func.id in self.subprocess_func_names and _literal_first_arg(node) == "task":
+                self.findings.append(
+                    Finding(
+                        self.path,
+                        node.lineno,
+                        "runtime subprocess invocation of go-task is forbidden",
+                    )
+                )
+            if node.func.id in self.shutil_which_names and _literal_first_arg(node) == "task":
                 self.findings.append(
                     Finding(
                         self.path,

--- a/scripts/verify_no_task_runtime.py
+++ b/scripts/verify_no_task_runtime.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Fail when runtime Python code hard-depends on go-task (#1659)."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAN_PATHS = (ROOT / "run", ROOT / "scripts")
+SUBPROCESS_FUNCS = {"run", "check_call", "check_output", "Popen", "call"}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    message: str
+
+
+def _is_name_or_attr(node: ast.AST, dotted: str) -> bool:
+    parts = dotted.split(".")
+    current = node
+    for expected in reversed(parts):
+        if isinstance(current, ast.Attribute):
+            if current.attr != expected:
+                return False
+            current = current.value
+            continue
+        if isinstance(current, ast.Name):
+            return current.id == expected and expected == parts[0]
+        return False
+    return isinstance(current, ast.Name) and current.id == parts[0]
+
+
+def _literal_first_arg(call: ast.Call) -> str | None:
+    if not call.args:
+        return None
+    first = call.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    if isinstance(first, (ast.List, ast.Tuple)) and first.elts:
+        head = first.elts[0]
+        if isinstance(head, ast.Constant) and isinstance(head.value, str):
+            return head.value
+    return None
+
+
+class Visitor(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.findings: list[Finding] = []
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        if isinstance(node.func, ast.Attribute):
+            if (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "subprocess"
+                and node.func.attr in SUBPROCESS_FUNCS
+                and _literal_first_arg(node) == "task"
+            ):
+                self.findings.append(
+                    Finding(
+                        self.path,
+                        node.lineno,
+                        "runtime subprocess invocation of go-task is forbidden",
+                    )
+                )
+            if (
+                node.func.attr == "which"
+                and _is_name_or_attr(node.func.value, "shutil")
+                and _literal_first_arg(node) == "task"
+            ):
+                self.findings.append(
+                    Finding(
+                        self.path,
+                        node.lineno,
+                        "runtime go-task PATH probe is forbidden",
+                    )
+                )
+        self.generic_visit(node)
+
+
+def _python_files() -> list[Path]:
+    files = [ROOT / "run"]
+    files.extend(
+        path
+        for path in sorted((ROOT / "scripts").glob("*.py"))
+        if path.name != Path(__file__).name
+    )
+    return files
+
+
+def scan() -> list[Finding]:
+    findings: list[Finding] = []
+    for path in _python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError) as exc:
+            findings.append(Finding(path, getattr(exc, "lineno", 1) or 1, str(exc)))
+            continue
+        visitor = Visitor(path)
+        visitor.visit(tree)
+        findings.extend(visitor.findings)
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    _ = argv
+    findings = scan()
+    if not findings:
+        print("No runtime go-task subprocess dependencies found")
+        return 0
+    print("Runtime go-task dependencies found:", file=sys.stderr)
+    for finding in findings:
+        rel = finding.path.relative_to(ROOT)
+        print(f"  {rel}:{finding.line}: {finding.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_session_ritual.py
+++ b/scripts/verify_session_ritual.py
@@ -19,7 +19,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from framework_commands import format_framework_command, run_framework_command  # noqa: E402
+from framework_commands import format_framework_command  # noqa: E402
 from policy import resolve_session_ritual_staleness_hours  # noqa: E402
 from ritual_sentinel import (  # noqa: E402
     RitualState,
@@ -155,8 +155,7 @@ def _default_runner(args: list[str], cwd: Path) -> tuple[int, str, str]:
             preflight_cache.main,
             ["--allow-missing-bootstrap", "--project-root", str(cwd), *argv],
         )
-    result = run_framework_command(command, argv, project_root=cwd, capture=True)
-    return result.code, result.stdout, result.stderr
+    return 2, "", f"unknown session ritual command: {command}"
 
 
 def _step_passes(step: dict[str, Any] | None) -> bool:

--- a/scripts/verify_session_ritual.py
+++ b/scripts/verify_session_ritual.py
@@ -19,6 +19,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from framework_commands import format_framework_command, run_framework_command  # noqa: E402
 from policy import resolve_session_ritual_staleness_hours  # noqa: E402
 from ritual_sentinel import (  # noqa: E402
     RitualState,
@@ -37,8 +38,8 @@ ENTRYPOINT_TIMEOUT_EXIT_CODE = 124
 QUICK_STEPS: tuple[str, ...] = ("alignment", "branch_policy", "triage_welcome")
 GATED_STEPS: tuple[str, ...] = ("doctor", "cache_fresh")
 GATED_ENTRYPOINT_COMMANDS: dict[str, tuple[str, ...]] = {
-    "doctor": ("doctor.cmd_doctor",),
-    "cache_fresh": ("preflight_cache.main", "--allow-missing-bootstrap"),
+    "doctor": ("doctor",),
+    "cache_fresh": ("verify:cache-fresh",),
 }
 
 
@@ -142,16 +143,20 @@ def _call_main(
 
 
 def _default_runner(args: list[str], cwd: Path) -> tuple[int, str, str]:
-    entrypoint, *argv = args
-    if entrypoint == "doctor.cmd_doctor":
+    command, *argv = args
+    if command == "doctor":
         import doctor  # noqa: PLC0415
 
-        return _call_main(doctor.cmd_doctor, argv)
-    if entrypoint == "preflight_cache.main":
+        return _call_main(doctor.cmd_doctor, ["--project-root", str(cwd), *argv])
+    if command == "verify:cache-fresh":
         import preflight_cache  # noqa: PLC0415
 
-        return _call_main(preflight_cache.main, argv)
-    return 2, "", f"unknown session ritual entrypoint: {entrypoint}"
+        return _call_main(
+            preflight_cache.main,
+            ["--allow-missing-bootstrap", "--project-root", str(cwd), *argv],
+        )
+    result = run_framework_command(command, argv, project_root=cwd, capture=True)
+    return result.code, result.stdout, result.stderr
 
 
 def _step_passes(step: dict[str, Any] | None) -> bool:
@@ -166,7 +171,7 @@ def _failed_step_message(tier_name: str, step_name: str, step: object) -> str:
     if step is None:
         return (
             f"session ritual {tier_name} step '{step_name}' is missing. "
-            "Run `task session:start` before implementation dispatch."
+            f"Run `{format_framework_command(['session:start'])}` before implementation dispatch."
         )
     if isinstance(step, dict) and step.get("deferred_reason"):
         return ""
@@ -183,11 +188,7 @@ def _run_gated_step(
     runner: Runner,
     now: datetime,
 ) -> str | None:
-    command = [
-        *GATED_ENTRYPOINT_COMMANDS[step_name],
-        "--project-root",
-        str(project_root),
-    ]
+    command = [*GATED_ENTRYPOINT_COMMANDS[step_name]]
     code, stdout, stderr = runner(command, project_root)
     message = stdout.strip() or stderr.strip() or f"{command[0]} exited {code}"
     payload.setdefault("gated_steps", {})[step_name] = ritual_step(
@@ -219,23 +220,24 @@ def _evaluate_loaded_state(
         return (
             1,
             "session ritual state belongs to a different worktree "
-            f"({state.worktree_path}); run `task session:start` here.",
+            f"({state.worktree_path}); run `{format_framework_command(['session:start'])}` here.",
         )
     if state.git_head != current_head:
         return (
             1,
             "session ritual state is stale because git HEAD changed. "
-            "Run `task session:start` again.",
+            f"Run `{format_framework_command(['session:start'])}` again.",
         )
     staleness = resolve_session_ritual_staleness_hours(project_root)
     if staleness.source == "default-on-error":
         return 2, staleness.error or "session ritual staleness policy is invalid"
     max_age = timedelta(hours=staleness.hours)
     if now - state.started_at > max_age:
+        start_command = format_framework_command(["session:start"])
         return (
             1,
             "session ritual state is stale "
-            f"(older than {staleness.hours}h). Run `task session:start` again.",
+            f"(older than {staleness.hours}h). Run `{start_command}` again.",
         )
     for step_name in QUICK_STEPS:
         step = state.quick_steps.get(step_name)
@@ -272,8 +274,9 @@ def verify(
     state, err = read_ritual_state(project_root)
     if state is None:
         code = 1 if missing_state_file else 2
+        start_command = format_framework_command(["session:start"])
         message = (
-            f"{err}. Run `task session:start` before implementation dispatch."
+            f"{err}. Run `{start_command}` before implementation dispatch."
             if code == 1
             else err or "ritual state invalid"
         )

--- a/scripts/verify_tools.py
+++ b/scripts/verify_tools.py
@@ -258,6 +258,7 @@ def verify_required_tools(
     *,
     install: bool = False,
     assume_yes: bool = False,
+    include_task: bool = False,
     platform_id: str | None = None,
     probe: ProbeFn = shutil.which,
     input_fn: InputFn = input,
@@ -269,7 +270,13 @@ def verify_required_tools(
     statuses: list[ToolStatus] = []
     lines: list[str] = []
 
-    for spec in TOOL_SPECS:
+    selected_specs = (
+        TOOL_SPECS
+        if include_task
+        else tuple(spec for spec in TOOL_SPECS if spec.name != "task")
+    )
+
+    for spec in selected_specs:
         found = _installed_command(spec, probe)
         if found:
             statuses.append(
@@ -385,6 +392,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--yes", action="store_true", help="Approve installer prompts.")
     parser.add_argument("--json", action="store_true", dest="emit_json")
     parser.add_argument(
+        "--include-task",
+        action="store_true",
+        help="Also require go-task for Taskfile-source workflows.",
+    )
+    parser.add_argument(
         "--platform",
         choices=("windows", "macos", "linux", "unknown"),
         help="Override platform detection for tests or diagnostics.",
@@ -398,6 +410,7 @@ def main(argv: list[str] | None = None) -> int:
     result = verify_required_tools(
         install=args.install,
         assume_yes=args.yes,
+        include_task=args.include_task,
         platform_id=args.platform,
         output_fn=captured.append,
     )

--- a/templates/agents-entry.md
+++ b/templates/agents-entry.md
@@ -15,7 +15,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 - ./PROJECT.md exists and is not a deprecation redirect (`<!-- deft:deprecated-redirect -->` or `<!-- Purpose: deprecation redirect -->`).
 - ./vbrief/ exists but any of the five lifecycle subfolders (proposed/, pending/, active/, completed/, cancelled/) is missing
 
-→ On detection: read .deft/core/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "task deft:migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
+→ On detection: read .deft/core/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "deft migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
 
 ⊗ Start Phase 1, Phase 2, or a Returning-Sessions workflow while pre-cutover artifacts are present — run migration first.
 
@@ -54,18 +54,18 @@ Check what exists before doing anything else:
 
 ## Session-start ritual (#1149)
 
-! On every interactive session start, run `task deft:session:start` after loading AGENTS.md. This records the quick-tier ritual in `.deft/ritual-state.json`: Deft alignment confirmation, branch-policy disclosure, required-tool guidance from `task deft:verify:tools`, default-branch sync warnings, and `task deft:triage:welcome` one-line state/nudge. The state is worktree- and HEAD-bound, and becomes stale after `plan.policy.sessionRitualStalenessHours` hours (default: 4).
+! On every interactive session start, run `deft session:start` after loading AGENTS.md. This records the quick-tier ritual in `.deft/ritual-state.json`: Deft alignment confirmation, branch-policy disclosure, required-tool guidance from `deft verify:tools`, default-branch sync warnings, and `deft triage:welcome` one-line state/nudge. The state is worktree- and HEAD-bound, and becomes stale after `plan.policy.sessionRitualStalenessHours` hours (default: 4).
 
-! Before any code-writing tool call or `start_agent` implementation dispatch, run `task deft:verify:session-ritual -- --tier=gated`. The gated tier fails closed unless the quick-tier state is fresh, then lazily records the doctor and cache-fresh Python entrypoints (the checks exposed to operators as `task deft:doctor` and `task deft:verify:cache-fresh`) in the same ritual state. The verifier is now step 0 of the pre-`start_agent` gate stack; any non-zero exit aborts dispatch.
+! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. The gated tier fails closed unless the quick-tier state is fresh, then lazily records the doctor and cache-fresh Python entrypoints (the checks exposed to operators as `deft doctor` and `deft verify:cache-fresh`) in the same ritual state. The verifier is now step 0 of the pre-`start_agent` gate stack; any non-zero exit aborts dispatch.
 
-? If a quick or gated step must be intentionally postponed, record the decision with `task deft:session:start -- --defer step=reason` using one of `alignment`, `branch_policy`, `triage_welcome`, `doctor`, or `cache_fresh`. Deferred steps satisfy the verifier but remain auditable in `.deft/ritual-state.json`.
+? If a quick or gated step must be intentionally postponed, record the decision with `deft session:start -- --defer step=reason` using one of `alignment`, `branch_policy`, `triage_welcome`, `doctor`, or `cache_fresh`. Deferred steps satisfy the verifier but remain auditable in `.deft/ritual-state.json`.
 
-⊗ Self-report the session-start ritual as complete without a fresh `task deft:session:start` state, or bypass `task deft:verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
+⊗ Self-report the session-start ritual as complete without a fresh `deft session:start` state, or bypass `deft verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
 
-`task deft:doctor` remains the install-integrity + toolchain + AGENTS.md managed-section freshness probe (#1308). When the managed-section is stale, the doctor points the operator at `task deft:agents:refresh` to regenerate AGENTS.md from `templates/agents-entry.md`. The canonical `scripts/doctor.py` (single owner post #1335/#1336) also detects payload staleness from the `<install>/VERSION` manifest and, when behind, emits the canonical headless upgrade command `deft-install --yes --upgrade --repo-root . --json` (#1339 / #1409). The installer itself calls `scripts/doctor.py --session --json` at the end of every run for the unified handoff.
+`deft doctor` remains the install-integrity + toolchain + AGENTS.md managed-section freshness probe (#1308). When the managed-section is stale, the doctor points the operator at `deft agents:refresh` to regenerate AGENTS.md from `templates/agents-entry.md`. The canonical `scripts/doctor.py` (single owner post #1335/#1336) also detects payload staleness from the `<install>/VERSION` manifest and, when behind, emits the canonical headless upgrade command `deft-install --yes --upgrade --repo-root . --json` (#1339 / #1409). The installer itself calls `scripts/doctor.py --session --json` at the end of every run for the unified handoff.
 
-**Canonical bootstrap / update path (#1339 #1340 #1409 Epic-5/6):** Use the published platform installer binary (from GitHub Releases) as the single deterministic entrypoint. For an existing install, the canonical headless refresh is `deft-install --yes --upgrade --repo-root . --json` (drop `--json` for human-readable output) -- it replaces the payload + manifest + AGENTS.md in one shot. Legacy `task deft:upgrade` / `run upgrade` are metadata-only acknowledgment (they do NOT replace the payload) and `task deft:relocate -- --confirm` is back-compat only; git-clone / submodule / legacy doctor surfaces are de-emphasized in UPGRADING.md / README / skills. Agent example: after running the installer command, start your session; the doctor output (or `task deft:doctor`) tells you the exact state and whether a re-install is needed for freshness.
-`task deft:triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `task deft:triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual.
+**Canonical bootstrap / update path (#1339 #1340 #1409 Epic-5/6):** Use the published platform installer binary (from GitHub Releases) as the single deterministic entrypoint. For an existing install, the canonical headless refresh is `deft-install --yes --upgrade --repo-root . --json` (drop `--json` for human-readable output) -- it replaces the payload + manifest + AGENTS.md in one shot. Legacy `deft upgrade` / `run upgrade` are metadata-only acknowledgment (they do NOT replace the payload) and `deft relocate -- --confirm` is back-compat only; git-clone / submodule / legacy doctor surfaces are de-emphasized in UPGRADING.md / README / skills. Agent example: after running the installer command, start your session; the doctor output (or `deft doctor`) tells you the exact state and whether a re-install is needed for freshness.
+`deft triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `deft triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual.
 
 ## Resume nudge (conditional, #1269)
 
@@ -75,23 +75,23 @@ Reserved placement for the optional 6th conditional step (resume nudge from the 
 
 ## WIP cap
 
-The `plan.policy.wipCap` field caps the number of in-flight scope vBRIEFs (`vbrief/pending/` + `vbrief/active/`). The framework default is 10 (per umbrella #1119 Current Shape v3). When the cap is reached, `task deft:scope:promote` refuses with a relief hint pointing at `task deft:scope:demote --batch --older-than-days 30` (D1 / #1121). Operators can override the cap from the consumer side via `task deft:triage:welcome --onboard` (the Phase 4 wipCap prompt) or by inspecting / editing the typed field via `task deft:policy:show --field=wipCap`.
+The `plan.policy.wipCap` field caps the number of in-flight scope vBRIEFs (`vbrief/pending/` + `vbrief/active/`). The framework default is 10 (per umbrella #1119 Current Shape v3). When the cap is reached, `deft scope:promote` refuses with a relief hint pointing at `deft scope:demote --batch --older-than-days 30` (D1 / #1121). Operators can override the cap from the consumer side via `deft triage:welcome --onboard` (the Phase 4 wipCap prompt) or by inspecting / editing the typed field via `deft policy:show --field=wipCap`.
 
 ## Cache-as-authoritative work selection (#1149)
 
-! When the operator asks "what should I work on next?" / "build a cohort" / "what's the queue?", run `task deft:triage:queue --limit=10` (D11 / #1128) and present the ranked list before suggesting anything else. The agent MUST NOT recommend work from memory or open-GitHub-issue intuition. This is the consumer-side mirror of the maintainer rule of the same name; the triage queue is the source of truth for what to work on next.
+! When the operator asks "what should I work on next?" / "build a cohort" / "what's the queue?", run `deft triage:queue --limit=10` (D11 / #1128) and present the ranked list before suggesting anything else. The agent MUST NOT recommend work from memory or open-GitHub-issue intuition. This is the consumer-side mirror of the maintainer rule of the same name; the triage queue is the source of truth for what to work on next.
 
-⊗ Recommend a specific issue or vBRIEF without consulting `task deft:triage:queue` (or showing the operator the result of the consultation).
+⊗ Recommend a specific issue or vBRIEF without consulting `deft triage:queue` (or showing the operator the result of the consultation).
 
 ## Content packs
 
 Deft ships versioned content packs (e.g. lessons learned from prior work) under `.deft/core/packs/`. Discover and LOAD pack content via the slice surface instead of reading whole pack files into context:
 
-- `task deft:packs:slice --list-packs` -- discover which packs exist (short-name + version + one-line description). Registry-driven, so new packs appear automatically with no edit here.
-- `task deft:packs:slice <pack> --list` -- discover the named slices a pack exposes.
-- `task deft:packs:slice <pack> <slice> [-- <filters>]` -- load just the slice you need; read the slice, not the whole file.
+- `deft packs:slice --list-packs` -- discover which packs exist (short-name + version + one-line description). Registry-driven, so new packs appear automatically with no edit here.
+- `deft packs:slice <pack> --list` -- discover the named slices a pack exposes.
+- `deft packs:slice <pack> <slice> [-- <filters>]` -- load just the slice you need; read the slice, not the whole file.
 
-! Before improvising on a problem, discover packs with `task deft:packs:slice --list-packs`, then load the relevant slice. This wiring references the discovery commands on purpose -- it never enumerates pack or slice names, so new packs/slices need no change here.
+! Before improvising on a problem, discover packs with `deft packs:slice --list-packs`, then load the relevant slice. This wiring references the discovery commands on purpose -- it never enumerates pack or slice names, so new packs/slices need no change here.
 
 ## Skill Routing
 
@@ -114,8 +114,8 @@ When user input matches a trigger keyword, read the corresponding skill (paths a
 - "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/skills/deft-directive-debug/SKILL.md`
 - "triage hygiene" / "work the cache" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
 - "what's next" / "queue" / "build a cohort" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
-- "welcome" / "onboard triage" -> invokes `task deft:triage:welcome --onboard` (N3 / #1143)
-- "lessons" / "prior art" / "what have we learned about X" -> discover packs with `task deft:packs:slice --list-packs`, then `task deft:packs:slice <pack> --list` and load the relevant slice before improvising (see Content packs above)
+- "welcome" / "onboard triage" -> invokes `deft triage:welcome --onboard` (N3 / #1143)
+- "lessons" / "prior art" / "what have we learned about X" -> discover packs with `deft packs:slice --list-packs`, then `deft packs:slice <pack> --list` and load the relevant slice before improvising (see Content packs above)
 
 The `deft-directive-release` skill is intentionally excluded -- it cuts deft framework releases against a temp clone of `deftai/directive` and is not a consumer-facing surface.
 
@@ -123,10 +123,10 @@ The `deft-directive-release` skill is intentionally excluded -- it cuts deft fra
 
 Three consumer-facing surfaces enforce the branch-policy contract (#746 / #747):
 
-- `task deft:check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `task deft:check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
-- `task deft:verify:branch` -- branch gate wired into the `task deft:check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
-- `.githooks/pre-commit` / `pre-push` -- local hooks installed via `task deft:setup`; verify via `task deft:verify:hooks-installed`.
-- `task deft:policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `task deft:policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
+- `deft check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `deft check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
+- `deft verify:branch` -- branch gate wired into the `deft check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
+- `.githooks/pre-commit` / `pre-push` -- local hooks installed via `deft setup`; verify via `deft verify:hooks-installed`.
+- `deft policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `deft policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
 
 ## Branch Policy Disclosure (#746)
 
@@ -137,9 +137,9 @@ When the active project's `vbrief/PROJECT-DEFINITION.vbrief.json` has `plan.poli
 This phrasing comes from `.deft/core/scripts/policy.py::disclosure_line` and stays in lockstep with the typed surface (#746). When the policy is OFF (default; `allowDirectCommitsToMaster=false`), no session-start disclosure is required -- the absence of the disclosure line itself signals the default-enforcing state.
 
 Override paths the user may invoke:
-- `task deft:policy:show` -- inspect resolved policy
-- `task deft:policy:enforce-branches` -- re-enable branch protection
-- `task deft:policy:allow-direct-commits -- --confirm` -- re-confirm opt-out (audited)
+- `deft policy:show` -- inspect resolved policy
+- `deft policy:enforce-branches` -- re-enable branch protection
+- `deft policy:allow-direct-commits -- --confirm` -- re-confirm opt-out (audited)
 - `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` -- emergency env-var bypass
 
 ⊗ Begin a session that will commit/push without surfacing the policy state when allowDirectCommitsToMaster=true.
@@ -157,12 +157,12 @@ Cross-reference: `.deft/core/docs/analysis/2026-05-26-issue-1353-grok-windows-ca
 
 ### Implementation Intent Gate (#810)
 
-- ! Run `task deft:vbrief:preflight -- <path>` before any code-writing tool call or `start_agent` dispatch -- the gate exits 0 only when the candidate vBRIEF lives in `vbrief/active/` AND `plan.status == "running"`. The Taskfile target resolves the wrapped script via `.deft/core/scripts/_resolve_preflight_path.py` (which probes the canonical, legacy, and in-repo install layouts in priority order) and fails closed with a structured `gate misconfigured` error pointing at `task deft:framework:doctor` if no candidate resolves -- the gate cannot silently fail open on a misconfigured install (#1046 / #1047). The helper names `task deft:vbrief:activate <path>` as its idempotent activation companion; story workflows should use the Story Start Gate below to bridge proposed/pending scope through `task deft:scope:promote` and `task deft:scope:activate` before invoking preflight.
+- ! Run `deft vbrief:preflight -- <path>` before any code-writing tool call or `start_agent` dispatch -- the gate exits 0 only when the candidate vBRIEF lives in `vbrief/active/` AND `plan.status == "running"`. The Taskfile target resolves the wrapped script via `.deft/core/scripts/_resolve_preflight_path.py` (which probes the canonical, legacy, and in-repo install layouts in priority order) and fails closed with a structured `gate misconfigured` error pointing at `deft framework:doctor` if no candidate resolves -- the gate cannot silently fail open on a misconfigured install (#1046 / #1047). The helper names `deft vbrief:activate <path>` as its idempotent activation companion; story workflows should use the Story Start Gate below to bridge proposed/pending scope through `deft scope:promote` and `deft scope:activate` before invoking preflight.
 - ! Require an explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) from the user before invoking the preflight gate or `start_agent` for implementation. When intent is ambiguous, ask one targeted question instead of inferring.
 - ⊗ Infer implementation intent from lifecycle vocabulary ("do the full PR process", "start the work", "poller agents"), branching language, or workflow shape. Workflow-shape vocabulary is NOT authorization to spawn an implementation agent.
 - ⊗ Treat affirmative continuation phrases (`yes`, `go`, `proceed`, `do it`) as implementation authorization unless the prior turn explicitly proposed implementation. Broad approval is not a substitute for an explicit action-verb directive.
 
-**Pre-`start_agent` gate stack (#1149/#1348):** Before dispatching an implementation sub-agent via `start_agent`, run the gates in the canonical order: (0) session ritual gate (#1348, `task deft:verify:session-ritual -- --tier=gated`) -> (1) story-start Gate 0 (#1378, `task deft:verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]`) -> (2) vBRIEF implementation-intent gate (#810, `task deft:vbrief:preflight -- <path>`) -> (3) `task deft:verify:cache-fresh` (D5 / #1127) -> (4) branch-policy gate (`task deft:verify:branch` and the `.githooks/pre-commit` / `pre-push` hooks) -> (5) `start_agent`. Any non-zero exit aborts dispatch.
+**Pre-`start_agent` gate stack (#1149/#1348):** Before dispatching an implementation sub-agent via `start_agent`, run the gates in the canonical order: (0) session ritual gate (#1348, `deft verify:session-ritual -- --tier=gated`) -> (1) story-start Gate 0 (#1378, `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]`) -> (2) vBRIEF implementation-intent gate (#810, `deft vbrief:preflight -- <path>`) -> (3) `deft verify:cache-fresh` (D5 / #1127) -> (4) branch-policy gate (`deft verify:branch` and the `.githooks/pre-commit` / `pre-push` hooks) -> (5) `start_agent`. Any non-zero exit aborts dispatch.
 
 ### Story Start Gate
 
@@ -171,11 +171,11 @@ Cross-reference: `.deft/core/docs/analysis/2026-05-26-issue-1353-grok-windows-ca
 - ⊗ Begin a new story while unrelated dirty work is present without explicit operator approval.
 - ! Resolve exactly one target story vBRIEF path by default. Batching multiple stories requires explicit operator approval and a short rationale.
 - ! When invoked as part of a swarm cohort dispatch, the approved Phase 5 allocation plan satisfies the "explicit operator approval and a short rationale" requirement above -- the dispatched paths and allocation rationale ARE the consent token. Do NOT re-prompt the parent for batching approval mid-cohort; the all-or-nothing dispatch envelope rule (#954) forbids mid-scope user-approval gates.
-- ! Within a swarm cohort, between stories, the working tree MUST be clean (a checkpoint commit + `task deft:scope:complete` just landed). If `git status --short` shows uncommitted state between stories, checkpoint-commit it and proceed -- do NOT pause to ask the operator. The dirty-tree "ask the operator" branch above applies only at the FIRST story-start of a fresh branch.
-- ! If the target story is in `vbrief/proposed/`, run `task deft:scope:promote -- <path>` first; if it is in `vbrief/pending/`, run `task deft:scope:activate -- <path>`. After activation, run `task deft:vbrief:preflight -- <active-story-path>` before code-writing.
+- ! Within a swarm cohort, between stories, the working tree MUST be clean (a checkpoint commit + `deft scope:complete` just landed). If `git status --short` shows uncommitted state between stories, checkpoint-commit it and proceed -- do NOT pause to ask the operator. The dirty-tree "ask the operator" branch above applies only at the FIRST story-start of a fresh branch.
+- ! If the target story is in `vbrief/proposed/`, run `deft scope:promote -- <path>` first; if it is in `vbrief/pending/`, run `deft scope:activate -- <path>`. After activation, run `deft vbrief:preflight -- <active-story-path>` before code-writing.
 - ! Default to one story per branch/PR. Create a checkpoint commit after each completed story before beginning another story, unless the operator explicitly approved batching.
-- ! After checks pass for the story, complete the lifecycle with `task deft:scope:complete -- <active-story-path>` before final PR handoff.
-- ! Before dispatching an implementation sub-agent, run the deterministic Gate 0 `task deft:verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]` ahead of `task deft:vbrief:preflight`. It machine-checks a clean working tree (or `--allow-dirty`), the target vBRIEF in `vbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token; three-state exit (0 ready / 1 not ready / 2 config error). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null; an absent section is the solo path. Any non-zero exit aborts dispatch.
+- ! After checks pass for the story, complete the lifecycle with `deft scope:complete -- <active-story-path>` before final PR handoff.
+- ! Before dispatching an implementation sub-agent, run the deterministic Gate 0 `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]` ahead of `deft vbrief:preflight`. It machine-checks a clean working tree (or `--allow-dirty`), the target vBRIEF in `vbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token; three-state exit (0 ready / 1 not ready / 2 config error). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null; an absent section is the solo path. Any non-zero exit aborts dispatch.
 
 ## Commands
 

--- a/tests/cli/test_ci_local.py
+++ b/tests/cli/test_ci_local.py
@@ -7,8 +7,8 @@ Covers (#233 plan.item ``task-ci-local``):
   --fail-fast / --no-fail-fast pair.
 - Host-matrix mapping (linux/macos/windows host -> matrix slice).
 - Step pipeline composition under each matrix and --skip-build.
-- ``task build:verify`` graceful absence: when ``task --list`` does not
-  contain ``build:verify``, the step is emitted with applies()=False
+- ``deft build:verify`` graceful absence: when the no-task command registry
+  does not expose ``build:verify``, the step is emitted with applies()=False
   and a non-empty skip reason; when present, applies()=True.
 - Runner behavior: OK / FAIL / SKIP rows; verbose output mirroring;
   fail-fast aborts subsequent steps; --no-fail-fast lets the pipeline
@@ -188,40 +188,13 @@ class TestHostMatrix:
 
 
 class TestBuildVerifyDetection:
-    def test_returns_false_when_task_missing(self, monkeypatch, tmp_path):
-        _patch_executables(monkeypatch, present=set())
-        assert ci_local._build_verify_available(tmp_path) is False
+    def test_returns_false_when_registry_lacks_build_verify(self, monkeypatch):
+        monkeypatch.setattr(ci_local, "has_command", lambda _name: False)
+        assert ci_local._framework_command_available("build:verify") is False
 
-    def test_returns_false_when_task_list_lacks_build_verify(self, monkeypatch, tmp_path):
-        _patch_executables(monkeypatch, present={"task"})
-        _stub_run(
-            monkeypatch,
-            returncode=0,
-            stdout="* build: Package framework for distribution\n* test: Run tests\n",
-        )
-        assert ci_local._build_verify_available(tmp_path) is False
-
-    def test_returns_true_when_task_list_contains_build_verify(self, monkeypatch, tmp_path):
-        _patch_executables(monkeypatch, present={"task"})
-        _stub_run(
-            monkeypatch,
-            returncode=0,
-            stdout="* build: Package framework\n* build:verify: Verify dist\n",
-        )
-        assert ci_local._build_verify_available(tmp_path) is True
-
-    def test_returns_false_when_task_list_fails(self, monkeypatch, tmp_path, capsys):
-        # Greptile P2 #713: when ``task --list`` fails (e.g. malformed
-        # Taskfile.yml) we must surface a warning so the underlying error
-        # isn't silently swallowed behind "build:verify not yet
-        # implemented".
-        _patch_executables(monkeypatch, present={"task"})
-        _stub_run(monkeypatch, returncode=2, stdout="", stderr="boom")
-        assert ci_local._build_verify_available(tmp_path) is False
-        captured = capsys.readouterr()
-        assert "task --list" in captured.err
-        assert "exited 2" in captured.err
-        assert "boom" in captured.err
+    def test_returns_true_when_registry_contains_build_verify(self, monkeypatch):
+        monkeypatch.setattr(ci_local, "has_command", lambda name: name == "build:verify")
+        assert ci_local._framework_command_available("build:verify") is True
 
 
 # ---------------------------------------------------------------------------
@@ -269,35 +242,32 @@ class TestPipelineComposition:
         assert "go: build darwin/arm64" not in names
         assert "go: build windows/amd64" not in names
 
-    def test_task_steps_when_task_present(self, monkeypatch, tmp_path):
-        _patch_executables(monkeypatch, present={"task"})
-        _stub_run(monkeypatch, returncode=0, stdout="")  # build:verify probe says absent
+    def test_framework_steps_are_present_without_task(self, monkeypatch, tmp_path):
+        _patch_executables(monkeypatch, present=set())
         _force_host(monkeypatch, "Linux")
         steps = ci_local.build_pipeline(tmp_path, matrix="linux", skip_build=False)
         names = [s.name for s in steps]
-        assert "task toolchain:check" in names
-        assert "task verify:stubs" in names
-        assert "task verify:links" in names
-        assert "task verify:rule-ownership" in names
-        assert "task vbrief:validate" in names
-        assert "task build" in names
-        assert "task build:verify" in names
+        assert "framework toolchain:check" in names
+        assert "framework verify:stubs" in names
+        assert "framework verify:links" in names
+        assert "framework verify:rule-ownership" in names
+        assert "framework vbrief:validate" in names
+        assert "framework build" in names
+        assert "framework build:verify" in names
 
     def test_task_build_verify_skipped_when_absent(self, monkeypatch, tmp_path):
-        _patch_executables(monkeypatch, present={"task"})
-        _stub_run(monkeypatch, returncode=0, stdout="* build: foo\n")
+        monkeypatch.setattr(ci_local, "has_command", lambda _name: False)
         _force_host(monkeypatch, "Linux")
         steps = ci_local.build_pipeline(tmp_path, matrix="linux", skip_build=False)
-        bv = next(s for s in steps if s.name == "task build:verify")
+        bv = next(s for s in steps if s.name == "framework build:verify")
         assert bv.applies() is False
         assert "not yet implemented" in bv.skip_reason()
 
     def test_task_build_verify_runs_when_present(self, monkeypatch, tmp_path):
-        _patch_executables(monkeypatch, present={"task"})
-        _stub_run(monkeypatch, returncode=0, stdout="* build:verify: Verify\n")
+        monkeypatch.setattr(ci_local, "has_command", lambda name: name == "build:verify")
         _force_host(monkeypatch, "Linux")
         steps = ci_local.build_pipeline(tmp_path, matrix="linux", skip_build=False)
-        bv = next(s for s in steps if s.name == "task build:verify")
+        bv = next(s for s in steps if s.name == "framework build:verify")
         assert bv.applies() is True
 
     def test_windows_dispatch_skipped_on_linux(self, monkeypatch, tmp_path):
@@ -476,19 +446,15 @@ class TestMain:
         rc = ci_local.main(["--root", str(missing)])
         assert rc == ci_local.EXIT_CONFIG_ERROR
 
-    def test_main_no_applicable_tools_exits_2(self, monkeypatch, tmp_path, capsys):
-        # Greptile P1 #713: with zero tools on PATH every step constructor
-        # emits an applies()=False probe row, so ``build_pipeline`` is
-        # non-empty but every step skips. The runner used to exit 0 in
-        # this shape (every-step-skipped), violating the documented
-        # three-state exit-code contract; the fix is to also exit 2 when
-        # ``not any(s.applies() for s in steps)``. This test exercises the
-        # natural no-tools path rather than monkeypatching build_pipeline.
+    def test_main_framework_step_failure_exits_1_without_task(self, monkeypatch, tmp_path, capsys):
+        # Missing go-task no longer suppresses framework-level checks. A
+        # non-framework temp root still fails as a step failure rather than
+        # the old "no applicable tools" config branch.
         _patch_executables(monkeypatch, present=set())
         rc = ci_local.main(["--root", str(tmp_path), "--matrix", "linux"])
-        assert rc == ci_local.EXIT_CONFIG_ERROR
+        assert rc == ci_local.EXIT_STEP_FAILED
         captured = capsys.readouterr()
-        assert "no CI steps applicable" in captured.err
+        assert "framework verify:rule-ownership" in captured.out
 
     def test_main_empty_pipeline_exits_2(self, monkeypatch, tmp_path, capsys):
         # Defensive coverage of the original ``not steps`` branch in case a
@@ -553,7 +519,7 @@ class TestRoundTrip:
                         seen_steps.append(_n) or (0, f"{_n} ok", "")
                     ),
                 )
-                for name in ("python: ruff lint", "task vbrief:validate")
+                for name in ("python: ruff lint", "framework vbrief:validate")
             ]
 
         monkeypatch.setattr(ci_local, "build_pipeline", fake_pipeline)
@@ -567,7 +533,7 @@ class TestRoundTrip:
             ]
         )
         assert rc == ci_local.EXIT_OK
-        assert seen_steps == ["python: ruff lint", "task vbrief:validate"]
+        assert seen_steps == ["python: ruff lint", "framework vbrief:validate"]
         captured = capsys.readouterr()
         # Aggregate summary lands on stdout.
         assert "ci:local summary" in captured.out

--- a/tests/cli/test_cmd_doctor.py
+++ b/tests/cli/test_cmd_doctor.py
@@ -749,7 +749,7 @@ def test_freshness_fresh_readable_emits_no_warning(
 def test_freshness_stale_points_at_agents_refresh(
     doctor_module, tmp_path, monkeypatch
 ):
-    """genuinely stale managed section -> warning pointing at `task agents:refresh` (#1389)."""
+    """genuinely stale managed section -> warning pointing at `deft agents:refresh` (#1389)."""
     _patch_shared_template(doctor_module, monkeypatch)
     (tmp_path / "AGENTS.md").write_text(
         "<!-- deft:managed-section v3 -->\nOLD STALE BODY\n<!-- /deft:managed-section -->\n",
@@ -758,9 +758,9 @@ def test_freshness_stale_points_at_agents_refresh(
 
     msgs = _collect_freshness(doctor_module, tmp_path)
 
-    assert any("task agents:refresh" in w for w in msgs["warn"]), (
+    assert any("deft agents:refresh" in w for w in msgs["warn"]), (
         "A stale managed section MUST point the operator at "
-        f"`task agents:refresh`. Warnings: {msgs['warn']}"
+        f"`deft agents:refresh`. Warnings: {msgs['warn']}"
     )
     warning_findings = [f for f in msgs["findings"] if f["severity"] == "warning"]
     assert warning_findings and warning_findings[0].get("status") == "stale", (

--- a/tests/cli/test_doctor_throttle.py
+++ b/tests/cli/test_doctor_throttle.py
@@ -317,7 +317,7 @@ def test_cmd_doctor_dirty_skip_blocks_with_exit_one(
     )
     assert "[doctor]" in result.stdout
     assert "UNRESOLVED" in result.stdout
-    assert "task doctor --full" in result.stdout
+    assert "deft doctor --full" in result.stdout
 
 
 def test_cmd_doctor_full_bypass_runs_checks(
@@ -372,7 +372,7 @@ def test_cmd_doctor_json_dirty_skip_schema(
     assert payload["status"] == "throttle-skipped"
     assert payload["last_error_count"] == 4
     assert payload["last_finding_count"] == 5
-    assert "task doctor --full" in payload["hint"]
+    assert "deft doctor --full" in payload["hint"]
 
 
 def test_cmd_doctor_full_run_persists_state(

--- a/tests/cli/test_framework_commands.py
+++ b/tests/cli/test_framework_commands.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make ``scripts/`` importable when running ``pytest tests/``.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import framework_commands  # noqa: E402
+
+
+def test_format_framework_command_defaults_to_deft_surface() -> None:
+    assert (
+        framework_commands.format_framework_command(["triage:welcome", "--onboard"])
+        == "deft triage:welcome --onboard"
+    )
+
+
+def test_format_framework_command_preserves_task_prefixed_surface() -> None:
+    assert (
+        framework_commands.format_framework_command(
+            ["triage:welcome", "--onboard"],
+            surface="task",
+            task_prefix="deft",
+        )
+        == "task deft:triage:welcome --onboard"
+    )
+
+
+def test_normalize_task_separator_keeps_taskfile_pass_through_compatible() -> None:
+    assert framework_commands.normalize_task_separator(["--", "--batch"]) == ["--batch"]
+    assert framework_commands.normalize_task_separator(["--batch"]) == ["--batch"]
+
+
+def test_issue_1659_runtime_commands_are_registered() -> None:
+    for name in (
+        "core:validate",
+        "core:lint",
+        "core:test",
+        "doctor",
+        "session:start",
+        "triage:welcome",
+        "verify:cache-fresh",
+        "verify:no-task-runtime",
+        "check:consumer",
+        "check:framework-source",
+    ):
+        assert framework_commands.has_command(name)
+
+
+def test_unknown_command_returns_cli_shaped_failure() -> None:
+    result = framework_commands.run_framework_command("__missing__", capture=True)
+
+    assert result.code == 2
+    assert "unknown framework command" in result.stderr

--- a/tests/cli/test_framework_commands.py
+++ b/tests/cli/test_framework_commands.py
@@ -42,6 +42,9 @@ def test_issue_1659_runtime_commands_are_registered() -> None:
         "doctor",
         "migrate:vbrief",
         "session:start",
+        "triage:audit",
+        "triage:queue",
+        "triage:show",
         "triage:welcome",
         "verify:cache-fresh",
         "verify:no-task-runtime",
@@ -56,6 +59,32 @@ def test_unknown_command_returns_cli_shaped_failure() -> None:
 
     assert result.code == 2
     assert "unknown framework command" in result.stderr
+
+
+def test_triage_queue_dispatches_queue_subcommand(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, list[str]] = {}
+
+    def fake_main(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setitem(sys.modules, "triage_queue", SimpleNamespace(main=fake_main))
+
+    result = framework_commands.run_framework_command(
+        "triage:queue",
+        ["--limit", "3"],
+        project_root=tmp_path,
+        capture=True,
+    )
+
+    assert result.code == 0
+    assert captured["argv"] == [
+        "queue",
+        "--project-root",
+        str(tmp_path.resolve()),
+        "--limit",
+        "3",
+    ]
 
 
 def test_migrate_vbrief_runs_preflight_then_migrator(monkeypatch, tmp_path: Path) -> None:

--- a/tests/cli/test_framework_commands.py
+++ b/tests/cli/test_framework_commands.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 # Make ``scripts/`` importable when running ``pytest tests/``.
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -39,6 +40,7 @@ def test_issue_1659_runtime_commands_are_registered() -> None:
         "core:lint",
         "core:test",
         "doctor",
+        "migrate:vbrief",
         "session:start",
         "triage:welcome",
         "verify:cache-fresh",
@@ -54,3 +56,64 @@ def test_unknown_command_returns_cli_shaped_failure() -> None:
 
     assert result.code == 2
     assert "unknown framework command" in result.stderr
+
+
+def test_migrate_vbrief_runs_preflight_then_migrator(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_preflight(argv: list[str]) -> int:
+        calls.append(("preflight", argv))
+        return 0
+
+    def fake_migrator(argv: list[str]) -> int:
+        calls.append(("migrator", argv))
+        return 0
+
+    monkeypatch.setitem(sys.modules, "migrate_preflight", SimpleNamespace(main=fake_preflight))
+    monkeypatch.setitem(sys.modules, "migrate_vbrief", SimpleNamespace(main=fake_migrator))
+
+    result = framework_commands.run_framework_command(
+        "migrate:vbrief",
+        ["--", "--dry-run"],
+        project_root=tmp_path,
+        capture=True,
+    )
+
+    assert result.code == 0
+    assert calls == [
+        (
+            "preflight",
+            [
+                "--project-root",
+                str(tmp_path.resolve()),
+                "--deft-root",
+                str(REPO_ROOT),
+            ],
+        ),
+        ("migrator", [str(tmp_path.resolve()), "--dry-run"]),
+    ]
+
+
+def test_migrate_vbrief_stops_when_preflight_fails(monkeypatch, tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def fake_preflight(argv: list[str]) -> int:
+        calls.append("preflight")
+        return 1
+
+    def fake_migrator(argv: list[str]) -> int:
+        calls.append("migrator")
+        return 0
+
+    monkeypatch.setitem(sys.modules, "migrate_preflight", SimpleNamespace(main=fake_preflight))
+    monkeypatch.setitem(sys.modules, "migrate_vbrief", SimpleNamespace(main=fake_migrator))
+
+    result = framework_commands.run_framework_command(
+        "migrate:vbrief",
+        ["--dry-run"],
+        project_root=tmp_path,
+        capture=True,
+    )
+
+    assert result.code == 1
+    assert calls == ["preflight"]

--- a/tests/cli/test_preflight_cache.py
+++ b/tests/cli/test_preflight_cache.py
@@ -197,8 +197,8 @@ class TestExitCodeContract:
         assert result.code == 1
         assert "stale" not in result.message.lower() or "max-age" in result.message
         # Remediation MUST name both bootstrap and fetch-all per issue body.
-        assert "task triage:bootstrap" in result.message
-        assert "task cache:fetch-all" in result.message
+        assert "deft triage:bootstrap" in result.message
+        assert "deft cache:fetch-all" in result.message
         assert "--allow-stale" in result.message
 
     def test_missing_cache_exits_two(self, preflight, tmp_path):
@@ -207,7 +207,7 @@ class TestExitCodeContract:
         result = preflight.evaluate(tmp_path, repo="deftai/directive")
         assert result.code == 2
         assert ".deft-cache/" in result.message
-        assert "task triage:bootstrap" in result.message
+        assert "deft triage:bootstrap" in result.message
 
     def test_missing_candidates_jsonl_exits_two(self, preflight, tmp_path):
         now = datetime(2026, 5, 17, 12, tzinfo=UTC)
@@ -218,7 +218,7 @@ class TestExitCodeContract:
         )
         assert result.code == 2
         assert "candidates.jsonl" in result.message
-        assert "task triage:bootstrap" in result.message
+        assert "deft triage:bootstrap" in result.message
 
     def test_empty_cache_repo_exits_two(self, preflight, tmp_path):
         """Cache root present but repo dir empty -> config error."""
@@ -275,7 +275,7 @@ class TestForIssueDecisionMatrix:
         )
         assert result.code == 1
         assert decision in result.message
-        assert "task triage:status" in result.message
+        assert "deft triage:status" in result.message
 
     def test_missing_decision_blocks(self, preflight, tmp_path):
         now = self._setup(tmp_path, datetime(2026, 5, 17, 12, tzinfo=UTC))
@@ -288,7 +288,7 @@ class TestForIssueDecisionMatrix:
         )
         assert result.code == 1
         assert "no triage decision" in result.message
-        assert "task triage:accept" in result.message
+        assert "deft triage:accept" in result.message
 
     def test_accept_decision_passes(self, preflight, tmp_path):
         now = self._setup(tmp_path, datetime(2026, 5, 17, 12, tzinfo=UTC))
@@ -670,7 +670,7 @@ class TestBackfillOnlyCacheState:
     The pre-#1245 gate iterated ``meta_paths`` from ``.deft-cache/`` and
     refused any state where every cached entry was outside the active
     ``plan.policy.triageScope[]`` subscription -- even when the consumer
-    had just run ``task triage:bootstrap`` and the backfilled ``accept``
+    had just run ``deft triage:bootstrap`` and the backfilled ``accept``
     audit-log rows showed they were actively triaging. The recommended
     recovery ("widen the subscription") was wrong; the actual state was a
     ``backfill-only cache`` (cached open issues simply did not happen to
@@ -782,11 +782,11 @@ class TestBackfillOnlyCacheState:
             tmp_path, repo="deftai/directive", now=now
         )
         assert result.code == 1
-        # Updated remediation now also names task triage:accept and is
+        # Updated remediation now also names deft triage:accept and is
         # explicit about the audit log being empty.
         assert "audit log" in result.message.lower()
-        assert "task triage:scope" in result.message
-        assert "task cache:fetch-all" in result.message
+        assert "deft triage:scope" in result.message
+        assert "deft cache:fetch-all" in result.message
 
     def test_backfill_only_for_issue_in_scope_accept_passes(
         self, preflight, tmp_path,
@@ -873,7 +873,7 @@ class TestBackfillOnlyCacheState:
         )
         assert result.code == 1
         assert "max-age" in result.message or "stale" in result.message.lower()
-        assert "task cache:fetch-all" in result.message
+        assert "deft cache:fetch-all" in result.message
 
     def test_candidates_jsonl_entries_not_evaluated_against_scope(
         self, preflight, tmp_path,
@@ -1046,9 +1046,9 @@ class TestCLI:
 
 class TestThreeStateMessaging:
     """Pin the #1240 state machine: the OK message distinguishes three
-    consumer states so ``task verify:cache-fresh`` no longer claims
+    consumer states so ``deft verify:cache-fresh`` no longer claims
     ``treating as bootstrap state`` after a successful
-    ``task triage:bootstrap``.
+    ``deft triage:bootstrap``.
     """
 
     def test_no_cache_exits_two_or_bootstrap_state_on_override(
@@ -1074,7 +1074,7 @@ class TestThreeStateMessaging:
     ):
         """State 2 (cache + empty audit log): "fresh bootstrap, no triage actions yet".
 
-        Mirrors the post-#1240 ``task triage:bootstrap`` end state where
+        Mirrors the post-#1240 ``deft triage:bootstrap`` end state where
         step 5 has seeded ``vbrief/.eval/candidates.jsonl`` as a zero-length
         file. The gate must exit 0 AND its message must accurately describe
         the state.

--- a/tests/cli/test_project_context.py
+++ b/tests/cli/test_project_context.py
@@ -13,6 +13,7 @@ Covers:
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -200,3 +201,59 @@ class TestResolveProjectRoot:
         result = pc.resolve_project_root(None, start=start)
         if result is not None:
             assert not str(result).startswith(str(start))
+
+
+# ---------------------------------------------------------------------------
+# dispatch_task_check
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchTaskCheck:
+    def test_selects_framework_source_and_accepts_command_result(self, tmp_path):
+        captured = {}
+
+        def fake_runner(command, project_root, framework_root):
+            captured["command"] = command
+            captured["project_root"] = project_root
+            captured["framework_root"] = framework_root
+            return pc.CommandResult(code=0)
+
+        rc = pc.dispatch_task_check(tmp_path, tmp_path, runner=fake_runner)
+
+        assert rc == 0
+        assert captured == {
+            "command": "check:framework-source",
+            "project_root": tmp_path,
+            "framework_root": tmp_path,
+        }
+
+    def test_accepts_completed_process_runner(self, tmp_path):
+        framework_root = tmp_path / "framework"
+        project_root = tmp_path / "project"
+        framework_root.mkdir()
+        project_root.mkdir()
+        captured = {}
+
+        def fake_runner(command, root, framework):
+            captured["command"] = command
+            captured["project_root"] = root
+            captured["framework_root"] = framework
+            return subprocess.CompletedProcess(
+                args=["deft", command],
+                returncode=7,
+                stdout="",
+                stderr="",
+            )
+
+        rc = pc.dispatch_task_check(
+            framework_root,
+            project_root,
+            runner=fake_runner,
+        )
+
+        assert rc == 7
+        assert captured == {
+            "command": "check:consumer",
+            "project_root": project_root,
+            "framework_root": framework_root,
+        }

--- a/tests/cli/test_release.py
+++ b/tests/cli/test_release.py
@@ -8,8 +8,7 @@ Covers:
   malformed/missing Unreleased rejected.
 - _section_for_version: extracts the body of a versioned heading.
 - _split_body_and_links: splits at the first [X.Y.Z]: or [Unreleased]: line.
-- task_has_target: matches task list output for present/absent targets.
-- run_ci: prefers ci:local; falls back to check; fails when neither exists.
+- run_ci: delegates to the Python ci_local entrypoint without requiring go-task.
 - run_pipeline: dry-run prints plan with no writes; dirty-tree refuses without
   --allow-dirty (exit 1) and accepts with the flag; wrong branch refuses (exit 1);
   --skip-tag suppresses git tag/push; --skip-release suppresses gh release;
@@ -383,102 +382,34 @@ class TestSplitBodyAndLinks:
 
 
 # ---------------------------------------------------------------------------
-# task_has_target / run_ci
+# run_ci
 # ---------------------------------------------------------------------------
 
 
-class TestTaskHasTarget:
-    def test_target_present(self, monkeypatch, tmp_path):
-        listing = (
-            "task: Available tasks for this project:\n"
-            "* ci:local: Run CI locally\n"
-            "* check: Run checks\n"
-        )
-
-        def fake_run(cmd, **kwargs):
-            return SimpleNamespace(stdout=listing, stderr="", returncode=0)
-
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        assert release.task_has_target("ci:local", cwd=tmp_path) is True
-        assert release.task_has_target("check", cwd=tmp_path) is True
-
-    def test_target_absent(self, monkeypatch, tmp_path):
-        listing = (
-            "task: Available tasks for this project:\n* check: Run checks\n"
-        )
-
-        def fake_run(cmd, **kwargs):
-            return SimpleNamespace(stdout=listing, stderr="", returncode=0)
-
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        assert release.task_has_target("ci:local", cwd=tmp_path) is False
-
-    def test_missing_task_binary(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(release, "task_binary_available", lambda: False)
-        assert release.task_has_target("ci:local", cwd=tmp_path) is False
-
-
 class TestRunCI:
-    def test_prefers_ci_local(self, monkeypatch, tmp_path):
-        invoked = {}
+    def test_runs_ci_local_entrypoint(self, monkeypatch, tmp_path):
+        captured = {}
 
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
+        def fake_main(argv):
+            captured["argv"] = list(argv)
+            return 0
 
-        def fake_has(target, *, cwd):
-            return target == "ci:local"
-
-        monkeypatch.setattr(release, "task_has_target", fake_has)
-
-        def fake_run(cmd, **kwargs):
-            invoked["cmd"] = cmd
-            return SimpleNamespace(returncode=0)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setitem(sys.modules, "ci_local", SimpleNamespace(main=fake_main))
         ok, reason = release.run_ci(tmp_path)
+
         assert ok is True
-        assert "ci:local" in reason
-        assert invoked["cmd"] == ["task", "ci:local"]
-
-    def test_falls_back_to_check(self, monkeypatch, tmp_path):
-        invoked = {}
-
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-
-        def fake_has(target, *, cwd):
-            return target == "check"
-
-        monkeypatch.setattr(release, "task_has_target", fake_has)
-
-        def fake_run(cmd, **kwargs):
-            invoked["cmd"] = cmd
-            return SimpleNamespace(returncode=0)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        ok, reason = release.run_ci(tmp_path)
-        assert ok is True
-        assert "check" in reason
-        assert invoked["cmd"] == ["task", "check"]
-
-    def test_reports_failure_when_neither_exists(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(release, "task_has_target", lambda *_a, **_kw: False)
-        ok, reason = release.run_ci(tmp_path)
-        assert ok is False
-        assert "neither" in reason
+        assert reason == "ran ci:local"
+        assert captured["argv"] == ["--root", str(tmp_path)]
 
     def test_reports_failure_when_ci_returns_nonzero(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(release, "task_has_target", lambda *_a, **_kw: True)
+        def fake_main(argv):
+            return 2
 
-        def fake_run(cmd, **kwargs):
-            return SimpleNamespace(returncode=2)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setitem(sys.modules, "ci_local", SimpleNamespace(main=fake_main))
         ok, reason = release.run_ci(tmp_path)
+
         assert ok is False
-        assert "exit 2" in reason
+        assert reason == "ci:local failed (exit 2)"
 
 
 # ---------------------------------------------------------------------------
@@ -1707,53 +1638,50 @@ class TestPipelineVerifyGate:
 
 
 class TestRunBuildVersionEnv:
-    """Coverage for #723: run_build MUST pass DEFT_RELEASE_VERSION to task build.
+    """Coverage for #723: run_build MUST pass DEFT_RELEASE_VERSION to build.
 
-    Without env propagation the Taskfile resolver would fall back to the
+    Without env propagation the version resolver would fall back to the
     latest annotated git tag, which lags the in-flight release tag during
-    `task release` (Step 6 builds before Step 8 creates the tag) -- the
+    release (Step 6 builds before Step 8 creates the tag) -- the
     exact root cause of `dist/deft-0.20.0.zip` during the v0.21.0 cut.
     """
 
     def test_run_build_passes_version_via_env(self, monkeypatch, tmp_path):
         captured = {}
 
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(release, "task_has_target", lambda *_a, **_kw: True)
+        def fake_run_framework_command(name, **kwargs):
+            captured["name"] = name
+            captured["project_root"] = kwargs.get("project_root")
+            captured["framework_root"] = kwargs.get("framework_root")
+            captured["env"] = dict(release.os.environ)
+            return SimpleNamespace(code=0)
 
-        def fake_run(cmd, **kwargs):
-            captured["cmd"] = list(cmd)
-            captured["env"] = kwargs.get("env")
-            return SimpleNamespace(returncode=0)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(release, "run_framework_command", fake_run_framework_command)
         ok, reason = release.run_build(tmp_path, "0.21.0")
+
         assert ok is True
-        assert captured["cmd"] == ["task", "build"]
+        assert captured["name"] == "build"
+        assert captured["project_root"] == tmp_path
+        assert captured["framework_root"] == tmp_path
         env = captured["env"]
-        assert env is not None, "run_build must set env= for DEFT_RELEASE_VERSION"
         assert env.get("DEFT_RELEASE_VERSION") == "0.21.0", (
             "#723: run_build MUST propagate DEFT_RELEASE_VERSION to the "
-            f"task build subprocess; observed env: {env!r}"
+            f"framework build dispatcher; observed env: {env!r}"
         )
         assert "DEFT_RELEASE_VERSION=0.21.0" in reason
 
     def test_run_build_omits_env_when_version_none(self, monkeypatch, tmp_path):
         captured = {}
 
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(release, "task_has_target", lambda *_a, **_kw: True)
+        def fake_run_framework_command(name, **kwargs):
+            captured["env"] = dict(release.os.environ)
+            return SimpleNamespace(code=0)
 
-        def fake_run(cmd, **kwargs):
-            captured["env"] = kwargs.get("env")
-            return SimpleNamespace(returncode=0)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(release, "run_framework_command", fake_run_framework_command)
         ok, reason = release.run_build(tmp_path, version=None)
+
         assert ok is True
         env = captured["env"]
-        # When version is None we still pass an env (os.environ.copy) but
-        # MUST NOT inject a stale/empty DEFT_RELEASE_VERSION key.
         assert "DEFT_RELEASE_VERSION" not in env
         assert "DEFT_RELEASE_VERSION" not in reason
 
@@ -1773,37 +1701,34 @@ class TestRunBuildVersionEnv:
         captured = {}
 
         monkeypatch.setenv("DEFT_RELEASE_VERSION", "stale-0.20.0")
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(release, "task_has_target", lambda *_a, **_kw: True)
 
-        def fake_run(cmd, **kwargs):
-            captured["env"] = kwargs.get("env")
-            return SimpleNamespace(returncode=0)
+        def fake_run_framework_command(name, **kwargs):
+            captured["env"] = dict(release.os.environ)
+            return SimpleNamespace(code=0)
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(release, "run_framework_command", fake_run_framework_command)
         ok, reason = release.run_build(tmp_path, version=None)
+
         assert ok is True
         env = captured["env"]
-        assert env is not None, "run_build must set env= for the subprocess"
         assert "DEFT_RELEASE_VERSION" not in env, (
             "#723 follow-up: run_build(version=None) MUST strip any inherited "
-            "DEFT_RELEASE_VERSION from the subprocess env so the Taskfile "
-            "resolver falls back to git describe -- otherwise stale parent-shell "
+            "DEFT_RELEASE_VERSION from the dispatcher env so the version resolver "
+            "falls back to git describe -- otherwise stale parent-shell "
             f"values silently re-leak. observed env value: {env.get('DEFT_RELEASE_VERSION')!r}"
         )
         assert "DEFT_RELEASE_VERSION" not in reason
+        assert release.os.environ.get("DEFT_RELEASE_VERSION") == "stale-0.20.0"
 
-    def test_run_build_skips_when_target_missing(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(release, "task_binary_available", lambda: True)
-        monkeypatch.setattr(release, "task_has_target", lambda *_a, **_kw: False)
+    def test_run_build_reports_dispatch_failure(self, monkeypatch, tmp_path):
+        def fake_run_framework_command(name, **kwargs):
+            return SimpleNamespace(code=4)
 
-        def boom(*_a, **_kw):  # pragma: no cover - asserted not called
-            raise AssertionError("task must not be invoked when target is missing")
-
-        monkeypatch.setattr(subprocess, "run", boom)
+        monkeypatch.setattr(release, "run_framework_command", fake_run_framework_command)
         ok, reason = release.run_build(tmp_path, "0.21.0")
-        assert ok is True
-        assert "not defined; skipping" in reason
+
+        assert ok is False
+        assert reason == "build failed (exit 4)"
 
     def test_pipeline_step6_pins_version_env(
         self, temp_project, monkeypatch, capsys

--- a/tests/cli/test_release.py
+++ b/tests/cli/test_release.py
@@ -413,6 +413,37 @@ class TestRunCI:
 
 
 # ---------------------------------------------------------------------------
+# refresh_roadmap
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshRoadmap:
+    def test_refresh_roadmap_ignores_release_process_argv(self, monkeypatch, tmp_path):
+        project = tmp_path / "project"
+        (project / "vbrief" / "pending").mkdir(parents=True)
+        (project / "vbrief" / "completed").mkdir(parents=True)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "release.py",
+                "0.21.0",
+                "--repo",
+                "deftai/directive",
+                "--skip-ci",
+            ],
+        )
+
+        ok, reason = release.refresh_roadmap(project)
+
+        assert ok, reason
+        assert reason == "ROADMAP.md re-rendered"
+        roadmap = project / "ROADMAP.md"
+        assert roadmap.is_file()
+        assert "No pending work items." in roadmap.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
 # Pipeline (run_pipeline / main)
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/test_release_e2e.py
+++ b/tests/cli/test_release_e2e.py
@@ -7,11 +7,11 @@ Coverage:
   - clone_repo_to_temp: subprocess.run argv + success / failure paths
   - set_origin_to_temp_repo: argv contains 'remote set-url' + temp URL
   - push_mirror: argv carries explicit heads+tags refspecs (no --mirror; #728)
-  - dispatch_task_release: argv carries --skip-ci + --skip-build
+  - dispatch_task_release: release.main argv carries --skip-ci + --skip-build
   - verify_draft_release: success path + isDraft=false refusal +
     tagName mismatch refusal
   - verify_tag: ls-remote presence / absence
-  - dispatch_task_release_rollback: argv shape
+  - dispatch_task_release_rollback: release_rollback.main argv shape
 - run_rehearsal: walks the seven steps in order; short-circuits on first
   failure; passes the configured version through
 - run_e2e: provision -> rehearse -> destroy ordering; cleanup runs even
@@ -320,26 +320,26 @@ class TestPushMirror:
 
 class TestDispatchTaskRelease:
     def test_argv_carries_skip_ci_and_skip_build(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(release_e2e.shutil, "which", lambda _: "/usr/bin/task")
         captured = {}
 
-        def fake_run(cmd, **kwargs):
-            captured["cmd"] = cmd
-            captured["env"] = kwargs.get("env")
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        def fake_call(entrypoint, argv, *, clone_dir):
+            captured["entrypoint"] = entrypoint
+            captured["argv"] = list(argv)
+            captured["clone_dir"] = clone_dir
+            return 0, ""
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(release_e2e, "_call_release_entrypoint", fake_call)
         ok, _ = release_e2e.dispatch_task_release(
             tmp_path, "0.0.1", "deftai/temp-x"
         )
         assert ok is True
         # #720 acceptance: --skip-ci AND --skip-build are passed through.
-        assert "--skip-ci" in captured["cmd"]
-        assert "--skip-build" in captured["cmd"]
-        assert captured["cmd"][0] == "task"
-        assert captured["cmd"][1] == "release"
-        assert "0.0.1" in captured["cmd"]
-        assert "deftai/temp-x" in captured["cmd"]
+        assert captured["entrypoint"] is release_e2e.release.main
+        assert "--skip-ci" in captured["argv"]
+        assert "--skip-build" in captured["argv"]
+        assert "0.0.1" in captured["argv"]
+        assert "deftai/temp-x" in captured["argv"]
+        assert captured["clone_dir"] == tmp_path
 
     def test_argv_carries_allow_vbrief_drift(self, monkeypatch, tmp_path):
         """Post-#754 harness fix: e2e rehearsal MUST pass --allow-vbrief-drift.
@@ -352,69 +352,74 @@ class TestDispatchTaskRelease:
         cut path against a real repo does NOT pass this flag and remains
         fully gated.
         """
-        monkeypatch.setattr(release_e2e.shutil, "which", lambda _: "/usr/bin/task")
         captured = {}
 
-        def fake_run(cmd, **kwargs):
-            captured["cmd"] = cmd
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        def fake_call(entrypoint, argv, *, clone_dir):
+            captured["argv"] = list(argv)
+            return 0, ""
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(release_e2e, "_call_release_entrypoint", fake_call)
         ok, _ = release_e2e.dispatch_task_release(
             tmp_path, "0.0.1", "deftai/temp-x"
         )
         assert ok is True
-        assert "--allow-vbrief-drift" in captured["cmd"], (
+        assert "--allow-vbrief-drift" in captured["argv"], (
             "e2e rehearsal MUST pass --allow-vbrief-drift to skip the "
             "vBRIEF-lifecycle-sync gate against an empty temp repo (#754 "
             "harness fix)"
         )
 
-    def test_pins_deft_project_root_to_clone_dir(self, monkeypatch, tmp_path):
-        """#728 cycle 2 P1: subprocess env MUST pin DEFT_PROJECT_ROOT to
+    def test_call_entrypoint_pins_deft_project_root_to_clone_dir(self, monkeypatch, tmp_path):
+        """#728 cycle 2 P1: entrypoint env MUST pin DEFT_PROJECT_ROOT to
         ``clone_dir``. Without this, an operator with the variable
-        exported would have ``task release`` resolve to the real
+        exported would have release.py resolve to the real
         directive repo and push spurious v0.0.1 artefacts to
         ``deftai/directive``."""
-        monkeypatch.setattr(release_e2e.shutil, "which", lambda _: "/usr/bin/task")
         monkeypatch.setenv("DEFT_PROJECT_ROOT", "/operator/real/repo")
         captured = {}
-
-        def fake_run(cmd, **kwargs):
-            captured["env"] = kwargs.get("env")
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         clone_dir = tmp_path / "clone"
-        ok, _ = release_e2e.dispatch_task_release(
-            clone_dir, "0.0.1", "deftai/temp-x"
-        )
-        assert ok is True
-        env = captured["env"]
-        assert env is not None
-        assert env.get("DEFT_PROJECT_ROOT") == str(clone_dir), (
-            "DEFT_PROJECT_ROOT must be pinned to clone_dir, got "
-            f"{env.get('DEFT_PROJECT_ROOT')!r}"
-        )
-        assert env["DEFT_PROJECT_ROOT"] != "/operator/real/repo"
+        clone_dir.mkdir()
 
-    def test_task_missing_returns_false(self, monkeypatch, tmp_path):
+        def fake_entrypoint(argv):
+            captured["argv"] = list(argv)
+            captured["env"] = release_e2e.os.environ.get("DEFT_PROJECT_ROOT")
+            captured["cwd"] = Path.cwd()
+            return 0
+
+        code, _ = release_e2e._call_release_entrypoint(
+            fake_entrypoint,
+            ["0.0.1"],
+            clone_dir=clone_dir,
+        )
+        assert code == 0
+        assert captured["env"] == str(clone_dir), (
+            "DEFT_PROJECT_ROOT must be pinned to clone_dir, got "
+            f"{captured['env']!r}"
+        )
+        assert captured["env"] != "/operator/real/repo"
+        assert captured["cwd"] == clone_dir
+        assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == "/operator/real/repo"
+
+    def test_task_missing_does_not_block_dispatch(self, monkeypatch, tmp_path):
         monkeypatch.setattr(release_e2e.shutil, "which", lambda _: None)
+        monkeypatch.setattr(
+            release_e2e,
+            "_call_release_entrypoint",
+            lambda *args, **kwargs: (0, ""),
+        )
+
         ok, reason = release_e2e.dispatch_task_release(
             tmp_path, "0.0.1", "deftai/x"
         )
-        assert ok is False
-        assert "task binary not found" in reason
+        assert ok is True
+        assert "release.py 0.0.1 --repo deftai/x" in reason
 
     def test_failure_surfaces_stderr(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(release_e2e.shutil, "which", lambda _: "/usr/bin/task")
-
-        def fake_run(cmd, **kwargs):
-            return SimpleNamespace(
-                stdout="", stderr="pipeline step failed", returncode=1
-            )
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            release_e2e,
+            "_call_release_entrypoint",
+            lambda *args, **kwargs: (1, "pipeline step failed"),
+        )
         ok, reason = release_e2e.dispatch_task_release(
             tmp_path, "0.0.1", "deftai/x"
         )
@@ -516,48 +521,54 @@ class TestVerifyTag:
 
 class TestDispatchTaskReleaseRollback:
     def test_argv_shape(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(release_e2e.shutil, "which", lambda _: "/usr/bin/task")
         captured = {}
 
-        def fake_run(cmd, **kwargs):
-            captured["cmd"] = cmd
-            captured["env"] = kwargs.get("env")
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        def fake_call(entrypoint, argv, *, clone_dir):
+            captured["entrypoint"] = entrypoint
+            captured["argv"] = list(argv)
+            captured["clone_dir"] = clone_dir
+            return 0, ""
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(release_e2e, "_call_release_entrypoint", fake_call)
         ok, _ = release_e2e.dispatch_task_release_rollback(
             tmp_path, "0.0.1", "deftai/x"
         )
         assert ok is True
-        assert captured["cmd"][0] == "task"
-        assert captured["cmd"][1] == "release:rollback"
-        assert "0.0.1" in captured["cmd"]
-        assert "deftai/x" in captured["cmd"]
+        assert captured["entrypoint"] is release_e2e.release_rollback.main
+        assert "0.0.1" in captured["argv"]
+        assert "deftai/x" in captured["argv"]
+        assert captured["clone_dir"] == tmp_path
 
-    def test_pins_deft_project_root_to_clone_dir(self, monkeypatch, tmp_path):
+    def test_call_entrypoint_pins_deft_project_root_to_clone_dir(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
         """#728 cycle 2 P1: same env-pinning rationale as
         dispatch_task_release. Without DEFT_PROJECT_ROOT pinned to
         clone_dir, an operator with the variable exported would have
-        ``task release:rollback`` resolve to the real directive repo
+        release_rollback.py resolve to the real directive repo
         and either fail with a false VIOLATION or mutate real history."""
-        monkeypatch.setattr(release_e2e.shutil, "which", lambda _: "/usr/bin/task")
         monkeypatch.setenv("DEFT_PROJECT_ROOT", "/operator/real/repo")
         captured = {}
-
-        def fake_run(cmd, **kwargs):
-            captured["env"] = kwargs.get("env")
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         clone_dir = tmp_path / "clone"
-        ok, _ = release_e2e.dispatch_task_release_rollback(
-            clone_dir, "0.0.1", "deftai/x"
+        clone_dir.mkdir()
+
+        def fake_entrypoint(argv):
+            captured["env"] = release_e2e.os.environ.get("DEFT_PROJECT_ROOT")
+            captured["cwd"] = Path.cwd()
+            return 0
+
+        code, _ = release_e2e._call_release_entrypoint(
+            fake_entrypoint,
+            ["0.0.1"],
+            clone_dir=clone_dir,
         )
-        assert ok is True
-        env = captured["env"]
-        assert env is not None
-        assert env.get("DEFT_PROJECT_ROOT") == str(clone_dir)
-        assert env["DEFT_PROJECT_ROOT"] != "/operator/real/repo"
+        assert code == 0
+        assert captured["env"] == str(clone_dir)
+        assert captured["env"] != "/operator/real/repo"
+        assert captured["cwd"] == clone_dir
+        assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == "/operator/real/repo"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_release_e2e.py
+++ b/tests/cli/test_release_e2e.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -322,10 +323,11 @@ class TestDispatchTaskRelease:
     def test_argv_carries_skip_ci_and_skip_build(self, monkeypatch, tmp_path):
         captured = {}
 
-        def fake_call(entrypoint, argv, *, clone_dir):
+        def fake_call(entrypoint, argv, *, clone_dir, timeout):
             captured["entrypoint"] = entrypoint
             captured["argv"] = list(argv)
             captured["clone_dir"] = clone_dir
+            captured["timeout"] = timeout
             return 0, ""
 
         monkeypatch.setattr(release_e2e, "_call_release_entrypoint", fake_call)
@@ -340,6 +342,7 @@ class TestDispatchTaskRelease:
         assert "0.0.1" in captured["argv"]
         assert "deftai/temp-x" in captured["argv"]
         assert captured["clone_dir"] == tmp_path
+        assert captured["timeout"] == release_e2e.RELEASE_ENTRYPOINT_TIMEOUT_SECONDS
 
     def test_argv_carries_allow_vbrief_drift(self, monkeypatch, tmp_path):
         """Post-#754 harness fix: e2e rehearsal MUST pass --allow-vbrief-drift.
@@ -354,8 +357,9 @@ class TestDispatchTaskRelease:
         """
         captured = {}
 
-        def fake_call(entrypoint, argv, *, clone_dir):
+        def fake_call(entrypoint, argv, *, clone_dir, timeout):
             captured["argv"] = list(argv)
+            captured["timeout"] = timeout
             return 0, ""
 
         monkeypatch.setattr(release_e2e, "_call_release_entrypoint", fake_call)
@@ -363,13 +367,18 @@ class TestDispatchTaskRelease:
             tmp_path, "0.0.1", "deftai/temp-x"
         )
         assert ok is True
+        assert captured["timeout"] == release_e2e.RELEASE_ENTRYPOINT_TIMEOUT_SECONDS
         assert "--allow-vbrief-drift" in captured["argv"], (
             "e2e rehearsal MUST pass --allow-vbrief-drift to skip the "
             "vBRIEF-lifecycle-sync gate against an empty temp repo (#754 "
             "harness fix)"
         )
 
-    def test_call_entrypoint_pins_deft_project_root_to_clone_dir(self, monkeypatch, tmp_path):
+    def test_call_entrypoint_pins_deft_project_root_to_clone_dir(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
         """#728 cycle 2 P1: entrypoint env MUST pin DEFT_PROJECT_ROOT to
         ``clone_dir``. Without this, an operator with the variable
         exported would have release.py resolve to the real
@@ -399,6 +408,63 @@ class TestDispatchTaskRelease:
         assert captured["env"] != "/operator/real/repo"
         assert captured["cwd"] == clone_dir
         assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == "/operator/real/repo"
+
+    def test_call_entrypoint_converts_unexpected_exception_to_failure(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setenv("DEFT_PROJECT_ROOT", "/operator/real/repo")
+        old_cwd = Path.cwd()
+        clone_dir = tmp_path / "clone"
+        clone_dir.mkdir()
+
+        def fail(_argv):
+            raise RuntimeError("boom")
+
+        code, output = release_e2e._call_release_entrypoint(
+            fail,
+            ["0.0.1"],
+            clone_dir=clone_dir,
+            timeout=1,
+        )
+
+        assert code == release_e2e.EXIT_VIOLATION
+        assert "RuntimeError: boom" in output
+        assert Path.cwd() == old_cwd
+        assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == "/operator/real/repo"
+
+    def test_call_entrypoint_times_out_on_hanging_entrypoint(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setenv("DEFT_PROJECT_ROOT", "/operator/real/repo")
+        old_cwd = Path.cwd()
+        clone_dir = tmp_path / "clone"
+        clone_dir.mkdir()
+        started = threading.Event()
+        release = threading.Event()
+
+        def hang(_argv):
+            started.set()
+            release.wait(5)
+            return 0
+
+        try:
+            code, output = release_e2e._call_release_entrypoint(
+                hang,
+                ["0.0.1"],
+                clone_dir=clone_dir,
+                timeout=0.05,
+            )
+            assert started.wait(1)
+            assert code == release_e2e.ENTRYPOINT_TIMEOUT_EXIT_CODE
+            assert "timed out" in output
+            assert Path.cwd() == old_cwd
+            assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == "/operator/real/repo"
+        finally:
+            release.set()
 
     def test_task_missing_does_not_block_dispatch(self, monkeypatch, tmp_path):
         monkeypatch.setattr(release_e2e.shutil, "which", lambda _: None)
@@ -523,10 +589,11 @@ class TestDispatchTaskReleaseRollback:
     def test_argv_shape(self, monkeypatch, tmp_path):
         captured = {}
 
-        def fake_call(entrypoint, argv, *, clone_dir):
+        def fake_call(entrypoint, argv, *, clone_dir, timeout):
             captured["entrypoint"] = entrypoint
             captured["argv"] = list(argv)
             captured["clone_dir"] = clone_dir
+            captured["timeout"] = timeout
             return 0, ""
 
         monkeypatch.setattr(release_e2e, "_call_release_entrypoint", fake_call)
@@ -538,6 +605,7 @@ class TestDispatchTaskReleaseRollback:
         assert "0.0.1" in captured["argv"]
         assert "deftai/x" in captured["argv"]
         assert captured["clone_dir"] == tmp_path
+        assert captured["timeout"] == release_e2e.ROLLBACK_ENTRYPOINT_TIMEOUT_SECONDS
 
     def test_call_entrypoint_pins_deft_project_root_to_clone_dir(
         self,

--- a/tests/cli/test_release_e2e.py
+++ b/tests/cli/test_release_e2e.py
@@ -30,6 +30,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -443,6 +444,8 @@ class TestDispatchTaskRelease:
         old_cwd = Path.cwd()
         clone_dir = tmp_path / "clone"
         clone_dir.mkdir()
+        next_dir = tmp_path / "next"
+        next_dir.mkdir()
         started = threading.Event()
         release = threading.Event()
 
@@ -463,8 +466,28 @@ class TestDispatchTaskRelease:
             assert "timed out" in output
             assert Path.cwd() == old_cwd
             assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == "/operator/real/repo"
+
+            release_e2e.os.chdir(next_dir)
+            release_e2e.os.environ["DEFT_PROJECT_ROOT"] = str(next_dir)
+            release.set()
+
+            def worker_alive():
+                return any(
+                    thread.name == "deft-release-entrypoint" and thread.is_alive()
+                    for thread in threading.enumerate()
+                )
+
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline:
+                if not worker_alive():
+                    break
+                time.sleep(0.01)
+            assert not worker_alive()
+            assert Path.cwd() == next_dir
+            assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == str(next_dir)
         finally:
             release.set()
+            release_e2e.os.chdir(old_cwd)
 
     def test_task_missing_does_not_block_dispatch(self, monkeypatch, tmp_path):
         monkeypatch.setattr(release_e2e.shutil, "which", lambda _: None)

--- a/tests/cli/test_release_e2e.py
+++ b/tests/cli/test_release_e2e.py
@@ -25,6 +25,7 @@ Refs #716, #720, #74.
 from __future__ import annotations
 
 import importlib.util
+import io
 import re
 import shutil
 import subprocess
@@ -487,6 +488,61 @@ class TestDispatchTaskRelease:
             assert release_e2e.os.environ.get("DEFT_PROJECT_ROOT") == str(next_dir)
         finally:
             release.set()
+            release_e2e.os.chdir(old_cwd)
+
+    def test_timed_out_entrypoint_does_not_restore_over_later_stdio_capture(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.setenv("DEFT_PROJECT_ROOT", "/operator/real/repo")
+        old_cwd = Path.cwd()
+        old_stdout, old_stderr = release_e2e.sys.stdout, release_e2e.sys.stderr
+        clone_dir = tmp_path / "clone"
+        clone_dir.mkdir()
+        started = threading.Event()
+        release = threading.Event()
+
+        def hang(_argv):
+            started.set()
+            release.wait(5)
+            return 0
+
+        try:
+            code, output = release_e2e._call_release_entrypoint(
+                hang,
+                ["0.0.1"],
+                clone_dir=clone_dir,
+                timeout=0.05,
+            )
+            assert started.wait(1)
+            assert code == release_e2e.ENTRYPOINT_TIMEOUT_EXIT_CODE
+            assert "timed out" in output
+
+            next_stdout = io.StringIO()
+            next_stderr = io.StringIO()
+            release_e2e.sys.stdout = next_stdout
+            release_e2e.sys.stderr = next_stderr
+            release.set()
+
+            def worker_alive():
+                return any(
+                    thread.name == "deft-release-entrypoint" and thread.is_alive()
+                    for thread in threading.enumerate()
+                )
+
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline:
+                if not worker_alive():
+                    break
+                time.sleep(0.01)
+            assert not worker_alive()
+            assert release_e2e.sys.stdout is next_stdout
+            assert release_e2e.sys.stderr is next_stderr
+        finally:
+            release.set()
+            release_e2e.sys.stdout = old_stdout
+            release_e2e.sys.stderr = old_stderr
             release_e2e.os.chdir(old_cwd)
 
     def test_task_missing_does_not_block_dispatch(self, monkeypatch, tmp_path):

--- a/tests/cli/test_verify_no_task_runtime.py
+++ b/tests/cli/test_verify_no_task_runtime.py
@@ -38,3 +38,31 @@ def test_scan_flags_task_subprocess_and_path_probe(tmp_path: Path, monkeypatch) 
     assert [finding.line for finding in findings] == [3, 4]
     assert findings[0].message == "runtime subprocess invocation of go-task is forbidden"
     assert findings[1].message == "runtime go-task PATH probe is forbidden"
+
+
+def test_scan_flags_import_aliases_and_direct_imports(
+    tmp_path: Path, monkeypatch
+) -> None:
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "import shutil as sh\n"
+        "import subprocess as sp\n"
+        "from shutil import which as find_tool\n"
+        "from subprocess import run as run_process\n"
+        'sp.run(["task", "check"])\n'
+        'run_process(("task", "check"))\n'
+        'sh.which("task")\n'
+        'find_tool("task")\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(verify_no_task_runtime, "_python_files", lambda: [probe])
+
+    findings = verify_no_task_runtime.scan()
+
+    assert [finding.line for finding in findings] == [5, 6, 7, 8]
+    assert [finding.message for finding in findings] == [
+        "runtime subprocess invocation of go-task is forbidden",
+        "runtime subprocess invocation of go-task is forbidden",
+        "runtime go-task PATH probe is forbidden",
+        "runtime go-task PATH probe is forbidden",
+    ]

--- a/tests/cli/test_verify_no_task_runtime.py
+++ b/tests/cli/test_verify_no_task_runtime.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make ``scripts/`` importable when running ``pytest tests/``.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import verify_no_task_runtime  # noqa: E402
+
+
+def test_scan_allows_non_task_subprocesses(tmp_path: Path, monkeypatch) -> None:
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "import subprocess\n"
+        'subprocess.run(["git", "status"], check=True)\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(verify_no_task_runtime, "_python_files", lambda: [probe])
+
+    assert verify_no_task_runtime.scan() == []
+
+
+def test_scan_flags_task_subprocess_and_path_probe(tmp_path: Path, monkeypatch) -> None:
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "import shutil\n"
+        "import subprocess\n"
+        'subprocess.check_output(["task", "check"])\n'
+        'shutil.which("task")\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(verify_no_task_runtime, "_python_files", lambda: [probe])
+
+    findings = verify_no_task_runtime.scan()
+
+    assert [finding.line for finding in findings] == [3, 4]
+    assert findings[0].message == "runtime subprocess invocation of go-task is forbidden"
+    assert findings[1].message == "runtime go-task PATH probe is forbidden"

--- a/tests/cli/test_verify_session_ritual.py
+++ b/tests/cli/test_verify_session_ritual.py
@@ -98,7 +98,7 @@ def test_missing_state_fails_closed(tmp_path: Path) -> None:
     result = verifier.verify(tmp_path, tier="quick", bypass=False)
 
     assert result.code == 1
-    assert "task session:start" in result.message
+    assert "deft session:start" in result.message
 
 
 def test_corrupt_state_is_config_error(tmp_path: Path) -> None:
@@ -205,15 +205,7 @@ def test_gated_tier_lazily_records_missing_steps(tmp_path: Path) -> None:
 
     assert result.code == 0
     state = json.loads((tmp_path / ".deft" / "ritual-state.json").read_text(encoding="utf-8"))
-    assert commands == [
-        ["doctor.cmd_doctor", "--project-root", str(tmp_path)],
-        [
-            "preflight_cache.main",
-            "--allow-missing-bootstrap",
-            "--project-root",
-            str(tmp_path),
-        ],
-    ]
+    assert commands == [["doctor"], ["verify:cache-fresh"]]
     assert state["gated_steps"]["doctor"]["ok"] is True
     assert state["gated_steps"]["cache_fresh"]["ok"] is True
 
@@ -243,26 +235,9 @@ def test_gated_tier_records_in_process_entrypoint_commands(
 
     state = json.loads((tmp_path / ".deft" / "ritual-state.json").read_text(encoding="utf-8"))
     assert result.code == 0
-    assert commands == [
-        ["doctor.cmd_doctor", "--project-root", str(tmp_path)],
-        [
-            "preflight_cache.main",
-            "--allow-missing-bootstrap",
-            "--project-root",
-            str(tmp_path),
-        ],
-    ]
-    assert state["gated_steps"]["doctor"]["command"] == [
-        "doctor.cmd_doctor",
-        "--project-root",
-        str(tmp_path),
-    ]
-    assert state["gated_steps"]["cache_fresh"]["command"] == [
-        "preflight_cache.main",
-        "--allow-missing-bootstrap",
-        "--project-root",
-        str(tmp_path),
-    ]
+    assert commands == [["doctor"], ["verify:cache-fresh"]]
+    assert state["gated_steps"]["doctor"]["command"] == ["doctor"]
+    assert state["gated_steps"]["cache_fresh"]["command"] == ["verify:cache-fresh"]
 
 
 def test_gated_tier_records_entrypoint_failure(tmp_path: Path) -> None:
@@ -272,7 +247,7 @@ def test_gated_tier_records_entrypoint_failure(tmp_path: Path) -> None:
     _write_state(tmp_path, head=head, started_at=now)
 
     def runner(command: list[str], cwd: Path) -> tuple[int, str, str]:
-        if command[0] == "preflight_cache.main":
+        if command[0] == "verify:cache-fresh":
             return 1, "", "cache stale"
         return 0, "doctor ok", ""
 
@@ -289,8 +264,7 @@ def test_gated_tier_records_entrypoint_failure(tmp_path: Path) -> None:
     assert "gated step 'cache_fresh' failed: cache stale" in result.message
     assert state["gated_steps"]["doctor"]["ok"] is True
     assert state["gated_steps"]["cache_fresh"]["ok"] is False
-    assert state["gated_steps"]["cache_fresh"]["command"][0] == "preflight_cache.main"
-    assert "--allow-missing-bootstrap" in state["gated_steps"]["cache_fresh"]["command"]
+    assert state["gated_steps"]["cache_fresh"]["command"] == ["verify:cache-fresh"]
 
 
 def test_subprocess_helpers_capture_text_as_utf8(tmp_path: Path, monkeypatch) -> None:
@@ -315,7 +289,7 @@ def test_subprocess_helpers_capture_text_as_utf8(tmp_path: Path, monkeypatch) ->
 
     monkeypatch.setitem(sys.modules, "doctor", SimpleNamespace(cmd_doctor=fake_cmd_doctor))
     task_code, task_stdout, task_stderr = verifier._default_runner(
-        ["doctor.cmd_doctor", "--project-root", str(tmp_path)],
+        ["doctor"],
         tmp_path,
     )
 
@@ -712,4 +686,4 @@ def test_cli_bypass_warns_to_stderr_when_failure_is_hidden(
     assert code == 0
     assert captured.out == ""
     assert "WARNING: DEFT_SESSION_RITUAL_SKIP=1 bypassed" in captured.err
-    assert "task session:start" in captured.err
+    assert "deft session:start" in captured.err

--- a/tests/cli/test_verify_session_ritual.py
+++ b/tests/cli/test_verify_session_ritual.py
@@ -306,6 +306,16 @@ def test_subprocess_helpers_capture_text_as_utf8(tmp_path: Path, monkeypatch) ->
         assert kwargs["errors"] == "replace"
 
 
+def test_default_runner_rejects_unregistered_gated_command(tmp_path: Path) -> None:
+    verifier = _load_module("verify_session_ritual", SCRIPTS_DIR / "verify_session_ritual.py")
+
+    code, stdout, stderr = verifier._default_runner(["future:gated"], tmp_path)
+
+    assert code == 2
+    assert stdout == ""
+    assert "unknown session ritual command: future:gated" in stderr
+
+
 def test_call_main_treats_system_exit_none_as_success() -> None:
     verifier = _load_module("verify_session_ritual", SCRIPTS_DIR / "verify_session_ritual.py")
 

--- a/tests/cli/test_verify_tools.py
+++ b/tests/cli/test_verify_tools.py
@@ -47,6 +47,7 @@ def test_missing_installable_tool_reports_prompt_manual_url_and_summary() -> Non
     lines: list[str] = []
 
     result = verify_tools.verify_required_tools(
+        include_task=True,
         platform_id="linux",
         probe=_probe_with("git", "uv", "python3", "gh", "apt-get"),
         output_fn=lines.append,
@@ -67,6 +68,7 @@ def test_non_interactive_guidance_omits_yes_no_prompt() -> None:
     lines: list[str] = []
 
     verify_tools.verify_required_tools(
+        include_task=True,
         platform_id="linux",
         probe=_probe_with("git", "uv", "python3", "gh", "apt-get"),
         output_fn=lines.append,
@@ -83,6 +85,7 @@ def test_interactive_guidance_includes_yes_no_prompt() -> None:
     verify_tools.verify_required_tools(
         install=True,
         assume_yes=False,
+        include_task=True,
         platform_id="linux",
         probe=_probe_with("git", "uv", "python3", "gh", "apt-get"),
         input_fn=lambda _prompt: "n",
@@ -108,6 +111,7 @@ def test_approved_install_runs_command_and_rechecks_tool() -> None:
     result = verify_tools.verify_required_tools(
         install=True,
         assume_yes=True,
+        include_task=True,
         platform_id="linux",
         probe=probe,
         run_fn=run,
@@ -126,6 +130,7 @@ def test_declined_install_keeps_manual_fallback_unresolved() -> None:
     result = verify_tools.verify_required_tools(
         install=True,
         assume_yes=False,
+        include_task=True,
         platform_id="linux",
         probe=_probe_with("git", "uv", "python3", "gh", "apt-get"),
         input_fn=lambda _prompt: "n",
@@ -152,6 +157,21 @@ def test_missing_manual_only_tool_skips_install_prompt() -> None:
     assert uv_status.installable is False
     assert any("no safe automated installer" in line for line in lines)
     assert not any("Install it now? (Y/n)" in line for line in lines)
+
+
+def test_missing_task_is_not_required_by_default() -> None:
+    verify_tools = _load_module()
+    lines: list[str] = []
+
+    result = verify_tools.verify_required_tools(
+        platform_id="linux",
+        probe=_probe_with("git", "uv", "python3", "gh", "apt-get"),
+        output_fn=lines.append,
+    )
+
+    assert result.exit_code == 0
+    assert not any(status.name == "task" for status in result.statuses)
+    assert lines == ["[deft tools] Required tools are available."]
 
 
 def test_missing_git_is_foundational_failure_without_auto_install() -> None:

--- a/tests/content/test_agents_entry_contract.py
+++ b/tests/content/test_agents_entry_contract.py
@@ -235,28 +235,28 @@ def test_managed_section_implementation_intent_gate_uses_required_tokens() -> No
 # ---------------------------------------------------------------------------
 
 _PROPAGATION_COMMAND_MARKERS: tuple[tuple[str, str], ...] = (
-    # Consumer AGENTS.md is generated for the canonical namespaced include,
-    # while the maintainer-side AGENTS.md is read inside this repo where bare
-    # task names resolve. Each pair is (consumer template, maintainer AGENTS).
-    ("task deft:session:start", "task session:start"),
-    ("task deft:verify:session-ritual", "task verify:session-ritual"),
-    ("task deft:verify:tools", "task verify:tools"),
-    ("task deft:triage:welcome --onboard", "task triage:welcome --onboard"),
-    ("task deft:triage:queue", "task triage:queue"),
+    # Consumer AGENTS.md is generated for package-manager installs, while the
+    # maintainer-side AGENTS.md is read inside this source repo where bare task
+    # names still resolve. Each pair is (consumer template, maintainer AGENTS).
+    ("deft session:start", "task session:start"),
+    ("deft verify:session-ritual", "task verify:session-ritual"),
+    ("deft verify:tools", "task verify:tools"),
+    ("deft triage:welcome --onboard", "task triage:welcome --onboard"),
+    ("deft triage:queue", "task triage:queue"),
     ("triage <N>", "triage <N>"),
-    ("task deft:verify:cache-fresh", "task verify:cache-fresh"),
-    ("task deft:verify:branch", "task verify:branch"),
+    ("deft verify:cache-fresh", "task verify:cache-fresh"),
+    ("deft verify:branch", "task verify:branch"),
     # #1378 Story C: deterministic story-start Gate 0 surfaced in both files.
-    ("task deft:verify:story-ready", "task verify:story-ready"),
-    ("task deft:doctor", "task doctor"),
-    ("task deft:agents:refresh", "task agents:refresh"),
+    ("deft verify:story-ready", "task verify:story-ready"),
+    ("deft doctor", "task doctor"),
+    ("deft agents:refresh", "task agents:refresh"),
     # #1643/#1637: content-pack discovery command. The command is namespaced
     # the same way on both surfaces (it lands only in the consumer managed
     # section via the refresh), so both halves of the pair are identical --
     # like the git-status / deft-install markers above.
     (
-        "task deft:packs:slice --list-packs",
-        "task deft:packs:slice --list-packs",
+        "deft packs:slice --list-packs",
+        "deft packs:slice --list-packs",
     ),
     # #1409: canonical headless upgrade command surfaced in both files.
     (
@@ -264,10 +264,10 @@ _PROPAGATION_COMMAND_MARKERS: tuple[tuple[str, str], ...] = (
         "deft-install --yes --upgrade --repo-root . --json",
     ),
     ("git status --short --branch", "git status --short --branch"),
-    ("task deft:scope:promote -- <path>", "task scope:promote -- <path>"),
-    ("task deft:scope:activate -- <path>", "task scope:activate -- <path>"),
+    ("deft scope:promote -- <path>", "task scope:promote -- <path>"),
+    ("deft scope:activate -- <path>", "task scope:activate -- <path>"),
     (
-        "task deft:scope:complete -- <active-story-path>",
+        "deft scope:complete -- <active-story-path>",
         "task scope:complete -- <active-story-path>",
     ),
 )
@@ -385,8 +385,8 @@ def test_consumer_template_does_not_use_unresolved_bare_task_names() -> None:
     template = _read_template()
     leaked = [marker for marker in _CONSUMER_FORBIDDEN_BARE_TASK_MARKERS if marker in template]
     assert not leaked, (
-        "templates/agents-entry.md must use `task deft:<name>` for consumer "
-        f"Directive tasks under the canonical include; found bare marker(s): {leaked}"
+        "templates/agents-entry.md must use `deft <name>` for consumer "
+        f"Directive commands; found bare task marker(s): {leaked}"
     )
 
 
@@ -489,11 +489,11 @@ def test_content_packs_note_references_discovery_commands() -> None:
     """#1643: the managed section names the pack/slice discovery commands."""
     section = _managed_section_text()
     assert "--list-packs" in section, (
-        "managed section MUST reference `task deft:packs:slice --list-packs` "
+        "managed section MUST reference `deft packs:slice --list-packs` "
         "as the pack-discovery command (#1643/#1637)."
     )
     assert "<pack> --list" in section, (
-        "managed section MUST reference `task deft:packs:slice <pack> --list` "
+        "managed section MUST reference `deft packs:slice <pack> --list` "
         "as the slice-discovery command (#1643/#1637)."
     )
 

--- a/tests/content/test_story_start_gate.py
+++ b/tests/content/test_story_start_gate.py
@@ -20,16 +20,16 @@ def test_agents_template_contains_story_start_dirty_tree_guard() -> None:
     text = _read("templates/agents-entry.md")
     assert "### Story Start Gate" in text
     assert "git status --short --branch" in text
-    assert "task deft:scope:promote -- <path>" in text
+    assert "deft scope:promote -- <path>" in text
     assert "current branch" in text
     assert "modified/untracked files" in text
     assert "commit existing work" in text
     assert "stash existing work" in text
     assert "include existing work in the current story" in text
     assert "unrelated dirty work" in text
-    assert "task deft:scope:activate -- <path>" in text
-    assert "task deft:vbrief:preflight -- <active-story-path>" in text
-    assert "task deft:scope:complete -- <active-story-path>" in text
+    assert "deft scope:activate -- <path>" in text
+    assert "deft vbrief:preflight -- <active-story-path>" in text
+    assert "deft scope:complete -- <active-story-path>" in text
 
 
 def test_agents_md_contains_story_start_lifecycle_guard() -> None:

--- a/tests/integration/test_consumer_tasks.py
+++ b/tests/integration/test_consumer_tasks.py
@@ -29,6 +29,7 @@ import sys
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -164,9 +165,9 @@ def test_task_check_dispatches_consumer_safe_gate_for_vendored_install(
     (framework_root / "Taskfile.yml").write_text("version: '3'\n", encoding="utf-8")
     calls: list[dict[str, object]] = []
 
-    def fake_runner(args, cwd=None):
-        calls.append({"args": args, "cwd": cwd})
-        return subprocess.CompletedProcess(args, 0)
+    def fake_runner(command, project_root, framework):
+        calls.append({"command": command, "project_root": project_root, "framework": framework})
+        return SimpleNamespace(code=0)
 
     rc = context.dispatch_task_check(
         framework_root,
@@ -177,13 +178,9 @@ def test_task_check_dispatches_consumer_safe_gate_for_vendored_install(
     assert rc == 0
     assert calls == [
         {
-            "args": [
-                "task",
-                "-t",
-                str(framework_root / "Taskfile.yml"),
-                "check:consumer",
-            ],
-            "cwd": str(consumer_project),
+            "command": "check:consumer",
+            "project_root": consumer_project,
+            "framework": framework_root,
         }
     ]
 
@@ -204,9 +201,9 @@ def test_task_check_dispatches_consumer_safe_gate_for_symlinked_core(
         pytest.skip(f"directory symlinks unavailable on this platform: {exc}")
     calls: list[dict[str, object]] = []
 
-    def fake_runner(args, cwd=None):
-        calls.append({"args": args, "cwd": cwd})
-        return subprocess.CompletedProcess(args, 0)
+    def fake_runner(command, project_root, framework):
+        calls.append({"command": command, "project_root": project_root, "framework": framework})
+        return SimpleNamespace(code=0)
 
     rc = context.dispatch_task_check(
         framework_root,
@@ -217,13 +214,9 @@ def test_task_check_dispatches_consumer_safe_gate_for_symlinked_core(
     assert rc == 0
     assert calls == [
         {
-            "args": [
-                "task",
-                "-t",
-                str(framework_root / "Taskfile.yml"),
-                "check:consumer",
-            ],
-            "cwd": str(consumer_project),
+            "command": "check:consumer",
+            "project_root": consumer_project,
+            "framework": framework_root,
         }
     ]
 
@@ -233,22 +226,18 @@ def test_task_check_dispatches_framework_self_check_in_framework_repo() -> None:
     context = _load_module("project_context_dispatch_source", SCRIPTS_DIR / "_project_context.py")
     calls: list[dict[str, object]] = []
 
-    def fake_runner(args, cwd=None):
-        calls.append({"args": args, "cwd": cwd})
-        return subprocess.CompletedProcess(args, 0)
+    def fake_runner(command, project_root, framework):
+        calls.append({"command": command, "project_root": project_root, "framework": framework})
+        return SimpleNamespace(code=0)
 
     rc = context.dispatch_task_check(REPO_ROOT, REPO_ROOT, runner=fake_runner)
 
     assert rc == 0
     assert calls == [
         {
-            "args": [
-                "task",
-                "-t",
-                str(REPO_ROOT / "Taskfile.yml"),
-                "check:framework-source",
-            ],
-            "cwd": str(REPO_ROOT),
+            "command": "check:framework-source",
+            "project_root": REPO_ROOT,
+            "framework": REPO_ROOT,
         }
     ]
 

--- a/tests/test_triage_welcome.py
+++ b/tests/test_triage_welcome.py
@@ -17,9 +17,6 @@ hops fire. Suites:
 from __future__ import annotations
 
 import json
-import os
-import shutil
-import subprocess
 import sys
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
@@ -155,16 +152,19 @@ def test_task_command_args_prefixes_task_name_only() -> None:
     )
 
 
-def test_run_task_uses_prefixed_argv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_task_dispatches_framework_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, object] = {}
 
-    def _fake_run(cmd: list[str], *, cwd: str, check: bool) -> SimpleNamespace:
-        captured["cmd"] = cmd
-        captured["cwd"] = cwd
-        captured["check"] = check
-        return SimpleNamespace(returncode=0)
+    def _fake_run_framework_command(command, argv, *, project_root):
+        captured["command"] = command
+        captured["argv"] = list(argv)
+        captured["project_root"] = project_root
+        return SimpleNamespace(code=0, stdout="", stderr="")
 
-    monkeypatch.setattr(triage_welcome.subprocess, "run", _fake_run)
+    monkeypatch.setattr(triage_welcome, "run_framework_command", _fake_run_framework_command)
     rc = triage_welcome._run_task(
         ["scope:demote", "--", "--batch"],
         cwd=tmp_path,
@@ -172,12 +172,11 @@ def test_run_task_uses_prefixed_argv(tmp_path: Path, monkeypatch: pytest.MonkeyP
     )
 
     assert rc == 0
-    cmd = captured["cmd"]
-    assert isinstance(cmd, list)
-    assert cmd[1:] == ["deft:scope:demote", "--", "--batch"]
-    assert Path(cmd[0]).name.lower().startswith("task")
-    assert captured["cwd"] == str(tmp_path)
-    assert captured["check"] is False
+    assert captured == {
+        "command": "scope:demote",
+        "argv": ["--", "--batch"],
+        "project_root": tmp_path,
+    }
 
 
 def test_run_default_mode_uses_prefixed_onboard_nudge(tmp_path: Path) -> None:
@@ -226,116 +225,35 @@ def test_cli_task_prefix_flag_threads_to_run_welcome(
     assert captured.get("task_prefix") == "deft"
 
 
-def _write_fake_task_binary(bin_dir: Path, log_path: Path) -> Path:
-    task_script = bin_dir / "fake_task.py"
-    task_script.write_text(
-        """#!/usr/bin/env python3
-import os
-import sys
-from pathlib import Path
-
-args = sys.argv[1:]
-with Path(os.environ["FAKE_TASK_LOG"]).open("a", encoding="utf-8") as handle:
-    handle.write(" ".join(args) + "\\n")
-if args and args[0].endswith("triage:bootstrap"):
-    candidates = Path.cwd() / "vbrief" / ".eval" / "candidates.jsonl"
-    candidates.parent.mkdir(parents=True, exist_ok=True)
-    candidates.touch()
-raise SystemExit(0)
-""",
-        encoding="utf-8",
-    )
-    task_script.chmod(0o755)
-    if os.name == "nt":
-        task_path = bin_dir / "task.cmd"
-        task_path.write_text(
-            f'@echo off\n"{sys.executable}" "{task_script}" %*\n',
-            encoding="utf-8",
-        )
-        return task_path
-    task_path = bin_dir / "task"
-    task_path.write_text(
-        f'#!/usr/bin/env sh\nexec "{sys.executable}" "{task_script}" "$@"\n',
-        encoding="utf-8",
-    )
-    task_path.chmod(0o755)
-    return task_path
-
-
-@pytest.mark.parametrize(
-    ("namespaced_include", "expected_prefix"),
-    [
-        pytest.param(False, "", id="direct-framework-taskfile"),
-        pytest.param(True, "deft:", id="consumer-namespaced-include"),
-    ],
-)
-def test_taskfile_welcome_dispatches_sibling_tasks_with_current_namespace(
+def test_welcome_dispatches_sibling_commands_in_process(
     tmp_path: Path,
-    namespaced_include: bool,
-    expected_prefix: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    real_task = shutil.which("task")
-    if real_task is None:
-        pytest.skip("go-task is not installed")
-
-    consumer = tmp_path / "consumer"
-    consumer.mkdir()
     _seed_project_definition(
-        consumer,
+        tmp_path,
         triage_scope=triage_welcome.SUBSCRIPTION_PRESETS["small"],
         wip_cap=10,
     )
-    if namespaced_include:
-        (consumer / "Taskfile.yml").write_text(
-            "version: '3'\n"
-            "includes:\n"
-            "  deft:\n"
-            f"    taskfile: {_REPO_ROOT / 'Taskfile.yml'}\n",
-            encoding="utf-8",
-        )
-        task_args = [real_task, "deft:triage:welcome"]
-    else:
-        task_args = [
-            real_task,
-            "-t",
-            str(_REPO_ROOT / "Taskfile.yml"),
-            "triage:welcome",
-        ]
+    invocations: list[list[str]] = []
 
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    log_path = tmp_path / "fake-task.log"
-    _write_fake_task_binary(fake_bin, log_path)
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
-    env["FAKE_TASK_LOG"] = str(log_path)
-    env["UV_FROZEN"] = "1"
+    def _record_run_task(args: list[str], *, cwd: Path) -> int:
+        invocations.append(list(args))
+        if args == ["triage:bootstrap"]:
+            _seed_candidates_log(tmp_path)
+        return 0
 
-    result = subprocess.run(
-        [*task_args, "--", "--onboard"],
-        cwd=consumer,
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=60,
+    monkeypatch.setattr(triage_welcome, "_run_task", _record_run_task)
+    outcome = triage_welcome.run_welcome(
+        tmp_path,
+        input_fn=_ScriptedInput([]),
+        output_fn=_CapturedOutput(),
+        run_subprocess=True,
+        task_prefix="deft:",
     )
 
-    assert result.returncode == 0, result.stderr
-    combined = result.stdout + result.stderr
-    assert 'Task "triage:' not in combined
-    invocations = log_path.read_text(encoding="utf-8").splitlines()
-    expected_invocations = {
-        f"{expected_prefix}triage:bootstrap",
-        f"{expected_prefix}triage:summary",
-    }
-    assert expected_invocations <= set(invocations)
-    if expected_prefix:
-        assert "triage:bootstrap" not in invocations
-        assert "triage:summary" not in invocations
-    else:
-        assert "deft:triage:bootstrap" not in invocations
-        assert "deft:triage:summary" not in invocations
+    assert outcome.exit_code == 0
+    assert ["triage:bootstrap"] in invocations
+    assert ["triage:summary"] in invocations
 
 
 # ---------------------------------------------------------------------------
@@ -587,7 +505,7 @@ def test_wip_exceeds_cap_offers_relief_dry_run_first(tmp_path: Path) -> None:
     assert outcome.relief_confirmed is False
     # Preview must have been emitted with the dry-run command text.
     joined = output.joined()
-    assert "task scope:demote -- --batch --older-than-days 30" in joined
+    assert "deft scope:demote -- --batch --older-than-days 30" in joined
     assert "2026-03-01-old.vbrief.json" in joined
     assert "Relief declined" in joined
 
@@ -761,7 +679,7 @@ def test_back_at_phase_2_rewinds_to_phase_1_without_recursion(
 def test_phase_3_bootstrap_failure_propagates_exit_code(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """SLizard P1: a non-zero ``task triage:bootstrap`` MUST set exit_code.
+    """SLizard P1: a non-zero ``deft triage:bootstrap`` MUST set exit_code.
 
     Pre-fix the bootstrap failure only warned to stderr and the ritual
     continued with `outcome.exit_code = 0`, making the dispatcher unable
@@ -782,14 +700,14 @@ def test_phase_3_bootstrap_failure_propagates_exit_code(
         run_subprocess=True,  # exercise the subprocess path
     )
     assert outcome.exit_code == 2
-    assert "`task triage:bootstrap` exited 17" in output.joined()
+    assert "`deft triage:bootstrap` exited 17" in output.joined()
     assert outcome.bootstrap_action == triage_welcome.BOOTSTRAP_ACTION_RAN
 
 
 def test_phase_5_scope_demote_failure_propagates_exit_code(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """SLizard P1: a non-zero ``task scope:demote`` MUST set exit_code.
+    """SLizard P1: a non-zero ``deft scope:demote`` MUST set exit_code.
 
     Configure WIP over the cap, confirm relief, and stub `_run_task` to
     return a non-zero code; assert outcome.exit_code == 2.
@@ -817,7 +735,7 @@ def test_phase_5_scope_demote_failure_propagates_exit_code(
     )
     assert outcome.exit_code == 2
     assert outcome.relief_confirmed is True
-    assert "`task scope:demote` exited 7" in output.joined()
+    assert "`deft scope:demote` exited 7" in output.joined()
 
 
 def test_write_triage_scope_propagates_non_import_errors_from_validator(
@@ -970,7 +888,7 @@ def test_skip_bootstrap_emits_visible_audit_message(
     assert "explicitly declined" in joined
     assert "--skip-bootstrap" in joined
     assert "vbrief/.eval/candidates.jsonl" in joined
-    assert "task triage:queue" in joined
+    assert "deft triage:queue" in joined
     # Persistent audit entry written to meta/policy-changes.log.
     audit_log = (tmp_path / triage_welcome.AUDIT_LOG_REL_PATH).read_text(encoding="utf-8")
     assert "action=bootstrap-declined" in audit_log
@@ -1557,7 +1475,7 @@ def test_session_start_nudge_lines_budget_one_with_overflow(tmp_path: Path) -> N
     """The budgeted ranking shows one headline + a +N overflow pointer."""
     _seed_project_definition(tmp_path)
     # One stranded (Tier-1) + one stale (Tier-2): budget 1 shows the stranded
-    # and overflows the stale to `task capacity:show`.
+    # and overflows the stale to `deft capacity:show`.
     _seed_stranded_epic(tmp_path, age_days=60)
     _seed_epic(
         tmp_path,
@@ -1570,7 +1488,7 @@ def test_session_start_nudge_lines_budget_one_with_overflow(tmp_path: Path) -> N
     assert len(lines) == 2
     assert "[TIER-1]" in lines[0]  # Tier-1 stranded ranks first
     assert "+1 more" in lines[1]
-    assert "task capacity:show" in lines[1]
+    assert "deft capacity:show" in lines[1]
 
 
 def test_run_welcome_phase1_emits_lifecycle_nudges(tmp_path: Path) -> None:

--- a/vbrief/active/2026-06-17-1659-decouple-framework-runtime-guidance-from-task-runner.vbrief.json
+++ b/vbrief/active/2026-06-17-1659-decouple-framework-runtime-guidance-from-task-runner.vbrief.json
@@ -1,0 +1,54 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF for #1659: decouple framework runtime and guidance from the task runner"
+  },
+  "plan": {
+    "title": "Decouple framework runtime and guidance from the task runner",
+    "status": "running",
+    "narratives": {
+      "Overview": "Package-manager installs must be able to run Deft through the `deft`/`run` surface without requiring go-task on PATH. Runtime code should call Python entrypoints or the shared framework command dispatcher, while generated guidance should prefer `deft <verb>` and reserve `task deft:<verb>` for Taskfile include users.",
+      "AcceptanceCriteria": "No runtime code path hard-depends on `task`; the `run`/future `deft` surface reaches the framework verbs needed by session, cache, triage, check, and release flows; generated AGENTS guidance points package consumers at `deft`; and a deterministic guard fails on future runtime go-task subprocess dependencies."
+    },
+    "items": [
+      {
+        "id": "A",
+        "title": "Add shared no-task framework command dispatcher",
+        "status": "completed"
+      },
+      {
+        "id": "B",
+        "title": "Migrate Class A runtime call sites away from go-task subprocesses",
+        "status": "completed"
+      },
+      {
+        "id": "C",
+        "title": "Update generated/session guidance to package-first commands",
+        "status": "completed"
+      },
+      {
+        "id": "D",
+        "title": "Add regression guard for runtime go-task dependencies",
+        "status": "completed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1659",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1659: Decouple framework runtime + guidance from the `task` runner (npm/pip readiness)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: Proposal: Publish Deft as an NPM + PIP CLI"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1670",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1670: spec: unified `deft` CLI surface"
+      }
+    ],
+    "updated": "2026-06-17T00:00:00Z"
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared Python framework command dispatcher so `run`/future `deft` can execute framework verbs without `task` on PATH
- migrate runtime call sites for triage/session/check/release/doctor/tool verification away from go-task subprocess dependencies
- update generated consumer AGENTS guidance to package-first `deft <verb>` commands while preserving Taskfile wrapper support
- add `verify:no-task-runtime` plus focused tests to prevent future runtime `task` subprocess/PATH dependencies

Closes #1659.
Refs #11, #1670.

## Validation
- `task check`
  - 8393 passed, 5 skipped, 9 deselected, 1 xfailed
- `uv run python scripts/verify_no_task_runtime.py`
- fork release tags reconciled through `v0.51.0` so the pyproject freshness gate resolves latest release correctly