### PR TITLE
chore(lifecycle): clear WIP — complete #1659 scope, defer #1595

### DIFF
--- a/vbrief/cancelled/2026-06-16-1595-pr3-extractor-provider-discipline-gate.vbrief.json
+++ b/vbrief/cancelled/2026-06-16-1595-pr3-extractor-provider-discipline-gate.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1595-pr3-extractor-provider-discipline-gate",
     "title": "Add codebase extractor provider contract and discipline gate",
-    "status": "running",
+    "status": "cancelled",
     "narratives": {
       "Description": "PR3 for #1595 adds the contract layer between authored codeStructure metadata and the later MAP projection: a deterministic dependency-free default extractor, an out-of-process provider handshake, an architecture-map artifact format, a kind-to-command registry, and the PR3 discipline gate. This preserves the current-shape decision that directive owns contracts and a safe default path, not a heavy in-repo map engine.",
       "ImplementationPlan": "1. Define the tier-1 architecture-map output format and provider handshake with independent formatVersion and contractVersion fields. 2. Implement an AST-free default extractor that uses repository tree walking and import-line heuristics only, with no network, model, or parser dependency. 3. Add provider selection/validation that accepts a conformant external provider artifact when configured and falls back to the default extractor on absence, mismatch, or provider failure. 4. Add a projection-kind registry for codebase-map so canonical projectionManifest entries remain invocation-agnostic. 5. Extend task codebase:validate-structure with PR3 discipline checks: hard-block derived-fact keys and undeclared canonical siblings, warn on boundedness heuristics, and validate deterministic referential integrity where possible. 6. Add focused tests, docs, and a brief CHANGELOG entry.",
@@ -118,6 +118,6 @@
       },
       "capacityBucket": "new-capability"
     },
-    "updated": "2026-06-16T20:20:00Z"
+    "updated": "2026-06-18T14:37:55Z"
   }
 }

--- a/vbrief/completed/2026-06-17-1659-decouple-framework-runtime-guidance-from-task-runner.vbrief.json
+++ b/vbrief/completed/2026-06-17-1659-decouple-framework-runtime-guidance-from-task-runner.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Decouple framework runtime and guidance from the task runner",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "Package-manager installs must be able to run Deft through the `deft`/`run` surface without requiring go-task on PATH. Runtime code should call Python entrypoints or the shared framework command dispatcher, while generated guidance should prefer `deft <verb>` and reserve `task deft:<verb>` for Taskfile include users.",
       "AcceptanceCriteria": "No runtime code path hard-depends on `task`; the `run`/future `deft` surface reaches the framework verbs needed by session, cache, triage, check, and release flows; generated AGENTS guidance points package consumers at `deft`; and a deterministic guard fails on future runtime go-task subprocess dependencies."
@@ -49,6 +49,10 @@
         "title": "Issue #1670: spec: unified `deft` CLI surface"
       }
     ],
-    "updated": "2026-06-17T00:00:00Z"
+    "updated": "2026-06-18T14:37:54Z",
+    "metadata": {
+      "completedAt": "2026-06-18T14:37:54Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Lifecycle housekeeping to clear the WIP board ahead of the release + Python→TS engine freeze (#1710 / #1530).

- **Complete** the `2026-06-17-1659-decouple-framework-runtime-guidance-from-task-runner` scope (`active/ → completed/`). PR #1693 merged and #1659 is closed; the merge didn't run `scope:complete`, leaving it stranded as a false-positive in-flight item.
- **Cancel** (defer) the `2026-06-16-1595-pr3-extractor-provider-discipline-gate` scope (`active/ → cancelled/`). It's `scripts/`-touching engine work that falls inside the upcoming freeze scope; parked now, restorable via `scope:restore` when the TS baseline lands. Issue #1595 remains open as the backlog item.

WIP is now **0/10, 0 in-flight**.

## Related

Refs #1530, #1710. Origin issue #1595 intentionally left OPEN.

## Verification

- `UV_NO_SYNC=1 task check` — passed (broken-link entries are pre-existing warnings, unrelated)
- `verify:wip-cap` — 0/10 in pending/+active/

## Checklist

- [x] `task check` passes locally
- [x] No CHANGELOG entry — internal vBRIEF lifecycle move, not a user-visible change
- [x] Feature branch (branch policy ON)

Made with [Cursor](https://cursor.com)