### PR TITLE
feat(ts-migration): port verify:encoding to @deftai/core + golden-output parity harness (#1718)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,43 @@ jobs:
       - name: Test with coverage (vitest)
         run: pnpm run test
 
+  parity:
+    name: Encoding parity (TS port vs Python oracle)
+    # #1718 tracer-bullet gate: golden-diffs the ported `verify:encoding`
+    # (@deftai/core) against the Python oracle (scripts/verify_encoding.py)
+    # over a fixture corpus of known corruption, cache-off. Needs BOTH the
+    # Node and Python toolchains, so it lives in its own job rather than the
+    # node-only `ts` lane or the python-only `python` lane.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Build (tsc -b project references)
+        run: pnpm run build
+
+      - name: Golden-diff parity (TS port vs Python oracle, cache-off)
+        run: node packages/cli/dist/parity.js
+
   go:
     name: Go (test + build)
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **TypeScript engine port begins with the encoding gate (#1718)** -- The `verify:encoding` corruption gate now has a TypeScript implementation in `@deftai/core` (plus a thin CLI preserving the 0/1/2 exit contract) that is proven to flag exactly the same files as the existing Python gate. A new golden-output parity harness builds a fixture corpus of known corruption and diffs the two implementations on every CI run (cache-off), so the Python-to-TypeScript migration can proceed without behavior drift. Refs #1717 #1530.
 
 ### Changed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "deft-ts": "./dist/bin.js"
+    "deft-ts": "./dist/bin.js",
+    "deft-verify-encoding": "./dist/verify-encoding.js",
+    "deft-encoding-parity": "./dist/parity.js"
   },
   "exports": {
     ".": {

--- a/packages/cli/src/parity.test.ts
+++ b/packages/cli/src/parity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { diffGates, findingKey, parseFindings } from "./parity.js";
+
+describe("parseFindings", () => {
+  it("extracts finding lines and ignores header/footer prose", () => {
+    const stderr = [
+      "verify_encoding: detected 2 hits (#798).",
+      "  Root cause: a Windows codepage decoded the bytes.",
+      "  bad.txt:1 [U+FFFD replacement char] broken  marker",
+      "  other.md:5 [U+2297 (\u2297) corrupted via cp437 read] some context",
+      "  ... and 0 more",
+    ].join("\n");
+    expect(parseFindings(stderr)).toEqual([
+      { path: "bad.txt", line: 1, label: "U+FFFD replacement char" },
+      { path: "other.md", line: 5, label: "U+2297 (\u2297) corrupted via cp437 read" },
+    ]);
+  });
+  it("returns [] for clean output", () => {
+    expect(parseFindings("verify_encoding: 10 file(s) clean ...")).toEqual([]);
+  });
+});
+
+describe("findingKey", () => {
+  it("joins path:line:label", () => {
+    expect(findingKey({ path: "a.md", line: 3, label: "X" })).toBe("a.md:3:X");
+  });
+});
+
+describe("diffGates", () => {
+  const f = { path: "a.txt", line: 1, label: "L" };
+  it("reports clean when exits and findings match", () => {
+    const r = diffGates({ exitCode: 1, findings: [f] }, { exitCode: 1, findings: [f] });
+    expect(r.ok).toBe(true);
+    expect(r.exitMismatch).toBe(false);
+  });
+  it("flags an exit-code mismatch", () => {
+    const r = diffGates({ exitCode: 1, findings: [f] }, { exitCode: 0, findings: [] });
+    expect(r.ok).toBe(false);
+    expect(r.exitMismatch).toBe(true);
+  });
+  it("reports findings only one side has", () => {
+    const r = diffGates(
+      { exitCode: 1, findings: [f] },
+      { exitCode: 1, findings: [{ path: "b.txt", line: 2, label: "M" }] },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.onlyPython).toEqual(["a.txt:1:L"]);
+    expect(r.onlyTs).toEqual(["b.txt:2:M"]);
+  });
+});

--- a/packages/cli/src/parity.ts
+++ b/packages/cli/src/parity.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1718): builds a throwaway git repo of
+ * known-corruption fixtures, runs BOTH the Python oracle
+ * (`scripts/verify_encoding.py`) and the ported TS gate against it with the
+ * cache off, and diffs structured findings + exit codes. A clean run proves
+ * the TS port detects identically to the Python implementation it replaces.
+ *
+ * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface ParityFinding {
+  readonly path: string;
+  readonly line: number;
+  readonly label: string;
+}
+
+export interface GateOutput {
+  readonly exitCode: number;
+  readonly findings: ParityFinding[];
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly pythonExit: number;
+  readonly tsExit: number;
+  readonly exitMismatch: boolean;
+  readonly onlyPython: string[];
+  readonly onlyTs: string[];
+}
+
+// Finding render is `  path:line [label] context`; capture path / line / label.
+const FINDING_RE = /^ {2}(.+?):(\d+) \[(.+?)\] /;
+
+/** Parse the rendered finding lines out of a gate's stderr. */
+export function parseFindings(stderr: string): ParityFinding[] {
+  const out: ParityFinding[] = [];
+  for (const line of stderr.split(/\r?\n/)) {
+    const m = FINDING_RE.exec(line);
+    if (m !== null) {
+      out.push({ path: m[1] as string, line: Number(m[2]), label: m[3] as string });
+    }
+  }
+  return out;
+}
+
+/** Stable key for a finding (path:line:label). */
+export function findingKey(f: ParityFinding): string {
+  return `${f.path}:${f.line}:${f.label}`;
+}
+
+/** Diff two gate outputs into a structured parity result. */
+export function diffGates(python: GateOutput, ts: GateOutput): ParityResult {
+  const pyKeys = new Set(python.findings.map(findingKey));
+  const tsKeys = new Set(ts.findings.map(findingKey));
+  const onlyPython = [...pyKeys].filter((k) => !tsKeys.has(k)).sort();
+  const onlyTs = [...tsKeys].filter((k) => !pyKeys.has(k)).sort();
+  const exitMismatch = python.exitCode !== ts.exitCode;
+  return {
+    ok: !exitMismatch && onlyPython.length === 0 && onlyTs.length === 0,
+    pythonExit: python.exitCode,
+    tsExit: ts.exitCode,
+    exitMismatch,
+    onlyPython,
+    onlyTs,
+  };
+}
+
+interface Capture {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCapture(cmd: string, args: string[], cwd: string): Capture {
+  try {
+    const stdout = execFileSync(cmd, args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return {
+      status: typeof e.status === "number" ? e.status : 2,
+      stdout: typeof e.stdout === "string" ? e.stdout : "",
+      stderr: typeof e.stderr === "string" ? e.stderr : "",
+    };
+  }
+}
+
+const BOM = "\ufeff";
+
+/**
+ * Fixture corpus exercised by the parity harness. Each entry maps a repo-rel
+ * path to its exact textual content. Covers: clean files, U+FFFD, cp437/cp1252
+ * mojibake, unexpected/ tolerated BOM, vBRIEF narrative control chars, markdown
+ * code-span false-positive guard, and the `-798-` allow-list carve-out.
+ */
+export const PARITY_FIXTURES: ReadonlyArray<readonly [string, string]> = [
+  ["clean.md", "# Title\n\nplain ascii prose\n"],
+  ["ufffd.txt", "line one\nbroken \ufffd marker\n"],
+  ["cp437.md", "a cp437 glyph \u0393\u00a3\u00f4 in prose\n"],
+  ["cp1252.txt", "a smart \u00e2\u20ac\u2122 quote in prose\n"],
+  ["bom.json", `${BOM}{"a": 1}\n`],
+  ["tolerated-bom.ps1", `${BOM}Write-Host 'ok'\n`],
+  ["md-quoted.md", "see the bigon `\u0393\u00a3\u00f4` inside a code span\n"],
+  [
+    "vbrief/active/2026-01-01-1-x.vbrief.json",
+    `${JSON.stringify({ plan: { narratives: { problem: "has a \u000b vtab" } } }, null, 2)}\n`,
+  ],
+  [
+    "vbrief/active/2026-01-01-798-recurrence.vbrief.json",
+    `${JSON.stringify({ plan: { narratives: { problem: "catalogs \u0393\u00a3\u00f4" } } }, null, 2)}\n`,
+  ],
+];
+
+/** Build the throwaway git repo with all fixtures; return its root path. */
+export function buildFixtureRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-encoding-parity-"));
+  for (const [rel, content] of PARITY_FIXTURES) {
+    const full = join(root, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content, { encoding: "utf8" });
+  }
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["add", "-A"], { cwd: root });
+  return root;
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
+    return resolve(process.env.DEFT_ROOT);
+  }
+  // dist layout: packages/cli/dist/parity.js -> repo root is three levels up.
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+/** Run both gates against a fresh fixture repo and diff them. */
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const repo = buildFixtureRepo();
+  try {
+    const py = runCapture(
+      "uv",
+      [
+        "run",
+        "python",
+        join(deftRoot, "scripts", "verify_encoding.py"),
+        "--all",
+        "--project-root",
+        repo,
+      ],
+      deftRoot,
+    );
+    const ts = runCapture(
+      "node",
+      [
+        join(deftRoot, "packages", "cli", "dist", "verify-encoding.js"),
+        "--all",
+        "--project-root",
+        repo,
+      ],
+      deftRoot,
+    );
+    return diffGates(
+      { exitCode: py.status, findings: parseFindings(py.stderr) },
+      { exitCode: ts.status, findings: parseFindings(ts.stderr) },
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `verify_encoding parity: CLEAN -- Python and TS agree (exit ${result.pythonExit}).`;
+  }
+  const lines = ["verify_encoding parity: DIVERGENCE"];
+  if (result.exitMismatch) {
+    lines.push(`  exit mismatch: python=${result.pythonExit} ts=${result.tsExit}`);
+  }
+  for (const k of result.onlyPython) {
+    lines.push(`  only python: ${k}`);
+  }
+  for (const k of result.onlyTs) {
+    lines.push(`  only ts:     ${k}`);
+  }
+  return lines.join("\n");
+}
+
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    process.exit(1);
+  } catch (err) {
+    process.stderr.write(`verify_encoding parity: harness error -- ${String(err)}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/parity.ts
+++ b/packages/cli/src/parity.ts
@@ -124,13 +124,21 @@ export const PARITY_FIXTURES: ReadonlyArray<readonly [string, string]> = [
 /** Build the throwaway git repo with all fixtures; return its root path. */
 export function buildFixtureRepo(): string {
   const root = mkdtempSync(join(tmpdir(), "deft-encoding-parity-"));
-  for (const [rel, content] of PARITY_FIXTURES) {
-    const full = join(root, rel);
-    mkdirSync(dirname(full), { recursive: true });
-    writeFileSync(full, content, { encoding: "utf8" });
+  // mkdtempSync already created the dir, so any failure below (a write error or
+  // git not being on PATH) must clean it up here -- the try/finally in
+  // runParity only fires once this function returns the path successfully.
+  try {
+    for (const [rel, content] of PARITY_FIXTURES) {
+      const full = join(root, rel);
+      mkdirSync(dirname(full), { recursive: true });
+      writeFileSync(full, content, { encoding: "utf8" });
+    }
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    execFileSync("git", ["add", "-A"], { cwd: root });
+  } catch (err) {
+    rmSync(root, { recursive: true, force: true });
+    throw err;
   }
-  execFileSync("git", ["init", "-q"], { cwd: root });
-  execFileSync("git", ["add", "-A"], { cwd: root });
   return root;
 }
 
@@ -195,7 +203,8 @@ function renderReport(result: ParityResult): string {
   return lines.join("\n");
 }
 
-if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+// Normalize via fileURLToPath so this fires on Windows too (see verify-encoding.ts).
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
   try {
     const result = runParity();
     if (result.ok) {

--- a/packages/cli/src/verify-encoding.test.ts
+++ b/packages/cli/src/verify-encoding.test.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { parseArgs, run } from "./verify-encoding.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function repo(content: string): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-cli-test-"));
+  temps.push(root);
+  writeFileSync(join(root, "f.txt"), content);
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["add", "-A"], { cwd: root });
+  return root;
+}
+
+function silentRun(argv: string[]): number {
+  const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  try {
+    return run(argv);
+  } finally {
+    out.mockRestore();
+    err.mockRestore();
+  }
+}
+
+describe("parseArgs", () => {
+  it("defaults to mode=all, root='.', no allow-list", () => {
+    expect(parseArgs([])).toMatchObject({
+      mode: "all",
+      projectRoot: ".",
+      allowList: null,
+      quiet: false,
+    });
+  });
+  it("parses --staged and --quiet", () => {
+    expect(parseArgs(["--staged", "--quiet"])).toMatchObject({ mode: "staged", quiet: true });
+  });
+  it("rejects --all with --staged", () => {
+    expect(parseArgs(["--all", "--staged"]).error).toBeDefined();
+  });
+  it("parses --project-root and --allow-list in space and = forms", () => {
+    expect(parseArgs(["--project-root", "/x"]).projectRoot).toBe("/x");
+    expect(parseArgs(["--project-root=/y"]).projectRoot).toBe("/y");
+    expect(parseArgs(["--allow-list", "/a"]).allowList).toBe("/a");
+    expect(parseArgs(["--allow-list=/b"]).allowList).toBe("/b");
+  });
+  it("errors on missing values and unknown flags", () => {
+    expect(parseArgs(["--project-root"]).error).toBeDefined();
+    expect(parseArgs(["--allow-list"]).error).toBeDefined();
+    expect(parseArgs(["--bogus"]).error).toBeDefined();
+  });
+});
+
+describe("run", () => {
+  it("returns 0 for a clean repo", () => {
+    expect(silentRun(["--all", "--project-root", repo("clean ascii\n")])).toBe(0);
+  });
+  it("returns 0 with --quiet for a clean repo", () => {
+    expect(silentRun(["--quiet", "--project-root", repo("clean ascii\n")])).toBe(0);
+  });
+  it("returns 1 for corruption", () => {
+    expect(silentRun(["--all", "--project-root", repo("broken \ufffd\n")])).toBe(1);
+  });
+  it("returns 2 for a bad argument", () => {
+    expect(silentRun(["--bogus"])).toBe(2);
+  });
+});

--- a/packages/cli/src/verify-encoding.ts
+++ b/packages/cli/src/verify-encoding.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { evaluate, type ScanMode } from "@deftai/core";
+
+interface ParsedArgs {
+  mode: ScanMode;
+  projectRoot: string;
+  allowList: string | null;
+  quiet: boolean;
+  error?: string;
+}
+
+/** Parse the verify-encoding CLI args, mirroring the Python argparse surface. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    mode: "all",
+    projectRoot: ".",
+    allowList: null,
+    quiet: false,
+  };
+  let sawAll = false;
+  let sawStaged = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--all") {
+      sawAll = true;
+      parsed.mode = "all";
+    } else if (arg === "--staged") {
+      sawStaged = true;
+      parsed.mode = "staged";
+    } else if (arg === "--quiet") {
+      parsed.quiet = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg === "--allow-list") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --allow-list: expected one argument" };
+      }
+      parsed.allowList = value;
+      i += 1;
+    } else if (arg?.startsWith("--allow-list=")) {
+      parsed.allowList = arg.slice("--allow-list=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  if (sawAll && sawStaged) {
+    return { ...parsed, error: "argument --staged: not allowed with argument --all" };
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code (no side effects on argv parse error -> 2). */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify_encoding: ${args.error}\n`);
+    return 2;
+  }
+  const projectRoot = resolve(args.projectRoot);
+  const allowListPath = args.allowList !== null ? resolve(args.allowList) : null;
+  const result = evaluate(projectRoot, { mode: args.mode, allowListPath });
+  if (result.exitCode === 0) {
+    if (!args.quiet) {
+      process.stdout.write(`${result.message}\n`);
+    }
+  } else {
+    process.stderr.write(`${result.message}\n`);
+  }
+  return result.exitCode;
+}
+
+// Only execute when invoked directly as a binary (not when imported in tests).
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/verify-encoding.ts
+++ b/packages/cli/src/verify-encoding.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { evaluate, type ScanMode } from "@deftai/core";
 
 interface ParsedArgs {
@@ -79,6 +80,9 @@ export function run(argv: string[]): number {
 }
 
 // Only execute when invoked directly as a binary (not when imported in tests).
-if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+// Normalize both sides via fileURLToPath so the guard fires on Windows too,
+// where process.argv[1] is a native backslash path and import.meta.url is a
+// forward-slash file:// URL -- a raw `file://${process.argv[1]}` never matches.
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
   process.exit(run(process.argv.slice(2)));
 }

--- a/packages/core/src/encoding/evaluate.test.ts
+++ b/packages/core/src/encoding/evaluate.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { evaluate } from "./evaluate.js";
+import { GitCommandError, gitStagedFiles, gitTrackedFiles } from "./git.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function buildRepo(files: Record<string, string | Buffer>, init = true): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-eval-test-"));
+  temps.push(root);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(root, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  if (init) {
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    execFileSync("git", ["add", "-A"], { cwd: root });
+  }
+  return root;
+}
+
+describe("git enumeration", () => {
+  it("lists tracked and staged files", () => {
+    const root = buildRepo({ "a.md": "ok\n", "b.txt": "ok\n" });
+    expect(gitTrackedFiles(root).sort()).toEqual(["a.md", "b.txt"]);
+    expect(gitStagedFiles(root).sort()).toEqual(["a.md", "b.txt"]);
+  });
+  it("throws GitCommandError outside a git repo", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-nogit-"));
+    temps.push(root);
+    expect(() => gitTrackedFiles(root)).toThrow(GitCommandError);
+  });
+});
+
+describe("evaluate", () => {
+  it("returns exit 0 for a clean repo", () => {
+    const root = buildRepo({ "clean.md": "# ok\n\nplain\n" });
+    const result = evaluate(root, { mode: "all" });
+    expect(result.exitCode).toBe(0);
+    expect(result.findings).toEqual([]);
+    expect(result.message).toContain("clean");
+  });
+
+  it("returns exit 1 with findings for corruption", () => {
+    const root = buildRepo({ "bad.txt": "smart \u00e2\u20ac\u2122 quote\n" });
+    const result = evaluate(root, { mode: "all" });
+    expect(result.exitCode).toBe(1);
+    expect(result.findings.length).toBe(1);
+    expect(result.message).toContain("bad.txt:1");
+  });
+
+  it("detects in staged mode", () => {
+    const root = buildRepo({ "bad.txt": "broken \ufffd marker\n" });
+    expect(evaluate(root, { mode: "staged" }).exitCode).toBe(1);
+  });
+
+  it("honors the -798- builtin allow-list", () => {
+    const root = buildRepo({
+      "vbrief/active/2026-01-01-798-x.vbrief.json": `${JSON.stringify({ note: "catalogs \u0393\u00a3\u00f4" })}\n`,
+    });
+    expect(evaluate(root, { mode: "all" }).exitCode).toBe(0);
+  });
+
+  it("returns exit 2 for an unknown mode", () => {
+    const root = buildRepo({ "a.md": "ok\n" });
+    // @ts-expect-error deliberately invalid mode to exercise the guard
+    expect(evaluate(root, { mode: "weird" }).exitCode).toBe(2);
+  });
+
+  it("returns exit 2 for a missing --allow-list path", () => {
+    const root = buildRepo({ "a.md": "ok\n" });
+    const result = evaluate(root, { mode: "all", allowListPath: join(root, "nope.txt") });
+    expect(result.exitCode).toBe(2);
+    expect(result.message).toContain("not found");
+  });
+
+  it("returns exit 2 outside a git working tree", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-nogit2-"));
+    temps.push(root);
+    expect(evaluate(root, { mode: "all" }).exitCode).toBe(2);
+  });
+
+  it("suppresses a file via a custom allow-list (comments + globs)", () => {
+    const root = buildRepo({ "bad.txt": "broken \ufffd marker\n" });
+    const allowDir = mkdtempSync(join(tmpdir(), "deft-allow-"));
+    temps.push(allowDir);
+    const allowFile = join(allowDir, "allow.txt");
+    writeFileSync(allowFile, "# documented exception\n\nbad.txt\n");
+    expect(evaluate(root, { mode: "all", allowListPath: allowFile }).exitCode).toBe(0);
+  });
+});

--- a/packages/core/src/encoding/evaluate.ts
+++ b/packages/core/src/encoding/evaluate.ts
@@ -1,0 +1,186 @@
+import { readFileSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { GitCommandError, GitNotFoundError, gitStagedFiles, gitTrackedFiles } from "./git.js";
+import { BUILTIN_ALLOW_LIST, SCANNABLE_EXTENSIONS } from "./patterns.js";
+import { type Finding, renderFinding, scanFile, suffixOf } from "./scan.js";
+import { fnmatchCase } from "./text.js";
+
+export type ScanMode = "all" | "staged";
+
+/** Result of an encoding-gate evaluation; mirrors the Python `evaluate` tuple. */
+export interface EvaluateResult {
+  readonly exitCode: 0 | 1 | 2;
+  readonly findings: Finding[];
+  readonly message: string;
+}
+
+export interface EvaluateOptions {
+  readonly mode?: ScanMode;
+  readonly allowListPath?: string | null;
+}
+
+/** Raised by `loadAllowList` when the path does not exist. */
+class AllowListNotFoundError extends Error {}
+
+function loadAllowList(path: string | null | undefined): string[] {
+  if (path === null || path === undefined) {
+    return [];
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "ENOENT") {
+      throw new AllowListNotFoundError(path);
+    }
+    throw err;
+  }
+  const out: string[] = [];
+  for (const line of raw.split(/\r\n|[\n\r]/)) {
+    const stripped = line.trim();
+    if (stripped.length === 0 || stripped.startsWith("#")) {
+      continue;
+    }
+    out.push(stripped);
+  }
+  return out;
+}
+
+function isAllowListed(relPath: string, patterns: string[]): boolean {
+  return patterns.some((pat) => fnmatchCase(relPath, pat));
+}
+
+function isFile(fullPath: string): boolean {
+  try {
+    return statSync(fullPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function filterScannable(
+  relPaths: string[],
+  projectRoot: string,
+  allowGlobs: string[],
+): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  const rootResolved = resolve(projectRoot);
+  for (const rel of relPaths) {
+    const posix = rel.replace(/\\/g, "/");
+    const full = resolve(rootResolved, rel);
+    const relCheck = relative(rootResolved, full);
+    if (relCheck.startsWith("..") || isAbsolute(relCheck)) {
+      continue;
+    }
+    if (!isFile(full)) {
+      continue;
+    }
+    if (!SCANNABLE_EXTENSIONS.has(suffixOf(full))) {
+      continue;
+    }
+    if (isAllowListed(posix, allowGlobs)) {
+      continue;
+    }
+    out.push([posix, full]);
+  }
+  return out;
+}
+
+/**
+ * Pure evaluation returning `{ exitCode, findings, message }`. Three-state
+ * exit (0 clean / 1 corruption / 2 config error), faithful to the Python
+ * `verify_encoding.evaluate`.
+ */
+export function evaluate(projectRoot: string, options: EvaluateOptions = {}): EvaluateResult {
+  const mode: ScanMode = options.mode ?? "all";
+  if (mode !== "all" && mode !== "staged") {
+    return {
+      exitCode: 2,
+      findings: [],
+      message: `verify_encoding: unrecognised mode '${mode}' (expected 'all' or 'staged').`,
+    };
+  }
+
+  let customGlobs: string[];
+  try {
+    customGlobs = loadAllowList(options.allowListPath);
+  } catch (err: unknown) {
+    if (err instanceof AllowListNotFoundError) {
+      return {
+        exitCode: 2,
+        findings: [],
+        message:
+          `verify_encoding: --allow-list file not found: ${err.message}\n` +
+          "  Recovery: pass an existing path or omit the flag.",
+      };
+    }
+    return {
+      exitCode: 2,
+      findings: [],
+      message:
+        `verify_encoding: --allow-list unreadable: ${String((err as Error).message)}\n` +
+        "  Recovery: check file permissions.",
+    };
+  }
+
+  const allowGlobs = [...BUILTIN_ALLOW_LIST, ...customGlobs];
+
+  let relPaths: string[];
+  try {
+    relPaths = mode === "staged" ? gitStagedFiles(projectRoot) : gitTrackedFiles(projectRoot);
+  } catch (err: unknown) {
+    if (err instanceof GitNotFoundError) {
+      return {
+        exitCode: 2,
+        findings: [],
+        message:
+          "verify_encoding: 'git' executable not found on PATH.\n" +
+          "  Recovery: install git or run inside a git working tree.",
+      };
+    }
+    if (err instanceof GitCommandError) {
+      return {
+        exitCode: 2,
+        findings: [],
+        message:
+          `verify_encoding: git failed -- ${err.message}\n` +
+          "  Recovery: ensure --project-root points at a git working tree.",
+      };
+    }
+    throw err;
+  }
+
+  const candidates = filterScannable(relPaths, projectRoot, allowGlobs);
+
+  const findings: Finding[] = [];
+  for (const [rel, full] of candidates) {
+    findings.push(...scanFile(rel, full));
+  }
+
+  if (findings.length > 0) {
+    const fileCount = new Set(findings.map((f) => f.path)).size;
+    const header =
+      `verify_encoding: detected ${findings.length} mojibake / ` +
+      `U+FFFD / unexpected-BOM hit(s) across ${fileCount} file(s) (#798).\n` +
+      "  Root cause: a Windows codepage (cp1252/cp437) decoded the bytes on the READ side\n" +
+      "  before any safe write could preserve them. Fix: rewrite the offending files with\n" +
+      "  UTF-8, re-read from a clean source (git checkout HEAD -- <path>), and do NOT\n" +
+      "  round-trip through PowerShell 5.1 again. See AGENTS.md ## PowerShell.\n" +
+      "  Allow-list a documented exception via --allow-list <path>.";
+    const shown = findings.slice(0, 50).map(renderFinding);
+    let body = shown.join("\n");
+    if (findings.length > 50) {
+      body += `\n  ... and ${findings.length - 50} more`;
+    }
+    return { exitCode: 1, findings, message: `${header}\n${body}` };
+  }
+
+  return {
+    exitCode: 0,
+    findings,
+    message:
+      `verify_encoding: ${candidates.length} file(s) clean -- no mojibake / ` +
+      "U+FFFD / unexpected-BOM detected (#798).",
+  };
+}

--- a/packages/core/src/encoding/git.ts
+++ b/packages/core/src/encoding/git.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+
+/** Raised when `git` is not on PATH (caller maps to exit 2). */
+export class GitNotFoundError extends Error {}
+
+/** Raised when a `git` invocation exits non-zero (caller maps to exit 2). */
+export class GitCommandError extends Error {}
+
+function runGit(args: string[], projectRoot: string): string {
+  try {
+    return execFileSync("git", args, {
+      cwd: projectRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException & { stderr?: string };
+    if (e.code === "ENOENT") {
+      throw new GitNotFoundError("'git' executable not found on PATH");
+    }
+    const stderr = typeof e.stderr === "string" ? e.stderr.trim() : String(e.message ?? err);
+    throw new GitCommandError(`git ${args.join(" ")} failed: ${stderr}`);
+  }
+}
+
+function splitLines(stdout: string): string[] {
+  return stdout.split("\n").filter((line) => line.trim().length > 0);
+}
+
+/** Return `git ls-files` output as a list of POSIX-form rel paths. */
+export function gitTrackedFiles(projectRoot: string): string[] {
+  return splitLines(runGit(["ls-files"], projectRoot));
+}
+
+/** Return `git diff --cached --name-only` output as POSIX-form rel paths. */
+export function gitStagedFiles(projectRoot: string): string[] {
+  return splitLines(runGit(["diff", "--cached", "--name-only", "--diff-filter=ACMR"], projectRoot));
+}

--- a/packages/core/src/encoding/index.ts
+++ b/packages/core/src/encoding/index.ts
@@ -1,0 +1,5 @@
+export * from "./evaluate.js";
+export * from "./git.js";
+export * from "./patterns.js";
+export * from "./scan.js";
+export * from "./text.js";

--- a/packages/core/src/encoding/patterns.ts
+++ b/packages/core/src/encoding/patterns.ts
@@ -1,0 +1,115 @@
+/**
+ * Encoding-gate constants, ported verbatim from the Python oracle
+ * (`scripts/verify_encoding.py`, #798) so the TS port golden-diffs clean
+ * against it. Any change here MUST be mirrored in the Python source and
+ * re-validated through the parity harness (#1718).
+ */
+
+/**
+ * Codepoint sequences that signal a Windows codepage round-trip corruption,
+ * mapped to a short label naming the canonical codepoint that was corrupted.
+ * Order matches the Python `MOJIBAKE_PATTERNS` dict.
+ */
+export const MOJIBAKE_PATTERNS: ReadonlyMap<string, string> = new Map([
+  // CP437-as-UTF-8 (Windows DOS codepage; recurrence record PR #844 / fix #846).
+  ["Γèù", "U+2297 (⊗) corrupted via cp437 read"],
+  ["Γ£ô", "U+2713 (✓) corrupted via cp437 read"],
+  ["ΓÇª", "U+2026 (…) corrupted via cp437 read"],
+  ["ΓÇö", "U+2014 (—) corrupted via cp437 read"],
+  ["ΓÇô", "U+2013 (–) corrupted via cp437 read"],
+  ["ΓÇó", "U+2022 (•) corrupted via cp437 read"],
+  ["ΓÇÖ", "U+2019 (’) corrupted via cp437 read"],
+  ["ΓÇÿ", "U+2018 (‘) corrupted via cp437 read"],
+  ["ΓÇ£", "U+201C (“) corrupted via cp437 read"],
+  ["ΓÇØ", "U+201D (”) corrupted via cp437 read"],
+  ["ΓåÆ", "U+2192 (→) corrupted via cp437 read"],
+  // CP1252-as-UTF-8 (Windows ANSI codepage; recurrence record #236, #240, #283, PR #795).
+  ["â€™", "U+2019 (’) corrupted via cp1252 read"],
+  ["â€˜", "U+2018 (‘) corrupted via cp1252 read"],
+  ["â€œ", "U+201C (“) corrupted via cp1252 read"],
+  ["â€\x9d", "U+201D (”) corrupted via cp1252 read"],
+  ["â€“", "U+2013 (–) corrupted via cp1252 read"],
+  ["â€”", "U+2014 (—) corrupted via cp1252 read"],
+  ["â€¦", "U+2026 (…) corrupted via cp1252 read"],
+  ["â€¢", "U+2022 (•) corrupted via cp1252 read"],
+  ["â†’", "U+2192 (→) corrupted via cp1252 read"],
+  ["Â§", "U+00A7 (§) corrupted via cp1252 read"],
+  ["Â°", "U+00B0 (°) corrupted via cp1252 read"],
+  ["Â´", "U+00B4 (´) corrupted via cp1252 read"],
+  ["Â\xad", "U+00AD (soft hyphen) corrupted via cp1252 read"],
+  ["Â©", "U+00A9 (©) corrupted via cp1252 read"],
+  ["Â®", "U+00AE (®) corrupted via cp1252 read"],
+  ["Â±", "U+00B1 (±) corrupted via cp1252 read"],
+]);
+
+/** U+FFFD REPLACEMENT CHARACTER — the universal mojibake marker. */
+export const REPLACEMENT_CHAR = "\ufffd";
+
+/** UTF-8 BOM byte sequence (EF BB BF). */
+export const UTF8_BOM: ReadonlyArray<number> = [0xef, 0xbb, 0xbf];
+
+/** Extensions where a leading UTF-8 BOM is non-canonical and should be flagged. */
+export const NO_BOM_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".md",
+  ".json",
+  ".yml",
+  ".yaml",
+  ".txt",
+]);
+
+/** Control characters that must not hide inside decoded vBRIEF narratives. */
+export const VBRIEF_CONTROL_CHAR_LABELS: ReadonlyMap<string, string> = new Map([
+  ["\b", "U+0008 backspace in vBRIEF narrative"],
+  ["\t", "U+0009 tab in vBRIEF narrative"],
+  ["\v", "U+000B vertical tab in vBRIEF narrative"],
+  ["\f", "U+000C form feed in vBRIEF narrative"],
+]);
+
+/** File extensions to scan by default (conservative; excludes binary). */
+export const SCANNABLE_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".md",
+  ".json",
+  ".yml",
+  ".yaml",
+  ".txt",
+  ".py",
+  ".sh",
+  ".ps1",
+  ".toml",
+  ".cfg",
+]);
+
+/**
+ * Path-glob patterns auto-skipped because the file legitimately contains
+ * mojibake byte sequences as part of its purpose. Matched against the path's
+ * POSIX form. Ported verbatim from the Python `BUILTIN_ALLOW_LIST`.
+ */
+export const BUILTIN_ALLOW_LIST: ReadonlyArray<string> = [
+  "vbrief/active/*-798-*.vbrief.json",
+  "vbrief/completed/*-798-*.vbrief.json",
+  "vbrief/cancelled/*-798-*.vbrief.json",
+  "vbrief/pending/*-798-*.vbrief.json",
+  "vbrief/proposed/*-798-*.vbrief.json",
+  ".deft/core/vbrief/active/*-798-*.vbrief.json",
+  ".deft/core/vbrief/completed/*-798-*.vbrief.json",
+  ".deft/core/vbrief/cancelled/*-798-*.vbrief.json",
+  ".deft/core/vbrief/pending/*-798-*.vbrief.json",
+  ".deft/core/vbrief/proposed/*-798-*.vbrief.json",
+  "deft/vbrief/active/*-798-*.vbrief.json",
+  "deft/vbrief/completed/*-798-*.vbrief.json",
+  "deft/vbrief/cancelled/*-798-*.vbrief.json",
+  "deft/vbrief/pending/*-798-*.vbrief.json",
+  "deft/vbrief/proposed/*-798-*.vbrief.json",
+  "history/archive/**",
+  "history/archive/**/*",
+  ".deft/core/history/archive/**",
+  ".deft/core/history/archive/**/*",
+  "deft/history/archive/**",
+  "deft/history/archive/**/*",
+  "scripts/verify_encoding.py",
+  "tests/cli/test_verify_encoding.py",
+  ".deft/core/scripts/verify_encoding.py",
+  ".deft/core/tests/cli/test_verify_encoding.py",
+  "deft/scripts/verify_encoding.py",
+  "deft/tests/cli/test_verify_encoding.py",
+];

--- a/packages/core/src/encoding/scan.test.ts
+++ b/packages/core/src/encoding/scan.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  type Finding,
+  isVbriefNarrativeControlScope,
+  renderFinding,
+  scanFile,
+  scanLine,
+  suffixOf,
+} from "./scan.js";
+
+const root = mkdtempSync(join(tmpdir(), "deft-scan-test-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+let counter = 0;
+function fixture(name: string, content: string | Buffer): string {
+  const full = join(root, `${counter++}-${name}`);
+  writeFileSync(full, content);
+  return full;
+}
+
+function labels(findings: Finding[]): string[] {
+  return findings.map((f) => f.label);
+}
+
+describe("suffixOf", () => {
+  it("lowercases the final extension", () => {
+    expect(suffixOf("a/b.MD")).toBe(".md");
+    expect(suffixOf("a.tar.gz")).toBe(".gz");
+  });
+  it("returns empty for no/leading-dot extension", () => {
+    expect(suffixOf("noext")).toBe("");
+    expect(suffixOf(".hidden")).toBe("");
+  });
+  it("handles backslash paths (Windows edge case)", () => {
+    expect(suffixOf("a\\b\\c.JSON")).toBe(".json");
+  });
+});
+
+describe("renderFinding", () => {
+  it("renders path:line [label] context", () => {
+    expect(renderFinding({ path: "a.md", line: 3, label: "X", context: "ctx" })).toBe(
+      "  a.md:3 [X] ctx",
+    );
+  });
+  it("truncates long context to 117 chars + ellipsis", () => {
+    const long = "z".repeat(200);
+    const out = renderFinding({ path: "a", line: 1, label: "L", context: long });
+    expect(out.endsWith("...")).toBe(true);
+    expect(out).toContain("z".repeat(117));
+    expect(out).not.toContain("z".repeat(118));
+  });
+});
+
+describe("isVbriefNarrativeControlScope", () => {
+  it("is true only for in-flight vBRIEFs", () => {
+    expect(isVbriefNarrativeControlScope("vbrief/active/x.vbrief.json")).toBe(true);
+    expect(isVbriefNarrativeControlScope("vbrief/proposed/x.vbrief.json")).toBe(true);
+    expect(isVbriefNarrativeControlScope("vbrief/completed/x.vbrief.json")).toBe(false);
+    expect(isVbriefNarrativeControlScope("vbrief/active/x.json")).toBe(false);
+    expect(isVbriefNarrativeControlScope("notes.md")).toBe(false);
+  });
+  it("normalizes backslash paths (Windows edge case)", () => {
+    expect(isVbriefNarrativeControlScope("vbrief\\active\\x.vbrief.json")).toBe(true);
+  });
+});
+
+describe("scanLine", () => {
+  it("flags U+FFFD", () => {
+    expect(labels(scanLine("a", 1, "broke \ufffd here"))).toContain("U+FFFD replacement char");
+  });
+  it("flags cp437 and cp1252 bigrams", () => {
+    expect(scanLine("a", 1, "x \u0393\u00a3\u00f4 y").length).toBe(1);
+    expect(scanLine("a", 1, "x \u00e2\u20ac\u2122 y").length).toBe(1);
+  });
+  it("returns nothing for clean lines", () => {
+    expect(scanLine("a", 1, "all clean ascii")).toEqual([]);
+  });
+});
+
+describe("scanFile", () => {
+  it("flags an unexpected BOM on .json", () => {
+    const full = fixture(
+      "bom.json",
+      Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from('{"a":1}')]),
+    );
+    expect(labels(scanFile("bom.json", full))).toContain("unexpected UTF-8 BOM");
+  });
+  it("tolerates a BOM on .ps1", () => {
+    const full = fixture(
+      "ok.ps1",
+      Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("Write-Host 1\n")]),
+    );
+    expect(scanFile("ok.ps1", full)).toEqual([]);
+  });
+  it("skips binary files (NUL in first 1024 bytes)", () => {
+    const full = fixture("bin.txt", Buffer.from("\u0000 \u0393\u00a3\u00f4 mojibake"));
+    expect(scanFile("bin.txt", full)).toEqual([]);
+  });
+  it("ignores mojibake quoted inside markdown code spans", () => {
+    const full = fixture("quoted.md", "see `\u0393\u00a3\u00f4` inline\n");
+    expect(scanFile("quoted.md", full)).toEqual([]);
+  });
+  it("flags unquoted markdown mojibake at the right line after a fenced block", () => {
+    const full = fixture(
+      "fenced.md",
+      "intro\n```\nignored \u0393\u00a3\u00f4\n```\nreal \u0393\u00a3\u00f4 hit\n",
+    );
+    const findings = scanFile("fenced.md", full);
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.line).toBe(5);
+  });
+  it("detects control chars in an active vBRIEF narrative", () => {
+    const content = `${JSON.stringify({ plan: { narratives: { problem: "bad\u000bvtab" } } }, null, 2)}\n`;
+    const full = fixture("vb.vbrief.json", content);
+    const findings = scanFile("vbrief/active/vb.vbrief.json", full);
+    expect(labels(findings)).toContain("U+000B vertical tab in vBRIEF narrative");
+  });
+  it("does not scan narrative controls for non-in-flight vBRIEFs", () => {
+    const content = `${JSON.stringify({ plan: { narratives: { problem: "bad\u000bvtab" } } }, null, 2)}\n`;
+    const full = fixture("done.vbrief.json", content);
+    expect(scanFile("vbrief/completed/done.vbrief.json", full)).toEqual([]);
+  });
+  it("flags a generic control char and a non-indentation tab in a narrative", () => {
+    const content = `${JSON.stringify({ plan: { narratives: { a: "x\u0007y", b: "prose\there" } } }, null, 2)}\n`;
+    const full = fixture("ctl.vbrief.json", content);
+    const ls = labels(scanFile("vbrief/active/ctl.vbrief.json", full));
+    expect(ls).toContain("U+0007 control character in vBRIEF narrative");
+    expect(ls).toContain("U+0009 tab in vBRIEF narrative");
+  });
+  it("allows leading-indentation tabs in a narrative", () => {
+    const content = `${JSON.stringify({ plan: { narratives: { a: "\t\tindented ok" } } }, null, 2)}\n`;
+    const full = fixture("indent.vbrief.json", content);
+    expect(scanFile("vbrief/active/indent.vbrief.json", full)).toEqual([]);
+  });
+  it("returns [] for an unreadable path", () => {
+    expect(scanFile("missing.md", join(root, "does-not-exist.md"))).toEqual([]);
+  });
+  it("ignores malformed vBRIEF JSON without throwing", () => {
+    const full = fixture("broken.vbrief.json", "{not json");
+    expect(scanFile("vbrief/active/broken.vbrief.json", full)).toEqual([]);
+  });
+
+  it("ignores active vBRIEFs lacking a plan.narratives object", () => {
+    const cases: Array<[string, unknown]> = [
+      ["arr.vbrief.json", []],
+      ["noplan.vbrief.json", { other: 1 }],
+      ["planstr.vbrief.json", { plan: "x" }],
+      ["narrstr.vbrief.json", { plan: { narratives: "x" } }],
+      ["narrnum.vbrief.json", { plan: { narratives: { problem: 5 } } }],
+    ];
+    for (const [name, value] of cases) {
+      const full = fixture(name, `${JSON.stringify(value)}\n`);
+      expect(scanFile(`vbrief/active/${name}`, full)).toEqual([]);
+    }
+  });
+});

--- a/packages/core/src/encoding/scan.ts
+++ b/packages/core/src/encoding/scan.ts
@@ -1,0 +1,217 @@
+import { readFileSync } from "node:fs";
+import {
+  MOJIBAKE_PATTERNS,
+  NO_BOM_EXTENSIONS,
+  REPLACEMENT_CHAR,
+  UTF8_BOM,
+  VBRIEF_CONTROL_CHAR_LABELS,
+} from "./patterns.js";
+import { pythonSplitlines, stripMarkdownQuotes } from "./text.js";
+
+/** One mojibake / U+FFFD / BOM detection record. */
+export interface Finding {
+  readonly path: string;
+  readonly line: number;
+  readonly label: string;
+  readonly context: string;
+}
+
+/** Render a finding as the Python oracle does: `  path:line [label] context`. */
+export function renderFinding(f: Finding): string {
+  const ctx = f.context.length <= 120 ? f.context : `${f.context.slice(0, 117)}...`;
+  return `  ${f.path}:${f.line} [${f.label}] ${ctx}`;
+}
+
+/** Lowercased final extension of a path, including the dot (e.g. ".md"). */
+export function suffixOf(path: string): string {
+  const base = path.replace(/\\/g, "/").split("/").pop() ?? "";
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) {
+    return "";
+  }
+  return base.slice(dot).toLowerCase();
+}
+
+/** Scan one line; return findings for U+FFFD + each mojibake pattern hit. */
+export function scanLine(
+  relPath: string,
+  lineno: number,
+  line: string,
+  context?: string,
+): Finding[] {
+  const findings: Finding[] = [];
+  const ctx = context !== undefined ? context : line;
+  if (line.includes(REPLACEMENT_CHAR)) {
+    findings.push({ path: relPath, line: lineno, label: "U+FFFD replacement char", context: ctx });
+  }
+  for (const [pattern, label] of MOJIBAKE_PATTERNS) {
+    if (line.includes(pattern)) {
+      findings.push({ path: relPath, line: lineno, label, context: ctx });
+    }
+  }
+  return findings;
+}
+
+function startsWithBom(raw: Buffer): boolean {
+  if (raw.length < UTF8_BOM.length) {
+    return false;
+  }
+  return UTF8_BOM.every((byte, i) => raw[i] === byte);
+}
+
+/**
+ * Scan one file for U+FFFD / mojibake / unexpected BOM. An unreadable or
+ * binary file returns an empty list rather than throwing (the gate is
+ * intentionally permissive on read failures). Mirrors Python `scan_file`.
+ */
+export function scanFile(relPath: string, fullPath: string): Finding[] {
+  const findings: Finding[] = [];
+  const suffix = suffixOf(fullPath);
+
+  let raw: Buffer;
+  try {
+    raw = readFileSync(fullPath);
+  } catch {
+    return findings;
+  }
+
+  if (NO_BOM_EXTENSIONS.has(suffix) && startsWithBom(raw)) {
+    findings.push({
+      path: relPath,
+      line: 1,
+      label: "unexpected UTF-8 BOM",
+      context: "leading bytes EF BB BF on a format where BOM is non-canonical",
+    });
+  }
+
+  // Node Buffer.toString('utf8') performs lossy U+FFFD replacement, matching
+  // Python bytes.decode('utf-8', errors='replace').
+  const text = raw.toString("utf8");
+
+  if (text.slice(0, 1024).includes("\u0000")) {
+    // Likely binary file — skip mojibake scan.
+    return findings;
+  }
+
+  let scanText = text;
+  if (suffix === ".md") {
+    scanText = stripMarkdownQuotes(text);
+  }
+
+  if (scanText === text) {
+    const lines = pythonSplitlines(text);
+    lines.forEach((line, idx) => {
+      findings.push(...scanLine(relPath, idx + 1, line));
+    });
+  } else {
+    const originalLines = pythonSplitlines(text);
+    const strippedLines = pythonSplitlines(scanText);
+    if (strippedLines.length < originalLines.length) {
+      while (strippedLines.length < originalLines.length) {
+        strippedLines.push("");
+      }
+    }
+    originalLines.forEach((orig, idx) => {
+      const stripped = strippedLines[idx] ?? "";
+      findings.push(...scanLine(relPath, idx + 1, stripped, orig));
+    });
+  }
+
+  if (isVbriefNarrativeControlScope(relPath)) {
+    findings.push(...scanVbriefNarrativeControls(relPath, text));
+  }
+
+  return findings;
+}
+
+/** Return true for in-flight vBRIEF files that may receive issue ingest. */
+export function isVbriefNarrativeControlScope(relPath: string): boolean {
+  if (!relPath.endsWith(".vbrief.json")) {
+    return false;
+  }
+  const normalized = `/${relPath.replace(/\\/g, "/")}`;
+  return normalized.includes("/vbrief/proposed/") || normalized.includes("/vbrief/active/");
+}
+
+function tabIsNonIndentation(value: string, index: number): boolean {
+  const lineStart = value.lastIndexOf("\n", index - 1) + 1;
+  for (const ch of value.slice(lineStart, index)) {
+    if (ch !== " " && ch !== "\t") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function decodedControlLabels(value: string): string[] {
+  const labels: string[] = [];
+  const seen = new Set<string>();
+  // Iterate by UTF-16 code unit index so lastIndexOf offsets line up; control
+  // chars of interest are all BMP single-unit characters.
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index] as string;
+    if (char === "\t" && !tabIsNonIndentation(value, index)) {
+      continue;
+    }
+    let label = VBRIEF_CONTROL_CHAR_LABELS.get(char);
+    const code = char.charCodeAt(0);
+    if (label === undefined && code < 32 && char !== "\n" && char !== "\r") {
+      label = `U+${code.toString(16).toUpperCase().padStart(4, "0")} control character in vBRIEF narrative`;
+    }
+    if (label !== undefined && !seen.has(label)) {
+      seen.add(label);
+      labels.push(label);
+    }
+  }
+  return labels;
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function jsonKeyLine(text: string, key: string): number {
+  const match = new RegExp(`"${escapeRegExp(key)}"\\s*:`).exec(text);
+  if (match === null) {
+    return 1;
+  }
+  return (text.slice(0, match.index).match(/\n/g) ?? []).length + 1;
+}
+
+/** Scan decoded `plan.narratives` strings for hidden control chars. */
+export function scanVbriefNarrativeControls(relPath: string, text: string): Finding[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (typeof data !== "object" || data === null) {
+    return [];
+  }
+  const plan = (data as Record<string, unknown>).plan;
+  if (typeof plan !== "object" || plan === null) {
+    return [];
+  }
+  const narratives = (plan as Record<string, unknown>).narratives;
+  if (typeof narratives !== "object" || narratives === null) {
+    return [];
+  }
+
+  const findings: Finding[] = [];
+  for (const [key, value] of Object.entries(narratives as Record<string, unknown>)) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const keyLine = jsonKeyLine(text, key);
+    for (const label of decodedControlLabels(value)) {
+      findings.push({
+        path: relPath,
+        line: keyLine,
+        label,
+        context: `plan.narratives.${key} contains ${label}`,
+      });
+    }
+  }
+  return findings;
+}

--- a/packages/core/src/encoding/text.test.ts
+++ b/packages/core/src/encoding/text.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { fnmatchCase, pythonSplitlines, stripMarkdownQuotes } from "./text.js";
+
+describe("pythonSplitlines", () => {
+  it("returns [] for empty input", () => {
+    expect(pythonSplitlines("")).toEqual([]);
+  });
+
+  it("does not emit a trailing empty for a final line break", () => {
+    expect(pythonSplitlines("a\nb\n")).toEqual(["a", "b"]);
+    expect(pythonSplitlines("a\nb")).toEqual(["a", "b"]);
+  });
+
+  it("keeps a leading empty line", () => {
+    expect(pythonSplitlines("\n")).toEqual([""]);
+    expect(pythonSplitlines("\na")).toEqual(["", "a"]);
+  });
+
+  it("treats CRLF as a single boundary (Windows edge case)", () => {
+    expect(pythonSplitlines("a\r\nb\r\nc")).toEqual(["a", "b", "c"]);
+  });
+
+  it("splits on bare CR (old-Mac edge case)", () => {
+    expect(pythonSplitlines("a\rb")).toEqual(["a", "b"]);
+  });
+
+  it("splits on the full Python boundary set (\\v \\f, line/para sep)", () => {
+    expect(pythonSplitlines("a\vb\fc\u2028d\u2029e")).toEqual(["a", "b", "c", "d", "e"]);
+  });
+});
+
+describe("stripMarkdownQuotes", () => {
+  it("removes inline code spans", () => {
+    expect(stripMarkdownQuotes("a `code` b")).toBe("a  b");
+  });
+
+  it("blanks fenced blocks while preserving line count", () => {
+    const text = "before\n```\nfenced mojibake line\n```\nafter\n";
+    const out = stripMarkdownQuotes(text);
+    expect(out.split("\n").length).toBe(text.split("\n").length);
+    expect(out).not.toContain("fenced mojibake line");
+    expect(out.startsWith("before\n")).toBe(true);
+    expect(out.trimEnd().endsWith("after")).toBe(true);
+  });
+
+  it("handles tilde fences too", () => {
+    expect(stripMarkdownQuotes("~~~\nx\n~~~")).toBe("\n\n");
+  });
+});
+
+describe("fnmatchCase", () => {
+  it("matches the -798- allow-list carve-out", () => {
+    expect(
+      fnmatchCase(
+        "vbrief/active/2026-01-01-798-x.vbrief.json",
+        "vbrief/active/*-798-*.vbrief.json",
+      ),
+    ).toBe(true);
+    expect(
+      fnmatchCase("vbrief/active/2026-01-01-1-x.vbrief.json", "vbrief/active/*-798-*.vbrief.json"),
+    ).toBe(false);
+  });
+
+  it("treats ** as matching across slashes", () => {
+    expect(fnmatchCase("history/archive/a/b/c.md", "history/archive/**")).toBe(true);
+    expect(fnmatchCase("history/archive/a/b/c.md", "history/archive/**/*")).toBe(true);
+  });
+
+  it("matches exact literal paths and rejects others", () => {
+    expect(fnmatchCase("scripts/verify_encoding.py", "scripts/verify_encoding.py")).toBe(true);
+    expect(fnmatchCase("scripts/other.py", "scripts/verify_encoding.py")).toBe(false);
+  });
+
+  it("treats a literal dot as a dot, not any-char", () => {
+    expect(fnmatchCase("aXtxt", "a.txt")).toBe(false);
+    expect(fnmatchCase("a.txt", "a.txt")).toBe(true);
+  });
+
+  it("supports ? and character classes including negation", () => {
+    expect(fnmatchCase("a1", "a?")).toBe(true);
+    expect(fnmatchCase("ab", "a[bc]")).toBe(true);
+    expect(fnmatchCase("ad", "a[bc]")).toBe(false);
+    expect(fnmatchCase("ad", "a[!bc]")).toBe(true);
+  });
+
+  it("treats an unterminated [ as a literal bracket", () => {
+    expect(fnmatchCase("a[", "a[")).toBe(true);
+    expect(fnmatchCase("ab", "a[")).toBe(false);
+  });
+
+  it("treats a leading ^ inside a class as a literal caret", () => {
+    expect(fnmatchCase("x^", "x[^y]")).toBe(true);
+    expect(fnmatchCase("xy", "x[^y]")).toBe(true);
+    expect(fnmatchCase("xz", "x[^y]")).toBe(false);
+  });
+});

--- a/packages/core/src/encoding/text.ts
+++ b/packages/core/src/encoding/text.ts
@@ -1,0 +1,113 @@
+/**
+ * Text helpers ported to match Python semantics exactly so the encoding gate
+ * golden-diffs clean against the Python oracle (#798 / #1718): line splitting
+ * (`str.splitlines`), markdown code-span stripping, and `fnmatch.fnmatchcase`
+ * glob matching for the allow-list.
+ */
+
+// Python str.splitlines() boundaries: \n \r \r\n \v \f \x1c \x1d \x1e \x85 \u2028 \u2029.
+// The control chars are the intentional boundary set ported from CPython for
+// golden-diff parity (#1718), not accidental input.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional Python splitlines() boundary set (#1718)
+const SPLITLINES_BOUNDARY = /\r\n|[\n\r\v\f\u001c\u001d\u001e\u0085\u2028\u2029]/g;
+
+/**
+ * Split `text` into lines using Python `str.splitlines()` semantics: splits on
+ * the full Unicode line-boundary set and does NOT emit a trailing empty string
+ * for a final line break. Empty input yields an empty array.
+ */
+export function pythonSplitlines(text: string): string[] {
+  if (text === "") {
+    return [];
+  }
+  const lines: string[] = [];
+  let last = 0;
+  SPLITLINES_BOUNDARY.lastIndex = 0;
+  let match: RegExpExecArray | null = SPLITLINES_BOUNDARY.exec(text);
+  while (match !== null) {
+    lines.push(text.slice(last, match.index));
+    last = match.index + match[0].length;
+    match = SPLITLINES_BOUNDARY.exec(text);
+  }
+  if (last < text.length) {
+    lines.push(text.slice(last));
+  }
+  return lines;
+}
+
+// Markdown inline-code span: single backtick to single backtick on one line.
+const MD_INLINE_CODE = /`[^`\r\n]*`/g;
+
+// Markdown fenced code block: ``` (or ~~~) ... matching close fence.
+// Flags: g (replace all), m (^/$ per line), s (dotall so .*? spans lines).
+const MD_FENCED_BLOCK = /^[ \t]*(```|~~~)[^\n]*\n.*?^[ \t]*\1[ \t\r]*$/gms;
+
+/** Replace a fenced block with the same number of newlines (line alignment). */
+function blankBlock(match: string): string {
+  const count = (match.match(/\n/g) ?? []).length;
+  return "\n".repeat(count);
+}
+
+/**
+ * Strip fenced code blocks and inline-code spans from markdown content.
+ * Fenced blocks are blanked newline-for-newline first (preserving line numbers),
+ * then inline spans are removed. Mirrors the Python `_strip_markdown_quotes`.
+ */
+export function stripMarkdownQuotes(text: string): string {
+  const withoutFences = text.replace(MD_FENCED_BLOCK, (m) => blankBlock(m));
+  return withoutFences.replace(MD_INLINE_CODE, "");
+}
+
+/**
+ * Translate a single `fnmatch`-style glob to an anchored regex source.
+ * Mirrors CPython `fnmatch.translate` for the subset used by the allow-list:
+ * `*` matches any run of characters (including `/`), `?` matches one character,
+ * `[...]` is a character class (`!` negates), everything else is literal.
+ */
+function fnmatchTranslate(pattern: string): string {
+  let out = "";
+  let i = 0;
+  const n = pattern.length;
+  while (i < n) {
+    const c = pattern.charAt(i);
+    i += 1;
+    if (c === "*") {
+      out += ".*";
+    } else if (c === "?") {
+      out += ".";
+    } else if (c === "[") {
+      let j = i;
+      if (j < n && pattern.charAt(j) === "!") {
+        j += 1;
+      }
+      if (j < n && pattern.charAt(j) === "]") {
+        j += 1;
+      }
+      while (j < n && pattern.charAt(j) !== "]") {
+        j += 1;
+      }
+      if (j >= n) {
+        out += "\\[";
+      } else {
+        let stuff = pattern.slice(i, j).replace(/\\/g, "\\\\");
+        i = j + 1;
+        if (stuff.startsWith("!")) {
+          stuff = `^${stuff.slice(1)}`;
+        } else if (stuff.startsWith("^")) {
+          stuff = `\\${stuff}`;
+        }
+        out += `[${stuff}]`;
+      }
+    } else {
+      out += c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return out;
+}
+
+/** Return true when `relPath` (POSIX form) matches the fnmatch `pattern`. */
+export function fnmatchCase(relPath: string, pattern: string): boolean {
+  // `s` flag so `.` (from `*`) spans any character, matching fnmatch's dotall.
+  const re = new RegExp(`^(?:${fnmatchTranslate(pattern)})$`, "s");
+  return re.test(relPath);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,11 +3,11 @@ import type { EngineInfo } from "@deftai/types";
 /**
  * `@deftai/core` — the deft directive engine core.
  *
- * Wave-1 skeleton (#1717): exposes only its identity and an `engineInfo()`
- * accessor that consumes a type from `@deftai/types`, proving the
- * types → core project reference resolves. Ported enforcement logic lands
- * with #1718 onward.
+ * Hosts the first ported enforcement gate (`verify:encoding`, #1718) under
+ * `./encoding`, alongside the Wave-1 identity accessor.
  */
+
+export * from "./encoding/index.js";
 
 export const CORE_PACKAGE = "@deftai/core" as const;
 

--- a/tasks/ts.yml
+++ b/tasks/ts.yml
@@ -32,3 +32,15 @@ tasks:
     dir: '{{.DEFT_ROOT}}'
     cmds:
       - pnpm run lint
+
+  encoding:
+    desc: "Run the ported verify:encoding gate (TS @deftai/core port, #1718)"
+    deps: [build]
+    cmds:
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/verify-encoding.js" --all --project-root "{{.DEFT_ROOT}}"
+
+  parity:
+    desc: "Golden-diff the ported verify:encoding gate vs the Python oracle, cache-off (#1718)"
+    deps: [build]
+    cmds:
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/parity.js"

--- a/vbrief/active/2026-06-18-1718-featts-migration-golden-output-parity-harness-verifyencoding.vbrief.json
+++ b/vbrief/active/2026-06-18-1718-featts-migration-golden-output-parity-harness-verifyencoding.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(ts-migration): golden-output parity harness + verify:encoding tracer-bullet port (Wave 1)",
-    "status": "pending",
+    "status": "running",
     "narratives": {
       "Description": "feat(ts-migration): golden-output parity harness + verify:encoding tracer-bullet port (Wave 1)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1718",
@@ -52,6 +52,6 @@
         "title": "Issue #1717"
       }
     ],
-    "updated": "2026-06-18T18:37:49Z"
+    "updated": "2026-06-18T18:47:48Z"
   }
 }

--- a/vbrief/completed/2026-06-18-1718-featts-migration-golden-output-parity-harness-verifyencoding.vbrief.json
+++ b/vbrief/completed/2026-06-18-1718-featts-migration-golden-output-parity-harness-verifyencoding.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(ts-migration): golden-output parity harness + verify:encoding tracer-bullet port (Wave 1)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "feat(ts-migration): golden-output parity harness + verify:encoding tracer-bullet port (Wave 1)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1718",
@@ -52,6 +52,10 @@
         "title": "Issue #1717"
       }
     ],
-    "updated": "2026-06-18T18:47:48Z"
+    "updated": "2026-06-18T19:05:04Z",
+    "metadata": {
+      "completedAt": "2026-06-18T19:05:04Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/vbrief/pending/2026-06-18-1718-featts-migration-golden-output-parity-harness-verifyencoding.vbrief.json
+++ b/vbrief/pending/2026-06-18-1718-featts-migration-golden-output-parity-harness-verifyencoding.vbrief.json
@@ -1,0 +1,57 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1718"
+  },
+  "plan": {
+    "title": "feat(ts-migration): golden-output parity harness + verify:encoding tracer-bullet port (Wave 1)",
+    "status": "pending",
+    "narratives": {
+      "Description": "feat(ts-migration): golden-output parity harness + verify:encoding tracer-bullet port (Wave 1)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1718",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2; umbrella epic #1545)\n\n## What to build\n\nBuild the golden-output parity harness (feeds identical fixtures to the Python implementation and the TS implementation, diffs structured outputs / exit states / filesystem effects) and use it to port **one real gate end-to-end** as the tracer bullet: `verify:encoding`. The ported gate is invoked through the existing `task` surface, golden-diffed against the Python oracle, and tested on Windows. Proves the entire end-to-end path before any other gate moves.\n\n## Acceptance criteria\n\n- [ ] Golden-output parity harness compares TS vs Python structured output, exit state, and filesystem effects\n- [ ] `verify:encoding` ported to `@deft/core` + a thin CLI executable with the three-state exit preserved\n- [ ] The ported gate is invoked via `task` and golden-diffs clean against the Python oracle (cache-off)\n- [ ] Windows path/encoding edge cases covered\n- [ ] `task check` passes\n\n## Standing invariants (all Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) and CI usage.\n- No agent-runtime dependency (that is Part 2, #1707); no monorepo orchestrator on day one (Nx never; Turborepo only on a measured trigger).\n\n## Type\n\nAFK\n\n## Blocked by\n\n- Blocked by #1717\n",
+      "Labels": "determinism, refactor, runtime-portability, tooling"
+    },
+    "items": [
+      {
+        "title": "Golden-output parity harness compares TS vs Python structured output, exit state, and filesystem effects",
+        "status": "proposed"
+      },
+      {
+        "title": "ported to  + a thin CLI executable with the three-state exit preserved",
+        "status": "proposed"
+      },
+      {
+        "title": "The ported gate is invoked via  and golden-diffs clean against the Python oracle (cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "Windows path/encoding edge cases covered",
+        "status": "proposed"
+      },
+      {
+        "title": "passes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "determinism",
+      "refactor",
+      "runtime-portability",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1718",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1718: feat(ts-migration): golden-output parity harness + verify:encoding tracer-bullet port (Wave 1)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1717",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1717"
+      }
+    ],
+    "updated": "2026-06-18T18:37:49Z"
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,15 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["packages/*/src/**/*.ts"],
-      exclude: ["**/*.test.ts", "packages/cli/src/bin.ts"],
+      exclude: [
+        "**/*.test.ts",
+        "packages/cli/src/bin.ts",
+        // Cross-toolchain harness runner: spawns the Python oracle, so it is
+        // validated by the dedicated `parity` CI job (#1718), not node-only
+        // unit tests. Its pure helpers (parseFindings/diffGates/findingKey)
+        // are still unit-tested in parity.test.ts.
+        "packages/cli/src/parity.ts",
+      ],
       reporter: ["text", "text-summary"],
       thresholds: {
         lines: 85,


### PR DESCRIPTION
## Summary

Wave-1 tracer bullet for the Python→TypeScript engine migration (#1530), unblocked by the scaffold (#1717 / PR #1733). Proves the end-to-end migration path: port one real enforcement gate, prove byte-for-byte behavior parity against the Python original, and gate that parity in CI.

- **Port `verify:encoding` (#798) to `@deftai/core`** — `packages/core/src/encoding/` mirrors `scripts/verify_encoding.py`: the cp1252/cp437 mojibake bigram catalog, U+FFFD + unexpected-BOM detection, markdown code-span stripping (with line-number alignment), vBRIEF narrative control-char scan, git enumeration, the builtin `-798-` allow-list, and a pure 3-state `evaluate()`.
- **Thin CLI** — `deft-verify-encoding` (`@deftai/cli`) preserving the `0 clean / 1 corruption / 2 config-error` exit contract and the `--all/--staged/--project-root/--allow-list/--quiet` surface.
- **Golden-output parity harness** — `deft-encoding-parity` builds a throwaway git repo of known-corruption fixtures and diffs the TS port against the Python oracle on structured findings + exit codes, cache-off. A clean run proves they detect identically.
- **Task + CI wiring** — `task ts:encoding`, `task ts:parity`, and a dedicated `parity` CI job (Node + Python toolchains).

## Parity evidence

- Real corpus (the whole repo): TS and Python both report **1585 files clean** — exact candidate-filtering parity.
- Fixture corpus (cp437, cp1252, U+FFFD, unexpected/tolerated BOM, vBRIEF control char, markdown code-span guard, `-798-` allow-list): **parity CLEAN** — identical findings + exit codes.

## Test plan

- [x] `pnpm run build` (tsc -b project references)
- [x] `pnpm run lint` (biome) clean
- [x] `pnpm run test` — 66 tests; coverage ≥85% (lines 92%, branches 88%, funcs 100%); includes Windows path/CRLF/BOM edge cases
- [x] `task ts:parity` CLEAN (TS port vs Python oracle)
- [x] `task check` green (Python/Go self-check; verify_encoding clean)
- [x] CHANGELOG `[Unreleased]` entry added

Refs #1718 #1717 #1530

Made with [Cursor](https://cursor.com)