### PR TITLE
fix: directive version reports installed engine version (#1918)

### DIFF
--- a/.planning/codebase/MAP.md
+++ b/.planning/codebase/MAP.md
@@ -2,8 +2,8 @@
 <!-- Purpose: generated codebase MAP projection -->
 <!-- Source of truth: vbrief/PROJECT-DEFINITION.vbrief.json plan.architecture.codeStructure -->
 <!-- Regenerate with: task codebase:map -->
-<!-- Artifact sha256: dbc3c00996c0eb157242a951c679cb81280fd15fb03a07e46df61f512af3dd0a -->
-<!-- Source digest sha256: a18320571af4a9f4d4d4142a3c779c3b59817b1d5322f8195857e62b74ec7583 -->
+<!-- Artifact sha256: cf629ace30bf26b86d06e94d322001d125e2430b090bb02d2fef8382cef2889e -->
+<!-- Source digest sha256: ba59cfbb012970a4322c47b2bbf9e45ef8f19c0d8214f2150e0f0f3d806c4f50 -->
 
 # Codebase MAP
 
@@ -14,7 +14,7 @@
 | Provider | `directive-default-extractor` `0.1` |
 | Provider mode | `default` |
 | Source | `vbrief/PROJECT-DEFINITION.vbrief.json` at `plan.architecture.codeStructure` |
-| Source digest | `a18320571af4a9f4d4d4142a3c779c3b59817b1d5322f8195857e62b74ec7583` |
+| Source digest | `ba59cfbb012970a4322c47b2bbf9e45ef8f19c0d8214f2150e0f0f3d806c4f50` |
 
 ## Modules
 
@@ -22,10 +22,10 @@
 | --- | --- | --- | --- | ---: |
 | `framework-content` | Framework Content | Agent-consumed standards, strategies, skills, templates, and documentation. | `AGENTS.md`, `SKILL.md`, `README.md`, `QUICK-START.md`, ... | 67 |
 | `python-tooling` | Python Tooling | Framework CLI helpers, validators, lifecycle tools, and automation scripts. | `run`, `run.py`, `run.bat`, `scripts/**/*.py` | 164 |
-| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1052 |
+| `typescript-engine` | TypeScript Engine | Node/TypeScript packages for the directive engine migration, CLI shims, and Python-oracle parity harnesses. | `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, ... | 1054 |
 | `task-runner` | Task Runner | Taskfile entry points that expose framework commands in source and consumer installs. | `Taskfile.yml`, `tasks/**/*.yml` | 47 |
 | `go-installer` | Go Installer | Standalone installer binary for end-user and maintainer installs. | `go.mod`, `cmd/deft-install/**/*.go` | 27 |
-| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 754 |
+| `vbrief-metadata` | vBRIEF Metadata | Structured project, scope, schema, lifecycle, and architecture metadata. | `vbrief/**/*.json`, `vbrief/**/*.md` | 755 |
 | `content-packs` | Content Packs | Curated, sliceable agent memory packs rendered and checked through the packs task namespace. | `packs/**/*.md`, `packs/**/*.json` | 0 |
 | `ci-release-automation` | CI and Release Automation | Repository automation for branch policy, hooks, GitHub Actions, PR readiness, and release publication. | `.github/**/*.yml`, `.github/**/*.yaml`, `.githooks/*` | 7 |
 | `test-suite` | Test Suite | CLI, content, integration, and regression tests for framework behavior. | `tests/**/*.py`, `tests/**/*.json` | 340 |
@@ -138,11 +138,11 @@
 | Language | Files |
 | --- | ---: |
 | Go | 26 |
-| JSON | 807 |
+| JSON | 808 |
 | Markdown | 69 |
 | Other | 5 |
 | Python | 457 |
-| TypeScript | 1040 |
+| TypeScript | 1042 |
 | YAML | 54 |
 
 ## Degraded Signals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`directive version` now reports the installed engine version (#1918)** — `engineInfo()` previously returned a hardcoded `0.0.0`, so `directive version` and the `deft` alias always showed `@deftai/directive-core@0.0.0` even after a correct npm install. The runtime banner now reads the version from the installed `@deftai/directive-core` package.json, matching registry metadata. Refs #1918 #1909.
 
 ### Removed
 

--- a/packages/cli/src/bin.test.ts
+++ b/packages/cli/src/bin.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { engineInfo } from "@deftai/directive-core";
 import { describe, expect, it } from "vitest";
 
-const VERSION_LINE = "@deftai/directive (engine: @deftai/directive-core@0.0.0)\n";
+const VERSION_LINE = `@deftai/directive (engine: @deftai/directive-core@${engineInfo().version})\n`;
 
 describe("dist/bin.js entrypoint", () => {
   const binPath = join(dirname(fileURLToPath(import.meta.url)), "../dist/bin.js");

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -1,3 +1,4 @@
+import { engineInfo } from "@deftai/directive-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CLI_MODULE_VERBS,
@@ -9,6 +10,9 @@ import {
   resolveCanonicalVerb,
   VERB_ALIASES,
 } from "./dispatch.js";
+
+const engineVersion = engineInfo().version;
+const VERSION_BANNER = `@deftai/directive (engine: @deftai/directive-core@${engineVersion})\n`;
 
 afterEach(() => {
   resetHandlerCacheForTests();
@@ -61,7 +65,7 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toBe("@deftai/directive (engine: @deftai/directive-core@0.0.0)\n");
+    expect(out.join("")).toBe(VERSION_BANNER);
   });
 
   it("returns 0 for -V and prints the engine banner", async () => {
@@ -73,7 +77,7 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toBe("@deftai/directive (engine: @deftai/directive-core@0.0.0)\n");
+    expect(out.join("")).toBe(VERSION_BANNER);
   });
 
   it("returns 0 for empty argv and prints help", async () => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,8 +1,10 @@
+import { engineInfo } from "@deftai/directive-core";
 import { describe, expect, it } from "vitest";
 import { banner, CLI_PACKAGE } from "./index.js";
 
 describe("@deftai/directive", () => {
   it("renders a banner spanning the full cli → core → types chain", () => {
-    expect(banner()).toBe(`${CLI_PACKAGE} (engine: @deftai/directive-core@0.0.0)`);
+    const { version } = engineInfo();
+    expect(banner()).toBe(`${CLI_PACKAGE} (engine: @deftai/directive-core@${version})`);
   });
 });

--- a/packages/core/src/engine-version.test.ts
+++ b/packages/core/src/engine-version.test.ts
@@ -1,20 +1,29 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
 
+function loadVersionReader() {
+  return import("./engine-version.js");
+}
+
 describe("readCorePackageVersion", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unmock("node:fs");
     vi.resetModules();
   });
 
   it("returns the version from the adjacent package.json", async () => {
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
-    const { readCorePackageVersion } = await import("./engine-version.js");
-    expect(readCorePackageVersion()).toBe(pkg.version);
+    const raw = readFileSync(pkgPath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    expect(parsed).not.toBeNull();
+    expect(typeof parsed).toBe("object");
+    const version = (parsed as { version: string }).version;
+    const { readCorePackageVersion } = await loadVersionReader();
+    expect(readCorePackageVersion()).toBe(version);
   });
 
   it("falls back when package.json cannot be read", async () => {
@@ -27,19 +36,31 @@ describe("readCorePackageVersion", () => {
         },
       };
     });
-    const { readCorePackageVersion } = await import("./engine-version.js");
+    const { readCorePackageVersion } = await loadVersionReader();
     expect(readCorePackageVersion()).toBe("0.0.0");
   });
 
   it("falls back when version field is missing or empty", async () => {
-    const original = readFileSync(pkgPath, "utf8");
-    try {
-      writeFileSync(pkgPath, JSON.stringify({ name: "@deftai/directive-core" }));
-      vi.resetModules();
-      const { readCorePackageVersion } = await import("./engine-version.js");
-      expect(readCorePackageVersion()).toBe("0.0.0");
-    } finally {
-      writeFileSync(pkgPath, original);
-    }
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        readFileSync: () => JSON.stringify({ name: "@deftai/directive-core" }),
+      };
+    });
+    const { readCorePackageVersion } = await loadVersionReader();
+    expect(readCorePackageVersion()).toBe("0.0.0");
+  });
+
+  it("falls back when package.json parses to null", async () => {
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        readFileSync: () => "null",
+      };
+    });
+    const { readCorePackageVersion } = await loadVersionReader();
+    expect(readCorePackageVersion()).toBe("0.0.0");
   });
 });

--- a/packages/core/src/engine-version.test.ts
+++ b/packages/core/src/engine-version.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+
+describe("readCorePackageVersion", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns the version from the adjacent package.json", async () => {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+    const { readCorePackageVersion } = await import("./engine-version.js");
+    expect(readCorePackageVersion()).toBe(pkg.version);
+  });
+
+  it("falls back when package.json cannot be read", async () => {
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        readFileSync: () => {
+          throw new Error("ENOENT");
+        },
+      };
+    });
+    const { readCorePackageVersion } = await import("./engine-version.js");
+    expect(readCorePackageVersion()).toBe("0.0.0");
+  });
+
+  it("falls back when version field is missing or empty", async () => {
+    const original = readFileSync(pkgPath, "utf8");
+    try {
+      writeFileSync(pkgPath, JSON.stringify({ name: "@deftai/directive-core" }));
+      vi.resetModules();
+      const { readCorePackageVersion } = await import("./engine-version.js");
+      expect(readCorePackageVersion()).toBe("0.0.0");
+    } finally {
+      writeFileSync(pkgPath, original);
+    }
+  });
+});

--- a/packages/core/src/engine-version.ts
+++ b/packages/core/src/engine-version.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FALLBACK_VERSION = "0.0.0";
+
+/** Reads `@deftai/directive-core` version from the installed package.json adjacent to dist/ or src/. */
+export function readCorePackageVersion(): string {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+    const parsed = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: unknown };
+    return typeof parsed.version === "string" && parsed.version.length > 0
+      ? parsed.version
+      : FALLBACK_VERSION;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}

--- a/packages/core/src/engine-version.ts
+++ b/packages/core/src/engine-version.ts
@@ -4,14 +4,20 @@ import { fileURLToPath } from "node:url";
 
 const FALLBACK_VERSION = "0.0.0";
 
+function parsePackageVersion(raw: string): string {
+  const parsed: unknown = JSON.parse(raw);
+  if (parsed === null || typeof parsed !== "object") {
+    return FALLBACK_VERSION;
+  }
+  const version = (parsed as { version?: unknown }).version;
+  return typeof version === "string" && version.length > 0 ? version : FALLBACK_VERSION;
+}
+
 /** Reads `@deftai/directive-core` version from the installed package.json adjacent to dist/ or src/. */
 export function readCorePackageVersion(): string {
   try {
     const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
-    const parsed = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: unknown };
-    return typeof parsed.version === "string" && parsed.version.length > 0
-      ? parsed.version
-      : FALLBACK_VERSION;
+    return parsePackageVersion(readFileSync(pkgPath, "utf8"));
   } catch {
     return FALLBACK_VERSION;
   }

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,8 +1,17 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { CORE_PACKAGE, engineInfo } from "./index.js";
 
+const pkgVersion = (
+  JSON.parse(
+    readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf8"),
+  ) as { version: string }
+).version;
+
 describe("@deftai/directive-core", () => {
   it("reports engine info backed by an @deftai/directive-types shape", () => {
-    expect(engineInfo()).toEqual({ name: CORE_PACKAGE, version: "0.0.0" });
+    expect(engineInfo()).toEqual({ name: CORE_PACKAGE, version: pkgVersion });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import type { EngineInfo } from "@deftai/directive-types";
+import { readCorePackageVersion } from "./engine-version.js";
 
 /**
  * `@deftai/directive-core` — the deft directive engine core.
@@ -55,5 +56,5 @@ export const CORE_PACKAGE = "@deftai/directive-core" as const;
 
 /** Returns identifying metadata for the core engine package. */
 export function engineInfo(): EngineInfo {
-  return { name: CORE_PACKAGE, version: "0.0.0" };
+  return { name: CORE_PACKAGE, version: readCorePackageVersion() };
 }

--- a/vbrief/active/2026-06-23-1918-directive-version-reports-hardcoded-engine-version-000.vbrief.json
+++ b/vbrief/active/2026-06-23-1918-directive-version-reports-hardcoded-engine-version-000.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1918"
+  },
+  "plan": {
+    "title": "directive version reports hardcoded engine version 0.0.0",
+    "status": "running",
+    "narratives": {
+      "Description": "directive version reports hardcoded engine version 0.0.0",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1918",
+      "Overview": "## Symptom\nAfter the v0.55.0 npm publish, `npm i -g @deftai/directive@0.55.0` then `directive version` (and the `deft` alias) prints:\n\n```\n@deftai/directive (engine: @deftai/directive-core@0.0.0)\n```\n\nThe published package metadata is correct (`@deftai/directive-core@0.55.0` on the registry); only the runtime-reported version is wrong.\n\n## Root cause\n`engineInfo()` returns a hardcoded version literal:\n\n`packages/core/src/index.ts:58`\n```ts\nexport function engineInfo(): EngineInfo {\n  return { name: CORE_PACKAGE, version: \"0.0.0\" };\n}\n```\n\n`banner()` (`packages/cli/src/index.ts:16`) and the `version` dispatch (`packages/cli/src/dispatch.ts:573`) both render `${info.name}@${info.version}`, so they always emit `0.0.0`. The publish workflow aligns `package.json` versions at publish time only, so nothing updates this literal.\n\n## Suggested fix\nSource the version from the package's own `package.json` at build or runtime (e.g. a generated `version.ts` written during `tsc -b`/build, or reading the installed `package.json`) instead of the hardcoded literal. Update the three tests that currently assert `0.0.0` (`index.test.ts`, `dispatch.test.ts`, `bin.test.ts`) accordingly.\n\n## Severity\nCosmetic — does not affect install or functionality, but `directive version` is the first thing a user runs to confirm their install, so a wrong number undermines confidence.\n\nFound during the #1909 first-publish smoke test. Refs #1909 #11"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1918",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1918: directive version reports hardcoded engine version 0.0.0"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1909",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1909"
+      }
+    ],
+    "updated": "2026-06-23T21:00:32Z"
+  }
+}


### PR DESCRIPTION
## Summary
- `engineInfo()` reads `@deftai/directive-core` version from the installed package's `package.json` instead of a hardcoded `0.0.0` literal.
- `directive version`, `-V`, and the `deft` alias banner now match the published npm package version after install.
- Updated core/CLI tests to assert against the live package version; added unit coverage for the version reader fallback paths.

## Test plan
- [x] `pnpm test` (vitest, including `engine-version.test.ts`, `index.test.ts`, `dispatch.test.ts`, `bin.test.ts`)
- [x] `uv run pytest tests/` (full Python suite, isolated)
- [x] `task verify:codebase-map-fresh`
- [x] `pnpm biome check` on changed TS files

Closes #1918

Made with [Cursor](https://cursor.com)