### PR TITLE
chore: freeze the Go installer at v0.56.0 (closes #1912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **The Go installer is now frozen at v0.56.0 — future Deft upgrades come from npm** — the legacy stage-1 bridge is pinned to its final published Go-installer release (`v0.56.0`). From here, the release pipeline's freeze gate enforces the line: tags at or below v0.56.0 still build Go binaries, anything above skips the Go build cleanly (per #1987) and ships via npm only. Existing legacy on-disk layouts are still migrated by the frozen v0.56.0 installer, which then hands off to `npx @deftai/directive` for all subsequent updates. Closes #1912. Refs #1972.
 
 ### Fixed
 - **A frozen Go installer no longer makes every later release show up as failed** — once the Go-installer bridge is frozen, the release pipeline's freeze gate now skips the Go binary build cleanly (a green run with a clear annotation) for any release above the frozen line, instead of hard-failing the whole Release workflow with a red X. npm publishing and the GitHub release notes were never affected; this just stops the post-freeze noise that looked like a broken release. An unparseable freeze setting still fails loudly. Closes #1987.
+- **The release rehearsal's frozen-bridge handoff now finds the published installer binary** — the legacy-bridge end-to-end leg matched assets named `deft-install-darwin-*`, but releases publish `install-<os>-<arch>` (with a single `install-macos-universal` fat binary for macOS). The asset matcher now resolves the real names on every host, so the pinned `legacy → bridge → npm` rehearsal exercises the actual v0.56.0 binary instead of failing to locate it. Refs #1912.
 
 ### Removed
 

--- a/packages/core/src/legacy-bridge/sot.ts
+++ b/packages/core/src/legacy-bridge/sot.ts
@@ -38,7 +38,7 @@
  * at freeze time. Leave it `null` otherwise. This is the only edit required to
  * pin the bridge version; the freeze + drift gates pick it up automatically.
  */
-export const LAST_GO_INSTALLER: string | null = null;
+export const LAST_GO_INSTALLER: string | null = "v0.56.0";
 
 /** Returns the frozen final Go-installer tag, or `null` while unfrozen. */
 export function lastGoInstaller(): string | null {

--- a/packages/core/src/release-e2e/legacy-bridge-leg.test.ts
+++ b/packages/core/src/release-e2e/legacy-bridge-leg.test.ts
@@ -235,59 +235,77 @@ describe("assertInstallerVersionMigrateAcceptable", () => {
 });
 
 describe("selectBridgeAsset", () => {
+  // The real published release asset names (release.yml softprops upload):
+  // install-<os>-<arch>, with macOS shipping a single universal fat binary.
   const multi = [
-    "deft-install-darwin-amd64",
-    "deft-install-darwin-arm64",
-    "deft-install-linux-amd64",
-    "deft-install-linux-arm64",
-    "deft-install-windows-amd64.exe",
+    "install-linux-amd64",
+    "install-linux-arm64",
+    "install-macos-universal",
+    "install-windows-amd64.exe",
+    "install-windows-arm64.exe",
     "checksums.txt",
   ];
 
-  it("returns none when no deft-install asset is present", () => {
+  it("returns none when no installer asset is present", () => {
     expect(selectBridgeAsset(["checksums.txt", "README.md"])).toEqual({ kind: "none" });
   });
 
-  it("uses the sole deft-install asset for a single-binary release", () => {
-    expect(selectBridgeAsset(["deft-install", "checksums.txt"])).toEqual({
+  it("uses the sole installer asset for a single-binary release", () => {
+    expect(selectBridgeAsset(["install", "checksums.txt"])).toEqual({
       kind: "ok",
-      name: "deft-install",
+      name: "install",
     });
   });
 
-  it("selects the GOOS/GOARCH-matching asset, not the alphabetical first", () => {
-    // Alphabetical assets[0] would be darwin-amd64; linux/amd64 must win on a linux host.
-    expect(selectBridgeAsset(multi, "linux", "x64")).toEqual({
+  it("accepts the legacy deft-install- prefix for back-compat", () => {
+    expect(selectBridgeAsset(["deft-install-linux-amd64", "checksums.txt"], "linux", "x64")).toEqual(
+      { kind: "ok", name: "deft-install-linux-amd64" },
+    );
+  });
+
+  it("selects the OS/arch-matching asset, not the alphabetical first", () => {
+    // Alphabetical assets[0] would be install-linux-amd64; the host match must win.
+    expect(selectBridgeAsset(multi, "linux", "arm64")).toEqual({
       kind: "ok",
-      name: "deft-install-linux-amd64",
-    });
-    expect(selectBridgeAsset(multi, "darwin", "arm64")).toEqual({
-      kind: "ok",
-      name: "deft-install-darwin-arm64",
+      name: "install-linux-arm64",
     });
     expect(selectBridgeAsset(multi, "win32", "x64")).toEqual({
       kind: "ok",
-      name: "deft-install-windows-amd64.exe",
+      name: "install-windows-amd64.exe",
     });
   });
 
-  it("falls back to a GOOS-only match when the arch suffix is absent", () => {
-    expect(
-      selectBridgeAsset(["deft-install-linux", "deft-install-darwin"], "linux", "x64"),
-    ).toEqual({ kind: "ok", name: "deft-install-linux" });
+  it("resolves the macOS universal binary on a darwin host (any arch)", () => {
+    // install-macos-universal carries no arch token, so the OS-only fallback
+    // picks it for both amd64 and arm64 darwin hosts.
+    expect(selectBridgeAsset(multi, "darwin", "arm64")).toEqual({
+      kind: "ok",
+      name: "install-macos-universal",
+    });
+    expect(selectBridgeAsset(multi, "darwin", "x64")).toEqual({
+      kind: "ok",
+      name: "install-macos-universal",
+    });
+  });
+
+  it("falls back to an OS-only match when the arch suffix is absent", () => {
+    expect(selectBridgeAsset(["install-linux", "install-macos"], "linux", "x64")).toEqual({
+      kind: "ok",
+      name: "install-linux",
+    });
   });
 
   it("reports no-platform-match (with candidates) when nothing matches the host", () => {
     const result = selectBridgeAsset(
-      ["deft-install-darwin-arm64", "deft-install-windows-amd64.exe"],
+      ["install-macos-universal", "install-windows-amd64.exe"],
       "linux",
       "x64",
     );
     expect(result.kind).toBe("no-platform-match");
     if (result.kind === "no-platform-match") {
       expect(result.candidates).toEqual([
-        "deft-install-darwin-arm64",
-        "deft-install-windows-amd64.exe",
+        "install-macos-universal",
+        "install-windows-amd64.exe",
       ]);
     }
   });
@@ -321,7 +339,7 @@ describe("downloadAndRunFrozenBridge", () => {
     expect(reason).toContain("release not found");
   });
 
-  it("FAILs when no deft-install asset is present in the download", () => {
+  it("FAILs when no installer asset is present in the download", () => {
     const emptyDir = freshRoot("frozen-empty-");
     const [okFlag, reason] = downloadAndRunFrozenBridge("v9.9.9", "/fixture", {
       which: whichFor("gh"),
@@ -329,7 +347,7 @@ describe("downloadAndRunFrozenBridge", () => {
       mkdtemp: () => emptyDir,
     });
     expect(okFlag).toBe(false);
-    expect(reason).toContain("no deft-install asset");
+    expect(reason).toContain("no installer asset");
   });
 
   it("cleans up the downloaded-binary temp dir on an early-return failure path", () => {
@@ -385,14 +403,19 @@ describe("runLegacyBridgeLeg", () => {
     expect(reason).toContain("skipped the real frozen-binary download");
   });
 
-  it("uses the real SoT reader by default (null today -> PENDING)", () => {
+  it("uses the real SoT reader by default (frozen at the pinned tag -> frozen path)", () => {
+    // Post-freeze (#1912) the real Tier-0 SoT is pinned, so the default reader
+    // takes the frozen stage-1 path. With gh absent (whichFor("npm")) the real
+    // frozen-binary download soft-skips while still reporting the frozen pin --
+    // proving the leg reads the live SoT rather than a stale null assumption.
     const [okFlag, reason] = runLegacyBridgeLeg(process.cwd(), {
       which: whichFor("npm"),
       resolveEngine: () => "npm",
       agentsTemplatePath: null,
     });
     expect(okFlag).toBe(true);
-    expect(reason).toContain("PENDING (SoT unfrozen)");
+    expect(reason).toContain("frozen pin");
+    expect(reason).toContain("SKIP");
   });
 
   it("validates the VERSION handshake on the SoT-null path with no binary download (a3)", () => {

--- a/packages/core/src/release-e2e/legacy-bridge-leg.ts
+++ b/packages/core/src/release-e2e/legacy-bridge-leg.ts
@@ -342,10 +342,19 @@ export function assertNpmHybridMigration(
   ];
 }
 
-/** Map a Node `process.platform` value to the Go release `GOOS` asset token. */
+/**
+ * Map a Node `process.platform` value to the published release OS asset token.
+ *
+ * The release workflow (.github/workflows/release.yml) uploads assets named
+ * `install-<os>-<arch>` where <os> is `windows` / `macos` / `linux` -- NOT the Go
+ * `GOOS` token. In particular macOS publishes a single `install-macos-universal`
+ * binary (the lipo'd fat binary), so a darwin host must look for `macos`, not
+ * `darwin`.
+ */
 function goOsToken(platform: NodeJS.Platform): string {
   if (platform === "win32") return "windows";
-  return platform; // "linux" / "darwin" line up with GOOS as-is
+  if (platform === "darwin") return "macos"; // assets are install-macos-universal
+  return platform; // "linux" lines up as-is
 }
 
 /** Map a Node `process.arch` value to the Go release `GOARCH` asset token. */
@@ -361,17 +370,26 @@ export type BridgeAssetSelection =
   | { kind: "no-platform-match"; candidates: string[] };
 
 /**
- * Pick the deft-install bridge binary matching the current host platform/arch.
+ * Match an installer binary asset. The release workflow uploads
+ * `install-<os>-<arch>` (e.g. `install-linux-amd64`, `install-windows-amd64.exe`,
+ * `install-macos-universal`); the legacy single-binary / `deft-install-` naming is
+ * also accepted for back-compat. Anchored at the start of the basename so sibling
+ * assets like `checksums.txt` / `README.md` are excluded.
+ */
+const INSTALLER_ASSET_RE = /^(?:deft-)?install(?:-|\.exe$|$)/i;
+
+/**
+ * Pick the installer bridge binary matching the current host platform/arch.
  *
- * Go releases publish one asset per OS/arch (e.g. `deft-install-linux-amd64`,
- * `deft-install-darwin-arm64`, `deft-install-windows-amd64.exe`). Selecting
- * `assets[0]` alphabetically silently picks the wrong binary on a multi-asset
- * release (darwin sorts before linux), producing an exec-format failure on a
- * non-Darwin runner. This resolves the host-matching asset instead and reports
- * a precise outcome when none matches:
- *   - single deft-install asset -> use it (single-binary releases, back-compat);
- *   - prefer an asset whose name carries BOTH the GOOS and GOARCH tokens;
- *   - else fall back to a GOOS-only match (releases that omit the arch suffix);
+ * The release publishes one asset per OS (`install-<os>-<arch>`, with macOS as a
+ * single `install-macos-universal` fat binary). Selecting `assets[0]`
+ * alphabetically silently picks the wrong binary on a multi-asset release,
+ * producing an exec-format failure on a mismatched runner. This resolves the
+ * host-matching asset instead and reports a precise outcome when none matches:
+ *   - single installer asset -> use it (single-binary releases, back-compat);
+ *   - prefer an asset whose name carries BOTH the OS and arch tokens;
+ *   - else fall back to an OS-only match (e.g. the macOS universal binary, which
+ *     carries no arch suffix, or releases that omit the arch suffix);
  *   - else `no-platform-match` so the caller fails loudly rather than guessing.
  */
 export function selectBridgeAsset(
@@ -379,7 +397,7 @@ export function selectBridgeAsset(
   platform: NodeJS.Platform = process.platform,
   arch: string = process.arch,
 ): BridgeAssetSelection {
-  const candidates = fileNames.filter((name) => /deft-install/i.test(name));
+  const candidates = fileNames.filter((name) => INSTALLER_ASSET_RE.test(name));
   if (candidates.length === 0) {
     return { kind: "none" };
   }
@@ -447,14 +465,14 @@ export function downloadAndRunFrozenBridge(
     if (selection.kind === "none") {
       return [
         false,
-        `frozen bridge ${pin} downloaded but no deft-install asset found in ${assetDir} ` +
+        `frozen bridge ${pin} downloaded but no installer asset (install-*) found in ${assetDir} ` +
           `(see ${GO_BRIDGE_RELEASES_URL})`,
       ];
     }
     if (selection.kind === "no-platform-match") {
       return [
         false,
-        `frozen bridge ${pin} downloaded but no deft-install asset matches ` +
+        `frozen bridge ${pin} downloaded but no installer asset matches ` +
           `${goOsToken(process.platform)}/${goArchToken(process.arch)} ` +
           `(candidates: ${selection.candidates.join(", ")}; see ${GO_BRIDGE_RELEASES_URL})`,
       ];

--- a/vbrief/active/2026-06-25-1912-freeze-go-installer.vbrief.json
+++ b/vbrief/active/2026-06-25-1912-freeze-go-installer.vbrief.json
@@ -1,0 +1,32 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF for the operator freeze action of epic #1912"
+  },
+  "plan": {
+    "title": "Freeze the Go installer at v0.56.0 (pin LAST_GO_INSTALLER)",
+    "status": "running",
+    "narratives": {
+      "Description": "Operator freeze action for epic #1912: pin the final Go-installer tag in the Tier-0 source of truth so the legacy stage-1 bridge is frozen and all future Deft upgrades flow through npm.",
+      "Origin": "Epic #1912 (freeze the Go installer / retire the Go bridge), Wave 5 runbook #1972 Step 3.",
+      "Overview": "The freeze-prep gates (verify:go-freeze, verify:bridge-drift), the npm handoff message, the pinned legacy-bridge e2e leg, and the freeze-gate graceful-skip (#1987) all landed and shipped in v0.56.0. v0.56.0 is published as the final Go installer (carries the npm-handoff guidance). This is the single operator edit that flips the freeze:\n\n- Set LAST_GO_INSTALLER = \"v0.56.0\" in packages/core/src/legacy-bridge/sot.ts (the only place the literal is allowed to live).\n\nOnce pinned: isFrozen() returns true; verify:go-freeze enforces the version ceiling (tags at/below v0.56.0 OK, above skip the Go build via the #1987 graceful-skip); verify:bridge-drift continues to refuse any surface that hardcodes a competing version; the pinned legacy-bridge e2e leg runs the real handoff instead of the PENDING advisory.\n\n## Acceptance\n- LAST_GO_INSTALLER pinned to \"v0.56.0\".\n- verify:go-freeze passes (advisory-to-enforcing flip is clean for the current tag state).\n- verify:bridge-drift passes (no competing hardcoded version surfaced).\n- task check green.\n- CHANGELOG [Unreleased] notes the freeze.\n\nCloses #1912. Refs #1972."
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1912",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1912: Freeze the Go installer / retire the Go bridge"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1972",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1972: Wave 5 finalization runbook"
+      }
+    ],
+    "updated": "2026-06-25T16:37:37Z",
+    "metadata": {
+      "capacityBucket": "maintenance"
+    }
+  }
+}

--- a/vbrief/completed/2026-06-25-1912-freeze-go-installer.vbrief.json
+++ b/vbrief/completed/2026-06-25-1912-freeze-go-installer.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Freeze the Go installer at v0.56.0 (pin LAST_GO_INSTALLER)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Operator freeze action for epic #1912: pin the final Go-installer tag in the Tier-0 source of truth so the legacy stage-1 bridge is frozen and all future Deft upgrades flow through npm.",
       "Origin": "Epic #1912 (freeze the Go installer / retire the Go bridge), Wave 5 runbook #1972 Step 3.",
@@ -24,9 +24,10 @@
         "title": "Issue #1972: Wave 5 finalization runbook"
       }
     ],
-    "updated": "2026-06-25T16:37:37Z",
+    "updated": "2026-06-25T16:46:21Z",
     "metadata": {
-      "capacityBucket": "maintenance"
+      "capacityBucket": "maintenance",
+      "completedAt": "2026-06-25T16:46:21Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
The freeze-prep work (gates, npm handoff message, pinned e2e leg, and the #1987 graceful-skip) all shipped in **v0.56.0**, which is published as the final Go installer. This is the single operator edit that flips the freeze:

- Pin `LAST_GO_INSTALLER = "v0.56.0"` in `packages/core/src/legacy-bridge/sot.ts` (the one place the bridge-version literal is allowed to live). `isFrozen()` is now `true`.
- From here the release pipeline's freeze gate enforces the line: tags ≤ v0.56.0 build Go binaries; anything above skips the Go build cleanly (#1987) and ships via npm only.
- Legacy on-disk layouts are still migrated by the frozen v0.56.0 installer, which then hands off to `npx @deftai/directive` for all future updates.

## Asset-naming fix surfaced by the real handoff
Pinning the SoT activated the **real** pinned `legacy → bridge → npm` handoff for the first time, which immediately failed: `selectBridgeAsset` matched `deft-install-darwin-*`, but releases publish `install-<os>-<arch>` (and a single `install-macos-universal` fat binary for macOS). Fixed the matcher + OS-token mapping so it resolves the real names on every host. **Verified end-to-end against the live v0.56.0 release** — the binary downloads, runs, normalizes a legacy fixture to canonical-vendored, and `directive migrate` stamps it npm-managed.

## Changes
- `packages/core/src/legacy-bridge/sot.ts`: pin the SoT.
- `packages/core/src/release-e2e/legacy-bridge-leg.ts`: `selectBridgeAsset` matches `(?:deft-)?install-*`; `goOsToken(darwin) → "macos"`; OS-only fallback resolves the macOS universal binary; error wording updated.
- `packages/core/src/release-e2e/legacy-bridge-leg.test.ts`: tests use the real published asset names; the real-SoT-reader leg test updated for the now-frozen default.
- `CHANGELOG.md`: user-facing freeze + fix entries.

## Test plan
- [x] `verify:go-freeze` — advisory pass (frozen at v0.56.0; enforcement runs on a tag push)
- [x] `verify:bridge-drift` — 4 surfaces scanned, all read the SoT, no competing hardcoded version
- [x] real pinned legacy-bridge handoff against live v0.56.0 — OK (download → run → normalize → migrate npm-hybrid)
- [x] `legacy-bridge-leg.test.ts` — 42 passing
- [x] `task check` — 8675 passed (local `verify:cache-fresh` fails on pre-existing stale closed-issue cache entries, unrelated to this change; not a CI gate)

Closes #1912
Refs #1972 #1987

Made with [Cursor](https://cursor.com)