### PR TITLE
feat(content): publish @deftai/directive-content with resolver fallback

### DIFF
--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 0eea74ba10cb90de3dc871a18f26386982e52898a3dfcd1b18abeb9f48df32e4 -->
-<!-- Source digest sha256: 058647d571e14f1b6410f3971bdc27582f5d73de75a42eba6efe2f5bf0ebab8a -->
+<!-- Artifact sha256: 07404feea6bfc53cbf64dec77acd8c6ce6be591817ef2c068b13ce76eb9e3725 -->
+<!-- Source digest sha256: f96c81566241162939850c2d8ca4ce19bf37ee964e9724a5fb65dc72a7a3473b -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `058647d571e14f1b6410f3971bdc27582f5d73de75a42eba6efe2f5bf0ebab8a` |
+| Source digest | `f96c81566241162939850c2d8ca4ce19bf37ee964e9724a5fb65dc72a7a3473b` |
 
 ## Modules
 
@@ -22,13 +22,13 @@
 | --- | --- | --- | --- | ---: |
 | `framework-content` | Framework Content | Agent-consumed standards, strategies, skills, templates, and documentation. | `AGENTS.md`, `SKILL.md`, `README.md`, `QUICK-START.md`, ... | 67 |
 | `python-tooling` | Python Tooling | Framework CLI helpers, validators, lifecycle tools, and automation scripts. | `run`, `run.py`, `run.bat`, `scripts/**/*.py` | 164 |
-| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1049 |
+| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1050 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
 | `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 746 |
 | `content-packs` | Content Packs | Curated, sliceable agent memory packs rendered and checked through the packs task namespace. | `packs/**/*.md`, `packs/**/*.json` | 0 |
 | `ci-release-automation` | CI and Release Automation | Repository automation for branch policy, hooks, GitHub Actions, PR readiness, and release publication. | `.github/**/*.yml`, `.github/**/*.yaml`, `.githooks/*` | 6 |
-| `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 339 |
+| `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 340 |
 
 ## Coupling
 
@@ -138,7 +138,7 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 799 |
+| JSON | 801 |
 | Markdown | 67 |
 | Other | 5 |
 | Python | 457 |

--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 048c1d1d83e98ff9e4b56de4744f5bf2d8ef3d53d83a0a9f9252ca9d82920a68 -->
-<!-- Source digest sha256: d7b3be2df31da1e29d45ca1b1825f3a6f4069a4d6eb3ff58ce0e2bdb63bef740 -->
+<!-- Artifact sha256: 366f1613ac7b37dd17ebf477735ec1e35a306e0d84cb4468b3bdc3aeb012a149 -->
+<!-- Source digest sha256: 519b787a3bb8c84959c5f7d7c7fd63e1b6778e75a576249ded173774bcd4eca7 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `d7b3be2df31da1e29d45ca1b1825f3a6f4069a4d6eb3ff58ce0e2bdb63bef740` |
+| Source digest | `519b787a3bb8c84959c5f7d7c7fd63e1b6778e75a576249ded173774bcd4eca7` |
 
 ## Modules
 

--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 4fe5c74e816993c8d344ceed1a8e1064267acad30a78fad2b7b8652224f0192f -->
-<!-- Source digest sha256: f595354b5798faa89dff21aa3209a66890f51b5fd70568b2f3840266f4f7a29b -->
+<!-- Artifact sha256: 048c1d1d83e98ff9e4b56de4744f5bf2d8ef3d53d83a0a9f9252ca9d82920a68 -->
+<!-- Source digest sha256: d7b3be2df31da1e29d45ca1b1825f3a6f4069a4d6eb3ff58ce0e2bdb63bef740 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `f595354b5798faa89dff21aa3209a66890f51b5fd70568b2f3840266f4f7a29b` |
+| Source digest | `d7b3be2df31da1e29d45ca1b1825f3a6f4069a4d6eb3ff58ce0e2bdb63bef740` |
 
 ## Modules
 
@@ -22,7 +22,7 @@
 | --- | --- | --- | --- | ---: |
 | `framework-content` | Framework Content | Agent-consumed standards, strategies, skills, templates, and documentation. | `AGENTS.md`, `SKILL.md`, `README.md`, `QUICK-START.md`, ... | 67 |
 | `python-tooling` | Python Tooling | Framework CLI helpers, validators, lifecycle tools, and automation scripts. | `run`, `run.py`, `run.bat`, `scripts/**/*.py` | 164 |
-| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1038 |
+| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1041 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
 | `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 746 |
@@ -137,11 +137,11 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 800 |
+| JSON | 801 |
 | Markdown | 67 |
 | Other | 5 |
 | Python | 457 |
-| TypeScript | 1027 |
+| TypeScript | 1029 |
 | YAML | 53 |
 
 ## Degraded Signals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Framework content now ships as `@deftai/directive-content` with resolver fallback (#11, #1669)** — The shippable `content/` tree is packaged as its own npm module with the C1 flatten preserved, and the TypeScript content-root resolver reads from the installed package when present or falls back to the vendored `.deft/core/` deposit across in-repo, hybrid, and external workspace layouts. Refs #11 #1669.
 - **Docs now state Deft = company, Directive = product, and show the npm install path (#423, #11, #1670)** — The identity model (Deft is the company, Directive is the product) is now documented, and `npm i -g @deftai/directive` with the `directive` command (`deft` alias) is called out as the emerging canonical install channel. The Go bootstrap installer remains documented during the staged retire window. Refs #423 #11 #1670.
 
 ### Changed

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@deftai/directive-content",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shippable Directive framework content in the consumer .deft/core/ layout (C1 flatten). Refs #11, #1669.",
+  "type": "module",
+  "files": [
+    "**/*"
+  ],
+  "scripts": {
+    "build": "node --input-type=module -e \"import{cpSync,existsSync,readdirSync,rmSync}from'node:fs';import{dirname,join}from'node:path';import{fileURLToPath}from'node:url';const pkg=dirname(fileURLToPath(import.meta.url));const src=join(pkg,'..','..','content');for(const name of readdirSync(src)){const from=join(src,name);const to=join(pkg,name);if(existsSync(to))rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true});}\"",
+    "clean": "node --input-type=module -e \"import{readdirSync,rmSync}from'node:fs';import{dirname,join}from'node:path';import{fileURLToPath}from'node:url';const pkg=dirname(fileURLToPath(import.meta.url));for(const name of readdirSync(pkg)){if(name==='package.json')continue;rmSync(join(pkg,name),{recursive:true,force:true});}\"",
+    "prepack": "pnpm run build",
+    "postpack": "pnpm run clean"
+  }
+}

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -8,9 +8,7 @@
     "**/*"
   ],
   "scripts": {
-    "build": "node --input-type=module -e \"import{cpSync,existsSync,readdirSync,rmSync}from'node:fs';import{dirname,join}from'node:path';import{fileURLToPath}from'node:url';const pkg=dirname(fileURLToPath(import.meta.url));const src=join(pkg,'..','..','content');for(const name of readdirSync(src)){const from=join(src,name);const to=join(pkg,name);if(existsSync(to))rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true});}\"",
-    "clean": "node --input-type=module -e \"import{readdirSync,rmSync}from'node:fs';import{dirname,join}from'node:path';import{fileURLToPath}from'node:url';const pkg=dirname(fileURLToPath(import.meta.url));for(const name of readdirSync(pkg)){if(name==='package.json')continue;rmSync(join(pkg,name),{recursive:true,force:true});}\"",
-    "prepack": "pnpm run build",
-    "postpack": "pnpm run clean"
+    "prepack": "node --input-type=module -e \"import{cpSync,existsSync,readdirSync,rmSync}from'node:fs';import{dirname,join}from'node:path';import{fileURLToPath}from'node:url';const pkg=dirname(fileURLToPath(import.meta.url));const src=join(pkg,'..','..','content');for(const name of readdirSync(src)){const from=join(src,name);const to=join(pkg,name);if(existsSync(to))rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true});}\"",
+    "postpack": "node --input-type=module -e \"import{readdirSync,rmSync}from'node:fs';import{dirname,join}from'node:path';import{fileURLToPath}from'node:url';const pkg=dirname(fileURLToPath(import.meta.url));for(const name of readdirSync(pkg)){if(name==='package.json')continue;rmSync(join(pkg,name),{recursive:true,force:true});}\""
   }
 }

--- a/packages/core/src/content-root.test.ts
+++ b/packages/core/src/content-root.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   CONTENT_DIRNAME,
@@ -22,19 +22,6 @@ describe("contentRoot (#1875 C1 flatten dual-context resolver)", () => {
     const root = mkdtempSync(join(tmpdir(), "content-root-"));
     created.push(root);
     return root;
-  }
-
-  function installContentPackage(projectRoot: string): string {
-    writeFileSync(join(projectRoot, "package.json"), '{"name":"fixture-project"}', "utf-8");
-    const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
-    mkdirSync(pkgDir, { recursive: true });
-    writeFileSync(
-      join(pkgDir, "package.json"),
-      JSON.stringify({ name: CONTENT_PACKAGE_NAME, version: "0.0.0" }),
-      "utf-8",
-    );
-    writeFileSync(join(pkgDir, "skills", ".keep"), "", "utf-8");
-    return pkgDir;
   }
 
   it("returns the content/ subdir when present (source checkout)", () => {
@@ -131,4 +118,23 @@ describe("contentRoot three operating modes (#11 S2 / @deftai/directive-content)
     expect(contentRoot(frameworkRoot)).toBe(pkgDir);
     expect(resolveContentPackageRoot(join(frameworkRoot, "scripts"))).toBe(pkgDir);
   });
+
+  // Regression: the ancestor walk MUST terminate at the filesystem root on every
+  // platform. A non-terminating walk (the Windows drive-root infinite loop the
+  // `resolve("/")` comparison caused) would never return, so this test would
+  // exceed its timeout and fail CI rather than hang it. The deep starting path
+  // also exercises the walk over many ancestor levels.
+  it("terminates and returns null from a deep path with no package anywhere", () => {
+    const project = freshProject();
+    const deep = join(project, ...Array.from({ length: 40 }, (_, i) => `level-${i}`));
+    mkdirSync(deep, { recursive: true });
+
+    expect(resolveContentPackageRoot(deep)).toBeNull();
+  }, 2000);
+
+  it("terminates when started from the filesystem root itself", () => {
+    // From the root, `dirname(root) === root`, so the idempotent-dirname stop
+    // condition must break on the first iteration rather than spin.
+    expect(resolveContentPackageRoot(parse(tmpdir()).root)).toBeNull();
+  }, 2000);
 });

--- a/packages/core/src/content-root.test.ts
+++ b/packages/core/src/content-root.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { CONTENT_DIRNAME, contentRoot } from "./content-root.js";
+import {
+  CONTENT_DIRNAME,
+  CONTENT_PACKAGE_NAME,
+  contentRoot,
+  resolveContentPackageRoot,
+} from "./content-root.js";
 
 describe("contentRoot (#1875 C1 flatten dual-context resolver)", () => {
   const created: string[] = [];
@@ -17,6 +22,19 @@ describe("contentRoot (#1875 C1 flatten dual-context resolver)", () => {
     const root = mkdtempSync(join(tmpdir(), "content-root-"));
     created.push(root);
     return root;
+  }
+
+  function installContentPackage(projectRoot: string): string {
+    writeFileSync(join(projectRoot, "package.json"), '{"name":"fixture-project"}', "utf-8");
+    const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: CONTENT_PACKAGE_NAME, version: "0.0.0" }),
+      "utf-8",
+    );
+    writeFileSync(join(pkgDir, "skills", ".keep"), "", "utf-8");
+    return pkgDir;
   }
 
   it("returns the content/ subdir when present (source checkout)", () => {
@@ -34,5 +52,83 @@ describe("contentRoot (#1875 C1 flatten dual-context resolver)", () => {
     const root = freshRoot();
     writeFileSync(join(root, CONTENT_DIRNAME), "not a dir", "utf-8");
     expect(contentRoot(root)).toBe(root);
+  });
+});
+
+describe("contentRoot three operating modes (#11 S2 / @deftai/directive-content)", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshProject(): string {
+    const root = mkdtempSync(join(tmpdir(), "content-mode-"));
+    created.push(root);
+    return root;
+  }
+
+  function installContentPackage(projectRoot: string): string {
+    writeFileSync(join(projectRoot, "package.json"), '{"name":"fixture-project"}', "utf-8");
+    const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: CONTENT_PACKAGE_NAME, version: "0.0.0" }),
+      "utf-8",
+    );
+    return pkgDir;
+  }
+
+  it("in-repo-vendored: prefers the npm content package when installed", () => {
+    const project = freshProject();
+    const frameworkRoot = join(project, "directive-source");
+    mkdirSync(join(frameworkRoot, CONTENT_DIRNAME), { recursive: true });
+    const pkgDir = installContentPackage(project);
+
+    expect(contentRoot(frameworkRoot)).toBe(pkgDir);
+    expect(resolveContentPackageRoot(frameworkRoot)).toBe(pkgDir);
+  });
+
+  it("in-repo-vendored: falls back to content/ when the npm package is absent", () => {
+    const project = freshProject();
+    const frameworkRoot = join(project, "directive-source");
+    mkdirSync(join(frameworkRoot, CONTENT_DIRNAME), { recursive: true });
+
+    expect(contentRoot(frameworkRoot)).toBe(join(frameworkRoot, CONTENT_DIRNAME));
+    expect(resolveContentPackageRoot(frameworkRoot)).toBeNull();
+  });
+
+  it("hybrid npm-engine: resolves the npm package over a flattened vendored deposit", () => {
+    const project = freshProject();
+    const frameworkRoot = join(project, ".deft", "core");
+    mkdirSync(frameworkRoot, { recursive: true });
+    mkdirSync(join(frameworkRoot, "skills"), { recursive: true });
+    writeFileSync(join(frameworkRoot, "skills", ".keep"), "", "utf-8");
+    const pkgDir = installContentPackage(project);
+
+    expect(contentRoot(frameworkRoot)).toBe(pkgDir);
+  });
+
+  it("hybrid npm-engine: falls back to the vendored .deft/core deposit when npm is absent", () => {
+    const project = freshProject();
+    const frameworkRoot = join(project, ".deft", "core");
+    mkdirSync(frameworkRoot, { recursive: true });
+    mkdirSync(join(frameworkRoot, "templates"), { recursive: true });
+    writeFileSync(join(frameworkRoot, "templates", "agents-entry.md"), "# template", "utf-8");
+
+    expect(contentRoot(frameworkRoot)).toBe(frameworkRoot);
+  });
+
+  it("external-workspace: resolves npm content from the project node_modules ancestor", () => {
+    const project = freshProject();
+    const frameworkRoot = join(project, ".deft", "core");
+    mkdirSync(frameworkRoot, { recursive: true });
+    const pkgDir = installContentPackage(project);
+
+    expect(contentRoot(frameworkRoot)).toBe(pkgDir);
+    expect(resolveContentPackageRoot(join(frameworkRoot, "scripts"))).toBe(pkgDir);
   });
 });

--- a/packages/core/src/content-root.ts
+++ b/packages/core/src/content-root.ts
@@ -35,11 +35,29 @@ import { dirname, join, resolve } from "node:path";
 export const CONTENT_DIRNAME = "content";
 export const CONTENT_PACKAGE_NAME = "@deftai/directive-content";
 
-/** Walk upward from `searchFrom` and return the installed content package root. */
+/**
+ * Defensive upper bound on the ancestor walk. A correctly-terminating walk
+ * stops at the filesystem root in far fewer than this many steps on every
+ * platform; the cap exists only so a future regression in the root-detection
+ * logic degrades to "not found" instead of hanging the process. 256 dwarfs any
+ * realistic absolute-path depth.
+ */
+const MAX_ANCESTOR_WALK_DEPTH = 256;
+
+/**
+ * Walk upward from `searchFrom` and return the installed content package root.
+ *
+ * Termination uses the idempotent-`dirname` pattern: `dirname` returns its own
+ * input at the filesystem root on BOTH POSIX (`/` -> `/`) and Windows (`C:\` ->
+ * `C:\`, `\\\\share` -> `\\\\share`), so `parent === dir` is the portable
+ * stop condition. A hardcoded `resolve("/")` comparison is NOT safe on Windows:
+ * `resolve("/")` yields the drive root of the CWD, which never equals the walk
+ * cursor when `searchFrom` is on a different drive (or a UNC path) -- the
+ * classic Windows drive-root infinite loop. A max-depth guard backstops both.
+ */
 export function resolveContentPackageRoot(searchFrom: string): string | null {
   let dir = resolve(searchFrom);
-  const filesystemRoot = resolve("/");
-  while (true) {
+  for (let depth = 0; depth < MAX_ANCESTOR_WALK_DEPTH; depth += 1) {
     const pkgJson = join(dir, "node_modules", "@deftai", "directive-content", "package.json");
     try {
       if (statSync(pkgJson).isFile()) {
@@ -48,8 +66,9 @@ export function resolveContentPackageRoot(searchFrom: string): string | null {
     } catch {
       // No physical install at this ancestor -- keep walking.
     }
-    if (dir === filesystemRoot) break;
-    dir = dirname(dir);
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   return null;
 }

--- a/packages/core/src/content-root.ts
+++ b/packages/core/src/content-root.ts
@@ -20,16 +20,45 @@
  * content paths off the returned root so the same code resolves both contexts
  * without a branch. Mirrors scripts/_content_root.py::content_root.
  *
- * Refs #1875 (content/ move), #1669 (Wave-1 LockedDecisions C1 flatten).
+ * #11 / C4 adds a third source: when `@deftai/directive-content` is installed
+ * in `node_modules`, the resolver prefers that package root (already flattened)
+ * and falls back to the vendored `.deft/core/` deposit / in-repo `content/`
+ * layout across in-repo-vendored, hybrid npm-engine, and external-workspace
+ * operating modes.
+ *
+ * Refs #1875 (content/ move), #1669 (Wave-1 LockedDecisions C1 flatten), #11.
  */
 
 import { statSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 export const CONTENT_DIRNAME = "content";
+export const CONTENT_PACKAGE_NAME = "@deftai/directive-content";
+
+/** Walk upward from `searchFrom` and return the installed content package root. */
+export function resolveContentPackageRoot(searchFrom: string): string | null {
+  let dir = resolve(searchFrom);
+  const filesystemRoot = resolve("/");
+  while (true) {
+    const pkgJson = join(dir, "node_modules", "@deftai", "directive-content", "package.json");
+    try {
+      if (statSync(pkgJson).isFile()) {
+        return dirname(pkgJson);
+      }
+    } catch {
+      // No physical install at this ancestor -- keep walking.
+    }
+    if (dir === filesystemRoot) break;
+    dir = dirname(dir);
+  }
+  return null;
+}
 
 /** Return the directory that holds flattened shippable content. */
 export function contentRoot(frameworkRoot: string): string {
+  const packageRoot = resolveContentPackageRoot(frameworkRoot);
+  if (packageRoot) return packageRoot;
+
   const candidate = join(frameworkRoot, CONTENT_DIRNAME);
   try {
     if (statSync(candidate).isDirectory()) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,8 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/content: {}
+
   packages/core:
     dependencies:
       '@deftai/directive-types':

--- a/vbrief/completed/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json
+++ b/vbrief/completed/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s2-content-package-resolver",
     "title": "Publish content as @deftai/directive-content and resolve it from the package",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Implement the C4-locked package shape: the content/ root ships as its own publishable package @deftai/directive-content, and the TS content-resolver reads content from the installed package across the three operating modes (in-repo vendored, hybrid npm-engine, external workspace) rather than only from the committed .deft/core/ deposit. This is the engine/content split's content half made real on npm.",
@@ -66,7 +66,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "strong",
         "missing_traces_justification": "Implements C4 (separate content package) + the content-resolver-from-package line of #1669 Wave 2, under #11; maintainer/runtime tooling with no spec-section trace."
-      }
+      },
+      "completedAt": "2026-06-23T03:39:37Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -76,6 +78,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-23T03:21:07Z"
+    "updated": "2026-06-23T03:39:37Z"
   }
 }

--- a/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
+++ b/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
@@ -35,7 +35,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json",
+        "uri": "completed/2026-06-23-publish-content-as-deftaidirective-content-and-resolve-it-fr.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Publish content as @deftai/directive-content and resolve it from the package",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
- Add `@deftai/directive-content` as a publishable npm package that materializes the repo `content/` tree with C1 flatten (consumer `.deft/core/` layout) via prepack.
- Extend `contentRoot()` to prefer an installed `@deftai/directive-content` package discovered by walking ancestor `node_modules`, falling back to the existing source `content/` vs vendored deposit probing.
- Add vitest coverage for in-repo-vendored, hybrid npm-engine, and external-workspace resolution modes.

Refs #11 #1669

## Test plan
- [x] `pnpm --filter @deftai/directive-content pack --dry-run` (flattened tarball: skills/, templates/, packs/, … at package root)
- [x] `pnpm -w exec vitest run packages/core/src/content-root.test.ts`
- [x] `task check`

Made with [Cursor](https://cursor.com)