### PR TITLE
chore: complete Wave-4 swarm cohort (#761 #1891 #1918 #1925)

### DIFF
--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -990,10 +990,10 @@
       {
         "id": "2026-04-30-761-install-paths-reframe-webinstaller-npm",
         "title": "docs: reframe install paths around webinstaller + npm/pip; demote Go binary to legacy",
-        "status": "running",
+        "status": "completed",
         "metadata": {
-          "source_path": "active/2026-04-30-761-install-paths-reframe-webinstaller-npm.vbrief.json",
-          "lifecycle_folder": "active",
+          "source_path": "completed/2026-04-30-761-install-paths-reframe-webinstaller-npm.vbrief.json",
+          "lifecycle_folder": "completed",
           "references": [
             {
               "uri": "https://github.com/deftai/directive/issues/761",

--- a/vbrief/completed/2026-04-30-761-install-paths-reframe-webinstaller-npm.vbrief.json
+++ b/vbrief/completed/2026-04-30-761-install-paths-reframe-webinstaller-npm.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "docs: reframe install paths around webinstaller + npm/pip; demote Go binary to legacy",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "SourceSection": "Phase 3 -- Documentation & Content Fixes"
     },
@@ -16,7 +16,9 @@
         "Description": "Reframe install documentation around webinstaller (https://webinstaller.fly.dev/) + npm/pip (#11), demote Go binary installer to legacy. Supersedes the cancelled code-signing brief.",
         "Description_source": "chore/proposed-vbrief-cleanup discussion",
         "Status_source": "filed-during-cleanup"
-      }
+      },
+      "completedAt": "2026-06-23T23:47:49Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -30,6 +32,6 @@
         "title": "Issue #11: Proposal: Publish Deft as an NPM + PIP CLI (related; this brief leads with webinstaller and references #11)"
       }
     ],
-    "updated": "2026-06-23T21:01:07Z"
+    "updated": "2026-06-23T23:47:49Z"
   }
 }

--- a/vbrief/completed/2026-06-23-1891-swarmsubagentbackend-left-live-un-flagged-after-1739-superse.vbrief.json
+++ b/vbrief/completed/2026-06-23-1891-swarmsubagentbackend-left-live-un-flagged-after-1739-superse.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "swarmSubagentBackend left live + un-flagged after #1739 supersession — half-migrated surfaces steer agents into the dead enum",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "swarmSubagentBackend left live + un-flagged after #1739 supersession — half-migrated surfaces steer agents into the dead enum",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1891",
@@ -27,6 +27,10 @@
         "title": "Issue #1891: swarmSubagentBackend left live + un-flagged after #1739 supersession — half-migrated surfaces steer agents into the dead enum"
       }
     ],
-    "updated": "2026-06-23T21:00:59Z"
+    "updated": "2026-06-23T23:47:49Z",
+    "metadata": {
+      "completedAt": "2026-06-23T23:47:49Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/vbrief/completed/2026-06-23-1918-directive-version-reports-hardcoded-engine-version-000.vbrief.json
+++ b/vbrief/completed/2026-06-23-1918-directive-version-reports-hardcoded-engine-version-000.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "directive version reports hardcoded engine version 0.0.0",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "directive version reports hardcoded engine version 0.0.0",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1918",
@@ -24,6 +24,10 @@
         "title": "Issue #1909"
       }
     ],
-    "updated": "2026-06-23T21:00:32Z"
+    "updated": "2026-06-23T23:47:49Z",
+    "metadata": {
+      "completedAt": "2026-06-23T23:47:49Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/vbrief/completed/2026-06-23-1925-releasee2e-npm-dry-run-false-fails-after-first-real-publish.vbrief.json
+++ b/vbrief/completed/2026-06-23-1925-releasee2e-npm-dry-run-false-fails-after-first-real-publish.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "release:e2e npm dry-run false-fails after first real publish (dummy 0.0.1 < published version)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "release:e2e npm dry-run false-fails after first real publish (dummy 0.0.1 < published version)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1925",
@@ -24,6 +24,10 @@
         "title": "Issue #1910"
       }
     ],
-    "updated": "2026-06-23T21:00:51Z"
+    "updated": "2026-06-23T23:47:49Z",
+    "metadata": {
+      "completedAt": "2026-06-23T23:47:49Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Lifecycle bookkeeping for the merged Wave-4 cohort: sweep the four story vBRIEFs `active/ -> completed/` and update their scope statuses in `PROJECT-DEFINITION.vbrief.json`.

All four implementation PRs already merged and their issues are closed:
- #1918 -> PR #1927 (engine version)
- #1925 -> PR #1928 (release:e2e dry-run)
- #1891 -> PR #1929 (swarmSubagentBackend deprecation signal)
- #761  -> PR #1930 (install/upgrade docs npm-canonical reframe)

## Test plan
- `task vbrief:validate` clean (751 scope vBRIEFs + PROJECT-DEFINITION)
- No code changes; vBRIEF lifecycle moves only

Made with [Cursor](https://cursor.com)