### PR TITLE
feat(release): port release_publish.py to TypeScript (#1729)

### DIFF
--- a/packages/cli/src/release-publish-parity.test.ts
+++ b/packages/cli/src/release-publish-parity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { diffParity, PARITY_SCENARIOS, pickOutput, renderReport } from "./release-publish-parity.js";
+
+describe("release-publish-parity helpers", () => {
+  it("exports expected scenarios including safety paths", () => {
+    const names = PARITY_SCENARIOS.map((s) => s.name);
+    expect(names).toContain("invalid-version");
+    expect(names).toContain("dry-run");
+    expect(names).toContain("help");
+    expect(names).toContain("missing-version");
+  });
+
+  it("diffParity detects exit mismatch", () => {
+    const diff = diffParity(
+      { name: "x", exitCode: 1, stdout: "", stderr: "a" },
+      { name: "x", exitCode: 0, stdout: "", stderr: "a" },
+      "stderr",
+    );
+    expect(diff.exitMismatch).toBe(true);
+    expect(diff.outputMismatch).toBe(false);
+  });
+
+  it("pickOutput selects stream", () => {
+    const result = { name: "x", exitCode: 0, stdout: "out", stderr: "err" };
+    expect(pickOutput(result, "stdout")).toBe("out");
+    expect(pickOutput(result, "stderr")).toBe("err");
+  });
+
+  it("renderReport clean", () => {
+    expect(
+      renderReport({
+        ok: true,
+        scenarios: [],
+      }),
+    ).toContain("CLEAN");
+  });
+});

--- a/packages/cli/src/release-publish-parity.test.ts
+++ b/packages/cli/src/release-publish-parity.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { diffParity, PARITY_SCENARIOS, pickOutput, renderReport } from "./release-publish-parity.js";
+import {
+  diffParity,
+  PARITY_SCENARIOS,
+  pickOutput,
+  renderReport,
+} from "./release-publish-parity.js";
 
 describe("release-publish-parity helpers", () => {
   it("exports expected scenarios including safety paths", () => {

--- a/packages/cli/src/release-publish-parity.ts
+++ b/packages/cli/src/release-publish-parity.ts
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1729): runs BOTH the Python oracle
+ * (`scripts/release_publish.py`) and the ported TS release:publish CLI
+ * with identical argv, then diffs exit codes and normalised stderr/stdout.
+ * Exit 0 only on byte-identical results (cache off).
+ *
+ * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
+ */
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface ScenarioResult {
+  readonly name: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ParityScenario {
+  readonly name: string;
+  readonly argv: readonly string[];
+  readonly compareStdout?: boolean;
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly scenarios: Array<{
+    readonly name: string;
+    readonly exitMismatch: boolean;
+    readonly pythonExit: number;
+    readonly tsExit: number;
+    readonly outputMismatch: boolean;
+    readonly pythonOutput: string;
+    readonly tsOutput: string;
+    readonly stream: "stdout" | "stderr";
+  }>;
+}
+
+export const PARITY_SCENARIOS: readonly ParityScenario[] = [
+  { name: "invalid-version", argv: ["not-a-version"] },
+  { name: "missing-version", argv: [] },
+  {
+    name: "dry-run",
+    argv: ["0.21.0", "--dry-run", "--repo", "deftai/directive"],
+  },
+  { name: "help", argv: ["--help"], compareStdout: true },
+];
+
+interface Capture {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCapture(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string | undefined> = {},
+): Capture {
+  const merged: Record<string, string | undefined> = {
+    ...process.env,
+    ...env,
+    DEFT_CACHE_DISABLE: "1",
+    PYTHONUTF8: "1",
+  };
+  for (const key of Object.keys(merged)) {
+    if (merged[key] === undefined) delete merged[key];
+  }
+  try {
+    const result = spawnSync(cmd, args, {
+      cwd,
+      encoding: "utf8",
+      env: merged as NodeJS.ProcessEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return {
+      status: result.status ?? 2,
+      stdout: typeof result.stdout === "string" ? result.stdout : "",
+      stderr: typeof result.stderr === "string" ? result.stderr : "",
+    };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return {
+      status: typeof e.status === "number" ? e.status : 2,
+      stdout: typeof e.stdout === "string" ? e.stdout : "",
+      stderr: typeof e.stderr === "string" ? e.stderr : "",
+    };
+  }
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
+    return resolve(process.env.DEFT_ROOT);
+  }
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+export function pickOutput(result: ScenarioResult, stream: "stdout" | "stderr"): string {
+  return stream === "stdout" ? result.stdout : result.stderr;
+}
+
+function runScenario(
+  deftRoot: string,
+  scenario: ParityScenario,
+): { python: ScenarioResult; ts: ScenarioResult } {
+  const argv = [...scenario.argv];
+  const pyArgs = ["run", "python", join(deftRoot, "scripts", "release_publish.py"), ...argv];
+  const tsArgs = [join(deftRoot, "packages", "cli", "dist", "release-publish.js"), ...argv];
+  const py = runCapture("uv", pyArgs, deftRoot);
+  const ts = runCapture("node", tsArgs, deftRoot);
+  return {
+    python: { name: scenario.name, exitCode: py.status, stdout: py.stdout, stderr: py.stderr },
+    ts: { name: scenario.name, exitCode: ts.status, stdout: ts.stdout, stderr: ts.stderr },
+  };
+}
+
+export function diffParity(
+  python: ScenarioResult,
+  ts: ScenarioResult,
+  stream: "stdout" | "stderr",
+): {
+  exitMismatch: boolean;
+  outputMismatch: boolean;
+  pythonOutput: string;
+  tsOutput: string;
+} {
+  const pythonOutput = pickOutput(python, stream);
+  const tsOutput = pickOutput(ts, stream);
+  return {
+    exitMismatch: python.exitCode !== ts.exitCode,
+    outputMismatch: pythonOutput !== tsOutput,
+    pythonOutput,
+    tsOutput,
+  };
+}
+
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const scenarios: ParityResult["scenarios"] = [];
+  for (const scenario of PARITY_SCENARIOS) {
+    const ran = runScenario(deftRoot, scenario);
+    const stream: "stdout" | "stderr" = scenario.compareStdout ? "stdout" : "stderr";
+    scenarios.push({
+      name: scenario.name,
+      pythonExit: ran.python.exitCode,
+      tsExit: ran.ts.exitCode,
+      stream,
+      ...diffParity(ran.python, ran.ts, stream),
+    });
+  }
+  const ok = scenarios.every((s) => !s.exitMismatch && !s.outputMismatch);
+  return { ok, scenarios };
+}
+
+export function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `release-publish parity: CLEAN -- Python and TS agree on ${result.scenarios.length} scenario(s).`;
+  }
+  const lines = ["release-publish parity: DIVERGENCE"];
+  for (const s of result.scenarios) {
+    if (s.exitMismatch || s.outputMismatch) {
+      lines.push(`  scenario: ${s.name}`);
+      if (s.exitMismatch) {
+        lines.push(`    exit mismatch: python=${s.pythonExit} ts=${s.tsExit}`);
+      }
+      if (s.outputMismatch) {
+        lines.push(`    stream: ${s.stream}`);
+        lines.push(`    python (${s.pythonOutput.length} bytes)`);
+        lines.push(`    ts (${s.tsOutput.length} bytes)`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    process.exit(1);
+  } catch (err) {
+    const msg = String(err).replace(/\r?\n/g, " ");
+    process.stderr.write(`release-publish parity: harness error -- ${msg}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/release-publish.ts
+++ b/packages/cli/src/release-publish.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { cmdReleasePublish } from "../../core/dist/release-publish/main.js";
+
+export function run(argv: string[]): number {
+  return cmdReleasePublish(argv);
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/src/release-publish/cli.ts
+++ b/packages/core/src/release-publish/cli.ts
@@ -1,0 +1,7 @@
+/* v8 ignore file -- thin shebang entry; covered via main.ts tests */
+import { fileURLToPath } from "node:url";
+import { cmdReleasePublish } from "./main.js";
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(cmdReleasePublish(process.argv.slice(2)));
+}

--- a/packages/core/src/release-publish/constants.ts
+++ b/packages/core/src/release-publish/constants.ts
@@ -1,0 +1,25 @@
+/** Byte-identical argparse --help from scripts/release_publish.py (Python 3.14). */
+export const RELEASE_PUBLISH_HELP =
+  "usage: release_publish [-h] [--dry-run] [--repo OWNER/REPO]\n" +
+  "                       [--project-root PATH]\n" +
+  "                       version\n" +
+  "\n" +
+  "Flip a draft GitHub release to public (#716 safety hardening). Companion to\n" +
+  "`task release` -- after reviewing the draft's binaries / notes / asset list,\n" +
+  "run `task release:publish -- <version>` to publish.\n" +
+  "\n" +
+  "positional arguments:\n" +
+  "  version              Release version, e.g. 0.21.0 (no leading 'v', strict\n" +
+  "                       X.Y.Z).\n" +
+  "\n" +
+  "options:\n" +
+  "  -h, --help           show this help message and exit\n" +
+  "  --dry-run            Print the publish plan without invoking gh release\n" +
+  "                       edit.\n" +
+  "  --repo OWNER/REPO    Override the GitHub repository (default: resolved from\n" +
+  "                       `git remote get-url origin`, falling back to\n" +
+  "                       'deftai/directive').\n" +
+  "  --project-root PATH  Repository root (default: $DEFT_PROJECT_ROOT or the\n" +
+  "                       parent of the scripts/ directory).\n";
+
+export const RELEASES_LIST_ENDPOINT_TEMPLATE = "repos/{repo}/releases?per_page=100";

--- a/packages/core/src/release-publish/coverage-boost.test.ts
+++ b/packages/core/src/release-publish/coverage-boost.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { parsePublishFlags } from "./flags.js";
+import { editReleasePublish, ghApiFindReleaseByTag } from "./gh-api.js";
+import { cmdReleasePublish } from "./main.js";
+
+describe("release-publish branch coverage boost", () => {
+  it("flags missing --repo value", () => {
+    const flags = parsePublishFlags(["0.21.0", "--repo"]);
+    expect(flags.unknown).toContain("--repo (missing value)");
+  });
+
+  it("flags missing --project-root value", () => {
+    const flags = parsePublishFlags(["0.21.0", "--project-root"]);
+    expect(flags.unknown).toContain("--project-root (missing value)");
+  });
+
+  it("flags empty --repo= value", () => {
+    const flags = parsePublishFlags(["0.21.0", "--repo="]);
+    expect(flags.unknown).toContain("--repo= (empty value)");
+  });
+
+  it("flags empty --project-root= value", () => {
+    const flags = parsePublishFlags(["0.21.0", "--project-root="]);
+    expect(flags.unknown).toContain("--project-root= (empty value)");
+  });
+
+  it("flags extra positional version", () => {
+    const flags = parsePublishFlags(["0.21.0", "0.22.0"]);
+    expect(flags.unknown).toContain("0.22.0");
+  });
+
+  it("ghApiFindReleaseByTag handles spawn throw", () => {
+    const [state, , reason] = ghApiFindReleaseByTag("/usr/bin/gh", "deftai/directive", "v0.21.0", {
+      spawnText: () => {
+        throw new Error("ENOENT");
+      },
+    });
+    expect(state).toBe("gh-error");
+    expect(reason).toContain("gh CLI not found");
+  });
+
+  it("editReleasePublish handles patch spawn throw", () => {
+    const [ok, reason] = editReleasePublish("0.21.0", "deftai/directive", 99, {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => {
+        throw new Error("ENOENT");
+      },
+    });
+    expect(ok).toBe(false);
+    expect(reason).toContain("gh CLI not found");
+  });
+
+  it("cmdReleasePublish surfaces validate errors", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(cmdReleasePublish(["not-a-version"])).toBe(2);
+    expect(String(stderr.mock.calls[0]?.[0])).toContain("Error:");
+    stderr.mockRestore();
+  });
+});

--- a/packages/core/src/release-publish/flags.test.ts
+++ b/packages/core/src/release-publish/flags.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { RELEASE_PUBLISH_HELP } from "./constants.js";
+import {
+  formatMissingVersionError,
+  formatReleasePublishHelp,
+  parsePublishFlags,
+} from "./flags.js";
+
+describe("release-publish flags", () => {
+  it("formats help byte-identical to Python argparse", () => {
+    expect(formatReleasePublishHelp()).toBe(RELEASE_PUBLISH_HELP);
+  });
+
+  it("parses dry-run and repo flags", () => {
+    const flags = parsePublishFlags([
+      "0.21.0",
+      "--dry-run",
+      "--repo",
+      "deftai/directive",
+      "--project-root",
+      "/tmp/root",
+    ]);
+    expect(flags.version).toBe("0.21.0");
+    expect(flags.dryRun).toBe(true);
+    expect(flags.repo).toBe("deftai/directive");
+    expect(flags.projectRoot).toBe("/tmp/root");
+  });
+
+  it("parses equals-form project root", () => {
+    const flags = parsePublishFlags(["0.21.0", "--project-root=/tmp/x"]);
+    expect(flags.projectRoot).toBe("/tmp/x");
+  });
+
+  it("collects unknown flags", () => {
+    const flags = parsePublishFlags(["0.21.0", "--bogus"]);
+    expect(flags.unknown).toEqual(["--bogus"]);
+  });
+
+  it("formats missing version error", () => {
+    expect(formatMissingVersionError()).toContain("arguments are required: version");
+  });
+});

--- a/packages/core/src/release-publish/flags.test.ts
+++ b/packages/core/src/release-publish/flags.test.ts
@@ -1,10 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { RELEASE_PUBLISH_HELP } from "./constants.js";
-import {
-  formatMissingVersionError,
-  formatReleasePublishHelp,
-  parsePublishFlags,
-} from "./flags.js";
+import { formatMissingVersionError, formatReleasePublishHelp, parsePublishFlags } from "./flags.js";
 
 describe("release-publish flags", () => {
   it("formats help byte-identical to Python argparse", () => {

--- a/packages/core/src/release-publish/flags.ts
+++ b/packages/core/src/release-publish/flags.ts
@@ -1,0 +1,63 @@
+import { RELEASE_PUBLISH_HELP } from "./constants.js";
+import type { PublishFlags } from "./types.js";
+
+export function formatReleasePublishHelp(): string {
+  return RELEASE_PUBLISH_HELP;
+}
+
+export function parsePublishFlags(args: readonly string[]): PublishFlags {
+  let help = false;
+  let dryRun = false;
+  let repo: string | null = null;
+  let projectRoot: string | null = null;
+  let version: string | null = null;
+  const unknown: string[] = [];
+
+  const takeValue = (flag: string, i: number): string | null => {
+    if (i + 1 >= args.length) {
+      unknown.push(`${flag} (missing value)`);
+      return null;
+    }
+    return args[i + 1] ?? null;
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i] ?? "";
+    if (token === "-h" || token === "--help") {
+      help = true;
+    } else if (token === "--dry-run") {
+      dryRun = true;
+    } else if (token === "--repo") {
+      repo = takeValue(token, i);
+      if (repo !== null) i += 1;
+    } else if (token.startsWith("--repo=")) {
+      repo = token.slice("--repo=".length) || null;
+      if (!repo) unknown.push("--repo= (empty value)");
+    } else if (token === "--project-root") {
+      projectRoot = takeValue(token, i);
+      if (projectRoot !== null) i += 1;
+    } else if (token.startsWith("--project-root=")) {
+      projectRoot = token.slice("--project-root=".length) || null;
+      if (!projectRoot) unknown.push("--project-root= (empty value)");
+    } else if (token.startsWith("-")) {
+      unknown.push(token);
+    } else if (version === null) {
+      version = token;
+    } else {
+      unknown.push(token);
+    }
+    i += 1;
+  }
+
+  return { help, version, repo, projectRoot, dryRun, unknown };
+}
+
+export function formatMissingVersionError(): string {
+  return (
+    "usage: release_publish [-h] [--dry-run] [--repo OWNER/REPO]\n" +
+    "                       [--project-root PATH]\n" +
+    "                       version\n" +
+    "release_publish: error: the following arguments are required: version\n"
+  );
+}

--- a/packages/core/src/release-publish/gh-api.test.ts
+++ b/packages/core/src/release-publish/gh-api.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from "vitest";
+import {
+  editReleasePublish,
+  ghApiFindReleaseByTag,
+  normaliseReleasePayload,
+  viewRelease,
+} from "./gh-api.js";
+import type { ReleasePublishSeams } from "./types.js";
+
+const REST_DRAFT = {
+  id: 1234567,
+  draft: true,
+  name: "v0.21.0",
+  tag_name: "v0.21.0",
+  html_url: "https://github.com/deftai/directive/releases/tag/v0.21.0",
+};
+
+const REST_PUBLISHED = { ...REST_DRAFT, draft: false };
+
+function makeRestRelease(
+  tag = "v0.21.0",
+  draft = true,
+  releaseId = 1234567,
+): Record<string, unknown> {
+  return {
+    id: releaseId,
+    draft,
+    name: tag,
+    tag_name: tag,
+    html_url: `https://github.com/deftai/directive/releases/tag/${tag}`,
+  };
+}
+
+function seamsWithGh(
+  handler: (args: readonly string[]) => { status: number; stdout: string; stderr: string },
+): ReleasePublishSeams {
+  return {
+    whichGh: () => "/usr/bin/gh",
+    spawnText: (_cmd, args) => handler(args),
+  };
+}
+
+describe("normaliseReleasePayload", () => {
+  it("maps REST keys to legacy shape", () => {
+    const payload = normaliseReleasePayload(REST_DRAFT);
+    expect(payload.isDraft).toBe(true);
+    expect(payload.tagName).toBe("v0.21.0");
+    expect(payload.url).toMatch(/^https:\/\/github.com\//);
+    expect(payload.id).toBe(1234567);
+  });
+});
+
+describe("ghApiFindReleaseByTag", () => {
+  it("returns draft state", () => {
+    const seams = seamsWithGh(() => ({
+      status: 0,
+      stdout: JSON.stringify([REST_DRAFT]),
+      stderr: "",
+    }));
+    const [state, body, reason] = ghApiFindReleaseByTag(
+      "/usr/bin/gh",
+      "deftai/directive",
+      "v0.21.0",
+      seams,
+    );
+    expect(state).toBe("draft");
+    expect(body?.isDraft).toBe(true);
+    expect(reason).toBe("");
+  });
+
+  it("returns published state", () => {
+    const seams = seamsWithGh(() => ({
+      status: 0,
+      stdout: JSON.stringify([REST_PUBLISHED]),
+      stderr: "",
+    }));
+    const [state, body] = ghApiFindReleaseByTag(
+      "/usr/bin/gh",
+      "deftai/directive",
+      "v0.21.0",
+      seams,
+    );
+    expect(state).toBe("published");
+    expect(body?.isDraft).toBe(false);
+  });
+
+  it("returns not-found when tag absent", () => {
+    const seams = seamsWithGh(() => ({
+      status: 0,
+      stdout: JSON.stringify([makeRestRelease("v0.20.0", false, 1)]),
+      stderr: "",
+    }));
+    const [state, body, reason] = ghApiFindReleaseByTag(
+      "/usr/bin/gh",
+      "deftai/directive",
+      "v9.9.9",
+      seams,
+    );
+    expect(state).toBe("not-found");
+    expect(body).toBeNull();
+    expect(reason).toContain("v9.9.9");
+  });
+
+  it("returns gh-error on non-zero exit", () => {
+    const seams = seamsWithGh(() => ({ status: 4, stdout: "", stderr: "auth required" }));
+    const [state, , reason] = ghApiFindReleaseByTag(
+      "/usr/bin/gh",
+      "deftai/directive",
+      "v0.21.0",
+      seams,
+    );
+    expect(state).toBe("gh-error");
+    expect(reason).toContain("auth required");
+  });
+
+  it("returns gh-error on non-json", () => {
+    const seams = seamsWithGh(() => ({ status: 0, stdout: "not json", stderr: "" }));
+    const [state, , reason] = ghApiFindReleaseByTag(
+      "/usr/bin/gh",
+      "deftai/directive",
+      "v0.21.0",
+      seams,
+    );
+    expect(state).toBe("gh-error");
+    expect(reason).toContain("non-JSON");
+  });
+
+  it("returns gh-error on non-list payload", () => {
+    const seams = seamsWithGh(() => ({
+      status: 0,
+      stdout: JSON.stringify({ message: "Internal Server Error" }),
+      stderr: "",
+    }));
+    const [state, , reason] = ghApiFindReleaseByTag(
+      "/usr/bin/gh",
+      "deftai/directive",
+      "v0.21.0",
+      seams,
+    );
+    expect(state).toBe("gh-error");
+    expect(reason).toContain("non-list");
+  });
+
+  it("uses paginate flag not graphql", () => {
+    let captured: readonly string[] = [];
+    const seams = seamsWithGh((args) => {
+      captured = args;
+      return { status: 0, stdout: JSON.stringify([REST_DRAFT]), stderr: "" };
+    });
+    ghApiFindReleaseByTag("/usr/bin/gh", "deftai/directive", "v0.21.0", seams);
+    expect(captured).toContain("--paginate");
+    expect(captured).toContain("repos/deftai/directive/releases?per_page=100");
+    expect(captured).not.toContain("--json");
+    expect(captured.some((a) => a.includes("/releases/tags/"))).toBe(false);
+  });
+
+  it("finds draft deep in concatenated list", () => {
+    const pageOne = Array.from({ length: 100 }, (_, i) =>
+      makeRestRelease(`v2.${i}.0`, false, 10000 + i),
+    );
+    const pageTwo = Array.from({ length: 49 }, (_, i) =>
+      makeRestRelease(`v3.${i}.0`, false, 20000 + i),
+    );
+    const target = makeRestRelease("v0.21.0", true, 999999);
+    const seams = seamsWithGh(() => ({
+      status: 0,
+      stdout: JSON.stringify([...pageOne, ...pageTwo, target]),
+      stderr: "",
+    }));
+    const [state, body] = ghApiFindReleaseByTag(
+      "/usr/bin/gh",
+      "deftai/directive",
+      "v0.21.0",
+      seams,
+    );
+    expect(state).toBe("draft");
+    expect(body?.id).toBe(999999);
+  });
+
+  it("skips non-object entries", () => {
+    const seams = seamsWithGh(() => ({
+      status: 0,
+      stdout: JSON.stringify(["bad", null, REST_DRAFT]),
+      stderr: "",
+    }));
+    const [state] = ghApiFindReleaseByTag("/usr/bin/gh", "deftai/directive", "v0.21.0", seams);
+    expect(state).toBe("draft");
+  });
+});
+
+describe("viewRelease", () => {
+  it("returns gh-error when gh missing", () => {
+    const [state, , reason] = viewRelease("0.21.0", "deftai/directive", {
+      whichGh: () => null,
+    });
+    expect(state).toBe("gh-error");
+    expect(reason).toContain("gh CLI not found");
+  });
+});
+
+describe("editReleasePublish", () => {
+  it("happy path issues list then patch", () => {
+    const cmds: string[][] = [];
+    const seams = seamsWithGh((args) => {
+      cmds.push([...args]);
+      if (args.includes("--paginate")) {
+        return { status: 0, stdout: JSON.stringify([REST_DRAFT]), stderr: "" };
+      }
+      return { status: 0, stdout: "{}", stderr: "" };
+    });
+    const [ok, reason] = editReleasePublish("0.21.0", "deftai/directive", undefined, seams);
+    expect(ok).toBe(true);
+    expect(reason).toContain("flipped v0.21.0");
+    expect(cmds.length).toBe(2);
+    const patch = cmds[1] ?? [];
+    expect(patch).toContain("--method");
+    expect(patch).toContain("PATCH");
+    expect(patch).toContain("draft=false");
+    expect(patch.some((a) => a === "repos/deftai/directive/releases/1234567")).toBe(true);
+  });
+
+  it("release_id provided skips get", () => {
+    const cmds: string[][] = [];
+    const seams = seamsWithGh((args) => {
+      cmds.push([...args]);
+      return { status: 0, stdout: "{}", stderr: "" };
+    });
+    const [ok] = editReleasePublish("0.21.0", "deftai/directive", 1234567, seams);
+    expect(ok).toBe(true);
+    expect(cmds.length).toBe(1);
+    expect(cmds[0]?.includes("--paginate")).toBe(false);
+  });
+
+  it("fails when list lookup fails", () => {
+    const seams = seamsWithGh(() => ({ status: 1, stdout: "", stderr: "server error" }));
+    const [ok, reason] = editReleasePublish("0.21.0", "deftai/directive", undefined, seams);
+    expect(ok).toBe(false);
+    expect(reason).toContain("could not resolve release id");
+  });
+
+  it("fails when release not found", () => {
+    const seams = seamsWithGh(() => ({ status: 0, stdout: "[]", stderr: "" }));
+    const [ok, reason] = editReleasePublish("0.21.0", "deftai/directive", undefined, seams);
+    expect(ok).toBe(false);
+    expect(reason).toContain("not found");
+  });
+
+  it("fails when payload missing id", () => {
+    const bad = { ...REST_DRAFT, id: undefined };
+    delete (bad as { id?: number }).id;
+    const seams = seamsWithGh(() => ({
+      status: 0,
+      stdout: JSON.stringify([bad]),
+      stderr: "",
+    }));
+    const [ok, reason] = editReleasePublish("0.21.0", "deftai/directive", undefined, seams);
+    expect(ok).toBe(false);
+    expect(reason).toContain("missing 'id'");
+  });
+
+  it("fails on patch error", () => {
+    let n = 0;
+    const seams = seamsWithGh(() => {
+      n += 1;
+      if (n === 1) {
+        return { status: 0, stdout: JSON.stringify([REST_DRAFT]), stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "permission denied" };
+    });
+    const [ok, reason] = editReleasePublish("0.21.0", "deftai/directive", undefined, seams);
+    expect(ok).toBe(false);
+    expect(reason).toContain("permission denied");
+    expect(reason).toContain("PATCH");
+  });
+
+  it("returns false when gh missing", () => {
+    const [ok, reason] = editReleasePublish("0.21.0", "deftai/directive", 1, {
+      whichGh: () => null,
+    });
+    expect(ok).toBe(false);
+    expect(reason).toContain("gh CLI not found");
+  });
+});

--- a/packages/core/src/release-publish/gh-api.ts
+++ b/packages/core/src/release-publish/gh-api.ts
@@ -1,5 +1,6 @@
 import { resolveGh } from "../release/gh.js";
 import { spawnText } from "../release/spawn.js";
+import type { SpawnResult } from "../release/types.js";
 import { RELEASES_LIST_ENDPOINT_TEMPLATE } from "./constants.js";
 import type { NormalisedRelease, ReleasePublishSeams, ViewReleaseState } from "./types.js";
 
@@ -21,7 +22,7 @@ export function ghApiFindReleaseByTag(
 ): [ViewReleaseState, NormalisedRelease | null, string] {
   const endpoint = RELEASES_LIST_ENDPOINT_TEMPLATE.replace("{repo}", repo);
   const spawn = seams.spawnText ?? spawnText;
-  let result;
+  let result: SpawnResult;
   try {
     result = spawn(ghPath, ["api", "--paginate", endpoint], {
       timeoutMs: 120_000,
@@ -103,7 +104,7 @@ export function editReleasePublish(
   }
 
   const endpoint = `repos/${repo}/releases/${resolvedId}`;
-  let result;
+  let result: SpawnResult;
   try {
     result = spawn(ghPath, ["api", endpoint, "--method", "PATCH", "-F", "draft=false"], {
       timeoutMs: 60_000,

--- a/packages/core/src/release-publish/gh-api.ts
+++ b/packages/core/src/release-publish/gh-api.ts
@@ -1,0 +1,119 @@
+import { resolveGh } from "../release/gh.js";
+import { spawnText } from "../release/spawn.js";
+import { RELEASES_LIST_ENDPOINT_TEMPLATE } from "./constants.js";
+import type { NormalisedRelease, ReleasePublishSeams, ViewReleaseState } from "./types.js";
+
+export function normaliseReleasePayload(restPayload: Record<string, unknown>): NormalisedRelease {
+  return {
+    isDraft: Boolean(restPayload.draft ?? false),
+    name: restPayload.name as string | null | undefined,
+    tagName: restPayload.tag_name as string | null | undefined,
+    url: restPayload.html_url as string | null | undefined,
+    id: restPayload.id as number | null | undefined,
+  };
+}
+
+export function ghApiFindReleaseByTag(
+  ghPath: string,
+  repo: string,
+  tag: string,
+  seams: ReleasePublishSeams = {},
+): [ViewReleaseState, NormalisedRelease | null, string] {
+  const endpoint = RELEASES_LIST_ENDPOINT_TEMPLATE.replace("{repo}", repo);
+  const spawn = seams.spawnText ?? spawnText;
+  let result;
+  try {
+    result = spawn(ghPath, ["api", "--paginate", endpoint], {
+      timeoutMs: 120_000,
+      env: { ...process.env },
+    });
+  } catch {
+    return ["gh-error", null, "gh CLI not found on PATH"];
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    return ["gh-error", null, `gh api ${endpoint} failed: ${stderr}`];
+  }
+  let restPayload: unknown;
+  try {
+    restPayload = JSON.parse(result.stdout);
+  } catch (exc) {
+    return ["gh-error", null, `gh api ${endpoint} returned non-JSON: ${String(exc)}`];
+  }
+  if (!Array.isArray(restPayload)) {
+    const typeName = restPayload === null ? "null" : typeof restPayload;
+    return ["gh-error", null, `gh api ${endpoint} returned non-list (${typeName})`];
+  }
+  for (const entry of restPayload) {
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+    if (record.tag_name !== tag) {
+      continue;
+    }
+    const payload = normaliseReleasePayload(record);
+    if (payload.isDraft) {
+      return ["draft", payload, ""];
+    }
+    return ["published", payload, ""];
+  }
+  return ["not-found", null, `release ${tag} not found on ${repo}`];
+}
+
+export function viewRelease(
+  version: string,
+  repo: string,
+  seams: ReleasePublishSeams = {},
+): [ViewReleaseState, NormalisedRelease | null, string] {
+  const ghPath = resolveGh(seams);
+  if (ghPath === null) {
+    return ["gh-error", null, "gh CLI not found on PATH"];
+  }
+  const tag = `v${version}`;
+  return ghApiFindReleaseByTag(ghPath, repo, tag, seams);
+}
+
+export function editReleasePublish(
+  version: string,
+  repo: string,
+  releaseId: number | null | undefined = undefined,
+  seams: ReleasePublishSeams = {},
+): [boolean, string] {
+  const ghPath = resolveGh(seams);
+  if (ghPath === null) {
+    return [false, "gh CLI not found on PATH"];
+  }
+  const tag = `v${version}`;
+  const spawn = seams.spawnText ?? spawnText;
+  let resolvedId = releaseId;
+
+  if (resolvedId === undefined || resolvedId === null) {
+    const [state, payload, reason] = ghApiFindReleaseByTag(ghPath, repo, tag, seams);
+    if (state === "not-found") {
+      return [false, `release ${tag} not found on ${repo}`];
+    }
+    if (state === "gh-error") {
+      return [false, `could not resolve release id: ${reason}`];
+    }
+    if (!payload || payload.id === undefined || payload.id === null) {
+      return [false, `release ${tag} payload missing 'id' field`];
+    }
+    resolvedId = payload.id;
+  }
+
+  const endpoint = `repos/${repo}/releases/${resolvedId}`;
+  let result;
+  try {
+    result = spawn(ghPath, ["api", endpoint, "--method", "PATCH", "-F", "draft=false"], {
+      timeoutMs: 60_000,
+      env: { ...process.env },
+    });
+  } catch {
+    return [false, "gh CLI not found on PATH"];
+  }
+  if (result.status !== 0) {
+    return [false, `gh api ${endpoint} (PATCH) failed: ${result.stderr.trim()}`];
+  }
+  return [true, `flipped ${tag} to published`];
+}

--- a/packages/core/src/release-publish/index.ts
+++ b/packages/core/src/release-publish/index.ts
@@ -1,0 +1,7 @@
+/* v8 ignore file -- re-export barrel; covered via main.ts */
+export * from "./constants.js";
+export * from "./flags.js";
+export * from "./gh-api.js";
+export * from "./main.js";
+export * from "./pipeline.js";
+export * from "./types.js";

--- a/packages/core/src/release-publish/main.test.ts
+++ b/packages/core/src/release-publish/main.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EXIT_CONFIG_ERROR } from "../release/constants.js";
+import { RELEASE_PUBLISH_HELP } from "./constants.js";
+import { cmdReleasePublish } from "./main.js";
+import * as pipeline from "./pipeline.js";
+
+describe("cmdReleasePublish", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints help to stdout", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    expect(cmdReleasePublish(["--help"])).toBe(0);
+    expect(stdout.mock.calls[0]?.[0]).toBe(RELEASE_PUBLISH_HELP);
+  });
+
+  it("invalid version exits 2", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(cmdReleasePublish(["not-a-version"])).toBe(EXIT_CONFIG_ERROR);
+    expect(String(stderr.mock.calls[0]?.[0])).toContain("Invalid version");
+  });
+
+  it("missing version exits 2", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(cmdReleasePublish([])).toBe(EXIT_CONFIG_ERROR);
+    expect(String(stderr.mock.calls[0]?.[0])).toContain("arguments are required: version");
+  });
+
+  it("unknown args exit 2", () => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(cmdReleasePublish(["0.21.0", "--bogus"])).toBe(EXIT_CONFIG_ERROR);
+  });
+
+  it("dry-run delegates to runPublish", () => {
+    const spy = vi.spyOn(pipeline, "runPublish").mockReturnValue(0);
+    expect(
+      cmdReleasePublish(["0.21.0", "--dry-run", "--repo", "deftai/directive"], {}),
+    ).toBe(0);
+    expect(spy.mock.calls[0]?.[0]).toMatchObject({
+      version: "0.21.0",
+      repo: "deftai/directive",
+      dryRun: true,
+    });
+  });
+});

--- a/packages/core/src/release-publish/main.test.ts
+++ b/packages/core/src/release-publish/main.test.ts
@@ -34,9 +34,7 @@ describe("cmdReleasePublish", () => {
 
   it("dry-run delegates to runPublish", () => {
     const spy = vi.spyOn(pipeline, "runPublish").mockReturnValue(0);
-    expect(
-      cmdReleasePublish(["0.21.0", "--dry-run", "--repo", "deftai/directive"], {}),
-    ).toBe(0);
+    expect(cmdReleasePublish(["0.21.0", "--dry-run", "--repo", "deftai/directive"], {})).toBe(0);
     expect(spy.mock.calls[0]?.[0]).toMatchObject({
       version: "0.21.0",
       repo: "deftai/directive",

--- a/packages/core/src/release-publish/main.ts
+++ b/packages/core/src/release-publish/main.ts
@@ -1,13 +1,9 @@
 import { EXIT_CONFIG_ERROR } from "../release/constants.js";
 import { resolveProjectRoot, resolveRepo } from "../release/paths.js";
-import {
-  formatMissingVersionError,
-  formatReleasePublishHelp,
-  parsePublishFlags,
-} from "./flags.js";
+import { validateVersion } from "../release/version.js";
+import { formatMissingVersionError, formatReleasePublishHelp, parsePublishFlags } from "./flags.js";
 import { runPublish } from "./pipeline.js";
 import type { PublishConfig, ReleasePublishSeams } from "./types.js";
-import { validateVersion } from "../release/version.js";
 
 export function cmdReleasePublish(
   args: readonly string[],

--- a/packages/core/src/release-publish/main.ts
+++ b/packages/core/src/release-publish/main.ts
@@ -1,0 +1,54 @@
+import { EXIT_CONFIG_ERROR } from "../release/constants.js";
+import { resolveProjectRoot, resolveRepo } from "../release/paths.js";
+import {
+  formatMissingVersionError,
+  formatReleasePublishHelp,
+  parsePublishFlags,
+} from "./flags.js";
+import { runPublish } from "./pipeline.js";
+import type { PublishConfig, ReleasePublishSeams } from "./types.js";
+import { validateVersion } from "../release/version.js";
+
+export function cmdReleasePublish(
+  args: readonly string[],
+  seams: ReleasePublishSeams = {},
+): number {
+  const flags = parsePublishFlags(args);
+
+  if (flags.help) {
+    process.stdout.write(formatReleasePublishHelp());
+    return 0;
+  }
+
+  if (flags.unknown.length > 0) {
+    process.stderr.write(
+      `release_publish: error: unrecognized arguments: ${flags.unknown.join(" ")}\n`,
+    );
+    return EXIT_CONFIG_ERROR;
+  }
+
+  if (flags.version === null) {
+    process.stderr.write(formatMissingVersionError());
+    return EXIT_CONFIG_ERROR;
+  }
+
+  try {
+    validateVersion(flags.version);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error: ${msg}\n`);
+    return EXIT_CONFIG_ERROR;
+  }
+
+  const projectRoot = resolveProjectRoot(flags.projectRoot);
+  const repo = resolveRepo(flags.repo, projectRoot, seams);
+
+  const config: PublishConfig = {
+    version: flags.version,
+    repo,
+    projectRoot,
+    dryRun: flags.dryRun,
+  };
+
+  return runPublish(config, seams);
+}

--- a/packages/core/src/release-publish/pipeline.test.ts
+++ b/packages/core/src/release-publish/pipeline.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EXIT_OK, EXIT_VIOLATION } from "../release/constants.js";
+import { emit, runPublish } from "./pipeline.js";
+import type { PublishConfig } from "./types.js";
+
+const baseConfig: PublishConfig = {
+  version: "0.21.0",
+  repo: "deftai/directive",
+  projectRoot: ".",
+  dryRun: false,
+};
+
+describe("emit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes publish prefix to stderr", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    emit("View v0.21.0", "OK");
+    expect(spy).toHaveBeenCalledWith("[publish] View v0.21.0... OK\n");
+  });
+});
+
+describe("runPublish", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dry-run emits REST plan without gh calls", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const rc = runPublish({ ...baseConfig, dryRun: true });
+    expect(rc).toBe(EXIT_OK);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).toContain("DRYRUN");
+    expect(out).toContain("--paginate");
+    expect(out).toContain("repos/deftai/directive/releases?per_page=100");
+    expect(out).toContain("tag_name == v0.21.0");
+    expect(out).toContain("-X PATCH");
+    expect(out).toContain("draft=false");
+    expect(out).not.toContain("release view");
+    expect(out).not.toContain("/releases/tags/");
+  });
+
+  it("happy path draft to published", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let viewCalls = 0;
+    const seams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: (_cmd: string, args: readonly string[]) => {
+        if (args.includes("--paginate")) {
+          viewCalls += 1;
+          const draft = viewCalls === 1;
+          return {
+            status: 0,
+            stdout: JSON.stringify([
+              {
+                id: 42,
+                draft,
+                tag_name: "v0.21.0",
+                html_url: "https://example.com/r",
+              },
+            ]),
+            stderr: "",
+          };
+        }
+        return { status: 0, stdout: "{}", stderr: "" };
+      },
+    };
+    const rc = runPublish(baseConfig, seams);
+    expect(rc).toBe(EXIT_OK);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).toContain("draft found");
+    expect(out).toContain("is now public");
+    expect(out).toContain("published successfully");
+  });
+
+  it("not-found exits violation", () => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({ status: 0, stdout: "[]", stderr: "" }),
+    };
+    expect(runPublish(baseConfig, seams)).toBe(EXIT_VIOLATION);
+  });
+
+  it("already published no-op", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({
+        status: 0,
+        stdout: JSON.stringify([
+          { id: 1, draft: false, tag_name: "v0.21.0", html_url: "https://example.com/r" },
+        ]),
+        stderr: "",
+      }),
+    };
+    expect(runPublish(baseConfig, seams)).toBe(EXIT_OK);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).toContain("NOOP");
+    expect(out).toContain("already published");
+  });
+
+  it("gh-error on view exits violation", () => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => ({ status: 4, stdout: "", stderr: "auth required" }),
+    };
+    const rc = runPublish(baseConfig, seams);
+    expect(rc).toBe(EXIT_VIOLATION);
+  });
+
+  it("edit failure exits violation", () => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let n = 0;
+    const seams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: () => {
+        n += 1;
+        if (n === 1) {
+          return {
+            status: 0,
+            stdout: JSON.stringify([
+              { id: 7, draft: true, tag_name: "v0.21.0", html_url: "https://example.com/r" },
+            ]),
+            stderr: "",
+          };
+        }
+        return { status: 1, stdout: "", stderr: "gh release edit failed: 404" };
+      },
+    };
+    const rc = runPublish(baseConfig, seams);
+    expect(rc).toBe(EXIT_VIOLATION);
+  });
+
+  it("post-edit verification mismatch exits violation", () => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const seams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: (_cmd: string, args: readonly string[]) => {
+        if (args.includes("--paginate")) {
+          return {
+            status: 0,
+            stdout: JSON.stringify([
+              { id: 9, draft: true, tag_name: "v0.21.0", html_url: "https://example.com/r" },
+            ]),
+            stderr: "",
+          };
+        }
+        return { status: 0, stdout: "{}", stderr: "" };
+      },
+    };
+    const rc = runPublish(baseConfig, seams);
+    expect(rc).toBe(EXIT_VIOLATION);
+  });
+
+  it("uses no url fallback when payload url missing", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let viewCalls = 0;
+    const seams = {
+      whichGh: () => "/usr/bin/gh",
+      spawnText: (_cmd: string, args: readonly string[]) => {
+        if (args.includes("--paginate")) {
+          viewCalls += 1;
+          const draft = viewCalls === 1;
+          return {
+            status: 0,
+            stdout: JSON.stringify([{ id: 42, draft, tag_name: "v0.21.0" }]),
+            stderr: "",
+          };
+        }
+        return { status: 0, stdout: "{}", stderr: "" };
+      },
+    };
+    runPublish(baseConfig, seams);
+    const out = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).toContain("<no url>");
+  });
+});

--- a/packages/core/src/release-publish/pipeline.ts
+++ b/packages/core/src/release-publish/pipeline.ts
@@ -1,0 +1,63 @@
+import { EXIT_OK, EXIT_VIOLATION } from "../release/constants.js";
+import { editReleasePublish, viewRelease } from "./gh-api.js";
+import type { PublishConfig, ReleasePublishSeams } from "./types.js";
+
+export function emit(label: string, status: string): void {
+  process.stderr.write(`[publish] ${label}... ${status}\n`);
+}
+
+export function runPublish(config: PublishConfig, seams: ReleasePublishSeams = {}): number {
+  const { version, repo, dryRun } = config;
+  const tag = `v${version}`;
+
+  const viewLabel = `View ${tag} on ${repo}`;
+  if (dryRun) {
+    emit(
+      viewLabel,
+      `DRYRUN (would run \`gh api --paginate repos/${repo}/releases?per_page=100\` and filter for tag_name == ${tag})`,
+    );
+    emit(
+      `Edit ${tag}`,
+      `DRYRUN (would run \`gh api -X PATCH repos/${repo}/releases/<id> -F draft=false\`)`,
+    );
+    return EXIT_OK;
+  }
+
+  const [state, payload, reason] = viewRelease(version, repo, seams);
+  if (state === "not-found") {
+    emit(viewLabel, `FAIL (release ${tag} not found on ${repo}: ${reason})`);
+    return EXIT_VIOLATION;
+  }
+  if (state === "gh-error") {
+    emit(viewLabel, `FAIL (${reason})`);
+    return EXIT_VIOLATION;
+  }
+  if (state === "published") {
+    emit(viewLabel, `NOOP (${tag} is already published; nothing to do)`);
+    return EXIT_OK;
+  }
+
+  emit(viewLabel, `OK (draft found at ${payload?.url ?? "<no url>"})`);
+
+  const editLabel = `Edit ${tag} (--draft=false)`;
+  const [ok, editReason] = editReleasePublish(version, repo, payload?.id ?? undefined, seams);
+  if (!ok) {
+    emit(editLabel, `FAIL (${editReason})`);
+    return EXIT_VIOLATION;
+  }
+  emit(editLabel, `OK (${editReason})`);
+
+  const verifyLabel = `Verify ${tag} is published`;
+  const [state2, , reason2] = viewRelease(version, repo, seams);
+  if (state2 !== "published") {
+    emit(
+      verifyLabel,
+      `FAIL (post-edit state is '${state2}'; expected 'published'; reason: ${reason2})`,
+    );
+    return EXIT_VIOLATION;
+  }
+  emit(verifyLabel, `OK (${tag} is now public)`);
+
+  process.stderr.write(`Release ${tag} published successfully on ${repo}.\n`);
+  return EXIT_OK;
+}

--- a/packages/core/src/release-publish/types.ts
+++ b/packages/core/src/release-publish/types.ts
@@ -1,0 +1,30 @@
+/* v8 ignore file -- type-only surface */
+import type { ReleaseSeams } from "../release/types.js";
+
+export interface PublishConfig {
+  readonly version: string;
+  readonly repo: string;
+  readonly projectRoot: string;
+  readonly dryRun: boolean;
+}
+
+export interface PublishFlags {
+  readonly help: boolean;
+  readonly version: string | null;
+  readonly repo: string | null;
+  readonly projectRoot: string | null;
+  readonly dryRun: boolean;
+  readonly unknown: readonly string[];
+}
+
+export interface NormalisedRelease {
+  readonly isDraft: boolean;
+  readonly name: string | null | undefined;
+  readonly tagName: string | null | undefined;
+  readonly url: string | null | undefined;
+  readonly id: number | null | undefined;
+}
+
+export type ViewReleaseState = "draft" | "published" | "not-found" | "gh-error";
+
+export type ReleasePublishSeams = ReleaseSeams;


### PR DESCRIPTION
## Summary

- Port `scripts/release_publish.py` to `packages/core/src/release-publish/` with CLI verb at `packages/cli/src/release-publish.ts`
- Reuses merged `@deftai/core/release` helpers (`validateVersion`, `resolveRepo`, `resolveGh`, `spawnText`, exit codes)
- REST paginated list+filter + PATCH `draft=false` flow matches Python oracle (#716, #961, #1016)

## Parity & coverage

- `release-publish-parity`: **CLEAN** (cache-off, 4 scenarios: invalid-version, missing-version, dry-run, help)
- `packages/core/src/release-publish` branch coverage: **91.34%** (≥88% gate)

## Test plan

- [x] `pnpm -r build`
- [x] `node packages/cli/dist/release-publish-parity.js` (CLEAN)
- [x] `pnpm exec vitest run packages/core/src/release-publish --coverage`
- [x] `TMPDIR=$(mktemp -d) DEFT_SESSION_RITUAL_SKIP=1 task check`

Refs #1530 #1729

Made with [Cursor](https://cursor.com)