### PR TITLE
docs: Wave 5 target npm-native distribution section in ARCHITECTURE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Architecture docs now describe the planned npm-native distribution model** — `docs/ARCHITECTURE.md` gains a clearly-marked "Wave 5 Target" section documenting the two-package npm model (`@deftai/directive` engine + `@deftai/directive-content` source), the `directive init` resolve-and-copy deposit (gitignored `.deft/core/`, no re-download), and the frozen Go binary's reduced role as a node-independent health gate. Fenced as target architecture, not current behavior, so it can't be misread as today's flow. Refs #1669 #1942 #1933.
 
 ### Changed
 - **Installer docs are clearer that Node is always required, and that setup is directory-scoped** — the README, UPGRADING.md, QUICK-START.md, and the AGENTS.md managed-section template no longer frame the Go installer as a "no-Node bootstrap." Node 20+ is always required to *run* Deft (the live gates run on the TypeScript engine), so the Go installer is reframed consistently as a legacy/offline + layout-migration bridge with an explicit "install Node first" pointer for machines without Node. The README also gains a note that project setup writes `.deft/` and `AGENTS.md` into the current working directory, so you should `cd` into your intended project folder first. Refs #1912 #761.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Architecture docs now describe the planned npm-native distribution model** — `docs/ARCHITECTURE.md` gains a clearly-marked "Wave 5 Target" section documenting the two-package npm model (`@deftai/directive` engine + `@deftai/directive-content` source), the `directive init` resolve-and-copy deposit (gitignored `.deft/core/`, no re-download), and the frozen Go binary's reduced role as a node-independent health gate. Fenced as target architecture, not current behavior, so it can't be misread as today's flow. Refs #1669 #1942 #1933.
+- **Architecture docs now describe the planned npm-native distribution model** — a clearly-marked "Wave 5 Target" section records the two-package npm model, the resolve-and-copy materialization step, and the frozen Go binary's reduced role as a health gate. Fenced as target architecture, not current behavior, so it cannot be misread as today's flow. Refs #1669 #1942 #1933.
 
 ### Changed
 - **Installer docs are clearer that Node is always required, and that setup is directory-scoped** — the README, UPGRADING.md, QUICK-START.md, and the AGENTS.md managed-section template no longer frame the Go installer as a "no-Node bootstrap." Node 20+ is always required to *run* Deft (the live gates run on the TypeScript engine), so the Go installer is reframed consistently as a legacy/offline + layout-migration bridge with an explicit "install Node first" pointer for machines without Node. The README also gains a note that project setup writes `.deft/` and `AGENTS.md` into the current working directory, so you should `cd` into your intended project folder first. Refs #1912 #761.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ flowchart LR
     npm["npm i -g @deftai/directive"] --> Global["Global npm tree<br/>node_modules/@deftai/directive + @deftai/directive-content"]
     Global -->|"directive init / update<br/>resolve-and-copy (no re-download)"| Proj["Project ./.deft/core/<br/>+ AGENTS.md, vbrief/, .githooks/"]
     Global --> Gate["Frozen Go gate (bundled)<br/>node-independent pre-engine health probe"]
-    Gate --> Proj
+    Gate -->|"health probe / legacy layout reshape"| Proj
 ```
 
 Key properties of the target model:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,34 @@ flowchart LR
 | CI/release automation | `.github/`, `.githooks/`, `tasks/pr.yml`, `tasks/release.yml`, release scripts | Branch policy, PR readiness, release, publish, rollback, and local hook enforcement. |
 | Tests | `tests/` | CLI, content, contract, lifecycle, and regression coverage. |
 
+## Wave 5 Target — npm-Native Distribution (planned, not yet implemented)
+
+> **Status: target architecture, not current behavior.** Today the Go installer downloads a payload tarball and deposits a *committed* `.deft/core/`. This section describes the npm-native model Wave 5 moves toward. Tracking: [#1669](https://github.com/deftai/directive/issues/1669) (epic), [#1933](https://github.com/deftai/directive/issues/1933), [#1942](https://github.com/deftai/directive/issues/1942), [#1941](https://github.com/deftai/directive/issues/1941), [#1912](https://github.com/deftai/directive/issues/1912), [#1860](https://github.com/deftai/directive/issues/1860).
+
+Distribution splits into two npm packages and a thin local materialization step:
+
+- **`@deftai/directive`** — the engine/CLI (Node 20+ required to *run* Deft). Binaries: `directive`, `deft`.
+- **`@deftai/directive-content`** — the framework content (skills, templates, schemas, standards) shipped pre-flattened in the consumer `.deft/core/` layout. It is a **dependency** of the engine, so npm resolves a version-coherent pair at install time.
+
+```mermaid
+flowchart LR
+    npm["npm i -g @deftai/directive"] --> Global["Global npm tree<br/>node_modules/@deftai/directive + @deftai/directive-content"]
+    Global -->|"directive init / update<br/>resolve-and-copy (no re-download)"| Proj["Project ./.deft/core/<br/>+ AGENTS.md, vbrief/, .githooks/"]
+    Global --> Gate["Frozen Go gate (bundled)<br/>node-independent pre-engine health probe"]
+    Gate --> Proj
+```
+
+Key properties of the target model:
+
+- **Global install ≠ project deposit.** `npm i -g` only places versioned files in the global npm tree; it never touches a project directory. `directive init` is the materialization step that **resolves the locally-installed `@deftai/directive-content` and copies its tree** into this project's `./.deft/core/`, then renders `AGENTS.md`, scaffolds `vbrief/`, installs `.githooks/`, deposits #1430 neutralization, and stamps provenance. `directive update` refreshes the same way. This is **resolve-and-copy, not re-download** — the on-machine content package is the source (the `node_modules` model).
+- **`.deft/core/` becomes gitignored** and is reconstituted by `directive init` on fresh checkouts (like `node_modules`), reversing today's committed-payload model.
+- **Per-project version pinning** via `devDependencies` + `npx` gives teams/CI a reproducible engine↔content pair.
+- **Frozen Go binary** stays bundled per-platform inside the npm package, but only as a **node-independent, read-only health gate** (every-session pre-engine probe) and a **legacy on-disk-layout reshaper**. It no longer fetches payloads or performs first-start installs (#1933).
+- **Offline** = sideload both package tarballs, then `directive init` copies locally — no network in the happy path.
+- **No surface bakes an install/upgrade command.** The engine, the Go gate, and `deft doctor` all point to the canonical install anchor in `README.md` rather than emitting a command that can go stale (#1912).
+
+When this lands, the "today" statements elsewhere that describe the committed-vendored model (README's "the installer vendors the deft framework payload into `.deft/core/`" and `content/events/README.md`'s "`.deft/core/` is a committed payload") must flip to match.
+
 ## Command Surface
 
 The command graph is broad; use `task --list` for the exact current surface. The important architectural groups are:


### PR DESCRIPTION
## Summary

Adds a clearly-fenced **"Wave 5 Target — npm-Native Distribution (planned, not yet implemented)"** section to `docs/ARCHITECTURE.md`, capturing the distribution architecture the Wave 5 decisions converged on so the design is recorded before the build starts.

The section documents:
- The **two-package npm model**: `@deftai/directive` (engine/CLI, Node 20+) + `@deftai/directive-content` (content source, shipped in the `.deft/core/` layout, a dependency of the engine).
- **`directive init` as resolve-and-copy** — resolves the locally-installed `@deftai/directive-content` and copies it into the project `.deft/core/` (no re-download); `directive update` refreshes the same way.
- **`.deft/core/` gitignored + reconstituted** (node_modules model), per-project version pinning.
- The **frozen Go binary** reduced to a node-independent, every-session read-only health gate + legacy-layout reshaper (no longer fetches payloads / first-start installs).
- Offline = sideload tarballs; no surface bakes install commands (all point to the README canonical anchor).
- A note that when this lands, the "today" committed-payload statements in the README and `content/events/README.md` must flip.

A mermaid diagram shows global npm tree → `directive init` copy → project `.deft/core/`, plus the Go gate.

**This is documentation only** and is explicitly marked as *target architecture, not current behavior*, so it can't be misread as today's flow. The actual mechanism is tracked in #1942 (with #1941 for the stage-2 migrate verb); the #1669 epic owns the wave.

## Test plan

- [x] `task verify:encoding` clean
- [x] `task check` passes (8673 passed, 10 skipped, 9 deselected)
- [x] Section is fenced as target/planned, not current
- [ ] Greptile review cycle clean (P0/P1 = 0)

Refs #1669 #1942 #1933 #1912 #1860

Made with [Cursor](https://cursor.com)