### PR TITLE
chore: activate Wave 2b stories (S2/S3/S6)

### DIFF
--- a/vbrief/active/2026-06-23-add-the-npm-publish-workflow-with-provenance.vbrief.json
+++ b/vbrief/active/2026-06-23-add-the-npm-publish-workflow-with-provenance.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s6-npm-publish-workflow",
     "title": "Add the npm publish workflow with provenance",
-    "status": "pending",
+    "status": "running",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Establish npm as the canonical v1 distribution channel (#1670 Decision-4): a GitHub Actions workflow that publishes @deftai/directive, @deftai/directive-core, @deftai/directive-types, and @deftai/directive-content to npm with provenance on a version tag. pip is explicitly out of scope for v1 (deferred; #1084 stays parked). Builds on the final package names from S1.",
@@ -77,6 +77,7 @@
         "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-06-23T03:21:08Z"
   }
 }

--- a/vbrief/active/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json
+++ b/vbrief/active/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s3-directive-verb-router",
     "title": "Implement the directive verb router and top-level UX verbs",
-    "status": "pending",
+    "status": "running",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Build the unified `directive <namespace> <verb>` command surface defined in #1670: it mirrors the existing `task <namespace>:<verb>` map one-to-one, and promotes the curated UX verbs (init, update, bootstrap, check, doctor, version, feature) to the top level. The router dispatches to the existing TS engine entrypoints; the `deft` alias accepts the identical surface. init/update delegation to deft-install is a separate story (S4); this story delivers the router skeleton plus the read-only/non-bootstrap verbs.",
@@ -75,6 +75,7 @@
         "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-06-23T03:21:08Z"
   }
 }

--- a/vbrief/active/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json
+++ b/vbrief/active/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s2-content-package-resolver",
     "title": "Publish content as @deftai/directive-content and resolve it from the package",
-    "status": "pending",
+    "status": "running",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Implement the C4-locked package shape: the content/ root ships as its own publishable package @deftai/directive-content, and the TS content-resolver reads content from the installed package across the three operating modes (in-repo vendored, hybrid npm-engine, external workspace) rather than only from the committed .deft/core/ deposit. This is the engine/content split's content half made real on npm.",
@@ -75,6 +75,7 @@
         "title": "Issue #11: NPM + PIP CLI distribution (`npm i -g @deftai/directive`, `pipx install deft-cli`)",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-06-23T03:21:07Z"
   }
 }

--- a/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
+++ b/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
@@ -35,13 +35,13 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "pending/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json",
+        "uri": "active/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Publish content as @deftai/directive-content and resolve it from the package",
         "TrustLevel": "internal"
       },
       {
-        "uri": "pending/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json",
+        "uri": "active/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Implement the directive verb router and top-level UX verbs",
         "TrustLevel": "internal"
@@ -59,7 +59,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "pending/2026-06-23-add-the-npm-publish-workflow-with-provenance.vbrief.json",
+        "uri": "active/2026-06-23-add-the-npm-publish-workflow-with-provenance.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Add the npm publish workflow with provenance",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
Activates the Wave 2b cohort of #11 (unblocked by S1 package rename, #1901):
- S2 — `@deftai/directive-content` package + resolver-from-package
- S3 — `directive <ns> <verb>` router + top-level UX verbs (#1670)
- S6 — npm publish workflow + provenance

S4 (`init`/`update` front-end) stays pending until S3 merges. Lifecycle artifacts only; no product code.

Refs #1669 #11 #1670

Made with [Cursor](https://cursor.com)