### PR TITLE
docs: document Deft=company / Directive=product and npm install paths (#11 S7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Docs now state Deft = company, Directive = product, and show the npm install path (#423, #11, #1670)** — README and getting-started now explain the identity model (`@deftai` scope / `.deft` footprint vs `@deftai/directive` product) and document `npm i -g @deftai/directive` with the `directive` command (`deft` alias) as the emerging canonical channel alongside the Go bootstrap installer. Refs #423 #11 #1670.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Docs now state Deft = company, Directive = product, and show the npm install path (#423, #11, #1670)** — README and getting-started now explain the identity model (`@deftai` scope / `.deft` footprint vs `@deftai/directive` product) and document `npm i -g @deftai/directive` with the `directive` command (`deft` alias) as the emerging canonical channel alongside the Go bootstrap installer. Refs #423 #11 #1670.
+- **Docs now state Deft = company, Directive = product, and show the npm install path (#423, #11, #1670)** — The identity model (Deft is the company, Directive is the product) is now documented, and `npm i -g @deftai/directive` with the `directive` command (`deft` alias) is called out as the emerging canonical install channel. The Go bootstrap installer remains documented during the staged retire window. Refs #423 #11 #1670.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,23 @@ Deft is a **layered set of standards files plus deterministic `task` tooling** t
 
 **📍 Roadmap:** See [ROADMAP.md](./ROADMAP.md) for the development timeline, open issues, and planned work.
 
+## Deft & Directive (naming)
+
+**Deft is the company; Directive is the product.** In docs and on npm, *Deft* names the organization and the on-disk footprint (`.deft/`, `@deftai/*` scope, `deft.md`). *Directive* names the framework you install and run — the published npm package is `@deftai/directive`, and the primary CLI command is `directive` (`deft` is retained as an alias). Existing `deft-install` / `deft` wording in older paths refers to the same product during the staged transition to the npm-first channel ([#423](https://github.com/deftai/directive/issues/423), [#11](https://github.com/deftai/directive/issues/11)).
+
 ## 🚀 Getting Started
+
+### npm (emerging canonical channel)
+
+When Node 20+ is already on your PATH, install Directive globally from npm:
+
+```bash
+npm i -g @deftai/directive
+```
+
+Then run `directive` (or the `deft` alias) from any project directory — for example `directive doctor`, `directive session:start`, or `npx @deftai/directive <verb>` without a global install. This is the emerging primary distribution path; the Go installer below remains the bootstrap option during the staged retire window.
+
+### Go installer (bootstrap / air-gapped)
 
 Download the installer for your platform from [GitHub Releases](https://github.com/deftai/directive/releases), run it, and follow the prompts.
 
@@ -44,7 +60,9 @@ Download the installer for your platform from [GitHub Releases](https://github.c
 
 > **📦 Brownfield adoption:** Adding Deft to an existing project with pre-v0.20 `SPECIFICATION.md` / `PROJECT.md`? See [docs/BROWNFIELD.md](./content/docs/BROWNFIELD.md) for the migration path (`task migrate:vbrief`) and what to expect.
 
-### 1. Install Deft
+### 1. Install Directive
+
+Prefer **`npm i -g @deftai/directive`** when Node 20+ is available (see [npm channel](#npm-emerging-canonical-channel) above). Otherwise use the platform Go installer:
 
 **Windows:**
 - Download `install-windows-amd64.exe` (or `install-windows-arm64.exe` for Surface / Copilot+ PCs)

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -4,18 +4,44 @@ Deft Directive is a Taskfile-first framework for AI-assisted software work. It c
 
 > **Note**: This guide is an orientation layer. For current architecture details, see [ARCHITECTURE.md](../../docs/ARCHITECTURE.md); for command behavior, see [commands.md](../commands.md).
 
+## Deft & Directive (naming)
+
+**Deft is the company; Directive is the product.** *Deft* names the organization and the on-disk footprint (`.deft/`, `@deftai/*` npm scope, user config under `~/.config/deft/`). *Directive* names the framework you install and run: the npm package is `@deftai/directive`, and the primary CLI is `directive` (`deft` is an alias). Legacy `deft-install` / `deft` paths in this guide refer to the same product during the staged transition ([#423](https://github.com/deftai/directive/issues/423)).
+
 ---
 
 ## Prerequisites
 
-<!-- TODO: Document required tools (Go 1.22+, Python 3.11+, uv, task) and supported platforms -->
+- **Node 20+** and **pnpm** for live gates and the npm distribution channel (see `.nvmrc` in the framework payload).
+- **Go 1.22+** only if you use the bootstrap Go installer or build from source.
+- **Python 3.11+**, **uv**, **task**, **git**, and **gh** for full framework workflows — run `directive toolchain:check` (or `deft toolchain:check`) after install.
 
 ---
 
 ## Installation
 
-Download a platform installer from the Deft release page and run it from the
-project you want to adopt:
+### npm (emerging canonical channel)
+
+When Node is already available, install Directive globally:
+
+```bash
+npm i -g @deftai/directive
+directive --version    # primary command
+deft --version         # alias — same binary
+```
+
+One-shot without a global install:
+
+```bash
+npx @deftai/directive doctor
+npx @deftai/directive session:start
+```
+
+This npm path is the emerging primary distribution channel under `@deftai/directive` ([#11](https://github.com/deftai/directive/issues/11)). The Go installer below remains documented as the bootstrap option during the staged retire window.
+
+### Go installer (bootstrap)
+
+Download a platform installer from the [Directive release page](https://github.com/deftai/directive/releases) and run it from the project you want to adopt:
 
 ```bash
 deft-install --yes --repo-root . --json

--- a/vbrief/completed/2026-06-23-document-the-deft-company-directive-product-model-and-npm-in.vbrief.json
+++ b/vbrief/completed/2026-06-23-document-the-deft-company-directive-product-model-and-npm-in.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s7-identity-docs",
     "title": "Document the Deft-company / Directive-product model and npm install paths",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Resolve the #423 tail: add the user-visible 'Deft is the company, Directive is the product' note and reframe the primary install paths around npm (`npm i -g @deftai/directive`; `directive` command with `deft` alias). The Go installer stays documented as the bootstrap path during the staged-retire window. This is the docs surface for the Wave-2 distribution change; the full #761 README/UPGRADING reframe remains Wave 4.",
@@ -62,7 +62,9 @@
         "file_scope_confidence": "high",
         "model_tier": "standard",
         "missing_traces_justification": "Resolves #423 (identity-model doc tail) + Wave-2 install-path surface under #11/#1669; documentation with no spec-section trace."
-      }
+      },
+      "completedAt": "2026-06-23T02:22:11Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -72,6 +74,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-23T02:10:30Z"
+    "updated": "2026-06-23T02:22:11Z"
   }
 }

--- a/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
+++ b/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
@@ -65,7 +65,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-23-document-the-deft-company-directive-product-model-and-npm-in.vbrief.json",
+        "uri": "completed/2026-06-23-document-the-deft-company-directive-product-model-and-npm-in.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Document the Deft-company / Directive-product model and npm install paths",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
- Add a concise **Deft = company, Directive = product** identity note to README and `content/docs/getting-started.md`, aligned with `@deftai/directive` naming.
- Document **`npm i -g @deftai/directive`** and the **`directive`** command (`deft` alias) as the emerging canonical install channel, with the Go installer retained as the bootstrap path during the staged retire window.
- Resolves the #423 documentation tail under Wave 2 of #11 / #1669 (S7 identity docs).

Refs #423 #11 #1670

## Test plan
- [x] Read-through confirms identity note + npm install paths in README and getting-started
- [x] `node packages/cli/dist/bin.js verify:links` exits 0 (no new broken references)
- [x] Pre-commit hooks pass (encoding, vBRIEF conformance, branch gate)

Made with [Cursor](https://cursor.com)