### PR TITLE
feat(release): port release.py core to TypeScript (#1729)

### DIFF
--- a/packages/cli/src/release-parity.ts
+++ b/packages/cli/src/release-parity.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1729): runs BOTH the Python oracle
+ * (`scripts/release.py`) and the ported TS release CLI with identical argv,
+ * then diffs exit codes and normalised stderr/stdout. Exit 0 only on
+ * byte-identical results (volatile ISO dates normalised in stderr).
+ *
+ * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SAMPLE_CHANGELOG = ` Changelog
+
+All notable changes to the project.
+
+## [Unreleased]
+
+### Added
+- New release automation (#74)
+
+### Changed
+- Refactored module X
+
+### Fixed
+- Bug Y
+
+## [0.20.2] - 2026-04-24
+
+### Added
+- Prior change
+
+## [0.20.0] - 2026-04-23
+
+### Added
+- Older change
+
+[Unreleased]: https://github.com/deftai/directive/compare/v0.20.2...HEAD
+[0.20.2]: https://github.com/deftai/directive/compare/v0.20.0...v0.20.2
+[0.20.0]: https://github.com/deftai/directive/compare/v0.19.0...v0.20.0
+`;
+
+export interface ScenarioResult {
+  readonly name: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ParityScenario {
+  readonly name: string;
+  readonly argv: readonly string[];
+  readonly setup?: (root: string) => void;
+  readonly compareStdout?: boolean;
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly scenarios: Array<{
+    readonly name: string;
+    readonly exitMismatch: boolean;
+    readonly pythonExit: number;
+    readonly tsExit: number;
+    readonly outputMismatch: boolean;
+    readonly pythonOutput: string;
+    readonly tsOutput: string;
+    readonly stream: "stdout" | "stderr";
+  }>;
+}
+
+export const PARITY_SCENARIOS: readonly ParityScenario[] = [
+  { name: "invalid-version", argv: ["not-a-version"] },
+  {
+    name: "dry-run-fixture",
+    argv: [
+      "0.21.0",
+      "--dry-run",
+      "--skip-tag",
+      "--skip-release",
+      "--repo",
+      "deftai/directive",
+      "--allow-vbrief-drift",
+      "--skip-ci",
+    ],
+    setup(root) {
+      writeFileSync(join(root, "CHANGELOG.md"), SAMPLE_CHANGELOG, "utf8");
+      execFileSync("git", ["init", "-q", "-b", "master", root]);
+      execFileSync("git", ["config", "user.email", "parity@test.local"], { cwd: root });
+      execFileSync("git", ["config", "user.name", "deft-parity"], { cwd: root });
+      execFileSync("git", ["add", "CHANGELOG.md"], { cwd: root });
+      execFileSync("git", ["commit", "-q", "-m", "init"], {
+        cwd: root,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "deft-parity",
+          GIT_AUTHOR_EMAIL: "parity@test.local",
+          GIT_COMMITTER_NAME: "deft-parity",
+          GIT_COMMITTER_EMAIL: "parity@test.local",
+        },
+      });
+    },
+  },
+  { name: "help", argv: ["--help"], compareStdout: true },
+];
+
+interface Capture {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCapture(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string | undefined> = {},
+): Capture {
+  const merged: Record<string, string | undefined> = {
+    ...process.env,
+    ...env,
+    DEFT_CACHE_DISABLE: "1",
+    PYTHONUTF8: "1",
+  };
+  for (const key of Object.keys(merged)) {
+    if (merged[key] === undefined) delete merged[key];
+  }
+  try {
+    const stdout = execFileSync(cmd, args, {
+      cwd,
+      encoding: "utf8",
+      env: merged as NodeJS.ProcessEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return {
+      status: typeof e.status === "number" ? e.status : 2,
+      stdout: typeof e.stdout === "string" ? e.stdout : "",
+      stderr: typeof e.stderr === "string" ? e.stderr : "",
+    };
+  }
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
+    return resolve(process.env.DEFT_ROOT);
+  }
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+/** Normalise volatile ISO dates in stderr while preserving semantics. */
+export function normaliseStderr(text: string): string {
+  return text.replace(/\d{4}-\d{2}-\d{2}/g, "YYYY-MM-DD");
+}
+
+export function pickOutput(
+  result: ScenarioResult,
+  stream: "stdout" | "stderr",
+): string {
+  return stream === "stdout" ? result.stdout : result.stderr;
+}
+
+function runScenario(
+  deftRoot: string,
+  scenario: ParityScenario,
+): { python: ScenarioResult; ts: ScenarioResult; projectRoot?: string } {
+  let cwd = deftRoot;
+  let tempRoot: string | undefined;
+  let projectRoot: string | undefined;
+  const argv = [...scenario.argv];
+
+  if (scenario.setup) {
+    tempRoot = mkdtempSync(join(tmpdir(), "deft-release-parity-"));
+    projectRoot = tempRoot;
+    scenario.setup(tempRoot);
+    const idx = argv.indexOf("--project-root");
+    if (idx === -1) {
+      argv.push("--project-root", tempRoot);
+    }
+    cwd = deftRoot;
+  }
+
+  try {
+    const pyArgs = ["run", "python", join(deftRoot, "scripts", "release.py"), ...argv];
+    const tsArgs = [join(deftRoot, "packages", "cli", "dist", "release.js"), ...argv];
+    const py = runCapture("uv", pyArgs, cwd);
+    const ts = runCapture("node", tsArgs, cwd);
+    return {
+      python: { name: scenario.name, exitCode: py.status, stdout: py.stdout, stderr: py.stderr },
+      ts: { name: scenario.name, exitCode: ts.status, stdout: ts.stdout, stderr: ts.stderr },
+      projectRoot,
+    };
+  } finally {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+export function diffParity(
+  python: ScenarioResult,
+  ts: ScenarioResult,
+  stream: "stdout" | "stderr",
+): {
+  exitMismatch: boolean;
+  outputMismatch: boolean;
+  pythonOutput: string;
+  tsOutput: string;
+} {
+  let pythonOutput = pickOutput(python, stream);
+  let tsOutput = pickOutput(ts, stream);
+  if (stream === "stderr") {
+    pythonOutput = normaliseStderr(pythonOutput);
+    tsOutput = normaliseStderr(tsOutput);
+  }
+  return {
+    exitMismatch: python.exitCode !== ts.exitCode,
+    outputMismatch: pythonOutput !== tsOutput,
+    pythonOutput,
+    tsOutput,
+  };
+}
+
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const scenarios: ParityResult["scenarios"] = [];
+  for (const scenario of PARITY_SCENARIOS) {
+    const ran = runScenario(deftRoot, scenario);
+    const stream: "stdout" | "stderr" = scenario.compareStdout ? "stdout" : "stderr";
+    scenarios.push({
+      name: scenario.name,
+      pythonExit: ran.python.exitCode,
+      tsExit: ran.ts.exitCode,
+      stream,
+      ...diffParity(ran.python, ran.ts, stream),
+    });
+  }
+  const ok = scenarios.every((s) => !s.exitMismatch && !s.outputMismatch);
+  return { ok, scenarios };
+}
+
+export function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `release parity: CLEAN -- Python and TS agree on ${result.scenarios.length} scenario(s).`;
+  }
+  const lines = ["release parity: DIVERGENCE"];
+  for (const s of result.scenarios) {
+    if (s.exitMismatch || s.outputMismatch) {
+      lines.push(`  scenario: ${s.name}`);
+      if (s.exitMismatch) {
+        lines.push(`    exit mismatch: python=${s.pythonExit} ts=${s.tsExit}`);
+      }
+      if (s.outputMismatch) {
+        lines.push(`    stream: ${s.stream}`);
+        lines.push(`    python (${s.pythonOutput.length} bytes)`);
+        lines.push(`    ts (${s.tsOutput.length} bytes)`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    process.exit(1);
+  } catch (err) {
+    const msg = String(err).replace(/\r?\n/g, " ");
+    process.stderr.write(`release parity: harness error -- ${msg}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/release-parity.ts
+++ b/packages/cli/src/release-parity.ts
@@ -8,7 +8,7 @@
  * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
  */
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -157,10 +157,7 @@ export function normaliseStderr(text: string): string {
   return text.replace(/\d{4}-\d{2}-\d{2}/g, "YYYY-MM-DD");
 }
 
-export function pickOutput(
-  result: ScenarioResult,
-  stream: "stdout" | "stderr",
-): string {
+export function pickOutput(result: ScenarioResult, stream: "stdout" | "stderr"): string {
   return stream === "stdout" ? result.stdout : result.stderr;
 }
 

--- a/packages/cli/src/release-parity.ts
+++ b/packages/cli/src/release-parity.ts
@@ -7,7 +7,7 @@
  *
  * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
  */
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -128,13 +128,17 @@ function runCapture(
     if (merged[key] === undefined) delete merged[key];
   }
   try {
-    const stdout = execFileSync(cmd, args, {
+    const result = spawnSync(cmd, args, {
       cwd,
       encoding: "utf8",
       env: merged as NodeJS.ProcessEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    return { status: 0, stdout, stderr: "" };
+    return {
+      status: result.status ?? 2,
+      stdout: typeof result.stdout === "string" ? result.stdout : "",
+      stderr: typeof result.stderr === "string" ? result.stderr : "",
+    };
   } catch (err: unknown) {
     const e = err as { status?: number; stdout?: string; stderr?: string };
     return {

--- a/packages/cli/src/release.ts
+++ b/packages/cli/src/release.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { cmdRelease } from "../../core/dist/release/main.js";
+
+export function run(argv: string[]): number {
+  return cmdRelease(argv);
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/src/release/changelog.test.ts
+++ b/packages/core/src/release/changelog.test.ts
@@ -63,9 +63,9 @@ describe("promoteChangelog", () => {
   });
 
   it("rejects missing Unreleased heading", () => {
-    expect(() => promoteChangelog("no heading", "0.21.0", "deftai/directive", "2026-04-28")).toThrow(
-      "does not contain",
-    );
+    expect(() =>
+      promoteChangelog("no heading", "0.21.0", "deftai/directive", "2026-04-28"),
+    ).toThrow("does not contain");
   });
 
   it("rejects multiline summary", () => {

--- a/packages/core/src/release/changelog.test.ts
+++ b/packages/core/src/release/changelog.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { promoteChangelog, sectionForVersion, splitBodyAndLinks } from "./changelog.js";
+
+const SAMPLE_CHANGELOG = ` Changelog
+
+All notable changes to the project.
+
+## [Unreleased]
+
+### Added
+- New release automation (#74)
+
+### Changed
+- Refactored module X
+
+### Fixed
+- Bug Y
+
+## [0.20.2] - 2026-04-24
+
+### Added
+- Prior change
+
+[Unreleased]: https://github.com/deftai/directive/compare/v0.20.2...HEAD
+[0.20.2]: https://github.com/deftai/directive/compare/v0.20.0...v0.20.2
+`;
+
+describe("splitBodyAndLinks", () => {
+  it("splits at first link line", () => {
+    const [body, footer] = splitBodyAndLinks(SAMPLE_CHANGELOG);
+    expect(body).toContain("## [Unreleased]");
+    expect(footer).toMatch(/^\[Unreleased\]:/m);
+  });
+
+  it("returns full text when no links", () => {
+    const text = "## [Unreleased]\n\n### Added\n";
+    expect(splitBodyAndLinks(text)).toEqual([text, ""]);
+  });
+});
+
+describe("promoteChangelog", () => {
+  it("promotes Unreleased heading and refreshes links", () => {
+    const out = promoteChangelog(SAMPLE_CHANGELOG, "0.21.0", "deftai/directive", "2026-04-28");
+    expect(out).toContain("## [0.21.0] - 2026-04-28");
+    expect(out).toContain("## [Unreleased]");
+    expect(out).toContain(
+      "[Unreleased]: https://github.com/deftai/directive/compare/v0.21.0...HEAD",
+    );
+    expect(out).toContain(
+      "[0.21.0]: https://github.com/deftai/directive/compare/v0.20.2...v0.21.0",
+    );
+  });
+
+  it("injects summary blockquote when provided", () => {
+    const out = promoteChangelog(
+      SAMPLE_CHANGELOG,
+      "0.21.0",
+      "deftai/directive",
+      "2026-04-28",
+      "Ship notes",
+    );
+    expect(out).toContain("> Ship notes");
+  });
+
+  it("rejects missing Unreleased heading", () => {
+    expect(() => promoteChangelog("no heading", "0.21.0", "deftai/directive", "2026-04-28")).toThrow(
+      "does not contain",
+    );
+  });
+
+  it("rejects multiline summary", () => {
+    expect(() =>
+      promoteChangelog(SAMPLE_CHANGELOG, "0.21.0", "deftai/directive", "2026-04-28", "a\nb"),
+    ).toThrow("single-line");
+  });
+});
+
+describe("sectionForVersion", () => {
+  it("extracts version section body", () => {
+    const body = sectionForVersion(SAMPLE_CHANGELOG, "0.20.2");
+    expect(body).toContain("Prior change");
+    expect(body).not.toContain("## [0.20.2]");
+  });
+
+  it("uses releases/tag link when no previous version", () => {
+    const text = `## [Unreleased]\n\n### Added\n- first\n`;
+    const out = promoteChangelog(text, "0.21.0", "deftai/directive", "2026-01-01");
+    expect(out).toContain("[0.21.0]: https://github.com/deftai/directive/releases/tag/v0.21.0");
+  });
+
+  it("treats empty summary like none", () => {
+    const withEmpty = promoteChangelog(
+      SAMPLE_CHANGELOG,
+      "0.21.0",
+      "deftai/directive",
+      "2026-04-28",
+      "",
+    );
+    const without = promoteChangelog(
+      SAMPLE_CHANGELOG,
+      "0.21.0",
+      "deftai/directive",
+      "2026-04-28",
+      null,
+    );
+    expect(withEmpty).toBe(without);
+  });
+});

--- a/packages/core/src/release/changelog.ts
+++ b/packages/core/src/release/changelog.ts
@@ -1,0 +1,132 @@
+import {
+  DEFAULT_REPO,
+  FRESH_UNRELEASED_BLOCK,
+  UNRELEASED_LINK_RE,
+  UNRELEASED_RE,
+  UPGRADE_BANNER_RELPATH,
+} from "./constants.js";
+
+/** Split CHANGELOG content into (body, link-footer). */
+export function splitBodyAndLinks(text: string): [string, string] {
+  const lines = text.split(/(?<=\n)/);
+  let firstLinkIdx: number | null = null;
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const line = lines[idx] ?? "";
+    if (line.startsWith("[Unreleased]:") || /^\[\d+\.\d+\.\d+\]:/.test(line)) {
+      firstLinkIdx = idx;
+      break;
+    }
+  }
+  if (firstLinkIdx === null) {
+    return [text, ""];
+  }
+  return [lines.slice(0, firstLinkIdx).join(""), lines.slice(firstLinkIdx).join("")];
+}
+
+function extractPreviousVersion(footer: string): string | null {
+  const match = UNRELEASED_LINK_RE.exec(footer);
+  return match?.groups?.prev ?? null;
+}
+
+/** Promote [Unreleased] to [<version>] - <today> and refresh the link footer. */
+export function promoteChangelog(
+  text: string,
+  version: string,
+  repo: string,
+  today: string,
+  summary: string | null = null,
+): string {
+  if (!UNRELEASED_RE.test(text)) {
+    throw new Error("CHANGELOG.md does not contain a '## [Unreleased]' heading.");
+  }
+  if (summary !== null && (summary.includes("\n") || summary.includes("\r"))) {
+    throw new Error(
+      "--summary is single-line; got embedded newline. " +
+        "Author the blockquote on a single line.",
+    );
+  }
+
+  const [body, footer] = splitBodyAndLinks(text);
+  let promotedHeading = `## [${version}] - ${today}`;
+  if (summary) {
+    promotedHeading = `${promotedHeading}\n\n> ${summary}\n`;
+  }
+  const freshBlock = `${FRESH_UNRELEASED_BLOCK.trimEnd()}\n\n`;
+  const replacement = freshBlock + promotedHeading;
+  const newBody = body.replace(UNRELEASED_RE, () => replacement);
+  if (newBody === body) {
+    throw new Error("Failed to locate exactly one '## [Unreleased]' heading.");
+  }
+
+  const prev = extractPreviousVersion(footer);
+  const newUnreleasedLink = `[Unreleased]: https://github.com/${repo}/compare/v${version}...HEAD`;
+  const versionLink = prev
+    ? `[${version}]: https://github.com/${repo}/compare/v${prev}...v${version}`
+    : `[${version}]: https://github.com/${repo}/releases/tag/v${version}`;
+
+  let newFooter: string;
+  if (footer) {
+    const footerLines = footer.split(/(?<=\n)/);
+    let replaced = false;
+    const newFooterLines: string[] = [];
+    for (const line of footerLines) {
+      if (!replaced && line.startsWith("[Unreleased]:")) {
+        newFooterLines.push(`${newUnreleasedLink}\n`);
+        newFooterLines.push(`${versionLink}\n`);
+        replaced = true;
+        continue;
+      }
+      newFooterLines.push(line);
+    }
+    if (!replaced) {
+      newFooterLines.unshift(`${versionLink}\n`);
+      newFooterLines.unshift(`${newUnreleasedLink}\n`);
+    }
+    newFooter = newFooterLines.join("");
+  } else {
+    newFooter = `${newUnreleasedLink}\n${versionLink}\n`;
+  }
+
+  return newBody + newFooter;
+}
+
+/** Extract the body of ## [<version>] - <date> for use as release notes. */
+export function sectionForVersion(text: string, version: string): string {
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Avoid /m on $ — JS $ with multiline matches every line end, not only EOF (Python \\Z).
+  const pattern = new RegExp(
+    `(?:^|\\n)##\\s+\\[${escaped}\\][^\\n]*\\n([\\s\\S]*?)(?=(?:\\n##\\s+\\[)|$)`,
+  );
+  const match = pattern.exec(text);
+  if (!match?.[1]) {
+    return "";
+  }
+  return match[1].trim();
+}
+
+/** Lead maintainer-mode GitHub release notes with the upgrade banner (#1413). */
+export function prependUpgradeBanner(
+  notes: string,
+  repo: string,
+  projectRoot: string,
+  readText: (path: string) => string | null,
+): string {
+  if (repo !== DEFAULT_REPO) {
+    return notes;
+  }
+  const bannerPath = `${projectRoot}/${UPGRADE_BANNER_RELPATH}`;
+  let banner: string | null;
+  try {
+    banner = readText(bannerPath);
+  } catch {
+    return notes;
+  }
+  if (banner === null) {
+    return notes;
+  }
+  const normalized = banner.replace(/\r\n/g, "\n").trim();
+  if (!normalized) {
+    return notes;
+  }
+  return `${normalized}\n\n${notes}`;
+}

--- a/packages/core/src/release/cli.ts
+++ b/packages/core/src/release/cli.ts
@@ -1,0 +1,7 @@
+/* v8 ignore file -- thin shebang entry; covered via main.ts tests */
+import { fileURLToPath } from "node:url";
+import { cmdRelease } from "./main.js";
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(cmdRelease(process.argv.slice(2)));
+}

--- a/packages/core/src/release/constants.ts
+++ b/packages/core/src/release/constants.ts
@@ -30,7 +30,12 @@ export const TOTAL_STEPS = 13;
 export const VERIFY_DRAFT_MAX_ATTEMPTS = 5;
 export const VERIFY_DRAFT_INTERVAL_SECONDS = 1.0;
 
-export const RELEASE_ARTIFACTS = ["CHANGELOG.md", "ROADMAP.md", "pyproject.toml", "uv.lock"] as const;
+export const RELEASE_ARTIFACTS = [
+  "CHANGELOG.md",
+  "ROADMAP.md",
+  "pyproject.toml",
+  "uv.lock",
+] as const;
 
 export const BRANCH_GATE_BYPASS_ENV = "DEFT_ALLOW_DEFAULT_BRANCH_COMMIT";
 export const DESTRUCTIVE_GH_GATE_BYPASS_ENV = "DEFT_ALLOW_DESTRUCTIVE_GH_VERBS";

--- a/packages/core/src/release/constants.ts
+++ b/packages/core/src/release/constants.ts
@@ -1,0 +1,92 @@
+/** Exit codes mirroring scripts/release.py. */
+export const EXIT_OK = 0;
+export const EXIT_VIOLATION = 1;
+export const EXIT_CONFIG_ERROR = 2;
+
+export const DEFAULT_REPO = "deftai/directive";
+export const DEFAULT_BASE_BRANCH = "master";
+
+export const UPGRADE_BANNER_RELPATH = ".github/release-notes/upgrade-banner.md";
+
+export const VERSION_RE = /^\d+\.\d+\.\d+$/;
+export const TAG_RE = /^v(\d+\.\d+\.\d+)$/;
+export const UNRELEASED_RE = /^##\s+\[Unreleased\]\s*$/m;
+export const UNRELEASED_LINK_RE =
+  /^\[Unreleased\]:\s+https?:\/\/github\.com\/[^/]+\/[^/]+\/compare\/v(?<prev>\d+\.\d+\.\d+)\.\.\.HEAD\s*$/m;
+
+export const FRESH_UNRELEASED_BLOCK =
+  "## [Unreleased]\n" +
+  "\n" +
+  "### Added\n" +
+  "\n" +
+  "### Changed\n" +
+  "\n" +
+  "### Fixed\n" +
+  "\n" +
+  "### Removed\n";
+
+export const TOTAL_STEPS = 13;
+
+export const VERIFY_DRAFT_MAX_ATTEMPTS = 5;
+export const VERIFY_DRAFT_INTERVAL_SECONDS = 1.0;
+
+export const RELEASE_ARTIFACTS = ["CHANGELOG.md", "ROADMAP.md", "pyproject.toml", "uv.lock"] as const;
+
+export const BRANCH_GATE_BYPASS_ENV = "DEFT_ALLOW_DEFAULT_BRANCH_COMMIT";
+export const DESTRUCTIVE_GH_GATE_BYPASS_ENV = "DEFT_ALLOW_DESTRUCTIVE_GH_VERBS";
+
+export const PYPROJECT_VERSION_LINE_RE = /version\s*=\s*"[^"]*"/;
+
+/** Byte-identical argparse --help from scripts/release.py (Python 3.12). */
+export const RELEASE_HELP =
+  "usage: release [-h] [--dry-run] [--skip-tag] [--skip-release] [--allow-dirty]\n" +
+  "               [--allow-vbrief-drift] [--skip-ci] [--skip-build] [--no-draft]\n" +
+  "               [--repo OWNER/REPO] [--base-branch BRANCH]\n" +
+  "               [--project-root PATH] [--summary TEXT]\n" +
+  "               version\n" +
+  "\n" +
+  "Automate the v0.X.Y release flow (#74): pre-flight, CI, CHANGELOG promote,\n" +
+  "ROADMAP refresh, build, tag, push, gh release. Halt-friendly: supports --dry-\n" +
+  "run / --skip-tag / --skip-release for safe rehearsals.\n" +
+  "\n" +
+  "positional arguments:\n" +
+  "  version               Release version, e.g. 0.21.0 (no leading 'v', strict\n" +
+  "                        X.Y.Z).\n" +
+  "\n" +
+  "options:\n" +
+  "  -h, --help            show this help message and exit\n" +
+  "  --dry-run             Print the full release plan without writing files or\n" +
+  "                        invoking external commands.\n" +
+  "  --skip-tag            Do not invoke git tag / git push origin <tag> (still\n" +
+  "                        updates CHANGELOG).\n" +
+  "  --skip-release        Do not invoke gh release create.\n" +
+  "  --allow-dirty         Bypass the dirty-tree pre-flight (use only for\n" +
+  "                        rehearsals).\n" +
+  "  --allow-vbrief-drift  Bypass the vBRIEF-lifecycle sync pre-flight gate\n" +
+  "                        (#734). Use only when the operator has reviewed the\n" +
+  "                        drift and explicitly accepts that closed-issue vBRIEFs\n" +
+  "                        may still live in non-terminal folders. The clean path\n" +
+  "                        is to run `task reconcile:issues -- --apply-lifecycle-\n" +
+  "                        fixes` first.\n" +
+  "  --skip-ci             Skip Step 3 (task ci:local / task check fallback).\n" +
+  "                        Used by `task release:e2e` to keep wall-clock\n" +
+  "                        manageable inside the auto-created temp repo (CI\n" +
+  "                        semantics are covered by the unit-test suite, not the\n" +
+  "                        e2e rehearsal).\n" +
+  "  --skip-build          Skip Step 6 (task build). Used by `task release:e2e`\n" +
+  "                        to keep wall-clock manageable; build artefacts are not\n" +
+  "                        needed for the draft-release verification step.\n" +
+  "  --no-draft            Publish the GitHub release immediately instead of\n" +
+  "                        creating a draft (default: --draft, paired with `task\n" +
+  "                        release:publish -- <version>`).\n" +
+  "  --repo OWNER/REPO     Override the GitHub repository (default: resolved from\n" +
+  "                        `git remote get-url origin`, falling back to\n" +
+  "                        'deftai/directive').\n" +
+  "  --base-branch BRANCH  Expected base branch for releases (default: master).\n" +
+  "  --project-root PATH   Repository root (default: $DEFT_PROJECT_ROOT or the\n" +
+  "                        parent of the scripts/ directory).\n" +
+  "  --summary TEXT        Optional one-line summary to inject as a Markdown\n" +
+  "                        blockquote at the top of the promoted CHANGELOG\n" +
+  "                        section. Flows through to the GitHub release body and\n" +
+  "                        the Slack announcement template (Phase 8). Recommended\n" +
+  "                        length 80-160 chars.\n";

--- a/packages/core/src/release/coverage-boost.test.ts
+++ b/packages/core/src/release/coverage-boost.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  checkTagAvailable,
-  createGithubRelease,
-  resolveGh,
-  verifyReleaseDraft,
-} from "./gh.js";
+import { checkTagAvailable, createGithubRelease, resolveGh, verifyReleaseDraft } from "./gh.js";
 import {
   checkGitClean,
   commitReleaseArtifacts,
@@ -13,11 +8,10 @@ import {
   pushRelease,
   releaseSubprocessEnv,
 } from "./git.js";
+import { runPipeline } from "./pipeline.js";
 import { syncPyprojectForRelease } from "./pyproject-sync.js";
 import { runUvLock } from "./python-bridge.js";
-import { runPipeline } from "./pipeline.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
-import { NonPublishableVersionError } from "./version.js";
 
 describe("git helpers", () => {
   const seams: ReleaseSeams = {
@@ -106,9 +100,15 @@ describe("gh helpers", () => {
       return true;
     }) as typeof process.stderr.write;
     try {
-      const [ok] = verifyReleaseDraft("/proj", "0.21.0", "deftai/directive", {}, {
-        whichGh: () => null,
-      });
+      const [ok] = verifyReleaseDraft(
+        "/proj",
+        "0.21.0",
+        "deftai/directive",
+        {},
+        {
+          whichGh: () => null,
+        },
+      );
       expect(ok).toBe(true);
       expect(lines.join("")).toContain("WARNING");
     } finally {
@@ -166,27 +166,42 @@ describe("syncPyprojectForRelease branches", () => {
   const py = `[project]\nversion = "0.20.0"\n`;
 
   it("handles non-publishable version", () => {
-    const [note] = syncPyprojectForRelease("/p", "0.0.0-test.1", { dryRun: false }, {
-      fileExists: () => true,
-      readFile: () => py,
-    });
+    const [note] = syncPyprojectForRelease(
+      "/p",
+      "0.0.0-test.1",
+      { dryRun: false },
+      {
+        fileExists: () => true,
+        readFile: () => py,
+      },
+    );
     expect(note).toContain("non-publishable");
   });
 
   it("returns new text on happy path", () => {
-    const [note, text] = syncPyprojectForRelease("/p", "0.21.0", { dryRun: false }, {
-      fileExists: () => true,
-      readFile: () => py,
-    });
+    const [note, text] = syncPyprojectForRelease(
+      "/p",
+      "0.21.0",
+      { dryRun: false },
+      {
+        fileExists: () => true,
+        readFile: () => py,
+      },
+    );
     expect(note).toContain("0.21.0");
     expect(text).toContain('version = "0.21.0"');
   });
 
   it("dry-run returns note without text", () => {
-    const [, text] = syncPyprojectForRelease("/p", "0.21.0", { dryRun: true }, {
-      fileExists: () => true,
-      readFile: () => py,
-    });
+    const [, text] = syncPyprojectForRelease(
+      "/p",
+      "0.21.0",
+      { dryRun: true },
+      {
+        fileExists: () => true,
+        readFile: () => py,
+      },
+    );
     expect(text).toBeNull();
   });
 });
@@ -287,9 +302,15 @@ describe("verifyReleaseDraft polling", () => {
   });
 
   it("disables gate when maxAttempts <= 0", () => {
-    const [ok] = verifyReleaseDraft("/p", "0.1.0", "r", { maxAttempts: 0 }, {
-      whichGh: () => "/usr/bin/gh",
-    });
+    const [ok] = verifyReleaseDraft(
+      "/p",
+      "0.1.0",
+      "r",
+      { maxAttempts: 0 },
+      {
+        whichGh: () => "/usr/bin/gh",
+      },
+    );
     expect(ok).toBe(true);
   });
 });
@@ -357,10 +378,7 @@ describe("runPipeline additional branches", () => {
       todayIso: () => "2026-01-01",
     };
     expect(
-      runPipeline(
-        { ...base, allowDirty: true, allowVbriefDrift: true, dryRun: true },
-        seams,
-      ),
+      runPipeline({ ...base, allowDirty: true, allowVbriefDrift: true, dryRun: true }, seams),
     ).toBe(0);
   });
 });

--- a/packages/core/src/release/coverage-boost.test.ts
+++ b/packages/core/src/release/coverage-boost.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkTagAvailable,
+  createGithubRelease,
+  resolveGh,
+  verifyReleaseDraft,
+} from "./gh.js";
+import {
+  checkGitClean,
+  commitReleaseArtifacts,
+  createTag,
+  currentBranch,
+  pushRelease,
+  releaseSubprocessEnv,
+} from "./git.js";
+import { syncPyprojectForRelease } from "./pyproject-sync.js";
+import { runUvLock } from "./python-bridge.js";
+import { runPipeline } from "./pipeline.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+import { NonPublishableVersionError } from "./version.js";
+
+describe("git helpers", () => {
+  const seams: ReleaseSeams = {
+    spawnText: (_cmd, args) => {
+      if (args.includes("status")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (args.includes("branch")) {
+        return { status: 0, stdout: "master\n", stderr: "" };
+      }
+      if (args.includes("add")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (args.includes("diff")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (args.includes("commit")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (args.includes("tag")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (args.includes("push")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      return { status: 0, stdout: "", stderr: "" };
+    },
+    fileExists: (p) => p.includes("CHANGELOG.md"),
+  };
+
+  it("checkGitClean returns true for clean tree", () => {
+    expect(checkGitClean("/proj", seams)[0]).toBe(true);
+  });
+
+  it("currentBranch reads git output", () => {
+    expect(currentBranch("/proj", seams)).toBe("master");
+  });
+
+  it("commitReleaseArtifacts no-ops when nothing staged", () => {
+    const [ok, msg] = commitReleaseArtifacts("/proj", "0.21.0", seams);
+    expect(ok).toBe(true);
+    expect(msg).toContain("no commit needed");
+  });
+
+  it("createTag succeeds", () => {
+    const [ok] = createTag("/proj", "0.21.0", seams);
+    expect(ok).toBe(true);
+  });
+
+  it("pushRelease succeeds", () => {
+    const [ok] = pushRelease("/proj", "0.21.0", "master", seams);
+    expect(ok).toBe(true);
+  });
+
+  it("releaseSubprocessEnv sets bypass flags", () => {
+    const env = releaseSubprocessEnv({ FOO: "bar" });
+    expect(env.DEFT_ALLOW_DEFAULT_BRANCH_COMMIT).toBe("1");
+    expect(env.DEFT_ALLOW_DESTRUCTIVE_GH_VERBS).toBe("1");
+    expect(env.FOO).toBe("bar");
+  });
+});
+
+describe("gh helpers", () => {
+  it("resolveGh returns null when missing", () => {
+    expect(resolveGh({ whichGh: () => null })).toBeNull();
+  });
+
+  it("createGithubRelease fails without gh", () => {
+    const [ok, reason] = createGithubRelease(
+      "/proj",
+      "0.21.0",
+      "deftai/directive",
+      "notes",
+      {},
+      { whichGh: () => null },
+    );
+    expect(ok).toBe(false);
+    expect(reason).toContain("not found");
+  });
+
+  it("verifyReleaseDraft skips when gh missing", () => {
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: string | Uint8Array) => {
+      lines.push(String(c));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const [ok] = verifyReleaseDraft("/proj", "0.21.0", "deftai/directive", {}, {
+        whichGh: () => null,
+      });
+      expect(ok).toBe(true);
+      expect(lines.join("")).toContain("WARNING");
+    } finally {
+      process.stderr.write = orig;
+    }
+  });
+
+  it("verifyReleaseDraft confirms draft state", () => {
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({
+        status: 0,
+        stdout: '{"isDraft": true}',
+        stderr: "",
+      }),
+      sleep: () => undefined,
+    };
+    const [ok, reason] = verifyReleaseDraft(
+      "/proj",
+      "0.21.0",
+      "deftai/directive",
+      { sleep: () => undefined },
+      seams,
+    );
+    expect(ok).toBe(true);
+    expect(reason).toContain("verified draft");
+  });
+
+  it("verifyReleaseDraft flips public release", () => {
+    let calls = 0;
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => {
+        calls += 1;
+        if (calls === 1) {
+          return { status: 0, stdout: '{"isDraft": false}', stderr: "" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      sleep: () => undefined,
+    };
+    const [ok, reason] = verifyReleaseDraft(
+      "/proj",
+      "0.21.0",
+      "deftai/directive",
+      { sleep: () => undefined },
+      seams,
+    );
+    expect(ok).toBe(true);
+    expect(reason).toContain("flipped to draft");
+  });
+});
+
+describe("syncPyprojectForRelease branches", () => {
+  const py = `[project]\nversion = "0.20.0"\n`;
+
+  it("handles non-publishable version", () => {
+    const [note] = syncPyprojectForRelease("/p", "0.0.0-test.1", { dryRun: false }, {
+      fileExists: () => true,
+      readFile: () => py,
+    });
+    expect(note).toContain("non-publishable");
+  });
+
+  it("returns new text on happy path", () => {
+    const [note, text] = syncPyprojectForRelease("/p", "0.21.0", { dryRun: false }, {
+      fileExists: () => true,
+      readFile: () => py,
+    });
+    expect(note).toContain("0.21.0");
+    expect(text).toContain('version = "0.21.0"');
+  });
+
+  it("dry-run returns note without text", () => {
+    const [, text] = syncPyprojectForRelease("/p", "0.21.0", { dryRun: true }, {
+      fileExists: () => true,
+      readFile: () => py,
+    });
+    expect(text).toBeNull();
+  });
+});
+
+describe("runUvLock", () => {
+  it("skips when no pyproject", () => {
+    const [ok, msg] = runUvLock("/proj", { fileExists: () => false });
+    expect(ok).toBe(true);
+    expect(msg).toContain("skipping uv lock");
+  });
+});
+
+describe("checkTagAvailable branches", () => {
+  it("reports remote tag conflict", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, args) => {
+        if (args.includes("tag") && args.includes("-l")) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        if (args.includes("ls-remote")) {
+          return { status: 0, stdout: "abc\trefs/tags/v0.21.0\n", stderr: "" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      whichGh: () => null,
+    };
+    const [ok, reason] = checkTagAvailable("0.21.0", "deftai/directive", "/p", seams);
+    expect(ok).toBe(false);
+    expect(reason).toContain("remote tag");
+  });
+
+  it("notes remote unverified when ls-remote fails", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, args) => {
+        if (args.includes("ls-remote")) {
+          return { status: 1, stdout: "", stderr: "network down" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      whichGh: () => null,
+    };
+    const [ok, reason] = checkTagAvailable("0.21.0", "deftai/directive", "/p", seams);
+    expect(ok).toBe(true);
+    expect(reason).toContain("UNVERIFIED");
+  });
+
+  it("detects existing GitHub release", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, args) => {
+        if (args[1] === "release") {
+          return { status: 0, stdout: '{"tagName":"v0.21.0"}', stderr: "" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      whichGh: () => "/usr/bin/gh",
+    };
+    const [ok] = checkTagAvailable("0.21.0", "deftai/directive", "/p", seams);
+    expect(ok).toBe(false);
+  });
+});
+
+describe("createGithubRelease success", () => {
+  it("creates release with notes file", () => {
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({ status: 0, stdout: "", stderr: "" }),
+    };
+    const [ok, reason] = createGithubRelease(
+      "/proj",
+      "0.21.0",
+      "deftai/directive",
+      "# Notes\n",
+      { draft: true, prerelease: true },
+      seams,
+    );
+    expect(ok).toBe(true);
+    expect(reason).toContain("draft");
+    expect(reason).toContain("prerelease");
+  });
+});
+
+describe("verifyReleaseDraft polling", () => {
+  it("returns inconclusive after not-found budget", () => {
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({ status: 1, stdout: "", stderr: "release not found" }),
+      sleep: () => undefined,
+    };
+    const [ok, reason] = verifyReleaseDraft(
+      "/proj",
+      "0.21.0",
+      "deftai/directive",
+      { maxAttempts: 2, interval: 0, sleep: () => undefined },
+      seams,
+    );
+    expect(ok).toBe(true);
+    expect(reason).toContain("inconclusive");
+  });
+
+  it("disables gate when maxAttempts <= 0", () => {
+    const [ok] = verifyReleaseDraft("/p", "0.1.0", "r", { maxAttempts: 0 }, {
+      whichGh: () => "/usr/bin/gh",
+    });
+    expect(ok).toBe(true);
+  });
+});
+
+describe("runPipeline additional branches", () => {
+  const changelog = `## [Unreleased]\n\n### Added\n- x\n`;
+
+  const base: ReleaseConfig = {
+    version: "0.21.0",
+    repo: "deftai/directive",
+    baseBranch: "master",
+    projectRoot: "/proj",
+    dryRun: false,
+    skipTag: true,
+    skipRelease: true,
+    allowDirty: false,
+    draft: true,
+    skipCi: true,
+    skipBuild: true,
+    summary: "Hello",
+    allowVbriefDrift: false,
+  };
+
+  it("runs vbrief drift failure path", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      checkVbriefLifecycleSync: () => [false, 2, "drift"],
+      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      readFile: () => changelog,
+    };
+    expect(runPipeline(base, seams)).toBe(1);
+  });
+
+  it("runs promote failure on bad changelog", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      checkVbriefLifecycleSync: () => [true, 0, ""],
+      checkTagAvailable: () => [true, "ok"],
+      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      readFile: () => "no unreleased",
+      todayIso: () => "2026-01-01",
+    };
+    expect(runPipeline({ ...base, allowVbriefDrift: true }, seams)).toBe(2);
+  });
+
+  it("accepts allow-dirty warn path", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: " M x\n", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      checkVbriefLifecycleSync: () => [true, 0, ""],
+      checkTagAvailable: () => [true, "ok"],
+      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      readFile: () => changelog,
+      todayIso: () => "2026-01-01",
+    };
+    expect(
+      runPipeline(
+        { ...base, allowDirty: true, allowVbriefDrift: true, dryRun: true },
+        seams,
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("runPipeline violation branches", () => {
+  const config: ReleaseConfig = {
+    version: "0.21.0",
+    repo: "deftai/directive",
+    baseBranch: "master",
+    projectRoot: "/proj",
+    dryRun: false,
+    skipTag: true,
+    skipRelease: true,
+    allowDirty: false,
+    draft: true,
+    skipCi: true,
+    skipBuild: true,
+    summary: null,
+    allowVbriefDrift: true,
+  };
+
+  it("fails on dirty tree", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, args) => {
+        if (args.includes("status")) {
+          return { status: 0, stdout: " M dirty\n", stderr: "" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    };
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+
+  it("fails on wrong branch", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, args) => {
+        if (args.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (args.includes("branch")) return { status: 0, stdout: "feature\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    };
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+});

--- a/packages/core/src/release/coverage-extra.test.ts
+++ b/packages/core/src/release/coverage-extra.test.ts
@@ -1,0 +1,164 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { commitReleaseArtifacts, checkGitClean } from "./git.js";
+import { syncPyprojectForRelease } from "./pyproject-sync.js";
+import { runPipeline } from "./pipeline.js";
+import { runUvLock } from "./python-bridge.js";
+import { defaultWhich, spawnText } from "./spawn.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+import { isPublishable } from "./version.js";
+import { parseReleaseFlags } from "./flags.js";
+
+describe("spawn edge branches", () => {
+  it("defaultWhich returns path for node", () => {
+    expect(defaultWhich("node")).toMatch(/node/);
+  });
+
+  it("spawnText handles missing binary", () => {
+    expect(spawnText("/nonexistent/binary-xyz", []).status).toBe(2);
+  });
+});
+
+describe("runUvLock without seams", () => {
+  it("skips when no pyproject on disk", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-uvlock-"));
+    const [ok, msg] = runUvLock(root);
+    expect(ok).toBe(true);
+    expect(msg).toContain("skipping uv lock");
+  });
+});
+
+describe("git commit branches", () => {
+  it("commits when cache diff is non-empty", () => {
+    const seams: ReleaseSeams = {
+      fileExists: () => true,
+      spawnText: (_c, a) => {
+        if (a.includes("diff")) return { status: 1, stdout: "", stderr: "" };
+        if (a.includes("commit")) return { status: 0, stdout: "", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    };
+    const [ok, msg] = commitReleaseArtifacts("/proj", "0.21.0", seams);
+    expect(ok).toBe(true);
+    expect(msg).toContain("committed");
+  });
+
+  it("handles no artifacts on disk", () => {
+    const [ok, msg] = commitReleaseArtifacts("/proj", "0.21.0", { fileExists: () => false });
+    expect(msg).toContain("none exist");
+    expect(ok).toBe(true);
+  });
+
+  it("returns dirty output when tree has changes", () => {
+    const [ok, out] = checkGitClean("/p", {
+      spawnText: () => ({ status: 0, stdout: " M file\n", stderr: "" }),
+    });
+    expect(ok).toBe(false);
+    expect(out).toContain("file");
+  });
+
+  it("fails when git commit fails", () => {
+    const seams: ReleaseSeams = {
+      fileExists: () => true,
+      spawnText: (_c, a) => {
+        if (a.includes("diff")) return { status: 1, stdout: "", stderr: "" };
+        if (a.includes("commit")) return { status: 1, stdout: "", stderr: "err" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    };
+    expect(commitReleaseArtifacts("/proj", "0.21.0", seams)[0]).toBe(false);
+  });
+});
+
+describe("syncPyprojectForRelease disk path", () => {
+  it("reports idempotent pyproject sync", () => {
+    const [note, text] = syncPyprojectForRelease("/p", "0.1.0", { dryRun: false }, {
+      fileExists: () => true,
+      readFile: () => '[project]\nversion = "0.1.0"\n',
+    });
+    expect(note).toContain("already at");
+    expect(text).toBeNull();
+  });
+});
+
+describe("isPublishable", () => {
+  it("classifies publishability", () => {
+    expect(isPublishable("1.0.0")).toBe(true);
+    expect(isPublishable("0.0.0-test.1")).toBe(false);
+    expect(isPublishable("bad")).toBe(false);
+  });
+});
+
+describe("parseReleaseFlags missing value at EOF", () => {
+  it("records --repo without value", () => {
+    const flags = parseReleaseFlags(["1.0.0", "--repo"]);
+    expect(flags.unknown).toContain("--repo (missing value)");
+  });
+});
+
+describe("pipeline branches extra", () => {
+  const CHANGELOG = `## [Unreleased]\n\n### Added\n- item\n`;
+
+  it("runs vbrief sync ok on non-dry-run", () => {
+    const config: ReleaseConfig = {
+      version: "0.21.0",
+      repo: "deftai/directive",
+      baseBranch: "master",
+      projectRoot: "/proj",
+      dryRun: false,
+      skipTag: true,
+      skipRelease: true,
+      allowDirty: false,
+      draft: true,
+      skipCi: true,
+      skipBuild: true,
+      summary: null,
+      allowVbriefDrift: false,
+    };
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      checkTagAvailable: () => [true, "ok"],
+      checkVbriefLifecycleSync: () => [true, 0, "no mismatches"],
+      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      readFile: () => CHANGELOG,
+      writeFile: () => undefined,
+      refreshRoadmap: () => [true, "ok"],
+      todayIso: () => "2026-04-28",
+    };
+    expect(runPipeline(config, seams)).toBe(0);
+  });
+
+  it("returns violation when runCi fails", () => {
+    const config: ReleaseConfig = {
+      version: "0.21.0",
+      repo: "deftai/directive",
+      baseBranch: "master",
+      projectRoot: "/proj",
+      dryRun: false,
+      skipTag: true,
+      skipRelease: true,
+      allowDirty: false,
+      draft: true,
+      skipCi: false,
+      skipBuild: true,
+      summary: null,
+      allowVbriefDrift: true,
+    };
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      checkTagAvailable: () => [true, "ok"],
+      runCi: () => [false, "ci:local failed (exit 1)"],
+    };
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+});

--- a/packages/core/src/release/coverage-extra.test.ts
+++ b/packages/core/src/release/coverage-extra.test.ts
@@ -1,15 +1,15 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { commitReleaseArtifacts, checkGitClean } from "./git.js";
-import { syncPyprojectForRelease } from "./pyproject-sync.js";
+import { parseReleaseFlags } from "./flags.js";
+import { checkGitClean, commitReleaseArtifacts } from "./git.js";
 import { runPipeline } from "./pipeline.js";
+import { syncPyprojectForRelease } from "./pyproject-sync.js";
 import { runUvLock } from "./python-bridge.js";
 import { defaultWhich, spawnText } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 import { isPublishable } from "./version.js";
-import { parseReleaseFlags } from "./flags.js";
 
 describe("spawn edge branches", () => {
   it("defaultWhich returns path for node", () => {
@@ -74,10 +74,15 @@ describe("git commit branches", () => {
 
 describe("syncPyprojectForRelease disk path", () => {
   it("reports idempotent pyproject sync", () => {
-    const [note, text] = syncPyprojectForRelease("/p", "0.1.0", { dryRun: false }, {
-      fileExists: () => true,
-      readFile: () => '[project]\nversion = "0.1.0"\n',
-    });
+    const [note, text] = syncPyprojectForRelease(
+      "/p",
+      "0.1.0",
+      { dryRun: false },
+      {
+        fileExists: () => true,
+        readFile: () => '[project]\nversion = "0.1.0"\n',
+      },
+    );
     expect(note).toContain("already at");
     expect(text).toBeNull();
   });

--- a/packages/core/src/release/coverage-final.test.ts
+++ b/packages/core/src/release/coverage-final.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { promoteChangelog } from "./changelog.js";
+import { runPipeline } from "./pipeline.js";
+import { syncPyprojectForRelease } from "./pyproject-sync.js";
+import { runUvLock } from "./python-bridge.js";
+import { defaultWhich } from "./spawn.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+import { cmdRelease } from "./main.js";
+
+const CHANGELOG = `## [Unreleased]\n\n### Added\n- item\n`;
+
+describe("spawn helpers", () => {
+  it("defaultWhich returns path or null", () => {
+    const r = defaultWhich("nonexistent-binary-xyz");
+    expect(r === null || typeof r === "string").toBe(true);
+  });
+});
+
+describe("pipeline write path", () => {
+  const config: ReleaseConfig = {
+    version: "0.21.0",
+    repo: "deftai/directive",
+    baseBranch: "master",
+    projectRoot: "/proj",
+    dryRun: false,
+    skipTag: true,
+    skipRelease: true,
+    allowDirty: false,
+    draft: true,
+    skipCi: true,
+    skipBuild: true,
+    summary: null,
+    allowVbriefDrift: true,
+  };
+
+  it("writes changelog and pyproject on happy path", () => {
+    const writes: Record<string, string> = {};
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      checkTagAvailable: () => [true, "ok"],
+      fileExists: (p) => p.endsWith("CHANGELOG.md") || p.endsWith("pyproject.toml"),
+      readFile: (p) =>
+        p.endsWith("pyproject.toml") ? '[project]\nversion = "0.20.0"\n' : CHANGELOG,
+      writeFile: (p, c) => {
+        writes[p] = c;
+      },
+      runUvLock: () => [true, "uv.lock regenerated"],
+      refreshRoadmap: () => [true, "ROADMAP.md re-rendered"],
+      todayIso: () => "2026-04-28",
+    };
+    expect(runPipeline(config, seams)).toBe(0);
+    expect(writes["/proj/CHANGELOG.md"]).toContain("## [0.21.0]");
+    expect(writes["/proj/pyproject.toml"]).toContain('0.21.0');
+  });
+
+  it("fails when uv lock fails", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      checkTagAvailable: () => [true, "ok"],
+      fileExists: (p) => p.endsWith("CHANGELOG.md") || p.endsWith("pyproject.toml"),
+      readFile: (p) =>
+        p.endsWith("pyproject.toml") ? '[project]\nversion = "0.20.0"\n' : CHANGELOG,
+      writeFile: () => undefined,
+      runUvLock: () => [false, "uv lock failed"],
+      todayIso: () => "2026-04-28",
+    };
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+});
+
+describe("syncPyprojectForRelease errors", () => {
+  it("returns FAIL for malformed pyproject", () => {
+    const [note] = syncPyprojectForRelease("/p", "0.21.0", { dryRun: false }, {
+      fileExists: () => true,
+      readFile: () => "[tool]\n",
+    });
+    expect(note).toContain("FAIL");
+  });
+});
+
+describe("runUvLock with uv present", () => {
+  it("fails when uv lock exits non-zero", () => {
+    const seams: ReleaseSeams = {
+      fileExists: () => true,
+      whichUv: () => "/usr/bin/uv",
+      spawnText: () => ({ status: 1, stdout: "", stderr: "conflict" }),
+    };
+    const [ok] = runUvLock("/proj", seams);
+    expect(ok).toBe(false);
+  });
+
+  it("warns when uv missing", () => {
+    const err: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: string | Uint8Array) => {
+      err.push(String(c));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const [ok] = runUvLock("/proj", { fileExists: () => true, whichUv: () => null });
+      expect(ok).toBe(true);
+      expect(err.join("")).toContain("WARNING");
+    } finally {
+      process.stderr.write = orig;
+    }
+  });
+});
+
+describe("cmdRelease unknown flags", () => {
+  it("returns 2 for unknown args", () => {
+    expect(cmdRelease(["--bogus-flag"])).toBe(2);
+  });
+});
+
+describe("promoteChangelog greenfield footer", () => {
+  it("prepends links when footer lacks Unreleased line", () => {
+    const text = `## [Unreleased]\n\n### Added\n- x\n`;
+    const out = promoteChangelog(text, "0.21.0", "deftai/directive", "2026-01-01");
+    expect(out).toContain("[Unreleased]:");
+    expect(out).toContain("[0.21.0]:");
+  });
+});

--- a/packages/core/src/release/coverage-final.test.ts
+++ b/packages/core/src/release/coverage-final.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { promoteChangelog } from "./changelog.js";
+import { cmdRelease } from "./main.js";
 import { runPipeline } from "./pipeline.js";
 import { syncPyprojectForRelease } from "./pyproject-sync.js";
 import { runUvLock } from "./python-bridge.js";
 import { defaultWhich } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
-import { cmdRelease } from "./main.js";
 
 const CHANGELOG = `## [Unreleased]\n\n### Added\n- item\n`;
 
@@ -54,7 +54,7 @@ describe("pipeline write path", () => {
     };
     expect(runPipeline(config, seams)).toBe(0);
     expect(writes["/proj/CHANGELOG.md"]).toContain("## [0.21.0]");
-    expect(writes["/proj/pyproject.toml"]).toContain('0.21.0');
+    expect(writes["/proj/pyproject.toml"]).toContain("0.21.0");
   });
 
   it("fails when uv lock fails", () => {
@@ -78,10 +78,15 @@ describe("pipeline write path", () => {
 
 describe("syncPyprojectForRelease errors", () => {
   it("returns FAIL for malformed pyproject", () => {
-    const [note] = syncPyprojectForRelease("/p", "0.21.0", { dryRun: false }, {
-      fileExists: () => true,
-      readFile: () => "[tool]\n",
-    });
+    const [note] = syncPyprojectForRelease(
+      "/p",
+      "0.21.0",
+      { dryRun: false },
+      {
+        fileExists: () => true,
+        readFile: () => "[tool]\n",
+      },
+    );
     expect(note).toContain("FAIL");
   });
 });

--- a/packages/core/src/release/flags.test.ts
+++ b/packages/core/src/release/flags.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { formatReleaseHelp, parseReleaseFlags } from "./flags.js";
+import { RELEASE_HELP } from "./constants.js";
+
+describe("parseReleaseFlags", () => {
+  it("parses full argv set", () => {
+    const flags = parseReleaseFlags([
+      "0.21.0",
+      "--dry-run",
+      "--skip-tag",
+      "--skip-release",
+      "--allow-dirty",
+      "--allow-vbrief-drift",
+      "--skip-ci",
+      "--skip-build",
+      "--no-draft",
+      "--repo",
+      "org/repo",
+      "--base-branch",
+      "main",
+      "--project-root",
+      "/tmp",
+      "--summary",
+      "One line",
+    ]);
+    expect(flags.version).toBe("0.21.0");
+    expect(flags.dryRun).toBe(true);
+    expect(flags.skipTag).toBe(true);
+    expect(flags.skipRelease).toBe(true);
+    expect(flags.allowDirty).toBe(true);
+    expect(flags.allowVbriefDrift).toBe(true);
+    expect(flags.skipCi).toBe(true);
+    expect(flags.skipBuild).toBe(true);
+    expect(flags.draft).toBe(false);
+    expect(flags.repo).toBe("org/repo");
+    expect(flags.baseBranch).toBe("main");
+    expect(flags.projectRoot).toBe("/tmp");
+    expect(flags.summary).toBe("One line");
+    expect(flags.unknown).toEqual([]);
+  });
+
+  it("parses equals-form flags", () => {
+    const flags = parseReleaseFlags([
+      "1.0.0",
+      "--repo=acme/widget",
+      "--base-branch=develop",
+      "--project-root=/x",
+      "--summary=hi",
+    ]);
+    expect(flags.repo).toBe("acme/widget");
+    expect(flags.baseBranch).toBe("develop");
+    expect(flags.projectRoot).toBe("/x");
+    expect(flags.summary).toBe("hi");
+  });
+
+  it("records unknown flags and missing values", () => {
+    const flags = parseReleaseFlags(["--nope", "--repo", "--project-root="]);
+    expect(flags.unknown.length).toBeGreaterThan(0);
+  });
+
+  it("sets help flag", () => {
+    expect(parseReleaseFlags(["--help"]).help).toBe(true);
+    expect(parseReleaseFlags(["-h"]).help).toBe(true);
+  });
+
+  it("rejects duplicate positional version", () => {
+    const flags = parseReleaseFlags(["0.1.0", "0.2.0"]);
+    expect(flags.version).toBe("0.1.0");
+    expect(flags.unknown).toContain("0.2.0");
+  });
+});
+
+describe("formatReleaseHelp", () => {
+  it("matches embedded argparse help", () => {
+    expect(formatReleaseHelp()).toBe(RELEASE_HELP);
+  });
+});

--- a/packages/core/src/release/flags.test.ts
+++ b/packages/core/src/release/flags.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatReleaseHelp, parseReleaseFlags } from "./flags.js";
 import { RELEASE_HELP } from "./constants.js";
+import { formatReleaseHelp, parseReleaseFlags } from "./flags.js";
 
 describe("parseReleaseFlags", () => {
   it("parses full argv set", () => {

--- a/packages/core/src/release/flags.ts
+++ b/packages/core/src/release/flags.ts
@@ -1,0 +1,109 @@
+import { DEFAULT_BASE_BRANCH, RELEASE_HELP } from "./constants.js";
+import type { ReleaseFlags } from "./types.js";
+
+export function parseReleaseFlags(args: readonly string[]): ReleaseFlags {
+  let help = false;
+  let dryRun = false;
+  let skipTag = false;
+  let skipRelease = false;
+  let allowDirty = false;
+  let allowVbriefDrift = false;
+  let skipCi = false;
+  let skipBuild = false;
+  let draft = true;
+  let repo: string | null = null;
+  let baseBranch = DEFAULT_BASE_BRANCH;
+  let projectRoot: string | null = null;
+  let summary: string | null = null;
+  let version: string | null = null;
+  const unknown: string[] = [];
+
+  const takeValue = (flag: string, i: number): string | null => {
+    if (i + 1 >= args.length) {
+      unknown.push(`${flag} (missing value)`);
+      return null;
+    }
+    return args[i + 1] ?? null;
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i] ?? "";
+    if (token === "-h" || token === "--help") {
+      help = true;
+    } else if (token === "--dry-run") {
+      dryRun = true;
+    } else if (token === "--skip-tag") {
+      skipTag = true;
+    } else if (token === "--skip-release") {
+      skipRelease = true;
+    } else if (token === "--allow-dirty") {
+      allowDirty = true;
+    } else if (token === "--allow-vbrief-drift") {
+      allowVbriefDrift = true;
+    } else if (token === "--skip-ci") {
+      skipCi = true;
+    } else if (token === "--skip-build") {
+      skipBuild = true;
+    } else if (token === "--no-draft") {
+      draft = false;
+    } else if (token === "--repo") {
+      repo = takeValue(token, i);
+      if (repo !== null) i += 1;
+    } else if (token.startsWith("--repo=")) {
+      repo = token.slice("--repo=".length) || null;
+      if (!repo) unknown.push("--repo= (empty value)");
+    } else if (token === "--base-branch") {
+      const v = takeValue(token, i);
+      if (v !== null) {
+        baseBranch = v;
+        i += 1;
+      }
+    } else if (token.startsWith("--base-branch=")) {
+      const v = token.slice("--base-branch=".length);
+      if (v) baseBranch = v;
+      else unknown.push("--base-branch= (empty value)");
+    } else if (token === "--project-root") {
+      projectRoot = takeValue(token, i);
+      if (projectRoot !== null) i += 1;
+    } else if (token.startsWith("--project-root=")) {
+      projectRoot = token.slice("--project-root=".length) || null;
+      if (!projectRoot) unknown.push("--project-root= (empty value)");
+    } else if (token === "--summary") {
+      summary = takeValue(token, i);
+      if (summary !== null) i += 1;
+    } else if (token.startsWith("--summary=")) {
+      summary = token.slice("--summary=".length) || null;
+      if (!summary) unknown.push("--summary= (empty value)");
+    } else if (token.startsWith("-")) {
+      unknown.push(token);
+    } else if (version === null) {
+      version = token;
+    } else {
+      unknown.push(token);
+    }
+    i += 1;
+  }
+
+  return {
+    help,
+    version,
+    repo,
+    baseBranch,
+    projectRoot,
+    dryRun,
+    skipTag,
+    skipRelease,
+    allowDirty,
+    allowVbriefDrift,
+    skipCi,
+    skipBuild,
+    draft,
+    summary,
+    unknown,
+  };
+}
+
+export function formatReleaseHelp(): string {
+  return RELEASE_HELP;
+}

--- a/packages/core/src/release/gh.test.ts
+++ b/packages/core/src/release/gh.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { prependUpgradeBanner } from "./changelog.js";
+import {
+  checkTagAvailable,
+  createGithubRelease,
+  verifyReleaseDraft,
+} from "./gh.js";
+import type { ReleaseSeams } from "./types.js";
+import { toPep440 } from "./version.js";
+import { parseReleaseFlags } from "./flags.js";
+
+describe("checkTagAvailable remaining branches", () => {
+  it("fails when git tag -l errors", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 1, stdout: "", stderr: "tag list fail" }),
+    };
+    const [ok, reason] = checkTagAvailable("0.21.0", "r", "/p", seams);
+    expect(ok).toBe(false);
+    expect(reason).toContain("git tag -l failed");
+  });
+
+  it("reports clean with gh verification", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a[0] === "release" && a[1] === "view") {
+          return { status: 1, stdout: "", stderr: "not found" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      whichGh: () => "/usr/bin/gh",
+    };
+    const [ok, reason] = checkTagAvailable("0.21.0", "deftai/directive", "/p", seams);
+    expect(ok).toBe(true);
+    expect(reason).toContain("no GitHub release");
+  });
+});
+
+describe("verifyReleaseDraft flip failure", () => {
+  it("returns false when flip fails", () => {
+    let calls = 0;
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => {
+        calls += 1;
+        if (calls === 1) {
+          return { status: 0, stdout: '{"isDraft":false}', stderr: "" };
+        }
+        return { status: 1, stdout: "", stderr: "edit failed" };
+      },
+      sleep: () => undefined,
+    };
+    const [ok] = verifyReleaseDraft(
+      "/p",
+      "0.21.0",
+      "r",
+      { sleep: () => undefined },
+      seams,
+    );
+    expect(ok).toBe(false);
+  });
+});
+
+describe("prependUpgradeBanner catch", () => {
+  it("returns notes when read throws", () => {
+    const out = prependUpgradeBanner("notes", "deftai/directive", "/r", () => {
+      throw new Error("read fail");
+    });
+    expect(out).toBe("notes");
+  });
+});
+
+describe("toPep440 type guard", () => {
+  it("throws for non-string version", () => {
+    expect(() => toPep440(1 as unknown as string)).toThrow(/must be a string/);
+  });
+});
+
+describe("parseReleaseFlags edge cases", () => {
+  it("handles empty equals values", () => {
+    const flags = parseReleaseFlags([
+      "1.0.0",
+      "--base-branch=",
+      "--repo=",
+      "--project-root=",
+      "--summary=",
+    ]);
+    expect(flags.unknown.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("createGithubRelease without draft flags", () => {
+  it("creates public non-prerelease release", () => {
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({ status: 0, stdout: "", stderr: "" }),
+    };
+    const [ok, reason] = createGithubRelease(
+      "/p",
+      "0.21.0",
+      "consumer/repo",
+      "body",
+      { draft: false, prerelease: false },
+      seams,
+    );
+    expect(ok).toBe(true);
+    expect(reason).not.toContain("draft");
+  });
+});

--- a/packages/core/src/release/gh.test.ts
+++ b/packages/core/src/release/gh.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { prependUpgradeBanner } from "./changelog.js";
-import {
-  checkTagAvailable,
-  createGithubRelease,
-  verifyReleaseDraft,
-} from "./gh.js";
+import { parseReleaseFlags } from "./flags.js";
+import { checkTagAvailable, createGithubRelease, verifyReleaseDraft } from "./gh.js";
 import type { ReleaseSeams } from "./types.js";
 import { toPep440 } from "./version.js";
-import { parseReleaseFlags } from "./flags.js";
 
 describe("checkTagAvailable remaining branches", () => {
   it("fails when git tag -l errors", () => {
@@ -49,13 +45,7 @@ describe("verifyReleaseDraft flip failure", () => {
       },
       sleep: () => undefined,
     };
-    const [ok] = verifyReleaseDraft(
-      "/p",
-      "0.21.0",
-      "r",
-      { sleep: () => undefined },
-      seams,
-    );
+    const [ok] = verifyReleaseDraft("/p", "0.21.0", "r", { sleep: () => undefined }, seams);
     expect(ok).toBe(false);
   });
 });

--- a/packages/core/src/release/gh.ts
+++ b/packages/core/src/release/gh.ts
@@ -1,0 +1,261 @@
+import { existsSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { defaultWhich, spawnText } from "./spawn.js";
+import type { ReleaseSeams } from "./types.js";
+import { runGit } from "./git.js";
+
+export function resolveGh(seams: ReleaseSeams = {}): string | null {
+  const which = seams.whichGh ?? defaultWhich;
+  return which("gh");
+}
+
+export function checkTagAvailable(
+  version: string,
+  repo: string,
+  projectRoot: string,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const tag = `v${version}`;
+
+  const local = runGit(projectRoot, ["tag", "-l", tag], seams);
+  if (local.status !== 0) {
+    return [false, `git tag -l failed: ${local.stderr.trim()}`];
+  }
+  if (local.stdout.trim() === tag) {
+    return [
+      false,
+      `local tag ${tag} already exists; choose a different version ` +
+        "(operator typo of a prior release is the most likely cause)",
+    ];
+  }
+
+  const remote = runGit(projectRoot, ["ls-remote", "--tags", "origin", `refs/tags/${tag}`], seams);
+  let remoteUnverifiedNote = "";
+  if (remote.status !== 0) {
+    const stderr = remote.stderr.trim();
+    const firstLine = stderr.split("\n")[0] ?? "no stderr";
+    remoteUnverifiedNote = ` (remote UNVERIFIED -- git ls-remote failed: ${firstLine})`;
+  } else if (remote.stdout.includes(`refs/tags/${tag}`)) {
+    return [false, `remote tag ${tag} already exists on origin; choose a different version`];
+  }
+
+  const ghPath = resolveGh(seams);
+  if (ghPath === null) {
+    return [
+      true,
+      `local clean${remoteUnverifiedNote} (gh CLI not on PATH; ` +
+        "GitHub release surface UNVERIFIED -- install gh or pass " +
+        "--skip-release to suppress this caveat)",
+    ];
+  }
+
+  const spawn = seams.spawnText ?? spawnText;
+  const gh = spawn(ghPath, ["release", "view", tag, "--repo", repo, "--json", "tagName"], {
+    cwd: projectRoot,
+    timeoutMs: 30_000,
+  });
+  if (gh.status === 0) {
+    return [false, `GitHub release ${tag} already exists on ${repo}; choose a different version`];
+  }
+  return [
+    true,
+    `local clean${remoteUnverifiedNote}; no GitHub release ${tag} on ${repo}`,
+  ];
+}
+
+export function createGithubRelease(
+  projectRoot: string,
+  version: string,
+  repo: string,
+  notes: string,
+  options: { draft?: boolean; prerelease?: boolean } = {},
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const draft = options.draft ?? true;
+  const prerelease = options.prerelease ?? false;
+  const ghPath = resolveGh(seams);
+  if (ghPath === null) {
+    return [false, "gh CLI not found on PATH"];
+  }
+
+  const tag = `v${version}`;
+  const cmd = [ghPath, "release", "create", tag, "--repo", repo, "--title", tag];
+  if (draft) cmd.push("--draft");
+  if (prerelease) cmd.push("--prerelease");
+
+  let notesFile: string | null = null;
+  if (notes) {
+    const dir = tmpdir();
+    notesFile = join(dir, `deft-release-notes-${process.pid}-${Date.now()}.md`);
+    writeFileSync(notesFile, notes, { encoding: "utf8" });
+    cmd.push("--notes-file", notesFile);
+  } else {
+    cmd.push("--generate-notes");
+  }
+
+  const spawn = seams.spawnText ?? spawnText;
+  try {
+    const result = spawn(cmd[0]!, cmd.slice(1), {
+      cwd: projectRoot,
+      timeoutMs: 120_000,
+      env: { ...process.env },
+    });
+    if (result.status !== 0) {
+      return [false, `gh release create failed: ${result.stderr.trim()}`];
+    }
+    const flags: string[] = [];
+    if (draft) flags.push("draft");
+    if (prerelease) flags.push("prerelease");
+    const suffix = flags.length > 0 ? ` (${flags.join(", ")})` : "";
+    return [true, `created GitHub release ${tag}${suffix}`];
+  } finally {
+    if (notesFile !== null) {
+      try {
+        unlinkSync(notesFile);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}
+
+type GhDraftState = "draft" | "public" | "not-found" | "error";
+
+function ghReleaseViewIsDraft(
+  ghPath: string,
+  version: string,
+  repo: string,
+  projectRoot: string,
+  seams: ReleaseSeams,
+): [GhDraftState, string] {
+  const tag = `v${version}`;
+  const spawn = seams.spawnText ?? spawnText;
+  const result = spawn(ghPath, ["release", "view", tag, "--repo", repo, "--json", "isDraft"], {
+    cwd: projectRoot,
+    timeoutMs: 30_000,
+    env: { ...process.env },
+  });
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    const lower = stderr.toLowerCase();
+    if (lower.includes("not found") || lower.includes("release not found")) {
+      return ["not-found", stderr];
+    }
+    return ["error", stderr];
+  }
+  try {
+    const payload = JSON.parse(result.stdout || "{}") as { isDraft?: boolean };
+    if (payload.isDraft === true) return ["draft", ""];
+    if (payload.isDraft === false) return ["public", ""];
+    return ["error", `isDraft missing from gh response: ${JSON.stringify(payload)}`];
+  } catch (exc) {
+    return ["error", `unparseable gh JSON: ${String(exc)}`];
+  }
+}
+
+function ghReleaseFlipToDraft(
+  ghPath: string,
+  version: string,
+  repo: string,
+  projectRoot: string,
+  seams: ReleaseSeams,
+): [boolean, string] {
+  const tag = `v${version}`;
+  const spawn = seams.spawnText ?? spawnText;
+  const result = spawn(ghPath, ["release", "edit", tag, "--repo", repo, "--draft=true"], {
+    cwd: projectRoot,
+    timeoutMs: 30_000,
+    env: { ...process.env },
+  });
+  if (result.status !== 0) {
+    return [false, `gh release edit failed: ${result.stderr.trim()}`];
+  }
+  return [true, `flipped ${tag} to draft`];
+}
+
+export function verifyReleaseDraft(
+  projectRoot: string,
+  version: string,
+  repo: string,
+  options: {
+    maxAttempts?: number;
+    interval?: number;
+    sleep?: (seconds: number) => void;
+  } = {},
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const maxAttempts = options.maxAttempts ?? 5;
+  const interval = options.interval ?? 1.0;
+  const sleepFn = options.sleep ?? seams.sleep ?? ((s: number) => {
+    const start = Date.now();
+    while (Date.now() - start < s * 1000) {
+      // busy-wait fallback for tests injecting sleep
+    }
+  });
+
+  if (maxAttempts <= 0) {
+    return [true, "verify gate disabled (max_attempts <= 0)"];
+  }
+
+  const ghPath = resolveGh(seams);
+  if (ghPath === null) {
+    process.stderr.write(
+      "WARNING: cannot verify draft state (gh CLI not found on PATH); " +
+        "defense-in-depth gate skipped (see #724)\n",
+    );
+    return [true, "gh CLI not found on PATH; verify gate skipped"];
+  }
+
+  let lastState = "";
+  let lastDetail = "";
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const [state, detail] = ghReleaseViewIsDraft(ghPath, version, repo, projectRoot, seams);
+    lastState = state;
+    lastDetail = detail;
+    if (state === "draft") {
+      return [true, `verified draft on attempt ${attempt}/${maxAttempts}`];
+    }
+    if (state === "public") {
+      process.stderr.write(
+        `WARNING: release v${version} landed as public; ` +
+          "flipping to draft (defense-in-depth, see #724)\n",
+      );
+      const [ok, reason] = ghReleaseFlipToDraft(ghPath, version, repo, projectRoot, seams);
+      if (ok) return [true, `flipped to draft (${reason})`];
+      return [false, reason];
+    }
+    if (attempt < maxAttempts) {
+      sleepFn(interval);
+    }
+  }
+
+  if (lastState === "not-found") {
+    process.stderr.write(
+      `WARNING: release v${version} not found within ` +
+        `${maxAttempts}*${interval}s budget; release.yml CI may still ` +
+        "be processing (see #724)\n",
+    );
+    return [true, "not found within budget; verify gate inconclusive"];
+  }
+
+  process.stderr.write(
+    `WARNING: verify gate could not confirm draft state for v${version}: ` +
+      `last state '${lastState}'; detail: ${lastDetail} (see #724)\n`,
+  );
+  return [true, `inconclusive (${lastState}); verify gate skipped`];
+}
+
+/** Read upgrade banner for prependUpgradeBanner seam. */
+export function readTextFile(path: string): string | null {
+  try {
+    if (!existsSync(path)) return null;
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function defaultMkdtemp(): string {
+  return mkdtempSync(join(tmpdir(), "deft-release-"));
+}

--- a/packages/core/src/release/gh.ts
+++ b/packages/core/src/release/gh.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runGit } from "./git.js";
 import { defaultWhich, spawnText } from "./spawn.js";
 import type { ReleaseSeams } from "./types.js";
-import { runGit } from "./git.js";
 
 export function resolveGh(seams: ReleaseSeams = {}): string | null {
   const which = seams.whichGh ?? defaultWhich;
@@ -58,10 +58,7 @@ export function checkTagAvailable(
   if (gh.status === 0) {
     return [false, `GitHub release ${tag} already exists on ${repo}; choose a different version`];
   }
-  return [
-    true,
-    `local clean${remoteUnverifiedNote}; no GitHub release ${tag} on ${repo}`,
-  ];
+  return [true, `local clean${remoteUnverifiedNote}; no GitHub release ${tag} on ${repo}`];
 }
 
 export function createGithubRelease(
@@ -96,7 +93,7 @@ export function createGithubRelease(
 
   const spawn = seams.spawnText ?? spawnText;
   try {
-    const result = spawn(cmd[0]!, cmd.slice(1), {
+    const result = spawn(ghPath, cmd.slice(1), {
       cwd: projectRoot,
       timeoutMs: 120_000,
       env: { ...process.env },
@@ -187,12 +184,15 @@ export function verifyReleaseDraft(
 ): [boolean, string] {
   const maxAttempts = options.maxAttempts ?? 5;
   const interval = options.interval ?? 1.0;
-  const sleepFn = options.sleep ?? seams.sleep ?? ((s: number) => {
-    const start = Date.now();
-    while (Date.now() - start < s * 1000) {
-      // busy-wait fallback for tests injecting sleep
-    }
-  });
+  const sleepFn =
+    options.sleep ??
+    seams.sleep ??
+    ((s: number) => {
+      const start = Date.now();
+      while (Date.now() - start < s * 1000) {
+        // busy-wait fallback for tests injecting sleep
+      }
+    });
 
   if (maxAttempts <= 0) {
     return [true, "verify gate disabled (max_attempts <= 0)"];

--- a/packages/core/src/release/git.ts
+++ b/packages/core/src/release/git.ts
@@ -28,10 +28,7 @@ export function runGit(
   });
 }
 
-export function checkGitClean(
-  projectRoot: string,
-  seams: ReleaseSeams = {},
-): [boolean, string] {
+export function checkGitClean(projectRoot: string, seams: ReleaseSeams = {}): [boolean, string] {
   const result = runGit(projectRoot, ["status", "--porcelain"], seams);
   if (result.status !== 0) {
     return [false, `git status failed: ${result.stderr.trim()}`];
@@ -70,9 +67,7 @@ export function commitReleaseArtifacts(
       }
     });
 
-  const pathsToStage = RELEASE_ARTIFACTS.filter((rel) =>
-    exists(`${projectRoot}/${rel}`),
-  );
+  const pathsToStage = RELEASE_ARTIFACTS.filter((rel) => exists(`${projectRoot}/${rel}`));
   if (pathsToStage.length === 0) {
     return [true, "no release artifacts to commit (none exist)"];
   }
@@ -88,12 +83,7 @@ export function commitReleaseArtifacts(
   }
 
   const subject = releaseCommitSubject(version);
-  const commit = runGit(
-    projectRoot,
-    ["commit", "-m", subject],
-    seams,
-    releaseSubprocessEnv(),
-  );
+  const commit = runGit(projectRoot, ["commit", "-m", subject], seams, releaseSubprocessEnv());
   if (commit.status !== 0) {
     return [false, `git commit failed: ${commit.stderr.trim()}`];
   }

--- a/packages/core/src/release/git.ts
+++ b/packages/core/src/release/git.ts
@@ -1,0 +1,138 @@
+import { existsSync, statSync } from "node:fs";
+import {
+  BRANCH_GATE_BYPASS_ENV,
+  DESTRUCTIVE_GH_GATE_BYPASS_ENV,
+  RELEASE_ARTIFACTS,
+} from "./constants.js";
+import { spawnText } from "./spawn.js";
+import type { ReleaseSeams } from "./types.js";
+
+export function releaseSubprocessEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return {
+    ...base,
+    [BRANCH_GATE_BYPASS_ENV]: "1",
+    [DESTRUCTIVE_GH_GATE_BYPASS_ENV]: "1",
+  };
+}
+
+export function runGit(
+  projectRoot: string,
+  args: readonly string[],
+  seams: ReleaseSeams = {},
+  env?: NodeJS.ProcessEnv,
+): ReturnType<typeof spawnText> {
+  const spawn = seams.spawnText ?? spawnText;
+  return spawn("git", ["-C", projectRoot, ...args], {
+    env,
+    timeoutMs: 30_000,
+  });
+}
+
+export function checkGitClean(
+  projectRoot: string,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const result = runGit(projectRoot, ["status", "--porcelain"], seams);
+  if (result.status !== 0) {
+    return [false, `git status failed: ${result.stderr.trim()}`];
+  }
+  const output = result.stdout.trim();
+  if (output) {
+    return [false, output];
+  }
+  return [true, ""];
+}
+
+export function currentBranch(projectRoot: string, seams: ReleaseSeams = {}): string {
+  const result = runGit(projectRoot, ["branch", "--show-current"], seams);
+  if (result.status !== 0) {
+    return "";
+  }
+  return result.stdout.trim();
+}
+
+export function releaseCommitSubject(version: string): string {
+  return `chore(release): v${version} -- promote CHANGELOG + ROADMAP`;
+}
+
+export function commitReleaseArtifacts(
+  projectRoot: string,
+  version: string,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const exists =
+    seams.fileExists ??
+    ((p: string) => {
+      try {
+        return existsSync(p) && statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+  const pathsToStage = RELEASE_ARTIFACTS.filter((rel) =>
+    exists(`${projectRoot}/${rel}`),
+  );
+  if (pathsToStage.length === 0) {
+    return [true, "no release artifacts to commit (none exist)"];
+  }
+
+  const add = runGit(projectRoot, ["add", "--", ...pathsToStage], seams);
+  if (add.status !== 0) {
+    return [false, `git add failed: ${add.stderr.trim()}`];
+  }
+
+  const diff = runGit(projectRoot, ["diff", "--cached", "--quiet"], seams);
+  if (diff.status === 0) {
+    return [true, "release artifacts already up-to-date; no commit needed"];
+  }
+
+  const subject = releaseCommitSubject(version);
+  const commit = runGit(
+    projectRoot,
+    ["commit", "-m", subject],
+    seams,
+    releaseSubprocessEnv(),
+  );
+  if (commit.status !== 0) {
+    return [false, `git commit failed: ${commit.stderr.trim()}`];
+  }
+  return [true, `committed release artifacts (${subject})`];
+}
+
+export function createTag(
+  projectRoot: string,
+  version: string,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const tag = `v${version}`;
+  const result = runGit(
+    projectRoot,
+    ["tag", "-a", tag, "-m", `Release ${tag}`],
+    seams,
+    releaseSubprocessEnv(),
+  );
+  if (result.status !== 0) {
+    return [false, `git tag failed: ${result.stderr.trim()}`];
+  }
+  return [true, `created tag ${tag}`];
+}
+
+export function pushRelease(
+  projectRoot: string,
+  version: string,
+  baseBranch: string,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const tag = `v${version}`;
+  const result = runGit(
+    projectRoot,
+    ["push", "--atomic", "origin", baseBranch, tag],
+    seams,
+    releaseSubprocessEnv(),
+  );
+  if (result.status !== 0) {
+    return [false, `git push failed: ${result.stderr.trim()}`];
+  }
+  return [true, `pushed ${baseBranch} + ${tag} to origin`];
+}

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -1,0 +1,14 @@
+/* v8 ignore file -- re-export barrel; covered via main.ts */
+export * from "./constants.js";
+export * from "./flags.js";
+export * from "./git.js";
+export * from "./gh.js";
+export * from "./main.js";
+export * from "./paths.js";
+export * from "./pipeline.js";
+export * from "./pyproject.js";
+export * from "./pyproject-sync.js";
+export * from "./python-bridge.js";
+export * from "./spawn.js";
+export * from "./types.js";
+export * from "./version.js";

--- a/packages/core/src/release/index.ts
+++ b/packages/core/src/release/index.ts
@@ -1,8 +1,8 @@
 /* v8 ignore file -- re-export barrel; covered via main.ts */
 export * from "./constants.js";
 export * from "./flags.js";
-export * from "./git.js";
 export * from "./gh.js";
+export * from "./git.js";
 export * from "./main.js";
 export * from "./paths.js";
 export * from "./pipeline.js";

--- a/packages/core/src/release/main.test.ts
+++ b/packages/core/src/release/main.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { cmdRelease } from "./main.js";
-import type { ReleaseSeams } from "./types.js";
 import { runPipeline } from "./pipeline.js";
+import type { ReleaseSeams } from "./types.js";
 
 const CHANGELOG = `## [Unreleased]\n\n### Added\n- x\n`;
 

--- a/packages/core/src/release/main.test.ts
+++ b/packages/core/src/release/main.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { cmdRelease } from "./main.js";
+import type { ReleaseSeams } from "./types.js";
+import { runPipeline } from "./pipeline.js";
+
+const CHANGELOG = `## [Unreleased]\n\n### Added\n- x\n`;
+
+describe("cmdRelease integration", () => {
+  it("runs dry-run pipeline end-to-end via seams", () => {
+    const err: string[] = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: string | Uint8Array) => {
+      err.push(String(c));
+      return true;
+    }) as typeof process.stderr.write;
+
+    const seams: ReleaseSeams = {
+      todayIso: () => "2026-06-19",
+      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      readFile: () => CHANGELOG,
+    };
+
+    try {
+      const code = cmdRelease(
+        [
+          "0.21.0",
+          "--dry-run",
+          "--skip-tag",
+          "--skip-release",
+          "--repo",
+          "deftai/directive",
+          "--project-root",
+          "/tmp/proj",
+          "--allow-vbrief-drift",
+          "--skip-ci",
+        ],
+        seams,
+      );
+      expect(code).toBe(0);
+      expect(err.join("")).toContain("DRYRUN");
+    } finally {
+      process.stderr.write = origErr;
+    }
+  });
+});
+
+describe("pipeline verify flip failure", () => {
+  it("returns violation when draft flip fails", () => {
+    const config = {
+      version: "0.21.0",
+      repo: "deftai/directive",
+      baseBranch: "master",
+      projectRoot: "/proj",
+      dryRun: false,
+      skipTag: true,
+      skipRelease: false,
+      allowDirty: false,
+      draft: true,
+      skipCi: true,
+      skipBuild: true,
+      summary: null,
+      allowVbriefDrift: true,
+    };
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        if (a[0] === "release" && a[1] === "view") {
+          return { status: 0, stdout: '{"isDraft":false}', stderr: "" };
+        }
+        if (a[0] === "release" && a[1] === "edit") {
+          return { status: 1, stdout: "", stderr: "edit fail" };
+        }
+        if (a[0] === "release" && a[1] === "create") {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      whichGh: () => "/usr/bin/gh",
+      checkTagAvailable: () => [true, "ok"],
+      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      readFile: () => CHANGELOG,
+      writeFile: () => undefined,
+      refreshRoadmap: () => [true, "ok"],
+      sleep: () => undefined,
+      todayIso: () => "2026-04-28",
+    };
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+});

--- a/packages/core/src/release/main.ts
+++ b/packages/core/src/release/main.ts
@@ -1,0 +1,54 @@
+import { EXIT_CONFIG_ERROR } from "./constants.js";
+import { formatReleaseHelp, parseReleaseFlags } from "./flags.js";
+import { runPipeline } from "./pipeline.js";
+import { resolveProjectRoot, resolveRepo } from "./paths.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+import { validateVersion } from "./version.js";
+
+export function cmdRelease(args: readonly string[], seams: ReleaseSeams = {}): number {
+  const flags = parseReleaseFlags(args);
+
+  if (flags.help) {
+    process.stdout.write(formatReleaseHelp());
+    return 0;
+  }
+
+  if (flags.unknown.length > 0) {
+    process.stderr.write(`release: error: unrecognized arguments: ${flags.unknown.join(" ")}\n`);
+    return EXIT_CONFIG_ERROR;
+  }
+
+  if (flags.version === null) {
+    process.stderr.write("release: error: the following arguments are required: version\n");
+    return EXIT_CONFIG_ERROR;
+  }
+
+  try {
+    validateVersion(flags.version);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error: ${msg}\n`);
+    return EXIT_CONFIG_ERROR;
+  }
+
+  const projectRoot = resolveProjectRoot(flags.projectRoot);
+  const repo = resolveRepo(flags.repo, projectRoot, seams);
+
+  const config: ReleaseConfig = {
+    version: flags.version,
+    repo,
+    baseBranch: flags.baseBranch,
+    projectRoot,
+    dryRun: flags.dryRun,
+    skipTag: flags.skipTag,
+    skipRelease: flags.skipRelease,
+    allowDirty: flags.allowDirty,
+    draft: flags.draft,
+    skipCi: flags.skipCi,
+    skipBuild: flags.skipBuild,
+    summary: flags.summary,
+    allowVbriefDrift: flags.allowVbriefDrift,
+  };
+
+  return runPipeline(config, seams);
+}

--- a/packages/core/src/release/main.ts
+++ b/packages/core/src/release/main.ts
@@ -1,7 +1,7 @@
 import { EXIT_CONFIG_ERROR } from "./constants.js";
 import { formatReleaseHelp, parseReleaseFlags } from "./flags.js";
-import { runPipeline } from "./pipeline.js";
 import { resolveProjectRoot, resolveRepo } from "./paths.js";
+import { runPipeline } from "./pipeline.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 import { validateVersion } from "./version.js";
 

--- a/packages/core/src/release/paths.test.ts
+++ b/packages/core/src/release/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveProjectRoot, resolveRepo, todayIso } from "./paths.js";
+import { resolveProjectRoot, resolveRepo } from "./paths.js";
 
 describe("paths", () => {
   it("resolveProjectRoot honours explicit path", () => {

--- a/packages/core/src/release/paths.test.ts
+++ b/packages/core/src/release/paths.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { resolveProjectRoot, resolveRepo, todayIso } from "./paths.js";
+
+describe("paths", () => {
+  it("resolveProjectRoot honours explicit path", () => {
+    expect(resolveProjectRoot("/tmp/x")).toBe("/tmp/x");
+  });
+
+  it("resolveProjectRoot honours DEFT_PROJECT_ROOT", () => {
+    const prev = process.env.DEFT_PROJECT_ROOT;
+    process.env.DEFT_PROJECT_ROOT = "/env/root";
+    try {
+      expect(resolveProjectRoot(null)).toBe("/env/root");
+    } finally {
+      if (prev === undefined) delete process.env.DEFT_PROJECT_ROOT;
+      else process.env.DEFT_PROJECT_ROOT = prev;
+    }
+  });
+
+  it("resolveRepo uses flag override", () => {
+    expect(resolveRepo("acme/r", "/tmp")).toBe("acme/r");
+  });
+
+  it("resolveRepo parses https remote", () => {
+    const [ok, repo] = ((): [boolean, string] => {
+      const r = resolveRepo(null, "/tmp", {
+        spawnText: () => ({
+          status: 0,
+          stdout: "https://github.com/deftai/directive.git\n",
+          stderr: "",
+        }),
+      });
+      return [true, r];
+    })();
+    expect(ok).toBe(true);
+    expect(repo).toBe("deftai/directive");
+  });
+
+  it("resolveRepo parses ssh remote", () => {
+    const repo = resolveRepo(null, "/tmp", {
+      spawnText: () => ({
+        status: 0,
+        stdout: "git@github.com:org/proj.git\n",
+        stderr: "",
+      }),
+    });
+    expect(repo).toBe("org/proj");
+  });
+
+  it("resolveRepo falls back on git failure", () => {
+    const repo = resolveRepo(null, "/tmp", {
+      spawnText: () => ({ status: 1, stdout: "", stderr: "err" }),
+    });
+    expect(repo).toBe("deftai/directive");
+  });
+
+  it("resolveRepo falls back on unparseable url", () => {
+    const repo = resolveRepo(null, "/tmp", {
+      spawnText: () => ({ status: 0, stdout: "not-a-url\n", stderr: "" }),
+    });
+    expect(repo).toBe("deftai/directive");
+  });
+
+  it("resolveProjectRoot uses framework root by default", () => {
+    const prev = process.env.DEFT_PROJECT_ROOT;
+    delete process.env.DEFT_PROJECT_ROOT;
+    try {
+      const root = resolveProjectRoot(null);
+      expect(root.length).toBeGreaterThan(0);
+    } finally {
+      if (prev !== undefined) process.env.DEFT_PROJECT_ROOT = prev;
+    }
+  });
+});

--- a/packages/core/src/release/paths.ts
+++ b/packages/core/src/release/paths.ts
@@ -1,0 +1,50 @@
+import { resolve } from "node:path";
+import { resolveDefaultFrameworkRoot, resolveScriptDir } from "../doctor/paths.js";
+import { DEFAULT_REPO } from "./constants.js";
+import { spawnText } from "./spawn.js";
+import type { ReleaseSeams } from "./types.js";
+
+export function resolveProjectRoot(argRoot: string | null): string {
+  if (argRoot !== null) {
+    return resolve(argRoot);
+  }
+  const envRoot = process.env.DEFT_PROJECT_ROOT?.trim();
+  if (envRoot) {
+    return resolve(envRoot);
+  }
+  return resolveDefaultFrameworkRoot();
+}
+
+export function resolveRepo(
+  argRepo: string | null,
+  projectRoot: string,
+  seams: Pick<ReleaseSeams, "spawnText"> = {},
+): string {
+  if (argRepo) {
+    return argRepo;
+  }
+  const spawn = seams.spawnText ?? spawnText;
+  const result = spawn("git", ["-C", projectRoot, "remote", "get-url", "origin"], {
+    timeoutMs: 10_000,
+  });
+  if (result.status !== 0) {
+    return DEFAULT_REPO;
+  }
+  const url = result.stdout.trim();
+  const match =
+    /^(?:https?:\/\/github\.com\/|git@github\.com:)(?<owner>[^/]+)\/(?<repo>[^/]+?)(?:\.git)?$/.exec(
+      url,
+    );
+  if (!match?.groups) {
+    return DEFAULT_REPO;
+  }
+  return `${match.groups.owner}/${match.groups.repo}`;
+}
+
+export function resolveScriptsDir(frameworkRoot?: string): string {
+  return resolveScriptDir(frameworkRoot);
+}
+
+export function todayIso(now: () => Date = () => new Date()): string {
+  return now().toISOString().slice(0, 10);
+}

--- a/packages/core/src/release/pipeline-branches.test.ts
+++ b/packages/core/src/release/pipeline-branches.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import { createGithubRelease, verifyReleaseDraft } from "./gh.js";
+import {
+  checkGitClean,
+  commitReleaseArtifacts,
+  createTag,
+  pushRelease,
+} from "./git.js";
+import { runPipeline } from "./pipeline.js";
+import { spawnText } from "./spawn.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+
+const CHANGELOG = `## [Unreleased]\n\n### Added\n- x\n`;
+
+function baseSeams(overrides: ReleaseSeams = {}): ReleaseSeams {
+  return {
+    spawnText: (_c, a) => {
+      if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+      if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+      return { status: 0, stdout: "", stderr: "" };
+    },
+    checkTagAvailable: () => [true, "ok"],
+    checkVbriefLifecycleSync: () => [true, 0, ""],
+    fileExists: (p) => /\.(md|toml)$/.test(p),
+    readFile: (p) =>
+      p.endsWith("pyproject.toml") ? '[project]\nversion = "0.20.0"\n' : CHANGELOG,
+    writeFile: () => undefined,
+    runUvLock: () => [true, "uv.lock regenerated"],
+    refreshRoadmap: () => [true, "ok"],
+    runBuild: () => [true, "ok"],
+    todayIso: () => "2026-04-28",
+    ...overrides,
+  };
+}
+
+const baseConfig: ReleaseConfig = {
+  version: "0.21.0",
+  repo: "deftai/directive",
+  baseBranch: "master",
+  projectRoot: "/proj",
+  dryRun: false,
+  skipTag: false,
+  skipRelease: false,
+  allowDirty: false,
+  draft: true,
+  skipCi: true,
+  skipBuild: false,
+  summary: null,
+  allowVbriefDrift: true,
+};
+
+describe("spawnText", () => {
+  it("returns status from spawnSync", () => {
+    const r = spawnText("echo", ["hello"], { timeoutMs: 5000 });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("hello");
+  });
+});
+
+describe("git failure branches", () => {
+  it("checkGitClean fails when git errors", () => {
+    const [ok] = checkGitClean("/p", {
+      spawnText: () => ({ status: 1, stdout: "", stderr: "boom" }),
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("commitReleaseArtifacts fails on git add", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_c, a) => {
+        if (a.includes("add")) return { status: 1, stdout: "", stderr: "add fail" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      fileExists: () => true,
+    };
+    const [ok] = commitReleaseArtifacts("/proj", "0.21.0", seams);
+    expect(ok).toBe(false);
+  });
+
+  it("createTag fails on git error", () => {
+    const [ok] = createTag("/proj", "0.21.0", {
+      spawnText: () => ({ status: 1, stdout: "", stderr: "tag fail" }),
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("pushRelease fails on git error", () => {
+    const [ok] = pushRelease("/proj", "0.21.0", "master", {
+      spawnText: () => ({ status: 1, stdout: "", stderr: "push fail" }),
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe("pipeline remaining branches", () => {
+  it("fails vbrief config error", () => {
+    expect(
+      runPipeline(
+        { ...baseConfig, allowVbriefDrift: false },
+        baseSeams({ checkVbriefLifecycleSync: () => [false, -1, "cfg"] }),
+      ),
+    ).toBe(2);
+  });
+
+  it("fails roadmap refresh", () => {
+    expect(
+      runPipeline(baseConfig, baseSeams({ refreshRoadmap: () => [false, "bad"] })),
+    ).toBe(1);
+  });
+
+  it("fails build step", () => {
+    expect(
+      runPipeline(baseConfig, baseSeams({ runBuild: () => [false, "build fail"] })),
+    ).toBe(1);
+  });
+
+  it("runs tag and push when skip_tag false", () => {
+    expect(
+      runPipeline({ ...baseConfig, skipRelease: true }, baseSeams()),
+    ).toBe(0);
+  });
+
+  it("creates github release when skip_release false", () => {
+    const seams = baseSeams({
+      whichGh: () => "/usr/bin/gh",
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        if (a[0] === "release" && a[1] === "view") {
+          return { status: 0, stdout: '{"isDraft":true}', stderr: "" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      sleep: () => undefined,
+    });
+    expect(
+      runPipeline(
+        { ...baseConfig, skipRelease: false, skipTag: true },
+        seams,
+      ),
+    ).toBe(0);
+  });
+
+  it("fails github release create", () => {
+    const seams = baseSeams({
+      whichGh: () => "/usr/bin/gh",
+      spawnText: (_c, a) => {
+        if (a[0] === "release" && a[1] === "create") {
+          return { status: 1, stdout: "", stderr: "create failed" };
+        }
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(
+      runPipeline({ ...baseConfig, skipRelease: false, skipTag: true }, seams),
+    ).toBe(1);
+  });
+
+  it("warns on allow-dirty non-dry-run", () => {
+    const seams = baseSeams({
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: " M d\n", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(
+      runPipeline(
+        { ...baseConfig, allowDirty: true, dryRun: false, skipRelease: true },
+        seams,
+      ),
+    ).toBe(0);
+  });
+
+  it("fails when commit step fails", () => {
+    const config: ReleaseConfig = {
+      ...baseConfig,
+      skipRelease: true,
+      skipBuild: true,
+      skipCi: true,
+      skipTag: false,
+    };
+    const seams = baseSeams({
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        if (a.includes("commit")) return { status: 1, stdout: "", stderr: "commit err" };
+        if (a.includes("diff")) return { status: 1, stdout: "", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      fileExists: () => true,
+    });
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+
+  it("fails when tag step fails", () => {
+    const config: ReleaseConfig = {
+      ...baseConfig,
+      skipRelease: true,
+      skipBuild: true,
+      skipCi: true,
+    };
+    const seams = baseSeams({
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        if (a.includes("tag") && a.includes("-a")) {
+          return { status: 1, stdout: "", stderr: "tag err" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+
+  it("fails when push step fails", () => {
+    const config: ReleaseConfig = {
+      ...baseConfig,
+      skipRelease: true,
+      skipBuild: true,
+      skipCi: true,
+    };
+    const seams = baseSeams({
+      spawnText: (_c, a) => {
+        if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+        if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+        if (a.includes("push")) return { status: 1, stdout: "", stderr: "push err" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(runPipeline(config, seams)).toBe(1);
+  });
+
+  it("skips verify when --no-draft", () => {
+    expect(
+      runPipeline(
+        { ...baseConfig, draft: false, skipRelease: true, skipTag: true },
+        baseSeams(),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("gh edge cases", () => {
+  it("createGithubRelease uses generate-notes when empty", () => {
+    let sawGenerate = false;
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: (_c, a) => {
+        if (a.includes("--generate-notes")) sawGenerate = true;
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    };
+    const [ok] = createGithubRelease("/p", "0.21.0", "r", "", {}, seams);
+    expect(ok).toBe(true);
+    expect(sawGenerate).toBe(true);
+  });
+
+  it("verifyReleaseDraft handles gh json error", () => {
+    const seams: ReleaseSeams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({ status: 0, stdout: "not-json", stderr: "" }),
+      sleep: () => undefined,
+    };
+    const [ok] = verifyReleaseDraft(
+      "/p",
+      "0.21.0",
+      "r",
+      { maxAttempts: 1, sleep: () => undefined },
+      seams,
+    );
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/core/src/release/pipeline-branches.test.ts
+++ b/packages/core/src/release/pipeline-branches.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createGithubRelease, verifyReleaseDraft } from "./gh.js";
-import {
-  checkGitClean,
-  commitReleaseArtifacts,
-  createTag,
-  pushRelease,
-} from "./git.js";
+import { checkGitClean, commitReleaseArtifacts, createTag, pushRelease } from "./git.js";
 import { runPipeline } from "./pipeline.js";
 import { spawnText } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
@@ -22,8 +17,7 @@ function baseSeams(overrides: ReleaseSeams = {}): ReleaseSeams {
     checkTagAvailable: () => [true, "ok"],
     checkVbriefLifecycleSync: () => [true, 0, ""],
     fileExists: (p) => /\.(md|toml)$/.test(p),
-    readFile: (p) =>
-      p.endsWith("pyproject.toml") ? '[project]\nversion = "0.20.0"\n' : CHANGELOG,
+    readFile: (p) => (p.endsWith("pyproject.toml") ? '[project]\nversion = "0.20.0"\n' : CHANGELOG),
     writeFile: () => undefined,
     runUvLock: () => [true, "uv.lock regenerated"],
     refreshRoadmap: () => [true, "ok"],
@@ -103,21 +97,15 @@ describe("pipeline remaining branches", () => {
   });
 
   it("fails roadmap refresh", () => {
-    expect(
-      runPipeline(baseConfig, baseSeams({ refreshRoadmap: () => [false, "bad"] })),
-    ).toBe(1);
+    expect(runPipeline(baseConfig, baseSeams({ refreshRoadmap: () => [false, "bad"] }))).toBe(1);
   });
 
   it("fails build step", () => {
-    expect(
-      runPipeline(baseConfig, baseSeams({ runBuild: () => [false, "build fail"] })),
-    ).toBe(1);
+    expect(runPipeline(baseConfig, baseSeams({ runBuild: () => [false, "build fail"] }))).toBe(1);
   });
 
   it("runs tag and push when skip_tag false", () => {
-    expect(
-      runPipeline({ ...baseConfig, skipRelease: true }, baseSeams()),
-    ).toBe(0);
+    expect(runPipeline({ ...baseConfig, skipRelease: true }, baseSeams())).toBe(0);
   });
 
   it("creates github release when skip_release false", () => {
@@ -133,12 +121,7 @@ describe("pipeline remaining branches", () => {
       },
       sleep: () => undefined,
     });
-    expect(
-      runPipeline(
-        { ...baseConfig, skipRelease: false, skipTag: true },
-        seams,
-      ),
-    ).toBe(0);
+    expect(runPipeline({ ...baseConfig, skipRelease: false, skipTag: true }, seams)).toBe(0);
   });
 
   it("fails github release create", () => {
@@ -153,9 +136,7 @@ describe("pipeline remaining branches", () => {
         return { status: 0, stdout: "", stderr: "" };
       },
     });
-    expect(
-      runPipeline({ ...baseConfig, skipRelease: false, skipTag: true }, seams),
-    ).toBe(1);
+    expect(runPipeline({ ...baseConfig, skipRelease: false, skipTag: true }, seams)).toBe(1);
   });
 
   it("warns on allow-dirty non-dry-run", () => {
@@ -167,10 +148,7 @@ describe("pipeline remaining branches", () => {
       },
     });
     expect(
-      runPipeline(
-        { ...baseConfig, allowDirty: true, dryRun: false, skipRelease: true },
-        seams,
-      ),
+      runPipeline({ ...baseConfig, allowDirty: true, dryRun: false, skipRelease: true }, seams),
     ).toBe(0);
   });
 
@@ -235,10 +213,7 @@ describe("pipeline remaining branches", () => {
 
   it("skips verify when --no-draft", () => {
     expect(
-      runPipeline(
-        { ...baseConfig, draft: false, skipRelease: true, skipTag: true },
-        baseSeams(),
-      ),
+      runPipeline({ ...baseConfig, draft: false, skipRelease: true, skipTag: true }, baseSeams()),
     ).toBe(0);
   });
 });

--- a/packages/core/src/release/pipeline.test.ts
+++ b/packages/core/src/release/pipeline.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { cmdRelease } from "./main.js";
+import { emit, runPipeline } from "./pipeline.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+import { prependUpgradeBanner } from "./changelog.js";
+import { formatReleaseHelp } from "./flags.js";
+import { syncPyprojectForRelease } from "./pyproject-sync.js";
+import { checkTagAvailable } from "./gh.js";
+
+describe("cmdRelease", () => {
+  it("returns 2 for invalid version", () => {
+    const err: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      err.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      expect(cmdRelease(["not-a-version"])).toBe(2);
+      expect(err.join("")).toContain("Invalid version");
+    } finally {
+      process.stderr.write = orig;
+    }
+  });
+
+  it("prints help on --help", () => {
+    const out: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      out.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      expect(cmdRelease(["--help"])).toBe(0);
+      expect(out.join("")).toBe(formatReleaseHelp());
+    } finally {
+      process.stdout.write = orig;
+    }
+  });
+
+  it("returns 2 when version missing", () => {
+    expect(cmdRelease(["--dry-run"])).toBe(2);
+  });
+});
+
+describe("runPipeline dry-run", () => {
+  const baseConfig: ReleaseConfig = {
+    version: "0.21.0",
+    repo: "deftai/directive",
+    baseBranch: "master",
+    projectRoot: "/tmp/proj",
+    dryRun: true,
+    skipTag: true,
+    skipRelease: true,
+    allowDirty: false,
+    draft: true,
+    skipCi: true,
+    skipBuild: false,
+    summary: null,
+    allowVbriefDrift: true,
+  };
+
+  it("emits DRYRUN steps and returns 0", () => {
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      lines.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    const seams: ReleaseSeams = {
+      todayIso: () => "2026-04-28",
+      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      readFile: () => `## [Unreleased]\n\n### Added\n`,
+    };
+
+    try {
+      expect(runPipeline(baseConfig, seams)).toBe(0);
+      const err = lines.join("");
+      expect(err).toContain("DRYRUN");
+      expect(err).toContain("SKIP (--skip-tag)");
+      expect(err).toContain("pipeline complete");
+    } finally {
+      process.stderr.write = orig;
+    }
+  });
+
+  it("returns config error when CHANGELOG missing", () => {
+    const seams: ReleaseSeams = {
+      fileExists: () => false,
+    };
+    expect(runPipeline(baseConfig, seams)).toBe(2);
+  });
+});
+
+describe("emit", () => {
+  it("formats step label", () => {
+    const chunks: string[] = [];
+    const target = { write: (s: string) => chunks.push(s) };
+    emit(1, "Test step", "OK", target as unknown as NodeJS.WriteStream);
+    expect(chunks[0]).toBe("[1/13] Test step... OK\n");
+  });
+});
+
+describe("prependUpgradeBanner", () => {
+  it("no-ops for consumer repo", () => {
+    expect(prependUpgradeBanner("notes", "other/repo", "/root", () => "banner")).toBe("notes");
+  });
+
+  it("prepends banner for maintainer repo", () => {
+    const out = prependUpgradeBanner("notes", "deftai/directive", "/root", () => "Upgrade me");
+    expect(out).toBe("Upgrade me\n\nnotes");
+  });
+
+  it("returns notes when banner is whitespace only", () => {
+    expect(prependUpgradeBanner("notes", "deftai/directive", "/r", () => "   \n")).toBe(
+      "notes",
+    );
+  });
+});
+
+describe("syncPyprojectForRelease", () => {
+  it("skips when pyproject absent", () => {
+    const [note] = syncPyprojectForRelease("/no/file", "0.21.0", { dryRun: true }, {
+      fileExists: () => false,
+    });
+    expect(note).toContain("skipping sync");
+  });
+});
+
+describe("checkTagAvailable", () => {
+  it("detects local tag conflict", () => {
+    const seams: ReleaseSeams = {
+      spawnText: (_cmd, args) => {
+        if (args.includes("tag") && args.includes("-l")) {
+          return { status: 0, stdout: "v0.21.0\n", stderr: "" };
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      whichGh: () => null,
+    };
+    const [ok, reason] = checkTagAvailable("0.21.0", "deftai/directive", "/proj", seams);
+    expect(ok).toBe(false);
+    expect(reason).toContain("local tag");
+  });
+});

--- a/packages/core/src/release/pipeline.test.ts
+++ b/packages/core/src/release/pipeline.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
-import { cmdRelease } from "./main.js";
-import { emit, runPipeline } from "./pipeline.js";
-import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+import { describe, expect, it } from "vitest";
 import { prependUpgradeBanner } from "./changelog.js";
 import { formatReleaseHelp } from "./flags.js";
-import { syncPyprojectForRelease } from "./pyproject-sync.js";
 import { checkTagAvailable } from "./gh.js";
+import { cmdRelease } from "./main.js";
+import { emit, runPipeline } from "./pipeline.js";
+import { syncPyprojectForRelease } from "./pyproject-sync.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 
 describe("cmdRelease", () => {
   it("returns 2 for invalid version", () => {
@@ -113,17 +113,20 @@ describe("prependUpgradeBanner", () => {
   });
 
   it("returns notes when banner is whitespace only", () => {
-    expect(prependUpgradeBanner("notes", "deftai/directive", "/r", () => "   \n")).toBe(
-      "notes",
-    );
+    expect(prependUpgradeBanner("notes", "deftai/directive", "/r", () => "   \n")).toBe("notes");
   });
 });
 
 describe("syncPyprojectForRelease", () => {
   it("skips when pyproject absent", () => {
-    const [note] = syncPyprojectForRelease("/no/file", "0.21.0", { dryRun: true }, {
-      fileExists: () => false,
-    });
+    const [note] = syncPyprojectForRelease(
+      "/no/file",
+      "0.21.0",
+      { dryRun: true },
+      {
+        fileExists: () => false,
+      },
+    );
     expect(note).toContain("skipping sync");
   });
 });

--- a/packages/core/src/release/pipeline.ts
+++ b/packages/core/src/release/pipeline.ts
@@ -372,7 +372,7 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
   }
 
   process.stderr.write(
-    `Release v${version} pipeline complete (dry_run=${config.dryRun}, skip_tag=${config.skipTag}, skip_release=${config.skipRelease}).\n`,
+    `Release v${version} pipeline complete (dry_run=${config.dryRun ? "True" : "False"}, skip_tag=${config.skipTag ? "True" : "False"}, skip_release=${config.skipRelease ? "True" : "False"}).\n`,
   );
   return EXIT_OK;
 }

--- a/packages/core/src/release/pipeline.ts
+++ b/packages/core/src/release/pipeline.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { prependUpgradeBanner, promoteChangelog, sectionForVersion } from "./changelog.js";
 import {
   EXIT_CONFIG_ERROR,
   EXIT_OK,
@@ -9,7 +10,7 @@ import {
   VERIFY_DRAFT_INTERVAL_SECONDS,
   VERIFY_DRAFT_MAX_ATTEMPTS,
 } from "./constants.js";
-import { prependUpgradeBanner, promoteChangelog, sectionForVersion } from "./changelog.js";
+import { checkTagAvailable, createGithubRelease, readTextFile, verifyReleaseDraft } from "./gh.js";
 import {
   checkGitClean,
   commitReleaseArtifacts,
@@ -18,12 +19,6 @@ import {
   pushRelease,
   releaseCommitSubject,
 } from "./git.js";
-import {
-  checkTagAvailable,
-  createGithubRelease,
-  readTextFile,
-  verifyReleaseDraft,
-} from "./gh.js";
 import { resolveScriptsDir, todayIso } from "./paths.js";
 import { pyprojectPathFor, syncPyprojectForRelease } from "./pyproject-sync.js";
 import {
@@ -71,11 +66,7 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
     } else if (config.allowDirty) {
       emit(1, label, `WARN (dirty, --allow-dirty set):\n${output}`);
     } else {
-      emit(
-        1,
-        label,
-        "FAIL (working tree is dirty; commit/stash or pass --allow-dirty)",
-      );
+      emit(1, label, "FAIL (working tree is dirty; commit/stash or pass --allow-dirty)");
       process.stderr.write(`${output}\n`);
       return EXIT_VIOLATION;
     }
@@ -100,11 +91,7 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
   if (config.allowVbriefDrift) {
     emit(3, label, "SKIP (--allow-vbrief-drift)");
   } else if (config.dryRun) {
-    emit(
-      3,
-      label,
-      "DRYRUN (would scan vbrief/ + gh open issues for closed-issue mismatches)",
-    );
+    emit(3, label, "DRYRUN (would scan vbrief/ + gh open issues for closed-issue mismatches)");
   } else {
     const [ok, mismatchCount, reason] = checkVbriefFn(projectRoot, config.repo);
     if (ok) {

--- a/packages/core/src/release/pipeline.ts
+++ b/packages/core/src/release/pipeline.ts
@@ -1,0 +1,391 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  EXIT_CONFIG_ERROR,
+  EXIT_OK,
+  EXIT_VIOLATION,
+  RELEASE_ARTIFACTS,
+  TOTAL_STEPS,
+  VERIFY_DRAFT_INTERVAL_SECONDS,
+  VERIFY_DRAFT_MAX_ATTEMPTS,
+} from "./constants.js";
+import { prependUpgradeBanner, promoteChangelog, sectionForVersion } from "./changelog.js";
+import {
+  checkGitClean,
+  commitReleaseArtifacts,
+  createTag,
+  currentBranch,
+  pushRelease,
+  releaseCommitSubject,
+} from "./git.js";
+import {
+  checkTagAvailable,
+  createGithubRelease,
+  readTextFile,
+  verifyReleaseDraft,
+} from "./gh.js";
+import { resolveScriptsDir, todayIso } from "./paths.js";
+import { pyprojectPathFor, syncPyprojectForRelease } from "./pyproject-sync.js";
+import {
+  checkVbriefLifecycleSync,
+  refreshRoadmap,
+  runBuild,
+  runCi,
+  runUvLock,
+} from "./python-bridge.js";
+import type { ReleaseConfig, ReleaseSeams } from "./types.js";
+import { isPrereleaseTag } from "./version.js";
+
+export function emit(step: number, label: string, status: string, target = process.stderr): void {
+  target.write(`[${step}/${TOTAL_STEPS}] ${label}... ${status}\n`);
+}
+
+export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): number {
+  const projectRoot = config.projectRoot;
+  const version = config.version;
+  const today = (seams.todayIso ?? todayIso)();
+  const changelogPath = join(projectRoot, "CHANGELOG.md");
+  const scriptsDir = resolveScriptsDir();
+  const readFile = seams.readFile ?? ((p: string) => readFileSync(p, "utf8"));
+  const writeFile = seams.writeFile ?? ((p: string, c: string) => writeFileSync(p, c, "utf8"));
+  const fileExists = seams.fileExists ?? ((p: string) => existsSync(p));
+
+  const runCiFn = seams.runCi ?? ((root: string) => runCi(root, scriptsDir, seams));
+  const refreshRoadmapFn =
+    seams.refreshRoadmap ?? ((root: string) => refreshRoadmap(root, scriptsDir, seams));
+  const checkVbriefFn =
+    seams.checkVbriefLifecycleSync ??
+    ((root: string, repo: string) => checkVbriefLifecycleSync(root, repo, scriptsDir, seams));
+  const runBuildFn =
+    seams.runBuild ?? ((root: string, v: string | null) => runBuild(root, scriptsDir, v, seams));
+  const runUvLockFn = seams.runUvLock ?? ((root: string) => runUvLock(root, seams));
+
+  // Step 1: dirty-tree guard.
+  let label = "Pre-flight git status";
+  if (config.dryRun) {
+    emit(1, label, `DRYRUN (would run \`git status --porcelain\` in ${projectRoot})`);
+  } else {
+    const [ok, output] = checkGitClean(projectRoot, seams);
+    if (ok) {
+      emit(1, label, "OK (tree clean)");
+    } else if (config.allowDirty) {
+      emit(1, label, `WARN (dirty, --allow-dirty set):\n${output}`);
+    } else {
+      emit(
+        1,
+        label,
+        "FAIL (working tree is dirty; commit/stash or pass --allow-dirty)",
+      );
+      process.stderr.write(`${output}\n`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 2: branch guard.
+  label = `Pre-flight branch == ${config.baseBranch}`;
+  if (config.dryRun) {
+    emit(2, label, `DRYRUN (would assert current branch == ${config.baseBranch})`);
+  } else {
+    const branch = currentBranch(projectRoot, seams);
+    if (branch === config.baseBranch) {
+      emit(2, label, `OK (on ${branch})`);
+    } else {
+      emit(2, label, `FAIL (on '${branch}'; expected '${config.baseBranch}')`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 3: vBRIEF lifecycle sync (#734).
+  label = "Pre-flight vBRIEF lifecycle sync";
+  if (config.allowVbriefDrift) {
+    emit(3, label, "SKIP (--allow-vbrief-drift)");
+  } else if (config.dryRun) {
+    emit(
+      3,
+      label,
+      "DRYRUN (would scan vbrief/ + gh open issues for closed-issue mismatches)",
+    );
+  } else {
+    const [ok, mismatchCount, reason] = checkVbriefFn(projectRoot, config.repo);
+    if (ok) {
+      emit(3, label, "OK (no mismatches)");
+    } else if (mismatchCount === -1) {
+      emit(3, label, `FAIL (${reason})`);
+      return EXIT_CONFIG_ERROR;
+    } else {
+      emit(
+        3,
+        label,
+        `FAIL (${mismatchCount} mismatches; run task reconcile:issues -- --apply-lifecycle-fixes to fix, or pass --allow-vbrief-drift to override)`,
+      );
+      process.stderr.write(`${reason}\n`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 4: tag availability pre-flight (#784).
+  label = "Pre-flight tag availability";
+  if (config.dryRun) {
+    emit(
+      4,
+      label,
+      `DRYRUN (would verify v${version} tag not present locally / on origin / as GitHub release on ${config.repo})`,
+    );
+  } else {
+    const checkTag =
+      seams.checkTagAvailable ??
+      ((v: string, r: string, root: string) => checkTagAvailable(v, r, root, seams));
+    const [ok, reason] = checkTag(version, config.repo, projectRoot);
+    if (ok) {
+      emit(4, label, `OK (${reason})`);
+    } else {
+      emit(4, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 5: CI.
+  label = "Pre-flight CI (task ci:local | fallback task check)";
+  if (config.skipCi) {
+    emit(5, label, "SKIP (--skip-ci)");
+  } else if (config.dryRun) {
+    emit(5, label, "DRYRUN (would run task ci:local with task check fallback)");
+  } else {
+    const [ok, reason] = runCiFn(projectRoot);
+    if (ok) {
+      emit(5, label, `OK (${reason})`);
+    } else {
+      emit(5, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 6: CHANGELOG promotion + pyproject sync.
+  label = "CHANGELOG promotion";
+  if (!fileExists(changelogPath)) {
+    emit(6, label, `FAIL (CHANGELOG.md not found at ${changelogPath})`);
+    return EXIT_CONFIG_ERROR;
+  }
+  const originalChangelog = readFile(changelogPath);
+  let promotedChangelog: string;
+  try {
+    promotedChangelog = promoteChangelog(
+      originalChangelog,
+      version,
+      config.repo,
+      today,
+      config.summary,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    emit(6, label, `FAIL (${msg})`);
+    return EXIT_CONFIG_ERROR;
+  }
+
+  let summaryNote: string;
+  if (config.summary) {
+    const truncated = config.summary.slice(0, 60);
+    const truncationSuffix = config.summary.length > 60 ? "..." : "";
+    summaryNote = ` summary: "${truncated}${truncationSuffix}"`;
+  } else {
+    summaryNote = " no summary";
+  }
+
+  const pyprojectPath = pyprojectPathFor(projectRoot);
+  const [pyprojectNote, promotedPyproject] = syncPyprojectForRelease(
+    pyprojectPath,
+    version,
+    { dryRun: config.dryRun },
+    seams,
+  );
+  if (pyprojectNote.startsWith("FAIL")) {
+    emit(6, label, pyprojectNote);
+    return EXIT_CONFIG_ERROR;
+  }
+
+  if (config.dryRun) {
+    emit(
+      6,
+      label,
+      `DRYRUN (would rewrite CHANGELOG.md: ## [Unreleased] -> ## [${version}] - ${today}; new compare link added;${summaryNote}; ${pyprojectNote}; would run \`uv lock\` to refresh uv.lock to ${version})`,
+    );
+  } else {
+    writeFile(changelogPath, promotedChangelog);
+    let uvLockNote = "uv.lock unchanged (pyproject not modified)";
+    if (promotedPyproject !== null) {
+      writeFile(pyprojectPath, promotedPyproject);
+      const [uvOk, uvNote] = runUvLockFn(projectRoot);
+      uvLockNote = uvNote;
+      if (!uvOk) {
+        emit(6, label, `FAIL (${uvLockNote})`);
+        return EXIT_VIOLATION;
+      }
+    }
+    emit(
+      6,
+      label,
+      `OK (## [${version}] - ${today};${summaryNote}; ${pyprojectNote}; ${uvLockNote})`,
+    );
+  }
+
+  // Step 7: ROADMAP refresh.
+  label = "ROADMAP refresh (task roadmap:render)";
+  if (config.dryRun) {
+    emit(7, label, "DRYRUN (would run task roadmap:render)");
+  } else {
+    const [ok, reason] = refreshRoadmapFn(projectRoot);
+    if (ok) {
+      emit(7, label, `OK (${reason})`);
+    } else {
+      emit(7, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 8: build dist.
+  label = `Build dist (task build, DEFT_RELEASE_VERSION=${version})`;
+  if (config.skipBuild) {
+    emit(8, label, "SKIP (--skip-build)");
+  } else if (config.dryRun) {
+    emit(8, label, `DRYRUN (would run \`task build\` with DEFT_RELEASE_VERSION=${version})`);
+  } else {
+    const [ok, reason] = runBuildFn(projectRoot, version);
+    if (ok) {
+      emit(8, label, `OK (${reason})`);
+    } else {
+      emit(8, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 9: commit release artifacts.
+  label = `Commit release artifacts (${RELEASE_ARTIFACTS.join(", ")})`;
+  if (config.skipTag) {
+    emit(9, label, "SKIP (--skip-tag)");
+  } else if (config.dryRun) {
+    emit(
+      9,
+      label,
+      `DRYRUN (would run \`git add ${RELEASE_ARTIFACTS.join(" ")}\` + \`git commit -m '${releaseCommitSubject(version)}'\`)`,
+    );
+  } else {
+    const [ok, reason] = commitReleaseArtifacts(projectRoot, version, seams);
+    if (ok) {
+      emit(9, label, `OK (${reason})`);
+    } else {
+      emit(9, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 10: git tag.
+  label = `Tag v${version}`;
+  if (config.skipTag) {
+    emit(10, label, "SKIP (--skip-tag)");
+  } else if (config.dryRun) {
+    emit(10, label, `DRYRUN (would run \`git tag -a v${version} -m 'Release v${version}'\`)`);
+  } else {
+    const [ok, reason] = createTag(projectRoot, version, seams);
+    if (ok) {
+      emit(10, label, `OK (${reason})`);
+    } else {
+      emit(10, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 11: push branch + tag atomically.
+  label = `Push ${config.baseBranch} + v${version} to origin (atomic)`;
+  if (config.skipTag) {
+    emit(11, label, "SKIP (--skip-tag)");
+  } else if (config.dryRun) {
+    emit(
+      11,
+      label,
+      `DRYRUN (would run \`git push --atomic origin ${config.baseBranch} v${version}\`)`,
+    );
+  } else {
+    const [ok, reason] = pushRelease(projectRoot, version, config.baseBranch, seams);
+    if (ok) {
+      emit(11, label, `OK (${reason})`);
+    } else {
+      emit(11, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 12: GitHub release.
+  const prerelease = isPrereleaseTag(version);
+  const draftSuffix = config.draft ? " (draft)" : " (PUBLIC)";
+  const prereleaseSuffix = prerelease ? " (prerelease)" : "";
+  label = `GitHub release v${version}${draftSuffix}${prereleaseSuffix}`;
+  let createSucceeded = false;
+  if (config.skipRelease) {
+    emit(12, label, "SKIP (--skip-release)");
+  } else if (config.dryRun) {
+    const draftFlag = config.draft ? " --draft" : "";
+    const prereleaseFlag = prerelease ? " --prerelease" : "";
+    emit(
+      12,
+      label,
+      `DRYRUN (would run \`gh release create v${version} --repo ${config.repo}${draftFlag}${prereleaseFlag} ...\`)`,
+    );
+  } else {
+    let notes = sectionForVersion(promotedChangelog, version);
+    notes = prependUpgradeBanner(notes, config.repo, projectRoot, readTextFile);
+    const [ok, reason] = createGithubRelease(
+      projectRoot,
+      version,
+      config.repo,
+      notes,
+      { draft: config.draft, prerelease },
+      seams,
+    );
+    if (ok) {
+      emit(12, label, `OK (${reason})`);
+      createSucceeded = true;
+    } else {
+      emit(12, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  // Step 13: post-create verify-isDraft gate (#724).
+  label = `Verify draft state of v${version} (#724 defense-in-depth)`;
+  if (config.skipRelease) {
+    emit(13, label, "SKIP (--skip-release)");
+  } else if (!config.draft) {
+    emit(13, label, "SKIP (--no-draft; intentional public release)");
+  } else if (config.dryRun) {
+    emit(
+      13,
+      label,
+      `DRYRUN (would poll \`gh release view v${version} --json isDraft\` up to ${VERIFY_DRAFT_MAX_ATTEMPTS}x at ${VERIFY_DRAFT_INTERVAL_SECONDS}s intervals; auto-flip via \`gh release edit --draft=true\` on isDraft=false)`,
+    );
+  } else if (!createSucceeded) {
+    emit(13, label, "SKIP (release was not created in this run)");
+  } else {
+    const [ok, reason] = verifyReleaseDraft(
+      projectRoot,
+      version,
+      config.repo,
+      {
+        maxAttempts: VERIFY_DRAFT_MAX_ATTEMPTS,
+        interval: VERIFY_DRAFT_INTERVAL_SECONDS,
+        sleep: seams.sleep,
+      },
+      seams,
+    );
+    if (ok) {
+      emit(13, label, `OK (${reason})`);
+    } else {
+      emit(13, label, `FAIL (${reason})`);
+      return EXIT_VIOLATION;
+    }
+  }
+
+  process.stderr.write(
+    `Release v${version} pipeline complete (dry_run=${config.dryRun}, skip_tag=${config.skipTag}, skip_release=${config.skipRelease}).\n`,
+  );
+  return EXIT_OK;
+}

--- a/packages/core/src/release/pyproject-sync.ts
+++ b/packages/core/src/release/pyproject-sync.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { updatePyprojectVersion } from "./pyproject.js";
+import type { ReleaseSeams } from "./types.js";
+import { NonPublishableVersionError, toPep440 } from "./version.js";
+
+export function syncPyprojectForRelease(
+  pyprojectPath: string,
+  version: string,
+  options: { dryRun: boolean },
+  seams: ReleaseSeams = {},
+): [string, string | null] {
+  const exists =
+    seams.fileExists ??
+    ((p: string) => {
+      try {
+        return existsSync(p) && statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+  const read = seams.readFile ?? ((p: string) => readFileSync(p, "utf8"));
+
+  if (!exists(pyprojectPath)) {
+    return ["no pyproject.toml; skipping sync", null];
+  }
+
+  let pepVersion: string;
+  try {
+    pepVersion = toPep440(version);
+  } catch (err) {
+    if (err instanceof NonPublishableVersionError) {
+      return [`non-publishable tag (${err.message}); skipping pyproject sync`, null];
+    }
+    if (err instanceof Error) {
+      return [`FAIL (cannot normalize version to PEP 440: ${err.message})`, null];
+    }
+    return [`FAIL (cannot normalize version to PEP 440: ${String(err)})`, null];
+  }
+
+  const original = read(pyprojectPath);
+  let newText: string;
+  try {
+    newText = updatePyprojectVersion(original, pepVersion);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return [`FAIL (pyproject.toml: ${msg})`, null];
+  }
+
+  if (newText === original) {
+    return [`pyproject already at ${pepVersion}`, null];
+  }
+  if (options.dryRun) {
+    return [`pyproject [project].version -> ${pepVersion}`, null];
+  }
+  return [`pyproject [project].version -> ${pepVersion}`, newText];
+}
+
+export function pyprojectPathFor(projectRoot: string): string {
+  return join(projectRoot, "pyproject.toml");
+}

--- a/packages/core/src/release/pyproject.test.ts
+++ b/packages/core/src/release/pyproject.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { updatePyprojectVersion } from "./pyproject.js";
+
+const SAMPLE = `[build-system]
+requires = ["hatchling"]
+
+[project]
+name = "deft"
+version = "0.20.0"
+description = "test"
+
+[tool.poetry]
+version = "9.9.9"
+`;
+
+describe("updatePyprojectVersion", () => {
+  it("rewrites [project].version only", () => {
+    const out = updatePyprojectVersion(SAMPLE, "0.21.0");
+    expect(out).toContain('version = "0.21.0"');
+    expect(out).toContain('[tool.poetry]\nversion = "9.9.9"');
+  });
+
+  it("is idempotent", () => {
+    const once = updatePyprojectVersion(SAMPLE, "0.21.0");
+    expect(updatePyprojectVersion(once, "0.21.0")).toBe(once);
+  });
+
+  it("rejects missing [project] version", () => {
+    expect(() => updatePyprojectVersion("[tool]\n", "0.21.0")).toThrow(/no \[project\]/);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(() => updatePyprojectVersion(1 as unknown as string, "0.21.0")).toThrow(/text must be/);
+    expect(() => updatePyprojectVersion(SAMPLE, "")).toThrow(/non-empty/);
+  });
+});

--- a/packages/core/src/release/pyproject.ts
+++ b/packages/core/src/release/pyproject.ts
@@ -1,0 +1,34 @@
+import { PYPROJECT_VERSION_LINE_RE } from "./constants.js";
+
+/** Rewrite [project].version in pyproject.toml content (#771). */
+export function updatePyprojectVersion(text: string, version: string): string {
+  if (typeof text !== "string") {
+    throw new Error(`text must be a string, got ${typeof text}`);
+  }
+  if (typeof version !== "string" || !version.trim()) {
+    throw new Error("version must be a non-empty string");
+  }
+
+  const lines = text.split(/(?<=\n)/);
+  let inProjectSection = false;
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const line = lines[idx] ?? "";
+    const stripped = line.trim();
+    if (!stripped || stripped.startsWith("#")) {
+      continue;
+    }
+    if (stripped.startsWith("[") && stripped.endsWith("]")) {
+      inProjectSection = stripped === "[project]";
+      continue;
+    }
+    if (inProjectSection && PYPROJECT_VERSION_LINE_RE.test(stripped)) {
+      const newLine = line.replace(PYPROJECT_VERSION_LINE_RE, `version = "${version}"`);
+      if (newLine === line) {
+        return text;
+      }
+      lines[idx] = newLine;
+      return lines.join("");
+    }
+  }
+  throw new Error("pyproject.toml has no [project] section with a version key");
+}

--- a/packages/core/src/release/python-bridge.test.ts
+++ b/packages/core/src/release/python-bridge.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkVbriefLifecycleSync,
+  refreshRoadmap,
+  runBuild,
+  runCi,
+  runUvLock,
+} from "./python-bridge.js";
+import type { ReleaseSeams } from "./types.js";
+
+describe("python-bridge with mocked spawn", () => {
+  it("runCi succeeds on exit 0", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 0, stdout: "", stderr: "" }),
+    };
+    const [ok, msg] = runCi("/proj", "/scripts", seams);
+    expect(ok).toBe(true);
+    expect(msg).toBe("ran ci:local");
+  });
+
+  it("runCi fails on non-zero", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 1, stdout: "", stderr: "fail" }),
+    };
+    const [ok] = runCi("/proj", "/scripts", seams);
+    expect(ok).toBe(false);
+  });
+
+  it("refreshRoadmap succeeds", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 0, stdout: "", stderr: "" }),
+    };
+    const [ok] = refreshRoadmap("/proj", "/scripts", seams);
+    expect(ok).toBe(true);
+  });
+
+  it("refreshRoadmap fails", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 1, stdout: "", stderr: "render err" }),
+    };
+    const [ok, msg] = refreshRoadmap("/proj", "/scripts", seams);
+    expect(ok).toBe(false);
+    expect(msg).toContain("roadmap:render failed");
+  });
+
+  it("runBuild succeeds with version env", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 0, stdout: "", stderr: "" }),
+    };
+    const [ok, msg] = runBuild("/proj", "/scripts", "0.21.0", seams);
+    expect(ok).toBe(true);
+    expect(msg).toContain("DEFT_RELEASE_VERSION=0.21.0");
+  });
+
+  it("runBuild fails", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 2, stdout: "", stderr: "" }),
+    };
+    const [ok] = runBuild("/proj", "/scripts", null, seams);
+    expect(ok).toBe(false);
+  });
+
+  it("checkVbriefLifecycleSync parses JSON ok", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({
+        status: 0,
+        stdout: JSON.stringify({ ok: true, mismatch_count: 0, reason: "no mismatches" }),
+        stderr: "",
+      }),
+    };
+    expect(checkVbriefLifecycleSync("/p", "r", "/scripts", seams)).toEqual([
+      true,
+      0,
+      "no mismatches",
+    ]);
+  });
+
+  it("checkVbriefLifecycleSync parses mismatch JSON", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({
+        status: 0,
+        stdout: JSON.stringify({ ok: false, mismatch_count: 1, reason: "drift" }),
+        stderr: "",
+      }),
+    };
+    const [ok, count, reason] = checkVbriefLifecycleSync("/p", "r", "/scripts", seams);
+    expect(ok).toBe(false);
+    expect(count).toBe(1);
+    expect(reason).toBe("drift");
+  });
+
+  it("checkVbriefLifecycleSync handles invalid JSON", () => {
+    const seams: ReleaseSeams = {
+      spawnText: () => ({ status: 0, stdout: "not json", stderr: "" }),
+    };
+    const [ok, count] = checkVbriefLifecycleSync("/p", "r", "/scripts", seams);
+    expect(ok).toBe(false);
+    expect(count).toBe(-1);
+  });
+
+  it("runUvLock succeeds", () => {
+    const seams: ReleaseSeams = {
+      fileExists: () => true,
+      whichUv: () => "/usr/bin/uv",
+      spawnText: () => ({ status: 0, stdout: "", stderr: "" }),
+    };
+    const [ok] = runUvLock("/proj", seams);
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/core/src/release/python-bridge.ts
+++ b/packages/core/src/release/python-bridge.ts
@@ -1,0 +1,174 @@
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { defaultWhich, spawnText } from "./spawn.js";
+import type { ReleaseSeams } from "./types.js";
+
+function runUvPython(
+  scriptsDir: string,
+  code: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+  seams: ReleaseSeams = {},
+): ReturnType<typeof spawnText> {
+  const spawn = seams.spawnText ?? spawnText;
+  return spawn("uv", ["run", "python", "-c", code], {
+    cwd,
+    env: { ...env, PYTHONUTF8: "1" },
+    timeoutMs: 300_000,
+  });
+}
+
+export function runCi(
+  projectRoot: string,
+  scriptsDir: string,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const code = [
+    "import sys",
+    `sys.path.insert(0, ${JSON.stringify(scriptsDir)})`,
+    "import ci_local",
+    `sys.exit(ci_local.main(['--root', ${JSON.stringify(projectRoot)}]))`,
+  ].join("\n");
+  const result = runUvPython(scriptsDir, code, scriptsDir, process.env, seams);
+  if (result.status !== 0) {
+    return [false, `ci:local failed (exit ${result.status})`];
+  }
+  return [true, "ran ci:local"];
+}
+
+export function refreshRoadmap(
+  projectRoot: string,
+  scriptsDir: string,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const pending = join(projectRoot, "vbrief", "pending");
+  const roadmap = join(projectRoot, "ROADMAP.md");
+  const completed = join(projectRoot, "vbrief", "completed");
+  const code = [
+    "import sys",
+    `sys.path.insert(0, ${JSON.stringify(scriptsDir)})`,
+    "import roadmap_render",
+    `ok, msg = roadmap_render.render_roadmap(${JSON.stringify(pending)}, ${JSON.stringify(roadmap)}, completed_dir=${JSON.stringify(completed)})`,
+    "if ok:",
+    "    sys.exit(0)",
+    "print(msg, file=sys.stderr)",
+    "sys.exit(1)",
+  ].join("\n");
+  const result = runUvPython(scriptsDir, code, projectRoot, process.env, seams);
+  if (result.status !== 0) {
+    const msg = result.stderr.trim() || result.stdout.trim();
+    return [false, `roadmap:render failed: ${msg}`];
+  }
+  return [true, "ROADMAP.md re-rendered"];
+}
+
+export function checkVbriefLifecycleSync(
+  projectRoot: string,
+  repo: string,
+  scriptsDir: string,
+  seams: ReleaseSeams = {},
+): [boolean, number, string] {
+  const code = [
+    "import json, sys",
+    "from pathlib import Path",
+    `scripts_dir = Path(${JSON.stringify(scriptsDir)})`,
+    "sys.path.insert(0, str(scripts_dir))",
+    "try:",
+    "    import reconcile_issues",
+    "except ImportError as exc:",
+    "    print(json.dumps({'ok': False, 'mismatch_count': -1, 'reason': f'reconcile_issues import failed: {exc}'}))",
+    "    sys.exit(0)",
+    `project_root = Path(${JSON.stringify(projectRoot)})`,
+    `repo = ${JSON.stringify(repo)}`,
+    "vbrief_dir = project_root / 'vbrief'",
+    "if not vbrief_dir.is_dir():",
+    "    print(json.dumps({'ok': False, 'mismatch_count': -1, 'reason': f'vbrief directory not found at {vbrief_dir}'}))",
+    "    sys.exit(0)",
+    "issue_to_vbriefs = reconcile_issues.scan_vbrief_dir(vbrief_dir)",
+    "issue_state_map = reconcile_issues.fetch_issue_states(repo, set(issue_to_vbriefs.keys()), cwd=project_root)",
+    "if issue_state_map is None:",
+    "    print(json.dumps({'ok': False, 'mismatch_count': -1, 'reason': 'failed to fetch issue states from gh'}))",
+    "    sys.exit(0)",
+    "report = reconcile_issues.reconcile(issue_to_vbriefs, issue_state_map)",
+    "mismatches = [rel for entry in report.get('no_open_issue', []) for rel in entry.get('vbrief_files', []) if not reconcile_issues.is_terminal_lifecycle_path(rel)]",
+    "count = len(mismatches)",
+    "if count == 0:",
+    "    print(json.dumps({'ok': True, 'mismatch_count': 0, 'reason': 'no mismatches'}))",
+    "else:",
+    "    suffix = ' ...' if count > 5 else ''",
+    "    preview = ', '.join(mismatches[:5])",
+    "    reason = f'{count} closed-issue vBRIEF(s) not in completed/ or cancelled/: {preview}{suffix}'",
+    "    print(json.dumps({'ok': False, 'mismatch_count': count, 'reason': reason}))",
+  ].join("\n");
+  const result = runUvPython(scriptsDir, code, projectRoot, process.env, seams);
+  try {
+    const payload = JSON.parse(result.stdout.trim()) as {
+      ok: boolean;
+      mismatch_count: number;
+      reason: string;
+    };
+    return [payload.ok, payload.mismatch_count, payload.reason];
+  } catch {
+    return [false, -1, `reconcile_issues bridge failed: ${result.stderr.trim() || result.stdout.trim()}`];
+  }
+}
+
+export function runBuild(
+  projectRoot: string,
+  scriptsDir: string,
+  version: string | null,
+  seams: ReleaseSeams = {},
+): [boolean, string] {
+  const env = { ...process.env };
+  if (version) {
+    env.DEFT_RELEASE_VERSION = version;
+  } else {
+    delete env.DEFT_RELEASE_VERSION;
+  }
+  const code = [
+    "import sys",
+    "from pathlib import Path",
+    `sys.path.insert(0, ${JSON.stringify(scriptsDir)})`,
+    "from framework_commands import run_framework_command",
+    `root = Path(${JSON.stringify(projectRoot)})`,
+    "result = run_framework_command('build', project_root=root, framework_root=root)",
+    "sys.exit(result.code)",
+  ].join("\n");
+  const result = runUvPython(scriptsDir, code, projectRoot, env, seams);
+  if (result.status !== 0) {
+    return [false, `build failed (exit ${result.status})`];
+  }
+  const suffix = version ? ` (DEFT_RELEASE_VERSION=${version})` : "";
+  return [true, `build ran clean${suffix}`];
+}
+
+export function runUvLock(projectRoot: string, seams: ReleaseSeams = {}): [boolean, string] {
+  const exists =
+    seams.fileExists ??
+    ((p: string) => {
+      try {
+        return existsSync(p) && statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+  if (!exists(join(projectRoot, "pyproject.toml"))) {
+    return [true, "no pyproject.toml; skipping uv lock"];
+  }
+  const whichUv = seams.whichUv ?? defaultWhich;
+  const uvPath = whichUv("uv");
+  if (uvPath === null) {
+    process.stderr.write(
+      "WARNING: uv binary not on PATH; skipping uv.lock regeneration " +
+        "(see #774). Run `uv lock` manually before pushing the release tag.\n",
+    );
+    return [true, "uv binary not on PATH; skipping uv lock"];
+  }
+  const spawn = seams.spawnText ?? spawnText;
+  const result = spawn(uvPath, ["lock"], { cwd: projectRoot, timeoutMs: 300_000 });
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    return [false, `uv lock failed (exit ${result.status}): ${stderr}`];
+  }
+  return [true, "uv.lock regenerated"];
+}

--- a/packages/core/src/release/python-bridge.ts
+++ b/packages/core/src/release/python-bridge.ts
@@ -4,7 +4,7 @@ import { defaultWhich, spawnText } from "./spawn.js";
 import type { ReleaseSeams } from "./types.js";
 
 function runUvPython(
-  scriptsDir: string,
+  _scriptsDir: string,
   code: string,
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -109,7 +109,11 @@ export function checkVbriefLifecycleSync(
     };
     return [payload.ok, payload.mismatch_count, payload.reason];
   } catch {
-    return [false, -1, `reconcile_issues bridge failed: ${result.stderr.trim() || result.stdout.trim()}`];
+    return [
+      false,
+      -1,
+      `reconcile_issues bridge failed: ${result.stderr.trim() || result.stdout.trim()}`,
+    ];
   }
 }
 

--- a/packages/core/src/release/spawn.ts
+++ b/packages/core/src/release/spawn.ts
@@ -1,0 +1,34 @@
+import { spawnSync } from "node:child_process";
+import type { SpawnResult } from "./types.js";
+
+export function defaultWhich(name: string): string | null {
+  const result = spawnSync("which", [name], { encoding: "utf8" });
+  if (result.status !== 0) {
+    return null;
+  }
+  const path = (result.stdout ?? "").trim();
+  return path || null;
+}
+
+export function spawnText(
+  cmd: string,
+  args: readonly string[],
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
+  } = {},
+): SpawnResult {
+  const result = spawnSync(cmd, [...args], {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    encoding: "utf8",
+    timeout: options.timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    status: result.status ?? (result.error ? 2 : 0),
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+}

--- a/packages/core/src/release/spawn.ts
+++ b/packages/core/src/release/spawn.ts
@@ -26,8 +26,18 @@ export function spawnText(
     timeout: options.timeoutMs,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  let status = result.status;
+  if (status === null) {
+    if (result.signal !== null && result.signal !== undefined) {
+      status = 128;
+    } else if (result.error) {
+      status = 2;
+    } else {
+      status = 0;
+    }
+  }
   return {
-    status: result.status ?? (result.error ? 2 : 0),
+    status,
     stdout: typeof result.stdout === "string" ? result.stdout : "",
     stderr: typeof result.stderr === "string" ? result.stderr : "",
   };

--- a/packages/core/src/release/types.ts
+++ b/packages/core/src/release/types.ts
@@ -1,0 +1,75 @@
+/* v8 ignore file -- type-only surface */
+export interface ReleaseConfig {
+  readonly version: string;
+  readonly repo: string;
+  readonly baseBranch: string;
+  readonly projectRoot: string;
+  readonly dryRun: boolean;
+  readonly skipTag: boolean;
+  readonly skipRelease: boolean;
+  readonly allowDirty: boolean;
+  readonly draft: boolean;
+  readonly skipCi: boolean;
+  readonly skipBuild: boolean;
+  readonly summary: string | null;
+  readonly allowVbriefDrift: boolean;
+}
+
+export interface ReleaseFlags {
+  readonly help: boolean;
+  readonly version: string | null;
+  readonly repo: string | null;
+  readonly baseBranch: string;
+  readonly projectRoot: string | null;
+  readonly dryRun: boolean;
+  readonly skipTag: boolean;
+  readonly skipRelease: boolean;
+  readonly allowDirty: boolean;
+  readonly allowVbriefDrift: boolean;
+  readonly skipCi: boolean;
+  readonly skipBuild: boolean;
+  readonly draft: boolean;
+  readonly summary: string | null;
+  readonly unknown: readonly string[];
+}
+
+export interface SpawnResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ReleaseSeams {
+  readonly todayIso?: () => string;
+  readonly sleep?: (seconds: number) => void;
+  readonly whichGh?: (name: string) => string | null;
+  readonly whichUv?: (name: string) => string | null;
+  readonly spawnText?: (
+    cmd: string,
+    args: readonly string[],
+    options: {
+      cwd?: string;
+      env?: NodeJS.ProcessEnv;
+      timeoutMs?: number;
+    },
+  ) => SpawnResult;
+  readonly writeFile?: (path: string, content: string) => void;
+  readonly readFile?: (path: string) => string;
+  readonly fileExists?: (path: string) => boolean;
+  readonly runCi?: (projectRoot: string) => [boolean, string];
+  readonly refreshRoadmap?: (projectRoot: string) => [boolean, string];
+  readonly checkVbriefLifecycleSync?: (
+    projectRoot: string,
+    repo: string,
+  ) => [boolean, number, string];
+  readonly runBuild?: (
+    projectRoot: string,
+    version: string | null,
+  ) => [boolean, string];
+  readonly runUvLock?: (projectRoot: string) => [boolean, string];
+  readonly checkTagAvailable?: (
+    version: string,
+    repo: string,
+    projectRoot: string,
+  ) => [boolean, string];
+}

--- a/packages/core/src/release/types.ts
+++ b/packages/core/src/release/types.ts
@@ -62,10 +62,7 @@ export interface ReleaseSeams {
     projectRoot: string,
     repo: string,
   ) => [boolean, number, string];
-  readonly runBuild?: (
-    projectRoot: string,
-    version: string | null,
-  ) => [boolean, string];
+  readonly runBuild?: (projectRoot: string, version: string | null) => [boolean, string];
   readonly runUvLock?: (projectRoot: string) => [boolean, string];
   readonly checkTagAvailable?: (
     version: string,

--- a/packages/core/src/release/version.test.ts
+++ b/packages/core/src/release/version.test.ts
@@ -1,17 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { NonPublishableVersionError, isPrereleaseTag, toPep440, validateVersion } from "./version.js";
+import {
+  isPrereleaseTag,
+  NonPublishableVersionError,
+  toPep440,
+  validateVersion,
+} from "./version.js";
 
 describe("validateVersion", () => {
   it.each(["0.0.0", "0.21.0", "1.2.3", "10.20.30"])("accepts %s", (v) => {
     expect(() => validateVersion(v)).not.toThrow();
   });
 
-  it.each(["v0.21.0", "0.21", "0.21.0-rc.1", "0.21.0+build", "0.21.0.0", "abc", ""])(
-    "rejects %s",
-    (v) => {
-      expect(() => validateVersion(v)).toThrow(/Invalid version/);
-    },
-  );
+  it.each([
+    "v0.21.0",
+    "0.21",
+    "0.21.0-rc.1",
+    "0.21.0+build",
+    "0.21.0.0",
+    "abc",
+    "",
+  ])("rejects %s", (v) => {
+    expect(() => validateVersion(v)).toThrow(/Invalid version/);
+  });
 });
 
 describe("isPrereleaseTag", () => {

--- a/packages/core/src/release/version.test.ts
+++ b/packages/core/src/release/version.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { NonPublishableVersionError, isPrereleaseTag, toPep440, validateVersion } from "./version.js";
+
+describe("validateVersion", () => {
+  it.each(["0.0.0", "0.21.0", "1.2.3", "10.20.30"])("accepts %s", (v) => {
+    expect(() => validateVersion(v)).not.toThrow();
+  });
+
+  it.each(["v0.21.0", "0.21", "0.21.0-rc.1", "0.21.0+build", "0.21.0.0", "abc", ""])(
+    "rejects %s",
+    (v) => {
+      expect(() => validateVersion(v)).toThrow(/Invalid version/);
+    },
+  );
+});
+
+describe("isPrereleaseTag", () => {
+  it.each([
+    ["v0.20.0-rc.1", true],
+    ["0.20.0-beta.2", true],
+    ["v0.20.0", false],
+    ["0.20.0", false],
+  ])("%s -> %s", (tag, expected) => {
+    expect(isPrereleaseTag(tag)).toBe(expected);
+  });
+});
+
+describe("toPep440", () => {
+  it.each([
+    ["v0.22.0", "0.22.0"],
+    ["0.20.0-rc.3", "0.20.0rc3"],
+    ["0.20.0-beta.2", "0.20.0b2"],
+    ["0.20.0-alpha.1", "0.20.0a1"],
+  ])("maps %s to %s", (input, expected) => {
+    expect(toPep440(input)).toBe(expected);
+  });
+
+  it("raises NonPublishableVersionError for test tags", () => {
+    expect(() => toPep440("0.0.0-test.1")).toThrow(NonPublishableVersionError);
+  });
+
+  it("rejects garbage input", () => {
+    expect(() => toPep440("")).toThrow(/non-empty/);
+    expect(() => toPep440("not-a-version")).toThrow(/Cannot normalize/);
+  });
+});

--- a/packages/core/src/release/version.ts
+++ b/packages/core/src/release/version.ts
@@ -1,0 +1,88 @@
+const PEP440_TAG_RE =
+  /^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<kind>rc|alpha|beta|test)\.(?<num>\d+))?$/;
+
+const PRE_KIND_MAP: Record<string, string> = {
+  alpha: "a",
+  beta: "b",
+  rc: "rc",
+};
+
+const NON_PUBLISHABLE_KINDS = new Set(["test"]);
+
+export class NonPublishableVersionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NonPublishableVersionError";
+  }
+}
+
+/** Raise Error when version does not match strict X.Y.Z semver. */
+export function validateVersion(version: string): void {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(
+      `Invalid version '${version}'. Expected strict semver X.Y.Z ` +
+        "(no leading 'v', no pre-release suffix).",
+    );
+  }
+}
+
+/** Return true when version carries a SemVer pre-release suffix (#425). */
+export function isPrereleaseTag(version: string): boolean {
+  let candidate = version.trim();
+  if (candidate.startsWith("v")) {
+    candidate = candidate.slice(1);
+  }
+  return candidate.includes("-");
+}
+
+/** Normalize a semver-shaped release tag to a PEP 440 version string (#771). */
+export function toPep440(version: string): string {
+  if (typeof version !== "string") {
+    throw new Error(`version must be a string, got ${typeof version}`);
+  }
+  const candidate = version.trim();
+  if (!candidate) {
+    throw new Error("version must be a non-empty string");
+  }
+  const match = PEP440_TAG_RE.exec(candidate);
+  if (match?.groups === undefined) {
+    throw new Error(
+      `Cannot normalize '${candidate}' to PEP 440: expected ` +
+        "[v]X.Y.Z or [v]X.Y.Z-(rc|alpha|beta|test).N",
+    );
+  }
+  const major = Number(match.groups.major);
+  const minor = Number(match.groups.minor);
+  const patch = Number(match.groups.patch);
+  const base = `${major}.${minor}.${patch}`;
+  const kind = match.groups.kind;
+  if (kind === undefined) {
+    return base;
+  }
+  if (NON_PUBLISHABLE_KINDS.has(kind)) {
+    throw new NonPublishableVersionError(
+      `Version '${candidate}' carries non-publishable pre-release ` +
+        `tag '${kind}'.${match.groups.num} -- release pipeline MUST ` +
+        "skip pyproject.toml [project].version sync for this tag.",
+    );
+  }
+  const pepKind = PRE_KIND_MAP[kind];
+  if (pepKind === undefined) {
+    throw new Error(
+      `Unmapped pre-release kind '${kind}' for version '${candidate}'; ` +
+        "add it to _PRE_KIND_MAP or _NON_PUBLISHABLE_KINDS to keep " +
+        "_PEP440_TAG_RE in lockstep with the publishability classifier.",
+    );
+  }
+  const pepNum = Number(match.groups.num);
+  return `${base}${pepKind}${pepNum}`;
+}
+
+export function isPublishable(version: string): boolean {
+  try {
+    toPep440(version);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Port `scripts/release.py` core to `packages/core/src/release/` — version validation, CHANGELOG promotion, `[version]` section extraction, 13-step pipeline orchestration, and Python-bridge integrations for CI/roadmap/reconcile/build.
- Add `packages/cli/src/release.ts` CLI seam and `packages/cli/src/release-parity.ts` golden parity harness (cache-off, ISO-date normalisation in stderr).
- 142 vitest unit tests; release module branch coverage **88.27%**.

## Parity
- `node packages/cli/dist/release-parity.js` → **CLEAN** (3 scenarios: invalid-version, dry-run-fixture, help)
- `DEFT_CACHE_DISABLE=1` on all oracle comparisons

## Test plan
- [x] `pnpm -r build`
- [x] `node packages/cli/dist/release-parity.js`
- [x] `pnpm exec vitest run packages/core/src/release` (142 tests)
- [x] `TMPDIR=$(mktemp -d) DEFT_SESSION_RITUAL_SKIP=1 task check`

Refs #1530 #1729

Made with [Cursor](https://cursor.com)