### PR TITLE
feat(pr): port pr_wait_mergeable.py cascade composer to TypeScript (#1730)

### DIFF
--- a/packages/cli/src/pr-wait-mergeable-parity.ts
+++ b/packages/cli/src/pr-wait-mergeable-parity.ts
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1730): runs BOTH the Python oracle
+ * (`scripts/pr_wait_mergeable.py`) and the ported TS CLI with a fake `gh`
+ * on PATH (cache-off), then diffs exit codes and byte-identical stdout/stderr.
+ *
+ * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
+ */
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HEAD_SHA = "abc1234567890def1234567890abcdef12345678";
+
+const FAKE_GH_PY = `import json
+import os
+import sys
+
+def classify(cmd):
+    joined = " ".join(cmd)
+    if "closingIssuesReferences" in joined:
+        return "closing-refs"
+    if "nameWithOwner" in joined:
+        return "repo-view"
+    if "headRefOid" in joined:
+        return "head-sha"
+    if "/check-runs" in joined:
+        return "check-runs"
+    if "/pulls/" in joined and "/comments" not in joined:
+        return "pr-view-rest"
+    if "/issues/" in joined and "/comments" in joined and "--jq" in cmd:
+        return "comments-jq"
+    if "/issues/" in joined and "/comments" in joined:
+        return "comments-rest"
+    if "pr" in cmd and "merge" in cmd:
+        return "merge"
+    return "unknown"
+
+responses = json.loads(os.environ.get("DEFT_FAKE_GH_RESPONSES", "{}"))
+label = classify(sys.argv[1:])
+resp = responses.get(label, {"returncode": 1, "stderr": f"unexpected gh call: {label}", "stdout": ""})
+stdout = resp.get("stdout", "")
+stderr = resp.get("stderr", "")
+if stdout:
+    sys.stdout.write(stdout)
+if stderr:
+    sys.stderr.write(stderr)
+sys.exit(int(resp.get("returncode", 0)))
+`;
+
+function cleanJqBody(sha: string = HEAD_SHA, confidence: number = 5): string {
+  return (
+    "## Greptile Summary\n\n" +
+    "No P0 or P1 issues found in this PR.\n\n" +
+    `**Confidence Score: ${confidence}/5**\n\n` +
+    "Last reviewed commit: [chore: small fix]" +
+    `(https://github.com/deftai/directive/commit/${sha})\n`
+  );
+}
+
+function greptileRestPayload(sha: string = HEAD_SHA, confidence: number = 5): string {
+  return JSON.stringify([
+    { user: { login: "greptile-apps[bot]" }, body: cleanJqBody(sha, confidence) },
+    { user: { login: "human-reviewer" }, body: "LGTM" },
+  ]);
+}
+
+function prRestPayload(sha: string = HEAD_SHA, state = "open", merged = false): string {
+  return JSON.stringify({
+    state,
+    merged,
+    mergeable: true,
+    mergeable_state: "clean",
+    head: { sha, ref: "fix/foo" },
+  });
+}
+
+function checkRunsPayload(): string {
+  return JSON.stringify({
+    total_count: 2,
+    check_runs: [
+      { name: "Greptile Review", status: "completed", conclusion: "success" },
+      { name: "CI / build", status: "completed", conclusion: "success" },
+    ],
+  });
+}
+
+function closingRefsPayload(...issueNumbers: number[]): string {
+  return JSON.stringify({
+    closingIssuesReferences: issueNumbers.map((n) => ({
+      number: n,
+      title: `Issue #${n}`,
+      url: `https://example/issues/${n}`,
+    })),
+  });
+}
+
+export interface FakeGhResponses {
+  readonly [label: string]: {
+    readonly returncode: number;
+    readonly stdout?: string;
+    readonly stderr?: string;
+  };
+}
+
+export interface ParityScenario {
+  readonly name: string;
+  readonly argv: readonly string[];
+  readonly responses: FakeGhResponses;
+  readonly stripGhRepo?: boolean;
+}
+
+export interface ScenarioResult {
+  readonly name: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly scenarios: Array<{
+    readonly name: string;
+    readonly exitMismatch: boolean;
+    readonly pythonExit: number;
+    readonly tsExit: number;
+    readonly stdoutMismatch: boolean;
+    readonly stderrMismatch: boolean;
+    readonly pythonStdout: string;
+    readonly tsStdout: string;
+    readonly pythonStderr: string;
+    readonly tsStderr: string;
+  }>;
+}
+
+export const PARITY_SCENARIOS: readonly ParityScenario[] = [
+  {
+    name: "merged-clean-json",
+    argv: ["1370", "--repo", "deftai/directive", "--json", "--cap-minutes", "60"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody() },
+      merge: { returncode: 0, stdout: "merged via squash\n" },
+    },
+  },
+  {
+    name: "merged-clean-human",
+    argv: ["1370", "--repo", "deftai/directive", "--cap-minutes", "60"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody() },
+      merge: { returncode: 0, stdout: "merged via squash\n" },
+    },
+  },
+  {
+    name: "protected-link-json",
+    argv: ["1370", "--repo", "deftai/directive", "--protected", "1119", "--json"],
+    responses: {
+      "closing-refs": { returncode: 0, stdout: closingRefsPayload(1119) },
+    },
+  },
+  {
+    name: "missing-repo-config-error",
+    argv: ["1370", "--json"],
+    responses: {},
+    stripGhRepo: true,
+  },
+  {
+    name: "cap-zero-timeout-json",
+    argv: ["1370", "--repo", "deftai/directive", "--json", "--cap-minutes", "0"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody(HEAD_SHA, 3) },
+    },
+  },
+  {
+    name: "malformed-protected-config-error",
+    argv: ["1370", "--repo", "deftai/directive", "--protected", "\u00b2"],
+    responses: {},
+  },
+  {
+    name: "sibling-merged-json",
+    argv: ["1370", "--repo", "deftai/directive", "--json", "--cap-minutes", "60"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 1, stderr: "primary boom" },
+      "comments-rest": { returncode: 1, stderr: "fallback1 boom" },
+      "pr-view-rest": {
+        returncode: 0,
+        stdout: prRestPayload(HEAD_SHA, "closed", true),
+      },
+      "check-runs": { returncode: 0, stdout: checkRunsPayload() },
+    },
+  },
+  {
+    name: "merge-failed-escalation-json",
+    argv: ["1370", "--repo", "deftai/directive", "--json", "--cap-minutes", "60"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody() },
+      merge: { returncode: 1, stderr: "branch protection refused\n" },
+    },
+  },
+  {
+    name: "protected-clean-then-merged-json",
+    argv: [
+      "1370",
+      "--repo",
+      "deftai/directive",
+      "--protected",
+      "1119,1140",
+      "--json",
+      "--cap-minutes",
+      "60",
+    ],
+    responses: {
+      "closing-refs": { returncode: 0, stdout: closingRefsPayload(701) },
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 0, stdout: cleanJqBody() },
+      merge: { returncode: 0, stdout: "merged via squash\n" },
+    },
+  },
+  {
+    name: "fallback1-clean-then-merged-json",
+    argv: ["1363", "--repo", "deftai/directive", "--json", "--cap-minutes", "60"],
+    responses: {
+      "head-sha": { returncode: 0, stdout: `${HEAD_SHA}\n` },
+      "comments-jq": { returncode: 1, stderr: "decode-crash" },
+      "comments-rest": { returncode: 0, stdout: greptileRestPayload() },
+      merge: { returncode: 0, stdout: "merged via squash\n" },
+    },
+  },
+];
+
+interface Capture {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function installFakeGh(): { binDir: string; cleanup: () => void } {
+  const binDir = mkdtempSync(join(tmpdir(), "deft-pr-wait-mergeable-fake-gh-"));
+  const ghBin = join(binDir, "gh");
+  const ghxBin = join(binDir, "ghx");
+  writeFileSync(ghBin, `#!/usr/bin/env python3\n${FAKE_GH_PY}`, "utf8");
+  writeFileSync(ghxBin, `#!/usr/bin/env python3\n${FAKE_GH_PY}`, "utf8");
+  chmodSync(ghBin, 0o755);
+  chmodSync(ghxBin, 0o755);
+  return {
+    binDir,
+    cleanup: () => {
+      rmSync(binDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function runCapture(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Capture {
+  const result = spawnSync(cmd, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    status: result.status ?? 2,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
+    return resolve(process.env.DEFT_ROOT);
+  }
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+export function normaliseHarnessNoise(text: string): string {
+  return text
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("Using CPython") &&
+        !line.startsWith("Creating virtual environment") &&
+        !line.startsWith("Installed "),
+    )
+    .join("\n");
+}
+
+export function diffParity(
+  python: ScenarioResult,
+  ts: ScenarioResult,
+): {
+  exitMismatch: boolean;
+  stdoutMismatch: boolean;
+  stderrMismatch: boolean;
+} {
+  const pythonStdout = normaliseHarnessNoise(python.stdout);
+  const tsStdout = normaliseHarnessNoise(ts.stdout);
+  const pythonStderr = normaliseHarnessNoise(python.stderr);
+  const tsStderr = normaliseHarnessNoise(ts.stderr);
+  return {
+    exitMismatch: python.exitCode !== ts.exitCode,
+    stdoutMismatch: pythonStdout !== tsStdout,
+    stderrMismatch: pythonStderr !== tsStderr,
+  };
+}
+
+function runScenario(
+  deftRoot: string,
+  scenario: ParityScenario,
+): { python: ScenarioResult; ts: ScenarioResult } {
+  const fake = installFakeGh();
+  try {
+    const pathPrefix = `${fake.binDir}:${process.env.PATH ?? ""}`;
+    const env: Record<string, string> = {
+      DEFT_CACHE_DISABLE: "1",
+      PYTHONUTF8: "1",
+      PATH: pathPrefix,
+      DEFT_FAKE_GH_RESPONSES: JSON.stringify(scenario.responses),
+    };
+    if (scenario.stripGhRepo) {
+      delete env.GH_REPO;
+    }
+    const py = runCapture(
+      "uv",
+      ["run", "python", join(deftRoot, "scripts", "pr_wait_mergeable.py"), ...scenario.argv],
+      deftRoot,
+      env,
+    );
+    const ts = runCapture(
+      "node",
+      [join(deftRoot, "packages", "cli", "dist", "pr-wait-mergeable.js"), ...scenario.argv],
+      deftRoot,
+      env,
+    );
+    return {
+      python: {
+        name: scenario.name,
+        exitCode: py.status,
+        stdout: py.stdout,
+        stderr: py.stderr,
+      },
+      ts: {
+        name: scenario.name,
+        exitCode: ts.status,
+        stdout: ts.stdout,
+        stderr: ts.stderr,
+      },
+    };
+  } finally {
+    fake.cleanup();
+  }
+}
+
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const scenarios: ParityResult["scenarios"] = [];
+  for (const scenario of PARITY_SCENARIOS) {
+    const ran = runScenario(deftRoot, scenario);
+    const diff = diffParity(ran.python, ran.ts);
+    scenarios.push({
+      name: scenario.name,
+      pythonExit: ran.python.exitCode,
+      tsExit: ran.ts.exitCode,
+      pythonStdout: normaliseHarnessNoise(ran.python.stdout),
+      tsStdout: normaliseHarnessNoise(ran.ts.stdout),
+      pythonStderr: normaliseHarnessNoise(ran.python.stderr),
+      tsStderr: normaliseHarnessNoise(ran.ts.stderr),
+      ...diff,
+    });
+  }
+  const ok = scenarios.every((s) => !s.exitMismatch && !s.stdoutMismatch && !s.stderrMismatch);
+  return { ok, scenarios };
+}
+
+export function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `pr_wait_mergeable parity: CLEAN -- Python and TS agree on ${result.scenarios.length} scenario(s).`;
+  }
+  const lines = ["pr_wait_mergeable parity: DIVERGENCE"];
+  for (const s of result.scenarios) {
+    if (s.exitMismatch || s.stdoutMismatch || s.stderrMismatch) {
+      lines.push(`  scenario: ${s.name}`);
+      if (s.exitMismatch) {
+        lines.push(`    exit mismatch: python=${s.pythonExit} ts=${s.tsExit}`);
+      }
+      if (s.stdoutMismatch) {
+        lines.push("    stdout mismatch:");
+        lines.push(`    python (${s.pythonStdout.length} bytes):`);
+        lines.push(s.pythonStdout.slice(0, 500));
+        lines.push(`    ts (${s.tsStdout.length} bytes):`);
+        lines.push(s.tsStdout.slice(0, 500));
+      }
+      if (s.stderrMismatch) {
+        lines.push("    stderr mismatch:");
+        lines.push(`    python (${s.pythonStderr.length} bytes):`);
+        lines.push(s.pythonStderr.slice(0, 500));
+        lines.push(`    ts (${s.tsStderr.length} bytes):`);
+        lines.push(s.tsStderr.slice(0, 500));
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    process.exit(1);
+  } catch (err) {
+    const msg = String(err).replace(/\r?\n/g, " ");
+    process.stderr.write(`pr_wait_mergeable parity: harness error -- ${msg}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/pr-wait-mergeable.ts
+++ b/packages/cli/src/pr-wait-mergeable.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { cmdPrWaitMergeable } from "../../core/dist/pr-wait-mergeable/main.js";
+
+export function run(argv: string[]): number {
+  return cmdPrWaitMergeable(argv);
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/src/pr-wait-mergeable/cascade.test.ts
+++ b/packages/core/src/pr-wait-mergeable/cascade.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { waitMergeableAndMerge } from "./cascade.js";
 import {
   EXIT_CONFIG_ERROR,

--- a/packages/core/src/pr-wait-mergeable/cascade.test.ts
+++ b/packages/core/src/pr-wait-mergeable/cascade.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitMergeableAndMerge } from "./cascade.js";
+import {
+  EXIT_CONFIG_ERROR,
+  EXIT_MERGED,
+  EXIT_TIMEOUT_OR_ESCALATION,
+} from "./constants.js";
+import { toResultDict } from "./result.js";
+import type { MergeFn, MonitorFn, ProtectedCheckFn } from "./types.js";
+
+function makeProtectedFn(returncode: number, stdout = "", stderr = ""): ProtectedCheckFn {
+  const calls: Array<readonly [number, string | null, readonly number[]]> = [];
+  const fn: ProtectedCheckFn = (prNumber, repo, protectedIssues) => {
+    calls.push([prNumber, repo, protectedIssues]);
+    return [returncode, stdout, stderr];
+  };
+  (fn as { calls: typeof calls }).calls = calls;
+  return fn;
+}
+
+function makeMonitorFn(returncode: number, payload: Record<string, unknown> | null, stderr = ""): MonitorFn {
+  const calls: Array<readonly [number, string, number]> = [];
+  const stdout = payload !== null ? JSON.stringify(payload, null, 2) : "";
+  const fn: MonitorFn = (prNumber, repo, capMinutes) => {
+    calls.push([prNumber, repo, capMinutes]);
+    return [returncode, stdout, stderr];
+  };
+  (fn as { calls: typeof calls }).calls = calls;
+  return fn;
+}
+
+function makeMergeFn(returncode: number, stdout = "", stderr = ""): MergeFn {
+  const calls: Array<readonly [number, string | null]> = [];
+  const fn: MergeFn = (prNumber, repo) => {
+    calls.push([prNumber, repo]);
+    return [returncode, stdout, stderr];
+  };
+  (fn as { calls: typeof calls }).calls = calls;
+  return fn;
+}
+
+function cleanMonitorPayload(prNumber = 1370): Record<string, unknown> {
+  return {
+    monitor_result: "CLEAN",
+    polls: 1,
+    readiness: {
+      pr_number: prNumber,
+      repo: "deftai/directive",
+      head_sha: "a".repeat(40),
+      verdict: {
+        found: true,
+        errored: false,
+        last_reviewed_sha: "a".repeat(40),
+        confidence: 5,
+        p0_count: 0,
+        p1_count: 0,
+        p2_count: 0,
+        raw_body_excerpt: "",
+      },
+      failures: [],
+      merge_ready: true,
+      via: "primary",
+    },
+  };
+}
+
+function capReachedPayload(): Record<string, unknown> {
+  return {
+    monitor_result: "CAP-REACHED",
+    polls: 12,
+    readiness: {
+      merge_ready: false,
+      via: "fallback2",
+      failures: ["fallback2 is a coarse signal, not a CLEAN verdict ..."],
+      partial_data: { pr_state: "open", merged: false },
+    },
+  };
+}
+
+function prMergedBySiblingPayload(): Record<string, unknown> {
+  return {
+    monitor_result: "PR-TERMINAL",
+    polls: 3,
+    readiness: {
+      merge_ready: false,
+      via: "fallback2",
+      partial_data: { pr_state: "closed", merged: true },
+    },
+  };
+}
+
+function prClosedPayload(): Record<string, unknown> {
+  return {
+    monitor_result: "PR-TERMINAL",
+    polls: 5,
+    readiness: {
+      merge_ready: false,
+      via: "fallback2",
+      partial_data: { pr_state: "closed", merged: false },
+    },
+  };
+}
+
+describe("waitMergeableAndMerge", () => {
+  it("clean monitor triggers merge and exits zero", () => {
+    const protectedFn = makeProtectedFn(0);
+    const monitorFn = makeMonitorFn(0, cleanMonitorPayload(1370));
+    const mergeFn = makeMergeFn(0, "merged via squash");
+
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn,
+      monitorFn,
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_MERGED);
+    expect(result.outcome).toBe("merged");
+    expect((protectedFn as { calls: unknown[] }).calls).toEqual([]);
+    expect((monitorFn as { calls: unknown[] }).calls).toEqual([[1370, "deftai/directive", 30]]);
+    expect((mergeFn as { calls: unknown[] }).calls).toEqual([[1370, "deftai/directive"]]);
+    expect(result.mergeStdout).toBe("merged via squash");
+  });
+
+  it("protected clean then clean monitor then merge", () => {
+    const protectedFn = makeProtectedFn(0);
+    const monitorFn = makeMonitorFn(0, cleanMonitorPayload(1371));
+    const mergeFn = makeMergeFn(0);
+
+    const result = waitMergeableAndMerge(1371, "deftai/directive", {
+      capMinutes: 15,
+      protected: [1119, 1140],
+      protectedFn,
+      monitorFn,
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_MERGED);
+    expect((protectedFn as { calls: unknown[] }).calls).toEqual([
+      [1371, "deftai/directive", [1119, 1140]],
+    ]);
+    expect((monitorFn as { calls: unknown[] }).calls).toHaveLength(1);
+    expect((mergeFn as { calls: unknown[] }).calls).toHaveLength(1);
+  });
+
+  it("monitor cap reached exits one without merging", () => {
+    const mergeFn = makeMergeFn(0);
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn: makeProtectedFn(0),
+      monitorFn: makeMonitorFn(1, capReachedPayload()),
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_TIMEOUT_OR_ESCALATION);
+    expect(result.outcome).toBe("cap-reached");
+    expect((mergeFn as { calls: unknown[] }).calls).toEqual([]);
+    expect(result.monitorResult.monitor_result).toBe("CAP-REACHED");
+  });
+
+  it("pr closed without merge exits one", () => {
+    const mergeFn = makeMergeFn(0);
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn: makeProtectedFn(0),
+      monitorFn: makeMonitorFn(3, prClosedPayload()),
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_TIMEOUT_OR_ESCALATION);
+    expect(result.outcome).toBe("pr-closed");
+    expect((mergeFn as { calls: unknown[] }).calls).toEqual([]);
+  });
+
+  it("protected link exits one before monitor or merge", () => {
+    const monitorFn = makeMonitorFn(0, cleanMonitorPayload());
+    const mergeFn = makeMergeFn(0);
+    const protectedFn = makeProtectedFn(
+      1,
+      "",
+      "FAIL: PR has persistent links to protected issue(s): #1119",
+    );
+
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [1119],
+      protectedFn,
+      monitorFn,
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_TIMEOUT_OR_ESCALATION);
+    expect(result.outcome).toBe("protected-linked");
+    expect((protectedFn as { calls: unknown[] }).calls).toEqual([[1370, "deftai/directive", [1119]]]);
+    expect((monitorFn as { calls: unknown[] }).calls).toEqual([]);
+    expect((mergeFn as { calls: unknown[] }).calls).toEqual([]);
+    expect(result.error).toContain("closingIssuesReferences");
+    expect(result.protectedCheck.returncode).toBe(1);
+  });
+
+  it("monitor config error propagates to exit two", () => {
+    const mergeFn = makeMergeFn(0);
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn: makeProtectedFn(0),
+      monitorFn: makeMonitorFn(2, { monitor_result: "CONFIG-ERROR" }),
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_CONFIG_ERROR);
+    expect(result.outcome).toBe("config-error");
+    expect((mergeFn as { calls: unknown[] }).calls).toEqual([]);
+  });
+
+  it("protected check external error collapses to config error", () => {
+    const monitorFn = makeMonitorFn(0, cleanMonitorPayload());
+    const mergeFn = makeMergeFn(0);
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [1119],
+      protectedFn: makeProtectedFn(2, "", "Error: gh CLI not found."),
+      monitorFn,
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_CONFIG_ERROR);
+    expect(result.outcome).toBe("config-error");
+    expect((monitorFn as { calls: unknown[] }).calls).toEqual([]);
+    expect((mergeFn as { calls: unknown[] }).calls).toEqual([]);
+  });
+
+  it("gh pr merge failure surfaces as exit one", () => {
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn: makeProtectedFn(0),
+      monitorFn: makeMonitorFn(0, cleanMonitorPayload()),
+      mergeFn: makeMergeFn(1, "", "branch protection refused"),
+    });
+
+    expect(result.exitCode).toBe(EXIT_TIMEOUT_OR_ESCALATION);
+    expect(result.outcome).toBe("merge-failed");
+    expect(result.error).toContain("branch protection");
+  });
+
+  it("pr merged by sibling returns exit zero without error field", () => {
+    const mergeFn = makeMergeFn(0);
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn: makeProtectedFn(0),
+      monitorFn: makeMonitorFn(3, prMergedBySiblingPayload()),
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_MERGED);
+    expect(result.outcome).toBe("merged-by-sibling");
+    expect((mergeFn as { calls: unknown[] }).calls).toEqual([]);
+    expect(result.error).toBeNull();
+    expect(toResultDict(result).error).toBeUndefined();
+  });
+
+  it("gh missing at merge stage exits two", () => {
+    const mergeFn = makeMergeFn(-1, "", "gh CLI not found. Install GitHub CLI.");
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn: makeProtectedFn(0),
+      monitorFn: makeMonitorFn(0, cleanMonitorPayload()),
+      mergeFn,
+    });
+
+    expect(result.exitCode).toBe(EXIT_CONFIG_ERROR);
+    expect(result.outcome).toBe("config-error");
+    expect(result.error).toContain("gh pr merge wrapper failed at OS layer");
+    expect(result.error).toContain("gh CLI not found");
+  });
+
+  it("includes monitor stderr tail in cap-reached error", () => {
+    const result = waitMergeableAndMerge(1370, "deftai/directive", {
+      capMinutes: 30,
+      protected: [],
+      protectedFn: makeProtectedFn(0),
+      monitorFn: makeMonitorFn(1, capReachedPayload(), "poll stderr tail marker"),
+      mergeFn: makeMergeFn(0),
+    });
+
+    expect(result.error).toContain("stderr tail:");
+    expect(result.error).toContain("poll stderr tail marker");
+  });
+});
+
+describe("toResultDict", () => {
+  it("omits empty optional fields", () => {
+    const dict = toResultDict({
+      prNumber: 1,
+      repo: "o/r",
+      outcome: "merged-by-sibling",
+      exitCode: 0,
+      monitorResult: { monitor_result: "PR-TERMINAL" },
+      protectedCheck: {},
+      mergeStdout: "",
+      mergeStderr: "",
+      error: null,
+    });
+    expect(dict.error).toBeUndefined();
+    expect(dict.merge_stdout).toBeUndefined();
+  });
+});

--- a/packages/core/src/pr-wait-mergeable/cascade.test.ts
+++ b/packages/core/src/pr-wait-mergeable/cascade.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { waitMergeableAndMerge } from "./cascade.js";
-import {
-  EXIT_CONFIG_ERROR,
-  EXIT_MERGED,
-  EXIT_TIMEOUT_OR_ESCALATION,
-} from "./constants.js";
+import { EXIT_CONFIG_ERROR, EXIT_MERGED, EXIT_TIMEOUT_OR_ESCALATION } from "./constants.js";
 import { toResultDict } from "./result.js";
 import type { MergeFn, MonitorFn, ProtectedCheckFn } from "./types.js";
 
@@ -18,7 +14,11 @@ function makeProtectedFn(returncode: number, stdout = "", stderr = ""): Protecte
   return fn;
 }
 
-function makeMonitorFn(returncode: number, payload: Record<string, unknown> | null, stderr = ""): MonitorFn {
+function makeMonitorFn(
+  returncode: number,
+  payload: Record<string, unknown> | null,
+  stderr = "",
+): MonitorFn {
   const calls: Array<readonly [number, string, number]> = [];
   const stdout = payload !== null ? JSON.stringify(payload, null, 2) : "";
   const fn: MonitorFn = (prNumber, repo, capMinutes) => {
@@ -194,7 +194,9 @@ describe("waitMergeableAndMerge", () => {
 
     expect(result.exitCode).toBe(EXIT_TIMEOUT_OR_ESCALATION);
     expect(result.outcome).toBe("protected-linked");
-    expect((protectedFn as { calls: unknown[] }).calls).toEqual([[1370, "deftai/directive", [1119]]]);
+    expect((protectedFn as { calls: unknown[] }).calls).toEqual([
+      [1370, "deftai/directive", [1119]],
+    ]);
     expect((monitorFn as { calls: unknown[] }).calls).toEqual([]);
     expect((mergeFn as { calls: unknown[] }).calls).toEqual([]);
     expect(result.error).toContain("closingIssuesReferences");

--- a/packages/core/src/pr-wait-mergeable/cascade.ts
+++ b/packages/core/src/pr-wait-mergeable/cascade.ts
@@ -1,16 +1,7 @@
 import { classifyMonitorOutcome, parseMonitorPayload } from "./classify.js";
-import {
-  EXIT_CONFIG_ERROR,
-  EXIT_MERGED,
-  EXIT_TIMEOUT_OR_ESCALATION,
-} from "./constants.js";
+import { EXIT_CONFIG_ERROR, EXIT_MERGED, EXIT_TIMEOUT_OR_ESCALATION } from "./constants.js";
 import { makeResult } from "./result.js";
-import type {
-  MergeFn,
-  MonitorFn,
-  ProtectedCheckFn,
-  WaitMergeableResult,
-} from "./types.js";
+import type { MergeFn, MonitorFn, ProtectedCheckFn, WaitMergeableResult } from "./types.js";
 import { runGhMerge, runMonitor, runProtectedCheck } from "./wrappers.js";
 
 export interface WaitMergeableOptions {
@@ -66,8 +57,7 @@ export function waitMergeableAndMerge(
         exitCode: EXIT_CONFIG_ERROR,
         protectedCheck: protectedCheckPayload,
         error:
-          `protected-issue check exited ${prcRc} (config error). ` +
-          `stderr: ${prcStderr.trim()}`,
+          `protected-issue check exited ${prcRc} (config error). ` + `stderr: ${prcStderr.trim()}`,
       });
     }
   }

--- a/packages/core/src/pr-wait-mergeable/cascade.ts
+++ b/packages/core/src/pr-wait-mergeable/cascade.ts
@@ -1,0 +1,147 @@
+import { classifyMonitorOutcome, parseMonitorPayload } from "./classify.js";
+import {
+  EXIT_CONFIG_ERROR,
+  EXIT_MERGED,
+  EXIT_TIMEOUT_OR_ESCALATION,
+} from "./constants.js";
+import { makeResult } from "./result.js";
+import type {
+  MergeFn,
+  MonitorFn,
+  ProtectedCheckFn,
+  WaitMergeableResult,
+} from "./types.js";
+import { runGhMerge, runMonitor, runProtectedCheck } from "./wrappers.js";
+
+export interface WaitMergeableOptions {
+  readonly protectedFn?: ProtectedCheckFn;
+  readonly monitorFn?: MonitorFn;
+  readonly mergeFn?: MergeFn;
+}
+
+/** Run protected-check -> wait -> merge cascade (#1369). */
+export function waitMergeableAndMerge(
+  prNumber: number,
+  repo: string,
+  options: {
+    readonly capMinutes: number;
+    readonly protected: readonly number[];
+  } & WaitMergeableOptions,
+): WaitMergeableResult {
+  const protectedFn = options.protectedFn ?? runProtectedCheck;
+  const monitorFn = options.monitorFn ?? runMonitor;
+  const mergeFn = options.mergeFn ?? runGhMerge;
+  const protectedIssues = options.protected;
+
+  let protectedCheckPayload: Record<string, unknown> = {};
+
+  if (protectedIssues.length > 0) {
+    const [prcRc, prcStdout, prcStderr] = protectedFn(prNumber, repo, protectedIssues);
+    protectedCheckPayload = {
+      returncode: prcRc,
+      stdout: prcStdout,
+      stderr: prcStderr,
+      protected: [...protectedIssues],
+    };
+
+    if (prcRc === 1) {
+      return makeResult({
+        prNumber,
+        repo,
+        outcome: "protected-linked",
+        exitCode: EXIT_TIMEOUT_OR_ESCALATION,
+        protectedCheck: protectedCheckPayload,
+        error:
+          "PR has a persistent closingIssuesReferences link to a " +
+          "protected issue (#701). Unlink via the PR's Development " +
+          "sidebar before re-running.",
+      });
+    }
+
+    if (prcRc !== 0) {
+      return makeResult({
+        prNumber,
+        repo,
+        outcome: "config-error",
+        exitCode: EXIT_CONFIG_ERROR,
+        protectedCheck: protectedCheckPayload,
+        error:
+          `protected-issue check exited ${prcRc} (config error). ` +
+          `stderr: ${prcStderr.trim()}`,
+      });
+    }
+  }
+
+  const [monRc, monStdout, monStderr] = monitorFn(prNumber, repo, options.capMinutes);
+  const monitorPayload = parseMonitorPayload(monStdout);
+  const [outcome, monitorExit] = classifyMonitorOutcome(monRc, monitorPayload);
+
+  if (outcome !== "clean") {
+    const errorPayload =
+      monitorExit === EXIT_MERGED
+        ? null
+        : monStderr.trim().length > 0
+          ? `monitor exited ${monRc} (outcome=${outcome}). stderr tail: ${monStderr.trim().slice(-200)}`
+          : `monitor exited ${monRc} (outcome=${outcome})`;
+
+    return makeResult({
+      prNumber,
+      repo,
+      outcome,
+      exitCode: monitorExit,
+      monitorResult: monitorPayload,
+      protectedCheck: protectedCheckPayload,
+      error: errorPayload,
+    });
+  }
+
+  const [mergeRc, mergeStdout, mergeStderr] = mergeFn(prNumber, repo);
+
+  if (mergeRc === 0) {
+    return makeResult({
+      prNumber,
+      repo,
+      outcome: "merged",
+      exitCode: EXIT_MERGED,
+      monitorResult: monitorPayload,
+      protectedCheck: protectedCheckPayload,
+      mergeStdout,
+      mergeStderr,
+      error: null,
+    });
+  }
+
+  if (mergeRc === -1) {
+    const tail = mergeStderr.trim();
+    return makeResult({
+      prNumber,
+      repo,
+      outcome: "config-error",
+      exitCode: EXIT_CONFIG_ERROR,
+      monitorResult: monitorPayload,
+      protectedCheck: protectedCheckPayload,
+      mergeStdout,
+      mergeStderr,
+      error:
+        tail.length > 0
+          ? `gh pr merge wrapper failed at OS layer (rc=-1). stderr: ${tail.slice(-200)}`
+          : "gh pr merge wrapper failed at OS layer (rc=-1).",
+    });
+  }
+
+  const mergeTail = mergeStderr.trim();
+  return makeResult({
+    prNumber,
+    repo,
+    outcome: "merge-failed",
+    exitCode: EXIT_TIMEOUT_OR_ESCALATION,
+    monitorResult: monitorPayload,
+    protectedCheck: protectedCheckPayload,
+    mergeStdout,
+    mergeStderr,
+    error:
+      mergeTail.length > 0
+        ? `gh pr merge exited ${mergeRc}. stderr: ${mergeTail.slice(-200)}`
+        : `gh pr merge exited ${mergeRc}`,
+  });
+}

--- a/packages/core/src/pr-wait-mergeable/classify.test.ts
+++ b/packages/core/src/pr-wait-mergeable/classify.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { classifyMonitorOutcome, parseMonitorPayload } from "./classify.js";
-import {
-  EXIT_CONFIG_ERROR,
-  EXIT_MERGED,
-  EXIT_TIMEOUT_OR_ESCALATION,
-} from "./constants.js";
+import { EXIT_CONFIG_ERROR, EXIT_MERGED, EXIT_TIMEOUT_OR_ESCALATION } from "./constants.js";
 
 describe("parseMonitorPayload", () => {
   it("returns empty object for blank stdout", () => {

--- a/packages/core/src/pr-wait-mergeable/classify.test.ts
+++ b/packages/core/src/pr-wait-mergeable/classify.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { classifyMonitorOutcome, parseMonitorPayload } from "./classify.js";
+import {
+  EXIT_CONFIG_ERROR,
+  EXIT_MERGED,
+  EXIT_TIMEOUT_OR_ESCALATION,
+} from "./constants.js";
+
+describe("parseMonitorPayload", () => {
+  it("returns empty object for blank stdout", () => {
+    expect(parseMonitorPayload("")).toEqual({});
+    expect(parseMonitorPayload("   ")).toEqual({});
+  });
+
+  it("returns empty object for invalid JSON", () => {
+    expect(parseMonitorPayload("not-json")).toEqual({});
+  });
+
+  it("parses dict payload", () => {
+    expect(parseMonitorPayload('{"monitor_result":"CLEAN"}')).toEqual({
+      monitor_result: "CLEAN",
+    });
+  });
+
+  it("returns empty object for non-object JSON", () => {
+    expect(parseMonitorPayload("[1,2]")).toEqual({});
+  });
+});
+
+describe("classifyMonitorOutcome", () => {
+  it("maps clean to exit merged path", () => {
+    expect(classifyMonitorOutcome(0, {})).toEqual(["clean", EXIT_MERGED]);
+  });
+
+  it("maps cap-reached", () => {
+    expect(classifyMonitorOutcome(1, {})).toEqual(["cap-reached", EXIT_TIMEOUT_OR_ESCALATION]);
+  });
+
+  it("maps config error", () => {
+    expect(classifyMonitorOutcome(2, {})).toEqual(["config-error", EXIT_CONFIG_ERROR]);
+  });
+
+  it("maps sibling merged", () => {
+    const payload = {
+      readiness: { partial_data: { merged: true, pr_state: "closed" } },
+    };
+    expect(classifyMonitorOutcome(3, payload)).toEqual(["merged-by-sibling", EXIT_MERGED]);
+  });
+
+  it("maps pr closed without merge", () => {
+    const payload = {
+      readiness: { partial_data: { merged: false, pr_state: "closed" } },
+    };
+    expect(classifyMonitorOutcome(3, payload)).toEqual(["pr-closed", EXIT_TIMEOUT_OR_ESCALATION]);
+  });
+
+  it("maps unknown monitor exit to config error", () => {
+    expect(classifyMonitorOutcome(99, {})).toEqual(["config-error", EXIT_CONFIG_ERROR]);
+  });
+});

--- a/packages/core/src/pr-wait-mergeable/classify.ts
+++ b/packages/core/src/pr-wait-mergeable/classify.ts
@@ -1,0 +1,52 @@
+import { EXIT_CONFIG_ERROR, EXIT_MERGED, EXIT_TIMEOUT_OR_ESCALATION } from "./constants.js";
+
+/** Map monitor_pr exit code onto helper outcome + exit code. */
+export function classifyMonitorOutcome(
+  monitorReturncode: number,
+  monitorPayload: Record<string, unknown>,
+): readonly [string, number] {
+  if (monitorReturncode === 0) {
+    return ["clean", EXIT_MERGED] as const;
+  }
+  if (monitorReturncode === 1) {
+    return ["cap-reached", EXIT_TIMEOUT_OR_ESCALATION] as const;
+  }
+  if (monitorReturncode === 2) {
+    return ["config-error", EXIT_CONFIG_ERROR] as const;
+  }
+  if (monitorReturncode === 3) {
+    const readiness =
+      typeof monitorPayload.readiness === "object" &&
+      monitorPayload.readiness !== null &&
+      !Array.isArray(monitorPayload.readiness)
+        ? (monitorPayload.readiness as Record<string, unknown>)
+        : {};
+    const partial =
+      typeof readiness.partial_data === "object" &&
+      readiness.partial_data !== null &&
+      !Array.isArray(readiness.partial_data)
+        ? (readiness.partial_data as Record<string, unknown>)
+        : {};
+    if (partial.merged === true) {
+      return ["merged-by-sibling", EXIT_MERGED] as const;
+    }
+    return ["pr-closed", EXIT_TIMEOUT_OR_ESCALATION] as const;
+  }
+  return ["config-error", EXIT_CONFIG_ERROR] as const;
+}
+
+/** Parse the monitor's --json envelope. Returns {} on failure. */
+export function parseMonitorPayload(stdout: string): Record<string, unknown> {
+  if (stdout.trim().length === 0) {
+    return {};
+  }
+  try {
+    const payload = JSON.parse(stdout) as unknown;
+    if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
+      return payload as Record<string, unknown>;
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}

--- a/packages/core/src/pr-wait-mergeable/constants.ts
+++ b/packages/core/src/pr-wait-mergeable/constants.ts
@@ -1,0 +1,4 @@
+/** Three-state exit codes — mirrors scripts/pr_wait_mergeable.py. */
+export const EXIT_MERGED = 0;
+export const EXIT_TIMEOUT_OR_ESCALATION = 1;
+export const EXIT_CONFIG_ERROR = 2;

--- a/packages/core/src/pr-wait-mergeable/coverage-boost.test.ts
+++ b/packages/core/src/pr-wait-mergeable/coverage-boost.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitMergeableAndMerge } from "./cascade.js";
+import { classifyMonitorOutcome } from "./classify.js";
+import { EXIT_CONFIG_ERROR } from "./constants.js";
+import { parseWaitMergeableArgs, runWaitMergeable } from "./main.js";
+import { makeResult, toResultDict } from "./result.js";
+import type { MonitorFn } from "./types.js";
+
+describe("coverage boost", () => {
+  it("parseWaitMergeableArgs handles flag errors", () => {
+    expect(parseWaitMergeableArgs(["1370", "--repo"]).error).toContain("--repo");
+    expect(parseWaitMergeableArgs(["1370", "--cap-minutes"]).error).toContain("--cap-minutes");
+    expect(parseWaitMergeableArgs(["1370", "--protected"]).error).toContain("--protected");
+    expect(parseWaitMergeableArgs(["1370", "--repo", "o/r", "--nope"]).error).toContain(
+      "unrecognized",
+    );
+    expect(parseWaitMergeableArgs(["1370", "--repo", "o/r", "extra"]).error).toContain(
+      "unrecognized",
+    );
+    expect(parseWaitMergeableArgs(["abc", "--repo", "o/r"]).error).toContain("invalid PR");
+    expect(parseWaitMergeableArgs(["1370", "--cap-minutes=bad"]).error).toContain(
+      "invalid --cap-minutes",
+    );
+    expect(parseWaitMergeableArgs(["1370", "--repo=o/r", "--protected=1"]).prNumber).toBe(1370);
+  });
+
+  it("classifyMonitorOutcome handles malformed readiness", () => {
+    expect(classifyMonitorOutcome(3, { readiness: "bad" })[0]).toBe("pr-closed");
+    expect(classifyMonitorOutcome(3, { readiness: { partial_data: "bad" } })[0]).toBe("pr-closed");
+  });
+
+  it("monitor error without stderr uses short message", () => {
+    const monitorFn: MonitorFn = () => [1, JSON.stringify({ monitor_result: "CAP-REACHED" }), ""];
+    const result = waitMergeableAndMerge(1, "o/r", {
+      capMinutes: 1,
+      protected: [],
+      monitorFn,
+    });
+    expect(result.error).toBe("monitor exited 1 (outcome=cap-reached)");
+  });
+
+  it("merge failure without stderr uses short message", () => {
+    const result = waitMergeableAndMerge(1, "o/r", {
+      capMinutes: 1,
+      protected: [],
+      monitorFn: () => [
+        0,
+        JSON.stringify({
+          monitor_result: "CLEAN",
+          readiness: { merge_ready: true, via: "primary" },
+        }),
+        "",
+      ],
+      mergeFn: () => [2, "", ""],
+    });
+    expect(result.error).toBe("gh pr merge exited 2");
+  });
+
+  it("merge rc -1 without stderr uses default config error", () => {
+    const result = waitMergeableAndMerge(1, "o/r", {
+      capMinutes: 1,
+      protected: [],
+      monitorFn: () => [
+        0,
+        JSON.stringify({
+          monitor_result: "CLEAN",
+          readiness: { merge_ready: true, via: "primary" },
+        }),
+        "",
+      ],
+      mergeFn: () => [-1, "", ""],
+    });
+    expect(result.error).toBe("gh pr merge wrapper failed at OS layer (rc=-1).");
+  });
+
+  it("toResultDict includes merge_stderr when set", () => {
+    const dict = toResultDict(
+      makeResult({
+        prNumber: 1,
+        repo: "o/r",
+        outcome: "merged",
+        exitCode: 0,
+        mergeStderr: "warn",
+        error: null,
+      }),
+    );
+    expect(dict.merge_stderr).toBe("warn");
+  });
+
+  it("human output includes merge stdout lines", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    runWaitMergeable(["1", "--repo", "o/r"], {
+      monitorFn: () => [
+        0,
+        JSON.stringify({
+          monitor_result: "CLEAN",
+          readiness: { merge_ready: true, via: "primary" },
+        }),
+        "",
+      ],
+      mergeFn: () => [0, "line1\nline2", ""],
+    });
+    const out = String(stdout.mock.calls.map((c) => c[0]).join(""));
+    expect(out).toContain("merge stdout:");
+    expect(out).toContain("line1");
+    stdout.mockRestore();
+    stderr.mockRestore();
+  });
+
+  it("parse error from argv maps to config exit", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(runWaitMergeable(["1", "--repo", "o/r", "--cap-minutes", "nope"])).toBe(
+      EXIT_CONFIG_ERROR,
+    );
+    stderr.mockRestore();
+  });
+
+  it("toResultDict includes protected_check and merge_stdout", () => {
+    const dict = toResultDict(
+      makeResult({
+        prNumber: 1,
+        repo: "o/r",
+        outcome: "merged",
+        exitCode: 0,
+        protectedCheck: { returncode: 0 },
+        mergeStdout: "done",
+        error: null,
+      }),
+    );
+    expect(dict.protected_check).toEqual({ returncode: 0 });
+    expect(dict.merge_stdout).toBe("done");
+  });
+});

--- a/packages/core/src/pr-wait-mergeable/index.ts
+++ b/packages/core/src/pr-wait-mergeable/index.ts
@@ -1,0 +1,22 @@
+export {
+  EXIT_CONFIG_ERROR,
+  EXIT_MERGED,
+  EXIT_TIMEOUT_OR_ESCALATION,
+} from "./constants.js";
+export { classifyMonitorOutcome, parseMonitorPayload } from "./classify.js";
+export { waitMergeableAndMerge } from "./cascade.js";
+export { cmdPrWaitMergeable, parseWaitMergeableArgs, runWaitMergeable } from "./main.js";
+export { makeResult, toResultDict } from "./result.js";
+export type {
+  MergeFn,
+  MonitorFn,
+  ProtectedCheckFn,
+  SubprocessTriple,
+  WaitMergeableResult,
+} from "./types.js";
+export {
+  captureExec,
+  runGhMerge,
+  runMonitor,
+  runProtectedCheck,
+} from "./wrappers.js";

--- a/packages/core/src/pr-wait-mergeable/index.ts
+++ b/packages/core/src/pr-wait-mergeable/index.ts
@@ -1,10 +1,10 @@
+export { waitMergeableAndMerge } from "./cascade.js";
+export { classifyMonitorOutcome, parseMonitorPayload } from "./classify.js";
 export {
   EXIT_CONFIG_ERROR,
   EXIT_MERGED,
   EXIT_TIMEOUT_OR_ESCALATION,
 } from "./constants.js";
-export { classifyMonitorOutcome, parseMonitorPayload } from "./classify.js";
-export { waitMergeableAndMerge } from "./cascade.js";
 export { cmdPrWaitMergeable, parseWaitMergeableArgs, runWaitMergeable } from "./main.js";
 export { makeResult, toResultDict } from "./result.js";
 export type {

--- a/packages/core/src/pr-wait-mergeable/main.test.ts
+++ b/packages/core/src/pr-wait-mergeable/main.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { cmdPrWaitMergeable, parseWaitMergeableArgs, runWaitMergeable } from "./main.js";
+import {
+  EXIT_CONFIG_ERROR,
+  EXIT_MERGED,
+} from "./constants.js";
+import type { MergeFn, MonitorFn, ProtectedCheckFn } from "./types.js";
+
+function cleanMonitorPayload(prNumber = 1370): Record<string, unknown> {
+  return {
+    monitor_result: "CLEAN",
+    polls: 1,
+    readiness: { merge_ready: true, via: "primary", pr_number: prNumber },
+  };
+}
+
+function makeProtectedFn(returncode: number): ProtectedCheckFn {
+  return () => [returncode, "", ""];
+}
+
+function makeMonitorFn(returncode: number, payload: Record<string, unknown>): MonitorFn {
+  return () => [returncode, JSON.stringify(payload, null, 2), ""];
+}
+
+function makeMergeFn(returncode: number, stdout = ""): MergeFn {
+  return () => [returncode, stdout, ""];
+}
+
+describe("parseWaitMergeableArgs", () => {
+  it("parses minimal argv", () => {
+    expect(parseWaitMergeableArgs(["1370", "--repo", "deftai/directive"])).toEqual({
+      prNumber: 1370,
+      repo: "deftai/directive",
+      capMinutes: 60,
+      protectedValues: [],
+      emitJson: false,
+    });
+  });
+
+  it("parses protected flags and json", () => {
+    expect(
+      parseWaitMergeableArgs([
+        "1370",
+        "--repo",
+        "deftai/directive",
+        "--protected",
+        "1119,1140",
+        "--cap-minutes",
+        "5",
+        "--json",
+      ]),
+    ).toMatchObject({
+      prNumber: 1370,
+      capMinutes: 5,
+      protectedValues: ["1119,1140"],
+      emitJson: true,
+    });
+  });
+
+  it("requires pr number", () => {
+    expect(parseWaitMergeableArgs([]).error).toContain("pr_number");
+  });
+});
+
+describe("runWaitMergeable", () => {
+  it("main without repo exits two", () => {
+    const prev = process.env.GH_REPO;
+    delete process.env.GH_REPO;
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    expect(runWaitMergeable(["1370"])).toBe(EXIT_CONFIG_ERROR);
+    expect(stderr.mock.calls[0]?.[0]).toContain("--repo");
+    stderr.mockRestore();
+    stdout.mockRestore();
+    if (prev !== undefined) process.env.GH_REPO = prev;
+  });
+
+  it("malformed protected token exits two", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    expect(
+      runWaitMergeable(["1370", "--repo", "deftai/directive", "--protected", "\u00b2"]),
+    ).toBe(EXIT_CONFIG_ERROR);
+    expect(stderr.mock.calls[0]?.[0]).toContain("Invalid protected issue token");
+    stderr.mockRestore();
+    stdout.mockRestore();
+  });
+
+  it("emits json envelope on clean then merged", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const code = runWaitMergeable(
+      ["1370", "--repo", "deftai/directive", "--cap-minutes", "5", "--json"],
+      {
+        protectedFn: makeProtectedFn(0),
+        monitorFn: makeMonitorFn(0, cleanMonitorPayload(1370)),
+        mergeFn: makeMergeFn(0, "merged: squash"),
+      },
+    );
+
+    expect(code).toBe(EXIT_MERGED);
+    const out = String(stdout.mock.calls[0]?.[0] ?? "");
+    const payload = JSON.parse(out) as Record<string, unknown>;
+    expect(payload.pr_number).toBe(1370);
+    expect(payload.outcome).toBe("merged");
+    expect(payload.exit_code).toBe(0);
+    expect(payload.merge_stdout).toBe("merged: squash");
+    stdout.mockRestore();
+    stderr.mockRestore();
+  });
+
+  it("cmdPrWaitMergeable delegates to runWaitMergeable", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    expect(cmdPrWaitMergeable(["1370"])).toBe(EXIT_CONFIG_ERROR);
+    stderr.mockRestore();
+    stdout.mockRestore();
+  });
+});

--- a/packages/core/src/pr-wait-mergeable/main.test.ts
+++ b/packages/core/src/pr-wait-mergeable/main.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { EXIT_CONFIG_ERROR, EXIT_MERGED } from "./constants.js";
 import { cmdPrWaitMergeable, parseWaitMergeableArgs, runWaitMergeable } from "./main.js";
-import {
-  EXIT_CONFIG_ERROR,
-  EXIT_MERGED,
-} from "./constants.js";
 import type { MergeFn, MonitorFn, ProtectedCheckFn } from "./types.js";
 
 function cleanMonitorPayload(prNumber = 1370): Record<string, unknown> {
@@ -78,9 +75,9 @@ describe("runWaitMergeable", () => {
   it("malformed protected token exits two", () => {
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    expect(
-      runWaitMergeable(["1370", "--repo", "deftai/directive", "--protected", "\u00b2"]),
-    ).toBe(EXIT_CONFIG_ERROR);
+    expect(runWaitMergeable(["1370", "--repo", "deftai/directive", "--protected", "\u00b2"])).toBe(
+      EXIT_CONFIG_ERROR,
+    );
     expect(stderr.mock.calls[0]?.[0]).toContain("Invalid protected issue token");
     stderr.mockRestore();
     stdout.mockRestore();

--- a/packages/core/src/pr-wait-mergeable/main.ts
+++ b/packages/core/src/pr-wait-mergeable/main.ts
@@ -1,0 +1,242 @@
+import { parseProtected } from "../pr-protected-issues/parse.js";
+import { waitMergeableAndMerge } from "./cascade.js";
+import {
+  EXIT_CONFIG_ERROR,
+  EXIT_MERGED,
+  EXIT_TIMEOUT_OR_ESCALATION,
+} from "./constants.js";
+import { toResultDict } from "./result.js";
+
+/** Match Python json.dumps(..., indent=2) default ensure_ascii=True. */
+function pythonJsonDumps(value: unknown): string {
+  const json = JSON.stringify(value, null, 2);
+  return json.replace(/[\u007f-\uffff]/g, (ch) => {
+    const code = ch.charCodeAt(0);
+    return `\\u${code.toString(16).padStart(4, "0")}`;
+  });
+}
+
+export interface ParsedWaitMergeableArgs {
+  readonly prNumber: number | null;
+  readonly repo: string | null;
+  readonly capMinutes: number;
+  readonly protectedValues: readonly string[];
+  readonly emitJson: boolean;
+  readonly error?: string;
+}
+
+export function parseWaitMergeableArgs(argv: readonly string[]): ParsedWaitMergeableArgs {
+  let prNumber: number | null = null;
+  let repo: string | null = null;
+  let capMinutes = 60;
+  const protectedValues: string[] = [];
+  let emitJson = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      emitJson = true;
+    } else if (arg === "--repo") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return {
+          prNumber,
+          repo,
+          capMinutes,
+          protectedValues,
+          emitJson,
+          error: "argument --repo: expected one argument",
+        };
+      }
+      repo = value;
+      i += 1;
+    } else if (arg?.startsWith("--repo=")) {
+      repo = arg.slice("--repo=".length);
+    } else if (arg === "--cap-minutes") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return {
+          prNumber,
+          repo,
+          capMinutes,
+          protectedValues,
+          emitJson,
+          error: "argument --cap-minutes: expected one argument",
+        };
+      }
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed)) {
+        return {
+          prNumber,
+          repo,
+          capMinutes,
+          protectedValues,
+          emitJson,
+          error: `invalid --cap-minutes value: ${value}`,
+        };
+      }
+      capMinutes = parsed;
+      i += 1;
+    } else if (arg?.startsWith("--cap-minutes=")) {
+      const value = arg.slice("--cap-minutes=".length);
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed)) {
+        return {
+          prNumber,
+          repo,
+          capMinutes,
+          protectedValues,
+          emitJson,
+          error: `invalid --cap-minutes value: ${value}`,
+        };
+      }
+      capMinutes = parsed;
+    } else if (arg === "--protected") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return {
+          prNumber,
+          repo,
+          capMinutes,
+          protectedValues,
+          emitJson,
+          error: "argument --protected: expected one argument",
+        };
+      }
+      protectedValues.push(value);
+      i += 1;
+    } else if (arg?.startsWith("--protected=")) {
+      protectedValues.push(arg.slice("--protected=".length));
+    } else if (arg?.startsWith("-")) {
+      return {
+        prNumber,
+        repo,
+        capMinutes,
+        protectedValues,
+        emitJson,
+        error: `unrecognized arguments: ${arg}`,
+      };
+    } else if (prNumber === null) {
+      const n = Number(arg);
+      if (!Number.isInteger(n)) {
+        return {
+          prNumber,
+          repo,
+          capMinutes,
+          protectedValues,
+          emitJson,
+          error: `invalid PR number: ${arg}`,
+        };
+      }
+      prNumber = n;
+    } else {
+      return {
+        prNumber,
+        repo,
+        capMinutes,
+        protectedValues,
+        emitJson,
+        error: `unrecognized arguments: ${arg}`,
+      };
+    }
+  }
+
+  if (prNumber === null) {
+    return {
+      prNumber,
+      repo,
+      capMinutes,
+      protectedValues,
+      emitJson,
+      error: "the following arguments are required: pr_number",
+    };
+  }
+
+  return { prNumber, repo, capMinutes, protectedValues, emitJson };
+}
+
+function summaryLabelForExit(exitCode: number): string {
+  switch (exitCode) {
+    case EXIT_MERGED:
+      return "MERGED";
+    case EXIT_TIMEOUT_OR_ESCALATION:
+      return "TIMEOUT-OR-ESCALATION";
+    case EXIT_CONFIG_ERROR:
+      return "CONFIG-ERROR";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export interface RunWaitMergeableOptions {
+  readonly protectedFn?: Parameters<typeof waitMergeableAndMerge>[2]["protectedFn"];
+  readonly monitorFn?: Parameters<typeof waitMergeableAndMerge>[2]["monitorFn"];
+  readonly mergeFn?: Parameters<typeof waitMergeableAndMerge>[2]["mergeFn"];
+}
+
+export function runWaitMergeable(
+  argv: readonly string[],
+  options: RunWaitMergeableOptions = {},
+): number {
+  const args = parseWaitMergeableArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`Error: ${args.error}\n`);
+    return EXIT_CONFIG_ERROR;
+  }
+
+  const repo = args.repo ?? process.env.GH_REPO ?? null;
+  if (repo === null || repo.length === 0) {
+    process.stderr.write("Error: --repo OWNER/REPO is required (or set $GH_REPO).\n");
+    return EXIT_CONFIG_ERROR;
+  }
+
+  let protectedIssues: number[];
+  try {
+    protectedIssues = parseProtected(args.protectedValues);
+  } catch (exc: unknown) {
+    const message = exc instanceof Error ? exc.message : String(exc);
+    process.stderr.write(`Error: ${message}\n`);
+    return EXIT_CONFIG_ERROR;
+  }
+
+  const result = waitMergeableAndMerge(args.prNumber as number, repo, {
+    capMinutes: args.capMinutes,
+    protected: protectedIssues,
+    protectedFn: options.protectedFn,
+    monitorFn: options.monitorFn,
+    mergeFn: options.mergeFn,
+  });
+
+  const summaryLabel = summaryLabelForExit(result.exitCode);
+  process.stderr.write(
+    `[pr_wait_mergeable] PR #${result.prNumber} repo=${result.repo} ` +
+      `result=${summaryLabel} outcome=${result.outcome}\n`,
+  );
+
+  if (args.emitJson) {
+    process.stdout.write(`${pythonJsonDumps(toResultDict(result))}\n`);
+  } else {
+    const lines: string[] = [];
+    lines.push(`PR #${result.prNumber} wait-mergeable-and-merge result: ${summaryLabel}`);
+    lines.push(`  outcome: ${result.outcome}`);
+    if (result.error !== null) {
+      lines.push(`  error:   ${result.error}`);
+    }
+    if (result.mergeStdout.trim().length > 0) {
+      lines.push("  merge stdout:");
+      for (const line of result.mergeStdout.trim().split("\n")) {
+        lines.push(`    ${line}`);
+      }
+    }
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+
+  return result.exitCode;
+}
+
+export function cmdPrWaitMergeable(
+  argv: readonly string[],
+  options: RunWaitMergeableOptions = {},
+): number {
+  return runWaitMergeable(argv, options);
+}

--- a/packages/core/src/pr-wait-mergeable/main.ts
+++ b/packages/core/src/pr-wait-mergeable/main.ts
@@ -1,10 +1,6 @@
 import { parseProtected } from "../pr-protected-issues/parse.js";
 import { waitMergeableAndMerge } from "./cascade.js";
-import {
-  EXIT_CONFIG_ERROR,
-  EXIT_MERGED,
-  EXIT_TIMEOUT_OR_ESCALATION,
-} from "./constants.js";
+import { EXIT_CONFIG_ERROR, EXIT_MERGED, EXIT_TIMEOUT_OR_ESCALATION } from "./constants.js";
 import { toResultDict } from "./result.js";
 
 /** Match Python json.dumps(..., indent=2) default ensure_ascii=True. */

--- a/packages/core/src/pr-wait-mergeable/result.ts
+++ b/packages/core/src/pr-wait-mergeable/result.ts
@@ -26,7 +26,10 @@ export function toResultDict(result: WaitMergeableResult): Record<string, unknow
 }
 
 export function makeResult(
-  fields: Omit<WaitMergeableResult, "monitorResult" | "protectedCheck" | "mergeStdout" | "mergeStderr"> & {
+  fields: Omit<
+    WaitMergeableResult,
+    "monitorResult" | "protectedCheck" | "mergeStdout" | "mergeStderr"
+  > & {
     readonly monitorResult?: Record<string, unknown>;
     readonly protectedCheck?: Record<string, unknown>;
     readonly mergeStdout?: string;

--- a/packages/core/src/pr-wait-mergeable/result.ts
+++ b/packages/core/src/pr-wait-mergeable/result.ts
@@ -1,0 +1,47 @@
+import type { WaitMergeableResult } from "./types.js";
+
+export function toResultDict(result: WaitMergeableResult): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    pr_number: result.prNumber,
+    repo: result.repo,
+    outcome: result.outcome,
+    exit_code: result.exitCode,
+  };
+  if (Object.keys(result.monitorResult).length > 0) {
+    payload.monitor_result = result.monitorResult;
+  }
+  if (Object.keys(result.protectedCheck).length > 0) {
+    payload.protected_check = result.protectedCheck;
+  }
+  if (result.mergeStdout.length > 0) {
+    payload.merge_stdout = result.mergeStdout;
+  }
+  if (result.mergeStderr.length > 0) {
+    payload.merge_stderr = result.mergeStderr;
+  }
+  if (result.error !== null) {
+    payload.error = result.error;
+  }
+  return payload;
+}
+
+export function makeResult(
+  fields: Omit<WaitMergeableResult, "monitorResult" | "protectedCheck" | "mergeStdout" | "mergeStderr"> & {
+    readonly monitorResult?: Record<string, unknown>;
+    readonly protectedCheck?: Record<string, unknown>;
+    readonly mergeStdout?: string;
+    readonly mergeStderr?: string;
+  },
+): WaitMergeableResult {
+  return {
+    monitorResult: fields.monitorResult ?? {},
+    protectedCheck: fields.protectedCheck ?? {},
+    mergeStdout: fields.mergeStdout ?? "",
+    mergeStderr: fields.mergeStderr ?? "",
+    prNumber: fields.prNumber,
+    repo: fields.repo,
+    outcome: fields.outcome,
+    exitCode: fields.exitCode,
+    error: fields.error,
+  };
+}

--- a/packages/core/src/pr-wait-mergeable/types.ts
+++ b/packages/core/src/pr-wait-mergeable/types.ts
@@ -18,10 +18,6 @@ export type ProtectedCheckFn = (
   protectedIssues: readonly number[],
 ) => SubprocessTriple;
 
-export type MonitorFn = (
-  prNumber: number,
-  repo: string,
-  capMinutes: number,
-) => SubprocessTriple;
+export type MonitorFn = (prNumber: number, repo: string, capMinutes: number) => SubprocessTriple;
 
 export type MergeFn = (prNumber: number, repo: string | null) => SubprocessTriple;

--- a/packages/core/src/pr-wait-mergeable/types.ts
+++ b/packages/core/src/pr-wait-mergeable/types.ts
@@ -1,0 +1,27 @@
+export interface WaitMergeableResult {
+  readonly prNumber: number;
+  readonly repo: string | null;
+  readonly outcome: string;
+  readonly exitCode: number;
+  readonly monitorResult: Record<string, unknown>;
+  readonly protectedCheck: Record<string, unknown>;
+  readonly mergeStdout: string;
+  readonly mergeStderr: string;
+  readonly error: string | null;
+}
+
+export type SubprocessTriple = readonly [number, string, string];
+
+export type ProtectedCheckFn = (
+  prNumber: number,
+  repo: string | null,
+  protectedIssues: readonly number[],
+) => SubprocessTriple;
+
+export type MonitorFn = (
+  prNumber: number,
+  repo: string,
+  capMinutes: number,
+) => SubprocessTriple;
+
+export type MergeFn = (prNumber: number, repo: string | null) => SubprocessTriple;

--- a/packages/core/src/pr-wait-mergeable/wrappers.test.ts
+++ b/packages/core/src/pr-wait-mergeable/wrappers.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import * as binary from "../scm/binary.js";
+import * as wrappers from "./wrappers.js";
+
+describe("captureExec", () => {
+  it("returns stdout on success", () => {
+    const result = wrappers.captureExec(process.execPath, ["-e", "process.stdout.write('ok')"], 5000);
+    expect(result.returncode).toBe(0);
+    expect(result.stdout).toBe("ok");
+  });
+
+  it("returns non-zero exit with captured streams", () => {
+    const result = wrappers.captureExec(
+      process.execPath,
+      ["-e", "process.stderr.write('boom'); process.exit(3)"],
+      5000,
+    );
+    expect(result.returncode).toBe(3);
+    expect(result.stderr).toBe("boom");
+  });
+
+  it("maps ENOENT to -1", () => {
+    const result = wrappers.captureExec("/nonexistent/binary-xyz", [], 1000);
+    expect(result.returncode).toBe(-1);
+    expect(result.stderr).toContain("executable not found");
+  });
+
+  it("maps ETIMEDOUT to -1", () => {
+    const result = wrappers.captureExec(process.execPath, ["-e", "setTimeout(()=>{}, 5000)"], 1);
+    expect(result.returncode).toBe(-1);
+    expect(result.stderr).toContain("timed out after");
+  });
+});
+
+describe("runGhMerge", () => {
+  it("returns -1 when gh missing", () => {
+    vi.spyOn(binary, "resolveBinary").mockImplementation(() => {
+      throw new Error("missing");
+    });
+    const [rc, , stderr] = wrappers.runGhMerge(1370, "deftai/directive");
+    expect(rc).toBe(-1);
+    expect(stderr).toContain("gh CLI not found");
+    vi.restoreAllMocks();
+  });
+
+  it("maps merge failure exit code", () => {
+    vi.spyOn(binary, "resolveBinary").mockReturnValue(process.execPath);
+    const [rc] = wrappers.runGhMerge(1370, "deftai/directive");
+    expect(rc).not.toBe(0);
+    vi.restoreAllMocks();
+  });
+
+  it("maps gh merge timeout via captureExec", () => {
+    vi.spyOn(binary, "resolveBinary").mockReturnValue(process.execPath);
+    const [rc, , stderr] = wrappers.runGhMerge(1370, null, { timeout: 0.001 });
+    expect(rc).toBe(-1);
+    expect(stderr).toContain("gh pr merge timed out after 0.001s");
+    vi.restoreAllMocks();
+  });
+
+  it("omits repo flag when null", () => {
+    vi.spyOn(binary, "resolveBinary").mockReturnValue(process.execPath);
+    const [rc] = wrappers.runGhMerge(1370, null);
+    expect(typeof rc).toBe("number");
+    vi.restoreAllMocks();
+  });
+});
+
+describe("runProtectedCheck", () => {
+  it("invokes protected cli and returns triple", () => {
+    const [rc] = wrappers.runProtectedCheck(1370, "deftai/directive", [1119]);
+    expect(typeof rc).toBe("number");
+  });
+
+  it("uses custom node executable path", () => {
+    const [rc, , stderr] = wrappers.runProtectedCheck(1370, null, [1119], {
+      nodeExecutable: "/nonexistent/node-binary",
+      timeout: 1,
+    });
+    expect(rc).toBe(-1);
+    expect(stderr).toContain("executable not found");
+  });
+});
+
+describe("runMonitor", () => {
+  it("invokes monitor cli and returns triple", () => {
+    const [rc, stdout] = wrappers.runMonitor(1370, "deftai/directive", 0);
+    expect(typeof rc).toBe("number");
+    expect(typeof stdout).toBe("string");
+  });
+
+  it("uses custom node executable path", () => {
+    const [rc, , stderr] = wrappers.runMonitor(1370, "deftai/directive", 0, {
+      nodeExecutable: "/nonexistent/node-binary",
+    });
+    expect(rc).toBe(-1);
+    expect(stderr).toContain("executable not found");
+  });
+});

--- a/packages/core/src/pr-wait-mergeable/wrappers.test.ts
+++ b/packages/core/src/pr-wait-mergeable/wrappers.test.ts
@@ -4,7 +4,11 @@ import * as wrappers from "./wrappers.js";
 
 describe("captureExec", () => {
   it("returns stdout on success", () => {
-    const result = wrappers.captureExec(process.execPath, ["-e", "process.stdout.write('ok')"], 5000);
+    const result = wrappers.captureExec(
+      process.execPath,
+      ["-e", "process.stdout.write('ok')"],
+      5000,
+    );
     expect(result.returncode).toBe(0);
     expect(result.stdout).toBe("ok");
   });

--- a/packages/core/src/pr-wait-mergeable/wrappers.ts
+++ b/packages/core/src/pr-wait-mergeable/wrappers.ts
@@ -129,14 +129,7 @@ export function runGhMerge(
   } catch {
     return [-1, "", "gh CLI not found. Install GitHub CLI."];
   }
-  const args = [
-    "pr",
-    "merge",
-    String(prNumber),
-    "--squash",
-    "--delete-branch",
-    "--admin",
-  ];
+  const args = ["pr", "merge", String(prNumber), "--squash", "--delete-branch", "--admin"];
   if (repo) {
     args.push("--repo", repo);
   }

--- a/packages/core/src/pr-wait-mergeable/wrappers.ts
+++ b/packages/core/src/pr-wait-mergeable/wrappers.ts
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveBinary } from "../scm/binary.js";
+import type { SubprocessTriple } from "./types.js";
+
+export interface CaptureExecResult {
+  readonly returncode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/** UTF-8-safe subprocess capture via spawnSync (no shell) — mirrors #1366. */
+export function captureExec(
+  executable: string,
+  args: readonly string[],
+  timeoutMs: number,
+): CaptureExecResult {
+  const result = spawnSync(executable, args, {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 10 * 1024 * 1024,
+    env: process.env,
+  });
+
+  if (result.error !== undefined) {
+    const code = (result.error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        returncode: -1,
+        stdout: "",
+        stderr: `executable not found: ${executable}`,
+      };
+    }
+    if (code === "ETIMEDOUT") {
+      return {
+        returncode: -1,
+        stdout: "",
+        stderr: `timed out after ${timeoutMs}ms`,
+      };
+    }
+    return {
+      returncode: -1,
+      stdout: "",
+      stderr: String(result.error.message ?? result.error),
+    };
+  }
+
+  return {
+    returncode: result.status ?? -1,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+}
+
+function cliScriptPath(name: string): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "../../../cli/dist", `${name}.js`);
+}
+
+export interface RunProtectedCheckOptions {
+  readonly nodeExecutable?: string;
+  readonly timeout?: number;
+}
+
+/** Invoke pr-protected-issues CLI and return (returncode, stdout, stderr). */
+export function runProtectedCheck(
+  prNumber: number,
+  repo: string | null,
+  protectedIssues: readonly number[],
+  options: RunProtectedCheckOptions = {},
+): SubprocessTriple {
+  const node = options.nodeExecutable ?? process.execPath;
+  const cmd: string[] = [
+    cliScriptPath("pr-protected-issues"),
+    String(prNumber),
+    "--protected",
+    protectedIssues.map(String).join(","),
+  ];
+  if (repo) {
+    cmd.push("--repo", repo);
+  }
+  const result = captureExec(node, cmd, (options.timeout ?? 60) * 1000);
+  return [result.returncode, result.stdout, result.stderr];
+}
+
+export interface RunMonitorOptions {
+  readonly nodeExecutable?: string;
+  readonly timeout?: number;
+}
+
+/** Invoke pr-monitor CLI with --json and return (returncode, stdout, stderr). */
+export function runMonitor(
+  prNumber: number,
+  repo: string,
+  capMinutes: number,
+  options: RunMonitorOptions = {},
+): SubprocessTriple {
+  const node = options.nodeExecutable ?? process.execPath;
+  const timeoutSec = options.timeout ?? capMinutes * 60 + 60;
+  const cmd: string[] = [
+    cliScriptPath("pr-monitor"),
+    String(prNumber),
+    "--repo",
+    repo,
+    "--cap-minutes",
+    String(capMinutes),
+    "--json",
+  ];
+  const result = captureExec(node, cmd, timeoutSec * 1000);
+  return [result.returncode, result.stdout, result.stderr];
+}
+
+export interface RunGhMergeOptions {
+  readonly timeout?: number;
+}
+
+/** Invoke ``gh pr merge --squash --delete-branch --admin``. */
+export function runGhMerge(
+  prNumber: number,
+  repo: string | null,
+  options: RunGhMergeOptions = {},
+): SubprocessTriple {
+  const timeoutSec = options.timeout ?? 120;
+  let binary: string;
+  try {
+    binary = resolveBinary();
+  } catch {
+    return [-1, "", "gh CLI not found. Install GitHub CLI."];
+  }
+  const args = [
+    "pr",
+    "merge",
+    String(prNumber),
+    "--squash",
+    "--delete-branch",
+    "--admin",
+  ];
+  if (repo) {
+    args.push("--repo", repo);
+  }
+  const result = captureExec(binary, args, timeoutSec * 1000);
+  if (result.returncode === -1) {
+    if (result.stderr.includes("timed out after")) {
+      return [-1, "", `gh pr merge timed out after ${timeoutSec}s`];
+    }
+    if (result.stderr.includes("executable not found")) {
+      return [-1, "", "gh CLI not found. Install GitHub CLI."];
+    }
+  }
+  return [result.returncode, result.stdout, result.stderr];
+}


### PR DESCRIPTION
## Summary
- Port `scripts/pr_wait_mergeable.py` (#1369) to `@deftai/core/pr-wait-mergeable`, composing the existing `pr-protected-issues`, `pr-monitor`, and `gh pr merge` primitives with protected-issue inspection strictly before the wait loop.
- Add CLI entrypoint `packages/cli/src/pr-wait-mergeable.ts` and cache-off golden parity harness `pr-wait-mergeable-parity.ts` (10 scenarios, byte-identical vs Python oracle).

## Test plan
- [x] `node packages/cli/dist/pr-wait-mergeable-parity.js` — CLEAN (cache-off, 10 scenarios)
- [x] `pnpm exec vitest run packages/core/src/pr-wait-mergeable --coverage` — 90.6% branch coverage (≥88% gate)
- [x] `TMPDIR=$(mktemp -d) DEFT_SESSION_RITUAL_SKIP=1 task check`

Refs #1530 #1730

Made with [Cursor](https://cursor.com)