### PR TITLE
fix(ci): provision Node/pnpm in the Windows task-dispatch job (#1828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,22 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Node + pnpm are required because the Wave 8 flip (#1828) repointed the
+      # lifecycle gates: `task scope:promote` now `deps: [_ensure-ts]`, which
+      # runs `pnpm run build` to compile the TS engine the dispatch invokes via
+      # `node packages/cli/dist/bin.js`. Without Node/pnpm on PATH this job
+      # failed `scope:_ensure-ts` with exit 127. Node 24 LTS pinned via .nvmrc;
+      # corepack activates the pnpm version from package.json `packageManager`.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Install Node dependencies (pnpm)
+        run: pnpm install --frozen-lockfile
+
       # #884 + #1070: idempotent ghx pre-install. Windows runner ->
       # upstream install.ps1 downloaded to a temp file, verified against
       # the pinned SHA256 (env.GHX_INSTALL_PS1_SHA256), and dot-sourced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **scm/cache/policy and remaining live gates now route through the TS engine (#1828 s6)** -- The scm stub, unified cache, typed policy surface, pack slice/render, roadmap render, codebase validators, and capacity show/backfill tasks now invoke `deft-ts` via `packages/cli/dist/bin.js` instead of `uv run python`, with Python scripts kept in-tree as parity oracles. Refs #1828 #1530.
 
 ### Fixed
+- **Restored the Windows task-dispatch CI job after the Wave 8 flip (#1828 follow-up)** -- The Wave 8 flip repointed `task scope:promote` to build and invoke the TS engine via `pnpm`/`node`, but the Windows regression-guard job only provisioned Python/uv/Task, so `scope:_ensure-ts` failed with exit 127 (`pnpm` not found) and master CI went red. The job now sets up Node (pinned via `.nvmrc`), enables corepack, and installs pnpm dependencies before exercising `scope:promote` end-to-end. Refs #1828 #1530.
 - **Fixed `task pr:*` and `task swarm:*` after the Wave 8 flip (#1828 s5 follow-up)** -- The pr/swarm Taskfile gates referenced `ts:build` without the leading-colon absolute namespace marker, so from the included fragments it resolved to the non-existent `pr:ts:build`/`swarm:ts:build` and broke `task pr:wait-mergeable-and-merge`, `task swarm:launch`, and siblings. Quoted `:ts:build` restores cross-namespace resolution. Refs #1828 #1530.
 
 ### Changed


### PR DESCRIPTION
## Summary
- The Wave 8 flip (#1828) repointed the lifecycle gates: `task scope:promote` now `deps: [_ensure-ts]`, which runs `pnpm run build` and dispatches the move via `node packages/cli/dist/bin.js`.
- The `windows-task-dispatch` regression-guard job only provisioned Python/uv/Task, so `scope:_ensure-ts` failed with **exit 127** (`pnpm` not found) and master CI went red.
- This adds `setup-node` (pinned via `.nvmrc`), `corepack enable`, and `pnpm install --frozen-lockfile` before the `scope:promote` end-to-end step, mirroring the Linux build jobs.

This unblocks the Wave 8.5 cohort PRs, which all inherit the red Windows job from master.

## Test plan
- [ ] `Windows (task dispatch regression)` job goes green on this PR (it exercises the exact fix path).
- [x] `ci.yml` parses as valid YAML.
- [x] Encoding gate clean.

Refs #1828 #1530.

Made with [Cursor](https://cursor.com)