### PR TITLE
fix: prune vendored TypeScript test files from the consumer .deft/core deposit (#1878)

### DIFF
--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 0ae509fa3cfca4eb4f4d71ce69e218c8885c9cf3514e29a9eca57f6edd47da55 -->
-<!-- Source digest sha256: f0d35dc310e0b9bcda2b43b2b2b464952c33b638ed604a532938374d68309d67 -->
+<!-- Artifact sha256: 29074239d9d9afffaf60d82602e3afaa8e3a5dc5d0cebf1d565be8aa613dab70 -->
+<!-- Source digest sha256: 417d9c250876aa72ca64ab59e8c97dba0d6e0d9aeb331202d38276aeb9713c31 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `f0d35dc310e0b9bcda2b43b2b2b464952c33b638ed604a532938374d68309d67` |
+| Source digest | `417d9c250876aa72ca64ab59e8c97dba0d6e0d9aeb331202d38276aeb9713c31` |
 
 ## Modules
 

--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 08c76d35fdd49cb43ba5c5bbfc8e500825a5f6543b767dd4bfc65c51e484285c -->
-<!-- Source digest sha256: ea5e8f8929ec488435abc0e8c45213d4ef79a275d3708cad8632e49d96f45869 -->
+<!-- Artifact sha256: 0ae509fa3cfca4eb4f4d71ce69e218c8885c9cf3514e29a9eca57f6edd47da55 -->
+<!-- Source digest sha256: f0d35dc310e0b9bcda2b43b2b2b464952c33b638ed604a532938374d68309d67 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `ea5e8f8929ec488435abc0e8c45213d4ef79a275d3708cad8632e49d96f45869` |
+| Source digest | `f0d35dc310e0b9bcda2b43b2b2b464952c33b638ed604a532938374d68309d67` |
 
 ## Modules
 
@@ -25,7 +25,7 @@
 | `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1034 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
-| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 748 |
+| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 749 |
 | `content-packs` | Content Packs | Curated, sliceable agent memory packs rendered and checked through the packs task namespace. | `packs/**/*.md`, `packs/**/*.json` | 6 |
 | `ci-release-automation` | CI and Release Automation | Repository automation for branch policy, hooks, GitHub Actions, PR readiness, and release publication. | `.github/**/*.yml`, `.github/**/*.yaml`, `.githooks/*` | 6 |
 | `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 339 |
@@ -137,7 +137,7 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 805 |
+| JSON | 806 |
 | Markdown | 273 |
 | Other | 5 |
 | Python | 455 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Vitest-based consumer projects no longer get red CI when upgrading to v0.53.x (#1878)** -- The vendored framework engine's own TypeScript test files (`*.test.*` / `*.spec.*` under `.deft/core/packages/`) were being discovered by a consumer's vitest run and failing CI (unresolved `@deftai/core` imports plus parity assertion failures). The installer now prunes those vendored test files from the `.deft/core/` deposit on every install and upgrade, and the release archive omits them too, so the consumer's vitest no longer discovers framework tests. Mirrors the existing Python self-test prune (#1474). Refs #1878.
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -108,8 +108,6 @@ This manual exclude is harmless to keep, but it becomes unnecessary once the ins
 
 ---
 
----
-
 <!-- 1046-prb: From v0.27.x -> v0.28 install-manifest transition BEGIN -->
 ## From v0.27.x -> v0.28 (canonical install manifest at `<install>/VERSION`)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,6 +85,29 @@ After Wave 8, live deft gates run through the TypeScript engine. **Node.js and p
 
 ---
 
+## From v0.53.0–v0.53.1 → v0.53.2 (vitest no longer discovers vendored framework tests, #1878)
+
+- **Applies when:** your project uses **vitest** AND you upgraded to v0.53.0 or v0.53.1, whose deposit vendored the TypeScript engine under `.deft/core/packages/` **including** the framework's own `*.test.ts` / `*.spec.ts` files. Detection: your vitest run discovers ~80+ files under `.deft/core/packages/` via its default include glob (`**/*.{test,spec}.?(c|m)[jt]s?(x)`) and CI fails with `ERR_MODULE_NOT_FOUND` for `@deftai/core` plus framework parity assertion failures. Projects that do not use vitest (or that already exclude `.deft/core/**`) are unaffected.
+- **Safe to auto-run:** Yes. The installer now prunes the vendored `*.test.*` / `*.spec.*` files from the `.deft/core/packages/` deposit on every install and upgrade (and the release archive omits them too), leaving no framework test files for your vitest to discover. The prune touches only the framework's own test SOURCE files; non-test engine sources are left intact. No operator action is required once you are on v0.53.2+.
+- **Restart required:** No -- the prune is a filesystem change to the vendored deposit; the agent's in-memory context does not depend on it.
+- **Commands:**
+  - `deft-install --yes --upgrade --repo-root . --json` (refreshes the `.deft/core/` deposit; the prune runs automatically as part of the install)
+  - Interim manual workaround **only if you are mid-upgrade on a still-red v0.53.0/v0.53.1 PR**: add `.deft/core/**` to your vitest config's `test.exclude` (and `coverage.exclude`) so vitest skips the vendored payload, then re-run CI:
+
+```ts
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '.deft/core/**'],
+    coverage: { exclude: ['.deft/core/**'] },
+  },
+});
+```
+
+This manual exclude is harmless to keep, but it becomes unnecessary once the installer prune lands in your deposit. Note: the deft-core-guard workflow (#1430) refuses a PR that mixes a `.deft/core/**` change with your own files, so apply the vitest-config exclude in a **separate** PR from the framework deposit.
+
+---
+
 ---
 
 <!-- 1046-prb: From v0.27.x -> v0.28 install-manifest transition BEGIN -->

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -348,6 +348,7 @@ func pruneVendoredTSTests(w *Wizard, projectDir string) (int, error) {
 	}
 
 	removed := 0
+	var removeErrs []error
 	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -364,13 +365,17 @@ func pruneVendoredTSTests(w *Wizard, projectDir string) (int, error) {
 			return nil
 		}
 		if rmErr := os.Remove(path); rmErr != nil {
-			return fmt.Errorf("could not remove %s: %w", path, rmErr)
+			removeErrs = append(removeErrs, fmt.Errorf("could not remove %s: %w", path, rmErr))
+			return nil
 		}
 		removed++
 		return nil
 	})
 	if walkErr != nil {
 		return removed, fmt.Errorf("could not prune vendored TypeScript test files under %s: %w", vendoredTSPackagesRelPath, walkErr)
+	}
+	if len(removeErrs) > 0 {
+		return removed, fmt.Errorf("could not prune vendored TypeScript test files under %s: %w", vendoredTSPackagesRelPath, errors.Join(removeErrs...))
 	}
 	if removed > 0 {
 		w.printf("Removed %d vendored TypeScript test file(s) under %s from the consumer deposit (#1878).\n", removed, vendoredTSPackagesRelPath)

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -43,6 +44,28 @@ const (
 // executed) in a consumer project. The canonical .deft/core/ layout is assumed,
 // mirroring coreGlob.
 const frameworkSelfTestRelPath = ".deft/core/tests"
+
+// vendoredTSPackagesRelPath is the vendored TypeScript engine workspace as
+// deposited into a consumer install at .deft/core/packages/{cli,core}/. v0.53.x
+// vendors the engine sources INCLUDING the framework's own *.test.ts / *.spec.ts
+// files. A consumer whose own test runner is vitest discovers those vendored
+// test files via the default include glob (**/*.{test,spec}.?(c|m)[jt]s?(x)) and
+// fails CI -- the tests import the @deftai/core workspace package which does not
+// resolve in the consumer's context (ERR_MODULE_NOT_FOUND), plus parity
+// assertion failures (#1878). pruneVendoredTSTests removes only the
+// vitest-discoverable test SOURCE files from the consumer deposit so the
+// framework's own tests are never discovered/executed in a consumer project,
+// while leaving the non-test engine sources intact. It is the TS-side companion
+// to pruneFrameworkSelfTests (#1474, which prunes the Python self-test suite).
+const vendoredTSPackagesRelPath = ".deft/core/packages"
+
+// vendoredTSTestFileRe matches a basename that vitest's default include glob
+// (**/*.{test,spec}.?(c|m)[jt]s?(x)) would discover as a test file:
+// *.test.{ts,tsx,js,jsx,cts,mts,cjs,mjs} and the *.spec.* equivalents,
+// case-insensitively. It is compiled once at package scope. Only files whose
+// basename matches are pruned; non-test engine sources (e.g. index.ts) are left
+// untouched (#1878).
+var vendoredTSTestFileRe = regexp.MustCompile(`(?i)\.(test|spec)\.(c|m)?[jt]sx?$`)
 
 // installerManagedMatcher classifies a single repo-relative (POSIX-separated)
 // changed path as installer-managed -- i.e. deposited and maintained by
@@ -263,6 +286,9 @@ func depositNeutralization(w *Wizard, projectDir string) {
 	if _, err := pruneFrameworkSelfTests(w, projectDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not prune framework self-tests: %v\n", err)
 	}
+	if _, err := pruneVendoredTSTests(w, projectDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not prune vendored TypeScript test files: %v\n", err)
+	}
 }
 
 // pruneFrameworkSelfTests removes the vendored framework self-test suite
@@ -292,6 +318,64 @@ func pruneFrameworkSelfTests(w *Wizard, projectDir string) (bool, error) {
 	}
 	w.printf("Removed vendored framework self-tests (%s) from the consumer deposit (#1474).\n", frameworkSelfTestRelPath)
 	return true, nil
+}
+
+// pruneVendoredTSTests removes the vendored TypeScript engine's own
+// vitest-discoverable test SOURCE files (*.test.* / *.spec.*) from the consumer
+// deposit at .deft/core/packages/ so a consumer whose own test runner is vitest
+// never discovers and fails on the framework's tests (#1878). It walks the
+// vendored packages tree and removes every regular FILE whose basename matches
+// vendoredTSTestFileRe; non-test engine sources are left intact. It runs on
+// every install (fresh + upgrade + re-vendor), after the payload deposit, so a
+// re-vendored tree is re-pruned. An absent packages/ dir is a clean no-op
+// (0, nil). Returns the count of removed files. Best-effort by contract: the
+// caller treats a removal failure as non-fatal, mirroring pruneFrameworkSelfTests
+// and depositNeutralization. The canonical .deft/core/ layout is assumed,
+// matching the rest of this neutralization deposit (coreGlob).
+func pruneVendoredTSTests(w *Wizard, projectDir string) (int, error) {
+	root := filepath.Join(projectDir, filepath.FromSlash(vendoredTSPackagesRelPath))
+	info, err := os.Stat(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("could not stat %s: %w", vendoredTSPackagesRelPath, err)
+	}
+	if !info.IsDir() {
+		// A regular file at the packages/ path is not the vendored engine
+		// workspace; leave it.
+		return 0, nil
+	}
+
+	removed := 0
+	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Only remove regular test SOURCE files; skip symlinks and other
+		// irregular entries so the prune never follows a link out of the tree.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if !vendoredTSTestFileRe.MatchString(d.Name()) {
+			return nil
+		}
+		if rmErr := os.Remove(path); rmErr != nil {
+			return fmt.Errorf("could not remove %s: %w", path, rmErr)
+		}
+		removed++
+		return nil
+	})
+	if walkErr != nil {
+		return removed, fmt.Errorf("could not prune vendored TypeScript test files under %s: %w", vendoredTSPackagesRelPath, walkErr)
+	}
+	if removed > 0 {
+		w.printf("Removed %d vendored TypeScript test file(s) under %s from the consumer deposit (#1878).\n", removed, vendoredTSPackagesRelPath)
+	}
+	return removed, nil
 }
 
 // EnsureGitattributes appends the linguist generated/vendored markers for

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -740,6 +740,161 @@ func TestDepositNeutralization_PrunesFrameworkTests(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Vendored TypeScript test-file pruning (#1878)
+// ---------------------------------------------------------------------------
+
+// TestPruneVendoredTSTests_RemovesTestFilesKeepsSources pins #1878 acceptance:
+// vitest-discoverable test SOURCE files under .deft/core/packages/ are removed
+// from the consumer deposit while the non-test engine sources survive.
+func TestPruneVendoredTSTests_RemovesTestFilesKeepsSources(t *testing.T) {
+	tmp := t.TempDir()
+	cliDir := filepath.Join(tmp, filepath.FromSlash(".deft/core/packages/cli"))
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A vitest-discoverable test file MUST be removed; its non-test sibling
+	// (same stem, no .test infix) MUST survive.
+	testFile := filepath.Join(cliDir, "foo.test.ts")
+	srcFile := filepath.Join(cliDir, "foo.ts")
+	if err := os.WriteFile(testFile, []byte("import './foo';\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcFile, []byte("export const foo = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := pruneVendoredTSTests(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Errorf("expected removed=1, got %d", removed)
+	}
+	if pathExists(testFile) {
+		t.Errorf("%s must be pruned from the consumer deposit", testFile)
+	}
+	if !pathExists(srcFile) {
+		t.Errorf("non-test engine source %s must be preserved", srcFile)
+	}
+}
+
+// TestPruneVendoredTSTests_SpecAndNestedExtensions covers the *.spec.* form, a
+// nested package path, and the broader extension set (tsx/js/mjs) so the glob's
+// breadth is pinned, while a plain .ts and a fixture that merely contains
+// "test" in its stem (without the .test infix) survive.
+func TestPruneVendoredTSTests_SpecAndNestedExtensions(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, filepath.FromSlash(".deft/core/packages"))
+	nested := filepath.Join(base, "core", "src", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	removeMe := []string{
+		filepath.Join(base, "core", "bar.spec.ts"),
+		filepath.Join(nested, "baz.test.tsx"),
+		filepath.Join(nested, "qux.spec.mjs"),
+		filepath.Join(nested, "zed.test.js"),
+	}
+	keepMe := []string{
+		filepath.Join(base, "core", "index.ts"),
+		filepath.Join(nested, "helper.ts"),
+		// "testdata"-style stem: contains the word but not the .test infix.
+		filepath.Join(nested, "tester.ts"),
+	}
+	for _, p := range append(append([]string{}, removeMe...), keepMe...) {
+		if err := os.WriteFile(p, []byte("// content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	removed, err := pruneVendoredTSTests(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != len(removeMe) {
+		t.Errorf("expected removed=%d, got %d", len(removeMe), removed)
+	}
+	for _, p := range removeMe {
+		if pathExists(p) {
+			t.Errorf("expected %s to be pruned", p)
+		}
+	}
+	for _, p := range keepMe {
+		if !pathExists(p) {
+			t.Errorf("expected non-test source %s to survive", p)
+		}
+	}
+}
+
+// TestPruneVendoredTSTests_NoOpWhenAbsent: a consumer with no vendored
+// packages/ dir is a clean no-op (no error, removed=0).
+func TestPruneVendoredTSTests_NoOpWhenAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, filepath.FromSlash(".deft/core")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := pruneVendoredTSTests(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatalf("absent packages/ dir must not error: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("expected removed=0 when there is no vendored packages/ dir, got %d", removed)
+	}
+}
+
+// TestPruneVendoredTSTests_LeavesRegularFile: a regular file at the packages/
+// path (not a directory) is not the vendored engine workspace and must be left.
+func TestPruneVendoredTSTests_LeavesRegularFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, filepath.FromSlash(vendoredTSPackagesRelPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not a dir\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := pruneVendoredTSTests(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 {
+		t.Errorf("a regular file at the packages/ path must NOT be walked, got removed=%d", removed)
+	}
+	if !pathExists(path) {
+		t.Error("the regular file at the packages/ path must be left intact")
+	}
+}
+
+// TestDepositNeutralization_PrunesVendoredTSTests pins #1878 at the integration
+// boundary: the full neutralization deposit prunes vendored TS test files while
+// leaving non-test engine sources intact.
+func TestDepositNeutralization_PrunesVendoredTSTests(t *testing.T) {
+	tmp := t.TempDir()
+	cliDir := filepath.Join(tmp, filepath.FromSlash(".deft/core/packages/cli/src"))
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testFile := filepath.Join(cliDir, "bin.test.ts")
+	srcFile := filepath.Join(cliDir, "bin.ts")
+	if err := os.WriteFile(testFile, []byte("// vitest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcFile, []byte("// engine source\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	depositNeutralization(newDepositWizard(), tmp)
+
+	if pathExists(testFile) {
+		t.Errorf("depositNeutralization must prune vendored TS test file %s (#1878)", testFile)
+	}
+	if !pathExists(srcFile) {
+		t.Error("depositNeutralization must NOT remove non-test engine sources")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // deft-core-guard refresh-on-upgrade + .githooks/ classification (#1478)
 // ---------------------------------------------------------------------------
 

--- a/scripts/build_dist.py
+++ b/scripts/build_dist.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 import tarfile
 import zipfile
@@ -110,6 +111,16 @@ EXIT_OK = 0
 EXIT_RUNTIME_ERROR = 1
 EXIT_CONFIG_ERROR = 2
 
+# Vendored TypeScript engine test-file exclusion (#1878). The dist artifact
+# ships the TypeScript engine sources under packages/{cli,core}/. The engine's
+# own *.test.* / *.spec.* files would be discovered by a vitest-based consumer's
+# default include glob (**/*.{test,spec}.?(c|m)[jt]s?(x)) and fail their CI, so
+# they are excluded from the produced artifact -- keeping the tarball/zip
+# consistent with the installer-side prune (pruneVendoredTSTests in
+# cmd/deft-install/deposit.go). Only test SOURCE files are dropped; non-test
+# engine sources (e.g. index.ts) are retained.
+_VENDORED_TS_TEST_RE = re.compile(r"(?i)\.(test|spec)\.(c|m)?[jt]sx?$")
+
 # Archive root directory inside the produced artifact. Consumers extracting
 # the tarball / zip get a single top-level ``deft/`` directory rather than
 # a sea of top-level files, matching the previous tar(1) behaviour where
@@ -150,6 +161,10 @@ def _iter_source_files(
        path starts with an entry in ``excluded_prefixes`` are dropped, keeping
        consumer archives free of source-repo forensic history while preserving
        runtime siblings such as ``vbrief/schemas/**``.
+    4. Vendored TS test-file pruning -- files under ``packages/`` whose basename
+       matches the vitest test glob (``*.test.*`` / ``*.spec.*``) are dropped so
+       a vitest-based consumer never discovers the framework's own tests, while
+       non-test engine sources are retained (#1878).
     """
     entries: list[tuple[Path, str]] = []
     for dirpath, dirnames, filenames in os.walk(root):
@@ -184,6 +199,11 @@ def _iter_source_files(
             rel_posix = rel.as_posix()
             if _matches_excluded_prefix(rel_posix, excluded_prefixes):
                 continue
+            if _is_vendored_ts_test(rel_posix):
+                # Drop the vendored TS engine's own test files so a
+                # vitest-based consumer does not discover and fail on them,
+                # mirroring the installer-side prune (#1878).
+                continue
             entries.append((abs_path, rel_posix))
     return entries
 
@@ -191,6 +211,21 @@ def _iter_source_files(
 def _matches_excluded_prefix(rel_posix: str, prefixes: tuple[str, ...]) -> bool:
     """Return True when ``rel_posix`` is at or below an excluded path prefix."""
     return any(rel_posix == prefix or rel_posix.startswith(f"{prefix}/") for prefix in prefixes)
+
+
+def _is_vendored_ts_test(rel_posix: str) -> bool:
+    """Return True for a vendored TypeScript engine test SOURCE file (#1878).
+
+    True only when the repo-relative POSIX path is under ``packages/`` AND its
+    basename matches the vitest-discoverable test glob (``*.test.*`` /
+    ``*.spec.*`` with a ``[jt]s``/``x``/``c``/``m`` extension). Non-test engine
+    sources under ``packages/`` (e.g. ``packages/core/src/index.ts``) return
+    False so only the framework's own tests are dropped from the artifact.
+    """
+    if rel_posix != "packages" and not rel_posix.startswith("packages/"):
+        return False
+    basename = rel_posix.rsplit("/", 1)[-1]
+    return _VENDORED_TS_TEST_RE.search(basename) is not None
 
 
 # ---- Archive writers --------------------------------------------------------

--- a/tests/cli/test_build_dist.py
+++ b/tests/cli/test_build_dist.py
@@ -141,6 +141,24 @@ def fake_project(tmp_path: Path) -> Path:
     (root / "secret.txt").write_text("top-secret\n", encoding="utf-8")
     (root / "secrets").mkdir()
     (root / "secrets" / "key.txt").write_text("api-key\n", encoding="utf-8")
+    # Vendored TypeScript engine workspace (#1878): the engine's own test
+    # SOURCE files must be excluded from the artifact while non-test sources
+    # are retained. A non-test file whose stem merely contains "test"
+    # (tester.ts) must NOT be pruned -- only the .test/.spec infix matches.
+    (root / "packages" / "core" / "src").mkdir(parents=True)
+    (root / "packages" / "core" / "src" / "index.ts").write_text(
+        "export const x = 1;\n", encoding="utf-8"
+    )
+    (root / "packages" / "core" / "src" / "index.test.ts").write_text(
+        "import './index';\n", encoding="utf-8"
+    )
+    (root / "packages" / "core" / "src" / "deep").mkdir(parents=True)
+    (root / "packages" / "core" / "src" / "deep" / "util.spec.tsx").write_text(
+        "// spec\n", encoding="utf-8"
+    )
+    (root / "packages" / "core" / "src" / "deep" / "tester.ts").write_text(
+        "// not a test file\n", encoding="utf-8"
+    )
     return root
 
 
@@ -444,6 +462,58 @@ class TestExcludeExtra:
         assert _has_path_component(members, "secrets"), (
             "Empty --exclude-extra unexpectedly pruned secrets/."
         )
+
+
+# ---------------------------------------------------------------------------
+# Vendored TypeScript engine test-file exclusion (#1878)
+# ---------------------------------------------------------------------------
+
+
+class TestVendoredTSTestExclusion:
+    """The dist artifact ships the TS engine sources under packages/ but MUST
+    NOT ship the engine's own *.test.* / *.spec.* files, so a vitest-based
+    consumer extracting the payload never discovers and fails on framework
+    tests. Mirrors the installer-side prune (pruneVendoredTSTests in
+    cmd/deft-install/deposit.go). Non-test engine sources are retained."""
+
+    def test_packages_test_files_excluded(self, fake_project: Path):
+        artifact = build_dist.build(fake_project, "0.53.2", "tar")
+        members = _list_archive_paths(artifact, "tar")
+        for excluded in (
+            "deft/packages/core/src/index.test.ts",
+            "deft/packages/core/src/deep/util.spec.tsx",
+        ):
+            assert excluded not in members, (
+                f"vendored TS test file {excluded!r} leaked into the artifact "
+                f"(#1878). packages members: "
+                f"{[m for m in members if m.startswith('deft/packages/')]}"
+            )
+
+    def test_packages_non_test_sources_retained(self, fake_project: Path):
+        artifact = build_dist.build(fake_project, "0.53.2", "tar")
+        members = _list_archive_paths(artifact, "tar")
+        for kept in (
+            "deft/packages/core/src/index.ts",
+            "deft/packages/core/src/deep/tester.ts",
+        ):
+            assert kept in members, (
+                f"non-test engine source {kept!r} must be retained in the "
+                f"artifact. packages members: "
+                f"{[m for m in members if m.startswith('deft/packages/')]}"
+            )
+
+    def test_is_vendored_ts_test_helper(self):
+        # Under packages/ + test glob -> True.
+        assert build_dist._is_vendored_ts_test("packages/cli/foo.test.ts")
+        assert build_dist._is_vendored_ts_test("packages/core/src/a.spec.tsx")
+        assert build_dist._is_vendored_ts_test("packages/core/b.test.mjs")
+        assert build_dist._is_vendored_ts_test("packages/core/c.spec.cts")
+        # Under packages/ but not a test file -> False.
+        assert not build_dist._is_vendored_ts_test("packages/core/src/index.ts")
+        assert not build_dist._is_vendored_ts_test("packages/core/tester.ts")
+        # Test glob but NOT under packages/ -> False (only the engine is pruned).
+        assert not build_dist._is_vendored_ts_test("scripts/foo.test.ts")
+        assert not build_dist._is_vendored_ts_test("tests/bar.spec.ts")
 
 
 # ---------------------------------------------------------------------------

--- a/vbrief/active/2026-06-22-1878-prune-vendored-ts-tests.vbrief.json
+++ b/vbrief/active/2026-06-22-1878-prune-vendored-ts-tests.vbrief.json
@@ -1,0 +1,78 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1878 (upgrade-blocker: vendored .deft/core/packages/**/*.test.ts break consumer vitest). Near-term deposit-hygiene hotfix, decoupled from the #1669 engine/content-split waves.",
+    "created": "2026-06-22T16:45:00Z",
+    "updated": "2026-06-22T16:45:00Z"
+  },
+  "plan": {
+    "id": "1878-prune-vendored-ts-tests",
+    "title": "Prune vendored TypeScript test files from the consumer .deft/core deposit",
+    "status": "running",
+    "narratives": {
+      "Description": "v0.53.x vendors the new TypeScript engine under .deft/core/packages/{cli,core}/ INCLUDING *.test.ts files. A consumer whose own test runner is vitest discovers ~84 vendored framework test files (default include glob) and fails CI: the tests import the @deftai/core workspace package which does not resolve in the consumer's context (ERR_MODULE_NOT_FOUND), plus 2 parity assertion failures. The installer-shipped deft-core-guard workflow (no-mixed-core-and-app, #1430) refuses a consumer-side vitest.config.ts exclude in the same PR as the framework deposit, forcing a confusing two-PR dance. This is an adoption/upgrade blocker hit by deftai/cartograph (tracked downstream as deftai/cartograph#69). The framework's own Python self-test suite is already pruned from the deposit (#1474, .deft/core/tests); the new TS test files are not. This story extends that prune to the vitest-discoverable test files under .deft/core/packages/. It is a near-term deposit-hygiene hotfix (target v0.53.2); the durable structural fix (manifest-driven deposit + de-vendored engine from npm) is owned by #1669 Wave 1/2 and is explicitly NOT a dependency of this hotfix.",
+      "ImplementationPlan": "1) deposit.go: add pruneVendoredTSTests(w, projectDir) sibling to pruneFrameworkSelfTests, called from depositNeutralization after the self-test prune. Walk .deft/core/packages/ and remove every file whose basename matches the vitest-discoverable test glob (*.test.ts/tsx/js/mjs/cts/mts and *.spec.* equivalents). Best-effort (log warning, never abort), idempotent, runs on fresh + upgrade + re-vendor. Absent packages/ dir is a clean no-op. Only test SOURCE files are removed (importers); non-test engine sources remain but are no longer vitest-discovered. 2) build_dist.py: drop the same test files from the produced dist artifact so the tarball/zip is consistent with the installer deposit (extend the path filter with a name-suffix test for the test glob under packages/). 3) Regression tests: cmd/deft-install/deposit_test.go -- assert a seeded .deft/core/packages/<pkg>/foo.test.ts is removed by depositNeutralization and a non-test .ts sibling survives; scripts test for build_dist that a packages/**/*.test.ts is excluded from the artifact. 4) CHANGELOG [Unreleased] entry (user-visible: vitest-based consumers no longer get red CI on the v0.53.x upgrade). 5) UPGRADING.md note for consumers already on a broken upgrade PR (manual .deft/core/** vitest exclude as the interim, fixed automatically going forward).",
+      "UserStory": "As a vitest-based consumer upgrading Deft to v0.53.x, I want the vendored framework's own TypeScript test files to be excluded from my .deft/core/ deposit so that my vitest run does not discover and fail on framework tests, and my framework-upgrade PR can go green without a confusing two-PR exclude dance."
+    },
+    "items": [
+      {
+        "title": "deposit.go: pruneVendoredTSTests removes vitest-discoverable test files under .deft/core/packages/",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "depositNeutralization prunes every *.test.* / *.spec.* file under .deft/core/packages/ on fresh + upgrade + re-vendor; absent dir is a no-op; non-test .ts sources survive; best-effort (warning, non-fatal)."
+        }
+      },
+      {
+        "title": "build_dist.py: exclude packages test files from the dist artifact",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The produced dist artifact contains zero packages/**/*.test.* files; non-test engine sources are retained."
+        }
+      },
+      {
+        "title": "Regression tests (Go deposit_test + build_dist test)",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Go test asserts seeded packages test file removed + non-test sibling kept; build_dist test asserts the test glob is excluded; task check passes."
+        }
+      },
+      {
+        "title": "CHANGELOG [Unreleased] + UPGRADING.md consumer note",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "CHANGELOG entry describes the user-visible upgrade fix with #1878 ref; UPGRADING.md documents the interim manual exclude for consumers mid-upgrade."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1878",
+        "related_epic": "#1669",
+        "downstream": "deftai/cartograph#69"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "depends_on": []
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1878",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1878: Upgrade to v0.53.x breaks consumer CI: vendored .deft/core/packages/*.test.ts discovered by consumer vitest"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1669: epic distributable Deft (engine/content split) -- owns the durable structural fix; NOT a dependency of this hotfix"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1474",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1474: prune framework self-tests from consumer deposit (the precedent this story extends to TS test files)"
+      }
+    ],
+    "updated": "2026-06-22T16:44:49Z"
+  }
+}

--- a/vbrief/completed/2026-06-22-1878-prune-vendored-ts-tests.vbrief.json
+++ b/vbrief/completed/2026-06-22-1878-prune-vendored-ts-tests.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1878-prune-vendored-ts-tests",
     "title": "Prune vendored TypeScript test files from the consumer .deft/core deposit",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "v0.53.x vendors the new TypeScript engine under .deft/core/packages/{cli,core}/ INCLUDING *.test.ts files. A consumer whose own test runner is vitest discovers ~84 vendored framework test files (default include glob) and fails CI: the tests import the @deftai/core workspace package which does not resolve in the consumer's context (ERR_MODULE_NOT_FOUND), plus 2 parity assertion failures. The installer-shipped deft-core-guard workflow (no-mixed-core-and-app, #1430) refuses a consumer-side vitest.config.ts exclude in the same PR as the framework deposit, forcing a confusing two-PR dance. This is an adoption/upgrade blocker hit by deftai/cartograph (tracked downstream as deftai/cartograph#69). The framework's own Python self-test suite is already pruned from the deposit (#1474, .deft/core/tests); the new TS test files are not. This story extends that prune to the vitest-discoverable test files under .deft/core/packages/. It is a near-term deposit-hygiene hotfix (target v0.53.2); the durable structural fix (manifest-driven deposit + de-vendored engine from npm) is owned by #1669 Wave 1/2 and is explicitly NOT a dependency of this hotfix.",
       "ImplementationPlan": "1) deposit.go: add pruneVendoredTSTests(w, projectDir) sibling to pruneFrameworkSelfTests, called from depositNeutralization after the self-test prune. Walk .deft/core/packages/ and remove every file whose basename matches the vitest-discoverable test glob (*.test.ts/tsx/js/mjs/cts/mts and *.spec.* equivalents). Best-effort (log warning, never abort), idempotent, runs on fresh + upgrade + re-vendor. Absent packages/ dir is a clean no-op. Only test SOURCE files are removed (importers); non-test engine sources remain but are no longer vitest-discovered. 2) build_dist.py: drop the same test files from the produced dist artifact so the tarball/zip is consistent with the installer deposit (extend the path filter with a name-suffix test for the test glob under packages/). 3) Regression tests: cmd/deft-install/deposit_test.go -- assert a seeded .deft/core/packages/<pkg>/foo.test.ts is removed by depositNeutralization and a non-test .ts sibling survives; scripts test for build_dist that a packages/**/*.test.ts is excluded from the artifact. 4) CHANGELOG [Unreleased] entry (user-visible: vitest-based consumers no longer get red CI on the v0.53.x upgrade). 5) UPGRADING.md note for consumers already on a broken upgrade PR (manual .deft/core/** vitest exclude as the interim, fixed automatically going forward).",
@@ -17,28 +17,28 @@
     "items": [
       {
         "title": "deposit.go: pruneVendoredTSTests removes vitest-discoverable test files under .deft/core/packages/",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "depositNeutralization prunes every *.test.* / *.spec.* file under .deft/core/packages/ on fresh + upgrade + re-vendor; absent dir is a no-op; non-test .ts sources survive; best-effort (warning, non-fatal)."
         }
       },
       {
         "title": "build_dist.py: exclude packages test files from the dist artifact",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "The produced dist artifact contains zero packages/**/*.test.* files; non-test engine sources are retained."
         }
       },
       {
         "title": "Regression tests (Go deposit_test + build_dist test)",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Go test asserts seeded packages test file removed + non-test sibling kept; build_dist test asserts the test glob is excluded; task check passes."
         }
       },
       {
         "title": "CHANGELOG [Unreleased] + UPGRADING.md consumer note",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "CHANGELOG entry describes the user-visible upgrade fix with #1878 ref; UPGRADING.md documents the interim manual exclude for consumers mid-upgrade."
         }
@@ -54,7 +54,9 @@
       "swarm": {
         "readiness": "ready",
         "depends_on": []
-      }
+      },
+      "completedAt": "2026-06-22T17:08:36Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -73,6 +75,6 @@
         "title": "Issue #1474: prune framework self-tests from consumer deposit (the precedent this story extends to TS test files)"
       }
     ],
-    "updated": "2026-06-22T16:44:49Z"
+    "updated": "2026-06-22T17:08:36Z"
   }
 }


### PR DESCRIPTION
## Summary

v0.53.x vendors the TypeScript engine under `.deft/core/packages/{cli,core}/` **including** the framework's own `*.test.ts` / `*.spec.ts` files. A consumer whose own test runner is vitest discovers ~84 vendored framework test files via the default include glob (`**/*.{test,spec}.?(c|m)[jt]s?(x)`) and fails CI: the tests import the `@deftai/core` workspace package which does not resolve in the consumer's context (`ERR_MODULE_NOT_FOUND`), plus parity assertion failures. This is an upgrade/adoption blocker (hit downstream by deftai/cartograph#69).

The framework's own Python self-test suite was already pruned from the consumer deposit (#1474, `.deft/core/tests/`); the new TS test files were not. This PR extends that prune to the vitest-discoverable test files under `.deft/core/packages/`. Near-term deposit-hygiene hotfix (target v0.53.2); the durable engine/content-split restructure is owned by #1669 and is **not** a dependency of this fix.

## Code paths touched

- **`cmd/deft-install/deposit.go` (primary)** — new `pruneVendoredTSTests(w, projectDir)` walks `.deft/core/packages/` with `filepath.WalkDir` and removes every regular file whose basename matches the vitest test glob (`(?i)\.(test|spec)\.(c|m)?[jt]sx?$`). Non-test engine sources are left intact; absent `packages/` dir is a clean no-op; best-effort (caller logs a warning, never aborts). Called from `depositNeutralization` right after `pruneFrameworkSelfTests`, so it runs on fresh install + upgrade + re-vendor. This is the correct mechanism vs. the prefix-based `tarballExcludedRepoPrefixes` (which can't target a glob without dropping the whole engine).
- **`scripts/build_dist.py` (consistency)** — new `_is_vendored_ts_test(rel_posix)` name-based filter drops the same test glob under `packages/` from the produced release archive while retaining non-test sources, keeping the tarball/zip consistent with the installer deposit.

## Regression tests

- `cmd/deft-install/deposit_test.go`: removes a seeded `*.test.ts` while keeping its non-test `.ts` sibling; covers `*.spec.*`, nested paths, and the `tsx/js/mjs` extension breadth; a stem that merely contains "test" survives; absent-dir no-op; regular-file-at-path no-op; full `depositNeutralization` integration.
- `tests/cli/test_build_dist.py`: asserts `packages/**/*.test.ts` / `*.spec.tsx` are excluded from the artifact while `packages/**/*.ts` non-test sources are retained, plus a unit test for the `_is_vendored_ts_test` helper.

## Interim consumer workaround

Consumers already mid-upgrade on a still-red v0.53.0/v0.53.1 PR can add `.deft/core/**` to their vitest `test.exclude` (and coverage exclude) as documented in the new `UPGRADING.md` section; once they upgrade to v0.53.2+ the installer prunes the files automatically and the manual exclude becomes unnecessary.

## Related Issues

Closes #1878

## Checklist

- [x] `/deft:change <name>` — N/A: scope tracked by `vbrief/active/2026-06-22-1878-prune-vendored-ts-tests.vbrief.json`
- [x] `CHANGELOG.md` — added entry under `[Unreleased]` `### Fixed`
- [ ] `ROADMAP.md` — N/A (batch-moved at release time)
- [x] Tests pass locally — `task check`: 8778 passed, 5 skipped, 9 deselected; `go test ./cmd/deft-install/...`: ok

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm #1878 closed — `gh issue view 1878 --json state --jq .state`
