### PR TITLE
docs(vbrief): ingest #1972 + decompose step 1 into swarm-ready stories

### DIFF
--- a/vbrief/pending/2026-06-25-add-npm-handoff-messaging-to-the-go-installer-success-path.vbrief.json
+++ b/vbrief/pending/2026-06-25-add-npm-handoff-messaging-to-the-go-installer-success-path.vbrief.json
@@ -1,0 +1,86 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1972-s1b-installer-npm-handoff",
+    "title": "Add npm-handoff messaging to the Go installer success path",
+    "status": "pending",
+    "planRef": "proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json",
+    "narratives": {
+      "Description": "The frozen Go installer is the last one consumers will run, so they must learn that future upgrades now come from the npm package. This story prints a handoff line on the installer success path in cmd/deft-install/main.go directing users to run npx @deftai/directive init for subsequent upgrades.",
+      "ImplementationPlan": "- Add a handoff message to the success summary path in cmd/deft-install/main.go so a completed install or upgrade prints the npm upgrade guidance to stderr.\n- Define the message text as a constant near the existing installer source constants so the script keeps one definition, and gate it behind the non-error success path only.\n- Add a Go test in cmd/deft-install that asserts the success output contains the npx @deftai/directive init handoff string and that an error path omits it.",
+      "UserStory": "As a consumer running the final Go installer, I want a clear handoff message, so that I know future Deft upgrades come from the npm package rather than re-running the installer.",
+      "Traces": "Issue #1972 step 1b; #1912 freeze prerequisite; #1942 npm-native init/update"
+    },
+    "items": [
+      {
+        "id": "1972-s1b-installer-npm-handoff-a1",
+        "title": "Given a successful install or upgrade, when the installer finishes, then it prints a handoff line instructing the user to run npx @deftai/directive init.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a successful install or upgrade, when the installer finishes, then it prints a handoff line instructing the user to run npx @deftai/directive init."
+        }
+      },
+      {
+        "id": "1972-s1b-installer-npm-handoff-a2",
+        "title": "Given an install that errors out, when the installer exits non-zero, then it does not print the npm handoff message.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an install that errors out, when the installer exits non-zero, then it does not print the npm handoff message."
+        }
+      },
+      {
+        "id": "1972-s1b-installer-npm-handoff-a3",
+        "title": "Given the success path runs under test, when the output is captured, then the test asserts the npm handoff string is present.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the success path runs under test, when the output is captured, then the test asserts the npm handoff string is present."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "cmd/deft-install/main.go",
+          "cmd/deft-install/handoff_test.go"
+        ],
+        "verify_commands": [
+          "go test ./cmd/deft-install/...",
+          "go build ./cmd/deft-install/"
+        ],
+        "expected_outputs": [
+          "installer success output includes the npm handoff line",
+          "Go test asserting the handoff string on success and its absence on error"
+        ],
+        "depends_on": [],
+        "conflict_group": "go-installer",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1972",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1972: Wave 5 finalization: freeze the Go bridge, retire Go, purge Python (runbook + recovery)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/closes",
+        "title": "Issue #1530"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1669"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-25-assert-the-installer-version-is-migrate-acceptable-in-the-le.vbrief.json
+++ b/vbrief/pending/2026-06-25-assert-the-installer-version-is-migrate-acceptable-in-the-le.vbrief.json
@@ -1,0 +1,86 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 3 decomposed from proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1972-s1c-version-handshake-e2e",
+    "title": "Assert the installer VERSION is migrate-acceptable in the legacy-bridge e2e leg",
+    "status": "pending",
+    "planRef": "proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json",
+    "narratives": {
+      "Description": "The freeze hinges on the Go installer writing a .deft/core/VERSION that directive migrate accepts as canonical-ready before stamping managed_by npm. Today the legacy-bridge e2e leg provisions a synthetic manifest, so this story drives an installer-shaped VERSION through parseInstallManifest and runMigrate so the handshake is asserted end to end rather than assumed.",
+      "ImplementationPlan": "- Extend packages/core/src/release-e2e/legacy-bridge-leg.ts so provisionCanonicalVendoredDeposit writes a VERSION matching the Go installer manifest field shape rather than a hand-built manifest.\n- Add an assertion in the stage-2 npm-hybrid step that parseInstallManifest accepts the installer-shaped VERSION and runMigrate returns migrated, then already-hybrid on the second run.\n- Cover the new path with a release-e2e test/fixture so the leg fails when the VERSION field shape drifts from what migrate accepts.",
+      "UserStory": "As a Deft release maintainer, I want the legacy-bridge e2e leg to assert the real installer VERSION is migrate-acceptable, so that the frozen-bridge to npm-hybrid handshake cannot silently break at freeze time.",
+      "Traces": "Issue #1972 step 1c; #1971 pinned legacy-bridge e2e leg; #1968 directive migrate"
+    },
+    "items": [
+      {
+        "id": "1972-s1c-version-handshake-e2e-a1",
+        "title": "Given a canonical-vendored deposit with an installer-shaped VERSION, when the e2e leg runs, then parseInstallManifest accepts it and runMigrate returns migrated.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a canonical-vendored deposit with an installer-shaped VERSION, when the e2e leg runs, then parseInstallManifest accepts it and runMigrate returns migrated."
+        }
+      },
+      {
+        "id": "1972-s1c-version-handshake-e2e-a2",
+        "title": "Given the VERSION field shape drifts from what migrate accepts, when the e2e leg runs, then the leg fails with a handshake mismatch reason.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the VERSION field shape drifts from what migrate accepts, when the e2e leg runs, then the leg fails with a handshake mismatch reason."
+        }
+      },
+      {
+        "id": "1972-s1c-version-handshake-e2e-a3",
+        "title": "Given the SoT is still null, when the e2e leg runs, then the stage-2 assertion still validates the VERSION handshake without downloading a binary.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the SoT is still null, when the e2e leg runs, then the stage-2 assertion still validates the VERSION handshake without downloading a binary."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release-e2e/legacy-bridge-leg.ts",
+          "packages/core/src/release-e2e/legacy-bridge-leg.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm --dir packages/core test -- legacy-bridge",
+          "task release:e2e -- --legacy-bridge"
+        ],
+        "expected_outputs": [
+          "e2e leg drives an installer-shaped VERSION through directive migrate",
+          "handshake mismatch fails the leg with a clear reason"
+        ],
+        "depends_on": [],
+        "conflict_group": "e2e-legacy-bridge",
+        "size": "M",
+        "file_scope_confidence": "medium",
+        "model_tier": "high"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1972",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1972: Wave 5 finalization: freeze the Go bridge, retire Go, purge Python (runbook + recovery)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/closes",
+        "title": "Issue #1530"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1669"
+      }
+    ]
+  }
+}

--- a/vbrief/pending/2026-06-25-reconcile-verifygo-freeze-version-source-to-a-release-tag-ch.vbrief.json
+++ b/vbrief/pending/2026-06-25-reconcile-verifygo-freeze-version-source-to-a-release-tag-ch.vbrief.json
@@ -1,0 +1,88 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "1972-s1a-freeze-gate-version-source",
+    "title": "Reconcile verify:go-freeze version source to a release-tag check",
+    "status": "pending",
+    "planRef": "proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json",
+    "narratives": {
+      "Description": "The freeze gate currently compares the pinned SoT against the `var version` literal in cmd/deft-install/main.go, but the real installer version is injected via ldflags at build time, so pinning the SoT to a 0.x tag would false-fail the gate. This story moves freeze enforcement to a release.yml tag check that refuses a Go installer build above the pinned SoT and neutralizes the brittle source-literal comparison in freeze-gate.ts.",
+      "ImplementationPlan": "- Change the comparison in packages/core/src/legacy-bridge/freeze-gate.ts so evaluateGoFreeze keys off the release tag input rather than the parseInstallerVersion source literal, keeping readInstallerVersion only where a release-time value is genuinely needed.\n- Add a guard step to the Go build job in .github/workflows/release.yml that reads lastGoInstaller() and fails the build when github.ref_name is above the pinned SoT.\n- Update packages/core/src/legacy-bridge/freeze-gate.test.ts to assert the tag-based comparison passes a 0.x tag at or below the pin and rejects a tag above it.",
+      "UserStory": "As a Deft release maintainer, I want the freeze gate to compare the release tag against the pinned installer SoT, so that pinning a 0.x freeze tag does not false-fail the gate against a stale source literal.",
+      "Traces": "Issue #1972 step 1a; #1912 freeze gate; #1969 SoT + verify:go-freeze"
+    },
+    "items": [
+      {
+        "id": "1972-s1a-freeze-gate-version-source-a1",
+        "title": "Given the SoT is pinned to a 0.x tag, when verify:go-freeze evaluates an equal-or-lower release tag, then the gate returns exit code 0.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the SoT is pinned to a 0.x tag, when verify:go-freeze evaluates an equal-or-lower release tag, then the gate returns exit code 0."
+        }
+      },
+      {
+        "id": "1972-s1a-freeze-gate-version-source-a2",
+        "title": "Given the SoT is pinned, when a release tag above the pinned tag is evaluated, then the gate fails and emits the above-the-line violation message.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the SoT is pinned, when a release tag above the pinned tag is evaluated, then the gate fails and emits the above-the-line violation message."
+        }
+      },
+      {
+        "id": "1972-s1a-freeze-gate-version-source-a3",
+        "title": "Given the SoT is null, when verify:go-freeze runs, then the gate returns an advisory pass and does not read the installer source literal.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the SoT is null, when verify:go-freeze runs, then the gate returns an advisory pass and does not read the installer source literal."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/legacy-bridge/freeze-gate.ts",
+          "packages/core/src/legacy-bridge/freeze-gate.test.ts",
+          ".github/workflows/release.yml"
+        ],
+        "verify_commands": [
+          "pnpm --dir packages/core test -- freeze-gate",
+          "task verify:go-freeze"
+        ],
+        "expected_outputs": [
+          "freeze-gate.ts keyed off the release tag instead of the source literal",
+          "release.yml refuses a Go build above the pinned SoT",
+          "freeze-gate.test.ts covers at/below/above the pinned tag"
+        ],
+        "depends_on": [],
+        "conflict_group": "freeze-gate",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "high"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1972",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1972: Wave 5 finalization: freeze the Go bridge, retire Go, purge Python (runbook + recovery)",
+        "TrustLevel": "external"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/closes",
+        "title": "Issue #1530"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1669"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-25-1967-bundle-githooks-consumer-taskfile-into-deftaidirective-conte.vbrief.json
+++ b/vbrief/proposed/2026-06-25-1967-bundle-githooks-consumer-taskfile-into-deftaidirective-conte.vbrief.json
@@ -1,0 +1,28 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1967"
+  },
+  "plan": {
+    "title": "Bundle .githooks/ + consumer Taskfile into @deftai/directive-content (npm-only deposit parity)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "Bundle .githooks/ + consumer Taskfile into @deftai/directive-content (npm-only deposit parity)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1967",
+      "Overview": "Surfaced by #1942 S5 (PR #1966) while adding the greenfield e2e leg.\n\n## Problem\n`@deftai/directive-content`'s prepack copies only the repo-root `content/` tree (`files: **/*`). After simulating prepack:\n- **`.githooks/` is NOT in the published content tree** (hooks live at repo root, outside `content/`).\n- **root `Taskfile.yml` is NOT in the published content tree** (also outside `content/`).\n\nSo a pure-npm `directive init` deposits a `.deft/core/` WITHOUT `.deft/core/.githooks` or a `.deft/core/Taskfile.yml`. Today `directive init` skips hook wiring gracefully (`writeConsumerGitHooks` logs \"absent — skipping\") and `ensureTaskfile` writes a project Taskfile with an include that won't resolve — so npm-only installs are missing the pre-commit/pre-push branch-policy hooks and the `.deft/core` Taskfile include the unit tests assume.\n\n## Why it matters / sequencing\nThis is currently masked because the **Go installer** still deposits hooks + Taskfile. But Wave 5 retires the Go `deft-install` source + pipeline (#1669 self-work) and the final Python purge (#1860). **The Go-delete MUST NOT land until this is fixed**, or npm-only installs silently lose branch-policy hook enforcement. Treat this as a gate on the Go-source-delete step.\n\n## Fix options\n1. Extend `@deftai/directive-content` packaging to include `.githooks/` + the consumer Taskfile (move them under `content/`, or add them to the prepack copy set), so the deposited tree matches what `init` expects.\n2. Or have `init` synthesize the consumer Taskfile + hooks from a TS template rather than copying from the content tree.\n\n## Acceptance\n- A pure-npm `directive init` (no Go binary) deposits `.deft/core/.githooks` + a resolvable `.deft/core/Taskfile.yml`, and `directive init` wires the hooks (no \"absent — skipping\").\n- The greenfield e2e leg (npm-ops.test.ts) asserts hooks + Taskfile presence rather than graceful-skip.\n\nRefs #1942 #1669 #1860"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1967",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1967: Bundle .githooks/ + consumer Taskfile into @deftai/directive-content (npm-only deposit parity)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1942",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1942"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json
+++ b/vbrief/proposed/2026-06-25-1972-wave-5-finalization-freeze-the-go-bridge-retire-go-purge-pyt.vbrief.json
@@ -1,0 +1,77 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1972"
+  },
+  "plan": {
+    "title": "Wave 5 finalization: freeze the Go bridge, retire Go, purge Python (runbook + recovery)",
+    "status": "proposed",
+    "narratives": {
+      "Description": "Wave 5 finalization: freeze the Go bridge, retire Go, purge Python (runbook + recovery)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1972",
+      "Overview": "## Why this issue\n\nWave 5 of #1669 (distributable Deft) is now a short, linear finish line. The npm-native init/update/migrate work has landed (#1942, #1941 / #1968) and the #1912 freeze-prep scaffolding is merged: #1969 (Tier-0 `lastGoInstaller` SoT + `verify:go-freeze` + `verify:bridge-drift`), #1970 (npm CLI legacy-layout refuse-preflight + stable-URL signposts), #1971 (pinned `--legacy-bridge` e2e leg). This issue consolidates everything that remains into one ordered runbook plus a standing recovery protocol, so the #1669 umbrella can be retired — its design work is done; only execution remains.\n\n**Freeze prerequisites:** (a) 53.x adoption blockers — **N/A** (maintainer decision 2026-06-24; no real 53.x adoption to clear); (b) stage-2 `directive migrate` — **done** (#1968); (c) npm published/live — **done** (#1909).\n\n> **Note (restructured 2026-06-25):** the Go *source/pipeline deletion* (originally step 4) is now a deferred decision tracked in #1979 — the Go installer is the bootstrap/legacy bridge and is more plausibly revived than Python, so the default is *keep* and revisit ~2mo post-freeze. #1967 moved into step 1 (npm must be feature-complete before npm becomes the blessed path). Python purge (#1860) is gated on the soak (step 3), not on the umbrella or on Go deletion.\n\n## Checklist (ordered)\n\n- [ ] **1. Freeze-build prep (npm must be feature-complete before the freeze blesses it as the path).**\n  - (a) **Reconcile the `verify:go-freeze` version source.** Coupling lives in `packages/core/src/legacy-bridge/freeze-gate.ts` (`DEFAULT_INSTALLER_VERSION_PATH = \"cmd/deft-install/main.go\"`, `parseInstallerVersion` reads the `var version = \"...\"` literal, today `1.0.0`). The real installer version is injected at build via ldflags (`-X main.version=<tag>`) and we are on the `0.x` line, so comparing the pin against the literal would false-fail (`1.0.0 > 0.x`). Preferred fix: move freeze enforcement to a `release.yml` tag check that refuses a Go build above the pinned SoT and drop/neutralize the source-literal comparison.\n  - (b) **npm-handoff messaging** in the installer success path (`cmd/deft-install/main.go`): \"this is the last Go installer; upgrades are now npm — run `npx @deftai/directive init`.\"\n  - (c) **`.deft/core/VERSION` handshake** — the installer must write a VERSION that `directive migrate` (#1968) accepts as canonical-ready before stamping `managed_by: npm`. Assert end-to-end in the `--legacy-bridge` e2e leg (`packages/core/src/release-e2e/legacy-bridge-leg.ts`).\n  - (d) **#1967 — npm feature-completeness.** Bundle `.githooks/` + the consumer Taskfile into `@deftai/directive-content` so npm-installed projects get hooks + tasks. The freeze makes npm the blessed path; it must deliver everything the Go installer used to *before* we freeze. This is a freeze prerequisite, not a later gate.\n- [ ] **2. Freeze release.** Choose the next `v0.x` version. In the release commit, pin `LAST_GO_INSTALLER = \"v0.x\"` in `packages/core/src/legacy-bridge/sot.ts` (and align `var version` only if step 1a kept the literal relevant). Run the **pre-cut rehearsal**: `task release -- 0.x --dry-run --skip-tag --skip-release`, `task release:e2e -- --legacy-bridge`, and the bundled `npm publish --dry-run`. Then cut the real tag (`task release -- 0.x`) — one tag ships the npm packages **and** the final Go installer binaries (the permanent frozen bridge).\n- [ ] **3. Soak / validate** the published release in the wild. This is the gate for step 4 and for the deferred Go-deletion decision (#1979).\n- [ ] **4. Python purge — #1860 (closes #1530).** Gated on step 3 (npm path proven), #1967 (step 1d), and an explicit **pre-0.20 migration decision** (see Gotchas): `task migrate:vbrief` is still Python (`scripts/migrate_vbrief.py`), so the purge must first either port it to TS or consciously declare pre-0.20 projects must migrate on an older Deft version. NOT gated on #1669 or on Go deletion.\n\n**Deferred (not a step):** Go installer source + build-pipeline deletion → #1979 (default *keep*; revisit ~2mo post-freeze).\n\n## Recovery protocol (forward-only)\n\nA bad published release is recoverable without unpublishing — this is the standing plan that makes an agent-cut freeze acceptable:\n\n- **Never `npm unpublish`** (breaks lockfiles; npm discourages it). Instead `npm deprecate @deftai/directive@<bad> \"superseded by <next>; see this issue\"` so installs of the bad version print a steer-away warning.\n- **Keep `latest` good:** `npm dist-tag add @deftai/directive@<good> latest` re-points consumers away from a bad version immediately, even before the fix ships.\n- **Ship the fix forward** as the next patch (`0.x.y+1`).\n- **The freeze is re-cuttable.** The SoT pins the *latest* frozen Go installer, not one tag forever. A bad frozen build is fixed by cutting a new frozen tag and re-pinning `LAST_GO_INSTALLER`; the gates and bridge follow the new pin. The freeze decision is reversible-by-forward-motion like any other release.\n\n**Pre-cut insurance (cheap):** rehearsal (dry-run + `--legacy-bridge` e2e + `npm publish --dry-run`) green, and the npm credential/provenance path confirmed live, before pushing the tag.\n\n## Gotchas (recorded so they aren't rediscovered)\n\n- `verify:go-freeze` keys off `cmd/deft-install/main.go` `var version` (`1.0.0` today). Pinning the SoT before step 1a reconciles this will false-fail the gate.\n- The `v*` tag triggers **two** workflows: `release.yml` (the GitHub release lands as a **draft**, operator-gated, reversible) and `npm-publish.yml` (publishes to the **public registry immediately**, NOT draft-gated). The npm publish is the irreversible moment — all reversible testing must happen in pre-cut rehearsal.\n- **Pre-0.20 migration is Python.** The frozen Go installer still migrates pre-0.20 projects fine (it deposits a payload that carries `task migrate:vbrief`), but `scripts/migrate_vbrief.py` runs via `uv ... run python`. The Python purge (#1860), not the Go freeze, is what removes this capability — so before #1860, decide explicitly: port `migrate:vbrief` to TS, or declare pre-0.20 projects must migrate on an older Deft version first.\n\n## Supersedes\n\nConsolidates the remaining Wave-5 tail of #1669 and the freeze execution of #1912. Dependencies tracked separately: #1967 (folded into step 1d), #1860 (step 4), #1979 (deferred Go-source deletion).\n\nRefs #1669 #1912 #1967 #1860 #1979 #1909\n",
+      "Labels": "enhancement, ci-cd, installer"
+    },
+    "items": [
+      {
+        "title": "**1. Freeze-build prep (npm must be feature-complete before the freeze blesses it as the path).**",
+        "status": "proposed"
+      },
+      {
+        "title": "**2. Freeze release.** Choose the next  version. In the release commit, pin  in  (and align  only if step 1a kept the literal relevant). Run the **pre-cut rehearsal**: , , and the bundled . Then cut the real tag () — one tag ships the npm packages **and** the final Go installer binaries (the permanent frozen bridge).",
+        "status": "proposed"
+      },
+      {
+        "title": "**3. Soak / validate** the published release in the wild. This is the gate for step 4 and for the deferred Go-deletion decision (#1979).",
+        "status": "proposed"
+      },
+      {
+        "title": "**4. Python purge — #1860 (closes #1530).** Gated on step 3 (npm path proven), #1967 (step 1d), and an explicit **pre-0.20 migration decision** (see Gotchas):  is still Python (), so the purge must first either port it to TS or consciously declare pre-0.20 projects must migrate on an older Deft version. NOT gated on #1669 or on Go deletion.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "ci-cd",
+      "installer"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1972",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1972: Wave 5 finalization: freeze the Go bridge, retire Go, purge Python (runbook + recovery)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1530",
+        "type": "x-vbrief/closes",
+        "title": "Issue #1530"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1669",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1669"
+      },
+      {
+        "uri": "pending/2026-06-25-reconcile-verifygo-freeze-version-source-to-a-release-tag-ch.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Reconcile verify:go-freeze version source to a release-tag check",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-25-add-npm-handoff-messaging-to-the-go-installer-success-path.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Add npm-handoff messaging to the Go installer success path",
+        "TrustLevel": "internal"
+      },
+      {
+        "uri": "pending/2026-06-25-assert-the-installer-version-is-migrate-acceptable-in-the-le.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Assert the installer VERSION is migrate-acceptable in the legacy-bridge e2e leg",
+        "TrustLevel": "internal"
+      }
+    ],
+    "metadata": {
+      "kind": "epic"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Ingests #1972 (Wave 5 finalization runbook) as the parent epic scope vBRIEF.
- Decomposes step 1 into three swarm-ready story vBRIEFs (1a freeze-gate version source, 1b installer npm-handoff, 1c VERSION-handshake e2e) — all `parallel_safe`, single dependency wave, no file overlap.
- Ingests #1967 (npm feature-completeness, step 1d) as its own scope.
- Records the decomposition draft under `vbrief/.eval/decompositions/`.

This is planning-only prep (no code changes) so the step-1 cohort exists on master before swarm allocation.

## Test plan
- [x] `task scope:decompose --check` validates the draft against the swarm-ready story contract
- [x] `task swarm:readiness` reports all three stories ready, one wave, no overlap, no missing fields
- [x] vBRIEF conformance gate clean on commit

Refs #1972 #1967

Made with [Cursor](https://cursor.com)