### PR TITLE
chore: decompose #11 into Wave 2 cohort + activate wave-1 stories

### DIFF
--- a/vbrief/active/2026-06-23-document-the-deft-company-directive-product-model-and-npm-in.vbrief.json
+++ b/vbrief/active/2026-06-23-document-the-deft-company-directive-product-model-and-npm-in.vbrief.json
@@ -1,0 +1,77 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 7 decomposed from proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json"
+  },
+  "plan": {
+    "id": "11-s7-identity-docs",
+    "title": "Document the Deft-company / Directive-product model and npm install paths",
+    "status": "running",
+    "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
+    "narratives": {
+      "Description": "Resolve the #423 tail: add the user-visible 'Deft is the company, Directive is the product' note and reframe the primary install paths around npm (`npm i -g @deftai/directive`; `directive` command with `deft` alias). The Go installer stays documented as the bootstrap path during the staged-retire window. This is the docs surface for the Wave-2 distribution change; the full #761 README/UPGRADING reframe remains Wave 4.",
+      "ImplementationPlan": "1. Add a concise identity-model note (Deft = company/org/scope/.deft footprint; Directive = product/bin) to README.md and the getting-started content.\n2. Add the npm install/quickstart paths (`npm i -g @deftai/directive`, `npx @deftai/directive ...`, `directive`/`deft`) alongside the existing installer path, marked as the emerging canonical channel.\n3. Verify with `node packages/cli/dist/bin.js verify links` (no broken links) and a docs read-through confirming the identity note + install paths are present.",
+      "UserStory": "As a new directive user, I want the docs to state plainly that Deft is the company and Directive is the product and to show the npm install path, so that I understand the naming and can install via npm."
+    },
+    "items": [
+      {
+        "id": "11-s7-a1",
+        "title": "identity-model note present",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When README and getting-started are read, then a clear 'Deft = company, Directive = product' note is present and consistent with the @deftai/directive naming."
+        }
+      },
+      {
+        "id": "11-s7-a2",
+        "title": "npm install paths documented",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the install docs are read, then `npm i -g @deftai/directive` and the `directive`/`deft` command are documented as the emerging canonical channel alongside the installer."
+        }
+      },
+      {
+        "id": "11-s7-a3",
+        "title": "no broken links",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When `directive verify links` runs over the edited docs, then it returns exit 0 with no broken references."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "README.md",
+          "content/getting-started.md"
+        ],
+        "verify_commands": [
+          "node packages/cli/dist/bin.js verify links"
+        ],
+        "expected_outputs": [
+          "Identity-model note (Deft=company / Directive=product) in README + getting-started",
+          "npm install/quickstart paths documented as emerging canonical channel",
+          "verify links green"
+        ],
+        "depends_on": [],
+        "conflict_group": "docs",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "Resolves #423 (identity-model doc tail) + Wave-2 install-path surface under #11/#1669; documentation with no spec-section trace."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
+        "TrustLevel": "external"
+      }
+    ],
+    "updated": "2026-06-23T02:10:30Z"
+  }
+}

--- a/vbrief/active/2026-06-23-migrate-product-slash-commands-to-deftdirective-with-aliases.vbrief.json
+++ b/vbrief/active/2026-06-23-migrate-product-slash-commands-to-deftdirective-with-aliases.vbrief.json
@@ -1,0 +1,79 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 5 decomposed from proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json"
+  },
+  "plan": {
+    "id": "11-s5-slash-command-namespace",
+    "title": "Migrate product slash commands to /deft:directive:* with aliases",
+    "status": "running",
+    "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
+    "narratives": {
+      "Description": "Resolve the #418 tail under the #1670 model: migrate product-level slash commands from /deft:* to /deft:directive:* with retained aliases + deprecation notes, while cross-product commands that operate on shared vBRIEF abstractions (/deft:continue, /deft:checkpoint) stay at the umbrella /deft:*. Skills stay deft-directive-* (no rename). Source edits go through templates/agents-entry.md + content/commands.md, then `task agents:refresh` regenerates AGENTS.md, honoring the #1309 template-propagation discipline.",
+      "ImplementationPlan": "1. Edit the command-surface source files content/commands.md and templates/agents-entry.md to define product commands under /deft:directive:* (change, run:<strategy>, ...), keep /deft:continue + /deft:checkpoint at the umbrella level, and document the old forms as deprecation-warning aliases.\n2. Run the agents-refresh CLI (`task agents:refresh`) to regenerate the AGENTS.md managed-section from the template file and confirm the managed-section contract test passes.\n3. Verify with the content/skills tests + the agents-entry contract test (tests/content/test_agents_entry_contract.py) that the new namespace + retained aliases are present and the cross-product commands remain at /deft:*.",
+      "UserStory": "As a directive user, I want product commands namespaced under /deft:directive:* (with old aliases still working), so that the command surface matches the deft-directive-* skills and leaves room for sibling-product command namespaces."
+    },
+    "items": [
+      {
+        "id": "11-s5-a1",
+        "title": "product commands namespaced",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the migration, when commands.md/agents-entry are inspected, then product commands appear under /deft:directive:* and the prior /deft:* forms are documented as deprecation-warning aliases."
+        }
+      },
+      {
+        "id": "11-s5-a2",
+        "title": "cross-product commands stay at umbrella",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the command surface is inspected, then /deft:continue and /deft:checkpoint remain at the umbrella /deft:* level (not migrated)."
+        }
+      },
+      {
+        "id": "11-s5-a3",
+        "title": "AGENTS.md regenerated and contract green",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When `task agents:refresh` runs and the agents-entry contract test executes, then AGENTS.md reflects the new namespace and the managed-section contract test passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/commands.md",
+          "templates/agents-entry.md"
+        ],
+        "verify_commands": [
+          "task agents:refresh",
+          "pnpm -w run build && node packages/cli/dist/bin.js verify links",
+          "uv run pytest tests/content/test_agents_entry_contract.py"
+        ],
+        "expected_outputs": [
+          "Product slash commands under /deft:directive:* with retained aliases",
+          "Cross-product /deft:continue + /deft:checkpoint preserved at umbrella",
+          "AGENTS.md regenerated; agents-entry contract test green"
+        ],
+        "depends_on": [],
+        "conflict_group": "command-surface",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "Resolves #418 (command namespace tail) under the #1670 model / #1669 Wave 2; documentation+template surface with no spec-section trace."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
+        "TrustLevel": "external"
+      }
+    ],
+    "updated": "2026-06-23T02:10:30Z"
+  }
+}

--- a/vbrief/active/2026-06-23-product-scope-the-npm-packages-and-wire-the-directivedeft-bi.vbrief.json
+++ b/vbrief/active/2026-06-23-product-scope-the-npm-packages-and-wire-the-directivedeft-bi.vbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json"
+  },
+  "plan": {
+    "id": "11-s1-package-rename",
+    "title": "Product-scope the npm packages and wire the directive/deft bins",
+    "status": "running",
+    "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
+    "narratives": {
+      "Description": "Rename the three published workspace packages from function-named to product-scoped per the #1670 identity model: @deftai/cli -> @deftai/directive, @deftai/core -> @deftai/directive-core, @deftai/types -> @deftai/directive-types. Rewrite every internal import specifier (~65 .ts files reference @deftai/core|types|cli) and the workspace/tsconfig project references so the build stays green. Expose a single user-facing bin named `directive` from @deftai/directive with `deft` retained as an alias (npm multi-bin). This is the foundational story the rest of Wave 2 builds on: it touches the shared import surface and every package.json, so it lands first and alone.",
+      "ImplementationPlan": "1. Rename the `name` field in packages/{cli,core,types}/package.json to the @deftai/directive* scheme and update the root pnpm-workspace + tsconfig project references and any `paths` aliases.\n2. Mechanically rewrite the import specifiers across the ~65 .ts files (@deftai/core -> @deftai/directive-core, @deftai/types -> @deftai/directive-types, @deftai/cli -> @deftai/directive) and replace the cli `bin` map with `directive` canonical + `deft` alias both pointing at dist/bin.js.\n3. Verify with a clean `pnpm -w install && pnpm -w run build` (tsc -b green), confirm `node packages/cli/dist/bin.js --version` resolves, and assert zero residual `@deftai/(core|types|cli)` specifiers remain in packages/**.",
+      "UserStory": "As a directive maintainer, I want the published packages named by product under the @deftai company scope with a `directive` bin (and `deft` alias), so that the distribution surface reflects Deft-the-company / Directive-the-product before anything is published to npm."
+    },
+    "items": [
+      {
+        "id": "11-s1-a1",
+        "title": "packages renamed and build green",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the three packages renamed to @deftai/directive, @deftai/directive-core, and @deftai/directive-types, when `pnpm -w install && pnpm -w run build` runs, then tsc -b completes with zero errors."
+        }
+      },
+      {
+        "id": "11-s1-a2",
+        "title": "no residual old specifiers",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the repo is scanned for `@deftai/core`, `@deftai/types`, or `@deftai/cli` import specifiers under packages/**, then zero matches remain."
+        }
+      },
+      {
+        "id": "11-s1-a3",
+        "title": "directive bin with deft alias",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given @deftai/directive declares bins `directive` and `deft` both pointing at dist/bin.js, when either `node $(npm bin)/directive --version` or `.../deft --version` runs, then the same version string prints."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/cli/package.json",
+          "packages/core/package.json",
+          "packages/types/package.json",
+          "pnpm-workspace.yaml",
+          "tsconfig.json",
+          "packages/**/*.ts (import-specifier rewrite only)"
+        ],
+        "verify_commands": [
+          "pnpm -w install && pnpm -w run build",
+          "node packages/cli/dist/bin.js --version",
+          "rg -c \"@deftai/(core|types|cli)\" packages --glob '*.ts'"
+        ],
+        "expected_outputs": [
+          "Three packages renamed to @deftai/directive*; build green",
+          "All ~65 cross-import specifiers rewritten; zero residual old specifiers",
+          "directive bin canonical + deft alias both resolving"
+        ],
+        "depends_on": [],
+        "conflict_group": "packaging-rename",
+        "size": "L",
+        "file_scope_confidence": "medium",
+        "model_tier": "strong",
+        "missing_traces_justification": "Distribution/packaging story for #11 (npm CLI channel) implementing the #1670 identity model under umbrella #1669 Wave 2; no specification.vbrief.json spec-section applies to maintainer distribution tooling."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
+        "TrustLevel": "external"
+      }
+    ],
+    "updated": "2026-06-23T02:10:29Z"
+  }
+}

--- a/vbrief/pending/2026-06-23-add-the-npm-publish-workflow-with-provenance.vbrief.json
+++ b/vbrief/pending/2026-06-23-add-the-npm-publish-workflow-with-provenance.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 6 decomposed from proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json"
+  },
+  "plan": {
+    "id": "11-s6-npm-publish-workflow",
+    "title": "Add the npm publish workflow with provenance",
+    "status": "pending",
+    "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
+    "narratives": {
+      "Description": "Establish npm as the canonical v1 distribution channel (#1670 Decision-4): a GitHub Actions workflow that publishes @deftai/directive, @deftai/directive-core, @deftai/directive-types, and @deftai/directive-content to npm with provenance on a version tag. pip is explicitly out of scope for v1 (deferred; #1084 stays parked). Builds on the final package names from S1.",
+      "ImplementationPlan": "1. Add .github/workflows/npm-publish.yml triggered on v* tags that builds the workspace and runs `npm publish --provenance --access public` for each @deftai/directive* package in dependency order.\n2. Add `publishConfig.access=public` + the `repository`/`provenance`-relevant fields to each published package.json and ensure files allowlists are correct.\n3. Verify with `npm publish --dry-run` per package (run in CI or locally with --dry-run) confirming the tarball contents and that provenance flags are accepted.",
+      "UserStory": "As a directive maintainer, I want a tag-triggered workflow that publishes the @deftai/directive* packages to npm with provenance, so that consumers can `npm i -g @deftai/directive` at a pinned version from a verifiable supply chain."
+    },
+    "items": [
+      {
+        "id": "11-s6-a1",
+        "title": "tag-triggered publish workflow",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a v* tag, when the npm-publish workflow runs, then it builds the workspace and publishes each @deftai/directive* package with `--provenance --access public` in dependency order."
+        }
+      },
+      {
+        "id": "11-s6-a2",
+        "title": "package publish config correct",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When `npm publish --dry-run` runs for each published package, then the tarball file allowlist is correct and publishConfig.access=public is set."
+        }
+      },
+      {
+        "id": "11-s6-a3",
+        "title": "pip explicitly out of scope",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the workflow and docs are reviewed, then no PyPI publish path is added and the v1-npm-only decision is recorded inline (#1084 remains deferred)."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          ".github/workflows/npm-publish.yml",
+          "packages/cli/package.json",
+          "packages/core/package.json",
+          "packages/types/package.json",
+          "packages/content/package.json"
+        ],
+        "verify_commands": [
+          "npm publish --dry-run --workspace @deftai/directive",
+          "node -e \"require('js-yaml').load(require('fs').readFileSync('.github/workflows/npm-publish.yml','utf8'))\""
+        ],
+        "expected_outputs": [
+          "New .github/workflows/npm-publish.yml (tag-triggered, provenance)",
+          "publishConfig + files allowlist on each published package",
+          "npm-only v1 (no PyPI path); #1084 deferred note"
+        ],
+        "depends_on": [
+          "11-s1-package-rename"
+        ],
+        "conflict_group": "ci-publish",
+        "size": "M",
+        "file_scope_confidence": "medium",
+        "model_tier": "standard",
+        "missing_traces_justification": "Implements #11 npm channel (canonical v1 per #1670 Decision-4) under #1669 Wave 2; CI/release tooling with no spec-section trace."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json
+++ b/vbrief/pending/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json
@@ -1,0 +1,80 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json"
+  },
+  "plan": {
+    "id": "11-s3-directive-verb-router",
+    "title": "Implement the directive verb router and top-level UX verbs",
+    "status": "pending",
+    "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
+    "narratives": {
+      "Description": "Build the unified `directive <namespace> <verb>` command surface defined in #1670: it mirrors the existing `task <namespace>:<verb>` map one-to-one, and promotes the curated UX verbs (init, update, bootstrap, check, doctor, version, feature) to the top level. The router dispatches to the existing TS engine entrypoints; the `deft` alias accepts the identical surface. init/update delegation to deft-install is a separate story (S4); this story delivers the router skeleton plus the read-only/non-bootstrap verbs.",
+      "ImplementationPlan": "1. Add a packages/cli/src/cli-router module that parses `<namespace> <verb>` and maps to the existing engine command handlers (verify:*, scope:*, vbrief:*, triage:*, etc.), with a curated top-level alias table for check/doctor/version/feature.\n2. Wire packages/cli/src/bin.ts to the router so both the `directive` and `deft` bins enter the same dispatch, preserving current --project-root handling.\n3. Verify with vitest router-mapping tests plus smoke invocations (`directive version`, `directive check`, `directive scope --help`) that resolve to the same handlers as the task surface.",
+      "UserStory": "As a directive user, I want a single `directive` command whose verbs mirror the task surface with friendly top-level shortcuts, so that I can drive the framework without memorizing the task runner namespaces."
+    },
+    "items": [
+      {
+        "id": "11-s3-a1",
+        "title": "namespace:verb parity with task surface",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the router, when `directive verify branch` (and a representative sample of scope/vbrief/triage verbs) runs, then it dispatches to the same engine handler as the corresponding `task <ns>:<verb>` with matching exit codes."
+        }
+      },
+      {
+        "id": "11-s3-a2",
+        "title": "top-level UX verbs",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When `directive version`, `directive check`, and `directive doctor` run, then each resolves to its promoted top-level handler and returns the same output as the underlying task aggregate."
+        }
+      },
+      {
+        "id": "11-s3-a3",
+        "title": "deft alias parity",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the same arguments, when invoked via `deft <...>` instead of `directive <...>`, then the dispatch and output are identical."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/cli-router/",
+          "packages/cli/src/bin.ts"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive test src/cli-router",
+          "node packages/cli/dist/bin.js version",
+          "node packages/cli/dist/bin.js verify branch --help"
+        ],
+        "expected_outputs": [
+          "New cli-router module mapping directive <ns> <verb> to engine handlers",
+          "Curated top-level UX verbs (init/update/bootstrap/check/doctor/version/feature)",
+          "Router-mapping vitest coverage; deft alias parity"
+        ],
+        "depends_on": [
+          "11-s1-package-rename"
+        ],
+        "conflict_group": "cli-router",
+        "size": "L",
+        "file_scope_confidence": "medium",
+        "model_tier": "strong",
+        "missing_traces_justification": "Implements the #1670 unified verb vocabulary under #11/#1669 Wave 2; maintainer CLI tooling with no spec-section trace."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-23-make-directive-initupdate-a-front-end-to-the-deft-install-bi.vbrief.json
+++ b/vbrief/pending/2026-06-23-make-directive-initupdate-a-front-end-to-the-deft-install-bi.vbrief.json
@@ -1,0 +1,77 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 4 decomposed from proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json"
+  },
+  "plan": {
+    "id": "11-s4-init-update-frontend",
+    "title": "Make directive init/update a front-end to the deft-install binary",
+    "status": "pending",
+    "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
+    "narratives": {
+      "Description": "Implement the #1670 Decision-3 transition contract: `directive init` and `directive update` delegate to the bundled deft-install Go binary (deft-install --yes --upgrade --repo-root . --json) rather than reimplementing bootstrap. This keeps a single bootstrap implementation during the staged Go-retire window; the CLI absorbs the logic only at Wave 5. Builds on the S3 router.",
+      "ImplementationPlan": "1. Add packages/cli/src/init-cli init/update command handlers that locate the bundled deft-install binary and shell out with the canonical flags, surfacing its JSON result.\n2. Route the handlers through the safe-subprocess capture contract (utf-8/errors=replace) and map deft-install exit codes to the directive CLI exit contract.\n3. Verify with vitest tests that stub the binary invocation (asserting the canonical argv + JSON passthrough) plus a smoke test against a temp repo fixture.",
+      "UserStory": "As a directive consumer, I want `directive init` and `directive update` to drive the proven deft-install bootstrap, so that I get one reliable install/upgrade path during the transition without a second bootstrap implementation."
+    },
+    "items": [
+      {
+        "id": "11-s4-a1",
+        "title": "init delegates with canonical argv",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When `directive init` runs, then it invokes the bundled deft-install binary with the canonical install argv and returns the binary's structured result."
+        }
+      },
+      {
+        "id": "11-s4-a2",
+        "title": "update delegates upgrade path",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When `directive update` runs, then it invokes deft-install with `--yes --upgrade --repo-root . --json` and maps a non-zero binary exit to a non-zero CLI exit."
+        }
+      },
+      {
+        "id": "11-s4-a3",
+        "title": "missing-binary diagnostic",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the bundled deft-install binary cannot be located, when init/update runs, then the CLI emits a clear remediation error rather than a raw spawn failure."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/init-cli/"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive test src/init-cli"
+        ],
+        "expected_outputs": [
+          "directive init/update delegate to bundled deft-install with canonical argv",
+          "Exit-code mapping + safe-subprocess capture",
+          "Vitest stubs asserting argv/JSON passthrough + missing-binary diagnostic"
+        ],
+        "depends_on": [
+          "11-s3-directive-verb-router"
+        ],
+        "conflict_group": "cli-router",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "Implements #1670 Decision-3 (front-end to deft-install) under #11/#1669 Wave 2; maintainer tooling with no spec-section trace."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json
+++ b/vbrief/pending/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json
@@ -1,0 +1,80 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json"
+  },
+  "plan": {
+    "id": "11-s2-content-package-resolver",
+    "title": "Publish content as @deftai/directive-content and resolve it from the package",
+    "status": "pending",
+    "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
+    "narratives": {
+      "Description": "Implement the C4-locked package shape: the content/ root ships as its own publishable package @deftai/directive-content, and the TS content-resolver reads content from the installed package across the three operating modes (in-repo vendored, hybrid npm-engine, external workspace) rather than only from the committed .deft/core/ deposit. This is the engine/content split's content half made real on npm.",
+      "ImplementationPlan": "1. Add packages/content/package.json (name @deftai/directive-content) that packages the content/ root as published files, with the C1 flatten preserved so consumers still land .deft/core/<x>.\n2. Extend the canonical resolver in packages/core/src/content-root.ts to resolve content from the installed @deftai/directive-content package location when present, falling back to the vendored .deft/core/ deposit, covering all three operating modes.\n3. Verify with vitest unit tests for each resolution mode plus a build that confirms the content package assembles the expected file tree.",
+      "UserStory": "As a directive consumer, I want the framework content delivered as its own npm package that the engine resolves from node_modules, so that the engine and content version and ship independently while a vendored .deft/core/ still works offline."
+    },
+    "items": [
+      {
+        "id": "11-s2-a1",
+        "title": "content package assembles",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given packages/content/package.json names @deftai/directive-content, when the package is built/packed, then the packed file tree contains the content/ assets flattened to the consumer .deft/core/ layout."
+        }
+      },
+      {
+        "id": "11-s2-a2",
+        "title": "resolver reads from package",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When @deftai/directive-content is present in node_modules, then content-root resolution returns the package path; when absent, then it falls back to the vendored .deft/core/ deposit."
+        }
+      },
+      {
+        "id": "11-s2-a3",
+        "title": "three-mode coverage",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given vitest cases for in-repo-vendored, hybrid npm-engine, and external-workspace modes, when the resolver test suite runs, then all three modes resolve content to the expected root with exit 0."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/content/package.json",
+          "packages/core/src/content-root.ts",
+          "packages/core/src/content-root.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test src/content-root",
+          "pnpm --filter @deftai/directive-content pack --dry-run"
+        ],
+        "expected_outputs": [
+          "New @deftai/directive-content package wrapping the content/ root with C1 flatten",
+          "Resolver reads content from package with vendored fallback",
+          "Vitest coverage for all three operating modes"
+        ],
+        "depends_on": [
+          "11-s1-package-rename"
+        ],
+        "conflict_group": "content-pkg",
+        "size": "L",
+        "file_scope_confidence": "medium",
+        "model_tier": "strong",
+        "missing_traces_justification": "Implements C4 (separate content package) + the content-resolver-from-package line of #1669 Wave 2, under #11; maintainer/runtime tooling with no spec-section trace."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/11",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
+        "TrustLevel": "external"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
+++ b/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
@@ -19,13 +19,56 @@
         "Status_source": "orphan: proposed default",
         "SourceConflict": "missing-from-spec",
         "Phase_source": "pre-migration ROADMAP (commit 3925468)"
-      }
+      },
+      "kind": "epic"
     },
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/11",
         "type": "x-vbrief/github-issue",
         "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)"
+      },
+      {
+        "uri": "active/2026-06-23-product-scope-the-npm-packages-and-wire-the-directivedeft-bi.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Product-scope the npm packages and wire the directive/deft bins",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Publish content as @deftai/directive-content and resolve it from the package",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Implement the directive verb router and top-level UX verbs",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-23-make-directive-initupdate-a-front-end-to-the-deft-install-bi.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Make directive init/update a front-end to the deft-install binary",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "active/2026-06-23-migrate-product-slash-commands-to-deftdirective-with-aliases.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Migrate product slash commands to /deft:directive:* with aliases",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-23-add-the-npm-publish-workflow-with-provenance.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Add the npm publish workflow with provenance",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "active/2026-06-23-document-the-deft-company-directive-product-model-and-npm-in.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Document the Deft-company / Directive-product model and npm install paths",
+        "TrustLevel": "internal"
       }
     ],
     "updated": "2026-05-20T12:38:34Z"


### PR DESCRIPTION
## Summary
- Decomposes **#11** (npm/pip CLI distribution) into **7 swarm-ready story vBRIEFs** per the locked **#1670** identity model (Deft = company / Directive = product).
- Activates the runnable **wave-1** set to `active/running` for swarm dispatch: S1 (package rename + bins), S5 (`/deft:directive:*` slash migration), S7 (identity docs).
- Wires parent #11 scope references to the generated children. Remaining stories (S2/S3/S4/S6) stay in `pending/` and activate as their blockers merge.

This is monitor-side swarm cohort setup; no product code changes. Lifecycle artifacts only.

## Test plan
- [x] `task scope:decompose --check` validated all 7 stories pass the swarm-ready quality gate
- [x] `task swarm:readiness` confirms the dependency DAG (wave 2a: S1‖S5‖S7)
- [x] pre-commit hooks (encoding, branch) green

Refs #1669 #11 #1670

Made with [Cursor](https://cursor.com)