### PR TITLE
chore(vbrief): decompose Wave 7 (#1787, #1788) into 5 swarm-ready stories

### DIFF
--- a/vbrief/pending/2026-06-19-port-agentsmd-version-platform-utilities-to-ts.vbrief.json
+++ b/vbrief/pending/2026-06-19-port-agentsmd-version-platform-utilities-to-ts.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json"
+  },
+  "plan": {
+    "id": "1787-s3-platform-utilities",
+    "title": "Port AGENTS.md + version + platform utilities to TS",
+    "status": "pending",
+    "planRef": "proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json",
+    "narratives": {
+      "Description": "Port the shared platform and text utilities from Python to TypeScript. Covers _agents_md, slug_normalize, resolve_version, resolve_changelog_unreleased, platform_capabilities, and ip_risk so AGENTS.md managed-section handling, slug normalization, version resolution, and changelog union-merge run on the TS engine identically.",
+      "ImplementationPlan": "1. Port _agents_md, slug_normalize, resolve_version, resolve_changelog_unreleased, platform_capabilities, and ip_risk into a packages/core/src/platform module, preserving the managed-section sha computation, changelog union-merge dedup-by-issue rule, and ReDoS-safe linear scanners. 2. Add a packages/cli/src/platform-parity.ts harness diffing TS output against the Python oracle cache-off across agents-refresh, slugify, version-resolve, and changelog-resolve fixtures. 3. Wire the module into @deftai/core, tasks/ts.yml, and CI with unit tests for the changelog union-merge and slug edge cases.",
+      "UserStory": "As a deft maintainer, I want the AGENTS.md, version, and changelog utilities running on the TypeScript engine, so that managed-section refresh and changelog resolution match the Python output exactly.",
+      "Traces": "#1787, #1530"
+    },
+    "items": [
+      {
+        "id": "1787-s3-platform-utilities-a1",
+        "title": "Given a changelog with conflicting Unreleased entries, when the TS resolver runs, then it union-merges and returns the same body as the Python oracle.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a changelog with conflicting Unreleased entries, when the TS resolver runs, then it union-merges and returns the same body as the Python oracle.",
+          "Traces": "#1787, #1530"
+        }
+      },
+      {
+        "id": "1787-s3-platform-utilities-a2",
+        "title": "Given an AGENTS.md managed section, when the TS agents-md renderer runs, then it computes the same section sha and emits identical content cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an AGENTS.md managed section, when the TS agents-md renderer runs, then it computes the same section sha and emits identical content cache-off.",
+          "Traces": "#1787, #1530"
+        }
+      },
+      {
+        "id": "1787-s3-platform-utilities-a3",
+        "title": "Given a raw title string, when the TS slug normalizer runs, then it returns the same slug as the Python module across unicode fixtures.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a raw title string, when the TS slug normalizer runs, then it returns the same slug as the Python module across unicode fixtures.",
+          "Traces": "#1787, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/platform/",
+          "packages/cli/src/platform-parity.ts"
+        ],
+        "verify_commands": [
+          "task ts:platform-parity"
+        ],
+        "expected_outputs": [
+          "platform parity: CLEAN"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-platform",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1787",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1787: feat(ts-migration): port session / ritual / lifecycle + packs surface to TS (Wave 7)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-19-port-lifecycle-hygiene-events-packs-to-ts.vbrief.json
+++ b/vbrief/pending/2026-06-19-port-lifecycle-hygiene-events-packs-to-ts.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json"
+  },
+  "plan": {
+    "id": "1787-s2-lifecycle-events-packs",
+    "title": "Port lifecycle hygiene + events + packs to TS",
+    "status": "pending",
+    "planRef": "proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json",
+    "narratives": {
+      "Description": "Port the lifecycle-hygiene, event-detection, and content-packs surface from Python to TypeScript. Covers _lifecycle_hygiene, _event_detect, _events, pack_render, packs_slice, and quarantine_ext so lifecycle nudges and pack slicing run on the TS engine with identical output.",
+      "ImplementationPlan": "1. Port _lifecycle_hygiene, _event_detect, and _events into a packages/core/src/lifecycle module and pack_render, packs_slice, quarantine_ext into a packages/core/src/packs module, preserving slice registry resolution and quarantine extension handling. 2. Add a packages/cli/src/lifecycle-packs-parity.ts harness that diffs TS pack-slice and lifecycle-event output against the Python oracle cache-off across list-packs, slice, and quarantine fixtures. 3. Wire both modules into @deftai/core, tasks/ts.yml, and CI with unit tests for the slice registry and event detection branches.",
+      "UserStory": "As a deft operator, I want lifecycle hygiene and the content-packs slice surface running on the TypeScript engine, so that pack discovery and lifecycle events behave identically to Python.",
+      "Traces": "#1787, #1530"
+    },
+    "items": [
+      {
+        "id": "1787-s2-lifecycle-events-packs-a1",
+        "title": "Given a packs registry, when the TS packs-slice list runs, then it returns the same pack and slice listing as the Python oracle cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a packs registry, when the TS packs-slice list runs, then it returns the same pack and slice listing as the Python oracle cache-off.",
+          "Traces": "#1787, #1530"
+        }
+      },
+      {
+        "id": "1787-s2-lifecycle-events-packs-a2",
+        "title": "Given a slice request with filters, when the TS pack_render runs, then it emits the same sliced content as Python byte-for-byte.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a slice request with filters, when the TS pack_render runs, then it emits the same sliced content as Python byte-for-byte.",
+          "Traces": "#1787, #1530"
+        }
+      },
+      {
+        "id": "1787-s2-lifecycle-events-packs-a3",
+        "title": "Given a worktree with lifecycle events, when the TS event detector runs, then it records the same hygiene nudges as the Python module.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a worktree with lifecycle events, when the TS event detector runs, then it records the same hygiene nudges as the Python module.",
+          "Traces": "#1787, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/lifecycle/",
+          "packages/core/src/packs/",
+          "packages/cli/src/lifecycle-packs-parity.ts"
+        ],
+        "verify_commands": [
+          "task ts:lifecycle-packs-parity"
+        ],
+        "expected_outputs": [
+          "lifecycle-packs parity: CLEAN"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-lifecycle-packs",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1787",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1787: feat(ts-migration): port session / ritual / lifecycle + packs surface to TS (Wave 7)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-19-port-session-start-ritual-sentinel-core-to-ts.vbrief.json
+++ b/vbrief/pending/2026-06-19-port-session-start-ritual-sentinel-core-to-ts.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json"
+  },
+  "plan": {
+    "id": "1787-s1-session-ritual-core",
+    "title": "Port session-start + ritual-sentinel core to TS",
+    "status": "pending",
+    "planRef": "proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json",
+    "narratives": {
+      "Description": "Port the session-start ritual engine and its gating sentinel from Python to TypeScript. Covers session_start, _session_start_hook, ritual_sentinel, resume_conditions, and verify_session_ritual so the quick-tier and gated-tier session ritual run on the TS engine with the same staleness, defer, and skip semantics.",
+      "ImplementationPlan": "1. Port the session_start, _session_start_hook, ritual_sentinel, resume_conditions, and verify_session_ritual Python modules into a new packages/core/src/session module, preserving the ritual-state JSON shape and tier semantics. 2. Add a packages/cli/src/session-parity.ts harness that diffs the TS ritual output against the frozen Python oracle cache-off and assert byte-identical state across quick/gated/defer/skip fixtures. 3. Wire the session module into @deftai/core, tasks/ts.yml, and CI, and add unit tests covering staleness expiry and defer paths.",
+      "UserStory": "As a deft session operator, I want the session-start ritual and its gated verifier running on the TypeScript engine, so that ritual state is recorded identically to the Python implementation.",
+      "Traces": "#1787, #1530"
+    },
+    "items": [
+      {
+        "id": "1787-s1-session-ritual-core-a1",
+        "title": "Given a fresh worktree, when the TS session-start ritual runs, then it records ritual state that matches the Python oracle byte-for-byte cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a fresh worktree, when the TS session-start ritual runs, then it records ritual state that matches the Python oracle byte-for-byte cache-off.",
+          "Traces": "#1787, #1530"
+        }
+      },
+      {
+        "id": "1787-s1-session-ritual-core-a2",
+        "title": "Given a stale ritual state past the staleness window, when the gated verifier runs, then it fails closed and emits the same diagnostic as Python.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a stale ritual state past the staleness window, when the gated verifier runs, then it fails closed and emits the same diagnostic as Python.",
+          "Traces": "#1787, #1530"
+        }
+      },
+      {
+        "id": "1787-s1-session-ritual-core-a3",
+        "title": "Given a deferred ritual step, when verify-session-ritual runs, then it returns the same three-state exit code as the Python module.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a deferred ritual step, when verify-session-ritual runs, then it returns the same three-state exit code as the Python module.",
+          "Traces": "#1787, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/session/",
+          "packages/cli/src/session-parity.ts"
+        ],
+        "verify_commands": [
+          "task ts:session-parity"
+        ],
+        "expected_outputs": [
+          "session parity: CLEAN"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-session",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1787",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1787: feat(ts-migration): port session / ritual / lifecycle + packs surface to TS (Wave 7)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-19-port-subagent-monitor-investigation-gates-to-ts.vbrief.json
+++ b/vbrief/pending/2026-06-19-port-subagent-monitor-investigation-gates-to-ts.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-19-1788-featts-migration-port-swarm-orchestration-verbs-to-ts-wave-7.vbrief.json"
+  },
+  "plan": {
+    "id": "1788-s2-monitor-investigation-gates",
+    "title": "Port subagent monitor + investigation gates to TS",
+    "status": "pending",
+    "planRef": "proposed/2026-06-19-1788-featts-migration-port-swarm-orchestration-verbs-to-ts-wave-7.vbrief.json",
+    "narratives": {
+      "Description": "Port the monitor and investigation-gate verbs from Python to TypeScript. Covers subagent_monitor, probe_session, verify_investigation, and verify_judgment_gates so monitor polling, probe-session state, and the investigation close gates run on the TS engine as advisory CLI verbs.",
+      "ImplementationPlan": "1. Port subagent_monitor, probe_session, verify_investigation, and verify_judgment_gates into a packages/core/src/orchestration module, preserving monitor poll state, probe completion criteria, and the investigation claim-ledger close-gate exit semantics. 2. Add a packages/cli/src/orchestration-parity.ts harness diffing TS verb output against the Python oracle cache-off across monitor-state, probe-session, investigation-close, and judgment-gate fixtures. 3. Wire the module into @deftai/core, tasks/ts.yml, and CI with unit tests for the investigation close-gate and judgment-gate failure branches.",
+      "UserStory": "As a swarm orchestrator, I want the subagent monitor and investigation-gate verbs running on the TypeScript engine, so that monitor state and investigation close gates behave identically to Python.",
+      "Traces": "#1788, #1530"
+    },
+    "items": [
+      {
+        "id": "1788-s2-monitor-investigation-gates-a1",
+        "title": "Given a running cohort, when the TS subagent-monitor verb runs, then it reports the same monitor state as the Python oracle cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a running cohort, when the TS subagent-monitor verb runs, then it reports the same monitor state as the Python oracle cache-off.",
+          "Traces": "#1788, #1530"
+        }
+      },
+      {
+        "id": "1788-s2-monitor-investigation-gates-a2",
+        "title": "Given an investigation with an open claim ledger, when the TS verify-investigation gate runs, then it blocks with the same exit code as Python.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an investigation with an open claim ledger, when the TS verify-investigation gate runs, then it blocks with the same exit code as Python.",
+          "Traces": "#1788, #1530"
+        }
+      },
+      {
+        "id": "1788-s2-monitor-investigation-gates-a3",
+        "title": "Given a probe session, when the TS probe verb runs, then it records the same completion-criteria state as the Python module.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a probe session, when the TS probe verb runs, then it records the same completion-criteria state as the Python module.",
+          "Traces": "#1788, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/orchestration/",
+          "packages/cli/src/orchestration-parity.ts"
+        ],
+        "verify_commands": [
+          "task ts:orchestration-parity"
+        ],
+        "expected_outputs": [
+          "orchestration parity: CLEAN"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-orchestration",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1788",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1788: feat(ts-migration): port swarm + orchestration verbs to TS (Wave 7)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-19-port-swarm-cohort-cli-verbs-to-ts.vbrief.json
+++ b/vbrief/pending/2026-06-19-port-swarm-cohort-cli-verbs-to-ts.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-19-1788-featts-migration-port-swarm-orchestration-verbs-to-ts-wave-7.vbrief.json"
+  },
+  "plan": {
+    "id": "1788-s1-swarm-cohort-verbs",
+    "title": "Port swarm cohort CLI verbs to TS",
+    "status": "pending",
+    "planRef": "proposed/2026-06-19-1788-featts-migration-port-swarm-orchestration-verbs-to-ts-wave-7.vbrief.json",
+    "narratives": {
+      "Description": "Port the harness-agnostic swarm cohort verbs from Python to TypeScript. Covers swarm_launch, swarm_complete_cohort, swarm_readiness, swarm_verify_review_clean, and swarm_worktrees so cohort launch-manifest emission, worktree-map resolution, and readiness checks run on the TS engine as advisory CLI verbs.",
+      "ImplementationPlan": "1. Port swarm_launch, swarm_complete_cohort, swarm_readiness, swarm_verify_review_clean, and swarm_worktrees into a packages/core/src/swarm module, preserving launch-manifest JSON shape, worktree-map collision detection, and review-clean checks as advisory verbs that never own a runtime. 2. Add a packages/cli/src/swarm-parity.ts harness diffing TS verb output against the Python oracle cache-off across launch-manifest, worktree-map, readiness, and review-clean fixtures. 3. Wire the module into @deftai/core, tasks/ts.yml, and CI with unit tests for worktree-map collision and readiness gating branches.",
+      "UserStory": "As a swarm orchestrator, I want the swarm cohort CLI verbs running on the TypeScript engine, so that launch manifests and worktree maps are produced identically to the Python implementation.",
+      "Traces": "#1788, #1530"
+    },
+    "items": [
+      {
+        "id": "1788-s1-swarm-cohort-verbs-a1",
+        "title": "Given a pre-approved cohort, when the TS swarm-launch verb runs, then it emits a launch manifest that matches the Python oracle byte-for-byte cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a pre-approved cohort, when the TS swarm-launch verb runs, then it emits a launch manifest that matches the Python oracle byte-for-byte cache-off.",
+          "Traces": "#1788, #1530"
+        }
+      },
+      {
+        "id": "1788-s1-swarm-cohort-verbs-a2",
+        "title": "Given a worktree map with a same-path collision, when the TS resolver runs, then it rejects with the same error as the Python module.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a worktree map with a same-path collision, when the TS resolver runs, then it rejects with the same error as the Python module.",
+          "Traces": "#1788, #1530"
+        }
+      },
+      {
+        "id": "1788-s1-swarm-cohort-verbs-a3",
+        "title": "Given an active cohort, when the TS readiness verb runs, then it returns the same three-state exit and allocatable list as Python.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an active cohort, when the TS readiness verb runs, then it returns the same three-state exit and allocatable list as Python.",
+          "Traces": "#1788, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/swarm/",
+          "packages/cli/src/swarm-parity.ts"
+        ],
+        "verify_commands": [
+          "task ts:swarm-parity"
+        ],
+        "expected_outputs": [
+          "swarm parity: CLEAN"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-swarm",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1788",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1788: feat(ts-migration): port swarm + orchestration verbs to TS (Wave 7)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1787-featts-migration-port-session-ritual-lifecycle-packs-surface.vbrief.json
@@ -1,0 +1,70 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1787"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port session / ritual / lifecycle + packs surface to TS (Wave 7)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port session / ritual / lifecycle + packs surface to TS (Wave 7)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1787",
+      "Overview": "## Parent\n#1530 (Part 1 of 2)\n\n## What to build\nPort the session/ritual/lifecycle + packs surface: `session_start`, `_session_start_hook`, `ritual_sentinel`, `resume_conditions`, `verify_session_ritual`, `_lifecycle_hygiene`, `_event_detect`, `_events`, `pack_render`, `packs_slice`, `quarantine_ext`, `_agents_md`, `slug_normalize`, `resolve_version`, `resolve_changelog_unreleased`, `platform_capabilities`, `ip_risk`.\n\n## Acceptance criteria\n- [ ] TS ports with cache-off golden parity vs the Python oracle\n- [ ] Wired into `@deftai/core`, `tasks/ts.yml`, CI\n- [ ] CHANGELOG entry; `task check` green\n\n## Standing invariants (all #1530 Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The golden parity gate runs **cache-off**.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) **and** has CI usage.\n- Subprocess/`gh` capture uses Node `execFile` with explicit UTF-8 (closes the #1366 class structurally; the Python `_safe_subprocess`/`_stdio_utf8` shims are NOT ported — the problem does not exist in Node).\n\n## Full-conversion scope note (#1530)\nPart of the **full** Python→TS conversion. Per operator decision (2026-06-19) the cutover (#1731) deletes nothing until the engine is wholly TS. Accepted non-ports: Python-runtime shims, build/packaging tooling (superseded by the pnpm/tsc build), pre-v0.20 migration tooling (retired with a deprecation notice), and the Go installer (separate keep/fold decision in #1731). Owning an agent runtime is out of scope — net-new future work (#1707), not a conversion.\n\n## Type\nAFK\n\n## Blocked by\n- Blocked by #1530 (Wave 6)",
+      "Labels": "refactor, runtime-portability, tooling, ts-migration, area:cli"
+    },
+    "items": [
+      {
+        "title": "TS ports with cache-off golden parity vs the Python oracle",
+        "status": "proposed"
+      },
+      {
+        "title": "Wired into , , CI",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG entry;  green",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "refactor",
+      "runtime-portability",
+      "tooling",
+      "ts-migration",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1787",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1787: feat(ts-migration): port session / ritual / lifecycle + packs surface to TS (Wave 7)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      },
+      {
+        "uri": "pending/2026-06-19-port-session-start-ritual-sentinel-core-to-ts.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port session-start + ritual-sentinel core to TS",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-19-port-lifecycle-hygiene-events-packs-to-ts.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port lifecycle hygiene + events + packs to TS",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-19-port-agentsmd-version-platform-utilities-to-ts.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port AGENTS.md + version + platform utilities to TS",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}

--- a/vbrief/proposed/2026-06-19-1788-featts-migration-port-swarm-orchestration-verbs-to-ts-wave-7.vbrief.json
+++ b/vbrief/proposed/2026-06-19-1788-featts-migration-port-swarm-orchestration-verbs-to-ts-wave-7.vbrief.json
@@ -1,0 +1,65 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1788"
+  },
+  "plan": {
+    "title": "feat(ts-migration): port swarm + orchestration verbs to TS (Wave 7)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): port swarm + orchestration verbs to TS (Wave 7)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1788",
+      "Overview": "## Parent\n#1530 (Part 1 of 2)\n\n## What to build\nPort the swarm/orchestration **CLI verbs** (harness-agnostic; this is NOT runtime ownership): `swarm_launch`, `swarm_complete_cohort`, `swarm_readiness`, `swarm_verify_review_clean`, `swarm_worktrees`, `subagent_monitor`, `probe_session`, `verify_investigation`, `verify_judgment_gates`.\n\n## Scope boundary\nThese stay advisory CLI verbs invoked by the external host harness. Owning an agent loop / refuse-to-dispatch enforcement is explicitly **out of scope** — that is the net-new #1707 question, not a conversion. Porting these verbs to typed `@deftai/core` surfaces *feeds* a future #1707 decision (something typed to wrap) without adopting a runtime.\n\n## Acceptance criteria\n- [ ] TS ports with cache-off golden parity vs the Python oracle\n- [ ] Wired into `@deftai/core`, `tasks/ts.yml`, CI\n- [ ] CHANGELOG entry; `task check` green\n\n## Standing invariants (all #1530 Part-1 children)\n- The Python suite is the **parity oracle** and runs **wholesale** (not affected-sliced) until deleted.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The golden parity gate runs **cache-off**.\n- No Python module is deleted until its TS replacement covers historical bug fixtures (not just happy-path) **and** has CI usage.\n- Subprocess/`gh` capture uses Node `execFile` with explicit UTF-8 (closes the #1366 class structurally; the Python `_safe_subprocess`/`_stdio_utf8` shims are NOT ported — the problem does not exist in Node).\n\n## Full-conversion scope note (#1530)\nPart of the **full** Python→TS conversion. Per operator decision (2026-06-19) the cutover (#1731) deletes nothing until the engine is wholly TS. Accepted non-ports: Python-runtime shims, build/packaging tooling (superseded by the pnpm/tsc build), pre-v0.20 migration tooling (retired with a deprecation notice), and the Go installer (separate keep/fold decision in #1731). Owning an agent runtime is out of scope — net-new future work (#1707), not a conversion.\n\n## Type\nAFK\n\n## Blocked by\n- Blocked by #1530 (Wave 6)",
+      "Labels": "swarm, refactor, runtime-portability, tooling, ts-migration, area:cli"
+    },
+    "items": [
+      {
+        "title": "TS ports with cache-off golden parity vs the Python oracle",
+        "status": "proposed"
+      },
+      {
+        "title": "Wired into , , CI",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG entry;  green",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "swarm",
+      "refactor",
+      "runtime-portability",
+      "tooling",
+      "ts-migration",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1788",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1788: feat(ts-migration): port swarm + orchestration verbs to TS (Wave 7)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/blocks",
+        "title": "Issue #1530"
+      },
+      {
+        "uri": "pending/2026-06-19-port-swarm-cohort-cli-verbs-to-ts.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port swarm cohort CLI verbs to TS",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-19-port-subagent-monitor-investigation-gates-to-ts.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port subagent monitor + investigation gates to TS",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Lands the Wave 7 decomposition for the #1530 Python->TS migration: ingests the two parents (#1787, #1788) and decomposes them into 5 swarm-ready child stories.

- **#1787** session/ritual/lifecycle/packs -> 3 stories: session-ritual core; lifecycle/events/packs; AGENTS.md/version/platform utilities
- **#1788** swarm/orchestration verbs -> 2 stories: swarm cohort verbs; monitor/investigation gates

All stories are `readiness: ready`, `parallel_safe: true`, with disjoint `file_scope` (new `packages/core/src/{session,lifecycle,packs,platform,swarm,orchestration}` dirs) and per-story golden-parity `verify_commands`.

## Test plan
- [ ] vBRIEF conformance + lifecycle validators pass in CI
- [ ] No code changes; vBRIEF artifacts only

Refs #1787 #1788 #1530.

Made with [Cursor](https://cursor.com)