### PR TITLE
chore(ts-migration): decompose Wave 8.5 -- maintainer test-suite conversion (#1838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Planned Wave 8.5 -- maintainer test-suite conversion to vitest (#1838)** -- Decomposed the content/CLI/integration pytest conversion (~234 files) into 8 swarm-ready story vBRIEFs and decoupled it from the destructive cutover: the test port is additive and no longer chained to #1731's bake window. #1731 shrinks to its irreversible delete-core (delete engine, retire parity harnesses, pytest teardown). Refs #1838 #1530.
 - **scm/cache/policy and remaining live gates now route through the TS engine (#1828 s6)** -- The scm stub, unified cache, typed policy surface, pack slice/render, roadmap render, codebase validators, and capacity show/backfill tasks now invoke `deft-ts` via `packages/cli/dist/bin.js` instead of `uv run python`, with Python scripts kept in-tree as parity oracles. Refs #1828 #1530.
 
 ### Fixed

--- a/vbrief/pending/2026-06-21-audit-installmigratecmd-cli-tests-for-retire-vs-retarget-buc.vbrief.json
+++ b/vbrief/pending/2026-06-21-audit-installmigratecmd-cli-tests-for-retire-vs-retarget-buc.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 7 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s7-cli-install-migrate-tail",
+    "title": "Audit install/migrate/cmd CLI tests for retire-vs-retarget (Bucket C)",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Audit the tests/cli tail covering migrate, precutover, cmd-gate, upgrade, run, setup, vendored, and relocate surfaces, which test code in the accepted-non-port set (pre-v0.20 migration tooling, the Go installer deposit, build/packaging). For each file decide retire-with-Wave-9 versus retarget at a TS equivalent, since blindly porting tests for soon-deleted code is wasted work.",
+      "ImplementationPlan": "1. For each tests/cli migrate/precutover/cmd/upgrade/run/setup/vendored/relocate test, classify the underlying script as accepted-non-port (retire at Wave 9) or live (retarget) and record a one-line rationale per file in the coverage map. 2. For the live retarget subset, add a vitest spec under packages/cli/src/install-cli invoking the deft-ts verb and asserting exit codes; leave accepted-non-port tests in python tagged for Wave-9 deletion. 3. Run task ts:check-lane and task core:test so both suites stay green.",
+      "UserStory": "As a maintainer, I want the install/migrate CLI tail triaged into retire-vs-retarget, so that I do not waste effort porting tests for code the cutover will delete.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s7-cli-install-migrate-tail-a1",
+        "title": "Given each install/migrate tail test, when audited, then the coverage map records a retire-at-Wave-9 or retarget classification with a one-line rationale.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given each install/migrate tail test, when audited, then the coverage map records a retire-at-Wave-9 or retarget classification with a one-line rationale.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s7-cli-install-migrate-tail-a2",
+        "title": "Given a live-code retarget spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same exit code as the python original.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a live-code retarget spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same exit code as the python original.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s7-cli-install-migrate-tail-a3",
+        "title": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/install-cli",
+          "tests/cli"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "install/migrate CLI tail triaged retire-vs-retarget"
+        ],
+        "depends_on": [],
+        "conflict_group": "cli-tests-install",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-port-content-skillspromptagentsmd-contract-tests-to-vitest.vbrief.json
+++ b/vbrief/pending/2026-06-21-port-content-skillspromptagentsmd-contract-tests-to-vitest.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s1-content-skills-contracts",
+    "title": "Port content skills/prompt/AGENTS.md contract tests to vitest",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Port the tests/content artifact tests covering skills, the agent-prompt preamble, AGENTS.md sections, the interview/speckit/cost phases, and swarm/refinement/triage skill contracts from pytest to vitest. These are Bucket-A mechanical conversions: each test reads a markdown or template artifact and asserts substrings, ordering, or shape, so the TS version reads the same file and asserts the same facts with no behavioral change.",
+      "ImplementationPlan": "1. For each in-scope tests/content/test_*skill*/agents_md/preamble/interview/speckit file, add an equivalent vitest spec under packages/core/src/content-contracts/skills/ that reads the same artifact via node fs and asserts the same substrings. 2. Record a coverage map (python file -> ts spec) so the Wave-9 pytest teardown is mechanical. 3. Run task ts:check-lane and task core:test to confirm both the new TS specs and the untouched python suite stay green; assert the new specs hold branch coverage at the floor.",
+      "UserStory": "As a maintainer pursuing full TS conversion, I want the skills/AGENTS.md content contracts asserted in vitest, so that those invariants survive the Wave-9 deletion of the python test suite.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s1-content-skills-contracts-a1",
+        "title": "Given the ported skills/AGENTS.md content specs, when task ts:check-lane runs, then the new vitest specs pass and assert the same artifact substrings as their pytest originals.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the ported skills/AGENTS.md content specs, when task ts:check-lane runs, then the new vitest specs pass and assert the same artifact substrings as their pytest originals.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s1-content-skills-contracts-a2",
+        "title": "Given the additive port, when task core:test runs, then the original python content tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive port, when task core:test runs, then the original python content tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s1-content-skills-contracts-a3",
+        "title": "Given the coverage map, when it is inspected, then every in-scope python file maps to a ts spec or a recorded existing-coverage entry.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the coverage map, when it is inspected, then every in-scope python file maps to a ts spec or a recorded existing-coverage entry.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/content-contracts/skills",
+          "tests/content"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "skills/AGENTS.md content contracts asserted in vitest"
+        ],
+        "depends_on": [],
+        "conflict_group": "content-contracts-skills",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-port-content-standardssecuritytaskfileschema-contract-tests.vbrief.json
+++ b/vbrief/pending/2026-06-21-port-content-standardssecuritytaskfileschema-contract-tests.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s2-content-standards-schema-contracts",
+    "title": "Port content standards/security/taskfile/schema contract tests to vitest",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Port the remaining tests/content artifact tests covering coding standards, security/patterns rules, taskfile structure, and the vBRIEF/strategy/allocation JSON schemas from pytest to vitest. Most are Bucket-A mechanical file-and-assert conversions, while a small Bucket-B minority (for example test_code_structure_profile) import a python module for a constant and must be retargeted at the TS module's exported equivalent instead of translated blindly.",
+      "ImplementationPlan": "1. Add vitest specs under packages/core/src/content-contracts/standards/ that read the standards/security/taskfile artifacts and assert the same substrings as the pytest originals. 2. For Bucket-B tests that import a python script constant, retarget the assertion at the TS module export (for example the code-structure schema version) and delete the python-import path. 3. Record the python-file -> ts-spec coverage map and run task ts:check-lane plus task core:test so both suites stay green with coverage held at the floor.",
+      "UserStory": "As a maintainer pursuing full TS conversion, I want the standards/security/taskfile/schema contracts asserted in vitest, so that those invariants survive the Wave-9 python deletion without losing the source-coupled checks.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s2-content-standards-schema-contracts-a1",
+        "title": "Given the ported standards/schema specs, when task ts:check-lane runs, then the new vitest specs pass and assert the same artifact facts as their pytest originals.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the ported standards/schema specs, when task ts:check-lane runs, then the new vitest specs pass and assert the same artifact facts as their pytest originals.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s2-content-standards-schema-contracts-a2",
+        "title": "Given a Bucket-B source-coupled test, when it is ported, then it asserts against the TS module export rather than importing a python script.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a Bucket-B source-coupled test, when it is ported, then it asserts against the TS module export rather than importing a python script.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s2-content-standards-schema-contracts-a3",
+        "title": "Given the additive port, when task core:test runs, then the original python content tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive port, when task core:test runs, then the original python content tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/content-contracts/standards",
+          "tests/content"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "standards/schema content contracts asserted in vitest"
+        ],
+        "depends_on": [],
+        "conflict_group": "content-contracts-standards",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-retarget-cachescmtriage-integration-e2e-tests-at-ts-entrypoi.vbrief.json
+++ b/vbrief/pending/2026-06-21-retarget-cachescmtriage-integration-e2e-tests-at-ts-entrypoi.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 8 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s8-integration-e2e-tests",
+    "title": "Retarget cache/scm/triage integration e2e tests at TS entrypoints",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Retarget the tests/integration end-to-end suites (cache, cache-quarantine, scm-smoke, triage-smoke, triage-bootstrap-at-scale, consumer-tasks) from the python entrypoints at the deft-ts dispatcher and TS modules. These are flow-level tests, so each is rebuilt to drive the live TS surface while asserting the same end-state as the python original.",
+      "ImplementationPlan": "1. For each tests/integration suite, add a vitest spec under packages/core/src/integration-e2e that drives the deft-ts verb or TS module end-to-end and asserts the same final cache/scm/triage state as the python flow. 2. Preserve the watchdog/at-scale timing assertions using injected clocks where the python test used real sleeps; record the coverage map. 3. Run task ts:check-lane and task core:test so both suites stay green.",
+      "UserStory": "As a maintainer, I want the cache/scm/triage integration flows asserted against the live TS surface, so that end-to-end behavior stays covered after the python flow is deleted in Wave 9.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s8-integration-e2e-tests-a1",
+        "title": "Given a retargeted integration spec, when task ts:check-lane runs, then it drives the deft-ts surface end-to-end and asserts the same final state as the python flow.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a retargeted integration spec, when task ts:check-lane runs, then it drives the deft-ts surface end-to-end and asserts the same final state as the python flow.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s8-integration-e2e-tests-a2",
+        "title": "Given the at-scale suite, when ported, then its timing assertions use injected clocks rather than real sleeps to stay fast.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the at-scale suite, when ported, then its timing assertions use injected clocks rather than real sleeps to stay fast.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s8-integration-e2e-tests-a3",
+        "title": "Given the additive change, when task core:test runs, then the python integration tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive change, when task core:test runs, then the python integration tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/integration-e2e",
+          "tests/integration"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "integration e2e flows retargeted at TS entrypoints"
+        ],
+        "depends_on": [],
+        "conflict_group": "integration-e2e",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-retarget-packspecrendercodebase-cli-tests-at-the-deft-ts-dis.vbrief.json
+++ b/vbrief/pending/2026-06-21-retarget-packspecrendercodebase-cli-tests-at-the-deft-ts-dis.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 6 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s6-cli-render-mapping-tests",
+    "title": "Retarget pack/spec/render/codebase CLI tests at the deft-ts dispatcher",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Retarget the tests/cli tests for the pack, spec, project, roadmap, framework-commands, codebase, and capacity surfaces from the python CLI at the deft-ts dispatcher. Each test is audited against the TS module's existing unit tests, and only genuinely missing render or mapping behavior becomes a new vitest spec.",
+      "ImplementationPlan": "1. For each tests/cli pack/spec/project/roadmap/framework/codebase/capacity test, audit the packages/core/src render and mapping modules' existing unit coverage; record redundant cases and add a vitest spec under packages/cli/src/render-cli for missing behavior that invokes the deft-ts verb and asserts argv and rendered output. 2. Record the coverage map and tag dedup'd python tests for Wave-9 deletion. 3. Run task ts:check-lane and task core:test so both suites stay green.",
+      "UserStory": "As a maintainer, I want the pack/spec/render/codebase CLI tests exercising the deft-ts dispatcher, so that the render and mapping CLI surface stays covered after the flip.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s6-cli-render-mapping-tests-a1",
+        "title": "Given a retargeted render/mapping CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same rendered output as the python original.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a retargeted render/mapping CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same rendered output as the python original.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s6-cli-render-mapping-tests-a2",
+        "title": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that covers the invariant.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that covers the invariant.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s6-cli-render-mapping-tests-a3",
+        "title": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/render-cli",
+          "tests/cli"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "render/mapping CLI tests retargeted at deft-ts dispatcher"
+        ],
+        "depends_on": [],
+        "conflict_group": "cli-tests-render",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-retarget-prswarmrelease-cli-tests-at-the-deft-ts-dispatcher.vbrief.json
+++ b/vbrief/pending/2026-06-21-retarget-prswarmrelease-cli-tests-at-the-deft-ts-dispatcher.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 4 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s4-cli-pr-swarm-release-tests",
+    "title": "Retarget pr/swarm/release CLI tests at the deft-ts dispatcher",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Retarget the tests/cli tests for the pr, swarm, release, subagent-monitor, probe, and resolve command surfaces from the python CLI at the deft-ts dispatcher. The release and pr clusters are the largest here, so each test is audited against the TS module's existing unit tests and only missing argument-surface behavior becomes a new vitest spec.",
+      "ImplementationPlan": "1. For each tests/cli pr/swarm/release/subagent/probe/resolve test, audit the corresponding packages/core/src module's existing unit coverage; record redundant cases and add a vitest spec under packages/cli/src/orchestration-cli for genuinely missing behavior that invokes the deft-ts verb and asserts argv plus exit codes. 2. Record the coverage map and tag dedup'd python tests for Wave-9 deletion. 3. Run task ts:check-lane and task core:test so both suites stay green with coverage at the floor.",
+      "UserStory": "As a maintainer, I want the pr/swarm/release CLI tests exercising the deft-ts dispatcher, so that the live orchestration CLI surface stays covered and redundant python cases are flagged for Wave-9 removal.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s4-cli-pr-swarm-release-tests-a1",
+        "title": "Given a retargeted pr/swarm/release CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same argv handling and exit code as the python original.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a retargeted pr/swarm/release CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same argv handling and exit code as the python original.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s4-cli-pr-swarm-release-tests-a2",
+        "title": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that covers the invariant.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that covers the invariant.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s4-cli-pr-swarm-release-tests-a3",
+        "title": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/orchestration-cli",
+          "tests/cli"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "pr/swarm/release CLI tests retargeted at deft-ts dispatcher"
+        ],
+        "depends_on": [],
+        "conflict_group": "cli-tests-orchestration",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-retarget-vbriefscopeissuereconcile-cli-tests-at-the-deft-ts.vbrief.json
+++ b/vbrief/pending/2026-06-21-retarget-vbriefscopeissuereconcile-cli-tests-at-the-deft-ts.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s3-cli-lifecycle-tests",
+    "title": "Retarget vbrief/scope/issue/reconcile CLI tests at the deft-ts dispatcher",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Retarget the tests/cli tests for the vbrief, preflight, scope, issue-ingest, and reconcile command surfaces from the python CLI at the deft-ts dispatcher built in Wave 8. Each test is audited against the TS module's existing unit tests first, so redundant cases are recorded as covered and only genuinely missing argument-surface behavior gets a new vitest spec.",
+      "ImplementationPlan": "1. For each tests/cli vbrief/scope/issue/reconcile test, audit whether the TS module under packages/core/src already asserts the invariant; if so record the mapping, otherwise add a vitest spec under packages/cli/src/lifecycle-cli that invokes the deft-ts verb and asserts argv handling and exit codes. 2. Mark dedup'd python tests for Wave-9 deletion in the coverage map without deleting them now. 3. Run task ts:check-lane and task core:test so the new specs and the python suite both stay green.",
+      "UserStory": "As a maintainer, I want the vbrief/scope/issue/reconcile CLI tests exercising the deft-ts dispatcher, so that the now-live TS CLI surface is covered and redundant python cases are flagged for Wave-9 removal.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s3-cli-lifecycle-tests-a1",
+        "title": "Given a retargeted lifecycle CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same argv handling and exit code as the python original.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a retargeted lifecycle CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same argv handling and exit code as the python original.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s3-cli-lifecycle-tests-a2",
+        "title": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that already covers the invariant.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that already covers the invariant.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s3-cli-lifecycle-tests-a3",
+        "title": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/lifecycle-cli",
+          "tests/cli"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "lifecycle CLI tests retargeted at deft-ts dispatcher"
+        ],
+        "depends_on": [],
+        "conflict_group": "cli-tests-lifecycle",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-21-retarget-verifydoctorpolicysession-cli-tests-at-the-deft-ts.vbrief.json
+++ b/vbrief/pending/2026-06-21-retarget-verifydoctorpolicysession-cli-tests-at-the-deft-ts.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 5 decomposed from proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json"
+  },
+  "plan": {
+    "id": "1838-s5-cli-verify-gates-tests",
+    "title": "Retarget verify/doctor/policy/session CLI tests at the deft-ts dispatcher",
+    "status": "pending",
+    "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
+    "narratives": {
+      "Description": "Retarget the tests/cli tests for the verify, doctor, policy, validate, session, and ritual gate surfaces from the python CLI at the deft-ts dispatcher. These exercise the consumer-critical gate engine, so each test is audited against the TS module's existing unit tests and only missing behavior becomes a new vitest spec.",
+      "ImplementationPlan": "1. For each tests/cli verify/doctor/policy/validate/session/ritual test, audit the packages/core/src module's existing unit coverage; record redundant cases and add a vitest spec under packages/cli/src/gates-cli for missing behavior that invokes the deft-ts verb and asserts argv and exit codes. 2. Record the coverage map and tag dedup'd python tests for Wave-9 deletion. 3. Run task ts:check-lane and task core:test so both suites stay green.",
+      "UserStory": "As a maintainer, I want the verify/doctor/policy/session CLI tests exercising the deft-ts dispatcher, so that the consumer-critical gate CLI surface stays covered after the flip.",
+      "Traces": "#1838, #1530"
+    },
+    "items": [
+      {
+        "id": "1838-s5-cli-verify-gates-tests-a1",
+        "title": "Given a retargeted verify/doctor/policy CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same argv handling and exit code as the python original.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a retargeted verify/doctor/policy CLI spec, when task ts:check-lane runs, then it invokes the deft-ts verb and asserts the same argv handling and exit code as the python original.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s5-cli-verify-gates-tests-a2",
+        "title": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that covers the invariant.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a redundant python CLI test, when audited, then the coverage map records the existing TS unit test that covers the invariant.",
+          "Traces": "#1838, #1530"
+        }
+      },
+      {
+        "id": "1838-s5-cli-verify-gates-tests-a3",
+        "title": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the additive change, when task core:test runs, then the python CLI tests still pass unchanged in-tree.",
+          "Traces": "#1838, #1530"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/gates-cli",
+          "tests/cli"
+        ],
+        "verify_commands": [
+          "task ts:check-lane",
+          "task core:test"
+        ],
+        "expected_outputs": [
+          "verify/doctor/policy CLI tests retargeted at deft-ts dispatcher"
+        ],
+        "depends_on": [],
+        "conflict_group": "cli-tests-gates",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json
+++ b/vbrief/proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json
@@ -1,0 +1,101 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1838"
+  },
+  "plan": {
+    "title": "feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1838",
+      "Overview": "## Parent\n\n#1530 (Part 1 of 2). Sits between Wave 8 (flip, #1828 ✅) and Wave 9 (delete, #1731). Added as a blocker of #1731.\n\n## Why this wave exists\n\nWave 8 (#1828) flipped the live `task` gate **execution** to the TS engine, but the **maintainer test suites are still Python-only**: `tests/content/` (78 files), `tests/cli/` (150 files), and `tests/integration/` (6 files) — ~234 files / ~8,700 assertions. \"Full conversion\" (the operator decision of 2026-06-19) explicitly includes these tests, but they were originally folded into Wave 9 (#1731) as items 9.3/9.4 and chained to the destructive delete + bake window.\n\nThat coupling was wrong: **porting tests does not require deleting Python.** vitest tests are purely additive — they coexist with pytest indefinitely. Only the *deletion* of `scripts/*.py` + retiring the parity oracles needs the 2-3 release bake. So this wave pulls the entire test-conversion body out of #1731 and stands it up independently, unblocking the bulk of the \"full conversion\" now while the genuinely irreversible delete stays correctly gated on #1731.\n\n## What to build\n\nPort / retarget every maintainer Python test to vitest, **additively** — the Python pytest suite stays green and in-tree throughout (nothing is deleted in this wave; the pytest teardown is Wave 9 / #1731). Three buckets:\n\n- **Bucket A — content artifact tests** (`tests/content/`, mostly): read `.md`/`.json`/template artifacts and assert substrings/ordering/shape. Mechanical pytest→vitest (`fs.readFileSync` + `expect().toContain()`). No Python dependency.\n- **Bucket B — source-coupled tests** (a minority of `tests/content/` + most of `tests/cli/`): tests that `import` a Python module or exercise the Python CLI argument surface. **Retarget** at the TS module / the `deft-ts` dispatcher (built in Wave 8 s0). Audit against the TS port's existing unit tests first: if the invariant is already covered, record the mapping and mark the pytest for Wave-9 deletion (do NOT delete now); only write a new TS test where coverage is genuinely missing. Not blind 1:1 translation.\n- **Bucket C — accepted-non-port residue**: CLI tests for code that is an accepted non-port (pre-v0.20 `migrate_*`/`precutover`/`_vbrief_legacy`, Go installer deposit, build/packaging tooling). Do NOT port these — audit and tag them \"stays Python until Wave 9 deletes the underlying code,\" with a one-line rationale per file.\n\n## Acceptance criteria\n\n- [ ] Every in-scope Python test is either (a) ported to an equivalent vitest test, (b) confirmed redundant against an existing TS unit test (mapping recorded, pytest tagged for Wave-9 deletion), or (c) tagged Bucket-C accepted-non-port with rationale.\n- [ ] The Python pytest suite stays green at every merge (additive — no Python test deleted in this wave).\n- [ ] `task ts:check-lane` stays green; global vitest branch coverage stays at/above the 85% floor (new tests must not drag coverage down).\n- [ ] `task check` (framework-source + consumer) stays green at every merge.\n- [ ] A per-story coverage map (Python test → TS test / existing-coverage / non-port) is recorded so Wave 9's pytest teardown is mechanical.\n\n## Proposed stories (decomposed separately)\n\n- **8.5.1** content: skills / prompt-preamble / AGENTS.md / interview / speckit contracts (~40 files, Bucket A)\n- **8.5.2** content: standards / security / patterns + taskfile / structure / schema / vBRIEF / strategy contracts (~38 files, Bucket A + a few Bucket B like `test_code_structure_profile`)\n- **8.5.3** CLI: vbrief / preflight / scope / issue / reconcile lifecycle (~35 files, Bucket B retarget+dedup)\n- **8.5.4** CLI: pr / swarm / release / subagent / probe / resolve (~28 files, Bucket B)\n- **8.5.5** CLI: verify / doctor / policy / validate / session / ritual gates (~22 files, Bucket B)\n- **8.5.6** CLI: pack / spec / project / roadmap / framework / codebase / capacity render+mapping (~24 files, Bucket B)\n- **8.5.7** CLI: migrate / cmd / upgrade / run / setup / install tail (~25 files — Bucket C audit: retire-vs-retarget per file)\n- **8.5.8** integration: cache / scm / triage / consumer-tasks e2e (~6 files, retarget at TS entrypoints)\n\n## Standing invariants\n\n- **Additive only** — Python pytest stays the live maintainer suite and runs wholesale until deleted in Wave 9 (#1731). No Python test is removed in this wave.\n- `task check` stays green at every step (strangler-fig; no big-bang).\n- New TS tests must hold vitest branch coverage at/above the 85% floor.\n\n## Type\n\nfeat (umbrella)\n",
+      "Labels": "process, runtime-portability, ts-migration"
+    },
+    "items": [
+      {
+        "title": "Every in-scope Python test is either (a) ported to an equivalent vitest test, (b) confirmed redundant against an existing TS unit test (mapping recorded, pytest tagged for Wave-9 deletion), or (c) tagged Bucket-C accepted-non-port with rationale.",
+        "status": "proposed"
+      },
+      {
+        "title": "The Python pytest suite stays green at every merge (additive — no Python test deleted in this wave).",
+        "status": "proposed"
+      },
+      {
+        "title": "stays green; global vitest branch coverage stays at/above the 85% floor (new tests must not drag coverage down).",
+        "status": "proposed"
+      },
+      {
+        "title": "(framework-source + consumer) stays green at every merge.",
+        "status": "proposed"
+      },
+      {
+        "title": "A per-story coverage map (Python test → TS test / existing-coverage / non-port) is recorded so Wave 9's pytest teardown is mechanical.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "process",
+      "runtime-portability",
+      "ts-migration"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1838",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)"
+      },
+      {
+        "uri": "pending/2026-06-21-port-content-skillspromptagentsmd-contract-tests-to-vitest.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port content skills/prompt/AGENTS.md contract tests to vitest",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-port-content-standardssecuritytaskfileschema-contract-tests.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Port content standards/security/taskfile/schema contract tests to vitest",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-retarget-vbriefscopeissuereconcile-cli-tests-at-the-deft-ts.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Retarget vbrief/scope/issue/reconcile CLI tests at the deft-ts dispatcher",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-retarget-prswarmrelease-cli-tests-at-the-deft-ts-dispatcher.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Retarget pr/swarm/release CLI tests at the deft-ts dispatcher",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-retarget-verifydoctorpolicysession-cli-tests-at-the-deft-ts.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Retarget verify/doctor/policy/session CLI tests at the deft-ts dispatcher",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-retarget-packspecrendercodebase-cli-tests-at-the-deft-ts-dis.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Retarget pack/spec/render/codebase CLI tests at the deft-ts dispatcher",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-audit-installmigratecmd-cli-tests-for-retire-vs-retarget-buc.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Audit install/migrate/cmd CLI tests for retire-vs-retarget (Bucket C)",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-21-retarget-cachescmtriage-integration-e2e-tests-at-ts-entrypoi.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Retarget cache/scm/triage integration e2e tests at TS entrypoints",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Files **Wave 8.5 / #1838** (port the maintainer pytest suites — content + CLI + integration, ~234 files — to vitest) as a child of #1530, and lands its **8 swarm-ready story vBRIEFs**.
- **Decouples test conversion from the destructive cutover.** The former #1731 items 9.3/9.4 move into #1838; the test port is additive (Python pytest stays green and in-tree throughout) and no longer chained to #1731's 2-3 release bake window.
- **#1731 shrinks to its delete-core** (coverage hardening, delete engine, retire parity harnesses, pytest teardown) and is now blocked by #1838.

## Story breakdown
| Story | Bucket | Domain |
|---|---|---|
| s1 | A | content: skills / AGENTS.md / preamble / interview / speckit |
| s2 | A (+a little B) | content: standards / security / taskfile / schema |
| s3 | B | CLI: vbrief / scope / issue / reconcile |
| s4 | B | CLI: pr / swarm / release |
| s5 | B | CLI: verify / doctor / policy / session |
| s6 | B | CLI: pack / spec / render / codebase |
| s7 | C | CLI: install / migrate tail (retire-vs-retarget audit) |
| s8 | — | integration: cache / scm / triage e2e |

## Test plan
- [x] `task scope:decompose -- <parent> --check` validates all 8 stories
- [x] vBRIEF conformance + encoding gates pass on push
- [ ] CI green

Planning artifacts only — no implementation dispatched. Refs #1838 #1530

Made with [Cursor](https://cursor.com)