### PR TITLE
fix(ci): repair master TS and Windows checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,12 +386,18 @@ jobs:
       # `node packages/cli/dist/bin.js`. Without Node/pnpm on PATH this job
       # failed `scope:_ensure-ts` with exit 127. Node 24 LTS pinned via .nvmrc;
       # corepack activates the pnpm version from package.json `packageManager`.
+      # The later task regression steps run from a fixture directory, so prepare
+      # the pinned pnpm as Corepack's default before leaving the workspace.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Enable corepack (pnpm)
-        run: corepack enable
+        shell: pwsh
+        run: |
+          corepack enable
+          $packageManager = (Get-Content package.json | ConvertFrom-Json).packageManager
+          corepack prepare $packageManager --activate
 
       - name: Install Node dependencies (pnpm)
         run: pnpm install --frozen-lockfile

--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 7f57378b597a7a69177906e1b2a85e89b78da2969f75f59e590572d07a653033 -->
-<!-- Source digest sha256: b9906661f8581d99eba79b3e4f620b01a904e5163ea2828ba14b0443ed2091ee -->
+<!-- Artifact sha256: 52fca6baddf3c901c9173f158593cc2233972fe0acab6f8b4e1c2b4d46c17cdb -->
+<!-- Source digest sha256: 44aae88d55d46a7563150b0b300f3896dc4d95ccd02e827eb066ce35ff8ad235 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `b9906661f8581d99eba79b3e4f620b01a904e5163ea2828ba14b0443ed2091ee` |
+| Source digest | `44aae88d55d46a7563150b0b300f3896dc4d95ccd02e827eb066ce35ff8ad235` |
 
 ## Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Master CI no longer fails after the npm publish release work (#1910, #1916)** -- The Windows task-dispatch regression job now prepares the root `packageManager` pnpm version as Corepack's default before running fixture-scoped tasks, and the npm publish rehearsal has explicit install/alignment short-circuit coverage so the TypeScript branch threshold stays green. Refs #1910 #1916.
 - **npm packages now actually publish with provenance (#1916, #1909)** — The publish workflow ran on a third-party (Blacksmith) runner, which npm's registry rejects for provenance-signed releases, so the first `v*` tag published nothing. The publish job now runs on a GitHub-hosted runner so the supply-chain provenance attestation is accepted, and a manual re-publish trigger lets an existing release tag be (re)published without recreating the tag. Refs #1916 #1909.
 
 ### Removed

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -152,6 +152,43 @@ describe("rehearseNpmPublish", () => {
     expect(calls.some((c) => c.includes("publish"))).toBe(false);
   });
 
+  it("short-circuits before build when install fails", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-install-fail-"));
+    scaffoldPackages(clone);
+    const calls: string[][] = [];
+    const seams: E2ESeams = {
+      which: (n) => `/usr/bin/${n}`,
+      spawnText: (cmd, args) => {
+        const full = [cmd, ...args];
+        calls.push(full);
+        return full.includes("install")
+          ? { status: 1, stdout: "lockfile mismatch", stderr: "" }
+          : ok();
+      },
+    };
+    const [okFlag, reason] = rehearseNpmPublish(clone, "0.0.1", seams);
+    expect(okFlag).toBe(false);
+    expect(reason).toContain("pnpm install failed");
+    expect(reason).toContain("lockfile mismatch");
+    expect(calls.some((c) => c.includes("build"))).toBe(false);
+  });
+
+  it("short-circuits before publish when version alignment fails", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-align-fail-"));
+    const calls: string[][] = [];
+    const seams: E2ESeams = {
+      which: (n) => `/usr/bin/${n}`,
+      spawnText: (cmd, args) => {
+        calls.push([cmd, ...args]);
+        return ok();
+      },
+    };
+    const [okFlag, reason] = rehearseNpmPublish(clone, "0.0.1", seams);
+    expect(okFlag).toBe(false);
+    expect(reason).toContain("version-align FAIL");
+    expect(calls.some((c) => c.includes("publish"))).toBe(false);
+  });
+
   it("short-circuits when the core publish fails", () => {
     const clone = mkdtempSync(join(tmpdir(), "deft-npm-pub-fail-"));
     scaffoldPackages(clone);


### PR DESCRIPTION
## Summary
- prepare the root packageManager pnpm version as Corepack's default in the Windows fixture job before task runs from a consumer directory
- add npm publish rehearsal short-circuit tests for install failures and version-alignment failures so branch coverage stays above the global threshold
- refresh the generated codebase MAP and note the master CI repair in the changelog

## Validation
- PATH="/tmp/deft-corepack-bin-directive:$PATH" pnpm exec vitest run packages/core/src/release-e2e/npm-ops.test.ts
- PATH="/tmp/deft-corepack-bin-directive:$PATH" pnpm run build
- PATH="/tmp/deft-corepack-bin-directive:$PATH" task codebase:validate-structure
- PATH="/tmp/deft-corepack-bin-directive:$PATH" task verify:codebase-map-fresh

## Note
Latest master (`eec52e5`) is already red on TypeScript coverage (84.99% branch threshold miss) and the Windows fixture Corepack/pnpm mismatch. This PR repairs those inherited master failures before rebasing the #1885/#1890 stack again.