### PR TITLE
fix(ts-migration): quote :ts:build dep in pr/swarm task fragments (#1828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Fixed `task pr:*` and `task swarm:*` after the Wave 8 flip (#1828 s5 follow-up)** -- The pr/swarm Taskfile gates referenced `ts:build` without the leading-colon absolute namespace marker, so from the included fragments it resolved to the non-existent `pr:ts:build`/`swarm:ts:build` and broke `task pr:wait-mergeable-and-merge`, `task swarm:launch`, and siblings. Quoted `:ts:build` restores cross-namespace resolution. Refs #1828 #1530.
+
 ### Changed
 - **Verify and preflight gates now run on the TypeScript engine (#1828 s2)** -- Consumer-critical `task verify:*` and `task vbrief:*` preflight gates in `tasks/verify.yml` and `tasks/vbrief.yml` route through the unified `deft-ts` dispatcher (`packages/cli/dist/bin.js`) with `ts:build` as a dependency so a clean checkout self-builds first. Python scripts remain in-tree as parity oracles; gates without a TS port yet (including `verify:cache-fresh`, session ritual, scm-boundary, and architecture-sor) still invoke Python until their Wave 8 follow-ups land. Refs #1828 #1530.
 

--- a/tasks/pr.yml
+++ b/tasks/pr.yml
@@ -21,7 +21,7 @@ vars:
 tasks:
   check-protected-issues:
     desc: "Verify NO protected (umbrella / staying-OPEN) issue is GitHub-side linked to a PR before squash merge (#701)"
-    deps: [ts:build]
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pr-protected-issues {{.CLI_ARGS}}
@@ -55,7 +55,7 @@ tasks:
   # Companion test:   tests/cli/test_pr_merge_readiness.py
   merge-ready:
     desc: "Verify a PR's Greptile review body satisfies the merge exit condition (confidence >3, no P0/P1, HEAD-SHA fresh, not errored)"
-    deps: [ts:build]
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pr-merge-readiness {{.CLI_ARGS}}
@@ -82,7 +82,7 @@ tasks:
   # Companion test:   tests/cli/test_pr_wait_mergeable.py
   wait-mergeable-and-merge:
     desc: "Wait until PR is mergeable (resilient cascade, #1368) and squash-merge with admin (#1369); Layer-3 protected-issue check (#701) chains before any merge call"
-    deps: [ts:build]
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pr-wait-mergeable {{.CLI_ARGS}}

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -28,7 +28,7 @@ tasks:
   # Companion test:   tests/cli/test_swarm_launch.py
   launch:
     desc: "Resolve a pre-approved cohort, enforce the #810 + swarm:readiness gates and sub-agent backend policy per story, and emit the launch-manifest JSON (#1387, #1531e)"
-    deps: [ts:build]
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-launch {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
@@ -46,7 +46,7 @@ tasks:
   # Skill citation:   skills/deft-directive-swarm/SKILL.md Phase 5 Exit Condition + Phase 5 -> 6 gate
   verify-review-clean:
     desc: "Verify EVERY PR in a swarm cohort is CLEAN on current HEAD (confidence > 3, no P0/P1, not errored) before raising the Phase 5 -> 6 merge gate (#1364)"
-    deps: [ts:build]
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-verify-review-clean {{.CLI_ARGS}}
@@ -66,7 +66,7 @@ tasks:
   # Skill citation:   skills/deft-directive-swarm/SKILL.md Phase 6 cohort completion sweep
   complete-cohort:
     desc: "Sweep a finished swarm cohort's stories active/ -> completed/ and complete their epic parents, keeping vbrief:validate green (#1487)"
-    deps: [ts:build]
+    deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-complete-cohort {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"


### PR DESCRIPTION
## Summary
- s5's Wave 8 flip (#1832) used `deps: [ts:build]` in `tasks/pr.yml` and `tasks/swarm.yml`. In included fragments that resolves to the non-existent `pr:ts:build` / `swarm:ts:build`, breaking `task pr:wait-mergeable-and-merge`, `task swarm:launch`, `task swarm:verify-review-clean`, etc.
- Fix: quoted absolute form `deps: [":ts:build"]` (matches the pattern s2/s3/s6 used).
- Root `Taskfile.yml` release tasks are unaffected (`ts:build` resolves at top level).

## Test plan
- [x] `task --dry pr:check-protected-issues` resolves ts:build → node bin
- [x] `task --dry swarm:verify-review-clean` resolves
- [x] `task --dry release` resolves
- [ ] CI green

Refs #1828 #1530

Made with [Cursor](https://cursor.com)