### PR TITLE
feat(#1942 S2): TS-native directive init greenfield deposit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`directive init` now deposits locally from the npm content package with no Go binary** — greenfield init resolves `@deftai/directive-content`, copies it into `.deft/core`, renders the AGENTS.md managed-section, scaffolds `vbrief/`, wires `.agents/skills`, `.githooks`, the #1430 neutralization, and the Taskfile include, while preserving the friendly wizard UX. Refs #1942.
 - **TypeScript deposit primitives resolve and copy npm content locally** — the engine package now depends on `@deftai/directive-content`, and new core helpers resolve the installed content package via Node module resolution and recursively copy its tree with file-mode preservation (executable hooks included). This is the foundation for TS-native `directive init`/`update` without GitHub tarball downloads. Refs #1942.
 - **Architecture docs now describe the planned npm-native distribution model** — a clearly-marked "Wave 5 Target" section records the two-package npm model, the resolve-and-copy materialization step, and the frozen Go binary's reduced role as a health gate. Fenced as target architecture, not current behavior, so it cannot be misread as today's flow. Refs #1669 #1942 #1933.
 

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -1,3 +1,4 @@
+import * as initDeposit from "@deftai/directive-core/init-deposit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { dispatch, resetHandlerCacheForTests } from "../dispatch.js";
 import {
@@ -141,26 +142,16 @@ describe("routeAndDispatch", () => {
     expect(out.join("")).toContain("@deftai/directive");
   });
 
-  it("returns exit code 2 when bundled deft-install is missing", async () => {
-    const previous = process.env.DEFT_INSTALL_BINARY;
-    delete process.env.DEFT_INSTALL_BINARY;
-    try {
-      const err: string[] = [];
-      const code = await routeAndDispatch(["init"], {
-        writeOut: () => {},
-        writeErr: (text) => {
-          err.push(text);
-        },
-      });
-      expect(code).toBe(2);
-      expect(err.join("")).toContain("bundled deft-install binary not found");
-    } finally {
-      if (previous === undefined) {
-        delete process.env.DEFT_INSTALL_BINARY;
-      } else {
-        process.env.DEFT_INSTALL_BINARY = previous;
-      }
-    }
+  it("routes init through the TS-native deposit path", async () => {
+    vi.spyOn(initDeposit, "runInitDepositCli").mockResolvedValue(0);
+    const out: string[] = [];
+    const code = await routeAndDispatch(["init"], {
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: () => {},
+    });
+    expect(code).toBe(0);
   });
 
   it("routes verify branch to the same handler as verify:branch", async () => {

--- a/packages/cli/src/init-cli/init-cli.test.ts
+++ b/packages/cli/src/init-cli/init-cli.test.ts
@@ -1,9 +1,12 @@
+import { spawnSync } from "node:child_process";
 import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as initDeposit from "@deftai/directive-core/init-deposit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DispatchIo } from "../dispatch.js";
 import { CANONICAL_INIT_ARGV, CANONICAL_UPDATE_ARGV } from "./constants.js";
+import { runInit } from "./init.js";
 import {
   bundledBinaryCandidates,
   cliPackageRoot,
@@ -62,27 +65,24 @@ describe("runDeftInstall delegation", () => {
     vi.restoreAllMocks();
   });
 
-  it("init invokes bundled binary with canonical install argv and passthrough JSON", () => {
-    const { io, out } = captureIo();
+  it("update invokes bundled binary with canonical upgrade argv", () => {
+    const { io } = captureIo();
     const runBinary = vi.fn((): { status: number; stdout: string; stderr: string } => ({
       status: 0,
-      stdout: '{"ok":true,"action":"install"}\n',
+      stdout: '{"ok":true,"action":"upgrade"}\n',
       stderr: "",
     }));
 
     const code = runDeftInstall({
-      verb: "init",
-      canonicalArgv: CANONICAL_INIT_ARGV,
+      verb: "update",
+      canonicalArgv: CANONICAL_UPDATE_ARGV,
       io,
       resolveBinaryDetailed: () => ({ ok: true, path: "/bundled/deft-install" }),
       runBinary,
     });
 
     expect(code).toBe(0);
-    expect(runBinary).toHaveBeenCalledOnce();
-    expect(runBinary.mock.calls[0]?.[0]).toBe("/bundled/deft-install");
-    expect(runBinary.mock.calls[0]?.[1]).toEqual([...CANONICAL_INIT_ARGV]);
-    expect(out.join("")).toContain('"action":"install"');
+    expect(runBinary.mock.calls[0]?.[1]).toEqual([...CANONICAL_UPDATE_ARGV]);
   });
 
   it("update maps non-zero binary exit to non-zero CLI exit", () => {
@@ -102,49 +102,41 @@ describe("runDeftInstall delegation", () => {
     });
 
     expect(code).toBe(3);
-    expect(runBinary.mock.calls[0]?.[1]).toEqual([...CANONICAL_UPDATE_ARGV]);
     expect(err.join("")).toContain("upgrade refused");
   });
+});
 
-  it("emits remediation when bundled binary cannot be located", () => {
-    const { io, err } = captureIo();
-    const code = runDeftInstall({
-      verb: "init",
-      canonicalArgv: CANONICAL_INIT_ARGV,
-      io,
-      resolveBinaryDetailed: () => ({
-        ok: false,
-        reason: "not-found",
-        packageRoot: "/pkg/root",
-        platform: "linux",
-        arch: "x64",
-      }),
-    });
-
-    expect(code).toBe(2);
-    const message = err.join("");
-    expect(message).toContain("directive init:");
-    expect(message).toContain("bundled deft-install binary not found");
-    expect(message).toContain("/pkg/root/vendor/deft-install/install-linux-amd64");
-    expect(message).toContain("DEFT_INSTALL_BINARY");
-    expect(message).not.toContain("ENOENT");
+describe("runInit TS-native deposit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it("reports unreadable DEFT_INSTALL_BINARY override distinctly", () => {
-    const { io, err } = captureIo();
-    const code = runDeftInstall({
-      verb: "update",
-      canonicalArgv: CANONICAL_UPDATE_ARGV,
-      io,
-      resolveBinaryDetailed: () => ({
-        ok: false,
-        reason: "override-unreadable",
-        path: "/bad/deft-install",
-      }),
-    });
+  it("does not spawn bundled deft-install on the happy path", async () => {
+    const spawnSpy = vi.spyOn(spawnSync as never, "apply" as never);
+    const depositSpy = vi.spyOn(initDeposit, "runInitDepositCli").mockResolvedValue(0);
+    const { io } = captureIo();
 
-    expect(code).toBe(2);
-    expect(err.join("")).toContain("DEFT_INSTALL_BINARY is set to /bad/deft-install");
+    const code = await runInit([], io);
+
+    expect(code).toBe(0);
+    expect(depositSpy).toHaveBeenCalledOnce();
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes canonical init argv through parseInitArgv", async () => {
+    const depositSpy = vi.spyOn(initDeposit, "runInitDepositCli").mockResolvedValue(0);
+    const { io } = captureIo();
+
+    await runInit(["--repo-root", "/tmp/custom"], io);
+
+    expect(depositSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectDir: "/tmp/custom",
+        jsonOut: true,
+        nonInteractive: true,
+      }),
+    );
+    expect(CANONICAL_INIT_ARGV).toContain("--yes");
   });
 });
 

--- a/packages/cli/src/init-cli/init.ts
+++ b/packages/cli/src/init-cli/init.ts
@@ -2,7 +2,7 @@ import { parseInitArgv, runInitDepositCli } from "@deftai/directive-core/init-de
 import type { DispatchIo } from "../dispatch.js";
 import { CANONICAL_INIT_ARGV } from "./constants.js";
 
-export function runInit(argv: readonly string[], io: DispatchIo): number | Promise<number> {
+export function runInit(argv: readonly string[], io: DispatchIo): Promise<number> {
   const args = parseInitArgv(CANONICAL_INIT_ARGV, argv);
   return runInitDepositCli({
     ...args,

--- a/packages/cli/src/init-cli/init.ts
+++ b/packages/cli/src/init-cli/init.ts
@@ -1,12 +1,12 @@
+import { parseInitArgv, runInitDepositCli } from "@deftai/directive-core/init-deposit";
 import type { DispatchIo } from "../dispatch.js";
 import { CANONICAL_INIT_ARGV } from "./constants.js";
-import { runDeftInstall } from "./run-deft-install.js";
 
-export function runInit(argv: readonly string[], io: DispatchIo): number {
-  return runDeftInstall({
-    verb: "init",
-    canonicalArgv: CANONICAL_INIT_ARGV,
-    userArgv: argv,
-    io,
+export function runInit(argv: readonly string[], io: DispatchIo): number | Promise<number> {
+  const args = parseInitArgv(CANONICAL_INIT_ARGV, argv);
+  return runInitDepositCli({
+    ...args,
+    writeOut: io.writeOut,
+    writeErr: io.writeErr,
   });
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -181,6 +181,10 @@
     "./ts-check-lane": {
       "types": "./dist/ts-check-lane/index.d.ts",
       "default": "./dist/ts-check-lane/index.js"
+    },
+    "./init-deposit": {
+      "types": "./dist/init-deposit/index.d.ts",
+      "default": "./dist/init-deposit/index.js"
     }
   },
   "files": [

--- a/packages/core/src/init-deposit/index.ts
+++ b/packages/core/src/init-deposit/index.ts
@@ -1,0 +1,2 @@
+export * from "./init-deposit.js";
+export * from "./scaffold.js";

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -188,6 +188,43 @@ describe("runInitDeposit", () => {
     expect(lines.join("")).toContain("Next steps:");
   });
 
+  it("printNextSteps notes when skills were already present", () => {
+    const lines: string[] = [];
+    printNextSteps(
+      {
+        projectDir: "/proj",
+        deftDir: "/proj/.deft/core",
+        skillsCreated: false,
+        taskfileWired: false,
+        configDir: "/cfg",
+      },
+      { printf: (text) => lines.push(text) },
+    );
+    expect(lines.join("")).toContain("already present");
+  });
+
+  it("falls back to core package version when content package.json lacks version", async () => {
+    const project = freshRoot("init-version-fallback-");
+    const contentRoot = installFakeContentPackage(project);
+    writeFileSync(
+      join(contentRoot, "package.json"),
+      JSON.stringify({ name: CONTENT_PACKAGE_NAME }),
+      "utf8",
+    );
+
+    await runInitDeposit(
+      { projectDir: project, jsonOut: false, nonInteractive: true },
+      { printf: () => {} },
+      {
+        resolveContentRoot: async () => contentRoot,
+        readPackageVersion: () => "0.99.0",
+        gitHooks: { getHooksPath: () => "", setHooksPath: () => true },
+      },
+    );
+
+    expect(readFileSync(join(project, ".deft/core", "VERSION"), "utf8")).toContain("0.99.0");
+  });
+
   it("returns exit code 1 when deposit fails", async () => {
     const out: string[] = [];
     const err: string[] = [];

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -151,7 +151,11 @@ describe("runInitDeposit", () => {
     });
 
     expect(code).toBe(0);
-    const payload = JSON.parse(out.join(""));
+    const parsed: unknown = JSON.parse(out.join(""));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("expected JSON object from init --json");
+    }
+    const payload = parsed as Record<string, unknown>;
     expect(payload.success).toBe(true);
     expect(payload.action).toBe("install");
     expect(payload.taskfile_wired).toBe(true);

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -1,0 +1,212 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CONTENT_PACKAGE_NAME } from "../deposit/resolve-content.js";
+import {
+  buildInstallSummaryJson,
+  parseInitArgv,
+  printNextSteps,
+  runInitDeposit,
+  runInitDepositCli,
+} from "./init-deposit.js";
+
+describe("parseInitArgv", () => {
+  it("merges canonical and user argv", () => {
+    const parsed = parseInitArgv(
+      ["--yes", "--repo-root", ".", "--json"],
+      ["--repo-root", "/tmp/proj"],
+    );
+    expect(parsed.nonInteractive).toBe(true);
+    expect(parsed.jsonOut).toBe(true);
+    expect(parsed.projectDir).toBe("/tmp/proj");
+  });
+
+  it("accepts Windows-style aliases", () => {
+    const parsed = parseInitArgv([], ["/yes", "/json", "/repo-root", "/tmp/win"]);
+    expect(parsed.nonInteractive).toBe(true);
+    expect(parsed.jsonOut).toBe(true);
+    expect(parsed.projectDir).toBe("/tmp/win");
+  });
+});
+
+describe("runInitDeposit", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshRoot(prefix: string): string {
+    const root = mkdtempSync(join(tmpdir(), prefix));
+    created.push(root);
+    return root;
+  }
+
+  function installFakeContentPackage(projectRoot: string): string {
+    const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
+    mkdirSync(join(pkgDir, "templates"), { recursive: true });
+    mkdirSync(join(pkgDir, "vbrief", "schemas"), { recursive: true });
+    mkdirSync(join(pkgDir, ".githooks"), { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: CONTENT_PACKAGE_NAME, version: "0.53.0" }),
+      "utf8",
+    );
+    copyFileSync(
+      join(process.cwd(), "content/templates/agents-entry.md"),
+      join(pkgDir, "templates/agents-entry.md"),
+    );
+    writeFileSync(join(pkgDir, "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(pkgDir, "vbrief", "schemas", "cache-meta.schema.json"), "{}\n", "utf8");
+    writeFileSync(join(pkgDir, "vbrief", "vbrief.md"), "# vbrief\n", "utf8");
+    writeFileSync(join(pkgDir, ".githooks", "pre-commit"), "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(join(pkgDir, ".githooks", "pre-commit"), 0o755);
+    writeFileSync(join(pkgDir, "Taskfile.yml"), "version: '3'\n", "utf8");
+    return pkgDir;
+  }
+
+  it("creates a complete greenfield deposit without spawning deft-install", async () => {
+    const spawnSpy = vi.spyOn(spawnSync as never, "apply" as never).mockImplementation(() => {
+      throw new Error("spawnSync should not be called on TS-native init happy path");
+    });
+
+    const project = freshRoot("init-deposit-");
+    const contentRoot = installFakeContentPackage(project);
+    const lines: string[] = [];
+
+    const result = await runInitDeposit(
+      { projectDir: project, jsonOut: false, nonInteractive: true },
+      { printf: (text) => lines.push(text) },
+      {
+        resolveContentRoot: async () => contentRoot,
+        nowIso: () => "2026-06-24T12:00:00Z",
+        gitHooks: { getHooksPath: () => "", setHooksPath: () => true },
+      },
+    );
+
+    expect(result.deftDir).toBe(join(project, ".deft/core"));
+    expect(readFileSync(join(result.deftDir, "main.md"), "utf8")).toContain("# Deft");
+    expect(readFileSync(join(project, "AGENTS.md"), "utf8")).toContain("deft:managed-section");
+    expect(existsSync(join(project, "vbrief", "active", ".gitkeep"))).toBe(true);
+    expect(existsSync(join(project, ".agents/skills/deft-directive-sync/SKILL.md"))).toBe(true);
+    expect(existsSync(join(project, ".githooks", "pre-commit"))).toBe(true);
+    expect(readFileSync(join(project, "Taskfile.yml"), "utf8")).toContain(
+      "./.deft/core/Taskfile.yml",
+    );
+    expect(readFileSync(join(project, "greptile.json"), "utf8")).toContain(".deft/core/**");
+    expect(result.taskfileWired).toBe(true);
+    expect(lines.join("")).toContain("AGENTS.md created");
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits JSON on stdout and wizard UX on stderr in --json mode", async () => {
+    const project = freshRoot("init-deposit-json-");
+    const contentRoot = installFakeContentPackage(project);
+    const out: string[] = [];
+    const err: string[] = [];
+
+    const code = await runInitDepositCli({
+      projectDir: project,
+      jsonOut: true,
+      nonInteractive: true,
+      writeOut: (text) => out.push(text),
+      writeErr: (text) => err.push(text),
+      seams: {
+        resolveContentRoot: async () => contentRoot,
+        gitHooks: { getHooksPath: () => "", setHooksPath: () => true },
+      },
+    });
+
+    expect(code).toBe(0);
+    const payload = JSON.parse(out.join(""));
+    expect(payload.success).toBe(true);
+    expect(payload.action).toBe("install");
+    expect(payload.taskfile_wired).toBe(true);
+    expect(err.join("")).toContain("Deft installed successfully");
+  });
+
+  it("buildInstallSummaryJson keeps stable array fields", () => {
+    const summary = buildInstallSummaryJson(
+      {
+        projectDir: "/proj",
+        deftDir: "/proj/.deft/core",
+        skillsCreated: true,
+        taskfileWired: true,
+        configDir: "/home/me/.config/deft",
+      },
+      { projectDir: "/proj", jsonOut: true, nonInteractive: true },
+    );
+    expect(summary.missing_tools).toEqual([]);
+    expect(summary.dirty_files).toEqual([]);
+  });
+
+  it("printNextSteps includes friendly wizard lines", () => {
+    const lines: string[] = [];
+    printNextSteps(
+      {
+        projectDir: "/proj",
+        deftDir: "/proj/.deft/core",
+        skillsCreated: true,
+        taskfileWired: true,
+        configDir: "/cfg",
+      },
+      { printf: (text) => lines.push(text) },
+    );
+    expect(lines.join("")).toContain("Next steps:");
+  });
+
+  it("returns exit code 1 when deposit fails", async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = await runInitDepositCli({
+      projectDir: "/nonexistent/should-not-matter",
+      jsonOut: true,
+      nonInteractive: true,
+      writeOut: (text) => out.push(text),
+      writeErr: (text) => err.push(text),
+      seams: {
+        resolveContentRoot: async () => {
+          throw new Error("content package missing");
+        },
+      },
+    });
+    expect(code).toBe(1);
+    expect(out.join("")).toContain("init_deposit_failed");
+    expect(err.join("")).toContain("content package missing");
+  });
+
+  it("prints wizard UX to stdout in interactive mode", async () => {
+    const project = freshRoot("init-deposit-interactive-");
+    const contentRoot = installFakeContentPackage(project);
+    const out: string[] = [];
+
+    const code = await runInitDepositCli({
+      projectDir: project,
+      jsonOut: false,
+      nonInteractive: true,
+      writeOut: (text) => out.push(text),
+      writeErr: () => {},
+      seams: {
+        resolveContentRoot: async () => contentRoot,
+        gitHooks: { getHooksPath: () => "", setHooksPath: () => true },
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("Deft installed successfully");
+  });
+});

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -15,10 +15,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CONTENT_PACKAGE_NAME } from "../deposit/resolve-content.js";
 import {
   buildInstallSummaryJson,
+  createUserConfigDir,
   parseInitArgv,
   printNextSteps,
   runInitDeposit,
   runInitDepositCli,
+  userConfigDir,
 } from "./init-deposit.js";
 
 describe("parseInitArgv", () => {
@@ -37,6 +39,23 @@ describe("parseInitArgv", () => {
     expect(parsed.nonInteractive).toBe(true);
     expect(parsed.jsonOut).toBe(true);
     expect(parsed.projectDir).toBe("/tmp/win");
+  });
+
+  it("honors DEFT_USER_PATH for the config directory", () => {
+    const previous = process.env.DEFT_USER_PATH;
+    const customDir = mkdtempSync(join(tmpdir(), "deft-user-"));
+    process.env.DEFT_USER_PATH = customDir;
+    try {
+      expect(userConfigDir()).toBe(customDir);
+      const lines: string[] = [];
+      writeFileSync(join(customDir, "USER.md"), "# existing\n", "utf8");
+      expect(createUserConfigDir({ printf: (text) => lines.push(text) })).toBe(customDir);
+      expect(lines.join("")).toContain("keeping existing file");
+    } finally {
+      if (previous === undefined) delete process.env.DEFT_USER_PATH;
+      else process.env.DEFT_USER_PATH = previous;
+      rmSync(customDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/init-deposit/init-deposit.ts
+++ b/packages/core/src/init-deposit/init-deposit.ts
@@ -1,0 +1,246 @@
+/**
+ * TS-native greenfield init deposit orchestrator (#1942 S2).
+ *
+ * Composes the S1 resolve-and-copy primitive with AGENTS.md render, vbrief
+ * scaffold, skills/githooks/#1430 neutralization, and Taskfile wiring.
+ * Refs #1942, #11, #1430.
+ */
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join, resolve } from "node:path";
+import { copyTree } from "../deposit/copy-tree.js";
+import { resolveInstalledContentRoot } from "../deposit/resolve-content.js";
+import { readCorePackageVersion } from "../engine-version.js";
+import {
+  CANONICAL_INSTALL_ROOT,
+  depositNeutralization,
+  ensureTaskfile,
+  type InitDepositIo,
+  type InstallManifestFields,
+  writeAgentsMd,
+  writeAgentsSkills,
+  writeConsumerGitHooks,
+  writeConsumerVbrief,
+  writeInstallManifest,
+} from "./scaffold.js";
+
+export interface InitDepositArgs {
+  readonly projectDir: string;
+  readonly jsonOut: boolean;
+  readonly nonInteractive: boolean;
+}
+
+export interface InitDepositResult {
+  readonly projectDir: string;
+  readonly deftDir: string;
+  readonly skillsCreated: boolean;
+  readonly taskfileWired: boolean;
+  readonly configDir: string;
+}
+
+export interface InitDepositSeams {
+  resolveContentRoot?: () => Promise<string>;
+  copyContent?: (src: string, dst: string) => Promise<void>;
+  readPackageVersion?: () => string;
+  nowIso?: () => string;
+  gitHooks?: Parameters<typeof writeConsumerGitHooks>[3];
+}
+
+export function parseInitArgv(
+  canonicalArgv: readonly string[],
+  userArgv: readonly string[] = [],
+): InitDepositArgs {
+  const args = [...canonicalArgv, ...userArgv];
+  let projectDir = process.cwd();
+  let jsonOut = false;
+  let nonInteractive = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--json" || arg === "/json") jsonOut = true;
+    if (
+      arg === "--yes" ||
+      arg === "--non-interactive" ||
+      arg === "/yes" ||
+      arg === "/non-interactive"
+    ) {
+      nonInteractive = true;
+    }
+    if ((arg === "--repo-root" || arg === "/repo-root") && args[i + 1]) {
+      projectDir = resolve(args[i + 1] ?? projectDir);
+      i += 1;
+    }
+  }
+
+  return { projectDir: resolve(projectDir), jsonOut, nonInteractive };
+}
+
+export function userConfigDir(): string {
+  const override = process.env.DEFT_USER_PATH?.trim();
+  if (override) return resolve(override);
+  if (platform() === "win32") {
+    const appData = process.env.APPDATA?.trim();
+    return appData ? join(appData, "deft") : join(homedir(), "AppData", "Roaming", "deft");
+  }
+  return join(homedir(), ".config", "deft");
+}
+
+export function createUserConfigDir(io: InitDepositIo): string {
+  const dir = userConfigDir();
+  mkdirSync(dir, { recursive: true });
+  const userMd = join(dir, "USER.md");
+  if (existsSync(userMd)) {
+    io.printf(`USER.md already exists at ${userMd} — keeping existing file.\n`);
+  }
+  return dir;
+}
+
+function readContentVersion(contentRoot: string, readVersion = readCorePackageVersion): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(contentRoot, "package.json"), "utf8")) as {
+      version?: string;
+    };
+    if (pkg.version?.trim()) return pkg.version.trim();
+  } catch {
+    // fall through
+  }
+  return readVersion();
+}
+
+export function buildInstallSummaryJson(
+  result: InitDepositResult,
+  options: InitDepositArgs,
+): Record<string, unknown> {
+  return {
+    success: true,
+    action: "install",
+    version: readCorePackageVersion(),
+    project_dir: result.projectDir,
+    deft_dir: result.deftDir,
+    legacy_layout: false,
+    update: false,
+    non_interactive: options.nonInteractive,
+    upgrade: false,
+    taskfile_wired: result.taskfileWired,
+    missing_tools: [],
+    maintainer_mode: false,
+    maintainer_tools: [],
+    skipped_consumer_projections: [],
+    user_config_dir: result.configDir,
+    skills_created: result.skillsCreated,
+    payload_layout: "vendored",
+    strategy: "vendor",
+    dirty_tree: false,
+    dirty_files: [],
+    staged_paths: [],
+    backup_path: "",
+    previous_version: "",
+  };
+}
+
+export function printNextSteps(result: InitDepositResult, io: InitDepositIo): void {
+  const skillsStatus = result.skillsCreated ? "created" : "already present";
+  io.printf("\n✓ Deft installed successfully!\n\n");
+  io.printf(`  Location     : ${result.deftDir}\n`);
+  io.printf("  AGENTS.md    : updated\n");
+  io.printf(`  Skills       : .agents/skills/ ${skillsStatus} (auto-discovered by AI agents)\n`);
+  io.printf(`  User config  : ${result.configDir}\n`);
+  io.printf("\nNext steps:\n");
+  io.printf(`  1. Open your AI coding assistant in ${result.projectDir}\n`);
+  io.printf("  2. Deft skill auto-discovery is partially implemented — if your agent doesn't\n");
+  io.printf('     start setup automatically, tell it: "Use AGENTS.md"\n');
+  io.printf(
+    "  3. On first session, the agent will guide you through creating USER.md and PROJECT-DEFINITION.vbrief.json\n",
+  );
+  io.printf("\n");
+}
+
+export async function runInitDeposit(
+  args: InitDepositArgs,
+  io: InitDepositIo,
+  seams: InitDepositSeams = {},
+): Promise<InitDepositResult> {
+  const projectDir = args.projectDir;
+  const deftDir = join(projectDir, CANONICAL_INSTALL_ROOT);
+  const resolveContent = seams.resolveContentRoot ?? resolveInstalledContentRoot;
+  const copyContent = seams.copyContent ?? copyTree;
+
+  const contentRoot = await resolveContent();
+  await copyContent(contentRoot, deftDir);
+
+  const nowIso = seams.nowIso ?? (() => new Date().toISOString().replace(/\.\d{3}Z$/, "Z"));
+  const version = readContentVersion(
+    contentRoot,
+    seams.readPackageVersion ?? readCorePackageVersion,
+  );
+  const manifestFields: InstallManifestFields = {
+    ref: version.startsWith("v") ? version : `v${version}`,
+    sha: "content-package",
+    tag: version.startsWith("v") ? version : `v${version}`,
+    installRoot: CANONICAL_INSTALL_ROOT,
+    fetchedAt: nowIso(),
+    fetchedBy: "directive-init",
+  };
+  writeInstallManifest(projectDir, deftDir, manifestFields);
+
+  writeAgentsMd(projectDir, deftDir, io);
+  const skillsCreated = writeAgentsSkills(projectDir, io);
+  await depositNeutralization(projectDir, io);
+  await writeConsumerVbrief(projectDir, deftDir, io);
+  writeConsumerGitHooks(projectDir, deftDir, io, seams.gitHooks);
+
+  let taskfileWired = false;
+  if (args.nonInteractive) {
+    taskfileWired = ensureTaskfile(projectDir, io);
+  }
+
+  const configDir = createUserConfigDir(io);
+
+  return {
+    projectDir,
+    deftDir,
+    skillsCreated,
+    taskfileWired,
+    configDir,
+  };
+}
+
+export interface RunInitDepositCliOptions extends InitDepositArgs {
+  readonly writeOut: (text: string) => void;
+  readonly writeErr: (text: string) => void;
+  readonly seams?: InitDepositSeams;
+}
+
+/** CLI-facing wrapper: runs deposit, emits JSON or wizard UX, returns exit code. */
+export async function runInitDepositCli(options: RunInitDepositCliOptions): Promise<number> {
+  const io: InitDepositIo = {
+    printf: (text) => {
+      if (options.jsonOut) {
+        options.writeErr(text);
+      } else {
+        options.writeOut(text);
+      }
+    },
+  };
+
+  try {
+    const result = await runInitDeposit(options, io, options.seams);
+    if (options.jsonOut) {
+      options.writeOut(`${JSON.stringify(buildInstallSummaryJson(result, options), null, 2)}\n`);
+      printNextSteps(result, { printf: options.writeErr });
+    } else {
+      printNextSteps(result, io);
+    }
+    return 0;
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    options.writeErr(`directive init: ${message}\n`);
+    if (options.jsonOut) {
+      options.writeOut(
+        `${JSON.stringify({ success: false, error: message, error_code: "init_deposit_failed" }, null, 2)}\n`,
+      );
+    }
+    return 1;
+  }
+}

--- a/packages/core/src/init-deposit/init-deposit.ts
+++ b/packages/core/src/init-deposit/init-deposit.ts
@@ -98,10 +98,11 @@ export function createUserConfigDir(io: InitDepositIo): string {
 
 function readContentVersion(contentRoot: string, readVersion = readCorePackageVersion): string {
   try {
-    const pkg = JSON.parse(readFileSync(join(contentRoot, "package.json"), "utf8")) as {
-      version?: string;
-    };
-    if (pkg.version?.trim()) return pkg.version.trim();
+    const parsed: unknown = JSON.parse(readFileSync(join(contentRoot, "package.json"), "utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const version = (parsed as { version?: string }).version;
+      if (version?.trim()) return version.trim();
+    }
   } catch {
     // fall through
   }

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -259,6 +259,21 @@ describe("init-deposit scaffold", () => {
     ).toBe(false);
   });
 
+  it("warns when git config cannot wire core.hooksPath", () => {
+    const project = freshRoot("scaffold-hooks-config-fail-");
+    const deftDir = join(project, ".deft/core");
+    seedFramework(deftDir);
+    const { lines, io } = captureIo();
+    expect(
+      writeConsumerGitHooks(project, deftDir, io, {
+        getHooksPath: () => "",
+        setHooksPath: () => false,
+      }),
+    ).toBe(true);
+    expect(lines.join("")).toContain("Warning: could not set core.hooksPath");
+    expect(lines.join("")).toContain(".githooks/ deposited");
+  });
+
   it("refreshes a stale deft-core guard and skips absent hook sources", () => {
     const project = freshRoot("scaffold-guard-refresh-");
     const deftDir = join(project, ".deft/core");

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -1,0 +1,289 @@
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
+import {
+  buildInstallManifestText,
+  CANONICAL_TASKFILE_INCLUDE,
+  depositNeutralization,
+  ensureCodeqlPathsIgnore,
+  ensureCoreGuardWorkflow,
+  ensureGitattributes,
+  ensureGreptileIgnore,
+  ensureTaskfile,
+  pruneFrameworkSelfTests,
+  pruneVendoredTsTests,
+  writeAgentsMd,
+  writeAgentsSkills,
+  writeConsumerGitHooks,
+  writeConsumerVbrief,
+  writeInstallManifest,
+} from "./scaffold.js";
+
+describe("init-deposit scaffold", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshRoot(prefix: string): string {
+    const root = mkdtempSync(join(tmpdir(), prefix));
+    created.push(root);
+    return root;
+  }
+
+  function captureIo(): { lines: string[]; io: { printf: (text: string) => void } } {
+    const lines: string[] = [];
+    return {
+      lines,
+      io: {
+        printf: (text) => {
+          lines.push(text);
+        },
+      },
+    };
+  }
+
+  function seedFramework(deftDir: string): void {
+    mkdirSync(join(deftDir, "templates"), { recursive: true });
+    copyFileSync(
+      join(process.cwd(), "content/templates/agents-entry.md"),
+      join(deftDir, "templates/agents-entry.md"),
+    );
+    mkdirSync(join(deftDir, "vbrief", "schemas"), { recursive: true });
+    writeFileSync(join(deftDir, "vbrief", "schemas", "example.schema.json"), "{}\n", "utf8");
+    writeFileSync(join(deftDir, "vbrief", "vbrief.md"), "# vbrief\n", "utf8");
+    mkdirSync(join(deftDir, ".githooks"), { recursive: true });
+    writeFileSync(join(deftDir, ".githooks", "pre-commit"), "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(join(deftDir, ".githooks", "pre-commit"), 0o755);
+  }
+
+  it("writes AGENTS.md managed section on greenfield", () => {
+    const project = freshRoot("scaffold-agents-");
+    const deftDir = join(project, ".deft/core");
+    seedFramework(deftDir);
+    const { io } = captureIo();
+
+    expect(writeAgentsMd(project, deftDir, io)).toBe(true);
+    const agents = readFileSync(join(project, "AGENTS.md"), "utf8");
+    expect(agents).toContain("<!-- deft:managed-section");
+    expect(agents).toContain(AGENTS_MANAGED_CLOSE);
+  });
+
+  it("deposits vbrief lifecycle dirs and schemas", async () => {
+    const project = freshRoot("scaffold-vbrief-");
+    const deftDir = join(project, ".deft/core");
+    seedFramework(deftDir);
+    const { io } = captureIo();
+
+    expect(await writeConsumerVbrief(project, deftDir, io)).toBe(true);
+    for (const sub of ["proposed", "pending", "active", "completed", "cancelled"]) {
+      expect(existsSync(join(project, "vbrief", sub, ".gitkeep"))).toBe(true);
+    }
+    expect(existsSync(join(project, "vbrief", "schemas", "example.schema.json"))).toBe(true);
+    expect(readFileSync(join(project, "vbrief", "vbrief.md"), "utf8")).toContain("# vbrief");
+  });
+
+  it("creates .agents/skills pointers idempotently", () => {
+    const project = freshRoot("scaffold-skills-");
+    const { io } = captureIo();
+
+    expect(writeAgentsSkills(project, io)).toBe(true);
+    expect(readFileSync(join(project, ".agents/skills/deft/SKILL.md"), "utf8")).toContain(
+      ".deft/core/SKILL.md",
+    );
+    expect(writeAgentsSkills(project, io)).toBe(false);
+  });
+
+  it("wires Taskfile include idempotently", () => {
+    const project = freshRoot("scaffold-taskfile-");
+    const { io } = captureIo();
+
+    expect(ensureTaskfile(project, io)).toBe(true);
+    const taskfile = readFileSync(join(project, "Taskfile.yml"), "utf8");
+    expect(taskfile).toContain(CANONICAL_TASKFILE_INCLUDE);
+    expect(ensureTaskfile(project, io)).toBe(false);
+  });
+
+  it("deposits consumer git hooks from framework payload", () => {
+    const project = freshRoot("scaffold-hooks-");
+    const deftDir = join(project, ".deft/core");
+    seedFramework(deftDir);
+    const { io } = captureIo();
+
+    expect(
+      writeConsumerGitHooks(project, deftDir, io, {
+        getHooksPath: () => "",
+        setHooksPath: () => true,
+      }),
+    ).toBe(true);
+    expect(readFileSync(join(project, ".githooks", "pre-commit"), "utf8")).toContain("#!/bin/sh");
+  });
+
+  it("deposits #1430 neutralization artifacts", async () => {
+    const project = freshRoot("scaffold-neutral-");
+    const { io } = captureIo();
+
+    await depositNeutralization(project, io);
+
+    expect(readFileSync(join(project, ".gitattributes"), "utf8")).toContain(".deft/core/**");
+    expect(readFileSync(join(project, "greptile.json"), "utf8")).toContain(".deft/core/**");
+    expect(readFileSync(join(project, ".github/codeql/codeql-config.yml"), "utf8")).toContain(
+      "paths-ignore",
+    );
+    expect(existsSync(join(project, ".github/workflows/deft-core-guard.yml"))).toBe(true);
+  });
+
+  it("skips AGENTS.md rewrite when the managed section is already current", () => {
+    const project = freshRoot("scaffold-agents-current-");
+    const deftDir = join(project, ".deft/core");
+    seedFramework(deftDir);
+    const { io } = captureIo();
+    writeAgentsMd(project, deftDir, io);
+    expect(writeAgentsMd(project, deftDir, io)).toBe(false);
+  });
+
+  it("inserts deft include into an existing top-level includes block", () => {
+    const project = freshRoot("scaffold-taskfile-includes-");
+    writeFileSync(
+      join(project, "Taskfile.yml"),
+      "version: '3'\nincludes:\n  app:\n    taskfile: ./app/Taskfile.yml\n",
+      "utf8",
+    );
+    const { io } = captureIo();
+    expect(ensureTaskfile(project, io)).toBe(true);
+    expect(readFileSync(join(project, "Taskfile.yml"), "utf8")).toContain(
+      CANONICAL_TASKFILE_INCLUDE,
+    );
+  });
+
+  it("skips vbrief deposit when the scaffold already exists", async () => {
+    const project = freshRoot("scaffold-vbrief-skip-");
+    const deftDir = join(project, ".deft/core");
+    seedFramework(deftDir);
+    const { io } = captureIo();
+    await writeConsumerVbrief(project, deftDir, io);
+    expect(await writeConsumerVbrief(project, deftDir, io)).toBe(false);
+  });
+
+  it("neutralization and manifest helpers are idempotent", async () => {
+    const project = freshRoot("scaffold-idempotent-");
+    const { io } = captureIo();
+    await depositNeutralization(project, io);
+    expect(ensureGitattributes(project, io)).toBe(false);
+    expect(ensureGreptileIgnore(project, io)).toBe(false);
+    expect(ensureCodeqlPathsIgnore(project, io)).toBe(false);
+    expect(ensureCoreGuardWorkflow(project, io)).toBe(false);
+
+    const manifestPath = writeInstallManifest(project, join(project, ".deft/core"), {
+      ref: "v0.53.0",
+      sha: "abc",
+      tag: "0.53.0",
+      installRoot: ".deft/core",
+      fetchedAt: "2026-06-24T12:00:00Z",
+      fetchedBy: "test",
+    });
+    expect(readFileSync(manifestPath, "utf8")).toContain("install_root: '.deft/core'");
+    expect(
+      buildInstallManifestText({
+        ref: "",
+        sha: "abc",
+        tag: "0.53.0",
+        installRoot: ".deft/core",
+        fetchedAt: "t",
+        fetchedBy: "test",
+      }),
+    ).toContain("tag: 'v0.53.0'");
+  });
+
+  it("prunes framework self-tests and vendored TS test files", async () => {
+    const project = freshRoot("scaffold-prune-");
+    const { io } = captureIo();
+    mkdirSync(join(project, ".deft/core/tests/unit"), { recursive: true });
+    writeFileSync(join(project, ".deft/core/tests/unit/a.test.ts"), "export {}\n", "utf8");
+    mkdirSync(join(project, ".deft/core/packages/cli/src"), { recursive: true });
+    writeFileSync(join(project, ".deft/core/packages/cli/src/foo.test.ts"), "export {}\n", "utf8");
+    writeFileSync(join(project, ".deft/core/packages/cli/src/index.ts"), "export {}\n", "utf8");
+
+    expect(await pruneFrameworkSelfTests(project, io)).toBe(true);
+    expect(await pruneVendoredTsTests(project, io)).toBe(1);
+    expect(existsSync(join(project, ".deft/core/tests"))).toBe(false);
+    expect(existsSync(join(project, ".deft/core/packages/cli/src/foo.test.ts"))).toBe(false);
+    expect(existsSync(join(project, ".deft/core/packages/cli/src/index.ts"))).toBe(true);
+  });
+
+  it("updates greptile.json and appends Taskfile include when no includes block exists", () => {
+    const project = freshRoot("scaffold-more-branches-");
+    writeFileSync(join(project, "greptile.json"), '{"reviewRules":[]}\n', "utf8");
+    writeFileSync(
+      join(project, "Taskfile.yml"),
+      "version: '3'\ntasks:\n  hi:\n    cmds: [echo hi]\n",
+      "utf8",
+    );
+    const { io } = captureIo();
+
+    expect(ensureGreptileIgnore(project, io)).toBe(true);
+    expect(ensureTaskfile(project, io)).toBe(true);
+    expect(readFileSync(join(project, "Taskfile.yml"), "utf8")).toContain(
+      CANONICAL_TASKFILE_INCLUDE,
+    );
+  });
+
+  it("skips hook wiring when consumer hooks already match the payload", () => {
+    const project = freshRoot("scaffold-hooks-skip-");
+    const deftDir = join(project, ".deft/core");
+    seedFramework(deftDir);
+    const { io } = captureIo();
+    writeConsumerGitHooks(project, deftDir, io, {
+      getHooksPath: () => ".githooks",
+      setHooksPath: () => true,
+    });
+    expect(
+      writeConsumerGitHooks(project, deftDir, io, {
+        getHooksPath: () => ".githooks",
+        setHooksPath: () => false,
+      }),
+    ).toBe(false);
+  });
+
+  it("refreshes a stale deft-core guard and skips absent hook sources", () => {
+    const project = freshRoot("scaffold-guard-refresh-");
+    const deftDir = join(project, ".deft/core");
+    const { io } = captureIo();
+    mkdirSync(join(project, ".github/workflows"), { recursive: true });
+    writeFileSync(
+      join(project, ".github/workflows/deft-core-guard.yml"),
+      "name: deft-core-guard\nold: true\n",
+      "utf8",
+    );
+    expect(ensureCoreGuardWorkflow(project, io)).toBe(true);
+    expect(writeConsumerGitHooks(project, deftDir, io)).toBe(false);
+  });
+
+  it("inserts deft include after an includes line with an inline comment", () => {
+    const project = freshRoot("scaffold-taskfile-comment-");
+    writeFileSync(
+      join(project, "Taskfile.yml"),
+      "version: '3'\nincludes:  # app tasks\n  app:\n    taskfile: ./app/Taskfile.yml\n",
+      "utf8",
+    );
+    const { io } = captureIo();
+    expect(ensureTaskfile(project, io)).toBe(true);
+    expect(readFileSync(join(project, "Taskfile.yml"), "utf8")).toContain(
+      CANONICAL_TASKFILE_INCLUDE,
+    );
+  });
+});

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -286,4 +286,34 @@ describe("init-deposit scaffold", () => {
       CANONICAL_TASKFILE_INCLUDE,
     );
   });
+
+  it("leaves a non-deft core guard workflow untouched", () => {
+    const project = freshRoot("scaffold-guard-foreign-");
+    mkdirSync(join(project, ".github/workflows"), { recursive: true });
+    writeFileSync(
+      join(project, ".github/workflows/deft-core-guard.yml"),
+      "name: custom-guard\n",
+      "utf8",
+    );
+    const { io } = captureIo();
+    expect(ensureCoreGuardWorkflow(project, io)).toBe(false);
+    expect(readFileSync(join(project, ".github/workflows/deft-core-guard.yml"), "utf8")).toContain(
+      "custom-guard",
+    );
+  });
+
+  it("updates an existing CodeQL config paths-ignore block", () => {
+    const project = freshRoot("scaffold-codeql-update-");
+    mkdirSync(join(project, ".github/codeql"), { recursive: true });
+    writeFileSync(
+      join(project, ".github/codeql/codeql-config.yml"),
+      "name: existing\npaths-ignore:\n  - 'dist/**'\n",
+      "utf8",
+    );
+    const { io } = captureIo();
+    expect(ensureCodeqlPathsIgnore(project, io)).toBe(true);
+    expect(readFileSync(join(project, ".github/codeql/codeql-config.yml"), "utf8")).toContain(
+      ".deft/core/**",
+    );
+  });
 });

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -316,4 +316,29 @@ describe("init-deposit scaffold", () => {
       ".deft/core/**",
     );
   });
+
+  it("appends CodeQL paths-ignore when no paths-ignore header exists", () => {
+    const project = freshRoot("scaffold-codeql-append-");
+    mkdirSync(join(project, ".github/codeql"), { recursive: true });
+    writeFileSync(
+      join(project, ".github/codeql/codeql-config.yml"),
+      "name: bare\nlanguages:\n  - javascript\n",
+      "utf8",
+    );
+    const { lines, io } = captureIo();
+    expect(ensureCodeqlPathsIgnore(project, io)).toBe(true);
+    const content = readFileSync(join(project, ".github/codeql/codeql-config.yml"), "utf8");
+    expect(content).toContain("paths-ignore");
+    expect(content).toContain(".deft/core/**");
+    expect(lines.join("")).toContain("updated");
+  });
+
+  it("continues neutralization when a step throws", async () => {
+    const project = freshRoot("scaffold-neutral-error-");
+    writeFileSync(join(project, "greptile.json"), "not-json", "utf8");
+    const { lines, io } = captureIo();
+    await depositNeutralization(project, io);
+    expect(lines.join("")).toContain("Warning: neutralization step failed");
+    expect(existsSync(join(project, ".gitattributes"))).toBe(true);
+  });
 });

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -1,0 +1,829 @@
+/**
+ * Greenfield deposit scaffold helpers — TS port of cmd/deft-install/setup.go +
+ * deposit.go + githooks.go surfaces consumed by directive init (#1942 S2).
+ *
+ * Refs #1942, #1430, #1463, #1179.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { platform } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { copyTree } from "../deposit/copy-tree.js";
+import { agentsRefreshPlan } from "../platform/agents-md.js";
+
+export interface InitDepositIo {
+  printf: (text: string) => void;
+}
+
+export const CANONICAL_INSTALL_ROOT = ".deft/core";
+export const CORE_GLOB = ".deft/core/**";
+
+const CODEQL_CONFIG_REL = ".github/codeql/codeql-config.yml";
+const CORE_GUARD_WORKFLOW_REL = ".github/workflows/deft-core-guard.yml";
+const FRAMEWORK_SELF_TEST_REL = ".deft/core/tests";
+const VENDORED_TS_PACKAGES_REL = ".deft/core/packages";
+
+const VENDORED_TS_TEST_RE = /\.(test|spec)\.(c|m)?[jt]sx?$/i;
+
+const CORE_GITATTRIBUTES_LINES = [
+  `${CORE_GLOB} linguist-generated=true`,
+  `${CORE_GLOB} linguist-vendored=true`,
+];
+
+const VBRIEF_LIFECYCLE_DIRS = ["proposed", "pending", "active", "completed", "cancelled"] as const;
+
+const VBRIEF_LIFECYCLE_GITKEEP = `# This file keeps the lifecycle directory present in version control and
+# survives installer packaging so the deft-directive-setup pre-cutover guard
+# (condition 3, see skills/deft-directive-setup/SKILL.md:32 and main.md:159)
+# does not fire on a fresh install. See #1179.
+`;
+
+const VBRIEF_README_BODY = `# vbrief/ -- scope vBRIEF lifecycle workspace
+
+This directory is your project's scope vBRIEF lifecycle workspace.
+
+- vbrief/proposed/  -- newly proposed scope vBRIEFs
+- vbrief/pending/   -- accepted, awaiting activation
+- vbrief/active/    -- in-flight implementation work
+- vbrief/completed/ -- merged / shipped
+- vbrief/cancelled/ -- closed without merge
+
+Schemas: vbrief/schemas/ (mirrored from the framework copy at install time).
+Reference template: .deft/core/vbrief/vbrief.md
+
+Do not commit vbrief/.eval/ -- it is the local audit-log private state and
+is covered by the canonical .gitignore baseline deposited by deft-install.
+`;
+
+export const MINIMAL_TASKFILE = `version: '3'
+
+# Taskfile for this project.
+# Installed by deft-install --yes (Epic-4). Add your own tasks below or in
+# additional included files. The deft include makes all framework tasks
+# (task check, task vbrief:*, task doctor, etc.) available from the project root.
+
+includes:
+  deft:
+    taskfile: ./.deft/core/Taskfile.yml
+    optional: true
+`;
+
+export const CANONICAL_TASKFILE_INCLUDE = "taskfile: ./.deft/core/Taskfile.yml";
+
+const DEFT_INCLUDE_CHILD_BLOCK =
+  "  # Added by deft-install --yes (Epic-4)\n" +
+  "  deft:\n" +
+  "    taskfile: ./.deft/core/Taskfile.yml\n" +
+  "    optional: true\n";
+
+const AGENTS_SKILLS: ReadonlyArray<{ dir: string; content: string }> = [
+  {
+    dir: "deft",
+    content: `---
+name: deft
+description: Apply deft framework standards for AI-assisted development. Use when starting projects, writing code, running tests, making commits, or when the user references deft, project standards, or coding guidelines.
+---
+
+Read and follow: .deft/core/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-setup",
+    content: `---
+name: deft-directive-setup
+description: >-
+  Set up a new project with Deft framework standards. Use when the user wants
+  to bootstrap user preferences, configure a project, or generate a project
+  specification. Walks through setup conversationally — no separate CLI needed.
+---
+
+Read and follow: .deft/core/skills/deft-directive-setup/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-build",
+    content: `---
+name: deft-directive-build
+description: >-
+  Build a project from scope vBRIEFs following Deft framework standards.
+  Use after deft-directive-setup has generated the project definition, or when
+  the user has scope vBRIEFs ready to implement. Handles scaffolding,
+  implementation, testing, and quality checks phase by phase.
+---
+
+Read and follow: .deft/core/skills/deft-directive-build/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-review-cycle",
+    content: `---
+name: deft-directive-review-cycle
+description: >-
+  Greptile bot reviewer response workflow. Use when running a review cycle
+  on a PR — to audit process prerequisites, fetch bot findings, fix all
+  issues in a single batch commit, and exit cleanly when no P0/P1 issues
+  remain. Enables cloud agents to run autonomous PR review cycles.
+---
+
+Read and follow: .deft/core/skills/deft-directive-review-cycle/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-refinement",
+    content: `---
+name: deft-directive-refinement
+description: >-
+  Structured refinement workflow. Compares open GitHub issues against
+  the roadmap, triages new issues one-at-a-time with human review, and updates
+  the roadmap with phase placement, analysis comments, and index entries.
+---
+
+Read and follow: .deft/core/skills/deft-directive-refinement/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-swarm",
+    content: `---
+name: deft-directive-swarm
+description: >-
+  Parallel local agent orchestration. Use when running multiple agents
+  on roadmap items simultaneously — to select non-overlapping tasks, set up
+  isolated worktrees, launch agents with proven prompts, monitor progress,
+  handle stalled review cycles, and close out PRs cleanly.
+---
+
+Read and follow: .deft/core/skills/deft-directive-swarm/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-interview",
+    content: `---
+name: deft-directive-interview
+description: >-
+  Deterministic structured Q&A interview skill. Use when a skill or workflow
+  needs to collect structured answers from the user — one question per turn,
+  numbered options, default acceptance, and a confirmation gate.
+---
+
+Read and follow: .deft/core/skills/deft-directive-interview/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-pre-pr",
+    content: `---
+name: deft-directive-pre-pr
+description: >-
+  Iterative pre-PR quality loop (Read-Write-Lint-Diff-Loop). Use before
+  pushing a branch for PR creation — structured self-review that agents run
+  to catch issues before they reach the bot reviewer.
+---
+
+Read and follow: .deft/core/skills/deft-directive-pre-pr/SKILL.md
+`,
+  },
+  {
+    dir: "deft-directive-sync",
+    content: `---
+name: deft-directive-sync
+description: >-
+  Session-start framework sync skill. Use at the beginning of a session to
+  pull latest framework updates, validate project files, and confirm alignment
+  before starting work.
+---
+
+Read and follow: .deft/core/skills/deft-directive-sync/SKILL.md
+`,
+  },
+];
+
+export interface InstallManifestFields {
+  ref: string;
+  sha: string;
+  tag: string;
+  installRoot: string;
+  fetchedAt: string;
+  fetchedBy: string;
+}
+
+const BARE_SEMVER = /^\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?$/;
+
+export function buildInstallManifestText(fields: InstallManifestFields): string {
+  let effectiveTag = fields.tag;
+  if (effectiveTag && !effectiveTag.startsWith("v") && BARE_SEMVER.test(effectiveTag)) {
+    effectiveTag = `v${effectiveTag}`;
+  }
+  const effectiveRef = fields.ref || effectiveTag;
+  return (
+    `ref: '${effectiveRef}'\n` +
+    `sha: '${fields.sha}'\n` +
+    `tag: '${effectiveTag}'\n` +
+    `install_root: '${fields.installRoot}'\n` +
+    `fetched_at: '${fields.fetchedAt}'\n` +
+    `fetched_by: '${fields.fetchedBy}'\n`
+  );
+}
+
+export function writeInstallManifest(
+  projectDir: string,
+  deftDir: string,
+  fields: InstallManifestFields,
+): string {
+  const installRoot =
+    fields.installRoot ||
+    relative(projectDir, deftDir).split("\\").join("/") ||
+    CANONICAL_INSTALL_ROOT;
+  const body = buildInstallManifestText({ ...fields, installRoot });
+  mkdirSync(deftDir, { recursive: true });
+  const path = join(deftDir, "VERSION");
+  writeFileSync(path, body, "utf8");
+  return path;
+}
+
+export function writeAgentsMd(projectDir: string, deftDir: string, io: InitDepositIo): boolean {
+  const plan = agentsRefreshPlan(projectDir, { frameworkRoot: deftDir }) as Record<string, unknown>;
+  const state = plan.state;
+  if (state === "current") {
+    io.printf(`AGENTS.md already advertises install root ${CANONICAL_INSTALL_ROOT} — skipping.\n`);
+    return false;
+  }
+  if (state === "template-missing" || state === "template-malformed" || state === "unreadable") {
+    throw new Error(`AGENTS.md render failed: ${String(state)}`);
+  }
+  const newContent = plan.new_content;
+  if (typeof newContent !== "string") {
+    throw new Error("AGENTS.md render produced no content");
+  }
+  const path = join(projectDir, "AGENTS.md");
+  writeFileSync(path, newContent, "utf8");
+  if (state === "absent") {
+    io.printf("AGENTS.md created.\n");
+  } else {
+    io.printf("AGENTS.md updated with deft entries.\n");
+  }
+  return true;
+}
+
+async function ensureVbriefLifecycleDirs(consumerVbrief: string): Promise<void> {
+  for (const sub of VBRIEF_LIFECYCLE_DIRS) {
+    const dir = join(consumerVbrief, sub);
+    await mkdir(dir, { recursive: true, mode: 0o755 });
+    const gitkeep = join(dir, ".gitkeep");
+    try {
+      await stat(gitkeep);
+      continue;
+    } catch {
+      // absent — may write below
+    }
+    const entries = await readdir(dir);
+    if (entries.length > 0) continue;
+    await writeFile(gitkeep, VBRIEF_LIFECYCLE_GITKEEP, "utf8");
+  }
+}
+
+function vbriefLifecycleDirsPresent(consumerVbrief: string): boolean {
+  return VBRIEF_LIFECYCLE_DIRS.every((sub) => {
+    try {
+      return statSync(join(consumerVbrief, sub)).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+}
+
+export async function writeConsumerVbrief(
+  projectDir: string,
+  deftDir: string,
+  io: InitDepositIo,
+): Promise<boolean> {
+  const consumerVbrief = join(projectDir, "vbrief");
+  const schemasDst = join(consumerVbrief, "schemas");
+  const vbriefMdDst = join(consumerVbrief, "vbrief.md");
+
+  const schemasPresent = existsSync(schemasDst) && statSync(schemasDst).isDirectory();
+  const vbriefMdPresent = existsSync(vbriefMdDst) && statSync(vbriefMdDst).isFile();
+  const lifecyclePresent = vbriefLifecycleDirsPresent(consumerVbrief);
+  if (schemasPresent && vbriefMdPresent && lifecyclePresent) {
+    io.printf("vbrief/ already present at project root — skipping.\n");
+    return false;
+  }
+
+  mkdirSync(consumerVbrief, { recursive: true });
+
+  if (!schemasPresent) {
+    const fwSchemas = join(deftDir, "vbrief", "schemas");
+    if (existsSync(fwSchemas) && statSync(fwSchemas).isDirectory()) {
+      await copyTree(fwSchemas, schemasDst);
+    } else {
+      mkdirSync(schemasDst, { recursive: true });
+    }
+  }
+
+  if (!vbriefMdPresent) {
+    const fwVbriefMd = join(deftDir, "vbrief", "vbrief.md");
+    if (existsSync(fwVbriefMd)) {
+      copyFileSync(fwVbriefMd, vbriefMdDst);
+    } else {
+      writeFileSync(vbriefMdDst, VBRIEF_README_BODY, "utf8");
+    }
+  }
+
+  await ensureVbriefLifecycleDirs(consumerVbrief);
+  io.printf("vbrief/ deposited at project root (schemas + vbrief.md + lifecycle dirs).\n");
+  return true;
+}
+
+export function writeAgentsSkills(projectDir: string, io: InitDepositIo): boolean {
+  const allExist = AGENTS_SKILLS.every((skill) =>
+    existsSync(join(projectDir, ".agents", "skills", skill.dir, "SKILL.md")),
+  );
+  if (allExist) {
+    io.printf(".agents/skills/ already present — skipping.\n");
+    return false;
+  }
+
+  for (const skill of AGENTS_SKILLS) {
+    const dir = join(projectDir, ".agents", "skills", skill.dir);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "SKILL.md");
+    if (existsSync(path)) continue;
+    writeFileSync(path, skill.content, "utf8");
+  }
+
+  io.printf(".agents/skills/ created — deft skills will be auto-discovered.\n");
+  return true;
+}
+
+function hasTopLevelIncludes(content: string): boolean {
+  if (!content) return false;
+  const norm = `\n${content.replace(/\r\n/g, "\n").replace(/\r/g, "\n")}`;
+  if (norm.includes("\nincludes:")) return true;
+  return content.trimStart().startsWith("includes:");
+}
+
+function insertDeftIncludeAfterIncludesLine(content: string): { content: string; ok: boolean } {
+  const norm = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const lines = norm.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    if (line.length === 0 || line[0] === " " || line[0] === "\t") continue;
+    const trimmed = line.trimEnd();
+    if (trimmed === "includes:") {
+      const out = [
+        ...lines.slice(0, i + 1),
+        ...DEFT_INCLUDE_CHILD_BLOCK.trimEnd().split("\n"),
+        ...lines.slice(i + 1),
+      ];
+      return { content: out.join("\n"), ok: true };
+    }
+    if (trimmed.startsWith("includes:") && trimmed.length > "includes:".length) {
+      const rest = trimmed.slice("includes:".length).trimStart();
+      if (rest.startsWith("#")) {
+        const out = [
+          ...lines.slice(0, i + 1),
+          ...DEFT_INCLUDE_CHILD_BLOCK.trimEnd().split("\n"),
+          ...lines.slice(i + 1),
+        ];
+        return { content: out.join("\n"), ok: true };
+      }
+    }
+  }
+  return { content, ok: false };
+}
+
+export function ensureTaskfile(projectDir: string, io: InitDepositIo): boolean {
+  const path = join(projectDir, "Taskfile.yml");
+  let existing = "";
+  if (existsSync(path)) {
+    existing = readFileSync(path, "utf8");
+  }
+
+  if (existing.includes(CANONICAL_TASKFILE_INCLUDE)) {
+    io.printf("Taskfile.yml already includes deft — skipping wiring.\n");
+    return false;
+  }
+
+  let resultText = "";
+  if (existing === "") {
+    resultText = MINIMAL_TASKFILE;
+    io.printf("Created minimal Taskfile.yml with deft include (Epic-4).\n");
+  } else if (hasTopLevelIncludes(existing)) {
+    const inserted = insertDeftIncludeAfterIncludesLine(existing);
+    if (inserted.ok) {
+      resultText = inserted.content;
+      io.printf(
+        "Inserted deft entry inside existing `includes:` block in Taskfile.yml (Epic-4).\n",
+      );
+    } else {
+      resultText =
+        `${existing}${existing.endsWith("\n") ? "" : "\n"}\n` +
+        "# deft-install --yes (Epic-4): could not locate the existing top-level `includes:` line for structural insertion; appended a fresh block. Manual merge recommended.\n" +
+        "includes:\n" +
+        "  deft:\n" +
+        "    taskfile: ./.deft/core/Taskfile.yml\n" +
+        "    optional: true\n";
+      io.printf(
+        "Appended fresh `includes:` block to Taskfile.yml -- top-level includes: detected but structural insertion fell through; manual merge recommended.\n",
+      );
+    }
+  } else {
+    resultText =
+      `${existing}${existing.endsWith("\n") ? "" : "\n"}\n` +
+      "# Added by deft-install --yes (Epic-4)\n" +
+      "includes:\n" +
+      "  deft:\n" +
+      "    taskfile: ./.deft/core/Taskfile.yml\n" +
+      "    optional: true\n";
+    io.printf("Appended new `includes:` block with deft entry to Taskfile.yml (Epic-4).\n");
+  }
+
+  writeFileSync(path, resultText, "utf8");
+  return true;
+}
+
+const HOOK_FILENAMES = ["pre-commit", "pre-push"] as const;
+const HOOK_FILE_MODE = 0o755;
+
+export interface GitHooksSeams {
+  getHooksPath?: (projectDir: string) => string | null;
+  setHooksPath?: (projectDir: string, value: string) => boolean;
+}
+
+export function writeConsumerGitHooks(
+  projectDir: string,
+  deftDir: string,
+  io: InitDepositIo,
+  seams: GitHooksSeams = {},
+): boolean {
+  const srcDir = join(deftDir, ".githooks");
+  if (!existsSync(srcDir) || !statSync(srcDir).isDirectory()) {
+    io.printf(`git hooks source ${srcDir} absent — skipping hook wiring.\n`);
+    return false;
+  }
+
+  const dstDir = join(projectDir, ".githooks");
+  mkdirSync(dstDir, { recursive: true });
+
+  let deposited = false;
+  for (const name of HOOK_FILENAMES) {
+    const src = join(srcDir, name);
+    if (!existsSync(src)) continue;
+    const data = readFileSync(src);
+    const dst = join(dstDir, name);
+    const existing = existsSync(dst) ? readFileSync(dst) : null;
+    if (!existing?.equals(data)) {
+      writeFileSync(dst, data, { mode: HOOK_FILE_MODE });
+      deposited = true;
+    }
+    if (platform() !== "win32") {
+      try {
+        const mode = statSync(dst).mode & 0o777;
+        if ((mode & 0o111) === 0) {
+          chmodSync(dst, HOOK_FILE_MODE);
+          deposited = true;
+        }
+      } catch {
+        // non-fatal
+      }
+    }
+  }
+
+  const getHooksPath =
+    seams.getHooksPath ??
+    ((dir: string) => {
+      try {
+        return execFileSync("git", ["-C", dir, "config", "--get", "core.hooksPath"], {
+          encoding: "utf8",
+        }).trim();
+      } catch {
+        return "";
+      }
+    });
+  const setHooksPath =
+    seams.setHooksPath ??
+    ((dir: string, value: string) => {
+      try {
+        execFileSync("git", ["-C", dir, "config", "core.hooksPath", value], { encoding: "utf8" });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+  const target = ".githooks";
+  const current = getHooksPath(projectDir) ?? "";
+  if (current !== target && setHooksPath(projectDir, target)) {
+    deposited = true;
+    io.printf("git hooks wired: core.hooksPath=.githooks (#1463).\n");
+  } else if (current === target) {
+    io.printf("git hooks already wired — skipping core.hooksPath write.\n");
+  }
+
+  if (deposited) {
+    io.printf(".githooks/ deposited at project root (#1463).\n");
+  }
+  return deposited;
+}
+
+function escapeEre(value: string): string {
+  return value.replace(/[.^$*+?()[\]{}|\\]/g, "\\$&");
+}
+
+function installerManagedGuardEre(): string {
+  const matchers: Array<{ exact?: string; prefix?: string }> = [
+    { exact: "AGENTS.md" },
+    { prefix: ".agents/" },
+    { prefix: ".githooks/" },
+    { exact: ".gitattributes" },
+    { exact: ".gitignore" },
+    { exact: "greptile.json" },
+    { exact: CODEQL_CONFIG_REL },
+    { exact: CORE_GUARD_WORKFLOW_REL },
+    { exact: "vbrief/.deft-version" },
+    { exact: "vbrief/vbrief.md" },
+    { prefix: "vbrief/schemas/" },
+    { prefix: "vbrief/migration/" },
+    ...VBRIEF_LIFECYCLE_DIRS.map((sub) => ({ exact: `vbrief/${sub}/.gitkeep` })),
+  ];
+  return matchers
+    .map((m) => (m.exact ? `^${escapeEre(m.exact)}$` : `^${escapeEre(m.prefix ?? "")}`))
+    .join("|");
+}
+
+function githubActionsExpr(expression: string): string {
+  return ["$", "{{ ", expression, " }}"].join("");
+}
+
+function coreGuardWorkflowContent(): string {
+  const baseSha = githubActionsExpr("github.event.pull_request.base.sha");
+  const headSha = githubActionsExpr("github.event.pull_request.head.sha");
+  return (
+    "name: deft-core-guard\n\n" +
+    "# Deft framework guard (#1430): a single PR should not mix changes to the\n" +
+    "# vendored framework payload (.deft/core/**) with changes to your own project\n" +
+    "# files. Framework updates come from `deft-install` / upgrade and should\n" +
+    "# land in their own PR so reviewers (and bot reviewers) can treat them as\n" +
+    "# packaged, machine-managed assets. Delete this file if you do not want the guard.\n" +
+    "on:\n" +
+    "  pull_request:\n\n" +
+    "permissions:\n" +
+    "  contents: read\n\n" +
+    "jobs:\n" +
+    "  no-mixed-core-and-app:\n" +
+    "    runs-on: ubuntu-latest\n" +
+    "    steps:\n" +
+    "      - uses: actions/checkout@v4\n" +
+    "        with:\n" +
+    "          fetch-depth: 0\n" +
+    "      - name: Refuse PRs that mix .deft/core/** with non-framework paths\n" +
+    "        env:\n" +
+    `          BASE_SHA: ${baseSha}\n` +
+    `          HEAD_SHA: ${headSha}\n` +
+    "        run: |\n" +
+    "          set -eu\n" +
+    '          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")\n' +
+    '          echo "Changed files:"\n' +
+    '          echo "$changed"\n' +
+    "          core=$(printf '%s\\n' \"$changed\" | grep -E '^\\.deft/core/' || true)\n" +
+    "          app=$(printf '%s\\n' \"$changed\" | grep -vE '^\\.deft/core/' | grep -vE '" +
+    installerManagedGuardEre() +
+    "' | grep -v '^$' || true)\n" +
+    '          if [ -n "$core" ] && [ -n "$app" ]; then\n' +
+    '            echo "::error title=deft-core guard (#1430)::This PR changes the vendored framework payload (.deft/core/**) AND non-framework files. Split the framework update into its own PR."\n' +
+    '            echo "--- framework (.deft/core/**) changes ---"; printf \'%s\\n\' "$core"\n' +
+    '            echo "--- non-framework changes ---"; printf \'%s\\n\' "$app"\n' +
+    "            exit 1\n" +
+    "          fi\n" +
+    '          echo "OK: no mixed framework + app changes."\n'
+  );
+}
+
+export function ensureGitattributes(projectDir: string, io: InitDepositIo): boolean {
+  const path = join(projectDir, ".gitattributes");
+  const existing = existsSync(path) ? readFileSync(path, "utf8") : "";
+  const present = new Set(existing.split("\n").map((line) => line.trim()));
+  const additions = CORE_GITATTRIBUTES_LINES.filter((line) => !present.has(line));
+  if (additions.length === 0) {
+    io.printf(`.gitattributes already marks ${CORE_GLOB} as generated/vendored — skipping.\n`);
+    return false;
+  }
+  let body = existing;
+  if (body && !body.endsWith("\n")) body += "\n";
+  if (body && !body.endsWith("\n\n")) body += "\n";
+  body +=
+    "# Deft framework: the vendored payload is packaged framework code, not\n" +
+    "# consumer source. Mark it generated + vendored so language stats and\n" +
+    "# diffs treat .deft/core/** as machine-managed (#1430).\n";
+  for (const add of additions) {
+    body += `${add}\n`;
+  }
+  writeFileSync(path, body, "utf8");
+  io.printf(`.gitattributes updated with linguist markers: ${additions.join(", ")}\n`);
+  return true;
+}
+
+function greptilePatternPresent(patterns: string, glob: string): boolean {
+  return patterns.split("\n").some((line) => line.trim() === glob);
+}
+
+function appendGreptilePattern(patterns: string, glob: string): string {
+  if (patterns.trim() === "") return glob;
+  if (patterns.endsWith("\n")) return `${patterns}${glob}`;
+  return `${patterns}\n${glob}`;
+}
+
+export function ensureGreptileIgnore(projectDir: string, io: InitDepositIo): boolean {
+  const path = join(projectDir, "greptile.json");
+  const fileExisted = existsSync(path);
+  let raw = fileExisted ? readFileSync(path, "utf8") : "";
+  if (!raw.trim()) raw = "{}";
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>;
+  } catch (cause) {
+    throw new Error(`could not parse greptile.json (leaving it unchanged): ${String(cause)}`);
+  }
+  let patterns = "";
+  if ("ignorePatterns" in obj) {
+    if (typeof obj.ignorePatterns !== "string") {
+      throw new Error("greptile.json ignorePatterns is not a newline-separated string");
+    }
+    patterns = obj.ignorePatterns;
+  }
+  if (fileExisted && greptilePatternPresent(patterns, CORE_GLOB)) {
+    io.printf(`greptile.json already ignores ${CORE_GLOB} — skipping.\n`);
+    return false;
+  }
+  obj.ignorePatterns = appendGreptilePattern(patterns, CORE_GLOB);
+  writeFileSync(path, `${JSON.stringify(obj, null, 2)}\n`, "utf8");
+  io.printf(
+    fileExisted
+      ? `greptile.json updated: bot review now ignores ${CORE_GLOB}.\n`
+      : `greptile.json created: bot review ignores ${CORE_GLOB}.\n`,
+  );
+  return true;
+}
+
+function codeqlConfigDefault(): string {
+  return (
+    "# Deft framework: exclude the vendored payload from CodeQL analysis (#1430).\n" +
+    "# .deft/core/** is packaged framework code, not consumer source.\n" +
+    'name: "CodeQL config (deft)"\n' +
+    "paths-ignore:\n" +
+    `  - '${CORE_GLOB}'\n`
+  );
+}
+
+function codeqlPathsIgnorePresent(content: string, glob: string): boolean {
+  const candidates = [`- '${glob}'`, `- "${glob}"`, `- ${glob}`];
+  let inBlock = false;
+  for (const line of content.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")) {
+    if (line.length > 0 && line[0] !== " " && line[0] !== "\t") {
+      const trimmed = line.trimEnd();
+      if (trimmed === "paths-ignore:") {
+        inBlock = true;
+        continue;
+      }
+      inBlock = false;
+      continue;
+    }
+    if (inBlock && candidates.includes(line.trim())) return true;
+  }
+  return false;
+}
+
+function insertCodeqlPathsIgnore(content: string, glob: string): { content: string; ok: boolean } {
+  const norm = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const lines = norm.split("\n");
+  const entry = `  - '${glob}'`;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    if (line.length === 0 || line[0] === " " || line[0] === "\t") continue;
+    if ((line.trimEnd() ?? "") === "paths-ignore:") {
+      const out = [...lines.slice(0, i + 1), entry, ...lines.slice(i + 1)];
+      return { content: out.join("\n"), ok: true };
+    }
+  }
+  return { content, ok: false };
+}
+
+export function ensureCodeqlPathsIgnore(projectDir: string, io: InitDepositIo): boolean {
+  const path = join(projectDir, CODEQL_CONFIG_REL);
+  if (!existsSync(path)) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, codeqlConfigDefault(), "utf8");
+    io.printf(`${CODEQL_CONFIG_REL} created: CodeQL ignores ${CORE_GLOB}.\n`);
+    return true;
+  }
+  const existing = readFileSync(path, "utf8");
+  if (codeqlPathsIgnorePresent(existing, CORE_GLOB)) {
+    io.printf(`${CODEQL_CONFIG_REL} already ignores ${CORE_GLOB} — skipping.\n`);
+    return false;
+  }
+  const inserted = insertCodeqlPathsIgnore(existing, CORE_GLOB);
+  const updated = inserted.ok
+    ? inserted.content
+    : `${existing}${existing.endsWith("\n") ? "" : "\n"}paths-ignore:\n  - '${CORE_GLOB}'\n`;
+  writeFileSync(path, updated, "utf8");
+  io.printf(`${CODEQL_CONFIG_REL} updated: CodeQL now ignores ${CORE_GLOB}.\n`);
+  return true;
+}
+
+export function ensureCoreGuardWorkflow(projectDir: string, io: InitDepositIo): boolean {
+  const path = join(projectDir, CORE_GUARD_WORKFLOW_REL);
+  const desired = coreGuardWorkflowContent();
+  if (existsSync(path)) {
+    const existing = readFileSync(path, "utf8");
+    if (existing === desired) {
+      io.printf(`${CORE_GUARD_WORKFLOW_REL} already current — skipping.\n`);
+      return false;
+    }
+    if (!existing.includes("name: deft-core-guard")) {
+      io.printf(`${CORE_GUARD_WORKFLOW_REL} present but not deft-managed — leaving unchanged.\n`);
+      return false;
+    }
+    writeFileSync(path, desired, "utf8");
+    io.printf(`${CORE_GUARD_WORKFLOW_REL} refreshed: deft-core-guard allowlist updated (#1478).\n`);
+    return true;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, desired, "utf8");
+  io.printf(
+    `${CORE_GUARD_WORKFLOW_REL} created: CI refuses PRs mixing ${CORE_GLOB} with app files.\n`,
+  );
+  return true;
+}
+
+export async function pruneFrameworkSelfTests(
+  projectDir: string,
+  io: InitDepositIo,
+): Promise<boolean> {
+  const path = join(projectDir, FRAMEWORK_SELF_TEST_REL);
+  try {
+    const info = await stat(path);
+    if (!info.isDirectory()) return false;
+  } catch {
+    return false;
+  }
+  await rm(path, { recursive: true, force: true });
+  io.printf(
+    `Removed vendored framework self-tests (${FRAMEWORK_SELF_TEST_REL}) from the consumer deposit (#1474).\n`,
+  );
+  return true;
+}
+
+export async function pruneVendoredTsTests(projectDir: string, io: InitDepositIo): Promise<number> {
+  const root = join(projectDir, VENDORED_TS_PACKAGES_REL);
+  try {
+    if (!(await stat(root)).isDirectory()) return 0;
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  async function walk(dir: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile() && VENDORED_TS_TEST_RE.test(entry.name)) {
+        await rm(full, { force: true });
+        removed += 1;
+      }
+    }
+  }
+  await walk(root);
+  if (removed > 0) {
+    io.printf(
+      `Removed ${removed} vendored TypeScript test file(s) under ${VENDORED_TS_PACKAGES_REL} from the consumer deposit (#1878).\n`,
+    );
+  }
+  return removed;
+}
+
+/** Best-effort #1430 neutralization deposit (mirrors depositNeutralization). */
+export async function depositNeutralization(projectDir: string, io: InitDepositIo): Promise<void> {
+  const steps: Array<() => boolean | Promise<boolean>> = [
+    () => ensureGitattributes(projectDir, io),
+    () => ensureGreptileIgnore(projectDir, io),
+    () => ensureCodeqlPathsIgnore(projectDir, io),
+    () => ensureCoreGuardWorkflow(projectDir, io),
+    () => pruneFrameworkSelfTests(projectDir, io),
+    async () => (await pruneVendoredTsTests(projectDir, io)) > 0,
+  ];
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (cause) {
+      io.printf(`Warning: neutralization step failed: ${String(cause)}\n`);
+    }
+  }
+}

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -473,7 +473,7 @@ export function writeConsumerGitHooks(
   const dstDir = join(projectDir, ".githooks");
   mkdirSync(dstDir, { recursive: true });
 
-  let deposited = false;
+  let filesDeposited = false;
   for (const name of HOOK_FILENAMES) {
     const src = join(srcDir, name);
     if (!existsSync(src)) continue;
@@ -482,14 +482,14 @@ export function writeConsumerGitHooks(
     const existing = existsSync(dst) ? readFileSync(dst) : null;
     if (!existing?.equals(data)) {
       writeFileSync(dst, data, { mode: HOOK_FILE_MODE });
-      deposited = true;
+      filesDeposited = true;
     }
     if (platform() !== "win32") {
       try {
         const mode = statSync(dst).mode & 0o777;
         if ((mode & 0o111) === 0) {
           chmodSync(dst, HOOK_FILE_MODE);
-          deposited = true;
+          filesDeposited = true;
         }
       } catch {
         // non-fatal
@@ -521,17 +521,27 @@ export function writeConsumerGitHooks(
 
   const target = ".githooks";
   const current = getHooksPath(projectDir) ?? "";
-  if (current !== target && setHooksPath(projectDir, target)) {
-    deposited = true;
-    io.printf("git hooks wired: core.hooksPath=.githooks (#1463).\n");
-  } else if (current === target) {
+  let configWired = false;
+  if (current !== target) {
+    if (setHooksPath(projectDir, target)) {
+      configWired = true;
+      io.printf("git hooks wired: core.hooksPath=.githooks (#1463).\n");
+    } else {
+      io.printf(
+        "Warning: could not set core.hooksPath=.githooks — run `git config core.hooksPath .githooks` manually.\n",
+      );
+    }
+  } else {
     io.printf("git hooks already wired — skipping core.hooksPath write.\n");
   }
 
-  if (deposited) {
+  if (filesDeposited) {
     io.printf(".githooks/ deposited at project root (#1463).\n");
+  } else if (configWired) {
+    io.printf(".githooks/ already present; git config updated (#1463).\n");
   }
-  return deposited;
+
+  return filesDeposited || configWired;
 }
 
 function escapeEre(value: string): string {
@@ -648,7 +658,11 @@ export function ensureGreptileIgnore(projectDir: string, io: InitDepositIo): boo
   if (!raw.trim()) raw = "{}";
   let obj: Record<string, unknown>;
   try {
-    obj = JSON.parse(raw) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("greptile.json root must be a JSON object");
+    }
+    obj = parsed as Record<string, unknown>;
   } catch (cause) {
     throw new Error(`could not parse greptile.json (leaving it unchanged): ${String(cause)}`);
   }

--- a/vbrief/active/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json
+++ b/vbrief/active/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "s2-directive-init-ts-native",
     "title": "S2: directive init TS-native greenfield deposit",
-    "status": "pending",
+    "status": "running",
     "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
     "narratives": {
       "Description": "directive init today spawnSyncs the bundled Go deft-install, which downloads and vendors .deft/core. This story rewrites init to orchestrate a fully TS-native greenfield deposit using the S1 primitive: copy the content tree into .deft/core, render the AGENTS.md managed-section (reusing the existing TS agents-md logic), scaffold vbrief/ (schemas + lifecycle dirs), deposit .agents/skills pointers + .githooks + the #1430 neutralization, and wire the Taskfile include. The friendly wizard UX is preserved and no Go binary is invoked on the happy path.",
@@ -115,6 +115,7 @@
         "type": "x-vbrief/related",
         "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
       }
-    ]
+    ],
+    "updated": "2026-06-24T19:36:47Z"
   }
 }

--- a/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
+++ b/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
@@ -90,7 +90,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "pending/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json",
+        "uri": "active/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "S2: directive init TS-native greenfield deposit",
         "TrustLevel": "internal"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
       "@deftai/directive-core/packs": sub("core", "packs"),
       "@deftai/directive-core/swarm": sub("core", "swarm"),
       "@deftai/directive-core/platform": sub("core", "platform"),
+      "@deftai/directive-core/init-deposit": sub("core", "init-deposit"),
       "@deftai/directive-core/ts-check-lane": sub("core", "ts-check-lane"),
       "@deftai/directive-core": src("core"),
     },


### PR DESCRIPTION
## Summary
- Rewrites `directive init` to perform a fully TypeScript-native greenfield deposit: resolve `@deftai/directive-content`, copy into `.deft/core`, render the AGENTS.md managed-section, scaffold `vbrief/`, deposit `.agents/skills` + `.githooks` + #1430 neutralization, and wire the Taskfile include.
- Preserves the friendly wizard UX and `--json` success shape; no Go `deft-install` binary is spawned on the happy path.
- Adds `packages/core/src/init-deposit/` orchestrator + scaffold modules with unit tests asserting the full deposit shape.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm --filter @deftai/directive-core test -- init-deposit`
- [x] `pnpm --filter @deftai/directive test -- init-cli`
- [x] `task check`

Refs #1942

Made with [Cursor](https://cursor.com)