### PR TITLE
chore(policy): restore branch enforcement after v0.53.0 cut

### DIFF
--- a/meta/policy-changes.log
+++ b/meta/policy-changes.log
@@ -35,3 +35,4 @@
 2026-06-18T15:05:19Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
 2026-06-18T15:21:36Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True
 2026-06-21T23:10:51Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
+2026-06-21T23:32:46Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -11034,7 +11034,7 @@
           }
         ]
       },
-      "allowDirectCommitsToMaster": true
+      "allowDirectCommitsToMaster": false
     },
     "updated": "2026-06-12T20:26:00Z"
   }


### PR DESCRIPTION
## Summary
- Restores `plan.policy.allowDirectCommitsToMaster=false` (branch-protection ON), which the v0.53.0 release session temporarily flipped to `true` and landed on `master`.
- Administrative cleanup closing out the release session per the `deft-directive-release` skill's restore-enforcement step.

## Test plan
- [x] `task policy:show -- --field=plan.policy.allowDirectCommitsToMaster` reports `current: false` after merge
- [x] Branch-protection gate (`task verify:branch`) re-enforces on `master`

Made with [Cursor](https://cursor.com)