### PR TITLE
chore(ts-migration): ingest Wave 6 stories (#1784/#1785/#1786)

### DIFF
--- a/vbrief/proposed/2026-06-19-1784-featts-migration-port-issue-github-intake-reconcile-to-ts-wa.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1784-featts-migration-port-issue-github-intake-reconcile-to-ts-wa.vbrief.json
@@ -1,0 +1,41 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1784"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port issue / GitHub intake + reconcile to TS (Wave 6)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port issue / GitHub intake + reconcile to TS (Wave 6)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1784",
+      "Overview": "## Parent\n#1530 (Part 1 of 2)\n\n## What to build\nPort the issue-intake and GitHub-reconcile surface: `issue_ingest`, `issue_emit`, `reconcile_issues`, `github_body`, `github_auth_modes`, `gh_rest`, `candidates_log`. Reuse the ported `@deftai/core/scm` adapter for all `gh` access.\n\n## Acceptance criteria\n- [ ] TS ports with cache-off golden parity vs the Python oracle\n- [ ] Wired into `@deftai/core`, `tasks/ts.yml`, CI\n- [ ] CHANGELOG entry; `task check` green\n\n## Standing invariants (all #1530 Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The golden parity gate runs **cache-off**.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) **and** has CI usage.\n- Subprocess/`gh` capture uses Node `execFile` with explicit UTF-8 (closes the #1366 class structurally; the Python `_safe_subprocess`/`_stdio_utf8` shims are NOT ported — the problem does not exist in Node).\n\n## Full-conversion scope note (#1530)\nPart of the **full** Python→TS conversion. Per operator decision (2026-06-19) the cutover (#1731) deletes nothing until the engine is wholly TS. Accepted non-ports: Python-runtime shims, build/packaging tooling (superseded by the pnpm/tsc build), pre-v0.20 migration tooling (retired with a deprecation notice), and the Go installer (separate keep/fold decision in #1731). Owning an agent runtime is out of scope — net-new future work (#1707), not a conversion.\n\n## Type\nAFK\n\n## Blocked by\n- Blocked by #1530 (Wave 5: vBRIEF spine)"
+    },
+    "items": [
+      {
+        "title": "TS ports with cache-off golden parity vs the Python oracle",
+        "status": "proposed"
+      },
+      {
+        "title": "Wired into , , CI",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG entry;  green",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1784",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1784: feat(ts-migration): port issue / GitHub intake + reconcile to TS (Wave 6)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-1785-featts-migration-port-the-spec-prd-render-family-to-ts-wave.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1785-featts-migration-port-the-spec-prd-render-family-to-ts-wave.vbrief.json
@@ -1,0 +1,41 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1785"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port the spec / PRD / render family to TS (Wave 6)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port the spec / PRD / render family to TS (Wave 6)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1785",
+      "Overview": "## Parent\n#1530 (Part 1 of 2)\n\n## What to build\nPort the rendering/spec surface: `spec_render`, `spec_validate`, `prd_render`, `project_render`, `roadmap_render`, `framework_commands`.\n\n## Acceptance criteria\n- [ ] TS ports with cache-off golden parity vs the Python oracle (rendered-output byte parity)\n- [ ] Wired into `@deftai/core`, `tasks/ts.yml`, CI\n- [ ] CHANGELOG entry; `task check` green\n\n## Standing invariants (all #1530 Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The golden parity gate runs **cache-off**.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) **and** has CI usage.\n- Subprocess/`gh` capture uses Node `execFile` with explicit UTF-8 (closes the #1366 class structurally; the Python `_safe_subprocess`/`_stdio_utf8` shims are NOT ported — the problem does not exist in Node).\n\n## Full-conversion scope note (#1530)\nPart of the **full** Python→TS conversion. Per operator decision (2026-06-19) the cutover (#1731) deletes nothing until the engine is wholly TS. Accepted non-ports: Python-runtime shims, build/packaging tooling (superseded by the pnpm/tsc build), pre-v0.20 migration tooling (retired with a deprecation notice), and the Go installer (separate keep/fold decision in #1731). Owning an agent runtime is out of scope — net-new future work (#1707), not a conversion.\n\n## Type\nAFK\n\n## Blocked by\n- Blocked by #1530 (Wave 5: vBRIEF spine)"
+    },
+    "items": [
+      {
+        "title": "TS ports with cache-off golden parity vs the Python oracle (rendered-output byte parity)",
+        "status": "proposed"
+      },
+      {
+        "title": "Wired into , , CI",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG entry;  green",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1785",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1785: feat(ts-migration): port the spec / PRD / render family to TS (Wave 6)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-1786-featts-migration-port-codebase-mapping-capacity-to-ts-wave-6.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1786-featts-migration-port-codebase-mapping-capacity-to-ts-wave-6.vbrief.json
@@ -1,0 +1,41 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1786"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port codebase mapping + capacity to TS (Wave 6)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port codebase mapping + capacity to TS (Wave 6)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1786",
+      "Overview": "## Parent\n#1530 (Part 1 of 2)\n\n## What to build\nPort the codebase-mapping and capacity surface: `codebase_provider`, `codebase_default_extractor`, `codebase_projection_registry`, `capacity_show`, `capacity_backfill`.\n\n## Acceptance criteria\n- [ ] TS ports with cache-off golden parity vs the Python oracle\n- [ ] Wired into `@deftai/core`, `tasks/ts.yml`, CI\n- [ ] CHANGELOG entry; `task check` green\n\n## Standing invariants (all #1530 Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The golden parity gate runs **cache-off**.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) **and** has CI usage.\n- Subprocess/`gh` capture uses Node `execFile` with explicit UTF-8 (closes the #1366 class structurally; the Python `_safe_subprocess`/`_stdio_utf8` shims are NOT ported — the problem does not exist in Node).\n\n## Full-conversion scope note (#1530)\nPart of the **full** Python→TS conversion. Per operator decision (2026-06-19) the cutover (#1731) deletes nothing until the engine is wholly TS. Accepted non-ports: Python-runtime shims, build/packaging tooling (superseded by the pnpm/tsc build), pre-v0.20 migration tooling (retired with a deprecation notice), and the Go installer (separate keep/fold decision in #1731). Owning an agent runtime is out of scope — net-new future work (#1707), not a conversion.\n\n## Type\nAFK\n\n## Blocked by\n- Blocked by #1530 (Wave 5: vBRIEF spine)"
+    },
+    "items": [
+      {
+        "title": "TS ports with cache-off golden parity vs the Python oracle",
+        "status": "proposed"
+      },
+      {
+        "title": "Wired into , , CI",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG entry;  green",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1786",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1786: feat(ts-migration): port codebase mapping + capacity to TS (Wave 6)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Lands the three Wave 6 story vBRIEFs in `proposed/` so the swarm can promote/activate them in isolated worktrees. Each Wave 6 issue is a coherent, disjoint-file-scope module family → one swarm story (same granularity as a Wave 5b story; no further decomposition needed):

- **#1784** — issue / GitHub intake + reconcile (`issue_ingest`, `issue_emit`, `reconcile_issues`, `github_body`, `github_auth_modes`, `gh_rest`, `candidates_log`) → reuses `@deftai/core/scm`
- **#1785** — spec / PRD / render family (`spec_render`, `spec_validate`, `prd_render`, `project_render`, `roadmap_render`, `framework_commands`)
- **#1786** — codebase mapping + capacity (`codebase_provider`, `codebase_default_extractor`, `codebase_projection_registry`, `capacity_show`, `capacity_backfill`)

Wave 5 (#1782 + #1783) is complete, so Wave 6 is unblocked.

## Test plan
- [x] `task check` green
- [ ] Stories promoted/activated and swarmed in a follow-up

Refs #1530

Made with [Cursor](https://cursor.com)