### PR TITLE
feat(cli): wire directive init/update to bundled deft-install

### DIFF
--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 9d3d2fb42b9769d52b0471f437e3017dc895b1d429f156c067ba59bfeacecda7 -->
-<!-- Source digest sha256: 8695d086e79b7d8e5cd4deff466ed2ff383c066dd5a04fb6e0167893ed945113 -->
+<!-- Artifact sha256: 0eea74ba10cb90de3dc871a18f26386982e52898a3dfcd1b18abeb9f48df32e4 -->
+<!-- Source digest sha256: 058647d571e14f1b6410f3971bdc27582f5d73de75a42eba6efe2f5bf0ebab8a -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `8695d086e79b7d8e5cd4deff466ed2ff383c066dd5a04fb6e0167893ed945113` |
+| Source digest | `058647d571e14f1b6410f3971bdc27582f5d73de75a42eba6efe2f5bf0ebab8a` |
 
 ## Modules
 
@@ -22,13 +22,13 @@
 | --- | --- | --- | --- | ---: |
 | `framework-content` | Framework Content | Agent-consumed standards, strategies, skills, templates, and documentation. | `AGENTS.md`, `SKILL.md`, `README.md`, `QUICK-START.md`, ... | 67 |
 | `python-tooling` | Python Tooling | Framework CLI helpers, validators, lifecycle tools, and automation scripts. | `run`, `run.py`, `run.bat`, `scripts/**/*.py` | 164 |
-| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1043 |
+| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1049 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
 | `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 746 |
 | `content-packs` | Content Packs | Curated, sliceable agent memory packs rendered and checked through the packs task namespace. | `packs/**/*.md`, `packs/**/*.json` | 0 |
 | `ci-release-automation` | CI and Release Automation | Repository automation for branch policy, hooks, GitHub Actions, PR readiness, and release publication. | `.github/**/*.yml`, `.github/**/*.yaml`, `.githooks/*` | 6 |
-| `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 340 |
+| `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 339 |
 
 ## Coupling
 
@@ -138,11 +138,11 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 800 |
+| JSON | 799 |
 | Markdown | 67 |
 | Other | 5 |
 | Python | 457 |
-| TypeScript | 1032 |
+| TypeScript | 1038 |
 | YAML | 53 |
 
 ## Degraded Signals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`directive init` and `directive update` delegate to bundled deft-install (#11 #1670)** — The npm CLI now shells out to the bundled Go installer with the canonical headless argv (`--yes --repo-root . --json` for init; `--yes --upgrade --repo-root . --json` for update), surfaces its JSON result, and emits a clear remediation message when the platform binary is missing. Refs #11 #1670.
 - **Unified `directive <namespace> <verb>` CLI router (#11 #1670)** — The npm CLI now routes `directive verify branch`, `directive scope promote`, and other namespace verbs to the same TypeScript handlers as `task <ns>:<verb>`, with top-level shortcuts for `version`, `check`, and `doctor`. The `deft` bin alias uses identical dispatch. Refs #11 #1670.
 - **Docs now state Deft = company, Directive = product, and show the npm install path (#423, #11, #1670)** — The identity model (Deft is the company, Directive is the product) is now documented, and `npm i -g @deftai/directive` with the `directive` command (`deft` alias) is called out as the emerging canonical install channel. The Go bootstrap installer remains documented during the staged retire window. Refs #423 #11 #1670.
 

--- a/packages/cli/src/cli-router/index.ts
+++ b/packages/cli/src/cli-router/index.ts
@@ -3,7 +3,20 @@
  */
 
 import { type DispatchIo, dispatch } from "../dispatch.js";
+import { runInit } from "../init-cli/init.js";
+import { runUpdate } from "../init-cli/update.js";
 import { routeArgv } from "./route-argv.js";
+
+function defaultIo(): DispatchIo {
+  return {
+    writeOut: (text) => {
+      process.stdout.write(text);
+    },
+    writeErr: (text) => {
+      process.stderr.write(text);
+    },
+  };
+}
 
 export {
   DEFERRED_TOP_LEVEL_VERBS,
@@ -24,12 +37,18 @@ export async function routeAndDispatch(argv: readonly string[], io?: DispatchIo)
   const routed = routeArgv(argv);
   if (routed.kind === "stub") {
     const message = routed.stubMessage ?? "directive: command not available";
-    if (io !== undefined) {
-      io.writeErr(`${message}\n`);
-    } else {
-      process.stderr.write(`${message}\n`);
-    }
+    const sink = io ?? defaultIo();
+    sink.writeErr(`${message}\n`);
     return 2;
   }
+
+  const [first, ...rest] = routed.argv;
+  if (first === "init") {
+    return runInit(rest, io ?? defaultIo());
+  }
+  if (first === "update") {
+    return runUpdate(rest, io ?? defaultIo());
+  }
+
   return dispatch(routed.argv, io);
 }

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -16,8 +16,8 @@ export const TOP_LEVEL_UX_VERBS = [
   "feature",
 ] as const;
 
-/** Stubbed until S4 lands deft-install delegation (#11). */
-export const STUBBED_TOP_LEVEL_VERBS = new Set<string>(["init", "update"]);
+/** Stubbed until a later story lands the handler (#1670 / #11). */
+export const STUBBED_TOP_LEVEL_VERBS = new Set<string>([]);
 
 /** Registered but not yet implemented as TS handlers. */
 export const DEFERRED_TOP_LEVEL_VERBS = new Set<string>(["bootstrap", "feature"]);
@@ -108,13 +108,14 @@ function routeTopLevel(first: string, rest: string[]): RoutedArgv | null {
   if (first === "check" || first === "doctor") {
     return { kind: "dispatch", argv: [first, ...rest] };
   }
+  if (first === "init" || first === "update") {
+    return { kind: "dispatch", argv: [first, ...rest] };
+  }
   if (STUBBED_TOP_LEVEL_VERBS.has(first)) {
     return {
       kind: "stub",
       argv: [],
-      stubMessage:
-        `directive ${first}: deft-install delegation is not wired yet (S4 / #11). ` +
-        "Use deft-install directly for now.",
+      stubMessage: `directive ${first}: not yet implemented in the TS CLI (#1670 / #11).`,
     };
   }
   if (DEFERRED_TOP_LEVEL_VERBS.has(first)) {

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -142,15 +142,25 @@ describe("routeAndDispatch", () => {
   });
 
   it("returns exit code 2 when bundled deft-install is missing", async () => {
-    const err: string[] = [];
-    const code = await routeAndDispatch(["init"], {
-      writeOut: () => {},
-      writeErr: (text) => {
-        err.push(text);
-      },
-    });
-    expect(code).toBe(2);
-    expect(err.join("")).toContain("bundled deft-install binary not found");
+    const previous = process.env.DEFT_INSTALL_BINARY;
+    delete process.env.DEFT_INSTALL_BINARY;
+    try {
+      const err: string[] = [];
+      const code = await routeAndDispatch(["init"], {
+        writeOut: () => {},
+        writeErr: (text) => {
+          err.push(text);
+        },
+      });
+      expect(code).toBe(2);
+      expect(err.join("")).toContain("bundled deft-install binary not found");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DEFT_INSTALL_BINARY;
+      } else {
+        process.env.DEFT_INSTALL_BINARY = previous;
+      }
+    }
   });
 
   it("routes verify branch to the same handler as verify:branch", async () => {

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -87,9 +87,11 @@ describe("routeArgv", () => {
     expect(routeArgv(["-h"]).argv).toEqual(["-h"]);
   });
 
-  it("stubs init and update until S4", () => {
-    expect(routeArgv(["init"]).kind).toBe("stub");
-    expect(routeArgv(["update"]).kind).toBe("stub");
+  it("routes init and update to dispatch handlers", () => {
+    expect(routeArgv(["init"]).kind).toBe("dispatch");
+    expect(routeArgv(["init"]).argv).toEqual(["init"]);
+    expect(routeArgv(["update"]).kind).toBe("dispatch");
+    expect(routeArgv(["update"]).argv).toEqual(["update"]);
   });
 
   it("registers every curated top-level UX verb", () => {
@@ -139,7 +141,7 @@ describe("routeAndDispatch", () => {
     expect(out.join("")).toContain("@deftai/directive");
   });
 
-  it("returns exit code 2 for stubbed init", async () => {
+  it("returns exit code 2 when bundled deft-install is missing", async () => {
     const err: string[] = [];
     const code = await routeAndDispatch(["init"], {
       writeOut: () => {},
@@ -148,7 +150,7 @@ describe("routeAndDispatch", () => {
       },
     });
     expect(code).toBe(2);
-    expect(err.join("")).toContain("deft-install");
+    expect(err.join("")).toContain("bundled deft-install binary not found");
   });
 
   it("routes verify branch to the same handler as verify:branch", async () => {

--- a/packages/cli/src/init-cli/constants.ts
+++ b/packages/cli/src/init-cli/constants.ts
@@ -1,0 +1,5 @@
+/** Canonical headless install argv (#1339 / #1409 / getting-started.md). */
+export const CANONICAL_INIT_ARGV = ["--yes", "--repo-root", ".", "--json"] as const;
+
+/** Canonical headless upgrade argv (#1339 / #1409). */
+export const CANONICAL_UPDATE_ARGV = ["--yes", "--upgrade", "--repo-root", ".", "--json"] as const;

--- a/packages/cli/src/init-cli/init-cli.test.ts
+++ b/packages/cli/src/init-cli/init-cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,7 +11,6 @@ import {
   resolveBundledDeftInstallBinary,
 } from "./resolve-binary.js";
 import { runDeftInstall } from "./run-deft-install.js";
-import { runUpdate } from "./update.js";
 
 function captureIo(): { io: DispatchIo; out: string[]; err: string[] } {
   const out: string[] = [];
@@ -43,6 +42,7 @@ describe("resolveBundledDeftInstallBinary", () => {
     const dir = mkdtempSync(join(tmpdir(), "deft-install-"));
     const binary = join(dir, "deft-install");
     writeFileSync(binary, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(binary, 0o755);
     expect(resolveBundledDeftInstallBinary({ env: { DEFT_INSTALL_BINARY: binary } })).toBe(binary);
   });
 
@@ -74,7 +74,7 @@ describe("runDeftInstall delegation", () => {
       verb: "init",
       canonicalArgv: CANONICAL_INIT_ARGV,
       io,
-      resolveBinary: () => "/bundled/deft-install",
+      resolveBinaryDetailed: () => ({ ok: true, path: "/bundled/deft-install" }),
       runBinary,
     });
 
@@ -97,7 +97,7 @@ describe("runDeftInstall delegation", () => {
       verb: "update",
       canonicalArgv: CANONICAL_UPDATE_ARGV,
       io,
-      resolveBinary: () => "/bundled/deft-install",
+      resolveBinaryDetailed: () => ({ ok: true, path: "/bundled/deft-install" }),
       runBinary,
     });
 
@@ -112,12 +112,13 @@ describe("runDeftInstall delegation", () => {
       verb: "init",
       canonicalArgv: CANONICAL_INIT_ARGV,
       io,
-      resolveBinary: () => null,
-      resolveBinaryOptions: {
+      resolveBinaryDetailed: () => ({
+        ok: false,
+        reason: "not-found",
         packageRoot: "/pkg/root",
         platform: "linux",
         arch: "x64",
-      },
+      }),
     });
 
     expect(code).toBe(2);
@@ -129,11 +130,21 @@ describe("runDeftInstall delegation", () => {
     expect(message).not.toContain("ENOENT");
   });
 
-  it("runUpdate surfaces missing-binary diagnostic", () => {
+  it("reports unreadable DEFT_INSTALL_BINARY override distinctly", () => {
     const { io, err } = captureIo();
-    const code = runUpdate([], io);
+    const code = runDeftInstall({
+      verb: "update",
+      canonicalArgv: CANONICAL_UPDATE_ARGV,
+      io,
+      resolveBinaryDetailed: () => ({
+        ok: false,
+        reason: "override-unreadable",
+        path: "/bad/deft-install",
+      }),
+    });
+
     expect(code).toBe(2);
-    expect(err.join("")).toContain("directive update:");
+    expect(err.join("")).toContain("DEFT_INSTALL_BINARY is set to /bad/deft-install");
   });
 });
 

--- a/packages/cli/src/init-cli/init-cli.test.ts
+++ b/packages/cli/src/init-cli/init-cli.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DispatchIo } from "../dispatch.js";
+import { CANONICAL_INIT_ARGV, CANONICAL_UPDATE_ARGV } from "./constants.js";
+import {
+  bundledBinaryCandidates,
+  cliPackageRoot,
+  releaseArtifactName,
+  resolveBundledDeftInstallBinary,
+} from "./resolve-binary.js";
+import { runDeftInstall } from "./run-deft-install.js";
+import { runUpdate } from "./update.js";
+
+function captureIo(): { io: DispatchIo; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    io: {
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: (text) => {
+        err.push(text);
+      },
+    },
+  };
+}
+
+describe("resolveBundledDeftInstallBinary", () => {
+  it("maps linux x64 to install-linux-amd64 under vendor/deft-install", () => {
+    expect(releaseArtifactName("linux", "x64")).toBe("install-linux-amd64");
+    const root = "/tmp/pkg";
+    expect(bundledBinaryCandidates(root, "linux", "x64")[0]).toBe(
+      "/tmp/pkg/vendor/deft-install/install-linux-amd64",
+    );
+  });
+
+  it("honors DEFT_INSTALL_BINARY when the path is readable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "deft-install-"));
+    const binary = join(dir, "deft-install");
+    writeFileSync(binary, "#!/bin/sh\nexit 0\n", "utf8");
+    expect(resolveBundledDeftInstallBinary({ env: { DEFT_INSTALL_BINARY: binary } })).toBe(binary);
+  });
+
+  it("returns null when bundled candidates are absent", () => {
+    expect(
+      resolveBundledDeftInstallBinary({
+        packageRoot: "/nonexistent/package",
+        platform: "linux",
+        arch: "x64",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("runDeftInstall delegation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("init invokes bundled binary with canonical install argv and passthrough JSON", () => {
+    const { io, out } = captureIo();
+    const runBinary = vi.fn((): { status: number; stdout: string; stderr: string } => ({
+      status: 0,
+      stdout: '{"ok":true,"action":"install"}\n',
+      stderr: "",
+    }));
+
+    const code = runDeftInstall({
+      verb: "init",
+      canonicalArgv: CANONICAL_INIT_ARGV,
+      io,
+      resolveBinary: () => "/bundled/deft-install",
+      runBinary,
+    });
+
+    expect(code).toBe(0);
+    expect(runBinary).toHaveBeenCalledOnce();
+    expect(runBinary.mock.calls[0]?.[0]).toBe("/bundled/deft-install");
+    expect(runBinary.mock.calls[0]?.[1]).toEqual([...CANONICAL_INIT_ARGV]);
+    expect(out.join("")).toContain('"action":"install"');
+  });
+
+  it("update maps non-zero binary exit to non-zero CLI exit", () => {
+    const { io, err } = captureIo();
+    const runBinary = vi.fn(() => ({
+      status: 3,
+      stdout: "",
+      stderr: "upgrade refused\n",
+    }));
+
+    const code = runDeftInstall({
+      verb: "update",
+      canonicalArgv: CANONICAL_UPDATE_ARGV,
+      io,
+      resolveBinary: () => "/bundled/deft-install",
+      runBinary,
+    });
+
+    expect(code).toBe(3);
+    expect(runBinary.mock.calls[0]?.[1]).toEqual([...CANONICAL_UPDATE_ARGV]);
+    expect(err.join("")).toContain("upgrade refused");
+  });
+
+  it("emits remediation when bundled binary cannot be located", () => {
+    const { io, err } = captureIo();
+    const code = runDeftInstall({
+      verb: "init",
+      canonicalArgv: CANONICAL_INIT_ARGV,
+      io,
+      resolveBinary: () => null,
+      resolveBinaryOptions: {
+        packageRoot: "/pkg/root",
+        platform: "linux",
+        arch: "x64",
+      },
+    });
+
+    expect(code).toBe(2);
+    const message = err.join("");
+    expect(message).toContain("directive init:");
+    expect(message).toContain("bundled deft-install binary not found");
+    expect(message).toContain("/pkg/root/vendor/deft-install/install-linux-amd64");
+    expect(message).toContain("DEFT_INSTALL_BINARY");
+    expect(message).not.toContain("ENOENT");
+  });
+
+  it("runUpdate surfaces missing-binary diagnostic", () => {
+    const { io, err } = captureIo();
+    const code = runUpdate([], io);
+    expect(code).toBe(2);
+    expect(err.join("")).toContain("directive update:");
+  });
+});
+
+describe("cliPackageRoot", () => {
+  it("resolves two levels above init-cli dist modules", () => {
+    const root = cliPackageRoot(new URL("./resolve-binary.ts", import.meta.url).href);
+    expect(root.endsWith("/packages/cli")).toBe(true);
+  });
+});

--- a/packages/cli/src/init-cli/init.ts
+++ b/packages/cli/src/init-cli/init.ts
@@ -1,0 +1,12 @@
+import type { DispatchIo } from "../dispatch.js";
+import { CANONICAL_INIT_ARGV } from "./constants.js";
+import { runDeftInstall } from "./run-deft-install.js";
+
+export function runInit(argv: readonly string[], io: DispatchIo): number {
+  return runDeftInstall({
+    verb: "init",
+    canonicalArgv: CANONICAL_INIT_ARGV,
+    userArgv: argv,
+    io,
+  });
+}

--- a/packages/cli/src/init-cli/resolve-binary.ts
+++ b/packages/cli/src/init-cli/resolve-binary.ts
@@ -1,0 +1,88 @@
+import { accessSync, constants as fsConstants } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Resolve @deftai/directive package root from a compiled init-cli module URL. */
+export function cliPackageRoot(fromModuleUrl: string = import.meta.url): string {
+  return join(dirname(fileURLToPath(fromModuleUrl)), "..", "..");
+}
+
+/** Release artifact basename for the current platform (#11 bundled layout). */
+export function releaseArtifactName(platform: NodeJS.Platform, arch: string): string {
+  const normalizedArch = arch === "x64" ? "amd64" : arch === "arm64" ? "arm64" : arch;
+  switch (platform) {
+    case "win32":
+      return `install-windows-${normalizedArch}.exe`;
+    case "darwin":
+      return `install-macos-${normalizedArch}`;
+    case "linux":
+      return `install-linux-${normalizedArch}`;
+    default:
+      return `install-${platform}-${normalizedArch}`;
+  }
+}
+
+/** Ordered search paths for the bundled deft-install binary. */
+export function bundledBinaryCandidates(
+  packageRoot: string,
+  platform: NodeJS.Platform,
+  arch: string,
+): readonly string[] {
+  const artifact = releaseArtifactName(platform, arch);
+  const genericName = platform === "win32" ? "deft-install.exe" : "deft-install";
+  return [
+    join(packageRoot, "vendor", "deft-install", artifact),
+    join(packageRoot, "vendor", "deft-install", genericName),
+  ];
+}
+
+function isReadableFile(path: string): boolean {
+  try {
+    accessSync(path, fsConstants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ResolveBinaryOptions {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  packageRoot?: string;
+  moduleUrl?: string;
+}
+
+/** Locate the bundled deft-install binary or an explicit DEFT_INSTALL_BINARY override. */
+export function resolveBundledDeftInstallBinary(options: ResolveBinaryOptions = {}): string | null {
+  const env = options.env ?? process.env;
+  const override = env.DEFT_INSTALL_BINARY?.trim();
+  if (override !== undefined && override.length > 0) {
+    return isReadableFile(override) ? override : null;
+  }
+
+  const packageRoot = options.packageRoot ?? cliPackageRoot(options.moduleUrl ?? import.meta.url);
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+
+  for (const candidate of bundledBinaryCandidates(packageRoot, platform, arch)) {
+    if (isReadableFile(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function missingBinaryMessage(
+  verb: "init" | "update",
+  packageRoot: string,
+  platform: NodeJS.Platform,
+  arch: string,
+): string {
+  const expected = bundledBinaryCandidates(packageRoot, platform, arch)[0];
+  return (
+    `directive ${verb}: bundled deft-install binary not found (expected ${expected}).\n` +
+    "Download a platform installer from https://github.com/deftai/directive/releases " +
+    "or set DEFT_INSTALL_BINARY to the absolute path of deft-install."
+  );
+}

--- a/packages/cli/src/init-cli/resolve-binary.ts
+++ b/packages/cli/src/init-cli/resolve-binary.ts
@@ -36,9 +36,13 @@ export function bundledBinaryCandidates(
   ];
 }
 
-function isReadableFile(path: string): boolean {
+function accessMode(platform: NodeJS.Platform): number {
+  return platform === "win32" ? fsConstants.R_OK : fsConstants.R_OK | fsConstants.X_OK;
+}
+
+function isRunnableBinary(path: string, platform: NodeJS.Platform): boolean {
   try {
-    accessSync(path, fsConstants.R_OK);
+    accessSync(path, accessMode(platform));
     return true;
   } catch {
     return false;
@@ -53,24 +57,41 @@ export interface ResolveBinaryOptions {
   moduleUrl?: string;
 }
 
-/** Locate the bundled deft-install binary or an explicit DEFT_INSTALL_BINARY override. */
-export function resolveBundledDeftInstallBinary(options: ResolveBinaryOptions = {}): string | null {
-  const env = options.env ?? process.env;
-  const override = env.DEFT_INSTALL_BINARY?.trim();
-  if (override !== undefined && override.length > 0) {
-    return isReadableFile(override) ? override : null;
-  }
+export type ResolveBinaryResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: "not-found"; packageRoot: string; platform: NodeJS.Platform; arch: string }
+  | { ok: false; reason: "override-unreadable"; path: string };
 
-  const packageRoot = options.packageRoot ?? cliPackageRoot(options.moduleUrl ?? import.meta.url);
+/** Locate the bundled deft-install binary or an explicit DEFT_INSTALL_BINARY override. */
+export function resolveBundledDeftInstallBinaryDetailed(
+  options: ResolveBinaryOptions = {},
+): ResolveBinaryResult {
+  const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
   const arch = options.arch ?? process.arch;
+  const packageRoot = options.packageRoot ?? cliPackageRoot(options.moduleUrl ?? import.meta.url);
+
+  const override = env.DEFT_INSTALL_BINARY?.trim();
+  if (override !== undefined && override.length > 0) {
+    if (isRunnableBinary(override, platform)) {
+      return { ok: true, path: override };
+    }
+    return { ok: false, reason: "override-unreadable", path: override };
+  }
 
   for (const candidate of bundledBinaryCandidates(packageRoot, platform, arch)) {
-    if (isReadableFile(candidate)) {
-      return candidate;
+    if (isRunnableBinary(candidate, platform)) {
+      return { ok: true, path: candidate };
     }
   }
-  return null;
+
+  return { ok: false, reason: "not-found", packageRoot, platform, arch };
+}
+
+/** Back-compat helper returning only the resolved path. */
+export function resolveBundledDeftInstallBinary(options: ResolveBinaryOptions = {}): string | null {
+  const resolved = resolveBundledDeftInstallBinaryDetailed(options);
+  return resolved.ok ? resolved.path : null;
 }
 
 export function missingBinaryMessage(
@@ -84,5 +105,12 @@ export function missingBinaryMessage(
     `directive ${verb}: bundled deft-install binary not found (expected ${expected}).\n` +
     "Download a platform installer from https://github.com/deftai/directive/releases " +
     "or set DEFT_INSTALL_BINARY to the absolute path of deft-install."
+  );
+}
+
+export function overrideUnreadableMessage(verb: "init" | "update", path: string): string {
+  return (
+    `directive ${verb}: DEFT_INSTALL_BINARY is set to ${path} but the path is missing or not executable.\n` +
+    "Fix the path or download a platform installer from https://github.com/deftai/directive/releases."
   );
 }

--- a/packages/cli/src/init-cli/run-deft-install.ts
+++ b/packages/cli/src/init-cli/run-deft-install.ts
@@ -1,10 +1,12 @@
 import { spawnSync } from "node:child_process";
+import { constants as osConstants } from "node:os";
 import type { DispatchIo } from "../dispatch.js";
 import {
   cliPackageRoot,
   missingBinaryMessage,
+  overrideUnreadableMessage,
   type ResolveBinaryOptions,
-  resolveBundledDeftInstallBinary,
+  resolveBundledDeftInstallBinaryDetailed,
 } from "./resolve-binary.js";
 
 const SUBPROCESS_MAX_BUFFER = 64 * 1024 * 1024;
@@ -16,6 +18,11 @@ export interface BinaryRunResult {
 }
 
 export type RunBinaryFn = (binary: string, args: readonly string[], cwd: string) => BinaryRunResult;
+
+function signalExitCode(signal: NodeJS.Signals): number {
+  const signum = osConstants.signals[signal];
+  return 128 + (typeof signum === "number" ? signum : 0);
+}
 
 /** Safe subprocess capture (#1366): utf-8 text mode with replace semantics. */
 export function defaultRunBinary(
@@ -35,7 +42,7 @@ export function defaultRunBinary(
   let stderr = typeof result.stderr === "string" ? result.stderr : "";
   if (status === null) {
     if (result.signal !== null && result.signal !== undefined) {
-      status = 128;
+      status = signalExitCode(result.signal);
     } else if (result.error) {
       status = 2;
       if (stderr.trim().length === 0) {
@@ -64,22 +71,30 @@ export interface RunDeftInstallOptions {
   userArgv?: readonly string[];
   io: DispatchIo;
   cwd?: string;
-  resolveBinary?: (options?: ResolveBinaryOptions) => string | null;
+  resolveBinaryDetailed?: (
+    options?: ResolveBinaryOptions,
+  ) => ReturnType<typeof resolveBundledDeftInstallBinaryDetailed>;
   resolveBinaryOptions?: ResolveBinaryOptions;
   runBinary?: RunBinaryFn;
 }
 
 /** Shell out to bundled deft-install with canonical argv and map exit codes. */
 export function runDeftInstall(options: RunDeftInstallOptions): number {
-  const resolveBinary = options.resolveBinary ?? resolveBundledDeftInstallBinary;
+  const resolveDetailed = options.resolveBinaryDetailed ?? resolveBundledDeftInstallBinaryDetailed;
   const resolveOptions = options.resolveBinaryOptions ?? {};
-  const binary = resolveBinary(resolveOptions);
+  const resolved = resolveDetailed(resolveOptions);
 
-  if (binary === null) {
+  if (!resolved.ok) {
+    if (resolved.reason === "override-unreadable") {
+      options.io.writeErr(`${overrideUnreadableMessage(options.verb, resolved.path)}\n`);
+      return 2;
+    }
     const packageRoot =
-      resolveOptions.packageRoot ?? cliPackageRoot(resolveOptions.moduleUrl ?? import.meta.url);
-    const platform = resolveOptions.platform ?? process.platform;
-    const arch = resolveOptions.arch ?? process.arch;
+      resolved.packageRoot ??
+      resolveOptions.packageRoot ??
+      cliPackageRoot(resolveOptions.moduleUrl ?? import.meta.url);
+    const platform = resolved.platform ?? resolveOptions.platform ?? process.platform;
+    const arch = resolved.arch ?? resolveOptions.arch ?? process.arch;
     options.io.writeErr(`${missingBinaryMessage(options.verb, packageRoot, platform, arch)}\n`);
     return 2;
   }
@@ -87,7 +102,7 @@ export function runDeftInstall(options: RunDeftInstallOptions): number {
   const args = [...options.canonicalArgv, ...(options.userArgv ?? [])];
   const cwd = options.cwd ?? process.cwd();
   const runBinary = options.runBinary ?? defaultRunBinary;
-  const result = runBinary(binary, args, cwd);
+  const result = runBinary(resolved.path, args, cwd);
 
   writeCaptured(result.stdout, options.io.writeOut);
   writeCaptured(result.stderr, options.io.writeErr);

--- a/packages/cli/src/init-cli/run-deft-install.ts
+++ b/packages/cli/src/init-cli/run-deft-install.ts
@@ -1,0 +1,95 @@
+import { spawnSync } from "node:child_process";
+import type { DispatchIo } from "../dispatch.js";
+import {
+  cliPackageRoot,
+  missingBinaryMessage,
+  type ResolveBinaryOptions,
+  resolveBundledDeftInstallBinary,
+} from "./resolve-binary.js";
+
+const SUBPROCESS_MAX_BUFFER = 64 * 1024 * 1024;
+
+export interface BinaryRunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type RunBinaryFn = (binary: string, args: readonly string[], cwd: string) => BinaryRunResult;
+
+/** Safe subprocess capture (#1366): utf-8 text mode with replace semantics. */
+export function defaultRunBinary(
+  binary: string,
+  args: readonly string[],
+  cwd: string,
+): BinaryRunResult {
+  const result = spawnSync(binary, [...args], {
+    cwd,
+    env: process.env,
+    encoding: "utf8",
+    maxBuffer: SUBPROCESS_MAX_BUFFER,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let status = result.status;
+  let stderr = typeof result.stderr === "string" ? result.stderr : "";
+  if (status === null) {
+    if (result.signal !== null && result.signal !== undefined) {
+      status = 128;
+    } else if (result.error) {
+      status = 2;
+      if (stderr.trim().length === 0) {
+        stderr = result.error.message;
+      }
+    } else {
+      status = 0;
+    }
+  }
+
+  return {
+    status,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr,
+  };
+}
+
+function writeCaptured(text: string, write: (chunk: string) => void): void {
+  if (text.length === 0) return;
+  write(text.endsWith("\n") ? text : `${text}\n`);
+}
+
+export interface RunDeftInstallOptions {
+  verb: "init" | "update";
+  canonicalArgv: readonly string[];
+  userArgv?: readonly string[];
+  io: DispatchIo;
+  cwd?: string;
+  resolveBinary?: (options?: ResolveBinaryOptions) => string | null;
+  resolveBinaryOptions?: ResolveBinaryOptions;
+  runBinary?: RunBinaryFn;
+}
+
+/** Shell out to bundled deft-install with canonical argv and map exit codes. */
+export function runDeftInstall(options: RunDeftInstallOptions): number {
+  const resolveBinary = options.resolveBinary ?? resolveBundledDeftInstallBinary;
+  const resolveOptions = options.resolveBinaryOptions ?? {};
+  const binary = resolveBinary(resolveOptions);
+
+  if (binary === null) {
+    const packageRoot =
+      resolveOptions.packageRoot ?? cliPackageRoot(resolveOptions.moduleUrl ?? import.meta.url);
+    const platform = resolveOptions.platform ?? process.platform;
+    const arch = resolveOptions.arch ?? process.arch;
+    options.io.writeErr(`${missingBinaryMessage(options.verb, packageRoot, platform, arch)}\n`);
+    return 2;
+  }
+
+  const args = [...options.canonicalArgv, ...(options.userArgv ?? [])];
+  const cwd = options.cwd ?? process.cwd();
+  const runBinary = options.runBinary ?? defaultRunBinary;
+  const result = runBinary(binary, args, cwd);
+
+  writeCaptured(result.stdout, options.io.writeOut);
+  writeCaptured(result.stderr, options.io.writeErr);
+  return result.status === 0 ? 0 : result.status;
+}

--- a/packages/cli/src/init-cli/update.ts
+++ b/packages/cli/src/init-cli/update.ts
@@ -1,0 +1,12 @@
+import type { DispatchIo } from "../dispatch.js";
+import { CANONICAL_UPDATE_ARGV } from "./constants.js";
+import { runDeftInstall } from "./run-deft-install.js";
+
+export function runUpdate(argv: readonly string[], io: DispatchIo): number {
+  return runDeftInstall({
+    verb: "update",
+    canonicalArgv: CANONICAL_UPDATE_ARGV,
+    userArgv: argv,
+    io,
+  });
+}

--- a/vbrief/completed/2026-06-23-make-directive-initupdate-a-front-end-to-the-deft-install-bi.vbrief.json
+++ b/vbrief/completed/2026-06-23-make-directive-initupdate-a-front-end-to-the-deft-install-bi.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "11-s4-init-update-frontend",
     "title": "Make directive init/update a front-end to the deft-install binary",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json",
     "narratives": {
       "Description": "Implement the #1670 Decision-3 transition contract: `directive init` and `directive update` delegate to the bundled deft-install Go binary (deft-install --yes --upgrade --repo-root . --json) rather than reimplementing bootstrap. This keeps a single bootstrap implementation during the staged Go-retire window; the CLI absorbs the logic only at Wave 5. Builds on the S3 router.",
@@ -63,7 +63,9 @@
         "file_scope_confidence": "high",
         "model_tier": "standard",
         "missing_traces_justification": "Implements #1670 Decision-3 (front-end to deft-install) under #11/#1669 Wave 2; maintainer tooling with no spec-section trace."
-      }
+      },
+      "completedAt": "2026-06-23T03:53:19Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -73,6 +75,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-23T03:47:16Z"
+    "updated": "2026-06-23T03:53:19Z"
   }
 }

--- a/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
+++ b/vbrief/proposed/2026-04-23-11-npm-pip-cli-distribution-npm-i-g-deftai-directive-pipx.vbrief.json
@@ -47,7 +47,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-23-make-directive-initupdate-a-front-end-to-the-deft-install-bi.vbrief.json",
+        "uri": "completed/2026-06-23-make-directive-initupdate-a-front-end-to-the-deft-install-bi.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Make directive init/update a front-end to the deft-install binary",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
- `directive init` and `directive update` now delegate to the bundled `deft-install` Go binary instead of exiting with S4 stubs.
- Init uses `--yes --repo-root . --json`; update adds `--upgrade` with the same headless flags.
- Subprocess capture uses utf-8 text mode with replace semantics; missing bundled binaries emit a remediation message pointing at GitHub Releases or `DEFT_INSTALL_BINARY`.

Refs #11 #1670

## Test plan
- [x] `pnpm exec vitest run packages/cli/src/init-cli packages/cli/src/cli-router`
- [x] `pnpm --filter @deftai/directive test src/init-cli` (story verify command via workspace vitest)
- [x] `task check`
- [x] Vitest stubs assert canonical argv, JSON passthrough, non-zero exit mapping, and missing-binary diagnostic

Made with [Cursor](https://cursor.com)