### PR TITLE
feat(pr): port pr_merge_readiness.py to TypeScript (#1730)

### DIFF
--- a/packages/cli/src/pr-merge-readiness-parity.test.ts
+++ b/packages/cli/src/pr-merge-readiness-parity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { diffParity, PARITY_SCENARIOS, pickOutput } from "./pr-merge-readiness-parity.js";
+
+describe("pr-merge-readiness parity helpers", () => {
+  it("pickOutput selects stream", () => {
+    const result = { name: "x", exitCode: 0, stdout: "out", stderr: "err" };
+    expect(pickOutput(result, "stdout")).toBe("out");
+    expect(pickOutput(result, "stderr")).toBe("err");
+  });
+
+  it("diffParity detects exit and output mismatch", () => {
+    const py = { name: "a", exitCode: 0, stdout: "same", stderr: "" };
+    const ts = { name: "a", exitCode: 1, stdout: "diff", stderr: "" };
+    const same = diffParity(py, py, "stdout");
+    expect(same.exitMismatch).toBe(false);
+    expect(same.outputMismatch).toBe(false);
+    const diff = diffParity(py, ts, "stdout");
+    expect(diff.exitMismatch).toBe(true);
+    expect(diff.outputMismatch).toBe(true);
+  });
+
+  it("parity scenarios are non-empty", () => {
+    expect(PARITY_SCENARIOS.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/packages/cli/src/pr-merge-readiness-parity.ts
+++ b/packages/cli/src/pr-merge-readiness-parity.ts
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1730): runs BOTH the Python oracle
+ * (`scripts/pr_merge_readiness.py`) and the ported TS CLI with a fake `gh`
+ * on PATH (cache-off), then diffs exit codes and byte-identical stdout/stderr.
+ *
+ * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
+ */
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HEAD_SHA = "abc1234567890def1234567890abcdef12345678";
+
+const FAKE_GH_PY = `import json
+import os
+import sys
+
+def classify(cmd):
+    joined = " ".join(cmd)
+    if "nameWithOwner" in joined:
+        return "repo-view"
+    if "headRefOid" in joined:
+        return "head-sha"
+    if "/check-runs" in joined:
+        return "check-runs"
+    if "/pulls/" in joined and "/comments" not in joined:
+        return "pr-view-rest"
+    if "/issues/" in joined and "/comments" in joined and "--jq" in cmd:
+        return "comments-jq"
+    if "/issues/" in joined and "/comments" in joined:
+        return "comments-rest"
+    return "unknown"
+
+responses = json.loads(os.environ.get("DEFT_FAKE_GH_RESPONSES", "{}"))
+label = classify(sys.argv[1:])
+resp = responses.get(label, {"returncode": 1, "stderr": f"unexpected gh call: {label}", "stdout": ""})
+stdout = resp.get("stdout", "")
+stderr = resp.get("stderr", "")
+if stdout:
+    sys.stdout.write(stdout)
+if stderr:
+    sys.stderr.write(stderr)
+sys.exit(int(resp.get("returncode", 0)))
+`;
+
+function cleanJqBody(sha: string = HEAD_SHA, confidence: number = 5, extra = ""): string {
+  return (
+    "## Greptile Summary\n\n" +
+    "No P0 or P1 issues found in this PR.\n\n" +
+    `**Confidence Score: ${confidence}/5**\n\n` +
+    "Last reviewed commit: [chore: small fix]" +
+    `(https://github.com/deftai/directive/commit/${sha})\n` +
+    extra
+  );
+}
+
+function greptileRestPayload(
+  sha: string = HEAD_SHA,
+  confidence: number = 5,
+  bodyExtra = "",
+): string {
+  return JSON.stringify([
+    { user: { login: "greptile-apps[bot]" }, body: cleanJqBody(sha, confidence, bodyExtra) },
+    { user: { login: "human-reviewer" }, body: "LGTM" },
+  ]);
+}
+
+function prRestPayload(sha: string = HEAD_SHA, state = "open", merged = false): string {
+  return JSON.stringify({
+    state,
+    merged,
+    mergeable: true,
+    mergeable_state: "clean",
+    head: { sha, ref: "fix/foo" },
+  });
+}
+
+function checkRunsPayload(): string {
+  return JSON.stringify({
+    total_count: 2,
+    check_runs: [
+      { name: "Greptile Review", status: "completed", conclusion: "success" },
+      { name: "CI / build", status: "completed", conclusion: "success" },
+    ],
+  });
+}
+
+export interface FakeGhResponses {
+  readonly [label: string]: {
+    readonly returncode: number;
+    readonly stdout?: string;
+    readonly stderr?: string;
+  };
+}
+
+export interface ParityScenario {
+  readonly name: string;
+  readonly argv: readonly string[];
+  readonly responses: FakeGhResponses;
+  readonly compareStream?: "stdout" | "stderr";
+}
+
+export interface ScenarioResult {
+  readonly name: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly scenarios: Array<{
+    readonly name: string;
+    readonly exitMismatch: boolean;
+    readonly pythonExit: number;
+    readonly tsExit: number;
+    readonly outputMismatch: boolean;
+    readonly pythonOutput: string;
+    readonly tsOutput: string;
+    readonly stream: "stdout" | "stderr";
+  }>;
+}
+
+export const PARITY_SCENARIOS: readonly ParityScenario[] = [
+  {
+    name: "primary-clean-json",
+    argv: ["1363", "--repo", "deftai/directive", "--json"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody() },
+    },
+  },
+  {
+    name: "primary-blocked-confidence-json",
+    argv: ["1363", "--repo", "deftai/directive", "--json"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody(HEAD_SHA, 3) },
+    },
+  },
+  {
+    name: "fallback1-via-jq-fail-json",
+    argv: ["1363", "--repo", "deftai/directive", "--json"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 1, stderr: "decode-crash" },
+      "comments-rest": { returncode: 0, stdout: greptileRestPayload() },
+    },
+  },
+  {
+    name: "fallback2-never-clean-json",
+    argv: ["1363", "--repo", "deftai/directive", "--json"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 1, stderr: "primary boom" },
+      "comments-rest": { returncode: 1, stderr: "fallback1 boom" },
+      "pr-view-rest": { returncode: 0, stdout: prRestPayload() },
+      "check-runs": { returncode: 0, stdout: checkRunsPayload() },
+    },
+  },
+  {
+    name: "total-failure-error-json",
+    argv: ["1363", "--repo", "deftai/directive", "--json"],
+    responses: {
+      "head-sha": { returncode: 1, stderr: "all-down" },
+      "pr-view-rest": { returncode: 1, stderr: "all-down" },
+    },
+  },
+  {
+    name: "non-ascii-utf8-body-json",
+    argv: ["1363", "--repo", "deftai/directive", "--json"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": {
+        returncode: 0,
+        stdout: cleanJqBody(HEAD_SHA, 5, "Review complete — no issues with smart “quotes”.\n"),
+      },
+    },
+  },
+  {
+    name: "informal-clean-json",
+    argv: ["1541", "--repo", "deftai/directive", "--json"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": {
+        returncode: 0,
+        stdout:
+          "The review has completed — both previously flagged issues are now resolved.\n\n" +
+          "The current diff is clean. No new issues to flag — looks solid. Good to proceed.\n",
+      },
+    },
+  },
+  {
+    name: "primary-clean-human",
+    argv: ["1363", "--repo", "deftai/directive"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody() },
+    },
+  },
+];
+
+interface Capture {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function installFakeGh(): { binDir: string; cleanup: () => void } {
+  const binDir = mkdtempSync(join(tmpdir(), "deft-pr-merge-readiness-fake-gh-"));
+  const ghBin = join(binDir, "gh");
+  const ghxBin = join(binDir, "ghx");
+  writeFileSync(ghBin, `#!/usr/bin/env python3\n${FAKE_GH_PY}`, "utf8");
+  writeFileSync(ghxBin, `#!/usr/bin/env python3\n${FAKE_GH_PY}`, "utf8");
+  chmodSync(ghBin, 0o755);
+  chmodSync(ghxBin, 0o755);
+  return {
+    binDir,
+    cleanup: () => {
+      rmSync(binDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function runCapture(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Capture {
+  const result = spawnSync(cmd, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    status: result.status ?? 2,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
+    return resolve(process.env.DEFT_ROOT);
+  }
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+function normaliseHarnessNoise(text: string): string {
+  return text
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("Using CPython") &&
+        !line.startsWith("Creating virtual environment") &&
+        !line.startsWith("Installed "),
+    )
+    .join("\n");
+}
+
+export function pickOutput(result: ScenarioResult, stream: "stdout" | "stderr"): string {
+  return stream === "stdout" ? result.stdout : result.stderr;
+}
+
+export function diffParity(
+  python: ScenarioResult,
+  ts: ScenarioResult,
+  stream: "stdout" | "stderr",
+): {
+  exitMismatch: boolean;
+  outputMismatch: boolean;
+  pythonOutput: string;
+  tsOutput: string;
+} {
+  const pythonOutput = normaliseHarnessNoise(pickOutput(python, stream));
+  const tsOutput = normaliseHarnessNoise(pickOutput(ts, stream));
+  return {
+    exitMismatch: python.exitCode !== ts.exitCode,
+    outputMismatch: pythonOutput !== tsOutput,
+    pythonOutput,
+    tsOutput,
+  };
+}
+
+function runScenario(
+  deftRoot: string,
+  scenario: ParityScenario,
+): { python: ScenarioResult; ts: ScenarioResult } {
+  const fake = installFakeGh();
+  try {
+    const pathPrefix = `${fake.binDir}:${process.env.PATH ?? ""}`;
+    const env = {
+      DEFT_CACHE_DISABLE: "1",
+      PYTHONUTF8: "1",
+      PATH: pathPrefix,
+      DEFT_FAKE_GH_RESPONSES: JSON.stringify(scenario.responses),
+    };
+    const py = runCapture(
+      "uv",
+      ["run", "python", join(deftRoot, "scripts", "pr_merge_readiness.py"), ...scenario.argv],
+      deftRoot,
+      env,
+    );
+    const ts = runCapture(
+      "node",
+      [join(deftRoot, "packages", "cli", "dist", "pr-merge-readiness.js"), ...scenario.argv],
+      deftRoot,
+      env,
+    );
+    return {
+      python: {
+        name: scenario.name,
+        exitCode: py.status,
+        stdout: py.stdout,
+        stderr: py.stderr,
+      },
+      ts: {
+        name: scenario.name,
+        exitCode: ts.status,
+        stdout: ts.stdout,
+        stderr: ts.stderr,
+      },
+    };
+  } finally {
+    fake.cleanup();
+  }
+}
+
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const scenarios: ParityResult["scenarios"] = [];
+  for (const scenario of PARITY_SCENARIOS) {
+    const ran = runScenario(deftRoot, scenario);
+    const stream = scenario.compareStream ?? "stdout";
+    scenarios.push({
+      name: scenario.name,
+      pythonExit: ran.python.exitCode,
+      tsExit: ran.ts.exitCode,
+      stream,
+      ...diffParity(ran.python, ran.ts, stream),
+    });
+  }
+  const ok = scenarios.every((s) => !s.exitMismatch && !s.outputMismatch);
+  return { ok, scenarios };
+}
+
+export function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `pr_merge_readiness parity: CLEAN -- Python and TS agree on ${result.scenarios.length} scenario(s).`;
+  }
+  const lines = ["pr_merge_readiness parity: DIVERGENCE"];
+  for (const s of result.scenarios) {
+    if (s.exitMismatch || s.outputMismatch) {
+      lines.push(`  scenario: ${s.name}`);
+      if (s.exitMismatch) {
+        lines.push(`    exit mismatch: python=${s.pythonExit} ts=${s.tsExit}`);
+      }
+      if (s.outputMismatch) {
+        lines.push(`    stream: ${s.stream}`);
+        lines.push(`    python (${s.pythonOutput.length} bytes):`);
+        lines.push(s.pythonOutput.slice(0, 500));
+        lines.push(`    ts (${s.tsOutput.length} bytes):`);
+        lines.push(s.tsOutput.slice(0, 500));
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    process.exit(1);
+  } catch (err) {
+    const msg = String(err).replace(/\r?\n/g, " ");
+    process.stderr.write(`pr_merge_readiness parity: harness error -- ${msg}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/pr-merge-readiness.ts
+++ b/packages/cli/src/pr-merge-readiness.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { cmdPrMergeReadiness } from "../../core/dist/pr-merge-readiness/main.js";
+
+export function run(argv: string[]): number {
+  return cmdPrMergeReadiness(argv);
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/src/pr-merge-readiness/compute.ts
+++ b/packages/core/src/pr-merge-readiness/compute.ts
@@ -1,0 +1,279 @@
+import {
+  FALLBACK2_NOT_CLEAN_MSG,
+  VIA_ERROR,
+  VIA_FALLBACK1,
+  VIA_FALLBACK2,
+  VIA_PRIMARY,
+} from "./constants.js";
+import { evaluateGates, isMergeReady } from "./evaluate.js";
+import {
+  fetchCheckRunsRest,
+  fetchGreptileBodyRest,
+  fetchGreptileCommentBody,
+  fetchPrHeadSha,
+  fetchPrHeadShaRest,
+  resolveRepo,
+} from "./gh.js";
+import { emptyVerdict, parseGreptileBody } from "./parse.js";
+import type { GateResult, RunGhFn } from "./types.js";
+
+function buildGateResult(
+  prNumber: number,
+  repo: string | null,
+  headSha: string | null,
+  body: string,
+  via: string,
+  partialData: Record<string, unknown> = {},
+  error: string | null = null,
+): GateResult {
+  const verdict = parseGreptileBody(body);
+  const failures = evaluateGates(prNumber, headSha, verdict);
+  return {
+    prNumber,
+    repo,
+    headSha,
+    verdict,
+    failures,
+    via,
+    partialData,
+    error,
+  };
+}
+
+function computePrimary(
+  prNumber: number,
+  repo: string | null,
+  runGh: RunGhFn,
+): { result: GateResult | null; partial: Record<string, unknown> } {
+  const partial: Record<string, unknown> = {};
+
+  const headSha = fetchPrHeadSha(prNumber, repo, runGh);
+  if (headSha === null) {
+    partial.primary_error = "gh pr view headRefOid returned non-zero";
+    return { result: null, partial };
+  }
+  partial.head_sha = headSha;
+
+  const body = fetchGreptileCommentBody(prNumber, repo, runGh);
+  if (body === null) {
+    partial.primary_error = "gh api /issues/<N>/comments --jq returned non-zero";
+    return { result: null, partial };
+  }
+
+  const verdict = parseGreptileBody(body);
+  const failures = evaluateGates(prNumber, headSha, verdict);
+  return {
+    result: {
+      prNumber,
+      repo,
+      headSha,
+      verdict,
+      failures,
+      via: VIA_PRIMARY,
+      partialData: {},
+      error: null,
+    },
+    partial,
+  };
+}
+
+function computeFallback1(
+  prNumber: number,
+  repo: string | null,
+  primaryPartial: Record<string, unknown>,
+  runGh: RunGhFn,
+): { result: GateResult | null; partial: Record<string, unknown> } {
+  const partial: Record<string, unknown> = { ...primaryPartial };
+
+  const resolved = resolveRepo(repo, runGh);
+  if (resolved.repo === null) {
+    partial.fallback1_error = resolved.error;
+    return { result: null, partial };
+  }
+
+  let headSha = typeof partial.head_sha === "string" ? partial.head_sha : null;
+  if (!headSha) {
+    const head = fetchPrHeadShaRest(prNumber, resolved.repo, runGh);
+    if (head.sha === null) {
+      partial.fallback1_error = head.error;
+      return { result: null, partial };
+    }
+    headSha = head.sha;
+    partial.head_sha = headSha;
+  }
+
+  const bodyResult = fetchGreptileBodyRest(prNumber, resolved.repo, runGh);
+  if (bodyResult.body === null) {
+    partial.fallback1_error = bodyResult.error;
+    return { result: null, partial };
+  }
+
+  const verdict = parseGreptileBody(bodyResult.body);
+  const failures = evaluateGates(prNumber, headSha, verdict);
+  const partialData: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(partial)) {
+    if (key !== "head_sha") {
+      partialData[key] = value;
+    }
+  }
+
+  return {
+    result: {
+      prNumber,
+      repo: resolved.repo,
+      headSha,
+      verdict,
+      failures,
+      via: VIA_FALLBACK1,
+      partialData,
+      error: null,
+    },
+    partial,
+  };
+}
+
+function computeFallback2(
+  prNumber: number,
+  repo: string | null,
+  priorPartial: Record<string, unknown>,
+  runGh: RunGhFn,
+): { result: GateResult | null; partial: Record<string, unknown> } {
+  const partial: Record<string, unknown> = { ...priorPartial };
+
+  const resolved = resolveRepo(repo, runGh);
+  if (resolved.repo === null) {
+    partial.fallback2_error = resolved.error;
+    return { result: null, partial };
+  }
+
+  const rc = runGh(["gh", "api", `repos/${resolved.repo}/pulls/${prNumber}`]);
+  if (rc.returncode !== 0) {
+    partial.fallback2_error = `gh api /pulls/${prNumber} failed: ${rc.stderr.trim()}`;
+    return { result: null, partial };
+  }
+
+  let prPayload: unknown;
+  try {
+    prPayload = rc.stdout.trim().length > 0 ? (JSON.parse(rc.stdout) as unknown) : null;
+  } catch (exc: unknown) {
+    const message = exc instanceof Error ? exc.message : String(exc);
+    partial.fallback2_error = `could not parse PR JSON: ${message}`;
+    return { result: null, partial };
+  }
+
+  if (prPayload === null || typeof prPayload !== "object" || Array.isArray(prPayload)) {
+    partial.fallback2_error = "unexpected PR JSON shape (not a dict)";
+    return { result: null, partial };
+  }
+
+  const pr = prPayload as Record<string, unknown>;
+  const state = pr.state;
+  const merged = Boolean(pr.merged);
+  const mergeable = pr.mergeable;
+  const mergeableState = pr.mergeable_state;
+  let headSha: string | null = null;
+  const headBlock = pr.head;
+  if (headBlock !== null && typeof headBlock === "object" && !Array.isArray(headBlock)) {
+    const candidate = (headBlock as Record<string, unknown>).sha;
+    if (typeof candidate === "string" && candidate.length > 0) {
+      headSha = candidate;
+    }
+  }
+  if (headSha === null && typeof partial.head_sha === "string") {
+    headSha = partial.head_sha;
+  }
+
+  let checkSummary: Record<string, unknown> | null = null;
+  if (headSha) {
+    const check = fetchCheckRunsRest(headSha, resolved.repo, runGh);
+    if (check.summary === null && check.error) {
+      partial.fallback2_check_runs_error = check.error;
+    } else {
+      checkSummary = check.summary;
+    }
+  }
+
+  const fallbackPartial: Record<string, unknown> = {
+    pr_state: state,
+    merged,
+    mergeable,
+    mergeable_state: mergeableState,
+    check_runs: checkSummary,
+  };
+  for (const key of ["primary_error", "fallback1_error", "fallback2_check_runs_error"] as const) {
+    if (key in partial) {
+      fallbackPartial[key] = partial[key];
+    }
+  }
+
+  return {
+    result: {
+      prNumber,
+      repo: resolved.repo,
+      headSha,
+      verdict: emptyVerdict(),
+      failures: [FALLBACK2_NOT_CLEAN_MSG],
+      via: VIA_FALLBACK2,
+      partialData: fallbackPartial,
+      error: null,
+    },
+    partial,
+  };
+}
+
+function errorResult(
+  prNumber: number,
+  repo: string | null,
+  partial: Record<string, unknown>,
+): GateResult {
+  const pieces: string[] = [];
+  for (const key of ["primary_error", "fallback1_error", "fallback2_error"] as const) {
+    if (key in partial) {
+      pieces.push(`${key}=${String(partial[key])}`);
+    }
+  }
+  const error =
+    pieces.length > 0
+      ? pieces.join("; ")
+      : "every fallback layer failed without a reportable error";
+
+  return {
+    prNumber,
+    repo,
+    headSha: typeof partial.head_sha === "string" ? partial.head_sha : null,
+    verdict: emptyVerdict(),
+    failures: [
+      "pr_merge_readiness external error -- every fallback layer " +
+        "failed; see partial_data for diagnostic detail (#1368).",
+    ],
+    via: VIA_ERROR,
+    partialData: { ...partial },
+    error,
+  };
+}
+
+/** Run the primary->fallback1->fallback2 cascade and return a result. */
+export function computeGateResult(
+  prNumber: number,
+  repo: string | null,
+  runGh: RunGhFn,
+): GateResult {
+  let { result, partial } = computePrimary(prNumber, repo, runGh);
+  if (result !== null) {
+    return result;
+  }
+
+  ({ result, partial } = computeFallback1(prNumber, repo, partial, runGh));
+  if (result !== null) {
+    return result;
+  }
+
+  ({ result, partial } = computeFallback2(prNumber, repo, partial, runGh));
+  if (result !== null) {
+    return result;
+  }
+
+  return errorResult(prNumber, repo, partial);
+}
+
+export { buildGateResult, isMergeReady };

--- a/packages/core/src/pr-merge-readiness/constants.ts
+++ b/packages/core/src/pr-merge-readiness/constants.ts
@@ -1,0 +1,47 @@
+export const EXIT_OK = 0;
+export const EXIT_MERGE_BLOCKED = 1;
+export const EXIT_EXTERNAL_ERROR = 2;
+
+export const GREPTILE_LOGIN = "greptile-apps[bot]";
+
+export const GREPTILE_ERRORED_SENTINEL = "Greptile encountered an error while reviewing this PR";
+
+export const LAST_REVIEWED_RE =
+  /Last reviewed commit:\s*\[[^\]]*\]\(https?:\/\/github\.com\/[^/]+\/[^/]+\/commit\/(?<sha>[0-9a-f]{7,40})/g;
+
+export const CONFIDENCE_RE = /Confidence Score:\s*(?<score>\d+)\s*\/\s*5/i;
+
+export const P0_BADGE = '<img alt="P0"';
+export const P1_BADGE = '<img alt="P1"';
+
+export const SECTION_RE = /###\s+(?<sev>P[012])\s+findings\s*\((?<count>\d+)\)/gi;
+
+export const INFORMAL_CLEAN_SIGNAL_RE =
+  /(?:diff is clean|(?:prior |previously flagged )?issues? (?:are )?now resolved|all prior issues resolved|no new issues(?: to flag)?|looks solid|good to proceed)/i;
+
+export const INFORMAL_CLEAN_STATE = "informal-clean missing-canonical-fields";
+
+export const INFORMAL_CLEAN_DIAGNOSTIC =
+  `Greptile ${INFORMAL_CLEAN_STATE} state (#1543): the latest Greptile bot ` +
+  "comment says the diff is clean / prior issues are resolved, but omits the " +
+  "canonical rolling-summary fields `Last reviewed commit:` and " +
+  "`Confidence Score: X/5` that merge gates require. Prose alone cannot " +
+  "prove review currency or confidence. Recovery: (1) comment " +
+  "`@greptileai review` on the PR to retrigger a canonical rolling summary, " +
+  "(2) wait for Greptile to edit its primary summary comment with both " +
+  "canonical fields on the current HEAD, or (3) document an explicit " +
+  "operator override per skills/deft-directive-swarm/SKILL.md Phase 6 " +
+  "Step 1. Do NOT keep polling -- this is not 'review still writing'.";
+
+export const VIA_PRIMARY = "primary";
+export const VIA_FALLBACK1 = "fallback1";
+export const VIA_FALLBACK2 = "fallback2";
+export const VIA_ERROR = "error";
+
+export const FALLBACK2_NOT_CLEAN_MSG =
+  "fallback2 is a coarse signal, not a CLEAN verdict -- the Greptile " +
+  "rolling-summary comment was not reachable on either the primary or " +
+  "fallback1 path. PR state / check-runs reported below as a heartbeat " +
+  "only; do NOT merge on this verdict alone (#1368).";
+
+export const GH_TIMEOUT_S = 60;

--- a/packages/core/src/pr-merge-readiness/coverage-boost.test.ts
+++ b/packages/core/src/pr-merge-readiness/coverage-boost.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from "vitest";
+import { computeGateResult } from "./compute.js";
+import { evaluateGates } from "./evaluate.js";
+import {
+  defaultRunGh,
+  fetchCheckRunsRest,
+  fetchGreptileCommentBody,
+  fetchPrHeadSha,
+  resolveRepo,
+} from "./gh.js";
+import { run } from "./main.js";
+import { printHuman } from "./output.js";
+import { emptyVerdict, parseGreptileBody } from "./parse.js";
+import type { RunGhFn } from "./types.js";
+
+const HEAD = "abc1234567890def1234567890abcdef12345678";
+
+describe("coverage boost branches", () => {
+  it("evaluateGates covers errored and missing confidence branches together", () => {
+    const v = {
+      ...emptyVerdict(),
+      found: true,
+      errored: true,
+      lastReviewedSha: null,
+      confidence: null,
+    };
+    const failures = evaluateGates(1, HEAD, v);
+    expect(failures.some((f) => f.includes("ERRORED"))).toBe(true);
+    expect(failures.some((f) => f.includes("Last reviewed commit"))).toBe(true);
+    expect(failures.some((f) => f.includes("Confidence Score"))).toBe(true);
+  });
+
+  it("parseGreptileBody mixed format uses section fallback", () => {
+    const body =
+      '<img alt="P2" src="x"> nit\n### P1 findings (1)\n\n' +
+      "**Confidence Score: 4/5**\n\n" +
+      "Last reviewed commit: [x](https://github.com/o/r/commit/abc1234)\n";
+    const v = parseGreptileBody(body);
+    expect(v.p1Count).toBe(1);
+    expect(v.p2Count).toBe(1);
+  });
+
+  it("fetchPrHeadSha logs stderr on failure", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const runGh: RunGhFn = () => ({ returncode: 1, stdout: "", stderr: "head fail" });
+    expect(fetchPrHeadSha(9, "deftai/directive", runGh)).toBeNull();
+    expect(stderr.mock.calls.join("")).toContain("head fail");
+    stderr.mockRestore();
+  });
+
+  it("fetchGreptileCommentBody resolves repo and handles empty repo", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const runGh: RunGhFn = (cmd) => {
+      if (cmd.join(" ").includes("nameWithOwner")) {
+        return { returncode: 0, stdout: "\n", stderr: "" };
+      }
+      return { returncode: 1, stdout: "", stderr: "x" };
+    };
+    expect(fetchGreptileCommentBody(1, null, runGh)).toBeNull();
+    stderr.mockRestore();
+  });
+
+  it("fetchGreptileCommentBody resolves repo from cwd", () => {
+    const runGh: RunGhFn = (cmd) => {
+      const j = cmd.join(" ");
+      if (j.includes("nameWithOwner")) {
+        return { returncode: 0, stdout: "deftai/directive\n", stderr: "" };
+      }
+      if (j.includes("/comments")) {
+        return { returncode: 0, stdout: "", stderr: "" };
+      }
+      return { returncode: 1, stdout: "", stderr: "" };
+    };
+    expect(fetchGreptileCommentBody(1, null, runGh)).toBe("");
+  });
+
+  it("resolveRepo empty gh output", () => {
+    const runGh: RunGhFn = () => ({ returncode: 0, stdout: "  \n", stderr: "" });
+    expect(resolveRepo(null, runGh).error).toContain("empty repo");
+  });
+
+  it("computeGateResult fallback1 repo resolution failure", () => {
+    const runGh: RunGhFn = (cmd) => {
+      const j = cmd.join(" ");
+      if (j.includes("headRefOid")) return { returncode: 1, stderr: "x", stdout: "" };
+      if (j.includes("nameWithOwner")) return { returncode: 1, stderr: "no repo", stdout: "" };
+      if (j.includes("/pulls/")) return { returncode: 1, stderr: "x", stdout: "" };
+      return { returncode: 1, stdout: "", stderr: "x" };
+    };
+    const result = computeGateResult(1, null, runGh);
+    expect(result.via).toBe("error");
+  });
+
+  it("computeGateResult fallback2 repo resolution failure", () => {
+    const runGh: RunGhFn = (cmd) => {
+      const j = cmd.join(" ");
+      if (j.includes("headRefOid")) return { returncode: 0, stdout: `${HEAD}\n`, stderr: "" };
+      if (j.includes("--jq")) return { returncode: 1, stdout: "", stderr: "x" };
+      if (j.includes("/comments")) return { returncode: 1, stdout: "", stderr: "x" };
+      if (j.includes("nameWithOwner")) return { returncode: 1, stdout: "", stderr: "bad repo" };
+      return { returncode: 1, stdout: "", stderr: "x" };
+    };
+    const result = computeGateResult(1, null, runGh);
+    expect(result.via).toBe("error");
+    expect(result.partialData.fallback2_error).toBeDefined();
+  });
+
+  it("computeGateResult fallback2 invalid PR json", () => {
+    const runGh: RunGhFn = (cmd) => {
+      const j = cmd.join(" ");
+      if (j.includes("headRefOid")) return { returncode: 0, stdout: `${HEAD}\n`, stderr: "" };
+      if (j.includes("--jq")) return { returncode: 1, stdout: "", stderr: "x" };
+      if (j.includes("/comments")) return { returncode: 1, stdout: "", stderr: "x" };
+      if (j.includes("/pulls/")) return { returncode: 0, stdout: "not-json", stderr: "" };
+      return { returncode: 1, stdout: "", stderr: "x" };
+    };
+    const result = computeGateResult(1, "deftai/directive", runGh);
+    expect(result.via).toBe("error");
+  });
+
+  it("fetchCheckRunsRest gh failure and empty body", () => {
+    expect(
+      fetchCheckRunsRest("sha", "deftai/directive", () => ({
+        returncode: 1,
+        stdout: "",
+        stderr: "e",
+      })).error,
+    ).toContain("failed");
+    expect(
+      fetchCheckRunsRest("sha", "deftai/directive", () => ({
+        returncode: 0,
+        stdout: "",
+        stderr: "",
+      })).error,
+    ).toContain("empty body");
+  });
+
+  it("fetchCheckRunsRest invalid json and wrong shape", () => {
+    expect(
+      fetchCheckRunsRest("sha", "deftai/directive", () => ({
+        returncode: 0,
+        stdout: "{",
+        stderr: "",
+      })).error,
+    ).toContain("parse");
+    expect(
+      fetchCheckRunsRest("sha", "deftai/directive", () => ({
+        returncode: 0,
+        stdout: "[]",
+        stderr: "",
+      })).error,
+    ).toContain("not a dict");
+  });
+
+  it("printHuman omits fallback2 greptile when absent", () => {
+    const out = printHuman({
+      prNumber: 1,
+      repo: "deftai/directive",
+      headSha: HEAD,
+      verdict: emptyVerdict(),
+      failures: ["fallback2 is a coarse signal"],
+      via: "fallback2",
+      partialData: { pr_state: "open", check_runs: { total: 0 } },
+      error: null,
+    });
+    expect(out).not.toContain("Greptile Review check:");
+  });
+
+  it("run prints human output when not json", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const runGh: RunGhFn = (cmd) => {
+      const j = cmd.join(" ");
+      if (j.includes("headRefOid")) return { returncode: 0, stdout: `${HEAD}\n`, stderr: "" };
+      if (j.includes("/comments")) {
+        return {
+          returncode: 0,
+          stdout:
+            "## Greptile Summary\n\n**Confidence Score: 5/5**\n\n" +
+            `Last reviewed commit: [x](https://github.com/deftai/directive/commit/${HEAD})\n`,
+          stderr: "",
+        };
+      }
+      return { returncode: 1, stdout: "", stderr: "" };
+    };
+    expect(run(["5", "--repo", "deftai/directive"], { runGh })).toBe(0);
+    expect(String(stdout.mock.calls[0]?.[0])).toContain("MERGE-READY");
+    stdout.mockRestore();
+  });
+
+  it("run rejects extra positional args", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(run(["1", "2"], { runGh: () => ({ returncode: 0, stdout: "", stderr: "" }) })).toBe(2);
+    stderr.mockRestore();
+  });
+
+  it("defaultRunGh rejects non-gh argv", () => {
+    expect(defaultRunGh(["git", "status"]).returncode).toBe(-1);
+  });
+});

--- a/packages/core/src/pr-merge-readiness/evaluate.ts
+++ b/packages/core/src/pr-merge-readiness/evaluate.ts
@@ -1,0 +1,75 @@
+import { INFORMAL_CLEAN_DIAGNOSTIC } from "./constants.js";
+import type { GreptileVerdict } from "./types.js";
+
+/** Return failure messages (empty list == merge-ready). */
+export function evaluateGates(
+  _prNumber: number,
+  headSha: string | null,
+  verdict: GreptileVerdict,
+): string[] {
+  const failures: string[] = [];
+
+  if (!verdict.found) {
+    failures.push(
+      "No Greptile rolling-summary comment found on the PR. " +
+        "Either Greptile has not posted yet, or the bot login filter is wrong. " +
+        "Wait for the review to land before merging (see #796 late-bot-review re-check).",
+    );
+    return failures;
+  }
+
+  if (verdict.errored) {
+    failures.push(
+      "Greptile review is in the ERRORED state on the current HEAD (#526). " +
+        "Retry via @greptileai or escalate per " +
+        "skills/deft-directive-swarm/SKILL.md Phase 6 Step 1.",
+    );
+  }
+
+  if (verdict.informalClean) {
+    failures.push(INFORMAL_CLEAN_DIAGNOSTIC);
+    return failures;
+  }
+
+  if (verdict.lastReviewedSha === null) {
+    failures.push(
+      "Could not parse `Last reviewed commit:` from Greptile body. " +
+        "The comment may be malformed or Greptile may still be writing it -- re-fetch.",
+    );
+  } else if (
+    headSha &&
+    !(headSha.startsWith(verdict.lastReviewedSha) || verdict.lastReviewedSha.startsWith(headSha))
+  ) {
+    failures.push(
+      `Greptile last reviewed ${verdict.lastReviewedSha} but PR HEAD is ${headSha}. ` +
+        "Review is stale -- wait for Greptile to re-review the latest commit.",
+    );
+  }
+
+  if (verdict.confidence === null) {
+    failures.push(
+      "Could not parse `Confidence Score: X/5` from Greptile body. " +
+        "Confidence is a required exit-condition input per " +
+        "skills/deft-directive-review-cycle/SKILL.md Phase 2 Step 6.",
+    );
+  } else if (verdict.confidence <= 3) {
+    failures.push(
+      `Greptile confidence is ${verdict.confidence}/5; exit condition requires > 3. ` +
+        "Address remaining findings or push clarifying changes.",
+    );
+  }
+
+  if (verdict.p0Count > 0 || verdict.p1Count > 0) {
+    failures.push(
+      `Greptile reports ${verdict.p0Count} P0 and ${verdict.p1Count} P1 findings ` +
+        "on the current HEAD. All P0 / P1 findings MUST be addressed before merge " +
+        "(P2 findings are non-blocking).",
+    );
+  }
+
+  return failures;
+}
+
+export function isMergeReady(failures: readonly string[]): boolean {
+  return failures.length === 0;
+}

--- a/packages/core/src/pr-merge-readiness/gh.test.ts
+++ b/packages/core/src/pr-merge-readiness/gh.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  defaultRunGh,
+  fetchCheckRunsRest,
+  fetchGreptileBodyRest,
+  fetchPrHeadShaRest,
+  resolveRepo,
+} from "./gh.js";
+import type { RunGhFn } from "./types.js";
+
+describe("defaultRunGh", () => {
+  it("rejects non-gh commands", () => {
+    expect(defaultRunGh(["git", "status"]).returncode).toBe(-1);
+  });
+});
+
+describe("fetchGreptileBodyRest paginate", () => {
+  const runGh: RunGhFn = (cmd) => {
+    if (cmd.join(" ").includes("/comments")) {
+      const page1 = JSON.stringify([{ user: { login: "human" }, body: "first" }]);
+      const page2 = JSON.stringify([
+        { user: { login: "greptile-apps[bot]" }, body: "clean summary" },
+      ]);
+      return { returncode: 0, stdout: page1 + page2, stderr: "" };
+    }
+    return { returncode: 1, stdout: "", stderr: "unexpected" };
+  };
+
+  it("collapses paginated arrays", () => {
+    const { body, error } = fetchGreptileBodyRest(1, "deftai/directive", runGh);
+    expect(error).toBe("");
+    expect(body).toBe("clean summary");
+  });
+
+  it("returns empty when no greptile comments", () => {
+    const empty: RunGhFn = () => ({ returncode: 0, stdout: "[]", stderr: "" });
+    expect(fetchGreptileBodyRest(1, "deftai/directive", empty).body).toBe("");
+  });
+
+  it("returns null on gh failure", () => {
+    const fail: RunGhFn = () => ({ returncode: 1, stdout: "", stderr: "boom" });
+    const result = fetchGreptileBodyRest(1, "deftai/directive", fail);
+    expect(result.body).toBeNull();
+    expect(result.error).toContain("failed");
+  });
+
+  it("returns null on invalid json", () => {
+    const bad: RunGhFn = () => ({ returncode: 0, stdout: "{not-json", stderr: "" });
+    const result = fetchGreptileBodyRest(1, "deftai/directive", bad);
+    expect(result.body).toBeNull();
+  });
+});
+
+describe("fetchPrHeadShaRest", () => {
+  it("extracts head.sha", () => {
+    const runGh: RunGhFn = () => ({
+      returncode: 0,
+      stdout: JSON.stringify({ head: { sha: "abc1234" } }),
+      stderr: "",
+    });
+    expect(fetchPrHeadShaRest(1, "deftai/directive", runGh).sha).toBe("abc1234");
+  });
+
+  it("handles empty body", () => {
+    const runGh: RunGhFn = () => ({ returncode: 0, stdout: "", stderr: "" });
+    expect(fetchPrHeadShaRest(1, "deftai/directive", runGh).sha).toBeNull();
+  });
+
+  it("handles malformed json", () => {
+    const runGh: RunGhFn = () => ({ returncode: 0, stdout: "not-json", stderr: "" });
+    expect(fetchPrHeadShaRest(1, "deftai/directive", runGh).error).toContain("parse");
+  });
+});
+
+describe("fetchCheckRunsRest", () => {
+  it("summarises check runs", () => {
+    const runGh: RunGhFn = () => ({
+      returncode: 0,
+      stdout: JSON.stringify({
+        check_runs: [
+          { name: "Greptile Review", status: "completed", conclusion: "success" },
+          { name: "CI", status: "completed", conclusion: "success" },
+        ],
+      }),
+      stderr: "",
+    });
+    const { summary } = fetchCheckRunsRest("sha", "deftai/directive", runGh);
+    expect(summary?.total).toBe(2);
+    expect(summary?.greptile_review).toEqual({ status: "completed", conclusion: "success" });
+  });
+
+  it("fails on missing check_runs list", () => {
+    const runGh: RunGhFn = () => ({ returncode: 0, stdout: "{}", stderr: "" });
+    expect(fetchCheckRunsRest("sha", "deftai/directive", runGh).summary).toBeNull();
+  });
+});
+
+describe("resolveRepo", () => {
+  it("returns provided repo unchanged", () => {
+    expect(resolveRepo("deftai/directive", vi.fn() as RunGhFn)).toEqual({
+      repo: "deftai/directive",
+      error: "",
+    });
+  });
+
+  it("resolves from gh repo view", () => {
+    const runGh: RunGhFn = () => ({
+      returncode: 0,
+      stdout: "deftai/directive\n",
+      stderr: "",
+    });
+    expect(resolveRepo(null, runGh).repo).toBe("deftai/directive");
+  });
+
+  it("errors when gh fails", () => {
+    const runGh: RunGhFn = () => ({ returncode: 1, stdout: "", stderr: "nope" });
+    expect(resolveRepo(null, runGh).repo).toBeNull();
+  });
+});

--- a/packages/core/src/pr-merge-readiness/gh.ts
+++ b/packages/core/src/pr-merge-readiness/gh.ts
@@ -1,0 +1,319 @@
+import { execFileSync } from "node:child_process";
+import { resolveBinary } from "../scm/binary.js";
+import { GH_TIMEOUT_S, GREPTILE_LOGIN } from "./constants.js";
+import type { RunGhFn, RunGhResult } from "./types.js";
+
+/** UTF-8-safe gh capture via execFile (no shell) — mirrors _safe_subprocess.run_text (#1366). */
+export function defaultRunGh(cmd: readonly string[]): RunGhResult {
+  if (cmd.length === 0 || cmd[0] !== "gh") {
+    return { returncode: -1, stdout: "", stderr: "expected gh as first argv element" };
+  }
+  const binary = resolveBinary();
+  const args = cmd.slice(1);
+  try {
+    const stdout = execFileSync(binary, args, {
+      encoding: "utf8",
+      timeout: GH_TIMEOUT_S * 1000,
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { returncode: 0, stdout: typeof stdout === "string" ? stdout : "", stderr: "" };
+  } catch (err: unknown) {
+    const e = err as {
+      status?: number;
+      stdout?: string;
+      stderr?: string;
+      code?: string;
+      message?: string;
+    };
+    if (e.code === "ENOENT") {
+      return { returncode: -1, stdout: "", stderr: "gh CLI not found. Install GitHub CLI." };
+    }
+    if (e.code === "ETIMEDOUT") {
+      return { returncode: -1, stdout: "", stderr: `gh CLI timed out: ${cmd.join(" ")}` };
+    }
+    return {
+      returncode: typeof e.status === "number" ? e.status : -1,
+      stdout: typeof e.stdout === "string" ? e.stdout : "",
+      stderr: typeof e.stderr === "string" ? e.stderr : String(e.message ?? ""),
+    };
+  }
+}
+
+export function fetchPrHeadSha(
+  prNumber: number,
+  repo: string | null,
+  runGh: RunGhFn,
+): string | null {
+  const cmd = ["gh", "pr", "view", String(prNumber), "--json", "headRefOid", "--jq", ".headRefOid"];
+  if (repo) {
+    cmd.push("--repo", repo);
+  }
+  const { returncode, stdout, stderr } = runGh(cmd);
+  if (returncode !== 0) {
+    process.stderr.write(
+      `Error: gh failed fetching PR #${prNumber} headRefOid: ${stderr.trim()}\n`,
+    );
+    return null;
+  }
+  const sha = stdout.trim();
+  return sha.length > 0 ? sha : null;
+}
+
+export function fetchGreptileCommentBody(
+  prNumber: number,
+  repo: string | null,
+  runGh: RunGhFn,
+): string | null {
+  let resolvedRepo = repo;
+  if (!resolvedRepo) {
+    const rc = runGh(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
+    if (rc.returncode !== 0) {
+      process.stderr.write(`Error: could not resolve --repo from cwd: ${rc.stderr.trim()}\n`);
+      return null;
+    }
+    resolvedRepo = rc.stdout.trim();
+    if (!resolvedRepo) {
+      process.stderr.write("Error: empty repo from gh repo view (specify --repo OWNER/REPO).\n");
+      return null;
+    }
+  }
+
+  const cmd = [
+    "gh",
+    "api",
+    `repos/${resolvedRepo}/issues/${prNumber}/comments`,
+    "--paginate",
+    "--jq",
+    `[.[] | select(.user.login == "${GREPTILE_LOGIN}")] | last | .body // ""`,
+  ];
+  const { returncode, stdout, stderr } = runGh(cmd);
+  if (returncode !== 0) {
+    process.stderr.write(
+      `Error: gh failed fetching comments for PR #${prNumber}: ${stderr.trim()}\n`,
+    );
+    return null;
+  }
+  return stdout;
+}
+
+export function resolveRepo(
+  repo: string | null,
+  runGh: RunGhFn,
+): { repo: string | null; error: string } {
+  if (repo) {
+    return { repo, error: "" };
+  }
+  const rc = runGh(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
+  if (rc.returncode !== 0) {
+    return { repo: null, error: `could not resolve --repo from cwd: ${rc.stderr.trim()}` };
+  }
+  const resolved = rc.stdout.trim();
+  if (!resolved) {
+    return { repo: null, error: "empty repo from gh repo view (specify --repo OWNER/REPO)" };
+  }
+  return { repo: resolved, error: "" };
+}
+
+export function fetchGreptileBodyRest(
+  prNumber: number,
+  repo: string,
+  runGh: RunGhFn,
+): { body: string | null; error: string } {
+  const rc = runGh(["gh", "api", `repos/${repo}/issues/${prNumber}/comments`, "--paginate"]);
+  if (rc.returncode !== 0) {
+    return {
+      body: null,
+      error: `gh api /issues/${prNumber}/comments failed: ${rc.stderr.trim()}`,
+    };
+  }
+  if (!rc.stdout.trim()) {
+    return { body: "", error: "" };
+  }
+
+  return parsePaginatedComments(rc.stdout.trim());
+}
+
+function parsePaginatedComments(text: string): { body: string | null; error: string } {
+  const comments: unknown[] = [];
+  const decoder = new PaginatedJsonDecoder();
+  let idx = 0;
+  while (idx < text.length) {
+    const result = decoder.rawDecode(text, idx);
+    if (result === null) {
+      if (idx < text.length) {
+        return { body: null, error: "could not parse REST comments JSON: invalid JSON at offset" };
+      }
+      break;
+    }
+    const [obj, end] = result;
+    if (Array.isArray(obj)) {
+      comments.push(...obj);
+    } else if (obj !== null && typeof obj === "object") {
+      comments.push(obj);
+    }
+    idx = end;
+  }
+
+  const greptileBodies: string[] = [];
+  for (const c of comments) {
+    if (
+      c !== null &&
+      typeof c === "object" &&
+      !Array.isArray(c) &&
+      "user" in c &&
+      c.user !== null &&
+      typeof c.user === "object" &&
+      !Array.isArray(c.user) &&
+      "login" in c.user &&
+      c.user.login === GREPTILE_LOGIN &&
+      "body" in c &&
+      typeof c.body === "string"
+    ) {
+      greptileBodies.push(c.body);
+    }
+  }
+  if (greptileBodies.length === 0) {
+    return { body: "", error: "" };
+  }
+  return { body: greptileBodies[greptileBodies.length - 1] ?? "", error: "" };
+}
+
+/** Mirrors Python json.JSONDecoder.raw_decode for concatenated paginate arrays. */
+class PaginatedJsonDecoder {
+  rawDecode(text: string, idx: number): [unknown, number] | null {
+    let pos = idx;
+    while (pos < text.length && /\s/.test(text.charAt(pos))) {
+      pos += 1;
+    }
+    if (pos >= text.length) {
+      return null;
+    }
+    try {
+      let end = pos;
+      let depth = 0;
+      let inString = false;
+      let isEscaped = false;
+      const startChar = text.charAt(pos);
+      if (startChar !== "[" && startChar !== "{") {
+        return null;
+      }
+      for (; end < text.length; end += 1) {
+        const ch = text.charAt(end);
+        if (inString) {
+          if (isEscaped) {
+            isEscaped = false;
+          } else if (ch === "\\") {
+            isEscaped = true;
+          } else if (ch === '"') {
+            inString = false;
+          }
+          continue;
+        }
+        if (ch === '"') {
+          inString = true;
+          continue;
+        }
+        if (ch === "[" || ch === "{") {
+          depth += 1;
+        } else if (ch === "]" || ch === "}") {
+          depth -= 1;
+          if (depth === 0) {
+            end += 1;
+            break;
+          }
+        }
+      }
+      const slice = text.slice(pos, end);
+      const obj = JSON.parse(slice) as unknown;
+      return [obj, end];
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function fetchPrHeadShaRest(
+  prNumber: number,
+  repo: string,
+  runGh: RunGhFn,
+): { sha: string | null; error: string } {
+  const rc = runGh(["gh", "api", `repos/${repo}/pulls/${prNumber}`]);
+  if (rc.returncode !== 0) {
+    return { sha: null, error: `gh api /pulls/${prNumber} failed: ${rc.stderr.trim()}` };
+  }
+  if (!rc.stdout.trim()) {
+    return { sha: null, error: "empty body from gh api /pulls/<N>" };
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rc.stdout) as unknown;
+  } catch (exc: unknown) {
+    const message = exc instanceof Error ? exc.message : String(exc);
+    return { sha: null, error: `could not parse PR JSON: ${message}` };
+  }
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    return { sha: null, error: "unexpected PR JSON shape (not a dict)" };
+  }
+  const head = (payload as Record<string, unknown>).head;
+  if (head !== null && typeof head === "object" && !Array.isArray(head)) {
+    const sha = (head as Record<string, unknown>).sha;
+    if (typeof sha === "string" && sha.length > 0) {
+      return { sha, error: "" };
+    }
+  }
+  return { sha: null, error: "PR JSON missing head.sha" };
+}
+
+export function fetchCheckRunsRest(
+  sha: string,
+  repo: string,
+  runGh: RunGhFn,
+): { summary: Record<string, unknown> | null; error: string } {
+  const rc = runGh(["gh", "api", `repos/${repo}/commits/${sha}/check-runs`]);
+  if (rc.returncode !== 0) {
+    return {
+      summary: null,
+      error: `gh api /commits/${"<"}sha>/check-runs failed: ${rc.stderr.trim()}`,
+    };
+  }
+  if (!rc.stdout.trim()) {
+    return { summary: null, error: "empty body from gh api /commits/<sha>/check-runs" };
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rc.stdout) as unknown;
+  } catch (exc: unknown) {
+    const message = exc instanceof Error ? exc.message : String(exc);
+    return { summary: null, error: `could not parse check-runs JSON: ${message}` };
+  }
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    return { summary: null, error: "unexpected check-runs JSON shape (not a dict)" };
+  }
+  const runs = (payload as Record<string, unknown>).check_runs;
+  if (!Array.isArray(runs)) {
+    return { summary: null, error: "check-runs JSON missing check_runs list" };
+  }
+  const summary: Record<string, unknown> = {
+    total: runs.length,
+    by_status: {} as Record<string, number>,
+    by_conclusion: {} as Record<string, number>,
+    greptile_review: null,
+  };
+  const byStatus = summary.by_status as Record<string, number>;
+  const byConclusion = summary.by_conclusion as Record<string, number>;
+  for (const run of runs) {
+    if (run === null || typeof run !== "object" || Array.isArray(run)) {
+      continue;
+    }
+    const r = run as Record<string, unknown>;
+    const status = typeof r.status === "string" ? r.status : "unknown";
+    const conclusion = typeof r.conclusion === "string" ? r.conclusion : "none";
+    byStatus[status] = (byStatus[status] ?? 0) + 1;
+    byConclusion[conclusion] = (byConclusion[conclusion] ?? 0) + 1;
+    if (r.name === "Greptile Review") {
+      summary.greptile_review = { status, conclusion };
+    }
+  }
+  return { summary, error: "" };
+}

--- a/packages/core/src/pr-merge-readiness/index.ts
+++ b/packages/core/src/pr-merge-readiness/index.ts
@@ -1,0 +1,8 @@
+export { computeGateResult } from "./compute.js";
+export * from "./constants.js";
+export { evaluateGates, isMergeReady } from "./evaluate.js";
+export { defaultRunGh } from "./gh.js";
+export { cmdPrMergeReadiness, parseArgs, run } from "./main.js";
+export { emitJson, exitCodeFor, gateResultToDict, printHuman } from "./output.js";
+export { emptyVerdict, isInformalCleanMissingCanonicalFields, parseGreptileBody } from "./parse.js";
+export type { GateResult, GreptileVerdict, RunGhFn, RunGhResult } from "./types.js";

--- a/packages/core/src/pr-merge-readiness/main.test.ts
+++ b/packages/core/src/pr-merge-readiness/main.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { cmdPrMergeReadiness, parseArgs, run } from "./main.js";
+import type { RunGhFn } from "./types.js";
+
+const HEAD = "abc1234567890def1234567890abcdef12345678";
+
+function fakeRunGh(): RunGhFn {
+  return (cmd) => {
+    const joined = cmd.join(" ");
+    if (joined.includes("headRefOid")) {
+      return { returncode: 0, stdout: `${HEAD}\n`, stderr: "" };
+    }
+    if (joined.includes("/comments")) {
+      return {
+        returncode: 0,
+        stdout:
+          "## Greptile Summary\n\n**Confidence Score: 5/5**\n\n" +
+          `Last reviewed commit: [x](https://github.com/deftai/directive/commit/${HEAD})\n`,
+        stderr: "",
+      };
+    }
+    return { returncode: 1, stdout: "", stderr: "unexpected" };
+  };
+}
+
+describe("parseArgs", () => {
+  it("parses pr number repo and json", () => {
+    expect(parseArgs(["1", "--repo", "deftai/directive", "--json"])).toEqual({
+      prNumber: 1,
+      repo: "deftai/directive",
+      emitJson: true,
+    });
+  });
+
+  it("parses --repo= form", () => {
+    expect(parseArgs(["2", "--repo=org/repo"])).toMatchObject({ prNumber: 2, repo: "org/repo" });
+  });
+
+  it("errors on missing pr number", () => {
+    expect(parseArgs(["--json"]).error).toContain("required");
+  });
+
+  it("errors on invalid pr number", () => {
+    expect(parseArgs(["abc"]).error).toContain("invalid");
+  });
+
+  it("errors on unknown flag", () => {
+    expect(parseArgs(["1", "--nope"]).error).toContain("unrecognized");
+  });
+
+  it("errors on missing --repo value", () => {
+    expect(parseArgs(["1", "--repo"]).error).toContain("--repo");
+  });
+});
+
+describe("run CLI", () => {
+  it("returns 0 for clean json run", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const code = run(["1", "--repo", "deftai/directive", "--json"], { runGh: fakeRunGh() });
+    expect(code).toBe(0);
+    expect(stdout.mock.calls[0]?.[0]).toContain('"merge_ready": true');
+    stdout.mockRestore();
+  });
+
+  it("returns 2 on parse error", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(run([], { runGh: fakeRunGh() })).toBe(2);
+    stderr.mockRestore();
+  });
+
+  it("cmdPrMergeReadiness delegates to run", () => {
+    expect(
+      cmdPrMergeReadiness(["1", "--repo", "deftai/directive", "--json"], { runGh: fakeRunGh() }),
+    ).toBe(0);
+  });
+});

--- a/packages/core/src/pr-merge-readiness/main.ts
+++ b/packages/core/src/pr-merge-readiness/main.ts
@@ -1,0 +1,79 @@
+import { computeGateResult } from "./compute.js";
+import { defaultRunGh } from "./gh.js";
+import { emitJson, exitCodeFor, printHuman } from "./output.js";
+import type { RunGhFn } from "./types.js";
+
+export interface ParsedArgs {
+  readonly prNumber: number | null;
+  readonly repo: string | null;
+  readonly emitJson: boolean;
+  readonly error?: string;
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  let prNumber: number | null = null;
+  let repo: string | null = null;
+  let json = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--repo") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { prNumber, repo, emitJson: json, error: "argument --repo: expected one argument" };
+      }
+      repo = value;
+      i += 1;
+    } else if (arg?.startsWith("--repo=")) {
+      repo = arg.slice("--repo=".length);
+    } else if (arg?.startsWith("-")) {
+      return { prNumber, repo, emitJson: json, error: `unrecognized arguments: ${arg}` };
+    } else if (prNumber === null) {
+      const n = Number(arg);
+      if (!Number.isInteger(n) || n <= 0) {
+        return { prNumber, repo, emitJson: json, error: `invalid PR number: ${arg}` };
+      }
+      prNumber = n;
+    } else {
+      return { prNumber, repo, emitJson: json, error: `unrecognized arguments: ${arg}` };
+    }
+  }
+
+  if (prNumber === null) {
+    return {
+      prNumber,
+      repo,
+      emitJson: json,
+      error: "the following arguments are required: pr_number",
+    };
+  }
+  return { prNumber, repo, emitJson: json };
+}
+
+export interface RunOptions {
+  readonly runGh?: RunGhFn;
+}
+
+export function run(argv: readonly string[], options: RunOptions = {}): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`pr_merge_readiness: ${args.error}\n`);
+    return 2;
+  }
+
+  const runGh = options.runGh ?? defaultRunGh;
+  const result = computeGateResult(args.prNumber as number, args.repo, runGh);
+
+  if (args.emitJson) {
+    process.stdout.write(emitJson(result));
+  } else {
+    process.stdout.write(printHuman(result));
+  }
+  return exitCodeFor(result);
+}
+
+export function cmdPrMergeReadiness(argv: readonly string[], options: RunOptions = {}): number {
+  return run(argv, options);
+}

--- a/packages/core/src/pr-merge-readiness/output.test.ts
+++ b/packages/core/src/pr-merge-readiness/output.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { computeGateResult } from "./compute.js";
+import { VIA_ERROR, VIA_FALLBACK2 } from "./constants.js";
+import { emitJson, exitCodeFor, gateResultToDict, printHuman } from "./output.js";
+import { emptyVerdict } from "./parse.js";
+import type { GateResult, RunGhFn } from "./types.js";
+
+const baseResult: GateResult = {
+  prNumber: 1363,
+  repo: "deftai/directive",
+  headSha: "abc1234567890def1234567890abcdef12345678",
+  verdict: {
+    ...emptyVerdict(),
+    found: true,
+    lastReviewedSha: "abc1234567890def1234567890abcdef12345678",
+    confidence: 5,
+  },
+  failures: [],
+  via: "primary",
+  partialData: {},
+  error: null,
+};
+
+describe("output helpers", () => {
+  it("serialises merge_ready true", () => {
+    const json = JSON.parse(emitJson(baseResult)) as Record<string, unknown>;
+    expect(json.merge_ready).toBe(true);
+    expect(json.via).toBe("primary");
+    expect((json.verdict as Record<string, unknown>).informal_clean).toBe(false);
+  });
+
+  it("includes partial_data and error when present", () => {
+    const blocked: GateResult = {
+      ...baseResult,
+      failures: ["blocked"],
+      via: VIA_ERROR,
+      partialData: { primary_error: "x" },
+      error: "primary_error=x",
+    };
+    const dict = gateResultToDict(blocked);
+    expect(dict.partial_data).toEqual({ primary_error: "x" });
+    expect(dict.error).toBe("primary_error=x");
+    expect(exitCodeFor(blocked)).toBe(2);
+  });
+
+  it("prints human merge-ready", () => {
+    const out = printHuman(baseResult);
+    expect(out).toContain("MERGE-READY");
+    expect(out).toContain("via=primary");
+  });
+
+  it("prints human merge-blocked", () => {
+    const out = printHuman({ ...baseResult, failures: ["low confidence"] });
+    expect(out).toContain("MERGE-BLOCKED");
+    expect(out).toContain("[1] low confidence");
+  });
+
+  it("prints human external-error", () => {
+    const out = printHuman({
+      ...baseResult,
+      failures: ["external"],
+      via: VIA_ERROR,
+      error: "boom",
+    });
+    expect(out).toContain("EXTERNAL-ERROR");
+    expect(out).toContain("Underlying error: boom");
+  });
+
+  it("prints fallback2 signal block", () => {
+    const out = printHuman({
+      ...baseResult,
+      failures: ["fallback2 is a coarse signal"],
+      via: VIA_FALLBACK2,
+      partialData: {
+        pr_state: "open",
+        merged: false,
+        mergeable: true,
+        mergeable_state: "clean",
+        check_runs: {
+          greptile_review: { status: "completed", conclusion: "success" },
+        },
+      },
+    });
+    expect(out).toContain("Fallback2 signal:");
+    expect(out).toContain(
+      "Greptile Review check: {'status': 'completed', 'conclusion': 'success'}",
+    );
+  });
+
+  it("exit code blocked vs ok", () => {
+    expect(exitCodeFor(baseResult)).toBe(0);
+    expect(exitCodeFor({ ...baseResult, failures: ["x"] })).toBe(1);
+  });
+});
+
+describe("compute branches", () => {
+  function fake(
+    responses: Record<string, { returncode: number; stdout?: string; stderr?: string }>,
+  ): RunGhFn {
+    const classify = (cmd: readonly string[]): string => {
+      const joined = cmd.join(" ");
+      if (joined.includes("headRefOid")) return "head-sha";
+      if (joined.includes("/check-runs")) return "check-runs";
+      if (joined.includes("/pulls/") && !joined.includes("/comments")) return "pr-view-rest";
+      if (joined.includes("/comments") && cmd.includes("--jq")) return "comments-jq";
+      if (joined.includes("/comments")) return "comments-rest";
+      if (joined.includes("nameWithOwner")) return "repo-view";
+      return "unknown";
+    };
+    return (cmd) => {
+      const label = classify(cmd);
+      const resp = responses[label] ?? { returncode: 1, stderr: label };
+      return { returncode: resp.returncode, stdout: resp.stdout ?? "", stderr: resp.stderr ?? "" };
+    };
+  }
+
+  it("fallback1 re-fetches head when primary head failed", () => {
+    const body =
+      "## Greptile Summary\n\n**Confidence Score: 5/5**\n\n" +
+      "Last reviewed commit: [x](https://github.com/deftai/directive/commit/abc1234567890def1234567890abcdef12345678)\n";
+    const result = computeGateResult(
+      1,
+      "deftai/directive",
+      fake({
+        "head-sha": { returncode: 1, stderr: "timeout" },
+        "pr-view-rest": {
+          returncode: 0,
+          stdout: JSON.stringify({ head: { sha: "abc1234567890def1234567890abcdef12345678" } }),
+        },
+        "comments-jq": { returncode: 1 },
+        "comments-rest": {
+          returncode: 0,
+          stdout: JSON.stringify([{ user: { login: "greptile-apps[bot]" }, body }]),
+        },
+      }),
+    );
+    expect(result.via).toBe("fallback1");
+    expect(result.failures).toEqual([]);
+  });
+
+  it("fallback2 preserves merged state", () => {
+    const result = computeGateResult(
+      1,
+      "deftai/directive",
+      fake({
+        "head-sha": { returncode: 0, stdout: "abc1234567890def1234567890abcdef12345678\n" },
+        "comments-jq": { returncode: 1 },
+        "comments-rest": { returncode: 1 },
+        "pr-view-rest": {
+          returncode: 0,
+          stdout: JSON.stringify({
+            state: "closed",
+            merged: true,
+            head: { sha: "abc1234567890def1234567890abcdef12345678" },
+          }),
+        },
+        "check-runs": { returncode: 1, stderr: "endpoint down" },
+      }),
+    );
+    expect(result.partialData.merged).toBe(true);
+    expect(result.partialData.fallback2_check_runs_error).toBeDefined();
+  });
+});

--- a/packages/core/src/pr-merge-readiness/output.ts
+++ b/packages/core/src/pr-merge-readiness/output.ts
@@ -1,0 +1,114 @@
+import {
+  EXIT_EXTERNAL_ERROR,
+  EXIT_MERGE_BLOCKED,
+  EXIT_OK,
+  VIA_ERROR,
+  VIA_FALLBACK2,
+} from "./constants.js";
+import { isMergeReady } from "./evaluate.js";
+import type { GateResult, GreptileVerdict } from "./types.js";
+
+function verdictToDict(verdict: GreptileVerdict): Record<string, unknown> {
+  return {
+    found: verdict.found,
+    errored: verdict.errored,
+    last_reviewed_sha: verdict.lastReviewedSha,
+    confidence: verdict.confidence,
+    p0_count: verdict.p0Count,
+    p1_count: verdict.p1Count,
+    p2_count: verdict.p2Count,
+    informal_clean: verdict.informalClean,
+    raw_body_excerpt: verdict.rawBodyExcerpt,
+  };
+}
+
+/** Serialise gate result matching Python `GateResult.to_dict()` key order. */
+export function gateResultToDict(result: GateResult): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    pr_number: result.prNumber,
+    repo: result.repo,
+    head_sha: result.headSha,
+    verdict: verdictToDict(result.verdict),
+    failures: [...result.failures],
+    merge_ready: isMergeReady(result.failures),
+    via: result.via,
+  };
+  if (Object.keys(result.partialData).length > 0) {
+    payload.partial_data = { ...result.partialData };
+  }
+  if (result.error !== null) {
+    payload.error = result.error;
+  }
+  return payload;
+}
+
+/** Match Python json.dumps(..., indent=2) default ensure_ascii=True. */
+function pythonJsonDumps(value: unknown): string {
+  const json = JSON.stringify(value, null, 2);
+  return json.replace(/[\u007f-\uffff]/g, (ch) => {
+    const code = ch.charCodeAt(0);
+    return `\\u${code.toString(16).padStart(4, "0")}`;
+  });
+}
+
+export function emitJson(result: GateResult): string {
+  return `${pythonJsonDumps(gateResultToDict(result))}\n`;
+}
+
+export function printHuman(result: GateResult): string {
+  const lines: string[] = [];
+  lines.push(`PR #${result.prNumber} merge-readiness check  (via=${result.via})`);
+  lines.push(`  HEAD SHA:           ${result.headSha ?? "<unknown>"}`);
+  lines.push(`  Greptile reviewed:  ${result.verdict.lastReviewedSha ?? "<not parsed>"}`);
+  const confidenceStr =
+    result.verdict.confidence !== null ? String(result.verdict.confidence) : "<not parsed>";
+  lines.push(`  Confidence:         ${confidenceStr}/5`);
+  lines.push(
+    `  Findings:           P0=${result.verdict.p0Count}  ` +
+      `P1=${result.verdict.p1Count}  P2=${result.verdict.p2Count}`,
+  );
+  lines.push(`  Errored sentinel:   ${result.verdict.errored ? "True" : "False"}`);
+  if (result.via === VIA_FALLBACK2 && Object.keys(result.partialData).length > 0) {
+    lines.push("  Fallback2 signal:");
+    for (const key of ["pr_state", "merged", "mergeable", "mergeable_state"] as const) {
+      if (key in result.partialData) {
+        lines.push(`    ${key}: ${String(result.partialData[key])}`);
+      }
+    }
+    const checkRuns = result.partialData.check_runs;
+    if (checkRuns !== null && typeof checkRuns === "object" && !Array.isArray(checkRuns)) {
+      const greptile = (checkRuns as Record<string, unknown>).greptile_review;
+      if (greptile !== null && greptile !== undefined && typeof greptile === "object") {
+        const g = greptile as Record<string, unknown>;
+        const status = typeof g.status === "string" ? g.status : "unknown";
+        const conclusion = typeof g.conclusion === "string" ? g.conclusion : "none";
+        lines.push(
+          `    Greptile Review check: {'status': '${status}', 'conclusion': '${conclusion}'}`,
+        );
+      }
+    }
+  }
+  if (isMergeReady(result.failures)) {
+    lines.push("");
+    lines.push("Result: MERGE-READY");
+  } else {
+    const label = result.via !== VIA_ERROR ? "MERGE-BLOCKED" : "EXTERNAL-ERROR";
+    lines.push("");
+    lines.push(`Result: ${label}`);
+    result.failures.forEach((fail, i) => {
+      lines.push(`  [${i + 1}] ${fail}`);
+    });
+    if (result.error !== null) {
+      lines.push("");
+      lines.push(`Underlying error: ${result.error}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function exitCodeFor(result: GateResult): number {
+  if (result.via === VIA_ERROR) {
+    return EXIT_EXTERNAL_ERROR;
+  }
+  return isMergeReady(result.failures) ? EXIT_OK : EXIT_MERGE_BLOCKED;
+}

--- a/packages/core/src/pr-merge-readiness/parse.test.ts
+++ b/packages/core/src/pr-merge-readiness/parse.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import { computeGateResult } from "./compute.js";
+import {
+  CONFIDENCE_RE,
+  GREPTILE_ERRORED_SENTINEL,
+  INFORMAL_CLEAN_DIAGNOSTIC,
+  VIA_FALLBACK1,
+  VIA_FALLBACK2,
+  VIA_PRIMARY,
+} from "./constants.js";
+import { evaluateGates } from "./evaluate.js";
+import { emptyVerdict, isInformalCleanMissingCanonicalFields, parseGreptileBody } from "./parse.js";
+import type { GreptileVerdict, RunGhFn } from "./types.js";
+
+const HEAD = "abc1234567890def1234567890abcdef12345678";
+
+function cleanBody(sha = HEAD, confidence = 5): string {
+  return (
+    "## Greptile Summary\n\n" +
+    "No P0 or P1 issues found in this PR.\n\n" +
+    `**Confidence Score: ${confidence}/5**\n\n` +
+    `Last reviewed commit: [chore](https://github.com/deftai/directive/commit/${sha})\n`
+  );
+}
+
+function verdict(overrides: Partial<GreptileVerdict> = {}): GreptileVerdict {
+  return { ...emptyVerdict(), found: true, lastReviewedSha: HEAD, confidence: 5, ...overrides };
+}
+
+describe("parseGreptileBody", () => {
+  it("returns not-found for empty and whitespace bodies", () => {
+    for (const body of ["", "\n", "\n\n\n\n", "   ", "\t", " \n \t \n "]) {
+      const v = parseGreptileBody(body);
+      expect(v.found).toBe(false);
+      expect(v.lastReviewedSha).toBeNull();
+      expect(v.confidence).toBeNull();
+    }
+  });
+
+  it("parses clean body fields", () => {
+    const sha = "deadbeef1234567890deadbeef1234567890abcd";
+    const v = parseGreptileBody(cleanBody(sha, 5));
+    expect(v.found).toBe(true);
+    expect(v.errored).toBe(false);
+    expect(v.lastReviewedSha).toBe(sha);
+    expect(v.confidence).toBe(5);
+    expect(v.p0Count).toBe(0);
+    expect(v.p1Count).toBe(0);
+  });
+
+  it("does not false-positive P0/P1 from clean summary prose", () => {
+    const v = parseGreptileBody(cleanBody());
+    expect(v.p0Count).toBe(0);
+    expect(v.p1Count).toBe(0);
+  });
+
+  it("counts badge findings", () => {
+    const body =
+      '<img alt="P0" src="x"> a\n<img alt="P1" src="x"> b\n<img alt="P2" src="x"> c\n' +
+      `**Confidence Score: 2/5**\n\n` +
+      `Last reviewed commit: [x](https://github.com/o/r/commit/aaaaaaa)\n`;
+    const v = parseGreptileBody(body);
+    expect(v.p0Count).toBe(1);
+    expect(v.p1Count).toBe(1);
+    expect(v.p2Count).toBe(1);
+    expect(v.confidence).toBe(2);
+  });
+
+  it("uses section heading fallback without badges", () => {
+    const body =
+      "### P0 findings (0)\n\n### P1 findings (1)\n\n### P2 findings (5)\n\n" +
+      "**Confidence Score: 4/5**\n\n" +
+      "Last reviewed commit: [x](https://github.com/o/r/commit/bbbbbbb)\n";
+    const v = parseGreptileBody(body);
+    expect(v.p1Count).toBe(1);
+    expect(v.p2Count).toBe(5);
+  });
+
+  it("detects errored sentinel", () => {
+    expect(parseGreptileBody(GREPTILE_ERRORED_SENTINEL).errored).toBe(true);
+  });
+
+  it("takes last SHA match not first", () => {
+    const body =
+      "quoted: Last reviewed commit: [x](https://github.com/o/r/commit/bbbbbbb)\n" +
+      "**Confidence Score: 4/5**\n\n" +
+      "<sub>Last reviewed commit: [real](https://github.com/o/r/commit/d65eb9f41c2bfd8c)</sub>\n";
+    expect(parseGreptileBody(body).lastReviewedSha).toBe("d65eb9f41c2bfd8c");
+  });
+
+  it("skips heading fallback when details format present", () => {
+    const body =
+      "<details><summary>Summary</summary>\n\nNo P0 or P1 issues found.\n\n" +
+      '```python\nbody = "### P1 findings (1)\\n"\n```\n\n' +
+      "**Confidence Score: 5/5**\n\n</details>\n\n" +
+      "<sub>Last reviewed commit: [fix](https://github.com/o/r/commit/85c0b1de994a)</sub>\n";
+    const v = parseGreptileBody(body);
+    expect(v.p1Count).toBe(0);
+    expect(v.lastReviewedSha).toBe("85c0b1de994a");
+  });
+
+  it("detects informal clean missing canonical fields", () => {
+    const body =
+      "Both previously flagged issues are now resolved.\n\n" +
+      "The current diff is clean. looks solid. Good to proceed.\n";
+    const v = parseGreptileBody(body);
+    expect(v.informalClean).toBe(true);
+  });
+
+  it("isInformalClean helper respects canonical fields", () => {
+    const v = parseGreptileBody(cleanBody());
+    expect(isInformalCleanMissingCanonicalFields(v, cleanBody())).toBe(false);
+  });
+});
+
+describe("evaluateGates", () => {
+  it("passes when all gates clean", () => {
+    expect(evaluateGates(1, HEAD, verdict())).toEqual([]);
+  });
+
+  it("fails when no greptile comment", () => {
+    const failures = evaluateGates(
+      1,
+      HEAD,
+      verdict({ found: false, lastReviewedSha: null, confidence: null }),
+    );
+    expect(failures.some((f) => f.includes("No Greptile rolling-summary"))).toBe(true);
+  });
+
+  it("fails on errored state", () => {
+    expect(
+      evaluateGates(1, HEAD, verdict({ errored: true })).some((f) => f.includes("ERRORED")),
+    ).toBe(true);
+  });
+
+  it("fails on stale sha", () => {
+    expect(
+      evaluateGates(
+        1,
+        "bbbbbbb00000000000000000000000000000000",
+        verdict({ lastReviewedSha: "aaaaaaa" }),
+      ).some((f) => f.includes("stale")),
+    ).toBe(true);
+  });
+
+  it("allows short sha prefix match", () => {
+    expect(evaluateGates(1, HEAD, verdict({ lastReviewedSha: "abc1234" }))).toEqual([]);
+  });
+
+  it("fails on low confidence", () => {
+    expect(
+      evaluateGates(1, HEAD, verdict({ confidence: 3 })).some((f) =>
+        f.includes("confidence is 3/5"),
+      ),
+    ).toBe(true);
+  });
+
+  it("passes confidence 4", () => {
+    expect(evaluateGates(1, HEAD, verdict({ confidence: 4 }))).toEqual([]);
+  });
+
+  it("fails on P1 findings", () => {
+    expect(
+      evaluateGates(1, HEAD, verdict({ p1Count: 1 })).some((f) => f.includes("P1 findings")),
+    ).toBe(true);
+  });
+
+  it("passes P2-only", () => {
+    expect(evaluateGates(1, HEAD, verdict({ p2Count: 5 }))).toEqual([]);
+  });
+
+  it("emits informal clean diagnostic", () => {
+    const failures = evaluateGates(
+      1,
+      HEAD,
+      verdict({ informalClean: true, lastReviewedSha: null, confidence: null }),
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain(INFORMAL_CLEAN_DIAGNOSTIC.slice(0, 40));
+    expect(failures[0]).toContain("@greptileai review");
+  });
+});
+
+describe("computeGateResult layered fallbacks", () => {
+  function installFakeGh(
+    responses: Record<string, { returncode: number; stdout?: string; stderr?: string }>,
+  ): RunGhFn {
+    const classify = (cmd: readonly string[]): string => {
+      const joined = cmd.join(" ");
+      if (joined.includes("nameWithOwner")) return "repo-view";
+      if (joined.includes("headRefOid")) return "head-sha";
+      if (joined.includes("/check-runs")) return "check-runs";
+      if (joined.includes("/pulls/") && !joined.includes("/comments")) return "pr-view-rest";
+      if (joined.includes("/issues/") && joined.includes("/comments") && cmd.includes("--jq"))
+        return "comments-jq";
+      if (joined.includes("/issues/") && joined.includes("/comments")) return "comments-rest";
+      return "unknown";
+    };
+    return (cmd) => {
+      const label = classify(cmd);
+      const resp = responses[label] ?? { returncode: 1, stderr: `unexpected ${label}` };
+      return {
+        returncode: resp.returncode,
+        stdout: resp.stdout ?? "",
+        stderr: resp.stderr ?? "",
+      };
+    };
+  }
+
+  it("primary clean via primary", () => {
+    const result = computeGateResult(
+      1363,
+      "deftai/directive",
+      installFakeGh({
+        "head-sha": { returncode: 0, stdout: `${HEAD}\n` },
+        "comments-jq": { returncode: 0, stdout: cleanBody() },
+      }),
+    );
+    expect(result.via).toBe(VIA_PRIMARY);
+    expect(result.failures).toEqual([]);
+    expect(result.headSha).toBe(HEAD);
+  });
+
+  it("primary blocked stays primary", () => {
+    const result = computeGateResult(
+      1363,
+      "deftai/directive",
+      installFakeGh({
+        "head-sha": { returncode: 0, stdout: `${HEAD}\n` },
+        "comments-jq": { returncode: 0, stdout: cleanBody(HEAD, 3) },
+      }),
+    );
+    expect(result.via).toBe(VIA_PRIMARY);
+    expect(result.failures.length).toBeGreaterThan(0);
+  });
+
+  it("fallback1 when jq fails", () => {
+    const rest = JSON.stringify([{ user: { login: "greptile-apps[bot]" }, body: cleanBody() }]);
+    const result = computeGateResult(
+      1363,
+      "deftai/directive",
+      installFakeGh({
+        "head-sha": { returncode: 0, stdout: `${HEAD}\n` },
+        "comments-jq": { returncode: 1, stderr: "rate-limited" },
+        "comments-rest": { returncode: 0, stdout: rest },
+      }),
+    );
+    expect(result.via).toBe(VIA_FALLBACK1);
+    expect(result.failures).toEqual([]);
+    expect(result.partialData.primary_error).toBeDefined();
+  });
+
+  it("fallback2 never clean", () => {
+    const result = computeGateResult(
+      1363,
+      "deftai/directive",
+      installFakeGh({
+        "head-sha": { returncode: 0, stdout: `${HEAD}\n` },
+        "comments-jq": { returncode: 1 },
+        "comments-rest": { returncode: 1 },
+        "pr-view-rest": {
+          returncode: 0,
+          stdout: JSON.stringify({
+            state: "open",
+            merged: false,
+            mergeable: true,
+            mergeable_state: "clean",
+            head: { sha: HEAD },
+          }),
+        },
+        "check-runs": {
+          returncode: 0,
+          stdout: JSON.stringify({
+            check_runs: [{ name: "Greptile Review", status: "completed", conclusion: "success" }],
+          }),
+        },
+      }),
+    );
+    expect(result.via).toBe(VIA_FALLBACK2);
+    expect(result.failures.some((f) => f.includes("fallback2 is a coarse signal"))).toBe(true);
+  });
+
+  it("total failure returns via error", () => {
+    const result = computeGateResult(
+      1363,
+      "deftai/directive",
+      installFakeGh({
+        "head-sha": { returncode: 1, stderr: "down" },
+        "pr-view-rest": { returncode: 1, stderr: "down" },
+      }),
+    );
+    expect(result.via).toBe("error");
+    expect(result.error).toBeTruthy();
+    expect(result.partialData.primary_error).toBeDefined();
+  });
+});
+
+describe("constants regex sanity", () => {
+  it("confidence regex is case-insensitive", () => {
+    expect(CONFIDENCE_RE.test("confidence score: 4 / 5")).toBe(true);
+  });
+});

--- a/packages/core/src/pr-merge-readiness/parse.ts
+++ b/packages/core/src/pr-merge-readiness/parse.ts
@@ -1,0 +1,104 @@
+import {
+  CONFIDENCE_RE,
+  GREPTILE_ERRORED_SENTINEL,
+  INFORMAL_CLEAN_SIGNAL_RE,
+  LAST_REVIEWED_RE,
+  P0_BADGE,
+  P1_BADGE,
+  SECTION_RE,
+} from "./constants.js";
+import type { GreptileVerdict } from "./types.js";
+
+export function emptyVerdict(): GreptileVerdict {
+  return {
+    found: false,
+    errored: false,
+    lastReviewedSha: null,
+    confidence: null,
+    p0Count: 0,
+    p1Count: 0,
+    p2Count: 0,
+    informalClean: false,
+    rawBodyExcerpt: "",
+  };
+}
+
+export function isInformalCleanMissingCanonicalFields(
+  verdict: GreptileVerdict,
+  body: string,
+): boolean {
+  if (!verdict.found || verdict.errored) {
+    return false;
+  }
+  if (verdict.lastReviewedSha !== null || verdict.confidence !== null) {
+    return false;
+  }
+  if (verdict.p0Count > 0 || verdict.p1Count > 0) {
+    return false;
+  }
+  return INFORMAL_CLEAN_SIGNAL_RE.test(body);
+}
+
+function countSubstring(body: string, needle: string): number {
+  let count = 0;
+  let idx = 0;
+  let found = body.indexOf(needle, idx);
+  while (found !== -1) {
+    count += 1;
+    idx = found + needle.length;
+    found = body.indexOf(needle, idx);
+  }
+  return count;
+}
+
+/** Parse a Greptile rolling-summary comment body into a structured verdict. */
+export function parseGreptileBody(body: string): GreptileVerdict {
+  if (!body?.trim()) {
+    return emptyVerdict();
+  }
+
+  const errored = body.trim().startsWith(GREPTILE_ERRORED_SENTINEL);
+
+  const shaMatches = [...body.matchAll(LAST_REVIEWED_RE)];
+  const lastReviewedSha =
+    shaMatches.length > 0 ? (shaMatches[shaMatches.length - 1]?.groups?.sha ?? null) : null;
+
+  const confMatch = CONFIDENCE_RE.exec(body);
+  const confidence = confMatch?.groups?.score !== undefined ? Number(confMatch.groups.score) : null;
+
+  let p0Count = countSubstring(body, P0_BADGE);
+  let p1Count = countSubstring(body, P1_BADGE);
+  let p2Count = countSubstring(body, '<img alt="P2"');
+
+  const hasDetailsFormat = body.includes("<details>");
+  if (!hasDetailsFormat && p0Count === 0 && p1Count === 0) {
+    for (const match of body.matchAll(SECTION_RE)) {
+      const sev = (match.groups?.sev ?? "").toUpperCase();
+      const count = Number(match.groups?.count ?? 0);
+      if (sev === "P0") {
+        p0Count = count;
+      } else if (sev === "P1") {
+        p1Count = count;
+      } else if (sev === "P2" && p2Count === 0) {
+        p2Count = count;
+      }
+    }
+  }
+
+  const verdict: GreptileVerdict = {
+    found: true,
+    errored,
+    lastReviewedSha,
+    confidence,
+    p0Count,
+    p1Count,
+    p2Count,
+    informalClean: false,
+    rawBodyExcerpt: body.slice(0, 200),
+  };
+
+  if (isInformalCleanMissingCanonicalFields(verdict, body)) {
+    return { ...verdict, informalClean: true };
+  }
+  return verdict;
+}

--- a/packages/core/src/pr-merge-readiness/types.ts
+++ b/packages/core/src/pr-merge-readiness/types.ts
@@ -1,0 +1,31 @@
+export interface GreptileVerdict {
+  readonly found: boolean;
+  readonly errored: boolean;
+  readonly lastReviewedSha: string | null;
+  readonly confidence: number | null;
+  readonly p0Count: number;
+  readonly p1Count: number;
+  readonly p2Count: number;
+  readonly informalClean: boolean;
+  readonly rawBodyExcerpt: string;
+}
+
+export interface GateResult {
+  readonly prNumber: number;
+  readonly repo: string | null;
+  readonly headSha: string | null;
+  readonly verdict: GreptileVerdict;
+  readonly failures: readonly string[];
+  readonly via: string;
+  readonly partialData: Readonly<Record<string, unknown>>;
+  readonly error: string | null;
+}
+
+export interface RunGhResult {
+  readonly returncode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/** Injectable gh subprocess seam (#1366 / parity harness). */
+export type RunGhFn = (cmd: readonly string[]) => RunGhResult;


### PR DESCRIPTION
## Summary
- Ports `scripts/pr_merge_readiness.py` to `packages/core/src/pr-merge-readiness/` with byte-identical cache-off parity vs the Python oracle (`pr-merge-readiness-parity` harness: 8 scenarios including primary/fallback1/fallback2/error, informal-clean, and non-ASCII UTF-8 bodies).
- Adds CLI verb `packages/cli/src/pr-merge-readiness.ts`; gh capture routes through `execFile` with explicit UTF-8 decoding (structural #1366 fix) and reuses `@deftai/core/scm` binary resolution.
- Module branch coverage: **88.62%** (290 branches, scoped vitest).

## Test plan
- [x] `node packages/cli/dist/pr-merge-readiness-parity.js` — CLEAN (cache-off)
- [x] `pnpm exec vitest run packages/core/src/pr-merge-readiness --coverage` — 88.62% branches
- [x] `TMPDIR=$(mktemp -d) DEFT_SESSION_RITUAL_SKIP=1 task check`

Refs #1530 #1730

Made with [Cursor](https://cursor.com)