### PR TITLE
feat(ts-migration): flip triage task surface to deft-ts engine (#1828 s3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Verify and preflight gates now run on the TypeScript engine (#1828 s2)** -- Consumer-critical `task verify:*` and `task vbrief:*` preflight gates in `tasks/verify.yml` and `tasks/vbrief.yml` route through the unified `deft-ts` dispatcher (`packages/cli/dist/bin.js`) with `ts:build` as a dependency so a clean checkout self-builds first. Python scripts remain in-tree as parity oracles; gates without a TS port yet (including `verify:cache-fresh`, session ritual, scm-boundary, and architecture-sor) still invoke Python until their Wave 8 follow-ups land. Refs #1828 #1530.
+- **Triage task surface now routes through the TypeScript engine (#1828 s3)** -- Every `task triage:*` gate in the triage Taskfile cluster invokes `deft-ts` via `packages/cli/dist/bin.js` with a `:ts:build` dependency, so queue, classify, welcome, scope, bulk, bootstrap, and smoketest operators hit the ported engine while Python scripts remain in-tree as parity oracles. Refs #1828 #1530.
 
 ### Fixed
 - **Closed a command-injection risk in the TypeScript version resolver (#1824)** -- The remote-tag lookup now rejects remote names that begin with `-` and passes the `--` end-of-options separator to git, so a crafted remote can no longer be smuggled in as a git option to execute an arbitrary command. Behavior is unchanged for all real remotes; this clears the `js/second-order-command-line-injection` CodeQL alert from the #1787 platform-utilities port. Refs #1824 #1787 #1530.

--- a/packages/core/src/triage/smoketest/index.ts
+++ b/packages/core/src/triage/smoketest/index.ts
@@ -306,7 +306,7 @@ export function runSmoketest(
 import json, sys
 from pathlib import Path
 sys.path.insert(0, ${JSON.stringify(deps.scriptsDir)})
-from triage_smoketest import AssertLog, TOTAL_STAGES, STAGE_LABELS, FIXTURE_REPO
+from triage_smoketest import AssertLog, TOTAL_STAGES, STAGE_LABELS
 import _triage_smoketest_stages as stages
 
 payload = json.loads(sys.stdin.read())

--- a/tasks/triage-actions.yml
+++ b/tasks/triage-actions.yml
@@ -32,71 +32,63 @@ tasks:
   accept:
     desc: "Accept an issue for triage. Records an audit entry. (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" accept {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions accept {{.CLI_ARGS}}
 
   reject:
     desc: "Reject an issue. Closes upstream via gh + applies triage-rejected label; rolls audit back on gh failure. (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" reject {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions reject {{.CLI_ARGS}}
 
   defer:
     desc: "Defer an issue. Records an audit entry. (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" defer {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions defer {{.CLI_ARGS}}
 
   needs-ac:
     desc: "Mark an issue as needing acceptance criteria + post AC-request comment upstream. (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" needs-ac {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions needs-ac {{.CLI_ARGS}}
 
   mark-duplicate:
     desc: "Link an issue as a duplicate of another (validated against Story 1 cache). (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" mark-duplicate {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions mark-duplicate {{.CLI_ARGS}}
 
   status:
     desc: "Print the latest triage decision for an issue. Read-only. (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" status {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions status {{.CLI_ARGS}}
 
   reset:
     desc: "Reset an issue's triage state. Appends a reset audit entry referencing prior; does NOT delete history. (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" reset {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions reset {{.CLI_ARGS}}
 
   history:
     desc: "Print the full triage timeline for an issue, ordered by timestamp. Read-only. (#845 Story 3)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_actions.py" history {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions history {{.CLI_ARGS}}

--- a/tasks/triage-bootstrap.yml
+++ b/tasks/triage-bootstrap.yml
@@ -30,20 +30,14 @@ vars:
   # joinPath idiom mirrors the existing convention documented in the root
   # Taskfile.yml header (#566): `{{.TASKFILE_DIR}}/..` evaluated by go-task's
   # eager templating yields a native-separator absolute path that
-  # `uv --project "{{.DEFT_ROOT}}" run python` can open on Windows / macOS / Linux.
+  # `node .../bin.js` can open on Windows / macOS / Linux.
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
   bootstrap:
     desc: "Idempotent triage v1 installer (#845): populate cache, backfill audit log, ensure gitignore for .deft-cache/ and vbrief/.eval/. Re-runnable; per-step progress on stderr; cache:fetch-all wall-clock cap (#952). -- task triage:bootstrap [-- --repo OWNER/NAME] [--limit N] [--state open|closed|all] [--fetch-timeout-s N] [--quiet] [--json]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      # PYTHONUTF8=1 is set at the root Taskfile.yml level (#540) and
-      # propagates here via go-task's include semantics; this belt-and-
-      # suspenders re-declaration keeps the fragment runnable directly via
-      # `task --taskfile tasks/triage-bootstrap.yml bootstrap` without
-      # inheriting from a parent.
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_bootstrap.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bootstrap --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-bulk.yml
+++ b/tasks/triage-bulk.yml
@@ -27,8 +27,8 @@ version: '3'
 #
 # Path resolution mirrors the convention from tasks/issue.yml + tasks/policy.yml:
 # `DEFT_ROOT` is defined locally via `joinPath .TASKFILE_DIR ".."` so
-# `uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/<name>.py"` resolves cleanly on
-# Windows under go-task's mvdan/sh interpreter (#566).
+# `node .../bin.js` resolves cleanly on Windows under go-task's mvdan/sh
+# interpreter (#566).
 
 vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
@@ -37,44 +37,39 @@ tasks:
   bulk-accept:
     desc: "Bulk accept candidates (#845 Story 4) -- task triage:bulk-accept -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" accept {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk accept {{.CLI_ARGS}}
 
   bulk-reject:
     desc: "Bulk reject candidates (#845 Story 4) -- task triage:bulk-reject -- --repo OWNER/NAME --reason 'why' [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" reject {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk reject {{.CLI_ARGS}}
 
   bulk-defer:
     desc: "Bulk defer candidates (#845 Story 4) -- task triage:bulk-defer -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" defer {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk defer {{.CLI_ARGS}}
 
   bulk-needs-ac:
     desc: "Bulk needs-ac candidates (#845 Story 4) -- task triage:bulk-needs-ac -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_bulk.py" needs-ac {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk needs-ac {{.CLI_ARGS}}
 
   refresh-active:
     desc: "Pre-swarm freshness gate (#845 Story 4) -- detects drift between cached and live `gh issue view` for every issue referenced in vbrief/active/*.vbrief.json"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_refresh.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-refresh --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-classify.yml
+++ b/tasks/triage-classify.yml
@@ -24,8 +24,7 @@ tasks:
   classify:
     desc: "Inspect / validate plan.policy.triageAutoClassify[] + triageHoldMarkers[] (#1129 / D10). -- task triage:classify -- [--list | --validate]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_classify.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-classify --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-queue.yml
+++ b/tasks/triage-queue.yml
@@ -28,26 +28,23 @@ tasks:
   queue:
     desc: "Print the ranked triage queue (#1128 / D11). -- task triage:queue [-- --repo OWNER/NAME] [--limit N]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_queue.py" queue --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-queue queue --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
 
   show:
     desc: "Per-issue triage detail (#1128 / D11). -- task triage:show -- <N> [--repo OWNER/NAME]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_queue.py" show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-queue show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
 
   audit:
     desc: "Audit-log surface (#1128 / D11, #1180). -- task triage:audit [-- --format=text|json] [--vbrief-staleness] [--since=<window>] [--action=<verb>] [--repo OWNER/NAME]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_queue.py" audit --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-queue audit --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-reconcile.yml
+++ b/tasks/triage-reconcile.yml
@@ -23,8 +23,7 @@ tasks:
   reconcile:
     desc: "Self-heal the triage audit log (#1468): backfill missing `accept` decisions for proposed/pending/active vBRIEFs carrying an x-vbrief/github-issue reference, without a cache re-fetch. Idempotent. -- task triage:reconcile [-- --repo OWNER/NAME] [--dry-run] [--json]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_reconcile.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-reconcile --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-scope-drift.yml
+++ b/tasks/triage-scope-drift.yml
@@ -23,8 +23,7 @@ tasks:
   scope-drift:
     desc: "Detect subscription drift -- unsubscribed labels/milestones on cached open issues (#1133 / D14). -- task triage:scope-drift [-- --ignore-label=L | --ignore-milestone=M]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_scope_drift.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-scope-drift --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-scope.yml
+++ b/tasks/triage-scope.yml
@@ -25,8 +25,7 @@ tasks:
   scope:
     desc: "Inspect / mutate / diff the typed plan.policy.triageScope[] subscription + triageScopeIgnores[] (#1131 / D12, #1133 / D14, #1182 / D14c). -- task triage:scope -- [--list] [--add-label=L | --add-milestone=M | --ignore-label=L] [--diff-from-upstream --repo OWNER/NAME] [--refresh-denominator --repo OWNER/NAME --count N]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_scope.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-scope --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-smoketest.yml
+++ b/tasks/triage-smoketest.yml
@@ -25,8 +25,9 @@ tasks:
   smoketest:
     desc: "Run the N6 (#1146) end-to-end smoketest against the hermetic 20-issue fixture. Exits 0 on PASS / 1 on first failure. -- task triage:smoketest [-- --verbose] [--keep-tempdir] [--cache-only]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     env:
-      PYTHONUTF8: "1"
+      DEFT_ROOT: '{{.DEFT_ROOT}}'
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_smoketest.py" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-smoketest {{.CLI_ARGS}}

--- a/tasks/triage-subscribe.yml
+++ b/tasks/triage-subscribe.yml
@@ -22,17 +22,15 @@ tasks:
   subscribe:
     desc: "Subscribe to a label / milestone / issue on plan.policy.triageScope[] (#1133 / D14). -- task triage:subscribe -- (--label=L | --milestone=M | --issue=N)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_subscribe.py" subscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-subscribe subscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
 
   unsubscribe:
     desc: "Unsubscribe a label / milestone / issue from plan.policy.triageScope[] (#1133 / D14). -- task triage:unsubscribe -- (--label=L | --milestone=M | --issue=N)"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_subscribe.py" unsubscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-subscribe unsubscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-summary.yml
+++ b/tasks/triage-summary.yml
@@ -23,8 +23,7 @@ tasks:
   summary:
     desc: "Emit the D2 (#1122) one-line triage state for the session-start ritual (N9 / #1149). Always exits 0; appends a JSONL record to vbrief/.eval/summary-history.jsonl. -- task triage:summary -- [--json] [--no-history]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_summary.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-summary --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/triage-welcome.yml
+++ b/tasks/triage-welcome.yml
@@ -24,9 +24,9 @@ tasks:
   welcome:
     desc: "Run the 6-phase onboarding ritual (N3 / #1143): detect prior state, prompt subscription scope, run triage:bootstrap, prompt wipCap, offer WIP relief, print triage:summary. Idempotent; re-run resumes cleanly. -- task triage:welcome -- [--no-subprocess]"
     internal: true
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     env:
-      PYTHONUTF8: "1"
       DEFT_TASK_PREFIX: '{{.DEFT_TASK_PREFIX | default ""}}'
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/triage_welcome.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-welcome --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/vbrief/completed/2026-06-21-flip-the-triage-task-surface-to-the-ts-engine.vbrief.json
+++ b/vbrief/completed/2026-06-21-flip-the-triage-task-surface-to-the-ts-engine.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1828-s3-flip-triage-surface",
     "title": "Flip the triage task surface to the TS engine",
-    "status": "pending",
+    "status": "completed",
     "planRef": "proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json",
     "narratives": {
       "Description": "Repoint the triage_* gates (actions, queue, classify, welcome, scope, scope-drift, reconcile, summary, subscribe, bulk, bootstrap, refresh, smoketest) from Python to the deft-ts dispatcher, keeping Python in-tree as oracle. This is the largest single cluster of live python invocations.",
@@ -76,7 +76,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-21T01:55:02Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -85,6 +87,7 @@
         "title": "Issue #1828: feat(ts-migration): Wave 8 -- flip live gates to the TS engine (Python stays as oracle/fallback, no deletions)",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-06-21T01:55:02Z"
   }
 }

--- a/vbrief/proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json
+++ b/vbrief/proposed/2026-06-21-1828-featts-migration-wave-8-flip-live-gates-to-the-ts-engine-pyt.vbrief.json
@@ -68,7 +68,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "pending/2026-06-21-flip-the-triage-task-surface-to-the-ts-engine.vbrief.json",
+        "uri": "completed/2026-06-21-flip-the-triage-task-surface-to-the-ts-engine.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Flip the triage task surface to the TS engine",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
- Repoint all 12 `tasks/triage-*.yml` gates from `uv run python scripts/triage_*.py` to `node packages/cli/dist/bin.js <verb>` with `deps: [":ts:build"]` so the live triage surface executes on the TS engine.
- Python triage scripts remain in-tree as parity oracles; no deletions.
- Fix TS smoketest stage-runner inline Python import (`FIXTURE_REPO` is not exported by the Python module).

## Test plan
- [x] `pnpm install`
- [x] `task ts:build`
- [x] `task ts:parity-all` — CLEAN
- [x] `task triage:smoketest` — passes via TS routing
- [x] `task ts:check-lane` — green (branch coverage ≥ 85%)
- [ ] `task check:framework-source` — pre-existing pytest-xdist ERROR storm on this worktree (also fails on clean tree without these changes); TS lane is authoritative for this story

Refs #1828 #1530

Made with [Cursor](https://cursor.com)