### PR TITLE
fix: run npm publish on GitHub-hosted runner for provenance (#1916)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,15 @@ on:
   push:
     tags:
       - "v*"
+  # Manual re-publish of an existing tag without tag surgery (#1916). Use when a
+  # tag-triggered run failed and the fix lives on a later commit: dispatch with
+  # the tag to (re)publish, e.g. v0.55.0.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)publish, e.g. v0.55.0"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -15,9 +24,19 @@ permissions:
 jobs:
   publish:
     name: Publish @deftai/directive* to npm
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted runner is REQUIRED for npm --provenance (#1916): the registry
+    # rejects Sigstore provenance bundles signed on self-hosted / third-party
+    # runners (e.g. Blacksmith) with HTTP 422 "Unsupported ... runner
+    # environment: self-hosted". Do NOT move this job to a Blacksmith runner.
+    runs-on: ubuntu-latest
+    # REF_NAME unifies the tag source across both triggers: github.ref_name for a
+    # push-tag run, inputs.tag for a manual workflow_dispatch re-publish.
+    env:
+      REF_NAME: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
 
       # Node 24 LTS pinned via .nvmrc; registry-url wires NODE_AUTH_TOKEN for npm.
       # id-token: write (workflow permissions) enables --provenance attestations.
@@ -39,7 +58,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${REF_NAME#v}"
           echo "Publishing npm packages at version ${VERSION}"
           for dir in packages/types packages/core packages/content packages/cli; do
             npm version "${VERSION}" --no-git-tag-version --allow-same-version --prefix "${dir}"
@@ -48,7 +67,7 @@ jobs:
       - name: Resolve workspace protocol for npm publish
         shell: bash
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ env.REF_NAME }}
         run: |
           set -euo pipefail
           VERSION="${VERSION#v}"

--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: fb3b7e498cbe5c6d19c41785f238c0b48a0a7546f190672f5d6d276f068e6bf0 -->
-<!-- Source digest sha256: 7b7611e98ca483e2978957622e1c248e8d856a42af81d8ac9b8757bc27cef21c -->
+<!-- Artifact sha256: 7f57378b597a7a69177906e1b2a85e89b78da2969f75f59e590572d07a653033 -->
+<!-- Source digest sha256: b9906661f8581d99eba79b3e4f620b01a904e5163ea2828ba14b0443ed2091ee -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `7b7611e98ca483e2978957622e1c248e8d856a42af81d8ac9b8757bc27cef21c` |
+| Source digest | `b9906661f8581d99eba79b3e4f620b01a904e5163ea2828ba14b0443ed2091ee` |
 
 ## Modules
 
@@ -25,7 +25,7 @@
 | `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1052 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
-| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 750 |
+| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 751 |
 | `content-packs` | Content Packs | Curated, sliceable agent memory packs rendered and checked through the packs task namespace. | `packs/**/*.md`, `packs/**/*.json` | 0 |
 | `ci-release-automation` | CI and Release Automation | Repository automation for branch policy, hooks, GitHub Actions, PR readiness, and release publication. | `.github/**/*.yml`, `.github/**/*.yaml`, `.githooks/*` | 7 |
 | `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 340 |
@@ -138,7 +138,7 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 803 |
+| JSON | 804 |
 | Markdown | 69 |
 | Other | 5 |
 | Python | 457 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **npm packages now actually publish with provenance (#1916, #1909)** — The publish workflow ran on a third-party (Blacksmith) runner, which npm's registry rejects for provenance-signed releases, so the first `v*` tag published nothing. The publish job now runs on a GitHub-hosted runner so the supply-chain provenance attestation is accepted, and a manual re-publish trigger lets an existing release tag be (re)published without recreating the tag. Refs #1916 #1909.
 
 ### Removed
 

--- a/vbrief/completed/2026-06-23-1916-npm-publish-workflow-uses-self-hosted-blacksmith-runner-inco.vbrief.json
+++ b/vbrief/completed/2026-06-23-1916-npm-publish-workflow-uses-self-hosted-blacksmith-runner-inco.vbrief.json
@@ -1,0 +1,33 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1916"
+  },
+  "plan": {
+    "title": "npm publish workflow uses self-hosted (Blacksmith) runner — incompatible with --provenance",
+    "status": "completed",
+    "narratives": {
+      "Description": "npm publish workflow uses self-hosted (Blacksmith) runner — incompatible with --provenance",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1916",
+      "Overview": "## Found during the v0.55.0 live npm smoke test (#1909)\n\nThe first real `v*` tag (`v0.55.0`) fired `.github/workflows/npm-publish.yml`, which failed at the registry:\n\n```\nnpm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@deftai%2fdirective-types\nError verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: \"self-hosted\".\nOnly \"github-hosted\" runners are supported when publishing with provenance.\n```\n\n### Root cause\nThe publish job runs on `runs-on: blacksmith-4vcpu-ubuntu-2404` (a third-party Blacksmith runner). `npm publish --provenance` requires a **GitHub-hosted** runner — the OIDC identity used to sign the Sigstore provenance bundle is only trusted from github-hosted runners. Blacksmith reads as `self-hosted`, so the registry rejects the bundle with HTTP 422.\n\n### Impact\n- Nothing published (all four `@deftai/directive*` packages are 404 — clean failure, no registry side effects).\n- The `v0.55.0` GitHub release is held as a draft pending the npm channel.\n\n### Fix\n- Move the publish job to `runs-on: ubuntu-latest` (github-hosted) and keep `--provenance`.\n- Add a `workflow_dispatch` trigger with a `tag` input so an existing tag (e.g. `v0.55.0`) can be (re)published without tag surgery.\n- First publish stays token-based (`NPM_TOKEN`); switch to OIDC trusted publishing after the packages exist (#1909).\n\nRefs #1909 #11 #1670"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1916",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1916: npm publish workflow uses self-hosted (Blacksmith) runner — incompatible with --provenance"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1909",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1909"
+      }
+    ],
+    "updated": "2026-06-23T18:24:24Z",
+    "metadata": {
+      "completedAt": "2026-06-23T18:24:24Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- The first live npm smoke test (`v0.55.0`) found that `.github/workflows/npm-publish.yml` ran on a third-party Blacksmith runner, which npm's registry rejects for `--provenance`-signed publishes (HTTP 422 "Unsupported ... runner environment: self-hosted"). Nothing published.
- Move the publish job to `ubuntu-latest` (GitHub-hosted) so the Sigstore provenance bundle is accepted; keep the `NPM_TOKEN`-based first publish.
- Add a `workflow_dispatch` trigger with a `tag` input so an existing release tag (e.g. `v0.55.0`) can be (re)published without recreating the tag; `REF_NAME` unifies the version source across both triggers.

## Test plan
- [x] `task check` green (8682 passed)
- [ ] After merge: `gh workflow run npm-publish.yml --ref master -f tag=v0.55.0`, confirm all four `@deftai/directive*` packages publish at 0.55.0 with provenance
- [ ] Publish the held `v0.55.0` GitHub release once npm lands

Closes #1916
Refs #1909 #11 #1670

Made with [Cursor](https://cursor.com)