### PR TITLE
feat: flip verify.yml gates to deft-ts dispatcher (#1854 Wave 8.6 s3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed -- Twelve high-severity CodeQL `js/polynomial-redos` alerts on master (plus one URL-substring sanitization finding) blocked unrelated PRs via diff-baseline mis-attribution. The flagged cache, scope, doctor, pr-merge-readiness, scm, slice, and triage modules now use linear scanners with byte-identical golden parity. Refs #1810 #1530.
 - **Cache quarantine scanner shell-vector detection is now ReDoS-safe (#1811 follow-up)** -- The `BODY_VECTOR_RE` regex in the cache quarantine scanner triggered a CodeQL `js/polynomial-redos` alert that the #1811 cleanup missed (and that mis-attributed to an unrelated PR). It is replaced with a single-pass linear recognizer that preserves byte-identical match semantics for the three shell-injection vectors (`curl|wget|fetch ... | sh`, `base64 -d/--decode/-D`, and `eval` delimiters), so scanner behavior and cache parity are unchanged. Refs #1811 #1530.
 
+### Changed
+- **Wave 8.6 verify.yml cluster now routes through the TypeScript engine (#1854 s3)** -- `task verify:stubs`, `verify:links`, `verify:rule-ownership`, `verify:scm-boundary`, `verify:capacity`, `verify:session-ritual`, `verify-strategy-output`, and `verify:no-task-runtime` invoke `deft-ts` via `packages/cli/dist/bin.js` instead of `uv run python`, with Python scripts kept as parity oracles. `verify:destructive-gh-verbs` and `verify:cache-fresh` remain on Python until their core modules land. Refs #1854 #1530.
+
 ### Removed
 
 ## [0.52.0] - 2026-06-18

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -390,10 +390,13 @@ tasks:
   verify-strategy-output:
     desc: "Deterministic v0.20 strategy output shape gate (#1166 s2). Fails on non-date-prefixed vBRIEFs in lifecycle dirs, missing PROJECT-DEFINITION.vbrief.json, or legacy specification.vbrief.json in user projects."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - task: verify:_ts-build
+        vars:
+          DEFT_ROOT: "{{.TASKFILE_DIR}}"
     cmds:
-      - uv --project "{{.TASKFILE_DIR}}" run python "{{.TASKFILE_DIR}}/scripts/validate_strategy_output.py" --project-root "{{.USER_WORKING_DIR}}"
+      # Oracle/fallback (parity): scripts/validate_strategy_output.py (#1854 s3).
+      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" validate-strategy-output --project-root "{{.USER_WORKING_DIR}}"
 
   # Pack-projection drift gate (#1294 / #1283, ADR-001). User-facing alias for
   # `packs:verify-drift`, defined at the root Taskfile so it carries the
@@ -411,10 +414,13 @@ tasks:
 
   verify:no-task-runtime:
     desc: "Fail when runtime Python code hard-depends on go-task (#1659)."
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - task: verify:_ts-build
+        vars:
+          DEFT_ROOT: "{{.TASKFILE_DIR}}"
     cmds:
-      - uv --project "{{.TASKFILE_DIR}}" run python "{{.TASKFILE_DIR}}/scripts/verify_no_task_runtime.py"
+      # Oracle/fallback (parity): scripts/verify_no_task_runtime.py (#1854 s3).
+      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" verify-no-task-runtime
 
   # `task check:slow` runs the @pytest.mark.slow lane that the default
   # `task check` skips (#975). The slow lane is dominated by the

--- a/packages/cli/src/content-validate-cli/validate-links.ts
+++ b/packages/cli/src/content-validate-cli/validate-links.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateLinks } from "@deftai/core/validate-content";
+
+interface ParsedArgs {
+  strict: boolean;
+  error?: string;
+}
+
+/** Parse validate-links CLI args, mirroring scripts/validate-links.py. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { strict: false };
+  for (const arg of argv) {
+    if (arg === "--strict") {
+      parsed.strict = true;
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`validate-links: ${args.error}\n`);
+    return 2;
+  }
+  const result = validateLinks.evaluate({
+    cwd: resolve("."),
+    strict: args.strict,
+    argv,
+    linkCheckStrict: process.env.LINK_CHECK_STRICT === "1",
+  });
+  process.stdout.write(`${result.message}\n`);
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/content-validate-cli/validate-strategy-output.ts
+++ b/packages/cli/src/content-validate-cli/validate-strategy-output.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateStrategyOutput } from "@deftai/core/validate-content";
+
+interface ParsedArgs {
+  projectRoot: string;
+  strict: boolean;
+  quiet: boolean;
+  error?: string;
+}
+
+/** Parse validate-strategy-output CLI args, mirroring scripts/validate_strategy_output.py. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { projectRoot: ".", strict: false, quiet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--strict") {
+      parsed.strict = true;
+    } else if (arg === "--quiet") {
+      parsed.quiet = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`validate_strategy_output: ${args.error}\n`);
+    return 2;
+  }
+  const result = validateStrategyOutput.evaluate({
+    projectRoot: resolve(args.projectRoot),
+    strict: args.strict,
+    quiet: args.quiet,
+  });
+  if (result.stream === "stdout" && result.message.length > 0) {
+    process.stdout.write(`${result.message}\n`);
+  } else if (result.stream === "stderr" && result.message.length > 0) {
+    process.stderr.write(`${result.message}\n`);
+  }
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/content-validate-cli/verify-capacity.ts
+++ b/packages/cli/src/content-validate-cli/verify-capacity.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { verifyCapacity } from "@deftai/core/validate-content";
+
+interface ParsedArgs {
+  projectRoot: string;
+  quiet: boolean;
+  error?: string;
+}
+
+/** Parse verify-capacity CLI args, mirroring scripts/verify_capacity.py. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { projectRoot: ".", quiet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--quiet") {
+      parsed.quiet = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify_capacity: ${args.error}\n`);
+    return 2;
+  }
+  const result = verifyCapacity.evaluate({
+    projectRoot: resolve(args.projectRoot),
+    quiet: args.quiet,
+  });
+  if (result.code === 0) {
+    if (!args.quiet && result.message.length > 0) {
+      process.stdout.write(`${result.message}\n`);
+    }
+  } else {
+    process.stderr.write(`${result.message}\n`);
+  }
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -83,6 +83,13 @@ export const CLI_MODULE_VERBS = [
   "verify-investigation",
   "verify-judgment-gates",
   "verify-no-task-runtime",
+  "validate-links",
+  "validate-strategy-output",
+  "verify-capacity",
+  "verify-scm-boundary",
+  "verify-session-ritual",
+  "verify-stubs",
+  "rule-ownership-lint",
   "verify-story-ready",
   "verify-tools",
   "verify-wip-cap",
@@ -132,6 +139,16 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "verify:tools": "verify-tools",
   "verify:investigation": "verify-investigation",
   "verify:judgment-gates": "verify-judgment-gates",
+  "verify:stubs": "verify-stubs",
+  "verify:links": "validate-links",
+  "validate:links": "validate-links",
+  "verify:rule-ownership": "rule-ownership-lint",
+  "rule:ownership-lint": "rule-ownership-lint",
+  "verify:scm-boundary": "verify-scm-boundary",
+  "verify:capacity": "verify-capacity",
+  "verify:session-ritual": "verify-session-ritual",
+  "verify-strategy-output": "validate-strategy-output",
+  "validate:strategy-output": "validate-strategy-output",
   "verify:codebase-map-fresh": "codebase-map-fresh",
   "codebase:map": "codebase-map",
   "triage:welcome": "triage-welcome",
@@ -149,6 +166,16 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "project:render": "project-render",
   doctor: "doctor",
   build: "framework-commands",
+};
+
+/** CLI modules living under verify-source-cli/ or content-validate-cli/ subdirs. */
+const SUBDIR_CLI_STEMS: Readonly<Record<string, string>> = {
+  "verify-stubs": "verify-source-cli/verify-stubs",
+  "rule-ownership-lint": "verify-source-cli/rule-ownership-lint",
+  "verify-scm-boundary": "verify-source-cli/verify-scm-boundary",
+  "validate-links": "content-validate-cli/validate-links",
+  "verify-capacity": "content-validate-cli/verify-capacity",
+  "validate-strategy-output": "content-validate-cli/validate-strategy-output",
 };
 
 const WRAPPER_CLI_STEMS = new Set<string>([
@@ -241,7 +268,9 @@ async function loadCliModuleHandler(stem: string, io: DispatchIo): Promise<Comma
   if (WRAPPER_CLI_STEMS.has(stem)) {
     return loadWrapperCliHandler(stem, io);
   }
-  const mod = (await import(`./${stem}.js`)) as Record<string, unknown>;
+  const subdir = SUBDIR_CLI_STEMS[stem];
+  const modulePath = subdir !== undefined ? `./${subdir}.js` : `./${stem}.js`;
+  const mod = (await import(modulePath)) as Record<string, unknown>;
   const handler = resolveHandler(mod);
   if (handler === null) {
     throw new Error(`module ${stem} has no command handler export`);

--- a/packages/cli/src/verify-session-ritual.ts
+++ b/packages/cli/src/verify-session-ritual.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { emitBypassWarning, emitVerifyJson, verifySessionRitual } from "@deftai/core/session";
+
+interface ParsedArgs {
+  projectRoot: string;
+  tier: "quick" | "gated";
+  emitJson: boolean;
+  error?: string;
+}
+
+/** Parse verify-session-ritual CLI args, mirroring scripts/verify_session_ritual.py. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { projectRoot: ".", tier: "quick", emitJson: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      parsed.emitJson = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg === "--tier") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --tier: expected one argument" };
+      }
+      if (value !== "quick" && value !== "gated") {
+        return { ...parsed, error: `argument --tier: invalid choice: '${value}'` };
+      }
+      parsed.tier = value;
+      i += 1;
+    } else if (arg?.startsWith("--tier=")) {
+      const value = arg.slice("--tier=".length);
+      if (value !== "quick" && value !== "gated") {
+        return { ...parsed, error: `argument --tier: invalid choice: '${value}'` };
+      }
+      parsed.tier = value;
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify_session_ritual: ${args.error}\n`);
+    return 2;
+  }
+  const projectRoot = resolve(args.projectRoot);
+  const result = verifySessionRitual(projectRoot, { tier: args.tier });
+  const warning = emitBypassWarning(result);
+  const warningNeeded = result.bypassed && result.wouldFailCode !== null;
+
+  if (args.emitJson) {
+    process.stdout.write(`${emitVerifyJson(result)}\n`);
+  } else if (result.code === 0) {
+    if (!warningNeeded) {
+      process.stdout.write(`${result.message}\n`);
+    }
+  } else {
+    process.stderr.write(`${result.message}\n`);
+  }
+  if (warning.length > 0) {
+    process.stderr.write(`${warning}\n`);
+  }
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/verify-source-cli/rule-ownership-lint.ts
+++ b/packages/cli/src/verify-source-cli/rule-ownership-lint.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluateRuleOwnership } from "@deftai/core/verify-source";
+
+interface ParsedArgs {
+  mapPath: string | null;
+  root: string | null;
+  error?: string;
+}
+
+/** Parse rule-ownership-lint CLI args, mirroring scripts/rule_ownership_lint.py. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { mapPath: null, root: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--map") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --map: expected one argument" };
+      }
+      parsed.mapPath = value;
+      i += 1;
+    } else if (arg?.startsWith("--map=")) {
+      parsed.mapPath = arg.slice("--map=".length);
+    } else if (arg === "--root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --root: expected one argument" };
+      }
+      parsed.root = value;
+      i += 1;
+    } else if (arg?.startsWith("--root=")) {
+      parsed.root = arg.slice("--root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`rule_ownership_lint: ${args.error}\n`);
+    return 2;
+  }
+  const root = resolve(args.root ?? ".");
+  const result = evaluateRuleOwnership(root, {
+    root,
+    mapPath: args.mapPath !== null ? resolve(args.mapPath) : undefined,
+  });
+  if (result.stream === "stdout") {
+    process.stdout.write(`${result.message}\n`);
+  } else {
+    process.stderr.write(`${result.message}\n`);
+  }
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/verify-source-cli/verify-scm-boundary.ts
+++ b/packages/cli/src/verify-source-cli/verify-scm-boundary.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluateScmBoundary } from "@deftai/core/verify-source";
+
+interface ParsedArgs {
+  projectRoot: string;
+  allowList: string | null;
+  quiet: boolean;
+  error?: string;
+}
+
+/** Parse verify-scm-boundary CLI args, mirroring scripts/verify_scm_boundary.py. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { projectRoot: ".", allowList: null, quiet: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--quiet") {
+      parsed.quiet = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg === "--allow-list") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --allow-list: expected one argument" };
+      }
+      parsed.allowList = value;
+      i += 1;
+    } else if (arg?.startsWith("--allow-list=")) {
+      parsed.allowList = arg.slice("--allow-list=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify_scm_boundary: ${args.error}\n`);
+    return 2;
+  }
+  const projectRoot = resolve(args.projectRoot);
+  const result = evaluateScmBoundary(projectRoot, {
+    allowListPath: args.allowList !== null ? resolve(args.allowList) : null,
+    quiet: args.quiet,
+  });
+  if (result.code === 0) {
+    if (!args.quiet && result.message.length > 0) {
+      process.stdout.write(`${result.message}\n`);
+    }
+  } else {
+    process.stderr.write(`${result.message}\n`);
+  }
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/verify-source-cli/verify-stubs.ts
+++ b/packages/cli/src/verify-source-cli/verify-stubs.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluateVerifyStubs } from "@deftai/core/verify-source";
+
+interface ParsedArgs {
+  projectRoot: string;
+  error?: string;
+}
+
+/** Parse verify-stubs CLI args (mirrors scripts/verify-stubs.py -- no flags). */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { projectRoot: "." };
+  for (const arg of argv) {
+    return { ...parsed, error: `unrecognized argument: ${arg}` };
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify-stubs: ${args.error}\n`);
+    return 2;
+  }
+  const result = evaluateVerifyStubs(resolve(args.projectRoot));
+  process.stdout.write(`${result.message}\n`);
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -13,24 +13,27 @@ tasks:
 
   stubs:
     desc: Scan source files for stub patterns (TODO, FIXME, HACK, return null, bare pass)
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ts-build
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/verify-stubs.py"
+      # Oracle/fallback (parity): scripts/verify-stubs.py (#1828 Wave 8 / #1854 s3).
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-stubs
 
   links:
     desc: Validate internal links in markdown files
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ts-build
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/validate-links.py"
+      # Oracle/fallback (parity): scripts/validate-links.py (#1828 Wave 8 / #1854 s3).
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" validate-links
 
   rule-ownership:
     desc: "Verify the Rule Ownership Map (conventions/rule-ownership.json) is in sync with its owner files (#635)"
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ts-build
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/rule_ownership_lint.py" --root "{{.DEFT_ROOT}}"
+      # Oracle/fallback (parity): scripts/rule_ownership_lint.py (#1828 Wave 8 / #1854 s3).
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" rule-ownership-lint --root "{{.DEFT_ROOT}}"
 
   branch:
     desc: "Detection-bound branch-protection gate (#747). Reads plan.policy.allowDirectCommitsToMaster from PROJECT-DEFINITION."
@@ -126,11 +129,12 @@ tasks:
   session-ritual:
     desc: "Fail-closed session ritual verifier (#1348). Flags: --tier quick|gated / --json. Set DEFT_SESSION_RITUAL_SKIP=1 for headless workers and CI."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ts-build
     # No sources/generates: this gate is time-, HEAD-, and worktree-sensitive.
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/verify_session_ritual.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      # Oracle/fallback (parity): scripts/verify_session_ritual.py (#1828 Wave 8 / #1854 s3).
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-session-ritual --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
 
   tools:
     desc: "Detect required Deft host tools and print install or manual guidance (#1187). Flags: --install / --yes / --json"
@@ -144,14 +148,15 @@ tasks:
   scm-boundary:
     desc: "Detection-bound gate against raw `gh` / `ghx` subprocess calls outside `scripts/scm.py` (#1145 / N5). Scans verb-layer Python files (`scripts/triage_*.py`, `scripts/scope_*.py`, `scripts/slice_*.py`, `scripts/_triage_*.py`, `scripts/_scope_*.py`, `scripts/resume_conditions.py`, `scripts/issue_ingest.py`) and fails loud when any of them invoke `gh` directly instead of going through `scm.call(source, verb, args)`. Three-state exit (0 clean / 1 violations / 2 config error). Document an exception via `--allow-list <path>` (file with newline-separated glob patterns)."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (`--allow-list <path>` / `--quiet`) that go-task's incremental-build
     # cache would silently swallow.
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/verify_scm_boundary.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      # Oracle/fallback (parity): scripts/verify_scm_boundary.py (#1828 Wave 8 / #1854 s3).
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-scm-boundary --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
 
   story-ready:
     desc: "Deterministic story-start Gate 0 (#1378 Story C). Inspects working-tree cleanliness, the target vBRIEF lifecycle (active/ + plan.status==running), and the dispatch envelope's `## Allocation context` consent token (Story A schema). Three-state exit (0 ready / 1 not ready / 2 config error). -- task verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>] [--allow-dirty] [--json]"
@@ -195,8 +200,8 @@ tasks:
   capacity:
     desc: "Three-state ADVISORY capacity gate (#1419 Slice 4). Reports trailing-window target-vs-actual bucket mix from plan.policy.capacityAllocation; exits 0 in the default advise posture (and on insufficient sample / unconfigured policy), 1 only under an explicit enforce posture with a sampled deficit, 2 on config error. DELIBERATELY NOT in the `task check` aggregate -- capacity must never fail-closed on the framework tree."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (--project-root / --quiet) that go-task's incremental-build cache would
@@ -204,7 +209,8 @@ tasks:
     # from the `task check` deps so a capacity deficit cannot wedge the
     # framework's own self-check (advise-mode discipline, #1419).
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/verify_capacity.py" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      # Oracle/fallback (parity): scripts/verify_capacity.py (#1828 Wave 8 / #1854 s3).
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-capacity --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
 
   judgment-gates:
     desc: "Three-state ADVISORY judgment-gate engine (#1419 Slice 3). Evaluates a candidate change (diff paths / labels / body) against plan.policy.judgmentGates + four default-on universal safety gates (secrets / infra / AGENTS.md+skills / installer). Advisory by default (always exits 0); opt-in --enforce fails closed (exit 1) when a mechanical block-tier gate fires without a recorded clearance; exit 2 on config error. -- task verify:judgment-gates [-- --base-ref <ref>] [--path P] [--label L] [--enforce] [--json]. DELIBERATELY NOT in the `task check` aggregate -- judgment gates must never fail-closed on the framework tree (advise -> observe -> block rollout, #1419)."


### PR DESCRIPTION
## Summary

Wave 8.6 story s3 (#1854): wire the remaining live-Python gates in `tasks/verify.yml` plus two root-Taskfile gates through `packages/cli/dist/bin.js`.

**Flipped to TypeScript (`deft-ts` verbs):**
- `verify:stubs` → `verify-stubs`
- `verify:links` → `validate-links`
- `verify:rule-ownership` → `rule-ownership-lint`
- `verify:scm-boundary` → `verify-scm-boundary`
- `verify:capacity` → `verify-capacity`
- `verify:session-ritual` → `verify-session-ritual`
- `verify-strategy-output` → `validate-strategy-output`
- `verify:no-task-runtime` → `verify-no-task-runtime` (repoint only; verb already existed)

**Still on Python (no TS core module yet — follow-up):**
- `verify:destructive-gh-verbs` (`scripts/preflight_gh.py --self-test`) — no `@deftai/core` port; classifier fixture self-test needs a dedicated module
- `verify:cache-fresh` (`scripts/preflight_cache.py`) — triage cache freshness gate not yet in TS engine

**Out of scope (other Wave 8.6 stories):**
- `verify:architecture-sor` remains Python

## Test plan

- [x] `task ts:parity-all` — CLEAN (verify-source, validate-content, session, verify-env harnesses)
- [x] `task verify:scm-boundary`, `task verify:capacity` — dispatch via `bin.js`
- [x] `task verify:encoding` — green
- [x] `task ts:check-lane` — green
- [x] `grep -rE 'uv .*run python' tasks/verify.yml` — only documented not-yet-portable lines (+ architecture-sor)

Refs #1854 #1530

Made with [Cursor](https://cursor.com)