### PR TITLE
feat(slice): port slice:* record-existing/list to TypeScript (#1727)

### DIFF
--- a/packages/cli/src/slice-parity.test.ts
+++ b/packages/cli/src/slice-parity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFixtureRepo,
+  diffCase,
+  normalizeOutput,
+  PARITY_CASES,
+  renderReport,
+} from "./slice-parity.js";
+
+describe("slice-parity helpers", () => {
+  it("normalizeOutput replaces volatile values", () => {
+    expect(
+      normalizeOutput(
+        "slice_id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee at 2026-05-14T17:00:00Z --project-root /tmp/x",
+      ),
+    ).toContain("slice_id=<UUID>");
+    expect(normalizeOutput("")).toBe("");
+  });
+
+  it("diffCase flags mismatches", () => {
+    const same = diffCase(
+      { exitCode: 0, stdout: "ok", stderr: "" },
+      { exitCode: 0, stdout: "ok", stderr: "" },
+      "x",
+    );
+    expect(same.exitMismatch).toBe(false);
+    const diff = diffCase(
+      { exitCode: 1, stdout: "", stderr: "err" },
+      { exitCode: 0, stdout: "", stderr: "other" },
+      "x",
+    );
+    expect(diff.exitMismatch).toBe(true);
+    expect(diff.stderrMismatch).toBe(true);
+  });
+
+  it("renderReport describes clean and divergent results", () => {
+    expect(renderReport({ ok: true, diffs: [] })).toContain("CLEAN");
+    expect(
+      renderReport({
+        ok: false,
+        diffs: [
+          {
+            caseName: "list-empty",
+            exitMismatch: true,
+            stdoutMismatch: true,
+            stderrMismatch: false,
+            pythonExit: 0,
+            tsExit: 2,
+          },
+        ],
+      }),
+    ).toContain("DIVERGENCE");
+  });
+
+  it.each(
+    PARITY_CASES.map((c) => [c.name, c] as const),
+  )("buildFixtureRepo handles %s", (_name, c) => {
+    const root = buildFixtureRepo(c.fixture);
+    expect(root.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/src/slice-parity.ts
+++ b/packages/cli/src/slice-parity.ts
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1727): runs BOTH the Python oracle
+ * (`scripts/slice_record_existing.py`) and the ported TS slice CLI with
+ * identical argv on throwaway fixtures, then diffs exit codes and
+ * normalised stdout/stderr (cache-off).
+ *
+ * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
+ */
+import { spawnSync } from "node:child_process";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortKeysDeep(item));
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      sorted[key] = sortKeysDeep(obj[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function seedJsonLine(record: Record<string, unknown>): string {
+  return JSON.stringify(sortKeysDeep(record)).replace(
+    /("(?:[^"\\]|\\.)*")|([:,])/g,
+    (_match, str: string | undefined, sep: string | undefined) =>
+      str !== undefined ? str : sep === ":" ? ": " : ", ",
+  );
+}
+
+export interface CommandCapture {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface SliceFixtureOptions {
+  readonly seedRecords?: ReadonlyArray<Record<string, unknown>>;
+}
+
+export interface ParityCase {
+  readonly name: string;
+  readonly argv: string[];
+  readonly fixture?: SliceFixtureOptions;
+}
+
+export interface ParityDiff {
+  readonly caseName: string;
+  readonly exitMismatch: boolean;
+  readonly stdoutMismatch: boolean;
+  readonly stderrMismatch: boolean;
+  readonly pythonExit: number;
+  readonly tsExit: number;
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly diffs: ParityDiff[];
+}
+
+/** Strip volatile absolute paths, UUIDs, and timestamps before compare. */
+export function normalizeOutput(text: string): string {
+  return text
+    .replace(/--project-root [^\s]+/g, "--project-root <ROOT>")
+    .replace(/slice_id=[0-9a-fA-F-]{36}/g, "slice_id=<UUID>")
+    .replace(/slice_id=[0-9a-fA-F-]{36}/g, "slice_id=<UUID>")
+    .replace(/"slice_id": "[0-9a-fA-F-]{36}"/g, '"slice_id": "<UUID>"')
+    .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/g, "<ISO>");
+}
+
+function runCapture(cmd: string, args: string[], cwd: string): CommandCapture {
+  const result = spawnSync(cmd, args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    exitCode: result.status ?? 2,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+}
+
+export function buildFixtureRepo(options: SliceFixtureOptions = {}): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-slice-parity-"));
+  mkdirSync(join(root, "vbrief", ".eval"), { recursive: true });
+  mkdirSync(join(root, ".git"));
+  const logPath = join(root, "vbrief", ".eval", "slices.jsonl");
+  for (const record of options.seedRecords ?? []) {
+    appendFileSync(logPath, `${seedJsonLine(record)}\n`, "utf8");
+  }
+  return root;
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
+    return resolve(process.env.DEFT_ROOT);
+  }
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+function runPythonSlice(deftRoot: string, repo: string, argv: string[]): CommandCapture {
+  return runCapture(
+    "uv",
+    [
+      "run",
+      "python",
+      join(deftRoot, "scripts", "slice_record_existing.py"),
+      ...argv,
+      "--project-root",
+      repo,
+    ],
+    deftRoot,
+  );
+}
+
+function runTsSlice(deftRoot: string, repo: string, argv: string[]): CommandCapture {
+  return runCapture(
+    "node",
+    [
+      join(deftRoot, "packages", "core", "dist", "slice", "cli.js"),
+      ...argv,
+      "--project-root",
+      repo,
+    ],
+    deftRoot,
+  );
+}
+
+/** Diff one parity case between Python oracle and TS CLI. */
+export function diffCase(python: CommandCapture, ts: CommandCapture, caseName: string): ParityDiff {
+  const pyOut = normalizeOutput(python.stdout);
+  const tsOut = normalizeOutput(ts.stdout);
+  const pyErr = normalizeOutput(python.stderr);
+  const tsErr = normalizeOutput(ts.stderr);
+  return {
+    caseName,
+    exitMismatch: python.exitCode !== ts.exitCode,
+    stdoutMismatch: pyOut !== tsOut,
+    stderrMismatch: pyErr !== tsErr,
+    pythonExit: python.exitCode,
+    tsExit: ts.exitCode,
+  };
+}
+
+export const PARITY_CASES: readonly ParityCase[] = [
+  { name: "list-empty", argv: ["list"] },
+  {
+    name: "list-seeded",
+    argv: ["list"],
+    fixture: {
+      seedRecords: [
+        {
+          slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          umbrella: 10,
+          umbrella_url: "https://github.com/owner/repo/issues/10",
+          sliced_at: "2026-05-14T17:00:00Z",
+          actor: "manual:operator",
+          children: [
+            { n: 11, url: "https://github.com/owner/repo/issues/11", wave: 1, role: "manual" },
+          ],
+          expected_close_signal: "all-children-merged",
+        },
+      ],
+    },
+  },
+  {
+    name: "list-json-seeded",
+    argv: ["list", "--json"],
+    fixture: {
+      seedRecords: [
+        {
+          slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          umbrella: 10,
+          umbrella_url: "https://github.com/owner/repo/issues/10",
+          sliced_at: "2026-05-14T17:00:00Z",
+          actor: "manual:operator",
+          children: [
+            { n: 11, url: "https://github.com/owner/repo/issues/11", wave: 1, role: "manual" },
+          ],
+          expected_close_signal: "all-children-merged",
+        },
+      ],
+    },
+  },
+  {
+    name: "record-existing-skip-validation",
+    argv: [
+      "record-existing",
+      "--umbrella=1",
+      "--children=2,3",
+      "--repo=owner/repo",
+      "--skip-validation",
+      "--sliced-at=2026-05-14T17:00:00Z",
+    ],
+  },
+  {
+    name: "record-existing-idempotent",
+    argv: [
+      "record-existing",
+      "--umbrella=1",
+      "--children=2,3",
+      "--repo=owner/repo",
+      "--skip-validation",
+      "--sliced-at=2026-05-14T17:00:00Z",
+    ],
+    fixture: {
+      seedRecords: [
+        {
+          slice_id: "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee",
+          umbrella: 1,
+          umbrella_url: "https://github.com/owner/repo/issues/1",
+          sliced_at: "2026-05-14T17:00:00Z",
+          actor: "manual:operator",
+          children: [
+            { n: 2, url: "https://github.com/owner/repo/issues/2", wave: 1, role: "manual" },
+            { n: 3, url: "https://github.com/owner/repo/issues/3", wave: 1, role: "manual" },
+          ],
+          expected_close_signal: "all-children-merged",
+        },
+      ],
+    },
+  },
+  {
+    name: "record-existing-dry-run",
+    argv: [
+      "record-existing",
+      "--umbrella=42",
+      "--children=100,101",
+      "--repo=owner/repo",
+      "--dry-run",
+      "--skip-validation",
+      "--sliced-at=2026-05-14T17:00:00Z",
+    ],
+  },
+  {
+    name: "duplicate-child",
+    argv: [
+      "record-existing",
+      "--umbrella=1",
+      "--children=2,2",
+      "--repo=owner/repo",
+      "--skip-validation",
+    ],
+  },
+  {
+    name: "umbrella-in-children",
+    argv: [
+      "record-existing",
+      "--umbrella=1",
+      "--children=1,2",
+      "--repo=owner/repo",
+      "--skip-validation",
+    ],
+  },
+  {
+    name: "wave-member-not-in-children",
+    argv: [
+      "record-existing",
+      "--umbrella=1",
+      "--children=2,3",
+      "--wave-2=999",
+      "--repo=owner/repo",
+      "--skip-validation",
+    ],
+  },
+  {
+    name: "cross-wave-collision",
+    argv: [
+      "record-existing",
+      "--umbrella=1",
+      "--children=2,3",
+      "--wave-1=2",
+      "--wave-2=2",
+      "--repo=owner/repo",
+      "--skip-validation",
+    ],
+  },
+  {
+    name: "default-subcommand",
+    argv: [
+      "--umbrella=1",
+      "--children=2",
+      "--repo=owner/repo",
+      "--skip-validation",
+      "--sliced-at=2026-05-14T17:00:00Z",
+    ],
+  },
+  {
+    name: "missing-project-root",
+    argv: ["list", "--project-root", "/no/such/deft-project-root-xyz"],
+  },
+];
+
+/** Run all parity cases; returns aggregate result. */
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const diffs: ParityDiff[] = [];
+  for (const testCase of PARITY_CASES) {
+    const pyRepo = buildFixtureRepo(testCase.fixture);
+    const tsRepo = buildFixtureRepo(testCase.fixture);
+    try {
+      const python = runPythonSlice(deftRoot, pyRepo, testCase.argv);
+      const ts = runTsSlice(deftRoot, tsRepo, testCase.argv);
+      diffs.push(diffCase(python, ts, testCase.name));
+    } finally {
+      rmSync(pyRepo, { recursive: true, force: true });
+      rmSync(tsRepo, { recursive: true, force: true });
+    }
+  }
+  const ok = diffs.every((d) => !d.exitMismatch && !d.stdoutMismatch && !d.stderrMismatch);
+  return { ok, diffs };
+}
+
+export function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `slice parity: CLEAN -- Python and TS agree on ${PARITY_CASES.length} case(s).`;
+  }
+  const lines = ["slice parity: DIVERGENCE"];
+  for (const d of result.diffs) {
+    if (d.exitMismatch || d.stdoutMismatch || d.stderrMismatch) {
+      lines.push(`  case: ${d.caseName}`);
+      if (d.exitMismatch) lines.push(`    exit: python=${d.pythonExit} ts=${d.tsExit}`);
+      if (d.stdoutMismatch) lines.push("    stdout mismatch");
+      if (d.stderrMismatch) lines.push("    stderr mismatch");
+    }
+  }
+  return lines.join("\n");
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    process.exit(1);
+  } catch (err) {
+    process.stderr.write(`slice parity: harness error -- ${String(err)}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/slice.test.ts
+++ b/packages/cli/src/slice.test.ts
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { run } from "./slice.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-cli-slice-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief", ".eval"), { recursive: true });
+  mkdirSync(join(root, ".git"));
+  return root;
+}
+
+describe("slice thin CLI", () => {
+  it("exports run function", () => {
+    expect(typeof run).toBe("function");
+  });
+
+  it("run delegates to core cli when built", () => {
+    const coreCli = join(dirname(fileURLToPath(import.meta.url)), "../../core/dist/slice/cli.js");
+    const root = makeRoot();
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      const code = run(["list", `--project-root=${root}`]);
+      expect(code).toBe(0);
+      expect(out.mock.calls.length + err.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      out.mockRestore();
+      err.mockRestore();
+    }
+    expect(spawnSync(process.execPath, [coreCli, "--help"]).status).toBeDefined();
+  });
+});

--- a/packages/cli/src/slice.ts
+++ b/packages/cli/src/slice.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Thin CLI entry for slice:record-existing / slice:list (#1727).
+ * Delegates to the core implementation at packages/core/dist/slice/cli.js.
+ */
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function coreCliPath(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "../../core/dist/slice/cli.js");
+}
+
+/** Run slice verbs with argv; returns process exit code. */
+export function run(argv: string[]): number {
+  const result = spawnSync(process.execPath, [coreCliPath(), ...argv], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (typeof result.stdout === "string" && result.stdout.length > 0) {
+    process.stdout.write(result.stdout);
+  }
+  if (typeof result.stderr === "string" && result.stderr.length > 0) {
+    process.stderr.write(result.stderr);
+  }
+  return result.status ?? 2;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/src/slice/barrel.test.ts
+++ b/packages/core/src/slice/barrel.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import * as slice from "./index.js";
+
+describe("slice barrel", () => {
+  it("re-exports core symbols", () => {
+    expect(typeof slice.main).toBe("function");
+    expect(typeof slice.readAll).toBe("function");
+    expect(typeof slice.runRecordExisting).toBe("function");
+    expect(slice.DEFAULT_ACTOR).toBe("manual:operator");
+  });
+});

--- a/packages/core/src/slice/cli-branches.test.ts
+++ b/packages/core/src/slice/cli-branches.test.ts
@@ -1,0 +1,100 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { parseCli, runCli } from "./cli.js";
+import { runList } from "./existing.js";
+import { pythonJsonStringify } from "./json.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-slice-cli-br-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief", ".eval"), { recursive: true });
+  mkdirSync(join(root, ".git"));
+  return root;
+}
+
+describe("cli branch coverage", () => {
+  it("parseCli handles empty argv and equals-form list flags", () => {
+    expect(parseCli([]).command).toBe("record-existing");
+    expect(parseCli(["list", "--project-root=/tmp/x"]).listProjectRoot).toBe("/tmp/x");
+  });
+
+  it("runCli returns help with exit 0", () => {
+    expect(runCli(["--help"]).exitCode).toBe(0);
+    expect(runCli(["list", "--help"]).exitCode).toBe(0);
+  });
+
+  it("runCli lists records with non-array children and json output", () => {
+    const root = makeRoot();
+    const path = join(root, "vbrief", ".eval", "slices.jsonl");
+    writeFileSync(
+      path,
+      `${pythonJsonStringify({
+        slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        umbrella: 5,
+        umbrella_url: "u",
+        sliced_at: "2026-05-14T17:00:00Z",
+        actor: "a",
+        children: "bad",
+        expected_close_signal: "all-children-merged",
+      })}\n`,
+      "utf8",
+    );
+    const listed = runList({ projectRoot: root, asJson: false });
+    expect(listed.stdout).toContain("children=0");
+    const json = runCli(["list", "--json", `--project-root=${root}`]);
+    expect(json.exitCode).toBe(0);
+    expect(json.stdout).toContain('"umbrella": 5');
+  });
+
+  it("parseCli handles dry-run, force, and skip-validation flags", () => {
+    const parsed = parseCli([
+      "record-existing",
+      "--umbrella=9",
+      "--children=10",
+      "--repo=o/r",
+      "--dry-run",
+      "--force",
+      "--skip-validation",
+    ]);
+    expect(parsed.recordArgs?.dryRun).toBe(true);
+    expect(parsed.recordArgs?.force).toBe(true);
+    expect(parsed.recordArgs?.skipValidation).toBe(true);
+  });
+
+  it("parseRecordExisting accepts all space-form optional flags", () => {
+    const parsed = parseCli([
+      "record-existing",
+      "--umbrella",
+      "1",
+      "--children",
+      "2",
+      "--actor",
+      "manual:carol",
+      "--expected-close-signal",
+      "manual",
+      "--sliced-at",
+      "2026-05-14T17:00:00Z",
+      "--notes",
+      "why",
+      "--repo",
+      "o/r",
+      "--project-root",
+      "/tmp/p",
+    ]);
+    expect(parsed.recordArgs).toMatchObject({
+      umbrella: 1,
+      actor: "manual:carol",
+      expectedCloseSignal: "manual",
+      notes: "why",
+      repo: "o/r",
+      projectRoot: "/tmp/p",
+    });
+  });
+});

--- a/packages/core/src/slice/cli.test.ts
+++ b/packages/core/src/slice/cli.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { main, parseCli, runCli } from "./cli.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-slice-cli-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief", ".eval"), { recursive: true });
+  mkdirSync(join(root, ".git"));
+  return root;
+}
+
+describe("parseCli", () => {
+  it("defaults to record-existing subcommand", () => {
+    const parsed = parseCli(["--umbrella=1", "--children=2", "--repo=o/r", "--skip-validation"]);
+    expect(parsed.command).toBe("record-existing");
+    expect(parsed.recordArgs?.umbrella).toBe(1);
+  });
+
+  it("parses list --json", () => {
+    const parsed = parseCli(["list", "--json"]);
+    expect(parsed.command).toBe("list");
+    expect(parsed.listAsJson).toBe(true);
+  });
+
+  it("surfaces wave flag parse errors", () => {
+    const parsed = parseCli(["record-existing", "--wave-2"]);
+    expect(parsed.error).toContain("missing value");
+  });
+});
+
+describe("runCli", () => {
+  it("lists empty project", () => {
+    const root = makeRoot();
+    const result = runCli(["list", `--project-root=${root}`]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("no records found");
+  });
+
+  it("returns usage-like errors for missing required flags", () => {
+    const result = runCli(["record-existing", "--repo=o/r"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("--umbrella");
+  });
+
+  it("main writes streams and returns exit code", () => {
+    const root = makeRoot();
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(main(["list", `--project-root=${root}`])).toBe(0);
+      expect(out.mock.calls.length).toBeGreaterThan(0);
+      expect(main(["--help"])).toBe(0);
+      expect(err.mock.calls.length).toBe(0);
+    } finally {
+      out.mockRestore();
+      err.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/slice/cli.ts
+++ b/packages/core/src/slice/cli.ts
@@ -1,0 +1,282 @@
+import { fileURLToPath } from "node:url";
+import {
+  consumeWaveFlags,
+  DEFAULT_ACTOR,
+  DEFAULT_EXPECTED_CLOSE_SIGNAL,
+  type RecordExistingArgs,
+  runList,
+  runRecordExisting,
+} from "./existing.js";
+
+export interface ParsedCli {
+  readonly command: "record-existing" | "list";
+  readonly recordArgs?: RecordExistingArgs;
+  readonly waveMap: Map<number, number[]>;
+  readonly listProjectRoot?: string | null;
+  readonly listAsJson?: boolean;
+  readonly error?: string;
+}
+
+function parseFlagValue(
+  argv: string[],
+  index: number,
+  prefix: string,
+): { value: string; next: number } | null {
+  const arg = argv[index];
+  if (arg === prefix) {
+    const value = argv[index + 1];
+    if (value === undefined) {
+      return null;
+    }
+    return { value, next: index + 2 };
+  }
+  if (arg?.startsWith(`${prefix}=`)) {
+    return { value: arg.slice(prefix.length + 1), next: index + 1 };
+  }
+  return undefined as unknown as null;
+}
+
+function parseRecordExisting(argv: string[]): { args: RecordExistingArgs; error?: string } {
+  const parsed = {
+    umbrella: 0,
+    children: "",
+    actor: DEFAULT_ACTOR,
+    expectedCloseSignal: DEFAULT_EXPECTED_CLOSE_SIGNAL,
+    slicedAt: null as string | null,
+    notes: null as string | null,
+    dryRun: false,
+    force: false,
+    skipValidation: false,
+    repo: null as string | null,
+    projectRoot: null as string | null,
+  };
+  let hasUmbrella = false;
+  let hasChildren = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--dry-run") {
+      parsed.dryRun = true;
+    } else if (arg === "--force") {
+      parsed.force = true;
+    } else if (arg === "--skip-validation") {
+      parsed.skipValidation = true;
+    } else if (arg === "--json") {
+      return { args: parsed, error: "unrecognized arguments: --json" };
+    } else {
+      const umbrella = parseFlagValue(argv, i, "--umbrella");
+      if (umbrella !== null && umbrella !== undefined) {
+        if (umbrella === null) {
+          return { args: parsed, error: "argument --umbrella: expected one argument" };
+        }
+        parsed.umbrella = Number.parseInt(umbrella.value, 10);
+        hasUmbrella = true;
+        i = umbrella.next - 1;
+        continue;
+      }
+      const children = parseFlagValue(argv, i, "--children");
+      if (children !== null && children !== undefined) {
+        if (children === null) {
+          return { args: parsed, error: "argument --children: expected one argument" };
+        }
+        parsed.children = children.value;
+        hasChildren = true;
+        i = children.next - 1;
+        continue;
+      }
+      const actor = parseFlagValue(argv, i, "--actor");
+      if (actor !== null && actor !== undefined) {
+        if (actor === null) {
+          return { args: parsed, error: "argument --actor: expected one argument" };
+        }
+        parsed.actor = actor.value;
+        i = actor.next - 1;
+        continue;
+      }
+      const signal = parseFlagValue(argv, i, "--expected-close-signal");
+      if (signal !== null && signal !== undefined) {
+        if (signal === null) {
+          return { args: parsed, error: "argument --expected-close-signal: expected one argument" };
+        }
+        parsed.expectedCloseSignal = signal.value;
+        i = signal.next - 1;
+        continue;
+      }
+      const slicedAt = parseFlagValue(argv, i, "--sliced-at");
+      if (slicedAt !== null && slicedAt !== undefined) {
+        if (slicedAt === null) {
+          return { args: parsed, error: "argument --sliced-at: expected one argument" };
+        }
+        parsed.slicedAt = slicedAt.value;
+        i = slicedAt.next - 1;
+        continue;
+      }
+      const notes = parseFlagValue(argv, i, "--notes");
+      if (notes !== null && notes !== undefined) {
+        if (notes === null) {
+          return { args: parsed, error: "argument --notes: expected one argument" };
+        }
+        parsed.notes = notes.value;
+        i = notes.next - 1;
+        continue;
+      }
+      const repo = parseFlagValue(argv, i, "--repo");
+      if (repo !== null && repo !== undefined) {
+        if (repo === null) {
+          return { args: parsed, error: "argument --repo: expected one argument" };
+        }
+        parsed.repo = repo.value;
+        i = repo.next - 1;
+        continue;
+      }
+      const projectRoot = parseFlagValue(argv, i, "--project-root");
+      if (projectRoot !== null && projectRoot !== undefined) {
+        if (projectRoot === null) {
+          return { args: parsed, error: "argument --project-root: expected one argument" };
+        }
+        parsed.projectRoot = projectRoot.value;
+        i = projectRoot.next - 1;
+        continue;
+      }
+      if (arg === "-h" || arg === "--help") {
+        return { args: parsed, error: "help" };
+      }
+      return { args: parsed, error: `unrecognized arguments: ${arg}` };
+    }
+  }
+
+  if (!hasUmbrella) {
+    return { args: parsed, error: "the following arguments are required: --umbrella" };
+  }
+  if (!hasChildren) {
+    return { args: parsed, error: "the following arguments are required: --children" };
+  }
+  return { args: parsed };
+}
+
+function parseList(argv: string[]): {
+  projectRoot: string | null;
+  asJson: boolean;
+  error?: string;
+} {
+  let projectRoot: string | null = null;
+  let asJson = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      asJson = true;
+      continue;
+    }
+    const root = parseFlagValue(argv, i, "--project-root");
+    if (root !== null && root !== undefined) {
+      if (root === null) {
+        return { projectRoot, asJson, error: "argument --project-root: expected one argument" };
+      }
+      projectRoot = root.value;
+      i = root.next - 1;
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      return { projectRoot, asJson, error: "help" };
+    }
+    return { projectRoot, asJson, error: `unrecognized arguments: ${arg}` };
+  }
+  return { projectRoot, asJson };
+}
+
+/** Parse argv mirroring slice_record_existing.py argparse surface. */
+export function parseCli(argv: string[]): ParsedCli {
+  let raw = [...argv];
+  if (raw.length > 0 && !["record-existing", "list", "-h", "--help"].includes(raw[0] ?? "")) {
+    raw = ["record-existing", ...raw];
+  } else if (raw.length === 0) {
+    raw = ["record-existing"];
+  }
+
+  let waveMap = new Map<number, number[]>();
+  if (raw[0] === "record-existing") {
+    try {
+      const consumed = consumeWaveFlags(raw);
+      waveMap = consumed.waveMap;
+      raw = consumed.remaining;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        command: "record-existing",
+        waveMap,
+        error: `error: ${msg}`,
+      };
+    }
+  }
+
+  const command = raw[0];
+  if (command === "-h" || command === "--help") {
+    return { command: "record-existing", waveMap, error: "help" };
+  }
+  if (command === "list") {
+    const parsed = parseList(raw.slice(1));
+    if (parsed.error !== undefined) {
+      return { command: "list", waveMap, error: parsed.error };
+    }
+    return {
+      command: "list",
+      waveMap,
+      listProjectRoot: parsed.projectRoot,
+      listAsJson: parsed.asJson,
+    };
+  }
+
+  const parsed = parseRecordExisting(raw.slice(1));
+  if (parsed.error !== undefined) {
+    return { command: "record-existing", waveMap, error: parsed.error };
+  }
+  return { command: "record-existing", recordArgs: parsed.args, waveMap };
+}
+
+/** Run slice CLI and return exit code + captured output. */
+export function runCli(argv: string[]): { exitCode: number; stdout: string; stderr: string } {
+  const parsed = parseCli(argv);
+  if (parsed.error !== undefined) {
+    if (parsed.error === "help") {
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    if (parsed.error.startsWith("error: ")) {
+      return { exitCode: 2, stdout: "", stderr: `${parsed.error}\n` };
+    }
+    return { exitCode: 2, stdout: "", stderr: `error: ${parsed.error}\n` };
+  }
+
+  if (parsed.command === "list") {
+    const result = runList({
+      projectRoot: parsed.listProjectRoot ?? null,
+      asJson: parsed.listAsJson ?? false,
+    });
+    return result;
+  }
+
+  if (parsed.recordArgs === undefined) {
+    return { exitCode: 2, stdout: "", stderr: "error: missing record-existing arguments\n" };
+  }
+
+  const result = runRecordExisting(parsed.recordArgs, parsed.waveMap);
+  return result;
+}
+
+/** CLI entrypoint writing directly to stdio. */
+export function main(argv: string[]): number {
+  const result = runCli(argv);
+  if (result.stdout.length > 0) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr.length > 0) {
+    process.stderr.write(result.stderr);
+  }
+  return result.exitCode;
+}
+
+export const CLI_HELP =
+  "usage: slice_record_existing.py [-h] {record-existing,list} ... (ported TS CLI)";
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/packages/core/src/slice/constants.ts
+++ b/packages/core/src/slice/constants.ts
@@ -1,0 +1,42 @@
+/** Default slices log path relative to project root. */
+export const DEFAULT_SLICES_LOG_REL_PATH = "vbrief/.eval/slices.jsonl";
+
+export const ENV_PROJECT_ROOT = "DEFT_PROJECT_ROOT";
+export const ENV_PROJECT_REPO = "DEFT_PROJECT_REPO";
+
+export const DEFAULT_ACTOR = "manual:operator";
+export const DEFAULT_EXPECTED_CLOSE_SIGNAL = "all-children-merged";
+export const DEFAULT_ROLE = "manual";
+
+export const VALID_EXPECTED_CLOSE_SIGNALS = new Set([
+  "all-children-merged",
+  "wave-1-merged",
+  "manual",
+]);
+
+export const REQUIRED_FIELDS = [
+  "slice_id",
+  "umbrella",
+  "umbrella_url",
+  "sliced_at",
+  "actor",
+  "children",
+  "expected_close_signal",
+] as const;
+
+export const OPTIONAL_FIELDS = ["notes"] as const;
+
+export const ALLOWED_FIELDS = new Set([...REQUIRED_FIELDS, ...OPTIONAL_FIELDS]);
+
+export const CHILD_REQUIRED_FIELDS = ["n", "url", "wave", "role"] as const;
+
+export const CHILD_ALLOWED_FIELDS = new Set(CHILD_REQUIRED_FIELDS);
+
+export const UUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export const ISO8601_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+export const WAVE_FLAG_RE = /^--wave-(\d+)(?:=(.*))?$/;
+
+export const PROJECT_ROOT_SENTINELS = ["vbrief", ".git"] as const;

--- a/packages/core/src/slice/errors.ts
+++ b/packages/core/src/slice/errors.ts
@@ -1,0 +1,15 @@
+/** Raised when a record passed to write_slice fails validation. */
+export class SliceRecordError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SliceRecordError";
+  }
+}
+
+/** Raised when an issue number cannot be validated via the SCM shim. */
+export class IssueValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IssueValidationError";
+  }
+}

--- a/packages/core/src/slice/existing.test.ts
+++ b/packages/core/src/slice/existing.test.ts
@@ -1,0 +1,283 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import type { CompletedProcess } from "../scm/call.js";
+import {
+  buildChildren,
+  childrenSet,
+  consumeWaveFlags,
+  findDuplicate,
+  parseChildrenCsv,
+  runList,
+  runRecordExisting,
+  summariseWaves,
+  validateIssueExists,
+} from "./existing.js";
+import { writeSliceUnlocked } from "./record.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-slice-existing-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief", ".eval"), { recursive: true });
+  mkdirSync(join(root, ".git"));
+  return root;
+}
+
+function fakeScm(existing: Set<number>) {
+  return (_source: string, _verb: string, args: readonly string[] | null): CompletedProcess => ({
+    args: [...(args ?? [])],
+    returncode: existing.has(Number(args?.[1])) ? 0 : 1,
+    stdout: "",
+    stderr: existing.has(Number(args?.[1])) ? "{}" : "missing",
+  });
+}
+
+describe("existing helpers", () => {
+  it("parseChildrenCsv validates input", () => {
+    expect(parseChildrenCsv("2,3")).toEqual([2, 3]);
+    expect(() => parseChildrenCsv("")).toThrow(/at least one/);
+    expect(() => parseChildrenCsv("2,2")).toThrow(/duplicate/);
+    expect(() => parseChildrenCsv("abc")).toThrow(/invalid child/);
+  });
+
+  it("consumeWaveFlags extracts wave assignments", () => {
+    const { waveMap, remaining } = consumeWaveFlags([
+      "record-existing",
+      "--wave-1=2",
+      "--wave-2=3",
+      "--umbrella=1",
+    ]);
+    expect(remaining).toEqual(["record-existing", "--umbrella=1"]);
+    expect(waveMap.get(1)).toEqual([2]);
+    expect(waveMap.get(2)).toEqual([3]);
+    expect(() =>
+      consumeWaveFlags(["record-existing", "--wave-1=2", "--wave-2=2", "--children=2,3"]),
+    ).toThrow(/both --wave/);
+  });
+
+  it("summariseWaves merges unassigned children into wave 1", () => {
+    expect(summariseWaves(new Map(), 3)).toBe("3 in wave 1 (default)");
+    expect(
+      summariseWaves(
+        new Map([
+          [1, [2]],
+          [2, [3]],
+        ]),
+        3,
+      ),
+    ).toBe("2 wave(s): wave-1=2, wave-2=1");
+  });
+
+  it("buildChildren assigns default wave and role", () => {
+    const children = buildChildren([2, 3], new Map([[2, [3]]]), "owner/repo");
+    expect(children[0]).toMatchObject({ n: 2, wave: 1, role: "manual" });
+    expect(children[1]).toMatchObject({ n: 3, wave: 2 });
+  });
+});
+
+describe("runRecordExisting", () => {
+  it("writes a valid entry with skip-validation", () => {
+    const root = makeRoot();
+    const result = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2,3",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "owner/repo",
+        projectRoot: root,
+      },
+      new Map(),
+      { newSliceId: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("slice_id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+
+  it("dry-run prints preview without writing", () => {
+    const root = makeRoot();
+    const result = runRecordExisting(
+      {
+        umbrella: 42,
+        children: "100,101",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: null,
+        dryRun: true,
+        force: false,
+        skipValidation: true,
+        repo: "owner/repo",
+        projectRoot: root,
+      },
+      new Map(),
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('"slice_id": "<dry-run>"');
+    expect(result.stderr).toContain("DRY-RUN");
+  });
+
+  it("is idempotent for matching umbrella + child set", () => {
+    const root = makeRoot();
+    const path = join(root, "vbrief", ".eval", "slices.jsonl");
+    writeSliceUnlocked(
+      {
+        slice_id: "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee",
+        umbrella: 1,
+        umbrella_url: "https://github.com/owner/repo/issues/1",
+        sliced_at: "2026-05-14T17:00:00Z",
+        actor: "manual:operator",
+        children: [
+          { n: 2, url: "https://github.com/owner/repo/issues/2", wave: 1, role: "manual" },
+          { n: 3, url: "https://github.com/owner/repo/issues/3", wave: 1, role: "manual" },
+        ],
+        expected_close_signal: "all-children-merged",
+      },
+      { path },
+    );
+    const args = {
+      umbrella: 1,
+      children: "2,3",
+      actor: "manual:operator",
+      expectedCloseSignal: "all-children-merged",
+      slicedAt: "2026-05-14T17:00:00Z",
+      notes: null,
+      dryRun: false,
+      force: false,
+      skipValidation: true,
+      repo: "owner/repo",
+      projectRoot: root,
+    };
+    const result = runRecordExisting(args, new Map());
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("already has a matching record");
+    expect(findDuplicate(1, [2, 3], path)).not.toBeNull();
+  });
+
+  it("rejects umbrella numbers listed as children", () => {
+    const root = makeRoot();
+    const result = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "1,2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: null,
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "owner/repo",
+        projectRoot: root,
+      },
+      new Map(),
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("cannot also appear in --children");
+  });
+
+  it("validates issue existence via scm shim", () => {
+    const root = makeRoot();
+    const ok = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: null,
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: false,
+        repo: "owner/repo",
+        projectRoot: root,
+      },
+      new Map(),
+      { scm: fakeScm(new Set([1, 2])) },
+    );
+    expect(ok.exitCode).toBe(0);
+
+    const bad = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2,3",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: null,
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: false,
+        repo: "owner/repo",
+        projectRoot: root,
+      },
+      new Map(),
+      { scm: fakeScm(new Set([1, 2])) },
+    );
+    expect(bad.exitCode).toBe(1);
+    expect(bad.stderr).toContain("issue #3");
+  });
+});
+
+describe("runList", () => {
+  it("lists seeded records and empty state", () => {
+    const root = makeRoot();
+    expect(runList({ projectRoot: root, asJson: false }).stdout).toContain("no records found");
+    const path = join(root, "vbrief", ".eval", "slices.jsonl");
+    writeSliceUnlocked(
+      {
+        slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        umbrella: 10,
+        umbrella_url: "u",
+        sliced_at: "2026-05-14T17:00:00Z",
+        actor: "skill:gh-slice",
+        children: [{ n: 11, url: "u", wave: 1, role: "manual" }],
+        expected_close_signal: "all-children-merged",
+        notes: "note",
+      },
+      { path },
+    );
+    const listed = runList({ projectRoot: root, asJson: false });
+    expect(listed.stdout).toContain("umbrella=#10");
+    expect(listed.stdout).toContain("notes='note'");
+    const json = runList({ projectRoot: root, asJson: true });
+    expect(json.stdout).toContain('"umbrella": 10');
+  });
+});
+
+describe("wave and validation helpers", () => {
+  it("consumeWaveFlags accepts space-separated wave values", () => {
+    const { waveMap } = consumeWaveFlags(["record-existing", "--wave-1", "2,3", "--umbrella=1"]);
+    expect(waveMap.get(1)).toEqual([2, 3]);
+  });
+
+  it("validateIssueExists maps scm failures to IssueValidationError", () => {
+    expect(() =>
+      validateIssueExists(1, "o/r", {
+        scm: () => {
+          throw new Error("timeout");
+        },
+      }),
+    ).toThrow(/timed out validating issue #1/);
+    expect(() =>
+      validateIssueExists(2, "o/r", {
+        scm: () => ({ args: [], returncode: 1, stdout: "", stderr: "" }),
+      }),
+    ).toThrow(/\(no stderr\)/);
+  });
+
+  it("childrenSet ignores malformed child entries", () => {
+    expect(childrenSet({ children: ["bad", { n: 2 }] }).has(2)).toBe(true);
+  });
+});

--- a/packages/core/src/slice/existing.ts
+++ b/packages/core/src/slice/existing.ts
@@ -1,0 +1,440 @@
+import type { CompletedProcess } from "../scm/call.js";
+import { call as scmCall } from "../scm/call.js";
+import { pyRepr } from "../scm/py-format.js";
+import {
+  DEFAULT_ACTOR,
+  DEFAULT_EXPECTED_CLOSE_SIGNAL,
+  DEFAULT_ROLE,
+  WAVE_FLAG_RE,
+} from "./constants.js";
+import { IssueValidationError, SliceRecordError } from "./errors.js";
+import { pythonJsonPretty } from "./json.js";
+import { appendLock, withAppendLock } from "./lock.js";
+import {
+  formatMissingRepoError,
+  formatMissingRootError,
+  resolveRootAndRepo,
+} from "./project-context.js";
+import { newSliceId, nowIso, readAll, slicesPath, writeSliceUnlocked } from "./record.js";
+
+export type ScmCaller = (
+  source: string,
+  verb: string,
+  args: readonly string[] | null,
+  options?: { check?: boolean; captureOutput?: boolean; text?: boolean; timeout?: number },
+) => CompletedProcess;
+
+export interface RecordExistingArgs {
+  readonly umbrella: number;
+  readonly children: string;
+  readonly actor: string;
+  readonly expectedCloseSignal: string;
+  readonly slicedAt: string | null;
+  readonly notes: string | null;
+  readonly dryRun: boolean;
+  readonly force: boolean;
+  readonly skipValidation: boolean;
+  readonly repo: string | null;
+  readonly projectRoot: string | null;
+}
+
+export interface ListArgs {
+  readonly projectRoot: string | null;
+  readonly asJson: boolean;
+}
+
+export interface ExistingDeps {
+  readonly scm?: ScmCaller;
+  readonly nowIso?: () => string;
+  readonly newSliceId?: () => string;
+  readonly findDuplicateFn?: typeof findDuplicate;
+  readonly withLock?: typeof withAppendLock;
+}
+
+export function parseChildrenCsv(value: string): number[] {
+  if (value.length === 0) {
+    throw new Error("expected at least one child issue number");
+  }
+  const out: number[] = [];
+  const seen = new Set<number>();
+  for (const part of value.split(",")) {
+    const token = part.trim();
+    if (token.length === 0) {
+      continue;
+    }
+    const n = Number.parseInt(token, 10);
+    if (Number.isNaN(n)) {
+      throw new Error(`invalid child issue number '${token}' (must be a positive int)`);
+    }
+    if (n < 1) {
+      throw new Error(`invalid child issue number ${n} (must be a positive int)`);
+    }
+    if (seen.has(n)) {
+      throw new Error(`duplicate child issue number ${n}`);
+    }
+    seen.add(n);
+    out.push(n);
+  }
+  if (out.length === 0) {
+    throw new Error("expected at least one child issue number");
+  }
+  return out;
+}
+
+export function consumeWaveFlags(rawArgs: string[]): {
+  waveMap: Map<number, number[]>;
+  remaining: string[];
+} {
+  const waveMap = new Map<number, number[]>();
+  const remaining: string[] = [];
+  let i = 0;
+  while (i < rawArgs.length) {
+    const token = rawArgs[i] ?? "";
+    const match = WAVE_FLAG_RE.exec(token);
+    if (!match) {
+      remaining.push(token);
+      i += 1;
+      continue;
+    }
+    const waveN = Number.parseInt(match[1] ?? "0", 10);
+    if (waveN < 1) {
+      throw new Error(`invalid wave number in '${token}' (must be >= 1)`);
+    }
+    let value: string | undefined;
+    if (match[2] !== undefined) {
+      value = match[2];
+      i += 1;
+    } else if (i + 1 < rawArgs.length) {
+      value = rawArgs[i + 1];
+      i += 2;
+    } else {
+      throw new Error(`missing value for '${token}'`);
+    }
+    const children = parseChildrenCsv(value ?? "");
+    const bucket = waveMap.get(waveN) ?? [];
+    for (const n of children) {
+      if (!bucket.includes(n)) {
+        bucket.push(n);
+      }
+    }
+    waveMap.set(waveN, bucket);
+  }
+
+  const placement = new Map<number, number>();
+  for (const [waveN, members] of waveMap) {
+    for (const n of members) {
+      const prior = placement.get(n);
+      if (prior !== undefined && prior !== waveN) {
+        throw new Error(
+          `child ${n} appears in both --wave-${prior} and --wave-${waveN}; each child belongs to one wave`,
+        );
+      }
+      placement.set(n, waveN);
+    }
+  }
+  return { waveMap, remaining };
+}
+
+export function repoSlugToUrl(repo: string, n: number): string {
+  return `https://github.com/${repo}/issues/${n}`;
+}
+
+export function buildChildren(
+  children: number[],
+  waveMap: Map<number, number[]>,
+  repo: string,
+): Record<string, unknown>[] {
+  const waveFor = new Map<number, number>();
+  for (const [waveN, members] of waveMap) {
+    for (const n of members) {
+      waveFor.set(n, waveN);
+    }
+  }
+  return children.map((n) => ({
+    n,
+    url: repoSlugToUrl(repo, n),
+    wave: waveFor.get(n) ?? 1,
+    role: DEFAULT_ROLE,
+  }));
+}
+
+export function childrenSet(record: Record<string, unknown>): Set<number> {
+  const children = record.children;
+  if (!Array.isArray(children)) {
+    return new Set();
+  }
+  const out = new Set<number>();
+  for (const child of children) {
+    if (child !== null && typeof child === "object" && !Array.isArray(child)) {
+      const n = (child as Record<string, unknown>).n;
+      if (typeof n === "number" && Number.isInteger(n)) {
+        out.add(n);
+      }
+    }
+  }
+  return out;
+}
+
+export function findDuplicate(
+  umbrella: number,
+  childrenNumbers: number[],
+  slicesLogPath: string,
+): Record<string, unknown> | null {
+  const target = new Set(childrenNumbers);
+  for (const record of readAll({ path: slicesLogPath })) {
+    if (record.umbrella !== umbrella) {
+      continue;
+    }
+    const childSet = childrenSet(record);
+    if (childSet.size === target.size && [...target].every((n) => childSet.has(n))) {
+      return record;
+    }
+  }
+  return null;
+}
+
+export function validateIssueExists(n: number, repo: string, deps: ExistingDeps = {}): void {
+  const scm = deps.scm ?? scmCall;
+  let proc: CompletedProcess;
+  try {
+    proc = scm(
+      "github-issue",
+      "issue",
+      ["view", String(n), "--repo", repo, "--json", "number,url"],
+      {
+        check: false,
+        captureOutput: true,
+        text: true,
+        timeout: 30,
+      },
+    );
+  } catch {
+    throw new IssueValidationError(`timed out validating issue #${n} in ${repo}`);
+  }
+  if (proc.returncode !== 0) {
+    const stderr = proc.stderr.trim() || "(no stderr)";
+    throw new IssueValidationError(`issue #${n} in ${repo} not found / inaccessible: ${stderr}`);
+  }
+}
+
+export function summariseWaves(waveMap: Map<number, number[]>, totalChildren: number): string {
+  if (waveMap.size === 0) {
+    return `${totalChildren} in wave 1 (default)`;
+  }
+  const placedByWave = new Map<number, number>();
+  for (const [waveN, members] of waveMap) {
+    placedByWave.set(waveN, members.length);
+  }
+  let placedTotal = 0;
+  for (const count of placedByWave.values()) {
+    placedTotal += count;
+  }
+  const unassigned = totalChildren - placedTotal;
+  if (unassigned > 0) {
+    placedByWave.set(1, (placedByWave.get(1) ?? 0) + unassigned);
+  }
+  const parts = [...placedByWave.keys()]
+    .sort((a, b) => a - b)
+    .map((waveN) => `wave-${waveN}=${placedByWave.get(waveN)}`);
+  return `${parts.length} wave(s): ${parts.join(", ")}`;
+}
+
+function duplicateMessage(umbrella: number, duplicate: Record<string, unknown>): string {
+  return (
+    `slice:record-existing: umbrella #${umbrella} already has a matching record (slice_id=${String(duplicate.slice_id)}, ` +
+    `actor=${String(duplicate.actor)}). Re-run with --force to write a second record.`
+  );
+}
+
+export interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export function runRecordExisting(
+  args: RecordExistingArgs,
+  waveMap: Map<number, number[]>,
+  deps: ExistingDeps = {},
+): CommandResult {
+  const resolved = resolveRootAndRepo(args.projectRoot, args.repo, true);
+  if (resolved.exitCode !== 0) {
+    const message =
+      resolved.repo === null && resolved.projectRoot !== "."
+        ? formatMissingRepoError()
+        : formatMissingRootError();
+    return { exitCode: resolved.exitCode, stdout: "", stderr: `${message}\n` };
+  }
+  const repo = resolved.repo;
+  if (repo === null) {
+    throw new Error("repo is None despite require_repo=True; this is a bug in resolveRootAndRepo");
+  }
+
+  let children: number[];
+  try {
+    children = parseChildrenCsv(args.children);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { exitCode: 2, stdout: "", stderr: `error: ${msg}\n` };
+  }
+
+  const declared = new Set(children);
+  for (const [waveN, members] of waveMap) {
+    for (const n of members) {
+      if (!declared.has(n)) {
+        return {
+          exitCode: 2,
+          stdout: "",
+          stderr: `error: --wave-${waveN} references child #${n} not present in --children\n`,
+        };
+      }
+    }
+  }
+
+  if (declared.has(args.umbrella)) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `error: umbrella #${args.umbrella} cannot also appear in --children\n`,
+    };
+  }
+
+  if (!args.skipValidation) {
+    try {
+      validateIssueExists(args.umbrella, repo, deps);
+      for (const n of children) {
+        validateIssueExists(n, repo, deps);
+      }
+    } catch (err) {
+      if (err instanceof IssueValidationError) {
+        return { exitCode: 1, stdout: "", stderr: `error: ${err.message}\n` };
+      }
+      if (err instanceof Error && err.message.includes("not yet supported")) {
+        return { exitCode: 1, stdout: "", stderr: `error: ${err.message}\n` };
+      }
+      throw err;
+    }
+  }
+
+  const logPath = slicesPath(resolved.projectRoot);
+  const findDup = deps.findDuplicateFn ?? findDuplicate;
+  const duplicate = findDup(args.umbrella, children, logPath);
+  if (duplicate !== null && !args.force) {
+    return { exitCode: 0, stdout: "", stderr: `${duplicateMessage(args.umbrella, duplicate)}\n` };
+  }
+
+  const childDicts = buildChildren(children, waveMap, repo);
+  const clock = deps.nowIso ?? nowIso;
+
+  if (args.dryRun) {
+    const proposed: Record<string, unknown> = {
+      slice_id: "<dry-run>",
+      umbrella: args.umbrella,
+      umbrella_url: repoSlugToUrl(repo, args.umbrella),
+      sliced_at: args.slicedAt ?? clock(),
+      actor: args.actor,
+      children: childDicts,
+      expected_close_signal: args.expectedCloseSignal,
+    };
+    if (args.notes !== null) {
+      proposed.notes = args.notes;
+    }
+    const waveSummary = summariseWaves(waveMap, children.length);
+    return {
+      exitCode: 0,
+      stdout: `${pythonJsonPretty(proposed)}\n`,
+      stderr:
+        `DRY-RUN: would write slices.jsonl entry for umbrella ` +
+        `#${args.umbrella} (${children.length} children, ${waveSummary}).\n`,
+    };
+  }
+
+  const record: Record<string, unknown> = {
+    slice_id: (deps.newSliceId ?? newSliceId)(),
+    umbrella: args.umbrella,
+    umbrella_url: repoSlugToUrl(repo, args.umbrella),
+    sliced_at: args.slicedAt ?? clock(),
+    actor: args.actor,
+    children: childDicts,
+    expected_close_signal: args.expectedCloseSignal,
+  };
+  if (args.notes !== null) {
+    record.notes = args.notes;
+  }
+
+  try {
+    const lock = deps.withLock ?? withAppendLock;
+    const outcome = lock(logPath, () => {
+      const authoritativeDup = findDup(args.umbrella, children, logPath);
+      if (authoritativeDup !== null && !args.force) {
+        return { kind: "duplicate" as const, duplicate: authoritativeDup };
+      }
+      const id = writeSliceUnlocked(record, { path: logPath });
+      return { kind: "written" as const, sliceId: id };
+    });
+    if (outcome.kind === "duplicate") {
+      return {
+        exitCode: 0,
+        stdout: "",
+        stderr: `${duplicateMessage(args.umbrella, outcome.duplicate)}\n`,
+      };
+    }
+    const waveSummary = summariseWaves(waveMap, children.length);
+    return {
+      exitCode: 0,
+      stdout:
+        `Wrote vbrief/.eval/slices.jsonl entry for umbrella ` +
+        `#${args.umbrella} (${children.length} children, ${waveSummary}). ` +
+        `slice_id=${outcome.sliceId}\n`,
+      stderr: "",
+    };
+  } catch (err) {
+    if (err instanceof SliceRecordError) {
+      return { exitCode: 1, stdout: "", stderr: `error: invalid record -- ${err.message}\n` };
+    }
+    throw err;
+  }
+}
+
+export function runList(args: ListArgs): CommandResult {
+  const resolved = resolveRootAndRepo(args.projectRoot, null, false);
+  if (resolved.exitCode !== 0) {
+    return { exitCode: 2, stdout: "", stderr: `${formatMissingRootError()}\n` };
+  }
+
+  const records = readAll({ path: slicesPath(resolved.projectRoot) });
+  if (args.asJson) {
+    return { exitCode: 0, stdout: `${pythonJsonPretty(records)}\n`, stderr: "" };
+  }
+
+  if (records.length === 0) {
+    return {
+      exitCode: 0,
+      stdout: "slice:list: no records found in vbrief/.eval/slices.jsonl (file absent or empty).\n",
+      stderr: "",
+    };
+  }
+
+  const lines = [`slice:list: ${records.length} record(s) in vbrief/.eval/slices.jsonl`];
+  for (const record of records) {
+    const umbrella = record.umbrella ?? "?";
+    const actor = record.actor ?? "?";
+    const slicedAt = record.sliced_at ?? "?";
+    const sliceId = record.slice_id ?? "?";
+    const children = record.children;
+    const childCount = Array.isArray(children) ? children.length : 0;
+    const signal = record.expected_close_signal ?? "?";
+    const notes = record.notes;
+    let line =
+      `  - umbrella=#${String(umbrella)} children=${childCount} ` +
+      `actor=${String(actor)} sliced_at=${String(slicedAt)} ` +
+      `signal=${String(signal)} slice_id=${String(sliceId)}`;
+    if (typeof notes === "string" && notes.length > 0) {
+      line += ` notes=${pyRepr(notes)}`;
+    }
+    lines.push(line);
+  }
+  return { exitCode: 0, stdout: `${lines.join("\n")}\n`, stderr: "" };
+}
+
+export { appendLock, DEFAULT_ACTOR, DEFAULT_EXPECTED_CLOSE_SIGNAL };

--- a/packages/core/src/slice/index.ts
+++ b/packages/core/src/slice/index.ts
@@ -1,0 +1,9 @@
+export { main, parseCli, runCli } from "./cli.js";
+export * from "./constants.js";
+export * from "./errors.js";
+export * from "./existing.js";
+export * from "./json.js";
+export * from "./lock.js";
+export * from "./project-context.js";
+export * from "./record.js";
+export * from "./validate.js";

--- a/packages/core/src/slice/json.test.ts
+++ b/packages/core/src/slice/json.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { pythonJsonPretty, pythonJsonStringify, sortKeysDeep } from "./json.js";
+
+describe("json helpers", () => {
+  it("sortKeysDeep sorts nested objects", () => {
+    expect(sortKeysDeep({ b: 1, a: { d: 2, c: 3 } })).toEqual({ a: { c: 3, d: 2 }, b: 1 });
+  });
+
+  it("pythonJsonStringify matches Python separators and key order", () => {
+    const value = {
+      slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      umbrella: 1,
+      children: [{ n: 2, role: "manual", url: "u", wave: 1 }],
+    };
+    expect(pythonJsonStringify(value)).toBe(
+      '{"children": [{"n": 2, "role": "manual", "url": "u", "wave": 1}], "slice_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "umbrella": 1}',
+    );
+  });
+
+  it("pythonJsonPretty emits indented sorted JSON", () => {
+    const pretty = pythonJsonPretty({ b: 1, a: 2 });
+    expect(pretty).toBe('{\n  "a": 2,\n  "b": 1\n}');
+  });
+});

--- a/packages/core/src/slice/json.ts
+++ b/packages/core/src/slice/json.ts
@@ -1,0 +1,29 @@
+/** Recursively sort object keys like Python json.dumps(..., sort_keys=True). */
+export function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortKeysDeep(item));
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      sorted[key] = sortKeysDeep(obj[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/** JSON.dumps(..., sort_keys=True, ensure_ascii=False) with Python separators. */
+export function pythonJsonStringify(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value)).replace(
+    /("(?:[^"\\]|\\.)*")|([:,])/g,
+    (_match, str: string | undefined, sep: string | undefined) =>
+      str !== undefined ? str : sep === ":" ? ": " : ", ",
+  );
+}
+
+/** JSON.dumps(..., sort_keys=True, ensure_ascii=False, indent=2). */
+export function pythonJsonPretty(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value), null, 2);
+}

--- a/packages/core/src/slice/lock-branches.test.ts
+++ b/packages/core/src/slice/lock-branches.test.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { appendLock, withAppendLock } from "./lock.js";
+
+describe("lock branches", () => {
+  it("times out when sidecar lock already exists", () => {
+    const path = join("/tmp", `deft-lock-busy-${Date.now()}.jsonl`);
+    fs.writeFileSync(`${path}.lock`, "\0");
+    let now = 0;
+    expect(() =>
+      withAppendLock(path, () => undefined, {
+        now: () => {
+          now += 31_000;
+          return now;
+        },
+        sleepMs: () => {
+          /* no-op */
+        },
+      }),
+    ).toThrow(/timed out acquiring lock/);
+  });
+
+  it("appendLock alias matches withAppendLock", () => {
+    const path = join("/tmp", `deft-lock-alias-${Date.now()}.jsonl`);
+    expect(appendLock(path, () => 42)).toBe(42);
+  });
+
+  it("defaultSleep path completes a normal lock cycle", () => {
+    const path = join("/tmp", `deft-lock-default-${Date.now()}.jsonl`);
+    expect(withAppendLock(path, () => "ok")).toBe("ok");
+  });
+});

--- a/packages/core/src/slice/lock.test.ts
+++ b/packages/core/src/slice/lock.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { withAppendLock } from "./lock.js";
+
+describe("withAppendLock", () => {
+  it("rejects reentrant acquisition", () => {
+    expect(() =>
+      withAppendLock("/tmp/deft-slice-lock-test.jsonl", () => {
+        withAppendLock("/tmp/deft-slice-lock-test.jsonl", () => undefined);
+      }),
+    ).toThrow(/not reentrant/);
+  });
+
+  it("times out when lock cannot be acquired", () => {
+    let now = 0;
+    expect(() =>
+      withAppendLock(
+        "/tmp/deft-slice-lock-timeout.jsonl",
+        () => {
+          withAppendLock("/tmp/deft-slice-lock-timeout.jsonl", () => undefined, {
+            now: () => now,
+            sleepMs: () => {
+              now += 1000;
+            },
+          });
+        },
+        {
+          now: () => now,
+          sleepMs: () => {
+            now += 1000;
+          },
+        },
+      ),
+    ).toThrow();
+  });
+});

--- a/packages/core/src/slice/lock.ts
+++ b/packages/core/src/slice/lock.ts
@@ -1,0 +1,65 @@
+import { closeSync, existsSync, mkdirSync, openSync, unlinkSync, writeSync } from "node:fs";
+import { dirname } from "node:path";
+
+const threadLocked = { held: false };
+
+export interface LockDeps {
+  readonly sleepMs?: (ms: number) => void;
+  readonly now?: () => number;
+}
+
+function defaultSleep(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* spin */
+  }
+}
+
+/** Serialise appenders across threads AND processes (sidecar lock file). */
+export function withAppendLock<T>(logPath: string, fn: () => T, deps: LockDeps = {}): T {
+  const sleepMs = deps.sleepMs ?? defaultSleep;
+  const now = deps.now ?? Date.now;
+  const lockPath = `${logPath}.lock`;
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  if (threadLocked.held) {
+    throw new Error("append lock is not reentrant");
+  }
+  threadLocked.held = true;
+  let fd: number | undefined;
+  try {
+    const deadline = now() + 30_000;
+    while (true) {
+      try {
+        fd = openSync(lockPath, "wx");
+        writeSync(fd, Buffer.from("\0"));
+        break;
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "EEXIST") {
+          throw err;
+        }
+        if (now() > deadline) {
+          throw new Error(`timed out acquiring lock for ${logPath}`);
+        }
+        sleepMs(20);
+      }
+    }
+    return fn();
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd);
+    }
+    threadLocked.held = false;
+    try {
+      if (existsSync(lockPath)) {
+        unlinkSync(lockPath);
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/** Public alias mirroring Python append_lock. */
+export const appendLock = withAppendLock;

--- a/packages/core/src/slice/project-context-branches.test.ts
+++ b/packages/core/src/slice/project-context-branches.test.ts
@@ -1,0 +1,32 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolveProjectRoot } from "./project-context.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+});
+
+describe("resolveProjectRoot walk", () => {
+  it("walks upward from a subdirectory to find vbrief/", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-slice-walk-"));
+    temps.push(root);
+    mkdirSync(join(root, "vbrief"));
+    const sub = join(root, "nested", "deep");
+    mkdirSync(sub, { recursive: true });
+    const prev = process.env.DEFT_PROJECT_ROOT;
+    delete process.env.DEFT_PROJECT_ROOT;
+    expect(resolveProjectRoot(undefined, sub)).toBe(root);
+    process.env.DEFT_PROJECT_ROOT = prev;
+  });
+
+  it("rejects invalid explicit project roots and env roots", () => {
+    expect(resolveProjectRoot("/path/does/not/exist-xyz")).toBeNull();
+    const prev = process.env.DEFT_PROJECT_ROOT;
+    process.env.DEFT_PROJECT_ROOT = "/missing/deft/env/root";
+    expect(resolveProjectRoot(undefined)).toBeNull();
+    process.env.DEFT_PROJECT_ROOT = prev;
+  });
+});

--- a/packages/core/src/slice/project-context.test.ts
+++ b/packages/core/src/slice/project-context.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  formatMissingRepoError,
+  formatMissingRootError,
+  normaliseRepoSlug,
+  resolveProjectRepo,
+  resolveProjectRoot,
+  resolveRootAndRepo,
+} from "./project-context.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-slice-ctx-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"));
+  return root;
+}
+
+describe("project-context", () => {
+  it("resolveProjectRoot prefers explicit and env values", () => {
+    const root = makeRoot();
+    expect(resolveProjectRoot(root)).toBe(root);
+    const prev = process.env.DEFT_PROJECT_ROOT;
+    process.env.DEFT_PROJECT_ROOT = root;
+    expect(resolveProjectRoot(undefined)).toBe(root);
+    process.env.DEFT_PROJECT_ROOT = prev;
+    expect(resolveProjectRoot("/missing/path/xyz")).toBeNull();
+  });
+
+  it("normaliseRepoSlug accepts slug and github URLs", () => {
+    expect(normaliseRepoSlug("owner/repo")).toBe("owner/repo");
+    expect(normaliseRepoSlug("https://github.com/owner/repo.git")).toBe("owner/repo");
+    expect(normaliseRepoSlug("bad")).toBeNull();
+  });
+
+  it("resolveProjectRepo honours explicit repo and env", () => {
+    const root = makeRoot();
+    expect(resolveProjectRepo("owner/repo", root)).toBe("owner/repo");
+    const prev = process.env.DEFT_PROJECT_REPO;
+    process.env.DEFT_PROJECT_REPO = "env/o";
+    expect(resolveProjectRepo(undefined, root)).toBe("env/o");
+    process.env.DEFT_PROJECT_REPO = "not-a-slug";
+    expect(resolveProjectRepo(undefined, root)).toBeNull();
+    process.env.DEFT_PROJECT_REPO = prev;
+  });
+
+  it("resolveRootAndRepo distinguishes missing root vs repo", () => {
+    const root = makeRoot();
+    expect(resolveRootAndRepo(root, "owner/repo", true)).toMatchObject({
+      exitCode: 0,
+      repo: "owner/repo",
+    });
+    expect(resolveRootAndRepo("/nope", null, false).exitCode).toBe(2);
+    expect(resolveRootAndRepo(root, null, true).exitCode).toBe(2);
+  });
+
+  it("formats actionable errors", () => {
+    expect(formatMissingRootError()).toContain("project root");
+    expect(formatMissingRepoError()).toContain("repo slug");
+  });
+
+  it("normaliseRepoSlug handles ssh github URLs and empty input", () => {
+    expect(normaliseRepoSlug("git@github.com:owner/repo.git")).toBe("owner/repo");
+    expect(normaliseRepoSlug("   ")).toBeNull();
+  });
+
+  it("resolveProjectRepo returns null for malformed explicit slugs", () => {
+    expect(resolveProjectRepo("not-a-valid-slug", makeRoot())).toBeNull();
+  });
+});

--- a/packages/core/src/slice/project-context.ts
+++ b/packages/core/src/slice/project-context.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { ENV_PROJECT_REPO, ENV_PROJECT_ROOT, PROJECT_ROOT_SENTINELS } from "./constants.js";
+
+function isProjectRoot(candidate: string): boolean {
+  return PROJECT_ROOT_SENTINELS.some((sentinel) => existsSync(resolve(candidate, sentinel)));
+}
+
+/** Resolve the consumer project root using the documented precedence. */
+export function resolveProjectRoot(cliProjectRoot?: string | null, start?: string): string | null {
+  if (cliProjectRoot !== undefined && cliProjectRoot !== null && cliProjectRoot.length > 0) {
+    const candidate = resolve(cliProjectRoot);
+    return existsSync(candidate) ? candidate : null;
+  }
+
+  const envRoot = process.env[ENV_PROJECT_ROOT]?.trim() ?? "";
+  if (envRoot.length > 0) {
+    const candidate = resolve(envRoot);
+    return existsSync(candidate) ? candidate : null;
+  }
+
+  const cwd = resolve(start ?? process.cwd());
+  let current = cwd;
+  while (true) {
+    if (isProjectRoot(current)) {
+      return current;
+    }
+    const parent = resolve(current, "..");
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return null;
+}
+
+/** Accept OWNER/NAME or a full GitHub URL, return OWNER/NAME. */
+export function normaliseRepoSlug(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const urlMatch = trimmed.match(/github\.com[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?(?:\s|$)/);
+  if (urlMatch?.[1] && urlMatch[2]) {
+    return `${urlMatch[1]}/${urlMatch[2]}`;
+  }
+  if (/^[^/\s]+\/[^/\s]+$/.test(trimmed)) {
+    return trimmed;
+  }
+  return null;
+}
+
+function detectRepoFromGit(projectRoot: string | null): string | null {
+  try {
+    const stdout = execFileSync("git", ["remote", "get-url", "origin"], {
+      cwd: projectRoot ?? undefined,
+      encoding: "utf8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return normaliseRepoSlug(stdout.trim());
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the consumer GitHub repo (OWNER/NAME). */
+export function resolveProjectRepo(
+  cliRepo: string | null | undefined,
+  projectRoot: string | null,
+): string | null {
+  if (cliRepo !== undefined && cliRepo !== null && cliRepo.length > 0) {
+    return normaliseRepoSlug(cliRepo);
+  }
+  const envRepo = process.env[ENV_PROJECT_REPO]?.trim() ?? "";
+  if (envRepo.length > 0) {
+    return normaliseRepoSlug(envRepo);
+  }
+  return detectRepoFromGit(projectRoot);
+}
+
+export interface RootRepoResult {
+  readonly projectRoot: string;
+  readonly repo: string | null;
+  readonly exitCode: number;
+}
+
+export function resolveRootAndRepo(
+  cliProjectRoot: string | null | undefined,
+  cliRepo: string | null | undefined,
+  requireRepo: boolean,
+): RootRepoResult {
+  const projectRoot = resolveProjectRoot(cliProjectRoot ?? undefined);
+  if (projectRoot === null) {
+    return { projectRoot: ".", repo: null, exitCode: 2 };
+  }
+  if (!requireRepo) {
+    return { projectRoot, repo: null, exitCode: 0 };
+  }
+  const repo = resolveProjectRepo(cliRepo ?? undefined, projectRoot);
+  if (repo === null) {
+    return { projectRoot, repo: null, exitCode: 2 };
+  }
+  return { projectRoot, repo, exitCode: 0 };
+}
+
+export function formatMissingRootError(): string {
+  return (
+    "error: cannot determine project root. Pass --project-root PATH, " +
+    "set $DEFT_PROJECT_ROOT, or run from inside a directory tree that " +
+    "contains vbrief/ or .git/ (#535)."
+  );
+}
+
+export function formatMissingRepoError(): string {
+  return (
+    "error: cannot determine repo slug. Pass --repo OWNER/NAME, " +
+    "set $DEFT_PROJECT_REPO, or run inside a git checkout with an " +
+    "origin remote."
+  );
+}

--- a/packages/core/src/slice/record.test.ts
+++ b/packages/core/src/slice/record.test.ts
@@ -1,0 +1,176 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { SliceRecordError } from "./errors.js";
+import { withAppendLock } from "./lock.js";
+import {
+  findBySliceId,
+  findByUmbrella,
+  newSliceId,
+  nowIso,
+  readAll,
+  writeSlice,
+  writeSliceUnlocked,
+} from "./record.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function makePath(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-slice-record-"));
+  temps.push(root);
+  const path = join(root, "slices.jsonl");
+  mkdirSync(join(root), { recursive: true });
+  return path;
+}
+
+const child = { n: 2, url: "https://github.com/o/r/issues/2", wave: 1, role: "manual" };
+
+describe("record module", () => {
+  it("newSliceId returns a UUID string", () => {
+    expect(newSliceId()).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("nowIso returns UTC Z suffix without fractional seconds", () => {
+    expect(nowIso()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  it("writeSlice uses generated ids when sliceId omitted", () => {
+    const path = makePath();
+    const sid = writeSlice(1, [child], {
+      umbrellaUrl: "https://github.com/o/r/issues/1",
+      actor: "manual:operator",
+      newSliceId: () => "dddddddd-bbbb-cccc-dddd-eeeeeeeeeeee",
+      nowIso: () => "2026-05-14T18:00:00Z",
+      path,
+    });
+    expect(sid).toBe("dddddddd-bbbb-cccc-dddd-eeeeeeeeeeee");
+    expect(readAll({ path })[0]?.sliced_at).toBe("2026-05-14T18:00:00Z");
+  });
+
+  it("writeSlice roundtrips through readAll", () => {
+    const path = makePath();
+    const sid = writeSlice(1, [child], {
+      umbrellaUrl: "https://github.com/o/r/issues/1",
+      actor: "manual:operator",
+      sliceId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      slicedAt: "2026-05-14T17:00:00Z",
+      path,
+    });
+    expect(sid).toBe("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    const records = readAll({ path });
+    expect(records).toHaveLength(1);
+    expect(records[0]?.umbrella).toBe(1);
+  });
+
+  it("writeSlice is idempotent on slice_id retry", () => {
+    const path = makePath();
+    const opts = {
+      umbrellaUrl: "https://github.com/o/r/issues/1",
+      actor: "manual:operator",
+      sliceId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      slicedAt: "2026-05-14T17:00:00Z",
+      path,
+    };
+    writeSlice(1, [child], opts);
+    writeSlice(1, [child], opts);
+    expect(readAll({ path })).toHaveLength(1);
+  });
+
+  it("writeSliceUnlocked rejects invalid records before writing", () => {
+    const path = makePath();
+    expect(() =>
+      writeSliceUnlocked(
+        {
+          slice_id: "bad",
+          umbrella: 1,
+          umbrella_url: "u",
+          sliced_at: "x",
+          actor: "a",
+          children: [],
+          expected_close_signal: "manual",
+        },
+        { path },
+      ),
+    ).toThrow(SliceRecordError);
+    expect(readAll({ path })).toEqual([]);
+  });
+
+  it("readAll tolerates missing file, blanks, and malformed lines", () => {
+    const path = makePath();
+    expect(readAll({ path: join(path, "missing.jsonl") })).toEqual([]);
+    const warnings: string[] = [];
+    writeSliceUnlocked(
+      {
+        slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        umbrella: 1,
+        umbrella_url: "u",
+        sliced_at: "2026-05-14T17:00:00Z",
+        actor: "a",
+        children: [child],
+        expected_close_signal: "all-children-merged",
+      },
+      { path },
+    );
+    const fdPath = path;
+    const existing = readFileSync(fdPath, "utf8");
+    const appended = `${existing}\n\n{bad}\n[1,2,3]\n   \n`;
+    writeFileSync(fdPath, appended, "utf8");
+    const records = readAll({ path, warn: (m) => warnings.push(m) });
+    expect(records).toHaveLength(1);
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  it("find helpers return targeted records", () => {
+    const path = makePath();
+    writeSlice(10, [child], {
+      umbrellaUrl: "u10",
+      actor: "a",
+      sliceId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      slicedAt: "2026-05-14T17:00:00Z",
+      path,
+    });
+    writeSlice(20, [child], {
+      umbrellaUrl: "u20",
+      actor: "a",
+      sliceId: "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee",
+      slicedAt: "2026-05-14T17:00:00Z",
+      path,
+    });
+    expect(findBySliceId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", { path })?.umbrella).toBe(10);
+    expect(findByUmbrella(20, { path })).toHaveLength(1);
+    expect(findBySliceId("nope", { path })).toBeNull();
+  });
+
+  it("writeSliceUnlocked logs malformed id lines via warn hook", () => {
+    const path = makePath();
+    writeFileSync(path, "{bad json\n", "utf8");
+    const warnings: string[] = [];
+    writeSliceUnlocked(
+      {
+        slice_id: "cccccccc-bbbb-cccc-dddd-eeeeeeeeeeee",
+        umbrella: 3,
+        umbrella_url: "u",
+        sliced_at: "2026-05-14T17:00:00Z",
+        actor: "a",
+        children: [child],
+        expected_close_signal: "all-children-merged",
+      },
+      { path, warn: (m) => warnings.push(m) },
+    );
+    expect(warnings.length).toBe(1);
+  });
+
+  it("withAppendLock serialises callbacks", () => {
+    const path = makePath();
+    const order: number[] = [];
+    withAppendLock(path, () => order.push(1));
+    withAppendLock(path, () => order.push(2));
+    expect(order).toEqual([1, 2]);
+  });
+});

--- a/packages/core/src/slice/record.ts
+++ b/packages/core/src/slice/record.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from "node:crypto";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { DEFAULT_SLICES_LOG_REL_PATH } from "./constants.js";
+import { pythonJsonStringify } from "./json.js";
+import { withAppendLock } from "./lock.js";
+import { validateRecord } from "./validate.js";
+
+export interface WriteSliceOptions {
+  readonly umbrellaUrl: string;
+  readonly actor: string;
+  readonly expectedCloseSignal?: string;
+  readonly sliceId?: string;
+  readonly slicedAt?: string;
+  readonly notes?: string;
+  readonly path?: string;
+  readonly nowIso?: () => string;
+  readonly newSliceId?: () => string;
+}
+
+export interface RecordModuleDeps {
+  readonly readFile?: typeof readFileSync;
+  readonly exists?: typeof existsSync;
+  readonly append?: typeof appendFileSync;
+  readonly fsync?: typeof fsyncSync;
+  readonly open?: typeof openSync;
+  readonly close?: typeof closeSync;
+  readonly mkdir?: typeof mkdirSync;
+  readonly withLock?: typeof withAppendLock;
+}
+
+const defaultDeps: Required<RecordModuleDeps> = {
+  readFile: readFileSync,
+  exists: existsSync,
+  append: appendFileSync,
+  fsync: fsyncSync,
+  open: openSync,
+  close: closeSync,
+  mkdir: mkdirSync,
+  withLock: withAppendLock,
+};
+
+function resolvePath(path: string | undefined): string {
+  return path !== undefined ? resolve(path) : resolve(DEFAULT_SLICES_LOG_REL_PATH);
+}
+
+export function newSliceId(): string {
+  return randomUUID();
+}
+
+/** Return the current UTC time in canonical ISO-8601 form with Z suffix (no fractional seconds). */
+export function nowIso(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function parseJsonlIds(
+  logPath: string,
+  deps: Required<RecordModuleDeps>,
+  warn?: (message: string) => void,
+): Set<string> {
+  if (!deps.exists(logPath)) {
+    return new Set();
+  }
+  const seen = new Set<string>();
+  const raw = deps.readFile(logPath, "utf8");
+  const lines = raw.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const stripped = lines[i]?.trim() ?? "";
+    if (stripped.length === 0) {
+      continue;
+    }
+    try {
+      const obj = JSON.parse(stripped) as unknown;
+      if (obj !== null && typeof obj === "object" && !Array.isArray(obj)) {
+        const sid = (obj as Record<string, unknown>).slice_id;
+        if (typeof sid === "string") {
+          seen.add(sid);
+        }
+      }
+    } catch (err) {
+      warn?.(`slices.jsonl: skipping malformed JSON on line ${i + 1}: ${String(err)}`);
+    }
+  }
+  return seen;
+}
+
+/** Validate + append record without acquiring the sidecar lock. */
+export function writeSliceUnlocked(
+  record: Record<string, unknown>,
+  options: { path?: string; deps?: RecordModuleDeps; warn?: (message: string) => void } = {},
+): string {
+  const deps = { ...defaultDeps, ...options.deps };
+  validateRecord(record);
+  const logPath = resolvePath(options.path);
+  deps.mkdir(dirname(logPath), { recursive: true });
+  const resolvedId = String(record.slice_id);
+  const existing = parseJsonlIds(logPath, deps, options.warn);
+  if (existing.has(resolvedId)) {
+    return resolvedId;
+  }
+  const line = `${pythonJsonStringify(record)}\n`;
+  deps.append(logPath, line, { encoding: "utf8" });
+  const fd = deps.open(logPath, "a");
+  try {
+    deps.fsync(fd);
+  } finally {
+    deps.close(fd);
+  }
+  return resolvedId;
+}
+
+/** Validate and atomically append a cohort record to slices.jsonl. */
+export function writeSlice(
+  umbrella: number,
+  children: Iterable<Record<string, unknown>>,
+  options: WriteSliceOptions,
+  deps: RecordModuleDeps = {},
+): string {
+  const mergedDeps = { ...defaultDeps, ...deps };
+  const resolvedId = options.sliceId ?? options.newSliceId?.() ?? newSliceId();
+  const record: Record<string, unknown> = {
+    slice_id: resolvedId,
+    umbrella,
+    umbrella_url: options.umbrellaUrl,
+    sliced_at: options.slicedAt ?? options.nowIso?.() ?? nowIso(),
+    actor: options.actor,
+    children: [...children].map((child) => ({ ...child })),
+    expected_close_signal: options.expectedCloseSignal ?? "all-children-merged",
+  };
+  if (options.notes !== undefined) {
+    record.notes = options.notes;
+  }
+  const logPath = resolvePath(options.path);
+  return mergedDeps.withLock(logPath, () =>
+    writeSliceUnlocked(record, { path: logPath, deps: mergedDeps }),
+  );
+}
+
+/** Return every well-formed slice record in insertion order. */
+export function readAll(
+  options: { path?: string; deps?: RecordModuleDeps; warn?: (message: string) => void } = {},
+): Record<string, unknown>[] {
+  const deps = { ...defaultDeps, ...options.deps };
+  const logPath = resolvePath(options.path);
+  if (!deps.exists(logPath)) {
+    return [];
+  }
+  const out: Record<string, unknown>[] = [];
+  const raw = deps.readFile(logPath, "utf8");
+  const lines = raw.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const stripped = lines[i]?.trim() ?? "";
+    if (stripped.length === 0) {
+      continue;
+    }
+    try {
+      const obj = JSON.parse(stripped) as unknown;
+      if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+        options.warn?.(
+          `slices.jsonl: skipping non-object entry on line ${i + 1} (got ${obj === null ? "null" : typeof obj})`,
+        );
+        continue;
+      }
+      out.push(obj as Record<string, unknown>);
+    } catch (err) {
+      options.warn?.(`slices.jsonl: skipping malformed JSON on line ${i + 1}: ${String(err)}`);
+    }
+  }
+  return out;
+}
+
+export function findBySliceId(
+  sliceId: string,
+  options: { path?: string; deps?: RecordModuleDeps } = {},
+): Record<string, unknown> | null {
+  for (const record of readAll(options)) {
+    if (record.slice_id === sliceId) {
+      return record;
+    }
+  }
+  return null;
+}
+
+export function findByUmbrella(
+  umbrella: number,
+  options: { path?: string; deps?: RecordModuleDeps } = {},
+): Record<string, unknown>[] {
+  return readAll(options).filter((record) => record.umbrella === umbrella);
+}
+
+export function slicesPath(projectRoot: string): string {
+  return join(resolve(projectRoot), DEFAULT_SLICES_LOG_REL_PATH);
+}

--- a/packages/core/src/slice/slice-branches.test.ts
+++ b/packages/core/src/slice/slice-branches.test.ts
@@ -1,0 +1,603 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { main, parseCli, runCli } from "./cli.js";
+import { runList, runRecordExisting, summariseWaves } from "./existing.js";
+import { withAppendLock } from "./lock.js";
+import { resolveProjectRoot } from "./project-context.js";
+import { findBySliceId, readAll, writeSlice, writeSliceUnlocked } from "./record.js";
+import { validateRecord } from "./validate.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-slice-branches-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief", ".eval"), { recursive: true });
+  mkdirSync(join(root, ".git"));
+  return root;
+}
+
+describe("slice branch coverage", () => {
+  it("parseCli covers record-existing flag errors and help", () => {
+    expect(parseCli(["record-existing", "--umbrella"]).error).toContain("--umbrella");
+    expect(parseCli(["record-existing", "--children"]).error).toContain("--children");
+    expect(parseCli(["record-existing", "--actor"]).error).toContain("--actor");
+    expect(parseCli(["record-existing", "--expected-close-signal"]).error).toContain(
+      "expected-close-signal",
+    );
+    expect(parseCli(["record-existing", "--sliced-at"]).error).toContain("--sliced-at");
+    expect(parseCli(["record-existing", "--notes"]).error).toContain("--notes");
+    expect(parseCli(["record-existing", "--repo"]).error).toContain("--repo");
+    expect(parseCli(["record-existing", "--project-root"]).error).toContain("--project-root");
+    expect(parseCli(["record-existing", "--nope"]).error).toContain("unrecognized");
+    expect(parseCli(["record-existing", "--json"]).error).toContain("unrecognized");
+    expect(parseCli(["-h"]).error).toBe("help");
+    expect(parseCli(["list", "--project-root"]).error).toContain("--project-root");
+    expect(parseCli(["list", "--nope"]).error).toContain("unrecognized");
+  });
+
+  it("runCli routes wave pre-pass and duplicate stderr paths", () => {
+    const root = makeRoot();
+    expect(
+      runCli([
+        "record-existing",
+        "--wave-1=9",
+        "--umbrella=1",
+        "--children=2",
+        "--repo=o/r",
+        "--skip-validation",
+        `--project-root=${root}`,
+      ]).exitCode,
+    ).toBe(2);
+    const dup = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+      { newSliceId: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" },
+    );
+    expect(dup.exitCode).toBe(0);
+    const again = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+    );
+    expect(again.stderr).toContain("already has a matching record");
+  });
+
+  it("runRecordExisting covers force, validation, and guard paths", () => {
+    const root = makeRoot();
+    writeSliceUnlocked(
+      {
+        slice_id: "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee",
+        umbrella: 1,
+        umbrella_url: "u",
+        sliced_at: "2026-05-14T17:00:00Z",
+        actor: "manual:operator",
+        children: [{ n: 2, url: "u2", wave: 1, role: "manual" }],
+        expected_close_signal: "all-children-merged",
+      },
+      { path: join(root, "vbrief", ".eval", "slices.jsonl") },
+    );
+    const forced = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: "note",
+        dryRun: false,
+        force: true,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+      { newSliceId: () => "cccccccc-bbbb-cccc-dddd-eeeeeeeeeeee" },
+    );
+    expect(forced.exitCode).toBe(0);
+    expect(readAll({ path: join(root, "vbrief", ".eval", "slices.jsonl") })).toHaveLength(2);
+
+    expect(
+      runRecordExisting(
+        {
+          umbrella: 1,
+          children: "1,2",
+          actor: "manual:operator",
+          expectedCloseSignal: "all-children-merged",
+          slicedAt: null,
+          notes: null,
+          dryRun: false,
+          force: false,
+          skipValidation: true,
+          repo: "o/r",
+          projectRoot: root,
+        },
+        new Map(),
+      ).exitCode,
+    ).toBe(2);
+
+    expect(
+      runRecordExisting(
+        {
+          umbrella: 1,
+          children: "2,2",
+          actor: "manual:operator",
+          expectedCloseSignal: "all-children-merged",
+          slicedAt: null,
+          notes: null,
+          dryRun: false,
+          force: false,
+          skipValidation: true,
+          repo: "o/r",
+          projectRoot: root,
+        },
+        new Map(),
+      ).exitCode,
+    ).toBe(2);
+
+    expect(
+      runRecordExisting(
+        {
+          umbrella: 1,
+          children: "2",
+          actor: "manual:operator",
+          expectedCloseSignal: "all-children-merged",
+          slicedAt: null,
+          notes: null,
+          dryRun: false,
+          force: false,
+          skipValidation: false,
+          repo: "o/r",
+          projectRoot: root,
+        },
+        new Map(),
+        {
+          scm: () => {
+            throw new Error("source='gitlab' not yet supported");
+          },
+        },
+      ).exitCode,
+    ).toBe(1);
+
+    expect(
+      runRecordExisting(
+        {
+          umbrella: 1,
+          children: "2",
+          actor: "manual:operator",
+          expectedCloseSignal: "all-children-merged",
+          slicedAt: null,
+          notes: null,
+          dryRun: false,
+          force: false,
+          skipValidation: true,
+          repo: null,
+          projectRoot: root,
+        },
+        new Map(),
+      ).exitCode,
+    ).toBe(2);
+
+    expect(() =>
+      runRecordExisting(
+        {
+          umbrella: 1,
+          children: "2",
+          actor: "manual:operator",
+          expectedCloseSignal: "all-children-merged",
+          slicedAt: null,
+          notes: null,
+          dryRun: false,
+          force: false,
+          skipValidation: true,
+          repo: "o/r",
+          projectRoot: root,
+        },
+        new Map(),
+        {
+          scm: () => ({ args: [], returncode: 0, stdout: "", stderr: "" }),
+          newSliceId: () => "bad-id",
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  it("validateRecord covers remaining child and field branches", () => {
+    const base = {
+      slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      umbrella: 1,
+      umbrella_url: "u",
+      sliced_at: "2026-05-14T17:00:00Z",
+      actor: "a",
+      children: [{ n: 2, url: "u", wave: 1, role: "r" }],
+      expected_close_signal: "all-children-merged",
+    };
+    expect(() => validateRecord({ ...base, umbrella_url: "" })).toThrow(/umbrella_url/);
+    expect(() => validateRecord({ ...base, actor: "" })).toThrow(/actor/);
+    expect(() => validateRecord({ ...base, children: [] })).toThrow(/non-empty list/);
+    expect(() =>
+      validateRecord({ ...base, children: [{ n: 2, url: "u", wave: 0, role: "r" }] }),
+    ).toThrow(/wave/);
+    expect(() =>
+      validateRecord({ ...base, children: [{ n: 2, url: "u", wave: 1, role: "" }] }),
+    ).toThrow(/role/);
+    expect(() =>
+      validateRecord({ ...base, children: [{ n: 2, url: "u", wave: 1, role: "r", extra: 1 }] }),
+    ).toThrow(/unknown field/);
+    expect(() => validateRecord({ ...base, children: ["bad"] })).toThrow(/must be a dict/);
+  });
+
+  it("record and lock modules cover idempotent unlocked write and lock timeout", () => {
+    const path = join(makeRoot(), "s.jsonl");
+    const record = {
+      slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      umbrella: 1,
+      umbrella_url: "u",
+      sliced_at: "2026-05-14T17:00:00Z",
+      actor: "a",
+      children: [{ n: 2, url: "u", wave: 1, role: "r" }],
+      expected_close_signal: "all-children-merged",
+    };
+    writeSliceUnlocked(record, { path });
+    expect(writeSliceUnlocked(record, { path })).toBe(record.slice_id);
+    expect(findBySliceId("missing", { path })).toBeNull();
+
+    let now = 0;
+    expect(() =>
+      withAppendLock(
+        path,
+        () => {
+          withAppendLock(path, () => undefined, {
+            now: () => now,
+            sleepMs: () => {
+              now += 31_000;
+            },
+          });
+        },
+        {
+          now: () => now,
+          sleepMs: () => {
+            now += 31_000;
+          },
+        },
+      ),
+    ).toThrow(/not reentrant|timed out/);
+  });
+
+  it("writeSlice supports notes and custom clocks", () => {
+    const path = join(makeRoot(), "s2.jsonl");
+    writeSlice(1, [{ n: 2, url: "u", wave: 1, role: "r" }], {
+      umbrellaUrl: "u1",
+      actor: "a",
+      notes: "n",
+      sliceId: "dddddddd-bbbb-cccc-dddd-eeeeeeeeeeee",
+      slicedAt: "2026-05-14T17:00:00Z",
+      path,
+      expectedCloseSignal: "manual",
+    });
+    expect(readAll({ path })[0]?.notes).toBe("n");
+  });
+
+  it("runRecordExisting hits authoritative duplicate under lock", () => {
+    const root = makeRoot();
+    let calls = 0;
+    const result = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+      {
+        newSliceId: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        findDuplicateFn: () => {
+          calls += 1;
+          if (calls === 1) {
+            return null;
+          }
+          return { slice_id: "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee", actor: "manual:operator" };
+        },
+      },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("already has a matching record");
+  });
+
+  it("runCli handles pre-pass wave errors", () => {
+    const result = runCli([
+      "record-existing",
+      "--wave-1=bad",
+      "--umbrella=1",
+      "--children=2",
+      "--repo=o/r",
+    ]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("error:");
+  });
+
+  it("project-context walks parents and rejects bad env roots", () => {
+    const prev = process.env.DEFT_PROJECT_ROOT;
+    process.env.DEFT_PROJECT_ROOT = "/missing/deft/root/path";
+    expect(resolveProjectRoot(undefined)).toBeNull();
+    process.env.DEFT_PROJECT_ROOT = prev;
+  });
+
+  it("runList and summariseWaves cover formatting branches", () => {
+    const root = makeRoot();
+    expect(runList({ projectRoot: "/missing-deft-root-xyz", asJson: false }).exitCode).toBe(2);
+    expect(summariseWaves(new Map([[2, [3, 4]]]), 3)).toBe("2 wave(s): wave-1=1, wave-2=2");
+    const prev = process.env.DEFT_PROJECT_ROOT;
+    delete process.env.DEFT_PROJECT_ROOT;
+    expect(resolveProjectRoot(undefined, root)).toBe(root);
+    process.env.DEFT_PROJECT_ROOT = prev;
+    expect(main(["list", `--project-root=${root}`])).toBe(0);
+  });
+
+  it("runRecordExisting surfaces missing repo when origin is absent", () => {
+    const root = makeRoot();
+    const result = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: null,
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: null,
+        projectRoot: root,
+      },
+      new Map(),
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("repo slug");
+  });
+
+  it("dry-run and write paths include optional notes", () => {
+    const root = makeRoot();
+    const dry = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: "backfill",
+        dryRun: true,
+        force: false,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+    );
+    expect(dry.stdout).toContain('"notes": "backfill"');
+    const write = runRecordExisting(
+      {
+        umbrella: 2,
+        children: "3",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: "saved",
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+      { newSliceId: () => "eeeeeeee-bbbb-cccc-dddd-eeeeeeeeeeee" },
+    );
+    expect(write.exitCode).toBe(0);
+    const saved = readAll({ path: join(root, "vbrief", ".eval", "slices.jsonl") }).find(
+      (r) => r.umbrella === 2,
+    );
+    expect(saved?.notes).toBe("saved");
+  });
+
+  it("parseCli accepts equals-form flags and wave equals syntax", () => {
+    const parsed = parseCli([
+      "record-existing",
+      "--umbrella=1",
+      "--children=2,3",
+      "--wave-1=2",
+      "--repo=o/r",
+      "--skip-validation",
+    ]);
+    expect(parsed.recordArgs?.umbrella).toBe(1);
+    expect(parsed.waveMap.get(1)).toEqual([2]);
+  });
+
+  it("main writes stderr for idempotent no-op", () => {
+    const root = makeRoot();
+    const args = [
+      "record-existing",
+      "--umbrella=1",
+      "--children=2",
+      "--repo=o/r",
+      "--skip-validation",
+      "--sliced-at=2026-05-14T17:00:00Z",
+      `--project-root=${root}`,
+    ];
+    expect(main(args)).toBe(0);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    try {
+      expect(main(args)).toBe(0);
+      expect(err.mock.calls.map((c) => String(c[0])).join("")).toContain(
+        "already has a matching record",
+      );
+    } finally {
+      err.mockRestore();
+      out.mockRestore();
+    }
+  });
+
+  it("rethrows unexpected dependency failures", () => {
+    const root = makeRoot();
+    expect(() =>
+      runRecordExisting(
+        {
+          umbrella: 1,
+          children: "2",
+          actor: "manual:operator",
+          expectedCloseSignal: "all-children-merged",
+          slicedAt: "2026-05-14T17:00:00Z",
+          notes: null,
+          dryRun: false,
+          force: false,
+          skipValidation: true,
+          repo: "o/r",
+          projectRoot: root,
+        },
+        new Map(),
+        {
+          findDuplicateFn: () => {
+            throw new Error("boom");
+          },
+        },
+      ),
+    ).toThrow("boom");
+
+    expect(() =>
+      runRecordExisting(
+        {
+          umbrella: 1,
+          children: "2",
+          actor: "manual:operator",
+          expectedCloseSignal: "all-children-merged",
+          slicedAt: "2026-05-14T17:00:00Z",
+          notes: null,
+          dryRun: false,
+          force: false,
+          skipValidation: true,
+          repo: "o/r",
+          projectRoot: root,
+        },
+        new Map(),
+        {
+          withLock: () => {
+            throw new Error("lock fail");
+          },
+        },
+      ),
+    ).toThrow("lock fail");
+  });
+
+  it("runRecordExisting returns exit 1 when issue validation fails", () => {
+    const root = makeRoot();
+    const result = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: null,
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: false,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+      {
+        scm: () => ({ args: [], returncode: 1, stdout: "", stderr: "404 Not Found" }),
+      },
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("issue #1");
+  });
+
+  it("runRecordExisting rejects wave members outside --children", () => {
+    const root = makeRoot();
+    const result = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: null,
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map([[1, [9]]]),
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("not present in --children");
+  });
+
+  it("runCli prefixes generic parse errors", () => {
+    expect(runCli(["record-existing"]).stderr).toContain("required: --umbrella");
+  });
+
+  it("runCli rejects record-existing without parsed args", () => {
+    expect(runCli(["record-existing"]).stderr).toContain("--umbrella");
+  });
+
+  it("runRecordExisting surfaces SliceRecordError from invalid generated record", () => {
+    const root = makeRoot();
+    const bad = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "not-an-iso-ts",
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "o/r",
+        projectRoot: root,
+      },
+      new Map(),
+      { newSliceId: () => "not-a-uuid" },
+    );
+    expect(bad.exitCode).toBe(1);
+    expect(bad.stderr).toContain("invalid record");
+  });
+});

--- a/packages/core/src/slice/validate.test.ts
+++ b/packages/core/src/slice/validate.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { SliceRecordError } from "./errors.js";
+import { validateRecord } from "./validate.js";
+
+const validRecord = {
+  slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  umbrella: 1,
+  umbrella_url: "https://github.com/o/r/issues/1",
+  sliced_at: "2026-05-14T17:00:00Z",
+  actor: "manual:operator",
+  children: [{ n: 2, url: "https://github.com/o/r/issues/2", wave: 1, role: "manual" }],
+  expected_close_signal: "all-children-merged",
+};
+
+describe("validateRecord", () => {
+  it("accepts a minimal valid record", () => {
+    expect(() => validateRecord(validRecord)).not.toThrow();
+  });
+
+  it("rejects non-object records", () => {
+    expect(() => validateRecord(null)).toThrow(SliceRecordError);
+    expect(() => validateRecord([])).toThrow(/must be a dict/);
+  });
+
+  it("rejects missing and extra fields", () => {
+    const { slice_id: _removed, ...missing } = validRecord;
+    expect(() => validateRecord(missing)).toThrow(/missing required field/);
+    expect(() => validateRecord({ ...validRecord, extra: true })).toThrow(/unknown field/);
+  });
+
+  it("rejects invalid slice_id, umbrella, sliced_at, and signal", () => {
+    expect(() => validateRecord({ ...validRecord, slice_id: "bad" })).toThrow(/slice_id/);
+    expect(() => validateRecord({ ...validRecord, umbrella: 0 })).toThrow(/umbrella/);
+    expect(() => validateRecord({ ...validRecord, sliced_at: "2026-05-14" })).toThrow(/sliced_at/);
+    expect(() => validateRecord({ ...validRecord, expected_close_signal: "nope" })).toThrow(
+      /expected_close_signal/,
+    );
+  });
+
+  it("validates child shape and notes type", () => {
+    expect(() =>
+      validateRecord({ ...validRecord, children: [{ url: "u", wave: 1, role: "r" }] }),
+    ).toThrow(/missing required field/);
+    expect(() =>
+      validateRecord({ ...validRecord, children: [{ n: 0, url: "u", wave: 1, role: "r" }] }),
+    ).toThrow(/children\[0\]\.n/);
+    expect(() =>
+      validateRecord({ ...validRecord, children: [{ n: 2, url: "", wave: 1, role: "r" }] }),
+    ).toThrow(/url/);
+    expect(() => validateRecord({ ...validRecord, notes: 1 })).toThrow(/notes must be a string/);
+  });
+});

--- a/packages/core/src/slice/validate.ts
+++ b/packages/core/src/slice/validate.ts
@@ -1,0 +1,111 @@
+import {
+  ALLOWED_FIELDS,
+  CHILD_ALLOWED_FIELDS,
+  CHILD_REQUIRED_FIELDS,
+  ISO8601_RE,
+  REQUIRED_FIELDS,
+  UUID_RE,
+  VALID_EXPECTED_CLOSE_SIGNALS,
+} from "./constants.js";
+import { SliceRecordError } from "./errors.js";
+
+function validateChild(child: unknown, index: number): void {
+  if (child === null || typeof child !== "object" || Array.isArray(child)) {
+    throw new SliceRecordError(
+      `children[${index}] must be a dict, got ${child === null ? "null" : typeof child}`,
+    );
+  }
+  const record = child as Record<string, unknown>;
+  const missing = CHILD_REQUIRED_FIELDS.filter((field) => !(field in record));
+  if (missing.length > 0) {
+    throw new SliceRecordError(`children[${index}] missing required field(s): ${missing}`);
+  }
+  const extras = Object.keys(record)
+    .filter((key) => !CHILD_ALLOWED_FIELDS.has(key as (typeof CHILD_REQUIRED_FIELDS)[number]))
+    .sort();
+  if (extras.length > 0) {
+    throw new SliceRecordError(`children[${index}] has unknown field(s): ${extras}`);
+  }
+  const n = record.n;
+  if (typeof n !== "number" || !Number.isInteger(n) || n < 1) {
+    throw new SliceRecordError(`children[${index}].n must be a positive int, got ${String(n)}`);
+  }
+  const url = record.url;
+  if (typeof url !== "string" || url.length === 0) {
+    throw new SliceRecordError(
+      `children[${index}].url must be a non-empty string, got ${String(url)}`,
+    );
+  }
+  const wave = record.wave;
+  if (typeof wave !== "number" || !Number.isInteger(wave) || wave < 1) {
+    throw new SliceRecordError(
+      `children[${index}].wave must be a positive int, got ${String(wave)}`,
+    );
+  }
+  const role = record.role;
+  if (typeof role !== "string" || role.length === 0) {
+    throw new SliceRecordError(
+      `children[${index}].role must be a non-empty string, got ${String(role)}`,
+    );
+  }
+}
+
+/** Hand-rolled mirror of vbrief/schemas/slices.schema.json. */
+export function validateRecord(record: unknown): void {
+  if (record === null || typeof record !== "object" || Array.isArray(record)) {
+    throw new SliceRecordError(
+      `record must be a dict, got ${record === null ? "null" : typeof record}`,
+    );
+  }
+  const obj = record as Record<string, unknown>;
+  const missing = REQUIRED_FIELDS.filter((field) => !(field in obj));
+  if (missing.length > 0) {
+    throw new SliceRecordError(`record missing required field(s): ${missing}`);
+  }
+  const extras = Object.keys(obj)
+    .filter((key) => !ALLOWED_FIELDS.has(key as (typeof REQUIRED_FIELDS)[number] | "notes"))
+    .sort();
+  if (extras.length > 0) {
+    throw new SliceRecordError(`record has unknown field(s): ${extras}`);
+  }
+  const sliceId = obj.slice_id;
+  if (typeof sliceId !== "string" || !UUID_RE.test(sliceId)) {
+    throw new SliceRecordError(`slice_id must be a UUID string, got ${String(sliceId)}`);
+  }
+  const umbrella = obj.umbrella;
+  if (typeof umbrella !== "number" || !Number.isInteger(umbrella) || umbrella < 1) {
+    throw new SliceRecordError(`umbrella must be a positive int, got ${String(umbrella)}`);
+  }
+  const umbrellaUrl = obj.umbrella_url;
+  if (typeof umbrellaUrl !== "string" || umbrellaUrl.length === 0) {
+    throw new SliceRecordError(
+      `umbrella_url must be a non-empty string, got ${String(umbrellaUrl)}`,
+    );
+  }
+  const slicedAt = obj.sliced_at;
+  if (typeof slicedAt !== "string" || !ISO8601_RE.test(slicedAt)) {
+    throw new SliceRecordError(
+      `sliced_at must be ISO-8601 UTC with Z suffix (e.g. 2026-05-13T18:00:00Z), got ${String(slicedAt)}`,
+    );
+  }
+  const actor = obj.actor;
+  if (typeof actor !== "string" || actor.length === 0) {
+    throw new SliceRecordError(`actor must be a non-empty string, got ${String(actor)}`);
+  }
+  const children = obj.children;
+  if (!Array.isArray(children) || children.length === 0) {
+    throw new SliceRecordError("children must be a non-empty list of child records");
+  }
+  for (let i = 0; i < children.length; i += 1) {
+    validateChild(children[i], i);
+  }
+  const expected = obj.expected_close_signal;
+  if (typeof expected !== "string" || !VALID_EXPECTED_CLOSE_SIGNALS.has(expected)) {
+    throw new SliceRecordError(
+      `expected_close_signal must be one of ${[...VALID_EXPECTED_CLOSE_SIGNALS].sort()}, got ${String(expected)}`,
+    );
+  }
+  if ("notes" in obj && typeof obj.notes !== "string") {
+    throw new SliceRecordError(`notes must be a string, got ${typeof obj.notes}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Port `slice:record-existing` and `slice:list` from Python (`scripts/slice_record.py` / `slice_record_existing.py`) to TypeScript under `packages/core/src/slice/`.
- Preserve `slices.jsonl` cohort-record shape (field order) and record-existing idempotency (matching umbrella + child set writes once).
- Add thin CLI wrapper (`packages/cli/src/slice.ts`) and parity harness (`slice-parity.ts`) that matches Python oracle output with cache OFF.

Refs #1530 #1727

## Test plan
- [x] `task ts:build`
- [x] `task ts:lint`
- [x] `task ts:test` (slice module ≥88% branch coverage)
- [x] `node packages/cli/dist/slice-parity.js` → CLEAN (12 cases)
- [ ] CI green on PR

## Notes
Shared wiring (`packages/core/src/index.ts`, `tasks/ts.yml`, CI workflow) intentionally deferred to integration PR per cohort plan.

Made with [Cursor](https://cursor.com)