### PR TITLE
chore(vbrief): decompose #1530 Wave-4a (#1729) into 4 release stories

### DIFF
--- a/vbrief/proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json
@@ -1,0 +1,94 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1729"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port the release pipeline (release*.py) to TS (Wave 4)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port the release pipeline (release*.py) to TS (Wave 4)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1729",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2; umbrella epic #1545)\n\n## What to build\n\nPort the release pipeline (`scripts/release*.py` -> `deft release:*`: release / publish / rollback / e2e, CHANGELOG section extraction, GitHub release body flow) to TS.\n\n## Acceptance criteria\n\n- [ ] `release:*` verbs run on TS with the publish/rollback/e2e flow preserved\n- [ ] CHANGELOG `[version]` section extraction + release-body flow reproduced\n- [ ] Golden-output parity vs the Python oracle (cache-off)\n- [ ] `task check` passes\n\n## Standing invariants (all Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) and CI usage.\n- No agent-runtime dependency (that is Part 2, #1707); no monorepo orchestrator on day one (Nx never; Turborepo only on a measured trigger).\n\n## Type\n\nAFK\n\n## Blocked by\n\n- Blocked by #1725\n- Blocked by #1726\n- Blocked by #1727\n- Blocked by #1728\n",
+      "Labels": "ci-cd, refactor, runtime-portability, tooling"
+    },
+    "items": [
+      {
+        "title": "verbs run on TS with the publish/rollback/e2e flow preserved",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG  section extraction + release-body flow reproduced",
+        "status": "proposed"
+      },
+      {
+        "title": "Golden-output parity vs the Python oracle (cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "passes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "ci-cd",
+      "refactor",
+      "runtime-portability",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1729",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1729: feat(ts-migration): port the release pipeline (release*.py) to TS (Wave 4)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1725"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1726",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1726"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1727",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1727"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1728"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-releasepy-core-version-bump-changelog-section-extra.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the release.py core (version bump + CHANGELOG section extraction + GitHub release-body flow) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-release-publishpy-releasepublish-flow-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port release_publish.py (release:publish flow) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-release-rollbackpy-releaserollback-flow-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port release_rollback.py (release:rollback flow) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-release-e2epy-releasee2e-rehearsal-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port release_e2e.py (release:e2e rehearsal) to TypeScript",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-release-e2epy-releasee2e-rehearsal-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-release-e2epy-releasee2e-rehearsal-to-typescript.vbrief.json
@@ -1,0 +1,100 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 4 decomposed from proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json"
+  },
+  "plan": {
+    "id": "1729-s4-release-e2e",
+    "title": "Port release_e2e.py (release:e2e rehearsal) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/release_e2e.py -- the release:e2e end-to-end rehearsal that exercises the full release flow against a temp/throwaway target before a real release -- to TypeScript. It builds on the shared release-core helpers from 1729-s1 and is independently buildable as a self-contained packages/core/src/release-e2e module with a golden parity binary.",
+      "ImplementationPlan": "1. Create the packages/core/src/release-e2e module porting the end-to-end rehearsal orchestration over the merged release-core helpers, with vitest unit tests in the module directory.\n2. Add packages/cli/src/release-e2e.ts exposing the TS `release:e2e` verb behind the CLI seam.\n3. Add packages/cli/src/release-e2e-parity.ts that runs the TS path and the Python scripts/release_e2e.py oracle and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want release:e2e available in TypeScript, so that the release rehearsal runs on the TS engine with the same end-to-end flow as the Python module."
+    },
+    "items": [
+      {
+        "id": "1729-s4-a1",
+        "title": "e2e rehearsal orchestration preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS release:e2e rehearsal returns the same end-to-end result against the throwaway target that the Python release_e2e.py module produces."
+        }
+      },
+      {
+        "id": "1729-s4-a2",
+        "title": "rehearsal pass/fail reporting preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running release:e2e reports rehearsal pass/fail with the same exit code and summary the Python module emits."
+        }
+      },
+      {
+        "id": "1729-s4-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the release-e2e-parity binary returns exit 0 and renders byte-identical output to the Python scripts/release_e2e.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release-e2e/",
+          "packages/cli/src/release-e2e.ts",
+          "packages/cli/src/release-e2e-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/release-e2e-parity.js",
+          "pnpm --filter @deftai/core test src/release-e2e"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/release-e2e module with vitest unit tests",
+          "New packages/cli/src/release-e2e-parity.ts parity binary",
+          "Byte-identical parity vs scripts/release_e2e.py under cache-off"
+        ],
+        "depends_on": [
+          "1729-s1-release-core"
+        ],
+        "conflict_group": "ts-wave4-release-e2e",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-4 framework-internal TS port traced to GitHub issue #1729 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1729",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1729: feat(ts-migration): port the release pipeline (release*.py) to TS (Wave 4)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1725"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1726",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1726"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1727",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1727"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1728"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-release-publishpy-releasepublish-flow-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-release-publishpy-releasepublish-flow-to-typescript.vbrief.json
@@ -1,0 +1,100 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json"
+  },
+  "plan": {
+    "id": "1729-s2-release-publish",
+    "title": "Port release_publish.py (release:publish flow) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/release_publish.py -- the release:publish flow that promotes a drafted release to published, drives the GitHub release create/edit, and applies the publish-time safety checks (#716) -- to TypeScript. It builds on the shared release-core helpers from 1729-s1 and is independently buildable as a self-contained packages/core/src/release-publish module with a golden parity binary.",
+      "ImplementationPlan": "1. Create the packages/core/src/release-publish module porting the publish promotion flow and publish-time safety checks over the merged release-core helpers, with vitest unit tests in the module directory.\n2. Add packages/cli/src/release-publish.ts exposing the TS `release:publish` verb behind the CLI seam.\n3. Add packages/cli/src/release-publish-parity.ts that runs the TS path and the Python scripts/release_publish.py oracle and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want release:publish available in TypeScript, so that publishing a drafted release runs on the TS engine with the same promotion flow and safety checks as the Python module."
+    },
+    "items": [
+      {
+        "id": "1729-s2-a1",
+        "title": "publish promotion flow preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS release:publish flow updates the GitHub release from draft to published using the same transition the Python release_publish.py module performs."
+        }
+      },
+      {
+        "id": "1729-s2-a2",
+        "title": "publish-time safety checks preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running release:publish against a release that fails a publish-time safety check is refused with the same guard message the Python module emits."
+        }
+      },
+      {
+        "id": "1729-s2-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the release-publish-parity binary returns exit 0 and renders byte-identical output to the Python scripts/release_publish.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release-publish/",
+          "packages/cli/src/release-publish.ts",
+          "packages/cli/src/release-publish-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/release-publish-parity.js",
+          "pnpm --filter @deftai/core test src/release-publish"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/release-publish module with vitest unit tests",
+          "New packages/cli/src/release-publish-parity.ts parity binary",
+          "Byte-identical parity vs scripts/release_publish.py under cache-off"
+        ],
+        "depends_on": [
+          "1729-s1-release-core"
+        ],
+        "conflict_group": "ts-wave4-release-publish",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-4 framework-internal TS port traced to GitHub issue #1729 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1729",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1729: feat(ts-migration): port the release pipeline (release*.py) to TS (Wave 4)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1725"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1726",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1726"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1727",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1727"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1728"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-release-rollbackpy-releaserollback-flow-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-release-rollbackpy-releaserollback-flow-to-typescript.vbrief.json
@@ -1,0 +1,100 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json"
+  },
+  "plan": {
+    "id": "1729-s3-release-rollback",
+    "title": "Port release_rollback.py (release:rollback flow) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/release_rollback.py -- the release:rollback flow that reverts a published or drafted release, unwinds the tag/release/CHANGELOG promotion, and applies the rollback-time safety guards (#716) -- to TypeScript. It builds on the shared release-core helpers from 1729-s1 and is independently buildable as a self-contained packages/core/src/release-rollback module with a golden parity binary.",
+      "ImplementationPlan": "1. Create the packages/core/src/release-rollback module porting the rollback flow, the tag/release/CHANGELOG unwind, and the rollback-time safety guards over the merged release-core helpers, with vitest unit tests in the module directory.\n2. Add packages/cli/src/release-rollback.ts exposing the TS `release:rollback` verb behind the CLI seam.\n3. Add packages/cli/src/release-rollback-parity.ts that runs the TS path and the Python scripts/release_rollback.py oracle and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want release:rollback available in TypeScript, so that reverting a release runs on the TS engine with the same unwind sequence and safety guards as the Python module."
+    },
+    "items": [
+      {
+        "id": "1729-s3-a1",
+        "title": "rollback unwind sequence preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS release:rollback flow deletes the tag and release and reverts the CHANGELOG promotion in the same sequence the Python release_rollback.py module performs."
+        }
+      },
+      {
+        "id": "1729-s3-a2",
+        "title": "rollback-time safety guards preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running release:rollback against a state that fails a rollback-time safety guard is refused with the same guard message the Python module emits."
+        }
+      },
+      {
+        "id": "1729-s3-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the release-rollback-parity binary returns exit 0 and renders byte-identical output to the Python scripts/release_rollback.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release-rollback/",
+          "packages/cli/src/release-rollback.ts",
+          "packages/cli/src/release-rollback-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/release-rollback-parity.js",
+          "pnpm --filter @deftai/core test src/release-rollback"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/release-rollback module with vitest unit tests",
+          "New packages/cli/src/release-rollback-parity.ts parity binary",
+          "Byte-identical parity vs scripts/release_rollback.py under cache-off"
+        ],
+        "depends_on": [
+          "1729-s1-release-core"
+        ],
+        "conflict_group": "ts-wave4-release-rollback",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-4 framework-internal TS port traced to GitHub issue #1729 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1729",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1729: feat(ts-migration): port the release pipeline (release*.py) to TS (Wave 4)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1725"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1726",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1726"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1727",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1727"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1728"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-releasepy-core-version-bump-changelog-section-extra.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-releasepy-core-version-bump-changelog-section-extra.vbrief.json
@@ -1,0 +1,98 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json"
+  },
+  "plan": {
+    "id": "1729-s1-release-core",
+    "title": "Port the release.py core (version bump + CHANGELOG section extraction + GitHub release-body flow) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1729-featts-migration-port-the-release-pipeline-releasepy-to-ts-w.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/release.py -- the release-pipeline core that the publish, rollback, and e2e flows all build on -- to TypeScript. This covers version resolution/bump, the CHANGELOG [version] section extraction (_section_for_version, including the 125,000-char GitHub release-body ceiling guard from #1242), the ROADMAP/CHANGELOG promotion flow, and the top-level `release` verb. It is dispatched first as the foundation because publish/rollback/e2e import these shared helpers; it is independently buildable as a self-contained packages/core/src/release module with a golden parity binary.",
+      "ImplementationPlan": "1. Create the packages/core/src/release module porting version resolution, CHANGELOG [version] section extraction (with the release-body length guard), the ROADMAP/CHANGELOG promotion flow, and the `release` verb, with vitest unit tests in the module directory.\n2. Add packages/cli/src/release.ts exposing the TS `release` verb behind the existing CLI seam.\n3. Add packages/cli/src/release-parity.ts that runs the TS path and the Python scripts/release.py oracle and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want the release pipeline core available in TypeScript, so that version bump, CHANGELOG section extraction, and the release-body flow run on the TS engine with the same output as the Python module."
+    },
+    "items": [
+      {
+        "id": "1729-s1-a1",
+        "title": "version resolution + bump preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS release core returns the same bumped version value that the Python release.py module produces for the same inputs."
+        }
+      },
+      {
+        "id": "1729-s1-a2",
+        "title": "CHANGELOG section extraction + release-body guard preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Extracting the CHANGELOG [version] section returns the same text the Python module returns, and a section exceeding the 125,000-char GitHub release-body ceiling is rejected with the same error."
+        }
+      },
+      {
+        "id": "1729-s1-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the release-parity binary returns exit 0 and renders byte-identical output to the Python scripts/release.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release/",
+          "packages/cli/src/release.ts",
+          "packages/cli/src/release-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/release-parity.js",
+          "pnpm --filter @deftai/core test src/release"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/release module with vitest unit tests",
+          "New packages/cli/src/release-parity.ts parity binary",
+          "Byte-identical parity vs scripts/release.py under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave4-release-core",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-4 framework-internal TS port traced to GitHub issue #1729 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1729",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1729: feat(ts-migration): port the release pipeline (release*.py) to TS (Wave 4)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1725",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1725"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1726",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1726"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1727",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1727"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1728",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1728"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Decomposes the Wave-4a release-pipeline umbrella (#1729) into 4 swarm-ready story vBRIEFs in `vbrief/proposed/`:

- **release core** — `release.py` → `packages/core/src/release/` (version bump, CHANGELOG `[version]` section extraction incl. the #1242 release-body ceiling guard, release-body flow, `release` verb). Foundation; dispatched first.
- **release:publish** — `release_publish.py` → `packages/core/src/release-publish/`
- **release:rollback** — `release_rollback.py` → `packages/core/src/release-rollback/`
- **release:e2e** — `release_e2e.py` → `packages/core/src/release-e2e/`

The three dependents (`publish`/`rollback`/`e2e`) `depend_on` the release core and own disjoint module directories so they stay parallel-safe once core lands. Each story carries a cache-off golden parity binary vs its Python oracle (strangler-fig invariant).

No engine behavior moves in this PR — it only adds proposed/ story vBRIEFs. WIP cap stays 1/10.

## Test plan
- [x] `task scope:decompose --check` validates all 4 stories (observable acceptance criteria)
- [x] `task check` green (vBRIEF validation, conformance, wip-cap 1/10, encoding)

Refs #1530 #1729