### PR TITLE
feat(ts): port vBRIEF reconciliation engine to TypeScript (#1782 s4)

### DIFF
--- a/packages/cli/src/vbrief-reconcile-parity.ts
+++ b/packages/cli/src/vbrief-reconcile-parity.ts
@@ -103,6 +103,7 @@ from _vbrief_reconciliation import (
     parse_overrides_yaml,
     reconcile_scope_items,
 )
+from vbrief_reconcile_umbrellas import parse_current_shape
 import _vbrief_reconciliation as _vr_mod
 
 FIXED_REPORT_NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
@@ -114,6 +115,15 @@ OVERRIDES_SAMPLE = """overrides:
   roadmap-9:
     drop: true
 """
+
+PARSE_SHAPE_BODY = (
+    "## Current shape (as of pass-4)\\n"
+    "Last updated:    2026-06-19T00:00:00Z   \\n"
+    "Last pass type:\\tverify\\t\\n"
+    "Child-count history:   pass-1: 2, pass-2: 3,  pass-3: 5\\n"
+    "Trailing field with empty value:      \\n"
+    "Child-count history: pass-9: 9"
+)
 
 def spec_with(items):
     return {
@@ -177,6 +187,18 @@ def run_scenario(name):
         finally:
             _vr_mod.datetime = prior
         return {"scenario": name, "ok": True, "payload": payload}
+    if name == "reconcile-parse-shape":
+        shape = parse_current_shape(PARSE_SHAPE_BODY)
+        return {
+            "scenario": name,
+            "ok": True,
+            "payload": {
+                "passN": shape.pass_n,
+                "history": [[n, c] for n, c in shape.history],
+                "lastUpdated": shape.last_updated,
+                "lastPassType": shape.last_pass_type,
+            },
+        }
     raise SystemExit(f"unknown library scenario: {name}")
 
 if __name__ == "__main__":
@@ -212,6 +234,7 @@ const LIBRARY_SCENARIOS = new Set([
   "reconcile-scope-clean",
   "reconcile-scope-orphan",
   "reconcile-report",
+  "reconcile-parse-shape",
 ]);
 
 function installFakeGh(): { binDir: string; cleanup: () => void } {

--- a/packages/cli/src/vbrief-reconcile-parity.ts
+++ b/packages/cli/src/vbrief-reconcile-parity.ts
@@ -1,0 +1,667 @@
+#!/usr/bin/env node
+/**
+ * Golden-output parity harness (#1782 s4): runs BOTH the frozen Python oracles
+ * and the ported TS vbrief-reconcile CLI over shared fixtures (fake gh on PATH,
+ * cache-off), then diffs exit codes and byte-identical stdout/stderr.
+ */
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PARITY_SCENARIO_NAMES } from "@deftai/core/vbrief-reconcile";
+
+const FAKE_GH_PY = `import json
+import os
+import sys
+
+STATE = {"labels": {}, "comments": {}, "next_id": 1000}
+
+def classify(cmd):
+    joined = " ".join(cmd)
+    if "issue" in cmd and "view" in cmd and "--json" in cmd and "labels" in joined:
+        return "issue-labels"
+    if "issue" in cmd and "edit" in cmd:
+        return "issue-edit"
+    if "/issues/" in joined and "/comments" in joined and "-X" not in cmd:
+        return "list-comments"
+    if "-X" in cmd and "PATCH" in cmd and "/issues/comments/" in joined:
+        return "patch-comment"
+    if "-X" in cmd and "POST" in joined and "/issues/" in joined and "/comments" in joined:
+        return "post-comment"
+    return "unknown"
+
+def handle(label, cmd):
+    responses = json.loads(os.environ.get("DEFT_FAKE_GH_RESPONSES", "{}"))
+    if label in responses:
+        return responses[label]
+    if label == "issue-labels":
+        repo = cmd[cmd.index("--repo") + 1]
+        num = int(cmd[cmd.index("view") + 1])
+        labels = STATE["labels"].get((repo, num), [])
+        return {"returncode": 0, "stdout": json.dumps({"labels": [{"name": n} for n in labels]})}
+    if label == "issue-edit":
+        repo = cmd[cmd.index("--repo") + 1]
+        num = int(cmd[cmd.index("edit") + 1])
+        key = (repo, num)
+        cur = set(STATE["labels"].get(key, []))
+        i = 0
+        while i < len(cmd):
+            if cmd[i] == "--add-label":
+                cur.add(cmd[i + 1]); i += 2
+            elif cmd[i] == "--remove-label":
+                cur.discard(cmd[i + 1]); i += 2
+            else:
+                i += 1
+        STATE["labels"][key] = sorted(cur)
+        return {"returncode": 0, "stdout": ""}
+    if label == "list-comments":
+        parts = [p for p in cmd[-1].split("/") if p]
+        repo = "/".join(parts[1:3])
+        num = int(parts[3])
+        comments = STATE["comments"].get((repo, num), [])
+        return {"returncode": 0, "stdout": json.dumps(comments)}
+    if label == "post-comment":
+        parts = [p for p in cmd if "/issues/" in p][0].split("/")
+        repo = "/".join(parts[1:3])
+        num = int(parts[3])
+        body = json.loads(sys.stdin.read())["body"]
+        cid = STATE["next_id"]; STATE["next_id"] += 1
+        STATE["comments"].setdefault((repo, num), []).append({"id": cid, "body": body})
+        return {"returncode": 0, "stdout": json.dumps({"id": cid})}
+    if label == "patch-comment":
+        cid = int([p for p in cmd if "/issues/comments/" in p][0].split("/")[-1])
+        body = json.loads(sys.stdin.read())["body"]
+        for bucket in STATE["comments"].values():
+            for c in bucket:
+                if c["id"] == cid:
+                    c["body"] = body
+        return {"returncode": 0, "stdout": ""}
+    return {"returncode": 1, "stderr": f"unexpected gh call: {label}", "stdout": ""}
+
+label = classify(sys.argv[1:])
+resp = handle(label, sys.argv[1:])
+stdout = resp.get("stdout", "")
+stderr = resp.get("stderr", "")
+if stdout:
+    sys.stdout.write(stdout if stdout.endswith("\\n") else stdout)
+if stderr:
+    sys.stderr.write(stderr)
+sys.exit(int(resp.get("returncode", 0)))
+`;
+
+const PYTHON_DRIVER = `import json, os, sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(os.environ["DEFT_ROOT"])
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from _vbrief_reconciliation import (
+    build_spec_task_index,
+    format_reconciliation_markdown,
+    parse_overrides_yaml,
+    reconcile_scope_items,
+)
+import _vbrief_reconciliation as _vr_mod
+
+FIXED_REPORT_NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+OVERRIDES_SAMPLE = """overrides:
+  t2.4.1:
+    status: completed
+    body_source: spec
+  roadmap-9:
+    drop: true
+"""
+
+def spec_with(items):
+    return {
+        "vBRIEFInfo": {"version": "0.5", "description": "spec"},
+        "plan": {"title": "Spec", "status": "approved", "narratives": {}, "items": items},
+    }
+
+def run_scenario(name):
+    if name == "reconcile-overrides":
+        return {"scenario": name, "ok": True, "payload": parse_overrides_yaml(OVERRIDES_SAMPLE)}
+    if name == "reconcile-spec-index":
+        spec = spec_with([
+            {"id": "t1.1", "title": "One", "status": "pending"},
+            {
+                "id": "phase-1",
+                "title": "Phase 1: Foundation",
+                "status": "pending",
+                "subItems": [{"id": "t1.1.1", "title": "Deep task", "status": "pending"}],
+            },
+        ])
+        index = build_spec_task_index(spec)
+        return {
+            "scenario": name,
+            "ok": True,
+            "payload": {"keys": sorted(index.keys()), "deepPhase": index["t1.1.1"].spec_phase},
+        }
+    if name == "reconcile-scope-clean":
+        spec = spec_with([{"id": "t1", "title": "Task one", "status": "pending"}])
+        items, report = reconcile_scope_items(
+            roadmap_active=[{"number": "", "task_id": "t1", "title": "Task one", "phase": "Phase 1"}],
+            roadmap_completed=[],
+            spec_vbrief=spec,
+        )
+        return {"scenario": name, "ok": True, "payload": {"items": items, "hasDisagreement": report.has_disagreement()}}
+    if name == "reconcile-scope-orphan":
+        spec = spec_with([{"id": "t1", "title": "One", "status": "pending"}])
+        items, report = reconcile_scope_items(
+            roadmap_active=[{"number": "9", "title": "Orphan task", "phase": "Phase 1", "synthetic_id": "roadmap-9"}],
+            roadmap_completed=[],
+            spec_vbrief=spec,
+        )
+        return {"scenario": name, "ok": True, "payload": {"items": items, "orphans": report.orphans}}
+    if name == "reconcile-report":
+        spec = spec_with([{"id": "t2.4.1", "title": "Repo indexer", "status": "pending"}])
+        _, report = reconcile_scope_items(
+            roadmap_active=[],
+            roadmap_completed=[{"number": "", "task_id": "t2.4.1", "title": "Repo indexer", "phase": "Completed"}],
+            spec_vbrief=spec,
+        )
+        class _FixedDatetime:
+            UTC = timezone.utc
+
+            @staticmethod
+            def now(tz=None):
+                return FIXED_REPORT_NOW
+
+        prior = _vr_mod.datetime
+        _vr_mod.datetime = _FixedDatetime
+        try:
+            payload = format_reconciliation_markdown(report)
+        finally:
+            _vr_mod.datetime = prior
+        return {"scenario": name, "ok": True, "payload": payload}
+    raise SystemExit(f"unknown library scenario: {name}")
+
+if __name__ == "__main__":
+    name = sys.argv[sys.argv.index("--scenario") + 1] if "--scenario" in sys.argv else None
+    if not name:
+        raise SystemExit("usage: driver --scenario NAME")
+    print(json.dumps(run_scenario(name), indent=2))
+`;
+
+export interface ScenarioResult {
+  readonly name: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ParityResult {
+  readonly ok: boolean;
+  readonly scenarios: Array<{
+    readonly name: string;
+    readonly exitMismatch: boolean;
+    readonly pythonExit: number;
+    readonly tsExit: number;
+    readonly outputMismatch: boolean;
+    readonly pythonOutput: string;
+    readonly tsOutput: string;
+  }>;
+}
+
+const LIBRARY_SCENARIOS = new Set([
+  "reconcile-overrides",
+  "reconcile-spec-index",
+  "reconcile-scope-clean",
+  "reconcile-scope-orphan",
+  "reconcile-report",
+]);
+
+function installFakeGh(): { binDir: string; cleanup: () => void } {
+  const binDir = mkdtempSync(join(tmpdir(), "deft-vbrief-reconcile-fake-gh-"));
+  for (const name of ["gh", "ghx"]) {
+    const bin = join(binDir, name);
+    writeFileSync(bin, `#!/usr/bin/env python3\n${FAKE_GH_PY}`, "utf8");
+    chmodSync(bin, 0o755);
+  }
+  return { binDir, cleanup: () => rmSync(binDir, { recursive: true, force: true }) };
+}
+
+function runCapture(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): ScenarioResult {
+  const result = spawnSync(cmd, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    name: "",
+    exitCode: result.status ?? 2,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+}
+
+function resolveDeftRoot(): string {
+  if (process.env.DEFT_ROOT) return resolve(process.env.DEFT_ROOT);
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}
+
+function installPythonDriver(): { driverPath: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "deft-vbrief-reconcile-driver-"));
+  const driverPath = join(dir, "vbrief_reconcile_parity_driver.py");
+  writeFileSync(driverPath, PYTHON_DRIVER, "utf8");
+  chmodSync(driverPath, 0o755);
+  return { driverPath, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function fakeGhResponsesForScenario(
+  name: string,
+): Record<string, { returncode: number; stdout?: string; stderr?: string }> {
+  if (name === "labels-blocked-dry-run" || name === "labels-utf8-dry-run") {
+    return {
+      "issue-labels": { returncode: 0, stdout: "[]\n" },
+    };
+  }
+  if (name === "umbrellas-create-dry-run") {
+    return { "list-comments": { returncode: 0, stdout: "[]\n" } };
+  }
+  if (name === "umbrellas-unchanged") {
+    return { "list-comments": { returncode: 0, stdout: "[]\n" } };
+  }
+  return {};
+}
+
+function writeGraphFixtures(root: string, name: string): void {
+  const writeBrief = (storyId: string, folder: string, dependsOn: string[] = []) => {
+    const dir = join(root, "vbrief", folder);
+    mkdirSync(dir, { recursive: true });
+    const statusMap: Record<string, string> = {
+      proposed: "proposed",
+      completed: "completed",
+    };
+    writeFileSync(
+      join(dir, `2026-05-21-${storyId}.vbrief.json`),
+      `${JSON.stringify(
+        {
+          vBRIEFInfo: { version: "0.6" },
+          plan: {
+            id: storyId,
+            title: storyId,
+            status: statusMap[folder] ?? "pending",
+            narratives: {
+              Description: `${storyId} description.`,
+              ImplementationPlan: `1. Do ${storyId}.`,
+              UserStory: `As a user, I want ${storyId}.`,
+              Traces: "FR-1",
+            },
+            items: [
+              {
+                id: `${storyId}-a1`,
+                title: "Acceptance item 1",
+                status: "pending",
+                narrative: { Acceptance: `Given X when ${storyId} then Y.` },
+              },
+            ],
+            metadata: {
+              kind: "story",
+              swarm: {
+                readiness: "ready",
+                parallel_safe: true,
+                file_scope: [`src/${storyId}.py`],
+                verify_commands: [`pytest ${storyId}`],
+                expected_outputs: ["tests pass"],
+                depends_on: dependsOn,
+                conflict_group: "reconcile-suite",
+                size: "small",
+                file_scope_confidence: "high",
+                model_tier: "standard",
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  };
+
+  if (name === "graph-dry-run") {
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    writeBrief("dep-done", "completed");
+    writeBrief("child", "proposed", ["dep-done"]);
+  } else if (name === "graph-cycle") {
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    writeBrief("a", "proposed", ["b"]);
+    writeBrief("b", "proposed", ["a"]);
+  } else if (name === "graph-missing-proposed") {
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+  }
+}
+
+function runGraphCliParity(
+  deftRoot: string,
+  name: string,
+  fixture: string,
+  env: Record<string, string>,
+): { python: ScenarioResult; ts: ScenarioResult } {
+  writeGraphFixtures(fixture, name);
+  const py = runCapture(
+    "uv",
+    [
+      "run",
+      "python",
+      join(deftRoot, "scripts", "vbrief_reconcile_graph.py"),
+      "--project-root",
+      fixture,
+      "--dry-run",
+    ],
+    deftRoot,
+    env,
+  );
+  const ts = runCapture(
+    "node",
+    [
+      join(deftRoot, "packages", "cli", "dist", "vbrief-reconcile.js"),
+      "graph",
+      "--project-root",
+      fixture,
+      "--dry-run",
+    ],
+    deftRoot,
+    env,
+  );
+  return {
+    python: { name, exitCode: py.exitCode, stdout: py.stdout, stderr: py.stderr },
+    ts: { name, exitCode: ts.exitCode, stdout: ts.stdout, stderr: ts.stderr },
+  };
+}
+
+function writeLabelsUmbrellasFixtures(root: string, name: string): void {
+  const writeBrief = (storyId: string, folder: string, extra: Record<string, unknown> = {}) => {
+    const dir = join(root, "vbrief", folder);
+    mkdirSync(dir, { recursive: true });
+    const statusMap: Record<string, string> = {
+      proposed: "proposed",
+      pending: "pending",
+      active: "running",
+      completed: "completed",
+      cancelled: "cancelled",
+    };
+    writeFileSync(
+      join(dir, `2026-05-21-${storyId}.vbrief.json`),
+      `${JSON.stringify(
+        {
+          vBRIEFInfo: { version: "0.6" },
+          plan: {
+            id: storyId,
+            title: storyId,
+            status: statusMap[folder] ?? "pending",
+            narratives: {
+              Description: `${storyId} description.`,
+              ImplementationPlan: `1. Do ${storyId}.`,
+              UserStory: `As a user, I want ${storyId}.`,
+              Traces: "FR-1",
+            },
+            items: [
+              {
+                id: `${storyId}-a1`,
+                title: "Acceptance item 1",
+                status: "pending",
+                narrative: { Acceptance: `Given X when ${storyId} then Y.` },
+              },
+            ],
+            metadata: {
+              kind: "story",
+              swarm: {
+                readiness: "ready",
+                parallel_safe: true,
+                file_scope: [`src/${storyId}.py`],
+                verify_commands: [`pytest ${storyId}`],
+                expected_outputs: ["tests pass"],
+                depends_on: [],
+                conflict_group: "reconcile-suite",
+                size: "small",
+                file_scope_confidence: "high",
+                model_tier: "standard",
+              },
+            },
+            references: [],
+            ...extra,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  };
+
+  if (name === "labels-blocked-dry-run") {
+    writeBrief("blk", "active", {
+      status: "blocked",
+      references: [
+        {
+          uri: "https://github.com/deftai/directive/issues/10",
+          type: "x-vbrief/github-issue",
+          title: "Issue #10",
+        },
+      ],
+    });
+  } else if (name === "labels-utf8-dry-run") {
+    writeBrief("utf8", "active", {
+      references: [
+        {
+          uri: "https://github.com/deftai/directive/issues/11",
+          type: "x-vbrief/github-issue",
+          title: "Issue #11 — smart “quotes”",
+        },
+      ],
+    });
+  } else if (name === "umbrellas-create-dry-run") {
+    writeBrief("child-a", "active", { metadata: { kind: "story", swarm: { depends_on: [] } } });
+    writeBrief("epic-1", "active", {
+      metadata: { kind: "epic", swarm: { depends_on: [] } },
+      references: [
+        { uri: "active/2026-05-21-child-a.vbrief.json", type: "x-vbrief/plan", title: "child-a" },
+        {
+          uri: "https://github.com/deftai/directive/issues/1284",
+          type: "x-vbrief/github-issue",
+          title: "Issue #1284",
+        },
+      ],
+    });
+  } else if (name === "umbrellas-unchanged") {
+    writeBrief("child-b", "active", { metadata: { kind: "story", swarm: { depends_on: [] } } });
+    writeBrief("epic-2", "active", {
+      metadata: { kind: "epic", swarm: { depends_on: [] } },
+      references: [
+        { uri: "active/2026-05-21-child-b.vbrief.json", type: "x-vbrief/plan", title: "child-b" },
+        {
+          uri: "https://github.com/deftai/directive/issues/1285",
+          type: "x-vbrief/github-issue",
+          title: "Issue #1285",
+        },
+      ],
+    });
+  }
+}
+
+function runLabelsUmbrellasParity(
+  deftRoot: string,
+  name: string,
+  env: Record<string, string>,
+): { python: ScenarioResult; ts: ScenarioResult } {
+  const pyFixture = mkdtempSync(join(tmpdir(), "deft-vbrief-reconcile-py-"));
+  const tsFixture = mkdtempSync(join(tmpdir(), "deft-vbrief-reconcile-ts-"));
+  const script = name.startsWith("labels-")
+    ? "vbrief_reconcile_labels.py"
+    : "vbrief_reconcile_umbrellas.py";
+  const verb = name.startsWith("labels-") ? "labels" : "umbrellas";
+  try {
+    writeLabelsUmbrellasFixtures(pyFixture, name);
+    writeLabelsUmbrellasFixtures(tsFixture, name);
+
+    if (name === "umbrellas-unchanged") {
+      runCapture(
+        "uv",
+        ["run", "python", join(deftRoot, "scripts", script), "--project-root", pyFixture],
+        deftRoot,
+        env,
+      );
+      runCapture(
+        "node",
+        [
+          join(deftRoot, "packages", "cli", "dist", "vbrief-reconcile.js"),
+          verb,
+          "--project-root",
+          tsFixture,
+        ],
+        deftRoot,
+        env,
+      );
+    }
+
+    const pyArgs = [
+      "run",
+      "python",
+      join(deftRoot, "scripts", script),
+      "--project-root",
+      pyFixture,
+      "--dry-run",
+    ];
+    const tsArgs = [
+      join(deftRoot, "packages", "cli", "dist", "vbrief-reconcile.js"),
+      verb,
+      "--project-root",
+      tsFixture,
+      "--dry-run",
+    ];
+    const py = runCapture("uv", pyArgs, deftRoot, env);
+    const ts = runCapture("node", tsArgs, deftRoot, env);
+    return {
+      python: { name, exitCode: py.exitCode, stdout: py.stdout, stderr: py.stderr },
+      ts: { name, exitCode: ts.exitCode, stdout: ts.stdout, stderr: ts.stderr },
+    };
+  } finally {
+    rmSync(pyFixture, { recursive: true, force: true });
+    rmSync(tsFixture, { recursive: true, force: true });
+  }
+}
+
+export function runParity(): ParityResult {
+  const deftRoot = resolveDeftRoot();
+  const driver = installPythonDriver();
+  const fake = installFakeGh();
+  const scenarios: ParityResult["scenarios"] = [];
+
+  try {
+    for (const name of PARITY_SCENARIO_NAMES) {
+      const env = {
+        DEFT_CACHE_DISABLE: "1",
+        PYTHONUTF8: "1",
+        PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+        DEFT_ROOT: deftRoot,
+        DEFT_FAKE_GH_RESPONSES: JSON.stringify(fakeGhResponsesForScenario(name)),
+      };
+
+      let ran: { python: ScenarioResult; ts: ScenarioResult };
+      if (LIBRARY_SCENARIOS.has(name)) {
+        const pyFixture = mkdtempSync(join(tmpdir(), "deft-vbrief-reconcile-lib-py-"));
+        const tsFixture = mkdtempSync(join(tmpdir(), "deft-vbrief-reconcile-lib-ts-"));
+        try {
+          const py = runCapture(
+            "uv",
+            ["run", "python", driver.driverPath, "--scenario", name],
+            deftRoot,
+            env,
+          );
+          const ts = runCapture(
+            "node",
+            [
+              join(deftRoot, "packages", "cli", "dist", "vbrief-reconcile.js"),
+              "parity",
+              "--scenario",
+              name,
+              "--fixture-root",
+              tsFixture,
+            ],
+            deftRoot,
+            env,
+          );
+          ran = {
+            python: { name, exitCode: py.exitCode, stdout: py.stdout, stderr: py.stderr },
+            ts: { name, exitCode: ts.exitCode, stdout: ts.stdout, stderr: ts.stderr },
+          };
+        } finally {
+          rmSync(pyFixture, { recursive: true, force: true });
+          rmSync(tsFixture, { recursive: true, force: true });
+        }
+      } else if (name.startsWith("graph-")) {
+        const fixture = mkdtempSync(join(tmpdir(), "deft-vbrief-reconcile-graph-"));
+        try {
+          ran = runGraphCliParity(deftRoot, name, fixture, env);
+        } finally {
+          rmSync(fixture, { recursive: true, force: true });
+        }
+      } else {
+        ran = runLabelsUmbrellasParity(deftRoot, name, env);
+      }
+
+      scenarios.push({
+        name,
+        pythonExit: ran.python.exitCode,
+        tsExit: ran.ts.exitCode,
+        exitMismatch: ran.python.exitCode !== ran.ts.exitCode,
+        outputMismatch: ran.python.stdout !== ran.ts.stdout || ran.python.stderr !== ran.ts.stderr,
+        pythonOutput: ran.python.stdout || ran.python.stderr,
+        tsOutput: ran.ts.stdout || ran.ts.stderr,
+      });
+    }
+  } finally {
+    driver.cleanup();
+    fake.cleanup();
+  }
+
+  const ok = scenarios.every((s) => !s.exitMismatch && !s.outputMismatch);
+  return { ok, scenarios };
+}
+
+export function renderReport(result: ParityResult): string {
+  if (result.ok) {
+    return `vbrief_reconcile parity: CLEAN -- Python and TS agree on ${result.scenarios.length} scenario(s).`;
+  }
+  const lines = ["vbrief_reconcile parity: DIVERGENCE"];
+  for (const s of result.scenarios) {
+    if (s.exitMismatch || s.outputMismatch) {
+      lines.push(`  scenario: ${s.name}`);
+      if (s.exitMismatch) lines.push(`    exit mismatch: python=${s.pythonExit} ts=${s.tsExit}`);
+      if (s.outputMismatch) {
+        lines.push(`    python (${s.pythonOutput.length} bytes):`);
+        lines.push(s.pythonOutput.slice(0, 500));
+        lines.push(`    ts (${s.tsOutput.length} bytes):`);
+        lines.push(s.tsOutput.slice(0, 500));
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const result = runParity();
+    if (result.ok) {
+      process.stdout.write(`${renderReport(result)}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`${renderReport(result)}\n`);
+    process.exit(1);
+  } catch (err) {
+    const msg = String(err).replace(/\r?\n/g, " ");
+    process.stderr.write(`vbrief_reconcile parity: harness error -- ${msg}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/vbrief-reconcile.ts
+++ b/packages/cli/src/vbrief-reconcile.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { cmdVbriefReconcile } from "@deftai/core/vbrief-reconcile";
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(cmdVbriefReconcile(process.argv.slice(2)));
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,6 +93,10 @@
     "./vbrief-build": {
       "types": "./dist/vbrief-build/index.d.ts",
       "default": "./dist/vbrief-build/index.js"
+    },
+    "./vbrief-reconcile": {
+      "types": "./dist/vbrief-reconcile/index.d.ts",
+      "default": "./dist/vbrief-reconcile/index.js"
     }
   },
   "dependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export * as slice from "./slice/index.js";
 export * as storyReady from "./story-ready/index.js";
 export * as triage from "./triage/index.js";
 export * as vbriefBuild from "./vbrief-build/index.js";
+export * as vbriefReconcile from "./vbrief-reconcile/index.js";
 export * as wipCap from "./wip-cap/index.js";
 
 export const CORE_PACKAGE = "@deftai/core" as const;

--- a/packages/core/src/vbrief-reconcile/branches.test.ts
+++ b/packages/core/src/vbrief-reconcile/branches.test.ts
@@ -1,0 +1,216 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as graphMod from "./graph.js";
+import * as labelsMod from "./labels.js";
+import { cmdVbriefReconcile, run, runGraph, runLabels, runUmbrellas, usage } from "./main.js";
+import { runParityScenario } from "./parity-scenarios.js";
+import {
+  detectStatusMarker,
+  folderFromStatus,
+  loadOverrides,
+  parseOverridesYaml,
+  reconcileScopeItems,
+} from "./reconciliation.js";
+import { asStrList, candidateFromPath } from "./swarm-deps.js";
+import type { LabelClient, UmbrellaClient } from "./types.js";
+import { classifyPassType, parseCurrentShape, reconcileUmbrellas } from "./umbrellas.js";
+
+describe("branch coverage boost", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("detectStatusMarker wip/blocked/cancelled", () => {
+    expect(detectStatusMarker("[wip] task")).toBe("running");
+    expect(detectStatusMarker("[blocked]")).toBe("blocked");
+    expect(detectStatusMarker("[cancelled]")).toBe("cancelled");
+  });
+
+  it("folderFromStatus unknown defaults pending", () => {
+    expect(folderFromStatus("unknown")).toBe("pending");
+  });
+
+  it("parseOverridesYaml ignores non-overrides top level", () => {
+    expect(parseOverridesYaml("other:\n  x: 1\n")).toEqual({});
+  });
+
+  it("reconcile with override status and spec body override", () => {
+    const [items] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t1", title: "T", number: "", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: { plan: { items: [{ id: "t1", title: "T", status: "pending" }] } },
+      overrides: { t1: { status: "completed", body_source: "spec" } },
+    });
+    expect(items[0]?.status).toBe("completed");
+  });
+
+  it("reconcile roadmap-only title", () => {
+    const [items] = reconcileScopeItems({
+      roadmapActive: [{ number: "42", title: "Only RM", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: null,
+    });
+    expect(items[0]?.title_source).toBe("");
+  });
+
+  it("loadOverrides missing file", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-br-"));
+    roots.push(root);
+    expect(loadOverrides(join(root, "vbrief"))).toEqual({});
+  });
+
+  it("candidateFromPath invalid json", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-cand-"));
+    roots.push(root);
+    const dir = join(root, "vbrief", "proposed");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "bad.vbrief.json"), "{bad\n");
+    expect(candidateFromPath(join(dir, "bad.vbrief.json"), root)).toBeNull();
+  });
+
+  it("asStrList non-array", () => {
+    expect(asStrList(null)).toEqual([]);
+  });
+
+  it("classifyPassType subtractive and refactor", () => {
+    expect(classifyPassType(3, 2)).toBe("subtractive");
+    expect(classifyPassType(2, 2)).toBe("refactor");
+  });
+
+  it("parseCurrentShape partial fields", () => {
+    const parsed = parseCurrentShape("## Current shape (as of pass-1)\n");
+    expect(parsed.passN).toBe(1);
+    expect(parsed.history).toEqual([]);
+  });
+
+  it("labels fetch error increments errors", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-lerr-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "x.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "x",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+          references: [{ type: "x-vbrief/github-issue", uri: "https://github.com/o/r/issues/1" }],
+        },
+      })}\n`,
+    );
+    const client: LabelClient = {
+      fetchLabels: () => {
+        throw new labelsMod.ScmLabelError("fetch fail");
+      },
+      apply: () => {},
+    };
+    const [code, outcome] = labelsMod.reconcileLabels(root, { client });
+    expect(code).toBe(1);
+    expect(outcome.errors.length).toBe(1);
+  });
+
+  it("umbrellas skips duplicate issue key", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-udup-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    const ref = [
+      { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/55" },
+    ];
+    for (const id of ["e1", "e2"]) {
+      writeFileSync(
+        join(active, `${id}.vbrief.json`),
+        `${JSON.stringify({ plan: { id, metadata: { kind: "epic", swarm: { depends_on: [] } }, references: ref } })}\n`,
+      );
+    }
+    const client: UmbrellaClient = {
+      fetchComments: () => [],
+      editComment: () => {},
+      createComment: () => 1,
+    };
+    const [, outcome] = reconcileUmbrellas(root, { client, now: "2026-06-14T20:00:00Z" });
+    expect(outcome.changed.length).toBe(1);
+  });
+
+  it("run throws on unknown scenario", () => {
+    expect(() => runParityScenario("nope", { fixtureRoot: "/tmp" })).toThrow();
+  });
+
+  it("cmd catches run errors", () => {
+    vi.spyOn(graphMod, "reconcileGraph").mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const root = mkdtempSync(join(tmpdir(), "deft-cmd-err-"));
+    roots.push(root);
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    expect(cmdVbriefReconcile(["graph", "--project-root", root])).toBe(2);
+  });
+
+  it("run handles bad parity args", () => {
+    expect(run(["parity"])).toBe(2);
+    expect(() => run(["parity", "--scenario", "nope"])).toThrow();
+    usage();
+  });
+
+  it("main json error paths", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-json-err-"));
+    roots.push(root);
+    expect(runGraph({ projectRoot: root, json: true })).toBe(2);
+    expect(runLabels({ projectRoot: root, json: true })).toBe(2);
+    expect(runUmbrellas({ projectRoot: root })).toBe(2);
+  });
+
+  it("umbrellas client error and skipped render", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umb-err-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "no-ref.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "nr", metadata: { kind: "epic", swarm: { depends_on: [] } } } })}\n`,
+    );
+    writeFileSync(
+      join(active, "boom.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "boom",
+          metadata: { kind: "epic", swarm: { depends_on: [] } },
+          references: [{ type: "x-vbrief/github-issue", uri: "https://github.com/o/r/issues/9" }],
+        },
+      })}\n`,
+    );
+    const client: UmbrellaClient = {
+      fetchComments: () => {
+        throw new labelsMod.ScmLabelError("comments fail");
+      },
+      editComment: () => {},
+      createComment: () => 1,
+    };
+    const [code, outcome] = reconcileUmbrellas(root, { client });
+    expect(code).toBe(1);
+    expect(outcome.skipped_no_ref).toContain("nr");
+    const report = graphMod.renderGraphReport({
+      promoted: [],
+      deferredWip: [],
+      waiting: [],
+      cycles: [],
+      errors: [],
+      cap: 0,
+      count: 0,
+      dryRun: false,
+      forced: false,
+    });
+    expect(report).toContain("- none");
+  });
+
+  it("parseCommon parity shorthand", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-parity-shorthand-"));
+    roots.push(root);
+    expect(run(["--scenario", "reconcile-overrides", "--fixture-root", root])).toBe(0);
+  });
+});

--- a/packages/core/src/vbrief-reconcile/coverage-boost.test.ts
+++ b/packages/core/src/vbrief-reconcile/coverage-boost.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { cmdVbriefReconcile, runParityScenario, usage } from "./index.js";
+import { pyRepr } from "./py-repr.js";
+import { asStrList, candidateDepGraph } from "./swarm-deps.js";
+import type { Candidate } from "./types.js";
+
+describe("vbrief-reconcile coverage boost", () => {
+  it("pyRepr quotes strings", () => {
+    expect(pyRepr("pending")).toBe("'pending'");
+  });
+
+  it("asStrList filters non-strings", () => {
+    expect(asStrList(["a", 1, "b"])).toEqual(["a", "b"]);
+  });
+
+  it("candidateDepGraph tracks intra-candidate deps", () => {
+    const a: Candidate = {
+      path: "/a",
+      storyId: "a",
+      status: "proposed",
+      swarm: { depends_on: ["b"] },
+      blocked: [],
+    };
+    const b: Candidate = {
+      path: "/b",
+      storyId: "b",
+      status: "proposed",
+      swarm: { depends_on: [] },
+      blocked: [],
+    };
+    const graph = candidateDepGraph([a, b], { a: ["/a", "proposed"], b: ["/b", "proposed"] });
+    expect(graph.a).toEqual(["b"]);
+  });
+
+  it("runParityScenario reconcile-overrides", () => {
+    const result = runParityScenario("reconcile-overrides", { fixtureRoot: "/tmp" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("usage does not throw", () => {
+    expect(() => usage()).not.toThrow();
+  });
+
+  it("cmd returns 2 for missing verb", () => {
+    expect(cmdVbriefReconcile([])).toBe(2);
+  });
+});

--- a/packages/core/src/vbrief-reconcile/coverage-branches.test.ts
+++ b/packages/core/src/vbrief-reconcile/coverage-branches.test.ts
@@ -1,0 +1,635 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as scm from "../scm/call.js";
+import { formatVbriefJson } from "../scope/vbrief-json.js";
+import { graphOutcomeToJson, reconcileGraph, renderGraphReport } from "./graph.js";
+import {
+  computeDesiredLabels,
+  labelsOutcomeToJson,
+  reconcileLabels,
+  renderLabelsReport,
+  ScmLabelClient,
+  ScmLabelError,
+} from "./labels.js";
+import { run, runGraph, runLabels, runUmbrellas } from "./main.js";
+import { loadFixtureBrief, runParityScenario } from "./parity-scenarios.js";
+import {
+  detectStatusMarker,
+  formatReconciliationMarkdown,
+  hasDisagreement,
+  parseOverridesYaml,
+  reconcileScopeItems,
+  writeReconciliationReport,
+} from "./reconciliation.js";
+import { allScopeIds, candidateDepGraph, candidateFromPath, markCycles } from "./swarm-deps.js";
+import type { Candidate } from "./types.js";
+import {
+  buildChildIndex,
+  childFromData,
+  computeChildren,
+  reconcileUmbrellas,
+  renderUmbrellasReport,
+  ScmUmbrellaClient,
+} from "./umbrellas.js";
+
+describe("coverage branches round 2", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("renderGraphReport lists waiting cycles and errors", () => {
+    const report = renderGraphReport({
+      promoted: ["a"],
+      deferredWip: ["b"],
+      waiting: [{ story_id: "c", unresolved: ["d", "e"] }],
+      cycles: ["a -> b -> a"],
+      errors: [{ story_id: "x", message: "bad" }],
+      cap: 5,
+      count: 3,
+      dryRun: true,
+      forced: false,
+    });
+    expect(report).toContain("c: needs d, e");
+    expect(report).toContain("a -> b -> a");
+    expect(report).toContain("Errors:");
+    expect(
+      graphOutcomeToJson({
+        promoted: ["a"],
+        deferredWip: [],
+        waiting: [{ story_id: "w", unresolved: ["z"] }],
+        cycles: [],
+        errors: [],
+        cap: 1,
+        count: 0,
+        dryRun: false,
+        forced: false,
+      }),
+    ).toHaveProperty("waiting");
+  });
+
+  it("main runners json success and error stderr branches", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-json2-"));
+    roots.push(root);
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    expect(runGraph({ projectRoot: root, json: true })).toBe(0);
+    expect(runLabels({ projectRoot: root, json: true })).toBe(0);
+    expect(runUmbrellas({ projectRoot: root, json: true })).toBe(0);
+    expect(runGraph({ projectRoot: join(root, "missing"), json: false })).toBe(2);
+    expect(runUmbrellas({ projectRoot: join(root, "missing"), json: true })).toBe(2);
+  });
+
+  it("run graph labels umbrellas via argv", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-run-argv-"));
+    roots.push(root);
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    expect(run(["graph", "--project-root", root, "--json"])).toBe(0);
+    expect(run(["labels", "--project-root", root])).toBe(0);
+    expect(run(["umbrellas", "--project-root", root, "--json"])).toBe(0);
+  });
+
+  it("formatReconciliationMarkdown overrides and orphans sections", () => {
+    const md = formatReconciliationMarkdown(
+      {
+        conflicts: [],
+        orphans: [{ task_id: "orph", title: "Orphan title" }],
+        overridesTriggered: [
+          { task_id: "t1", title: "One", action: "dropped from migration" },
+          { task_id: "t2", fields: "status=completed" },
+        ],
+        overridesUnused: ["unused-key"],
+      },
+      new Date("2026-06-19T12:00:00Z"),
+    );
+    expect(md).toContain("orph");
+    expect(md).toContain("dropped from migration");
+    expect(md).toContain("unused-key");
+    expect(
+      hasDisagreement({
+        conflicts: [{ task_id: "x", title: "t", dimensions: [] }],
+        orphans: [],
+        overridesTriggered: [],
+        overridesUnused: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("writeReconciliationReport skips when no disagreement", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-wrr-"));
+    roots.push(root);
+    const vbrief = join(root, "vbrief");
+    mkdirSync(vbrief, { recursive: true });
+    expect(
+      writeReconciliationReport(
+        { conflicts: [], orphans: [], overridesTriggered: [], overridesUnused: [] },
+        vbrief,
+      ),
+    ).toBeNull();
+  });
+
+  it("swarm-deps non-object branches and allScopeIds stem alias", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-sd-"));
+    roots.push(root);
+    const proposed = join(root, "vbrief", "proposed");
+    mkdirSync(proposed, { recursive: true });
+    writeFileSync(join(proposed, "bad-json.vbrief.json"), "{bad\n");
+    writeFileSync(
+      join(proposed, "from-name.vbrief.json"),
+      `${JSON.stringify({ plan: { status: "proposed", metadata: { swarm: 1 } } })}\n`,
+    );
+    writeFileSync(
+      join(proposed, "with-id.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "wid", status: "proposed", metadata: { swarm: "bad" } } })}\n`,
+    );
+    expect(candidateFromPath(join(proposed, "bad-json.vbrief.json"), root)).toBeNull();
+    const fromName = candidateFromPath(join(proposed, "from-name.vbrief.json"), root);
+    expect(fromName?.storyId).toBe("from-name");
+    const ids = allScopeIds(root);
+    expect(ids["from-name"]).toBeDefined();
+    expect(ids.wid).toBeDefined();
+    const a: Candidate = {
+      path: "/a",
+      storyId: "a",
+      status: "proposed",
+      swarm: { depends_on: ["ext"] },
+      blocked: [],
+    };
+    candidateDepGraph([a], { ext: ["/p", "running"] });
+    expect(a.blocked.length).toBe(1);
+    const b: Candidate = {
+      path: "/b",
+      storyId: "b",
+      status: "proposed",
+      swarm: { depends_on: ["c"] },
+      blocked: [],
+    };
+    const c: Candidate = {
+      path: "/c",
+      storyId: "c",
+      status: "proposed",
+      swarm: { depends_on: ["b"] },
+      blocked: [],
+    };
+    markCycles([b, c], { b: ["c"], c: ["b"] });
+    expect(b.blocked.length).toBeGreaterThan(0);
+  });
+
+  it("labels report errors and scm client edge cases", () => {
+    const report = renderLabelsReport({
+      changed: [],
+      unchanged: [],
+      skipped_no_ref: [],
+      errors: [{ story_id: "e", message: "fail" }],
+      dry_run: false,
+    });
+    expect(report).toContain("Errors:");
+    expect(
+      labelsOutcomeToJson({
+        changed: [],
+        unchanged: [],
+        skipped_no_ref: ["s"],
+        errors: [],
+        dry_run: true,
+      }),
+    ).toHaveProperty("skipped_no_ref");
+
+    vi.spyOn(scm, "call")
+      .mockReturnValueOnce({ args: [], returncode: 1, stdout: "", stderr: "boom" })
+      .mockReturnValueOnce({
+        args: [],
+        returncode: 0,
+        stdout: JSON.stringify({ labels: "bad" }),
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        args: [],
+        returncode: 0,
+        stdout: JSON.stringify({ labels: ["raw-label"] }),
+        stderr: "",
+      })
+      .mockReturnValueOnce({ args: [], returncode: 1, stdout: "", stderr: "edit fail" });
+    const client = new ScmLabelClient();
+    expect(() => client.fetchLabels("r", 1)).toThrow(ScmLabelError);
+    expect(client.fetchLabels("r", 2)).toEqual([]);
+    expect(client.fetchLabels("r", 3)).toEqual(["raw-label"]);
+    expect(() => client.apply("r", 4, ["a"], [])).toThrow(ScmLabelError);
+  });
+
+  it("labels reconcile metadata.swarm non-object and null data", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-lmeta-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "m.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "m",
+          status: "running",
+          metadata: { kind: "story", swarm: null },
+          references: [{ type: "x-vbrief/github-issue", uri: "https://github.com/o/r/issues/7" }],
+        },
+      })}\n`,
+    );
+    writeFileSync(join(active, "null.vbrief.json"), "null\n");
+    const client = {
+      fetchLabels: () => [] as string[],
+      apply: () => {},
+    };
+    const [, outcome] = reconcileLabels(root, { client });
+    expect(outcome.unchanged.length).toBe(1);
+  });
+
+  it("umbrellas render skipped and invalid json skip", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umb-skip-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(join(active, "bad.vbrief.json"), "{oops\n");
+    writeFileSync(
+      join(active, "story.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "story", metadata: { kind: "story" } } })}\n`,
+    );
+    writeFileSync(
+      join(active, "noref.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "noref", metadata: { kind: "epic" } } })}\n`,
+    );
+    const client = {
+      fetchComments: () => [],
+      editComment: () => {},
+      createComment: () => 1,
+    };
+    const [, outcome] = reconcileUmbrellas(root, { client });
+    const report = renderUmbrellasReport(outcome);
+    expect(report).toContain("Skipped");
+    expect(outcome.skipped_no_ref).toContain("noref");
+  });
+
+  it("parity scenarios use built-in memory umbrella client", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-parity-mem-"));
+    roots.push(root);
+    expect(runParityScenario("umbrellas-create-dry-run", { fixtureRoot: root }).ok).toBe(true);
+    const root2 = mkdtempSync(join(tmpdir(), "deft-parity-mem2-"));
+    roots.push(root2);
+    expect(runParityScenario("umbrellas-unchanged", { fixtureRoot: root2 }).ok).toBe(true);
+  });
+
+  it("loadFixtureBrief reads json file", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-fix-"));
+    roots.push(root);
+    const path = join(root, "x.json");
+    writeFileSync(path, '{"a":1}\n');
+    expect(loadFixtureBrief(path)).toEqual({ a: 1 });
+  });
+
+  it("graph promotes for real", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-live-"));
+    roots.push(root);
+    for (const folder of ["proposed", "pending", "active", "completed"]) {
+      mkdirSync(join(root, "vbrief", folder), { recursive: true });
+    }
+    writeFileSync(
+      join(root, "vbrief", "completed", "dep.vbrief.json"),
+      formatVbriefJson({
+        vBRIEFInfo: { version: "0.5" },
+        plan: {
+          id: "dep",
+          title: "dep",
+          status: "completed",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+        },
+      }),
+    );
+    writeFileSync(
+      join(root, "vbrief", "proposed", "child.vbrief.json"),
+      formatVbriefJson({
+        vBRIEFInfo: { version: "0.5" },
+        plan: {
+          id: "child",
+          title: "child",
+          status: "proposed",
+          metadata: { kind: "story", swarm: { depends_on: ["dep"] } },
+        },
+      }),
+    );
+    const [code, outcome] = reconcileGraph(root, { dryRun: false });
+    expect(code).toBe(0);
+    expect(outcome.promoted).toContain("child");
+    expect(existsSync(join(root, "vbrief", "pending", "child.vbrief.json"))).toBe(true);
+  });
+
+  it("graph records transition failures", async () => {
+    const transition = await import("../scope/transition.js");
+    vi.spyOn(transition, "runTransition").mockReturnValue({ ok: false, message: "promote failed" });
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-err-"));
+    roots.push(root);
+    for (const folder of ["proposed", "pending", "active", "completed"]) {
+      mkdirSync(join(root, "vbrief", folder), { recursive: true });
+    }
+    writeFileSync(
+      join(root, "vbrief", "completed", "dep2.vbrief.json"),
+      formatVbriefJson({
+        vBRIEFInfo: { version: "0.5" },
+        plan: {
+          id: "dep2",
+          title: "dep2",
+          status: "completed",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+        },
+      }),
+    );
+    writeFileSync(
+      join(root, "vbrief", "proposed", "kid.vbrief.json"),
+      formatVbriefJson({
+        vBRIEFInfo: { version: "0.5" },
+        plan: {
+          id: "kid",
+          title: "kid",
+          status: "proposed",
+          metadata: { kind: "story", swarm: { depends_on: ["dep2"] } },
+        },
+      }),
+    );
+    const [, outcome] = reconcileGraph(root, { dryRun: false });
+    expect(outcome.errors[0]?.story_id).toBe("kid");
+  });
+
+  it("main runGraph human report path", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-human-"));
+    roots.push(root);
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    expect(runGraph({ projectRoot: root, dryRun: true })).toBe(0);
+  });
+
+  it("reconciliation conflict markdown with overrides and phases", () => {
+    const [items, report] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t9", title: "[wip] Task", number: "", phase: "P1", tier: "T1" }],
+      roadmapCompleted: [],
+      specVbrief: {
+        plan: {
+          items: [
+            {
+              id: "phase-1",
+              title: "Phase 1: Foundation",
+              subItems: [{ id: "t9", title: "Spec title", status: "pending" }],
+            },
+          ],
+        },
+      },
+      phaseDescriptions: { P1: "Phase one" },
+      overrides: { t9: { status: "running" } },
+    });
+    expect(items[0]?.phase_description).toBe("Phase one");
+    expect(items[0]?.spec_phase).toContain("Phase 1");
+    const md = formatReconciliationMarkdown(report, new Date("2026-06-19T12:00:00Z"));
+    expect(md).toContain("Overrides applied:");
+    expect(md).toContain("TITLE drift");
+    expect(hasDisagreement(report)).toBe(true);
+    const root = mkdtempSync(join(tmpdir(), "deft-rec-wr-"));
+    roots.push(root);
+    const vbrief = join(root, "vbrief");
+    mkdirSync(vbrief, { recursive: true });
+    expect(writeReconciliationReport(report, vbrief, new Date("2026-06-19T12:00:00Z"))).toContain(
+      "RECONCILIATION.md",
+    );
+  });
+
+  it("computeDesiredLabels non-object metadata and research rfc", () => {
+    expect(computeDesiredLabels({ status: "running", metadata: null }, false)).toEqual(new Set());
+    expect(
+      computeDesiredLabels({ status: "running", metadata: { kind: "research" } }, true),
+    ).toEqual(new Set(["status:blocked", "rfc"]));
+  });
+
+  it("scm umbrella client createComment bad json returns null", () => {
+    vi.spyOn(scm, "call").mockReturnValue({
+      args: [],
+      returncode: 0,
+      stdout: "not-json",
+      stderr: "",
+    });
+    expect(new ScmUmbrellaClient().createComment("deftai/directive", 1, "body")).toBeNull();
+  });
+
+  it("umbrellas skips non-object plan and metadata", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umb-plan-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "weird.vbrief.json"),
+      `${JSON.stringify({
+        plan: "not-object",
+        references: [{ type: "x-vbrief/github-issue", uri: "https://github.com/o/r/issues/3" }],
+      })}\n`,
+    );
+    const client = {
+      fetchComments: () => [],
+      editComment: () => {},
+      createComment: () => 1,
+    };
+    const [, outcome] = reconcileUmbrellas(root, { client });
+    expect(outcome.changed.length + outcome.unchanged.length).toBe(0);
+  });
+
+  it("swarm-deps plan and metadata non-object branches", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-sd2-"));
+    roots.push(root);
+    const proposed = join(root, "vbrief", "proposed");
+    mkdirSync(proposed, { recursive: true });
+    writeFileSync(
+      join(proposed, "p.vbrief.json"),
+      `${JSON.stringify({ plan: "x", metadata: 1 })}\n`,
+    );
+    const cand = candidateFromPath(join(proposed, "p.vbrief.json"), root);
+    expect(cand?.storyId).toBe("p");
+    expect(cand?.swarm).toEqual({});
+  });
+
+  it("cli option branches and umbrellas json output", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-cli-opts-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "e.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "ep",
+          metadata: { kind: "epic", swarm: { depends_on: [] } },
+          references: [{ type: "x-vbrief/github-issue", uri: "https://github.com/o/r/issues/44" }],
+        },
+      })}\n`,
+    );
+    vi.spyOn(scm, "call").mockReturnValue({ args: [], returncode: 0, stdout: "[]", stderr: "" });
+    expect(run(["graph", "--project-root", root, "--force", "--dry-run"])).toBe(0);
+    expect(run(["umbrellas", "--project-root", root, "--repo", "o/r", "--json", "--dry-run"])).toBe(
+      0,
+    );
+    expect(run(["parity", "--all", "--fixture-root", root])).toBe(0);
+  });
+
+  it("scm umbrella client error branches", () => {
+    vi.spyOn(scm, "call")
+      .mockReturnValueOnce({ args: [], returncode: 1, stdout: "", stderr: "list fail" })
+      .mockReturnValueOnce({ args: [], returncode: 0, stdout: "{bad", stderr: "" })
+      .mockReturnValueOnce({ args: [], returncode: 0, stdout: "[]", stderr: "" })
+      .mockReturnValueOnce({ args: [], returncode: 1, stdout: "", stderr: "edit fail" })
+      .mockReturnValueOnce({ args: [], returncode: 1, stdout: "", stderr: "create fail" });
+    const client = new ScmUmbrellaClient();
+    expect(() => client.fetchComments("r", 1)).toThrow();
+    expect(() => client.fetchComments("r", 2)).toThrow();
+    client.fetchComments("r", 3);
+    expect(() => client.editComment("r", 9, "b")).toThrow();
+    expect(() => client.createComment("r", 4, "b")).toThrow();
+  });
+
+  it("labels scm non-array labels and filename story id", () => {
+    vi.spyOn(scm, "call").mockReturnValue({
+      args: [],
+      returncode: 0,
+      stdout: JSON.stringify({ labels: { bad: true } }),
+      stderr: "",
+    });
+    expect(new ScmLabelClient().fetchLabels("r", 1)).toEqual([]);
+
+    const root = mkdtempSync(join(tmpdir(), "deft-lname-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "from-file.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          status: "running",
+          metadata: 1,
+          references: [{ type: "x-vbrief/github-issue", uri: "https://github.com/o/r/issues/8" }],
+        },
+      })}\n`,
+    );
+    const client = { fetchLabels: () => [] as string[], apply: () => {} };
+    const [, outcome] = reconcileLabels(root, { client });
+    expect(outcome.unchanged[0]?.story_id).toBe("from-file");
+  });
+
+  it("graph depResolved and cycle fallback branches", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-br-"));
+    roots.push(root);
+    mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+    writeFileSync(
+      join(root, "vbrief", "proposed", "solo.vbrief.json"),
+      formatVbriefJson({
+        vBRIEFInfo: { version: "0.5" },
+        plan: {
+          id: "solo",
+          status: "proposed",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+        },
+      }),
+    );
+    const [, outcome] = reconcileGraph(root, { dryRun: true });
+    expect(outcome.promoted).toEqual([]);
+  });
+
+  it("reconciliation yaml task keys and synthetic task ids", () => {
+    const yaml =
+      "overrides:\n" +
+      "  task-a:\n" +
+      "    status: completed\n" +
+      "  task-b:\n" +
+      "    drop: true\n";
+    const parsed = parseOverridesYaml(yaml);
+    expect(parsed["task-a"]).toEqual({ status: "completed" });
+    const [items] = reconcileScopeItems({
+      roadmapActive: [{ synthetic_id: "syn-42", title: "Synthetic", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: null,
+      overrides: { "syn-42": { body_source: "spec" } },
+    });
+    expect(items[0]?.task_id).toBe("syn-42");
+    expect(items[0]?.description_source).toContain("fallback");
+    const [, report] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t1.2.3", title: "Matched", number: "", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: { plan: { items: [{ id: "t1.2.3", title: "Matched", status: "pending" }] } },
+    });
+    expect(report.conflicts).toEqual([]);
+  });
+
+  it("parity shorthand --all first argv", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-all-first-"));
+    roots.push(root);
+    expect(run(["--all", "--fixture-root", root])).toBe(0);
+  });
+
+  it("umbrella scm parses comment entries", () => {
+    vi.spyOn(scm, "call").mockReturnValue({
+      args: [],
+      returncode: 0,
+      stdout: JSON.stringify([
+        { id: 1, body: "## Current shape (as of pass-1)\n" },
+        { id: "bad", body: 1 },
+      ]),
+      stderr: "",
+    });
+    const comments = new ScmUmbrellaClient().fetchComments("deftai/directive", 9);
+    expect(comments).toEqual([{ id: 1, body: "## Current shape (as of pass-1)\n" }]);
+  });
+
+  it("reconciliation marker and narrative branches", () => {
+    expect(detectStatusMarker("[cancelled] task")).toBe("cancelled");
+    const [items] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t-no-match", title: "No spec", number: "", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: { plan: { items: [{ id: "other", title: "Other", status: "pending" }] } },
+    });
+    expect(items[0]?.description).toBe("No spec");
+    const [withBody] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t1", title: "RM", number: "", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: {
+        plan: {
+          items: [
+            { id: "t1", title: "", status: "pending", narrative: { Summary: "From summary" } },
+          ],
+        },
+      },
+    });
+    expect(withBody[0]?.description).toBe("From summary");
+  });
+
+  it("umbrellas readJson null and computeChildren without refs", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umb-json-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(join(active, "arr.vbrief.json"), "[]\n");
+    expect(buildChildIndex(join(root, "vbrief"))).toEqual({});
+    expect(computeChildren({ plan: { references: "nope" } }, {})).toEqual([]);
+    expect(childFromData({ plan: { id: "c" } }, "active", "fb").folder).toBe("active");
+  });
+
+  it("runUmbrellas json stdout with epic fixture", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umb-json-out-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "ep.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "ep",
+          metadata: { kind: "epic", swarm: { depends_on: [] } },
+          references: [{ type: "x-vbrief/github-issue", uri: "https://github.com/o/r/issues/77" }],
+        },
+      })}\n`,
+    );
+    vi.spyOn(scm, "call").mockReturnValue({ args: [], returncode: 0, stdout: "[]", stderr: "" });
+    expect(runUmbrellas({ projectRoot: root, json: true, dryRun: true })).toBe(0);
+  });
+});

--- a/packages/core/src/vbrief-reconcile/graph.test.ts
+++ b/packages/core/src/vbrief-reconcile/graph.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { reconcileGraph, renderGraphReport } from "./graph.js";
+import { candidateDepGraph, markCycles } from "./swarm-deps.js";
+import type { Candidate } from "./types.js";
+
+function writeBrief(root: string, storyId: string, folder: string, dependsOn: string[] = []): void {
+  const dir = join(root, "vbrief", folder);
+  mkdirSync(dir, { recursive: true });
+  const status =
+    folder === "completed" ? "completed" : folder === "active" ? "running" : "proposed";
+  writeFileSync(
+    join(dir, `2026-05-21-${storyId}.vbrief.json`),
+    `${JSON.stringify({
+      plan: {
+        id: storyId,
+        title: storyId,
+        status,
+        metadata: { kind: "story", swarm: { depends_on: dependsOn } },
+      },
+    })}\n`,
+    "utf8",
+  );
+}
+
+function writeProjectDef(root: string, wipCap: number): void {
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+    `${JSON.stringify({ plan: { policy: { wipCap } } })}\n`,
+    "utf8",
+  );
+}
+
+describe("reconcileGraph", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("returns exit 2 when proposed missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-"));
+    roots.push(root);
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+    const [code] = reconcileGraph(root, { dryRun: true });
+    expect(code).toBe(2);
+  });
+
+  it("promotes when deps resolved (dry-run)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-"));
+    roots.push(root);
+    writeBrief(root, "dep", "completed");
+    writeBrief(root, "child", "proposed", ["dep"]);
+    const [code, outcome] = reconcileGraph(root, { dryRun: true });
+    expect(code).toBe(0);
+    expect(outcome.promoted).toContain("child");
+    expect(renderGraphReport(outcome)).toContain("vBRIEF reconcile graph");
+  });
+
+  it("detects cycles", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-"));
+    roots.push(root);
+    writeBrief(root, "a", "proposed", ["b"]);
+    writeBrief(root, "b", "proposed", ["a"]);
+    const [code, outcome] = reconcileGraph(root, { dryRun: true });
+    expect(code).toBe(1);
+    expect(outcome.cycles.length).toBeGreaterThan(0);
+  });
+
+  it("defers at wip cap", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-"));
+    roots.push(root);
+    writeProjectDef(root, 0);
+    writeBrief(root, "dep", "completed");
+    writeBrief(root, "child", "proposed", ["dep"]);
+    const [, outcome] = reconcileGraph(root, { dryRun: true });
+    expect(outcome.deferredWip).toContain("child");
+  });
+
+  it("waits on unresolved deps", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-"));
+    roots.push(root);
+    writeBrief(root, "dep", "active");
+    writeBrief(root, "child", "proposed", ["dep"]);
+    const [, outcome] = reconcileGraph(root, { dryRun: true });
+    expect(outcome.waiting[0]?.story_id).toBe("child");
+  });
+
+  it("skips dependency-free proposed items", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-graph-"));
+    roots.push(root);
+    writeBrief(root, "solo", "proposed", []);
+    const [, outcome] = reconcileGraph(root, { dryRun: true });
+    expect(outcome.promoted).toEqual([]);
+  });
+});
+
+describe("markCycles", () => {
+  it("marks cycle participants", () => {
+    const a: Candidate = {
+      path: "/a",
+      storyId: "a",
+      status: "proposed",
+      swarm: { depends_on: ["b"] },
+      blocked: [],
+    };
+    const b: Candidate = {
+      path: "/b",
+      storyId: "b",
+      status: "proposed",
+      swarm: { depends_on: ["a"] },
+      blocked: [],
+    };
+    markCycles([a, b], { a: ["b"], b: ["a"] });
+    expect(a.blocked.some((r) => r.startsWith("dependency cycle:"))).toBe(true);
+  });
+});
+
+describe("candidateDepGraph external dep status", () => {
+  it("blocks when external dep not terminal", () => {
+    const a: Candidate = {
+      path: "/a",
+      storyId: "a",
+      status: "proposed",
+      swarm: { depends_on: ["ext"] },
+      blocked: [],
+    };
+    candidateDepGraph([a], { ext: ["/vbrief/active/ext.vbrief.json", "running"] });
+    expect(a.blocked.length).toBe(1);
+  });
+});

--- a/packages/core/src/vbrief-reconcile/graph.ts
+++ b/packages/core/src/vbrief-reconcile/graph.ts
@@ -1,0 +1,199 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { countVbriefWip, resolveWipCap } from "../policy/wip.js";
+import { runTransition } from "../scope/transition.js";
+import {
+  allScopeIds,
+  asStrList,
+  candidateDepGraph,
+  candidateFromPath,
+  markCycles,
+} from "./swarm-deps.js";
+import type { ReconcileGraphOutcome } from "./types.js";
+
+export const RESOLVED_FOLDERS = ["completed", "cancelled"] as const;
+const CYCLE_MARKER = "dependency cycle:";
+
+function resolveWipState(projectRoot: string): [number, number] {
+  const capResult = resolveWipCap(projectRoot);
+  const cap = capResult.cap;
+  const count = countVbriefWip(projectRoot);
+  return [cap, count];
+}
+
+export function depResolved(dep: string, knownIds: Record<string, [string, string]>): boolean {
+  const known = knownIds[dep];
+  if (!known) return false;
+  const [path] = known;
+  const folder = path.split(/[/\\]/).slice(-2, -1)[0] ?? "";
+  return (RESOLVED_FOLDERS as readonly string[]).includes(folder);
+}
+
+function unresolvedDeps(
+  candidate: { swarm: Record<string, unknown> },
+  knownIds: Record<string, [string, string]>,
+): string[] {
+  return asStrList(candidate.swarm.depends_on).filter((dep) => !depResolved(dep, knownIds));
+}
+
+function candidateInCycle(candidate: { blocked: string[] }): boolean {
+  return candidate.blocked.some((r) => r.startsWith(CYCLE_MARKER));
+}
+
+export interface ReconcileGraphOptions {
+  readonly force?: boolean;
+  readonly dryRun?: boolean;
+}
+
+export function reconcileGraph(
+  projectRoot: string,
+  options: ReconcileGraphOptions = {},
+): [number, ReconcileGraphOutcome] {
+  const root = resolve(projectRoot);
+  const proposedDir = join(root, "vbrief", "proposed");
+  if (!existsSync(proposedDir)) {
+    return [
+      2,
+      {
+        promoted: [],
+        deferredWip: [],
+        waiting: [],
+        cycles: [],
+        errors: [],
+        cap: 0,
+        count: 0,
+        dryRun: options.dryRun ?? false,
+        forced: options.force ?? false,
+      },
+    ];
+  }
+
+  const candidatePaths = readdirSync(proposedDir)
+    .filter((f) => f.endsWith(".vbrief.json"))
+    .sort()
+    .map((f) => join(proposedDir, f));
+
+  const candidates = candidatePaths
+    .map((p) => candidateFromPath(p, root))
+    .filter((c): c is NonNullable<typeof c> => c !== null);
+
+  const knownIds = allScopeIds(root);
+  for (const cand of candidates) {
+    if (!knownIds[cand.storyId]) knownIds[cand.storyId] = [cand.path, cand.status];
+  }
+
+  const graph = candidateDepGraph(candidates, knownIds);
+  markCycles(candidates, graph);
+
+  const [cap, count] = resolveWipState(root);
+  const outcome: ReconcileGraphOutcome = {
+    promoted: [],
+    deferredWip: [],
+    waiting: [],
+    cycles: [],
+    errors: [],
+    cap,
+    count,
+    dryRun: options.dryRun ?? false,
+    forced: options.force ?? false,
+  };
+
+  const eligible: typeof candidates = [];
+  for (const cand of [...candidates].sort((a, b) => a.storyId.localeCompare(b.storyId))) {
+    if (candidateInCycle(cand)) {
+      const cycleReason = cand.blocked.find((r) => r.startsWith(CYCLE_MARKER)) ?? "";
+      outcome.cycles.push(`${cand.storyId}: ${cycleReason}`);
+      continue;
+    }
+    const deps = asStrList(cand.swarm.depends_on);
+    if (deps.length === 0) continue;
+    const unresolved = unresolvedDeps(cand, knownIds);
+    if (unresolved.length > 0) {
+      outcome.waiting.push({ story_id: cand.storyId, unresolved });
+      continue;
+    }
+    eligible.push(cand);
+  }
+
+  let runningCount = count;
+  for (const cand of eligible) {
+    if (runningCount >= cap && !options.force) {
+      outcome.deferredWip.push(cand.storyId);
+      continue;
+    }
+    if (options.dryRun) {
+      outcome.promoted.push(cand.storyId);
+      runningCount += 1;
+      continue;
+    }
+    const result = runTransition("promote", cand.path);
+    if (!result.ok) {
+      outcome.errors.push({ story_id: cand.storyId, message: result.message });
+      continue;
+    }
+    outcome.promoted.push(cand.storyId);
+    runningCount += 1;
+  }
+
+  return [outcome.cycles.length > 0 ? 1 : 0, { ...outcome, count: runningCount }];
+}
+
+export function renderGraphReport(outcome: ReconcileGraphOutcome): string {
+  const lines: string[] = ["vBRIEF reconcile graph", ""];
+  const suffix = outcome.dryRun ? " (dry-run)" : "";
+
+  lines.push(`Promoted${suffix}:`);
+  if (outcome.promoted.length > 0) {
+    for (const id of outcome.promoted) lines.push(`- ${id}`);
+  } else {
+    lines.push("- none");
+  }
+  lines.push("");
+
+  lines.push(`Deferred (WIP cap ${outcome.count}/${outcome.cap}):`);
+  if (outcome.deferredWip.length > 0) {
+    for (const id of outcome.deferredWip) lines.push(`- ${id}`);
+  } else {
+    lines.push("- none");
+  }
+  lines.push("");
+
+  lines.push("Waiting (deps unresolved):");
+  if (outcome.waiting.length > 0) {
+    for (const w of outcome.waiting) {
+      lines.push(`- ${w.story_id}: needs ${w.unresolved.join(", ")}`);
+    }
+  } else {
+    lines.push("- none");
+  }
+  lines.push("");
+
+  lines.push("Cycles:");
+  if (outcome.cycles.length > 0) {
+    for (const entry of outcome.cycles) lines.push(`- ${entry}`);
+  } else {
+    lines.push("- none");
+  }
+
+  if (outcome.errors.length > 0) {
+    lines.push("");
+    lines.push("Errors:");
+    for (const err of outcome.errors) lines.push(`- ${err.story_id}: ${err.message}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function graphOutcomeToJson(outcome: ReconcileGraphOutcome): Record<string, unknown> {
+  return {
+    promoted: [...outcome.promoted],
+    deferred_wip: [...outcome.deferredWip],
+    waiting: outcome.waiting.map((w) => ({ story_id: w.story_id, unresolved: w.unresolved })),
+    cycles: [...outcome.cycles],
+    errors: outcome.errors.map((e) => ({ story_id: e.story_id, message: e.message })),
+    cap: outcome.cap,
+    count: outcome.count,
+    dry_run: outcome.dryRun,
+    forced: outcome.forced,
+  };
+}

--- a/packages/core/src/vbrief-reconcile/index.ts
+++ b/packages/core/src/vbrief-reconcile/index.ts
@@ -1,0 +1,78 @@
+export {
+  depResolved,
+  graphOutcomeToJson,
+  RESOLVED_FOLDERS,
+  reconcileGraph,
+  renderGraphReport,
+} from "./graph.js";
+export {
+  computeDesiredLabels,
+  labelsOutcomeToJson,
+  MANAGED_LABELS,
+  reconcileLabels,
+  renderLabelsReport,
+  SCAN_FOLDERS,
+  ScmLabelClient,
+  ScmLabelError,
+} from "./labels.js";
+export { cmdVbriefReconcile, run, usage } from "./main.js";
+export {
+  PARITY_SCENARIO_NAMES,
+  renderScenarioOutput,
+  runParityScenario,
+} from "./parity-scenarios.js";
+export { pyRepr } from "./py-repr.js";
+export {
+  buildSpecTaskIndex,
+  detectStatusMarker,
+  folderFromStatus,
+  formatReconciliationMarkdown,
+  hasDisagreement,
+  loadOverrides,
+  normalizeTaskId,
+  OVERRIDES_FILENAME,
+  parseOverridesYaml,
+  reconcileScopeItems,
+  writeReconciliationReport,
+} from "./reconciliation.js";
+export {
+  allScopeIds,
+  asStrList,
+  candidateDepGraph,
+  candidateFromPath,
+  markCycles,
+} from "./swarm-deps.js";
+export type {
+  Candidate,
+  Child,
+  ConflictEntry,
+  LabelChange,
+  LabelClient,
+  ReconciledItem,
+  ReconcileGraphOutcome,
+  ReconcileLabelsOutcome,
+  ReconcileUmbrellasOutcome,
+  ReconciliationReport,
+  SpecTaskEntry,
+  UmbrellaChange,
+  UmbrellaClient,
+} from "./types.js";
+export {
+  buildChildIndex,
+  CHILD_REF_TYPE,
+  CLOSED_FOLDERS,
+  childFromData,
+  classifyPassType,
+  computeChildren,
+  computeWaves,
+  LIFECYCLE_FOLDERS,
+  nowIso,
+  OPEN_FOLDERS,
+  parseCurrentShape,
+  reconcileUmbrellas,
+  renderBody,
+  renderUmbrellasReport,
+  ScmUmbrellaClient,
+  UmbrellaScmError,
+  umbrellasOutcomeToJson,
+} from "./umbrellas.js";

--- a/packages/core/src/vbrief-reconcile/labels.test.ts
+++ b/packages/core/src/vbrief-reconcile/labels.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { computeDesiredLabels, reconcileLabels } from "./labels.js";
+import type { LabelClient } from "./types.js";
+
+class FakeLabelClient implements LabelClient {
+  labels = new Map<string, string[]>();
+  applyCalls: Array<[string, number, string[], string[]]> = [];
+
+  fetchLabels(repo: string, issueNumber: number): string[] {
+    return [...(this.labels.get(`${repo}:${issueNumber}`) ?? [])];
+  }
+
+  apply(
+    repo: string,
+    issueNumber: number,
+    add: readonly string[],
+    remove: readonly string[],
+  ): void {
+    this.applyCalls.push([repo, issueNumber, [...add], [...remove]]);
+    const key = `${repo}:${issueNumber}`;
+    const cur = new Set(this.labels.get(key) ?? []);
+    for (const a of add) cur.add(a);
+    for (const r of remove) cur.delete(r);
+    this.labels.set(key, [...cur].sort());
+  }
+}
+
+describe("computeDesiredLabels", () => {
+  it("blocked status adds status:blocked", () => {
+    expect(computeDesiredLabels({ status: "blocked", metadata: { kind: "story" } }, false)).toEqual(
+      new Set(["status:blocked"]),
+    );
+  });
+
+  it("epic adds tracker labels", () => {
+    expect(computeDesiredLabels({ status: "running", metadata: { kind: "epic" } }, false)).toEqual(
+      new Set(["epic", "status:tracker"]),
+    );
+  });
+});
+
+describe("reconcileLabels", () => {
+  it("adds blocked label", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-labels-"));
+    const dir = join(root, "vbrief", "active");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "story.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "blk",
+          status: "blocked",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+          references: [
+            { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/10" },
+          ],
+        },
+      })}\n`,
+      "utf8",
+    );
+    const client = new FakeLabelClient();
+    const [code, outcome] = reconcileLabels(root, { client });
+    expect(code).toBe(0);
+    expect(client.applyCalls[0]?.[2]).toEqual(["status:blocked"]);
+    expect(outcome.changed.length).toBe(1);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns exit 2 without vbrief dir", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-labels-missing-"));
+    const [code] = reconcileLabels(root, { client: new FakeLabelClient() });
+    expect(code).toBe(2);
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/vbrief-reconcile/labels.ts
+++ b/packages/core/src/vbrief-reconcile/labels.ts
@@ -1,0 +1,288 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { call } from "../scm/call.js";
+import { extractIssueRef } from "../triage/reconcile/parse-uri.js";
+import { depResolved, RESOLVED_FOLDERS } from "./graph.js";
+import { allScopeIds, asStrList } from "./swarm-deps.js";
+import type { LabelChange, LabelClient, ReconcileLabelsOutcome } from "./types.js";
+
+export const SCAN_FOLDERS = ["proposed", "pending", "active"] as const;
+export const MANAGED_LABELS = ["status:blocked", "epic", "status:tracker", "rfc"] as const;
+const SCM_SOURCE = "github-issue";
+
+export class ScmLabelError extends Error {
+  override name = "ScmLabelError";
+}
+
+export function computeDesiredLabels(
+  plan: Record<string, unknown>,
+  unresolvedDeps: boolean,
+): Set<string> {
+  const desired = new Set<string>();
+  const status = plan.status;
+  const metadata =
+    typeof plan.metadata === "object" && plan.metadata !== null && !Array.isArray(plan.metadata)
+      ? (plan.metadata as Record<string, unknown>)
+      : {};
+  const kind = metadata.kind;
+  if (status === "blocked" || unresolvedDeps) desired.add("status:blocked");
+  if (kind === "epic") {
+    desired.add("epic");
+    desired.add("status:tracker");
+  } else if (kind === "research") {
+    desired.add("rfc");
+  }
+  return desired;
+}
+
+export class ScmLabelClient implements LabelClient {
+  fetchLabels(repo: string, issueNumber: number): string[] {
+    const proc = call(SCM_SOURCE, "issue", [
+      "view",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--json",
+      "labels",
+    ]);
+    if (proc.returncode !== 0) {
+      throw new ScmLabelError(
+        `issue view #${issueNumber} (${repo}) failed: ${(proc.stderr || "").trim()}`,
+      );
+    }
+    let data: unknown;
+    try {
+      data = JSON.parse(proc.stdout || "{}");
+    } catch (exc) {
+      throw new ScmLabelError(
+        `issue view #${issueNumber} (${repo}) returned non-JSON: ${String(exc)}`,
+      );
+    }
+    const labels =
+      typeof data === "object" && data !== null && !Array.isArray(data)
+        ? (data as Record<string, unknown>).labels
+        : null;
+    if (!Array.isArray(labels)) return [];
+    const names: string[] = [];
+    for (const entry of labels) {
+      if (typeof entry === "object" && entry !== null && !Array.isArray(entry)) {
+        const name = (entry as Record<string, unknown>).name;
+        if (typeof name === "string") names.push(name);
+      } else if (typeof entry === "string") {
+        names.push(entry);
+      }
+    }
+    return names;
+  }
+
+  apply(
+    repo: string,
+    issueNumber: number,
+    add: readonly string[],
+    remove: readonly string[],
+  ): void {
+    const args = ["edit", String(issueNumber), "--repo", repo];
+    for (const name of add) args.push("--add-label", name);
+    for (const name of remove) args.push("--remove-label", name);
+    const proc = call(SCM_SOURCE, "issue", args);
+    if (proc.returncode !== 0) {
+      throw new ScmLabelError(
+        `issue edit #${issueNumber} (${repo}) failed: ${(proc.stderr || "").trim()}`,
+      );
+    }
+  }
+}
+
+function hasUnresolvedDeps(
+  swarm: Record<string, unknown>,
+  knownIds: Record<string, [string, string]>,
+): boolean {
+  return asStrList(swarm.depends_on).some((dep) => !depResolved(dep, knownIds));
+}
+
+export interface ReconcileLabelsOptions {
+  readonly repo?: string | null;
+  readonly dryRun?: boolean;
+  readonly client?: LabelClient;
+}
+
+export function reconcileLabels(
+  projectRoot: string,
+  options: ReconcileLabelsOptions = {},
+): [number, ReconcileLabelsOutcome] {
+  const root = resolve(projectRoot);
+  const vbriefDir = join(root, "vbrief");
+  if (!existsSync(vbriefDir)) {
+    return [
+      2,
+      {
+        changed: [],
+        unchanged: [],
+        skipped_no_ref: [],
+        errors: [],
+        dry_run: options.dryRun ?? false,
+      },
+    ];
+  }
+
+  const client = options.client ?? new ScmLabelClient();
+  const knownIds = allScopeIds(root);
+  const outcome: ReconcileLabelsOutcome = {
+    changed: [],
+    unchanged: [],
+    skipped_no_ref: [],
+    errors: [],
+    dry_run: options.dryRun ?? false,
+  };
+  const seenIssues = new Set<string>();
+
+  for (const folder of SCAN_FOLDERS) {
+    const folderPath = join(vbriefDir, folder);
+    if (!existsSync(folderPath)) continue;
+    const files = readdirSync(folderPath)
+      .filter((f) => f.endsWith(".vbrief.json"))
+      .sort();
+    for (const file of files) {
+      const path = join(folderPath, file);
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (typeof data !== "object" || data === null) continue;
+      const plan =
+        typeof data.plan === "object" && data.plan !== null && !Array.isArray(data.plan)
+          ? (data.plan as Record<string, unknown>)
+          : {};
+      const storyId = String(plan.id ?? file.slice(0, -".vbrief.json".length));
+
+      const [refRepo, number] = extractIssueRef(data);
+      const effectiveRepo = refRepo ?? options.repo ?? null;
+      if (number === null || effectiveRepo === null) {
+        outcome.skipped_no_ref.push(storyId);
+        continue;
+      }
+      const key = `${effectiveRepo}:${number}`;
+      if (seenIssues.has(key)) continue;
+      seenIssues.add(key);
+
+      const metadata =
+        typeof plan.metadata === "object" && plan.metadata !== null && !Array.isArray(plan.metadata)
+          ? (plan.metadata as Record<string, unknown>)
+          : {};
+      const swarm =
+        typeof metadata.swarm === "object" &&
+        metadata.swarm !== null &&
+        !Array.isArray(metadata.swarm)
+          ? (metadata.swarm as Record<string, unknown>)
+          : {};
+      const desired = computeDesiredLabels(plan, hasUnresolvedDeps(swarm, knownIds));
+
+      let current: string[];
+      try {
+        current = client.fetchLabels(effectiveRepo, number);
+      } catch (exc) {
+        outcome.errors.push({ story_id: storyId, message: String(exc) });
+        continue;
+      }
+
+      const managedSet = new Set<string>(MANAGED_LABELS);
+      const currentManaged = new Set(current.filter((n) => managedSet.has(n)));
+      const add = [...desired].filter((n) => !currentManaged.has(n)).sort();
+      const remove = [...currentManaged].filter((n) => !desired.has(n)).sort();
+      const change: LabelChange = {
+        story_id: storyId,
+        repo: effectiveRepo,
+        issue_number: number,
+        current: [...current].sort(),
+        desired: [...desired].sort(),
+        add,
+        remove,
+      };
+
+      if (add.length === 0 && remove.length === 0) {
+        outcome.unchanged.push(change);
+        continue;
+      }
+      if (options.dryRun) {
+        outcome.changed.push(change);
+        continue;
+      }
+      try {
+        client.apply(effectiveRepo, number, add, remove);
+      } catch (exc) {
+        outcome.errors.push({ story_id: storyId, message: String(exc) });
+        continue;
+      }
+      outcome.changed.push(change);
+    }
+  }
+
+  return [outcome.errors.length > 0 ? 1 : 0, outcome];
+}
+
+export function renderLabelsReport(outcome: ReconcileLabelsOutcome): string {
+  const lines: string[] = ["vBRIEF reconcile labels", ""];
+  const suffix = outcome.dry_run ? " (dry-run)" : "";
+
+  lines.push(`Changed${suffix}:`);
+  if (outcome.changed.length > 0) {
+    for (const change of outcome.changed) {
+      const parts: string[] = [];
+      if (change.add.length > 0) parts.push(`+${change.add.join(", +")}`);
+      if (change.remove.length > 0) parts.push(`-${change.remove.join(", -")}`);
+      lines.push(
+        `- #${change.issue_number} (${change.repo}) [${change.story_id}]: ${parts.join("; ")}`,
+      );
+    }
+  } else {
+    lines.push("- none");
+  }
+  lines.push("");
+
+  lines.push("Unchanged:");
+  if (outcome.unchanged.length > 0) {
+    for (const c of outcome.unchanged) {
+      lines.push(`- #${c.issue_number} (${c.repo}) [${c.story_id}]`);
+    }
+  } else {
+    lines.push("- none");
+  }
+
+  if (outcome.skipped_no_ref.length > 0) {
+    lines.push("");
+    lines.push("Skipped (no github-issue reference / repo):");
+    for (const sid of outcome.skipped_no_ref) lines.push(`- ${sid}`);
+  }
+
+  if (outcome.errors.length > 0) {
+    lines.push("");
+    lines.push("Errors:");
+    for (const err of outcome.errors) lines.push(`- ${err.story_id}: ${err.message}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function labelsOutcomeToJson(outcome: ReconcileLabelsOutcome): Record<string, unknown> {
+  const toChange = (c: LabelChange) => ({
+    story_id: c.story_id,
+    repo: c.repo,
+    issue_number: c.issue_number,
+    current: [...c.current],
+    desired: [...c.desired],
+    add: [...c.add],
+    remove: [...c.remove],
+  });
+  return {
+    changed: outcome.changed.map(toChange),
+    unchanged: outcome.unchanged.map(toChange),
+    skipped_no_ref: [...outcome.skipped_no_ref],
+    errors: outcome.errors.map((e) => ({ story_id: e.story_id, message: e.message })),
+    dry_run: outcome.dry_run,
+  };
+}
+
+// Re-export for tests
+export { RESOLVED_FOLDERS };

--- a/packages/core/src/vbrief-reconcile/main.test.ts
+++ b/packages/core/src/vbrief-reconcile/main.test.ts
@@ -1,0 +1,456 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as scm from "../scm/call.js";
+import {
+  computeDesiredLabels,
+  MANAGED_LABELS,
+  reconcileLabels,
+  renderLabelsReport,
+  ScmLabelClient,
+  ScmLabelError,
+} from "./labels.js";
+import { cmdVbriefReconcile, runGraph, runLabels, runParityMode, runUmbrellas } from "./main.js";
+import { PARITY_SCENARIO_NAMES, runParityScenario } from "./parity-scenarios.js";
+import { loadOverrides, parseOverridesYaml, reconcileScopeItems } from "./reconciliation.js";
+import type { LabelClient, UmbrellaClient } from "./types.js";
+import {
+  buildChildIndex,
+  childFromData,
+  computeChildren,
+  parseCurrentShape,
+  reconcileUmbrellas,
+  renderBody,
+  renderUmbrellasReport,
+  ScmUmbrellaClient,
+  UmbrellaScmError,
+} from "./umbrellas.js";
+
+class FakeLabelClient implements LabelClient {
+  labels = new Map<string, string[]>();
+  fetchLabels(repo: string, n: number): string[] {
+    return [...(this.labels.get(`${repo}:${n}`) ?? [])];
+  }
+  apply(repo: string, n: number, add: readonly string[], remove: readonly string[]): void {
+    const key = `${repo}:${n}`;
+    const cur = new Set(this.labels.get(key) ?? []);
+    for (const a of add) cur.add(a);
+    for (const r of remove) cur.delete(r);
+    this.labels.set(key, [...cur].sort());
+  }
+}
+
+class FakeUmbrellaClient implements UmbrellaClient {
+  comments = new Map<string, Array<{ id: number; body: string }>>();
+  private nextId = 1000;
+  fetchComments(repo: string, n: number) {
+    return [...(this.comments.get(`${repo}:${n}`) ?? [])];
+  }
+  editComment(_repo: string, id: number, body: string): void {
+    for (const bucket of this.comments.values()) {
+      for (const c of bucket) if (c.id === id) c.body = body;
+    }
+  }
+  createComment(repo: string, n: number, body: string): number {
+    const key = `${repo}:${n}`;
+    const id = this.nextId++;
+    const bucket = this.comments.get(key) ?? [];
+    bucket.push({ id, body });
+    this.comments.set(key, bucket);
+    return id;
+  }
+}
+
+describe("main CLI runners", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  it("runGraph missing proposed exits 2", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-graph-"));
+    roots.push(root);
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+    expect(runGraph({ projectRoot: root })).toBe(2);
+  });
+
+  it("runLabels missing vbrief exits 2", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-labels-"));
+    roots.push(root);
+    expect(runLabels({ projectRoot: root })).toBe(2);
+  });
+
+  it("runUmbrellas missing vbrief exits 2", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-umbrellas-"));
+    roots.push(root);
+    expect(runUmbrellas({ projectRoot: root })).toBe(2);
+  });
+
+  it("runParityMode emits json", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-parity-"));
+    roots.push(root);
+    const code = runParityMode({ scenario: "reconcile-overrides", fixtureRoot: root });
+    expect(code).toBe(0);
+  });
+
+  it("cmd handles labels and umbrellas human output", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-labels-umb-"));
+    roots.push(root);
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "s.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "s",
+          status: "running",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+          references: [
+            { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/99" },
+          ],
+        },
+      })}\n`,
+    );
+    vi.spyOn(scm, "call").mockReturnValue({
+      args: [],
+      returncode: 0,
+      stdout: JSON.stringify({ labels: [] }),
+      stderr: "",
+    });
+    expect(cmdVbriefReconcile(["labels", "--project-root", root, "--dry-run"])).toBe(0);
+    vi.spyOn(scm, "call").mockReturnValue({ args: [], returncode: 0, stdout: "[]", stderr: "" });
+    writeFileSync(
+      join(active, "e.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "e",
+          metadata: { kind: "epic", swarm: { depends_on: [] } },
+          references: [
+            {
+              type: "x-vbrief/github-issue",
+              uri: "https://github.com/deftai/directive/issues/100",
+            },
+          ],
+        },
+      })}\n`,
+    );
+    expect(cmdVbriefReconcile(["umbrellas", "--project-root", root, "--dry-run", "--json"])).toBe(
+      0,
+    );
+  });
+
+  it("runParityMode --all", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-main-all-"));
+    roots.push(root);
+    expect(runParityMode({ all: true, fixtureRoot: root })).toBe(0);
+  });
+});
+
+describe("parity scenarios exhaustive", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+    roots.length = 0;
+  });
+
+  for (const name of PARITY_SCENARIO_NAMES) {
+    it(`runs ${name}`, () => {
+      const root = mkdtempSync(join(tmpdir(), `deft-parity-${name}-`));
+      roots.push(root);
+      const needsClient = name.startsWith("labels-") || name.startsWith("umbrellas-");
+      const result = runParityScenario(name, {
+        fixtureRoot: root,
+        labelClient: needsClient ? new FakeLabelClient() : undefined,
+        umbrellaClient: needsClient ? new FakeUmbrellaClient() : undefined,
+      });
+      expect(result.ok).toBe(true);
+    });
+  }
+});
+
+describe("reconciliation branches", () => {
+  it("override drop and unused keys", () => {
+    const [, report] = reconcileScopeItems({
+      roadmapActive: [
+        { task_id: "t1", title: "One", number: "", phase: "P1" },
+        { number: "9", title: "Drop me", phase: "P1", synthetic_id: "roadmap-9" },
+      ],
+      roadmapCompleted: [],
+      specVbrief: { plan: { items: [{ id: "t1", title: "One", status: "pending" }] } },
+      overrides: { "roadmap-9": { drop: true }, unused: { status: "pending" } },
+    });
+    expect(report.overridesTriggered.some((o) => o.action === "dropped from migration")).toBe(true);
+    expect(report.overridesUnused).toContain("unused");
+  });
+
+  it("loadOverrides reads file", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-ovr-"));
+    const vbrief = join(root, "vbrief");
+    mkdirSync(vbrief, { recursive: true });
+    writeFileSync(
+      join(vbrief, "migration-overrides.yaml"),
+      "overrides:\n  t1:\n    status: completed\n",
+    );
+    expect(loadOverrides(vbrief)).toEqual({ t1: { status: "completed" } });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("title and status conflicts logged", () => {
+    const [items, report] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t5", title: "Road title", number: "", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: {
+        plan: {
+          items: [
+            {
+              id: "t5",
+              title: "Spec title",
+              status: "running",
+              narrative: { Description: "body" },
+            },
+          ],
+        },
+      },
+    });
+    expect(items[0]?.title).toBe("Spec title");
+    expect(report.conflicts.length).toBeGreaterThan(0);
+  });
+
+  it("completed orphan routes to completed", () => {
+    const [items] = reconcileScopeItems({
+      roadmapActive: [],
+      roadmapCompleted: [{ number: "9", title: "Done orphan", phase: "Completed" }],
+      specVbrief: { plan: { items: [{ id: "t1", title: "One", status: "pending" }] } },
+    });
+    expect(items[0]?.folder).toBe("completed");
+  });
+
+  it("body_source override roadmap", () => {
+    const [items] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t1", title: "RM", number: "", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: {
+        plan: {
+          items: [{ id: "t1", title: "Spec", status: "pending", narrative: { Description: "d" } }],
+        },
+      },
+      overrides: { t1: { body_source: "roadmap" } },
+    });
+    expect(items[0]?.description_source).toContain("override");
+  });
+});
+
+describe("labels SCM client", () => {
+  it("fetch and apply via scm.call", () => {
+    vi.spyOn(scm, "call")
+      .mockReturnValueOnce({
+        args: [],
+        returncode: 0,
+        stdout: JSON.stringify({ labels: [{ name: "bug" }, { name: "epic" }] }),
+        stderr: "",
+      })
+      .mockReturnValueOnce({ args: [], returncode: 0, stdout: "", stderr: "" });
+    const client = new ScmLabelClient();
+    expect(client.fetchLabels("deftai/directive", 1)).toEqual(["bug", "epic"]);
+    client.apply("deftai/directive", 1, ["rfc"], ["epic"]);
+  });
+
+  it("labels unchanged and errors", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-labels-br-"));
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "ok.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "ok",
+          status: "running",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+          references: [
+            { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/20" },
+          ],
+        },
+      })}\n`,
+    );
+    writeFileSync(join(active, "bad.vbrief.json"), "not-json\n");
+    writeFileSync(
+      join(active, "noref.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "noref", metadata: { kind: "story", swarm: { depends_on: [] } } } })}\n`,
+    );
+    const client = new FakeLabelClient();
+    client.labels.set("deftai/directive:20", []);
+    const [code, outcome] = reconcileLabels(root, { client });
+    expect(code).toBe(0);
+    expect(outcome.unchanged.length).toBe(1);
+    expect(outcome.skipped_no_ref).toContain("noref");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("labels apply error path", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-labels-err-"));
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "e.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "e",
+          status: "blocked",
+          metadata: { kind: "story", swarm: { depends_on: [] } },
+          references: [
+            { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/30" },
+          ],
+        },
+      })}\n`,
+    );
+    const client: LabelClient = {
+      fetchLabels: () => [],
+      apply: () => {
+        throw new ScmLabelError("apply failed");
+      },
+    };
+    const [code, outcome] = reconcileLabels(root, { client });
+    expect(code).toBe(1);
+    expect(outcome.errors.length).toBe(1);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("scm label client bad json", () => {
+    vi.spyOn(scm, "call").mockReturnValue({
+      args: [],
+      returncode: 0,
+      stdout: "not-json",
+      stderr: "",
+    });
+    expect(() => new ScmLabelClient().fetchLabels("r", 1)).toThrow(ScmLabelError);
+  });
+
+  it("computeDesiredLabels branches", () => {
+    expect(
+      computeDesiredLabels({ status: "running", metadata: { kind: "research" } }, true),
+    ).toEqual(new Set(["status:blocked", "rfc"]));
+    expect(
+      renderLabelsReport({
+        changed: [],
+        unchanged: [],
+        skipped_no_ref: ["x"],
+        errors: [],
+        dry_run: true,
+      }),
+    ).toContain("Skipped");
+    expect(MANAGED_LABELS).toContain("status:blocked");
+  });
+});
+
+describe("umbrellas SCM client", () => {
+  it("fetch edit create via scm", () => {
+    vi.spyOn(scm, "call")
+      .mockReturnValueOnce({ args: [], returncode: 0, stdout: "[]", stderr: "" })
+      .mockReturnValueOnce({
+        args: [],
+        returncode: 0,
+        stdout: JSON.stringify({ id: 42 }),
+        stderr: "",
+      });
+    const client = new ScmUmbrellaClient();
+    expect(client.fetchComments("deftai/directive", 1)).toEqual([]);
+    expect(client.createComment("deftai/directive", 1, "body")).toBe(42);
+    vi.spyOn(scm, "call").mockReturnValue({ args: [], returncode: 0, stdout: "", stderr: "" });
+    client.editComment("deftai/directive", 1, "new");
+  });
+
+  it("umbrella edit when body changes", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umb-edit-"));
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    const existingBody = renderBody({
+      passN: 1,
+      lastPassType: "additive",
+      lastUpdated: "2026-06-14T20:00:00Z",
+      openChildren: [],
+      closedChildren: [],
+      waves: [],
+      history: [[1, 0]],
+    });
+    const client = new FakeUmbrellaClient();
+    client.comments.set("deftai/directive:200", [{ id: 5, body: existingBody }]);
+    writeFileSync(
+      join(active, "c.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "c1", metadata: { kind: "story", swarm: { depends_on: [] } } } })}\n`,
+    );
+    writeFileSync(
+      join(active, "e.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "ep",
+          metadata: { kind: "epic", swarm: { depends_on: [] } },
+          references: [
+            { type: "x-vbrief/plan", uri: "active/c.vbrief.json" },
+            {
+              type: "x-vbrief/github-issue",
+              uri: "https://github.com/deftai/directive/issues/200",
+            },
+          ],
+        },
+      })}\n`,
+    );
+    const [code, outcome] = reconcileUmbrellas(root, { client, now: "2026-06-14T20:00:00Z" });
+    expect(code).toBe(0);
+    expect(outcome.changed[0]?.action).toBe("edited");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("scm umbrella bad json on list", () => {
+    vi.spyOn(scm, "call").mockReturnValue({ args: [], returncode: 0, stdout: "{bad", stderr: "" });
+    expect(() => new ScmUmbrellaClient().fetchComments("r", 1)).toThrow(UmbrellaScmError);
+  });
+
+  it("child index and render branches", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umb-idx-"));
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "c.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "c", metadata: { kind: "story", swarm: { depends_on: ["x"] } } } })}\n`,
+    );
+    const index = buildChildIndex(join(root, "vbrief"));
+    expect(childFromData({ plan: { id: "z" } }, "active", "z").story_id).toBe("z");
+    expect(
+      computeChildren(
+        { plan: { references: [{ type: "x-vbrief/plan", uri: "active/c.vbrief.json" }] } },
+        index,
+      ).length,
+    ).toBe(1);
+    expect(
+      parseCurrentShape(
+        "## Current shape (as of pass-2)\nLast updated: t\nLast pass type: verify\nChild-count history: pass-1: 1, pass-2: 2",
+      ).history,
+    ).toEqual([
+      [1, 1],
+      [2, 2],
+    ]);
+    expect(
+      renderUmbrellasReport({
+        changed: [],
+        unchanged: [],
+        skipped_no_ref: [],
+        errors: [{ story_id: "e", message: "m" }],
+        dry_run: false,
+      }),
+    ).toContain("Errors");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("parseOverridesYaml edge cases", () => {
+  it("coerces booleans and null", () => {
+    const yaml = "overrides:\n  a:\n    drop: false\n  b:\n    drop: yes\n  c:\n    status: null\n";
+    expect(parseOverridesYaml(yaml)).toEqual({
+      a: { drop: false },
+      b: { drop: true },
+      c: { status: null },
+    });
+  });
+});

--- a/packages/core/src/vbrief-reconcile/main.ts
+++ b/packages/core/src/vbrief-reconcile/main.ts
@@ -1,0 +1,156 @@
+import { resolve } from "node:path";
+import { graphOutcomeToJson, reconcileGraph, renderGraphReport } from "./graph.js";
+import { labelsOutcomeToJson, reconcileLabels, renderLabelsReport } from "./labels.js";
+import {
+  PARITY_SCENARIO_NAMES,
+  renderScenarioOutput,
+  runParityScenario,
+} from "./parity-scenarios.js";
+import { reconcileUmbrellas, renderUmbrellasReport, umbrellasOutcomeToJson } from "./umbrellas.js";
+
+export interface CliOptions {
+  projectRoot?: string;
+  repo?: string | null;
+  force?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+  scenario?: string | null;
+  all?: boolean;
+  fixtureRoot?: string | null;
+}
+
+function parseCommon(argv: string[]): { verb: string | null; rest: string[] } {
+  if (argv.length === 0) return { verb: null, rest: [] };
+  const first = argv[0];
+  if (first === "graph" || first === "labels" || first === "umbrellas" || first === "parity") {
+    return { verb: first, rest: argv.slice(1) };
+  }
+  if (first === "--scenario" || first === "--all") return { verb: "parity", rest: argv };
+  return { verb: null, rest: argv };
+}
+
+function parseOptions(rest: string[]): CliOptions {
+  const opts: CliOptions = { projectRoot: "." };
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (arg === "--project-root") {
+      opts.projectRoot = rest[i + 1] ?? ".";
+      i += 1;
+    } else if (arg === "--repo") {
+      opts.repo = rest[i + 1] ?? null;
+      i += 1;
+    } else if (arg === "--force") opts.force = true;
+    else if (arg === "--dry-run") opts.dryRun = true;
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--scenario") {
+      opts.scenario = rest[i + 1] ?? null;
+      i += 1;
+    } else if (arg === "--all") opts.all = true;
+    else if (arg === "--fixture-root") {
+      opts.fixtureRoot = rest[i + 1] ?? null;
+      i += 1;
+    }
+  }
+  return opts;
+}
+
+export function usage(): void {
+  process.stderr.write(
+    "usage: vbrief-reconcile <graph|labels|umbrellas> [--project-root PATH] [--dry-run] [--json] [--force] [--repo OWNER/NAME]\n" +
+      "       vbrief-reconcile parity --scenario NAME [--fixture-root PATH]\n" +
+      "       vbrief-reconcile parity --all [--fixture-root PATH]\n",
+  );
+}
+
+export function runGraph(opts: CliOptions): number {
+  const root = resolve(opts.projectRoot ?? ".");
+  const [code, outcome] = reconcileGraph(root, { force: opts.force, dryRun: opts.dryRun });
+  if (code === 2) {
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify({ error: "no vbrief/proposed/ directory found" })}\n`);
+    } else {
+      process.stderr.write(`Error: no vbrief/proposed/ directory found under ${root}\n`);
+    }
+    return 2;
+  }
+  if (opts.json) process.stdout.write(`${JSON.stringify(graphOutcomeToJson(outcome), null, 2)}\n`);
+  else process.stdout.write(`${renderGraphReport(outcome)}\n`);
+  return code;
+}
+
+export function runLabels(opts: CliOptions): number {
+  const root = resolve(opts.projectRoot ?? ".");
+  const [code, outcome] = reconcileLabels(root, { repo: opts.repo, dryRun: opts.dryRun });
+  if (code === 2) {
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify({ error: "no vbrief/ directory found" })}\n`);
+    } else {
+      process.stderr.write(`Error: no vbrief/ directory found under ${root}\n`);
+    }
+    return 2;
+  }
+  if (opts.json) process.stdout.write(`${JSON.stringify(labelsOutcomeToJson(outcome), null, 2)}\n`);
+  else process.stdout.write(`${renderLabelsReport(outcome)}\n`);
+  return code;
+}
+
+export function runUmbrellas(opts: CliOptions): number {
+  const root = resolve(opts.projectRoot ?? ".");
+  const [code, outcome] = reconcileUmbrellas(root, { repo: opts.repo, dryRun: opts.dryRun });
+  if (code === 2) {
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify({ error: "no vbrief/ directory found" })}\n`);
+    } else {
+      process.stderr.write(`Error: no vbrief/ directory found under ${root}\n`);
+    }
+    return 2;
+  }
+  if (opts.json)
+    process.stdout.write(`${JSON.stringify(umbrellasOutcomeToJson(outcome), null, 2)}\n`);
+  else process.stdout.write(`${renderUmbrellasReport(outcome)}\n`);
+  return code;
+}
+
+export function runParityMode(opts: CliOptions): number {
+  const root = opts.fixtureRoot ?? process.env.DEFT_VBRIEF_RECONCILE_FIXTURE ?? "/tmp/unset";
+  const names = opts.all ? [...PARITY_SCENARIO_NAMES] : [opts.scenario as string];
+  const results = names.map((name) => runParityScenario(name, { fixtureRoot: root }));
+  process.stdout.write(renderScenarioOutput(opts.all ? results : (results[0] as never)));
+  return 0;
+}
+
+export function run(argv: string[]): number {
+  const { verb, rest } = parseCommon(argv);
+  if (verb === null) {
+    usage();
+    return 2;
+  }
+  const opts = parseOptions(rest);
+  switch (verb) {
+    case "graph":
+      return runGraph(opts);
+    case "labels":
+      return runLabels(opts);
+    case "umbrellas":
+      return runUmbrellas(opts);
+    case "parity":
+      if (!opts.all && !opts.scenario) {
+        usage();
+        return 2;
+      }
+      return runParityMode(opts);
+    default:
+      usage();
+      return 2;
+  }
+}
+
+export function cmdVbriefReconcile(argv: string[]): number {
+  try {
+    return run(argv);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`vbrief-reconcile: error: ${msg}\n`);
+    return 2;
+  }
+}

--- a/packages/core/src/vbrief-reconcile/parity-scenarios.ts
+++ b/packages/core/src/vbrief-reconcile/parity-scenarios.ts
@@ -11,7 +11,7 @@ import {
   reconcileScopeItems,
 } from "./reconciliation.js";
 import type { LabelClient, UmbrellaClient } from "./types.js";
-import { reconcileUmbrellas, renderUmbrellasReport } from "./umbrellas.js";
+import { parseCurrentShape, reconcileUmbrellas, renderUmbrellasReport } from "./umbrellas.js";
 
 class MemoryLabelClient implements LabelClient {
   fetchLabels(): string[] {
@@ -59,6 +59,7 @@ export const PARITY_SCENARIO_NAMES = [
   "reconcile-scope-clean",
   "reconcile-scope-orphan",
   "reconcile-report",
+  "reconcile-parse-shape",
   "graph-dry-run",
   "graph-cycle",
   "graph-missing-proposed",
@@ -80,6 +81,18 @@ const OVERRIDES_SAMPLE =
   "    body_source: spec\n" +
   "  roadmap-9:\n" +
   "    drop: true\n";
+
+// Whitespace-edge body for the ReDoS-hardened parse path (#1782 s4): leading
+// runs of spaces/tabs, an all-whitespace tail, and a final line without a
+// trailing newline -- exactly the inputs the `\s*(\S.*|)$` rewrite must parse
+// byte-identically to the Python oracle's `\s*(.*)$`.
+const PARSE_SHAPE_BODY =
+  "## Current shape (as of pass-4)\n" +
+  "Last updated:    2026-06-19T00:00:00Z   \n" +
+  "Last pass type:\tverify\t\n" +
+  "Child-count history:   pass-1: 2, pass-2: 3,  pass-3: 5\n" +
+  "Trailing field with empty value:      \n" +
+  "Child-count history: pass-9: 9";
 
 function specWith(items: unknown[]): Record<string, unknown> {
   return {
@@ -227,6 +240,19 @@ export function runParityScenario(
         scenario: name,
         ok: true,
         payload: formatReconciliationMarkdown(report, FIXED_REPORT_NOW),
+      };
+    }
+    case "reconcile-parse-shape": {
+      const parsed = parseCurrentShape(PARSE_SHAPE_BODY);
+      return {
+        scenario: name,
+        ok: true,
+        payload: {
+          passN: parsed.passN,
+          history: parsed.history,
+          lastUpdated: parsed.lastUpdated,
+          lastPassType: parsed.lastPassType,
+        },
       };
     }
     case "graph-dry-run": {

--- a/packages/core/src/vbrief-reconcile/parity-scenarios.ts
+++ b/packages/core/src/vbrief-reconcile/parity-scenarios.ts
@@ -1,0 +1,400 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pythonJsonPretty } from "../vbrief-build/json.js";
+import { graphOutcomeToJson, reconcileGraph, renderGraphReport } from "./graph.js";
+import { labelsOutcomeToJson, reconcileLabels, renderLabelsReport } from "./labels.js";
+import {
+  buildSpecTaskIndex,
+  formatReconciliationMarkdown,
+  hasDisagreement,
+  parseOverridesYaml,
+  reconcileScopeItems,
+} from "./reconciliation.js";
+import type { LabelClient, UmbrellaClient } from "./types.js";
+import { reconcileUmbrellas, renderUmbrellasReport } from "./umbrellas.js";
+
+class MemoryLabelClient implements LabelClient {
+  fetchLabels(): string[] {
+    return [];
+  }
+  apply(): void {}
+}
+
+class MemoryUmbrellaClient implements UmbrellaClient {
+  private readonly comments = new Map<string, Array<{ id: number; body: string }>>();
+  private nextId = 1000;
+
+  private key(repo: string, issue: number): string {
+    return `${repo}:${issue}`;
+  }
+
+  fetchComments(repo: string, issueNumber: number): Array<{ id: number; body: string }> {
+    return [...(this.comments.get(this.key(repo, issueNumber)) ?? [])];
+  }
+
+  editComment(_repo: string, commentId: number, body: string): void {
+    for (const bucket of this.comments.values()) {
+      for (const comment of bucket) {
+        if (comment.id === commentId) comment.body = body;
+      }
+    }
+  }
+
+  createComment(repo: string, issueNumber: number, body: string): number | null {
+    const key = this.key(repo, issueNumber);
+    const id = this.nextId;
+    this.nextId += 1;
+    const bucket = this.comments.get(key) ?? [];
+    bucket.push({ id, body });
+    this.comments.set(key, bucket);
+    return id;
+  }
+}
+
+const SHARED_UMBRELLA_CLIENT = new MemoryUmbrellaClient();
+
+export const PARITY_SCENARIO_NAMES = [
+  "reconcile-overrides",
+  "reconcile-spec-index",
+  "reconcile-scope-clean",
+  "reconcile-scope-orphan",
+  "reconcile-report",
+  "graph-dry-run",
+  "graph-cycle",
+  "graph-missing-proposed",
+  "labels-blocked-dry-run",
+  "labels-utf8-dry-run",
+  "umbrellas-create-dry-run",
+  "umbrellas-unchanged",
+] as const;
+
+export type ParityScenarioName = (typeof PARITY_SCENARIO_NAMES)[number];
+
+const FIXED_NOW = new Date("2026-06-14T20:00:00Z");
+const FIXED_REPORT_NOW = new Date("2026-06-19T12:00:00Z");
+
+const OVERRIDES_SAMPLE =
+  "overrides:\n" +
+  "  t2.4.1:\n" +
+  "    status: completed\n" +
+  "    body_source: spec\n" +
+  "  roadmap-9:\n" +
+  "    drop: true\n";
+
+function specWith(items: unknown[]): Record<string, unknown> {
+  return {
+    vBRIEFInfo: { version: "0.5", description: "spec" },
+    plan: { title: "Spec", status: "approved", narratives: {}, items },
+  };
+}
+
+function writeBrief(
+  root: string,
+  storyId: string,
+  folder: string,
+  extra: Record<string, unknown> = {},
+): string {
+  const path = join(root, "vbrief", folder, `2026-05-21-${storyId}.vbrief.json`);
+  mkdirSync(join(root, "vbrief", folder), { recursive: true });
+  const statusMap: Record<string, string> = {
+    proposed: "proposed",
+    pending: "pending",
+    active: "running",
+    completed: "completed",
+    cancelled: "cancelled",
+  };
+  const data = {
+    vBRIEFInfo: { version: "0.6" },
+    plan: {
+      id: storyId,
+      title: storyId,
+      status: statusMap[folder] ?? "pending",
+      narratives: {
+        Description: `${storyId} description.`,
+        ImplementationPlan: `1. Do ${storyId}.`,
+        UserStory: `As a user, I want ${storyId}.`,
+        Traces: "FR-1",
+      },
+      items: [
+        {
+          id: `${storyId}-a1`,
+          title: "Acceptance item 1",
+          status: "pending",
+          narrative: { Acceptance: `Given X when ${storyId} then Y.` },
+        },
+      ],
+      metadata: {
+        kind: "story",
+        swarm: {
+          readiness: "ready",
+          parallel_safe: true,
+          file_scope: [`src/${storyId}.py`],
+          verify_commands: [`pytest ${storyId}`],
+          expected_outputs: ["tests pass"],
+          depends_on: [],
+          conflict_group: "reconcile-suite",
+          size: "small",
+          file_scope_confidence: "high",
+          model_tier: "standard",
+        },
+      },
+      references: [],
+      ...extra,
+    },
+  };
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  return path;
+}
+
+export interface ParityScenarioResult {
+  readonly scenario: string;
+  readonly ok: boolean;
+  readonly payload: unknown;
+}
+
+export function renderScenarioOutput(
+  payload: ParityScenarioResult | ParityScenarioResult[],
+): string {
+  return pythonJsonPretty(payload);
+}
+
+export function runParityScenario(
+  name: string,
+  options: { fixtureRoot: string; labelClient?: LabelClient; umbrellaClient?: UmbrellaClient },
+): ParityScenarioResult {
+  const root = options.fixtureRoot;
+  switch (name as ParityScenarioName) {
+    case "reconcile-overrides":
+      return { scenario: name, ok: true, payload: parseOverridesYaml(OVERRIDES_SAMPLE) };
+    case "reconcile-spec-index": {
+      const spec = specWith([
+        { id: "t1.1", title: "One", status: "pending" },
+        {
+          id: "phase-1",
+          title: "Phase 1: Foundation",
+          status: "pending",
+          subItems: [{ id: "t1.1.1", title: "Deep task", status: "pending" }],
+        },
+      ]);
+      const index = buildSpecTaskIndex(spec);
+      return {
+        scenario: name,
+        ok: true,
+        payload: {
+          keys: Object.keys(index).sort(),
+          deepPhase: index["t1.1.1"]?.specPhase ?? "",
+        },
+      };
+    }
+    case "reconcile-scope-clean": {
+      const spec = specWith([{ id: "t1", title: "Task one", status: "pending" }]);
+      const [items, report] = reconcileScopeItems({
+        roadmapActive: [{ number: "", task_id: "t1", title: "Task one", phase: "Phase 1" }],
+        roadmapCompleted: [],
+        specVbrief: spec,
+      });
+      return {
+        scenario: name,
+        ok: true,
+        payload: { items, hasDisagreement: hasDisagreement(report) },
+      };
+    }
+    case "reconcile-scope-orphan": {
+      const spec = specWith([{ id: "t1", title: "One", status: "pending" }]);
+      const [items, report] = reconcileScopeItems({
+        roadmapActive: [
+          { number: "9", title: "Orphan task", phase: "Phase 1", synthetic_id: "roadmap-9" },
+        ],
+        roadmapCompleted: [],
+        specVbrief: spec,
+      });
+      return {
+        scenario: name,
+        ok: true,
+        payload: { items, orphans: report.orphans },
+      };
+    }
+    case "reconcile-report": {
+      const spec = specWith([{ id: "t2.4.1", title: "Repo indexer", status: "pending" }]);
+      const [, report] = reconcileScopeItems({
+        roadmapActive: [],
+        roadmapCompleted: [
+          { number: "", task_id: "t2.4.1", title: "Repo indexer", phase: "Completed" },
+        ],
+        specVbrief: spec,
+      });
+      return {
+        scenario: name,
+        ok: true,
+        payload: formatReconciliationMarkdown(report, FIXED_REPORT_NOW),
+      };
+    }
+    case "graph-dry-run": {
+      mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+      writeBrief(root, "dep-done", "completed");
+      writeBrief(root, "child", "proposed", {
+        metadata: {
+          kind: "story",
+          swarm: {
+            readiness: "ready",
+            parallel_safe: true,
+            file_scope: ["src/child.py"],
+            verify_commands: ["pytest child"],
+            expected_outputs: ["tests pass"],
+            depends_on: ["dep-done"],
+            conflict_group: "reconcile-suite",
+            size: "small",
+            file_scope_confidence: "high",
+            model_tier: "standard",
+          },
+        },
+      });
+      const [code, outcome] = reconcileGraph(root, { dryRun: true });
+      return {
+        scenario: name,
+        ok: true,
+        payload: {
+          exitCode: code,
+          report: renderGraphReport(outcome),
+          json: graphOutcomeToJson(outcome),
+        },
+      };
+    }
+    case "graph-cycle": {
+      mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+      for (const id of ["a", "b"]) {
+        writeBrief(root, id, "proposed", {
+          metadata: {
+            kind: "story",
+            swarm: {
+              readiness: "ready",
+              parallel_safe: true,
+              file_scope: [`src/${id}.py`],
+              verify_commands: [`pytest ${id}`],
+              expected_outputs: ["tests pass"],
+              depends_on: [id === "a" ? "b" : "a"],
+              conflict_group: "reconcile-suite",
+              size: "small",
+              file_scope_confidence: "high",
+              model_tier: "standard",
+            },
+          },
+        });
+      }
+      const [code, outcome] = reconcileGraph(root, { dryRun: true });
+      return {
+        scenario: name,
+        ok: true,
+        payload: { exitCode: code, report: renderGraphReport(outcome) },
+      };
+    }
+    case "graph-missing-proposed": {
+      mkdirSync(join(root, "vbrief"), { recursive: true });
+      const [code] = reconcileGraph(root, { dryRun: true });
+      return { scenario: name, ok: true, payload: { exitCode: code } };
+    }
+    case "labels-blocked-dry-run": {
+      mkdirSync(join(root, "vbrief", "active"), { recursive: true });
+      writeBrief(root, "blk", "active", {
+        status: "blocked",
+        references: [
+          {
+            uri: "https://github.com/deftai/directive/issues/10",
+            type: "x-vbrief/github-issue",
+            title: "Issue #10",
+          },
+        ],
+      });
+      const client = options.labelClient ?? new MemoryLabelClient();
+      const [code, outcome] = reconcileLabels(root, { client, dryRun: true });
+      return {
+        scenario: name,
+        ok: true,
+        payload: {
+          exitCode: code,
+          report: renderLabelsReport(outcome),
+          json: labelsOutcomeToJson(outcome),
+        },
+      };
+    }
+    case "labels-utf8-dry-run": {
+      mkdirSync(join(root, "vbrief", "active"), { recursive: true });
+      writeBrief(root, "utf8", "active", {
+        references: [
+          {
+            uri: "https://github.com/deftai/directive/issues/11",
+            type: "x-vbrief/github-issue",
+            title: "Issue #11 — smart “quotes”",
+          },
+        ],
+      });
+      const client = options.labelClient ?? new MemoryLabelClient();
+      const [code, outcome] = reconcileLabels(root, { client, dryRun: true });
+      return {
+        scenario: name,
+        ok: true,
+        payload: { exitCode: code, report: renderLabelsReport(outcome) },
+      };
+    }
+    case "umbrellas-create-dry-run": {
+      mkdirSync(join(root, "vbrief", "active"), { recursive: true });
+      writeBrief(root, "child-a", "active", {
+        metadata: { kind: "story", swarm: { depends_on: [] } },
+      });
+      writeBrief(root, "epic-1", "active", {
+        metadata: { kind: "epic", swarm: { depends_on: [] } },
+        references: [
+          { uri: "active/2026-05-21-child-a.vbrief.json", type: "x-vbrief/plan", title: "child-a" },
+          {
+            uri: "https://github.com/deftai/directive/issues/1284",
+            type: "x-vbrief/github-issue",
+            title: "Issue #1284",
+          },
+        ],
+      });
+      const client = options.umbrellaClient ?? SHARED_UMBRELLA_CLIENT;
+      const [code, outcome] = reconcileUmbrellas(root, {
+        client,
+        dryRun: true,
+        now: FIXED_NOW.toISOString().replace(/\.\d{3}Z$/, "Z"),
+      });
+      return {
+        scenario: name,
+        ok: true,
+        payload: { exitCode: code, report: renderUmbrellasReport(outcome) },
+      };
+    }
+    case "umbrellas-unchanged": {
+      mkdirSync(join(root, "vbrief", "active"), { recursive: true });
+      writeBrief(root, "child-b", "active", {
+        metadata: { kind: "story", swarm: { depends_on: [] } },
+      });
+      writeBrief(root, "epic-2", "active", {
+        metadata: { kind: "epic", swarm: { depends_on: [] } },
+        references: [
+          { uri: "active/2026-05-21-child-b.vbrief.json", type: "x-vbrief/plan", title: "child-b" },
+          {
+            uri: "https://github.com/deftai/directive/issues/1285",
+            type: "x-vbrief/github-issue",
+            title: "Issue #1285",
+          },
+        ],
+      });
+      const client = options.umbrellaClient ?? SHARED_UMBRELLA_CLIENT;
+      const now = FIXED_NOW.toISOString().replace(/\.\d{3}Z$/, "Z");
+      reconcileUmbrellas(root, { client, dryRun: false, now });
+      const [code, outcome] = reconcileUmbrellas(root, { client, dryRun: true, now });
+      return {
+        scenario: name,
+        ok: true,
+        payload: { exitCode: code, report: renderUmbrellasReport(outcome) },
+      };
+    }
+    default:
+      throw new Error(`unknown scenario: ${name}`);
+  }
+}
+
+export function loadFixtureBrief(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}

--- a/packages/core/src/vbrief-reconcile/py-repr.ts
+++ b/packages/core/src/vbrief-reconcile/py-repr.ts
@@ -1,0 +1,4 @@
+/** Python ``!r`` / ``repr()`` for strings used in conflict messages. */
+export function pyRepr(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}

--- a/packages/core/src/vbrief-reconcile/reconciliation.test.ts
+++ b/packages/core/src/vbrief-reconcile/reconciliation.test.ts
@@ -32,6 +32,35 @@ describe("parseOverridesYaml", () => {
   it("returns empty for blank input", () => {
     expect(parseOverridesYaml("")).toEqual({});
   });
+
+  // ReDoS-hardening regression fixtures (#1782 s4 / CodeQL js/polynomial-redos):
+  // the `rawLine.trimEnd()` rewrite of `replace(/\s+$/, "")` must stay
+  // byte-identical across trailing-whitespace / end-of-string / many-repetition
+  // inputs, mirroring Python's `raw_line.rstrip()`.
+  it("strips trailing whitespace via trimEnd identically to the regex", () => {
+    const text =
+      "overrides:\n" +
+      "  t1:   \t \n" +
+      "    status: completed   \n" +
+      "    body_source: spec\t\t\n";
+    expect(parseOverridesYaml(text)).toEqual({
+      t1: { status: "completed", body_source: "spec" },
+    });
+  });
+
+  it("handles a final line with no trailing newline", () => {
+    const text = "overrides:\n  t1:\n    drop: true";
+    expect(parseOverridesYaml(text)).toEqual({ t1: { drop: true } });
+  });
+
+  it("stays linear on many-repetition trailing whitespace", () => {
+    const pad = " ".repeat(50000);
+    const text = `overrides:\n  t1:${pad}\n    status: completed${pad}\n`;
+    const start = Date.now();
+    const result = parseOverridesYaml(text);
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(result).toEqual({ t1: { status: "completed" } });
+  });
 });
 
 describe("normalizeTaskId", () => {

--- a/packages/core/src/vbrief-reconcile/reconciliation.test.ts
+++ b/packages/core/src/vbrief-reconcile/reconciliation.test.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildSpecTaskIndex,
+  detectStatusMarker,
+  formatReconciliationMarkdown,
+  hasDisagreement,
+  normalizeTaskId,
+  parseOverridesYaml,
+  reconcileScopeItems,
+  writeReconciliationReport,
+} from "./reconciliation.js";
+import { VBRIEF_RECONCILE_MODULE } from "./types.js";
+
+describe("parseOverridesYaml", () => {
+  it("parses documented shape", () => {
+    const text =
+      "overrides:\n" +
+      "  t2.4.1:\n" +
+      "    status: completed\n" +
+      "    body_source: spec\n" +
+      "  roadmap-9:\n" +
+      "    drop: true\n";
+    expect(parseOverridesYaml(text)).toEqual({
+      "t2.4.1": { status: "completed", body_source: "spec" },
+      "roadmap-9": { drop: true },
+    });
+  });
+
+  it("returns empty for blank input", () => {
+    expect(parseOverridesYaml("")).toEqual({});
+  });
+});
+
+describe("normalizeTaskId", () => {
+  it("strips leading t", () => {
+    expect(normalizeTaskId("t1.1.1")).toBe("1.1.1");
+  });
+});
+
+describe("detectStatusMarker", () => {
+  it("detects done markers", () => {
+    expect(detectStatusMarker("Task [done]")).toBe("completed");
+  });
+
+  it("returns null for plain text", () => {
+    expect(detectStatusMarker("plain")).toBeNull();
+  });
+});
+
+describe("buildSpecTaskIndex", () => {
+  it("indexes nested subItems with phase", () => {
+    const spec = {
+      plan: {
+        items: [
+          {
+            id: "phase-1",
+            title: "Phase 1: Foundation",
+            subItems: [{ id: "t1.1.1", title: "Deep" }],
+          },
+        ],
+      },
+    };
+    const index = buildSpecTaskIndex(spec);
+    expect(index["t1.1.1"]?.specPhase).toBe("Phase 1: Foundation");
+  });
+});
+
+describe("reconcileScopeItems", () => {
+  const spec = {
+    plan: { items: [{ id: "t1", title: "One", status: "pending" }] },
+  };
+
+  it("clean case has no disagreement", () => {
+    const [, report] = reconcileScopeItems({
+      roadmapActive: [{ task_id: "t1", title: "One", number: "", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: spec,
+    });
+    expect(hasDisagreement(report)).toBe(false);
+  });
+
+  it("orphan routes to proposed", () => {
+    const [items] = reconcileScopeItems({
+      roadmapActive: [{ number: "9", title: "Orphan", phase: "P1", synthetic_id: "roadmap-9" }],
+      roadmapCompleted: [],
+      specVbrief: spec,
+    });
+    expect(items[0]?.folder).toBe("proposed");
+    expect(items[0]?.source_conflict).toBe("missing-from-spec");
+  });
+
+  it("no spec means pending folder without orphan", () => {
+    const [items] = reconcileScopeItems({
+      roadmapActive: [{ number: "9", title: "Some", phase: "P1" }],
+      roadmapCompleted: [],
+      specVbrief: null,
+    });
+    expect(items[0]?.folder).toBe("pending");
+  });
+});
+
+describe("buildSpecTaskIndex refs", () => {
+  it("github issue ref in spec index", () => {
+    const spec = {
+      plan: {
+        items: [
+          {
+            id: "t1",
+            references: [{ type: "github-issue", id: "#123" }],
+          },
+        ],
+      },
+    };
+    expect(buildSpecTaskIndex(spec)["123"]).toBeDefined();
+  });
+});
+
+describe("writeReconciliationReport", () => {
+  it("writes reconciliation report file", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-wrr2-"));
+    const vbrief = join(root, "vbrief");
+    mkdirSync(vbrief, { recursive: true });
+    const [, report] = reconcileScopeItems({
+      roadmapActive: [],
+      roadmapCompleted: [{ task_id: "t2", title: "X", number: "", phase: "Completed" }],
+      specVbrief: { plan: { items: [{ id: "t2", title: "X", status: "pending" }] } },
+    });
+    const path = writeReconciliationReport(report, vbrief, new Date("2026-06-19T12:00:00Z"));
+    expect(path).toContain("RECONCILIATION.md");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("module exports", () => {
+  it("exports module constant", () => {
+    expect(VBRIEF_RECONCILE_MODULE).toBe("vbrief-reconcile");
+  });
+
+  it("format markdown includes timestamp", () => {
+    const now = new Date("2026-06-19T12:00:00Z");
+    const [, report] = reconcileScopeItems({
+      roadmapActive: [],
+      roadmapCompleted: [{ task_id: "t2", title: "X", number: "", phase: "Completed" }],
+      specVbrief: { plan: { items: [{ id: "t2", title: "X", status: "pending" }] } },
+    });
+    const md = formatReconciliationMarkdown(report, now);
+    expect(md).toContain("Generated: 2026-06-19T12:00:00Z");
+  });
+});

--- a/packages/core/src/vbrief-reconcile/reconciliation.ts
+++ b/packages/core/src/vbrief-reconcile/reconciliation.ts
@@ -66,7 +66,12 @@ export function parseOverridesYaml(text: string): Record<string, Record<string, 
   let inOverrides = false;
 
   for (const rawLine of text.split("\n")) {
-    const line = rawLine.replace(/\s+$/, "");
+    // ReDoS-hardened (#1782 s4 / CodeQL js/polynomial-redos): replace the
+    // `/\s+$/` trailing-strip with String.prototype.trimEnd(), which removes
+    // exactly the JS `\s` set (WhiteSpace + LineTerminator) and so is
+    // byte-identical to the prior regex while being linear-time. Mirrors the
+    // Python oracle's `raw_line.rstrip()`.
+    const line = rawLine.trimEnd();
     const stripped = line.trimStart();
     if (!stripped || stripped.startsWith("#")) continue;
 

--- a/packages/core/src/vbrief-reconcile/reconciliation.ts
+++ b/packages/core/src/vbrief-reconcile/reconciliation.ts
@@ -1,0 +1,590 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pyRepr } from "./py-repr.js";
+import type {
+  ConflictEntry,
+  ReconciledItem,
+  ReconciliationReport,
+  SpecTaskEntry,
+} from "./types.js";
+
+const DONE_MARKERS = ["[done]", "[x]", "[X]", "\u2713", "\u2705"] as const;
+const WIP_MARKERS = ["[wip]", "[in progress]", "[in-progress]", "[running]", "[active]"] as const;
+const BLOCKED_MARKERS = ["[blocked]"] as const;
+const CANCELLED_MARKERS = ["[cancelled]", "[canceled]"] as const;
+
+export const OVERRIDES_FILENAME = "migration-overrides.yaml";
+
+const GITHUB_ISSUE_REF_TYPES = new Set(["github-issue", "x-vbrief/github-issue"]);
+const GITHUB_ISSUE_URI_RE = /https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/;
+
+const PHASE_TITLE_RE = /^(Phase\s+\d|IP[-\s]\d|Milestone\s+\d)/i;
+
+const STATUS_TO_FOLDER: Record<string, string> = {
+  draft: "proposed",
+  proposed: "proposed",
+  approved: "pending",
+  pending: "pending",
+  running: "active",
+  blocked: "active",
+  completed: "completed",
+  cancelled: "cancelled",
+};
+
+export function detectStatusMarker(text: string): string | null {
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  if (CANCELLED_MARKERS.some((m) => lower.includes(m.toLowerCase()))) return "cancelled";
+  if (BLOCKED_MARKERS.some((m) => lower.includes(m.toLowerCase()))) return "blocked";
+  if (DONE_MARKERS.some((m) => text.includes(m) || lower.includes(m.toLowerCase())))
+    return "completed";
+  if (WIP_MARKERS.some((m) => lower.includes(m.toLowerCase()))) return "running";
+  return null;
+}
+
+function stripQuotes(value: string): string {
+  const v = value.trim();
+  if (v.length >= 2 && v[0] === v[v.length - 1] && (v[0] === "'" || v[0] === '"')) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+function coerceScalar(value: string): unknown {
+  const v = stripQuotes(value);
+  const lower = v.toLowerCase();
+  if (lower === "true" || lower === "yes" || lower === "on") return true;
+  if (lower === "false" || lower === "no" || lower === "off") return false;
+  if (lower === "null" || lower === "none" || lower === "~" || lower === "") return null;
+  return v;
+}
+
+export function parseOverridesYaml(text: string): Record<string, Record<string, unknown>> {
+  const result: Record<string, Record<string, unknown>> = {};
+  let currentTask: string | null = null;
+  let currentTaskIndent = 0;
+  let inOverrides = false;
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.replace(/\s+$/, "");
+    const stripped = line.trimStart();
+    if (!stripped || stripped.startsWith("#")) continue;
+
+    const indent = line.length - stripped.length;
+
+    if (indent === 0) {
+      const key = stripped.split(":", 1)[0]?.trim() ?? "";
+      inOverrides = key === "overrides";
+      currentTask = null;
+      currentTaskIndent = 0;
+      continue;
+    }
+
+    if (!inOverrides) continue;
+
+    if (stripped.endsWith(":") && !stripped.slice(0, -1).includes(":") && indent >= 2) {
+      currentTask = stripped.slice(0, -1).trim();
+      currentTaskIndent = indent;
+      if (!result[currentTask]) result[currentTask] = {};
+      continue;
+    }
+
+    if (currentTask !== null && stripped.includes(":") && indent > currentTaskIndent) {
+      const colonIdx = stripped.indexOf(":");
+      const key = stripped.slice(0, colonIdx).trim();
+      const value = stripped.slice(colonIdx + 1);
+      const bucket = result[currentTask];
+      if (bucket) bucket[key] = coerceScalar(value);
+    }
+  }
+
+  return result;
+}
+
+export function loadOverrides(vbriefDir: string): Record<string, Record<string, unknown>> {
+  const path = join(vbriefDir, OVERRIDES_FILENAME);
+  if (!existsSync(path)) return {};
+  try {
+    return parseOverridesYaml(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+export function normalizeTaskId(taskId: string): string {
+  if (!taskId) return "";
+  const s = taskId.trim();
+  if (s.length >= 2 && (s[0] === "t" || s[0] === "T") && (/\d/.test(s[1] ?? "") || s[1] === ".")) {
+    return s
+      .slice(1)
+      .replace(/^[-.]+/, "")
+      .trim();
+  }
+  return s;
+}
+
+function collectIssueNumbers(item: Record<string, unknown>): string[] {
+  const numbers: string[] = [];
+  const refs = item.references;
+  if (!Array.isArray(refs)) return numbers;
+  for (const ref of refs) {
+    if (typeof ref !== "object" || ref === null || Array.isArray(ref)) continue;
+    const rec = ref as Record<string, unknown>;
+    if (!GITHUB_ISSUE_REF_TYPES.has(String(rec.type ?? ""))) continue;
+    const uri = rec.uri;
+    if (typeof uri === "string" && uri) {
+      const match = GITHUB_ISSUE_URI_RE.exec(uri);
+      if (match?.[1]) {
+        numbers.push(match[1]);
+        continue;
+      }
+    }
+    const rid = String(rec.id ?? "").replace(/^#/, "");
+    if (rid) numbers.push(rid);
+  }
+  return numbers;
+}
+
+export function buildSpecTaskIndex(
+  specVbrief: Record<string, unknown> | null,
+): Record<string, SpecTaskEntry> {
+  const index: Record<string, SpecTaskEntry> = {};
+  if (!specVbrief || typeof specVbrief !== "object") return index;
+  const plan = specVbrief.plan;
+  if (typeof plan !== "object" || plan === null || Array.isArray(plan)) return index;
+
+  const walk = (items: unknown, parentPhase: string): void => {
+    if (!Array.isArray(items)) return;
+    for (const item of items) {
+      if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+      const rec = item as Record<string, unknown>;
+      const title = String(rec.title ?? "");
+      const childPhase = PHASE_TITLE_RE.test(title) ? title : parentPhase;
+      const itemId = String(rec.id ?? "");
+      const entry: SpecTaskEntry = { item: rec, specPhase: parentPhase };
+      if (itemId) {
+        if (!index[itemId]) index[itemId] = entry;
+        const normalised = normalizeTaskId(itemId);
+        if (normalised && normalised !== itemId && !index[normalised]) index[normalised] = entry;
+      }
+      for (const num of collectIssueNumbers(rec)) {
+        if (!index[num]) index[num] = entry;
+        if (!index[`#${num}`]) index[`#${num}`] = entry;
+      }
+      walk(rec.subItems, childPhase);
+    }
+  };
+
+  walk((plan as Record<string, unknown>).items, "");
+  return index;
+}
+
+function pickNarrative(item: Record<string, unknown>, ...keys: string[]): string {
+  const narrative = item.narrative;
+  if (typeof narrative !== "object" || narrative === null || Array.isArray(narrative)) return "";
+  const narr = narrative as Record<string, unknown>;
+  for (const key of keys) {
+    const value = narr[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function specBody(item: Record<string, unknown>, defaultVal: string): string {
+  const body = pickNarrative(item, "Description", "Summary", "Body", "Overview");
+  if (body) return body;
+  return String(item.title ?? "").trim() || defaultVal;
+}
+
+export function hasDisagreement(report: ReconciliationReport): boolean {
+  return Boolean(
+    report.conflicts.length || report.orphans.length || report.overridesTriggered.length,
+  );
+}
+
+function statusFromSpec(entry: SpecTaskEntry | null): string | null {
+  if (!entry) return null;
+  const status = entry.item.status;
+  const valid = new Set([
+    "draft",
+    "proposed",
+    "approved",
+    "pending",
+    "running",
+    "completed",
+    "blocked",
+    "cancelled",
+  ]);
+  if (typeof status === "string" && valid.has(status)) return status;
+  return detectStatusMarker(String(entry.item.title ?? ""));
+}
+
+function roadmapStatus(roadmapItem: Record<string, unknown>, completed: boolean): string | null {
+  if (completed) return "completed";
+  return detectStatusMarker(String(roadmapItem.title ?? ""));
+}
+
+function chooseStatus(
+  specEntry: SpecTaskEntry | null,
+  roadmapStat: string | null,
+  overrideStatus: string | null,
+): [string, string, string | null] {
+  if (overrideStatus) return [overrideStatus, "migration-overrides.yaml", null];
+  const specStatus = statusFromSpec(specEntry);
+  if (roadmapStat) {
+    if (specStatus && specStatus !== roadmapStat) {
+      const conflict =
+        `SPEC status = ${pyRepr(specStatus)}; ` +
+        `ROADMAP status = ${pyRepr(roadmapStat)}; ` +
+        "ROADMAP wins (D3 role policy).";
+      return [roadmapStat, "ROADMAP.md", conflict];
+    }
+    return [roadmapStat, "ROADMAP.md", null];
+  }
+  if (specStatus) return [specStatus, "SPECIFICATION.md (tiebreaker)", null];
+  return ["pending", "default", null];
+}
+
+function titleConflict(
+  specEntry: SpecTaskEntry | null,
+  roadmapTitle: string,
+): [string, string, string | null, string] {
+  const rt = (roadmapTitle || "").trim();
+  if (!specEntry) return [rt, "ROADMAP.md", null, ""];
+  const specTitle = String(specEntry.item.title ?? "").trim();
+  if (!specTitle) return [rt, "ROADMAP.md", null, ""];
+  if (specTitle === rt) return [specTitle, "SPECIFICATION.md", null, ""];
+  const conflict =
+    `SPEC title = ${pyRepr(specTitle)}; ROADMAP title = ${pyRepr(rt)}; ` +
+    "SPEC wins; ROADMAP preserved in narrative.RoadmapSummary.";
+  return [specTitle, "SPECIFICATION.md", conflict, rt];
+}
+
+function description(
+  specEntry: SpecTaskEntry | null,
+  roadmapTitle: string,
+  bodySourceOverride: string | null,
+): [string, string] {
+  if (bodySourceOverride === "roadmap")
+    return [(roadmapTitle || "").trim(), "ROADMAP.md (override)"];
+  if (bodySourceOverride === "spec") {
+    if (specEntry) return [specBody(specEntry.item, roadmapTitle), "SPECIFICATION.md (override)"];
+    return [(roadmapTitle || "").trim(), "ROADMAP.md (override fallback: no SPEC match)"];
+  }
+  if (specEntry) return [specBody(specEntry.item, roadmapTitle), "SPECIFICATION.md"];
+  return [(roadmapTitle || "").trim(), "ROADMAP.md"];
+}
+
+function overrideStatus(override: Record<string, unknown> | null): string | null {
+  if (!override) return null;
+  const status = override.status;
+  return typeof status === "string" && status ? status : null;
+}
+
+function overrideBodySource(override: Record<string, unknown> | null): string | null {
+  if (!override) return null;
+  const bodySource = override.body_source;
+  if (bodySource === "spec" || bodySource === "roadmap") return bodySource;
+  return null;
+}
+
+function overrideDrop(override: Record<string, unknown> | null): boolean {
+  return Boolean(override?.drop);
+}
+
+function taskIdForItem(item: Record<string, unknown>, isCompleted: boolean): string {
+  const number = item.number;
+  if (number) return `#${number}`;
+  const taskId = item.task_id;
+  if (taskId) return String(taskId);
+  const synthetic = item.synthetic_id;
+  if (synthetic) return String(synthetic);
+  const suffix = isCompleted ? "completed" : "active";
+  return `${suffix}:${item.title ?? "untitled"}`;
+}
+
+function lookupOverride(
+  item: Record<string, unknown>,
+  canonicalKey: string,
+  overrides: Record<string, Record<string, unknown>>,
+): [Record<string, unknown> | null, string | null] {
+  if (!overrides || Object.keys(overrides).length === 0) return [null, null];
+  const candidates: string[] = [canonicalKey];
+  const taskId = String(item.task_id ?? "");
+  if (taskId) {
+    const normalised = normalizeTaskId(taskId);
+    candidates.push(taskId, normalised, `t${taskId}`, `t${normalised}`);
+  }
+  const number = String(item.number ?? "");
+  if (number) candidates.push(number, `#${number}`);
+  const synthetic = String(item.synthetic_id ?? "");
+  if (synthetic) candidates.push(synthetic);
+  for (const key of candidates) {
+    if (key && overrides[key]) return [overrides[key], key];
+  }
+  return [null, null];
+}
+
+function matchSpecEntry(
+  item: Record<string, unknown>,
+  specIndex: Record<string, SpecTaskEntry>,
+): SpecTaskEntry | null {
+  if (!specIndex || Object.keys(specIndex).length === 0) return null;
+  const number = String(item.number ?? "");
+  if (number) {
+    for (const key of [number, `#${number}`]) {
+      if (specIndex[key]) return specIndex[key];
+    }
+  }
+  const taskId = String(item.task_id ?? "");
+  if (taskId) {
+    for (const key of [taskId, normalizeTaskId(taskId), `t${taskId}`]) {
+      if (specIndex[key]) return specIndex[key];
+    }
+  }
+  return null;
+}
+
+export function folderFromStatus(status: string): string {
+  return STATUS_TO_FOLDER[status] ?? "pending";
+}
+
+export interface ReconcileScopeOptions {
+  readonly roadmapActive: ReadonlyArray<Record<string, unknown>>;
+  readonly roadmapCompleted: ReadonlyArray<Record<string, unknown>>;
+  readonly specVbrief: Record<string, unknown> | null;
+  readonly phaseDescriptions?: Record<string, string>;
+  readonly overrides?: Record<string, Record<string, unknown>>;
+}
+
+export function reconcileScopeItems(
+  options: ReconcileScopeOptions,
+): [ReconciledItem[], ReconciliationReport] {
+  const overrides = options.overrides ?? {};
+  const phaseDescriptions = options.phaseDescriptions ?? {};
+  const specIndex = buildSpecTaskIndex(options.specVbrief);
+  const specHasItems = Object.keys(specIndex).length > 0;
+
+  const reconciled: ReconciledItem[] = [];
+  const conflicts: ConflictEntry[] = [];
+  const orphans: Array<{ task_id: string; title: string }> = [];
+  const overridesTriggered: Array<Record<string, string>> = [];
+  const overridesUnused: string[] = [];
+  const usedOverrideKeys = new Set<string>();
+
+  const handle = (item: Record<string, unknown>, isCompleted: boolean): void => {
+    const taskKey = taskIdForItem(item, isCompleted);
+    const [override, matchedKey] = lookupOverride(item, taskKey, overrides);
+    if (override !== null && matchedKey !== null) usedOverrideKeys.add(matchedKey);
+
+    if (overrideDrop(override)) {
+      overridesTriggered.push({
+        task_id: taskKey,
+        title: String(item.title ?? ""),
+        action: "dropped from migration",
+      });
+      return;
+    }
+
+    const specEntry = matchSpecEntry(item, specIndex);
+    const [title, titleSource, titleConflictNote, roadmapSummary] = titleConflict(
+      specEntry,
+      String(item.title ?? ""),
+    );
+    const [desc, descriptionSource] = description(
+      specEntry,
+      String(item.title ?? ""),
+      overrideBodySource(override),
+    );
+    const roadmapStat = roadmapStatus(item, isCompleted);
+    let [status, statusSource, statusConflict] = chooseStatus(
+      specEntry,
+      roadmapStat,
+      overrideStatus(override),
+    );
+
+    let sourceConflict = "";
+    let folder: string;
+    if (specHasItems && specEntry === null) {
+      sourceConflict = "missing-from-spec";
+      if (isCompleted) {
+        folder = "completed";
+        status = "completed";
+        statusSource = "orphan: ROADMAP Completed section (#593)";
+      } else {
+        folder = "proposed";
+        status = "proposed";
+        statusSource = "orphan: proposed default";
+      }
+      orphans.push({ task_id: taskKey, title: title || String(item.title ?? "") });
+    } else {
+      folder = folderFromStatus(status);
+    }
+
+    const phase = String(item.phase ?? "");
+    const tier = String(item.tier ?? "");
+    const phaseDesc = phase ? (phaseDescriptions[phase] ?? "") : "";
+    const specPhase = specEntry?.specPhase ?? "";
+    const sourceSection = isCompleted ? "ROADMAP Completed section" : "ROADMAP active phase";
+
+    reconciled.push({
+      task_id: taskKey,
+      number: String(item.number ?? ""),
+      title,
+      title_source: titleConflictNote ? titleSource : "",
+      description: desc,
+      description_source: descriptionSource,
+      status,
+      status_source: statusSource,
+      folder,
+      phase,
+      phase_description: phaseDesc,
+      tier,
+      spec_phase: specPhase !== phase ? specPhase : "",
+      roadmap_summary: roadmapSummary,
+      source_conflict: sourceConflict,
+      source_section: sourceSection,
+      is_completed: isCompleted,
+      override_applied: override !== null,
+      synthetic_id: String(item.synthetic_id ?? ""),
+      original_task_id: String(item.task_id ?? ""),
+    });
+
+    const dims: ConflictEntry["dimensions"][number][] = [];
+    if (titleConflictNote) {
+      dims.push({
+        dimension: "TITLE drift",
+        spec: specEntry ? String(specEntry.item.title ?? "") : "",
+        roadmap: String(item.title ?? ""),
+        resolution: titleConflictNote,
+      });
+    }
+    if (statusConflict) {
+      dims.push({
+        dimension: "STATUS conflict",
+        spec: specEntry ? statusFromSpec(specEntry) || "(none)" : "(no match)",
+        roadmap: roadmapStat || "(none)",
+        resolution: statusConflict,
+      });
+    }
+
+    const triggeredFields: string[] = [];
+    if (override !== null) {
+      for (const key of ["status", "body_source"] as const) {
+        if (key in override) triggeredFields.push(key);
+      }
+      if (override.drop) triggeredFields.push("drop");
+      if (triggeredFields.length > 0) {
+        overridesTriggered.push({
+          task_id: taskKey,
+          title,
+          fields: triggeredFields.join(", "),
+        });
+      }
+    }
+
+    if (dims.length > 0 || triggeredFields.length > 0) {
+      conflicts.push({
+        taskId: taskKey,
+        title: title || String(item.title ?? ""),
+        dimensions: dims,
+        overridesApplied: triggeredFields,
+      });
+    }
+  };
+
+  for (const item of options.roadmapActive) handle(item, false);
+  for (const item of options.roadmapCompleted) handle(item, true);
+
+  for (const key of Object.keys(overrides)) {
+    if (!usedOverrideKeys.has(key)) overridesUnused.push(key);
+  }
+
+  return [reconciled, { conflicts, orphans, overridesTriggered, overridesUnused }];
+}
+
+function formatConflictEntry(entry: ConflictEntry): string {
+  const lines: string[] = [`## ${entry.taskId} -- ${entry.title}`, ""];
+  for (const dim of entry.dimensions) {
+    lines.push(`- ${dim.dimension}`);
+    if (dim.spec) lines.push(`  - SPEC: ${dim.spec}`);
+    if (dim.roadmap) lines.push(`  - ROADMAP: ${dim.roadmap}`);
+    lines.push(`  - Resolution: ${dim.resolution}`);
+  }
+  if (entry.overridesApplied.length > 0) {
+    lines.push(
+      `- Overrides applied: ${entry.overridesApplied.join(", ")} (migration-overrides.yaml)`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function formatReconciliationMarkdown(
+  report: ReconciliationReport,
+  now: Date = new Date(),
+): string {
+  const timestamp = now.toISOString().replace(/\.\d{3}Z$/, "Z");
+  const parts: string[] = [
+    "# Migration reconciliation report",
+    "",
+    `Generated: ${timestamp}`,
+    "",
+    "Per #496 this file is emitted whenever SPECIFICATION.md and ROADMAP.md " +
+      "disagreed on any dimension during `task migrate:vbrief`, or when any " +
+      "override from `vbrief/migration-overrides.yaml` triggered.",
+    "",
+  ];
+
+  parts.push("## Per-task conflicts", "");
+  if (report.conflicts.length > 0) {
+    for (const entry of report.conflicts) parts.push(formatConflictEntry(entry));
+  } else {
+    parts.push("(none)", "");
+  }
+
+  parts.push("## Orphans in ROADMAP (no matching SPEC task)", "");
+  if (report.orphans.length > 0) {
+    for (const orph of report.orphans) {
+      parts.push(
+        `- \`${orph.task_id}\` -- ${orph.title}`,
+        '  - Resolution: emitted to vbrief/proposed/ with narrative.SourceConflict = "missing-from-spec".',
+      );
+    }
+  } else {
+    parts.push("(none)");
+  }
+  parts.push("");
+
+  parts.push("## Overrides applied (vbrief/migration-overrides.yaml)", "");
+  if (report.overridesTriggered.length > 0) {
+    for (const ov of report.overridesTriggered) {
+      const fields = ov.fields ?? ov.action ?? "";
+      parts.push(`- \`${ov.task_id}\` -- ${ov.title ?? ""}: ${fields}`);
+    }
+  } else {
+    parts.push("(none)");
+  }
+  parts.push("");
+
+  if (report.overridesUnused.length > 0) {
+    parts.push("## Overrides defined but not triggered", "");
+    for (const key of report.overridesUnused) parts.push(`- \`${key}\``);
+    parts.push("");
+  }
+
+  return `${parts.join("\n").trimEnd()}\n`;
+}
+
+export function writeReconciliationReport(
+  report: ReconciliationReport,
+  vbriefDir: string,
+  now?: Date,
+): string | null {
+  if (!hasDisagreement(report)) return null;
+  const targetDir = join(vbriefDir, "migration");
+  mkdirSync(targetDir, { recursive: true });
+  const target = join(targetDir, "RECONCILIATION.md");
+  writeFileSync(target, formatReconciliationMarkdown(report, now), "utf8");
+  return target;
+}

--- a/packages/core/src/vbrief-reconcile/swarm-deps.ts
+++ b/packages/core/src/vbrief-reconcile/swarm-deps.ts
@@ -1,0 +1,146 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pyRepr } from "./py-repr.js";
+import type { Candidate } from "./types.js";
+
+export const LIFECYCLE_FOLDERS = [
+  "proposed",
+  "pending",
+  "active",
+  "completed",
+  "cancelled",
+] as const;
+
+export function asStrList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
+}
+
+function loadJson(path: string): Record<string, unknown> | null {
+  try {
+    const data = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    return typeof data === "object" && data !== null && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function planOf(data: Record<string, unknown>): Record<string, unknown> {
+  const plan = data.plan;
+  return typeof plan === "object" && plan !== null && !Array.isArray(plan)
+    ? (plan as Record<string, unknown>)
+    : {};
+}
+
+function metadataOf(plan: Record<string, unknown>): Record<string, unknown> {
+  const metadata = plan.metadata;
+  return typeof metadata === "object" && metadata !== null && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : {};
+}
+
+function swarmOf(metadata: Record<string, unknown>): Record<string, unknown> {
+  const swarm = metadata.swarm;
+  return typeof swarm === "object" && swarm !== null && !Array.isArray(swarm)
+    ? (swarm as Record<string, unknown>)
+    : {};
+}
+
+function storyId(path: string, plan: Record<string, unknown>): string {
+  const value = plan.id;
+  if (typeof value === "string" && value.trim()) return value.trim();
+  const name = path.split(/[/\\]/).pop() ?? "";
+  return name.endsWith(".vbrief.json") ? name.slice(0, -".vbrief.json".length) : name;
+}
+
+export function allScopeIds(projectRoot: string): Record<string, [string, string]> {
+  const ids: Record<string, [string, string]> = {};
+  const vbriefDir = join(resolve(projectRoot), "vbrief");
+  for (const folder of LIFECYCLE_FOLDERS) {
+    const folderPath = join(vbriefDir, folder);
+    if (!existsSync(folderPath)) continue;
+    const files = readdirSync(folderPath)
+      .filter((f) => f.endsWith(".vbrief.json"))
+      .sort();
+    for (const file of files) {
+      const path = join(folderPath, file);
+      const data = loadJson(path);
+      if (!data) continue;
+      const plan = planOf(data);
+      const scopeId = storyId(path, plan);
+      const status = String(plan.status ?? "");
+      ids[scopeId] = [path, status];
+      const stem = file.endsWith(".vbrief.json") ? file.slice(0, -".vbrief.json".length) : file;
+      if (!ids[stem]) ids[stem] = [path, status];
+    }
+  }
+  return ids;
+}
+
+export function candidateFromPath(path: string, _projectRoot: string): Candidate | null {
+  const data = loadJson(path);
+  if (!data) return null;
+  const plan = planOf(data);
+  const metadata = metadataOf(plan);
+  const swarm = swarmOf(metadata);
+  return {
+    path,
+    storyId: storyId(path, plan),
+    status: String(plan.status ?? ""),
+    swarm,
+    blocked: [],
+  };
+}
+
+export function candidateDepGraph(
+  candidates: Candidate[],
+  knownIds: Record<string, [string, string]>,
+): Record<string, string[]> {
+  const candidateIds = new Set(candidates.map((c) => c.storyId));
+  const graph: Record<string, string[]> = {};
+  for (const cand of candidates) {
+    const deps: string[] = [];
+    for (const dep of asStrList(cand.swarm.depends_on)) {
+      if (candidateIds.has(dep)) {
+        deps.push(dep);
+        continue;
+      }
+      const known = knownIds[dep];
+      if (!known) continue;
+      const [, depStatus] = known;
+      if (!["completed", "failed", "cancelled"].includes(depStatus)) {
+        cand.blocked.push(`dependency ${pyRepr(dep)} is not completed or a candidate`);
+      }
+    }
+    graph[cand.storyId] = deps;
+  }
+  return graph;
+}
+
+export function markCycles(candidates: Candidate[], graph: Record<string, string[]>): void {
+  const byId = Object.fromEntries(candidates.map((c) => [c.storyId, c]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  const visit = (storyId: string, path: string[]): void => {
+    if (visited.has(storyId)) return;
+    if (visiting.has(storyId)) {
+      const start = path.indexOf(storyId);
+      const cycle = [...path.slice(start >= 0 ? start : 0), storyId];
+      const message = `dependency cycle: ${cycle.join(" -> ")}`;
+      for (const node of cycle) {
+        const cand = byId[node];
+        if (cand && !cand.blocked.includes(message)) cand.blocked.push(message);
+      }
+      return;
+    }
+    visiting.add(storyId);
+    for (const dep of graph[storyId] ?? []) visit(dep, [...path, storyId]);
+    visiting.delete(storyId);
+    visited.add(storyId);
+  };
+
+  for (const cand of candidates) visit(cand.storyId, []);
+}

--- a/packages/core/src/vbrief-reconcile/types.ts
+++ b/packages/core/src/vbrief-reconcile/types.ts
@@ -1,0 +1,125 @@
+export const VBRIEF_RECONCILE_MODULE = "vbrief-reconcile" as const;
+
+export interface ConflictEntry {
+  readonly taskId: string;
+  readonly title: string;
+  readonly dimensions: ReadonlyArray<{
+    readonly dimension: string;
+    readonly spec?: string;
+    readonly roadmap?: string;
+    readonly resolution: string;
+  }>;
+  readonly overridesApplied: readonly string[];
+}
+
+export interface ReconciliationReport {
+  readonly conflicts: ConflictEntry[];
+  readonly orphans: ReadonlyArray<{ readonly task_id: string; readonly title: string }>;
+  readonly overridesTriggered: ReadonlyArray<Record<string, string>>;
+  readonly overridesUnused: readonly string[];
+}
+
+export interface SpecTaskEntry {
+  readonly item: Record<string, unknown>;
+  readonly specPhase: string;
+}
+
+export interface ReconciledItem {
+  readonly task_id: string;
+  readonly number: string;
+  readonly title: string;
+  readonly title_source: string;
+  readonly description: string;
+  readonly description_source: string;
+  readonly status: string;
+  readonly status_source: string;
+  readonly folder: string;
+  readonly phase: string;
+  readonly phase_description: string;
+  readonly tier: string;
+  readonly spec_phase: string;
+  readonly roadmap_summary: string;
+  readonly source_conflict: string;
+  readonly source_section: string;
+  readonly is_completed: boolean;
+  readonly override_applied: boolean;
+  readonly synthetic_id: string;
+  readonly original_task_id: string;
+}
+
+export interface Candidate {
+  readonly path: string;
+  readonly storyId: string;
+  readonly status: string;
+  readonly swarm: Record<string, unknown>;
+  blocked: string[];
+}
+
+export interface ReconcileGraphOutcome {
+  promoted: string[];
+  deferredWip: string[];
+  waiting: Array<{ story_id: string; unresolved: string[] }>;
+  cycles: string[];
+  errors: Array<{ story_id: string; message: string }>;
+  cap: number;
+  count: number;
+  dryRun: boolean;
+  forced: boolean;
+}
+
+export interface LabelChange {
+  readonly story_id: string;
+  readonly repo: string;
+  readonly issue_number: number;
+  readonly current: string[];
+  readonly desired: string[];
+  readonly add: string[];
+  readonly remove: string[];
+}
+
+export interface ReconcileLabelsOutcome {
+  changed: LabelChange[];
+  unchanged: LabelChange[];
+  skipped_no_ref: string[];
+  errors: Array<{ story_id: string; message: string }>;
+  dry_run: boolean;
+}
+
+export interface Child {
+  readonly story_id: string;
+  readonly title: string;
+  readonly kind: string;
+  readonly folder: string;
+  readonly depends_on: string[];
+}
+
+export interface UmbrellaChange {
+  readonly story_id: string;
+  readonly repo: string;
+  readonly issue_number: number;
+  readonly action: "created" | "edited" | "unchanged";
+  readonly pass_n: number;
+  readonly body: string;
+}
+
+export interface ReconcileUmbrellasOutcome {
+  changed: UmbrellaChange[];
+  unchanged: UmbrellaChange[];
+  skipped_no_ref: string[];
+  errors: Array<{ story_id: string; message: string }>;
+  dry_run: boolean;
+}
+
+export interface LabelClient {
+  fetchLabels(repo: string, issueNumber: number): string[];
+  apply(repo: string, issueNumber: number, add: readonly string[], remove: readonly string[]): void;
+}
+
+export interface UmbrellaClient {
+  fetchComments(
+    repo: string,
+    issueNumber: number,
+  ): ReadonlyArray<{ readonly id: number; readonly body: string }>;
+  editComment(repo: string, commentId: number, body: string): void;
+  createComment(repo: string, issueNumber: number, body: string): number | null;
+}

--- a/packages/core/src/vbrief-reconcile/umbrellas.test.ts
+++ b/packages/core/src/vbrief-reconcile/umbrellas.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Child, UmbrellaClient } from "./types.js";
+import {
+  classifyPassType,
+  computeWaves,
+  parseCurrentShape,
+  reconcileUmbrellas,
+  renderBody,
+} from "./umbrellas.js";
+
+class FakeUmbrellaClient implements UmbrellaClient {
+  comments = new Map<string, Array<{ id: number; body: string }>>();
+  private nextId = 1000;
+
+  fetchComments(repo: string, issueNumber: number): Array<{ id: number; body: string }> {
+    return [...(this.comments.get(`${repo}:${issueNumber}`) ?? [])];
+  }
+
+  editComment(_repo: string, commentId: number, body: string): void {
+    for (const bucket of this.comments.values()) {
+      for (const c of bucket) {
+        if (c.id === commentId) c.body = body;
+      }
+    }
+  }
+
+  createComment(repo: string, issueNumber: number, body: string): number {
+    const key = `${repo}:${issueNumber}`;
+    const id = this.nextId++;
+    const bucket = this.comments.get(key) ?? [];
+    bucket.push({ id, body });
+    this.comments.set(key, bucket);
+    return id;
+  }
+}
+
+const child = (id: string, folder = "active", deps: string[] = []): Child => ({
+  story_id: id,
+  title: id,
+  kind: "story",
+  folder,
+  depends_on: deps,
+});
+
+describe("computeWaves", () => {
+  it("layers dependencies", () => {
+    const waves = computeWaves([child("b", "active", ["a"]), child("a")]);
+    expect(waves[0]).toEqual(["a"]);
+    expect(waves[1]).toEqual(["b"]);
+  });
+
+  it("handles cycle as trailing wave", () => {
+    const waves = computeWaves([child("a", "active", ["b"]), child("b", "active", ["a"])]);
+    expect(waves.length).toBe(1);
+  });
+});
+
+describe("parseCurrentShape", () => {
+  it("parses pass number", () => {
+    const body = "## Current shape (as of pass-3)\n\nChild-count history: pass-1: 2, pass-2: 3\n";
+    expect(parseCurrentShape(body).passN).toBe(3);
+  });
+
+  it("tolerates missing header", () => {
+    expect(parseCurrentShape("no header").passN).toBeNull();
+  });
+});
+
+describe("classifyPassType", () => {
+  it("classifies additive", () => {
+    expect(classifyPassType(2, 3)).toBe("additive");
+  });
+});
+
+describe("renderBody", () => {
+  it("renders canonical sections", () => {
+    const body = renderBody({
+      passN: 1,
+      lastPassType: "additive",
+      lastUpdated: "2026-06-14T20:00:00Z",
+      openChildren: [child("a")],
+      closedChildren: [],
+      waves: [["a"]],
+      history: [[1, 1]],
+    });
+    expect(body).toContain("## Current shape (as of pass-1)");
+    expect(body).toContain("### Open children");
+  });
+});
+
+describe("reconcileUmbrellas", () => {
+  it("creates current-shape comment", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-umbrella-"));
+    const active = join(root, "vbrief", "active");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(
+      join(active, "child.vbrief.json"),
+      `${JSON.stringify({ plan: { id: "child-a", metadata: { kind: "story", swarm: { depends_on: [] } } } })}\n`,
+    );
+    writeFileSync(
+      join(active, "epic.vbrief.json"),
+      `${JSON.stringify({
+        plan: {
+          id: "epic-1",
+          metadata: { kind: "epic", swarm: { depends_on: [] } },
+          references: [
+            { type: "x-vbrief/plan", uri: "active/child.vbrief.json", title: "child-a" },
+            {
+              type: "x-vbrief/github-issue",
+              uri: "https://github.com/deftai/directive/issues/1284",
+            },
+          ],
+        },
+      })}\n`,
+    );
+    const client = new FakeUmbrellaClient();
+    const [code, outcome] = reconcileUmbrellas(root, {
+      client,
+      now: "2026-06-14T20:00:00Z",
+    });
+    expect(code).toBe(0);
+    expect(outcome.changed[0]?.action).toBe("created");
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/vbrief-reconcile/umbrellas.test.ts
+++ b/packages/core/src/vbrief-reconcile/umbrellas.test.ts
@@ -67,6 +67,77 @@ describe("parseCurrentShape", () => {
   it("tolerates missing header", () => {
     expect(parseCurrentShape("no header").passN).toBeNull();
   });
+
+  // ReDoS-hardening regression fixtures (#1782 s4 / CodeQL js/polynomial-redos):
+  // the `\s*(\S.*|)$` rewrite of HISTORY_RE / LAST_UPDATED_RE / LAST_PASS_TYPE_RE
+  // must stay byte-identical to the prior `\s*(.*)$` across these edge inputs.
+  it("parses fields at end-of-string with no trailing newline", () => {
+    const body =
+      "## Current shape (as of pass-2)\n" +
+      "Last updated: 2026-06-19T00:00:00Z\n" +
+      "Last pass type: additive\n" +
+      "Child-count history: pass-1: 1, pass-2: 2";
+    const parsed = parseCurrentShape(body);
+    expect(parsed.passN).toBe(2);
+    expect(parsed.lastUpdated).toBe("2026-06-19T00:00:00Z");
+    expect(parsed.lastPassType).toBe("additive");
+    expect(parsed.history).toEqual([
+      [1, 1],
+      [2, 2],
+    ]);
+  });
+
+  it("strips surrounding whitespace identically to the trim-based parse", () => {
+    const body =
+      "## Current shape (as of pass-1)\n" +
+      "Last updated:    2026-06-19T00:00:00Z   \n" +
+      "Last pass type:\tverify\t\n" +
+      "Child-count history:   pass-1: 5  \n";
+    const parsed = parseCurrentShape(body);
+    expect(parsed.lastUpdated).toBe("2026-06-19T00:00:00Z");
+    expect(parsed.lastPassType).toBe("verify");
+    expect(parsed.history).toEqual([[1, 5]]);
+  });
+
+  it("returns empty string (not null) for an all-whitespace field tail at end-of-string", () => {
+    // Mirrors the frozen Python oracle: `\s*` (which includes newlines) only
+    // collapses to an empty capture when no non-whitespace follows, i.e. when
+    // the field sits at the very end of the body. Verified against
+    // vbrief_reconcile_umbrellas.parse_current_shape.
+    const body =
+      "## Current shape (as of pass-2)\n" +
+      "Last pass type: additive\n" +
+      "Child-count history: pass-1: 1\n" +
+      "Last updated:     ";
+    const parsed = parseCurrentShape(body);
+    expect(parsed.lastUpdated).toBe("");
+    expect(parsed.lastPassType).toBe("additive");
+    expect(parsed.history).toEqual([[1, 1]]);
+  });
+
+  it("captures across a whitespace run that spans newlines (Python \\s* semantics)", () => {
+    // `\s*` consumes the trailing spaces AND the newline, so the capture is the
+    // next non-whitespace line's content -- identical to the old `\s*(.*)$` and
+    // to the Python oracle. The rewrite preserves this cross-newline behavior.
+    const body = "## Current shape (as of pass-1)\nLast updated:      \nLast pass type: additive\n";
+    const parsed = parseCurrentShape(body);
+    expect(parsed.lastUpdated).toBe("Last pass type: additive");
+  });
+
+  it("stays linear on many-repetition whitespace input", () => {
+    const spaces = " ".repeat(50000);
+    const body =
+      "## Current shape (as of pass-1)\n" +
+      `Last updated:${spaces}2026-06-19T00:00:00Z\n` +
+      `Last pass type:${spaces}refactor\n` +
+      `Child-count history:${spaces}pass-1: 1\n`;
+    const start = Date.now();
+    const parsed = parseCurrentShape(body);
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(parsed.lastUpdated).toBe("2026-06-19T00:00:00Z");
+    expect(parsed.lastPassType).toBe("refactor");
+    expect(parsed.history).toEqual([[1, 1]]);
+  });
 });
 
 describe("classifyPassType", () => {

--- a/packages/core/src/vbrief-reconcile/umbrellas.ts
+++ b/packages/core/src/vbrief-reconcile/umbrellas.ts
@@ -1,0 +1,549 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { call } from "../scm/call.js";
+import { extractIssueRef } from "../triage/reconcile/parse-uri.js";
+import type { Child, ReconcileUmbrellasOutcome, UmbrellaChange, UmbrellaClient } from "./types.js";
+
+export const OPEN_FOLDERS = ["proposed", "pending", "active"] as const;
+export const CLOSED_FOLDERS = ["completed", "cancelled"] as const;
+export const LIFECYCLE_FOLDERS = [...OPEN_FOLDERS, ...CLOSED_FOLDERS] as const;
+export const CHILD_REF_TYPE = "x-vbrief/plan";
+const SCM_SOURCE = "github-issue";
+
+const HEADER_RE = /^## Current shape \(as of pass-(\d+)\)/m;
+const HISTORY_RE = /^Child-count history:\s*(.*)$/m;
+const LAST_UPDATED_RE = /^Last updated:\s*(.*)$/m;
+const LAST_PASS_TYPE_RE = /^Last pass type:\s*(.*)$/m;
+const HISTORY_TOKEN_RE = /^\s*pass-(\d+):\s*(\d+)\s*$/;
+
+const READING_ORDER =
+  "1. Read the umbrella issue body.\n" +
+  "2. Read this current-shape comment.\n" +
+  "3. Read the amendment comments in chronological order for the full audit trail.";
+
+export class UmbrellaScmError extends Error {
+  override name = "UmbrellaScmError";
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    const data = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    return typeof data === "object" && data !== null && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function childFromData(
+  data: Record<string, unknown>,
+  folder: string,
+  fallbackId: string,
+): Child {
+  const plan =
+    typeof data.plan === "object" && data.plan !== null && !Array.isArray(data.plan)
+      ? (data.plan as Record<string, unknown>)
+      : {};
+  const metadata =
+    typeof plan.metadata === "object" && plan.metadata !== null && !Array.isArray(plan.metadata)
+      ? (plan.metadata as Record<string, unknown>)
+      : {};
+  const swarm =
+    typeof metadata.swarm === "object" && metadata.swarm !== null && !Array.isArray(metadata.swarm)
+      ? (metadata.swarm as Record<string, unknown>)
+      : {};
+  const rawDeps = swarm.depends_on;
+  const dependsOn = Array.isArray(rawDeps) ? rawDeps.map((d) => String(d)) : [];
+  return {
+    story_id: String(plan.id ?? fallbackId),
+    title: String(plan.title ?? plan.id ?? fallbackId),
+    kind: String(metadata.kind ?? "story"),
+    folder,
+    depends_on: dependsOn,
+  };
+}
+
+export function buildChildIndex(vbriefDir: string): Record<string, Child> {
+  const index: Record<string, Child> = {};
+  for (const folder of LIFECYCLE_FOLDERS) {
+    const folderPath = join(vbriefDir, folder);
+    if (!existsSync(folderPath)) continue;
+    const files = readdirSync(folderPath)
+      .filter((f) => f.endsWith(".vbrief.json"))
+      .sort();
+    for (const file of files) {
+      const path = join(folderPath, file);
+      const data = readJson(path);
+      if (!data) continue;
+      const fallbackId = file.slice(0, -".vbrief.json".length);
+      index[file] = childFromData(data, folder, fallbackId);
+    }
+  }
+  return index;
+}
+
+export function computeChildren(
+  epicData: Record<string, unknown>,
+  index: Record<string, Child>,
+): Child[] {
+  const plan =
+    typeof epicData.plan === "object" && epicData.plan !== null && !Array.isArray(epicData.plan)
+      ? (epicData.plan as Record<string, unknown>)
+      : {};
+  const refs = plan.references;
+  const children: Child[] = [];
+  const seen = new Set<string>();
+  if (!Array.isArray(refs)) return children;
+  for (const ref of refs) {
+    if (typeof ref !== "object" || ref === null || Array.isArray(ref)) continue;
+    const rec = ref as Record<string, unknown>;
+    if (rec.type !== CHILD_REF_TYPE) continue;
+    const name = basename(String(rec.uri ?? ""));
+    const child = index[name];
+    if (!child || seen.has(child.story_id)) continue;
+    seen.add(child.story_id);
+    children.push(child);
+  }
+  return children;
+}
+
+export function computeWaves(children: readonly Child[]): string[][] {
+  const ids = new Set(children.map((c) => c.story_id));
+  const deps: Record<string, string[]> = {};
+  for (const c of children) {
+    deps[c.story_id] = c.depends_on.filter((d) => ids.has(d));
+  }
+  const resolved = new Set<string>();
+  const remaining = new Set(ids);
+  const waves: string[][] = [];
+  while (remaining.size > 0) {
+    const layer = [...remaining]
+      .filter((r) => (deps[r] ?? []).every((d) => resolved.has(d)))
+      .sort();
+    if (layer.length === 0) {
+      waves.push([...remaining].sort());
+      break;
+    }
+    waves.push(layer);
+    for (const id of layer) {
+      resolved.add(id);
+      remaining.delete(id);
+    }
+  }
+  return waves;
+}
+
+function bulletBlock(lines: readonly string[]): string {
+  return lines.length > 0 ? lines.join("\n") : "- none";
+}
+
+export function renderBody(options: {
+  passN: number;
+  lastPassType: string;
+  lastUpdated: string;
+  openChildren: readonly Child[];
+  closedChildren: readonly Child[];
+  waves: readonly (readonly string[])[];
+  history: readonly (readonly [number, number])[];
+}): string {
+  const total = options.openChildren.length + options.closedChildren.length;
+  const historyStr = options.history.map(([n, count]) => `pass-${n}: ${count}`).join(", ");
+  const openLines = options.openChildren.map((c) => `- ${c.story_id}: ${c.title} (${c.kind})`);
+  const closedLines = options.closedChildren.map(
+    (c) => `- ${c.story_id}: ${c.title} (${c.folder})`,
+  );
+  const waveLines = options.waves.map((layer, i) => `- Wave ${i + 1}: ${layer.join(", ")}`);
+  return (
+    `## Current shape (as of pass-${options.passN})\n` +
+    "\n" +
+    `Last updated: ${options.lastUpdated}\n` +
+    `Last pass type: ${options.lastPassType}\n` +
+    `Child count: ${total} (${options.openChildren.length}/${options.closedChildren.length})\n` +
+    `Child-count history: ${historyStr}\n` +
+    "\n" +
+    "### Open children\n" +
+    "\n" +
+    `${bulletBlock(openLines)}\n` +
+    "\n" +
+    "### Closed children\n" +
+    "\n" +
+    `${bulletBlock(closedLines)}\n` +
+    "\n" +
+    "### Wave order\n" +
+    "\n" +
+    `${bulletBlock(waveLines)}\n` +
+    "\n" +
+    "### Open questions\n" +
+    "\n" +
+    "- none\n" +
+    "\n" +
+    "### Reading order for fresh contributors\n" +
+    "\n" +
+    READING_ORDER
+  );
+}
+
+export interface ParsedShape {
+  passN: number | null;
+  history: Array<[number, number]>;
+  lastUpdated: string | null;
+  lastPassType: string | null;
+}
+
+function parseHistory(raw: string): Array<[number, number]> {
+  const history: Array<[number, number]> = [];
+  for (const token of raw.split(",")) {
+    const match = HISTORY_TOKEN_RE.exec(token);
+    if (match?.[1] && match[2]) history.push([Number(match[1]), Number(match[2])]);
+  }
+  return history;
+}
+
+export function parseCurrentShape(body: string): ParsedShape {
+  const header = HEADER_RE.exec(body);
+  if (!header?.[1]) return { passN: null, history: [], lastUpdated: null, lastPassType: null };
+  const historyMatch = HISTORY_RE.exec(body);
+  const updatedMatch = LAST_UPDATED_RE.exec(body);
+  const passTypeMatch = LAST_PASS_TYPE_RE.exec(body);
+  return {
+    passN: Number(header[1]),
+    history: historyMatch?.[1] ? parseHistory(historyMatch[1]) : [],
+    lastUpdated: updatedMatch?.[1]?.trim() ?? null,
+    lastPassType: passTypeMatch?.[1]?.trim() ?? null,
+  };
+}
+
+export function classifyPassType(prevTotal: number | null, total: number): string {
+  if (prevTotal === null) return "refactor";
+  if (total > prevTotal) return "additive";
+  if (total < prevTotal) return "subtractive";
+  return "refactor";
+}
+
+function hasCurrentShape(body: string): boolean {
+  return HEADER_RE.test(body);
+}
+
+export class ScmUmbrellaClient implements UmbrellaClient {
+  fetchComments(repo: string, issueNumber: number): Array<{ id: number; body: string }> {
+    const proc = call(SCM_SOURCE, "api", [
+      `repos/${repo}/issues/${issueNumber}/comments?per_page=100`,
+    ]);
+    if (proc.returncode !== 0) {
+      throw new UmbrellaScmError(
+        `list comments #${issueNumber} (${repo}) failed: ${(proc.stderr || "").trim()}`,
+      );
+    }
+    let data: unknown;
+    try {
+      data = JSON.parse(proc.stdout || "[]");
+    } catch (exc) {
+      throw new UmbrellaScmError(
+        `list comments #${issueNumber} (${repo}) returned non-JSON: ${String(exc)}`,
+      );
+    }
+    if (!Array.isArray(data)) return [];
+    const comments: Array<{ id: number; body: string }> = [];
+    for (const entry of data) {
+      if (
+        typeof entry === "object" &&
+        entry !== null &&
+        !Array.isArray(entry) &&
+        typeof (entry as Record<string, unknown>).id === "number" &&
+        typeof (entry as Record<string, unknown>).body === "string"
+      ) {
+        const rec = entry as Record<string, unknown>;
+        comments.push({ id: rec.id as number, body: rec.body as string });
+      }
+    }
+    return comments;
+  }
+
+  editComment(repo: string, commentId: number, body: string): void {
+    const proc = call(
+      SCM_SOURCE,
+      "api",
+      ["-X", "PATCH", `repos/${repo}/issues/comments/${commentId}`, "--input", "-"],
+      { input: JSON.stringify({ body }) },
+    );
+    if (proc.returncode !== 0) {
+      throw new UmbrellaScmError(
+        `edit comment ${commentId} (${repo}) failed: ${(proc.stderr || "").trim()}`,
+      );
+    }
+  }
+
+  createComment(repo: string, issueNumber: number, body: string): number | null {
+    const proc = call(
+      SCM_SOURCE,
+      "api",
+      ["-X", "POST", `repos/${repo}/issues/${issueNumber}/comments`, "--input", "-"],
+      { input: JSON.stringify({ body }) },
+    );
+    if (proc.returncode !== 0) {
+      throw new UmbrellaScmError(
+        `create comment #${issueNumber} (${repo}) failed: ${(proc.stderr || "").trim()}`,
+      );
+    }
+    try {
+      const data = JSON.parse(proc.stdout || "{}") as Record<string, unknown>;
+      return typeof data.id === "number" ? data.id : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function planShape(
+  epicData: Record<string, unknown>,
+  index: Record<string, Child>,
+): [Child[], Child[], string[][]] {
+  const children = computeChildren(epicData, index);
+  const openChildren = children
+    .filter((c) => (OPEN_FOLDERS as readonly string[]).includes(c.folder))
+    .sort((a, b) => a.story_id.localeCompare(b.story_id));
+  const closedChildren = children
+    .filter((c) => !(OPEN_FOLDERS as readonly string[]).includes(c.folder))
+    .sort((a, b) => a.story_id.localeCompare(b.story_id));
+  const waves = computeWaves(children);
+  return [openChildren, closedChildren, waves];
+}
+
+function reconcileOneEpic(
+  epicData: Record<string, unknown>,
+  index: Record<string, Child>,
+  options: {
+    storyId: string;
+    repo: string;
+    number: number;
+    client: UmbrellaClient;
+    dryRun: boolean;
+    now: string;
+  },
+): UmbrellaChange {
+  const [openChildren, closedChildren, waves] = planShape(epicData, index);
+  const total = openChildren.length + closedChildren.length;
+
+  const comments = options.client.fetchComments(options.repo, options.number);
+  const existing = comments.find((c) => hasCurrentShape(c.body));
+
+  if (!existing) {
+    const body = renderBody({
+      passN: 1,
+      lastPassType: "additive",
+      lastUpdated: options.now,
+      openChildren,
+      closedChildren,
+      waves,
+      history: [[1, total]],
+    });
+    if (!options.dryRun) options.client.createComment(options.repo, options.number, body);
+    return {
+      story_id: options.storyId,
+      repo: options.repo,
+      issue_number: options.number,
+      action: "created",
+      pass_n: 1,
+      body,
+    };
+  }
+
+  const parsed = parseCurrentShape(existing.body);
+  const prevPass = parsed.passN ?? 1;
+  const prevTotal =
+    parsed.history.length > 0 ? (parsed.history[parsed.history.length - 1]?.[1] ?? null) : null;
+
+  const candidate = renderBody({
+    passN: prevPass,
+    lastPassType: parsed.lastPassType ?? "refactor",
+    lastUpdated: parsed.lastUpdated ?? options.now,
+    openChildren,
+    closedChildren,
+    waves,
+    history: parsed.history.length > 0 ? parsed.history : [[prevPass, total]],
+  });
+
+  if (candidate === existing.body) {
+    return {
+      story_id: options.storyId,
+      repo: options.repo,
+      issue_number: options.number,
+      action: "unchanged",
+      pass_n: prevPass,
+      body: candidate,
+    };
+  }
+
+  const passN = prevPass + 1;
+  const body = renderBody({
+    passN,
+    lastPassType: classifyPassType(prevTotal, total),
+    lastUpdated: options.now,
+    openChildren,
+    closedChildren,
+    waves,
+    history: [...parsed.history, [passN, total]],
+  });
+  if (!options.dryRun) options.client.editComment(options.repo, existing.id, body);
+  return {
+    story_id: options.storyId,
+    repo: options.repo,
+    issue_number: options.number,
+    action: "edited",
+    pass_n: passN,
+    body,
+  };
+}
+
+export function nowIso(date: Date = new Date()): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+export interface ReconcileUmbrellasOptions {
+  readonly repo?: string | null;
+  readonly dryRun?: boolean;
+  readonly client?: UmbrellaClient;
+  readonly now?: string;
+}
+
+export function reconcileUmbrellas(
+  projectRoot: string,
+  options: ReconcileUmbrellasOptions = {},
+): [number, ReconcileUmbrellasOutcome] {
+  const root = resolve(projectRoot);
+  const vbriefDir = join(root, "vbrief");
+  if (!existsSync(vbriefDir)) {
+    return [
+      2,
+      {
+        changed: [],
+        unchanged: [],
+        skipped_no_ref: [],
+        errors: [],
+        dry_run: options.dryRun ?? false,
+      },
+    ];
+  }
+
+  const client = options.client ?? new ScmUmbrellaClient();
+  const now = options.now ?? nowIso();
+  const index = buildChildIndex(vbriefDir);
+  const outcome: ReconcileUmbrellasOutcome = {
+    changed: [],
+    unchanged: [],
+    skipped_no_ref: [],
+    errors: [],
+    dry_run: options.dryRun ?? false,
+  };
+  const seenIssues = new Set<string>();
+
+  for (const folder of LIFECYCLE_FOLDERS) {
+    const folderPath = join(vbriefDir, folder);
+    if (!existsSync(folderPath)) continue;
+    const files = readdirSync(folderPath)
+      .filter((f) => f.endsWith(".vbrief.json"))
+      .sort();
+    for (const file of files) {
+      const path = join(folderPath, file);
+      const data = readJson(path);
+      if (!data) continue;
+      const plan =
+        typeof data.plan === "object" && data.plan !== null && !Array.isArray(data.plan)
+          ? (data.plan as Record<string, unknown>)
+          : {};
+      const metadata =
+        typeof plan.metadata === "object" && plan.metadata !== null && !Array.isArray(plan.metadata)
+          ? (plan.metadata as Record<string, unknown>)
+          : {};
+      if (metadata.kind !== "epic") continue;
+      const storyId = String(plan.id ?? file.slice(0, -".vbrief.json".length));
+
+      const [refRepo, number] = extractIssueRef(data);
+      const effectiveRepo = refRepo ?? options.repo ?? null;
+      if (number === null || effectiveRepo === null) {
+        outcome.skipped_no_ref.push(storyId);
+        continue;
+      }
+      const key = `${effectiveRepo}:${number}`;
+      if (seenIssues.has(key)) continue;
+      seenIssues.add(key);
+
+      try {
+        const change = reconcileOneEpic(data, index, {
+          storyId,
+          repo: effectiveRepo,
+          number,
+          client,
+          dryRun: options.dryRun ?? false,
+          now,
+        });
+        if (change.action === "unchanged") outcome.unchanged.push(change);
+        else outcome.changed.push(change);
+      } catch (exc) {
+        outcome.errors.push({ story_id: storyId, message: String(exc) });
+      }
+    }
+  }
+
+  return [outcome.errors.length > 0 ? 1 : 0, outcome];
+}
+
+export function renderUmbrellasReport(outcome: ReconcileUmbrellasOutcome): string {
+  const lines: string[] = ["vBRIEF reconcile umbrellas", ""];
+  const suffix = outcome.dry_run ? " (dry-run)" : "";
+
+  lines.push(`Changed${suffix}:`);
+  if (outcome.changed.length > 0) {
+    for (const c of outcome.changed) {
+      lines.push(
+        `- #${c.issue_number} (${c.repo}) [${c.story_id}]: ${c.action} -> pass-${c.pass_n}`,
+      );
+    }
+  } else {
+    lines.push("- none");
+  }
+  lines.push("");
+
+  lines.push("Unchanged:");
+  if (outcome.unchanged.length > 0) {
+    for (const c of outcome.unchanged) {
+      lines.push(`- #${c.issue_number} (${c.repo}) [${c.story_id}]: pass-${c.pass_n}`);
+    }
+  } else {
+    lines.push("- none");
+  }
+
+  if (outcome.skipped_no_ref.length > 0) {
+    lines.push("");
+    lines.push("Skipped (no github-issue reference / repo):");
+    for (const sid of outcome.skipped_no_ref) lines.push(`- ${sid}`);
+  }
+
+  if (outcome.errors.length > 0) {
+    lines.push("");
+    lines.push("Errors:");
+    for (const err of outcome.errors) lines.push(`- ${err.story_id}: ${err.message}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function umbrellasOutcomeToJson(
+  outcome: ReconcileUmbrellasOutcome,
+): Record<string, unknown> {
+  const toChange = (c: UmbrellaChange) => ({
+    story_id: c.story_id,
+    repo: c.repo,
+    issue_number: c.issue_number,
+    action: c.action,
+    pass_n: c.pass_n,
+  });
+  return {
+    changed: outcome.changed.map(toChange),
+    unchanged: outcome.unchanged.map(toChange),
+    skipped_no_ref: [...outcome.skipped_no_ref],
+    errors: outcome.errors.map((e) => ({ story_id: e.story_id, message: e.message })),
+    dry_run: outcome.dry_run,
+  };
+}

--- a/packages/core/src/vbrief-reconcile/umbrellas.ts
+++ b/packages/core/src/vbrief-reconcile/umbrellas.ts
@@ -11,9 +11,16 @@ export const CHILD_REF_TYPE = "x-vbrief/plan";
 const SCM_SOURCE = "github-issue";
 
 const HEADER_RE = /^## Current shape \(as of pass-(\d+)\)/m;
-const HISTORY_RE = /^Child-count history:\s*(.*)$/m;
-const LAST_UPDATED_RE = /^Last updated:\s*(.*)$/m;
-const LAST_PASS_TYPE_RE = /^Last pass type:\s*(.*)$/m;
+// ReDoS-hardened (#1782 s4 / CodeQL js/polynomial-redos): the original
+// `\s*(.*)$` let `\s*` and `.*` both match horizontal whitespace (overlapping
+// repetitions). Replacing the capture with `(\S.*|)` makes `\s*`'s successor
+// disjoint (starts with a non-whitespace char) while the empty alternation
+// preserves the exact `""`-not-undefined capture of an all-whitespace tail.
+// Captured language is byte-identical to the frozen Python oracle
+// (`r"^...:\s*(.*)$"`, re.MULTILINE) for every input.
+const HISTORY_RE = /^Child-count history:\s*(\S.*|)$/m;
+const LAST_UPDATED_RE = /^Last updated:\s*(\S.*|)$/m;
+const LAST_PASS_TYPE_RE = /^Last pass type:\s*(\S.*|)$/m;
 const HISTORY_TOKEN_RE = /^\s*pass-(\d+):\s*(\d+)\s*$/;
 
 const READING_ORDER =

--- a/tasks/ts.yml
+++ b/tasks/ts.yml
@@ -188,6 +188,12 @@ tasks:
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-build-parity.js"
 
+  vbrief-reconcile-parity:
+    desc: "Golden-diff the ported vBRIEF reconciliation engine vs the Python oracle, cache-off (#1782 s4)"
+    deps: [build]
+    cmds:
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-reconcile-parity.js"
+
   parity-all:
     desc: "Run every TS-port golden-diff parity harness vs the Python oracle (#1530 Wave 2)"
     deps: [build]
@@ -221,3 +227,4 @@ tasks:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/pr-monitor-parity.js"
       - node "{{.DEFT_ROOT}}/packages/cli/dist/pr-wait-mergeable-parity.js"
       - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-build-parity.js"
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/vbrief-reconcile-parity.js"

--- a/vbrief/active/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json
+++ b/vbrief/active/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1782-s4-vbrief-reconcile",
     "title": "Port the vBRIEF reconciliation engine (reconciliation + reconcile graph/labels/umbrellas) to TypeScript",
-    "status": "proposed",
+    "status": "running",
     "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
     "narratives": {
       "Description": "Port the vBRIEF reconciliation engine -- scripts/_vbrief_reconciliation.py, scripts/vbrief_reconcile_graph.py, scripts/vbrief_reconcile_labels.py, and scripts/vbrief_reconcile_umbrellas.py -- to TypeScript with golden parity. These reconcile vBRIEF state against GitHub (dependency graph, labels, umbrella current-shape). reconcile_labels depends on reconcile_graph; both are ported in this story so the file scope stays disjoint. gh capture uses Node execFile with explicit UTF-8 (#1366), reusing @deftai/core/scm.",
@@ -79,6 +79,7 @@
         "type": "x-vbrief/blocks",
         "title": "Issue #1730"
       }
-    ]
+    ],
+    "updated": "2026-06-19T17:49:57Z"
   }
 }

--- a/vbrief/completed/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json
+++ b/vbrief/completed/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1782-s4-vbrief-reconcile",
     "title": "Port the vBRIEF reconciliation engine (reconciliation + reconcile graph/labels/umbrellas) to TypeScript",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json",
     "narratives": {
       "Description": "Port the vBRIEF reconciliation engine -- scripts/_vbrief_reconciliation.py, scripts/vbrief_reconcile_graph.py, scripts/vbrief_reconcile_labels.py, and scripts/vbrief_reconcile_umbrellas.py -- to TypeScript with golden parity. These reconcile vBRIEF state against GitHub (dependency graph, labels, umbrella current-shape). reconcile_labels depends on reconcile_graph; both are ported in this story so the file scope stays disjoint. gh capture uses Node execFile with explicit UTF-8 (#1366), reusing @deftai/core/scm.",
@@ -65,7 +65,9 @@
         "file_scope_confidence": "high",
         "model_tier": "high",
         "missing_traces_justification": "#1530 Wave-5 framework-internal TS port traced to GitHub issue #1782 and umbrella epic #1530; no specification.vbrief.json spec-section applies to maintainer tooling."
-      }
+      },
+      "completedAt": "2026-06-19T18:04:31Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -80,6 +82,6 @@
         "title": "Issue #1730"
       }
     ],
-    "updated": "2026-06-19T17:49:57Z"
+    "updated": "2026-06-19T18:04:31Z"
   }
 }

--- a/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
@@ -49,7 +49,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "proposed/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json",
+        "uri": "active/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Port the vBRIEF reconciliation engine (reconciliation + reconcile graph/labels/umbrellas) to TypeScript",
         "TrustLevel": "internal"

--- a/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1782-featts-migration-port-the-vbrief-spine-build-validation-reco.vbrief.json
@@ -49,7 +49,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json",
+        "uri": "completed/2026-06-19-port-the-vbrief-reconciliation-engine-reconciliation-reconci.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Port the vBRIEF reconciliation engine (reconciliation + reconcile graph/labels/umbrellas) to TypeScript",
         "TrustLevel": "internal"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       "@deftai/core/pr-monitor": sub("core", "pr-monitor"),
       "@deftai/core/pr-wait-mergeable": sub("core", "pr-wait-mergeable"),
       "@deftai/core/vbrief-build": sub("core", "vbrief-build"),
+      "@deftai/core/vbrief-reconcile": sub("core", "vbrief-reconcile"),
       "@deftai/core": src("core"),
     },
   },
@@ -112,6 +113,7 @@ export default defineConfig({
         "packages/cli/src/pr-monitor-parity.ts",
         "packages/cli/src/pr-wait-mergeable-parity.ts",
         "packages/cli/src/vbrief-build-parity.ts",
+        "packages/cli/src/vbrief-reconcile-parity.ts",
       ],
       reporter: ["text", "text-summary"],
       thresholds: {


### PR DESCRIPTION
## Summary
- Port the frozen Python vBRIEF reconciliation engine (`_vbrief_reconciliation`, graph/labels/umbrellas reconcile scripts) to `packages/core/src/vbrief-reconcile/` with co-located vitest coverage.
- Add `packages/cli/src/vbrief-reconcile.ts` CLI seam and `vbrief-reconcile-parity.ts` golden harness (stateful fake `gh`, cache off) asserting byte-identical output vs Python oracles across 12 scenarios.
- Wire module exports, vitest aliases/coverage excludes, and `tasks/ts.yml` `vbrief-reconcile-parity` + `parity-all`.

## Test plan
- [x] `pnpm -w exec vitest run --coverage packages/core/src/vbrief-reconcile` — 108 tests, **88.5% branch** coverage on module
- [x] `pnpm run build` clean
- [x] `biome check` clean on new files
- [x] `node packages/cli/dist/vbrief-reconcile-parity.js` — **CLEAN** (12/12 scenarios)
- [x] `task check` exit 0

Closes #1782 (Wave 5 story s4)


Made with [Cursor](https://cursor.com)