### PR TITLE
chore(policy): restore branch protection after v0.52.0 release

### DIFF
--- a/meta/policy-changes.log
+++ b/meta/policy-changes.log
@@ -33,3 +33,4 @@
 2026-06-17T01:42:02Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
 2026-06-17T01:51:15Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True
 2026-06-18T15:05:19Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
+2026-06-18T15:21:36Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -11019,7 +11019,7 @@
           }
         ]
       },
-      "allowDirectCommitsToMaster": true
+      "allowDirectCommitsToMaster": false
     },
     "updated": "2026-06-12T20:26:00Z"
   }


### PR DESCRIPTION
Restores `plan.policy.allowDirectCommitsToMaster = false` after the v0.52.0 release session (the release skill's documented opt-out → restore cycle). Branch protection is back ON.

Refs the v0.52.0 release.

Made with [Cursor](https://cursor.com)