### PR TITLE
feat(ts): port vBRIEF activate verb to TypeScript (#1782 s5)

### DIFF
--- a/packages/cli/src/vbrief-activate-parity.ts
+++ b/packages/cli/src/vbrief-activate-parity.ts
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1782 s5): runs BOTH the Python oracle
+ * (`scripts/vbrief_activate.py`) and the ported TS vbrief-activate CLI over
+ * temp fixture vBRIEF trees, then diffs exit codes and byte-identical
+ * stdout/stderr (cache-off). Mutating scenarios also compare destination
+ * JSON with the volatile ``vBRIEFInfo.updated`` field stripped.
+ *
+ * Exit codes: 0 parity / 1 divergence / 2 harness setup error.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface CommandCapture {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ParityCase {
+  readonly name: string;
+  readonly folder: string;
+  readonly status: string;
+  readonly mutates?: boolean;
+  readonly rawOverride?: string;
+  readonly payloadOverride?: Record<string, unknown>;
+  readonly preSeedActive?: boolean;
+  readonly missingPath?: boolean;
+}
+
+export interface ParityDiff {
+  readonly caseName: string;
+  readonly exitMismatch: boolean;
+  readonly stdoutMismatch: boolean;
+  readonly stderrMismatch: boolean;
+  readonly sideEffectMismatch: boolean;
+  readonly pythonExit: number;
+  readonly tsExit: number;
+  readonly pythonStdout: string;
+  readonly pythonStderr: string;
+  readonly tsStdout: string;
+  readonly tsStderr: string;
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly diffs: ParityDiff[];
+}
+
+const FIXTURE_NAME = "2026-05-01-test.vbrief.json";
+
+export const PARITY_CASES: readonly ParityCase[] = [
+  { name: "pending-to-active", folder: "pending", status: "pending", mutates: true },
+  { name: "approved-to-active", folder: "pending", status: "approved", mutates: true },
+  { name: "already-active-noop", folder: "active", status: "running" },
+  { name: "proposed-reject", folder: "proposed", status: "proposed" },
+  { name: "completed-reject", folder: "completed", status: "completed" },
+  { name: "active-blocked-reject", folder: "active", status: "blocked" },
+  { name: "pending-draft-reject", folder: "pending", status: "draft" },
+  { name: "nonexistent-reject", folder: "pending", status: "pending", missingPath: true },
+  { name: "malformed-json", folder: "pending", status: "pending", rawOverride: "{ not json" },
+  {
+    name: "missing-plan",
+    folder: "pending",
+    status: "pending",
+    payloadOverride: { vBRIEFInfo: { version: "0.6" } },
+  },
+  {
+    name: "missing-plan-status",
+    folder: "pending",
+    status: "pending",
+    payloadOverride: { vBRIEFInfo: { version: "0.6" }, plan: { title: "T" } },
+  },
+  {
+    name: "destination-collision",
+    folder: "pending",
+    status: "pending",
+    preSeedActive: true,
+  },
+];
+
+function runCapture(cmd: string, args: string[], cwd: string): CommandCapture {
+  try {
+    const stdout = execFileSync(cmd, args, {
+      cwd,
+      encoding: "utf8",
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { exitCode: 0, stdout, stderr: "" };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return {
+      exitCode: typeof e.status === "number" ? e.status : 2,
+      stdout: typeof e.stdout === "string" ? e.stdout : "",
+      stderr: typeof e.stderr === "string" ? e.stderr : "",
+    };
+  }
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
+    return resolve(process.env.DEFT_ROOT);
+  }
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+function writeFixture(repo: string, testCase: ParityCase): string {
+  const full = join(repo, "vbrief", testCase.folder, FIXTURE_NAME);
+  mkdirSync(dirname(full), { recursive: true });
+  if (testCase.rawOverride !== undefined) {
+    writeFileSync(full, testCase.rawOverride, "utf8");
+    return full;
+  }
+  if (testCase.payloadOverride !== undefined) {
+    writeFileSync(full, JSON.stringify(testCase.payloadOverride), "utf8");
+    return full;
+  }
+  writeFileSync(
+    full,
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6", updated: "2026-04-30T00:00:00Z" },
+      plan: { title: "T", status: testCase.status, items: [] },
+    }),
+    "utf8",
+  );
+  return full;
+}
+
+function setupRepo(testCase: ParityCase): { repo: string; vbriefPath: string } {
+  const repo = mkdtempSync(join(tmpdir(), "deft-vbrief-activate-parity-"));
+  mkdirSync(join(repo, "vbrief"), { recursive: true });
+  if (testCase.missingPath === true) {
+    return { repo, vbriefPath: join(repo, "vbrief", "pending", "missing.vbrief.json") };
+  }
+  const vbriefPath = writeFixture(repo, testCase);
+  if (testCase.preSeedActive === true) {
+    const activePath = join(repo, "vbrief", "active", FIXTURE_NAME);
+    mkdirSync(dirname(activePath), { recursive: true });
+    writeFileSync(activePath, "{}", "utf8");
+  }
+  return { repo, vbriefPath };
+}
+
+function stripUpdatedField(repo: string): string | null {
+  const dest = join(repo, "vbrief", "active", FIXTURE_NAME);
+  if (!existsSync(dest)) {
+    return null;
+  }
+  const payload = JSON.parse(readFileSync(dest, "utf8")) as Record<string, unknown>;
+  const info = payload.vBRIEFInfo;
+  if (info !== null && typeof info === "object" && !Array.isArray(info)) {
+    delete (info as Record<string, unknown>).updated;
+  }
+  return JSON.stringify(payload);
+}
+
+function runPython(deftRoot: string, vbriefPath: string): CommandCapture {
+  return runCapture(
+    "uv",
+    ["run", "python", join(deftRoot, "scripts", "vbrief_activate.py"), vbriefPath],
+    deftRoot,
+  );
+}
+
+function runTs(deftRoot: string, vbriefPath: string): CommandCapture {
+  return runCapture(
+    "node",
+    [join(deftRoot, "packages", "cli", "dist", "vbrief-activate.js"), vbriefPath],
+    deftRoot,
+  );
+}
+
+export function diffCase(
+  python: CommandCapture,
+  ts: CommandCapture,
+  caseName: string,
+  sideEffectMismatch: boolean,
+): ParityDiff {
+  return {
+    caseName,
+    exitMismatch: python.exitCode !== ts.exitCode,
+    stdoutMismatch: python.stdout !== ts.stdout,
+    stderrMismatch: python.stderr !== ts.stderr,
+    sideEffectMismatch,
+    pythonExit: python.exitCode,
+    tsExit: ts.exitCode,
+    pythonStdout: python.stdout,
+    pythonStderr: python.stderr,
+    tsStdout: ts.stdout,
+    tsStderr: ts.stderr,
+  };
+}
+
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const diffs: ParityDiff[] = [];
+
+  for (const testCase of PARITY_CASES) {
+    const pySetup = setupRepo(testCase);
+    const tsSetup = testCase.mutates === true ? setupRepo(testCase) : pySetup;
+    try {
+      const py = runPython(deftRoot, pySetup.vbriefPath);
+      const ts = runTs(deftRoot, tsSetup.vbriefPath);
+
+      let sideEffectMismatch = false;
+      if (testCase.mutates === true && py.exitCode === 0 && ts.exitCode === 0) {
+        const pyBody = stripUpdatedField(pySetup.repo);
+        const tsBody = stripUpdatedField(tsSetup.repo);
+        sideEffectMismatch = pyBody !== tsBody;
+        if (pyBody !== null && tsBody !== null) {
+          const pyPendingGone = !existsSync(pySetup.vbriefPath);
+          const tsPendingGone = !existsSync(tsSetup.vbriefPath);
+          sideEffectMismatch =
+            sideEffectMismatch ||
+            pyPendingGone !== tsPendingGone ||
+            !pyPendingGone ||
+            !tsPendingGone;
+        }
+      }
+
+      diffs.push(diffCase(py, ts, testCase.name, sideEffectMismatch));
+    } finally {
+      rmSync(pySetup.repo, { recursive: true, force: true });
+      if (tsSetup.repo !== pySetup.repo) {
+        rmSync(tsSetup.repo, { recursive: true, force: true });
+      }
+    }
+  }
+
+  const ok = diffs.every(
+    (d) => !d.exitMismatch && !d.stdoutMismatch && !d.stderrMismatch && !d.sideEffectMismatch,
+  );
+  return { ok, diffs };
+}
+
+export function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `vbrief-activate parity: CLEAN -- Python and TS agree on ${result.diffs.length} scenario(s).`;
+  }
+  const lines = ["vbrief-activate parity: DIVERGENCE"];
+  for (const d of result.diffs) {
+    if (d.exitMismatch || d.stdoutMismatch || d.stderrMismatch || d.sideEffectMismatch) {
+      lines.push(`  scenario: ${d.caseName}`);
+      if (d.exitMismatch) {
+        lines.push(`    exit mismatch: python=${d.pythonExit} ts=${d.tsExit}`);
+      }
+      if (d.stdoutMismatch) {
+        lines.push(`    python stdout: ${JSON.stringify(d.pythonStdout)}`);
+        lines.push(`    ts stdout:     ${JSON.stringify(d.tsStdout)}`);
+      }
+      if (d.stderrMismatch) {
+        lines.push(`    python stderr: ${JSON.stringify(d.pythonStderr)}`);
+        lines.push(`    ts stderr:     ${JSON.stringify(d.tsStderr)}`);
+      }
+      if (d.sideEffectMismatch) {
+        lines.push("    side-effect mismatch (active/ payload or source removal)");
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+export function runParityCli(): number {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      return 0;
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    return 1;
+  } catch (err) {
+    const msg = String(err).replace(/\r?\n/g, " ");
+    process.stderr.write(`vbrief-activate parity: harness error -- ${msg}\n`);
+    return 2;
+  }
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(runParityCli());
+}

--- a/packages/cli/src/vbrief-activate.ts
+++ b/packages/cli/src/vbrief-activate.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { run } from "@deftai/core/vbrief-activate";
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,6 +93,10 @@
     "./vbrief-build": {
       "types": "./dist/vbrief-build/index.d.ts",
       "default": "./dist/vbrief-build/index.js"
+    },
+    "./vbrief-activate": {
+      "types": "./dist/vbrief-activate/index.d.ts",
+      "default": "./dist/vbrief-activate/index.js"
     }
   },
   "dependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * as scope from "./scope/index.js";
 export * as slice from "./slice/index.js";
 export * as storyReady from "./story-ready/index.js";
 export * as triage from "./triage/index.js";
+export * as vbriefActivate from "./vbrief-activate/index.js";
 export * as vbriefBuild from "./vbrief-build/index.js";
 export * as wipCap from "./wip-cap/index.js";
 

--- a/packages/core/src/vbrief-activate/activate.mock.test.ts
+++ b/packages/core/src/vbrief-activate/activate.mock.test.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("activate statSync failure branch", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports statSync failures after existsSync succeeds", async () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-activate-stat-"));
+    roots.push(root);
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "pending", items: [] },
+      }),
+      "utf8",
+    );
+
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        existsSync: (target: string) => target === path || actual.existsSync(target),
+        statSync: (target: string) => {
+          if (target === path) {
+            throw new Error("stat denied");
+          }
+          return actual.statSync(target);
+        },
+      };
+    });
+
+    const { activate } = await import("./activate.js");
+    const result = activate(path);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Could not read vBRIEF");
+    expect(result.message).toContain("stat denied");
+  });
+});

--- a/packages/core/src/vbrief-activate/activate.test.ts
+++ b/packages/core/src/vbrief-activate/activate.test.ts
@@ -1,0 +1,219 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { activate } from "./activate.js";
+
+const FIXTURE_NAME = "2026-05-01-test.vbrief.json";
+const FIXED_NOW = new Date("2026-06-19T12:00:00.000Z");
+
+function writeVbrief(
+  base: string,
+  folder: string,
+  options: {
+    status?: string;
+    rawOverride?: string;
+    payloadOverride?: Record<string, unknown>;
+  } = {},
+): string {
+  const dir = join(base, "vbrief", folder);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, FIXTURE_NAME);
+  if (options.rawOverride !== undefined) {
+    writeFileSync(path, options.rawOverride, "utf8");
+    return path;
+  }
+  if (options.payloadOverride !== undefined) {
+    writeFileSync(path, JSON.stringify(options.payloadOverride), "utf8");
+    return path;
+  }
+  writeFileSync(
+    path,
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6", updated: "2026-04-30T00:00:00Z" },
+      plan: { title: "T", status: options.status ?? "pending", items: [] },
+    }),
+    "utf8",
+  );
+  return path;
+}
+
+describe("activate", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function tempRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "deft-activate-test-"));
+    roots.push(root);
+    return root;
+  }
+
+  it("flips pending to active and moves the file", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", { status: "pending" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toContain("Activated");
+
+    const dest = join(root, "vbrief", "active", FIXTURE_NAME);
+    expect(existsSync(dest)).toBe(true);
+    expect(existsSync(src)).toBe(false);
+
+    const payload = JSON.parse(readFileSync(dest, "utf8")) as {
+      plan: { status: string };
+      vBRIEFInfo: { updated: string };
+    };
+    expect(payload.plan.status).toBe("running");
+    expect(payload.vBRIEFInfo.updated).toBe("2026-06-19T12:00:00Z");
+  });
+
+  it("accepts approved status", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", { status: "approved" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(0);
+    const dest = join(root, "vbrief", "active", FIXTURE_NAME);
+    const payload = JSON.parse(readFileSync(dest, "utf8")) as { plan: { status: string } };
+    expect(payload.plan.status).toBe("running");
+  });
+
+  it("is idempotent for already-active running vBRIEFs", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "active", { status: "running" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toContain("No-op");
+    expect(existsSync(src)).toBe(true);
+  });
+
+  it("rejects proposed folder", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "proposed", { status: "proposed" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("only pending/ vBRIEFs can be activated");
+    expect(existsSync(src)).toBe(true);
+  });
+
+  it("rejects completed folder", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "completed", { status: "completed" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("only pending/ vBRIEFs can be activated");
+  });
+
+  it("rejects active folder with blocked status", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "active", { status: "blocked" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("task scope:unblock");
+  });
+
+  it("rejects ineligible pending status", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", { status: "draft" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("only ['approved', 'pending']");
+  });
+
+  it("rejects missing path", () => {
+    const root = tempRoot();
+    const result = activate(join(root, "missing.vbrief.json"), { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("vBRIEF not found");
+  });
+
+  it("rejects malformed json", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", { rawOverride: "{ not json" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("is not valid JSON");
+  });
+
+  it("rejects missing plan", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", {
+      payloadOverride: { vBRIEFInfo: { version: "0.6" } },
+    });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("lacks a `plan` object");
+  });
+
+  it("rejects missing plan.status", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", {
+      payloadOverride: { vBRIEFInfo: { version: "0.6" }, plan: { title: "T" } },
+    });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("lacks `plan.status`");
+  });
+
+  it("rejects destination collision", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", { status: "pending" });
+    const activeDir = join(root, "vbrief", "active");
+    mkdirSync(activeDir, { recursive: true });
+    writeFileSync(join(activeDir, FIXTURE_NAME), "{}", "utf8");
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Refusing to overwrite");
+    expect(existsSync(src)).toBe(true);
+  });
+
+  it("creates vBRIEFInfo when absent", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", {
+      payloadOverride: { plan: { title: "T", status: "pending", items: [] } },
+    });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(0);
+    const dest = join(root, "vbrief", "active", FIXTURE_NAME);
+    const payload = JSON.parse(readFileSync(dest, "utf8")) as { vBRIEFInfo: { updated: string } };
+    expect(payload.vBRIEFInfo.updated).toBe("2026-06-19T12:00:00Z");
+  });
+
+  it("rejects non-object vBRIEFInfo", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", {
+      payloadOverride: { vBRIEFInfo: "bad", plan: { title: "T", status: "pending", items: [] } },
+    });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("non-object `vBRIEFInfo`");
+  });
+
+  it("rejects top-level array json", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", { rawOverride: "[]" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("top-level value is not a JSON object");
+  });
+
+  it("rejects top-level null json", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "pending", { rawOverride: "null" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("top-level value is not a JSON object");
+  });
+
+  it("rejects cancelled folder", () => {
+    const root = tempRoot();
+    const src = writeVbrief(root, "cancelled", { status: "cancelled" });
+    const result = activate(src, { now: FIXED_NOW });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("only pending/ vBRIEFs can be activated");
+  });
+});

--- a/packages/core/src/vbrief-activate/activate.ts
+++ b/packages/core/src/vbrief-activate/activate.ts
@@ -1,0 +1,235 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname } from "node:path";
+import { utcNowIso } from "../scope/vbrief-json.js";
+import { pythonJsonPretty } from "../vbrief-build/json.js";
+import {
+  ACTIVE_FOLDER,
+  ELIGIBLE_STATUSES_FOR_FLIP,
+  formatEligibleStatusList,
+  SOURCE_FOLDERS,
+  TARGET_STATUS,
+} from "./constants.js";
+
+export interface ActivateResult {
+  readonly exitCode: 0 | 1;
+  readonly message: string;
+}
+
+/** Map Node ``JSON.parse`` errors to CPython ``json.JSONDecodeError.msg`` for parity. */
+function nodeJsonErrorToPythonMsg(nodeMessage: string): string {
+  if (
+    nodeMessage.includes("Expected property name") ||
+    nodeMessage.includes("Expected double-quoted property name")
+  ) {
+    return "Expecting property name enclosed in double quotes";
+  }
+  if (
+    nodeMessage.startsWith("Unexpected token") ||
+    nodeMessage.startsWith("Unexpected end of JSON input")
+  ) {
+    return "Expecting value";
+  }
+  if (nodeMessage.includes("Unexpected non-whitespace character after JSON")) {
+    return "Extra data";
+  }
+  const atPos = nodeMessage.indexOf(" at position ");
+  return atPos >= 0 ? nodeMessage.slice(0, atPos) : nodeMessage;
+}
+
+function loadVbrief(vbriefPath: string): {
+  payload: Record<string, unknown> | null;
+  error: string | null;
+} {
+  let raw: string;
+  try {
+    raw = readFileSync(vbriefPath, "utf8");
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException;
+    return {
+      payload: null,
+      error: `Could not read vBRIEF at ${vbriefPath}: ${String(e.message)}.`,
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw) as unknown;
+  } catch (err: unknown) {
+    const e = err as SyntaxError;
+    const lineCol = /\(line (\d+) column \d+\)/.exec(e.message);
+    const line = lineCol ? Number(lineCol[1]) : 1;
+    const pyMsg = nodeJsonErrorToPythonMsg(e.message);
+    return {
+      payload: null,
+      error: `vBRIEF at ${vbriefPath} is not valid JSON: ${pyMsg} (line ${line}).`,
+    };
+  }
+
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    return {
+      payload: null,
+      error: `vBRIEF at ${vbriefPath} top-level value is not a JSON object.`,
+    };
+  }
+
+  return { payload: payload as Record<string, unknown>, error: null };
+}
+
+export interface ActivateOptions {
+  readonly now?: Date;
+}
+
+/**
+ * Pure activator — returns ``{ exitCode, message }``. Faithful to
+ * ``scripts/vbrief_activate.py::activate``.
+ */
+export function activate(vbriefPath: string, options: ActivateOptions = {}): ActivateResult {
+  const now = options.now ?? new Date();
+
+  if (!existsSync(vbriefPath)) {
+    return { exitCode: 1, message: `vBRIEF not found at ${vbriefPath}.` };
+  }
+
+  let st: ReturnType<typeof statSync>;
+  try {
+    st = statSync(vbriefPath);
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException;
+    return {
+      exitCode: 1,
+      message: `Could not read vBRIEF at ${vbriefPath}: ${String(e.message)}.`,
+    };
+  }
+
+  if (!st.isFile()) {
+    return { exitCode: 1, message: `vBRIEF path ${vbriefPath} is not a regular file.` };
+  }
+
+  const { payload, error } = loadVbrief(vbriefPath);
+  if (error !== null || payload === null) {
+    return { exitCode: 1, message: error ?? "vBRIEF could not be loaded." };
+  }
+
+  const plan = payload.plan;
+  if (plan === null || typeof plan !== "object" || Array.isArray(plan)) {
+    return {
+      exitCode: 1,
+      message: `vBRIEF at ${vbriefPath} lacks a \`plan\` object -- malformed.`,
+    };
+  }
+  const planObj = plan as Record<string, unknown>;
+
+  const status = planObj.status;
+  if (typeof status !== "string" || status.length === 0) {
+    return { exitCode: 1, message: `vBRIEF at ${vbriefPath} lacks \`plan.status\` -- malformed.` };
+  }
+
+  const folder = basename(dirname(vbriefPath));
+
+  if (folder === ACTIVE_FOLDER && status === TARGET_STATUS) {
+    return { exitCode: 0, message: `No-op: ${vbriefPath} already active.` };
+  }
+
+  if (folder === ACTIVE_FOLDER) {
+    return {
+      exitCode: 1,
+      message:
+        `vBRIEF is already in active/ but plan.status is '${status}', ` +
+        `not '${TARGET_STATUS}'. Use the appropriate task (e.g. ` +
+        "`task scope:unblock`) instead of `task vbrief:activate`.",
+    };
+  }
+
+  if (!SOURCE_FOLDERS.has(folder)) {
+    return {
+      exitCode: 1,
+      message:
+        `vBRIEF is in ${folder}/ -- only pending/ vBRIEFs can be activated. ` +
+        "Use the lifecycle tasks (`task scope:promote`, etc.) to move it " +
+        "into pending/ first.",
+    };
+  }
+
+  if (!ELIGIBLE_STATUSES_FOR_FLIP.has(status)) {
+    return {
+      exitCode: 1,
+      message:
+        `plan.status is '${status}' -- only ${formatEligibleStatusList()} can be flipped to ` +
+        `'${TARGET_STATUS}'.`,
+    };
+  }
+
+  planObj.status = TARGET_STATUS;
+
+  let info = payload.vBRIEFInfo;
+  if (info === undefined) {
+    info = {};
+    payload.vBRIEFInfo = info;
+  }
+  if (info === null || typeof info !== "object" || Array.isArray(info)) {
+    return {
+      exitCode: 1,
+      message: `vBRIEF at ${vbriefPath} has a non-object \`vBRIEFInfo\` -- malformed.`,
+    };
+  }
+  (info as Record<string, unknown>).updated = utcNowIso(now);
+
+  const vbriefDir = dirname(dirname(vbriefPath));
+  const activeDir = `${vbriefDir}/${ACTIVE_FOLDER}`;
+  try {
+    mkdirSync(activeDir, { recursive: true });
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException;
+    return { exitCode: 1, message: `Could not create ${activeDir}: ${String(e.message)}.` };
+  }
+
+  const fileName = basename(vbriefPath);
+  const dest = `${activeDir}/${fileName}`;
+  if (existsSync(dest)) {
+    return {
+      exitCode: 1,
+      message:
+        `Refusing to overwrite existing destination ${dest}. Resolve the ` +
+        "collision manually before re-running `task vbrief:activate`.",
+    };
+  }
+
+  const tmp = `${dest}.tmp`;
+  try {
+    writeFileSync(tmp, pythonJsonPretty(payload), "utf8");
+    renameSync(tmp, dest);
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException;
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    return { exitCode: 1, message: `Could not write ${dest}: ${String(e.message)}.` };
+  }
+
+  try {
+    unlinkSync(vbriefPath);
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException;
+    return {
+      exitCode: 1,
+      message:
+        `Wrote ${dest} but could not remove source ${vbriefPath}: ${String(e.message)}. ` +
+        "Manual cleanup required.",
+    };
+  }
+
+  return {
+    exitCode: 0,
+    message: `Activated ${fileName}: pending/ -> active/ (status: ${TARGET_STATUS}).`,
+  };
+}

--- a/packages/core/src/vbrief-activate/constants.ts
+++ b/packages/core/src/vbrief-activate/constants.ts
@@ -1,0 +1,15 @@
+/** Folders the lifecycle move flows between (source allow-list). */
+export const SOURCE_FOLDERS = new Set(["pending"]);
+
+export const ACTIVE_FOLDER = "active";
+
+export const ELIGIBLE_STATUSES_FOR_FLIP = new Set(["pending", "approved"]);
+
+export const TARGET_STATUS = "running";
+
+export const ELIGIBLE_STATUSES_SORTED = ["approved", "pending"] as const;
+
+/** Python ``str(sorted(ELIGIBLE_STATUSES_FOR_FLIP))`` for error messages. */
+export function formatEligibleStatusList(): string {
+  return `[${ELIGIBLE_STATUSES_SORTED.map((s) => `'${s}'`).join(", ")}]`;
+}

--- a/packages/core/src/vbrief-activate/coverage-boost.test.ts
+++ b/packages/core/src/vbrief-activate/coverage-boost.test.ts
@@ -1,0 +1,209 @@
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { activate } from "./activate.js";
+import { formatEligibleStatusList } from "./constants.js";
+import { parseArgs, run } from "./main.js";
+
+describe("vbrief-activate coverage boost", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function tempRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "deft-activate-boost-"));
+    roots.push(root);
+    return root;
+  }
+
+  it("rejects a directory path", () => {
+    const root = tempRoot();
+    const dirPath = join(root, "vbrief", "pending", "dir.vbrief.json");
+    mkdirSync(dirPath, { recursive: true });
+    const result = activate(dirPath);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("not a regular file");
+  });
+
+  it("maps extra-data json errors", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(path, '{"plan":{"status":"pending"}}{}', "utf8");
+    const result = activate(path);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Extra data");
+  });
+
+  it("maps property-name json errors", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(path, "{bad", "utf8");
+    const result = activate(path);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/Expecting property name|Expecting value/);
+  });
+
+  it("reports write failures", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    const pendingDir = join(root, "vbrief", "pending");
+    mkdirSync(pendingDir, { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "pending", items: [] },
+      }),
+      "utf8",
+    );
+    const activeDir = join(root, "vbrief", "active");
+    mkdirSync(activeDir, { recursive: true });
+    chmodSync(activeDir, 0o555);
+
+    const result = activate(path);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Could not write");
+    chmodSync(activeDir, 0o755);
+  });
+
+  it("reports unlink failures after successful write", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    const pendingDir = join(root, "vbrief", "pending");
+    mkdirSync(pendingDir, { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "pending", items: [] },
+      }),
+      "utf8",
+    );
+    chmodSync(pendingDir, 0o555);
+
+    const result = activate(path, { now: new Date("2026-06-19T12:00:00.000Z") });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("could not remove source");
+    chmodSync(pendingDir, 0o755);
+  });
+
+  it("run writes success to stdout", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "pending", items: [] },
+      }),
+      "utf8",
+    );
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const code = run([path], { now: new Date("2026-06-19T12:00:00.000Z") });
+    expect(code).toBe(0);
+    expect(stdout.mock.calls[0]?.[0]).toContain("Activated");
+    stdout.mockRestore();
+  });
+
+  it("run writes reject to stderr", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const code = run(["/does/not/exist.vbrief.json"]);
+    expect(code).toBe(1);
+    stderr.mockRestore();
+  });
+
+  it("reports read errors from loadVbrief", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "pending", items: [] },
+      }),
+      "utf8",
+    );
+    chmodSync(path, 0o000);
+    const result = activate(path);
+    chmodSync(path, 0o644);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Could not read vBRIEF");
+  });
+
+  it("reports mkdir failures for active directory", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "pending", items: [] },
+      }),
+      "utf8",
+    );
+    chmodSync(join(root, "vbrief"), 0o555);
+    const result = activate(path, { now: new Date("2026-06-19T12:00:00.000Z") });
+    chmodSync(join(root, "vbrief"), 0o755);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Could not create");
+  });
+
+  it("reports empty plan.status as malformed", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "", items: [] },
+      }),
+      "utf8",
+    );
+    const result = activate(path);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("lacks `plan.status`");
+  });
+
+  it("parseArgs returns the positional path", () => {
+    expect(parseArgs(["/tmp/a.vbrief.json"]).vbriefPath).toBe("/tmp/a.vbrief.json");
+  });
+
+  it("formatEligibleStatusList matches Python repr", () => {
+    expect(formatEligibleStatusList()).toBe("['approved', 'pending']");
+  });
+
+  it("serializes output with trailing newline parity", () => {
+    const root = tempRoot();
+    const path = join(root, "vbrief", "pending", "x.vbrief.json");
+    mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        {
+          vBRIEFInfo: { version: "0.6", updated: "2026-04-30T00:00:00Z" },
+          plan: { title: "T", status: "pending", items: [] },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    activate(path, { now: new Date("2026-06-19T12:00:00.000Z") });
+    const dest = join(root, "vbrief", "active", "x.vbrief.json");
+    const body = readFileSync(dest, "utf8");
+    expect(body.endsWith("\n")).toBe(true);
+    expect(body.includes("\r\n")).toBe(false);
+  });
+});

--- a/packages/core/src/vbrief-activate/index.ts
+++ b/packages/core/src/vbrief-activate/index.ts
@@ -1,0 +1,11 @@
+export type { ActivateOptions, ActivateResult } from "./activate.js";
+export { activate } from "./activate.js";
+export {
+  ACTIVE_FOLDER,
+  ELIGIBLE_STATUSES_FOR_FLIP,
+  formatEligibleStatusList,
+  SOURCE_FOLDERS,
+  TARGET_STATUS,
+} from "./constants.js";
+export type { ParsedArgs, RunOptions } from "./main.js";
+export { cmdVbriefActivate, parseArgs, run } from "./main.js";

--- a/packages/core/src/vbrief-activate/main.test.ts
+++ b/packages/core/src/vbrief-activate/main.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { cmdVbriefActivate, parseArgs, run } from "./main.js";
+
+describe("parseArgs", () => {
+  it("parses a single vbrief path", () => {
+    expect(parseArgs(["/tmp/foo.vbrief.json"])).toEqual({ vbriefPath: "/tmp/foo.vbrief.json" });
+  });
+
+  it("errors when path missing", () => {
+    expect(parseArgs([]).error).toContain("required");
+  });
+
+  it("errors on extra arguments", () => {
+    expect(parseArgs(["a", "b"]).error).toContain("unrecognized");
+  });
+});
+
+describe("run CLI", () => {
+  it("returns 2 on parse error", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(run([])).toBe(2);
+    stderr.mockRestore();
+  });
+
+  it("cmdVbriefActivate delegates to run", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(cmdVbriefActivate([])).toBe(2);
+    stderr.mockRestore();
+  });
+});

--- a/packages/core/src/vbrief-activate/main.ts
+++ b/packages/core/src/vbrief-activate/main.ts
@@ -1,0 +1,44 @@
+import { activate } from "./activate.js";
+
+export interface ParsedArgs {
+  readonly vbriefPath: string | null;
+  readonly error?: string;
+}
+
+/** Parse vbrief-activate CLI args, mirroring the Python argparse surface (#810). */
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  if (argv.length === 0) {
+    return { vbriefPath: null, error: "the following arguments are required: vbrief_path" };
+  }
+  if (argv.length > 1) {
+    return { vbriefPath: null, error: `unrecognized arguments: ${argv.slice(1).join(" ")}` };
+  }
+  return { vbriefPath: argv[0] ?? null };
+}
+
+export interface RunOptions {
+  readonly now?: Date;
+}
+
+/** Run the activator and return the process exit code (parse errors -> 2). */
+export function run(argv: readonly string[], options: RunOptions = {}): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`vbrief_activate.py: ${args.error}\n`);
+    return 2;
+  }
+  const vbriefPath = args.vbriefPath as string;
+  const result = activate(vbriefPath, options);
+
+  if (result.exitCode === 0) {
+    process.stdout.write(`${result.message}\n`);
+  } else {
+    process.stderr.write(`${result.message}\n`);
+  }
+  return result.exitCode;
+}
+
+/** CLI entry alias for task wiring. */
+export function cmdVbriefActivate(argv: readonly string[], options: RunOptions = {}): number {
+  return run(argv, options);
+}

--- a/tasks/ts.yml
+++ b/tasks/ts.yml
@@ -188,6 +188,12 @@ tasks:
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-build-parity.js"
 
+  vbrief-activate-parity:
+    desc: "Golden-diff the ported vbrief_activate.py lifecycle verb vs the Python oracle, cache-off (#1782 s5)"
+    deps: [build]
+    cmds:
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-activate-parity.js"
+
   parity-all:
     desc: "Run every TS-port golden-diff parity harness vs the Python oracle (#1530 Wave 2)"
     deps: [build]
@@ -221,3 +227,4 @@ tasks:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/pr-monitor-parity.js"
       - node "{{.DEFT_ROOT}}/packages/cli/dist/pr-wait-mergeable-parity.js"
       - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-build-parity.js"
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-activate-parity.js"

--- a/vbrief/active/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json
+++ b/vbrief/active/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1782-s5-vbrief-activate",
     "title": "Port the vBRIEF activate lifecycle verb to TypeScript",
-    "status": "proposed",
+    "status": "running",
     "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
     "narratives": {
       "Description": "Port scripts/vbrief_activate.py -- the lifecycle verb that moves a vBRIEF from pending to active and sets plan.status to running -- to TypeScript with golden parity. Reuses the vbrief-build foundation types (#1782-s1).",
@@ -71,6 +71,7 @@
         "type": "x-vbrief/blocks",
         "title": "Issue #1730"
       }
-    ]
+    ],
+    "updated": "2026-06-19T17:49:59Z"
   }
 }

--- a/vbrief/completed/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1782-s5-vbrief-activate",
     "title": "Port the vBRIEF activate lifecycle verb to TypeScript",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
     "narratives": {
       "Description": "Port scripts/vbrief_activate.py -- the lifecycle verb that moves a vBRIEF from pending to active and sets plan.status to running -- to TypeScript with golden parity. Reuses the vbrief-build foundation types (#1782-s1).",
@@ -57,7 +57,9 @@
         "file_scope_confidence": "high",
         "model_tier": "high",
         "missing_traces_justification": "#1530 Wave-5 framework-internal TS port traced to GitHub issue #1782 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
-      }
+      },
+      "completedAt": "2026-06-19T17:55:12Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -72,6 +74,6 @@
         "title": "Issue #1730"
       }
     ],
-    "updated": "2026-06-19T17:49:59Z"
+    "updated": "2026-06-19T17:55:12Z"
   }
 }

--- a/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
@@ -55,7 +55,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json",
+        "uri": "completed/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Port the vBRIEF activate lifecycle verb to TypeScript",
         "TrustLevel": "internal"

--- a/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
@@ -55,7 +55,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "proposed/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json",
+        "uri": "active/2026-06-19-port-the-vbrief-activate-lifecycle-verb-to-typescript.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Port the vBRIEF activate lifecycle verb to TypeScript",
         "TrustLevel": "internal"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       "@deftai/core/pr-monitor": sub("core", "pr-monitor"),
       "@deftai/core/pr-wait-mergeable": sub("core", "pr-wait-mergeable"),
       "@deftai/core/vbrief-build": sub("core", "vbrief-build"),
+      "@deftai/core/vbrief-activate": sub("core", "vbrief-activate"),
       "@deftai/core": src("core"),
     },
   },
@@ -112,6 +113,7 @@ export default defineConfig({
         "packages/cli/src/pr-monitor-parity.ts",
         "packages/cli/src/pr-wait-mergeable-parity.ts",
         "packages/cli/src/vbrief-build-parity.ts",
+        "packages/cli/src/vbrief-activate-parity.ts",
       ],
       reporter: ["text", "text-summary"],
       thresholds: {


### PR DESCRIPTION
## Summary
- Port `scripts/vbrief_activate.py` to `@deftai/core/vbrief-activate` with byte-identical lifecycle semantics (pending→active move, `plan.status=running`, `vBRIEFInfo.updated` stamp, atomic write via `.tmp` + rename).
- Add `packages/cli/src/vbrief-activate.ts` CLI seam and `vbrief-activate-parity.ts` golden harness (12 scenarios vs frozen Python oracle).
- Wire subpath export, vitest alias/coverage exclude, and `tasks/ts.yml` `vbrief-activate-parity` + `parity-all` entries.

## Test plan
- [x] `pnpm --filter @deftai/core test src/vbrief-activate` (vbrief-activate module ~91% branches)
- [x] `pnpm run build`
- [x] `pnpm exec biome check` on new files
- [x] `node packages/cli/dist/vbrief-activate-parity.js` — CLEAN (12 scenarios)
- [x] `task check`

Refs #1782 / #1530 Wave 5 story 1782-s5.

Made with [Cursor](https://cursor.com)