### PR TITLE
chore(scope): complete swarm story vBRIEFs (#1886, #1945)

### DIFF
--- a/vbrief/completed/2026-06-24-1886-cache-faithfulness-reconcile-default-ritual-heal-drift-gate.vbrief.json
+++ b/vbrief/completed/2026-06-24-1886-cache-faithfulness-reconcile-default-ritual-heal-drift-gate.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "fix(triage,cache): make the triage cache faithful to upstream state (reconcile-default + self-healing ritual + drift-aware freshness gate)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "The triage cache never reconciles open→closed transitions, so triage:queue surfaces closed/completed work as untriaged and verify:cache-fresh reports a materially-wrong cache as fresh. Make 'fresh' mean 'faithful to upstream state for everything in scope' rather than 'something was fetched recently': fold the existing cacheRefreshClosed reconcile into the default cache:fetch-all run, make the session ritual self-healing, and make the freshness gate completeness/drift-aware. Also fold secondary finding #1 (evaluate.ts reads d.issue but the writer emits issue_number).",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1886",
@@ -57,7 +57,7 @@
         "title": "Issue #1886: Triage cache never reconciles open→closed issues; queue surfaces closed/completed work as untriaged and verify:cache-fresh can't detect the drift"
       }
     ],
-    "updated": "2026-06-24T15:57:08Z",
+    "updated": "2026-06-24T18:24:47Z",
     "id": "2026-06-24-1886-cache-faithfulness-reconcile-default-ritual-heal-drift-gate",
     "metadata": {
       "kind": "story",
@@ -88,7 +88,8 @@
         "model_tier": "leaf-implementation",
         "missing_traces_justification": "Traced to the evidence-closed forensic investigation in issue #1886 (root-cause facts 1-4 + proposed fix) rather than a spec section."
       },
-      "capacityBucket": "bug-fix"
+      "capacityBucket": "bug-fix",
+      "completedAt": "2026-06-24T18:24:47Z"
     }
   }
 }

--- a/vbrief/completed/2026-06-24-1945-ts-triage-actions-verb-parity-port.vbrief.json
+++ b/vbrief/completed/2026-06-24-1945-ts-triage-actions-verb-parity-port.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "fix(triage,ts): port the missing triage-actions verbs to TS (needs-ac/mark-duplicate/status/reset/history)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "The TypeScript triage-actions CLI implements only accept/reject/defer. The router maps five more verbs to the same module (needs-ac, mark-duplicate, status, reset, history) but the TS CLI rejects them at its arg guard, so they exist only in the Python twin scripts/triage_actions.py. Port the five missing verbs to the TS actions module + CLI with parity tests against the Python oracle. This is a hard parity prerequisite for the #1860 Python purge.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1945",
@@ -61,7 +61,7 @@
         "title": "Issue #1886 (parent finding this was split from)"
       }
     ],
-    "updated": "2026-06-24T15:57:32Z",
+    "updated": "2026-06-24T18:24:48Z",
     "id": "2026-06-24-1945-ts-triage-actions-verb-parity-port",
     "metadata": {
       "kind": "story",
@@ -91,7 +91,8 @@
         "model_tier": "leaf-implementation",
         "missing_traces_justification": "Traced to the Python oracle scripts/triage_actions.py via parity fixtures, not a spec section."
       },
-      "capacityBucket": "new-capability"
+      "capacityBucket": "new-capability",
+      "completedAt": "2026-06-24T18:24:48Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

Post-merge lifecycle bookkeeping: move the two swarm story vBRIEFs from `vbrief/active/` to `vbrief/completed/` now that their implementation PRs merged.

- #1886 cache faithfulness — PR #1947 (merged)
- #1945 TS triage-actions verb parity — PR #1946 (merged)

vBRIEF folder move + `plan.status` flip to `completed` only; no code changes.

## Test plan

- [x] `task scope:complete` ran for both vBRIEFs (active/ -> completed/)

Refs #1886 #1945

Made with [Cursor](https://cursor.com)