### PR TITLE
chore: complete Wave-3 umbrella vBRIEFs (#1724-1728)

### DIFF
--- a/vbrief/completed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json
+++ b/vbrief/completed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(ts-migration): port the scm.py SCM boundary to a TS adapter (Wave 3)",
-    "status": "proposed",
+    "status": "completed",
     "narratives": {
       "Description": "feat(ts-migration): port the scm.py SCM boundary to a TS adapter (Wave 3)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1724",
@@ -55,7 +55,10 @@
       }
     ],
     "metadata": {
-      "kind": "epic"
-    }
+      "kind": "epic",
+      "completedAt": "2026-06-19T10:32:53Z",
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-06-19T10:32:53Z"
   }
 }

--- a/vbrief/completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json
+++ b/vbrief/completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(ts-migration): port the triage:* family to TS (Wave 3)",
-    "status": "proposed",
+    "status": "completed",
     "narratives": {
       "Description": "feat(ts-migration): port the triage:* family to TS (Wave 3)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1725",
@@ -97,7 +97,10 @@
       }
     ],
     "metadata": {
-      "kind": "epic"
-    }
+      "kind": "epic",
+      "completedAt": "2026-06-19T10:32:54Z",
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-06-19T10:32:54Z"
   }
 }

--- a/vbrief/completed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json
+++ b/vbrief/completed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(ts-migration): port the scope:* lifecycle family to TS (Wave 3)",
-    "status": "proposed",
+    "status": "completed",
     "narratives": {
       "Description": "feat(ts-migration): port the scope:* lifecycle family to TS (Wave 3)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1726",
@@ -54,7 +54,10 @@
       }
     ],
     "metadata": {
-      "kind": "epic"
-    }
+      "kind": "epic",
+      "completedAt": "2026-06-19T10:32:54Z",
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-06-19T10:32:54Z"
   }
 }

--- a/vbrief/completed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json
+++ b/vbrief/completed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(ts-migration): port the slice:* family to TS (Wave 3)",
-    "status": "proposed",
+    "status": "completed",
     "narratives": {
       "Description": "feat(ts-migration): port the slice:* family to TS (Wave 3)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1727",
@@ -54,7 +54,10 @@
       }
     ],
     "metadata": {
-      "kind": "epic"
-    }
+      "kind": "epic",
+      "completedAt": "2026-06-19T10:32:33Z",
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-06-19T10:32:33Z"
   }
 }

--- a/vbrief/completed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json
+++ b/vbrief/completed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(ts-migration): port cache + deft doctor to TS (Wave 3)",
-    "status": "proposed",
+    "status": "completed",
     "narratives": {
       "Description": "feat(ts-migration): port cache + deft doctor to TS (Wave 3)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1728",
@@ -60,7 +60,10 @@
       }
     ],
     "metadata": {
-      "kind": "epic"
-    }
+      "kind": "epic",
+      "completedAt": "2026-06-19T10:32:55Z",
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-06-19T10:32:55Z"
   }
 }

--- a/vbrief/completed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-deft-doctor-doctorpy-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1728-s2-doctor",
     "title": "Port deft doctor (doctor.py) to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/doctor.py (deft doctor: install-integrity, toolchain probe, AGENTS.md managed-section freshness, and payload-staleness detection from the VERSION manifest) to a TypeScript doctor module under packages/core. This story depends on the cache port because the doctor cache-fresh probe reads the cache module; it is independently buildable thereafter as a self-contained module with a golden parity binary.",
       "ImplementationPlan": "1. Create the packages/core/src/doctor module that ports the install-integrity, toolchain, managed-section freshness, and payload-staleness probes, reading the ported cache module for the cache-fresh check, with vitest unit tests in the module directory.\n2. Reproduce the canonical headless upgrade command emitted when the payload manifest is behind, matching the Python doctor.py source strings.\n3. Add a packages/cli/src/doctor-parity.ts parity binary that runs the TS doctor and the Python scripts/doctor.py oracle and asserts byte-identical output with cache off.",

--- a/vbrief/completed/2026-06-19-port-the-scmpy-scm-boundary-to-a-typescript-adapter.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-the-scmpy-scm-boundary-to-a-typescript-adapter.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1724-s1-scm-adapter",
     "title": "Port the scm.py SCM boundary to a TypeScript adapter",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json",
+    "planRef": "completed/2026-06-19-1724-featts-migration-port-the-scmpy-scm-boundary-to-a-ts-adapter.vbrief.json",
     "narratives": {
       "Description": "Port the scripts/scm.py boundary (the scm.call(source, verb, args) shim, the ghx->gh preference ladder in resolve_binary, and the github-issue NotImplementedError for non-GitHub sources) to a TypeScript SCM adapter under packages/core. This is the shared foundation that the Wave-3 triage, scope, and slice families call to reach GitHub, so it is built and merged first; it is independently buildable because the adapter is a self-contained module with a golden parity binary and no dependency on any other Wave-3 port.",
       "ImplementationPlan": "1. Create the packages/core/src/scm module that ports resolve_binary (the ghx->gh ladder), the call(source, verb, args) dispatch, and the non-github-issue rejection path, with vitest unit tests in the same module directory.\n2. Add a packages/cli/src/scm-parity.ts parity binary that runs the TS adapter and the Python scripts/scm.py oracle over a fixture corpus and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary, keeping the Python suite as the authoritative oracle until cutover.",

--- a/vbrief/completed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-the-scope-lifecycle-family-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1726-s1-scope-lifecycle",
     "title": "Port the scope:* lifecycle family to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json",
+    "planRef": "completed/2026-06-19-1726-featts-migration-port-the-scope-lifecycle-family-to-ts-wave.vbrief.json",
     "narratives": {
       "Description": "Port the scripts/scope_lifecycle.py family (promote, activate, complete, cancel, restore, block, unblock, fail, demote, and undo) to TypeScript, preserving the atomic plan.status plus plan.updated plus folder-move semantics and the audit log. This is kept as one story rather than split because every transition shares the same atomic write engine and audit path, so splitting it across parallel workers would force overlapping edits to the same module; it remains independently buildable as a single self-contained scope module with a golden parity binary.",
       "ImplementationPlan": "1. Create the packages/core/src/scope module that ports each lifecycle transition over the atomic status plus timestamp plus folder-move engine and the audit log writer, with vitest unit tests in the module directory.\n2. Port scope undo so non-terminal transitions are reversible and terminal actions are refused, matching the Python reversibility contract.\n3. Add a packages/cli/src/scope-lifecycle-parity.ts parity binary that runs the TS transitions and the Python scripts/scope_lifecycle.py oracle and asserts byte-identical output with cache off.",

--- a/vbrief/completed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-the-slice-family-record-existing-list-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1727-s1-slice-record",
     "title": "Port the slice:* family (record-existing / list) to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1727-featts-migration-port-the-slice-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port the scripts/slice_record.py family (slice:record-existing and slice:list) to TypeScript, preserving the slices.jsonl cohort-record shape and the record-existing idempotency contract. This story is independently buildable because the slice module is self-contained, reads and writes only the cohort-record file, and ships a golden parity binary against the Python oracle.",
       "ImplementationPlan": "1. Create the packages/core/src/slice module that ports record-existing and list over the slices.jsonl cohort-record file, preserving field order and idempotency, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/slice-parity.ts parity binary that runs the TS verbs and the Python scripts/slice_record.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the authoritative oracle.",

--- a/vbrief/completed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-the-unified-content-cache-cachepy-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1728-s1-cache",
     "title": "Port the unified content cache (cache.py) to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1728-featts-migration-port-cache-deft-doctor-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/cache.py (the unified content cache and quarantine: put, get, invalidate, fetch-all, prune, plus TTL handling) to a TypeScript cache module under packages/core. This story is independently buildable because the cache module is self-contained, owns its on-disk cache directory, and ships a golden parity binary against the Python oracle; it is sequenced before the doctor port because the deft doctor cache-fresh probe reads the cache.",
       "ImplementationPlan": "1. Create the packages/core/src/cache module that ports put, get, invalidate, fetch-all, and prune over the on-disk cache with TTL expiry and the quarantine path, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/cache-parity.ts parity binary that runs the TS cache verbs and the Python scripts/cache.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module stays the authoritative oracle.",

--- a/vbrief/completed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triage-aux-verbs-a-welcome-refresh-reconcile-scope-drif.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s7-triage-aux-a",
     "title": "Port triage aux verbs A (welcome / refresh / reconcile / scope-drift) to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port the first aux cluster of the triage family (scripts/triage_welcome.py, triage_refresh.py, triage_reconcile.py, and triage_scope_drift.py) to TypeScript, preserving the welcome surface wording, the cache refresh path, the origin reconciliation, and the scope-drift detection. This story is independently buildable because each verb gets its own packages/core/src/triage subdirectory with no overlap with the other triage stories, and it ships a golden parity binary against the Python oracles.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/welcome, refresh, reconcile, and scope-drift modules that port the four Python scripts, with vitest unit tests in each module directory.\n2. Add a packages/cli/src/triage-aux-a-parity.ts parity binary that runs each TS verb and its Python oracle (triage_welcome.py, triage_refresh.py, triage_reconcile.py, triage_scope_drift.py) and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python modules remain the oracles.",

--- a/vbrief/completed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triage-aux-verbs-b-bulk-subscribe-help-smoketest-to-typ.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s8-triage-aux-b",
     "title": "Port triage aux verbs B (bulk / subscribe / help / smoketest) to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port the second aux cluster of the triage family (scripts/triage_bulk.py, triage_subscribe.py, triage_help.py, and triage_smoketest.py) to TypeScript, preserving the bulk action surface, the subscription handling, the help text, and the smoketest self-check. This story is independently buildable because each verb gets its own packages/core/src/triage subdirectory with no overlap with the other triage stories, and it ships a golden parity binary against the Python oracles.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/bulk, subscribe, help, and smoketest modules that port the four Python scripts, with vitest unit tests in each module directory.\n2. Add a packages/cli/src/triage-aux-b-parity.ts parity binary that runs each TS verb and its Python oracle (triage_bulk.py, triage_subscribe.py, triage_help.py, triage_smoketest.py) and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python modules remain the oracles.",

--- a/vbrief/completed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triageaccept-reject-defer-actions-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s4-triage-actions",
     "title": "Port triage:accept / reject / defer actions to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/triage_actions.py to a TypeScript triage actions module, preserving the accept, reject, and defer transitions and the cache mutations they apply to candidate state. This story is independently buildable in its own packages/core/src/triage/actions subdirectory and ships a golden parity binary against the Python oracle.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/actions module that ports the accept, reject, and defer handlers and their candidate-state cache mutations from triage_actions.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-actions-parity.ts parity binary that runs the TS actions and the Python scripts/triage_actions.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",

--- a/vbrief/completed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triagebootstrap-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s5-triage-bootstrap",
     "title": "Port triage:bootstrap to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/triage_bootstrap.py to a TypeScript triage bootstrap module, preserving the candidate-corpus bootstrap that seeds the triage cache and the watchdog timing safeguards it applies. This story is independently buildable in its own packages/core/src/triage/bootstrap subdirectory and ships a golden parity binary against the Python oracle.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/bootstrap module that ports the cache-seeding bootstrap and its watchdog guards from triage_bootstrap.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-bootstrap-parity.ts parity binary that runs the TS bootstrap and the Python scripts/triage_bootstrap.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",

--- a/vbrief/completed/2026-06-19-port-triageclassify-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triageclassify-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s3-triage-classify",
     "title": "Port triage:classify to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/triage_classify.py to a TypeScript triage classify module, preserving the candidate classification logic (resume, orphan, urgent, and label-derived buckets) that feeds the queue ranking. This story is independently buildable in its own packages/core/src/triage/classify subdirectory and ships a golden parity binary against the Python oracle.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/classify module that ports the classification rules and bucket assignment from triage_classify.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-classify-parity.ts parity binary that runs the TS classifier and the Python scripts/triage_classify.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",

--- a/vbrief/completed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triagequeue-ranking-resumeorphanurgent-order-to-typescr.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s1-triage-queue",
     "title": "Port triage:queue (ranking + RESUME/ORPHAN/URGENT order) to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/triage_queue.py to a TypeScript triage queue module, preserving the candidate ranking order and the [RESUME], [ORPHAN], and [URGENT] classification tags exactly. This is the highest-risk triage slice because the ranking order is observable in operator output, so it ships a golden parity binary; it is independently buildable in its own packages/core/src/triage/queue subdirectory.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/queue module that ports the candidate ranking comparator and the RESUME/ORPHAN/URGENT tagging from triage_queue.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-queue-parity.ts parity binary that runs the TS queue and the Python scripts/triage_queue.py oracle and asserts byte-identical ranked output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the authoritative oracle.",

--- a/vbrief/completed/2026-06-19-port-triagescope-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triagescope-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s6-triage-scope",
     "title": "Port triage:scope to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/triage_scope.py to a TypeScript triage scope module, preserving the triageScope configuration resolution and the scope-membership decisions that gate which candidates appear in the queue. This story is independently buildable in its own packages/core/src/triage/scope subdirectory and ships a golden parity binary against the Python oracle.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/scope module that ports the triageScope resolution and scope-membership predicate from triage_scope.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-scope-parity.ts parity binary that runs the TS scope and the Python scripts/triage_scope.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",

--- a/vbrief/completed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-triagesummary-welcome-one-liner-to-typescript.vbrief.json
@@ -7,7 +7,7 @@
     "id": "1725-s2-triage-summary",
     "title": "Port triage:summary (welcome one-liner) to TypeScript",
     "status": "completed",
-    "planRef": "proposed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
+    "planRef": "completed/2026-06-19-1725-featts-migration-port-the-triage-family-to-ts-wave-3.vbrief.json",
     "narratives": {
       "Description": "Port scripts/triage_summary.py to a TypeScript triage summary module, preserving the triage-cache one-line headline and the in-flight count plus scope-gap wording the welcome surface emits. This story is independently buildable in its own packages/core/src/triage/summary subdirectory and ships a golden parity binary against the Python oracle.",
       "ImplementationPlan": "1. Create the packages/core/src/triage/summary module that ports the headline composition, the filesystem-truth in-flight count, and the scope-gap line from triage_summary.py, with vitest unit tests in the module directory.\n2. Add a packages/cli/src/triage-summary-parity.ts parity binary that runs the TS summary and the Python scripts/triage_summary.py oracle and asserts byte-identical output with cache off.\n3. Verify the port with the new vitest tests and the parity binary while the Python module remains the oracle.",


### PR DESCRIPTION
## Summary
Wave 3 of the #1530 TS-migration epic is fully landed (scm, triage family, scope lifecycle, slice, cache, doctor — all ported, merged, and wired into `@deftai/core`). This closes out the bookkeeping:

- Moves the 5 umbrella vBRIEFs from `vbrief/proposed/` → `vbrief/completed/`.
- The lifecycle move auto-rewires the 13 child `planRef`s to the umbrellas' new `completed/` paths, preserving D4 reference integrity.
- Closes the 5 umbrella GitHub issues (#1724–#1728).
- WIP cap returns to 1/10 (only the #1530 epic remains in `pending/`).

## Test plan
- [x] `task check` green (validate + lint + test + encoding + vBRIEF conformance + wip-cap)
- [x] `task validate` — all 988 markdown / 669 scope vBRIEFs pass D4
- [x] Confirmed child `planRef`s point to `completed/` umbrella paths

Closes #1724
Closes #1725
Closes #1726
Closes #1727
Closes #1728

Made with [Cursor](https://cursor.com)