### PR TITLE
chore(vbrief): repair Wave-3 swarm planning

### DIFF
--- a/vbrief/proposed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json
@@ -14,7 +14,7 @@
     },
     "items": [
       {
-        "title": "-equivalent TS adapter preserves the ghx->gh ladder and source abstraction",
+        "title": "`scm.call`-equivalent TS adapter preserves the ghx->gh ladder and source abstraction",
         "status": "proposed"
       },
       {
@@ -26,7 +26,7 @@
         "status": "proposed"
       },
       {
-        "title": "passes",
+        "title": "`task check` passes",
         "status": "proposed"
       }
     ],

--- a/vbrief/proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json
@@ -14,11 +14,11 @@
     },
     "items": [
       {
-        "title": "/  and the accept/reject/defer surface run on TS",
+        "title": "`triage:summary` / `triage:queue` and the accept/reject/defer surface run on TS",
         "status": "proposed"
       },
       {
-        "title": "Queue ranking + // ordering reproduced",
+        "title": "Queue ranking + `[RESUME]`/`[ORPHAN]`/`[URGENT]` ordering reproduced",
         "status": "proposed"
       },
       {
@@ -26,7 +26,7 @@
         "status": "proposed"
       },
       {
-        "title": "passes",
+        "title": "`task check` passes",
         "status": "proposed"
       }
     ],

--- a/vbrief/proposed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json
@@ -14,11 +14,11 @@
     },
     "items": [
       {
-        "title": "All  transitions run on TS with atomic status+timestamp+folder-move semantics",
+        "title": "All `scope:*` transitions run on TS with atomic status+timestamp+folder-move semantics",
         "status": "proposed"
       },
       {
-        "title": "reversibility preserved (terminal actions refused)",
+        "title": "`scope:undo` reversibility preserved (terminal actions refused)",
         "status": "proposed"
       },
       {
@@ -26,7 +26,7 @@
         "status": "proposed"
       },
       {
-        "title": "passes",
+        "title": "`task check` passes",
         "status": "proposed"
       }
     ],

--- a/vbrief/proposed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json
@@ -14,7 +14,7 @@
     },
     "items": [
       {
-        "title": "/  run on TS with the cohort-record shape preserved",
+        "title": "`slice:record-existing` / `slice:list` run on TS with the cohort-record shape preserved",
         "status": "proposed"
       },
       {
@@ -26,7 +26,7 @@
         "status": "proposed"
       },
       {
-        "title": "passes",
+        "title": "`task check` passes",
         "status": "proposed"
       }
     ],

--- a/vbrief/proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json
@@ -14,11 +14,11 @@
     },
     "items": [
       {
-        "title": "verbs run on TS with TTL/quarantine semantics preserved",
+        "title": "`cache:*` verbs run on TS with TTL/quarantine semantics preserved",
         "status": "proposed"
       },
       {
-        "title": "reproduces the install-integrity / toolchain / freshness probes",
+        "title": "`deft doctor` reproduces the install-integrity / toolchain / freshness probes",
         "status": "proposed"
       },
       {
@@ -26,7 +26,7 @@
         "status": "proposed"
       },
       {
-        "title": "passes",
+        "title": "`task check` passes",
         "status": "proposed"
       }
     ],

--- a/vbrief/proposed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json
@@ -67,6 +67,7 @@
           "Byte-identical parity vs scripts/doctor.py under cache-off"
         ],
         "depends_on": [
+          "1724-s1-scm-adapter",
           "1728-s1-cache"
         ],
         "conflict_group": "ts-wave3-cache-doctor",

--- a/vbrief/proposed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json
@@ -66,7 +66,9 @@
           "New packages/cli/src/scope-lifecycle-parity.ts parity binary",
           "Byte-identical parity vs scripts/scope_lifecycle.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-scope",
         "size": "L",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json
@@ -58,7 +58,9 @@
           "New packages/cli/src/slice-parity.ts parity binary",
           "Byte-identical parity vs scripts/slice_record.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-slice",
         "size": "M",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json
@@ -66,7 +66,9 @@
           "New packages/cli/src/cache-parity.ts parity binary",
           "Byte-identical parity vs scripts/cache.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-cache-doctor",
         "size": "M",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json
@@ -64,7 +64,9 @@
           "New packages/cli/src/triage-aux-a-parity.ts parity binary",
           "Byte-identical parity vs the four Python triage oracles under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "L",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json
@@ -64,7 +64,9 @@
           "New packages/cli/src/triage-aux-b-parity.ts parity binary",
           "Byte-identical parity vs the four Python triage oracles under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "L",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json
@@ -58,7 +58,9 @@
           "New packages/cli/src/triage-actions-parity.ts parity binary",
           "Byte-identical parity vs scripts/triage_actions.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "M",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json
@@ -58,7 +58,9 @@
           "New packages/cli/src/triage-bootstrap-parity.ts parity binary",
           "Byte-identical parity vs scripts/triage_bootstrap.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "L",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triageclassify-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triageclassify-to-typescript.vbrief.json
@@ -58,7 +58,9 @@
           "New packages/cli/src/triage-classify-parity.ts parity binary",
           "Byte-identical parity vs scripts/triage_classify.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "M",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json
@@ -58,7 +58,9 @@
           "New packages/cli/src/triage-queue-parity.ts parity binary",
           "Byte-identical parity vs scripts/triage_queue.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "L",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triagescope-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagescope-to-typescript.vbrief.json
@@ -58,7 +58,9 @@
           "New packages/cli/src/triage-scope-parity.ts parity binary",
           "Byte-identical parity vs scripts/triage_scope.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "M",
         "file_scope_confidence": "high",

--- a/vbrief/proposed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json
@@ -58,7 +58,9 @@
           "New packages/cli/src/triage-summary-parity.ts parity binary",
           "Byte-identical parity vs scripts/triage_summary.py under cache-off"
         ],
-        "depends_on": [],
+        "depends_on": [
+          "1724-s1-scm-adapter"
+        ],
         "conflict_group": "ts-wave3-triage",
         "size": "M",
         "file_scope_confidence": "high",


### PR DESCRIPTION
## Summary

Repairs the Wave-3 planning artifacts merged in #1744 so the next #1530 swarm allocation has clean machine-readable inputs.

- Restores backtick-delimited acceptance-title text in the five Wave-3 scope vBRIEFs (#1724-#1728), matching the preserved Overview acceptance criteria.
- Adds  to the  list for every Wave-3b story so Swarm readiness report

No candidate vBRIEFs found. produces the intended 3a -> 3b -> doctor sequencing.
- Preserves the existing  ->  dependency.

This stays outside the #1710 frozen engine paths: vBRIEF planning data only.

## Test plan

- [x] OK: vBRIEF validation passed: 669 scope vBRIEF(s), PROJECT-DEFINITION
- [x] Swarm readiness report

Ready stories:
- 1728-s2-doctor: Port deft doctor (doctor.py) to TypeScript (vbrief/proposed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json)
- 1724-s1-scm-adapter: Port the scm.py SCM boundary to a TypeScript adapter (vbrief/proposed/2026-06-19-port-the-scmpy-scm-boundary-to-a-typescript-adapter.vbrief.json)
- 1726-s1-scope-lifecycle: Port the scope:* lifecycle family to TypeScript (vbrief/proposed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json)
- 1727-s1-slice-record: Port the slice:* family (record-existing / list) to TypeScript (vbrief/proposed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json)
- 1728-s1-cache: Port the unified content cache (cache.py) to TypeScript (vbrief/proposed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json)
- 1725-s7-triage-aux-a: Port triage aux verbs A (welcome / refresh / reconcile / scope-drift) to TypeScript (vbrief/proposed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json)
- 1725-s8-triage-aux-b: Port triage aux verbs B (bulk / subscribe / help / smoketest) to TypeScript (vbrief/proposed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json)
- 1725-s4-triage-actions: Port triage:accept / reject / defer actions to TypeScript (vbrief/proposed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json)
- 1725-s5-triage-bootstrap: Port triage:bootstrap to TypeScript (vbrief/proposed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json)
- 1725-s3-triage-classify: Port triage:classify to TypeScript (vbrief/proposed/2026-06-19-port-triageclassify-to-typescript.vbrief.json)
- 1725-s1-triage-queue: Port triage:queue (ranking + RESUME/ORPHAN/URGENT order) to TypeScript (vbrief/proposed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json)
- 1725-s6-triage-scope: Port triage:scope to TypeScript (vbrief/proposed/2026-06-19-port-triagescope-to-typescript.vbrief.json)
- 1725-s2-triage-summary: Port triage:summary (welcome one-liner) to TypeScript (vbrief/proposed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json)

Blocked stories:
- none

Decomposition-needed epics/phases:
- none

Dependency waves:
- wave 1: 1724-s1-scm-adapter
- wave 2: 1725-s1-triage-queue, 1725-s2-triage-summary, 1725-s3-triage-classify, 1725-s4-triage-actions, 1725-s5-triage-bootstrap, 1725-s6-triage-scope, 1725-s7-triage-aux-a, 1725-s8-triage-aux-b, 1726-s1-scope-lifecycle, 1727-s1-slice-record, 1728-s1-cache
- wave 3: 1728-s2-doctor

Conflict groups:
- ts-wave3-cache-doctor: 1728-s1-cache, 1728-s2-doctor
- ts-wave3-scm: 1724-s1-scm-adapter
- ts-wave3-scope: 1726-s1-scope-lifecycle
- ts-wave3-slice: 1727-s1-slice-record
- ts-wave3-triage: 1725-s1-triage-queue, 1725-s2-triage-summary, 1725-s3-triage-classify, 1725-s4-triage-actions, 1725-s5-triage-bootstrap, 1725-s6-triage-scope, 1725-s7-triage-aux-a, 1725-s8-triage-aux-b

File overlap matrix:
- none

Missing fields:
- none
- [x] All checks passed!
tests/cli/test_resolve_changelog_unreleased.py:721: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_resolve_changelog_unreleased.py:730: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_reconcile_issues_754.py:405: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_reconcile_issues.py:292: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_reconcile_issues.py:301: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_reconcile_issues.py:472: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_pr_merge_readiness_fallbacks.py:574: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_pr_check_closing_keywords.py:203: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief_canonical_refs.py:165: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_issue_ingest_canonical_refs.py:243: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_upgrade_gate.py:80: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:129: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:135: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:146: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:147: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:151: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:153: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:164: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:189: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_vbrief_validation.py:204: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cmd_gate/test_state_detection.py:279: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cmd_gate/test_state_detection.py:316: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cmd_gate/test_case_k.py:492: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cmd_gate/test_case_k.py:527: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_vbrief_lifecycle.py:303: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_upgrade_banner.py:266: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_upgrade_banner.py:292: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_subprocess_path.py:205: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_subprocess_path.py:306: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_subprocess_path.py:422: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_rollback.py:566: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_publish.py:551: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_publish.py:876: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_publish.py:911: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_publish.py:933: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_e2e.py:732: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_e2e.py:875: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_e2e.py:918: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_e2e.py:945: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_branch_gate.py:188: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release_branch_gate.py:436: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release.py:653: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release.py:1190: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release.py:1384: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release.py:1416: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release.py:1455: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release.py:1456: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_release.py:1559: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_preflight_implementation.py:313: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_preflight_implementation.py:340: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_preflight_implementation.py:367: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_preflight_cache.py:1277: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_pr_wait_mergeable.py:579: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief_fixtures.py:52: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief_fixtures.py:64: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief_fixtures.py:77: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief_fixtures.py:92: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief_fixtures.py:113: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief_fixtures.py:137: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_migrate_vbrief.py:2511: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_issue_emit.py:68: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_hooks_encoding.py:149: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_github_auth_modes.py:85: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_framework_doctor_prose.py:460: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_framework_doctor_prose.py:511: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_framework_doctor_prose.py:548: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_framework_doctor_prose.py:592: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_cmd_doctor.py:694: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_ci_local.py:322: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_ci_local.py:331: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_ci_local.py:346: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_ci_local.py:368: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_ci_local.py:378: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_ci_local.py:393: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/cli/test_ci_local.py:510: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 292 source files
============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/davidcall/tools/deft/directive-freeze-help
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.0.0
collected 8450 items / 9 deselected / 8441 selected

tests/cli/test_agents_md_module.py ..........                            [  0%]
tests/cli/test_behavioral_events.py .................................    [  0%]
tests/cli/test_bootstrap.py ......                                       [  0%]
tests/cli/test_build_dist.py ..................................          [  0%]
tests/cli/test_capacity_backfill.py .....................                [  1%]
tests/cli/test_capacity_show.py ........................                 [  1%]
tests/cli/test_ci_local.py ............................................. [  2%]
..                                                                       [  2%]
tests/cli/test_cmd_agents_refresh.py .....................               [  2%]
tests/cli/test_cmd_check_updates.py .............................        [  2%]
tests/cli/test_cmd_doctor.py .......................                     [  2%]
tests/cli/test_cmd_gate.py ...................                           [  3%]
tests/cli/test_cmd_spec.py ..........                                    [  3%]
tests/cli/test_code_structure_validate.py .......................        [  3%]
tests/cli/test_codebase_default_extractor.py ....                        [  3%]
tests/cli/test_codebase_projection_registry.py ....                      [  3%]
tests/cli/test_codebase_provider.py .............                        [  3%]
tests/cli/test_doctor.py ..                                              [  3%]
tests/cli/test_doctor_locate_manifest.py ..................              [  4%]
tests/cli/test_doctor_payload_staleness.py ...                           [  4%]
tests/cli/test_doctor_throttle.py ....................                   [  4%]
tests/cli/test_events.py .................                               [  4%]
tests/cli/test_framework_commands.py ........                            [  4%]
tests/cli/test_framework_doctor.py ............................          [  4%]
tests/cli/test_framework_doctor_prose.py ..............                  [  5%]
tests/cli/test_gh_rest.py .............................................. [  5%]
...............................                                          [  6%]
tests/cli/test_github_auth_modes.py ..................                   [  6%]
tests/cli/test_hooks_encoding.py .....                                   [  6%]
tests/cli/test_import_smoke.py .....                                     [  6%]
tests/cli/test_ingest_filters.py ..............                          [  6%]
tests/cli/test_install_manifest_root.py ..............                   [  6%]
tests/cli/test_issue_emit.py .................................           [  7%]
tests/cli/test_issue_ingest.py ............                              [  7%]
tests/cli/test_issue_ingest_body_parsing.py ..................           [  7%]
tests/cli/test_issue_ingest_canonical_refs.py ......                     [  7%]
tests/cli/test_issue_ingest_direct.py .................................. [  7%]
..................                                                       [  8%]
tests/cli/test_issue_ingest_escape_corruption.py ..                      [  8%]
tests/cli/test_lifecycle_task_exit_semantics.py .                        [  8%]
tests/cli/test_loop_bugs.py ...                                          [  8%]
tests/cli/test_managed_section_v3.py ......................              [  8%]
tests/cli/test_migrate_preflight.py .........................            [  8%]
tests/cli/test_migrate_vbrief.py ....................................... [  9%]
........................................................................ [ 10%]
........................................................................ [ 10%]
......................                                                   [ 11%]
tests/cli/test_migrate_vbrief_canonical_refs.py ..........               [ 11%]
tests/cli/test_migrate_vbrief_fixtures.py .............................. [ 11%]
..................                                                       [ 11%]
tests/cli/test_migrate_vbrief_rc4.py ..............................      [ 12%]
tests/cli/test_mypy_scope_parity.py .....                                [ 12%]
tests/cli/test_pack_migrate_patterns.py ..............                   [ 12%]
tests/cli/test_pack_migrate_rules.py .....................               [ 12%]
tests/cli/test_pack_migrate_strategies.py ...................            [ 12%]
tests/cli/test_pack_migrate_swarm_spec.py .............                  [ 13%]
tests/cli/test_pack_render.py .......................................... [ 13%]
...................                                                      [ 13%]
tests/cli/test_packs_slice.py .......................................... [ 14%]
......................................                                   [ 14%]
tests/cli/test_platform_capabilities.py ...............                  [ 14%]
tests/cli/test_policy.py ............................................... [ 15%]
.....................................................................    [ 16%]
tests/cli/test_policy_set.py ........                                    [ 16%]
tests/cli/test_pr_check_closing_keywords.py ........................     [ 16%]
tests/cli/test_pr_check_protected_issues.py .........................    [ 16%]
tests/cli/test_pr_merge_readiness.py ................................... [ 17%]
.....                                                                    [ 17%]
tests/cli/test_pr_merge_readiness_fallbacks.py ......................... [ 17%]
....                                                                     [ 17%]
tests/cli/test_pr_wait_mergeable.py .......................              [ 18%]
tests/cli/test_prd_render.py .........                                   [ 18%]
tests/cli/test_precutover_guard.py ..................................... [ 18%]
...                                                                      [ 18%]
tests/cli/test_preflight_architecture_sor.py ...............             [ 18%]
tests/cli/test_preflight_branch.py ................                      [ 19%]
tests/cli/test_preflight_cache.py ...................................... [ 19%]
..............                                                           [ 19%]
tests/cli/test_preflight_gh.py ......................................... [ 20%]
...................................                                      [ 20%]
tests/cli/test_preflight_implementation.py ............................. [ 20%]
...s                                                                     [ 20%]
tests/cli/test_preflight_story_start.py ................................ [ 21%]
................                                                         [ 21%]
tests/cli/test_probe_session.py ........                                 [ 21%]
tests/cli/test_project.py ..........                                     [ 21%]
tests/cli/test_project_context.py ..................s..                  [ 21%]
tests/cli/test_project_render.py .........................               [ 22%]
tests/cli/test_project_user_defaults.py ......                           [ 22%]
tests/cli/test_reconcile_issues.py ..................................... [ 22%]
....................                                                     [ 22%]
tests/cli/test_reconcile_issues_754.py .............                     [ 23%]
tests/cli/test_reconcile_issues_apply.py ...........                     [ 23%]
tests/cli/test_reconcile_issues_direct.py .....................          [ 23%]
tests/cli/test_release.py .............................................. [ 24%]
........................................                                 [ 24%]
tests/cli/test_release_branch_gate.py .................                  [ 24%]
tests/cli/test_release_e2e.py .......................................... [ 25%]
...                                                                      [ 25%]
tests/cli/test_release_prerelease.py ...............                     [ 25%]
tests/cli/test_release_publish.py .....................................  [ 25%]
tests/cli/test_release_pyproject_sync.py ............................... [ 26%]
.                                                                        [ 26%]
tests/cli/test_release_rollback.py ..................................... [ 26%]
...................                                                      [ 26%]
tests/cli/test_release_rollback_725.py ...........                       [ 27%]
tests/cli/test_release_skip_flags.py .....                               [ 27%]
tests/cli/test_release_subprocess_path.py ...........................    [ 27%]
tests/cli/test_release_summary.py ..........                             [ 27%]
tests/cli/test_release_tag_availability.py ...............               [ 27%]
tests/cli/test_release_upgrade_banner.py ..........                      [ 27%]
tests/cli/test_release_vbrief_lifecycle.py ...............               [ 28%]
tests/cli/test_remote_probe_throttle.py ................                 [ 28%]
tests/cli/test_resolve_changelog_unreleased.py ......................... [ 28%]
.............................                                            [ 28%]
tests/cli/test_resolve_version.py ...................................... [ 29%]
...............................................                          [ 29%]
tests/cli/test_resume.py ..............                                  [ 30%]
tests/cli/test_roadmap_render.py ....................................... [ 30%]
...............                                                          [ 30%]
tests/cli/test_rule_ownership_lint.py .........................          [ 30%]
tests/cli/test_run_bat_path.py ss                                        [ 30%]
tests/cli/test_run_version.py ..........................                 [ 31%]
tests/cli/test_safe_subprocess.py ................                       [ 31%]
tests/cli/test_scope_decompose.py ............................           [ 31%]
tests/cli/test_scope_decompose_unit.py ................................. [ 32%]
.........................................................                [ 32%]
tests/cli/test_scope_demote.py ...................                       [ 33%]
tests/cli/test_scope_lifecycle.py ...................................... [ 33%]
..............................                                           [ 33%]
tests/cli/test_scope_undo.py .................                           [ 34%]
tests/cli/test_session_start.py ............                             [ 34%]
tests/cli/test_setup_ghx.py ......................................       [ 34%]
tests/cli/test_spec.py ......................................            [ 35%]
tests/cli/test_spec_render.py ..............                             [ 35%]
tests/cli/test_spec_sizing.py .........................                  [ 35%]
tests/cli/test_subagent_monitor.py .......................               [ 35%]
tests/cli/test_swarm_complete_cohort.py .................                [ 36%]
tests/cli/test_swarm_launch.py ......................................... [ 36%]
................                                                         [ 36%]
tests/cli/test_swarm_readiness.py .................................      [ 37%]
tests/cli/test_swarm_verify_review_clean.py ..............               [ 37%]
tests/cli/test_swarm_worktrees.py ..........................             [ 37%]
tests/cli/test_task_scripts.py ....................................      [ 38%]
tests/cli/test_triage_queue.py ......................................... [ 38%]
..............................                                           [ 38%]
tests/cli/test_upgrade_gate.py ...........................               [ 39%]
tests/cli/test_upgrade_gate_remote_drift.py ........                     [ 39%]
tests/cli/test_usermd_gate.py .........                                  [ 39%]
tests/cli/test_validate.py ..                                            [ 39%]
tests/cli/test_validate_strategy_output.py ..........                    [ 39%]
tests/cli/test_vbrief_activate.py ..............                         [ 39%]
tests/cli/test_vbrief_fidelity_legacy.py ............................... [ 40%]
...............                                                          [ 40%]
tests/cli/test_vbrief_migrate_conformance.py ................            [ 40%]
tests/cli/test_vbrief_preflight_resolver.py .................            [ 40%]
tests/cli/test_vbrief_reconcile_graph.py ...........................     [ 40%]
tests/cli/test_vbrief_reconcile_labels.py .............................. [ 41%]
....                                                                     [ 41%]
tests/cli/test_vbrief_reconcile_umbrellas.py ........................... [ 41%]
...............                                                          [ 41%]
tests/cli/test_vbrief_reconciliation.py ...............................  [ 42%]
tests/cli/test_vbrief_routing.py ...............................         [ 42%]
tests/cli/test_vbrief_validate.py ...................................... [ 43%]
.............                                                            [ 43%]
tests/cli/test_vbrief_validate_direct.py ............................... [ 43%]
...........................                                              [ 43%]
tests/cli/test_vbrief_validate_direct_orchestration.py ................. [ 44%]
..................                                                       [ 44%]
tests/cli/test_vbrief_validate_issue_536.py ...................          [ 44%]
tests/cli/test_vbrief_validation.py .................................... [ 44%]
.                                                                        [ 44%]
tests/cli/test_vendored_install_metadata.py ........................     [ 45%]
tests/cli/test_verify_capacity.py ......                                 [ 45%]
tests/cli/test_verify_encoding.py ...................................... [ 45%]
..............                                                           [ 45%]
tests/cli/test_verify_hooks_installed.py .............                   [ 46%]
tests/cli/test_verify_investigation.py ....................              [ 46%]
tests/cli/test_verify_judgment_gates.py ........................         [ 46%]
tests/cli/test_verify_no_task_runtime.py ...                             [ 46%]
tests/cli/test_verify_scm_boundary.py ...........................        [ 46%]
tests/cli/test_verify_session_ritual.py ..........................       [ 47%]
tests/cli/test_verify_tools.py .........                                 [ 47%]
tests/cli/test_verify_vbrief_conformance.py ................             [ 47%]
tests/cmd_gate/test_case_k.py ............................               [ 47%]
tests/cmd_gate/test_state_detection.py ............................      [ 48%]
tests/content/test_500_discoverability.py ..................             [ 48%]
tests/content/test_agent_prompt_preamble_template.py ................... [ 48%]
.......                                                                  [ 48%]
tests/content/test_agents_entry_contract.py ....................         [ 49%]
tests/content/test_agents_md.py ..............                           [ 49%]
tests/content/test_agents_md_current_shape.py ....................       [ 49%]
tests/content/test_agents_md_preamble.py .........                       [ 49%]
tests/content/test_agents_md_session_start.py ................           [ 49%]
tests/content/test_allocation_context_schema.py ..............           [ 49%]
tests/content/test_allocation_context_skills.py ........................ [ 50%]
........                                                                 [ 50%]
tests/content/test_branch_gate.py .............                          [ 50%]
tests/content/test_change_and_skills.py .................                [ 50%]
tests/content/test_code_structure_profile.py ....                        [ 50%]
tests/content/test_coding_rules.py ................                      [ 50%]
tests/content/test_consumer_config_example.py .......................... [ 51%]
                                                                         [ 51%]
tests/content/test_contracts.py ........................................ [ 51%]
........................................................................ [ 52%]
........................................................................ [ 53%]
........................................................................ [ 54%]
........................................................................ [ 55%]
..............                                                           [ 55%]
tests/content/test_cost_phase.py ..................................      [ 55%]
tests/content/test_debugging.py .........................                [ 55%]
tests/content/test_decomposition_readiness.py ......                     [ 55%]
tests/content/test_deprecated_skill_redirects.py ....................... [ 56%]
............................                                             [ 56%]
tests/content/test_deterministic_questions.py ...............            [ 56%]
tests/content/test_emit_hints.py ............................            [ 57%]
tests/content/test_glossary.py ........                                  [ 57%]
tests/content/test_install_oneliner.py ........                          [ 57%]
tests/content/test_interview_always_structured.py .....................  [ 57%]
tests/content/test_interview_click_commit.py ..................          [ 57%]
tests/content/test_interview_deterministic.py ........................   [ 58%]
tests/content/test_ip_risk_skill.py ....................                 [ 58%]
tests/content/test_issue_creation_label_guidance.py .....                [ 58%]
tests/content/test_machine_generated_banner.py .......                   [ 58%]
tests/content/test_main_guidance.py ......................               [ 58%]
tests/content/test_main_md_preamble.py ................                  [ 58%]
tests/content/test_mermaid_guidance.py ..                                [ 58%]
tests/content/test_patterns_executor_layer_credentials.py .............. [ 59%]
.........                                                                [ 59%]
tests/content/test_patterns_llm_app.py .........................         [ 59%]
tests/content/test_patterns_prompt_assembly.py ........................  [ 59%]
tests/content/test_patterns_role_as_overlay.py ......................... [ 60%]
........                                                                 [ 60%]
tests/content/test_phase3_export_prompt.py .......                       [ 60%]
tests/content/test_plain_english_ux.py ...........................       [ 60%]
tests/content/test_pre_pr_skill_closing_keyword_rule.py ....             [ 60%]
tests/content/test_probe_skill.py ...............                        [ 60%]
tests/content/test_pyproject_version_freshness.py ....                   [ 60%]
tests/content/test_quickstart_combined_remediation.py .......            [ 60%]
tests/content/test_readme_brownfield.py ...............                  [ 61%]
tests/content/test_refinement_skill.py ...............                   [ 61%]
tests/content/test_release_workflow.py ..........                        [ 61%]
tests/content/test_review_cycle_skill.py ...................             [ 61%]
tests/content/test_security_extensions.py ...........                    [ 61%]
tests/content/test_security_standards.py ...............                 [ 61%]
tests/content/test_setup_swarm_bridge.py ............................... [ 62%]
......                                                                   [ 62%]
tests/content/test_shape.py ............................................ [ 62%]
....                                                                     [ 62%]
tests/content/test_skill_frontmatter.py s........                        [ 63%]
tests/content/test_skills.py ........................................... [ 63%]
........................................................................ [ 64%]
...................................................................      [ 65%]
tests/content/test_skills_preflight_call.py ....                         [ 65%]
tests/content/test_speckit_phase3_gate.py ........                       [ 65%]
tests/content/test_speckit_phase4.py ....................                [ 65%]
tests/content/test_standards.py ........................................ [ 66%]
........................................................................ [ 66%]
........................................................................ [ 67%]
........................................................................ [ 68%]
........................................................................ [ 69%]
........................................................................ [ 70%]
........................................................................ [ 71%]
........................................................................ [ 71%]
........................................................................ [ 72%]
........................................................................ [ 73%]
............................                                             [ 74%]
tests/content/test_story_start_gate.py ..........                        [ 74%]
tests/content/test_strategy_chaining.py .......................          [ 74%]
tests/content/test_strategy_conversions.py ................              [ 74%]
tests/content/test_strategy_outputs.py .....................             [ 74%]
tests/content/test_strategy_vbrief.py ...........                        [ 74%]
tests/content/test_structure.py ........................................ [ 75%]
.                                                                        [ 75%]
tests/content/test_swarm_headless_launch.py ............................ [ 75%]
.............................                                            [ 76%]
tests/content/test_swarm_poller_template.py ............................ [ 76%]
...........................                                              [ 76%]
tests/content/test_swarm_skill.py ...................................... [ 77%]
........................................................................ [ 78%]
.......................................................                  [ 78%]
tests/content/test_system_of_record_gate.py ..                           [ 78%]
tests/content/test_taskfile_caching.py ................................. [ 79%]
..............                                                           [ 79%]
tests/content/test_taskfile_cli_args.py ................................ [ 79%]
..............                                                           [ 79%]
tests/content/test_taskfile_paths.py ................................... [ 80%]
........................................................                 [ 80%]
tests/content/test_taskfile_release_names.py ...                         [ 80%]
tests/content/test_taskfile_uv_project_pin.py .......................... [ 81%]
.......................                                                  [ 81%]
tests/content/test_taskfile_zip_parity.py .......                        [ 81%]
tests/content/test_triage_skill.py ............                          [ 81%]
tests/content/test_upgrading_bigjump_triage.py .......                   [ 81%]
tests/content/test_upgrading_sections.py ....                            [ 81%]
tests/content/test_vbrief_model.py ..................................... [ 82%]
........................................................                 [ 83%]
tests/content/test_vbrief_schema.py ................                     [ 83%]
tests/contract/test_no_legacy_deft_paths_in_agents_template.py ........  [ 83%]
tests/contract/test_no_legacy_deft_run.py ...                            [ 83%]
tests/integration/test_cache_e2e.py .....                                [ 83%]
tests/integration/test_cache_quarantine.py ....                          [ 83%]
tests/integration/test_consumer_tasks.py ..........                      [ 83%]
tests/integration/test_scm_smoke.py ................                     [ 83%]
tests/integration/test_triage_bootstrap_at_scale.py .                    [ 83%]
tests/integration/test_triage_smoke.py ...                               [ 83%]
tests/relocate/test_preflight.py ............                            [ 83%]
tests/relocate/test_self_bootstrap.py ..........................         [ 84%]
tests/relocate/test_state_matrix.py .....................                [ 84%]
tests/scripts/test_ip_risk.py .........................................  [ 85%]
tests/scripts/test_slug_normalize.py ................................... [ 85%]
.......                                                                  [ 85%]
tests/test_cache.py .................................................... [ 86%]
........................                                                 [ 86%]
tests/test_cache_eviction.py .....................................       [ 86%]
tests/test_cache_fetch.py .......................                        [ 87%]
tests/test_cache_scanner.py ............................................ [ 87%]
........................................................................ [ 88%]
................................                                         [ 88%]
tests/test_candidates_log.py .......                                     [ 88%]
tests/test_eval_governance.py ......                                     [ 89%]
tests/test_github_body.py ........                                       [ 89%]
tests/test_policy_show.py .........................................      [ 89%]
tests/test_project_definition_io_lock.py ...                             [ 89%]
tests/test_resume_conditions.py ........................................ [ 90%]
.............                                                            [ 90%]
tests/test_ritual_sentinel.py ..................................         [ 90%]
tests/test_scm_call.py ..............                                    [ 90%]
tests/test_scm_rest.py ............................                      [ 91%]
tests/test_scm_stub.py ...................................               [ 91%]
tests/test_slice_record.py ..........................................    [ 92%]
tests/test_slice_record_existing.py .........................            [ 92%]
tests/test_triage_actions.py ...........                                 [ 92%]
tests/test_triage_bootstrap.py ..................................        [ 92%]
tests/test_triage_bulk.py ...............                                [ 93%]
tests/test_triage_classify.py .......................................... [ 93%]
...................                                                      [ 93%]
tests/test_triage_help.py ..........................................     [ 94%]
tests/test_triage_queue.py ............................................. [ 94%]
...........................                                              [ 95%]
tests/test_triage_queue_stale_closed.py ................                 [ 95%]
tests/test_triage_reconcile.py .................                         [ 95%]
tests/test_triage_refresh.py ............                                [ 95%]
tests/test_triage_reject_missing_label.py ........                       [ 95%]
tests/test_triage_scope.py ............................................. [ 96%]
.....................................................                    [ 96%]
tests/test_triage_scope_d14c.py .......................................  [ 97%]
tests/test_triage_scope_drift.py .........................               [ 97%]
tests/test_triage_smoketest_fixture.py .......                           [ 97%]
tests/test_triage_subscribe.py ...................                       [ 98%]
tests/test_triage_summary.py ........................................... [ 98%]
.........                                                                [ 98%]
tests/test_triage_welcome.py ........................................... [ 99%]
...................                                                      [ 99%]
tests/test_triage_welcome_wip_cap.py ........                            [ 99%]
tests/test_wip_cap.py ..............................................     [100%]

=========== 8436 passed, 5 skipped, 9 deselected in 74.74s (0:01:14) ===========
✓ .agents/skills/deft/SKILL.md
✓ .agents/skills/deft-directive-article-review/SKILL.md
✓ .agents/skills/deft-directive-build/SKILL.md
✓ .agents/skills/deft-directive-cost/SKILL.md
✓ .agents/skills/deft-directive-debug/SKILL.md
✓ .agents/skills/deft-directive-gh-arch/SKILL.md
✓ .agents/skills/deft-directive-gh-slice/SKILL.md
✓ .agents/skills/deft-directive-glossary/SKILL.md
✓ .agents/skills/deft-directive-interview/SKILL.md
✓ .agents/skills/deft-directive-pre-pr/SKILL.md
✓ .agents/skills/deft-directive-refinement/SKILL.md
✓ .agents/skills/deft-directive-release/SKILL.md
✓ .agents/skills/deft-directive-review-cycle/SKILL.md
✓ .agents/skills/deft-directive-setup/SKILL.md
✓ .agents/skills/deft-directive-swarm/SKILL.md
✓ .agents/skills/deft-directive-sync/SKILL.md
✓ .agents/skills/deft-directive-triage/SKILL.md
✓ .agents/skills/deft-directive-write-skill/SKILL.md
✓ .github/PULL_REQUEST_TEMPLATE.md
✓ .github/release-notes/upgrade-banner.md
✓ .planning/codebase/ARCHITECTURE.md
✓ .planning/codebase/CONCERNS.md
✓ .planning/codebase/CONVENTIONS.md
✓ .planning/codebase/STACK.md
✓ .pytest_cache/README.md
✓ AGENTS.md
✓ CHANGELOG.md
✓ CONTRIBUTING.md
✓ LICENSE.md
✓ PRD.md
✓ PROJECT.md
✓ QUICK-START.md
✓ README.md
✓ REFERENCES.md
✓ ROADMAP.md
✓ SKILL.md
✓ SPECIFICATION.md
✓ UPGRADING.md
✓ coding/build-output.md
✓ coding/coding.md
✓ coding/debugging.md
✓ coding/holzmann.md
✓ coding/hygiene.md
✓ coding/security.md
✓ coding/testing.md
✓ coding/toolchain.md
✓ commands.md
✓ context/context.md
✓ context/deterministic-split.md
✓ context/examples.md
✓ context/fractal-summaries.md
✓ context/long-horizon.md
✓ context/spec-deltas.md
✓ context/tool-design.md
✓ context/working-memory.md
✓ contracts/boundary-maps.md
✓ contracts/deterministic-questions.md
✓ contracts/hierarchy.md
✓ conventions/machine-generated-banner.md
✓ conventions/references.md
✓ conventions/task-caching.md
✓ conventions/vbrief-filenames.md
✓ core/glossary.md
✓ core/project.md
✓ core/ralph.md
✓ core/versioning.md
✓ deployments/README.md
✓ deployments/agentuity/README.md
✓ deployments/agentuity/via-cli.md
✓ deployments/agentuity/via-cloud.md
✓ deployments/agentuity/via-github-actions.md
✓ deployments/agentuity/via-gravity-network.md
✓ deployments/agentuity/via-vpc.md
✓ deployments/aws/README.md
✓ deployments/aws/via-app-runner.md
✓ deployments/aws/via-ecs-fargate.md
✓ deployments/aws/via-elastic-beanstalk.md
✓ deployments/aws/via-lambda.md
✓ deployments/azure/README.md
✓ deployments/azure/via-aks.md
✓ deployments/azure/via-app-service.md
✓ deployments/azure/via-container-apps.md
✓ deployments/azure/via-functions.md
✓ deployments/cloud-gov/README.md
✓ deployments/cloud-gov/agents/compliance-docs.md
✓ deployments/cloud-gov/agents.md
✓ deployments/cloud-gov/cicd.md
✓ deployments/cloud-gov/deployment.md
✓ deployments/cloud-gov/logging.md
✓ deployments/cloud-gov/manifest.md
✓ deployments/cloud-gov/overview.md
✓ deployments/cloud-gov/security.md
✓ deployments/cloud-gov/services.md
✓ deployments/cloud-gov/upstream/README.md
✓ deployments/cloudflare/README.md
✓ deployments/cloudflare/via-dashboard.md
✓ deployments/cloudflare/via-git.md
✓ deployments/cloudflare/via-github-actions.md
✓ deployments/cloudflare/via-terraform.md
✓ deployments/cloudflare/via-wrangler.md
✓ deployments/fly-io/README.md
✓ deployments/fly-io/via-dockerfile.md
✓ deployments/fly-io/via-flyctl.md
✓ deployments/fly-io/via-github-actions.md
✓ deployments/fly-io/via-multi-region.md
✓ deployments/google/README.md
✓ deployments/google/via-app-engine.md
✓ deployments/google/via-cloud-functions.md
✓ deployments/google/via-cloud-run.md
✓ deployments/google/via-gke.md
✓ deployments/netlify/README.md
✓ deployments/netlify/via-cli.md
✓ deployments/netlify/via-functions.md
✓ deployments/netlify/via-git.md
✓ deployments/vercel/README.md
✓ deployments/vercel/via-api.md
✓ deployments/vercel/via-cli.md
✓ deployments/vercel/via-git.md
✓ docs/ARCHITECTURE.md
✓ docs/BROWNFIELD.md
✓ docs/CONCEPTS.md
✓ docs/FILES.md
✓ docs/RELEASING.md
✓ docs/agent-stuck-in-a-loop.md
✓ docs/agents-md-vs-skill-md.md
✓ docs/ai-agent-teaming.md
✓ docs/ai-coding-trust-paradox.md
✓ docs/analysis/2026-05-26-issue-1353-grok-windows-capture-opensrc-audit.md
✓ docs/analysis/2026-06-12-lifecycle-taskfile-exit-smoke.md
✓ docs/article-review-2026-05-01-03.md
✓ docs/audit-2026-05-10-installer-conformance.md
✓ docs/audit-2026-05-11-installer-conformance-recheck.md
✓ docs/claude-code-integration.md
✓ docs/code-structure-profile.md
✓ docs/codebase-map-source-of-truth.md
✓ docs/decisions/ADR-001.md
✓ docs/design-deft-cache-quarantine.md
✓ docs/example-project-definition.md
✓ docs/getting-started.md
✓ docs/gitcrawl-fallback.md
✓ docs/good-agents-md.md
✓ docs/harness-is-everything-deft-plan.md
✓ docs/install-manifest.md
✓ docs/privacy-nfr.md
✓ docs/quarantine-spec.md
✓ docs/refactoring-guidelines.md
✓ docs/reference/forensic-research/README.md
✓ docs/reference/forensic-research/SKILL.md
✓ docs/reference/forensic-research/VENDORED.md
✓ docs/reference/forensic-research/examples/slizard/code-facts.md
✓ docs/reference/forensic-research/examples/slizard/failures.md
✓ docs/reference/forensic-research/examples/slizard/investigate-production.md
✓ docs/reference/forensic-research/examples/slizard/slizard-production.md
✓ docs/reference/forensic-research/references/domains/TEMPLATE.md
✓ docs/reference/forensic-research/references/domains/code-debug.md
✓ docs/reference/forensic-research/references/failures.md
✓ docs/reference/forensic-research/references/follow-ups.md
✓ docs/reference/forensic-research/references/forensic-mode.md
✓ docs/reference/forensic-research/references/investigation-profile.md
✓ docs/reference/forensic-research/references/orchestrator-protocol.md
✓ docs/reference/forensic-research/references/outcome-template.md
✓ docs/reference/forensic-research/references/question-framing.md
✓ docs/reference/forensic-research/references/subagent-prompts.md
✓ docs/research/deft-directive-research.md
✓ docs/security.md
✓ docs/smoke-2026-05-06-v0.26.0-scale.md
✓ docs/smoke-2026-05-07-v0.26.0-rerun.md
✓ docs/smoke-2026-05-10-v0.27.1-relocator-dogfood.md
✓ docs/subagent-heartbeat.md
✓ docs/superpowers.md
✓ docs/system-of-record-gate.md
✓ docs/the-harness-is-everything.md
✓ docs/thousand-skills.md
✓ docs/valuable-go-task-improvements.md
✓ docs/versioning.md
✓ events/README.md
✓ glossary.md
✓ history/README.md
✓ history/analysis-2026-03-22-issue-chain-68-94.md
✓ history/archive/2026-03-20-agent-auto-alignment/design.md
✓ history/archive/2026-03-20-agent-auto-alignment/proposal.md
✓ history/archive/2026-03-20-agents-md-onboarding/design.md
✓ history/archive/2026-03-20-agents-md-onboarding/proposal.md
✓ history/changes/README.md
✓ history/changes/fix-171-175-commit-gate-and-review-cycle-discipline/CHANGE.md
✓ history/changes/fix-172-oz-agent-run-correction/CHANGE.md
✓ history/implementation-2026-03-13-fix-interview-strategy.md
✓ history/plan-2026-03-11-cross-platform-agent-skills.md
✓ history/plan-2026-03-12-cross-platform-agent-skills-impl.md
✓ history/plan-2026-03-12-go-installer-impl.md
✓ history/plan-2026-03-12-single-entry-installer.md
✓ history/plan-2026-03-13-fix-interview-strategy.md
✓ history/plan-2026-03-29-fix-vbrief-generation.md
✓ history/plan-2026-05-06-883-overnight-rc-chain.md
✓ history/plan-2026-06-01-1387-headless-swarm-launch.md
✓ history/plan-2026-06-05-swarm-fix-4-issues.md
✓ history/proposals/2026-04-18-more-determinism.md
✓ history/proposals/2026-04-28-vbrief-x-consumer-extension-namespace.md
✓ history/session-2026-05-03-phase-1-fix-now-cohort-and-v0.24.0-release.md
✓ history/todo-2026-03-13-retired.md
✓ incidents/2026-04-pocketos-railway-prod-db-wipe.md
✓ incidents/README.md
✓ incidents/_template.md
✓ interfaces/cli.md
✓ interfaces/rest.md
✓ interfaces/tui.md
✓ interfaces/web.md
✓ languages/6502-DASM.md
✓ languages/c.md
✓ languages/commands.md
✓ languages/cpp.md
✓ languages/csharp.md
✓ languages/dart.md
✓ languages/delphi.md
✓ languages/elixir.md
✓ languages/go.md
✓ languages/java.md
✓ languages/javascript.md
✓ languages/julia.md
✓ languages/kotlin.md
✓ languages/markdown.md
✓ languages/mermaid.md
✓ languages/officejs.md
✓ languages/python.md
✓ languages/r.md
✓ languages/rust.md
✓ languages/sql.md
✓ languages/swift.md
✓ languages/typescript.md
✓ languages/vba.md
✓ languages/vhdl.md
✓ languages/visual-basic.md
✓ languages/zig.md
✓ main.md
✓ meta/SOUL.md
✓ meta/code-field.md
✓ meta/ideas.md
✓ meta/lessons.md
✓ meta/morals.md
✓ meta/philosophy.md
✓ meta/security.md
✓ meta/suggestions.md
✓ patterns/executor-layer-credentials.md
✓ patterns/llm-app.md
✓ patterns/multi-agent.md
✓ patterns/prompt-assembly-layer-ordering.md
✓ patterns/role-as-overlay.md
✓ platforms/2600.md
✓ platforms/unity.md
✓ references/composer-skill-porting.md
✓ references/cost-models.md
✓ references/ip-risk.md
✓ references/plain-english-ux.md
✓ resilience/context-pruning.md
✓ resilience/continue-here.md
✓ scm/changelog.md
✓ scm/git.md
✓ scm/github.md
✓ skills/deft-build/SKILL.md
✓ skills/deft-directive-article-review/SKILL.md
✓ skills/deft-directive-build/SKILL.md
✓ skills/deft-directive-cost/SKILL.md
✓ skills/deft-directive-debug/SKILL.md
✓ skills/deft-directive-decompose/SKILL.md
✓ skills/deft-directive-gh-arch/SKILL.md
✓ skills/deft-directive-gh-slice/SKILL.md
✓ skills/deft-directive-glossary/SKILL.md
✓ skills/deft-directive-interview/SKILL.md
✓ skills/deft-directive-pre-pr/SKILL.md
✓ skills/deft-directive-probe/SKILL.md
✓ skills/deft-directive-refinement/SKILL.md
✓ skills/deft-directive-release/SKILL.md
✓ skills/deft-directive-review-cycle/SKILL.md
✓ skills/deft-directive-setup/SKILL.md
✓ skills/deft-directive-swarm/SKILL.md
✓ skills/deft-directive-sync/SKILL.md
✓ skills/deft-directive-triage/SKILL.md
✓ skills/deft-directive-write-skill/SKILL.md
✓ skills/deft-interview/SKILL.md
✓ skills/deft-pre-pr/SKILL.md
✓ skills/deft-review-cycle/SKILL.md
✓ skills/deft-roadmap-refresh/SKILL.md
✓ skills/deft-setup/SKILL.md
✓ skills/deft-swarm/SKILL.md
✓ skills/deft-sync/SKILL.md
✓ specs/strategy-chaining/SPECIFICATION.md
✓ specs/testbed/SPECIFICATION.md
✓ strategies/README.md
✓ strategies/artifact-guards.md
✓ strategies/bdd.md
✓ strategies/brownfield.md
✓ strategies/discuss.md
✓ strategies/emit-hints.md
✓ strategies/enterprise.md
✓ strategies/interview.md
✓ strategies/map.md
✓ strategies/probe.md
✓ strategies/rapid.md
✓ strategies/research.md
✓ strategies/roadmap.md
✓ strategies/speckit.md
✓ strategies/v0-20-contract.md
✓ strategies/yolo.md
✓ swarm/swarm.md
✓ templates/COST-ESTIMATE.md
✓ templates/PULL_REQUEST_TEMPLATE.md
✓ templates/agent-prompt-preamble.md
✓ templates/agents-entry.md
✓ templates/agents-entry.placeholders.md
✓ templates/make-spec-example.md
✓ templates/make-spec.md
✓ templates/specification.md
✓ templates/swarm-greptile-poller-prompt.md
✓ tests/fixtures/migration/README.md
✓ tests/fixtures/migration/active-routing/ROADMAP.md
✓ tests/fixtures/migration/cancelled-routing/ROADMAP.md
✓ tests/fixtures/migration/clean/ROADMAP.md
✓ tests/fixtures/migration/completed-routing/ROADMAP.md
✓ tests/fixtures/migration/orphan/ROADMAP.md
✓ tests/fixtures/migration/registry-mirror/ROADMAP.md
✓ tests/fixtures/migration/roadmap-stale/ROADMAP.md
✓ tests/fixtures/migration/spec-stale/ROADMAP.md
✓ tests/fixtures/pre_cutover_customized/PROJECT.md
✓ tests/fixtures/pre_cutover_customized/ROADMAP.md
✓ tests/fixtures/pre_cutover_customized/SPECIFICATION.md
✓ tests/fixtures/pre_cutover_customized.expected/PROJECT.md
✓ tests/fixtures/pre_cutover_customized.expected/SPECIFICATION.md
✓ tests/fixtures/safety/PROJECT.md
✓ tests/fixtures/safety/ROADMAP.md
✓ tests/fixtures/safety/SPECIFICATION.md
✓ tests/fixtures/triage_smoketest/README.md
✓ tools/RWLDL.md
✓ tools/greptile.md
✓ tools/installer.md
✓ tools/taskfile-migration.md
✓ tools/taskfile.md
✓ tools/telemetry.md
✓ vbrief/.eval/README.md
✓ vbrief/.eval/_tmp_976_body_after.md
✓ vbrief/.eval/_tmp_976_body_before.md
✓ vbrief/.eval/_tmp_985_body_after_pairing.md
✓ vbrief/.eval/_tmp_985_body_before_pairing.md
✓ vbrief/.eval/_tmp_988_body_after_pairing.md
✓ vbrief/.eval/_tmp_988_body_before_pairing.md
✓ vbrief/migration/LEGACY-REPORT.md
✓ vbrief/migration/RECONCILIATION.md
✓ vbrief/vbrief.md
✓ verification/integration.md
✓ verification/plan-checking.md
✓ verification/uat.md
✓ verification/verification.md
✓ All 351 markdown files validated
  go: go version go1.26.3 darwin/arm64
  uv: uv 0.11.10 (Homebrew 2026-05-05 aarch64-apple-darwin)
  git: git version 2.50.1 (Apple Git-155)
  gh: gh version 2.88.1 (2026-03-12)

All required tools available
No stub patterns found in source files
Found 8 broken internal link(s) (warnings):
  CHANGELOG.md:1317 -> url
  CHANGELOG.md:1319 -> <commit-url>
  UPGRADING.md:117 -> ./scripts/framework_doctor.py
  UPGRADING.md:156 -> ./scripts/framework_doctor.py
  docs/install-manifest.md:144 -> ../scripts/framework_doctor.py
  history/proposals/2026-04-18-more-determinism.md:3 -> ../../vbrief/pending/2026-04-23-233-more-determinism-full-initiative-phase-0-spec.vbrief.json
  scm/changelog.md:127 -> url
  templates/swarm-greptile-poller-prompt.md:543 -> <url>/commit/<sha>
✓ deft branch-protection: feature branch 'chore/1530-wave3-vbrief-fixes' -- proceeding.
✓ verify_encoding: 1608 file(s) clean -- no mojibake / U+FFFD / unexpected-BOM detected (#798).
✓ verify_vbrief_conformance: 672 vBRIEF file(s) clean -- no bare keys (#1620).
✓ deft destructive-gh-verb gate (self-test): 20/20 fixtures classified as expected.
verify_scm_boundary: 36 verb-layer file(s) clean -- every `gh` / `ghx` invocation routes through `scm.call` (#1145 / N5).
No runtime go-task subprocess dependencies found
✓ deft cache-fresh: .deft-cache/github-issue/ absent and --allow-missing-bootstrap was passed -- treating as bootstrap state (consumer runs `deft triage:bootstrap` to opt in).
pack-drift: all 44 projection(s) in sync.
✓ verify:wip-cap: 1/10 in pending/+active/ (within cap; source=default).
OK: vBRIEF validation passed: 669 scope vBRIEF(s), PROJECT-DEFINITION
✓ Strategy output shape conforms to v0.20 contract (8436 passed, 5 skipped, 9 deselected)

Refs #1530, #1724, #1725, #1726, #1727, #1728, #1744

Made with Codex.