### PR TITLE
chore(vbrief): decompose #1782 vBRIEF spine into 5 swarm-ready TS-port stories

### DIFF
--- a/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
@@ -1,0 +1,74 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1782"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1782",
+      "Overview": "## Parent\n#1530 (Part 1 of 2)\n\n## What to build\nPort directive's vBRIEF core — the highest fan-in surface the rest of the engine reads through — to TypeScript with golden parity: `_vbrief_build`, `_vbrief_validation`, `_vbrief_fidelity`, `_vbrief_routing`, `_vbrief_safety`, `_vbrief_sources`, `_vbrief_story_quality`, `_vbrief_reconciliation`, `_vbrief_speckit`, `vbrief_validate`, `vbrief_activate`, `vbrief_reconcile_graph/labels/umbrellas`, `verify_vbrief_conformance`, `_project_definition_io`.\n\n## Why first\nIssue intake, scope lifecycle, swarm, and several `task check` gates all read/validate vBRIEFs. Porting the spine first de-risks every downstream Bucket-B wave.\n\n## Acceptance criteria\n- [ ] TS ports with cache-off golden parity vs the Python oracle (incl. validation/conformance failure fixtures)\n- [ ] Wired into `@deftai/core` (export + subpath), `tasks/ts.yml` parity targets, CI golden-diff steps\n- [ ] CHANGELOG entry; `task check` green\n\n## Standing invariants (all #1530 Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The golden parity gate runs **cache-off**.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) **and** has CI usage.\n- Subprocess/`gh` capture uses Node `execFile` with explicit UTF-8 (closes the #1366 class structurally; the Python `_safe_subprocess`/`_stdio_utf8` shims are NOT ported — the problem does not exist in Node).\n\n## Full-conversion scope note (#1530)\nPart of the **full** Python→TS conversion. Per operator decision (2026-06-19) the cutover (#1731) deletes nothing until the engine is wholly TS. Accepted non-ports: Python-runtime shims, build/packaging tooling (superseded by the pnpm/tsc build), pre-v0.20 migration tooling (retired with a deprecation notice), and the Go installer (separate keep/fold decision in #1731). Owning an agent runtime is out of scope — net-new future work (#1707), not a conversion.\n\n## Type\nAFK\n\n## Blocked by\n- Blocked by #1730"
+    },
+    "items": [
+      {
+        "title": "TS ports with cache-off golden parity vs the Python oracle (incl. validation/conformance failure fixtures)",
+        "status": "proposed"
+      },
+      {
+        "title": "Wired into  (export + subpath),  parity targets, CI golden-diff steps",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG entry;  green",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1782",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1782: feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1730",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1730"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-vbrief-construction-foundation-project-definition-i.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the vBRIEF construction foundation (project-definition I/O + build/sources/routing/speckit) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-vbrief-validation-primitives-validation-fidelity-st.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the vBRIEF validation primitives (validation / fidelity / story-quality / safety) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the vBRIEF reconciliation engine (reconciliation + reconcile graph/labels/umbrellas) to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the vBRIEF activate lifecycle verb to TypeScript",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-19-port-the-vbriefvalidate-cli-verifyvbrief-conformance-gate-to.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port the vbrief:validate CLI + verify:vbrief-conformance gate to TypeScript (composer)",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json
@@ -1,0 +1,76 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 4 decomposed from proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json"
+  },
+  "plan": {
+    "id": "1782-s5-vbrief-activate",
+    "title": "Port the vBRIEF activate lifecycle verb to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/vbrief_activate.py -- the lifecycle verb that moves a vBRIEF from pending to active and sets plan.status to running -- to TypeScript with golden parity. Reuses the vbrief-build foundation types (#1782-s1).",
+      "ImplementationPlan": "1. Create packages/core/src/vbrief-activate with the TS port of the activate transition, with vitest unit tests.\n2. Add packages/cli/src/vbrief-activate-parity.ts that drives the TS path and the frozen Python scripts/vbrief_activate.py over fixtures and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want the vBRIEF activate verb in TypeScript, so that the pending-to-active transition runs on the TS engine with the same output and side effects as the Python module."
+    },
+    "items": [
+      {
+        "id": "1782-s5-a1",
+        "title": "activate transition preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS activate verb on a pending vBRIEF fixture updates its lifecycle folder to active and persists plan.status as running, matching what the Python vbrief_activate.py module produces."
+        }
+      },
+      {
+        "id": "1782-s5-a2",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the vbrief-activate-parity binary returns exit 0 and renders byte-identical output to the Python scripts/vbrief_activate.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/vbrief-activate/",
+          "packages/cli/src/vbrief-activate-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/vbrief-activate-parity.js",
+          "pnpm --filter @deftai/core test src/vbrief-activate"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/vbrief-activate module with vitest unit tests",
+          "New packages/cli/src/vbrief-activate-parity.ts parity binary",
+          "Byte-identical parity vs scripts/vbrief_activate.py under cache-off"
+        ],
+        "depends_on": [
+          "1782-s1-vbrief-build"
+        ],
+        "conflict_group": "ts-wave5-vbrief-activate",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-5 framework-internal TS port traced to GitHub issue #1782 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1782",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1782: feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1730",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1730"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-vbrief-construction-foundation-project-definition-i.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-vbrief-construction-foundation-project-definition-i.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json"
+  },
+  "plan": {
+    "id": "1782-s1-vbrief-build",
+    "title": "Port the vBRIEF construction foundation (project-definition I/O + build/sources/routing/speckit) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
+    "narratives": {
+      "Description": "Port the vBRIEF construction foundation -- scripts/_project_definition_io.py, scripts/_vbrief_build.py, scripts/_vbrief_sources.py, scripts/_vbrief_routing.py, and scripts/_vbrief_speckit.py -- to TypeScript with golden parity. This is the highest-fan-in layer the rest of the vBRIEF spine reads through (build constructs vBRIEF records, sources resolves origins, routing places lifecycle folders, speckit assembles narratives, project-definition-io reads/writes PROJECT-DEFINITION). Dispatched first; the validation, reconcile, and activate stories build on its types. Subprocess/gh capture (where present) uses Node execFile with explicit UTF-8 (#1366).",
+      "ImplementationPlan": "1. Create packages/core/src/vbrief-build with TS ports of project-definition I/O, the build constructor, source resolution, lifecycle routing, and speckit narrative assembly, with vitest unit tests in the module directory.\n2. Add packages/cli/src/vbrief-build-parity.ts that drives the TS functions and a python -c invocation of the frozen Python helpers over shared fixtures and asserts byte-identical output with cache off (the Python modules are the oracle and are NOT modified).",
+      "UserStory": "As a directive maintainer, I want the vBRIEF construction foundation available in TypeScript, so that record construction, source resolution, routing, and narrative assembly run on the TS engine with the same output as the Python modules."
+    },
+    "items": [
+      {
+        "id": "1782-s1-a1",
+        "title": "construction + routing output preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS vbrief-build foundation returns the same constructed vBRIEF record, resolved sources, and lifecycle-folder routing that the Python _vbrief_build/_vbrief_sources/_vbrief_routing modules produce for the same inputs."
+        }
+      },
+      {
+        "id": "1782-s1-a2",
+        "title": "project-definition I/O round-trip preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Reading and writing a PROJECT-DEFINITION fixture through the TS project-definition I/O returns the same parsed structure and serialized bytes the Python _project_definition_io module produces."
+        }
+      },
+      {
+        "id": "1782-s1-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the vbrief-build-parity binary returns exit 0 and renders byte-identical output to the Python construction-foundation oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/vbrief-build/",
+          "packages/cli/src/vbrief-build-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/vbrief-build-parity.js",
+          "pnpm --filter @deftai/core test src/vbrief-build"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/vbrief-build module with vitest unit tests",
+          "New packages/cli/src/vbrief-build-parity.ts parity binary",
+          "Byte-identical parity vs the Python construction foundation under cache-off"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-wave5-vbrief-build",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-5 framework-internal TS port traced to GitHub issue #1782 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1782",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1782: feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1730",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1730"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json
@@ -1,0 +1,84 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json"
+  },
+  "plan": {
+    "id": "1782-s4-vbrief-reconcile",
+    "title": "Port the vBRIEF reconciliation engine (reconciliation + reconcile graph/labels/umbrellas) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
+    "narratives": {
+      "Description": "Port the vBRIEF reconciliation engine -- scripts/_vbrief_reconciliation.py, scripts/vbrief_reconcile_graph.py, scripts/vbrief_reconcile_labels.py, and scripts/vbrief_reconcile_umbrellas.py -- to TypeScript with golden parity. These reconcile vBRIEF state against GitHub (dependency graph, labels, umbrella current-shape). reconcile_labels depends on reconcile_graph; both are ported in this story so the file scope stays disjoint. gh capture uses Node execFile with explicit UTF-8 (#1366), reusing @deftai/core/scm.",
+      "ImplementationPlan": "1. Create packages/core/src/vbrief-reconcile with TS ports of the reconciliation core, graph reconcile, label reconcile, and umbrella reconcile, reusing @deftai/core/scm for gh, with vitest unit tests.\n2. Add packages/cli/src/vbrief-reconcile-parity.ts that drives the TS path and the frozen Python modules over fixtures (fake gh on PATH) and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want the vBRIEF reconciliation engine in TypeScript, so that graph/label/umbrella reconciliation runs on the TS engine with the same output as the Python modules and UTF-8-safe gh capture."
+    },
+    "items": [
+      {
+        "id": "1782-s4-a1",
+        "title": "reconciliation output preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS reconciliation engine returns the same graph/label/umbrella reconcile actions the Python _vbrief_reconciliation/vbrief_reconcile_graph/labels/umbrellas modules produce for the same fixture."
+        }
+      },
+      {
+        "id": "1782-s4-a2",
+        "title": "UTF-8-safe gh capture by default",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running reconcile against a fixture whose gh output carries non-ASCII bytes returns the reconcile actions and emits no decode error, because capture uses execFile with explicit UTF-8."
+        }
+      },
+      {
+        "id": "1782-s4-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the vbrief-reconcile-parity binary returns exit 0 and renders byte-identical output to the Python reconciliation oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/vbrief-reconcile/",
+          "packages/cli/src/vbrief-reconcile-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/vbrief-reconcile-parity.js",
+          "pnpm --filter @deftai/core test src/vbrief-reconcile"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/vbrief-reconcile module with vitest unit tests",
+          "New packages/cli/src/vbrief-reconcile-parity.ts parity binary",
+          "Byte-identical parity vs the Python reconciliation engine under cache-off"
+        ],
+        "depends_on": [
+          "1782-s1-vbrief-build"
+        ],
+        "conflict_group": "ts-wave5-vbrief-reconcile",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-5 framework-internal TS port traced to GitHub issue #1782 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1782",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1782: feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1730",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1730"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-vbrief-validation-primitives-validation-fidelity-st.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-vbrief-validation-primitives-validation-fidelity-st.vbrief.json
@@ -1,0 +1,84 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json"
+  },
+  "plan": {
+    "id": "1782-s2-vbrief-validation",
+    "title": "Port the vBRIEF validation primitives (validation / fidelity / story-quality / safety) to TypeScript",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
+    "narratives": {
+      "Description": "Port the vBRIEF validation primitives -- scripts/_vbrief_validation.py, scripts/_vbrief_fidelity.py, scripts/_vbrief_story_quality.py, and scripts/_vbrief_safety.py -- to TypeScript with golden parity. These are the rule checks the vbrief:validate CLI composes. NOTE: _vbrief_fidelity imports _vbrief_legacy (which is in the retire bucket, NOT ported wholesale); this story absorbs ONLY the specific legacy helper(s) fidelity consumes, ported into the vbrief-validation module, and does not port the rest of _vbrief_legacy. Reuses the vbrief-build foundation types (#1782-s1).",
+      "ImplementationPlan": "1. Create packages/core/src/vbrief-validation with TS ports of the validation rule set, fidelity checks (absorbing the specific _vbrief_legacy helper fidelity depends on), story-quality observable-verb checks, and safety checks, with vitest unit tests.\n2. Add packages/cli/src/vbrief-validation-parity.ts that drives the TS checks and a python -c invocation of the frozen Python modules over shared fixtures (valid + each failure class) and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want the vBRIEF validation primitives in TypeScript, so that validation, fidelity, story-quality, and safety checks run on the TS engine with the same verdicts and messages as the Python modules."
+    },
+    "items": [
+      {
+        "id": "1782-s2-a1",
+        "title": "validation verdicts + messages preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS validation primitives returns the same pass/fail verdicts and diagnostic messages the Python _vbrief_validation/_vbrief_story_quality/_vbrief_safety modules produce for valid and each invalid fixture."
+        }
+      },
+      {
+        "id": "1782-s2-a2",
+        "title": "fidelity check preserved without porting legacy wholesale",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS fidelity check returns the same result the Python _vbrief_fidelity module produces, with only the consumed _vbrief_legacy helper absorbed into the TS module (the rest of _vbrief_legacy stays unported)."
+        }
+      },
+      {
+        "id": "1782-s2-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the vbrief-validation-parity binary returns exit 0 and renders byte-identical output to the Python validation-primitives oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/vbrief-validation/",
+          "packages/cli/src/vbrief-validation-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/vbrief-validation-parity.js",
+          "pnpm --filter @deftai/core test src/vbrief-validation"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/vbrief-validation module with vitest unit tests",
+          "New packages/cli/src/vbrief-validation-parity.ts parity binary",
+          "Byte-identical parity vs the Python validation primitives under cache-off"
+        ],
+        "depends_on": [
+          "1782-s1-vbrief-build"
+        ],
+        "conflict_group": "ts-wave5-vbrief-validation",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-5 framework-internal TS port traced to GitHub issue #1782 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1782",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1782: feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1730",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1730"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-port-the-vbriefvalidate-cli-verifyvbrief-conformance-gate-to.vbrief.json
+++ b/vbrief/proposed/2026-06-19-port-the-vbriefvalidate-cli-verifyvbrief-conformance-gate-to.vbrief.json
@@ -1,0 +1,86 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 5 decomposed from proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json"
+  },
+  "plan": {
+    "id": "1782-s3-vbrief-validate",
+    "title": "Port the vbrief:validate CLI + verify:vbrief-conformance gate to TypeScript (composer)",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
+    "narratives": {
+      "Description": "Port scripts/vbrief_validate.py (the full vBRIEF validator CLI) and scripts/verify_vbrief_conformance.py (the bare-key conformance gate, #1620) to TypeScript with golden parity. This is the composer: it orchestrates the vbrief-build foundation (#1782-s1) and the validation primitives (#1782-s2), so it is dispatched after both land. It is the gate task check runs as vbrief:validate. gh/subprocess capture uses Node execFile with explicit UTF-8 (#1366).",
+      "ImplementationPlan": "1. Create packages/core/src/vbrief-validate composing @deftai/core/vbrief-build and @deftai/core/vbrief-validation, porting the full validator CLI and the conformance gate, with vitest unit tests.\n2. Add packages/cli/src/vbrief-validate.ts exposing the TS validate + conformance verbs behind the existing CLI seam.\n3. Add packages/cli/src/vbrief-validate-parity.ts that runs the TS path and the Python scripts/vbrief_validate.py + verify_vbrief_conformance.py oracle over the full vbrief/ tree and asserts byte-identical output with cache off.",
+      "UserStory": "As a directive maintainer, I want vbrief:validate and verify:vbrief-conformance in TypeScript, so that the validation gate task check runs executes on the TS engine with the same verdicts and report as the Python modules."
+    },
+    "items": [
+      {
+        "id": "1782-s3-a1",
+        "title": "validate report preserved over the full tree",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS vbrief:validate over the repository vbrief/ tree returns the same scope-count, PROJECT-DEFINITION verdict, and per-file diagnostics the Python vbrief_validate.py module produces."
+        }
+      },
+      {
+        "id": "1782-s3-a2",
+        "title": "conformance gate verdict preserved",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the TS verify:vbrief-conformance gate returns the same three-state exit and bare-key findings the Python verify_vbrief_conformance.py module produces for the same fixtures."
+        }
+      },
+      {
+        "id": "1782-s3-a3",
+        "title": "golden parity vs Python oracle",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Running the vbrief-validate-parity binary returns exit 0 and renders byte-identical output to the Python vbrief_validate.py + verify_vbrief_conformance.py oracle with cache off."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/vbrief-validate/",
+          "packages/cli/src/vbrief-validate.ts",
+          "packages/cli/src/vbrief-validate-parity.ts"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/vbrief-validate-parity.js",
+          "pnpm --filter @deftai/core test src/vbrief-validate"
+        ],
+        "expected_outputs": [
+          "New packages/core/src/vbrief-validate module composing vbrief-build + vbrief-validation, with vitest unit tests",
+          "New packages/cli/src/vbrief-validate-parity.ts parity binary",
+          "Byte-identical parity vs scripts/vbrief_validate.py + verify_vbrief_conformance.py under cache-off"
+        ],
+        "depends_on": [
+          "1782-s1-vbrief-build",
+          "1782-s2-vbrief-validation"
+        ],
+        "conflict_group": "ts-wave5-vbrief-validate",
+        "size": "L",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "#1530 Wave-5 framework-internal TS port traced to GitHub issue #1782 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1782",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1782: feat(ts-migration): port the vBRIEF spine (build / validation / reconcile / conformance) to TS (Wave 5)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1730",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1730"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Wave 5 of the #1530 full Python->TS conversion. Decomposes the ~8,000-line vBRIEF spine (#1782) into 5 swarm-ready stories with disjoint file scope and a foundation -> parallel -> composer dispatch shape.

## Stories
| id | scope | depends_on |
|----|-------|-----------|
| `s1` vbrief-build | project-definition I/O + `_vbrief_build`/`sources`/`routing`/`speckit` | -- (foundation) |
| `s2` vbrief-validation | `_vbrief_validation`/`fidelity`/`story_quality`/`safety` | s1 |
| `s4` vbrief-reconcile | `_vbrief_reconciliation` + `reconcile_graph`/`labels`/`umbrellas` | s1 |
| `s5` vbrief-activate | `vbrief_activate` | s1 |
| `s3` vbrief-validate (composer) | `vbrief_validate` CLI + `verify_vbrief_conformance` | s1 + s2 |

## Design notes
- **`_vbrief_legacy.py` stays unported** (retire bucket). s2 absorbs only the specific legacy helper `_vbrief_fidelity` consumes.
- Each story carries a **cache-off golden-parity binary** that diffs the TS path against the frozen Python oracle; the Python modules are **not** modified.
- Helper-only modules (s1, s2) get parity via a thin `python -c` oracle driver over shared fixtures.

## Test plan
- [x] `task scope:decompose --check` -- 5 stories validated (observable acceptance criteria)
- [x] `task vbrief:validate` -- 687 scope vBRIEFs OK, D4 references intact
- [x] `task verify:vbrief-conformance` -- 684 files clean

Refs #1530 #1782

Made with [Cursor](https://cursor.com)