### PR TITLE
test(ts-migration): retarget lifecycle CLI tests at deft-ts (#1838 s3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Retarget verify/doctor/policy/session CLI tests at the deft-ts dispatcher (#1838 s5)** -- Added `packages/cli/src/gates-cli/` vitest specs that invoke `node packages/cli/dist/bin.js` for consumer-critical gate verbs (doctor, policy, verify-*, session:start, framework-commands aliases) with a per-file coverage map recorded in the PR body; Python pytest suites remain unchanged. Refs #1838 #1530.
+- **Lifecycle CLI pytest retarget specs at the deft-ts dispatcher (#1838 s3)** -- Additive vitest specs under `packages/cli/src/lifecycle-cli/` exercise vbrief, scope, intake, reconcile, and preflight verbs through the unified `deft-ts` dispatcher, with a per-file coverage map recording existing TS unit coverage vs Wave-9 pytest dedup candidates. Python CLI tests remain unchanged and green. Refs #1838 #1530.
 
 ### Changed
 - **Planned Wave 8.5 -- maintainer test-suite conversion to vitest (#1838)** -- Decomposed the content/CLI/integration pytest conversion (~234 files) into 8 swarm-ready story vBRIEFs and decoupled it from the destructive cutover: the test port is additive and no longer chained to #1731's bake window. #1731 shrinks to its irreversible delete-core (delete engine, retire parity harnesses, pytest teardown). Refs #1838 #1530.

--- a/packages/cli/src/lifecycle-cli/coverage-map.test.ts
+++ b/packages/cli/src/lifecycle-cli/coverage-map.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { LIFECYCLE_CLI_COVERAGE_MAP, LIFECYCLE_PYTHON_TEST_FILES } from "./coverage-map.js";
+
+const EXPECTED_PYTHON_FILES = [
+  "tests/cli/test_issue_emit.py",
+  "tests/cli/test_issue_ingest.py",
+  "tests/cli/test_issue_ingest_body_parsing.py",
+  "tests/cli/test_issue_ingest_canonical_refs.py",
+  "tests/cli/test_issue_ingest_direct.py",
+  "tests/cli/test_issue_ingest_escape_corruption.py",
+  "tests/cli/test_preflight_architecture_sor.py",
+  "tests/cli/test_preflight_branch.py",
+  "tests/cli/test_preflight_cache.py",
+  "tests/cli/test_preflight_gh.py",
+  "tests/cli/test_preflight_implementation.py",
+  "tests/cli/test_preflight_story_start.py",
+  "tests/cli/test_reconcile_issues.py",
+  "tests/cli/test_reconcile_issues_754.py",
+  "tests/cli/test_reconcile_issues_apply.py",
+  "tests/cli/test_reconcile_issues_direct.py",
+  "tests/cli/test_scope_decompose.py",
+  "tests/cli/test_scope_decompose_unit.py",
+  "tests/cli/test_scope_demote.py",
+  "tests/cli/test_scope_lifecycle.py",
+  "tests/cli/test_scope_undo.py",
+  "tests/cli/test_vbrief_activate.py",
+  "tests/cli/test_vbrief_fidelity_legacy.py",
+  "tests/cli/test_vbrief_migrate_conformance.py",
+  "tests/cli/test_vbrief_preflight_resolver.py",
+  "tests/cli/test_vbrief_reconcile_graph.py",
+  "tests/cli/test_vbrief_reconcile_labels.py",
+  "tests/cli/test_vbrief_reconcile_umbrellas.py",
+  "tests/cli/test_vbrief_reconciliation.py",
+  "tests/cli/test_vbrief_routing.py",
+  "tests/cli/test_vbrief_validate.py",
+  "tests/cli/test_vbrief_validate_direct.py",
+  "tests/cli/test_vbrief_validate_direct_orchestration.py",
+  "tests/cli/test_vbrief_validate_issue_536.py",
+  "tests/cli/test_vbrief_validation.py",
+];
+
+describe("lifecycle CLI coverage map (#1838 s3)", () => {
+  it("lists every in-scope pytest file exactly once", () => {
+    expect(LIFECYCLE_CLI_COVERAGE_MAP).toHaveLength(EXPECTED_PYTHON_FILES.length);
+    expect([...LIFECYCLE_PYTHON_TEST_FILES].sort()).toEqual([...EXPECTED_PYTHON_FILES].sort());
+  });
+
+  it("assigns a non-empty TS target to every entry", () => {
+    for (const entry of LIFECYCLE_CLI_COVERAGE_MAP) {
+      expect(entry.tsTarget.length).toBeGreaterThan(0);
+      expect(entry.notes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("flags Wave-9 dedup candidates for fully ported surfaces", () => {
+    const wave9 = LIFECYCLE_CLI_COVERAGE_MAP.filter((e) => e.wave9Delete);
+    expect(wave9.length).toBeGreaterThan(20);
+    const pythonOracles = LIFECYCLE_CLI_COVERAGE_MAP.filter(
+      (e) => e.disposition === "python-oracle",
+    );
+    expect(pythonOracles.map((e) => e.pythonTest)).toEqual([
+      "tests/cli/test_scope_decompose.py",
+      "tests/cli/test_preflight_architecture_sor.py",
+      "tests/cli/test_preflight_cache.py",
+      "tests/cli/test_preflight_gh.py",
+    ]);
+  });
+});

--- a/packages/cli/src/lifecycle-cli/coverage-map.ts
+++ b/packages/cli/src/lifecycle-cli/coverage-map.ts
@@ -1,0 +1,276 @@
+/**
+ * Wave 8.5 Bucket B coverage map: pytest CLI tests → TS vitest / existing-coverage (#1838 s3).
+ * Python tests remain in-tree until Wave 9 (#1731); entries tagged wave9-delete are dedup candidates.
+ */
+
+export type CoverageDisposition = "existing-coverage" | "lifecycle-cli-dispatch" | "python-oracle";
+
+export interface CoverageMapEntry {
+  readonly pythonTest: string;
+  readonly tsTarget: string;
+  readonly disposition: CoverageDisposition;
+  readonly wave9Delete: boolean;
+  readonly notes: string;
+}
+
+/** Canonical mapping for lifecycle CLI pytest files in scope of story 1838-s3. */
+export const LIFECYCLE_CLI_COVERAGE_MAP: readonly CoverageMapEntry[] = [
+  {
+    pythonTest: "tests/cli/test_vbrief_activate.py",
+    tsTarget:
+      "packages/core/src/vbrief-activate/{activate,main,coverage-boost}.test.ts + lifecycle-cli/dispatch-vbrief.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Module matrix in core; deft-ts vbrief-activate argv/exit in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_fidelity_legacy.py",
+    tsTarget: "packages/core/src/vbrief-validation/fidelity.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Legacy fidelity normalization covered in TS vbrief-validation module.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_migrate_conformance.py",
+    tsTarget: "packages/core/src/vbrief-validate/main.test.ts (scanVbrief/conformance)",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Conformance scan parity in vbrief-validate TS port.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_preflight_resolver.py",
+    tsTarget:
+      "packages/cli/src/vbrief-preflight.test.ts + lifecycle-cli/dispatch-preflight.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: false,
+    notes:
+      "Install-layout resolver still Python-only; TS preflight gate + dispatcher alias covered.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_reconcile_graph.py",
+    tsTarget: "packages/core/src/vbrief-reconcile/graph.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Dependency-graph promotion logic in TS vbrief-reconcile.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_reconcile_labels.py",
+    tsTarget: "packages/core/src/vbrief-reconcile/labels.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Label/status derivation covered in TS reconcile engine.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_reconcile_umbrellas.py",
+    tsTarget: "packages/core/src/vbrief-reconcile/umbrellas.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Umbrella current-shape render/parse in TS.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_reconciliation.py",
+    tsTarget: "packages/core/src/vbrief-reconcile/reconciliation.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Override reconciliation table covered in TS.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_routing.py",
+    tsTarget: "packages/core/src/vbrief-build/routing.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Status↔folder routing map in TS vbrief-build.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_validate.py",
+    tsTarget: "packages/core/src/vbrief-validate/main.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "validateAll matrix in core; deft-ts vbrief-validate argv in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_validate_direct.py",
+    tsTarget: "packages/core/src/vbrief-validate/branches.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Direct validate orchestration branches in TS.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_validate_direct_orchestration.py",
+    tsTarget: "packages/core/src/vbrief-validate/branches.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Reference/orchestration warnings in TS validate-all.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_validate_issue_536.py",
+    tsTarget: "packages/core/src/vbrief-validate/branches.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "x-vbrief/github-issue reference counting in TS.",
+  },
+  {
+    pythonTest: "tests/cli/test_vbrief_validation.py",
+    tsTarget: "packages/core/src/vbrief-validation/validation.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Slug/title normalization in core; deft-ts vbrief-validation argv in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_scope_decompose.py",
+    tsTarget: "packages/core/src/scope/decomposed-refs.test.ts",
+    disposition: "python-oracle",
+    wave9Delete: false,
+    notes:
+      "scope:decompose CLI still Python; unit helpers partially covered in decomposed-refs TS.",
+  },
+  {
+    pythonTest: "tests/cli/test_scope_decompose_unit.py",
+    tsTarget: "packages/core/src/scope/decomposed-refs.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: false,
+    notes: "Pure decomposition helpers; CLI entry remains Python until Wave 9.",
+  },
+  {
+    pythonTest: "tests/cli/test_scope_demote.py",
+    tsTarget: "packages/core/src/scope/demote.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Demote transitions in core; deft-ts scope-lifecycle argv in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_scope_lifecycle.py",
+    tsTarget: "packages/core/src/scope/{main,transition,scope-exhaustive}.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Promote/activate/complete matrix in core; scope-lifecycle dispatcher in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_scope_undo.py",
+    tsTarget: "packages/core/src/scope/undo.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Undo round-trip covered in TS scope module.",
+  },
+  {
+    pythonTest: "tests/cli/test_issue_emit.py",
+    tsTarget: "packages/core/src/intake/issue-emit.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Emit body/render in core; deft-ts issue-emit argv in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_issue_ingest.py",
+    tsTarget:
+      "packages/core/src/intake/{issue-ingest,intake-cli-and-branches}.test.ts + lifecycle-cli/dispatch-intake.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Ingest happy-path/duplicate in core; dispatcher routing in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_issue_ingest_body_parsing.py",
+    tsTarget: "packages/core/src/intake/markdown-scanners.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Checkbox/AC body scanners in TS intake module.",
+  },
+  {
+    pythonTest: "tests/cli/test_issue_ingest_canonical_refs.py",
+    tsTarget: "packages/core/src/intake/issue-ingest.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "v0.6 canonical reference shape in TS ingest.",
+  },
+  {
+    pythonTest: "tests/cli/test_issue_ingest_direct.py",
+    tsTarget: "packages/core/src/intake/intake-coverage-boost.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Repo URL / gh helper branches in TS intake.",
+  },
+  {
+    pythonTest: "tests/cli/test_issue_ingest_escape_corruption.py",
+    tsTarget: "packages/core/src/intake/intake-cli-and-branches.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Literal escape preservation in TS ingest path.",
+  },
+  {
+    pythonTest: "tests/cli/test_reconcile_issues.py",
+    tsTarget: "packages/core/src/intake/reconcile-issues.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Reconcile classification in core; deft-ts reconcile-issues argv in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_reconcile_issues_754.py",
+    tsTarget: "packages/core/src/intake/reconcile-issues.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Batch gh state fetch (>500) in TS reconcile module.",
+  },
+  {
+    pythonTest: "tests/cli/test_reconcile_issues_apply.py",
+    tsTarget: "packages/core/src/intake/reconcile-issues.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "Apply/move section-C entries in TS reconcile.",
+  },
+  {
+    pythonTest: "tests/cli/test_reconcile_issues_direct.py",
+    tsTarget: "packages/core/src/intake/intake-coverage-boost.test.ts",
+    disposition: "existing-coverage",
+    wave9Delete: true,
+    notes: "gh subprocess error branches in TS reconcile helpers.",
+  },
+  {
+    pythonTest: "tests/cli/test_preflight_architecture_sor.py",
+    tsTarget: "python-oracle (scripts/preflight_architecture_sor.py)",
+    disposition: "python-oracle",
+    wave9Delete: false,
+    notes: "Architecture SOR preflight not yet on deft-ts; stays Python until TS port.",
+  },
+  {
+    pythonTest: "tests/cli/test_preflight_branch.py",
+    tsTarget:
+      "packages/core/src/branch/evaluate.test.ts + packages/cli/src/verify-branch.test.ts + lifecycle-cli/dispatch-preflight.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Branch gate in core/cli; verify-branch + vbrief:preflight alias via dispatcher.",
+  },
+  {
+    pythonTest: "tests/cli/test_preflight_cache.py",
+    tsTarget: "python-oracle (scripts/preflight_cache.py)",
+    disposition: "python-oracle",
+    wave9Delete: false,
+    notes:
+      "verify:cache-fresh still Python-only per Wave 8 notes; TS cache module covers fetch not preflight gate.",
+  },
+  {
+    pythonTest: "tests/cli/test_preflight_gh.py",
+    tsTarget: "python-oracle (scripts/preflight_gh.py)",
+    disposition: "python-oracle",
+    wave9Delete: false,
+    notes:
+      "Destructive gh preflight still Python-only; intake github-auth-modes partially overlaps read paths.",
+  },
+  {
+    pythonTest: "tests/cli/test_preflight_implementation.py",
+    tsTarget:
+      "packages/core/src/preflight/evaluate.test.ts + packages/cli/src/vbrief-preflight.test.ts + lifecycle-cli/dispatch-preflight.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes:
+      "#810 state matrix in core; vbrief:preflight / vbrief-preflight dispatcher in lifecycle-cli.",
+  },
+  {
+    pythonTest: "tests/cli/test_preflight_story_start.py",
+    tsTarget:
+      "packages/core/src/story-ready/evaluate.test.ts + packages/cli/src/verify-story-ready.test.ts + lifecycle-cli/dispatch-preflight.test.ts",
+    disposition: "lifecycle-cli-dispatch",
+    wave9Delete: true,
+    notes: "Gate 0 matrix in core; verify:story-ready alias via deft-ts dispatcher.",
+  },
+] as const;
+
+export const LIFECYCLE_PYTHON_TEST_FILES = LIFECYCLE_CLI_COVERAGE_MAP.map((e) => e.pythonTest);

--- a/packages/cli/src/lifecycle-cli/dispatch-intake.test.ts
+++ b/packages/cli/src/lifecycle-cli/dispatch-intake.test.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { runDispatch } from "./helpers.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function makeProjectRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-lc-intake-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief", "proposed"), { recursive: true });
+  return root;
+}
+
+describe("deft-ts intake / reconcile verbs (#1838 s3)", () => {
+  it("issue-ingest exits non-zero for missing vbrief dir", async () => {
+    const root = makeProjectRoot();
+    const result = await runDispatch([
+      "issue-ingest",
+      "42",
+      "--repo",
+      "o/r",
+      "--project-root",
+      root,
+      "--vbrief-dir",
+      join(root, "missing"),
+    ]);
+    expect(result.exitCode).toBeGreaterThan(0);
+  });
+
+  it("issue-ingest accepts numeric issue positional", async () => {
+    const root = makeProjectRoot();
+    const result = await runDispatch([
+      "issue-ingest",
+      "99",
+      "--repo",
+      "o/r",
+      "--project-root",
+      root,
+      "--vbrief-dir",
+      join(root, "vbrief", "proposed"),
+      "--dry-run",
+    ]);
+    expect(result.exitCode).toBeGreaterThan(0);
+  });
+
+  it("issue-emit requires --vbrief-path or umbrella/per-vbrief flags", async () => {
+    const result = await runDispatch(["issue-emit"]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("reconcile-issues reports missing vbrief dir with exit 1", async () => {
+    const result = await runDispatch(["reconcile-issues", "--vbrief-dir", "/nonexistent/path"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("reconcile-issues accepts --project-root and --json flags", async () => {
+    const root = makeProjectRoot();
+    const result = await runDispatch([
+      "reconcile-issues",
+      "--vbrief-dir",
+      join(root, "vbrief"),
+      "--project-root",
+      root,
+      "--json",
+    ]);
+    expect(result.exitCode).toBeGreaterThanOrEqual(0);
+    expect(result.exitCode).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/cli/src/lifecycle-cli/dispatch-preflight.test.ts
+++ b/packages/cli/src/lifecycle-cli/dispatch-preflight.test.ts
@@ -1,0 +1,115 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolveCanonicalVerb } from "../dispatch.js";
+import { runDispatch } from "./helpers.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function gitCommit(cwd: string, message: string): void {
+  execFileSync("git", ["commit", "-q", "-m", message], {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "deft-test",
+      GIT_AUTHOR_EMAIL: "test@test.local",
+      GIT_COMMITTER_NAME: "deft-test",
+      GIT_COMMITTER_EMAIL: "test@test.local",
+    },
+  });
+}
+
+function buildRepo(branch = "master"): { root: string; vbriefPath: string } {
+  const root = mkdtempSync(join(tmpdir(), "deft-lc-pf-"));
+  temps.push(root);
+  const dir = join(root, "vbrief", "active");
+  mkdirSync(dir, { recursive: true });
+  const vbriefPath = join(dir, "story.vbrief.json");
+  writeFileSync(
+    vbriefPath,
+    JSON.stringify({
+      plan: { status: "running", title: "T", items: [] },
+      vBRIEFInfo: { version: "0.6" },
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6" },
+      plan: { title: "PROJECT-DEFINITION", status: "running", items: [] },
+    }),
+    "utf8",
+  );
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["branch", "-M", branch], { cwd: root });
+  execFileSync("git", ["add", "-A"], { cwd: root });
+  gitCommit(root, "init");
+  return { root, vbriefPath };
+}
+
+describe("deft-ts preflight / verify gates (#1838 s3)", () => {
+  it("resolves verify and preflight task aliases", () => {
+    expect(resolveCanonicalVerb("verify:story-ready")).toBe("verify-story-ready");
+    expect(resolveCanonicalVerb("verify:branch")).toBe("verify-branch");
+    expect(resolveCanonicalVerb("vbrief:preflight")).toBe("vbrief-preflight");
+  });
+
+  it("verify-story-ready requires --vbrief-path", async () => {
+    const result = await runDispatch(["verify-story-ready"]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("verify:story-ready alias matches canonical on clean repo", async () => {
+    const { root, vbriefPath } = buildRepo();
+    const canonical = await runDispatch([
+      "verify-story-ready",
+      "--vbrief-path",
+      vbriefPath,
+      "--project-root",
+      root,
+    ]);
+    const alias = await runDispatch([
+      "verify:story-ready",
+      "--vbrief-path",
+      vbriefPath,
+      "--project-root",
+      root,
+    ]);
+    expect(alias.exitCode).toBe(canonical.exitCode);
+    expect(canonical.exitCode).toBe(0);
+  });
+
+  it("verify-branch blocks default-branch commits by default", async () => {
+    const { root } = buildRepo("master");
+    const result = await runDispatch(["verify-branch", "--project-root", root]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("verify:branch alias matches verify-branch exit code", async () => {
+    const { root } = buildRepo("master");
+    const canonical = await runDispatch(["verify-branch", "--project-root", root]);
+    const alias = await runDispatch(["verify:branch", "--project-root", root]);
+    expect(alias.exitCode).toBe(canonical.exitCode);
+  });
+
+  it("verify-story-ready returns 2 for unknown flags", async () => {
+    const { root, vbriefPath } = buildRepo();
+    const result = await runDispatch([
+      "verify-story-ready",
+      "--vbrief-path",
+      vbriefPath,
+      "--project-root",
+      root,
+      "--not-real",
+    ]);
+    expect(result.exitCode).toBe(2);
+  });
+});

--- a/packages/cli/src/lifecycle-cli/dispatch-scope.test.ts
+++ b/packages/cli/src/lifecycle-cli/dispatch-scope.test.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { runDispatch } from "./helpers.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function makeVbriefRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-lc-scope-"));
+  temps.push(root);
+  for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+    mkdirSync(join(root, "vbrief", folder), { recursive: true });
+  }
+  return root;
+}
+
+describe("deft-ts scope lifecycle verb (#1838 s3)", () => {
+  it("scope-lifecycle returns usage error for incomplete argv", async () => {
+    const result = await runDispatch(["scope-lifecycle", "promote"]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("scope-lifecycle rejects unknown subcommand", async () => {
+    const root = makeVbriefRoot();
+    const result = await runDispatch([
+      "scope-lifecycle",
+      "not-a-verb",
+      join(root, "vbrief", "pending", "x.vbrief.json"),
+      "--project-root",
+      root,
+    ]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("scope-lifecycle promote rejects missing vbrief path", async () => {
+    const root = makeVbriefRoot();
+    const result = await runDispatch(["scope-lifecycle", "promote", "--project-root", root]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("triage-scope alias routes to triage-scope handler", async () => {
+    const root = makeVbriefRoot();
+    const result = await runDispatch(["triage:scope", "--project-root", root, "--help"]);
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/lifecycle-cli/dispatch-vbrief.test.ts
+++ b/packages/cli/src/lifecycle-cli/dispatch-vbrief.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolveCanonicalVerb } from "../dispatch.js";
+import { runDispatch } from "./helpers.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function writePendingVbrief(root: string, status = "pending"): string {
+  const dir = join(root, "vbrief", "pending");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "2026-06-21-story.vbrief.json");
+  writeFileSync(
+    path,
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6", updated: "2026-06-01T00:00:00Z" },
+      plan: { title: "Story", status, items: [] },
+    }),
+    "utf8",
+  );
+  return path;
+}
+
+describe("deft-ts vbrief lifecycle verbs (#1838 s3)", () => {
+  it("resolves task-style vbrief aliases to canonical verbs", () => {
+    expect(resolveCanonicalVerb("vbrief:preflight")).toBe("vbrief-preflight");
+    expect(resolveCanonicalVerb("vbrief:validate")).toBe("vbrief-validate");
+    expect(resolveCanonicalVerb("vbrief:activate")).toBe("vbrief-activate");
+  });
+
+  it("vbrief-preflight rejects missing --vbrief-path with exit 2", async () => {
+    const result = await runDispatch(["vbrief-preflight"]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("vbrief-preflight alias vbrief:preflight matches canonical exit code", async () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-lc-pf-"));
+    temps.push(root);
+    const path = writePendingVbrief(root);
+    const canonical = await runDispatch(["vbrief-preflight", "--vbrief-path", path]);
+    const alias = await runDispatch(["vbrief:preflight", "--vbrief-path", path]);
+    expect(alias.exitCode).toBe(canonical.exitCode);
+    expect(canonical.exitCode).toBe(1);
+  });
+
+  it("vbrief-activate requires a positional vbrief path", async () => {
+    const result = await runDispatch(["vbrief-activate"]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("vbrief-activate promotes pending vBRIEF via dispatcher", async () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-lc-act-"));
+    temps.push(root);
+    const src = writePendingVbrief(root);
+    const result = await runDispatch(["vbrief-activate", src]);
+    expect(result.exitCode).toBe(0);
+    const dest = join(root, "vbrief", "active", "2026-06-21-story.vbrief.json");
+    expect(existsSync(dest)).toBe(true);
+    expect(existsSync(src)).toBe(false);
+  });
+
+  it("vbrief-validate --help exits 0 through dispatcher", async () => {
+    const result = await runDispatch(["vbrief-validate", "--help"]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("vbrief-validate skips missing vbrief dir with exit 0", async () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-lc-val-"));
+    temps.push(root);
+    const result = await runDispatch([
+      "vbrief-validate",
+      "--vbrief-dir",
+      join(root, "missing-vbrief"),
+    ]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("vbrief-validation rejects unknown flags with exit 2", async () => {
+    const result = await runDispatch(["vbrief-validation", "--not-a-flag"]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("vbrief-reconcile requires --project-root", async () => {
+    const result = await runDispatch(["vbrief-reconcile"]);
+    expect(result.exitCode).toBe(2);
+  });
+});

--- a/packages/cli/src/lifecycle-cli/helpers.ts
+++ b/packages/cli/src/lifecycle-cli/helpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared helpers for lifecycle CLI retarget specs (#1838 s3).
+ */
+import { type DispatchIo, dispatch } from "../dispatch.js";
+
+export interface CapturedDispatch {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/** Invoke the unified deft-ts dispatcher with captured stdout/stderr. */
+export async function runDispatch(argv: readonly string[]): Promise<CapturedDispatch> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const io: DispatchIo = {
+    writeOut: (text) => {
+      out.push(text);
+    },
+    writeErr: (text) => {
+      err.push(text);
+    },
+  };
+  const exitCode = await dispatch([...argv], io);
+  return { exitCode, stdout: out.join(""), stderr: err.join("") };
+}

--- a/vbrief/completed/2026-06-21-retarget-vbriefscopeissuereconcile-cli-tests-at-the-deft-ts.vbrief.json
+++ b/vbrief/completed/2026-06-21-retarget-vbriefscopeissuereconcile-cli-tests-at-the-deft-ts.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1838-s3-cli-lifecycle-tests",
     "title": "Retarget vbrief/scope/issue/reconcile CLI tests at the deft-ts dispatcher",
-    "status": "pending",
+    "status": "completed",
     "planRef": "proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json",
     "narratives": {
       "Description": "Retarget the tests/cli tests for the vbrief, preflight, scope, issue-ingest, and reconcile command surfaces from the python CLI at the deft-ts dispatcher built in Wave 8. Each test is audited against the TS module's existing unit tests first, so redundant cases are recorded as covered and only genuinely missing argument-surface behavior gets a new vitest spec.",
@@ -64,7 +64,9 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-21T12:20:08Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -73,6 +75,7 @@
         "title": "Issue #1838: feat(ts-migration): Wave 8.5 -- port the maintainer test suites to vitest (content + CLI + integration; additive, no deletions)",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-06-21T12:20:08Z"
   }
 }

--- a/vbrief/proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json
+++ b/vbrief/proposed/2026-06-21-1838-featts-migration-wave-85-port-the-maintainer-test-suites-to.vbrief.json
@@ -58,7 +58,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "pending/2026-06-21-retarget-vbriefscopeissuereconcile-cli-tests-at-the-deft-ts.vbrief.json",
+        "uri": "completed/2026-06-21-retarget-vbriefscopeissuereconcile-cli-tests-at-the-deft-ts.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Retarget vbrief/scope/issue/reconcile CLI tests at the deft-ts dispatcher",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary

- Adds additive vitest specs under `packages/cli/src/lifecycle-cli/` that exercise vbrief, scope, intake, reconcile, and preflight verbs through the unified `deft-ts` dispatcher (argv handling + exit codes).
- Records a per-file coverage map linking 35 in-scope pytest CLI files to existing `@deftai/core` unit tests, new dispatch specs, or Python-oracle surfaces pending TS port.
- Python CLI tests are unchanged; 1144 in-scope pytest assertions remain green.

Refs #1838 #1530

## Coverage map (pytest → TS / disposition)

| Python test | TS target | Disposition | Wave-9 dedup |
|---|---|---|---|
| `tests/cli/test_vbrief_activate.py` | packages/core/src/vbrief-activate/{activate,main,coverage-boost}.test.ts<br>lifecycle-cli/dispatch-vbrief.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_vbrief_fidelity_legacy.py` | packages/core/src/vbrief-validation/fidelity.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_migrate_conformance.py` | packages/core/src/vbrief-validate/main.test.ts (scanVbrief/conformance) | existing-coverage | yes |
| `tests/cli/test_vbrief_preflight_resolver.py` | packages/cli/src/vbrief-preflight.test.ts<br>lifecycle-cli/dispatch-preflight.test.ts | lifecycle-cli-dispatch | no |
| `tests/cli/test_vbrief_reconcile_graph.py` | packages/core/src/vbrief-reconcile/graph.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_reconcile_labels.py` | packages/core/src/vbrief-reconcile/labels.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_reconcile_umbrellas.py` | packages/core/src/vbrief-reconcile/umbrellas.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_reconciliation.py` | packages/core/src/vbrief-reconcile/reconciliation.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_routing.py` | packages/core/src/vbrief-build/routing.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_validate.py` | packages/core/src/vbrief-validate/main.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_vbrief_validate_direct.py` | packages/core/src/vbrief-validate/branches.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_validate_direct_orchestration.py` | packages/core/src/vbrief-validate/branches.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_validate_issue_536.py` | packages/core/src/vbrief-validate/branches.test.ts | existing-coverage | yes |
| `tests/cli/test_vbrief_validation.py` | packages/core/src/vbrief-validation/validation.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_scope_decompose.py` | packages/core/src/scope/decomposed-refs.test.ts | python-oracle | no |
| `tests/cli/test_scope_decompose_unit.py` | packages/core/src/scope/decomposed-refs.test.ts | existing-coverage | no |
| `tests/cli/test_scope_demote.py` | packages/core/src/scope/demote.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_scope_lifecycle.py` | packages/core/src/scope/{main,transition,scope-exhaustive}.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_scope_undo.py` | packages/core/src/scope/undo.test.ts | existing-coverage | yes |
| `tests/cli/test_issue_emit.py` | packages/core/src/intake/issue-emit.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_issue_ingest.py` | packages/core/src/intake/{issue-ingest,intake-cli-and-branches}.test.ts<br>lifecycle-cli/dispatch-intake.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_issue_ingest_body_parsing.py` | packages/core/src/intake/markdown-scanners.test.ts | existing-coverage | yes |
| `tests/cli/test_issue_ingest_canonical_refs.py` | packages/core/src/intake/issue-ingest.test.ts | existing-coverage | yes |
| `tests/cli/test_issue_ingest_direct.py` | packages/core/src/intake/intake-coverage-boost.test.ts | existing-coverage | yes |
| `tests/cli/test_issue_ingest_escape_corruption.py` | packages/core/src/intake/intake-cli-and-branches.test.ts | existing-coverage | yes |
| `tests/cli/test_reconcile_issues.py` | packages/core/src/intake/reconcile-issues.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_reconcile_issues_754.py` | packages/core/src/intake/reconcile-issues.test.ts | existing-coverage | yes |
| `tests/cli/test_reconcile_issues_apply.py` | packages/core/src/intake/reconcile-issues.test.ts | existing-coverage | yes |
| `tests/cli/test_reconcile_issues_direct.py` | packages/core/src/intake/intake-coverage-boost.test.ts | existing-coverage | yes |
| `tests/cli/test_preflight_architecture_sor.py` | python-oracle (scripts/preflight_architecture_sor.py) | python-oracle | no |
| `tests/cli/test_preflight_branch.py` | packages/core/src/branch/evaluate.test.ts<br>packages/cli/src/verify-branch.test.ts<br>lifecycle-cli/dispatch-preflight.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_preflight_cache.py` | python-oracle (scripts/preflight_cache.py) | python-oracle | no |
| `tests/cli/test_preflight_gh.py` | python-oracle (scripts/preflight_gh.py) | python-oracle | no |
| `tests/cli/test_preflight_implementation.py` | packages/core/src/preflight/evaluate.test.ts<br>packages/cli/src/vbrief-preflight.test.ts<br>lifecycle-cli/dispatch-preflight.test.ts | lifecycle-cli-dispatch | yes |
| `tests/cli/test_preflight_story_start.py` | packages/core/src/story-ready/evaluate.test.ts<br>packages/cli/src/verify-story-ready.test.ts<br>lifecycle-cli/dispatch-preflight.test.ts | lifecycle-cli-dispatch | yes |

## Test plan

- [x] `pnpm exec vitest run packages/cli/src/lifecycle-cli` (27 specs)
- [x] `task ts:check-lane` green (lint + build + vitest coverage ≥85%)
- [x] `uv run pytest tests/cli/test_{vbrief,preflight,scope,issue,reconcile}*.py` (1144 passed)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)