### PR TITLE
feat(#1942 S1): TS resolve-and-copy deposit primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **TypeScript deposit primitives resolve and copy npm content locally** — the engine package now depends on `@deftai/directive-content`, and new core helpers resolve the installed content package via Node module resolution and recursively copy its tree with file-mode preservation (executable hooks included). This is the foundation for TS-native `directive init`/`update` without GitHub tarball downloads. Refs #1942.
 - **Architecture docs now describe the planned npm-native distribution model** — a clearly-marked "Wave 5 Target" section records the two-package npm model, the resolve-and-copy materialization step, and the frozen Go binary's reduced role as a health gate. Fenced as target architecture, not current behavior, so it cannot be misread as today's flow. Refs #1669 #1942 #1933.
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,8 @@
     "provenance": true
   },
   "dependencies": {
-    "@deftai/directive-core": "workspace:*"
+    "@deftai/directive-core": "workspace:*",
+    "@deftai/directive-content": "workspace:*"
   },
   "scripts": {
     "build": "tsc -b"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -197,6 +197,7 @@
     "provenance": true
   },
   "dependencies": {
+    "@deftai/directive-content": "workspace:*",
     "@deftai/directive-types": "workspace:*"
   },
   "scripts": {

--- a/packages/core/src/deposit/copy-tree.test.ts
+++ b/packages/core/src/deposit/copy-tree.test.ts
@@ -1,0 +1,60 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { copyTree } from "./copy-tree.js";
+
+describe("copyTree (#1477 mode-preserving recursive copy)", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshRoot(prefix: string): string {
+    const root = mkdtempSync(join(tmpdir(), prefix));
+    created.push(root);
+    return root;
+  }
+
+  it("copies nested directories and preserves the executable bit", async () => {
+    const workspace = freshRoot("copy-tree-");
+    const src = join(workspace, "src");
+    const dst = join(workspace, "dst");
+
+    mkdirSync(join(src, "nested", "bin"), { recursive: true });
+    writeFileSync(join(src, "nested", "readme.txt"), "hello", "utf-8");
+    chmodSync(join(src, "nested", "readme.txt"), 0o644);
+
+    const hook = join(src, "nested", "bin", "hook");
+    writeFileSync(hook, "#!/bin/sh\necho hook\n", "utf-8");
+    chmodSync(hook, 0o755);
+
+    await copyTree(src, dst);
+
+    expect(readFileSync(join(dst, "nested", "readme.txt"), "utf-8")).toBe("hello");
+    expect(statSync(join(dst, "nested", "readme.txt")).mode & 0o777).toBe(0o644);
+    expect(readFileSync(join(dst, "nested", "bin", "hook"), "utf-8")).toBe(
+      "#!/bin/sh\necho hook\n",
+    );
+    expect(statSync(join(dst, "nested", "bin", "hook")).mode & 0o777).toBe(0o755);
+  });
+
+  it("rejects a non-directory source", async () => {
+    const workspace = freshRoot("copy-tree-file-");
+    const file = join(workspace, "not-a-dir");
+    writeFileSync(file, "x", "utf-8");
+
+    await expect(copyTree(file, join(workspace, "dst"))).rejects.toThrow(/not a directory/);
+  });
+});

--- a/packages/core/src/deposit/copy-tree.ts
+++ b/packages/core/src/deposit/copy-tree.ts
@@ -1,0 +1,61 @@
+/**
+ * copy-tree.ts — recursively copy a directory tree with file-mode preservation.
+ *
+ * Mirrors cmd/deft-install/setup.go `copyDir` / `copyFile` (#1477): intermediate
+ * directories are created mode 0o755; files keep their source permission bits
+ * (including the executable bit for hooks and the `run` launcher).
+ *
+ * Refs #1942 S1, #1477.
+ */
+
+import { createReadStream, createWriteStream } from "node:fs";
+import { chmod, mkdir, readdir, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { pipeline } from "node:stream/promises";
+
+const DEFAULT_FILE_MODE = 0o644;
+const DEFAULT_DIR_MODE = 0o755;
+
+async function copyFilePreserveMode(src: string, dst: string): Promise<void> {
+  let mode = DEFAULT_FILE_MODE;
+  try {
+    const info = await stat(src);
+    mode = info.mode & 0o777;
+  } catch {
+    // Stat failure is non-fatal — fall back to 0o644 (mirrors Go copyFile).
+  }
+
+  await mkdir(dirname(dst), { recursive: true, mode: DEFAULT_DIR_MODE });
+  await pipeline(createReadStream(src), createWriteStream(dst, { mode }));
+  // createWriteStream mode applies on create; chmod ensures the final bits match
+  // the source even when the destination file already existed.
+  await chmod(dst, mode);
+}
+
+async function copyDirContents(src: string, dst: string): Promise<void> {
+  await mkdir(dst, { recursive: true, mode: DEFAULT_DIR_MODE });
+  const entries = await readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = join(src, entry.name);
+    const dstPath = join(dst, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirContents(srcPath, dstPath);
+    } else if (entry.isFile() || entry.isSymbolicLink()) {
+      // Copy regular files; symlinks are copied as file bodies (same as Go walk copyFile).
+      await copyFilePreserveMode(srcPath, dstPath);
+    }
+  }
+}
+
+/**
+ * Recursively copy `src` into `dst`, preserving nested structure and file modes.
+ *
+ * The contents of `src` are placed under `dst` (equivalent to Go `copyDir`).
+ */
+export async function copyTree(src: string, dst: string): Promise<void> {
+  const srcInfo = await stat(src);
+  if (!srcInfo.isDirectory()) {
+    throw new Error(`copyTree: source ${src} is not a directory`);
+  }
+  await copyDirContents(src, dst);
+}

--- a/packages/core/src/deposit/copy-tree.ts
+++ b/packages/core/src/deposit/copy-tree.ts
@@ -38,10 +38,10 @@ async function copyDirContents(src: string, dst: string): Promise<void> {
   for (const entry of entries) {
     const srcPath = join(src, entry.name);
     const dstPath = join(dst, entry.name);
-    if (entry.isDirectory()) {
+    const srcStat = await stat(srcPath);
+    if (srcStat.isDirectory()) {
       await copyDirContents(srcPath, dstPath);
-    } else if (entry.isFile() || entry.isSymbolicLink()) {
-      // Copy regular files; symlinks are copied as file bodies (same as Go walk copyFile).
+    } else {
       await copyFilePreserveMode(srcPath, dstPath);
     }
   }

--- a/packages/core/src/deposit/resolve-content.test.ts
+++ b/packages/core/src/deposit/resolve-content.test.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CONTENT_PACKAGE_NAME,
+  ContentPackageNotFoundError,
+  contentPackageRootFromResolvedEntry,
+  resolveInstalledContentRoot,
+} from "./resolve-content.js";
+
+describe("resolveInstalledContentRoot", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "resolve-content-"));
+    created.push(root);
+    return root;
+  }
+
+  function installContentPackage(projectRoot: string): string {
+    const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: CONTENT_PACKAGE_NAME, version: "0.0.0" }),
+      "utf-8",
+    );
+    writeFileSync(join(pkgDir, "main.md"), "# content", "utf-8");
+    return pkgDir;
+  }
+
+  it("returns the package root when resolution succeeds", async () => {
+    const project = freshRoot();
+    const pkgDir = installContentPackage(project);
+
+    const root = await resolveInstalledContentRoot(async () => join(pkgDir, "package.json"));
+    expect(root).toBe(pkgDir);
+  });
+
+  it("finds the package root when resolution lands on an nested entry file", async () => {
+    const project = freshRoot();
+    const pkgDir = installContentPackage(project);
+    const nested = join(pkgDir, "skills", "example");
+    mkdirSync(nested, { recursive: true });
+    const skillFile = join(nested, "SKILL.md");
+    writeFileSync(skillFile, "# skill", "utf-8");
+
+    const root = await resolveInstalledContentRoot(async () => skillFile);
+    expect(root).toBe(pkgDir);
+  });
+
+  it("rejects an uninstalled package with an actionable error", async () => {
+    await expect(
+      resolveInstalledContentRoot(async () => {
+        throw new Error("Cannot find package '@deftai/directive-content'");
+      }),
+    ).rejects.toMatchObject({
+      name: "ContentPackageNotFoundError",
+      message: expect.stringContaining("pnpm add @deftai/directive-content"),
+    });
+  });
+
+  it("rejects when resolution succeeds but the package name does not match", async () => {
+    const project = freshRoot();
+    const bogus = join(project, "node_modules", "other", "package");
+    mkdirSync(bogus, { recursive: true });
+    writeFileSync(join(bogus, "package.json"), JSON.stringify({ name: "other-pkg" }), "utf-8");
+
+    await expect(
+      resolveInstalledContentRoot(async () => join(bogus, "package.json")),
+    ).rejects.toBeInstanceOf(ContentPackageNotFoundError);
+  });
+});
+
+describe("contentPackageRootFromResolvedEntry", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the directory when resolved entry is package.json", () => {
+    const root = mkdtempSync(join(tmpdir(), "resolve-entry-"));
+    created.push(root);
+    const pkgDir = join(root, "node_modules", "@deftai", "directive-content");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: CONTENT_PACKAGE_NAME }),
+      "utf-8",
+    );
+
+    expect(contentPackageRootFromResolvedEntry(join(pkgDir, "package.json"))).toBe(pkgDir);
+  });
+});

--- a/packages/core/src/deposit/resolve-content.test.ts
+++ b/packages/core/src/deposit/resolve-content.test.ts
@@ -88,6 +88,21 @@ describe("contentPackageRootFromResolvedEntry", () => {
     }
   });
 
+  it("skips package.json files whose JSON root is null", () => {
+    const root = mkdtempSync(join(tmpdir(), "resolve-entry-null-"));
+    created.push(root);
+    const pkgDir = join(root, "node_modules", "@deftai", "directive-content");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(root, "package.json"), "null", "utf-8");
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: CONTENT_PACKAGE_NAME }),
+      "utf-8",
+    );
+
+    expect(contentPackageRootFromResolvedEntry(join(pkgDir, "package.json"))).toBe(pkgDir);
+  });
+
   it("returns the directory when resolved entry is package.json", () => {
     const root = mkdtempSync(join(tmpdir(), "resolve-entry-"));
     created.push(root);

--- a/packages/core/src/deposit/resolve-content.ts
+++ b/packages/core/src/deposit/resolve-content.ts
@@ -1,0 +1,79 @@
+/**
+ * resolve-content.ts — resolve the installed @deftai/directive-content package root.
+ *
+ * Used by the TS-native init/update deposit path (#1942 S1) to locate the npm
+ * content package before copying its tree into `.deft/core/`. Mirrors the
+ * package-resolution half of the Go installer's content fetch, but reads from
+ * the local node_modules install instead of a GitHub tarball.
+ *
+ * Refs #1942, #11, #1477.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CONTENT_PACKAGE_NAME = "@deftai/directive-content";
+
+/** Thrown when {@link resolveInstalledContentRoot} cannot resolve the content package. */
+export class ContentPackageNotFoundError extends Error {
+  override readonly name = "ContentPackageNotFoundError";
+}
+
+type ResolveSpecifier = (specifier: string) => Promise<string>;
+
+async function defaultResolveSpecifier(specifier: string): Promise<string> {
+  return fileURLToPath(await import.meta.resolve(specifier));
+}
+
+/**
+ * Walk upward from `resolvedEntry` until a `package.json` names
+ * {@link CONTENT_PACKAGE_NAME}; returns that directory.
+ */
+export function contentPackageRootFromResolvedEntry(resolvedEntry: string): string {
+  let dir = statSync(resolvedEntry).isDirectory() ? resolvedEntry : dirname(resolvedEntry);
+  for (;;) {
+    const pkgJsonPath = join(dir, "package.json");
+    try {
+      if (statSync(pkgJsonPath).isFile()) {
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { name?: string };
+        if (pkg.name === CONTENT_PACKAGE_NAME) {
+          return dir;
+        }
+      }
+    } catch {
+      // Missing or unreadable package.json — keep walking.
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  throw new ContentPackageNotFoundError(
+    `Resolved ${CONTENT_PACKAGE_NAME} entry at ${resolvedEntry}, but no matching package root was found. ` +
+      "Reinstall with `pnpm add @deftai/directive-content` or `npm i @deftai/directive-content`.",
+  );
+}
+
+/**
+ * Resolve the installed {@link CONTENT_PACKAGE_NAME} package root via Node module
+ * resolution (`import.meta.resolve`).
+ */
+export async function resolveInstalledContentRoot(
+  resolveSpecifier: ResolveSpecifier = defaultResolveSpecifier,
+): Promise<string> {
+  let resolvedEntry: string;
+  try {
+    resolvedEntry = await resolveSpecifier(CONTENT_PACKAGE_NAME);
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    throw new ContentPackageNotFoundError(
+      `${CONTENT_PACKAGE_NAME} is not installed or could not be resolved. ` +
+        "Install it with `pnpm add @deftai/directive-content` or `npm i @deftai/directive-content` " +
+        "so init/update can deposit framework content locally. " +
+        `Resolution error: ${detail}`,
+    );
+  }
+  return contentPackageRootFromResolvedEntry(resolvedEntry);
+}

--- a/packages/core/src/deposit/resolve-content.ts
+++ b/packages/core/src/deposit/resolve-content.ts
@@ -36,8 +36,12 @@ export function contentPackageRootFromResolvedEntry(resolvedEntry: string): stri
     const pkgJsonPath = join(dir, "package.json");
     try {
       if (statSync(pkgJsonPath).isFile()) {
-        const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { name?: string };
-        if (pkg.name === CONTENT_PACKAGE_NAME) {
+        const parsed: unknown = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          (parsed as { name?: string }).name === CONTENT_PACKAGE_NAME
+        ) {
           return dir;
         }
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@deftai/directive-content':
+        specifier: workspace:*
+        version: link:../content
       '@deftai/directive-core':
         specifier: workspace:*
         version: link:../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@deftai/directive-content':
+        specifier: workspace:*
+        version: link:../content
       '@deftai/directive-types':
         specifier: workspace:*
         version: link:../types

--- a/vbrief/active/2026-06-24-s1-content-dependency-ts-resolve-and-copy-deposit-primitive.vbrief.json
+++ b/vbrief/active/2026-06-24-s1-content-dependency-ts-resolve-and-copy-deposit-primitive.vbrief.json
@@ -1,0 +1,110 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json"
+  },
+  "plan": {
+    "id": "s1-content-deposit-primitive",
+    "title": "S1: content dependency + TS resolve-and-copy deposit primitive",
+    "status": "running",
+    "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
+    "narratives": {
+      "Description": "directive init/update currently obtain framework content only via the Go binary's GitHub-tarball download, and @deftai/directive depends solely on @deftai/directive-core. This story adds @deftai/directive-content as a dependency of the engine package and builds a pure TS deposit primitive that resolves the installed content package via Node module resolution and recursively copies its tree into a target directory with file-mode preservation. It is the foundation every later init/update story builds on, and is independently buildable and testable in isolation from the CLI verbs.",
+      "ImplementationPlan": "- Add @deftai/directive-content (workspace:*) to packages/cli/package.json dependencies alongside @deftai/directive-core.\n- Implement packages/core/src/deposit/resolve-content.ts using import.meta.resolve('@deftai/directive-content') with a graceful error when the package is unresolvable, and packages/core/src/deposit/copy-tree.ts that recursively copies a source tree preserving the executable bit (mirroring cmd/deft-install copyFile/copyDir #1477).\n- Unit-test resolution success/failure and a copy round-trip (including mode preservation and nested dirs) in colocated *.test.ts files.",
+      "UserStory": "As a Deft engine package, I want to resolve and copy the installed content package tree locally, so that init/update can deposit .deft/core from npm without any network download."
+    },
+    "items": [
+      {
+        "id": "s1-content-deposit-primitive-a1",
+        "title": "When pnpm install runs, it resolves @deftai/directive-content as a dependency of the engine package without error.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When pnpm install runs, it resolves @deftai/directive-content as a dependency of the engine package without error."
+        }
+      },
+      {
+        "id": "s1-content-deposit-primitive-a2",
+        "title": "resolve-content.ts returns the resolved content package root and rejects an uninstalled package with an actionable error.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "resolve-content.ts returns the resolved content package root and rejects an uninstalled package with an actionable error."
+        }
+      },
+      {
+        "id": "s1-content-deposit-primitive-a3",
+        "title": "copy-tree.ts creates a recursive copy of the source tree preserving the executable bit and nested directories.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "copy-tree.ts creates a recursive copy of the source tree preserving the executable bit and nested directories."
+        }
+      },
+      {
+        "id": "s1-content-deposit-primitive-a4",
+        "title": "When the unit tests run, they cover resolution success, resolution failure, and a copy round-trip that preserves file modes.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the unit tests run, they cover resolution success, resolution failure, and a copy round-trip that preserves file modes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/package.json",
+          "packages/core/src/deposit/resolve-content.ts",
+          "packages/core/src/deposit/resolve-content.test.ts",
+          "packages/core/src/deposit/copy-tree.ts",
+          "packages/core/src/deposit/copy-tree.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm install",
+          "pnpm run build",
+          "pnpm --filter @deftai/directive-core test -- deposit",
+          "task check"
+        ],
+        "expected_outputs": [
+          "@deftai/directive-content resolvable from the CLI package",
+          "resolve-content + copy-tree primitives exported with passing unit tests"
+        ],
+        "depends_on": [],
+        "conflict_group": "deposit-primitive",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to cmd/deft-install/setup.go (copyFile/copyDir, #1477) and the #1942 deposit-mechanism comment (resolve-and-copy), not a spec section."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1942",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1942: TS-native directive init/update deposit + gitignore .deft/core (HARD prereq for Go neuter)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/related",
+        "title": "Epic #1669 (distributable Deft) -- Wave 5"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/related",
+        "title": "Issue #1912 (frozen Go binary + gate) -- gated on this issue"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1941",
+        "type": "x-vbrief/related",
+        "title": "Issue #1941 (stage-2 migrate) -- owns the vendored->hybrid un-commit transition"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1933",
+        "type": "x-vbrief/related",
+        "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
+      }
+    ],
+    "updated": "2026-06-24T18:52:32Z"
+  }
+}

--- a/vbrief/completed/2026-06-24-s1-content-dependency-ts-resolve-and-copy-deposit-primitive.vbrief.json
+++ b/vbrief/completed/2026-06-24-s1-content-dependency-ts-resolve-and-copy-deposit-primitive.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "s1-content-deposit-primitive",
     "title": "S1: content dependency + TS resolve-and-copy deposit primitive",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
     "narratives": {
       "Description": "directive init/update currently obtain framework content only via the Go binary's GitHub-tarball download, and @deftai/directive depends solely on @deftai/directive-core. This story adds @deftai/directive-content as a dependency of the engine package and builds a pure TS deposit primitive that resolves the installed content package via Node module resolution and recursively copies its tree into a target directory with file-mode preservation. It is the foundation every later init/update story builds on, and is independently buildable and testable in isolation from the CLI verbs.",
@@ -75,7 +75,9 @@
         "file_scope_confidence": "high",
         "model_tier": "leaf-implementation",
         "missing_traces_justification": "Traced to cmd/deft-install/setup.go (copyFile/copyDir, #1477) and the #1942 deposit-mechanism comment (resolve-and-copy), not a spec section."
-      }
+      },
+      "completedAt": "2026-06-24T19:23:06Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -105,6 +107,6 @@
         "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
       }
     ],
-    "updated": "2026-06-24T18:52:32Z"
+    "updated": "2026-06-24T19:23:06Z"
   }
 }

--- a/vbrief/pending/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json
+++ b/vbrief/pending/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json
@@ -1,0 +1,120 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json"
+  },
+  "plan": {
+    "id": "s2-directive-init-ts-native",
+    "title": "S2: directive init TS-native greenfield deposit",
+    "status": "pending",
+    "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
+    "narratives": {
+      "Description": "directive init today spawnSyncs the bundled Go deft-install, which downloads and vendors .deft/core. This story rewrites init to orchestrate a fully TS-native greenfield deposit using the S1 primitive: copy the content tree into .deft/core, render the AGENTS.md managed-section (reusing the existing TS agents-md logic), scaffold vbrief/ (schemas + lifecycle dirs), deposit .agents/skills pointers + .githooks + the #1430 neutralization, and wire the Taskfile include. The friendly wizard UX is preserved and no Go binary is invoked on the happy path.",
+      "ImplementationPlan": "- Replace the runDeftInstall delegation in packages/cli/src/init-cli/init.ts with a call into a new packages/core/src/init-deposit/init-deposit.ts orchestrator that composes the S1 copy primitive with AGENTS.md render (packages/core/src/platform/agents-md.ts), vbrief scaffold, skills/githooks/neutralization, and Taskfile wiring.\n- Port the idempotency + wizard-output behavior from cmd/deft-install setup.go (WriteAgentsMD, WriteConsumerVbrief, EnsureTaskfile, WriteAgentsSkills) into TS, keeping the existing wizard UX text.\n- Add unit tests asserting a complete greenfield deposit (.deft/core populated, AGENTS.md managed-section present, vbrief lifecycle dirs created) with no Go binary spawn.",
+      "UserStory": "As a new Deft user, I want directive init to deposit a complete .deft/core, AGENTS.md, and vbrief scaffold from the installed content package, so that I can start using Deft on a fresh repo with no Go binary and no network download."
+    },
+    "items": [
+      {
+        "id": "s2-directive-init-ts-native-a1",
+        "title": "When directive init runs on a fresh repo, it creates a complete .deft/core copied from the content package with no Go binary spawned.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When directive init runs on a fresh repo, it creates a complete .deft/core copied from the content package with no Go binary spawned."
+        }
+      },
+      {
+        "id": "s2-directive-init-ts-native-a2",
+        "title": "init renders the AGENTS.md managed-section and creates vbrief/ with schemas and the five lifecycle directories.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "init renders the AGENTS.md managed-section and creates vbrief/ with schemas and the five lifecycle directories."
+        }
+      },
+      {
+        "id": "s2-directive-init-ts-native-a3",
+        "title": "init creates .agents/skills pointers, .githooks, and the #1430 neutralization, and updates the Taskfile include idempotently.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "init creates .agents/skills pointers, .githooks, and the #1430 neutralization, and updates the Taskfile include idempotently."
+        }
+      },
+      {
+        "id": "s2-directive-init-ts-native-a4",
+        "title": "init displays the friendly wizard UX output on the greenfield deposit path for the operator.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "init displays the friendly wizard UX output on the greenfield deposit path for the operator."
+        }
+      },
+      {
+        "id": "s2-directive-init-ts-native-a5",
+        "title": "When the unit tests run, they confirm the full greenfield deposit shape and that no Go binary is spawned.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the unit tests run, they confirm the full greenfield deposit shape and that no Go binary is spawned."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/cli/src/init-cli/init.ts",
+          "packages/cli/src/init-cli/init-cli.test.ts",
+          "packages/core/src/init-deposit/init-deposit.ts",
+          "packages/core/src/init-deposit/init-deposit.test.ts",
+          "packages/core/src/init-deposit/scaffold.ts",
+          "packages/core/src/init-deposit/scaffold.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm run build",
+          "pnpm --filter @deftai/directive-core test -- init-deposit",
+          "pnpm --filter @deftai/directive test -- init-cli",
+          "task check"
+        ],
+        "expected_outputs": [
+          "directive init deposits .deft/core + AGENTS.md + vbrief scaffold from the content package, no Go binary",
+          "init-deposit orchestrator + scaffold modules with passing unit tests"
+        ],
+        "depends_on": [
+          "s1-content-deposit-primitive"
+        ],
+        "conflict_group": "init-deposit",
+        "size": "large",
+        "file_scope_confidence": "medium",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to cmd/deft-install/setup.go (WriteAgentsMD, WriteConsumerVbrief, EnsureTaskfile, WriteAgentsSkills) and #1942 scope, not a spec section."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1942",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1942: TS-native directive init/update deposit + gitignore .deft/core (HARD prereq for Go neuter)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/related",
+        "title": "Epic #1669 (distributable Deft) -- Wave 5"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/related",
+        "title": "Issue #1912 (frozen Go binary + gate) -- gated on this issue"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1941",
+        "type": "x-vbrief/related",
+        "title": "Issue #1941 (stage-2 migrate) -- owns the vendored->hybrid un-commit transition"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1933",
+        "type": "x-vbrief/related",
+        "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-24-s3-directive-update-ts-native-healthy-path-refresh.vbrief.json
+++ b/vbrief/pending/2026-06-24-s3-directive-update-ts-native-healthy-path-refresh.vbrief.json
@@ -1,0 +1,119 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json"
+  },
+  "plan": {
+    "id": "s3-directive-update-ts-native",
+    "title": "S3: directive update TS-native healthy-path refresh",
+    "status": "pending",
+    "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
+    "narratives": {
+      "Description": "directive update today spawnSyncs the Go binary's upgrade path to refresh .deft/core. This story rewrites update to refresh .deft/core idempotently from the pinned @deftai/directive-content using the S1 primitive and the S2 orchestrator, re-render the AGENTS.md managed-section in place (surgical, self-healing), and honor the #1430 deft-core-guard PR separation. The refresh is engine-vs-content version-skew aware and emits the wizard's refresh side-effect disclosure.",
+      "ImplementationPlan": "- Replace the runDeftInstall delegation in packages/cli/src/init-cli/update.ts with a packages/core/src/init-deposit/refresh.ts path that re-copies content into .deft/core and re-renders the managed-section via the shared agents-md logic.\n- Port the surgical managed-section rewrite + refresh side-effect disclosure semantics from cmd/deft-install setup.go (WriteAgentsMD rewrite branch) and add a version-skew check comparing the resolved content version against the recorded deposit.\n- Add unit tests for an idempotent re-run (no spurious diffs), a stale managed-section rewrite, and a version-skew notice.",
+      "UserStory": "As an existing Deft user, I want directive update to refresh .deft/core and the AGENTS.md managed-section idempotently from the pinned content package, so that upgrades are clean, repeatable, and respect the core-guard PR separation."
+    },
+    "items": [
+      {
+        "id": "s3-directive-update-ts-native-a1",
+        "title": "When directive update runs, it refreshes .deft/core from the pinned content package with no Go binary spawned.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When directive update runs, it refreshes .deft/core from the pinned content package with no Go binary spawned."
+        }
+      },
+      {
+        "id": "s3-directive-update-ts-native-a2",
+        "title": "update re-renders the AGENTS.md managed-section surgically and a second run creates no new diff (idempotent).",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "update re-renders the AGENTS.md managed-section surgically and a second run creates no new diff (idempotent)."
+        }
+      },
+      {
+        "id": "s3-directive-update-ts-native-a3",
+        "title": "update honors the #1430 deft-core-guard separation and emits the refresh side-effect disclosure to the operator.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "update honors the #1430 deft-core-guard separation and emits the refresh side-effect disclosure to the operator."
+        }
+      },
+      {
+        "id": "s3-directive-update-ts-native-a4",
+        "title": "When the engine and content versions diverge, update emits a version-skew notice to the operator.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the engine and content versions diverge, update emits a version-skew notice to the operator."
+        }
+      },
+      {
+        "id": "s3-directive-update-ts-native-a5",
+        "title": "When the unit tests run, they cover idempotent re-run, stale managed-section rewrite, and the version-skew notice.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the unit tests run, they cover idempotent re-run, stale managed-section rewrite, and the version-skew notice."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/cli/src/init-cli/update.ts",
+          "packages/cli/src/init-cli/update.test.ts",
+          "packages/core/src/init-deposit/refresh.ts",
+          "packages/core/src/init-deposit/refresh.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm run build",
+          "pnpm --filter @deftai/directive-core test -- refresh",
+          "pnpm --filter @deftai/directive test -- update",
+          "task check"
+        ],
+        "expected_outputs": [
+          "directive update refreshes .deft/core idempotently from the content package, no Go binary",
+          "refresh module with idempotency + version-skew unit tests"
+        ],
+        "depends_on": [
+          "s1-content-deposit-primitive",
+          "s2-directive-init-ts-native"
+        ],
+        "conflict_group": "init-deposit",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to cmd/deft-install/setup.go (WriteAgentsMD rewrite branch, refresh side-effects) and #1942 scope, not a spec section."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1942",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1942: TS-native directive init/update deposit + gitignore .deft/core (HARD prereq for Go neuter)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/related",
+        "title": "Epic #1669 (distributable Deft) -- Wave 5"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/related",
+        "title": "Issue #1912 (frozen Go binary + gate) -- gated on this issue"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1941",
+        "type": "x-vbrief/related",
+        "title": "Issue #1941 (stage-2 migrate) -- owns the vendored->hybrid un-commit transition"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1933",
+        "type": "x-vbrief/related",
+        "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-24-s4-gitignore-deftcore-greenfield-write-reconstitution.vbrief.json
+++ b/vbrief/pending/2026-06-24-s4-gitignore-deftcore-greenfield-write-reconstitution.vbrief.json
@@ -1,0 +1,107 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 4 decomposed from proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json"
+  },
+  "plan": {
+    "id": "s4-gitignore-deft-core-reconstitution",
+    "title": "S4: gitignore .deft/core greenfield write + reconstitution",
+    "status": "pending",
+    "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
+    "narratives": {
+      "Description": "In the hybrid world .deft/core becomes gitignored and reconstituted by directive init (the node_modules model), which kills the upgrade churn loop (#1672). This story makes greenfield init write the .deft/core entry into .gitignore so the deposit is born ignored and never committed (no tracked-but-ignored half-state for new users), and makes the deposit idempotently reconstitutable when .deft/core is absent. Per the locked Option B journey split, this story does NOT un-commit an existing tracked deposit; the vendored->hybrid `git rm --cached` transition is owned by #1941.",
+      "ImplementationPlan": "- Extend the init-deposit gitignore step (packages/core/src/init-deposit/gitignore.ts) so greenfield init appends the .deft/core ignore entry to the canonical baseline, while preserving the existing selective entries and the EnsureGitignoreLines heal behavior ported from cmd/deft-install setup.go.\n- Make the deposit reconstitution idempotent: when .deft/core is absent, init re-copies it from the content package; when present, it is left/refreshed without re-writing the ignore entry.\n- Add unit tests for the born-ignored greenfield path, idempotent reconstitution, and the explicit non-un-commit of an already-tracked deposit (asserting #1941 owns that transition).",
+      "UserStory": "As a new Deft user, I want .deft/core gitignored and reconstitutable by directive init, so that my repo stays clean of framework-payload churn and the deposit rebuilds like node_modules."
+    },
+    "items": [
+      {
+        "id": "s4-gitignore-deft-core-reconstitution-a1",
+        "title": "When greenfield init runs, it creates a .deft/core entry in .gitignore so the deposit is never committed.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When greenfield init runs, it creates a .deft/core entry in .gitignore so the deposit is never committed."
+        }
+      },
+      {
+        "id": "s4-gitignore-deft-core-reconstitution-a2",
+        "title": "When .deft/core is absent, directive init recreates it idempotently from the installed content package.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When .deft/core is absent, directive init recreates it idempotently from the installed content package."
+        }
+      },
+      {
+        "id": "s4-gitignore-deft-core-reconstitution-a3",
+        "title": "When an existing tracked .deft/core deposit is present, init and update leave it tracked and defer the un-commit to #1941.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When an existing tracked .deft/core deposit is present, init and update leave it tracked and defer the un-commit to #1941."
+        }
+      },
+      {
+        "id": "s4-gitignore-deft-core-reconstitution-a4",
+        "title": "When the unit tests run, they cover born-ignored greenfield, idempotent reconstitution, and the non-un-commit behavior.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the unit tests run, they cover born-ignored greenfield, idempotent reconstitution, and the non-un-commit behavior."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/core/src/init-deposit/gitignore.ts",
+          "packages/core/src/init-deposit/gitignore.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm run build",
+          "pnpm --filter @deftai/directive-core test -- gitignore",
+          "task check"
+        ],
+        "expected_outputs": [
+          ".deft/core gitignored on greenfield init; deposit reconstitutable",
+          "gitignore module with born-ignored + reconstitution unit tests"
+        ],
+        "depends_on": [
+          "s2-directive-init-ts-native"
+        ],
+        "conflict_group": "init-deposit",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to cmd/deft-install/setup.go (EnsureGitignoreLines / canonicalGitignoreLines) and the #1942 decision-G journey split, not a spec section."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1942",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1942: TS-native directive init/update deposit + gitignore .deft/core (HARD prereq for Go neuter)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/related",
+        "title": "Epic #1669 (distributable Deft) -- Wave 5"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/related",
+        "title": "Issue #1912 (frozen Go binary + gate) -- gated on this issue"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1941",
+        "type": "x-vbrief/related",
+        "title": "Issue #1941 (stage-2 migrate) -- owns the vendored->hybrid un-commit transition"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1933",
+        "type": "x-vbrief/related",
+        "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-24-s5-docs-flip-greenfieldupgrade-e2e-legs.vbrief.json
+++ b/vbrief/pending/2026-06-24-s5-docs-flip-greenfieldupgrade-e2e-legs.vbrief.json
@@ -1,0 +1,110 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 5 decomposed from proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json"
+  },
+  "plan": {
+    "id": "s5-docs-flip-e2e-legs",
+    "title": "S5: docs flip + greenfield/upgrade e2e legs",
+    "status": "pending",
+    "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
+    "narratives": {
+      "Description": "Today's docs describe the Go-tarball, committed-.deft/core model, which contradicts the npm resolve-and-copy + gitignored model this epic delivers. This story flips the now-stale committed-payload statements (README, content/events/README.md) and finalizes the docs/ARCHITECTURE.md npm two-package section from a Wave 5 Target note to current behavior, then adds greenfield and upgrade legs to the pinned e2e so the deposit journeys are regression-guarded. It lands last because it documents and tests the behavior the earlier stories implement.",
+      "ImplementationPlan": "- Flip the stale current-model statements: README install/payload framing and content/events/README.md '.deft/core/ is a committed payload' to the npm resolve-and-copy + gitignored model, and un-fence the docs/ARCHITECTURE.md Wave 5 Target section to current behavior.\n- Add greenfield (nothing -> hybrid) and upgrade (hybrid -> newer hybrid) legs to the pinned release e2e exercising directive init/update deposit without the Go binary.\n- Verify the e2e legs run green and the docs no longer assert a committed payload.",
+      "UserStory": "As a Deft operator reading the docs, I want the install/architecture docs to describe the npm resolve-and-copy + gitignored model and the e2e to cover the deposit journeys, so that the documentation matches reality and the deposit path is regression-guarded."
+    },
+    "items": [
+      {
+        "id": "s5-docs-flip-e2e-legs-a1",
+        "title": "When a reader opens README and content/events/README.md, the text describes the resolve-and-copy gitignored model rather than a committed payload.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When a reader opens README and content/events/README.md, the text describes the resolve-and-copy gitignored model rather than a committed payload."
+        }
+      },
+      {
+        "id": "s5-docs-flip-e2e-legs-a2",
+        "title": "docs/ARCHITECTURE.md renders the npm two-package section as current behavior rather than a Wave 5 Target.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "docs/ARCHITECTURE.md renders the npm two-package section as current behavior rather than a Wave 5 Target."
+        }
+      },
+      {
+        "id": "s5-docs-flip-e2e-legs-a3",
+        "title": "The pinned e2e creates greenfield and upgrade deposit legs that exercise directive init and update without the Go binary.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "The pinned e2e creates greenfield and upgrade deposit legs that exercise directive init and update without the Go binary."
+        }
+      },
+      {
+        "id": "s5-docs-flip-e2e-legs-a4",
+        "title": "When the e2e legs run, they validate the deposit journeys and complete green.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "When the e2e legs run, they validate the deposit journeys and complete green."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "docs/ARCHITECTURE.md",
+          "README.md",
+          "content/events/README.md",
+          "packages/core/src/release-e2e/npm-ops.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm run build",
+          "pnpm --filter @deftai/directive-core test -- release-e2e",
+          "task check"
+        ],
+        "expected_outputs": [
+          "docs describe the npm resolve-and-copy + gitignored model (no committed-payload claims)",
+          "e2e greenfield + upgrade deposit legs green"
+        ],
+        "depends_on": [
+          "s2-directive-init-ts-native",
+          "s3-directive-update-ts-native"
+        ],
+        "conflict_group": "docs-e2e",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to the #1942 documentation-acceptance comment (flip stale committed-payload statements) and docs/ARCHITECTURE.md Wave 5 Target section, not a spec section."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1942",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1942: TS-native directive init/update deposit + gitignore .deft/core (HARD prereq for Go neuter)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/related",
+        "title": "Epic #1669 (distributable Deft) -- Wave 5"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/related",
+        "title": "Issue #1912 (frozen Go binary + gate) -- gated on this issue"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1941",
+        "type": "x-vbrief/related",
+        "title": "Issue #1941 (stage-2 migrate) -- owns the vendored->hybrid un-commit transition"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1933",
+        "type": "x-vbrief/related",
+        "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
+++ b/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
@@ -84,7 +84,7 @@
         "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
       },
       {
-        "uri": "active/2026-06-24-s1-content-dependency-ts-resolve-and-copy-deposit-primitive.vbrief.json",
+        "uri": "completed/2026-06-24-s1-content-dependency-ts-resolve-and-copy-deposit-primitive.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "S1: content dependency + TS resolve-and-copy deposit primitive",
         "TrustLevel": "internal"

--- a/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
+++ b/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
@@ -1,0 +1,123 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1942 (Wave 5 keystone)"
+  },
+  "plan": {
+    "title": "feat(cli): TS-native directive init/update deposit (absorb healthy-path bootstrap) + gitignore .deft/core",
+    "status": "proposed",
+    "narratives": {
+      "Description": "directive init / directive update today spawnSync the bundled Go deft-install binary, which downloads a tarball and vendors .deft/core. The #1933 decree (Go stops fetching the payload and never first-starts) and the #1912 freeze will break both the greenfield deposit (init) and the healthy-path upgrade (update) the moment they apply. This epic moves the deposit into the TS CLI: init/update resolve the locally-installed @deftai/directive-content package and copy its tree into .deft/core (no network), render the AGENTS.md managed-section, scaffold vbrief/, install githooks + the #1430 neutralization, and write the canonical .gitignore. It is the HARD prerequisite that must land before the Go neuter.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1942",
+      "Overview": "## What to build\n\nA TS-native deposit path so directive init (greenfield: nothing -> hybrid) and directive update (healthy-path: hybrid -> newer hybrid) no longer route through the Go binary.\n\nDeposit mechanism (locked, #1942 comment 2026-06-24): resolve @deftai/directive-content via Node module resolution and recursively COPY its tree into .deft/core -- NOT a tarball download. This requires adding @deftai/directive-content as a dependency of @deftai/directive (today the CLI depends only on -core).\n\nExisting TS building blocks that shrink the port: packages/core/src/content-root.ts (resolver, #1894), packages/core/src/platform/agents-md.ts + packages/core/src/doctor/agents-md.ts (managed-section logic), packages/core/src/packs/pack-render.ts. The Go logic to absorb lives in cmd/deft-install/{setup.go,upgrade.go,deposit.go,wizard.go}: VendorDeft (minus fetch), WriteAgentsMD, WriteConsumerVbrief, EnsureGitignoreLines, EnsureTaskfile, WriteAgentsSkills, the #1430 neutralization deposit, and the wizard UX.\n\n## gitignore decision (Option B + journey split, locked 2026-06-24)\n\nGreenfield init is born hybrid: it writes .deft/core to .gitignore from the first deposit so the deposit is never committed (no tracked-but-ignored half-state for new users). update on an EXISTING committed deposit does NOT unilaterally un-commit; the one-time `git rm --cached .deft/core` vendored->hybrid transition is deferred to #1941 (stage-2 migrate). #1942 builds the gitignore-write + idempotent reconstitution capability only.\n\n## Boundaries\n\n- Legacy-layout reshape stays the frozen Go binary (#1912).\n- The pre-engine gate stays the frozen Go binary (#1912) -- NOT absorbed into the TS CLI (bootstrap paradox, #1933).\n- The vendored->hybrid un-commit transition is #1941, not here.\n\n## Acceptance (epic-level, decomposed into stories)\n\n- directive init deposits a complete .deft/core + AGENTS.md + vbrief scaffold from the content package, no Go binary involved.\n- directive update refreshes .deft/core idempotently, re-renders the managed-section, respects core-guard separation.\n- .deft/core is gitignored on greenfield init and fully reconstitutable.\n- Friendly wizard UX preserved.\n- Covered by unit tests + greenfield + upgrade e2e legs.\n- Lands BEFORE the Go first-start removal / stop-fetch (#1912 / #1933).",
+      "Labels": "enhancement, area:cli, area:install, wave-5",
+      "ImplementationPlan": "- S1: add @deftai/directive-content dep to @deftai/directive; build a TS resolve-and-copy deposit primitive in packages/core (import.meta.resolve + recursive copy with mode preservation).\n- S2: rewrite directive init to orchestrate the TS deposit (copy content -> .deft/core, render AGENTS.md, scaffold vbrief, skills/githooks/neutralization, gitignore, Taskfile) instead of spawning Go; preserve wizard UX.\n- S3: rewrite directive update to refresh .deft/core idempotently from pinned content, re-render the managed-section, honor core-guard separation, be version-skew aware.\n- S4: greenfield gitignore .deft/core write + idempotent reconstitution (no un-commit; defer that to #1941).\n- S5: flip stale committed-payload docs (ARCHITECTURE/README/events), add greenfield + upgrade e2e legs.",
+      "UserStory": "As a new Deft user on an npm install, I want directive init/update to deposit and refresh .deft/core from the installed content package with no Go binary, so that the framework works offline-by-copy and the Go installer can be frozen and neutered."
+    },
+    "items": [
+      {
+        "title": "S1: content dependency + TS resolve-and-copy deposit primitive",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "@deftai/directive-content is a dependency of @deftai/directive; a TS deposit primitive resolves and recursively copies the content tree with mode preservation."
+        }
+      },
+      {
+        "title": "S2: directive init TS-native greenfield deposit",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "directive init deposits a complete .deft/core + AGENTS.md + vbrief scaffold + skills/githooks/neutralization from the content package with no Go binary involved."
+        }
+      },
+      {
+        "title": "S3: directive update TS-native healthy-path refresh",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "directive update refreshes .deft/core idempotently from pinned content, re-renders the managed-section, and respects core-guard separation."
+        }
+      },
+      {
+        "title": "S4: gitignore .deft/core greenfield write + reconstitution",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "greenfield init writes .deft/core to .gitignore and the deposit is fully reconstitutable; no existing tracked deposit is un-committed (deferred to #1941)."
+        }
+      },
+      {
+        "title": "S5: docs flip + greenfield/upgrade e2e legs",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "stale committed-payload statements are flipped and the pinned e2e covers the greenfield and upgrade deposit journeys."
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "area:cli",
+      "area:install",
+      "wave-5"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1942",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1942: TS-native directive init/update deposit + gitignore .deft/core (HARD prereq for Go neuter)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/related",
+        "title": "Epic #1669 (distributable Deft) -- Wave 5"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/related",
+        "title": "Issue #1912 (frozen Go binary + gate) -- gated on this issue"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1941",
+        "type": "x-vbrief/related",
+        "title": "Issue #1941 (stage-2 migrate) -- owns the vendored->hybrid un-commit transition"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1933",
+        "type": "x-vbrief/related",
+        "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
+      },
+      {
+        "uri": "active/2026-06-24-s1-content-dependency-ts-resolve-and-copy-deposit-primitive.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "S1: content dependency + TS resolve-and-copy deposit primitive",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "S2: directive init TS-native greenfield deposit",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-24-s3-directive-update-ts-native-healthy-path-refresh.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "S3: directive update TS-native healthy-path refresh",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-24-s4-gitignore-deftcore-greenfield-write-reconstitution.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "S4: gitignore .deft/core greenfield write + reconstitution",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-24-s5-docs-flip-greenfieldupgrade-e2e-legs.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "S5: docs flip + greenfield/upgrade e2e legs",
+        "TrustLevel": "internal"
+      }
+    ],
+    "id": "2026-06-24-1942-ts-native-init-update-deposit",
+    "metadata": {
+      "kind": "epic",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `@deftai/directive-content` as a `workspace:*` dependency of `@deftai/directive` (the engine CLI package).
- Implements pure core deposit primitives: `resolveInstalledContentRoot()` (via `import.meta.resolve`) and `copyTree()` with file-mode preservation mirroring Go `copyFile`/`copyDir` (#1477).
- Unit tests cover resolution success/failure and a recursive copy round-trip with executable-bit preservation.

This is S1 of epic #1942 — foundation only; init/update CLI wiring lands in S2/S3.

## Test plan

- [x] `pnpm install`
- [x] `pnpm run build`
- [x] `pnpm -w exec vitest run packages/core/src/deposit`
- [x] `task check` (all tests pass; local `verify:cache-fresh` stale-cache warning is environmental)

Refs #1942

Made with [Cursor](https://cursor.com)