### PR TITLE
feat: publish to npm via OIDC trusted publishing, retire NPM_TOKEN (#1919)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,8 +38,10 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
-      # Node 24 LTS pinned via .nvmrc; registry-url wires NODE_AUTH_TOKEN for npm.
-      # id-token: write (workflow permissions) enables --provenance attestations.
+      # Node 24 LTS pinned via .nvmrc (npm >= 11.5.1 ships with it, required for
+      # OIDC trusted publishing). registry-url points npm at the public registry.
+      # id-token: write (workflow permissions) is used for BOTH the OIDC publish
+      # auth (no NPM_TOKEN needed, #1919) and the --provenance attestations.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
@@ -91,23 +93,15 @@ jobs:
       - name: Publish @deftai/directive-types
         working-directory: packages/types
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @deftai/directive-core
         working-directory: packages/core
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @deftai/directive-content
         working-directory: packages/content
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @deftai/directive
         working-directory: packages/cli
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: 7f57378b597a7a69177906e1b2a85e89b78da2969f75f59e590572d07a653033 -->
-<!-- Source digest sha256: b9906661f8581d99eba79b3e4f620b01a904e5163ea2828ba14b0443ed2091ee -->
+<!-- Artifact sha256: 96f5233987638de6dd18377545e2299d59767f0af96dbe5fdb6d0beada811a48 -->
+<!-- Source digest sha256: 7e6906f3fdc94137513f7e0107d6d64713bbe06b5c8bea0ecc9f5e5a7361aa1f -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `b9906661f8581d99eba79b3e4f620b01a904e5163ea2828ba14b0443ed2091ee` |
+| Source digest | `7e6906f3fdc94137513f7e0107d6d64713bbe06b5c8bea0ecc9f5e5a7361aa1f` |
 
 ## Modules
 
@@ -25,7 +25,7 @@
 | `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1052 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
-| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 751 |
+| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 752 |
 | `content-packs` | Content Packs | Curated, sliceable agent memory packs rendered and checked through the packs task namespace. | `packs/**/*.md`, `packs/**/*.json` | 0 |
 | `ci-release-automation` | CI and Release Automation | Repository automation for branch policy, hooks, GitHub Actions, PR readiness, and release publication. | `.github/**/*.yml`, `.github/**/*.yaml`, `.githooks/*` | 7 |
 | `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 340 |
@@ -138,7 +138,7 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 804 |
+| JSON | 805 |
 | Markdown | 69 |
 | Other | 5 |
 | Python | 457 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **npm publishing now uses OIDC trusted publishing instead of a stored token (#1919, #1909)** — The publish workflow authenticates to npm via GitHub's short-lived OIDC identity rather than a long-lived `NPM_TOKEN` secret, so there is no standing credential to leak or rotate. Requires a one-time per-package trusted-publisher configuration on npmjs.com. Refs #1919 #1909.
 
 ### Fixed
 - **npm packages now actually publish with provenance (#1916, #1909)** — The publish workflow ran on a third-party (Blacksmith) runner, which npm's registry rejects for provenance-signed releases, so the first `v*` tag published nothing. The publish job now runs on a GitHub-hosted runner so the supply-chain provenance attestation is accepted, and a manual re-publish trigger lets an existing release tag be (re)published without recreating the tag. Refs #1916 #1909.

--- a/vbrief/completed/2026-06-23-1919-migrate-npm-publishing-to-oidc-trusted-publishing-and-retire.vbrief.json
+++ b/vbrief/completed/2026-06-23-1919-migrate-npm-publishing-to-oidc-trusted-publishing-and-retire.vbrief.json
@@ -1,0 +1,54 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1919"
+  },
+  "plan": {
+    "title": "Migrate npm publishing to OIDC trusted publishing and retire NPM_TOKEN",
+    "status": "completed",
+    "narratives": {
+      "Description": "Migrate npm publishing to OIDC trusted publishing and retire NPM_TOKEN",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1919",
+      "Overview": "**Umbrella:** #1909 (npm provisioning) — steady-state credential hardening.\n\n## Why\nThe first publish (v0.55.0) used the long-lived `NPM_TOKEN` repo secret because trusted publishing can't be configured for packages that don't exist yet. Now that all four `@deftai/directive*` packages exist on npmjs.com, we can switch to **OIDC trusted publishing** and delete the standing credential.\n\nBenefits: no long-lived secret to leak or rotate; the publish authenticates via a short-lived, per-run GitHub OIDC identity. The workflow already declares `permissions: id-token: write`, and the publish job already runs on a GitHub-hosted runner (`ubuntu-latest`, #1916), so both prerequisites are met.\n\n## Scope / checklist\n- [ ] On npmjs.com, configure a **trusted publisher** for each package (`@deftai/directive`, `@deftai/directive-core`, `@deftai/directive-content`, `@deftai/directive-types`), pointing at `deftai/directive` + the `.github/workflows/npm-publish.yml` workflow.\n- [ ] Remove the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env from the four publish steps in `.github/workflows/npm-publish.yml` (OIDC needs no token).\n- [ ] Delete the `NPM_TOKEN` GitHub Actions secret (`gh secret delete NPM_TOKEN --repo deftai/directive`).\n- [ ] Validate end-to-end with a patch release (or a `workflow_dispatch` re-publish on a test tag) that publishes cleanly with provenance and **no** token.\n- [ ] Document the final setup (org ownership, trusted-publisher config, what to do if OIDC publish fails) in the release runbook (the remaining #1909 doc item).\n\n## Acceptance\n- A `v*` tag publishes all four packages with provenance using OIDC only; `NPM_TOKEN` no longer exists.\n\nRefs #1909 #1916 #11 #1670"
+    },
+    "items": [
+      {
+        "title": "On npmjs.com, configure a **trusted publisher** for each package (, , , ), pointing at  + the  workflow.",
+        "status": "proposed"
+      },
+      {
+        "title": "Remove the  env from the four publish steps in  (OIDC needs no token).",
+        "status": "proposed"
+      },
+      {
+        "title": "Delete the  GitHub Actions secret ().",
+        "status": "proposed"
+      },
+      {
+        "title": "Validate end-to-end with a patch release (or a  re-publish on a test tag) that publishes cleanly with provenance and **no** token.",
+        "status": "proposed"
+      },
+      {
+        "title": "Document the final setup (org ownership, trusted-publisher config, what to do if OIDC publish fails) in the release runbook (the remaining #1909 doc item).",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1919",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1919: Migrate npm publishing to OIDC trusted publishing and retire NPM_TOKEN"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1909",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1909"
+      }
+    ],
+    "updated": "2026-06-23T18:43:05Z",
+    "metadata": {
+      "completedAt": "2026-06-23T18:43:05Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the four publish steps so npm authenticates via GitHub's short-lived OIDC identity (`id-token: write` is already granted, and the publish job already runs on a GitHub-hosted runner per #1916).
- Eliminates the long-lived `NPM_TOKEN` secret — nothing standing to leak or rotate.

## ⚠️ Merge ordering (important)
This PR MUST NOT merge until the per-package **trusted publisher** is configured on npmjs.com for all four packages (org `deftai`, repo `directive`, workflow `npm-publish.yml`). Until then, removing the token would leave the next publish with no auth. After merge, delete the secret: `gh secret delete NPM_TOKEN --repo deftai/directive`.

## Test plan
- [x] `task check` green (8682 passed)
- [ ] Trusted publishers configured on npmjs.com (manual, owner account)
- [ ] After merge + secret deletion: next release (or patch) publishes all four packages with provenance via OIDC, no token

Closes #1919
Refs #1909 #1916

Made with [Cursor](https://cursor.com)