### PR TITLE
fix(ts): harden polynomial-ReDoS regex in swarm/launch.ts safeSegment (#1822)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Hardened a ReDoS-prone regex in the TypeScript swarm launcher (#1822)** -- The swarm cohort branch-name sanitizer no longer uses a backtracking regex to strip leading/trailing separators, so pathological story IDs (long runs of `-`/`.`) can't cause slow processing. Branch names are unchanged for all normal inputs; this clears the `js/polynomial-redos` CodeQL alert introduced by the #1788 swarm-verbs port. Refs #1822 #1788 #1530.
+
 ### Added
 - **Lifecycle hygiene, events, and content-packs ported to TypeScript (#1787 s2)** -- Lifecycle nudges, detection-bound and behavioral event helpers, pack rendering, slice registry access, and quarantine extension handling now run on the TypeScript engine with byte-identical golden parity against the frozen Python oracle (cache off). Operators get the same pack discovery, slice filtering, and lifecycle hygiene output while Wave 7 of the Python-to-TypeScript migration proceeds without behavior drift. Refs #1787 #1530.
 - **Session-start and ritual-sentinel core ported to TypeScript (#1787 s1)** -- The session-start ritual recorder, fail-closed verify gate, resume-nudge sentinel, and resume-condition evaluator now live in `@deftai/core/session` with the same quick/gated tier semantics, staleness window, defer/skip behavior, and three-state exit contracts as the Python modules. A golden parity harness diffs five fixture scenarios cache-off on CI so Wave 7 of the migration cannot drift. Refs #1787 #1530.

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -366,7 +366,15 @@ function safeSegment(text: string): string {
       cleaned += "-";
     }
   }
-  cleaned = cleaned.replace(/^[-.]+|[-.]+$/g, "");
+  let start = 0;
+  let end = cleaned.length;
+  while (start < end && (cleaned[start] === "-" || cleaned[start] === ".")) {
+    start += 1;
+  }
+  while (end > start && (cleaned[end - 1] === "-" || cleaned[end - 1] === ".")) {
+    end -= 1;
+  }
+  cleaned = cleaned.slice(start, end);
   return cleaned.length > 0 ? cleaned : "story";
 }
 

--- a/packages/core/src/swarm/swarm.test.ts
+++ b/packages/core/src/swarm/swarm.test.ts
@@ -113,6 +113,68 @@ describe("swarm readiness + launch", () => {
     expect(looksLikePath("100")).toBe(false);
     expect(looksLikePath("a.vbrief.json")).toBe(true);
   });
+
+  it("safeSegment strips leading/trailing separators with byte-identical output (#1822)", () => {
+    // Reference oracle: the original regex semantics this fix replaced.
+    const oracle = (raw: string): string => {
+      let cleaned = "";
+      for (const ch of raw.trim()) {
+        cleaned +=
+          (ch >= "A" && ch <= "Z") ||
+          (ch >= "a" && ch <= "z") ||
+          (ch >= "0" && ch <= "9") ||
+          ch === "." ||
+          ch === "_" ||
+          ch === "-"
+            ? ch
+            : "-";
+      }
+      cleaned = cleaned.replace(/^[-.]+|[-.]+$/g, "");
+      return cleaned.length > 0 ? cleaned : "story";
+    };
+    const branchOf = (storyId: string): string => {
+      const manifest = buildManifest(
+        [{ token: "x", story_id: storyId, path: "/p/a.json", relpath: "r" }],
+        {
+          projectRoot: "/proj",
+          dispatchKind: "solo",
+          allocationPlanId: null,
+          batchingRationale: "t",
+          operatorApprovalEvidence: "e",
+        },
+      );
+      return (manifest[0]?.branch as string).replace(/^swarm\//, "");
+    };
+    for (const input of [
+      "s1",
+      "----abc----",
+      "..weird..name..",
+      "-.-.-.-.",
+      "feature/Some Thing!",
+      "trailing---",
+      "---leading",
+      "a-b.c_d",
+    ]) {
+      expect(branchOf(input)).toBe(oracle(input));
+    }
+  });
+
+  it("safeSegment runs in linear time on pathological separator runs (#1822)", () => {
+    const evil = `${"-".repeat(100_000)}story${"-".repeat(100_000)}`;
+    const started = Date.now();
+    const manifest = buildManifest(
+      [{ token: "x", story_id: evil, path: "/p/a.json", relpath: "r" }],
+      {
+        projectRoot: "/proj",
+        dispatchKind: "solo",
+        allocationPlanId: null,
+        batchingRationale: "t",
+        operatorApprovalEvidence: "e",
+      },
+    );
+    expect(Date.now() - started).toBeLessThan(1000);
+    expect(manifest[0]?.branch).toBe("swarm/story");
+  });
 });
 
 describe("swarm subagent backend", () => {


### PR DESCRIPTION
## Summary
- Replaces the backtracking `/^[-.]+|[-.]+$/g` leading/trailing-separator strip in `swarm/launch.ts` `safeSegment()` with a single-pass linear scanner (byte-identical branch-name output for all inputs).
- Clears the `js/polynomial-redos` CodeQL high-severity alert introduced on master by the #1788 swarm cohort verbs port (#1820) — same ReDoS class as the #1810/#1811 backlog and the #1816 `scanner.ts` linearization.

## Test plan
- [x] `pnpm run build` clean
- [x] New equivalence tests assert byte-identical output vs the original regex semantics across 8 representative inputs (leading/trailing/interior separators, spaces, special chars)
- [x] New pathological linear-time test: 100k-char `-` runs complete in <1s and produce `swarm/story`
- [x] `task ts:swarm-parity` CLEAN (5 cases) — branch derivation unchanged
- [x] `biome check` clean on changed files

Refs #1822 #1788 #1530

Made with [Cursor](https://cursor.com)