### PR TITLE
chore(policy): route leaf coding sub-agents to Composer (#1531a)

### DIFF
--- a/meta/policy-changes.log
+++ b/meta/policy-changes.log
@@ -34,3 +34,4 @@
 2026-06-17T01:51:15Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True
 2026-06-18T15:05:19Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
 2026-06-18T15:21:36Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True
+2026-06-18T19:42:54Z actor=task policy:subagent-backend swarmSubagentBackend=composer previous=None

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -11019,7 +11019,8 @@
           }
         ]
       },
-      "allowDirectCommitsToMaster": false
+      "allowDirectCommitsToMaster": false,
+      "swarmSubagentBackend": "composer"
     },
     "updated": "2026-06-12T20:26:00Z"
   }


### PR DESCRIPTION
## Summary

Sets `plan.policy.swarmSubagentBackend=composer` on this repo's `PROJECT-DEFINITION` so the swarm **leaf-implementation** tier dispatches to a Composer-class coding agent (#1531a).

- The `composer` backend exposes only the `leaf-implementation` role. Review-cycle, orchestration/strategist, and merge roles stay on a strong, review-capable model per the #1531 role boundary.
- Backend availability is resolved at dispatch time by the harness; this commit records operator intent (the `composer` provider currently probes `unavailable` in the local harness, which is expected until a Composer backend is wired up).
- Includes the `meta/policy-changes.log` audit row written by `task policy:subagent-backend`.

## Test plan

- [x] `task policy:subagent-backend -- --set composer` succeeded (typed source, audit-logged)
- [x] pre-commit hooks green (branch-policy, verify_encoding, vBRIEF conformance)

Refs #1531 #1531a

Made with [Cursor](https://cursor.com)