### PR TITLE
chore(scope): complete #1942 S2 init deposit story

### DIFF
--- a/vbrief/completed/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json
+++ b/vbrief/completed/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "s2-directive-init-ts-native",
     "title": "S2: directive init TS-native greenfield deposit",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json",
     "narratives": {
       "Description": "directive init today spawnSyncs the bundled Go deft-install, which downloads and vendors .deft/core. This story rewrites init to orchestrate a fully TS-native greenfield deposit using the S1 primitive: copy the content tree into .deft/core, render the AGENTS.md managed-section (reusing the existing TS agents-md logic), scaffold vbrief/ (schemas + lifecycle dirs), deposit .agents/skills pointers + .githooks + the #1430 neutralization, and wire the Taskfile include. The friendly wizard UX is preserved and no Go binary is invoked on the happy path.",
@@ -86,7 +86,9 @@
         "file_scope_confidence": "medium",
         "model_tier": "leaf-implementation",
         "missing_traces_justification": "Traced to cmd/deft-install/setup.go (WriteAgentsMD, WriteConsumerVbrief, EnsureTaskfile, WriteAgentsSkills) and #1942 scope, not a spec section."
-      }
+      },
+      "completedAt": "2026-06-24T20:14:07Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -116,6 +118,6 @@
         "title": "Issue #1933 (decree: stop-fetch + never-first-start)"
       }
     ],
-    "updated": "2026-06-24T19:36:47Z"
+    "updated": "2026-06-24T20:14:07Z"
   }
 }

--- a/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
+++ b/vbrief/proposed/2026-06-24-1942-ts-native-init-update-deposit.vbrief.json
@@ -90,7 +90,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json",
+        "uri": "completed/2026-06-24-s2-directive-init-ts-native-greenfield-deposit.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "S2: directive init TS-native greenfield deposit",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
- Move S2 vBRIEF from `vbrief/active/` to `vbrief/completed/` after PR #1956 merged
- Update epic dependency URI in the proposed umbrella vBRIEF

## Test plan
- [x] Lifecycle move only; no code changes

Refs #1942

Made with [Cursor](https://cursor.com)