### PR TITLE
chore(vbrief): decompose #1530 Wave-3 into 13 swarm-ready stories

### DIFF
--- a/vbrief/proposed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json
@@ -1,0 +1,61 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1724"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port the scm.py SCM boundary to a TS adapter (Wave 3)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port the scm.py SCM boundary to a TS adapter (Wave 3)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1724",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2; umbrella epic #1545)\n\n## What to build\n\nPort the `scripts/scm.py` boundary (the `scm.call(source, verb, args)` shim, the ghx->gh preference ladder, the github-issue NotImplementedError for non-GitHub sources) to a TS SCM adapter. Shared dependency for the triage/scope/slice families.\n\n## Acceptance criteria\n\n- [ ] `scm.call`-equivalent TS adapter preserves the ghx->gh ladder and source abstraction\n- [ ] Non-GitHub sources raise the deferred-abstraction error\n- [ ] Golden-output parity vs the Python oracle (cache-off)\n- [ ] `task check` passes\n\n## Standing invariants (all Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) and CI usage.\n- No agent-runtime dependency (that is Part 2, #1707); no monorepo orchestrator on day one (Nx never; Turborepo only on a measured trigger).\n\n## Type\n\nHITL\n\n## Blocked by\n\n- Blocked by #1718\n",
+      "Labels": "refactor, runtime-portability, tooling, scm"
+    },
+    "items": [
+      {
+        "title": "-equivalent TS adapter preserves the ghx->gh ladder and source abstraction",
+        "status": "proposed"
+      },
+      {
+        "title": "Non-GitHub sources raise the deferred-abstraction error",
+        "status": "proposed"
+      },
+      {
+        "title": "Golden-output parity vs the Python oracle (cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "passes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "refactor",
+      "runtime-portability",
+      "tooling",
+      "scm"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1724: feat(ts-migration): port the scm.py SCM boundary to a TS adapter (Wave 3)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1718",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1718"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-scmpy-scm-boundary-to-a-typescript-adapter.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the scm.py SCM boundary to a TypeScript adapter",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json
@@ -1,0 +1,103 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1725"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port the triage:* family to TS (Wave 3)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port the triage:* family to TS (Wave 3)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1725",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2; umbrella epic #1545)\n\n## What to build\n\nPort the `triage:*` verb family (`scripts/triage_*.py`: summary, queue, classification, bootstrap, accept/reject/defer, scope) to `@deft/core` + CLI, preserving cache semantics and queue ranking order.\n\n## Acceptance criteria\n\n- [ ] `triage:summary` / `triage:queue` and the accept/reject/defer surface run on TS\n- [ ] Queue ranking + `[RESUME]`/`[ORPHAN]`/`[URGENT]` ordering reproduced\n- [ ] Golden-output parity vs the Python oracle (cache-off)\n- [ ] `task check` passes\n\n## Standing invariants (all Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) and CI usage.\n- No agent-runtime dependency (that is Part 2, #1707); no monorepo orchestrator on day one (Nx never; Turborepo only on a measured trigger).\n\n## Type\n\nAFK\n\n## Blocked by\n\n- Blocked by #1724\n",
+      "Labels": "triage, refactor, runtime-portability, tooling"
+    },
+    "items": [
+      {
+        "title": "/  and the accept/reject/defer surface run on TS",
+        "status": "proposed"
+      },
+      {
+        "title": "Queue ranking + // ordering reproduced",
+        "status": "proposed"
+      },
+      {
+        "title": "Golden-output parity vs the Python oracle (cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "passes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "triage",
+      "refactor",
+      "runtime-portability",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage:queue (ranking + RESUME/ORPHAN/URGENT order) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage:summary (welcome one-liner) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triageclassify-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage:classify to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage:accept / reject / defer actions to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage:bootstrap to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triagescope-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage:scope to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage aux verbs A (welcome / refresh / reconcile / scope-drift) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port triage aux verbs B (bulk / subscribe / help / smoketest) to TypeScript",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json
@@ -1,0 +1,60 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1726"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port the scope:* lifecycle family to TS (Wave 3)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port the scope:* lifecycle family to TS (Wave 3)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1726",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2; umbrella epic #1545)\n\n## What to build\n\nPort the `scope:*` lifecycle family (`scripts/scope_lifecycle.py`: promote/activate/complete/cancel/restore/block/unblock/fail/undo) to TS, preserving atomic `plan.status` + `plan.updated` + folder-move semantics and the audit log.\n\n## Acceptance criteria\n\n- [ ] All `scope:*` transitions run on TS with atomic status+timestamp+folder-move semantics\n- [ ] `scope:undo` reversibility preserved (terminal actions refused)\n- [ ] Golden-output parity vs the Python oracle (cache-off)\n- [ ] `task check` passes\n\n## Standing invariants (all Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) and CI usage.\n- No agent-runtime dependency (that is Part 2, #1707); no monorepo orchestrator on day one (Nx never; Turborepo only on a measured trigger).\n\n## Type\n\nAFK\n\n## Blocked by\n\n- Blocked by #1724\n",
+      "Labels": "refactor, runtime-portability, tooling"
+    },
+    "items": [
+      {
+        "title": "All  transitions run on TS with atomic status+timestamp+folder-move semantics",
+        "status": "proposed"
+      },
+      {
+        "title": "reversibility preserved (terminal actions refused)",
+        "status": "proposed"
+      },
+      {
+        "title": "Golden-output parity vs the Python oracle (cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "passes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "refactor",
+      "runtime-portability",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1726",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1726: feat(ts-migration): port the scope:* lifecycle family to TS (Wave 3)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the scope:* lifecycle family to TypeScript",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json
@@ -1,0 +1,60 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1727"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port the slice:* family to TS (Wave 3)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port the slice:* family to TS (Wave 3)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1727",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2; umbrella epic #1545)\n\n## What to build\n\nPort the `slice:*` family (`scripts/slice_record.py`, `slice:record-existing`, `slice:list`) to TS, preserving the `slices.jsonl` cohort-record shape and idempotency.\n\n## Acceptance criteria\n\n- [ ] `slice:record-existing` / `slice:list` run on TS with the cohort-record shape preserved\n- [ ] Idempotent on a matching umbrella+child set\n- [ ] Golden-output parity vs the Python oracle (cache-off)\n- [ ] `task check` passes\n\n## Standing invariants (all Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) and CI usage.\n- No agent-runtime dependency (that is Part 2, #1707); no monorepo orchestrator on day one (Nx never; Turborepo only on a measured trigger).\n\n## Type\n\nAFK\n\n## Blocked by\n\n- Blocked by #1724\n",
+      "Labels": "refactor, runtime-portability, tooling"
+    },
+    "items": [
+      {
+        "title": "/  run on TS with the cohort-record shape preserved",
+        "status": "proposed"
+      },
+      {
+        "title": "Idempotent on a matching umbrella+child set",
+        "status": "proposed"
+      },
+      {
+        "title": "Golden-output parity vs the Python oracle (cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "passes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "refactor",
+      "runtime-portability",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1727",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1727: feat(ts-migration): port the slice:* family to TS (Wave 3)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the slice:* family (record-existing / list) to TypeScript",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json
@@ -1,0 +1,66 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1728"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port cache + deft doctor to TS (Wave 3)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port cache + deft doctor to TS (Wave 3)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1728",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2; umbrella epic #1545)\n\n## What to build\n\nPort `scripts/cache.py` (the unified content cache + quarantine: put/get/invalidate/fetch-all/prune, TTL) and `scripts/doctor.py` (`deft doctor`: install-integrity + toolchain + managed-section freshness + payload staleness) to TS.\n\n## Acceptance criteria\n\n- [ ] `cache:*` verbs run on TS with TTL/quarantine semantics preserved\n- [ ] `deft doctor` reproduces the install-integrity / toolchain / freshness probes\n- [ ] Golden-output parity vs the Python oracle (cache-off)\n- [ ] `task check` passes\n\n## Standing invariants (all Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) and CI usage.\n- No agent-runtime dependency (that is Part 2, #1707); no monorepo orchestrator on day one (Nx never; Turborepo only on a measured trigger).\n\n## Type\n\nAFK\n\n## Blocked by\n\n- Blocked by #1724\n",
+      "Labels": "refactor, runtime-portability, tooling"
+    },
+    "items": [
+      {
+        "title": "verbs run on TS with TTL/quarantine semantics preserved",
+        "status": "proposed"
+      },
+      {
+        "title": "reproduces the install-integrity / toolchain / freshness probes",
+        "status": "proposed"
+      },
+      {
+        "title": "Golden-output parity vs the Python oracle (cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "passes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "refactor",
+      "runtime-portability",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1728: feat(ts-migration): port cache + deft doctor to TS (Wave 3)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the unified content cache (cache.py) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port deft doctor (doctor.py) to TypeScript",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json
@@ -1,0 +1,93 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1728-s2-doctor",
+    "title": "Port deft doctor (doctor.py) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/doctor.py (deft doctor: install-integrity, toolchain probe, AGENTS.md managed-section freshness, and payload-staleness detection from the VERSION manifest) to a TypeScript doctor module under packages/core. This story depends on the cache port because the doctor cache-fresh probe reads the cache module; it is independently buildable thereafter as a self-contained module with a golden parity binary.",
+      "ImplementationPlan": "1. Create the packages/core/src/doctor module that ports the install-integrity, toolchain, managed-section freshness, and payload-staleness probes, reading the ported cache module for the cache-fresh check, with vitest unit tests in the module directory.\n2. Reproduce the canonical headless upgrade command emitted when the payload manifest is behind, matching the Python doctor.py source strings.\n3. Add a packages/cli/src/doctor-parity.ts parity binary that runs the TS doctor and the Python scripts/doctor.py oracle and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want deft doctor available in TypeScript, so that the install-integrity, toolchain, managed-section freshness, and payload-staleness probes run on the TS engine without the Python doctor.py module."
+    },
+    "items": [
+      {
+        "id": "1728-s2-a1",
+        "title": "healthy install probes",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running deft doctor on a healthy install returns exit 0 and emits the install-integrity, toolchain, and freshness probe results."
+        }
+      },
+      {
+        "id": "1728-s2-a2",
+        "title": "stale managed section detected",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running deft doctor against a stale AGENTS.md managed section shows the staleness and redirects the operator to agents:refresh."
+        }
+      },
+      {
+        "id": "1728-s2-a3",
+        "title": "behind payload emits upgrade command",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running deft doctor against a behind payload manifest emits the canonical headless deft-install upgrade command."
+        }
+      },
+      {
+        "id": "1728-s2-a4",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the doctor parity binary returns exit 0 and renders byte-identical output to the Python doctor.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/doctor/",
+          "packages/cli/src/doctor.ts",
+          "packages/cli/src/doctor-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/doctor-parity.js",
+          "pnpm --filter @deftai/core test src/doctor"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/doctor module with vitest unit tests",
+          "New packages/cli/src/doctor-parity.ts parity binary",
+          "Byte-identical parity vs scripts/doctor.py under cache-off"
+        ],
+        "depends_on": [
+          "1728-s1-cache"
+        ],
+        "conflict_group": "ts-wave3-cache-doctor",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1728 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1728: feat(ts-migration): port cache + deft doctor to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-scmpy-scm-boundary-to-a-typescript-adapter.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-scmpy-scm-boundary-to-a-typescript-adapter.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json"
+  },
+  "plan": {
+    "id": "1724-s1-scm-adapter",
+    "title": "Port the scm.py SCM boundary to a TypeScript adapter",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json",
+    "narratives": {
+      "Description": "Port the scripts/scm.py boundary (the scm.call(source, verb, args) shim, the ghx->gh preference ladder in resolve_binary, and the github-issue NotImplementedError for non-GitHub sources) to a TypeScript SCM adapter under packages/core. This is the shared foundation that the Wave-3 triage, scope, and slice families call to reach GitHub, so it is built and merged first; it is independently buildable because the adapter is a self-contained module with a golden parity binary and no dependency on any other Wave-3 port.",
+      "ImplementationPlan": "1. Create the packages/core/src/scm module that ports resolve_binary (the ghx->gh ladder), the call(source, verb, args) dispatch, and the non-github-issue rejection path, with vitest unit tests in the same module directory.\n2. Add a packages/cli/src/scm-parity.ts parity binary that runs the TS adapter and the Python scripts/scm.py oracle over a fixture corpus and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary, keeping the Python suite as the authoritative oracle until cutover.",
+      "UserStory": "As a directive maintainer, I want the SCM boundary available as a TypeScript adapter, so that the triage, scope, and slice families can route GitHub access through TS instead of the Python scm.py shim."
+    },
+    "items": [
+      {
+        "id": "1724-s1-a1",
+        "title": "ghx->gh ladder preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The TS adapter returns ghx as the binary when ghx is on PATH and falls back to gh when it is absent, preserving the documented preference ladder."
+        }
+      },
+      {
+        "id": "1724-s1-a2",
+        "title": "non-GitHub source rejected",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Calling the adapter with a non github-issue source rejects the request and emits the deferred-abstraction NotImplementedError-equivalent error rather than shelling out."
+        }
+      },
+      {
+        "id": "1724-s1-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the scm parity binary returns exit 0 and renders byte-identical output to the Python scm.py oracle across the fixture corpus with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/scm/",
+          "packages/cli/src/scm-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/scm-parity.js",
+          "pnpm --filter @deftai/core test src/scm"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/scm module with vitest unit tests",
+          "New packages/cli/src/scm-parity.ts parity binary",
+          "Byte-identical parity vs scripts/scm.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-scm",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1724 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1724: feat(ts-migration): port the scm.py SCM boundary to a TS adapter (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1718",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1718"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json
@@ -1,0 +1,91 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json"
+  },
+  "plan": {
+    "id": "1726-s1-scope-lifecycle",
+    "title": "Port the scope:* lifecycle family to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json",
+    "narratives": {
+      "Description": "Port the scripts/scope_lifecycle.py family (promote, activate, complete, cancel, restore, block, unblock, fail, demote, and undo) to TypeScript, preserving the atomic plan.status plus plan.updated plus folder-move semantics and the audit log. This is kept as one story rather than split because every transition shares the same atomic write engine and audit path, so splitting it across parallel workers would force overlapping edits to the same module; it remains independently buildable as a single self-contained scope module with a golden parity binary.",
+      "ImplementationPlan": "1. Create the packages/core/src/scope module that ports each lifecycle transition over the atomic status plus timestamp plus folder-move engine and the audit log writer, with vitest unit tests in the module directory.\n2. Port scope undo so non-terminal transitions are reversible and terminal actions are refused, matching the Python reversibility contract.\n3. Add a packages/cli/src/scope-lifecycle-parity.ts parity binary that runs the TS transitions and the Python scripts/scope_lifecycle.py oracle and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want the scope:* lifecycle transitions available in TypeScript, so that vBRIEF promote, activate, complete, and recovery moves run on the TS engine with the same atomic semantics as the Python module."
+    },
+    "items": [
+      {
+        "id": "1726-s1-a1",
+        "title": "atomic transition semantics preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running a scope transition such as promote, activate, or complete updates plan.status and plan.updated and moves the vBRIEF to the matching lifecycle folder atomically."
+        }
+      },
+      {
+        "id": "1726-s1-a2",
+        "title": "undo reversibility preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running scope undo after a non-terminal transition restores the prior status and folder, while undo after a terminal action is rejected."
+        }
+      },
+      {
+        "id": "1726-s1-a3",
+        "title": "audit log entries recorded",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Each transition records an audit-log entry that matches the field shape the Python scope_lifecycle.py module writes."
+        }
+      },
+      {
+        "id": "1726-s1-a4",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the scope-lifecycle parity binary returns exit 0 and renders byte-identical output to the Python scope_lifecycle.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/scope/",
+          "packages/cli/src/scope-lifecycle.ts",
+          "packages/cli/src/scope-lifecycle-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/scope-lifecycle-parity.js",
+          "pnpm --filter @deftai/core test src/scope"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/scope module with vitest unit tests",
+          "New packages/cli/src/scope-lifecycle-parity.ts parity binary",
+          "Byte-identical parity vs scripts/scope_lifecycle.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-scope",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1726 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1726",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1726: feat(ts-migration): port the scope:* lifecycle family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1727-s1-slice-record",
+    "title": "Port the slice:* family (record-existing / list) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port the scripts/slice_record.py family (slice:record-existing and slice:list) to TypeScript, preserving the slices.jsonl cohort-record shape and the record-existing idempotency contract. This story is independently buildable because the slice module is self-contained, reads and writes only the cohort-record file, and ships a golden parity binary against the Python oracle.",
+      "ImplementationPlan": "1. Create the packages/core/src/slice module that ports record-existing and list over the slices.jsonl cohort-record file, preserving field order and idempotency, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/slice-parity.ts parity binary that runs the TS verbs and the Python scripts/slice_record.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the authoritative oracle.",
+      "UserStory": "As a directive maintainer, I want the slice:* cohort-record commands available in TypeScript, so that recording and listing umbrella cohort slices no longer depends on the Python slice_record.py module."
+    },
+    "items": [
+      {
+        "id": "1727-s1-a1",
+        "title": "slice:list reproduces cohort shape",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running slice:list on the TS port returns the recorded cohort entries in the same slices.jsonl shape the Python module produces."
+        }
+      },
+      {
+        "id": "1727-s1-a2",
+        "title": "record-existing is idempotent",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running slice:record-existing twice on a matching umbrella and child set persists exactly one cohort record, preserving idempotency."
+        }
+      },
+      {
+        "id": "1727-s1-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the slice parity binary returns exit 0 and renders byte-identical output to the Python slice_record.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/slice/",
+          "packages/cli/src/slice.ts",
+          "packages/cli/src/slice-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/slice-parity.js",
+          "pnpm --filter @deftai/core test src/slice"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/slice module with vitest unit tests",
+          "New packages/cli/src/slice-parity.ts parity binary",
+          "Byte-identical parity vs scripts/slice_record.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-slice",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1727 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1727",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1727: feat(ts-migration): port the slice:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json
@@ -1,0 +1,91 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1728-s1-cache",
+    "title": "Port the unified content cache (cache.py) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/cache.py (the unified content cache and quarantine: put, get, invalidate, fetch-all, prune, plus TTL handling) to a TypeScript cache module under packages/core. This story is independently buildable because the cache module is self-contained, owns its on-disk cache directory, and ships a golden parity binary against the Python oracle; it is sequenced before the doctor port because the deft doctor cache-fresh probe reads the cache.",
+      "ImplementationPlan": "1. Create the packages/core/src/cache module that ports put, get, invalidate, fetch-all, and prune over the on-disk cache with TTL expiry and the quarantine path, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/cache-parity.ts parity binary that runs the TS cache verbs and the Python scripts/cache.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module stays the authoritative oracle.",
+      "UserStory": "As a directive maintainer, I want the content cache available in TypeScript, so that cache put, get, invalidate, prune, and quarantine run on the TS engine with the same TTL semantics as cache.py."
+    },
+    "items": [
+      {
+        "id": "1728-s1-a1",
+        "title": "put/get honor TTL",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running cache put then get returns the stored entry until its TTL expires, after which get returns a miss."
+        }
+      },
+      {
+        "id": "1728-s1-a2",
+        "title": "invalidate and prune behavior",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running cache invalidate deletes the targeted entry and running prune removes every entry past its TTL."
+        }
+      },
+      {
+        "id": "1728-s1-a3",
+        "title": "quarantine preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "An undecodable or corrupt payload persists to the quarantine path rather than being served, matching the Python cache quarantine behavior."
+        }
+      },
+      {
+        "id": "1728-s1-a4",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the cache parity binary returns exit 0 and renders byte-identical output to the Python cache.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/cache/",
+          "packages/cli/src/cache.ts",
+          "packages/cli/src/cache-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/cache-parity.js",
+          "pnpm --filter @deftai/core test src/cache"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/cache module with vitest unit tests",
+          "New packages/cli/src/cache-parity.ts parity binary",
+          "Byte-identical parity vs scripts/cache.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-cache-doctor",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1728 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1728: feat(ts-migration): port cache + deft doctor to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json
@@ -1,0 +1,89 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 7 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s7-triage-aux-a",
+    "title": "Port triage aux verbs A (welcome / refresh / reconcile / scope-drift) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port the first aux cluster of the triage family (scripts/triage_welcome.py, triage_refresh.py, triage_reconcile.py, and triage_scope_drift.py) to TypeScript, preserving the welcome surface wording, the cache refresh path, the origin reconciliation, and the scope-drift detection. This story is independently buildable because each verb gets its own packages/core/src/triage subdirectory with no overlap with the other triage stories, and it ships a golden parity binary against the Python oracles.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/welcome, refresh, reconcile, and scope-drift modules that port the four Python scripts, with vitest unit tests in each module directory.\n2. Add a packages/cli/src/triage-aux-a-parity.ts parity binary that runs each TS verb and its Python oracle (triage_welcome.py, triage_refresh.py, triage_reconcile.py, triage_scope_drift.py) and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python modules remain the oracles.",
+      "UserStory": "As an operator running session-start triage, I want the welcome, refresh, reconcile, and scope-drift verbs available in TypeScript, so that those triage surfaces run on the TS engine with the same wording as the Python modules."
+    },
+    "items": [
+      {
+        "id": "1725-s7-a1",
+        "title": "welcome and refresh reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:welcome and triage:refresh on the TS port renders the same surface wording and refreshes the cache the same way the Python modules do."
+        }
+      },
+      {
+        "id": "1725-s7-a2",
+        "title": "reconcile and scope-drift reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:reconcile and triage:scope-drift on the TS port returns the same stale origins and scope drift the Python modules report."
+        }
+      },
+      {
+        "id": "1725-s7-a3",
+        "title": "golden parity vs Python oracles",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-aux-a parity binary returns exit 0 and renders byte-identical output to the four Python oracles with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/welcome/",
+          "packages/core/src/triage/refresh/",
+          "packages/core/src/triage/reconcile/",
+          "packages/core/src/triage/scope-drift/",
+          "packages/cli/src/triage-welcome.ts",
+          "packages/cli/src/triage-refresh.ts",
+          "packages/cli/src/triage-reconcile.ts",
+          "packages/cli/src/triage-scope-drift.ts",
+          "packages/cli/src/triage-aux-a-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-aux-a-parity.js",
+          "pnpm --filter @deftai/core test src/triage/welcome"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage welcome, refresh, reconcile, scope-drift modules with vitest unit tests",
+          "New packages/cli/src/triage-aux-a-parity.ts parity binary",
+          "Byte-identical parity vs the four Python triage oracles under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json
@@ -1,0 +1,89 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 8 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s8-triage-aux-b",
+    "title": "Port triage aux verbs B (bulk / subscribe / help / smoketest) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port the second aux cluster of the triage family (scripts/triage_bulk.py, triage_subscribe.py, triage_help.py, and triage_smoketest.py) to TypeScript, preserving the bulk action surface, the subscription handling, the help text, and the smoketest self-check. This story is independently buildable because each verb gets its own packages/core/src/triage subdirectory with no overlap with the other triage stories, and it ships a golden parity binary against the Python oracles.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/bulk, subscribe, help, and smoketest modules that port the four Python scripts, with vitest unit tests in each module directory.\n2. Add a packages/cli/src/triage-aux-b-parity.ts parity binary that runs each TS verb and its Python oracle (triage_bulk.py, triage_subscribe.py, triage_help.py, triage_smoketest.py) and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python modules remain the oracles.",
+      "UserStory": "As an operator using bulk and help triage verbs, I want bulk, subscribe, help, and smoketest available in TypeScript, so that those triage surfaces run on the TS engine with the same output as the Python modules."
+    },
+    "items": [
+      {
+        "id": "1725-s8-a1",
+        "title": "bulk and subscribe reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:bulk and triage:subscribe on the TS port updates candidate state for bulk actions and subscriptions identically to the Python modules."
+        }
+      },
+      {
+        "id": "1725-s8-a2",
+        "title": "help and smoketest reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:help renders the same help text and triage:smoketest returns the same pass or fail verdict the Python modules produce."
+        }
+      },
+      {
+        "id": "1725-s8-a3",
+        "title": "golden parity vs Python oracles",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-aux-b parity binary returns exit 0 and renders byte-identical output to the four Python oracles with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/bulk/",
+          "packages/core/src/triage/subscribe/",
+          "packages/core/src/triage/help/",
+          "packages/core/src/triage/smoketest/",
+          "packages/cli/src/triage-bulk.ts",
+          "packages/cli/src/triage-subscribe.ts",
+          "packages/cli/src/triage-help.ts",
+          "packages/cli/src/triage-smoketest.ts",
+          "packages/cli/src/triage-aux-b-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-aux-b-parity.js",
+          "pnpm --filter @deftai/core test src/triage/bulk"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage bulk, subscribe, help, smoketest modules with vitest unit tests",
+          "New packages/cli/src/triage-aux-b-parity.ts parity binary",
+          "Byte-identical parity vs the four Python triage oracles under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 4 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s4-triage-actions",
+    "title": "Port triage:accept / reject / defer actions to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/triage_actions.py to a TypeScript triage actions module, preserving the accept, reject, and defer transitions and the cache mutations they apply to candidate state. This story is independently buildable in its own packages/core/src/triage/actions subdirectory and ships a golden parity binary against the Python oracle.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/actions module that ports the accept, reject, and defer handlers and their candidate-state cache mutations from triage_actions.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-actions-parity.ts parity binary that runs the TS actions and the Python scripts/triage_actions.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",
+      "UserStory": "As an operator deciding on candidates, I want triage accept, reject, and defer available in TypeScript, so that those transitions run on the TS engine with the same cache effects as the Python module."
+    },
+    "items": [
+      {
+        "id": "1725-s4-a1",
+        "title": "accept/reject/defer transitions run",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:accept, triage:reject, or triage:defer on the TS port updates the candidate state in the cache the same way the Python module does."
+        }
+      },
+      {
+        "id": "1725-s4-a2",
+        "title": "defer records reason and window",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:defer persists the defer reason and suppression window on the candidate, matching the Python module's recorded fields."
+        }
+      },
+      {
+        "id": "1725-s4-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-actions parity binary returns exit 0 and renders byte-identical output to the Python triage_actions.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/actions/",
+          "packages/cli/src/triage-actions.ts",
+          "packages/cli/src/triage-actions-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-actions-parity.js",
+          "pnpm --filter @deftai/core test src/triage/actions"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage/actions module with vitest unit tests",
+          "New packages/cli/src/triage-actions-parity.ts parity binary",
+          "Byte-identical parity vs scripts/triage_actions.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 5 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s5-triage-bootstrap",
+    "title": "Port triage:bootstrap to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/triage_bootstrap.py to a TypeScript triage bootstrap module, preserving the candidate-corpus bootstrap that seeds the triage cache and the watchdog timing safeguards it applies. This story is independently buildable in its own packages/core/src/triage/bootstrap subdirectory and ships a golden parity binary against the Python oracle.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/bootstrap module that ports the cache-seeding bootstrap and its watchdog guards from triage_bootstrap.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-bootstrap-parity.ts parity binary that runs the TS bootstrap and the Python scripts/triage_bootstrap.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",
+      "UserStory": "As an operator setting up triage, I want triage:bootstrap available in TypeScript, so that seeding the triage cache runs on the TS engine with the same candidate corpus as the Python module."
+    },
+    "items": [
+      {
+        "id": "1725-s5-a1",
+        "title": "cache seeded identically",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:bootstrap on the TS port creates a triage cache whose candidate corpus matches the corpus the Python module seeds."
+        }
+      },
+      {
+        "id": "1725-s5-a2",
+        "title": "watchdog guards preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The TS bootstrap fails closed on the same watchdog timeout conditions the Python module enforces rather than seeding a partial cache."
+        }
+      },
+      {
+        "id": "1725-s5-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-bootstrap parity binary returns exit 0 and renders byte-identical output to the Python triage_bootstrap.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/bootstrap/",
+          "packages/cli/src/triage-bootstrap.ts",
+          "packages/cli/src/triage-bootstrap-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-bootstrap-parity.js",
+          "pnpm --filter @deftai/core test src/triage/bootstrap"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage/bootstrap module with vitest unit tests",
+          "New packages/cli/src/triage-bootstrap-parity.ts parity binary",
+          "Byte-identical parity vs scripts/triage_bootstrap.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triageclassify-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triageclassify-to-typescript.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s3-triage-classify",
+    "title": "Port triage:classify to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/triage_classify.py to a TypeScript triage classify module, preserving the candidate classification logic (resume, orphan, urgent, and label-derived buckets) that feeds the queue ranking. This story is independently buildable in its own packages/core/src/triage/classify subdirectory and ships a golden parity binary against the Python oracle.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/classify module that ports the classification rules and bucket assignment from triage_classify.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-classify-parity.ts parity binary that runs the TS classifier and the Python scripts/triage_classify.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",
+      "UserStory": "As an operator triaging candidates, I want triage:classify available in TypeScript, so that candidate classification runs on the TS engine with the same buckets as the Python module."
+    },
+    "items": [
+      {
+        "id": "1725-s3-a1",
+        "title": "classification buckets reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:classify on the TS port returns the same classification bucket for each candidate that the Python module assigns."
+        }
+      },
+      {
+        "id": "1725-s3-a2",
+        "title": "label-derived rules preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The TS classifier validates label-derived classifications identically to the Python module across the fixture corpus."
+        }
+      },
+      {
+        "id": "1725-s3-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-classify parity binary returns exit 0 and renders byte-identical output to the Python triage_classify.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/classify/",
+          "packages/cli/src/triage-classify.ts",
+          "packages/cli/src/triage-classify-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-classify-parity.js",
+          "pnpm --filter @deftai/core test src/triage/classify"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage/classify module with vitest unit tests",
+          "New packages/cli/src/triage-classify-parity.ts parity binary",
+          "Byte-identical parity vs scripts/triage_classify.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s1-triage-queue",
+    "title": "Port triage:queue (ranking + RESUME/ORPHAN/URGENT order) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/triage_queue.py to a TypeScript triage queue module, preserving the candidate ranking order and the [RESUME], [ORPHAN], and [URGENT] classification tags exactly. This is the highest-risk triage slice because the ranking order is observable in operator output, so it ships a golden parity binary; it is independently buildable in its own packages/core/src/triage/queue subdirectory.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/queue module that ports the candidate ranking comparator and the RESUME/ORPHAN/URGENT tagging from triage_queue.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-queue-parity.ts parity binary that runs the TS queue and the Python scripts/triage_queue.py oracle and asserts byte-identical ranked output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the authoritative oracle.",
+      "UserStory": "As an operator asking what to work on next, I want triage:queue available in TypeScript, so that the ranked work queue and its RESUME/ORPHAN/URGENT tags come from the TS engine with the same order as the Python module."
+    },
+    "items": [
+      {
+        "id": "1725-s1-a1",
+        "title": "ranking order preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:queue on the TS port returns candidates in the same ranked order the Python module produces for an identical cache."
+        }
+      },
+      {
+        "id": "1725-s1-a2",
+        "title": "classification tags reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The TS queue renders the [RESUME], [ORPHAN], and [URGENT] tags on the same candidates the Python module tags."
+        }
+      },
+      {
+        "id": "1725-s1-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-queue parity binary returns exit 0 and renders byte-identical output to the Python triage_queue.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/queue/",
+          "packages/cli/src/triage-queue.ts",
+          "packages/cli/src/triage-queue-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-queue-parity.js",
+          "pnpm --filter @deftai/core test src/triage/queue"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage/queue module with vitest unit tests",
+          "New packages/cli/src/triage-queue-parity.ts parity binary",
+          "Byte-identical parity vs scripts/triage_queue.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triagescope-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagescope-to-typescript.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 6 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s6-triage-scope",
+    "title": "Port triage:scope to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/triage_scope.py to a TypeScript triage scope module, preserving the triageScope configuration resolution and the scope-membership decisions that gate which candidates appear in the queue. This story is independently buildable in its own packages/core/src/triage/scope subdirectory and ships a golden parity binary against the Python oracle.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/scope module that ports the triageScope resolution and scope-membership predicate from triage_scope.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-scope-parity.ts parity binary that runs the TS scope and the Python scripts/triage_scope.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",
+      "UserStory": "As an operator scoping triage, I want triage:scope available in TypeScript, so that scope-membership decisions run on the TS engine with the same configuration resolution as the Python module."
+    },
+    "items": [
+      {
+        "id": "1725-s6-a1",
+        "title": "scope membership reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:scope on the TS port returns the same in-scope and out-of-scope decision per candidate that the Python module returns."
+        }
+      },
+      {
+        "id": "1725-s6-a2",
+        "title": "configured vs default scope distinguished",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The TS scope module emits the configured-versus-not-configured wording for triageScope exactly as the Python module distinguishes them."
+        }
+      },
+      {
+        "id": "1725-s6-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-scope parity binary returns exit 0 and renders byte-identical output to the Python triage_scope.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/scope/",
+          "packages/cli/src/triage-scope.ts",
+          "packages/cli/src/triage-scope-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-scope-parity.js",
+          "pnpm --filter @deftai/core test src/triage/scope"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage/scope module with vitest unit tests",
+          "New packages/cli/src/triage-scope-parity.ts parity binary",
+          "Byte-identical parity vs scripts/triage_scope.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json"
+  },
+  "plan": {
+    "id": "1725-s2-triage-summary",
+    "title": "Port triage:summary (welcome one-liner) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/triage_summary.py to a TypeScript triage summary module, preserving the triage-cache one-line headline and the in-flight count plus scope-gap wording the welcome surface emits. This story is independently buildable in its own packages/core/src/triage/summary subdirectory and ships a golden parity binary against the Python oracle.",
+      "ImplementationPlan": "1. Create the packages/core/src/triage/summary module that ports the headline composition, the filesystem-truth in-flight count, and the scope-gap line from triage_summary.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-summary-parity.ts parity binary that runs the TS summary and the Python scripts/triage_summary.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",
+      "UserStory": "As an operator starting a session, I want triage:summary available in TypeScript, so that the one-line triage headline and in-flight count come from the TS engine with the same wording as the Python module."
+    },
+    "items": [
+      {
+        "id": "1725-s2-a1",
+        "title": "headline wording reproduced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running triage:summary on the TS port renders the same one-line headline text the Python module emits for an identical cache."
+        }
+      },
+      {
+        "id": "1725-s2-a2",
+        "title": "in-flight count is filesystem-truth",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The TS summary returns the in-flight count from a live count of running active vBRIEFs, matching the Python filesystem-truth count."
+        }
+      },
+      {
+        "id": "1725-s2-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the triage-summary parity binary returns exit 0 and renders byte-identical output to the Python triage_summary.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/summary/",
+          "packages/cli/src/triage-summary.ts",
+          "packages/cli/src/triage-summary-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/triage-summary-parity.js",
+          "pnpm --filter @deftai/core test src/triage/summary"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/triage/summary module with vitest unit tests",
+          "New packages/cli/src/triage-summary-parity.ts parity binary",
+          "Byte-identical parity vs scripts/triage_summary.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave3-triage",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "#1530 Wave-3 framework-internal TS port traced to GitHub issue #1725 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1725: feat(ts-migration): port the triage:* family to TS (Wave 3)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1724",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1724"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Decomposes the five #1530 **Wave-3** family issues into **13 swarm-ready story vBRIEFs** so the verb-family ports can be allocated to the swarm in micro-waves.

- **Ingested** #1724 (scm adapter), #1725 (triage), #1726 (scope lifecycle), #1727 (slice), #1728 (cache+doctor) as scope vBRIEFs.
- **Decomposed** into 13 stories under `vbrief/proposed/` (backlog):
  - **3a foundation:** `1724-s1-scm-adapter` (blocks all of 3b — every 3b module imports `@deftai/core/scm`).
  - **3b leaves:** 8 triage verbs (queue, summary, classify, actions, bootstrap, scope, aux-a, aux-b), `1726-s1-scope-lifecycle`, `1727-s1-slice-record`, `1728-s1-cache`, `1728-s2-doctor` (doctor `depends_on` cache).
- All 13 pass `task swarm:readiness` (0 blocked, 0 file overlap, 0 missing fields).
- Each leaf scopes only its own `packages/core/src/<module>/` + CLI/parity files; shared wiring stays a per-micro-wave integration step (same pattern as the Wave-2 Integration PR).
- Stories stay in `proposed/` as backlog and are promoted/activated in 3a→3b batches within the default `wipCap` of 10 (the cap is pinned for deft's own repo per #1186).

No code changes — planning artifacts only.

## Test plan

- [x] `task scope:decompose ... --check` validates all 5 drafts
- [x] `task swarm:readiness` reports all 13 ready
- [x] `task vbrief:validate` + `verify:vbrief-conformance` clean (ref integrity)
- [x] `task check` green

Refs #1530

Made with [Cursor](https://cursor.com)