### PR TITLE
fix(ts): use -- end-of-options separator for git ls-remote (CodeQL follow-up to #1825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Closed a command-injection risk in the TypeScript version resolver (#1824)** -- The remote-tag lookup now rejects remote names that begin with `-` (and passes `--end-of-options` to git), so a crafted remote can no longer be smuggled in as a git option to execute an arbitrary command. Behavior is unchanged for all real remotes; this clears the `js/second-order-command-line-injection` CodeQL alert from the #1787 platform-utilities port. Refs #1824 #1787 #1530.
+- **Closed a command-injection risk in the TypeScript version resolver (#1824)** -- The remote-tag lookup now rejects remote names that begin with `-` and passes the `--` end-of-options separator to git, so a crafted remote can no longer be smuggled in as a git option to execute an arbitrary command. Behavior is unchanged for all real remotes; this clears the `js/second-order-command-line-injection` CodeQL alert from the #1787 platform-utilities port. Refs #1824 #1787 #1530.
 - **Hardened a ReDoS-prone regex in the TypeScript swarm launcher (#1822)** -- The swarm cohort branch-name sanitizer no longer uses a backtracking regex to strip leading/trailing separators, so pathological story IDs (long runs of `-`/`.`) can't cause slow processing. Branch names are unchanged for all normal inputs; this clears the `js/polynomial-redos` CodeQL alert introduced by the #1788 swarm-verbs port. Refs #1822 #1788 #1530.
 
 ### Added

--- a/packages/core/src/platform/resolve-version.ts
+++ b/packages/core/src/platform/resolve-version.ts
@@ -265,19 +265,16 @@ export function latestRemotePublishableTag(remote = "origin", repoRoot?: string)
   // Guard against second-order command injection: a remote beginning with "-"
   // (e.g. "--upload-pack=<cmd>") would be parsed by git as an option and could
   // execute an arbitrary command. Legitimate remote names/URLs never start with
-  // "-", so reject them outright. "--end-of-options" is defense-in-depth.
+  // "-", so reject them outright; the "--" end-of-options separator below is the
+  // load-bearing barrier (git stops parsing options after it).
   if (remote.startsWith("-")) return null;
   const cwd = repoRoot ?? frameworkRoot();
   try {
-    const stdout = execFileSync(
-      "git",
-      ["ls-remote", "--tags", "--refs", "--end-of-options", remote],
-      {
-        cwd,
-        encoding: "utf8",
-        timeout: 10_000,
-      },
-    );
+    const stdout = execFileSync("git", ["ls-remote", "--tags", "--refs", "--", remote], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+    });
     return latestPublishableTag(stdout.split("\n"));
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- Follow-up to #1825: the `startsWith("-")` guard alone did not clear the `js/second-order-command-line-injection` CodeQL alert on `platform/resolve-version.ts` (CodeQL doesn't recognize git's `--end-of-options` spelling as a sanitizer).
- Switches the `git ls-remote` invocation to the POSIX `--` end-of-options separator, which CodeQL honors as an option-injection barrier. The `startsWith("-")` guard is retained for defense in depth.

## Test plan
- [x] `pnpm run build` clean
- [x] Existing hermetic guard test (option-like remotes return null) still passes (56 platform branch-coverage tests)
- [x] `git ls-remote --tags --refs -- origin` verified to work
- [x] `task ts:platform-parity` CLEAN (6 cases)
- [x] `biome check` clean

Refs #1824 #1787 #1530

Made with [Cursor](https://cursor.com)