### PR TITLE
docs(readme): mark npm channel not-yet-published; steer installs to Go installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,19 @@ Deft is a **layered set of standards files plus deterministic `task` tooling** t
 
 ## 🚀 Getting Started
 
-### npm (emerging canonical channel)
+### npm (coming soon — not yet published)
 
-When Node 20+ is already on your PATH, install Directive globally from npm:
+> ⚠️ **The `@deftai/directive` npm package is not yet published** to the registry (provisioning tracked by [#1909](https://github.com/deftai/directive/issues/1909)). **Until it goes live, install via the [Go installer](#go-installer-bootstrap--air-gapped) below.** The command shown here is what the install will become once the package is published.
+
+<!-- TODO(#1909): flip to npm-canonical and remove this "coming soon" notice when @deftai/directive is published -->
+
+Once published, when Node 20+ is already on your PATH you will install Directive globally from npm:
 
 ```bash
 npm i -g @deftai/directive
 ```
 
-Then run `directive` (or the `deft` alias) from any project directory — for example `directive doctor`, `directive session:start`, or `npx @deftai/directive <verb>` without a global install. This is the emerging primary distribution path; the Go installer below remains the bootstrap option during the staged retire window.
+Then run `directive` (or the `deft` alias) from any project directory — for example `directive doctor`, `directive session:start`, or `npx @deftai/directive <verb>` without a global install. This is the emerging primary distribution path; the Go installer below remains the install/bootstrap option today and during the staged retire window.
 
 ### Go installer (bootstrap / air-gapped)
 
@@ -62,7 +66,7 @@ Download the installer for your platform from [GitHub Releases](https://github.c
 
 ### 1. Install Directive
 
-Prefer **`npm i -g @deftai/directive`** when Node 20+ is available (see [npm channel](#npm-emerging-canonical-channel) above). Otherwise use the platform Go installer:
+Until the npm package is published ([#1909](https://github.com/deftai/directive/issues/1909)), install via the platform **Go installer** below. (Once live, **`npm i -g @deftai/directive`** will be the preferred path when Node 20+ is available — see [npm channel](#npm-coming-soon--not-yet-published) above.)
 
 **Windows:**
 - Download `install-windows-amd64.exe` (or `install-windows-arm64.exe` for Surface / Copilot+ PCs)


### PR DESCRIPTION
## Summary
The README's Getting Started section led with `npm i -g @deftai/directive` as a runnable install path ("emerging canonical channel", "Prefer npm…"), but the `@deftai/directive` package is **not published to the npm registry yet** (provisioning tracked by #1909). Anyone following the README today hits a 404.

This is a minimal, reversible **stopgap** (not the Wave-4 reframe owned by #761):
- Renames the section to **"npm (coming soon — not yet published)"** with a clear notice pointing at #1909.
- Steers installs to the **Go installer** until npm goes live.
- Reframes the npm command as "what install becomes once published."
- Leaves a `<!-- TODO(#1909) -->` marker so the flip is easy to find.

Removal of this banner is an acceptance item on **#1909** (the event that makes npm actually live).

## Test plan
- [ ] Rendered README: npm section reads as "coming soon", Go installer is the current path.
- [ ] In-page anchor `#npm-coming-soon--not-yet-published` resolves (the only internal link to the renamed heading was updated; no other references remain).
- [ ] No mojibake / encoding regressions (pre-commit `verify_encoding` clean).

Refs #11 #1909

Made with [Cursor](https://cursor.com)