### PR TITLE
fix(ts): guard git ls-remote remote arg against second-order command injection (#1824)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Closed a command-injection risk in the TypeScript version resolver (#1824)** -- The remote-tag lookup now rejects remote names that begin with `-` (and passes `--end-of-options` to git), so a crafted remote can no longer be smuggled in as a git option to execute an arbitrary command. Behavior is unchanged for all real remotes; this clears the `js/second-order-command-line-injection` CodeQL alert from the #1787 platform-utilities port. Refs #1824 #1787 #1530.
 - **Hardened a ReDoS-prone regex in the TypeScript swarm launcher (#1822)** -- The swarm cohort branch-name sanitizer no longer uses a backtracking regex to strip leading/trailing separators, so pathological story IDs (long runs of `-`/`.`) can't cause slow processing. Branch names are unchanged for all normal inputs; this clears the `js/polynomial-redos` CodeQL alert introduced by the #1788 swarm-verbs port. Refs #1822 #1788 #1530.
 
 ### Added

--- a/packages/core/src/platform/branch-coverage.test.ts
+++ b/packages/core/src/platform/branch-coverage.test.ts
@@ -168,6 +168,17 @@ describe("resolve-version parse + classify branch coverage", () => {
     expect(latestLocalPublishableTag("/nonexistent-platform-branch-xyz")).toBeNull();
     expect(latestRemotePublishableTag("origin", "/nonexistent-platform-branch-xyz")).toBeNull();
   });
+
+  it("latestRemotePublishableTag rejects option-like remotes without shelling out (#1824)", () => {
+    // The leading-dash guard must short-circuit BEFORE execFileSync so a remote
+    // that git would parse as an option (argument injection) never reaches git.
+    // The fast return (no 10s git timeout) also proves no subprocess was spawned.
+    const started = Date.now();
+    for (const evil of ["--upload-pack=touch /tmp/pwned", "-x", "--exec=evil"]) {
+      expect(latestRemotePublishableTag(evil)).toBeNull();
+    }
+    expect(Date.now() - started).toBeLessThan(500);
+  });
 });
 
 describe("agents-md hasV3ManagedMarker branch coverage", () => {

--- a/packages/core/src/platform/resolve-version.ts
+++ b/packages/core/src/platform/resolve-version.ts
@@ -262,13 +262,22 @@ export function latestLocalPublishableTag(repoRoot?: string): string | null {
 }
 
 export function latestRemotePublishableTag(remote = "origin", repoRoot?: string): string | null {
+  // Guard against second-order command injection: a remote beginning with "-"
+  // (e.g. "--upload-pack=<cmd>") would be parsed by git as an option and could
+  // execute an arbitrary command. Legitimate remote names/URLs never start with
+  // "-", so reject them outright. "--end-of-options" is defense-in-depth.
+  if (remote.startsWith("-")) return null;
   const cwd = repoRoot ?? frameworkRoot();
   try {
-    const stdout = execFileSync("git", ["ls-remote", "--tags", "--refs", remote], {
-      cwd,
-      encoding: "utf8",
-      timeout: 10_000,
-    });
+    const stdout = execFileSync(
+      "git",
+      ["ls-remote", "--tags", "--refs", "--end-of-options", remote],
+      {
+        cwd,
+        encoding: "utf8",
+        timeout: 10_000,
+      },
+    );
     return latestPublishableTag(stdout.split("\n"));
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- Adds a leading-dash guard to `latestRemotePublishableTag()` in `platform/resolve-version.ts` (a `remote` starting with `-` returns null) plus `--end-of-options` before the positional remote, closing the `js/second-order-command-line-injection` CodeQL alert introduced by the #1787 s3 platform port (#1816).
- Behavior-preserving for all legitimate remotes; the live network path is not exercised by the parity harness, so golden parity is unaffected (`platform parity: CLEAN` retained).

## Test plan
- [x] `pnpm run build` clean
- [x] New hermetic guard test: option-like remotes (`--upload-pack=...`, `-x`, `--exec=...`) return null in <500ms, proving no subprocess is spawned
- [x] `task ts:platform-parity` CLEAN (6 cases)
- [x] `biome check` clean on changed files

Refs #1824 #1787 #1530

Made with [Cursor](https://cursor.com)