### PR TITLE
fix(triage,ts): port missing triage-actions verbs to TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Installer docs are clearer that Node is always required, and that setup is directory-scoped** — the README, UPGRADING.md, QUICK-START.md, and the AGENTS.md managed-section template no longer frame the Go installer as a "no-Node bootstrap." Node 20+ is always required to *run* Deft (the live gates run on the TypeScript engine), so the Go installer is reframed consistently as a legacy/offline + layout-migration bridge with an explicit "install Node first" pointer for machines without Node. The README also gains a note that project setup writes `.deft/` and `AGENTS.md` into the current working directory, so you should `cd` into your intended project folder first. Refs #1912 #761.
 
 ### Fixed
+- **All triage decision verbs now work on npm-only installs** — the TypeScript triage-actions CLI implements needs-ac, mark-duplicate, status, reset, and history alongside accept/reject/defer, with parity tests against the Python oracle so these verbs keep working after the planned Python purge. Closes #1945.
 
 ### Removed
 

--- a/packages/cli/src/triage-actions-parity.ts
+++ b/packages/cli/src/triage-actions-parity.ts
@@ -11,6 +11,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cachePut } from "../../core/dist/cache/operations.js";
 
 export interface CommandCapture {
   readonly exitCode: number;
@@ -21,6 +22,7 @@ export interface CommandCapture {
 export interface ParityCase {
   readonly name: string;
   readonly argv: readonly string[];
+  readonly seed?: string;
 }
 
 export interface ParityDiff {
@@ -102,8 +104,11 @@ function pythonWrapperScript(deftRoot: string, fixtureRoot: string): string {
     "sys.path.insert(0, str(deft_root / 'scripts'))",
     "import candidates_log as cl",
     "cl.DEFAULT_LOG_PATH = fixture / 'vbrief/.eval/candidates.jsonl'",
+    "import cache as cache_mod",
+    "cache_mod.DEFAULT_CACHE_ROOT = fixture / '.deft-cache'",
     "import triage_actions",
     "triage_actions.candidates_log = cl",
+    "triage_actions.cache = cache_mod",
     "raise SystemExit(triage_actions.main(sys.argv[1:]))",
   ].join("\n");
 }
@@ -193,6 +198,71 @@ export const PARITY_CASES: readonly ParityCase[] = [
     name: "accept-idempotent",
     argv: ["accept", "--issue", "9", "--repo", "deftai/directive", "--actor", "agent:test"],
   },
+  {
+    name: "needs-ac-default",
+    argv: ["needs-ac", "--issue", "10", "--repo", "deftai/directive", "--actor", "agent:test"],
+  },
+  {
+    name: "status-empty",
+    argv: ["status", "--issue", "11", "--repo", "deftai/directive"],
+  },
+  {
+    name: "status-with-defer",
+    argv: ["status", "--issue", "12", "--repo", "deftai/directive"],
+    seed: "defer-status",
+  },
+  {
+    name: "reset-no-prior",
+    argv: ["reset", "--issue", "13", "--repo", "deftai/directive"],
+  },
+  {
+    name: "reset-success",
+    argv: ["reset", "--issue", "14", "--repo", "deftai/directive", "--actor", "agent:test"],
+    seed: "defer-reset",
+  },
+  {
+    name: "reset-idempotent",
+    argv: ["reset", "--issue", "15", "--repo", "deftai/directive"],
+    seed: "reset-idempotent",
+  },
+  {
+    name: "history-empty",
+    argv: ["history", "--issue", "16", "--repo", "deftai/directive"],
+  },
+  {
+    name: "history-multi",
+    argv: ["history", "--issue", "17", "--repo", "deftai/directive"],
+    seed: "history-multi",
+  },
+  {
+    name: "mark-duplicate-missing-cache",
+    argv: ["mark-duplicate", "--issue", "18", "--repo", "deftai/directive", "--of", "99"],
+  },
+  {
+    name: "mark-duplicate-success",
+    argv: [
+      "mark-duplicate",
+      "--issue",
+      "19",
+      "--repo",
+      "deftai/directive",
+      "--of",
+      "20",
+      "--actor",
+      "agent:test",
+    ],
+    seed: "mark-duplicate-cache",
+  },
+  {
+    name: "mark-duplicate-idempotent",
+    argv: ["mark-duplicate", "--issue", "21", "--repo", "deftai/directive", "--of", "22"],
+    seed: "mark-duplicate-idempotent",
+  },
+  {
+    name: "mark-duplicate-self",
+    argv: ["mark-duplicate", "--issue", "23", "--repo", "deftai/directive", "--of", "23"],
+    seed: "mark-duplicate-cache-self",
+  },
 ];
 
 function seedAcceptFixture(fixtureRoot: string): void {
@@ -211,6 +281,81 @@ function seedAcceptFixture(fixtureRoot: string): void {
   );
 }
 
+function seedAuditEntry(
+  fixtureRoot: string,
+  issueNumber: number,
+  decision: string,
+  extras: Record<string, unknown> = {},
+): void {
+  const entry = {
+    actor: "agent:test",
+    decision,
+    decision_id: "11111111-1111-1111-1111-111111111111",
+    issue_number: issueNumber,
+    repo: "deftai/directive",
+    timestamp: "2026-06-18T12:00:00Z",
+    ...extras,
+  };
+  const path = join(fixtureRoot, "vbrief/.eval/candidates.jsonl");
+  const line = `${JSON.stringify(entry, Object.keys(entry).sort())}\n`;
+  writeFileSync(path, line, { encoding: "utf8", flag: "a" });
+}
+
+function seedCacheIssue(fixtureRoot: string, issueNumber: number): void {
+  const cacheRoot = join(fixtureRoot, ".deft-cache");
+  cachePut(
+    "github-issue",
+    `deftai/directive/${issueNumber}`,
+    { number: issueNumber, title: "parity fixture", body: "fixture body" },
+    { cacheRoot },
+  );
+}
+
+function seedFixture(fixtureRoot: string, seed: string | undefined): void {
+  if (seed === undefined) return;
+  switch (seed) {
+    case "defer-status":
+      seedAuditEntry(fixtureRoot, 12, "defer", { reason: "later" });
+      break;
+    case "defer-reset":
+      seedAuditEntry(fixtureRoot, 14, "defer", { reason: "later" });
+      break;
+    case "reset-idempotent":
+      seedAuditEntry(fixtureRoot, 15, "reset", {
+        decision_id: "22222222-2222-2222-2222-222222222222",
+        prior_decision_id: "11111111-1111-1111-1111-111111111111",
+      });
+      break;
+    case "history-multi":
+      seedAuditEntry(fixtureRoot, 17, "defer", {
+        decision_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        reason: "first",
+        timestamp: "2026-06-18T10:00:00Z",
+      });
+      seedAuditEntry(fixtureRoot, 17, "needs-ac", {
+        decision_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        reason: "needs criteria",
+        timestamp: "2026-06-18T11:00:00Z",
+      });
+      break;
+    case "mark-duplicate-cache":
+      seedCacheIssue(fixtureRoot, 20);
+      break;
+    case "mark-duplicate-idempotent":
+      seedCacheIssue(fixtureRoot, 22);
+      seedAuditEntry(fixtureRoot, 21, "mark-duplicate", {
+        decision_id: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        linked_to: 22,
+      });
+      break;
+    case "mark-duplicate-cache-self":
+      seedCacheIssue(fixtureRoot, 23);
+      break;
+    default:
+      break;
+  }
+}
+
 /** Run all parity cases; returns aggregate result. */
 export function runParity(): ParityResult {
   const deftRoot = resolveDeftRoot();
@@ -221,6 +366,9 @@ export function runParity(): ParityResult {
     if (testCase.name === "accept-idempotent") {
       seedAcceptFixture(pyFixture);
       seedAcceptFixture(tsFixture);
+    } else {
+      seedFixture(pyFixture, testCase.seed);
+      seedFixture(tsFixture, testCase.seed);
     }
     try {
       const python = runPythonTriageAction(deftRoot, pyFixture, testCase.argv);

--- a/packages/cli/src/triage-actions.test.ts
+++ b/packages/cli/src/triage-actions.test.ts
@@ -98,6 +98,12 @@ describe("run", () => {
     expect(run(["accept", "--repo", "deftai/directive"])).toBe(2);
   });
 
+  it("returns 2 for mark-duplicate with invalid --of", () => {
+    expect(
+      run(["mark-duplicate", "--issue", "7", "--repo", "deftai/directive", "--of", "abc"]),
+    ).toBe(2);
+  });
+
   it("returns 2 for mark-duplicate without --of", () => {
     expect(run(["mark-duplicate", "--issue", "7", "--repo", "deftai/directive"])).toBe(2);
   });

--- a/packages/cli/src/triage-actions.test.ts
+++ b/packages/cli/src/triage-actions.test.ts
@@ -98,6 +98,36 @@ describe("run", () => {
     expect(run(["accept", "--repo", "deftai/directive"])).toBe(2);
   });
 
+  it("returns 2 for mark-duplicate without --of", () => {
+    expect(run(["mark-duplicate", "--issue", "7", "--repo", "deftai/directive"])).toBe(2);
+  });
+
+  it("returns 0 for status with no prior decision", () => {
+    const root = makeProjectRoot();
+    expect(
+      run(["status", "--issue", "7", "--repo", "deftai/directive", "--project-root", root]),
+    ).toBe(0);
+  });
+
+  it("returns 1 for reset without prior decision", () => {
+    const root = makeProjectRoot();
+    expect(
+      run(["reset", "--issue", "7", "--repo", "deftai/directive", "--project-root", root]),
+    ).toBe(1);
+  });
+
+  it("parses --of and --comment flags", () => {
+    const parsed = parseArgs([
+      "mark-duplicate",
+      "--issue=7",
+      "--repo=deftai/directive",
+      "--of=42",
+      "--comment=needs AC",
+    ]);
+    expect(parsed.ofN).toBe(42);
+    expect(parsed.comment).toBe("needs AC");
+  });
+
   it("returns 2 for unrecognized flag", () => {
     expect(parseArgs(["defer", "--bogus"]).error).toMatch(/unrecognized argument/);
   });

--- a/packages/cli/src/triage-actions.ts
+++ b/packages/cli/src/triage-actions.ts
@@ -146,7 +146,7 @@ export function run(argv: string[]): number {
     process.stderr.write("triage_actions: argument --reason: expected one argument\n");
     return 2;
   }
-  if (args.cmd === "mark-duplicate" && args.ofN === undefined) {
+  if (args.cmd === "mark-duplicate" && (args.ofN === undefined || Number.isNaN(args.ofN))) {
     process.stderr.write("triage_actions: argument --of: expected one argument\n");
     return 2;
   }
@@ -181,11 +181,12 @@ export function run(argv: string[]): number {
       });
       process.stdout.write(`needs-ac #${n} (${repo}) -> ${decisionId}\n`);
     } else if (args.cmd === "mark-duplicate") {
-      const decisionId = markDuplicate(n, repo, args.ofN ?? 0, deps, {
+      const ofN = args.ofN as number;
+      const decisionId = markDuplicate(n, repo, ofN, deps, {
         actor: args.actor,
         projectRoot,
       });
-      process.stdout.write(`mark-duplicate #${n} -> #${args.ofN} (${repo}) -> ${decisionId}\n`);
+      process.stdout.write(`mark-duplicate #${n} -> #${ofN} (${repo}) -> ${decisionId}\n`);
     } else if (args.cmd === "status") {
       process.stdout.write(`${formatDecision(status(n, repo, deps, { projectRoot }))}\n`);
     } else if (args.cmd === "reset") {

--- a/packages/cli/src/triage-actions.ts
+++ b/packages/cli/src/triage-actions.ts
@@ -5,10 +5,27 @@ import {
   accept,
   createDefaultDeps,
   deferAction,
+  formatDecision,
+  history,
+  markDuplicate,
+  needsAc,
   reject,
+  reset,
+  status,
   TriageError,
   UpstreamCloseError,
 } from "../../core/dist/triage/actions/index.js";
+
+const VALID_CMDS = new Set([
+  "accept",
+  "reject",
+  "defer",
+  "needs-ac",
+  "mark-duplicate",
+  "status",
+  "reset",
+  "history",
+]);
 
 interface ParsedArgs {
   cmd?: string;
@@ -17,6 +34,8 @@ interface ParsedArgs {
   reason?: string;
   resumeOn?: string;
   actor?: string;
+  comment?: string;
+  ofN?: number;
   projectRoot: string;
   error?: string;
 }
@@ -70,6 +89,21 @@ export function parseArgs(argv: string[]): ParsedArgs {
       i += 1;
     } else if (arg?.startsWith("--actor=")) {
       parsed.actor = arg.slice("--actor=".length);
+    } else if (arg === "--comment") {
+      const value = argv[i + 1];
+      if (value === undefined)
+        return { ...parsed, error: "argument --comment: expected one argument" };
+      parsed.comment = value;
+      i += 1;
+    } else if (arg?.startsWith("--comment=")) {
+      parsed.comment = arg.slice("--comment=".length);
+    } else if (arg === "--of") {
+      const value = argv[i + 1];
+      if (value === undefined) return { ...parsed, error: "argument --of: expected one argument" };
+      parsed.ofN = Number.parseInt(value, 10);
+      i += 1;
+    } else if (arg?.startsWith("--of=")) {
+      parsed.ofN = Number.parseInt(arg.slice("--of=".length), 10);
     } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined)
@@ -92,7 +126,7 @@ export function run(argv: string[]): number {
     process.stderr.write(`triage_actions: ${args.error}\n`);
     return 2;
   }
-  if (args.cmd !== "accept" && args.cmd !== "reject" && args.cmd !== "defer") {
+  if (!VALID_CMDS.has(args.cmd ?? "")) {
     process.stderr.write(`triage_actions: unknown subcommand ${args.cmd ?? ""}\n`);
     return 2;
   }
@@ -112,6 +146,10 @@ export function run(argv: string[]): number {
     process.stderr.write("triage_actions: argument --reason: expected one argument\n");
     return 2;
   }
+  if (args.cmd === "mark-duplicate" && args.ofN === undefined) {
+    process.stderr.write("triage_actions: argument --of: expected one argument\n");
+    return 2;
+  }
 
   const projectRoot = resolve(args.projectRoot);
   const deps = createDefaultDeps(projectRoot);
@@ -128,13 +166,40 @@ export function run(argv: string[]): number {
         projectRoot,
       });
       process.stdout.write(`reject #${n} (${repo}) -> ${decisionId}\n`);
-    } else {
+    } else if (args.cmd === "defer") {
       const decisionId = deferAction(n, repo, args.reason, deps, {
         actor: args.actor,
         resumeOn: args.resumeOn,
         projectRoot,
       });
       process.stdout.write(`defer #${n} (${repo}) -> ${decisionId}\n`);
+    } else if (args.cmd === "needs-ac") {
+      const decisionId = needsAc(n, repo, deps, {
+        actor: args.actor,
+        comment: args.comment,
+        projectRoot,
+      });
+      process.stdout.write(`needs-ac #${n} (${repo}) -> ${decisionId}\n`);
+    } else if (args.cmd === "mark-duplicate") {
+      const decisionId = markDuplicate(n, repo, args.ofN ?? 0, deps, {
+        actor: args.actor,
+        projectRoot,
+      });
+      process.stdout.write(`mark-duplicate #${n} -> #${args.ofN} (${repo}) -> ${decisionId}\n`);
+    } else if (args.cmd === "status") {
+      process.stdout.write(`${formatDecision(status(n, repo, deps, { projectRoot }))}\n`);
+    } else if (args.cmd === "reset") {
+      const decisionId = reset(n, repo, deps, { actor: args.actor, projectRoot });
+      process.stdout.write(`reset #${n} (${repo}) -> ${decisionId}\n`);
+    } else {
+      const entries = history(n, repo, deps, { projectRoot });
+      if (entries.length === 0) {
+        process.stdout.write(`${formatDecision(null)}\n`);
+      } else {
+        for (const entry of entries) {
+          process.stdout.write(`${formatDecision(entry)}\n`);
+        }
+      }
     }
   } catch (err) {
     if (err instanceof TriageError || err instanceof UpstreamCloseError) {

--- a/packages/core/src/triage/actions/index.test.ts
+++ b/packages/core/src/triage/actions/index.test.ts
@@ -2,13 +2,19 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { cachePut } from "../../cache/operations.js";
 import { createCandidatesLog, resolveAuditLogPath, rollbackAuditEntry } from "./candidates-log.js";
 import { CandidatesLogError } from "./errors.js";
 import {
   accept,
   createDefaultDeps,
   deferAction,
+  history,
+  markDuplicate,
+  needsAc,
   reject,
+  reset,
+  status,
   TriageError,
   UpstreamCloseError,
 } from "./index.js";
@@ -428,5 +434,182 @@ describe("deferAction", () => {
     deferAction(7, "deftai/directive", "later", deps, { projectRoot: root });
     const text = readFileSync(resolveAuditLogPath(root), "utf8");
     expect(text).toMatch(/"actor":"(agent:triage|[^"]+)"/);
+  });
+});
+
+describe("needsAc", () => {
+  it("records needs-ac audit entry and tolerates gh comment failure", () => {
+    const root = makeRepo();
+    const stderrLines: string[] = [];
+    const deps = fakeDeps(root);
+    deps.stderr = (line) => stderrLines.push(line);
+    deps.scm = {
+      call() {
+        throw new UpstreamCloseError("gh issue comment failed: forbidden");
+      },
+    };
+    const id = needsAc(10, "deftai/directive", deps, { actor: "agent:test", projectRoot: root });
+    expect(id).toBe("11111111-1111-1111-1111-111111111111");
+    const text = readFileSync(resolveAuditLogPath(root), "utf8");
+    expect(text).toContain('"decision":"needs-ac"');
+    expect(stderrLines.some((line) => line.includes("needs-ac comment not posted"))).toBe(true);
+  });
+});
+
+describe("markDuplicate", () => {
+  it("rejects when target equals source", () => {
+    const root = makeRepo();
+    const deps = fakeDeps(root);
+    expect(() => markDuplicate(5, "deftai/directive", 5, deps, { projectRoot: root })).toThrow(
+      /cannot equal source/,
+    );
+  });
+
+  it("rejects when cache target is missing", () => {
+    const root = makeRepo();
+    const deps = fakeDeps(root);
+    expect(() => markDuplicate(5, "deftai/directive", 6, deps, { projectRoot: root })).toThrow(
+      /not found in cache/,
+    );
+  });
+
+  it("records mark-duplicate when cache target exists", () => {
+    const root = makeRepo();
+    cachePut(
+      "github-issue",
+      "deftai/directive/6",
+      { number: 6, title: "dup", body: "body" },
+      { cacheRoot: join(root, ".deft-cache") },
+    );
+    const deps = fakeDeps(root);
+    const id = markDuplicate(5, "deftai/directive", 6, deps, { projectRoot: root });
+    expect(id).toBe("11111111-1111-1111-1111-111111111111");
+    const text = readFileSync(resolveAuditLogPath(root), "utf8");
+    expect(text).toContain('"decision":"mark-duplicate"');
+    expect(text).toContain('"linked_to":6');
+  });
+
+  it("is idempotent for the same duplicate target", () => {
+    const root = makeRepo();
+    cachePut(
+      "github-issue",
+      "deftai/directive/6",
+      { number: 6, title: "dup", body: "body" },
+      { cacheRoot: join(root, ".deft-cache") },
+    );
+    const prior: AuditEntry = {
+      decision_id: "prior-dup",
+      timestamp: "2026-06-18T12:00:00Z",
+      repo: "deftai/directive",
+      issue_number: 5,
+      decision: "mark-duplicate",
+      actor: "agent:test",
+      linked_to: 6,
+    };
+    const deps = fakeDeps(root, { latest: prior });
+    expect(markDuplicate(5, "deftai/directive", 6, deps, { projectRoot: root })).toBe("prior-dup");
+  });
+});
+
+describe("status", () => {
+  it("returns null when no decision exists", () => {
+    const root = makeRepo();
+    const deps = fakeDeps(root);
+    expect(status(7, "deftai/directive", deps, { projectRoot: root })).toBeNull();
+  });
+
+  it("returns the latest decision", () => {
+    const root = makeRepo();
+    const prior: AuditEntry = {
+      decision_id: "prior-id",
+      timestamp: "2026-06-18T12:00:00Z",
+      repo: "deftai/directive",
+      issue_number: 7,
+      decision: "defer",
+      actor: "agent:test",
+      reason: "later",
+    };
+    const deps = fakeDeps(root, { latest: prior });
+    expect(status(7, "deftai/directive", deps, { projectRoot: root })?.decision).toBe("defer");
+  });
+});
+
+describe("reset", () => {
+  it("rejects when no prior decision exists", () => {
+    const root = makeRepo();
+    const deps = fakeDeps(root);
+    expect(() => reset(7, "deftai/directive", deps, { projectRoot: root })).toThrow(
+      /no prior decision/,
+    );
+  });
+
+  it("records reset referencing prior decision_id", () => {
+    const root = makeRepo();
+    const prior: AuditEntry = {
+      decision_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      timestamp: "2026-06-18T12:00:00Z",
+      repo: "deftai/directive",
+      issue_number: 7,
+      decision: "defer",
+      actor: "agent:test",
+    };
+    const deps = fakeDeps(root, { latest: prior });
+    const id = reset(7, "deftai/directive", deps, { projectRoot: root });
+    expect(id).toBe("11111111-1111-1111-1111-111111111111");
+    const text = readFileSync(resolveAuditLogPath(root), "utf8");
+    expect(text).toContain('"decision":"reset"');
+    expect(text).toContain('"prior_decision_id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"');
+  });
+
+  it("is idempotent when already reset", () => {
+    const root = makeRepo();
+    const prior: AuditEntry = {
+      decision_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      timestamp: "2026-06-18T12:00:00Z",
+      repo: "deftai/directive",
+      issue_number: 7,
+      decision: "reset",
+      actor: "agent:test",
+      prior_decision_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    };
+    const deps = fakeDeps(root, { latest: prior });
+    expect(reset(7, "deftai/directive", deps, { projectRoot: root })).toBe(
+      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    );
+  });
+});
+
+describe("history", () => {
+  it("returns entries ordered by timestamp", () => {
+    const root = makeRepo();
+    const log = createCandidatesLog(root);
+    const path = resolveAuditLogPath(root);
+    log.append(
+      {
+        decision_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        timestamp: "2026-06-18T10:00:00Z",
+        repo: "deftai/directive",
+        issue_number: 7,
+        decision: "defer",
+        actor: "agent:test",
+        reason: "first",
+      },
+      { path },
+    );
+    log.append(
+      {
+        decision_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        timestamp: "2026-06-18T11:00:00Z",
+        repo: "deftai/directive",
+        issue_number: 7,
+        decision: "needs-ac",
+        actor: "agent:test",
+        reason: "needs criteria",
+      },
+      { path },
+    );
+    const deps = fakeDeps(root);
+    const entries = history(7, "deftai/directive", deps, { projectRoot: root });
+    expect(entries.map((e) => e.decision)).toEqual(["defer", "needs-ac"]);
   });
 });

--- a/packages/core/src/triage/actions/index.ts
+++ b/packages/core/src/triage/actions/index.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cacheGet } from "../../cache/operations.js";
 import { call } from "../../scm/call.js";
 import { ScmStubError } from "../../scm/errors.js";
 import { createCandidatesLog, resolveAuditLogPath, rollbackAuditEntry } from "./candidates-log.js";
@@ -46,6 +48,9 @@ export const REJECTED_LABEL_DESCRIPTION = "Issue rejected during deft triage";
 
 const TERMINAL_DECISIONS = new Set(["accept", "reject", "mark-duplicate"]);
 const DEFAULT_ACTOR = "agent:triage";
+const DEFAULT_NEEDS_AC_COMMENT =
+  "This issue lacks acceptance criteria. Please add a Test/Acceptance " +
+  "narrative before this can be triaged. (deft #845)";
 
 function resolveDeftRoot(): string {
   if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
@@ -154,6 +159,32 @@ function buildEntry(
 
 function logPathFor(projectRoot: string): string {
   return resolveAuditLogPath(projectRoot);
+}
+
+function cacheRootFor(projectRoot: string): string {
+  return join(projectRoot, ".deft-cache");
+}
+
+function findByIssue(issueNumber: number, repo: string, projectRoot: string): AuditEntry[] {
+  const logPath = logPathFor(projectRoot);
+  if (!existsSync(logPath)) {
+    return [];
+  }
+  const out: AuditEntry[] = [];
+  const raw = readFileSync(logPath, "utf8");
+  for (const line of raw.split("\n")) {
+    const stripped = line.trim();
+    if (!stripped) continue;
+    try {
+      const row = JSON.parse(stripped) as AuditEntry;
+      if (row.repo === repo && row.issue_number === issueNumber) {
+        out.push(row);
+      }
+    } catch {
+      // Preserve parity with candidates_log read tolerance for malformed lines.
+    }
+  }
+  return out;
 }
 
 function isIdempotentRepeat(
@@ -359,6 +390,109 @@ export function deferAction(
   });
   const logPath = logPathFor(projectRoot);
   return deps.candidatesLog.append(entry, { path: logPath });
+}
+
+/** Record a needs-ac audit entry and best-effort post an AC-request comment upstream. */
+export function needsAc(
+  issueNumber: number,
+  repo: string,
+  deps: TriageActionsDeps,
+  options: { actor?: string | null; comment?: string | null; projectRoot?: string } = {},
+): string {
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const body = options.comment ?? DEFAULT_NEEDS_AC_COMMENT;
+  const actor = resolveActor(options.actor);
+  const entry = buildEntry(deps, "needs-ac", issueNumber, repo, actor, { reason: body });
+  const logPath = logPathFor(projectRoot);
+  const decisionId = deps.candidatesLog.append(entry, { path: logPath });
+  const writeErr = deps.stderr ?? ((message: string) => process.stderr.write(`${message}\n`));
+  try {
+    runGh(deps, ["issue", "comment", String(issueNumber), "--repo", repo, "--body", body]);
+  } catch (exc) {
+    writeErr(
+      `triage_actions: needs-ac comment not posted for #${issueNumber} (${repo}): ${exc instanceof Error ? exc.message : String(exc)}`,
+    );
+  }
+  return decisionId;
+}
+
+/** Validate duplicate target in cache and record a mark-duplicate audit entry. */
+export function markDuplicate(
+  issueNumber: number,
+  repo: string,
+  ofN: number,
+  deps: TriageActionsDeps,
+  options: { actor?: string | null; projectRoot?: string } = {},
+): string {
+  const projectRoot = options.projectRoot ?? process.cwd();
+  if (ofN === issueNumber) {
+    throw new TriageError(`mark-duplicate target #${ofN} cannot equal source #${issueNumber}`);
+  }
+  const key = `${repo}/${ofN}`;
+  try {
+    cacheGet("github-issue", key, { allowStale: true, cacheRoot: cacheRootFor(projectRoot) });
+  } catch (exc) {
+    throw new TriageError(
+      `mark-duplicate target #${ofN} not found in cache for ${repo}: ${exc instanceof Error ? exc.message : String(exc)}`,
+    );
+  }
+  const prior = isIdempotentRepeat(deps, issueNumber, repo, "mark-duplicate", projectRoot, ofN);
+  if (prior !== null) {
+    return prior.decision_id;
+  }
+  const actor = resolveActor(options.actor);
+  const entry = buildEntry(deps, "mark-duplicate", issueNumber, repo, actor, { linked_to: ofN });
+  const logPath = logPathFor(projectRoot);
+  return deps.candidatesLog.append(entry, { path: logPath });
+}
+
+/** Return the latest decision for ``issueNumber`` in ``repo`` (null if none). */
+export function status(
+  issueNumber: number,
+  repo: string,
+  deps: TriageActionsDeps,
+  options: { projectRoot?: string } = {},
+): AuditEntry | null {
+  const projectRoot = options.projectRoot ?? process.cwd();
+  return deps.candidatesLog.latestDecision(issueNumber, repo, {
+    path: logPathFor(projectRoot),
+  });
+}
+
+/** Record a reset audit entry referencing the prior decision_id (history is never deleted). */
+export function reset(
+  issueNumber: number,
+  repo: string,
+  deps: TriageActionsDeps,
+  options: { actor?: string | null; projectRoot?: string } = {},
+): string {
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const logPath = logPathFor(projectRoot);
+  const prior = deps.candidatesLog.latestDecision(issueNumber, repo, { path: logPath });
+  if (prior === null) {
+    throw new TriageError(`cannot reset #${issueNumber}: no prior decision recorded for ${repo}`);
+  }
+  if (prior.decision === "reset") {
+    return prior.decision_id;
+  }
+  const actor = resolveActor(options.actor);
+  const entry = buildEntry(deps, "reset", issueNumber, repo, actor, {
+    prior_decision_id: prior.decision_id,
+  });
+  return deps.candidatesLog.append(entry, { path: logPath });
+}
+
+/** Return audit entries for ``issueNumber`` ordered ascending by timestamp. */
+export function history(
+  issueNumber: number,
+  repo: string,
+  _deps: TriageActionsDeps,
+  options: { projectRoot?: string } = {},
+): AuditEntry[] {
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const entries = findByIssue(issueNumber, repo, projectRoot);
+  entries.sort((a, b) => String(a.timestamp).localeCompare(String(b.timestamp)));
+  return entries;
 }
 
 /** Format a decision entry for CLI ``status`` / ``history`` output. */

--- a/packages/core/src/triage/actions/index.ts
+++ b/packages/core/src/triage/actions/index.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { CacheNotFoundError } from "../../cache/errors.js";
 import { cacheGet } from "../../cache/operations.js";
 import { call } from "../../scm/call.js";
 import { ScmStubError } from "../../scm/errors.js";
@@ -176,7 +177,9 @@ function findByIssue(issueNumber: number, repo: string, projectRoot: string): Au
     const stripped = line.trim();
     if (!stripped) continue;
     try {
-      const row = JSON.parse(stripped) as AuditEntry;
+      const parsed = JSON.parse(stripped) as unknown;
+      if (typeof parsed !== "object" || parsed === null) continue;
+      const row = parsed as AuditEntry;
       if (row.repo === repo && row.issue_number === issueNumber) {
         out.push(row);
       }
@@ -432,9 +435,12 @@ export function markDuplicate(
   try {
     cacheGet("github-issue", key, { allowStale: true, cacheRoot: cacheRootFor(projectRoot) });
   } catch (exc) {
-    throw new TriageError(
-      `mark-duplicate target #${ofN} not found in cache for ${repo}: ${exc instanceof Error ? exc.message : String(exc)}`,
-    );
+    if (exc instanceof CacheNotFoundError) {
+      throw new TriageError(
+        `mark-duplicate target #${ofN} not found in cache for ${repo}: ${exc.message}`,
+      );
+    }
+    throw exc;
   }
   const prior = isIdempotentRepeat(deps, issueNumber, repo, "mark-duplicate", projectRoot, ofN);
   if (prior !== null) {

--- a/vbrief/active/2026-06-24-1945-ts-triage-actions-verb-parity-port.vbrief.json
+++ b/vbrief/active/2026-06-24-1945-ts-triage-actions-verb-parity-port.vbrief.json
@@ -1,0 +1,97 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1945"
+  },
+  "plan": {
+    "title": "fix(triage,ts): port the missing triage-actions verbs to TS (needs-ac/mark-duplicate/status/reset/history)",
+    "status": "running",
+    "narratives": {
+      "Description": "The TypeScript triage-actions CLI implements only accept/reject/defer. The router maps five more verbs to the same module (needs-ac, mark-duplicate, status, reset, history) but the TS CLI rejects them at its arg guard, so they exist only in the Python twin scripts/triage_actions.py. Port the five missing verbs to the TS actions module + CLI with parity tests against the Python oracle. This is a hard parity prerequisite for the #1860 Python purge.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1945",
+      "Overview": "## What to build\n\nPort the five missing triage verbs from scripts/triage_actions.py to TypeScript so they no longer depend on the Python runtime.\n\nToday packages/cli/src/triage-actions.ts only accepts accept/reject/defer (arg guard at line ~95); packages/core/src/triage/actions/index.ts exports only accept/reject/deferAction/formatDecision. The router (packages/cli/src/cli-router/route-argv.ts) maps needs-ac, mark-duplicate, status, reset, and history to the same module, and the Python twin implements all of them.\n\n## Acceptance criteria\n\n- [ ] TS triage-actions implements needs-ac, mark-duplicate, status, reset, history (in addition to accept/reject/defer)\n- [ ] reset records a reversible audit entry referencing the prior decision_id (history is never deleted)\n- [ ] mark-duplicate validates the of_n target against the local cache and records linked_to\n- [ ] status returns the latest decision; history returns all entries for the issue in order\n- [ ] Parity tests vs the Python oracle (scripts/triage_actions.py) for all five verbs, cache off\n- [ ] task check passes\n\n## Type\n\nAFK\n\n## Out of scope\n\n- The cache-faithfulness fix (reconcile-default / self-healing ritual / drift-aware freshness gate) is tracked separately in #1886 and owned by a sibling worker; this story MUST NOT edit packages/core/src/cache/, packages/core/src/preflight-cache/, or the session-ritual / triage:welcome call sites.",
+      "Labels": "bug, triage, area:vbrief",
+      "ImplementationPlan": "- packages/core/src/triage/actions/index.ts: add needsAc, markDuplicate, status, reset, history exports mirroring scripts/triage_actions.py semantics (reset references prior decision_id; mark-duplicate validates of_n in cache and records linked_to).\n- packages/cli/src/triage-actions.ts: extend the arg guard + dispatch to handle the five new subcommands with their flags.\n- packages/cli/src/triage-actions-parity.ts: add parity fixtures for the five verbs against the Python oracle (cache off).\n- Unit tests in packages/core/src/triage/actions/.",
+      "UserStory": "As a deft operator on an npm-only install, I want all triage verbs implemented in TypeScript, so that needs-ac/mark-duplicate/status/reset/history keep working after the #1860 Python purge."
+    },
+    "items": [
+      {
+        "title": "TS triage-actions implements the five missing verbs",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "packages/cli/src/triage-actions.ts and packages/core/src/triage/actions/index.ts implement needs-ac, mark-duplicate, status, reset, and history alongside accept/reject/defer."
+        }
+      },
+      {
+        "title": "reset is a reversible audit entry referencing the prior decision",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "reset records a new audit entry referencing the prior decision_id without deleting history; replaying status after reset reflects the reset decision."
+        }
+      },
+      {
+        "title": "mark-duplicate validates of_n and records linked_to",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "mark-duplicate validates the of_n target exists in the local cache and records linked_to on the audit entry, with idempotency on the same target."
+        }
+      },
+      {
+        "title": "Parity vs the Python oracle for all five verbs",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "packages/cli/src/triage-actions-parity.ts emits identical output/exit codes to scripts/triage_actions.py for needs-ac/mark-duplicate/status/reset/history with cache off; task check passes."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "triage",
+      "area:vbrief"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1945",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1945: triage-actions TS CLI ports only accept/reject/defer; needs-ac/mark-duplicate/status/reset/history are Python-only (break on #1860 Python purge)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1886",
+        "type": "x-vbrief/related",
+        "title": "Issue #1886 (parent finding this was split from)"
+      }
+    ],
+    "updated": "2026-06-24T15:57:32Z",
+    "id": "2026-06-24-1945-ts-triage-actions-verb-parity-port",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/actions/index.ts",
+          "packages/core/src/triage/actions/index.test.ts",
+          "packages/cli/src/triage-actions.ts",
+          "packages/cli/src/triage-actions.test.ts",
+          "packages/cli/src/triage-actions-parity.ts"
+        ],
+        "verify_commands": [
+          "pnpm run build",
+          "task check"
+        ],
+        "expected_outputs": [
+          "needs-ac/mark-duplicate/status/reset/history work on the TS CLI",
+          "triage-actions parity exits 0 vs the Python oracle (cache off)",
+          "task check passes with new tests"
+        ],
+        "depends_on": [],
+        "conflict_group": "ts-triage-actions",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to the Python oracle scripts/triage_actions.py via parity fixtures, not a spec section."
+      },
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Port the five triage-actions verbs that were Python-only (needs-ac, mark-duplicate, status, reset, history) to the TypeScript core actions module and CLI.
- `reset` appends a reversible audit entry referencing the prior `decision_id`; history is never deleted.
- `mark-duplicate` validates the `--of` target against the local cache and records `linked_to`, with idempotency on the same target.
- Parity harness compares all five verbs against `scripts/triage_actions.py` (cache off).

## Test plan

- [x] `task check` passes (including TS parity harness and new unit tests)
- [x] `needs-ac` records audit entry and tolerates upstream comment failure
- [x] `mark-duplicate` rejects missing cache targets and self-duplicates
- [x] `status` / `history` / `reset` behave per Python oracle

Closes #1945
