### PR TITLE
docs(getting-started): gate npm install behind #1909 not-yet-published notice

### DIFF
--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 76f3af166ef2517a2dffc742dd2225c248b37d77e8f322151f826d03e7bd28f5 -->
-<!-- Source digest sha256: def7044aff821cb00533c270abf43290808549d9b96e956418dcc1feaa52483a -->
+<!-- Artifact sha256: 9b802373016c31a9255124825e76524d0a60742b09d610d8fce70a02f4ec3aed -->
+<!-- Source digest sha256: f220bdb4f91e7cfddf572c3141a1c372f0b088a3c6557639beee65a04b841c44 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `def7044aff821cb00533c270abf43290808549d9b96e956418dcc1feaa52483a` |
+| Source digest | `f220bdb4f91e7cfddf572c3141a1c372f0b088a3c6557639beee65a04b841c44` |
 
 ## Modules
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -20,9 +20,13 @@ Deft Directive is a Taskfile-first framework for AI-assisted software work. It c
 
 ## Installation
 
-### npm (emerging canonical channel)
+### npm (coming soon — not yet published)
 
-When Node is already available, install Directive globally:
+> ⚠️ **The `@deftai/directive` npm package is not yet published** to the registry (provisioning tracked by [#1909](https://github.com/deftai/directive/issues/1909)). **Until it goes live, install via the [Go installer](#go-installer-bootstrap) below.** The commands shown here are what the install will become once the package is published.
+
+<!-- TODO(#1909): flip to npm-canonical and remove this "coming soon" notice when @deftai/directive is published -->
+
+Once published, when Node is already available you will install Directive globally:
 
 ```bash
 npm i -g @deftai/directive
@@ -30,14 +34,14 @@ directive --version    # primary command
 deft --version         # alias — same binary
 ```
 
-One-shot without a global install:
+One-shot without a global install (also once published):
 
 ```bash
 npx @deftai/directive doctor
 npx @deftai/directive session:start
 ```
 
-This npm path is the emerging primary distribution channel under `@deftai/directive` ([#11](https://github.com/deftai/directive/issues/11)). The Go installer below remains documented as the bootstrap option during the staged retire window.
+This npm path is the emerging primary distribution channel under `@deftai/directive` ([#11](https://github.com/deftai/directive/issues/11)); the Go installer below remains the install/bootstrap option today and during the staged retire window.
 
 ### Go installer (bootstrap)
 


### PR DESCRIPTION
## Summary
`content/docs/getting-started.md` instructed consumers to run `npm i -g @deftai/directive` as a working install, but the package is **not yet published** (provisioning tracked by #1909). Because this file is vendored into every consumer's `.deft/core/`, that was the higher-impact instance of the premature-npm-advertising issue already fixed in `README.md`.

This change mirrors the README's existing treatment:
- Retitles the section to **"npm (coming soon — not yet published)"**.
- Adds the ⚠ **not-yet-published** notice pointing at the Go installer until #1909 lands.
- Adds the matching `<!-- TODO(#1909): flip to npm-canonical ... -->` comment so the flip is discoverable when the package goes live.
- Frames the `npm i` / `npx` commands as "once published".

Also includes an **incidental** one-commit refresh of `.planning/codebase/MAP.md` (digest-only, pre-existing drift from the S6/cleanup merges) so `verify:codebase-map-fresh` / `task check` is green.

## Test plan
- [x] `task check` — 8671 passed (only prior failure was the stale MAP, fixed by the digest refresh commit)
- [x] `verify:encoding` clean on the doc change
- [ ] CI green on all lanes

Refs #1909 #761 #1669

Made with [Cursor](https://cursor.com)