### PR TITLE
fix(test): make render-cli deft-ts-runner repo-root assertion hermetic (#1838)

### DIFF
--- a/packages/cli/src/render-cli/deft-ts-runner.test.ts
+++ b/packages/cli/src/render-cli/deft-ts-runner.test.ts
@@ -1,10 +1,13 @@
 import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveBinPath, resolveRepoRoot, runDeftTs, runDeftTsArgv } from "./deft-ts-runner.js";
 
 describe("deft-ts runner", () => {
   it("resolves repo root and built bin", () => {
-    expect(resolveRepoRoot()).toContain("1838-s6-cli-render");
+    const root = resolveRepoRoot();
+    expect(existsSync(resolve(root, "package.json"))).toBe(true);
+    expect(existsSync(resolve(root, "packages/cli"))).toBe(true);
     expect(existsSync(resolveBinPath())).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- The Wave 8.5 s6 render-cli spec (`deft-ts-runner.test.ts`) asserted `resolveRepoRoot()` `toContain("1838-s6-cli-render")` — a leaked **worktree-name** assertion. It only held inside the agent's worktree; on CI/master the repo root is `/home/runner/_work/directive/directive`, so the `TypeScript (build + lint + test)` job went red after #1846 merged.
- Replaced with a hermetic check: the resolved root contains `package.json` and `packages/cli`, and the built bin exists.

This restores the TS job on master and unblocks the remaining Wave 8.5 PRs (s8 #1845, s1 #1848, s2 #1849), which all inherit the bad test via rebase.

## Test plan
- [x] `pnpm exec vitest run packages/cli/src/render-cli/deft-ts-runner.test.ts` — 3/3 pass locally.
- [ ] `TypeScript (build + lint + test)` green on this PR / master.

Refs #1838 #1530.

Made with [Cursor](https://cursor.com)