### PR TITLE
fix: release:e2e npm dry-run bypasses implicit latest tag (#1925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **`directive version` now reports the installed engine version (#1918)** — `engineInfo()` previously returned a hardcoded `0.0.0`, so `directive version` and the `deft` alias always showed `@deftai/directive-core@0.0.0` even after a correct npm install. The runtime banner now reads the version from the installed `@deftai/directive-core` package.json, matching registry metadata. Refs #1918 #1909.
 
+- **Release rehearsal no longer false-fails on npm dry-run after real packages are published (#1925)** — `task release:e2e` now passes a throwaway `e2e-rehearsal` dist-tag to `npm publish --dry-run`, so the fixed rehearsal version `0.0.1` no longer trips npm's implicit-`latest` check once `@deftai/directive*` is live at a higher version. Refs #1925.
+
 ### Removed
 
 ## [0.55.1] - 2026-06-23

--- a/packages/core/src/release-e2e/constants.ts
+++ b/packages/core/src/release-e2e/constants.ts
@@ -14,6 +14,8 @@ export const REHEARSAL_VERSION = "0.0.1";
  * .github/workflows/npm-publish.yml (types -> core -> content -> cli).
  */
 export const NPM_PUBLISH_PACKAGES = ["types", "core", "content", "cli"] as const;
+/** #1925: throwaway dist-tag so dry-run does not apply `latest` to 0.0.1. */
+export const NPM_E2E_REHEARSAL_TAG = "e2e-rehearsal";
 export const NPM_INSTALL_TIMEOUT_SECONDS = 600;
 export const NPM_BUILD_TIMEOUT_SECONDS = 600;
 export const NPM_PUBLISH_DRYRUN_TIMEOUT_SECONDS = 180;

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -121,7 +121,11 @@ describe("rehearseNpmPublish", () => {
     expect(reason).toContain("npm publish --dry-run clean for 4 packages");
     expect(calls[0]?.cmd).toContain("install");
     expect(calls[1]?.cmd).toContain("build");
-    const publishCwds = calls.filter((c) => c.cmd.includes("publish")).map((c) => c.cwd);
+    const publishCalls = calls.filter((c) => c.cmd.includes("publish"));
+    expect(
+      publishCalls.every((c) => c.cmd.includes("--tag") && c.cmd.includes("e2e-rehearsal")),
+    ).toBe(true);
+    const publishCwds = publishCalls.map((c) => c.cwd);
     expect(publishCwds).toEqual([
       join(clone, "packages", "types"),
       join(clone, "packages", "core"),

--- a/packages/core/src/release-e2e/npm-ops.ts
+++ b/packages/core/src/release-e2e/npm-ops.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { defaultWhich, spawnText } from "../release/spawn.js";
 import {
   NPM_BUILD_TIMEOUT_SECONDS,
+  NPM_E2E_REHEARSAL_TAG,
   NPM_INSTALL_TIMEOUT_SECONDS,
   NPM_PUBLISH_DRYRUN_TIMEOUT_SECONDS,
   NPM_PUBLISH_PACKAGES,
@@ -119,7 +120,9 @@ export function alignNpmPackageVersions(cloneDir: string, version: string): [boo
  *   2. Resolve pnpm (or `corepack pnpm`) and `pnpm install --frozen-lockfile`.
  *   3. `pnpm -w run build`; dist/ must exist for the dist-only files allowlist.
  *   4. Align the four package.json versions + resolve the workspace protocol.
- *   5. `npm publish --dry-run --access public` per package in dependency order.
+ *   5. `npm publish --dry-run --access public --tag e2e-rehearsal` per package
+ *      in dependency order (#1925 bypasses implicit-`latest` when the rehearsal
+ *      sentinel is below the highest published version).
  *
  * Returns [ok, reason] like verifyDraftRelease / verifyTag.
  */
@@ -173,10 +176,10 @@ export function rehearseNpmPublish(
   for (const pkg of NPM_PUBLISH_PACKAGES) {
     const pkgDir = join(cloneDir, "packages", pkg);
     [ok, reason] = runNpmStep(
-      [npmPath, "publish", "--dry-run", "--access", "public"],
+      [npmPath, "publish", "--dry-run", "--access", "public", "--tag", NPM_E2E_REHEARSAL_TAG],
       pkgDir,
       env,
-      `npm publish --dry-run packages/${pkg}`,
+      `npm publish --dry-run --tag ${NPM_E2E_REHEARSAL_TAG} packages/${pkg}`,
       NPM_PUBLISH_DRYRUN_TIMEOUT_SECONDS,
       seams,
     );

--- a/scripts/release_e2e.py
+++ b/scripts/release_e2e.py
@@ -52,8 +52,9 @@ spurious ``v0.0.1`` artefacts to ``deftai/directive``.
    g. ``rehearse_npm_publish`` (#1910) -- mirror ``npm-publish.yml`` against
       the clone: ``pnpm install`` + ``pnpm -w run build``, align the four
       ``@deftai/directive*`` ``package.json`` versions + resolve the
-      ``workspace:`` protocol, then ``npm publish --dry-run --access public``
-      per package in dependency order (types -> core -> content -> cli). This
+      ``workspace:`` protocol, then ``npm publish --dry-run --access public
+      --tag e2e-rehearsal`` per package in dependency order (types -> core ->
+      content -> cli). This
       catches a broken ``files`` allowlist, version drift, or dependency-order
       bug BEFORE a real ``v*`` tag fires the publish workflow, without ever
       touching the real registry. Soft-skips when ``npm`` is absent from PATH;
@@ -142,6 +143,10 @@ REHEARSAL_VERSION = "0.0.1"
 # #1910: dependency order for the npm publish dry-run rehearsal, mirroring
 # .github/workflows/npm-publish.yml (types -> core -> content -> cli).
 NPM_PUBLISH_PACKAGES = ("types", "core", "content", "cli")
+# #1925: throwaway dist-tag so npm publish --dry-run does not try to apply
+# ``latest`` to the fixed rehearsal sentinel ``0.0.1`` once real packages
+# exist at a higher version on the registry.
+NPM_E2E_REHEARSAL_TAG = "e2e-rehearsal"
 NPM_INSTALL_TIMEOUT_SECONDS = 600
 NPM_BUILD_TIMEOUT_SECONDS = 600
 NPM_PUBLISH_DRYRUN_TIMEOUT_SECONDS = 180
@@ -745,8 +750,11 @@ def rehearse_npm_publish(clone_dir: Path, version: str) -> tuple[bool, str]:
        allowlist to produce a meaningful tarball.
     4. Align the four ``package.json`` versions to ``<version>`` and resolve
        the ``workspace:`` protocol (folds in the item-4 version assertion).
-    5. ``npm publish --dry-run --access public`` per package in dependency
-       order (types -> core -> content -> cli).
+    5. ``npm publish --dry-run --access public --tag e2e-rehearsal`` per
+       package in dependency order (types -> core -> content -> cli). The
+       throwaway dist-tag bypasses npm's implicit-``latest`` check when the
+       rehearsal sentinel version is below the highest published version
+       (#1925).
 
     Returns ``(ok, reason)`` like ``verify_draft_release`` / ``verify_tag`` so
     the orchestrator and tests treat it uniformly. Because installing +
@@ -784,8 +792,18 @@ def rehearse_npm_publish(clone_dir: Path, version: str) -> tuple[bool, str]:
     for pkg in NPM_PUBLISH_PACKAGES:
         pkg_dir = clone_dir / "packages" / pkg
         ok, reason = _run_npm_step(
-            [npm_path, "publish", "--dry-run", "--access", "public"],
-            pkg_dir, env, f"npm publish --dry-run packages/{pkg}",
+            [
+                npm_path,
+                "publish",
+                "--dry-run",
+                "--access",
+                "public",
+                "--tag",
+                NPM_E2E_REHEARSAL_TAG,
+            ],
+            pkg_dir,
+            env,
+            f"npm publish --dry-run --tag {NPM_E2E_REHEARSAL_TAG} packages/{pkg}",
             NPM_PUBLISH_DRYRUN_TIMEOUT_SECONDS,
         )
         if not ok:

--- a/tests/cli/test_release_e2e.py
+++ b/tests/cli/test_release_e2e.py
@@ -1187,6 +1187,8 @@ class TestRehearseNpmPublish:
         assert "install" in calls[0][0]
         assert "build" in calls[1][0]
         # Remaining commands are npm publish --dry-run per package in order.
+        publish_cmds = [cmd for cmd, _cwd in calls if "publish" in cmd]
+        assert all("--tag" in cmd and "e2e-rehearsal" in cmd for cmd in publish_cmds)
         publish_dirs = [cwd for cmd, cwd in calls if "publish" in cmd]
         assert publish_dirs == [
             str(tmp_path / "packages" / "types"),

--- a/vbrief/active/2026-06-23-1925-releasee2e-npm-dry-run-false-fails-after-first-real-publish.vbrief.json
+++ b/vbrief/active/2026-06-23-1925-releasee2e-npm-dry-run-false-fails-after-first-real-publish.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1925"
+  },
+  "plan": {
+    "title": "release:e2e npm dry-run false-fails after first real publish (dummy 0.0.1 < published version)",
+    "status": "running",
+    "narratives": {
+      "Description": "release:e2e npm dry-run false-fails after first real publish (dummy 0.0.1 < published version)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1925",
+      "Overview": "## Symptom\n`task release:e2e` (the #1910 npm rehearsal step) fails at `npm publish --dry-run` once real packages exist on the registry at a higher version:\n\n```\nnpm error Cannot implicitly apply the \"latest\" tag because previously published version 0.55.0 is higher than the new version 0.0.1. You must specify a tag using --tag.\n```\n\nObserved during the v0.55.1 cut (2026-06-23). The GitHub-pipeline steps (clone, push-mirror, task release, verify draft, verify tag, rollback) all pass; only the npm dry-run trips.\n\n## Root cause\nThe e2e harness rehearses with a fixed dummy version `0.0.1`. Before any real publish this was fine, but now that `@deftai/directive*` is live at `0.55.0`/`0.55.1`, npm's `--dry-run` refuses to implicitly apply the `latest` dist-tag to a *lower* version. This is a harness artifact, not a real release blocker (an actual release version is always higher than the latest published).\n\n## Impact\n`task release:e2e` now exits non-zero on the npm step on every cut, forcing operators to re-run with `--skip-npm` and lose the npm-channel rehearsal. The skill's Phase 3 hard-refusal semantics then have to be manually overridden.\n\n## Suggested fix (pick one)\n- Have the harness derive a rehearsal version *above* the latest published version (e.g. query `npm view <pkg> version` and bump), or\n- Pass `--tag e2e-rehearsal` (a throwaway dist-tag) to the dry-run so the implicit-latest check is bypassed, or\n- Point the rehearsal at a dummy/scoped package name that has no published history.\n\nFound during the v0.55.1 release. Refs #1910 #1909."
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1925",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1925: release:e2e npm dry-run false-fails after first real publish (dummy 0.0.1 < published version)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1910",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1910"
+      }
+    ],
+    "updated": "2026-06-23T21:00:51Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Pass `--tag e2e-rehearsal` to every `npm publish --dry-run` in the release:e2e harness (Python + TypeScript paths) so the fixed rehearsal version `0.0.1` no longer fails once `@deftai/directive*` is published at a higher version on npm.
- Add unit-test assertions that publish commands include the throwaway dist-tag.

## Root cause

After the first real npm publish at 0.55.x, npm refuses to implicitly apply the `latest` dist-tag to a lower dry-run version (`0.0.1`), causing `task release:e2e` to exit non-zero on the npm step even though the GitHub pipeline rehearsal passes.

## Test plan

- [x] `uv run pytest tests/cli/test_release_e2e.py::TestRehearseNpmPublish`
- [x] `pnpm exec vitest run packages/core/src/release-e2e/npm-ops.test.ts`
- [x] `task check` (8670 passed)

Closes #1925

Made with [Cursor](https://cursor.com)