### PR TITLE
fix(subprocess-capture): apply shared GH_MAX_BUFFER to gh --paginate sites (#1867)

### DIFF
--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 2bbf18f17687ff2e81f4687d5a2e232c69b6f5bdb2c12b1d81176e077eaa4d99 -->
-<!-- Source digest sha256: 418c977b8c31432119a2652b4ed34aece026029445b84b4e9e0f2df9325717e3 -->
+<!-- Artifact sha256: 5768c03d7f5df0eb4aa0020f944ffd01e10e494053592de9be594f6cfe9c0f10 -->
+<!-- Source digest sha256: 69615839c07423557a6d676534f7f7463ea9ea716352f05c44e702c45101cd20 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `418c977b8c31432119a2652b4ed34aece026029445b84b4e9e0f2df9325717e3` |
+| Source digest | `69615839c07423557a6d676534f7f7463ea9ea716352f05c44e702c45101cd20` |
 
 ## Modules
 
@@ -22,10 +22,10 @@
 | --- | --- | --- | --- | ---: |
 | `framework-content` | Framework Content | Agent-consumed standards, strategies, skills, templates, and documentation. | `AGENTS.md`, `SKILL.md`, `README.md`, `QUICK-START.md`, ... | 270 |
 | `python-tooling` | Python Tooling | Framework CLI helpers, validators, lifecycle tools, and automation scripts. | `run`, `run.py`, `run.bat`, `scripts/**/*.py` | 163 |
-| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1028 |
+| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1030 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
-| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 746 |
+| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 747 |
 | `content-packs` | Content Packs | Curated, sliceable agent memory packs rendered and checked through the packs task namespace. | `packs/**/*.md`, `packs/**/*.json` | 6 |
 | `ci-release-automation` | CI and Release Automation | Repository automation for branch policy, hooks, GitHub Actions, PR readiness, and release publication. | `.github/**/*.yml`, `.github/**/*.yaml`, `.githooks/*` | 6 |
 | `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 339 |
@@ -137,11 +137,11 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 803 |
+| JSON | 804 |
 | Markdown | 273 |
 | Other | 5 |
 | Python | 455 |
-| TypeScript | 1017 |
+| TypeScript | 1019 |
 | YAML | 53 |
 
 ## Degraded Signals

--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 5768c03d7f5df0eb4aa0020f944ffd01e10e494053592de9be594f6cfe9c0f10 -->
-<!-- Source digest sha256: 69615839c07423557a6d676534f7f7463ea9ea716352f05c44e702c45101cd20 -->
+<!-- Artifact sha256: e826b3d5b2badbaf114c0cb33b250867f6b8996ff85dd1c7699c5b5c012f9fed -->
+<!-- Source digest sha256: b8f78adaab30831d2c38dfcab0579f054d6b71557200a3428ee807407192e2c8 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `69615839c07423557a6d676534f7f7463ea9ea716352f05c44e702c45101cd20` |
+| Source digest | `b8f78adaab30831d2c38dfcab0579f054d6b71557200a3428ee807407192e2c8` |
 
 ## Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`task release:publish` and `triage:scope` no longer fail with a blank error on large repos (#1867)** -- Several `gh api --paginate` capture sites inherited Node's 1 MB stdout limit, so once a repo's release or label/milestone list grew past ~1 MB the command aborted with an empty error message (this blocked the v0.53.0 publish until a manual workaround). All `gh`/git capture sites now share a single 64 MB ceiling and surface the real failure reason instead of a blank one, so publish, rollback, and `triage:scope --diff-from-upstream` work on mature repos. Refs #1867.
 
 ### Removed
 

--- a/packages/core/src/pr-closing-keywords/gh.ts
+++ b/packages/core/src/pr-closing-keywords/gh.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { resolveBinary } from "../scm/binary.js";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { GH_TIMEOUT_S } from "./constants.js";
 import type { RunGhFn, RunGhResult } from "./types.js";
 
@@ -16,7 +16,7 @@ export function defaultRunGh(cmd: readonly string[]): RunGhResult {
       encoding: "utf8",
       timeout: GH_TIMEOUT_S * 1000,
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: GH_MAX_BUFFER,
+      maxBuffer: SUBPROCESS_MAX_BUFFER,
     });
     return { returncode: 0, stdout: typeof stdout === "string" ? stdout : "", stderr: "" };
   } catch (err: unknown) {

--- a/packages/core/src/pr-closing-keywords/gh.ts
+++ b/packages/core/src/pr-closing-keywords/gh.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { resolveBinary } from "../scm/binary.js";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { GH_TIMEOUT_S } from "./constants.js";
 import type { RunGhFn, RunGhResult } from "./types.js";
 
@@ -15,7 +16,7 @@ export function defaultRunGh(cmd: readonly string[]): RunGhResult {
       encoding: "utf8",
       timeout: GH_TIMEOUT_S * 1000,
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: 10 * 1024 * 1024,
+      maxBuffer: GH_MAX_BUFFER,
     });
     return { returncode: 0, stdout: typeof stdout === "string" ? stdout : "", stderr: "" };
   } catch (err: unknown) {

--- a/packages/core/src/pr-merge-readiness/gh.ts
+++ b/packages/core/src/pr-merge-readiness/gh.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { resolveBinary } from "../scm/binary.js";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { GH_TIMEOUT_S, GREPTILE_LOGIN } from "./constants.js";
 import type { RunGhFn, RunGhResult } from "./types.js";
 
@@ -15,7 +16,7 @@ export function defaultRunGh(cmd: readonly string[]): RunGhResult {
       encoding: "utf8",
       timeout: GH_TIMEOUT_S * 1000,
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: 10 * 1024 * 1024,
+      maxBuffer: GH_MAX_BUFFER,
     });
     return { returncode: 0, stdout: typeof stdout === "string" ? stdout : "", stderr: "" };
   } catch (err: unknown) {

--- a/packages/core/src/pr-merge-readiness/gh.ts
+++ b/packages/core/src/pr-merge-readiness/gh.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { resolveBinary } from "../scm/binary.js";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { GH_TIMEOUT_S, GREPTILE_LOGIN } from "./constants.js";
 import type { RunGhFn, RunGhResult } from "./types.js";
 
@@ -16,7 +16,7 @@ export function defaultRunGh(cmd: readonly string[]): RunGhResult {
       encoding: "utf8",
       timeout: GH_TIMEOUT_S * 1000,
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: GH_MAX_BUFFER,
+      maxBuffer: SUBPROCESS_MAX_BUFFER,
     });
     return { returncode: 0, stdout: typeof stdout === "string" ? stdout : "", stderr: "" };
   } catch (err: unknown) {

--- a/packages/core/src/pr-protected-issues/gh.ts
+++ b/packages/core/src/pr-protected-issues/gh.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { resolveBinary } from "../scm/binary.js";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { GH_TIMEOUT_S } from "./constants.js";
 import type { RunGhFn, RunGhResult } from "./types.js";
 
@@ -16,7 +16,7 @@ export function defaultRunGh(cmd: readonly string[]): RunGhResult {
       encoding: "utf8",
       timeout: GH_TIMEOUT_S * 1000,
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: GH_MAX_BUFFER,
+      maxBuffer: SUBPROCESS_MAX_BUFFER,
     });
     return { returncode: 0, stdout: typeof stdout === "string" ? stdout : "", stderr: "" };
   } catch (err: unknown) {

--- a/packages/core/src/pr-protected-issues/gh.ts
+++ b/packages/core/src/pr-protected-issues/gh.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { resolveBinary } from "../scm/binary.js";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { GH_TIMEOUT_S } from "./constants.js";
 import type { RunGhFn, RunGhResult } from "./types.js";
 
@@ -15,7 +16,7 @@ export function defaultRunGh(cmd: readonly string[]): RunGhResult {
       encoding: "utf8",
       timeout: GH_TIMEOUT_S * 1000,
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: 10 * 1024 * 1024,
+      maxBuffer: GH_MAX_BUFFER,
     });
     return { returncode: 0, stdout: typeof stdout === "string" ? stdout : "", stderr: "" };
   } catch (err: unknown) {

--- a/packages/core/src/pr-wait-mergeable/wrappers.ts
+++ b/packages/core/src/pr-wait-mergeable/wrappers.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveBinary } from "../scm/binary.js";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import type { SubprocessTriple } from "./types.js";
 
 export interface CaptureExecResult {
@@ -21,7 +21,7 @@ export function captureExec(
     encoding: "utf8",
     timeout: timeoutMs,
     stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer: GH_MAX_BUFFER,
+    maxBuffer: SUBPROCESS_MAX_BUFFER,
     env: process.env,
   });
 

--- a/packages/core/src/pr-wait-mergeable/wrappers.ts
+++ b/packages/core/src/pr-wait-mergeable/wrappers.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveBinary } from "../scm/binary.js";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import type { SubprocessTriple } from "./types.js";
 
 export interface CaptureExecResult {
@@ -20,7 +21,7 @@ export function captureExec(
     encoding: "utf8",
     timeout: timeoutMs,
     stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer: 10 * 1024 * 1024,
+    maxBuffer: GH_MAX_BUFFER,
     env: process.env,
   });
 

--- a/packages/core/src/release/spawn.test.ts
+++ b/packages/core/src/release/spawn.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { spawnText } from "./spawn.js";
+
+describe("spawnText maxBuffer (#1867)", () => {
+  it("uses a multi-megabyte ceiling, well above Node's 1 MB default", () => {
+    // Regression guard for the constant the helper relies on.
+    expect(GH_MAX_BUFFER).toBeGreaterThan(1024 * 1024);
+  });
+
+  it("captures stdout larger than Node's 1 MB default without failing", () => {
+    // 2 MB overflows the 1 MB default that caused the empty-error publish
+    // failure; with GH_MAX_BUFFER applied the capture must succeed cleanly.
+    const bytes = 2 * 1024 * 1024;
+    const result = spawnText(process.execPath, [
+      "-e",
+      `process.stdout.write("x".repeat(${bytes}))`,
+    ]);
+    expect(result.status).toBe(0);
+    expect(result.stdout.length).toBe(bytes);
+    expect(result.stderr).toBe("");
+  });
+
+  it("surfaces a non-empty stderr when the spawn itself errors", () => {
+    // ENOENT (binary missing) yields status=null + empty stderr from spawnSync;
+    // spawnText must map that to a non-zero status with a real message so the
+    // failure is never reported as a blank reason (#1867).
+    const result = spawnText("deft-nonexistent-binary-xyz", ["api"]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/release/spawn.test.ts
+++ b/packages/core/src/release/spawn.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { spawnText } from "./spawn.js";
 
 describe("spawnText maxBuffer (#1867)", () => {
   it("uses a multi-megabyte ceiling, well above Node's 1 MB default", () => {
     // Regression guard for the constant the helper relies on.
-    expect(GH_MAX_BUFFER).toBeGreaterThan(1024 * 1024);
+    expect(SUBPROCESS_MAX_BUFFER).toBeGreaterThan(1024 * 1024);
   });
 
   it("captures stdout larger than Node's 1 MB default without failing", () => {
     // 2 MB overflows the 1 MB default that caused the empty-error publish
-    // failure; with GH_MAX_BUFFER applied the capture must succeed cleanly.
+    // failure; with SUBPROCESS_MAX_BUFFER applied the capture must succeed cleanly.
     const bytes = 2 * 1024 * 1024;
     const result = spawnText(process.execPath, [
       "-e",

--- a/packages/core/src/release/spawn.ts
+++ b/packages/core/src/release/spawn.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import type { SpawnResult } from "./types.js";
 
 export function defaultWhich(name: string): string | null {
@@ -24,14 +25,21 @@ export function spawnText(
     env: options.env ?? process.env,
     encoding: "utf8",
     timeout: options.timeoutMs,
+    maxBuffer: GH_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
   let status = result.status;
+  let stderr = typeof result.stderr === "string" ? result.stderr : "";
   if (status === null) {
     if (result.signal !== null && result.signal !== undefined) {
       status = 128;
     } else if (result.error) {
       status = 2;
+      // ENOBUFS (stdout over maxBuffer) and similar spawn failures leave stderr
+      // empty; surface the error so callers never report a blank reason (#1867).
+      if (stderr.trim().length === 0) {
+        stderr = result.error.message;
+      }
     } else {
       status = 0;
     }
@@ -39,6 +47,6 @@ export function spawnText(
   return {
     status,
     stdout: typeof result.stdout === "string" ? result.stdout : "",
-    stderr: typeof result.stderr === "string" ? result.stderr : "",
+    stderr,
   };
 }

--- a/packages/core/src/release/spawn.ts
+++ b/packages/core/src/release/spawn.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import type { SpawnResult } from "./types.js";
 
 export function defaultWhich(name: string): string | null {
@@ -25,7 +25,7 @@ export function spawnText(
     env: options.env ?? process.env,
     encoding: "utf8",
     timeout: options.timeoutMs,
-    maxBuffer: GH_MAX_BUFFER,
+    maxBuffer: SUBPROCESS_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
   let status = result.status;

--- a/packages/core/src/scm/gh-rest.ts
+++ b/packages/core/src/scm/gh-rest.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { resolveBinary } from "./binary.js";
 import { pyRepr } from "./py-format.js";
 
@@ -68,12 +69,20 @@ export function runGhApi(
     encoding: "utf8",
     timeout: timeoutMs,
     env: process.env,
+    maxBuffer: GH_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  let stderr = typeof result.stderr === "string" ? result.stderr : "";
+  // A spawn-level failure (e.g. ENOBUFS when stdout exceeds maxBuffer) yields a
+  // null status and empty stderr; surface error.message so the GhRestError that
+  // wraps this never reports a blank reason (#1867).
+  if (result.status === null && result.error && stderr.trim().length === 0) {
+    stderr = result.error.message;
+  }
   return {
     returncode: result.status ?? 1,
     stdout: typeof result.stdout === "string" ? result.stdout : "",
-    stderr: typeof result.stderr === "string" ? result.stderr : "",
+    stderr,
   };
 }
 

--- a/packages/core/src/scm/gh-rest.ts
+++ b/packages/core/src/scm/gh-rest.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import { resolveBinary } from "./binary.js";
 import { pyRepr } from "./py-format.js";
 
@@ -69,7 +69,7 @@ export function runGhApi(
     encoding: "utf8",
     timeout: timeoutMs,
     env: process.env,
-    maxBuffer: GH_MAX_BUFFER,
+    maxBuffer: SUBPROCESS_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stderr = typeof result.stderr === "string" ? result.stderr : "";

--- a/packages/core/src/subprocess/max-buffer.ts
+++ b/packages/core/src/subprocess/max-buffer.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared stdout ceiling for subprocess captures of `gh` / git output.
+ *
+ * Node's `spawnSync` / `execFileSync` default to a 1 MB stdout buffer. A
+ * `gh api --paginate` response that concatenates every page (e.g. a repo's
+ * full release or issue list) routinely exceeds 1 MB. When it does, the
+ * capture aborts with `error.code === "ENOBUFS"`, a `null` status, truncated
+ * stdout, and an EMPTY stderr -- surfacing downstream as a failure with no
+ * detail (#1867: `task release:publish` / `release:rollback` and consumer
+ * `task triage:scope -- --diff-from-upstream`).
+ *
+ * Every `gh` / git capture site MUST pass this ceiling so large responses
+ * succeed, and MUST surface `result.error.message` when stderr is empty so an
+ * overflow is never silent again.
+ */
+export const GH_MAX_BUFFER = 64 * 1024 * 1024;

--- a/packages/core/src/subprocess/max-buffer.ts
+++ b/packages/core/src/subprocess/max-buffer.ts
@@ -1,16 +1,17 @@
 /**
- * Shared stdout ceiling for subprocess captures of `gh` / git output.
+ * Shared stdout ceiling for subprocess captures whose output can be large.
  *
  * Node's `spawnSync` / `execFileSync` default to a 1 MB stdout buffer. A
  * `gh api --paginate` response that concatenates every page (e.g. a repo's
- * full release or issue list) routinely exceeds 1 MB. When it does, the
- * capture aborts with `error.code === "ENOBUFS"`, a `null` status, truncated
- * stdout, and an EMPTY stderr -- surfacing downstream as a failure with no
- * detail (#1867: `task release:publish` / `release:rollback` and consumer
- * `task triage:scope -- --diff-from-upstream`).
+ * full release or issue list), and other potentially large captures (a
+ * `uv run python` gate, a spawned Node helper), routinely exceed 1 MB. When
+ * they do, the capture aborts with `error.code === "ENOBUFS"`, a `null`
+ * status, truncated stdout, and an EMPTY stderr -- surfacing downstream as a
+ * failure with no detail (#1867: `task release:publish` / `release:rollback`
+ * and consumer `task triage:scope -- --diff-from-upstream`).
  *
- * Every `gh` / git capture site MUST pass this ceiling so large responses
- * succeed, and MUST surface `result.error.message` when stderr is empty so an
- * overflow is never silent again.
+ * Every subprocess capture site that may produce a large response MUST pass
+ * this ceiling, and MUST surface `result.error.message` when stderr is empty
+ * so an overflow is never silent again.
  */
-export const GH_MAX_BUFFER = 64 * 1024 * 1024;
+export const SUBPROCESS_MAX_BUFFER = 64 * 1024 * 1024;

--- a/packages/core/src/swarm/subprocess.ts
+++ b/packages/core/src/swarm/subprocess.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 
 export interface TextCaptureResult {
   readonly returncode: number;
@@ -21,7 +21,7 @@ export function runText(
       cwd: options.cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: GH_MAX_BUFFER,
+      maxBuffer: SUBPROCESS_MAX_BUFFER,
     });
     return {
       returncode: 0,

--- a/packages/core/src/swarm/subprocess.ts
+++ b/packages/core/src/swarm/subprocess.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { GH_MAX_BUFFER } from "../subprocess/max-buffer.js";
 
 export interface TextCaptureResult {
   readonly returncode: number;
@@ -20,7 +21,7 @@ export function runText(
       cwd: options.cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: 10 * 1024 * 1024,
+      maxBuffer: GH_MAX_BUFFER,
     });
     return {
       returncode: 0,

--- a/packages/core/src/triage/bootstrap/index.ts
+++ b/packages/core/src/triage/bootstrap/index.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
+import { GH_MAX_BUFFER } from "../../subprocess/max-buffer.js";
 import {
   stepEnsureGitignoreEntry,
   stepEnsureGitignoreEvalEntries,
@@ -212,7 +213,7 @@ print(json.dumps(out))
   const { stdout } = await execFileAsync("uv", ["run", "python", "-c", script, payload], {
     cwd: deftRoot,
     encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024,
+    maxBuffer: GH_MAX_BUFFER,
   });
   const parsed = JSON.parse(String(stdout).trim()) as {
     succeeded?: number | null;

--- a/packages/core/src/triage/bootstrap/index.ts
+++ b/packages/core/src/triage/bootstrap/index.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
-import { GH_MAX_BUFFER } from "../../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../../subprocess/max-buffer.js";
 import {
   stepEnsureGitignoreEntry,
   stepEnsureGitignoreEvalEntries,
@@ -213,7 +213,7 @@ print(json.dumps(out))
   const { stdout } = await execFileAsync("uv", ["run", "python", "-c", script, payload], {
     cwd: deftRoot,
     encoding: "utf8",
-    maxBuffer: GH_MAX_BUFFER,
+    maxBuffer: SUBPROCESS_MAX_BUFFER,
   });
   const parsed = JSON.parse(String(stdout).trim()) as {
     succeeded?: number | null;

--- a/packages/core/src/triage/scope/mutations.ts
+++ b/packages/core/src/triage/scope/mutations.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { GH_MAX_BUFFER } from "../../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../../subprocess/max-buffer.js";
 import { collectMilestoneSubscribedNames, rulesRequestIsOpen } from "./milestone.js";
 import { addIgnore, subscribe } from "./mutations-core.js";
 import { resolveScopeIgnores, resolveScopeRules } from "./resolve.js";
@@ -180,7 +180,7 @@ function fetchNamesViaGh(binary: string, path: string, nameField: string): Set<s
     proc = spawnSync(binary, ["api", "--paginate", path], {
       encoding: "utf8",
       timeout: 30_000,
-      maxBuffer: GH_MAX_BUFFER,
+      maxBuffer: SUBPROCESS_MAX_BUFFER,
     });
   } catch {
     throw new Error(`\`${binary} api ${path}\` timed out after 30s -- check your network.`);
@@ -200,7 +200,7 @@ function fetchNamesViaGh(binary: string, path: string, nameField: string): Set<s
   if (proc.status !== 0) {
     const errText =
       String(proc.stderr ?? proc.stdout ?? "").trim() || (proc.error ? proc.error.message : "");
-    throw new Error(`\`${binary} api ${path}\` failed (exit ${proc.status}): ${errText}`);
+    throw new Error(`\`${binary} api ${path}\` failed (exit ${proc.status ?? 1}): ${errText}`);
   }
   return parseGhPaginatedNames(String(proc.stdout ?? ""), nameField);
 }

--- a/packages/core/src/triage/scope/mutations.ts
+++ b/packages/core/src/triage/scope/mutations.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { GH_MAX_BUFFER } from "../../subprocess/max-buffer.js";
 import { collectMilestoneSubscribedNames, rulesRequestIsOpen } from "./milestone.js";
 import { addIgnore, subscribe } from "./mutations-core.js";
 import { resolveScopeIgnores, resolveScopeRules } from "./resolve.js";
@@ -179,6 +180,7 @@ function fetchNamesViaGh(binary: string, path: string, nameField: string): Set<s
     proc = spawnSync(binary, ["api", "--paginate", path], {
       encoding: "utf8",
       timeout: 30_000,
+      maxBuffer: GH_MAX_BUFFER,
     });
   } catch {
     throw new Error(`\`${binary} api ${path}\` timed out after 30s -- check your network.`);
@@ -196,7 +198,8 @@ function fetchNamesViaGh(binary: string, path: string, nameField: string): Set<s
     }
   }
   if (proc.status !== 0) {
-    const errText = String(proc.stderr ?? proc.stdout ?? "").trim();
+    const errText =
+      String(proc.stderr ?? proc.stdout ?? "").trim() || (proc.error ? proc.error.message : "");
     throw new Error(`\`${binary} api ${path}\` failed (exit ${proc.status}): ${errText}`);
   }
   return parseGhPaginatedNames(String(proc.stdout ?? ""), nameField);

--- a/packages/core/src/triage/scope/scope-mutations-fetch.test.ts
+++ b/packages/core/src/triage/scope/scope-mutations-fetch.test.ts
@@ -8,7 +8,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { GH_MAX_BUFFER } from "../../subprocess/max-buffer.js";
+import { SUBPROCESS_MAX_BUFFER } from "../../subprocess/max-buffer.js";
 import { runCliCapture } from "./cli.js";
 import { coveragePath, writeCoverageDenominator } from "./coverage.js";
 import { fetchUpstreamLabelsAndMilestones } from "./mutations.js";
@@ -125,7 +125,7 @@ describe("mutations gh fetch branches", () => {
     );
   });
 
-  it("passes GH_MAX_BUFFER so --paginate responses over 1 MB do not overflow (#1867)", () => {
+  it("passes SUBPROCESS_MAX_BUFFER so --paginate responses over 1 MB do not overflow (#1867)", () => {
     mockedSpawn.mockReturnValue({
       status: 0,
       stdout: "[]",
@@ -136,7 +136,7 @@ describe("mutations gh fetch branches", () => {
     } as ReturnType<typeof spawnSync>);
     fetchUpstreamLabelsAndMilestones("o/r", "gh");
     const options = mockedSpawn.mock.calls[0]?.[2] as { maxBuffer?: number } | undefined;
-    expect(options?.maxBuffer).toBe(GH_MAX_BUFFER);
+    expect(options?.maxBuffer).toBe(SUBPROCESS_MAX_BUFFER);
   });
 
   it("surfaces a non-empty message when the spawn errors with empty stderr (#1867)", () => {

--- a/packages/core/src/triage/scope/scope-mutations-fetch.test.ts
+++ b/packages/core/src/triage/scope/scope-mutations-fetch.test.ts
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { GH_MAX_BUFFER } from "../../subprocess/max-buffer.js";
 import { runCliCapture } from "./cli.js";
 import { coveragePath, writeCoverageDenominator } from "./coverage.js";
 import { fetchUpstreamLabelsAndMilestones } from "./mutations.js";
@@ -122,6 +123,37 @@ describe("mutations gh fetch branches", () => {
     expect(() => fetchUpstreamLabelsAndMilestones("o/r", "missing-gh")).toThrow(
       /not found on PATH/,
     );
+  });
+
+  it("passes GH_MAX_BUFFER so --paginate responses over 1 MB do not overflow (#1867)", () => {
+    mockedSpawn.mockReturnValue({
+      status: 0,
+      stdout: "[]",
+      stderr: "",
+      pid: 1,
+      output: [null, "", ""],
+      signal: null,
+    } as ReturnType<typeof spawnSync>);
+    fetchUpstreamLabelsAndMilestones("o/r", "gh");
+    const options = mockedSpawn.mock.calls[0]?.[2] as { maxBuffer?: number } | undefined;
+    expect(options?.maxBuffer).toBe(GH_MAX_BUFFER);
+  });
+
+  it("surfaces a non-empty message when the spawn errors with empty stderr (#1867)", () => {
+    // ENOBUFS leaves status=null, stderr="", and a populated error -- the
+    // failure must carry error.message instead of a blank reason.
+    const err = new Error("stdout maxBuffer length exceeded") as NodeJS.ErrnoException;
+    err.code = "ENOBUFS";
+    mockedSpawn.mockReturnValue({
+      status: null,
+      stdout: "",
+      stderr: "",
+      pid: 0,
+      output: [null, "", ""],
+      signal: null,
+      error: err,
+    } as ReturnType<typeof spawnSync>);
+    expect(() => fetchUpstreamLabelsAndMilestones("o/r", "gh")).toThrow(/maxBuffer/);
   });
 
   it("throws when gh returns non-list payload", () => {

--- a/vbrief/completed/2026-06-21-1867-bugsubprocess-capture-gh-api-paginate-sites-lack-maxbuffer-1.vbrief.json
+++ b/vbrief/completed/2026-06-21-1867-bugsubprocess-capture-gh-api-paginate-sites-lack-maxbuffer-1.vbrief.json
@@ -1,0 +1,37 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1867"
+  },
+  "plan": {
+    "title": "bug(subprocess-capture): gh api --paginate sites lack maxBuffer; >1MB responses fail (release publish/rollback + consumer triage:scope)",
+    "status": "completed",
+    "narratives": {
+      "Description": "bug(subprocess-capture): gh api --paginate sites lack maxBuffer; >1MB responses fail (release publish/rollback + consumer triage:scope)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1867",
+      "Overview": "## Symptom\n`task release:publish -- 0.53.0` (and `release:rollback`) fail immediately at the release-lookup step with an **empty** error:\n\n```\n[publish] View v0.53.0 on deftai/directive... FAIL (gh api repos/deftai/directive/releases?per_page=100 failed: )\n```\n\nRunning the same `gh api --paginate repos/deftai/directive/releases?per_page=100` manually works and exits 0.\n\n## Root cause (a bug *class*, not a single site)\nSeveral subprocess-capture sites invoke `gh api --paginate ...` (or otherwise capture a potentially large response) via `spawnSync` **without an explicit `maxBuffer`**, so they inherit Node's 1 MB default. When the response exceeds 1 MB, `spawnSync` returns `error = ENOBUFS`, `status = null`, truncated `stdout`, and **empty `stderr`** — surfacing as a failure with no detail.\n\nFor `deftai/directive` the `--paginate` releases response is ~1.46 MB (96+ releases), so publish/rollback fail. `--paginate` concatenates *all* pages into one response, so the size grows unbounded with total release count (~68+ releases crosses 1 MB at deft's ~15 KB/release).\n\n## Affected sites\n- **`packages/core/src/release/spawn.ts::spawnText`** — backs `release:publish` / `release:rollback` (`release-publish/gh-api.ts` uses `gh api --paginate`). Affects **any** project (incl. consumers) running `task release` once its repo has enough releases.\n- **`packages/core/src/triage/scope/mutations.ts::fetchNamesViaGh`** — `gh api --paginate` for `task triage:scope -- --diff-from-upstream`. **Consumer-facing**: breaks immediately against a large upstream repo, independent of release count.\n- **`packages/core/src/scm/gh-rest.ts::runGhApi`** — central REST shim; no `maxBuffer`. Lower risk (list helpers paginate in JS, one bounded page per call) but worth hardening defensively as the highest-leverage chokepoint.\n\n## Already safe (no change needed)\nPR cascade (`pr-merge-readiness`, `pr-protected-issues`, `pr-closing-keywords`, `pr-wait-mergeable`), `swarm/subprocess.ts`, and `triage/bootstrap/index.ts` already set `maxBuffer: 10 MB` (learned in the #1366 cycle).\n\n## Fix\n- Introduce a shared `GH_MAX_BUFFER` constant (align with the existing 10 MB, or bump to 64 MB) and apply it at the three unguarded sites above.\n- Surface `result.error.message` on overflow so the failure is never an empty error again.\n- Add regression tests: (a) maxBuffer is applied, (b) the empty-stderr / `result.error` mapping yields a non-empty message.\n\nRefs #1729 #1530 #1366.",
+      "Labels": "bug"
+    },
+    "items": [],
+    "tags": [
+      "bug"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1867",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1867: bug(subprocess-capture): gh api --paginate sites lack maxBuffer; >1MB responses fail (release publish/rollback + consumer triage:scope)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1729",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1729"
+      }
+    ],
+    "updated": "2026-06-21T23:59:42Z",
+    "metadata": {
+      "completedAt": "2026-06-21T23:59:42Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the bug class behind the v0.53.0 publish failure (#1867): several `gh api --paginate` capture sites used `spawnSync` without an explicit `maxBuffer`, inheriting Node's 1 MB stdout default. Once a repo's `--paginate` response crossed 1 MB the capture aborted with `ENOBUFS` — `status=null`, truncated stdout, **empty stderr** — surfacing as a failure with no detail.

- New shared `GH_MAX_BUFFER` (64 MB) constant in `packages/core/src/subprocess/max-buffer.ts`.
- Applied at the **three unguarded** sites:
  - `release/spawn.ts::spawnText` — `release:publish` / `release:rollback` (affects any project, incl. consumers, once the repo has enough releases; deft's was ~1.46 MB / 96+ releases).
  - `triage/scope/mutations.ts::fetchNamesViaGh` — **consumer-facing** `task triage:scope -- --diff-from-upstream` against a large upstream.
  - `scm/gh-rest.ts::runGhApi` — central REST shim (defensive; its list helpers paginate in JS so it was low-risk, but it's the highest-leverage chokepoint).
- Surface `result.error.message` when stderr is empty, so an overflow is never a blank error again.
- Consolidated the six already-safe `10 * 1024 * 1024` literals (`pr-merge-readiness`, `pr-protected-issues`, `pr-closing-keywords`, `pr-wait-mergeable`, `swarm/subprocess`, `triage/bootstrap`) onto the shared constant — single source of truth.

## Consumer impact
Yes, this affected consumers, two ways: (1) `task release` on a consumer repo with ~68+ releases, and (2) `triage:scope --diff-from-upstream` against a large upstream repo, immediately. Both are fixed.

## Test plan
- [x] New `release/spawn.test.ts`: 2 MB stdout captured cleanly (would fail under the old 1 MB default); spawn-error maps to a non-empty stderr message.
- [x] Extended `scope-mutations-fetch.test.ts`: asserts `maxBuffer === GH_MAX_BUFFER` is passed; ENOBUFS-style error surfaces a non-empty message.
- [x] `task check` green (8775 passed).
- [x] `task ts:check-lane` green (coverage thresholds met).

Closes #1867

Made with [Cursor](https://cursor.com)