### PR TITLE
feat(commands): namespace product slash commands under /deft:directive:*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `content/templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=8f010c664a2c refreshed=2026-06-17T12:39:17Z session=90e3a65c4ce4 -->
+<!-- deft:managed-section v3 sha=35d735c249ac refreshed=2026-06-23T02:17:28Z session=315f07a8c69e -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -424,6 +424,15 @@ Deft ships versioned content packs (e.g. lessons learned from prior work) under 
 
 ! Before improvising on a problem, discover packs with `deft packs:slice --list-packs`, then load the relevant slice. This wiring references the discovery commands on purpose -- it never enumerates pack or slice names, so new packs/slices need no change here.
 
+## Codebase MAP Projection (#1595 / #1498)
+
+`vbrief/PROJECT-DEFINITION.vbrief.json` `plan.architecture.codeStructure` is the durable codebase-structure source. `.planning/codebase/MAP.md` is a generated orientation projection from that metadata plus provider/code-derived facts.
+
+- ~ If `.planning/codebase/MAP.md` exists, read it as orientation before broad codebase scanning.
+- ~ If it is absent or may be stale, run `deft codebase:map` and `deft verify:codebase-map-fresh` when those commands resolve; treat the result as advisory unless the current task edits `plan.architecture.codeStructure`, a configured provider artifact, or the generated MAP itself.
+- ! When the MAP is wrong, update `plan.architecture.codeStructure` or the selected provider artifact, then regenerate the MAP.
+- ⊗ Treat a stale or absent MAP as an unrelated implementation blocker, hand-edit `.planning/codebase/MAP.md`, or make the generated projection more authoritative than the vBRIEF metadata.
+
 ## Skill Routing
 
 When user input matches a trigger keyword, read the corresponding skill (paths are relative to the consumer's project root and resolve under `.deft/core/skills/`):
@@ -439,7 +448,7 @@ When user input matches a trigger keyword, read the corresponding skill (paths a
 - "sync" / "good morning" / "update deft" / "update vbrief" / "sync frameworks" -> `.deft/core/skills/deft-directive-sync/SKILL.md`
 - "pre-pr" / "quality loop" / "rwldl" / "self-review" -> `.deft/core/skills/deft-directive-pre-pr/SKILL.md`
 - "interview loop" / "q&a loop" / "run interview loop" -> `.deft/core/skills/deft-directive-interview/SKILL.md`
-- "run probe" / "/deft:run:probe" / "probe" -> `.deft/core/skills/deft-directive-probe/SKILL.md`
+- "run probe" / "/deft:directive:run:probe" / "probe" -> `.deft/core/skills/deft-directive-probe/SKILL.md` (deprecated alias: `/deft:run:probe`)
 - "glossary" / "ubiquitous language" / "domain model" / "DDD" / "define terms" -> `.deft/core/skills/deft-directive-glossary/SKILL.md`
 - "improve architecture" / "deep modules" / "interface design" / "refactor RFC" -> `.deft/core/skills/deft-directive-gh-arch/SKILL.md`
 - "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/skills/deft-directive-debug/SKILL.md`
@@ -510,12 +519,24 @@ Cross-reference: `.deft/core/docs/analysis/2026-05-26-issue-1353-grok-windows-ca
 
 ## Commands
 
-- /deft:change <name>        — Propose a scoped change
-- /deft:run:interview        — Structured spec interview
-- /deft:run:speckit          — Five-phase spec workflow (large projects)
-- /deft:run:discuss <topic>  — Feynman-style alignment
-- /deft:run:research <topic> — Research before planning
-- /deft:run:map              — Map an existing codebase
+Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `content/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
+
+**Directive product (`/deft:directive:*`):**
+
+- /deft:directive:change <name>        — Propose a scoped change (alias: `/deft:change`, deprecated)
+- /deft:directive:run:interview        — Structured spec interview (alias: `/deft:run:interview`, deprecated)
+- /deft:directive:run:speckit          — Five-phase spec workflow (alias: `/deft:run:speckit`, deprecated)
+- /deft:directive:run:discuss <topic>  — Feynman-style alignment (alias: `/deft:run:discuss`, deprecated)
+- /deft:directive:run:research <topic> — Research before planning (alias: `/deft:run:research`, deprecated)
+- /deft:directive:run:map              — Map an existing codebase (alias: `/deft:run:map`, deprecated)
+
+**Cross-product (umbrella `/deft:*`):**
+
+- /deft:continue — Resume from continue checkpoint
+- /deft:checkpoint — Save session state to `./vbrief/continue.vbrief.json`
+
+**CLI compatibility:**
+
 - .deft/core/run bootstrap         — CLI setup (terminal users)
 - .deft/core/run spec              — CLI spec generation
 <!-- /deft:managed-section -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Product slash commands now live under `/deft:directive:*`** — Directive framework commands (`change`, `run:<strategy>`, etc.) are namespaced under `/deft:directive:*` to match the `deft-directive-*` skills and leave room for sibling-product namespaces. Prior `/deft:*` product forms remain as deprecation-warning aliases; cross-product session commands (`/deft:continue`, `/deft:checkpoint`) stay at the umbrella `/deft:*` level. Refs #418 #1670.
+
 ### Fixed
 
 ### Removed

--- a/content/commands.md
+++ b/content/commands.md
@@ -19,7 +19,63 @@ flowchart LR
     Active -->|"task scope:complete"| Completed["completed scope"]
 ```
 
-`task --list` is the authoritative command index. This file explains the main command families and the older `/deft:change` folder workflow that remains as historical/compatibility guidance.
+`task --list` is the authoritative command index. This file explains the main command families, the agent slash-command surface, and the older `/deft:directive:change` folder workflow that remains as historical/compatibility guidance.
+
+---
+
+## Slash Command Namespaces (#418 / #1670)
+
+Deft exposes two slash-command namespaces. **Product-level** commands for the Directive framework live under `/deft:directive:*` (matching the `deft-directive-*` skill prefix). **Cross-product** commands that operate on shared vBRIEF abstractions stay at the umbrella `/deft:*` level so sibling products can share them.
+
+### Directive product commands (`/deft:directive:*`)
+
+When the user types a product slash command, agents MUST route to the corresponding skill or strategy file.
+
+**Change lifecycle** (see [Historical `/deft:directive:change` folder workflow](#historical-deftdirectivechange-folder-workflow) below):
+
+- `/deft:directive:change <name>` — Create a scoped change proposal in `history/changes/<name>/`
+- `/deft:directive:change:apply` — Implement tasks from the active change
+- `/deft:directive:change:verify` — Verify the active change against acceptance criteria
+- `/deft:directive:change:archive` — Archive completed change to `history/archive/`
+
+**Strategies** — `/deft:directive:run:<name>` maps to `strategies/<name>.md`:
+
+- `/deft:directive:run:interview <name>` — Structured interview with sizing gate ([strategies/interview.md](./strategies/interview.md))
+- `/deft:directive:run:yolo <name>` — Auto-pilot interview ([strategies/yolo.md](./strategies/yolo.md))
+- `/deft:directive:run:map` — Brownfield codebase mapping ([strategies/map.md](./strategies/map.md))
+- `/deft:directive:run:discuss <topic>` — Feynman-style alignment ([strategies/discuss.md](./strategies/discuss.md))
+- `/deft:directive:run:research <domain>` — Research before planning ([strategies/research.md](./strategies/research.md))
+- `/deft:directive:run:speckit <name>` — Five-phase spec workflow ([strategies/speckit.md](./strategies/speckit.md))
+- `/deft:directive:run:probe` — Adversarial plan stress-testing ([skills/deft-directive-probe/SKILL.md](./skills/deft-directive-probe/SKILL.md))
+
+**Naming rule:** `/deft:directive:run:<x>` always maps to `strategies/<x>.md` (or the matching skill when noted). Custom strategies follow the same pattern.
+
+### Cross-product commands (umbrella `/deft:*`)
+
+These commands are NOT migrated — they operate on shared vBRIEF session abstractions usable across Deft products:
+
+- `/deft:continue` — Resume from continue checkpoint ([resilience/continue-here.md](./resilience/continue-here.md))
+- `/deft:checkpoint` — Save session state to `./vbrief/continue.vbrief.json`
+
+### Deprecation aliases (prior `/deft:*` product forms)
+
+The legacy product forms below remain accepted but SHOULD emit a deprecation warning directing the user to the `/deft:directive:*` equivalent. Prefer the namespaced form in new documentation and skill routing.
+
+| Deprecated alias | Canonical form |
+|------------------|----------------|
+| `/deft:change` | `/deft:directive:change` |
+| `/deft:change:apply` | `/deft:directive:change:apply` |
+| `/deft:change:verify` | `/deft:directive:change:verify` |
+| `/deft:change:archive` | `/deft:directive:change:archive` |
+| `/deft:run:interview` | `/deft:directive:run:interview` |
+| `/deft:run:yolo` | `/deft:directive:run:yolo` |
+| `/deft:run:map` | `/deft:directive:run:map` |
+| `/deft:run:discuss` | `/deft:directive:run:discuss` |
+| `/deft:run:research` | `/deft:directive:run:research` |
+| `/deft:run:speckit` | `/deft:directive:run:speckit` |
+| `/deft:run:probe` | `/deft:directive:run:probe` |
+
+Skills retain the `deft-directive-*` prefix — only the slash-command surface is namespaced.
 
 ---
 
@@ -210,9 +266,9 @@ Canonical install/upgrade is handled by the published `deft-install` binary, and
 
 ---
 
-## Historical `/deft:change` Folder Workflow
+## Historical `/deft:directive:change` Folder Workflow
 
-Older guidance used `history/changes/<name>/` folders with `proposal.vbrief.json`, `tasks.vbrief.json`, and optional spec deltas. That pattern remains useful as historical context and may still appear in archived work, but the active repository workflow is scope-vBRIEF lifecycle under `vbrief/`.
+Older guidance used `history/changes/<name>/` folders with `proposal.vbrief.json`, `tasks.vbrief.json`, and optional spec deltas. Invoke via `/deft:directive:change <name>` (alias: `/deft:change <name>`, deprecated). That pattern remains useful as historical context and may still appear in archived work, but the active repository workflow is scope-vBRIEF lifecycle under `vbrief/`.
 
 If a future change uses `history/changes/`, files MUST use vBRIEF `0.6`, not the obsolete `0.5` examples.
 

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -117,7 +117,7 @@ When user input matches a trigger keyword, read the corresponding skill (paths a
 - "sync" / "good morning" / "update deft" / "update vbrief" / "sync frameworks" -> `.deft/core/skills/deft-directive-sync/SKILL.md`
 - "pre-pr" / "quality loop" / "rwldl" / "self-review" -> `.deft/core/skills/deft-directive-pre-pr/SKILL.md`
 - "interview loop" / "q&a loop" / "run interview loop" -> `.deft/core/skills/deft-directive-interview/SKILL.md`
-- "run probe" / "/deft:run:probe" / "probe" -> `.deft/core/skills/deft-directive-probe/SKILL.md`
+- "run probe" / "/deft:directive:run:probe" / "probe" -> `.deft/core/skills/deft-directive-probe/SKILL.md` (deprecated alias: `/deft:run:probe`)
 - "glossary" / "ubiquitous language" / "domain model" / "DDD" / "define terms" -> `.deft/core/skills/deft-directive-glossary/SKILL.md`
 - "improve architecture" / "deep modules" / "interface design" / "refactor RFC" -> `.deft/core/skills/deft-directive-gh-arch/SKILL.md`
 - "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/skills/deft-directive-debug/SKILL.md`
@@ -188,12 +188,24 @@ Cross-reference: `.deft/core/docs/analysis/2026-05-26-issue-1353-grok-windows-ca
 
 ## Commands
 
-- /deft:change <name>        — Propose a scoped change
-- /deft:run:interview        — Structured spec interview
-- /deft:run:speckit          — Five-phase spec workflow (large projects)
-- /deft:run:discuss <topic>  — Feynman-style alignment
-- /deft:run:research <topic> — Research before planning
-- /deft:run:map              — Map an existing codebase
+Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `content/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
+
+**Directive product (`/deft:directive:*`):**
+
+- /deft:directive:change <name>        — Propose a scoped change (alias: `/deft:change`, deprecated)
+- /deft:directive:run:interview        — Structured spec interview (alias: `/deft:run:interview`, deprecated)
+- /deft:directive:run:speckit          — Five-phase spec workflow (alias: `/deft:run:speckit`, deprecated)
+- /deft:directive:run:discuss <topic>  — Feynman-style alignment (alias: `/deft:run:discuss`, deprecated)
+- /deft:directive:run:research <topic> — Research before planning (alias: `/deft:run:research`, deprecated)
+- /deft:directive:run:map              — Map an existing codebase (alias: `/deft:run:map`, deprecated)
+
+**Cross-product (umbrella `/deft:*`):**
+
+- /deft:continue — Resume from continue checkpoint
+- /deft:checkpoint — Save session state to `./vbrief/continue.vbrief.json`
+
+**CLI compatibility:**
+
 - .deft/core/run bootstrap         — CLI setup (terminal users)
 - .deft/core/run spec              — CLI spec generation
 <!-- /deft:managed-section -->

--- a/vbrief/completed/2026-06-23-migrate-product-slash-commands-to-deftdirective-with-aliases.vbrief.json
+++ b/vbrief/completed/2026-06-23-migrate-product-slash-commands-to-deftdirective-with-aliases.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s5-slash-command-namespace",
     "title": "Migrate product slash commands to /deft:directive:* with aliases",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Resolve the #418 tail under the #1670 model: migrate product-level slash commands from /deft:* to /deft:directive:* with retained aliases + deprecation notes, while cross-product commands that operate on shared vBRIEF abstractions (/deft:continue, /deft:checkpoint) stay at the umbrella /deft:*. Skills stay deft-directive-* (no rename). Source edits go through templates/agents-entry.md + content/commands.md, then `task agents:refresh` regenerates AGENTS.md, honoring the #1309 template-propagation discipline.",
@@ -64,7 +64,9 @@
         "file_scope_confidence": "high",
         "model_tier": "standard",
         "missing_traces_justification": "Resolves #418 (command namespace tail) under the #1670 model / #1669 Wave 2; documentation+template surface with no spec-section trace."
-      }
+      },
+      "completedAt": "2026-06-23T02:19:29Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -74,6 +76,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-23T02:10:30Z"
+    "updated": "2026-06-23T02:19:29Z"
   }
 }

--- a/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
+++ b/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
@@ -53,7 +53,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-23-migrate-product-slash-commands-to-deftdirective-with-aliases.vbrief.json",
+        "uri": "completed/2026-06-23-migrate-product-slash-commands-to-deftdirective-with-aliases.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Migrate product slash commands to /deft:directive:* with aliases",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary

- Migrate Directive product slash commands from `/deft:*` to `/deft:directive:*` with deprecation-warning aliases documented in `content/commands.md` and the consumer `agents-entry.md` template.
- Keep cross-product session commands (`/deft:continue`, `/deft:checkpoint`) at the umbrella `/deft:*` level.
- Regenerate `AGENTS.md` managed section via `cmd_agents_refresh`; skills retain the `deft-directive-*` prefix.

Refs #418 #1670

## Test plan

- [x] `uv run python -c "from run import cmd_agents_refresh; cmd_agents_refresh([])"` — managed section refreshed
- [x] `node packages/cli/dist/bin.js framework-commands verify:links` — link check passes (warnings only)
- [x] `uv run pytest tests/content/test_agents_entry_contract.py` — 20 passed
- [x] `uv run pytest tests/content/` — 3145 passed
- [x] Pre-commit hooks (encoding, vbrief conformance, branch gate) passed on commit


Made with [Cursor](https://cursor.com)