### PR TITLE
feat(ts-migration): wire-flip scope-undo/demote/decompose/changelog/arch-sor to TS dispatcher (#1854)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+### Added
+- **scope-decompose, scope-undo, scope-demote, changelog-resolve-unreleased, and architecture-preflight-sor wired into the TypeScript engine (#1854 Wave 8.6 s4)** -- Five Python scripts are now dispatched from the `deft-ts` unified CLI entry point: `scope_decompose.py` and `preflight_architecture_sor.py` are ported as new `@deftai/core` modules with full Vitest unit suites (including edge-case fixtures mirrored from the Python tests); `scope_undo.py`, `scope_demote.py`, and `resolve_changelog_unreleased.py` are wire-flipped to existing TS modules. The corresponding Taskfiles (`tasks/scope.yml`, `scope-undo.yml`, `changelog.yml`, `architecture.yml`) now invoke `node packages/cli/dist/bin.js` instead of `uv run python`. Refs #1854 #1530.
+
 ## [0.52.0] - 2026-06-18
 
 > Deft commands now run without go-task via a package-first deft <verb> surface, plus a provider-ready codebase-map contract and refreshed architecture docs.

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -123,6 +123,11 @@ export const CORE_MODULE_VERBS = [
   "pack-migrate-patterns",
   "pack-migrate-swarm-spec",
   "policy-set",
+  "scope-undo",
+  "scope-demote",
+  "scope-decompose",
+  "changelog-resolve-unreleased",
+  "architecture-preflight-sor",
 ] as const;
 
 /** Task-style aliases (framework_commands / Taskfile names). */
@@ -457,6 +462,30 @@ async function loadCoreModuleHandler(verb: string, io: DispatchIo): Promise<Comm
       return loadPythonScriptHandler("pack_migrate_swarm_spec.py");
     case "policy-set":
       return loadPythonScriptHandler("policy_set.py");
+    case "scope-undo": {
+      const { undoMain } = await import("../../core/dist/scope/main.js");
+      return undoMain;
+    }
+    case "scope-demote": {
+      const { demoteMain } = await import("../../core/dist/scope/main.js");
+      return demoteMain;
+    }
+    case "scope-decompose": {
+      const { decomposeMain } = await import("../../core/dist/scope/decompose.js");
+      return decomposeMain;
+    }
+    case "changelog-resolve-unreleased": {
+      const { changelogResolveUnreleasedMain } = await import(
+        "../../core/dist/platform/changelog-cli.js"
+      );
+      return changelogResolveUnreleasedMain;
+    }
+    case "architecture-preflight-sor": {
+      const { architecturePreflightSorMain } = await import(
+        "../../core/dist/architecture/sor-preflight.js"
+      );
+      return architecturePreflightSorMain;
+    }
     default:
       throw new Error(`unknown core verb: ${verb}`);
   }

--- a/packages/core/src/architecture/sor-preflight.test.ts
+++ b/packages/core/src/architecture/sor-preflight.test.ts
@@ -9,6 +9,8 @@ import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   architecturePreflightSorMain,
+  type DetectedSignal,
+  evaluateDiff,
   evaluateDiffText,
   evaluateStory,
   scanDiff,
@@ -300,5 +302,491 @@ describe("architecturePreflightSorMain", () => {
   it("unrecognized arg exits 2", () => {
     const code = architecturePreflightSorMain(["--unknown-flag"]);
     expect(code).toBe(2);
+  });
+
+  it("--story-path= equals form exits 0 for passing fixture", () => {
+    const code = architecturePreflightSorMain([
+      `--story-path=${fixture("durable_db_passes.vbrief.json")}`,
+      "--project-root=/tmp",
+    ]);
+    expect(code).toBe(0);
+  });
+
+  it("--json flag emits JSON and exits 1 for failing fixture", () => {
+    const code = architecturePreflightSorMain([
+      "--json",
+      "--story-path",
+      fixture("durable_json_fails.vbrief.json"),
+    ]);
+    expect(code).toBe(1);
+  });
+
+  it("--base-ref against a non-git dir exits 2 (gate misconfigured)", () => {
+    const dir = mkTmp();
+    expect(architecturePreflightSorMain(["--base-ref", "HEAD", "--project-root", dir])).toBe(2);
+  });
+
+  it("--base-ref= equals form against a non-git dir exits 2", () => {
+    const dir = mkTmp();
+    expect(architecturePreflightSorMain([`--base-ref=HEAD`, `--project-root=${dir}`])).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for the additional coverage suites
+// ---------------------------------------------------------------------------
+
+function mkTmp(): string {
+  const dir = join(tmpdir(), `sor-cov-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function durableSurface(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "Workspaces",
+    classification: "durable_product_state",
+    approvedStorage: ["database"],
+    owner: "platform-team",
+    permissionBoundary: "tenant",
+    migrationRequired: true,
+    auditRequired: true,
+    concurrencyRequired: true,
+    concurrencySemantics: "optimistic",
+    transactionBoundary: "request",
+    recoverySemantics: "rollback",
+    conflictDetection: "version",
+    deleteSemantics: "soft",
+    migrationPath: "alembic",
+    ...over,
+  };
+}
+
+function cacheSurface(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "Cache",
+    classification: "cache",
+    approvedStorage: ["database"],
+    invalidationRules: "ttl 5m",
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateRecord -- surface classification branches
+// ---------------------------------------------------------------------------
+
+describe("validateRecord surface branches", () => {
+  it("flags unknown classification", () => {
+    const result = validateRecord({ stateSurfaces: [{ name: "X", classification: "bogus" }] });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("Unknown or missing classification");
+  });
+
+  it("flags durable surface with no approvedStorage and missing required fields", () => {
+    const result = validateRecord({
+      stateSurfaces: [{ name: "U", classification: "durable_product_state" }],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("no approvedStorage");
+    expect(result.message).toContain("missing required field");
+  });
+
+  it("flags durable surface that approves unsafe local storage", () => {
+    const result = validateRecord({
+      stateSurfaces: [durableSurface({ approvedStorage: ["json_file"] })],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("unsafe local storage");
+  });
+
+  it("passes a fully-specified durable database surface", () => {
+    const result = validateRecord({ stateSurfaces: [durableSurface()] });
+    expect(result.code).toBe(0);
+  });
+
+  it("flags a file-backed cache without invalidation rules", () => {
+    const result = validateRecord({
+      stateSurfaces: [{ name: "C", classification: "cache", approvedStorage: ["json_file"] }],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("invalidation");
+  });
+
+  it("flags an import/export artifact marked live", () => {
+    const result = validateRecord({
+      stateSurfaces: [{ name: "Exp", classification: "import_export_artifact", liveState: true }],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("live or authoritative");
+  });
+
+  it("flags a canonical artifact marked mutable", () => {
+    const result = validateRecord({
+      stateSurfaces: [{ name: "Can", classification: "canonical_artifact", mutable: true }],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("mutable or authoritative");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateReferenceApps
+// ---------------------------------------------------------------------------
+
+describe("validateReferenceApps", () => {
+  const parityStory = {
+    plan: {
+      narratives: { Description: "Implementation modeled after the reference app for parity." },
+    },
+  };
+
+  it("flags missing auth and permission comparison groups", () => {
+    const record = {
+      stateSurfaces: [durableSurface()],
+      referenceApplicationComparisons: [
+        { note: "We compare database persistence schema with the reference app." },
+      ],
+    };
+    const result = validateRecord(record, { storyPayload: parityStory });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("comparison");
+  });
+
+  it("passes when all comparison groups are covered", () => {
+    const record = {
+      stateSurfaces: [durableSurface()],
+      referenceApplicationComparisons: [
+        {
+          note:
+            "database persistence schema parity; auth session identity parity; " +
+            "permission authorization ownership role membership parity.",
+        },
+      ],
+    };
+    const result = validateRecord(record, { storyPayload: parityStory });
+    expect(result.code).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRecord -- diff signal validation
+// ---------------------------------------------------------------------------
+
+describe("validateRecord signal validation", () => {
+  function sig(over: Partial<DetectedSignal> & { kind: string }): DetectedSignal {
+    return { path: "app/x.py", line: 3, detail: "x", ...over };
+  }
+
+  it("flags storage forbidden by a surface", () => {
+    const record = { stateSurfaces: [durableSurface({ forbiddenStorage: ["json_file"] })] };
+    const result = validateRecord(record, {
+      signals: [sig({ kind: "filesystem_write", storage: "json_file" })],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("forbids");
+  });
+
+  it("flags storage with no approving surface", () => {
+    const result = validateRecord(
+      { stateSurfaces: [cacheSurface()] },
+      { signals: [sig({ kind: "filesystem_write", storage: "json_file" })] },
+    );
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("without a state surface");
+  });
+
+  it("flags a mutation endpoint with no durable owner", () => {
+    const result = validateRecord(
+      { stateSurfaces: [cacheSurface()] },
+      { signals: [sig({ kind: "mutation_endpoint", line: null })] },
+    );
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("no durable owner");
+  });
+
+  it("flags an auth signal with no auth surface", () => {
+    const result = validateRecord(
+      { stateSurfaces: [cacheSurface()] },
+      { signals: [sig({ kind: "auth_state" })] },
+    );
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("no auth_session_state");
+  });
+
+  it("flags a workflow signal with no durable owner", () => {
+    const result = validateRecord(
+      { stateSurfaces: [cacheSurface()] },
+      { signals: [sig({ kind: "workflow_state" })] },
+    );
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("no durable or service-backed owner");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanDiff -- signal kind coverage
+// ---------------------------------------------------------------------------
+
+describe("scanDiff signal kinds", () => {
+  function diffFor(path: string, line: string): string {
+    return [
+      `diff --git a/${path} b/${path}`,
+      `--- a/${path}`,
+      `+++ b/${path}`,
+      "@@ -0,0 +1 @@",
+      `+${line}`,
+      "",
+    ].join("\n");
+  }
+
+  it("detects a stateful module name via path", () => {
+    const [signals] = scanDiff(diffFor("app/user_repository.py", "x = 1"));
+    expect(signals.some((s) => s.kind === "state_module")).toBe(true);
+  });
+
+  it("detects a database migration path", () => {
+    const [signals] = scanDiff(diffFor("app/migrations/001_init.py", "x = 1"));
+    expect(signals.some((s) => s.kind === "database_model" && s.storage === "database")).toBe(true);
+  });
+
+  it("detects in-memory state in a store module", () => {
+    const [signals] = scanDiff(diffFor("app/session_store.py", "_data = {}"));
+    expect(signals.some((s) => s.kind === "in_memory_state")).toBe(true);
+  });
+
+  it("detects a mutation endpoint", () => {
+    const [signals] = scanDiff(diffFor("app/routes.py", '@app.post("/items")'));
+    expect(signals.some((s) => s.kind === "mutation_endpoint")).toBe(true);
+  });
+
+  it("detects a database model declaration", () => {
+    const [signals] = scanDiff(diffFor("app/models.py", "class Item(models.Model):"));
+    expect(signals.some((s) => s.kind === "database_model")).toBe(true);
+  });
+
+  it("detects an auth/session signal", () => {
+    const [signals] = scanDiff(diffFor("app/svc.py", "session = get_session(user)"));
+    expect(signals.some((s) => s.kind === "auth_state")).toBe(true);
+  });
+
+  it("detects a workflow state change", () => {
+    const [signals] = scanDiff(diffFor("app/worker.py", "class JobQueue:"));
+    expect(signals.some((s) => s.kind === "workflow_state")).toBe(true);
+  });
+
+  it("infers yaml/toml/sqlite storage from filesystem writes", () => {
+    const [yaml] = scanDiff(diffFor("app/a.py", 'Path("config.yaml").write_text(data)'));
+    expect(yaml.some((s) => s.storage === "yaml_file")).toBe(true);
+    const [toml] = scanDiff(diffFor("app/b.py", 'Path("c.toml").write_text(data)'));
+    expect(toml.some((s) => s.storage === "toml_file")).toBe(true);
+    const [sqlite] = scanDiff(diffFor("app/c.py", 'Path("d.db").write_text(data)'));
+    expect(sqlite.some((s) => s.storage === "sqlite_file")).toBe(true);
+    const [fs] = scanDiff(diffFor("app/d.py", 'Path("plain").write_text(data)'));
+    expect(fs.some((s) => s.storage === "filesystem")).toBe(true);
+  });
+
+  it("handles deletions (+++ /dev/null), context and removed lines", () => {
+    const diff = [
+      "diff --git a/app/old.py b/app/old.py",
+      "--- a/app/old.py",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-x = 1",
+      "diff --git a/app/keep.py b/app/keep.py",
+      "--- a/app/keep.py",
+      "+++ b/app/keep.py",
+      "@@ -1,3 +1,3 @@",
+      " context line",
+      "-removed = 1",
+      "+added = 2",
+      "",
+    ].join("\n");
+    const [, changedPaths] = scanDiff(diff);
+    expect(changedPaths).toContain("app/keep.py");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateDiffText -- multi-record and no-record branches
+// ---------------------------------------------------------------------------
+
+describe("evaluateDiffText record resolution", () => {
+  function sorVbrief(): unknown {
+    return { architecture: { systemOfRecord: { stateSurfaces: [durableSurface()] } } };
+  }
+
+  it("returns code 2 when multiple changed vBRIEFs carry SoR records", () => {
+    const proj = mkTmp();
+    mkdirSync(join(proj, "vbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(proj, "vbrief", "active", "a.vbrief.json"),
+      JSON.stringify(sorVbrief()),
+      "utf8",
+    );
+    writeFileSync(
+      join(proj, "vbrief", "active", "b.vbrief.json"),
+      JSON.stringify(sorVbrief()),
+      "utf8",
+    );
+    const diff = [
+      "diff --git a/vbrief/active/a.vbrief.json b/vbrief/active/a.vbrief.json",
+      "+++ b/vbrief/active/a.vbrief.json",
+      "@@ -0,0 +1 @@",
+      "+{}",
+      "diff --git a/vbrief/active/b.vbrief.json b/vbrief/active/b.vbrief.json",
+      "+++ b/vbrief/active/b.vbrief.json",
+      "@@ -0,0 +1 @@",
+      "+{}",
+      "diff --git a/app/repo.py b/app/repo.py",
+      "+++ b/app/repo.py",
+      "@@ -0,0 +1 @@",
+      '+Path("x.json").write_text(json.dumps(d))',
+      "",
+    ].join("\n");
+    const result = evaluateDiffText(diff, { projectRoot: proj });
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("multiple changed vBRIEFs");
+  });
+
+  it("returns code 1 when a stateful signal has no design record at all", () => {
+    const proj = mkTmp();
+    const diff = [
+      "diff --git a/app/repo.py b/app/repo.py",
+      "+++ b/app/repo.py",
+      "@@ -0,0 +1 @@",
+      '+Path("x.json").write_text(json.dumps(d))',
+      "",
+    ].join("\n");
+    const result = evaluateDiffText(diff, { projectRoot: proj });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("no matching architecture.systemOfRecord");
+  });
+
+  it("resolves a single changed vBRIEF record automatically", () => {
+    const proj = mkTmp();
+    mkdirSync(join(proj, "vbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(proj, "vbrief", "active", "only.vbrief.json"),
+      JSON.stringify(sorVbrief()),
+      "utf8",
+    );
+    const diff = [
+      "diff --git a/vbrief/active/only.vbrief.json b/vbrief/active/only.vbrief.json",
+      "+++ b/vbrief/active/only.vbrief.json",
+      "@@ -0,0 +1 @@",
+      "+{}",
+      "diff --git a/app/models.py b/app/models.py",
+      "+++ b/app/models.py",
+      "@@ -0,0 +1 @@",
+      "+class Item(models.Model):",
+      "",
+    ].join("\n");
+    const result = evaluateDiffText(diff, { projectRoot: proj });
+    expect(result.code).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateDiff -- git invocation error path
+// ---------------------------------------------------------------------------
+
+describe("evaluateDiff", () => {
+  it("returns code 2 when git diff cannot run (non-git dir)", () => {
+    const dir = mkTmp();
+    const result = evaluateDiff(dir, "HEAD");
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("gate misconfigured");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Additional normalization / edge branches
+// ---------------------------------------------------------------------------
+
+describe("storageMatches alias coverage", () => {
+  it("matches external_service aliases", () => {
+    expect(storageMatches("external_service", "api provider")).toBe(true);
+  });
+
+  it("matches via long-alias substring inclusion", () => {
+    expect(storageMatches("database", "myapplication_database_backend")).toBe(true);
+  });
+
+  it("does not match an unrelated short token", () => {
+    expect(storageMatches("database", "cache")).toBe(false);
+  });
+});
+
+describe("validateRecord additional surface edge cases", () => {
+  it("treats stateSurfaces that is not an array as missing", () => {
+    const result = validateRecord({ stateSurfaces: "nope" });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("missing or empty");
+  });
+
+  it("reports unnamed surface and non-string classification", () => {
+    const result = validateRecord({ stateSurfaces: [{ classification: 123 }] });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("<unnamed>");
+  });
+
+  it("accepts durable required fields supplied as arrays/objects", () => {
+    const surface = durableSurface({
+      owner: ["platform"],
+      recoverySemantics: { mode: "rollback" },
+    });
+    const result = validateRecord({ stateSurfaces: [surface] });
+    expect(result.code).toBe(0);
+  });
+
+  it("flags a durable required field supplied as an empty array", () => {
+    const surface = durableSurface({ owner: [] });
+    const result = validateRecord({ stateSurfaces: [surface] });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("missing required field 'owner'");
+  });
+
+  it("flags an import/export artifact whose live flag is the string 'true'", () => {
+    const result = validateRecord({
+      stateSurfaces: [
+        { name: "E", classification: "import_export_artifact", authoritative: "true" },
+      ],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("live or authoritative");
+  });
+});
+
+describe("evaluateDiffText changed-folder filters", () => {
+  function sorVbrief(): unknown {
+    return { architecture: { systemOfRecord: { stateSurfaces: [durableSurface()] } } };
+  }
+
+  it("reads SoR records from a changed vbrief/pending path and skips other folders", () => {
+    const proj = mkTmp();
+    mkdirSync(join(proj, "vbrief", "pending"), { recursive: true });
+    writeFileSync(
+      join(proj, "vbrief", "pending", "only.vbrief.json"),
+      JSON.stringify(sorVbrief()),
+      "utf8",
+    );
+    const diff = [
+      "diff --git a/vbrief/completed/old.vbrief.json b/vbrief/completed/old.vbrief.json",
+      "+++ b/vbrief/completed/old.vbrief.json",
+      "@@ -0,0 +1 @@",
+      "+{}",
+      "diff --git a/vbrief/pending/only.vbrief.json b/vbrief/pending/only.vbrief.json",
+      "+++ b/vbrief/pending/only.vbrief.json",
+      "@@ -0,0 +1 @@",
+      "+{}",
+      "diff --git a/app/models.py b/app/models.py",
+      "+++ b/app/models.py",
+      "@@ -0,0 +1 @@",
+      "+class Item(models.Model):",
+      "",
+    ].join("\n");
+    const result = evaluateDiffText(diff, { projectRoot: proj });
+    expect(result.code).toBe(0);
   });
 });

--- a/packages/core/src/architecture/sor-preflight.test.ts
+++ b/packages/core/src/architecture/sor-preflight.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Vitest tests for sor-preflight.ts -- mirror key Python test cases from
+ * tests/cli/test_preflight_architecture_sor.py including non-happy-path fixtures.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  architecturePreflightSorMain,
+  evaluateDiffText,
+  evaluateStory,
+  scanDiff,
+  storageMatches,
+  systemOfRecord,
+  validateRecord,
+} from "./sor-preflight.js";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..", "..");
+const FIXTURE_DIR = join(REPO_ROOT, "tests", "fixtures", "sor_gate");
+
+function fixture(name: string): string {
+  return join(FIXTURE_DIR, name);
+}
+
+function _writeStory(dir: string, payload: unknown): string {
+  const path = join(dir, "vbrief", "active", "story.vbrief.json");
+  mkdirSync(join(dir, "vbrief", "active"), { recursive: true });
+  writeFileSync(path, JSON.stringify(payload, null, 2), "utf8");
+  return path;
+}
+
+describe("evaluateStory", () => {
+  it("durable_product_state on json_file fails", () => {
+    const result = evaluateStory(fixture("durable_json_fails.vbrief.json"));
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("Durable");
+    expect(result.message).toContain("json_file");
+  });
+
+  it("durable_product_state on approved DB passes", () => {
+    const result = evaluateStory(fixture("durable_db_passes.vbrief.json"));
+    expect(result.code).toBe(0);
+  });
+
+  it("canonical_artifact file reads pass", () => {
+    const result = evaluateStory(fixture("canonical_artifact_passes.vbrief.json"));
+    expect(result.code).toBe(0);
+  });
+
+  it("cache file passes with invalidation metadata", () => {
+    const good = evaluateStory(fixture("cache_file_passes.vbrief.json"));
+    expect(good.code).toBe(0);
+  });
+
+  it("cache file fails without invalidation metadata", () => {
+    const raw = JSON.parse(
+      readFileSync(fixture("cache_file_passes.vbrief.json"), "utf8"),
+    ) as Record<string, unknown>;
+    const arch = raw.architecture as Record<string, unknown>;
+    const sor = arch.systemOfRecord as Record<string, unknown>;
+    const surfaces = sor.stateSurfaces as Record<string, unknown>[];
+    const surface = { ...surfaces[0]! };
+    delete surface.invalidationRules;
+    sor.stateSurfaces = [surface];
+    const tmpDir = join(tmpdir(), `sor-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    const badPath = join(tmpDir, "story.vbrief.json");
+    writeFileSync(badPath, JSON.stringify(raw, null, 2), "utf8");
+    const bad = evaluateStory(badPath);
+    expect(bad.code).toBe(1);
+    expect(bad.message).toContain("invalidation");
+  });
+
+  it("reference-app parity fails without persistence/auth comparison", () => {
+    const result = evaluateStory(fixture("reference_app_missing_comparison_fails.vbrief.json"));
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("Reference-application parity");
+  });
+
+  it("missing story path returns code 2", () => {
+    const result = evaluateStory("/nonexistent/path/story.vbrief.json");
+    expect(result.code).toBe(2);
+  });
+
+  it("non-JSON file returns code 2", () => {
+    const tmpPath = join(tmpdir(), `bad-json-${Date.now()}.json`);
+    writeFileSync(tmpPath, "not json", "utf8");
+    const result = evaluateStory(tmpPath);
+    expect(result.code).toBe(2);
+  });
+});
+
+describe("evaluateDiffText", () => {
+  it("canonical artifact file reads pass", () => {
+    const diff = `\
+diff --git a/app/catalog.py b/app/catalog.py
+--- a/app/catalog.py
++++ b/app/catalog.py
+@@ -0,0 +1 @@
++CATALOG = json.loads(Path("seed-catalog.json").read_text(encoding="utf-8"))
+`;
+    const result = evaluateDiffText(diff, {
+      projectRoot: REPO_ROOT,
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("no stateful diff signals");
+  });
+
+  it("durable db diff passes with mutation and model signals", () => {
+    const diff = `\
+diff --git a/app/models.py b/app/models.py
+--- a/app/models.py
++++ b/app/models.py
+@@ -0,0 +1,3 @@
++class Workspace(Base):
++    __tablename__ = "workspaces"
++    id = db.Column(db.String, primary_key=True)
+diff --git a/app/routes.py b/app/routes.py
+--- a/app/routes.py
++++ b/app/routes.py
+@@ -0,0 +1,2 @@
++@app.post("/workspaces")
++def create_workspace():
+`;
+    const result = evaluateDiffText(diff, {
+      projectRoot: REPO_ROOT,
+      storyPath: fixture("durable_db_passes.vbrief.json"),
+    });
+    expect(result.code).toBe(0);
+  });
+
+  it("declared db but diff implements json_file fails", () => {
+    const diff = `\
+diff --git a/app/workspace_repository.py b/app/workspace_repository.py
+--- a/app/workspace_repository.py
++++ b/app/workspace_repository.py
+@@ -0,0 +1 @@
++Path("workspaces.json").write_text(json.dumps(workspaces), encoding="utf-8")
+`;
+    const result = evaluateDiffText(diff, {
+      projectRoot: REPO_ROOT,
+      storyPath: fixture("durable_db_passes.vbrief.json"),
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("json_file");
+    const msg = result.message;
+    expect(msg.includes("forbids") || msg.includes("without a state surface")).toBe(true);
+  });
+
+  it("browser storage passes for ephemeral_ui_state", () => {
+    const diff = `\
+diff --git a/web/sidebar.ts b/web/sidebar.ts
+--- a/web/sidebar.ts
++++ b/web/sidebar.ts
+@@ -0,0 +1 @@
++localStorage.setItem("selectedSidebarTab", tabId)
+`;
+    const ok = evaluateDiffText(diff, {
+      projectRoot: REPO_ROOT,
+      storyPath: fixture("browser_ephemeral_passes.vbrief.json"),
+    });
+    expect(ok.code).toBe(0);
+  });
+
+  it("browser storage fails for durable state story", () => {
+    const diff = `\
+diff --git a/web/sidebar.ts b/web/sidebar.ts
+--- a/web/sidebar.ts
++++ b/web/sidebar.ts
+@@ -0,0 +1 @@
++localStorage.setItem("selectedSidebarTab", tabId)
+`;
+    const blocked = evaluateDiffText(diff, {
+      projectRoot: REPO_ROOT,
+      storyPath: fixture("durable_db_passes.vbrief.json"),
+    });
+    expect(blocked.code).toBe(1);
+    expect(blocked.message).toContain("browser_storage");
+  });
+});
+
+describe("scanDiff", () => {
+  it("exempts its own helper files", () => {
+    const diff = `\
+diff --git a/scripts/_sor_gate_diff.py b/scripts/_sor_gate_diff.py
+--- a/scripts/_sor_gate_diff.py
++++ b/scripts/_sor_gate_diff.py
+@@ -0,0 +1,3 @@
++r"(write_text|write_bytes)"
++r"\\b(auth|session|permission)\\b"
++Path("workspaces.json").write_text("{}")
+`;
+    const [signals] = scanDiff(diff);
+    expect(signals).toHaveLength(0);
+  });
+
+  it("detects filesystem writes in non-exempt paths", () => {
+    const diff = `\
+diff --git a/app/store.py b/app/store.py
+--- a/app/store.py
++++ b/app/store.py
+@@ -0,0 +1 @@
++Path("data.json").write_text(json.dumps(data))
+`;
+    const [signals] = scanDiff(diff);
+    expect(signals.some((s) => s.kind === "filesystem_write")).toBe(true);
+  });
+});
+
+describe("storageMatches", () => {
+  it("matches exact json_file", () => {
+    expect(storageMatches("json_file", "json_file")).toBe(true);
+  });
+
+  it("matches database aliases", () => {
+    expect(storageMatches("database", "application database")).toBe(true);
+  });
+
+  it("filesystem does not match json_file", () => {
+    expect(storageMatches("filesystem", "json_file")).toBe(false);
+  });
+
+  it("database does not match indexeddb (browser)", () => {
+    expect(storageMatches("database", "indexeddb")).toBe(false);
+  });
+});
+
+describe("validateRecord", () => {
+  it("null record returns code 1", () => {
+    const result = validateRecord(null);
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("no architecture.systemOfRecord");
+  });
+
+  it("empty stateSurfaces returns code 1", () => {
+    const result = validateRecord({ stateSurfaces: [] });
+    expect(result.code).toBe(1);
+  });
+
+  it("valid cache surface passes", () => {
+    const record = {
+      stateSurfaces: [
+        {
+          name: "MyCache",
+          classification: "cache",
+          approvedStorage: "json_file",
+          invalidationRules: "expires after 5 minutes",
+        },
+      ],
+    };
+    const result = validateRecord(record);
+    expect(result.code).toBe(0);
+  });
+});
+
+describe("systemOfRecord", () => {
+  it("extracts from top-level architecture", () => {
+    const payload = {
+      architecture: { systemOfRecord: { stateSurfaces: [] } },
+    };
+    expect(systemOfRecord(payload)).not.toBeNull();
+  });
+
+  it("extracts from plan.architecture", () => {
+    const payload = {
+      plan: { architecture: { systemOfRecord: { stateSurfaces: [] } } },
+    };
+    expect(systemOfRecord(payload)).not.toBeNull();
+  });
+
+  it("returns null when absent", () => {
+    expect(systemOfRecord({ plan: {} })).toBeNull();
+  });
+});
+
+describe("architecturePreflightSorMain", () => {
+  it("--story-path passing fixture exits 0", () => {
+    const code = architecturePreflightSorMain([
+      "--story-path",
+      fixture("durable_db_passes.vbrief.json"),
+    ]);
+    expect(code).toBe(0);
+  });
+
+  it("--story-path failing fixture exits 1", () => {
+    const code = architecturePreflightSorMain([
+      "--story-path",
+      fixture("durable_json_fails.vbrief.json"),
+    ]);
+    expect(code).toBe(1);
+  });
+
+  it("no args exits 2", () => {
+    const code = architecturePreflightSorMain([]);
+    expect(code).toBe(2);
+  });
+
+  it("unrecognized arg exits 2", () => {
+    const code = architecturePreflightSorMain(["--unknown-flag"]);
+    expect(code).toBe(2);
+  });
+});

--- a/packages/core/src/architecture/sor-preflight.ts
+++ b/packages/core/src/architecture/sor-preflight.ts
@@ -1,0 +1,1038 @@
+/**
+ * architecture/sor-preflight.ts -- System-of-record architecture preflight gate.
+ *
+ * Faithful TypeScript port of scripts/preflight_architecture_sor.py and
+ * scripts/_sor_gate_diff.py. Answers one question:
+ *   "Is this the correct system of record for this kind of state?"
+ *
+ * Two modes:
+ * - Story/spec mode: validates the story's architecture.systemOfRecord design record.
+ * - Diff mode: scans changed runtime code for risky persistence signals and requires
+ *   a matching design record.
+ *
+ * Exit codes: 0 pass / 1 architecture violation / 2 gate misconfigured
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, extname, join, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Classification constants
+// ---------------------------------------------------------------------------
+
+export const STATE_CLASSIFICATIONS = new Set([
+  "durable_product_state",
+  "auth_session_state",
+  "authorization_state",
+  "audit_event_state",
+  "external_integration_state",
+  "canonical_artifact",
+  "cache",
+  "projection",
+  "import_export_artifact",
+  "dev_only_fixture",
+  "ephemeral_ui_state",
+]);
+
+export const DURABLE_CLASSIFICATIONS = new Set([
+  "durable_product_state",
+  "auth_session_state",
+  "authorization_state",
+  "audit_event_state",
+  "external_integration_state",
+]);
+
+export const SECURITY_CLASSIFICATIONS = new Set(["auth_session_state", "authorization_state"]);
+
+export const LOCAL_STORAGE_CLASSES = new Set([
+  "json_file",
+  "yaml_file",
+  "toml_file",
+  "sqlite_file",
+  "browser_storage",
+  "in_memory",
+  "local_config",
+  "filesystem",
+]);
+
+export const FILE_STORAGE_CLASSES = new Set(["json_file", "yaml_file", "toml_file", "filesystem"]);
+
+export const DB_STORAGE_ALIASES = new Set([
+  "application_database",
+  "database",
+  "db",
+  "postgres",
+  "postgresql",
+  "mysql",
+  "mariadb",
+  "sqlite",
+  "sqlite_file",
+  "sql",
+  "dynamodb",
+  "firestore",
+  "cosmosdb",
+]);
+
+export const EXTERNAL_STORAGE_ALIASES = new Set([
+  "external_service",
+  "service",
+  "provider",
+  "external_provider",
+  "third_party_provider",
+  "api_provider",
+]);
+
+const STORAGE_ALIASES: Record<string, Set<string>> = {
+  json_file: new Set(["json", "json_file", "local_json", "mutable_json"]),
+  yaml_file: new Set(["yaml", "yml", "yaml_file", "local_yaml", "mutable_yaml"]),
+  toml_file: new Set(["toml", "toml_file", "local_toml", "mutable_toml"]),
+  sqlite_file: new Set(["sqlite", "sqlite_file", "sqlite_db", "db_file", "local_db"]),
+  browser_storage: new Set([
+    "browser_storage",
+    "local_storage",
+    "session_storage",
+    "indexeddb",
+    "indexed_db",
+  ]),
+  in_memory: new Set(["in_memory", "memory", "process_memory", "process_local"]),
+  filesystem: new Set(["filesystem", "file", "files", "local_file", "local_files"]),
+  database: DB_STORAGE_ALIASES,
+  external_service: EXTERNAL_STORAGE_ALIASES,
+};
+
+export const DURABLE_REQUIRED_FIELDS = [
+  "owner",
+  "approvedStorage",
+  "permissionBoundary",
+  "migrationRequired",
+  "auditRequired",
+  "concurrencyRequired",
+  "concurrencySemantics",
+  "transactionBoundary",
+  "recoverySemantics",
+  "conflictDetection",
+  "deleteSemantics",
+  "migrationPath",
+];
+
+export const LOW_RISK_PATH_PREFIXES: readonly string[] = [
+  ".github/",
+  "docs/",
+  "history/",
+  "meta/",
+  "references/",
+  "templates/",
+  "tests/",
+  "vbrief/",
+];
+
+export const LOW_RISK_SUFFIXES = new Set([".md", ".rst", ".txt"]);
+
+export const SCANNER_EXEMPT_PATHS = new Set([
+  "scripts/preflight_architecture_sor.py",
+  "scripts/_sor_gate_diff.py",
+]);
+
+// ---------------------------------------------------------------------------
+// Data structures
+// ---------------------------------------------------------------------------
+
+export interface GateFinding {
+  reason: string;
+  requiredFix: string;
+  stateSurface?: string;
+  classification?: string;
+  detectedStorage?: string;
+  approvedStorage?: string;
+}
+
+export interface GateResult {
+  code: number;
+  message: string;
+  findings: readonly GateFinding[];
+}
+
+export interface DetectedSignal {
+  kind: string;
+  path: string;
+  line: number | null;
+  detail: string;
+  storage?: string;
+}
+
+type JsonObj = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Normalization helpers
+// ---------------------------------------------------------------------------
+
+export function norm(value: unknown): string {
+  let text = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  text = text.replace(/[\s./:-]+/g, "_");
+  text = text.replace(/_+/g, "_");
+  return text.replace(/^_+|_+$/g, "");
+}
+
+function asStringList(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.filter((item) => typeof item === "string") as string[];
+  return [];
+}
+
+function nonEmpty(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value) || (typeof value === "object" && value !== null)) {
+    return Object.keys(value).length > 0 || (Array.isArray(value) && value.length > 0);
+  }
+  if (typeof value === "boolean") return true;
+  return value !== null && value !== undefined;
+}
+
+function truthyFlag(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    return ["1", "true", "yes", "on", "guarded", "excluded"].includes(value.trim().toLowerCase());
+  }
+  return false;
+}
+
+function _containsAny(text: string, tokens: Set<string>): boolean {
+  const normalised = norm(text);
+  for (const token of tokens) {
+    if (normalised.includes(token)) return true;
+  }
+  return false;
+}
+
+export function storageMatches(storage: string, declared: unknown): boolean {
+  const wanted = norm(storage);
+  const aliases = new Set<string>([wanted]);
+  const baseAliases = STORAGE_ALIASES[wanted];
+  if (baseAliases) for (const a of baseAliases) aliases.add(a);
+  if (DB_STORAGE_ALIASES.has(wanted)) for (const a of DB_STORAGE_ALIASES) aliases.add(a);
+  if (EXTERNAL_STORAGE_ALIASES.has(wanted))
+    for (const a of EXTERNAL_STORAGE_ALIASES) aliases.add(a);
+
+  const longAliases = new Set([...aliases].filter((a) => a.length > 6));
+
+  for (const item of asStringList(declared)) {
+    const token = norm(item);
+    if (aliases.has(token)) return true;
+    if (token.length > 6 && [...longAliases].some((alias) => token.includes(alias))) return true;
+  }
+  return false;
+}
+
+function approvedStorageText(surface: JsonObj): string {
+  const values = asStringList(surface.approvedStorage);
+  return values.length > 0 ? values.join(", ") : "<missing>";
+}
+
+function storageIsLocalUnsafe(value: unknown): boolean {
+  for (const item of asStringList(value)) {
+    const token = norm(item);
+    if (LOCAL_STORAGE_CLASSES.has(token)) return true;
+    if ([...LOCAL_STORAGE_CLASSES].some((alias) => token.includes(alias))) return true;
+  }
+  return false;
+}
+
+function _approvedDatabase(value: unknown): boolean {
+  return asStringList(value).some((item) => storageMatches("database", item));
+}
+
+function _approvedExternal(value: unknown): boolean {
+  return asStringList(value).some((item) => storageMatches("external_service", item));
+}
+
+// ---------------------------------------------------------------------------
+// JSON loading
+// ---------------------------------------------------------------------------
+
+function loadJsonFile(path: string): [JsonObj | null, GateResult | null] {
+  if (!existsSync(path)) {
+    return [
+      null,
+      {
+        code: 2,
+        message: `system-of-record gate misconfigured: story path not found: ${path}`,
+        findings: [],
+      },
+    ];
+  }
+  if (!statSync(path).isFile()) {
+    return [
+      null,
+      {
+        code: 2,
+        message: `system-of-record gate misconfigured: story path is not a file: ${path}`,
+        findings: [],
+      },
+    ];
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    return [
+      null,
+      {
+        code: 2,
+        message: `system-of-record gate misconfigured: could not read ${path}: ${String(err)}`,
+        findings: [],
+      },
+    ];
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch (err: unknown) {
+    const e = err as { message?: string; lineNumber?: number };
+    return [
+      null,
+      {
+        code: 2,
+        message: `system-of-record gate misconfigured: ${path} is not valid JSON: ${e.message ?? String(err)}`,
+        findings: [],
+      },
+    ];
+  }
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return [
+      null,
+      {
+        code: 2,
+        message: `system-of-record gate misconfigured: ${path} top-level value is not an object`,
+        findings: [],
+      },
+    ];
+  }
+  return [payload as JsonObj, null];
+}
+
+// ---------------------------------------------------------------------------
+// Record extraction
+// ---------------------------------------------------------------------------
+
+export function systemOfRecord(payload: JsonObj): JsonObj | null {
+  const architecture = payload.architecture;
+  if (typeof architecture === "object" && architecture !== null && !Array.isArray(architecture)) {
+    const sor = (architecture as JsonObj).systemOfRecord;
+    if (typeof sor === "object" && sor !== null && !Array.isArray(sor)) return sor as JsonObj;
+  }
+  const plan = payload.plan;
+  if (typeof plan === "object" && plan !== null && !Array.isArray(plan)) {
+    const planArch = (plan as JsonObj).architecture;
+    if (typeof planArch === "object" && planArch !== null && !Array.isArray(planArch)) {
+      const sor = (planArch as JsonObj).systemOfRecord;
+      if (typeof sor === "object" && sor !== null && !Array.isArray(sor)) return sor as JsonObj;
+    }
+  }
+  return null;
+}
+
+function storyMentionsReferenceApp(payload: JsonObj): boolean {
+  const text = JSON.stringify(payload).toLowerCase();
+  return /reference[- ]app|reference application|modeled after|modelled after|parity/.test(text);
+}
+
+function recordSurfaces(record: JsonObj): JsonObj[] {
+  const surfaces = record.stateSurfaces;
+  if (!Array.isArray(surfaces)) return [];
+  return surfaces.filter(
+    (s) => typeof s === "object" && s !== null && !Array.isArray(s),
+  ) as JsonObj[];
+}
+
+function surfaceName(surface: JsonObj): string {
+  const name = surface.name;
+  return typeof name === "string" && name.trim().length > 0 ? name.trim() : "<unnamed>";
+}
+
+function surfaceClassification(surface: JsonObj): string {
+  const raw = surface.classification;
+  if (typeof raw !== "string") return "";
+  return norm(raw);
+}
+
+function surfaceAllowsStorage(surface: JsonObj, storage: string): boolean {
+  const approvedList = surface.approvedStorage;
+  if (storageMatches(storage, approvedList)) return true;
+  const forbiddenList = surface.forbiddenStorage;
+  if (storageMatches(storage, forbiddenList)) return false;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Surface validation
+// ---------------------------------------------------------------------------
+
+function formatFailure(findings: GateFinding[]): string {
+  const lines: string[] = ["FAIL system-of-record gate: architecture violations found."];
+  for (const finding of findings) {
+    lines.push(`  Violation: ${finding.reason}`);
+    lines.push(`  Fix: ${finding.requiredFix}`);
+    if (finding.stateSurface) lines.push(`  Surface: ${finding.stateSurface}`);
+    if (finding.detectedStorage) lines.push(`  Detected storage: ${finding.detectedStorage}`);
+    if (finding.approvedStorage) lines.push(`  Approved storage: ${finding.approvedStorage}`);
+  }
+  return lines.join("\n");
+}
+
+function validateSurface(surface: JsonObj, findings: GateFinding[]): void {
+  const name = surfaceName(surface);
+  const classification = surfaceClassification(surface);
+
+  if (!STATE_CLASSIFICATIONS.has(classification)) {
+    findings.push({
+      stateSurface: name,
+      reason: `Unknown or missing classification '${classification}' for state surface '${name}'.`,
+      requiredFix: `Set classification to one of: ${[...STATE_CLASSIFICATIONS].join(", ")}.`,
+    });
+    return;
+  }
+
+  if (DURABLE_CLASSIFICATIONS.has(classification)) {
+    const approvedList = surface.approvedStorage;
+    if (!approvedList || (Array.isArray(approvedList) && approvedList.length === 0)) {
+      findings.push({
+        stateSurface: name,
+        classification,
+        reason: `Durable state surface '${name}' has no approvedStorage.`,
+        requiredFix: "Declare the approved storage system (e.g., database, external_service).",
+      });
+    }
+
+    if (storageIsLocalUnsafe(approvedList)) {
+      findings.push({
+        stateSurface: name,
+        classification,
+        detectedStorage: approvedStorageText(surface),
+        reason: `Durable state surface '${name}' approves unsafe local storage.`,
+        requiredFix:
+          "Durable state must use a database or external service, not local file/memory storage.",
+      });
+    }
+
+    for (const field of DURABLE_REQUIRED_FIELDS) {
+      if (!nonEmpty(surface[field])) {
+        findings.push({
+          stateSurface: name,
+          classification,
+          reason: `Durable state surface '${name}' is missing required field '${field}'.`,
+          requiredFix: `Add '${field}' to the design record surface for '${name}'.`,
+        });
+      }
+    }
+  }
+
+  if (classification === "cache") {
+    const approvedList = surface.approvedStorage;
+    if (approvedList && FILE_STORAGE_CLASSES.has(norm(asStringList(approvedList)[0] ?? ""))) {
+      if (!nonEmpty(surface.invalidationRules)) {
+        findings.push({
+          stateSurface: name,
+          classification,
+          reason: `Cache surface '${name}' uses file storage but has no invalidation rules.`,
+          requiredFix: "Add invalidationRules describing when the cache is invalidated.",
+        });
+      }
+    }
+  }
+
+  if (
+    classification === "import_export_artifact" &&
+    (truthyFlag(surface.liveState) || truthyFlag(surface.authoritative))
+  ) {
+    findings.push({
+      stateSurface: name,
+      classification,
+      reason: "Import/export artifact is marked as live or authoritative state.",
+      requiredFix: "Use it only as a temporary transfer artifact, not live application state.",
+    });
+  }
+
+  if (
+    classification === "canonical_artifact" &&
+    (truthyFlag(surface.mutable) || truthyFlag(surface.authoritative))
+  ) {
+    findings.push({
+      stateSurface: name,
+      classification,
+      reason: "Canonical artifact is marked mutable or authoritative app persistence.",
+      requiredFix:
+        "Use canonical artifacts as evidence/source-authored input, not mutable app records.",
+    });
+  }
+}
+
+const REFERENCE_EVIDENCE_GROUPS: Record<string, Set<string>> = {
+  persistence: new Set(["persistence", "database", "schema", "storage", "repository"]),
+  auth: new Set(["auth", "authentication", "session", "identity"]),
+  permission: new Set(["permission", "authorization", "ownership", "membership", "role"]),
+};
+
+function validateReferenceApps(
+  record: JsonObj,
+  storyPayload: JsonObj | null | undefined,
+  findings: GateFinding[],
+): void {
+  if (!storyMentionsReferenceApp({ ...(record ?? {}), ...(storyPayload ?? {}) })) return;
+
+  const refs = record.referenceApplicationComparisons;
+  if (!Array.isArray(refs) || refs.length === 0) {
+    findings.push({
+      reason: "Reference-application parity story missing referenceApplicationComparisons.",
+      requiredFix:
+        "Add referenceApplicationComparisons documenting how this implementation compares to the reference app's persistence, auth, and permission handling.",
+    });
+    return;
+  }
+  for (const group of Object.keys(REFERENCE_EVIDENCE_GROUPS)) {
+    const groupTerms = REFERENCE_EVIDENCE_GROUPS[group]!;
+    const covered = (refs as unknown[]).some((ref) => {
+      const text = JSON.stringify(ref).toLowerCase();
+      return [...groupTerms].some((term) => text.includes(term));
+    });
+    if (!covered) {
+      findings.push({
+        reason: `Reference-application parity story is missing '${group}' comparison in referenceApplicationComparisons.`,
+        requiredFix: `Add a comparison entry covering ${group} semantics.`,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Signal validation
+// ---------------------------------------------------------------------------
+
+function signalLocation(signal: DetectedSignal): string {
+  return signal.line !== null ? `${signal.path}:${signal.line}` : signal.path;
+}
+
+function validateSignals(record: JsonObj, signals: DetectedSignal[]): GateFinding[] {
+  const surfaces = recordSurfaces(record);
+  const findings: GateFinding[] = [];
+  const durableSurfaces = surfaces.filter((s) =>
+    DURABLE_CLASSIFICATIONS.has(surfaceClassification(s)),
+  );
+  const authSurfaces = surfaces.filter((s) =>
+    SECURITY_CLASSIFICATIONS.has(surfaceClassification(s)),
+  );
+
+  for (const signal of signals) {
+    if (signal.storage) {
+      const matchingSurfaces = surfaces.filter((s) => surfaceAllowsStorage(s, signal.storage!));
+      const forbiddenMatches = surfaces.filter((s) =>
+        asStringList(s.forbiddenStorage).some((item) => storageMatches(signal.storage!, item)),
+      );
+      if (forbiddenMatches.length > 0) {
+        const surface = forbiddenMatches[0]!;
+        findings.push({
+          stateSurface: surfaceName(surface),
+          classification: surfaceClassification(surface),
+          detectedStorage: signal.storage,
+          approvedStorage: approvedStorageText(surface),
+          reason: `The diff implements ${signal.storage} at ${signalLocation(signal)}, but the design record forbids that storage.`,
+          requiredFix:
+            "Move the implementation to the approved system of record or update the design record before implementation.",
+        });
+      } else if (matchingSurfaces.length === 0) {
+        findings.push({
+          detectedStorage: signal.storage,
+          reason: `The diff implements ${signal.storage} at ${signalLocation(signal)} without a state surface that approves it.`,
+          requiredFix:
+            "Declare a matching state surface, or move the implementation to the approved system of record.",
+        });
+      }
+    }
+
+    if (signal.kind === "mutation_endpoint" && durableSurfaces.length === 0) {
+      findings.push({
+        reason: `Stateful create/update/delete API signal at ${signalLocation(signal)} has no durable owner in the design record.`,
+        requiredFix:
+          "Declare the durable state surface that owns this mutation, including permission and recovery semantics.",
+      });
+    }
+
+    if (signal.kind === "auth_state" && authSurfaces.length === 0) {
+      findings.push({
+        reason: `Auth/session/permission signal at ${signalLocation(signal)} has no auth_session_state or authorization_state surface.`,
+        requiredFix: "Declare the approved auth/session or authorization system of record.",
+      });
+    }
+
+    if (signal.kind === "workflow_state" && durableSurfaces.length === 0) {
+      findings.push({
+        reason: `Workflow/job/runtime state signal at ${signalLocation(signal)} has no durable or service-backed owner.`,
+        requiredFix: "Declare the job/workflow state owner and recovery semantics.",
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// validate_record
+// ---------------------------------------------------------------------------
+
+export function validateRecord(
+  record: JsonObj | null,
+  opts: { storyPayload?: JsonObj | null; signals?: DetectedSignal[] } = {},
+): GateResult {
+  if (record === null) {
+    const finding: GateFinding = {
+      reason: "Triggered story has no architecture.systemOfRecord design record.",
+      requiredFix:
+        "Add a system-of-record block classifying each state surface before implementation.",
+    };
+    return { code: 1, message: formatFailure([finding]), findings: [finding] };
+  }
+
+  const findings: GateFinding[] = [];
+  const surfaces = recordSurfaces(record);
+  if (!Array.isArray(record.stateSurfaces) || surfaces.length === 0) {
+    findings.push({
+      reason: "systemOfRecord.stateSurfaces is missing or empty.",
+      requiredFix: "Declare at least one state surface with classification and approvedStorage.",
+    });
+  }
+  for (const surface of surfaces) {
+    validateSurface(surface, findings);
+  }
+
+  validateReferenceApps(record, opts.storyPayload ?? null, findings);
+
+  if (opts.signals && opts.signals.length > 0) {
+    findings.push(...validateSignals(record, opts.signals));
+  }
+
+  if (findings.length > 0) {
+    return { code: 1, message: formatFailure(findings), findings };
+  }
+  return { code: 0, message: "OK system-of-record gate passed.", findings: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Diff scanner (port of _sor_gate_diff.py)
+// ---------------------------------------------------------------------------
+
+function isLowRiskPath(path: string): boolean {
+  const clean = path.replace(/^\.\//, "");
+  if (SCANNER_EXEMPT_PATHS.has(clean)) return true;
+  if (LOW_RISK_SUFFIXES.has(extname(clean).toLowerCase())) return true;
+  return LOW_RISK_PATH_PREFIXES.some((prefix) => clean.startsWith(prefix));
+}
+
+function storageFromLine(path: string, line: string): string {
+  const text = `${path} ${line}`.toLowerCase();
+  if (/\.ya?ml\b/.test(text)) return "yaml_file";
+  if (/\.toml\b/.test(text)) return "toml_file";
+  if (/\.(sqlite|sqlite3|db)\b/.test(text)) return "sqlite_file";
+  if (/\.json\b/.test(text)) return "json_file";
+  return "filesystem";
+}
+
+function pathNameSignal(path: string): DetectedSignal | null {
+  if (isLowRiskPath(path)) return null;
+  const name = basename(path).toLowerCase();
+  if (
+    /(registry|repository|store|manager|service)/.test(name) &&
+    /\.(py|js|jsx|ts|tsx|go|rb|java|kt)$/.test(name)
+  ) {
+    return { kind: "state_module", path, line: null, detail: "stateful module name" };
+  }
+  if (/migrations?\//.test(path) || /\bmigration/.test(name)) {
+    return {
+      kind: "database_model",
+      path,
+      line: null,
+      detail: "database migration path",
+      storage: "database",
+    };
+  }
+  return null;
+}
+
+function looksLikeWorkflowStateChange(stripped: string): boolean {
+  if (/^(#|\/\/|\/\*|\*)/.test(stripped)) return false;
+  const term =
+    "(workflow|workflows|job|jobs|queue|queues|runtime|orchestration|job_queue|workflow_queue|runtime_state|orchestration_state|worker_state|run_state)";
+  const action =
+    "(create|schedule|enqueue|dequeue|start|complete|fail|cancel|retry|update|delete|upsert|persist|save|load|restore|claim|lease|dispatch)";
+  const patterns = [
+    new RegExp(`\\b(def|function|func)\\s+(${action}_${term}|${term}_${action})\\b`, "i"),
+    /\b(class|type)\s+\w*(Workflow|Job|Queue|Runtime|Orchestration|WorkerState|RunState)\w*/,
+    new RegExp(
+      `\\b(${term})\\.(append|add|put|enqueue|dequeue|submit|dispatch|schedule|start|complete|fail|cancel|retry|update|delete|save|persist)\\s*\\(`,
+      "i",
+    ),
+    new RegExp(`\\b(${term})\\s*\\[[^\\]]+\\]\\s*=`, "i"),
+    new RegExp(`\\b(${term})\\s*=\\s*(new\\s+Map\\(|\\{\\}|\\[\\])`, "i"),
+    new RegExp(`\\b(${action}_${term}|${term}_${action})\\s*\\(`, "i"),
+  ];
+  return patterns.some((p) => p.test(stripped));
+}
+
+function lineSignals(path: string, lineNo: number | null, line: string): DetectedSignal[] {
+  if (isLowRiskPath(path)) return [];
+  const stripped = line.trim();
+  const signals: DetectedSignal[] = [];
+
+  if (
+    /write_text|write_bytes|fs\.(writeFile|writeFileSync|appendFile|createWriteStream)|Deno\.write(Text)?File|os\.WriteFile|ioutil\.WriteFile|Files\.write|open\([^)]*,\s*['"][^'"]*[wax]/.test(
+      stripped,
+    )
+  ) {
+    signals.push({
+      kind: "filesystem_write",
+      path,
+      line: lineNo,
+      detail: stripped,
+      storage: storageFromLine(path, stripped),
+    });
+  }
+
+  if (/\b(localStorage|sessionStorage|indexedDB|caches\.open)\b/.test(stripped)) {
+    signals.push({
+      kind: "browser_storage",
+      path,
+      line: lineNo,
+      detail: stripped,
+      storage: "browser_storage",
+    });
+  }
+
+  const pathName = basename(path).toLowerCase();
+  if (
+    /(registry|repository|store|manager)/.test(pathName) &&
+    /(new\s+Map\(|=\s*\{\}\s*(#|\/\/|$)|:\s*dict\[)/.test(stripped)
+  ) {
+    signals.push({
+      kind: "in_memory_state",
+      path,
+      line: lineNo,
+      detail: stripped,
+      storage: "in_memory",
+    });
+  }
+
+  if (
+    /@\w+\.(post|put|patch|delete)\b|\b(router|app)\.(post|put|patch|delete)\s*\(|\b(def|function|func)\s+(create|select|update|delete|upsert)_?/i.test(
+      stripped,
+    )
+  ) {
+    signals.push({ kind: "mutation_endpoint", path, line: lineNo, detail: stripped });
+  }
+
+  if (
+    /CREATE\s+TABLE|ALTER\s+TABLE|sqlalchemy|db\.Column|models\.Model|prisma|typeorm|sequelize|ActiveRecord/i.test(
+      stripped,
+    )
+  ) {
+    signals.push({
+      kind: "database_model",
+      path,
+      line: lineNo,
+      detail: stripped,
+      storage: "database",
+    });
+  }
+
+  if (/\b(auth|session|permission|membership|role|grant|tenant|organization)\b/i.test(stripped)) {
+    signals.push({ kind: "auth_state", path, line: lineNo, detail: stripped });
+  }
+
+  if (looksLikeWorkflowStateChange(stripped)) {
+    signals.push({ kind: "workflow_state", path, line: lineNo, detail: stripped });
+  }
+
+  return signals;
+}
+
+export function scanDiff(diffText: string): [DetectedSignal[], string[]] {
+  const signals: DetectedSignal[] = [];
+  const changedPaths: string[] = [];
+  let currentPath: string | null = null;
+  let newLineNo: number | null = null;
+
+  for (const rawLine of diffText.split("\n")) {
+    if (rawLine.startsWith("diff --git ")) {
+      const parts = rawLine.split(/\s+/);
+      if (parts.length >= 4) {
+        const candidate = parts[3] ?? "";
+        currentPath = candidate.startsWith("b/") ? candidate.slice(2) : candidate;
+        if (!changedPaths.includes(currentPath)) {
+          changedPaths.push(currentPath);
+          const ps = pathNameSignal(currentPath);
+          if (ps) signals.push(ps);
+        }
+      }
+      newLineNo = null;
+      continue;
+    }
+
+    if (rawLine.startsWith("+++ ")) {
+      const target = rawLine.slice(4).trim();
+      if (target === "/dev/null") {
+        currentPath = null;
+        continue;
+      }
+      currentPath = target.startsWith("b/") ? target.slice(2) : target;
+      if (!changedPaths.includes(currentPath)) {
+        changedPaths.push(currentPath);
+        const ps = pathNameSignal(currentPath);
+        if (ps) signals.push(ps);
+      }
+      continue;
+    }
+
+    if (rawLine.startsWith("@@ ")) {
+      const m = rawLine.match(/\+(\d+)/);
+      newLineNo = m ? parseInt(m[1]!, 10) : null;
+      continue;
+    }
+
+    if (currentPath === null) continue;
+
+    if (rawLine.startsWith("+") && !rawLine.startsWith("+++")) {
+      const line = rawLine.slice(1);
+      signals.push(...lineSignals(currentPath, newLineNo, line));
+      if (newLineNo !== null) newLineNo += 1;
+    } else if (rawLine.startsWith("-") && !rawLine.startsWith("---")) {
+      // skip removed lines
+    } else if (newLineNo !== null) {
+      newLineNo += 1;
+    }
+  }
+
+  return [signals, changedPaths];
+}
+
+function changedStoryRecords(
+  projectRoot: string,
+  changedPaths: string[],
+): [Array<[string, JsonObj, JsonObj]>, GateResult | null] {
+  const records: Array<[string, JsonObj, JsonObj]> = [];
+  for (const rel of changedPaths) {
+    if (!rel.endsWith(".vbrief.json")) continue;
+    if (
+      !rel.startsWith("vbrief/active/") &&
+      !rel.startsWith("vbrief/pending/") &&
+      !rel.startsWith("vbrief/proposed/")
+    )
+      continue;
+    const path = join(resolve(projectRoot), rel);
+    const [payload, error] = loadJsonFile(path);
+    if (error !== null) return [[], error];
+    if (payload !== null) {
+      const record = systemOfRecord(payload);
+      if (record !== null) records.push([path, payload, record]);
+    }
+  }
+  return [records, null];
+}
+
+export function evaluateDiffText(
+  diffText: string,
+  opts: { projectRoot: string; storyPath?: string },
+): GateResult {
+  const [signals, changedPaths] = scanDiff(diffText);
+  if (signals.length === 0) {
+    return {
+      code: 0,
+      message: "OK system-of-record gate passed: no stateful diff signals detected.",
+      findings: [],
+    };
+  }
+
+  let payload: JsonObj | null = null;
+  let record: JsonObj | null = null;
+
+  if (opts.storyPath) {
+    const [p, error] = loadJsonFile(opts.storyPath);
+    if (error !== null) return error;
+    payload = p;
+    if (payload) record = systemOfRecord(payload);
+  } else {
+    const [records, error] = changedStoryRecords(opts.projectRoot, changedPaths);
+    if (error !== null) return error;
+    if (records.length === 1) {
+      [, payload, record] = records[0]!;
+    } else if (records.length > 1) {
+      return {
+        code: 2,
+        message:
+          "system-of-record gate misconfigured: multiple changed vBRIEFs contain system-of-record records; pass --story-path.",
+        findings: [],
+      };
+    }
+  }
+
+  if (record === null) {
+    const finding: GateFinding = {
+      reason:
+        "Diff contains stateful persistence signals, but no matching architecture.systemOfRecord design record was supplied or changed.",
+      requiredFix:
+        "Run `task architecture:sor-preflight -- --story-path <path>` after adding the design record, or pass --story-path to this diff gate.",
+      detectedStorage: signals[0]?.storage,
+    };
+    return { code: 1, message: formatFailure([finding]), findings: [finding] };
+  }
+
+  const result = validateRecord(record, { storyPayload: payload, signals });
+  if (result.code === 0) {
+    return {
+      code: 0,
+      message: `OK system-of-record gate passed: ${signals.length} stateful diff signal(s) matched.`,
+      findings: [],
+    };
+  }
+  return result;
+}
+
+function gitDiff(projectRoot: string, baseRef: string): [string | null, GateResult | null] {
+  const result = spawnSync("git", ["diff", "--unified=0", "--no-ext-diff", baseRef, "--"], {
+    cwd: resolve(projectRoot),
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  if (result.error) {
+    return [
+      null,
+      {
+        code: 2,
+        message: `system-of-record gate misconfigured: could not run git diff: ${result.error.message}`,
+        findings: [],
+      },
+    ];
+  }
+  if (result.status !== 0) {
+    const detail =
+      (result.stderr ?? "").trim() ||
+      (result.stdout ?? "").trim() ||
+      `git diff exited ${result.status}`;
+    return [
+      null,
+      {
+        code: 2,
+        message: `system-of-record gate misconfigured: could not diff against ${baseRef}: ${detail}`,
+        findings: [],
+      },
+    ];
+  }
+  return [result.stdout ?? "", null];
+}
+
+export function evaluateDiff(
+  projectRoot: string,
+  baseRef: string,
+  opts: { storyPath?: string } = {},
+): GateResult {
+  const [diffText, error] = gitDiff(projectRoot, baseRef);
+  if (error !== null) return error;
+  return evaluateDiffText(diffText!, { projectRoot, ...opts });
+}
+
+export function evaluateStory(storyPath: string): GateResult {
+  const [payload, error] = loadJsonFile(storyPath);
+  if (error !== null) return error;
+  return validateRecord(systemOfRecord(payload!), { storyPayload: payload });
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function emitJson(result: GateResult): string {
+  return JSON.stringify({
+    ok: result.code === 0,
+    exit_code: result.code,
+    message: result.message,
+    findings: result.findings.map((f) => ({
+      state_surface: f.stateSurface ?? null,
+      classification: f.classification ?? null,
+      detected_storage: f.detectedStorage ?? null,
+      approved_storage: f.approvedStorage ?? null,
+      reason: f.reason,
+      required_fix: f.requiredFix,
+    })),
+  });
+}
+
+function parseSorArgs(argv: string[]): {
+  storyPath?: string;
+  baseRef?: string;
+  projectRoot: string;
+  emitJson: boolean;
+  error?: string;
+} {
+  let storyPath: string | undefined;
+  let baseRef: string | undefined;
+  let projectRoot = ".";
+  let doEmitJson = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--story-path") {
+      storyPath = argv[i + 1];
+      i += 1;
+    } else if (arg?.startsWith("--story-path=")) {
+      storyPath = arg.slice("--story-path=".length);
+    } else if (arg === "--base-ref") {
+      baseRef = argv[i + 1];
+      i += 1;
+    } else if (arg?.startsWith("--base-ref=")) {
+      baseRef = arg.slice("--base-ref=".length);
+    } else if (arg === "--project-root") {
+      projectRoot = argv[i + 1] ?? ".";
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      projectRoot = arg.slice("--project-root=".length);
+    } else if (arg === "--json") {
+      doEmitJson = true;
+    } else {
+      return { projectRoot, emitJson: doEmitJson, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return { storyPath, baseRef, projectRoot, emitJson: doEmitJson };
+}
+
+/** CLI entry for architecture-preflight-sor (mirrors preflight_architecture_sor.py main()). */
+export function architecturePreflightSorMain(argv: string[]): number {
+  const parsed = parseSorArgs(argv);
+  if (parsed.error !== undefined) {
+    process.stderr.write(`Error: ${parsed.error}\n`);
+    return 2;
+  }
+
+  const { storyPath, baseRef, projectRoot, emitJson: doEmitJson } = parsed;
+  let result: GateResult;
+
+  if (baseRef !== undefined) {
+    result = evaluateDiff(projectRoot, baseRef, { storyPath });
+  } else if (storyPath !== undefined) {
+    result = evaluateStory(storyPath);
+  } else {
+    result = {
+      code: 2,
+      message: "system-of-record gate misconfigured: pass --story-path, --base-ref, or both.",
+      findings: [],
+    };
+  }
+
+  if (doEmitJson) {
+    process.stdout.write(`${emitJson(result)}\n`);
+  } else if (result.code === 0) {
+    process.stdout.write(`${result.message}\n`);
+  } else {
+    process.stderr.write(`${result.message}\n`);
+  }
+
+  return result.code;
+}

--- a/packages/core/src/content-contracts/standards/system_of_record_gate.test.ts
+++ b/packages/core/src/content-contracts/standards/system_of_record_gate.test.ts
@@ -35,7 +35,8 @@ describe("test_system_of_record_gate.py", () => {
     const verify_tasks = readText("tasks/verify.yml");
     expect(taskfile).toContain("tasks/architecture.yml");
     expect(architecture_tasks).toContain("sor-preflight");
-    expect(architecture_tasks).toContain("preflight_architecture_sor.py");
+    // architecture.yml now dispatches via Node.js CLI (wire-flipped in #1854)
+    expect(architecture_tasks).toContain("architecture-preflight-sor");
     expect(verify_tasks).toContain("architecture-sor");
     expect(verify_tasks).toContain("preflight_architecture_sor.py");
   });

--- a/packages/core/src/platform/changelog-cli.test.ts
+++ b/packages/core/src/platform/changelog-cli.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Vitest tests for changelog-cli.ts (wire-flip CLI wrapper for changelog:resolve-unreleased).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { changelogResolveUnreleasedMain } from "./changelog-cli.js";
+
+const MINIMAL_CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+### Added
+- Some new feature
+
+## [1.0.0] - 2024-01-01
+
+### Added
+- Initial release
+`;
+
+describe("changelogResolveUnreleasedMain", () => {
+  let dir = "";
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "changelog-cli-test-"));
+  });
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = "";
+    }
+  });
+
+  it("exits 0 with valid CHANGELOG on dry-run", () => {
+    const p = join(dir, "CHANGELOG.md");
+    writeFileSync(p, MINIMAL_CHANGELOG, "utf8");
+    const code = changelogResolveUnreleasedMain(["--changelog-path", p, "--dry-run"]);
+    expect(code).toBe(0);
+  });
+
+  it("exits 0 silently with --quiet flag", () => {
+    const p = join(dir, "CHANGELOG.md");
+    writeFileSync(p, MINIMAL_CHANGELOG, "utf8");
+    const code = changelogResolveUnreleasedMain(["--changelog-path", p, "--dry-run", "--quiet"]);
+    expect(code).toBe(0);
+  });
+
+  it("exits 0 with --changelog-path= equals form", () => {
+    const p = join(dir, "CHANGELOG.md");
+    writeFileSync(p, MINIMAL_CHANGELOG, "utf8");
+    const code = changelogResolveUnreleasedMain([`--changelog-path=${p}`, "--dry-run"]);
+    expect(code).toBe(0);
+  });
+
+  it("exits 2 for missing --changelog-path value", () => {
+    const code = changelogResolveUnreleasedMain(["--changelog-path"]);
+    expect(code).toBe(2);
+  });
+
+  it("exits 2 for unrecognized argument", () => {
+    const code = changelogResolveUnreleasedMain(["--unknown-flag"]);
+    expect(code).toBe(2);
+  });
+
+  it("handles non-existent CHANGELOG path", () => {
+    const p = join(dir, "nonexistent.md");
+    const code = changelogResolveUnreleasedMain(["--changelog-path", p, "--dry-run"]);
+    // evaluateChangelogPath returns a non-zero code when file doesn't exist
+    expect(code).not.toBe(0);
+  });
+
+  it("handles non-file path (directory)", () => {
+    const subdir = join(dir, "subdir");
+    mkdirSync(subdir);
+    const code = changelogResolveUnreleasedMain(["--changelog-path", subdir, "--dry-run"]);
+    expect(code).not.toBe(0);
+  });
+});

--- a/packages/core/src/platform/changelog-cli.ts
+++ b/packages/core/src/platform/changelog-cli.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { evaluateChangelogPath } from "./resolve-changelog-unreleased.js";
+
+function parseChangelogCliArgs(argv: string[]): {
+  changelogPath: string;
+  dryRun: boolean;
+  quiet: boolean;
+  error?: string;
+} {
+  let changelogPath = "CHANGELOG.md";
+  let dryRun = false;
+  let quiet = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--changelog-path") {
+      const v = argv[i + 1];
+      if (v === undefined) {
+        return { changelogPath, dryRun, quiet, error: "missing --changelog-path value" };
+      }
+      changelogPath = v;
+      i += 1;
+    } else if (arg?.startsWith("--changelog-path=")) {
+      changelogPath = arg.slice("--changelog-path=".length);
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--quiet") {
+      quiet = true;
+    } else {
+      return { changelogPath, dryRun, quiet, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return { changelogPath, dryRun, quiet };
+}
+
+/** CLI entry for changelog:resolve-unreleased (mirrors resolve_changelog_unreleased.py). */
+export function changelogResolveUnreleasedMain(argv: string[]): number {
+  const parsed = parseChangelogCliArgs(argv);
+  if (parsed.error !== undefined) {
+    process.stderr.write(
+      `resolve_changelog_unreleased: ${parsed.error}\n` +
+        `Usage: changelog-resolve-unreleased [--changelog-path PATH] [--dry-run] [--quiet]\n`,
+    );
+    return 2;
+  }
+
+  const absPath = resolve(parsed.changelogPath);
+  const exists = existsSync(absPath);
+  const isFile = exists && statSync(absPath).isFile();
+
+  const [code, message, warnings] = evaluateChangelogPath(absPath, {
+    exists,
+    isFile,
+    readText: () => readFileSync(absPath, "utf8"),
+    dryRun: parsed.dryRun,
+    writeText: (content) => writeFileSync(absPath, content, "utf8"),
+  });
+
+  for (const w of warnings) {
+    process.stderr.write(`warning: ${w}\n`);
+  }
+
+  if (code === 0) {
+    if (!parsed.quiet) {
+      process.stdout.write(`${message}\n`);
+    }
+  } else {
+    process.stderr.write(`${message}\n`);
+  }
+  return code;
+}

--- a/packages/core/src/scope/decompose.test.ts
+++ b/packages/core/src/scope/decompose.test.ts
@@ -8,14 +8,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  acceptanceTextsFromItems,
   applyDecomposition,
   asStrList,
   DecompositionError,
   decomposeMain,
   deprecatedSubitemsIssues,
+  itemHasAcceptance,
   itemHasTraces,
   itemsHaveAcceptance,
   missingRequiredSwarmFields,
+  storyQualityIssues,
   validateDraft,
 } from "./decompose.js";
 
@@ -483,3 +486,611 @@ function readdirSafe(dir: string): string[] {
     return [];
   }
 }
+
+// ---------------------------------------------------------------------------
+// Shared good narrative fragments
+// ---------------------------------------------------------------------------
+
+const GOOD_DESC =
+  "The auth model persistence behavior stores user identity and session state for the " +
+  "authentication workflow. The story covers focused model changes plus matching unit tests.";
+const GOOD_PLAN =
+  "Update the auth model persistence code so valid payloads are saved through the existing " +
+  "model boundary.\nAdd focused model tests for successful persistence and missing-record " +
+  "behavior using the auth model test fixture.";
+const GOOD_US =
+  "As an auth maintainer, I want persisted user records, so that login state survives requests.";
+const GOOD_AC1 =
+  "Given a valid user payload, when the auth model saves it, then the user record persists.";
+const GOOD_AC2 =
+  "Given an existing user, when the auth model loads it, then the saved identity returns.";
+
+function goodSwarm(): Record<string, unknown> {
+  return {
+    readiness: "ready",
+    parallel_safe: true,
+    file_scope: ["src/auth/model.ts", "tests/auth/model.test.ts"],
+    verify_commands: ["npm test -- auth/model"],
+    expected_outputs: ["auth model tests pass"],
+    depends_on: [],
+    conflict_group: "auth",
+    size: "small",
+    file_scope_confidence: "high",
+    model_tier: "medium",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// acceptanceTextsFromItems / itemHasAcceptance
+// ---------------------------------------------------------------------------
+
+describe("acceptanceTextsFromItems", () => {
+  it("returns empty for non-array", () => {
+    expect(acceptanceTextsFromItems("nope")).toEqual([]);
+    expect(acceptanceTextsFromItems(null)).toEqual([]);
+  });
+
+  it("skips non-object items", () => {
+    expect(acceptanceTextsFromItems([1, "x", null])).toEqual([]);
+  });
+
+  it("collects acceptance from narrative and nested items/subItems", () => {
+    const texts = acceptanceTextsFromItems([
+      { narrative: { Acceptance: "top" } },
+      { items: [{ narrative: { Acceptance: "nested-items" } }] },
+      { subItems: [{ narrative: { Acceptance: "nested-sub" } }] },
+    ]);
+    expect(texts).toContain("top");
+    expect(texts).toContain("nested-items");
+    expect(texts).toContain("nested-sub");
+  });
+});
+
+describe("itemHasAcceptance", () => {
+  it("true when narrative has acceptance", () => {
+    expect(itemHasAcceptance({ narrative: { Acceptance: "x" } })).toBe(true);
+  });
+
+  it("true when nested child has acceptance", () => {
+    expect(itemHasAcceptance({ items: [{ narrative: { Acceptance: "y" } }] })).toBe(true);
+    expect(itemHasAcceptance({ subItems: [{ narrative: { Acceptance: "z" } }] })).toBe(true);
+  });
+
+  it("false when no acceptance anywhere", () => {
+    expect(itemHasAcceptance({ foo: 1 })).toBe(false);
+    expect(itemHasAcceptance({ narrative: { Acceptance: "   " } })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// storyQualityIssues
+// ---------------------------------------------------------------------------
+
+describe("storyQualityIssues", () => {
+  function baseOpts(over: Partial<Parameters<typeof storyQualityIssues>[0]> = {}) {
+    return {
+      title: "Auth model",
+      description: GOOD_DESC,
+      implementationPlan: GOOD_PLAN,
+      userStory: GOOD_US,
+      acceptanceTexts: [GOOD_AC1, GOOD_AC2],
+      acceptanceCountJustification: "",
+      swarm: goodSwarm(),
+      concurrentReady: true,
+      ...over,
+    };
+  }
+
+  it("good story returns no issues", () => {
+    expect(storyQualityIssues(baseOpts())).toEqual([]);
+  });
+
+  it("flags a malformed user story", () => {
+    const issues = storyQualityIssues(baseOpts({ userStory: "I just want stuff" }));
+    expect(issues.some((i) => i.includes("As a <role>"))).toBe(true);
+  });
+
+  it("flags an empty description", () => {
+    const issues = storyQualityIssues(baseOpts({ description: "" }));
+    expect(issues.some((i) => i.includes("Description is required"))).toBe(true);
+  });
+
+  it("flags a too-short description", () => {
+    const issues = storyQualityIssues(baseOpts({ description: "Too short." }));
+    expect(issues.some((i) => i.includes("two concrete sentences"))).toBe(true);
+  });
+
+  it("flags an empty implementation plan", () => {
+    const issues = storyQualityIssues(baseOpts({ implementationPlan: "" }));
+    expect(issues.some((i) => i.includes("ImplementationPlan is required"))).toBe(true);
+  });
+
+  it("flags a generic implementation plan", () => {
+    const issues = storyQualityIssues(baseOpts({ implementationPlan: "Make it work." }));
+    expect(issues.some((i) => i.includes("concrete code paths"))).toBe(true);
+  });
+
+  it("flags a placeholder implementation plan", () => {
+    const issues = storyQualityIssues(
+      baseOpts({
+        implementationPlan:
+          "TODO refine from parent scope later in the model service code with tests.",
+      }),
+    );
+    expect(issues.some((i) => i.includes("must not be placeholder"))).toBe(true);
+  });
+
+  it("flags acceptance count outside 2-5 without justification", () => {
+    const issues = storyQualityIssues(baseOpts({ acceptanceTexts: [GOOD_AC1] }));
+    expect(issues.some((i) => i.includes("2-5 acceptance criteria"))).toBe(true);
+  });
+
+  it("accepts a single acceptance criterion when justified", () => {
+    const issues = storyQualityIssues(
+      baseOpts({
+        acceptanceTexts: [GOOD_AC1],
+        acceptanceCountJustification: "Single behavior is intentionally atomic for this slice.",
+      }),
+    );
+    expect(issues.some((i) => i.includes("2-5 acceptance criteria"))).toBe(false);
+  });
+
+  it("flags placeholder, docs-only, vague, and non-observable acceptance criteria", () => {
+    const issues = storyQualityIssues(
+      baseOpts({
+        acceptanceTexts: [
+          "TBD",
+          "Documentation updated for the relevant section of the docs site.",
+          "The milestone is complete and ready for the next phase of broad project work.",
+        ],
+      }),
+    );
+    expect(issues.some((i) => i.includes("placeholder acceptance"))).toBe(true);
+    expect(issues.some((i) => i.includes("docs-only"))).toBe(true);
+    expect(issues.some((i) => i.includes("observable behavior"))).toBe(true);
+  });
+
+  it("flags acceptance that duplicates the title", () => {
+    const issues = storyQualityIssues(
+      baseOpts({ title: GOOD_AC1, acceptanceTexts: [GOOD_AC1, GOOD_AC2] }),
+    );
+    expect(issues.some((i) => i.includes("duplicates title or description"))).toBe(true);
+  });
+
+  it("flags broad file_scope and generic verify command when concurrent-ready", () => {
+    const swarm = { ...goodSwarm(), file_scope: ["backend"], verify_commands: ["pytest"] };
+    const issues = storyQualityIssues(baseOpts({ swarm }));
+    expect(issues.some((i) => i.includes("broad file_scope"))).toBe(true);
+    expect(issues.some((i) => i.includes("generic verify command"))).toBe(true);
+  });
+
+  it("flags glob file_scope patterns", () => {
+    const swarm = { ...goodSwarm(), file_scope: ["src/*"] };
+    const issues = storyQualityIssues(baseOpts({ swarm }));
+    expect(issues.some((i) => i.includes("broad file_scope"))).toBe(true);
+  });
+
+  it("flags parallel_safe=false and file_scope_confidence=low for ready stories", () => {
+    const swarm = { ...goodSwarm(), parallel_safe: false, file_scope_confidence: "low" };
+    const issues = storyQualityIssues(baseOpts({ swarm }));
+    expect(issues.some((i) => i.includes("parallel_safe=true"))).toBe(true);
+    expect(issues.some((i) => i.includes("file_scope_confidence above low"))).toBe(true);
+  });
+
+  it("skips concurrency checks when not concurrent-ready", () => {
+    const swarm = { ...goodSwarm(), file_scope: ["backend"], verify_commands: ["pytest"] };
+    const issues = storyQualityIssues(baseOpts({ swarm, concurrentReady: false }));
+    expect(issues.some((i) => i.includes("broad file_scope"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDraft -- narrative-form + traces-from-references paths
+// ---------------------------------------------------------------------------
+
+describe("validateDraft narrative + traces variants", () => {
+  it("accepts a story using narratives + items object form", () => {
+    const story = {
+      id: "story-narr",
+      title: "Narrative story",
+      narratives: {
+        Description: GOOD_DESC,
+        ImplementationPlan: GOOD_PLAN,
+        UserStory: GOOD_US,
+        Traces: "FR-1",
+      },
+      items: [
+        { id: "a1", title: GOOD_AC1, narrative: { Acceptance: GOOD_AC1 } },
+        { id: "a2", title: GOOD_AC2, narrative: { Acceptance: GOOD_AC2 } },
+      ],
+      swarm: goodSwarm(),
+    };
+    expect(validateDraft([story])).toEqual(["story-narr"]);
+  });
+
+  it("derives traces from a spec-section reference", () => {
+    const story = {
+      id: "story-ref",
+      title: "Ref story",
+      description: GOOD_DESC,
+      implementation_plan: GOOD_PLAN,
+      user_story: GOOD_US,
+      acceptance: [GOOD_AC1, GOOD_AC2],
+      traces: [],
+      references: [{ type: "x-vbrief/spec-section", uri: "specification.vbrief.json#auth" }],
+      swarm: goodSwarm(),
+    };
+    expect(validateDraft([story])).toEqual(["story-ref"]);
+  });
+
+  it("derives traces from missing_traces_justification", () => {
+    const swarm = { ...goodSwarm(), missing_traces_justification: "No FR yet; exploratory slice." };
+    const story = {
+      id: "story-mtj",
+      title: "MTJ story",
+      description: GOOD_DESC,
+      implementation_plan: GOOD_PLAN,
+      user_story: GOOD_US,
+      acceptance: [GOOD_AC1, GOOD_AC2],
+      traces: [],
+      swarm,
+    };
+    expect(validateDraft([story])).toEqual(["story-mtj"]);
+  });
+
+  it("accepts stories from a children object map", () => {
+    const story = {
+      id: "story-child",
+      title: "Child story",
+      description: GOOD_DESC,
+      implementation_plan: GOOD_PLAN,
+      user_story: GOOD_US,
+      acceptance: [GOOD_AC1, GOOD_AC2],
+      traces: ["FR-1"],
+      swarm: goodSwarm(),
+    };
+    // storySpecs accepts an object map under `children`
+    const ids = validateDraft([story]);
+    expect(ids).toEqual(["story-child"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyDecomposition -- error + parent-mutation branches
+// ---------------------------------------------------------------------------
+
+describe("applyDecomposition error + mutation branches", () => {
+  function setup(): { proj: string; parentPath: string; draftPath: string } {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    return { proj, parentPath, draftPath };
+  }
+
+  it("throws on invalid JSON parent", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeFileSync(parentPath, "not json", "utf8");
+    writeJson(draftPath, goodDraft());
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: true,
+        date: "2026-06-01",
+      }),
+    ).toThrow("invalid JSON");
+  });
+
+  it("throws when parent is not a JSON object", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeFileSync(parentPath, "[]", "utf8");
+    writeJson(draftPath, goodDraft());
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: true,
+        date: "2026-06-01",
+      }),
+    ).toThrow("expected a JSON object");
+  });
+
+  it("throws when output_dir is not a lifecycle folder", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, goodParent());
+    writeJson(draftPath, goodDraft("vbrief/foobar"));
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("vbrief lifecycle folder");
+  });
+
+  it("throws when output_dir is outside vbrief/", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, goodParent());
+    writeJson(draftPath, goodDraft(join(tmpdir(), `outside-${Date.now()}`, "pending")));
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("inside vbrief/");
+  });
+
+  it("throws when parent is outside vbrief/", () => {
+    const { proj, draftPath } = setup();
+    const parentOutside = join(proj, "parent.vbrief.json");
+    writeJson(parentOutside, goodParent());
+    writeJson(draftPath, goodDraft());
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath: parentOutside,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("must be inside");
+  });
+
+  it("creates metadata and references on a minimal parent plan", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, {
+      vBRIEFInfo: { version: "0.6" },
+      plan: { id: "ip-1", title: "IP-1", status: "pending", narratives: {}, items: [] },
+    });
+    writeJson(draftPath, goodDraft());
+    const actions = applyDecomposition({
+      projectRoot: proj,
+      parentPath,
+      draftPath,
+      checkOnly: false,
+      date: "2026-06-01",
+    });
+    expect(actions.some((a) => a.startsWith("UPDATE"))).toBe(true);
+    const updated = JSON.parse(readFileSync(parentPath, "utf8")) as Record<string, unknown>;
+    const plan = updated.plan as Record<string, unknown>;
+    expect((plan.metadata as Record<string, unknown>).kind).toBe("epic");
+    expect(Array.isArray(plan.references)).toBe(true);
+  });
+
+  it("creates a plan block when the parent has none", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, { vBRIEFInfo: { version: "0.6" } });
+    writeJson(draftPath, goodDraft());
+    const actions = applyDecomposition({
+      projectRoot: proj,
+      parentPath,
+      draftPath,
+      checkOnly: false,
+      date: "2026-06-01",
+    });
+    expect(actions.some((a) => a.startsWith("CREATE"))).toBe(true);
+  });
+
+  it("throws when parent plan is not an object", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, { vBRIEFInfo: { version: "0.6" }, plan: [] });
+    writeJson(draftPath, goodDraft());
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("plan must be an object");
+  });
+
+  it("throws when parent plan.metadata is not an object", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, {
+      vBRIEFInfo: { version: "0.6" },
+      plan: { id: "ip-1", title: "IP-1", status: "pending", metadata: [] },
+    });
+    writeJson(draftPath, goodDraft());
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("plan.metadata must be an object");
+  });
+
+  it("throws when parent plan.references is not an array", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, {
+      vBRIEFInfo: { version: "0.6" },
+      plan: {
+        id: "ip-1",
+        title: "IP-1",
+        status: "pending",
+        metadata: { kind: "epic" },
+        references: {},
+      },
+    });
+    writeJson(draftPath, goodDraft());
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("plan.references must be an array");
+  });
+
+  it("throws when a story status is active/running", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(parentPath, goodParent());
+    const draft = goodDraft();
+    (draft.stories as Record<string, unknown>[])[0]!.status = "running";
+    writeJson(draftPath, draft);
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("active/running");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decomposeMain -- additional CLI branches
+// ---------------------------------------------------------------------------
+
+describe("decomposeMain extra CLI branches", () => {
+  function setup(): { proj: string; parentPath: string; draftPath: string } {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    return { proj, parentPath, draftPath };
+  }
+
+  it("unrecognized argument returns 2", () => {
+    expect(decomposeMain(["--bogus-flag"])).toBe(2);
+  });
+
+  it("draft supplied without parent returns 2", () => {
+    expect(decomposeMain(["--draft", "draft.json"])).toBe(2);
+  });
+
+  it("nonexistent draft returns 2", () => {
+    const { proj, parentPath } = setup();
+    expect(
+      decomposeMain([parentPath, "--draft", "/nonexistent/draft.json", "--project-root", proj]),
+    ).toBe(2);
+  });
+
+  it("check mode with parent + draft returns 0 and writes nothing", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(draftPath, goodDraft());
+    const code = decomposeMain([
+      parentPath,
+      "--draft",
+      draftPath,
+      "--check",
+      "--project-root",
+      proj,
+    ]);
+    expect(code).toBe(0);
+    const childFiles = readdirSafe(join(proj, "vbrief", "pending")).filter(
+      (f) => f !== "parent.vbrief.json",
+    );
+    expect(childFiles).toHaveLength(0);
+  });
+
+  it("supports --draft= and --project-root= equals forms", () => {
+    const { proj, parentPath, draftPath } = setup();
+    writeJson(draftPath, goodDraft());
+    const code = decomposeMain([
+      parentPath,
+      `--draft=${draftPath}`,
+      `--project-root=${proj}`,
+      "--date=2026-06-01",
+    ]);
+    expect(code).toBe(0);
+  });
+
+  it("returns 1 when the draft fails validation", () => {
+    const { proj, parentPath, draftPath } = setup();
+    const badStory = { ...goodStory(), title: "" };
+    writeJson(draftPath, { stories: [badStory] });
+    const code = decomposeMain([
+      parentPath,
+      "--draft",
+      draftPath,
+      "--date",
+      "2026-06-01",
+      "--project-root",
+      proj,
+    ]);
+    expect(code).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alternate field-name extraction paths
+// ---------------------------------------------------------------------------
+
+function altStory(): Record<string, unknown> {
+  return {
+    story_id: "story-alt",
+    title: "Alt story",
+    filename: "2026-06-01-custom.vbrief.json",
+    summary: GOOD_DESC,
+    ImplementationPlan: [GOOD_PLAN],
+    UserStory: GOOD_US,
+    acceptance_items: [GOOD_AC1, GOOD_AC2],
+    traces: ["FR-1"],
+    readiness: "ready",
+    parallel_safe: true,
+    file_scope: ["src/auth/alt.ts", "tests/auth/alt.test.ts"],
+    verify_commands: ["npm test -- auth/alt"],
+    expected_outputs: ["alt tests pass"],
+    depends_on: [],
+    conflict_group: "auth",
+    size: "small",
+    file_scope_confidence: "high",
+    model_tier: "medium",
+    acceptance_criteria_justification: "Two criteria is sufficient for this focused slice.",
+  };
+}
+
+describe("alternate field extraction", () => {
+  it("validates a story that uses story_id/summary/ImplementationPlan/UserStory + top-level swarm", () => {
+    expect(validateDraft([altStory()])).toEqual(["story-alt"]);
+  });
+
+  it("validates a story keyed by `key`", () => {
+    const story = { ...altStory(), story_id: undefined, key: "story-keyed" };
+    delete (story as Record<string, unknown>).story_id;
+    expect(validateDraft([story])).toEqual(["story-keyed"]);
+  });
+
+  it("applies a draft using the explicit filename and narrative assembly", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    writeJson(draftPath, { stories: [altStory()] });
+    const actions = applyDecomposition({
+      projectRoot: proj,
+      parentPath,
+      draftPath,
+      checkOnly: false,
+      date: "2026-06-01",
+    });
+    expect(actions.some((a) => a.includes("2026-06-01-custom.vbrief.json"))).toBe(true);
+    const childPath = join(proj, "vbrief", "pending", "2026-06-01-custom.vbrief.json");
+    const child = JSON.parse(readFileSync(childPath, "utf8")) as Record<string, unknown>;
+    const plan = child.plan as Record<string, unknown>;
+    const narratives = plan.narratives as Record<string, string>;
+    expect(narratives.Description).toBe(GOOD_DESC);
+    expect(narratives.ImplementationPlan).toBe(GOOD_PLAN);
+    expect(narratives.UserStory).toBe(GOOD_US);
+    expect(narratives.Traces).toBe("FR-1");
+  });
+});

--- a/packages/core/src/scope/decompose.test.ts
+++ b/packages/core/src/scope/decompose.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Vitest tests for scope/decompose.ts -- mirror key Python test cases from
+ * tests/cli/test_scope_decompose_unit.py including non-happy-path/edge cases.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  applyDecomposition,
+  asStrList,
+  DecompositionError,
+  decomposeMain,
+  deprecatedSubitemsIssues,
+  itemHasTraces,
+  itemsHaveAcceptance,
+  missingRequiredSwarmFields,
+  validateDraft,
+} from "./decompose.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function tmpProject(): string {
+  const dir = join(tmpdir(), `decompose-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(dir, "vbrief", "pending"), { recursive: true });
+  mkdirSync(join(dir, "vbrief", "proposed"), { recursive: true });
+  mkdirSync(join(dir, "vbrief", "active"), { recursive: true });
+  mkdirSync(join(dir, "vbrief", "completed"), { recursive: true });
+  mkdirSync(join(dir, "vbrief", "cancelled"), { recursive: true });
+  return dir;
+}
+
+function writeJson(path: string, data: unknown): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2), "utf8");
+}
+
+function goodStory(
+  storyId = "story-auth-model",
+  title = "Auth model",
+  deps: string[] = [],
+): Record<string, unknown> {
+  return {
+    id: storyId,
+    title,
+    description:
+      `${title} persistence behavior stores user identity and session ` +
+      "state for the authentication workflow. The story covers focused " +
+      "model changes plus matching unit tests for save and load.",
+    implementation_plan: [
+      "Update the auth model persistence code so valid user payloads " +
+        "are saved through the existing model boundary.",
+      "Add focused model tests for successful persistence and " +
+        "missing-record behavior using the auth model test fixture.",
+    ],
+    user_story:
+      "As an auth maintainer, I want persisted user records, " +
+      "so that login state survives requests.",
+    acceptance: [
+      "Given a valid user payload, when the auth model saves it, then the user record persists.",
+      "Given an existing user, when the auth model loads it, then the saved identity returns.",
+    ],
+    traces: ["FR-1"],
+    swarm: {
+      readiness: "ready",
+      parallel_safe: true,
+      file_scope: ["src/auth/model.ts", "tests/auth/model.test.ts"],
+      verify_commands: ["npm test -- auth/model"],
+      expected_outputs: ["auth model tests pass"],
+      depends_on: deps,
+      conflict_group: "auth",
+      size: "small",
+      file_scope_confidence: "high",
+      model_tier: "medium",
+    },
+  };
+}
+
+function goodDraft(outputDir?: string, status?: string): Record<string, unknown> {
+  const story1 = goodStory();
+  const story2 = {
+    ...goodStory("story-auth-routes", "Auth routes", ["story-auth-model"]),
+    swarm: {
+      ...(goodStory().swarm as Record<string, unknown>),
+      file_scope: ["src/auth/routes.ts", "tests/auth/routes.test.ts"],
+      verify_commands: ["npm test -- auth/routes"],
+      depends_on: ["story-auth-model"],
+    },
+  };
+  const draft: Record<string, unknown> = { stories: [story1, story2] };
+  if (outputDir !== undefined) draft.output_dir = outputDir;
+  if (status !== undefined) draft.status = status;
+  return draft;
+}
+
+function goodParent(): Record<string, unknown> {
+  return {
+    vBRIEFInfo: { version: "0.6" },
+    plan: {
+      id: "ip-1",
+      title: "IP-1: Auth",
+      status: "pending",
+      narratives: {
+        Acceptance: "Auth epic acceptance remains as context.",
+        Traces: "FR-1, IP-1",
+      },
+      items: [],
+      metadata: { kind: "phase" },
+      references: [
+        {
+          uri: "specification.vbrief.json",
+          type: "x-vbrief/plan",
+          title: "Specification",
+          TrustLevel: "internal",
+        },
+      ],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// asStrList
+// ---------------------------------------------------------------------------
+
+describe("asStrList", () => {
+  it("handles null/undefined", () => {
+    expect(asStrList(null)).toEqual([]);
+    expect(asStrList(undefined)).toEqual([]);
+  });
+
+  it("handles empty string", () => {
+    expect(asStrList("")).toEqual([]);
+    expect(asStrList("  ")).toEqual([]);
+  });
+
+  it("handles string", () => {
+    expect(asStrList("alpha")).toEqual(["alpha"]);
+  });
+
+  it("handles mixed array", () => {
+    expect(asStrList(["a", "", " b ", 3])).toEqual(["a", "b", "3"]);
+  });
+
+  it("returns empty for objects/numbers", () => {
+    expect(asStrList({ a: 1 })).toEqual([]);
+    expect(asStrList(42)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// itemHasTraces / itemsHaveAcceptance
+// ---------------------------------------------------------------------------
+
+describe("itemHasTraces", () => {
+  it("finds traces in narrative", () => {
+    expect(itemHasTraces({ narrative: { Traces: "FR-1" } })).toBe(true);
+  });
+
+  it("false for no traces", () => {
+    expect(itemHasTraces({ narrative: { Acceptance: "yes" } })).toBe(false);
+  });
+
+  it("walks nested items", () => {
+    expect(itemHasTraces({ items: [{ narrative: { Traces: "FR-2" } }] })).toBe(true);
+  });
+});
+
+describe("itemsHaveAcceptance", () => {
+  it("returns false for non-list", () => {
+    expect(itemsHaveAcceptance("not-list")).toBe(false);
+  });
+
+  it("returns false for empty", () => {
+    expect(itemsHaveAcceptance([])).toBe(false);
+  });
+
+  it("returns false when no acceptance", () => {
+    expect(itemsHaveAcceptance([{ no: "acc" }])).toBe(false);
+  });
+
+  it("returns true when any item has acceptance", () => {
+    expect(itemsHaveAcceptance([{ narrative: { Acceptance: "yes" } }])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// missingRequiredSwarmFields
+// ---------------------------------------------------------------------------
+
+describe("missingRequiredSwarmFields", () => {
+  it("empty swarm lists every required field", () => {
+    const missing = missingRequiredSwarmFields({});
+    const expected = [
+      "plan.metadata.swarm.file_scope",
+      "plan.metadata.swarm.verify_commands",
+      "plan.metadata.swarm.expected_outputs",
+      "plan.metadata.swarm.depends_on",
+      "plan.metadata.swarm.conflict_group",
+      "plan.metadata.swarm.size",
+      "plan.metadata.swarm.file_scope_confidence",
+      "plan.metadata.swarm.model_tier",
+    ];
+    for (const field of expected) {
+      expect(missing).toContain(field);
+    }
+  });
+
+  it("depends_on present drops only depends_on entry", () => {
+    const missing = missingRequiredSwarmFields({ depends_on: [] });
+    expect(missing).not.toContain("plan.metadata.swarm.depends_on");
+    expect(missing).toContain("plan.metadata.swarm.file_scope");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deprecatedSubitemsIssues
+// ---------------------------------------------------------------------------
+
+describe("deprecatedSubitemsIssues", () => {
+  it("returns empty for null", () => {
+    expect(deprecatedSubitemsIssues(null)).toEqual([]);
+  });
+
+  it("detects subItems", () => {
+    const items = [{ subItems: [{ name: "x" }] }];
+    const issues = deprecatedSubitemsIssues(items);
+    expect(issues.some((i) => i.includes("subItems is deprecated"))).toBe(true);
+  });
+
+  it("detects nested deprecated items", () => {
+    const items = [
+      {
+        items: [{ subItems: [{}] }],
+      },
+    ];
+    const issues = deprecatedSubitemsIssues(items);
+    expect(issues.some((i) => i.includes(".items[0].subItems is deprecated"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDraft
+// ---------------------------------------------------------------------------
+
+describe("validateDraft", () => {
+  it("happy path returns ordered story ids", () => {
+    const draft = goodDraft();
+    const stories = (draft.stories as unknown[]).map((s) => s as Record<string, unknown>);
+    const ids = validateDraft(stories);
+    expect(ids).toEqual(["story-auth-model", "story-auth-routes"]);
+  });
+
+  it("throws on duplicate story id", () => {
+    const story = goodStory();
+    expect(() => validateDraft([story, story] as Record<string, unknown>[])).toThrow(
+      DecompositionError,
+    );
+    expect(() => validateDraft([story, story] as Record<string, unknown>[])).toThrow("duplicate");
+  });
+
+  it("throws on missing required field (description)", () => {
+    const story = { ...goodStory(), description: "" };
+    expect(() => validateDraft([story])).toThrow(DecompositionError);
+  });
+
+  it("throws on dependency cycle", () => {
+    const s1 = { ...goodStory("s1", "Story 1", ["s2"]) };
+    const s2 = { ...goodStory("s2", "Story 2", ["s1"]) };
+    (s1.swarm as Record<string, unknown>).depends_on = ["s2"];
+    (s2.swarm as Record<string, unknown>).depends_on = ["s1"];
+    expect(() => validateDraft([s1, s2] as Record<string, unknown>[])).toThrow("dependency cycle");
+  });
+
+  it("throws on unknown dependency reference", () => {
+    const story = goodStory("s1", "S1", ["nonexistent"]);
+    expect(() => validateDraft([story] as Record<string, unknown>[])).toThrow("unknown story");
+  });
+
+  it("throws on non-array stories draft", () => {
+    expect(() => {
+      const draft = { stories: "bad" };
+      const stories = (draft as unknown as { stories: unknown }).stories;
+      if (!Array.isArray(stories))
+        throw new DecompositionError("draft must contain a stories array");
+    }).toThrow(DecompositionError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyDecomposition
+// ---------------------------------------------------------------------------
+
+describe("applyDecomposition", () => {
+  it("check-only validates and returns actions without writing files", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "2026-05-12-parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    writeJson(draftPath, goodDraft());
+    const actions = applyDecomposition({
+      projectRoot: proj,
+      parentPath,
+      draftPath,
+      checkOnly: true,
+      date: "2026-05-12",
+    });
+    expect(actions[0]).toContain("VALIDATED 2");
+    expect(actions.some((a) => a.startsWith("CHECK"))).toBe(true);
+    // Files should NOT have been written
+    const childDir = join(proj, "vbrief", "pending");
+    const childFiles = readdirSafe(childDir).filter((f) => f !== "2026-05-12-parent.vbrief.json");
+    expect(childFiles).toHaveLength(0);
+  });
+
+  it("apply creates child vBRIEFs and updates parent", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "2026-05-12-parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    writeJson(draftPath, goodDraft());
+    const actions = applyDecomposition({
+      projectRoot: proj,
+      parentPath,
+      draftPath,
+      checkOnly: false,
+      date: "2026-06-01",
+    });
+    expect(actions.some((a) => a.startsWith("CREATE"))).toBe(true);
+    expect(actions.some((a) => a.startsWith("UPDATE"))).toBe(true);
+    // Two child files should be created in pending
+    const childDir = join(proj, "vbrief", "pending");
+    const childFiles = readdirSafe(childDir).filter((f) => f !== "2026-05-12-parent.vbrief.json");
+    expect(childFiles.length).toBeGreaterThanOrEqual(2);
+    // Parent should reference children
+    const updatedParent = JSON.parse(readFileSync(parentPath, "utf8")) as Record<string, unknown>;
+    const plan = updatedParent.plan as Record<string, unknown>;
+    const refs = plan.references as unknown[];
+    expect(refs.some((r) => (r as Record<string, unknown>).type === "x-vbrief/plan")).toBe(true);
+  });
+
+  it("throws when output_dir is active", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    writeJson(draftPath, goodDraft("vbrief/active"));
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("must not be vbrief/active");
+  });
+
+  it("throws when status is running", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    writeJson(draftPath, goodDraft(undefined, "running"));
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("active/running");
+  });
+
+  it("throws when child file already exists", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    const draft = goodDraft();
+    writeJson(draftPath, draft);
+    applyDecomposition({
+      projectRoot: proj,
+      parentPath,
+      draftPath,
+      checkOnly: false,
+      date: "2026-06-01",
+    });
+    // Re-write parent to clean state (already modified)
+    writeJson(parentPath, goodParent());
+    expect(() =>
+      applyDecomposition({
+        projectRoot: proj,
+        parentPath,
+        draftPath,
+        checkOnly: false,
+        date: "2026-06-01",
+      }),
+    ).toThrow("already exists");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decomposeMain CLI
+// ---------------------------------------------------------------------------
+
+describe("decomposeMain", () => {
+  it("--check with no args prints OK", () => {
+    expect(decomposeMain(["--check"])).toBe(0);
+  });
+
+  it("missing parent + draft returns 2", () => {
+    expect(decomposeMain([])).toBe(2);
+  });
+
+  it("missing draft alone returns 2", () => {
+    expect(decomposeMain(["some-parent.vbrief.json"])).toBe(2);
+  });
+
+  it("nonexistent parent returns 2", () => {
+    expect(decomposeMain(["--draft", "draft.json", "/nonexistent/parent.vbrief.json"])).toBe(2);
+  });
+
+  it("invalid date returns 2", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    writeJson(draftPath, goodDraft());
+    expect(
+      decomposeMain([
+        parentPath,
+        "--draft",
+        draftPath,
+        "--date",
+        "not-a-date",
+        "--project-root",
+        proj,
+      ]),
+    ).toBe(2);
+  });
+
+  it("full apply returns 0", () => {
+    const proj = tmpProject();
+    const parentPath = join(proj, "vbrief", "pending", "parent.vbrief.json");
+    writeJson(parentPath, goodParent());
+    const draftPath = join(proj, "vbrief", ".eval", "draft.json");
+    mkdirSync(join(proj, "vbrief", ".eval"), { recursive: true });
+    writeJson(draftPath, goodDraft());
+    expect(
+      decomposeMain([
+        parentPath,
+        "--draft",
+        draftPath,
+        "--date",
+        "2026-06-01",
+        "--project-root",
+        proj,
+      ]),
+    ).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+import { readdirSync } from "node:fs";
+
+function readdirSafe(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}

--- a/packages/core/src/scope/decompose.ts
+++ b/packages/core/src/scope/decompose.ts
@@ -1,0 +1,1151 @@
+/**
+ * scope/decompose.ts -- Apply or validate an approved epic/phase -> story decomposition draft.
+ *
+ * Faithful TypeScript port of scripts/scope_decompose.py + scripts/_vbrief_story_quality.py.
+ * The command is deterministic: it never invents stories from a parent scope.
+ * A caller supplies a draft with child story definitions; this module validates
+ * that draft, writes the child story vBRIEFs, and updates the parent scope references.
+ */
+
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { referenceWithDefaultTrust, slugify } from "../vbrief-build/build.js";
+import { EMITTED_VBRIEF_VERSION } from "../vbrief-build/constants.js";
+import { formatVbriefJson } from "./vbrief-json.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LIFECYCLE_FOLDERS = new Set(["proposed", "pending", "active", "completed", "cancelled"]);
+const ACTIVE_DECOMPOSITION_STATUSES = new Set(["active", "running"]);
+const READY = "ready";
+const STORY_READINESS_STATES = new Set([READY, "sequential", "needs_refinement"]);
+
+// ---------------------------------------------------------------------------
+// DecompositionError
+// ---------------------------------------------------------------------------
+
+export class DecompositionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DecompositionError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+type JsonObj = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// File I/O helpers
+// ---------------------------------------------------------------------------
+
+function loadJson(path: string): JsonObj {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    throw new DecompositionError(`${path}: cannot read file: ${String(err)}`);
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    throw new DecompositionError(`${path}: invalid JSON: ${String(err)}`);
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    throw new DecompositionError(`${path}: expected a JSON object`);
+  }
+  return data as JsonObj;
+}
+
+function writeJson(path: string, data: JsonObj): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, formatVbriefJson(data), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Story quality helpers (ported from _vbrief_story_quality.py)
+// ---------------------------------------------------------------------------
+
+const BROAD_FILE_SCOPE_ROOTS = new Set(["backend", "frontend", "docs", "vbrief"]);
+
+const CODE_PATH_TERMS = [
+  "api",
+  "cli",
+  "component",
+  "config",
+  "database",
+  "endpoint",
+  "file",
+  "handler",
+  "model",
+  "module",
+  "repository",
+  "route",
+  "schema",
+  "script",
+  "service",
+  "source",
+  "src/",
+];
+
+const VERIFY_EVIDENCE_TERMS = [
+  "assert",
+  "evidence",
+  "fixture",
+  "report",
+  "spec",
+  "test",
+  "tests/",
+  "verify",
+];
+
+const GENERIC_VERIFY_COMMANDS = new Set([
+  "cargo test",
+  "go test ./...",
+  "npm run test",
+  "npm test",
+  "pytest",
+  "task check",
+]);
+
+const PLACEHOLDER_ACCEPTANCE_PATTERNS = [
+  "acceptance criteria for",
+  "copy from parent",
+  "copy from specification",
+  "placeholder",
+  "refine from parent",
+  "tbd",
+  "to be defined",
+  "to refine",
+  "to refine from parent scope",
+  "todo",
+];
+
+const DOCS_ONLY_ACCEPTANCE_PATTERNS = [
+  "docs updated",
+  "documentation updated",
+  "readme updated",
+  "update docs",
+  "update documentation",
+  "update readme",
+];
+
+const GENERIC_IMPLEMENTATION_PATTERNS = [
+  "add tests so it works",
+  "change the code",
+  "implement the feature",
+  "make it work",
+  "update the code",
+  "works as expected",
+];
+
+const VAGUE_ACCEPTANCE_PATTERNS = [
+  "displays a message",
+  "handles errors",
+  "is implemented",
+  "is updated",
+  "passes tests",
+  "shows a message",
+  "the system displays a message",
+  "updates the ui",
+  "works as expected",
+];
+
+const OBSERVABLE_TERMS = [
+  "blocks",
+  "creates",
+  "deletes",
+  "displays",
+  "emits",
+  "fails",
+  "persists",
+  "records",
+  "redirects",
+  "rejects",
+  "renders",
+  "returns",
+  "saves",
+  "shows",
+  "stores",
+  "updates",
+  "validates",
+  "when ",
+  "given ",
+  "then ",
+];
+
+const USER_STORY_RE = /^\s*As\s+an?\s+[^,]+,\s*I\s+want\s+.+,\s*so\s+that\s+.+\.\s*$/is;
+
+export function asStrList(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  if (typeof value === "string") return value.trim().length > 0 ? [value.trim()] : [];
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item).trim()).filter((s) => s.length > 0);
+  }
+  return [];
+}
+
+export function acceptanceTextsFromItems(items: unknown): string[] {
+  const texts: string[] = [];
+  if (!Array.isArray(items)) return texts;
+  for (const item of items) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+    const obj = item as JsonObj;
+    const narrative = obj.narrative;
+    if (typeof narrative === "object" && narrative !== null && !Array.isArray(narrative)) {
+      const acc = (narrative as JsonObj).Acceptance;
+      if (typeof acc === "string" && acc.trim().length > 0) texts.push(acc.trim());
+    }
+    for (const childKey of ["items", "subItems"]) {
+      texts.push(...acceptanceTextsFromItems(obj[childKey]));
+    }
+  }
+  return texts;
+}
+
+export function itemHasAcceptance(item: JsonObj): boolean {
+  const narrative = item.narrative;
+  if (typeof narrative === "object" && narrative !== null && !Array.isArray(narrative)) {
+    const acc = (narrative as JsonObj).Acceptance;
+    if (typeof acc === "string" && acc.trim().length > 0) return true;
+  }
+  for (const childKey of ["items", "subItems"]) {
+    const children = item[childKey];
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        if (typeof child === "object" && child !== null && !Array.isArray(child)) {
+          if (itemHasAcceptance(child as JsonObj)) return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+export function itemsHaveAcceptance(items: unknown): boolean {
+  if (!Array.isArray(items)) return false;
+  return items.some(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      !Array.isArray(item) &&
+      itemHasAcceptance(item as JsonObj),
+  );
+}
+
+export function itemHasTraces(item: JsonObj): boolean {
+  const narrative = item.narrative;
+  if (typeof narrative === "object" && narrative !== null && !Array.isArray(narrative)) {
+    const val = (narrative as JsonObj).Traces;
+    if (typeof val === "string" && val.trim().length > 0) return true;
+  }
+  for (const childKey of ["items", "subItems"]) {
+    const children = item[childKey];
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        if (typeof child === "object" && child !== null && !Array.isArray(child)) {
+          if (itemHasTraces(child as JsonObj)) return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+export function missingRequiredSwarmFields(swarm: JsonObj): string[] {
+  const missing: string[] = [];
+  for (const key of ["file_scope", "verify_commands", "expected_outputs"]) {
+    if (asStrList(swarm[key]).length === 0) missing.push(`plan.metadata.swarm.${key}`);
+  }
+  if (!("depends_on" in swarm)) missing.push("plan.metadata.swarm.depends_on");
+  for (const key of ["conflict_group", "size", "file_scope_confidence", "model_tier"]) {
+    const val = swarm[key];
+    if (typeof val !== "string" || val.trim().length === 0) {
+      missing.push(`plan.metadata.swarm.${key}`);
+    }
+  }
+  return missing;
+}
+
+export function deprecatedSubitemsIssues(items: unknown, prefix = "plan.items"): string[] {
+  const issues: string[] = [];
+  function visit(children: unknown, path: string): void {
+    if (!Array.isArray(children)) return;
+    for (let i = 0; i < children.length; i += 1) {
+      const item = children[i];
+      if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+      const obj = item as JsonObj;
+      const itemPath = `${path}[${i}]`;
+      if ("subItems" in obj) issues.push(`${itemPath}.subItems is deprecated; use items`);
+      visit(obj.items, `${itemPath}.items`);
+      visit(obj.subItems, `${itemPath}.subItems`);
+    }
+  }
+  visit(items, prefix);
+  return issues;
+}
+
+function sentenceCount(value: string): number {
+  return value
+    .trim()
+    .split(/[.!?]+(?:\s+|$)/)
+    .filter((p) => p.trim().length > 0).length;
+}
+
+function stepCount(value: string): number {
+  const lines = value
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  const bulletLines = lines.filter((l) => /^([-*]|\d+[.)])\s+/.test(l));
+  if (bulletLines.length >= 2) return bulletLines.length;
+  return sentenceCount(value);
+}
+
+function wordCount(value: string): number {
+  return (value.match(/\b\w+\b/g) ?? []).length;
+}
+
+function normalizeStr(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function normalizeCommand(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function descriptionIssues(description: string): string[] {
+  if (!description.trim()) return ["plan.narratives.Description is required"];
+  if (sentenceCount(description) < 2 || wordCount(description) < 20) {
+    return ["plan.narratives.Description must contain at least two concrete sentences"];
+  }
+  return [];
+}
+
+function implementationPlanIssues(implementationPlan: string): string[] {
+  if (!implementationPlan.trim()) return ["plan.narratives.ImplementationPlan is required"];
+  const issues: string[] = [];
+  if (stepCount(implementationPlan) < 2 || wordCount(implementationPlan) < 20) {
+    issues.push("plan.narratives.ImplementationPlan must contain at least two concrete steps");
+  }
+  const lower = implementationPlan.toLowerCase();
+  if (PLACEHOLDER_ACCEPTANCE_PATTERNS.some((p) => lower.includes(p))) {
+    issues.push("plan.narratives.ImplementationPlan must not be placeholder text");
+  }
+  if (
+    GENERIC_IMPLEMENTATION_PATTERNS.some((p) => lower.includes(p)) ||
+    !(
+      CODE_PATH_TERMS.some((t) => lower.includes(t)) &&
+      VERIFY_EVIDENCE_TERMS.some((t) => lower.includes(t))
+    )
+  ) {
+    issues.push(
+      "plan.narratives.ImplementationPlan must identify concrete code paths and verification evidence",
+    );
+  }
+  return issues;
+}
+
+function fileScopeIssues(swarm: JsonObj): string[] {
+  const issues: string[] = [];
+  for (const filePath of asStrList(swarm.file_scope)) {
+    const normalized = filePath.trim().replace(/^\/+|\/+$/g, "");
+    const root = normalized.split("/")[0] ?? "";
+    if (
+      /[*?[]/.test(normalized) ||
+      BROAD_FILE_SCOPE_ROOTS.has(normalized) ||
+      filePath.replace(/\/$/, "") in BROAD_FILE_SCOPE_ROOTS ||
+      (BROAD_FILE_SCOPE_ROOTS.has(root) && (normalized === root || normalized === `${root}/*`))
+    ) {
+      issues.push(`broad file_scope is not swarm-ready: ${filePath}`);
+    }
+  }
+  return issues;
+}
+
+function verifyCommandIssues(swarm: JsonObj): string[] {
+  const commands = asStrList(swarm.verify_commands).map((c) => c.toLowerCase());
+  if (commands.length === 1 && GENERIC_VERIFY_COMMANDS.has(normalizeCommand(commands[0] ?? ""))) {
+    return [`generic verify command is not swarm-ready: ${commands[0]}`];
+  }
+  return [];
+}
+
+export function storyQualityIssues(opts: {
+  title: string;
+  description: string;
+  implementationPlan: string;
+  userStory: string;
+  acceptanceTexts: string[];
+  acceptanceCountJustification: string;
+  swarm: JsonObj;
+  concurrentReady?: boolean;
+}): string[] {
+  const {
+    title,
+    description,
+    implementationPlan,
+    userStory,
+    acceptanceTexts,
+    acceptanceCountJustification,
+    swarm,
+    concurrentReady = true,
+  } = opts;
+
+  const issues: string[] = [];
+
+  if (!USER_STORY_RE.test(userStory ?? "")) {
+    issues.push("UserStory must match 'As a <role>, I want <capability>, so that <outcome>.'");
+  }
+  issues.push(...descriptionIssues(description));
+  issues.push(...implementationPlanIssues(implementationPlan));
+
+  if (
+    !(acceptanceTexts.length >= 2 && acceptanceTexts.length <= 5) &&
+    !acceptanceCountJustification.trim()
+  ) {
+    issues.push("2-5 acceptance criteria required unless justified");
+  }
+
+  const normalizedTitle = normalizeStr(title);
+  const normalizedDescription = normalizeStr(description);
+
+  for (const criterion of acceptanceTexts) {
+    const lower = criterion.toLowerCase();
+    const normalized = normalizeStr(criterion);
+    if (PLACEHOLDER_ACCEPTANCE_PATTERNS.some((p) => lower.includes(p))) {
+      issues.push("placeholder acceptance criterion");
+    }
+    if (normalized && (normalized === normalizedTitle || normalized === normalizedDescription)) {
+      issues.push("acceptance criterion duplicates title or description");
+    }
+    if (DOCS_ONLY_ACCEPTANCE_PATTERNS.some((p) => lower.includes(p))) {
+      issues.push("vague docs-only acceptance criterion");
+    }
+    if (wordCount(criterion) < 8 || VAGUE_ACCEPTANCE_PATTERNS.some((p) => lower.includes(p))) {
+      issues.push("acceptance criterion must describe specific observable behavior");
+    }
+    if (!OBSERVABLE_TERMS.some((t) => lower.includes(t))) {
+      issues.push("acceptance criterion must describe observable behavior");
+    }
+  }
+
+  if (concurrentReady) {
+    issues.push(...fileScopeIssues(swarm));
+    issues.push(...verifyCommandIssues(swarm));
+    if (swarm.parallel_safe === false) {
+      issues.push(
+        "readiness=ready requires parallel_safe=true; use readiness=sequential or needs_refinement for non-concurrent work",
+      );
+    }
+    if (swarm.file_scope_confidence === "low") {
+      issues.push("readiness=ready requires file_scope_confidence above low");
+    }
+  }
+
+  return dedupe(issues);
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+function vbriefDir(projectRoot: string): string {
+  return join(resolve(projectRoot), "vbrief");
+}
+
+function relToVbrief(vbriefDirPath: string, path: string): string {
+  const resolvedPath = resolve(path);
+  const resolvedVbrief = resolve(vbriefDirPath);
+  if (resolvedPath.startsWith(`${resolvedVbrief}/`) || resolvedPath === resolvedVbrief) {
+    return resolvedPath.slice(resolvedVbrief.length + 1).replace(/\\/g, "/");
+  }
+  throw new DecompositionError(`${path}: path must be inside ${vbriefDirPath}`);
+}
+
+function defaultStatusForFolderName(folderName: string): string {
+  const map: Record<string, string> = {
+    proposed: "proposed",
+    pending: "pending",
+    active: "running",
+    completed: "completed",
+    cancelled: "cancelled",
+  };
+  return map[folderName] ?? "pending";
+}
+
+function normalizeStatus(value: unknown, defaultStatus: string): string {
+  if (value === null || value === undefined) return defaultStatus;
+  const s = String(value).trim().toLowerCase();
+  return s.length > 0 ? s : defaultStatus;
+}
+
+function isValidCreationDate(value: string): boolean {
+  if (value.length !== 10) return false;
+  const d = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return false;
+  return d.toISOString().slice(0, 10) === value;
+}
+
+// ---------------------------------------------------------------------------
+// Story extraction helpers
+// ---------------------------------------------------------------------------
+
+function storySpecs(draft: JsonObj): JsonObj[] {
+  let stories = draft.stories ?? draft.children ?? [];
+  if (typeof stories === "object" && stories !== null && !Array.isArray(stories)) {
+    stories = Object.values(stories);
+  }
+  if (!Array.isArray(stories)) {
+    throw new DecompositionError("draft must contain a stories array");
+  }
+  const normalized: JsonObj[] = [];
+  for (let i = 0; i < stories.length; i += 1) {
+    const story = stories[i];
+    if (typeof story !== "object" || story === null || Array.isArray(story)) {
+      throw new DecompositionError(`stories[${i + 1}] must be an object`);
+    }
+    normalized.push(story as JsonObj);
+  }
+  return normalized;
+}
+
+function storyId(story: JsonObj, index: number): string {
+  const raw = story.id ?? story.story_id ?? story.key;
+  if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
+  const title = String(story.title ?? `story-${index}`);
+  return slugify(title) || `story-${index}`;
+}
+
+function swarmMeta(story: JsonObj): JsonObj {
+  const metadata =
+    typeof story.metadata === "object" && story.metadata !== null && !Array.isArray(story.metadata)
+      ? (story.metadata as JsonObj)
+      : {};
+  let swarm = story.swarm ?? (metadata as JsonObj).swarm ?? {};
+  if (typeof swarm !== "object" || swarm === null || Array.isArray(swarm)) swarm = {};
+  const swarmObj = swarm as JsonObj;
+  for (const key of [
+    "readiness",
+    "parallel_safe",
+    "file_scope",
+    "verify_commands",
+    "expected_outputs",
+    "depends_on",
+    "conflict_group",
+    "size",
+    "file_scope_confidence",
+    "model_tier",
+    "missing_traces_justification",
+  ]) {
+    if (key in story && !(key in swarmObj)) {
+      swarmObj[key] = story[key];
+    }
+  }
+  return swarmObj;
+}
+
+function storyHasTraces(story: JsonObj, items: unknown[], sw: JsonObj): boolean {
+  const narratives = story.narratives;
+  if (typeof narratives === "object" && narratives !== null && !Array.isArray(narratives)) {
+    const val = (narratives as JsonObj).Traces;
+    if (typeof val === "string" && val.trim().length > 0) return true;
+  }
+  if (asStrList(story.traces).length > 0) return true;
+  if (
+    items.some(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        !Array.isArray(item) &&
+        itemHasTraces(item as JsonObj),
+    )
+  )
+    return true;
+  if (asStrList(sw.missing_traces_justification).length > 0) return true;
+  const refs = story.references;
+  if (Array.isArray(refs)) {
+    for (const ref of refs) {
+      if (typeof ref === "object" && ref !== null && !Array.isArray(ref)) {
+        if ((ref as JsonObj).type === "x-vbrief/spec-section") return true;
+      }
+    }
+  }
+  return false;
+}
+
+function storyDescription(story: JsonObj): string {
+  const narratives = story.narratives;
+  if (typeof narratives === "object" && narratives !== null && !Array.isArray(narratives)) {
+    const val = (narratives as JsonObj).Description;
+    if (typeof val === "string" && val.trim().length > 0) return val.trim();
+  }
+  for (const key of ["description", "summary"]) {
+    const val = story[key];
+    if (typeof val === "string" && val.trim().length > 0) return val.trim();
+  }
+  return "";
+}
+
+function storyImplementationPlan(story: JsonObj): string {
+  const narratives = story.narratives;
+  if (typeof narratives === "object" && narratives !== null && !Array.isArray(narratives)) {
+    const val = (narratives as JsonObj).ImplementationPlan;
+    if (typeof val === "string" && val.trim().length > 0) return val.trim();
+  }
+  for (const key of ["implementation_plan", "ImplementationPlan"]) {
+    const values = asStrList(story[key]);
+    if (values.length > 0) return values.join("\n");
+  }
+  return "";
+}
+
+function storyUserStory(story: JsonObj): string {
+  const narratives = story.narratives;
+  if (typeof narratives === "object" && narratives !== null && !Array.isArray(narratives)) {
+    const val = (narratives as JsonObj).UserStory;
+    if (typeof val === "string" && val.trim().length > 0) return val.trim();
+  }
+  for (const key of ["user_story", "UserStory"]) {
+    const val = story[key];
+    if (typeof val === "string" && val.trim().length > 0) return val.trim();
+  }
+  return "";
+}
+
+function acceptanceCountJustification(story: JsonObj, sw: JsonObj): string {
+  for (const val of [
+    sw.acceptance_criteria_justification,
+    story.acceptance_criteria_justification,
+  ]) {
+    if (typeof val === "string" && val.trim().length > 0) return val.trim();
+  }
+  const narratives = story.narratives;
+  if (typeof narratives === "object" && narratives !== null && !Array.isArray(narratives)) {
+    const val = (narratives as JsonObj).AcceptanceJustification;
+    if (typeof val === "string" && val.trim().length > 0) return val.trim();
+  }
+  return "";
+}
+
+function itemsFromStory(stId: string, story: JsonObj): JsonObj[] {
+  const items = story.items;
+  if (Array.isArray(items) && items.length > 0) return items as JsonObj[];
+  const acceptance = [...asStrList(story.acceptance), ...asStrList(story.acceptance_items)];
+  const traces = asStrList(story.traces).join(", ");
+  return acceptance.map((criterion, i) => {
+    const narrative: JsonObj = { Acceptance: criterion };
+    if (traces.length > 0) narrative.Traces = traces;
+    return {
+      id: `${stId}-a${i + 1}`,
+      title: criterion,
+      status: "pending",
+      narrative,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DAG validation
+// ---------------------------------------------------------------------------
+
+function validateDag(storyIds: string[], depsByStory: Record<string, string[]>): void {
+  const known = new Set(storyIds);
+  for (const [id, deps] of Object.entries(depsByStory)) {
+    for (const dep of deps) {
+      if (!known.has(dep)) {
+        throw new DecompositionError(`${id}: depends_on references unknown story '${dep}'`);
+      }
+    }
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(id: string, path: string[]): void {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) {
+      const start = path.indexOf(id);
+      const cycle = [...(start >= 0 ? path.slice(start) : path), id].join(" -> ");
+      throw new DecompositionError(`dependency cycle detected: ${cycle}`);
+    }
+    visiting.add(id);
+    for (const dep of depsByStory[id] ?? []) {
+      visit(dep, [...path, id]);
+    }
+    visiting.delete(id);
+    visited.add(id);
+  }
+
+  for (const id of storyIds) visit(id, []);
+}
+
+// ---------------------------------------------------------------------------
+// validate_draft
+// ---------------------------------------------------------------------------
+
+export function validateDraft(stories: JsonObj[]): string[] {
+  const storyIds: string[] = [];
+  const depsByStory: Record<string, string[]> = {};
+  const seen = new Set<string>();
+
+  for (let i = 0; i < stories.length; i += 1) {
+    const story = stories[i]!;
+    const id = storyId(story, i + 1);
+    if (seen.has(id)) {
+      throw new DecompositionError(`duplicate story id '${id}'`);
+    }
+    seen.add(id);
+    storyIds.push(id);
+    const sw = swarmMeta(story);
+    const deps = asStrList(sw.depends_on ?? story.depends_on);
+    depsByStory[id] = deps;
+
+    const items = itemsFromStory(id, story);
+    const description = storyDescription(story);
+    const implementationPlan = storyImplementationPlan(story);
+    const userStory = storyUserStory(story);
+
+    const issues: string[] = [];
+
+    const rawId = story.id ?? story.story_id ?? story.key;
+    if (typeof rawId !== "string" || !rawId.trim()) issues.push("id");
+
+    const rawTitle = story.title;
+    if (typeof rawTitle !== "string" || !rawTitle.trim()) issues.push("title");
+
+    if (!description) issues.push("plan.narratives.Description");
+    if (!implementationPlan) issues.push("plan.narratives.ImplementationPlan");
+    if (!userStory) issues.push("plan.narratives.UserStory");
+
+    const readiness = sw.readiness;
+    if (!STORY_READINESS_STATES.has(String(readiness ?? ""))) {
+      issues.push("plan.metadata.swarm.readiness");
+    }
+    const parallelSafe = sw.parallel_safe;
+    if (parallelSafe !== true && parallelSafe !== false) {
+      issues.push("plan.metadata.swarm.parallel_safe");
+    }
+    if (items.length === 0) issues.push("plan.items");
+    if (items.length > 0 && !itemsHaveAcceptance(items)) {
+      issues.push("plan.items[].narrative.Acceptance");
+    }
+    issues.push(...deprecatedSubitemsIssues(items));
+    issues.push(...missingRequiredSwarmFields(sw));
+    if (!storyHasTraces(story, items, sw)) {
+      issues.push("Traces or missing_traces_justification");
+    }
+    issues.push(
+      ...storyQualityIssues({
+        title: String(story.title ?? id),
+        description,
+        implementationPlan,
+        userStory,
+        acceptanceTexts: acceptanceTextsFromItems(items),
+        acceptanceCountJustification: acceptanceCountJustification(story, sw),
+        swarm: sw,
+        concurrentReady: readiness === READY,
+      }),
+    );
+
+    if (issues.length > 0) {
+      throw new DecompositionError(`${id}: story invalid: ${issues.join(", ")}`);
+    }
+  }
+
+  validateDag(storyIds, depsByStory);
+  return storyIds;
+}
+
+// ---------------------------------------------------------------------------
+// Reference normalization
+// ---------------------------------------------------------------------------
+
+function normalizeReferences(refs: unknown): JsonObj[] {
+  if (!Array.isArray(refs)) return [];
+  return refs
+    .filter((ref) => typeof ref === "object" && ref !== null && !Array.isArray(ref))
+    .map((ref) => referenceWithDefaultTrust(ref as JsonObj));
+}
+
+function childProvenanceReferences(refs: unknown): JsonObj[] {
+  return normalizeReferences(refs).filter(
+    (ref) =>
+      !String(ref.type ?? "")
+        .toLowerCase()
+        .includes("acceptance"),
+  );
+}
+
+function dedupeReferences(refs: JsonObj[]): JsonObj[] {
+  const out: JsonObj[] = [];
+  const seen = new Set<string>();
+  for (const ref of refs) {
+    const key = `${String(ref.uri ?? ref.url ?? "")}|${String(ref.type ?? "")}|${String(ref.title ?? "")}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(ref);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Build child vBRIEF
+// ---------------------------------------------------------------------------
+
+function storyNarratives(story: JsonObj): Record<string, string> {
+  const narratives: Record<string, string> = {};
+  const raw = story.narratives;
+  if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+    for (const [k, v] of Object.entries(raw as JsonObj)) {
+      if (typeof v === "string" && v.trim().length > 0) narratives[k] = v.trim();
+    }
+  }
+  for (const [draftKey, narrativeKey] of [
+    ["description", "Description"],
+    ["summary", "Description"],
+    ["implementation_plan", "ImplementationPlan"],
+    ["ImplementationPlan", "ImplementationPlan"],
+    ["user_story", "UserStory"],
+    ["UserStory", "UserStory"],
+    ["traces", "Traces"],
+  ] as const) {
+    if (narrativeKey in narratives) continue;
+    const values = asStrList(story[draftKey]);
+    if (values.length > 0) {
+      const sep = narrativeKey === "ImplementationPlan" ? "\n" : ", ";
+      narratives[narrativeKey] = values.join(sep);
+    }
+  }
+  return narratives;
+}
+
+function childFilename(story: JsonObj, stId: string, title: string, date: string): string {
+  const fn = story.filename;
+  if (typeof fn === "string" && fn.endsWith(".vbrief.json")) return fn;
+  const sl = slugify(title) || slugify(stId) || "story";
+  return `${date}-${sl}.vbrief.json`;
+}
+
+function buildChildVbrief(opts: {
+  story: JsonObj;
+  storyId: string;
+  storyIndex: number;
+  parent: JsonObj;
+  parentRel: string;
+  status: string;
+}): JsonObj {
+  const { story, storyId: stId, storyIndex, parent, parentRel, status } = opts;
+  const title = String(story.title ?? stId);
+  const sw = swarmMeta(story);
+  const items = itemsFromStory(stId, story);
+  const metadata: JsonObj =
+    typeof story.metadata === "object" && story.metadata !== null && !Array.isArray(story.metadata)
+      ? { ...(story.metadata as JsonObj) }
+      : {};
+  metadata.kind = "story";
+  metadata.swarm = sw;
+
+  const parentPlan =
+    typeof parent.plan === "object" && parent.plan !== null && !Array.isArray(parent.plan)
+      ? (parent.plan as JsonObj)
+      : {};
+  const parentRefs = childProvenanceReferences(parentPlan.references);
+  const storyRefs = normalizeReferences(story.references);
+
+  return {
+    vBRIEFInfo: {
+      version: EMITTED_VBRIEF_VERSION,
+      description: `Story vBRIEF ${storyIndex} decomposed from ${parentRel}`,
+    },
+    plan: {
+      id: stId,
+      title,
+      status,
+      planRef: parentRel,
+      narratives: storyNarratives(story),
+      items,
+      metadata,
+      references: dedupeReferences([...parentRefs, ...storyRefs]),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// apply_decomposition
+// ---------------------------------------------------------------------------
+
+export interface ApplyDecompositionOptions {
+  projectRoot: string;
+  parentPath: string;
+  draftPath: string;
+  checkOnly: boolean;
+  date: string;
+}
+
+export function applyDecomposition(opts: ApplyDecompositionOptions): string[] {
+  const { projectRoot, parentPath, draftPath, checkOnly, date } = opts;
+  const vbriefDirPath = vbriefDir(projectRoot);
+
+  const parent = loadJson(parentPath);
+  const draft = loadJson(draftPath);
+  const stories = storySpecs(draft);
+  const stIds = validateDraft(stories);
+
+  let outputDir: string;
+  const draftOutputDir = draft.output_dir;
+  if (typeof draftOutputDir === "string" && draftOutputDir.trim().length > 0) {
+    outputDir = isAbsolute(draftOutputDir.trim())
+      ? draftOutputDir.trim()
+      : join(projectRoot, draftOutputDir.trim());
+  } else {
+    outputDir = join(vbriefDirPath, "pending");
+  }
+  outputDir = resolve(outputDir);
+
+  const outputFolderName = basename(outputDir);
+  if (!LIFECYCLE_FOLDERS.has(outputFolderName)) {
+    throw new DecompositionError("output_dir must be a vbrief lifecycle folder");
+  }
+  if (!outputDir.startsWith(`${resolve(vbriefDirPath)}/`) && outputDir !== resolve(vbriefDirPath)) {
+    throw new DecompositionError("output_dir must be inside vbrief/");
+  }
+  if (outputFolderName === "active") {
+    throw new DecompositionError(
+      "output_dir must not be vbrief/active; write pending stories and use task scope:activate when work begins",
+    );
+  }
+
+  const status = normalizeStatus(draft.status, defaultStatusForFolderName(outputFolderName));
+  if (ACTIVE_DECOMPOSITION_STATUSES.has(status)) {
+    throw new DecompositionError(
+      "decomposition cannot create active/running child stories; write pending stories and use task scope:activate when work begins",
+    );
+  }
+
+  const parentRel = relToVbrief(vbriefDirPath, parentPath);
+  const actions: string[] = [`VALIDATED ${stories.length} story decomposition draft`];
+
+  const childPaths: Array<{ target: string; storyId: string; title: string }> = [];
+  const childDocs: JsonObj[] = [];
+
+  for (let i = 0; i < stories.length; i += 1) {
+    const story = stories[i]!;
+    const stId = stIds[i]!;
+    const title = String(story.title ?? stId);
+    const storyStatus = normalizeStatus(story.status, status);
+    if (ACTIVE_DECOMPOSITION_STATUSES.has(storyStatus)) {
+      throw new DecompositionError(
+        `${stId}: decomposition cannot create active/running child stories; write pending stories and use task scope:activate when work begins`,
+      );
+    }
+    const filename = childFilename(story, stId, title, date);
+    const target = join(outputDir, filename);
+    if (!checkOnly && existsSync(target)) {
+      throw new DecompositionError(
+        `${target}: child story path already exists; overwriting is not supported`,
+      );
+    }
+    const child = buildChildVbrief({
+      story,
+      storyId: stId,
+      storyIndex: i + 1,
+      parent,
+      parentRel,
+      status: storyStatus,
+    });
+    childPaths.push({ target, storyId: stId, title });
+    childDocs.push(child);
+    const verb = checkOnly ? "CHECK" : "CREATE";
+    actions.push(`${verb} ${relToVbrief(vbriefDirPath, target)}`);
+  }
+
+  if (checkOnly) return actions;
+
+  for (const { target } of childPaths) {
+    mkdirSync(dirname(target), { recursive: true });
+  }
+  for (let i = 0; i < childPaths.length; i += 1) {
+    // biome-ignore lint/style/noNonNullAssertion: loop bound ensures these exist
+    writeJson(childPaths[i]!.target, childDocs[i]!);
+  }
+
+  let parentPlan = parent.plan;
+  if (parentPlan === null || parentPlan === undefined) {
+    parentPlan = {};
+    parent.plan = parentPlan;
+  }
+  if (typeof parentPlan !== "object" || Array.isArray(parentPlan)) {
+    throw new DecompositionError(`${parentPath}: plan must be an object`);
+  }
+  const planObj = parentPlan as JsonObj;
+  let metadata = planObj.metadata;
+  if (metadata === null || metadata === undefined) {
+    metadata = {};
+    planObj.metadata = metadata;
+  }
+  if (typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new DecompositionError(`${parentPath}: plan.metadata must be an object`);
+  }
+  const metaObj = metadata as JsonObj;
+  if (!metaObj.kind) metaObj.kind = "epic";
+
+  let references = planObj.references;
+  if (references === null || references === undefined) {
+    references = [];
+    planObj.references = references;
+  }
+  if (!Array.isArray(references)) {
+    throw new DecompositionError(`${parentPath}: plan.references must be an array`);
+  }
+
+  for (const { target, title } of childPaths) {
+    (references as JsonObj[]).push(
+      referenceWithDefaultTrust({
+        uri: relToVbrief(vbriefDirPath, target),
+        type: "x-vbrief/plan",
+        title,
+      }),
+    );
+  }
+  planObj.references = dedupeReferences(
+    (references as unknown[])
+      .filter((r) => typeof r === "object" && r !== null && !Array.isArray(r))
+      .map((r) => r as JsonObj),
+  );
+
+  writeJson(parentPath, parent);
+  actions.push(`UPDATE ${parentRel} references`);
+  return actions;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseDecomposeArgs(argv: string[]): {
+  parent?: string;
+  draft?: string;
+  check: boolean;
+  date?: string;
+  projectRoot: string;
+  error?: string;
+} {
+  let parent: string | undefined;
+  let draft: string | undefined;
+  let check = false;
+  let date: string | undefined;
+  let projectRoot = ".";
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--draft") {
+      draft = argv[i + 1];
+      i += 1;
+    } else if (arg?.startsWith("--draft=")) {
+      draft = arg.slice("--draft=".length);
+    } else if (arg === "--check") {
+      check = true;
+    } else if (arg === "--date") {
+      date = argv[i + 1];
+      i += 1;
+    } else if (arg?.startsWith("--date=")) {
+      date = arg.slice("--date=".length);
+    } else if (arg === "--project-root") {
+      projectRoot = argv[i + 1] ?? ".";
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      projectRoot = arg.slice("--project-root=".length);
+    } else if (!arg?.startsWith("-") && parent === undefined) {
+      parent = arg;
+    } else {
+      return { check, projectRoot, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return { parent, draft, check, date, projectRoot };
+}
+
+/** CLI entry for scope-decompose (mirrors scope_decompose.py main()). */
+export function decomposeMain(argv: string[]): number {
+  const parsed = parseDecomposeArgs(argv);
+  if (parsed.error !== undefined) {
+    process.stderr.write(`ERROR: ${parsed.error}\n`);
+    return 2;
+  }
+
+  const { parent, draft, check, projectRoot } = parsed;
+  const projRoot = resolve(projectRoot);
+
+  if (parent === undefined && draft === undefined) {
+    if (check) {
+      process.stdout.write("OK no decomposition draft supplied; nothing to apply.\n");
+      return 0;
+    }
+    process.stderr.write("ERROR: parent path and --draft are required\n");
+    return 2;
+  }
+  if (parent === undefined || draft === undefined) {
+    process.stderr.write("ERROR: parent path and --draft are required\n");
+    return 2;
+  }
+
+  const parentPath = isAbsolute(parent) ? parent : join(projRoot, parent);
+  const draftPath = isAbsolute(draft) ? draft : join(projRoot, draft);
+
+  if (!existsSync(parentPath)) {
+    process.stderr.write(`ERROR: parent vBRIEF not found: ${parentPath}\n`);
+    return 2;
+  }
+  if (!existsSync(draftPath)) {
+    process.stderr.write(`ERROR: decomposition draft not found: ${draftPath}\n`);
+    return 2;
+  }
+
+  const dateStr = parsed.date ?? new Date().toISOString().slice(0, 10);
+  if (!isValidCreationDate(dateStr)) {
+    process.stderr.write(`ERROR: --date must be YYYY-MM-DD, got '${dateStr}'\n`);
+    return 2;
+  }
+
+  if (!check) {
+    try {
+      accessSync(parentPath, constants.W_OK);
+    } catch {
+      process.stderr.write(`ERROR: parent vBRIEF is not writable: ${parentPath}\n`);
+      return 2;
+    }
+  }
+
+  try {
+    const actions = applyDecomposition({
+      projectRoot: projRoot,
+      parentPath: resolve(parentPath),
+      draftPath: resolve(draftPath),
+      checkOnly: check,
+      date: dateStr,
+    });
+    for (const action of actions) {
+      process.stdout.write(`${action}\n`);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof DecompositionError) {
+      process.stderr.write(`ERROR: ${err.message}\n`);
+      return 1;
+    }
+    process.stderr.write(`ERROR: ${String(err)}\n`);
+    return 1;
+  }
+}

--- a/tasks/architecture.yml
+++ b/tasks/architecture.yml
@@ -7,9 +7,7 @@ tasks:
   sor-preflight:
     desc: "System-of-record architecture preflight. Run before stateful implementation: task architecture:sor-preflight -- --story-path <path>"
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     # Per conventions/task-caching.md: no sources/generates because this target
     # forwards user-supplied story paths and flags via CLI_ARGS.
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/preflight_architecture_sor.py" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" architecture-preflight-sor {{.CLI_ARGS}}

--- a/tasks/changelog.yml
+++ b/tasks/changelog.yml
@@ -20,7 +20,5 @@ tasks:
   resolve-unreleased:
     desc: "Union-merge CHANGELOG.md [Unreleased] conflicts (#911) -- task changelog:resolve-unreleased [-- --changelog-path PATH] [--dry-run]"
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/resolve_changelog_unreleased.py" {{.CLI_ARGS}}
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" changelog-resolve-unreleased {{.CLI_ARGS}}

--- a/tasks/scope-undo.yml
+++ b/tasks/scope-undo.yml
@@ -32,7 +32,5 @@ tasks:
   undo:
     desc: "Reverse a scope-lifecycle audit entry (#1134). Single: `task scope:undo -- <decision_id>` / `task scope:undo -- --decision-id=<uuid>`. Batch: `task scope:undo -- --batch-id=<uuid>`. Optional `--dry-run`."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_undo.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-undo {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -118,11 +118,10 @@ tasks:
   decompose:
     desc: "Apply/check an approved epic/phase -> story decomposition draft"
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ensure-ts
     cmds:
-      # Keep CLI_ARGS bare; go-task shell-escapes pass-through args and quoting breaks multi-arg calls.
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_decompose.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-decompose {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
 
   # Operator-driven demote (D1 / #1121). Moves a vBRIEF scope from
   # vbrief/pending/ back to vbrief/proposed/ and appends a structured
@@ -136,7 +135,7 @@ tasks:
   demote:
     desc: "Demote a vBRIEF scope: pending/ -> proposed/ (#1121). Single-file or --batch --older-than-days N (default 45)."
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - _ensure-ts
     cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/scope_demote.py" {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-demote {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"

--- a/tests/content/test_system_of_record_gate.py
+++ b/tests/content/test_system_of_record_gate.py
@@ -37,7 +37,10 @@ def test_taskfile_surfaces_system_of_record_gate() -> None:
     verify_tasks = _read("tasks/verify.yml")
     assert "tasks/architecture.yml" in taskfile
     assert "sor-preflight" in architecture_tasks
-    assert "preflight_architecture_sor.py" in architecture_tasks
+    # Wave 8.6 (#1854): tasks/architecture.yml flipped from the Python script to
+    # the TS dispatcher verb. verify.yml's architecture-sor gate is not in this
+    # wave's scope and still references the Python script.
+    assert "architecture-preflight-sor" in architecture_tasks
     assert "architecture-sor" in verify_tasks
     assert "preflight_architecture_sor.py" in verify_tasks
 


### PR DESCRIPTION
## Summary

Wave 8.6 s4 -- five Python scripts migrated to the unified deft-ts TypeScript dispatcher as part of #1530.

**Wire-flips** (existing TS modules, Taskfile-only changes):
- `scope_undo.py` → `core/src/scope/main.ts` (`undoMain`); `tasks/scope-undo.yml`
- `scope_demote.py` → `core/src/scope/main.ts` (`demoteMain`); `tasks/scope.yml`
- `resolve_changelog_unreleased.py` → `core/src/platform` (`changelogResolveUnreleasedMain`); `tasks/changelog.yml`

**Real ports** (new TS modules + Vitest tests):
- `scope_decompose.py` → `packages/core/src/scope/decompose.ts` + `scope-decompose` verb in dispatch.ts; `tasks/scope.yml`
- `preflight_architecture_sor.py` + `_sor_gate_diff.py` → `packages/core/src/architecture/sor-preflight.ts` + `architecture-preflight-sor` verb; `tasks/architecture.yml`

**Test coverage added:**
- `packages/core/src/scope/decompose.test.ts` — 34 tests covering `asStrList`, `itemHasTraces`, `validateDraft` (happy path, cycles, unknown deps, duplicates), `applyDecomposition` (check-only, file creation, error conditions), `decomposeMain` CLI
- `packages/core/src/architecture/sor-preflight.test.ts` — 29 tests covering `evaluateStory`, `evaluateDiffText`, `scanDiff`, `storageMatches`, `validateRecord`, `systemOfRecord`, `architecturePreflightSorMain` with sor_gate fixtures
- `packages/core/src/platform/changelog-cli.test.ts` — 7 tests covering the CLI wrapper

**Content-contract update:** `system_of_record_gate.test.ts` updated to assert the Node.js verb (`architecture-preflight-sor`) instead of the Python script now that `tasks/architecture.yml` is wire-flipped.

## Verify results
- `task ts:scope-lifecycle-parity`: CLEAN -- Python and TS agree on 3 scenario(s)
- All 5 new CLI verbs dispatch via `node packages/cli/dist/bin.js`: `scope-undo`, `scope-demote`, `scope-decompose`, `changelog-resolve-unreleased`, `architecture-preflight-sor`
- `grep -rE 'uv .*run python' tasks/scope.yml tasks/scope-undo.yml tasks/changelog.yml tasks/architecture.yml` → only a comment line, no actual commands
- New test suites: 29 + 34 + 7 = 70 passing tests
- `task ts:check-lane` fails on pre-existing branch coverage threshold (84.62% branches vs 85% target); this was failing before my changes too (confirmed by stash baseline check)

## Known blocker
`task ts:check-lane` branch coverage threshold (85%) was already failing on the baseline branch (84.62%) before this story's changes. My additions kept it at 84.62%. Flagging for orchestrator; resolution tracked by the baseline story.

Closes #1854
Refs #1530 Wave 8.6 s4

Made with [Cursor](https://cursor.com)