### PR TITLE
fix: freeze gate skips Go build gracefully instead of failing release.yml (#1987)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,20 +11,30 @@ permissions:
 
 jobs:
   # -----------------------------------------------------------------------
-  # Freeze gate (#1972 / #1912): refuse a Go-installer release ABOVE the pinned
-  # Tier-0 SoT. Runs ONCE in a dedicated job (not per build-matrix leg) and the
-  # build job gates on it via needs:, so a violation fails fast -- once -- before
-  # any platform build starts. The real installer version is ldflags-injected in
-  # the build job (`-X main.version=${{ github.ref_name }}`), so the freeze line
-  # is the release TAG vs the SoT -- not the stale `var version` source literal.
-  # Reads the pinned value from sot.ts (no version hardcoded here); advisory while
-  # the SoT is null (unfrozen).
+  # Freeze gate (#1972 / #1912): weigh a Go-installer release tag against the
+  # pinned Tier-0 SoT. Runs ONCE in a dedicated job (not per build-matrix leg).
+  # When the tag is ABOVE the frozen line the gate does NOT fail the workflow
+  # (#1987); it emits frozen_skip=true and the build job (+ its downstream Go
+  # jobs, via the needs chain) skip cleanly so the run stays green -- npm publish
+  # (npm-publish.yml) is a separate workflow and ships regardless. The only
+  # hard-fail left is an unparseable SoT (fail-loud, never fail-open). The real
+  # installer version is ldflags-injected in the build job
+  # (`-X main.version=${{ github.ref_name }}`), so the freeze line is the release
+  # TAG vs the SoT -- not the stale `var version` source literal. Reads the
+  # pinned value from sot.ts (no version hardcoded here); advisory while the SoT
+  # is null (unfrozen).
   # -----------------------------------------------------------------------
   freeze-gate:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # frozen_skip (#1987): "true" when the release tag is ABOVE the pinned SoT, so
+    # the Go binary build + release-asset upload skip cleanly (green) instead of
+    # hard-failing the workflow. Unset/empty on every other path (build runs).
+    outputs:
+      frozen_skip: ${{ steps.gate.outputs.frozen_skip }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Refuse a Go-installer release above the frozen SoT
+        id: gate
         shell: bash
         run: |
           set -euo pipefail
@@ -55,8 +65,15 @@ jobs:
           pin_core="$(core "${pinned}")"
           highest="$(printf '%s\n%s\n' "$pin_core" "$tag_core" | sort -V | tail -n1)"
           if [ "$tag_core" != "$pin_core" ] && [ "$highest" = "$tag_core" ]; then
-            echo "::error::FAIL: release tag ${GITHUB_REF_NAME} is ABOVE the frozen Go-installer bridge tag ${pinned} (#1912/#1972). No Go-installer release past the frozen line is allowed; cut at or below ${pinned}, or roll the freeze SoT forward in sot.ts."
-            exit 1
+            # #1987: the Go installer is frozen (SoT pinned) and this tag is past
+            # the line. Rather than hard-fail the whole Release workflow (a red X
+            # on every post-freeze tag, even though npm still ships), skip the Go
+            # binary build + release-asset upload cleanly. The build job gates on
+            # this output via `if:`, and its downstream Go jobs skip via the needs
+            # chain, so the run stays green.
+            echo "::notice::release tag ${GITHUB_REF_NAME} is ABOVE the frozen Go-installer bridge tag ${pinned} (#1912/#1972). The Go installer is frozen; skipping the Go binary build + release-asset upload. npm publish (npm-publish.yml) is unaffected. To resume Go builds, roll the freeze SoT forward in sot.ts."
+            echo "frozen_skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "OK: release tag ${GITHUB_REF_NAME} is at or below the frozen line (${pinned})."
 
@@ -65,6 +82,10 @@ jobs:
   # -----------------------------------------------------------------------
   build:
     needs: freeze-gate
+    # #1987: skip the Go binary build (and, via the needs chain, every downstream
+    # Go job incl. the release-asset upload) when the freeze gate flagged the tag
+    # as above the frozen line. npm publish runs in a separate workflow regardless.
+    if: ${{ needs.freeze-gate.outputs.frozen_skip != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **A frozen Go installer no longer makes every later release show up as failed** — once the Go-installer bridge is frozen, the release pipeline's freeze gate now skips the Go binary build cleanly (a green run with a clear annotation) for any release above the frozen line, instead of hard-failing the whole Release workflow with a red X. npm publishing and the GitHub release notes were never affected; this just stops the post-freeze noise that looked like a broken release. An unparseable freeze setting still fails loudly. Closes #1987.
 
 ### Removed
 

--- a/packages/core/src/content-contracts/standards/release_workflow.test.ts
+++ b/packages/core/src/content-contracts/standards/release_workflow.test.ts
@@ -99,3 +99,23 @@ describe("test_release_workflow.py", () => {
     expect(releasingDocText).toContain("DEFT_ALLOW_DEFAULT_BRANCH_COMMIT");
   });
 });
+
+describe("#1987 freeze-gate graceful skip", () => {
+  it("freeze-gate job declares the frozen_skip output from the gate step", () => {
+    expect(workflowText).toContain("frozen_skip: ${{ steps.gate.outputs.frozen_skip }}");
+  });
+  it("the above-the-line branch sets frozen_skip=true and exits 0 (no hard-fail)", () => {
+    expect(workflowText).toContain('echo "frozen_skip=true" >> "$GITHUB_OUTPUT"');
+    // The old hard-fail wording for a tag above the frozen line must be gone.
+    expect(workflowText).not.toContain("No Go-installer release past the frozen line is allowed");
+  });
+  it("the build job is gated on frozen_skip so it skips cleanly when frozen", () => {
+    expect(workflowText).toContain("needs.freeze-gate.outputs.frozen_skip != 'true'");
+  });
+  it("the unparseable-SoT case still fails loud (fail-closed, never fail-open)", () => {
+    const codeOnly = stripYamlComments(workflowText);
+    // The "Refusing to fail open" branch must still exit 1 on an unparseable SoT.
+    expect(codeOnly).toContain("Refusing to fail open");
+    expect(/Refusing to fail open[\s\S]*?exit 1/m.test(codeOnly)).toBe(true);
+  });
+});

--- a/vbrief/active/2026-06-25-1987-freeze-gate-graceful-skip.vbrief.json
+++ b/vbrief/active/2026-06-25-1987-freeze-gate-graceful-skip.vbrief.json
@@ -1,0 +1,37 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1987"
+  },
+  "plan": {
+    "title": "Freeze gate should skip Go build gracefully (green) instead of hard-failing release.yml post-freeze",
+    "status": "running",
+    "narratives": {
+      "Description": "Freeze gate should skip Go build gracefully (green) instead of hard-failing release.yml post-freeze",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1987",
+      "Overview": "Surfaced while reviewing the #1912/#1972 freeze mechanics.\n\n## Problem\nOnce the operator pins LAST_GO_INSTALLER in packages/core/src/legacy-bridge/sot.ts, the freeze-gate job in .github/workflows/release.yml hard-fails (exit 1) for any release tag whose core version is above the pin. Because build: needs: freeze-gate (and the rest of the Go chain transitively needs build), every post-freeze tag push makes the Release workflow show as a red/failed run. This is cosmetic/operational, not functional: npm packages still publish (separate npm-publish.yml, no freeze gate), the GitHub release + CHANGELOG body still gets created by the operator's local task release, and only the Go binaries are (correctly) not built. But a permanently-red Release workflow after every release is easy to misread as 'the release broke.'\n\n## Fix\nMake the freeze gate skip the Go build gracefully when a tag is above the pin instead of failing the workflow:\n- freeze-gate exits 0 and emits a job output (frozen_skip=true) when the tag is above the pinned SoT.\n- The build job gains a job-level if: that no-ops when frozen_skip == 'true'; downstream Go jobs auto-skip via the needs chain.\n- Keep the genuine fail-loud path for the unparseable-SoT case (must still hard-fail).\n\n## Acceptance\n- Post-freeze (LAST_GO_INSTALLER pinned), pushing a tag above the pin yields a green Release workflow with the Go build skipped and a clear skip annotation.\n- Go binaries are still produced for tags at/below the pin.\n- The unparseable-SoT case still fails loud.\n- npm publish + GitHub-release-notes paths remain unaffected.\n\nRefs #1912 #1972"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1987",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1987: Freeze gate should skip Go build gracefully instead of hard-failing release.yml post-freeze"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1912"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1972",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1972"
+      }
+    ],
+    "updated": "2026-06-25T16:26:45Z",
+    "metadata": {
+      "capacityBucket": "maintenance"
+    }
+  }
+}

--- a/vbrief/completed/2026-06-25-1987-freeze-gate-graceful-skip.vbrief.json
+++ b/vbrief/completed/2026-06-25-1987-freeze-gate-graceful-skip.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Freeze gate should skip Go build gracefully (green) instead of hard-failing release.yml post-freeze",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Freeze gate should skip Go build gracefully (green) instead of hard-failing release.yml post-freeze",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1987",
@@ -29,9 +29,10 @@
         "title": "Issue #1972"
       }
     ],
-    "updated": "2026-06-25T16:26:45Z",
+    "updated": "2026-06-25T16:29:59Z",
     "metadata": {
-      "capacityBucket": "maintenance"
+      "capacityBucket": "maintenance",
+      "completedAt": "2026-06-25T16:29:59Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Once the Go-installer bridge is frozen (`LAST_GO_INSTALLER` pinned in `sot.ts`), the `freeze-gate` job in `release.yml` previously hard-failed (`exit 1`) for any release tag above the pin. Because `build: needs: freeze-gate` (and the rest of the Go chain transitively needs `build`), every post-freeze tag push made the **Release** workflow show as a red/failed run — even though npm still publishes and the GitHub release notes are still created.
- This makes the gate **skip gracefully** instead: `freeze-gate` emits `frozen_skip=true` and exits 0 when the tag is above the pin; the `build` job gates on `needs.freeze-gate.outputs.frozen_skip != 'true'`, and downstream Go jobs skip via the `needs` chain. The run stays green with a clear `::notice::` annotation.
- The genuine **fail-loud** path (unparseable SoT) is preserved — it still `exit 1`s and refuses to fail open.
- npm publish (`npm-publish.yml`, separate workflow) and the operator-driven GitHub release notes are unaffected on every path.

## Changes
- `.github/workflows/release.yml`: `freeze-gate` declares a `frozen_skip` job output set by the gate step (`id: gate`); above-the-line branch sets the output + `exit 0`; `build` gains an `if:` guard.
- `packages/core/src/content-contracts/standards/release_workflow.test.ts`: 4 new assertions locking in the output declaration, the build guard, the skip-not-fail branch, and the preserved fail-loud unparseable case.
- `CHANGELOG.md`: user-facing `### Fixed` entry.

## Test plan
- [x] `release_workflow.test.ts` — 14 passing (10 existing + 4 new)
- [x] `task check` — 8675 passed (cache-fresh refreshed separately)
- [x] workflow YAML parses; job graph verified (`freeze-gate` output + `build` if-guard)

Closes #1987
Refs #1912 #1972

Made with [Cursor](https://cursor.com)