### PR TITLE
chore(ts-migration): Wave 8 decomposition -- flip live gates to TS (7 stories)

### DIFF
--- a/vbrief/pending/2026-06-21-build-the-unified-deft-ts-cli-dispatcher-exposing-all-ported.vbrief.json
+++ b/vbrief/pending/2026-06-21-build-the-unified-deft-ts-cli-dispatcher-exposing-all-ported.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1828-s0-unified-deft-ts-dispatcher",
+    "title": "Build the unified deft-ts CLI dispatcher exposing all ported verbs",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
+    "narratives": {
+      "Description": "Replace the bin.ts banner stub with a unified `deft-ts <verb> [args]` dispatcher that routes to every ported command module in packages/cli and packages/core. Today only ~13 of 96 command modules are exposed as bins; the live-gate flip stories (s2-s6) cannot route Taskfiles to TS until one stable entrypoint exists. This is a prerequisite that blocks the domain-flip stories.",
+      "ImplementationPlan": "1. Replace packages/cli/src/bin.ts with a subcommand dispatcher that maps verb names to the existing command-module main() handlers, forwarding argv and exit codes unchanged. 2. Register the full verb table covering all 96 ported modules; expose `deft-ts --help` listing the verbs. 3. Keep per-command bins working for back-compat. 4. Add unit tests for verb routing, unknown-verb error, and exit-code passthrough; ensure `task ts:build` and `task ts:lint` stay green.",
+      "UserStory": "As a maintainer flipping live gates to TS, I want one stable `deft-ts <verb>` entrypoint, so that Taskfile gates can route to the TS engine through a single binary instead of 96 separate bins.",
+      "Traces": "#1828, #1530"
+    },
+    "items": [
+      {
+        "id": "1828-s0-unified-deft-ts-dispatcher-a1",
+        "title": "Given a known verb name and args, when `deft-ts <verb> [args]` runs, then it routes to that command module and exits with the same code the module's main() returns.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a known verb name and args, when `deft-ts <verb> [args]` runs, then it routes to that command module and exits with the same code the module's main() returns.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s0-unified-deft-ts-dispatcher-a2",
+        "title": "Given an unknown verb, when `deft-ts <verb>` runs, then it prints an error naming the verb and exits non-zero.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an unknown verb, when `deft-ts <verb>` runs, then it prints an error naming the verb and exits non-zero.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s0-unified-deft-ts-dispatcher-a3",
+        "title": "Given `deft-ts --help`, when it runs, then it prints the full list of registered verbs.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given `deft-ts --help`, when it runs, then it prints the full list of registered verbs.",
+          "Traces": "#1828, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/bin.ts",
+          "packages/cli/src/dispatch.ts"
+        ],
+        "verify_commands": [
+          "task ts:build",
+          "task ts:test"
+        ],
+        "expected_outputs": [
+          "deft-ts dispatcher routes all registered verbs"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-cli-dispatch",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-enforce-node-as-a-required-consumer-runtime-in-doctortoolcha.vbrief.json
+++ b/vbrief/pending/2026-06-21-enforce-node-as-a-required-consumer-runtime-in-doctortoolcha.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1828-s1-node-runtime-enforcement",
+    "title": "Enforce Node as a required consumer runtime in doctor/toolchain",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
+    "narratives": {
+      "Description": "Make Node/pnpm a required runtime once live gates are TS-backed. Today consumers require Python (uv) and the TS lane is guarded/optional. Update doctor and toolchain:check to detect a missing Node toolchain and fail with a clear, actionable message rather than a stack trace, and document the new requirement in install/upgrade surfaces. Prerequisite, runnable in parallel with s0.",
+      "ImplementationPlan": "1. Extend the TS doctor module (packages/core/src/doctor) to probe for a Node runtime and emit an actionable remediation line when absent. 2. Wire the same probe into toolchain:check guidance. 3. Update install/upgrade docs to state Node is required for TS-backed gates. 4. Add unit tests for the present-Node and absent-Node branches asserting the exit code and the remediation message.",
+      "UserStory": "As a consumer running deft after the flip, I want a clear error when Node is missing, so that I know to install the now-required Node runtime instead of hitting an opaque failure.",
+      "Traces": "#1828, #1530"
+    },
+    "items": [
+      {
+        "id": "1828-s1-node-runtime-enforcement-a1",
+        "title": "Given a host without a Node runtime, when doctor runs, then it reports the missing-Node condition with an actionable remediation line and exits non-zero.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a host without a Node runtime, when doctor runs, then it reports the missing-Node condition with an actionable remediation line and exits non-zero.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s1-node-runtime-enforcement-a2",
+        "title": "Given a host with a Node runtime, when doctor runs, then the Node check passes and does not change unrelated doctor output.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a host with a Node runtime, when doctor runs, then the Node check passes and does not change unrelated doctor output.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s1-node-runtime-enforcement-a3",
+        "title": "Given the install/upgrade docs, when read, then they state that Node is a required runtime for TS-backed gates.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the install/upgrade docs, when read, then they state that Node is a required runtime for TS-backed gates.",
+          "Traces": "#1828, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/doctor/",
+          "tasks/toolchain.yml"
+        ],
+        "verify_commands": [
+          "task ts:test",
+          "task ts:doctor-parity"
+        ],
+        "expected_outputs": [
+          "doctor reports missing Node with remediation"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-doctor-toolchain",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-flip-prswarmrelease-gates-to-the-ts-engine.vbrief.json
+++ b/vbrief/pending/2026-06-21-flip-prswarmrelease-gates-to-the-ts-engine.vbrief.json
@@ -1,0 +1,80 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 6 decomposed from proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1828-s5-flip-pr-swarm-release",
+    "title": "Flip pr/swarm/release gates to the TS engine",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
+    "narratives": {
+      "Description": "Repoint the pr_*, swarm_*, release*, and resolve_* gates from Python to the deft-ts dispatcher, keeping Python in-tree as oracle. Covers pr_wait_mergeable, pr_merge_readiness, pr_check_protected_issues, swarm_launch, swarm_complete_cohort, swarm_verify_review_clean, release/release_publish/release_rollback/release_e2e, resolve_version, resolve_changelog_unreleased.",
+      "ImplementationPlan": "1. In tasks/pr.yml, tasks/swarm.yml, and the release verbs defined in the root Taskfile.yml, replace each `uv run python scripts/<name>.py` invocation with the corresponding deft-ts verb call, leaving the scripts on disk. 2. Run the existing pr/swarm/release parity harnesses (task ts:parity-all) cache-off to confirm byte-identical output against the Python oracle. 3. Exercise the protected-issue check and a release dry-run through the flipped gates and confirm `task check:framework-source` stays green as the verification evidence; release-publish/rollback verbs are exercised in dry-run/parity mode only.",
+      "UserStory": "As an orchestrator, I want the pr/swarm/release verbs executing on the TS engine, so that cascade automation and release tooling behave identically to Python.",
+      "Traces": "#1828, #1530"
+    },
+    "items": [
+      {
+        "id": "1828-s5-flip-pr-swarm-release-a1",
+        "title": "Given the flipped pr/swarm/release gates, when each task runs, then its output is byte-identical to the Python oracle cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flipped pr/swarm/release gates, when each task runs, then its output is byte-identical to the Python oracle cache-off.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s5-flip-pr-swarm-release-a2",
+        "title": "Given a protected-issue check, when run through the TS engine, then it returns the same escalation exit as the Python path.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a protected-issue check, when run through the TS engine, then it returns the same escalation exit as the Python path.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s5-flip-pr-swarm-release-a3",
+        "title": "Given the flip, when the python pr/swarm/release scripts are inspected, then they remain present in-tree as oracle.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flip, when the python pr/swarm/release scripts are inspected, then they remain present in-tree as oracle.",
+          "Traces": "#1828, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/pr.yml",
+          "tasks/swarm.yml",
+          "Taskfile.yml"
+        ],
+        "verify_commands": [
+          "task ts:parity-all"
+        ],
+        "expected_outputs": [
+          "pr/swarm/release gates route to TS, parity CLEAN"
+        ],
+        "depends_on": [
+          "1828-s0-unified-deft-ts-dispatcher"
+        ],
+        "conflict_group": "taskfile-pr-release",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-flip-scmcachepolicy-and-remaining-gates-to-the-ts-engine.vbrief.json
+++ b/vbrief/pending/2026-06-21-flip-scmcachepolicy-and-remaining-gates-to-the-ts-engine.vbrief.json
@@ -1,0 +1,85 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 7 decomposed from proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1828-s6-flip-scm-cache-policy-misc",
+    "title": "Flip scm/cache/policy and remaining gates to the TS engine",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
+    "narratives": {
+      "Description": "Repoint the remaining live gates (scm, cache, policy_set, pack_render, roadmap_render, github_body, validate_strategy_output, codebase/capacity validators) from Python to the deft-ts dispatcher, keeping Python in-tree as oracle. This story closes out the long tail so no live `task` gate still invokes Python.",
+      "ImplementationPlan": "1. In tasks/scm.yml, tasks/cache.yml, tasks/policy.yml, tasks/packs.yml, tasks/roadmap.yml, tasks/codebase.yml, and tasks/capacity.yml, replace each `uv run python scripts/<name>.py` invocation with the corresponding deft-ts verb call, leaving the scripts on disk as oracle. 2. Run the existing scm/cache/policy parity harnesses (task ts:parity-all) cache-off to confirm byte-identical output against the Python oracle. 3. Grep the Taskfiles to confirm no live (non-parity-oracle) gate still calls `uv run python`, and confirm `task check:framework-source` stays green as the verification evidence.",
+      "UserStory": "As a maintainer, I want the remaining scm/cache/policy gates executing on the TS engine, so that after this story no live task gate still invokes Python.",
+      "Traces": "#1828, #1530"
+    },
+    "items": [
+      {
+        "id": "1828-s6-flip-scm-cache-policy-misc-a1",
+        "title": "Given the flipped scm/cache/policy/misc gates, when each task runs, then its output is byte-identical to the Python oracle cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flipped scm/cache/policy/misc gates, when each task runs, then its output is byte-identical to the Python oracle cache-off.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s6-flip-scm-cache-policy-misc-a2",
+        "title": "Given the completed flip, when the Taskfiles are scanned, then no live (non-parity-oracle) gate invokes `uv run python`.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the completed flip, when the Taskfiles are scanned, then no live (non-parity-oracle) gate invokes `uv run python`.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s6-flip-scm-cache-policy-misc-a3",
+        "title": "Given the flip, when the remaining python scripts are inspected, then they remain present in-tree as oracle.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flip, when the remaining python scripts are inspected, then they remain present in-tree as oracle.",
+          "Traces": "#1828, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/scm.yml",
+          "tasks/cache.yml",
+          "tasks/policy.yml",
+          "tasks/packs.yml",
+          "tasks/roadmap.yml",
+          "tasks/codebase.yml",
+          "tasks/capacity.yml"
+        ],
+        "verify_commands": [
+          "task ts:parity-all",
+          "task check:framework-source"
+        ],
+        "expected_outputs": [
+          "all remaining gates route to TS, parity CLEAN"
+        ],
+        "depends_on": [
+          "1828-s0-unified-deft-ts-dispatcher"
+        ],
+        "conflict_group": "taskfile-scm-misc",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-flip-scopevbrief-lifecycle-gates-to-the-ts-engine.vbrief.json
+++ b/vbrief/pending/2026-06-21-flip-scopevbrief-lifecycle-gates-to-the-ts-engine.vbrief.json
@@ -1,0 +1,81 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 5 decomposed from proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1828-s4-flip-scope-vbrief-lifecycle",
+    "title": "Flip scope/vbrief lifecycle gates to the TS engine",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
+    "narratives": {
+      "Description": "Repoint the scope and vbrief lifecycle gates (scope_lifecycle, vbrief_activate, slice_record_existing, issue_ingest, reconcile_issues, vbrief_reconcile_*) from Python to the deft-ts dispatcher. The python scripts stay in-tree as the parity oracle and field fallback so no lifecycle behavior is removed in this wave.",
+      "ImplementationPlan": "1. In tasks/scope.yml, tasks/slice.yml, tasks/issue.yml, and tasks/reconcile.yml, replace each `uv run python scripts/<name>.py` invocation with the corresponding deft-ts verb call, leaving the scripts on disk. 2. Run the existing per-module parity harnesses (task ts:parity-all) cache-off to confirm byte-identical output against the Python oracle. 3. Exercise a promote/activate/complete sequence through the flipped gates and confirm `task check:framework-source` stays green as the verification evidence.",
+      "UserStory": "As a maintainer, I want the scope/vbrief lifecycle verbs executing on the TS engine, so that promote/activate/complete and intake behave identically to Python.",
+      "Traces": "#1828, #1530"
+    },
+    "items": [
+      {
+        "id": "1828-s4-flip-scope-vbrief-lifecycle-a1",
+        "title": "Given the flipped lifecycle gates, when each scope/vbrief lifecycle task runs, then its output is byte-identical to the Python oracle cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flipped lifecycle gates, when each scope/vbrief lifecycle task runs, then its output is byte-identical to the Python oracle cache-off.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s4-flip-scope-vbrief-lifecycle-a2",
+        "title": "Given a scope promote/activate/complete sequence, when run through the TS engine, then the vBRIEF lands in the same lifecycle folder as the Python path.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a scope promote/activate/complete sequence, when run through the TS engine, then the vBRIEF lands in the same lifecycle folder as the Python path.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s4-flip-scope-vbrief-lifecycle-a3",
+        "title": "Given the flip, when the python lifecycle scripts are inspected, then they remain present in-tree as oracle.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flip, when the python lifecycle scripts are inspected, then they remain present in-tree as oracle.",
+          "Traces": "#1828, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/scope.yml",
+          "tasks/slice.yml",
+          "tasks/issue.yml",
+          "tasks/reconcile.yml"
+        ],
+        "verify_commands": [
+          "task ts:parity-all"
+        ],
+        "expected_outputs": [
+          "lifecycle gates route to TS, parity CLEAN"
+        ],
+        "depends_on": [
+          "1828-s0-unified-deft-ts-dispatcher"
+        ],
+        "conflict_group": "taskfile-lifecycle",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-flip-the-triage-task-surface-to-the-ts-engine.vbrief.json
+++ b/vbrief/pending/2026-06-21-flip-the-triage-task-surface-to-the-ts-engine.vbrief.json
@@ -1,0 +1,90 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 4 decomposed from proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1828-s3-flip-triage-surface",
+    "title": "Flip the triage task surface to the TS engine",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
+    "narratives": {
+      "Description": "Repoint the triage_* gates (actions, queue, classify, welcome, scope, scope-drift, reconcile, summary, subscribe, bulk, bootstrap, refresh, smoketest) from Python to the deft-ts dispatcher, keeping Python in-tree as oracle. This is the largest single cluster of live python invocations.",
+      "ImplementationPlan": "1. In the tasks/triage-*.yml files, replace python invocations with deft-ts verb calls for each triage gate. 2. Keep scripts/triage_*.py in-tree. 3. Confirm byte-identical output vs the Python oracle via the existing triage parity harnesses cache-off and that the triage smoketest stays green.",
+      "UserStory": "As an operator, I want the triage verbs executing on the TS engine, so that the queue, classification, and welcome surfaces behave identically to Python.",
+      "Traces": "#1828, #1530"
+    },
+    "items": [
+      {
+        "id": "1828-s3-flip-triage-surface-a1",
+        "title": "Given the flipped triage gates, when each `task triage:*` runs, then its output is byte-identical to the Python oracle cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flipped triage gates, when each `task triage:*` runs, then its output is byte-identical to the Python oracle cache-off.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s3-flip-triage-surface-a2",
+        "title": "Given the flip, when `task triage:smoketest` runs, then it passes routing through the TS engine.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flip, when `task triage:smoketest` runs, then it passes routing through the TS engine.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s3-flip-triage-surface-a3",
+        "title": "Given the flip, when scripts/triage_*.py are inspected, then they remain present in-tree as oracle.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flip, when scripts/triage_*.py are inspected, then they remain present in-tree as oracle.",
+          "Traces": "#1828, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/triage-actions.yml",
+          "tasks/triage-queue.yml",
+          "tasks/triage-classify.yml",
+          "tasks/triage-welcome.yml",
+          "tasks/triage-scope.yml",
+          "tasks/triage-scope-drift.yml",
+          "tasks/triage-reconcile.yml",
+          "tasks/triage-summary.yml",
+          "tasks/triage-subscribe.yml",
+          "tasks/triage-bulk.yml",
+          "tasks/triage-bootstrap.yml",
+          "tasks/triage-smoketest.yml"
+        ],
+        "verify_commands": [
+          "task ts:parity-all",
+          "task triage:smoketest"
+        ],
+        "expected_outputs": [
+          "triage gates route to TS, parity CLEAN"
+        ],
+        "depends_on": [
+          "1828-s0-unified-deft-ts-dispatcher"
+        ],
+        "conflict_group": "taskfile-triage",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-flip-verifypreflight-gates-to-the-ts-engine-consumer-critica.vbrief.json
+++ b/vbrief/pending/2026-06-21-flip-verifypreflight-gates-to-the-ts-engine-consumer-critica.vbrief.json
@@ -1,0 +1,80 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1828-s2-flip-verify-preflight-gates",
+    "title": "Flip verify/preflight gates to the TS engine (consumer-critical set first)",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
+    "narratives": {
+      "Description": "Repoint the consumer-critical verify/preflight gates from `uv run python scripts/*.py` to the deft-ts dispatcher, keeping the Python scripts in-tree as oracle/fallback. Covers verify:branch, verify:encoding, vbrief:validate, story-ready, cache-fresh and the rest of the check:consumer set so consumers run the TS engine for the gates they depend on most.",
+      "ImplementationPlan": "1. In tasks/verify.yml and tasks/vbrief.yml, replace the python invocations for the verify/preflight gates with deft-ts verb calls. 2. Keep scripts/*.py in-tree untouched. 3. Confirm each flipped gate's output is byte-identical to the Python oracle via the existing parity harness (cache-off) and that `task check:consumer` plus `task check:framework-source` stay green.",
+      "UserStory": "As a consumer, I want the verify/preflight gates executing on the TS engine, so that the gates I rely on most run identically to the Python implementation they replace.",
+      "Traces": "#1828, #1530"
+    },
+    "items": [
+      {
+        "id": "1828-s2-flip-verify-preflight-gates-a1",
+        "title": "Given the flipped verify/preflight gates, when each `task verify:*` / preflight gate runs, then its output is byte-identical to the Python oracle cache-off.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flipped verify/preflight gates, when each `task verify:*` / preflight gate runs, then its output is byte-identical to the Python oracle cache-off.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s2-flip-verify-preflight-gates-a2",
+        "title": "Given the flip, when `task check:consumer` runs, then it passes routing through the TS engine.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flip, when `task check:consumer` runs, then it passes routing through the TS engine.",
+          "Traces": "#1828, #1530"
+        }
+      },
+      {
+        "id": "1828-s2-flip-verify-preflight-gates-a3",
+        "title": "Given the flip, when the Python scripts are inspected, then they remain present in-tree as oracle/fallback.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the flip, when the Python scripts are inspected, then they remain present in-tree as oracle/fallback.",
+          "Traces": "#1828, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/verify.yml",
+          "tasks/vbrief.yml"
+        ],
+        "verify_commands": [
+          "task ts:parity-all",
+          "task check:consumer"
+        ],
+        "expected_outputs": [
+          "verify/preflight gates route to TS, parity CLEAN"
+        ],
+        "depends_on": [
+          "1828-s0-unified-deft-ts-dispatcher"
+        ],
+        "conflict_group": "taskfile-verify",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json
+++ b/vbrief/proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json
@@ -1,0 +1,99 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1828"
+  },
+  "plan": {
+    "title": "feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1828",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2). Precedes the delete/cutover #1731 (this wave is added as a blocker of #1731).\n\n## Why this wave exists\n\nAll Python->TS ports (Waves 1-7) are complete and parity-proven, but the **live execution path is still Python**: the Taskfiles invoke `scripts/*.py` at ~160 sites across 104 distinct scripts (e.g. `verify:branch` still runs `uv run python scripts/preflight_branch.py`). The TS engine runs in **shadow** -- built and byte-identical via the golden-diff harnesses, but not yet wired into what `task`/`deft` actually executes.\n\n#1731 (delete) assumes this flip has happened (\"CI usage\") but never scoped it as its own bake-able step. Wave 8 is that missing middle step: **repoint the live gates to the TS engine while keeping Python in-tree as oracle + fallback, then bake for 2-3 releases before any deletion.** This avoids a big-bang flip+delete that would remove the parity oracle and the field fallback in a single motion while TS branch coverage sits right at the 85% floor.\n\n## What to build\n\nFlip every live gate/verb from `uv run python scripts/X.py` to the ported TS engine, additively and domain-by-domain, with the golden-diff parity harness as the equivalence gate. No Python is deleted in this wave.\n\n## Decision recorded (operator, 2026-06-20)\n\n**Node/pnpm becomes a required consumer runtime.** Today consumers require Python (`uv`) and the TS lane is guarded/optional (`ts:check-lane` skips when Node is absent). After this wave the live gates are TS-backed, so Node is mandatory. `doctor`/`toolchain:check` must fail with a clear, actionable message when Node is absent (not a stack trace).\n\n## Acceptance criteria\n\n- [ ] A unified `deft-ts <verb> [args]` dispatcher exists (today `bin.ts` is a banner stub and only ~13 of 96 command modules are exposed as bins)\n- [ ] `doctor`/`toolchain:check` enforce Node presence with an actionable error\n- [ ] Every live `task` gate routes to the TS engine; `scripts/*.py` remain in-tree as oracle/fallback\n- [ ] Each flipped gate's `task <gate>` output is byte-identical to the Python original (parity harness green, cache-off)\n- [ ] `task check` (framework-source + consumer) stays green at every merge\n- [ ] After all flips merge, a 2-3 release bake window elapses before #1731 (delete) proceeds\n\n## Proposed stories (decomposed separately)\n\n- **8.0** Unified `deft-ts` dispatcher + expose all 96 verbs (prerequisite, blocks the rest)\n- **8.1** Consumer Node-runtime enforcement in `doctor`/`toolchain:check` + install/upgrade docs (prerequisite, parallel with 8.0)\n- **8.2** Flip verify/preflight gates (the consumer-critical `check:consumer` set first)\n- **8.3** Flip triage surface (`triage_*` -- largest cluster)\n- **8.4** Flip scope/vbrief lifecycle (`scope_lifecycle`, `vbrief_*`, `slice_*`, `issue_ingest`, `reconcile_*`)\n- **8.5** Flip pr/swarm/release (`pr_*`, `swarm_*`, `release*`, `resolve_*`)\n- **8.6** Flip scm/cache/policy/misc (`scm`, `cache`, `policy_set`, `pack_render`, `roadmap_render`, `github_body`)\n\n## Standing invariants (inherited from #1731)\n\n- The Python suite remains the **parity oracle** and runs wholesale until deleted (Wave 9 / #1731).\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- The parity gate runs **cache-off** so a golden diff is never served from cache.\n\n## Type\n\nfeat (umbrella)",
+      "Labels": "process, runtime-portability, ts-migration"
+    },
+    "items": [
+      {
+        "title": "A unified  dispatcher exists (today  is a banner stub and only ~13 of 96 command modules are exposed as bins)",
+        "status": "proposed"
+      },
+      {
+        "title": "/ enforce Node presence with an actionable error",
+        "status": "proposed"
+      },
+      {
+        "title": "Every live  gate routes to the TS engine;  remain in-tree as oracle/fallback",
+        "status": "proposed"
+      },
+      {
+        "title": "Each flipped gate's  output is byte-identical to the Python original (parity harness green, cache-off)",
+        "status": "proposed"
+      },
+      {
+        "title": "(framework-source + consumer) stays green at every merge",
+        "status": "proposed"
+      },
+      {
+        "title": "After all flips merge, a 2-3 release bake window elapses before #1731 (delete) proceeds",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "process",
+      "runtime-portability",
+      "ts-migration"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1828",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)"
+      },
+      {
+        "uri": "pending/2026-06-21-build-the-unified-deft-ts-cli-dispatcher-exposing-all-ported.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Build the unified deft-ts CLI dispatcher exposing all ported verbs",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-enforce-node-as-a-required-consumer-runtime-in-doctortoolcha.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Enforce Node as a required consumer runtime in doctor/toolchain",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-flip-verifypreflight-gates-to-the-ts-engine-consumer-critica.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Flip verify/preflight gates to the TS engine (consumer-critical set first)",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-flip-the-triage-task-surface-to-the-ts-engine.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Flip the triage task surface to the TS engine",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-flip-scopevbrief-lifecycle-gates-to-the-ts-engine.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Flip scope/vbrief lifecycle gates to the TS engine",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-flip-prswarmrelease-gates-to-the-ts-engine.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Flip pr/swarm/release gates to the TS engine",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-flip-scmcachepolicy-and-remaining-gates-to-the-ts-engine.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Flip scm/cache/policy and remaining gates to the TS engine",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Decomposes Wave 8 umbrella #1828 into 7 swarm-ready story vBRIEFs.
- Wave 8 = flip the live `task`/gate execution path from `uv run python scripts/*.py` to the ported TS engine, **keeping Python in-tree as oracle/fallback** (no deletions).
- Stories: s0 unified `deft-ts` dispatcher (prereq), s1 Node-runtime enforcement (prereq), s2-s6 domain gate flips (verify/preflight, triage, scope/vbrief lifecycle, pr/swarm/release, scm/cache/policy).
- Delete/cutover remains #1731 (now blocked by #1828).

## Test plan
- [x] `task scope:decompose --check` validated all 7 stories
- [x] pre-commit hooks (branch gate, encoding, vBRIEF conformance) clean
- [ ] CI green

Refs #1828 #1530

Made with [Cursor](https://cursor.com)