### PR TITLE
feat(cli): directive namespace verb router (#11 S3)

### DIFF
--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 4fe5c74e816993c8d344ceed1a8e1064267acad30a78fad2b7b8652224f0192f -->
-<!-- Source digest sha256: f595354b5798faa89dff21aa3209a66890f51b5fd70568b2f3840266f4f7a29b -->
+<!-- Artifact sha256: 9d3d2fb42b9769d52b0471f437e3017dc895b1d429f156c067ba59bfeacecda7 -->
+<!-- Source digest sha256: 8695d086e79b7d8e5cd4deff466ed2ff383c066dd5a04fb6e0167893ed945113 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `f595354b5798faa89dff21aa3209a66890f51b5fd70568b2f3840266f4f7a29b` |
+| Source digest | `8695d086e79b7d8e5cd4deff466ed2ff383c066dd5a04fb6e0167893ed945113` |
 
 ## Modules
 
@@ -22,7 +22,7 @@
 | --- | --- | --- | --- | ---: |
 | `framework-content` | Framework Content | Agent-consumed standards, strategies, skills, templates, and documentation. | `AGENTS.md`, `SKILL.md`, `README.md`, `QUICK-START.md`, ... | 67 |
 | `python-tooling` | Python Tooling | Framework CLI helpers, validators, lifecycle tools, and automation scripts. | `run`, `run.py`, `run.bat`, `scripts/**/*.py` | 164 |
-| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1038 |
+| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1043 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
 | `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 746 |
@@ -69,6 +69,7 @@
 | `cmd/deft-install/upgrade_test.go` | `go-installer` | heuristic |
 | `cmd/deft-install/upgrade.go` | `go-installer` | heuristic |
 | `cmd/deft-install/wizard.go` | `go-installer` | heuristic |
+| `packages/cli/src/cli-router/index.ts` | `typescript-engine` | heuristic |
 | `packages/cli/src/index.ts` | `typescript-engine` | heuristic |
 | `packages/core/src/branch/index.ts` | `typescript-engine` | heuristic |
 | `packages/core/src/cache/index.ts` | `typescript-engine` | heuristic |
@@ -141,7 +142,7 @@
 | Markdown | 67 |
 | Other | 5 |
 | Python | 457 |
-| TypeScript | 1027 |
+| TypeScript | 1032 |
 | YAML | 53 |
 
 ## Degraded Signals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Unified `directive <namespace> <verb>` CLI router (#11 #1670)** — The npm CLI now routes `directive verify branch`, `directive scope promote`, and other namespace verbs to the same TypeScript handlers as `task <ns>:<verb>`, with top-level shortcuts for `version`, `check`, and `doctor`. The `deft` bin alias uses identical dispatch. Refs #11 #1670.
 - **Docs now state Deft = company, Directive = product, and show the npm install path (#423, #11, #1670)** — The identity model (Deft is the company, Directive is the product) is now documented, and `npm i -g @deftai/directive` with the `directive` command (`deft` alias) is called out as the emerging canonical install channel. The Go bootstrap installer remains documented during the staged retire window. Refs #423 #11 #1670.
 
 ### Changed

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { dispatch } from "./dispatch.js";
+import { routeAndDispatch } from "./cli-router/index.js";
 
-const code = await dispatch(process.argv.slice(2));
+const code = await routeAndDispatch(process.argv.slice(2));
 process.exit(code);

--- a/packages/cli/src/cli-router/index.ts
+++ b/packages/cli/src/cli-router/index.ts
@@ -1,0 +1,35 @@
+/**
+ * CLI router entry: `directive <namespace> <verb>` → flat dispatcher (#1670 / #11 S3).
+ */
+
+import { type DispatchIo, dispatch } from "../dispatch.js";
+import { routeArgv } from "./route-argv.js";
+
+export {
+  DEFERRED_TOP_LEVEL_VERBS,
+  PR_VERB_MAP,
+  type RoutedArgv,
+  type RouteKind,
+  routeArgv,
+  SCOPE_LIFECYCLE_VERBS,
+  STUBBED_TOP_LEVEL_VERBS,
+  SUBCOMMAND_ROUTES,
+  TOP_LEVEL_UX_VERBS,
+  taskKeyToDispatchArgv,
+  VERIFY_VERB_MAP,
+} from "./route-argv.js";
+
+/** Route user argv then dispatch to the existing engine handlers. */
+export async function routeAndDispatch(argv: readonly string[], io?: DispatchIo): Promise<number> {
+  const routed = routeArgv(argv);
+  if (routed.kind === "stub") {
+    const message = routed.stubMessage ?? "directive: command not available";
+    if (io !== undefined) {
+      io.writeErr(`${message}\n`);
+    } else {
+      process.stderr.write(`${message}\n`);
+    }
+    return 2;
+  }
+  return dispatch(routed.argv, io);
+}

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -1,0 +1,271 @@
+/**
+ * Maps `directive <namespace> <verb>` argv to flat dispatcher verbs (#1670 / #11 S3).
+ * Mirrors the `task <namespace>:<verb>` surface one-to-one.
+ */
+
+import { resolveCanonicalVerb } from "../dispatch.js";
+
+/** Top-level UX verbs promoted above the namespace layer (#1670). */
+export const TOP_LEVEL_UX_VERBS = [
+  "init",
+  "update",
+  "bootstrap",
+  "check",
+  "doctor",
+  "version",
+  "feature",
+] as const;
+
+/** Stubbed until S4 lands deft-install delegation (#11). */
+export const STUBBED_TOP_LEVEL_VERBS = new Set<string>(["init", "update"]);
+
+/** Registered but not yet implemented as TS handlers. */
+export const DEFERRED_TOP_LEVEL_VERBS = new Set<string>(["bootstrap", "feature"]);
+
+/** scope:* lifecycle verbs routed through scope-lifecycle handler. */
+export const SCOPE_LIFECYCLE_VERBS = new Set([
+  "promote",
+  "activate",
+  "complete",
+  "fail",
+  "cancel",
+  "restore",
+  "block",
+  "unblock",
+]);
+
+/** pr:* task names that do not hyphenate 1:1 to handler stems. */
+export const PR_VERB_MAP: Readonly<Record<string, string>> = {
+  "merge-ready": "pr-merge-readiness",
+  "check-protected-issues": "pr-protected-issues",
+  "check-closing-keywords": "pr-closing-keywords",
+  "wait-mergeable-and-merge": "pr-wait-mergeable",
+};
+
+/** verify:* aliases that map to non-verify-* handler stems. */
+export const VERIFY_VERB_MAP: Readonly<Record<string, string>> = {
+  routing: "swarm-routing-verify",
+  "codebase-map-fresh": "codebase-map-fresh",
+  "strategy-output": "validate-strategy-output",
+  "vbrief-conformance": "vbrief-validate",
+  "destructive-gh-verbs": "preflight-gh",
+  "cache-fresh": "preflight-cache",
+  "pack-drift": "pack-render",
+};
+
+/** Namespace handlers that require a subcommand token after the handler stem. */
+export const SUBCOMMAND_ROUTES: Readonly<Record<string, readonly [string, string]>> = {
+  "triage:accept": ["triage-actions", "accept"],
+  "triage:reject": ["triage-actions", "reject"],
+  "triage:defer": ["triage-actions", "defer"],
+  "triage:needs-ac": ["triage-actions", "needs-ac"],
+  "triage:mark-duplicate": ["triage-actions", "mark-duplicate"],
+  "triage:status": ["triage-actions", "status"],
+  "triage:reset": ["triage-actions", "reset"],
+  "triage:history": ["triage-actions", "history"],
+  "triage:bulk-accept": ["triage-bulk", "accept"],
+  "triage:bulk-reject": ["triage-bulk", "reject"],
+  "triage:bulk-defer": ["triage-bulk", "defer"],
+  "triage:bulk-needs-ac": ["triage-bulk", "needs-ac"],
+  "triage:show": ["triage-queue", "show"],
+  "triage:audit": ["triage-queue", "audit"],
+  "cache:put": ["cache", "put"],
+  "cache:get": ["cache", "get"],
+  "cache:invalidate": ["cache", "invalidate"],
+  "cache:fetch-all": ["cache", "fetch-all"],
+  "cache:prune": ["cache", "prune"],
+  "policy:show": ["policy", "show"],
+  "policy:enforce-branches": ["policy", "enforce-branches"],
+  "policy:allow-direct-commits": ["policy", "allow-direct-commits"],
+  "vbrief:reconcile-graph": ["vbrief-reconcile", "graph"],
+  "vbrief:reconcile-labels": ["vbrief-reconcile", "labels"],
+  "vbrief:reconcile-umbrellas": ["vbrief-reconcile", "umbrellas"],
+  "slice:record-existing": ["slice", "record-existing"],
+  "slice:list": ["slice", "list"],
+  "github-body:issue-create": ["github-body", "issue-create"],
+  "github-body:issue-edit": ["github-body", "issue-edit"],
+  "github-body:comment-create": ["github-body", "comment-create"],
+  "github-body:comment-edit": ["github-body", "comment-edit"],
+  "github-body:pr-edit": ["github-body", "pr-edit"],
+};
+
+export type RouteKind = "dispatch" | "stub";
+
+export interface RoutedArgv {
+  kind: RouteKind;
+  argv: string[];
+  stubMessage?: string;
+}
+
+function isMetaVerb(token: string): boolean {
+  return token === "--help" || token === "-h" || token === "--version" || token === "-V";
+}
+
+function routeTopLevel(first: string, rest: string[]): RoutedArgv | null {
+  if (first === "version") {
+    return { kind: "dispatch", argv: ["--version", ...rest] };
+  }
+  if (first === "check" || first === "doctor") {
+    return { kind: "dispatch", argv: [first, ...rest] };
+  }
+  if (STUBBED_TOP_LEVEL_VERBS.has(first)) {
+    return {
+      kind: "stub",
+      argv: [],
+      stubMessage:
+        `directive ${first}: deft-install delegation is not wired yet (S4 / #11). ` +
+        "Use deft-install directly for now.",
+    };
+  }
+  if (DEFERRED_TOP_LEVEL_VERBS.has(first)) {
+    return {
+      kind: "stub",
+      argv: [],
+      stubMessage: `directive ${first}: not yet implemented in the TS CLI (#1670 / #11).`,
+    };
+  }
+  return null;
+}
+
+function routeSubcommandKey(ns: string, verb: string, rest: string[]): RoutedArgv | null {
+  const colonKey = `${ns}:${verb}`;
+  const mapped = SUBCOMMAND_ROUTES[colonKey];
+  if (mapped !== undefined) {
+    return { kind: "dispatch", argv: [...mapped, ...rest] };
+  }
+  return null;
+}
+
+function routeNamespaceVerb(ns: string, verb: string, rest: string[]): RoutedArgv | null {
+  const colonKey = `${ns}:${verb}`;
+
+  const subcommand = routeSubcommandKey(ns, verb, rest);
+  if (subcommand !== null) return subcommand;
+
+  if (resolveCanonicalVerb(colonKey) !== null) {
+    return { kind: "dispatch", argv: [colonKey, ...rest] };
+  }
+
+  if (ns === "scope") {
+    if (SCOPE_LIFECYCLE_VERBS.has(verb)) {
+      return { kind: "dispatch", argv: ["scope-lifecycle", verb, ...rest] };
+    }
+    if (verb === "demote") return { kind: "dispatch", argv: ["scope-demote", ...rest] };
+    if (verb === "decompose") return { kind: "dispatch", argv: ["scope-decompose", ...rest] };
+    if (verb === "undo") return { kind: "dispatch", argv: ["scope-undo", ...rest] };
+  }
+
+  if (ns === "pr") {
+    const prStem = PR_VERB_MAP[verb];
+    if (prStem !== undefined) {
+      return { kind: "dispatch", argv: [prStem, ...rest] };
+    }
+  }
+
+  if (ns === "verify") {
+    const verifyStem = VERIFY_VERB_MAP[verb];
+    if (verifyStem !== undefined) {
+      return { kind: "dispatch", argv: [verifyStem, ...rest] };
+    }
+  }
+
+  if (ns === "issue" && verb === "ingest") {
+    return { kind: "dispatch", argv: ["issue-ingest", ...rest] };
+  }
+  if (ns === "issue" && verb === "emit") {
+    return { kind: "dispatch", argv: ["issue-emit", ...rest] };
+  }
+
+  if (ns === "triage" && verb.startsWith("bulk-")) {
+    return { kind: "dispatch", argv: ["triage-bulk", verb.slice("bulk-".length), ...rest] };
+  }
+
+  const hyphenStem = `${ns}-${verb}`;
+  if (resolveCanonicalVerb(hyphenStem) !== null) {
+    return { kind: "dispatch", argv: [hyphenStem, ...rest] };
+  }
+
+  return null;
+}
+
+function routeThreeToken(
+  ns: string,
+  verb: string,
+  subverb: string,
+  rest: string[],
+): RoutedArgv | null {
+  if (ns === "scm" && verb === "issue") {
+    return { kind: "dispatch", argv: ["scm", "issue", subverb, ...rest] };
+  }
+
+  if (ns === "vbrief" && verb === "reconcile") {
+    return { kind: "dispatch", argv: ["vbrief-reconcile", subverb, ...rest] };
+  }
+
+  if (ns === "policy" && verb === "set") {
+    return { kind: "dispatch", argv: ["policy-set", subverb, ...rest] };
+  }
+
+  const compositeKey = `${ns}:${verb}-${subverb}`;
+  const subcommand = SUBCOMMAND_ROUTES[compositeKey];
+  if (subcommand !== undefined) {
+    return { kind: "dispatch", argv: [...subcommand, ...rest] };
+  }
+
+  return null;
+}
+
+/**
+ * Transform user-facing argv (`directive <ns> <verb>` or top-level UX) into
+ * flat dispatcher argv consumed by `dispatch()`.
+ */
+export function routeArgv(argv: readonly string[]): RoutedArgv {
+  if (argv.length === 0) {
+    return { kind: "dispatch", argv: [] };
+  }
+
+  const [first, second, third, ...tail] = argv;
+  if (first === undefined) {
+    return { kind: "dispatch", argv: [] };
+  }
+
+  if (isMetaVerb(first) || first === "help") {
+    return { kind: "dispatch", argv: [...argv] };
+  }
+
+  const topLevel = routeTopLevel(first, argv.slice(1));
+  if (topLevel !== null) return topLevel;
+
+  if (argv.length === 1 && resolveCanonicalVerb(first) !== null) {
+    return { kind: "dispatch", argv: [first] };
+  }
+
+  if (second !== undefined) {
+    const nsRoute = routeNamespaceVerb(
+      first,
+      second,
+      third !== undefined ? [third, ...tail] : tail,
+    );
+    if (nsRoute !== null) return nsRoute;
+  }
+
+  if (second !== undefined && third !== undefined) {
+    const threeToken = routeThreeToken(first, second, third, tail);
+    if (threeToken !== null) return threeToken;
+  }
+
+  return { kind: "dispatch", argv: [...argv] };
+}
+
+/** Map `namespace:verb` task key to flat dispatcher argv (test seam). */
+export function taskKeyToDispatchArgv(
+  taskKey: string,
+  rest: readonly string[] = [],
+): string[] | null {
+  const colon = taskKey.indexOf(":");
+  if (colon <= 0) return null;
+  const ns = taskKey.slice(0, colon);
+  const verb = taskKey.slice(colon + 1);
+  const routed = routeNamespaceVerb(ns, verb, [...rest]);
+  return routed?.kind === "dispatch" ? routed.argv : null;
+}

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dispatch, resetHandlerCacheForTests } from "../dispatch.js";
+import {
+  PR_VERB_MAP,
+  routeAndDispatch,
+  routeArgv,
+  SCOPE_LIFECYCLE_VERBS,
+  TOP_LEVEL_UX_VERBS,
+  taskKeyToDispatchArgv,
+} from "./index.js";
+
+afterEach(() => {
+  resetHandlerCacheForTests();
+  vi.restoreAllMocks();
+});
+
+describe("routeArgv", () => {
+  it("promotes version to --version", () => {
+    expect(routeArgv(["version"]).argv).toEqual(["--version"]);
+  });
+
+  it("passes check and doctor through as top-level handlers", () => {
+    expect(routeArgv(["check", "--project-root", "."]).argv).toEqual([
+      "check",
+      "--project-root",
+      ".",
+    ]);
+    expect(routeArgv(["doctor", "--help"]).argv).toEqual(["doctor", "--help"]);
+  });
+
+  it("maps verify branch to verify:branch", () => {
+    expect(routeArgv(["verify", "branch", "--help"]).argv).toEqual(["verify:branch", "--help"]);
+  });
+
+  it("maps scope promote to scope-lifecycle promote", () => {
+    expect(routeArgv(["scope", "promote", "path.vbrief.json"]).argv).toEqual([
+      "scope-lifecycle",
+      "promote",
+      "path.vbrief.json",
+    ]);
+  });
+
+  it("maps triage queue to triage:queue", () => {
+    expect(routeArgv(["triage", "queue", "--limit", "5"]).argv).toEqual([
+      "triage:queue",
+      "--limit",
+      "5",
+    ]);
+  });
+
+  it("maps triage accept to triage-actions accept", () => {
+    expect(routeArgv(["triage", "accept", "--issue", "1"]).argv).toEqual([
+      "triage-actions",
+      "accept",
+      "--issue",
+      "1",
+    ]);
+  });
+
+  it("maps vbrief validate to vbrief:validate", () => {
+    expect(routeArgv(["vbrief", "validate"]).argv).toEqual(["vbrief:validate"]);
+  });
+
+  it("maps pr merge-ready to pr-merge-readiness", () => {
+    expect(routeArgv(["pr", "merge-ready", "--repo", "deftai/directive"]).argv).toEqual([
+      "pr-merge-readiness",
+      "--repo",
+      "deftai/directive",
+    ]);
+  });
+
+  it("maps verify routing to swarm-routing-verify", () => {
+    expect(routeArgv(["verify", "routing"]).argv).toEqual(["swarm-routing-verify"]);
+  });
+
+  it("maps scm issue list to scm issue list", () => {
+    expect(routeArgv(["scm", "issue", "list"]).argv).toEqual(["scm", "issue", "list"]);
+  });
+
+  it("preserves legacy flat verbs", () => {
+    expect(routeArgv(["verify:encoding", "--help"]).argv).toEqual(["verify:encoding", "--help"]);
+    expect(routeArgv(["verify-encoding"]).argv).toEqual(["verify-encoding"]);
+  });
+
+  it("passes meta flags through unchanged", () => {
+    expect(routeArgv(["--help"]).argv).toEqual(["--help"]);
+    expect(routeArgv(["-h"]).argv).toEqual(["-h"]);
+  });
+
+  it("stubs init and update until S4", () => {
+    expect(routeArgv(["init"]).kind).toBe("stub");
+    expect(routeArgv(["update"]).kind).toBe("stub");
+  });
+
+  it("registers every curated top-level UX verb", () => {
+    for (const verb of TOP_LEVEL_UX_VERBS) {
+      const routed = routeArgv([verb]);
+      expect(["dispatch", "stub"]).toContain(routed.kind);
+    }
+  });
+
+  it("covers every scope lifecycle verb", () => {
+    for (const verb of SCOPE_LIFECYCLE_VERBS) {
+      expect(routeArgv(["scope", verb]).argv[0]).toBe("scope-lifecycle");
+      expect(routeArgv(["scope", verb]).argv[1]).toBe(verb);
+    }
+  });
+
+  it("covers every pr alias in PR_VERB_MAP", () => {
+    for (const [taskVerb, handler] of Object.entries(PR_VERB_MAP)) {
+      expect(routeArgv(["pr", taskVerb]).argv).toEqual([handler]);
+    }
+  });
+});
+
+describe("taskKeyToDispatchArgv", () => {
+  it("mirrors representative task keys from verify/scope/vbrief/triage", () => {
+    expect(taskKeyToDispatchArgv("verify:branch")).toEqual(["verify:branch"]);
+    expect(taskKeyToDispatchArgv("scope:promote", ["x.vbrief.json"])).toEqual([
+      "scope-lifecycle",
+      "promote",
+      "x.vbrief.json",
+    ]);
+    expect(taskKeyToDispatchArgv("vbrief:preflight")).toEqual(["vbrief:preflight"]);
+    expect(taskKeyToDispatchArgv("triage:welcome")).toEqual(["triage:welcome"]);
+  });
+});
+
+describe("routeAndDispatch", () => {
+  it("deft alias parity: same routing path as directive", async () => {
+    const out: string[] = [];
+    const code = await routeAndDispatch(["version"], {
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: () => {},
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("@deftai/directive");
+  });
+
+  it("returns exit code 2 for stubbed init", async () => {
+    const err: string[] = [];
+    const code = await routeAndDispatch(["init"], {
+      writeOut: () => {},
+      writeErr: (text) => {
+        err.push(text);
+      },
+    });
+    expect(code).toBe(2);
+    expect(err.join("")).toContain("deft-install");
+  });
+
+  it("routes verify branch to the same handler as verify:branch", async () => {
+    const handler = vi.fn(() => 0);
+    vi.doMock("../verify-branch.js", () => ({ run: handler }));
+    resetHandlerCacheForTests();
+
+    await routeAndDispatch(["verify", "branch", "--help"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+
+    const colonHandler = vi.fn(() => 0);
+    vi.doMock("../verify-branch.js", () => ({ run: colonHandler }));
+    resetHandlerCacheForTests();
+
+    await dispatch(["verify:branch", "--help"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(colonHandler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0]).toEqual(colonHandler.mock.calls[0]);
+  });
+});

--- a/vbrief/completed/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json
+++ b/vbrief/completed/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s3-directive-verb-router",
     "title": "Implement the directive verb router and top-level UX verbs",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Build the unified `directive <namespace> <verb>` command surface defined in #1670: it mirrors the existing `task <namespace>:<verb>` map one-to-one, and promotes the curated UX verbs (init, update, bootstrap, check, doctor, version, feature) to the top level. The router dispatches to the existing TS engine entrypoints; the `deft` alias accepts the identical surface. init/update delegation to deft-install is a separate story (S4); this story delivers the router skeleton plus the read-only/non-bootstrap verbs.",
@@ -66,7 +66,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "strong",
         "missing_traces_justification": "Implements the #1670 unified verb vocabulary under #11/#1669 Wave 2; maintainer CLI tooling with no spec-section trace."
-      }
+      },
+      "completedAt": "2026-06-23T03:36:58Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -76,6 +78,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-23T03:21:08Z"
+    "updated": "2026-06-23T03:36:58Z"
   }
 }

--- a/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
+++ b/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
@@ -41,7 +41,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json",
+        "uri": "completed/2026-06-23-implement-the-directive-verb-router-and-top-level-ux-verbs.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Implement the directive verb router and top-level UX verbs",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary

- Adds `packages/cli/src/cli-router/` to route `directive <namespace> <verb>` to the existing TS dispatcher, mirroring the `task <ns>:<verb>` surface one-to-one.
- Promotes top-level UX verbs: `version`, `check`, and `doctor` resolve directly; `init`/`update` are registered but stubbed until S4 wires deft-install delegation.
- Wires `bin.ts` through the router so `directive` and `deft` bins share identical dispatch.

Refs #11 #1670

## Test plan

- [x] `pnpm exec vitest run packages/cli/src/cli-router/router.test.ts` (20 tests)
- [x] `node packages/cli/dist/bin.js version`
- [x] `node packages/cli/dist/bin.js verify branch --help` (exit 2, matches `verify:branch`)
- [x] `task check:framework-source` (isolated)
- [x] `task ts:check-lane`


Made with [Cursor](https://cursor.com)