### PR TITLE
chore(policy): restore branch enforcement after v0.53.1 cut

### DIFF
--- a/meta/policy-changes.log
+++ b/meta/policy-changes.log
@@ -37,3 +37,4 @@
 2026-06-21T23:10:51Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
 2026-06-21T23:32:46Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True
 2026-06-22T00:25:21Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
+2026-06-22T00:43:24Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -11034,7 +11034,7 @@
           }
         ]
       },
-      "allowDirectCommitsToMaster": true
+      "allowDirectCommitsToMaster": false
     },
     "updated": "2026-06-12T20:26:00Z"
   }


### PR DESCRIPTION
Reverts the typed direct-commit opt-in used for the v0.53.1 release session. `allowDirectCommitsToMaster=false` -- branch-protection policy is ON again. Mirrors #1866 (the v0.53.0 restore).

Made with [Cursor](https://cursor.com)