### PR TITLE
fix: redirect vendored run update to npm canonical path (#1998)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vendored `run update` now points at npm instead of dead-ending** — the compatibility `run update` stub no longer tells operators to manually replace the deft directory; it signposts `npm i -g @deftai/directive@latest` and `npx @deftai/directive update` so future deposits steer consumers to the post-freeze upgrade path. Closes #1998.
+
 ### Removed
 
 ## [0.56.2] - 2026-06-25

--- a/run
+++ b/run
@@ -3942,11 +3942,27 @@ def cmd_doctor(args: List[str]):
 # ===
 
 def cmd_update(args: List[str]):
-    """Update command - update deft framework"""
+    """Update command -- redirect to the canonical npm upgrade path (#1998).
+
+    Post-freeze (#1912) the vendored ``run update`` surface does not replace
+    the framework payload. It signposts the npm CLI instead of dead-ending with
+    a manual directory swap.
+    """
     print_header(f"Deft CLI v{VERSION} - Update")
     print()
-    info("Deft update functionality not yet implemented")
-    warn("Manual update: Replace deft directory with latest version from repository")
+    info(
+        "Framework payload updates are delivered via npm post-freeze (#1912). "
+        "This vendored `run update` command does not replace the payload."
+    )
+    info(
+        "Install and upgrade via npm: `npm i -g @deftai/directive` (install) or "
+        "`npm i -g @deftai/directive@latest` (upgrade). Node >= 20 is required."
+    )
+    info("Refresh this project's vendored payload: `npx @deftai/directive update`")
+    info(
+        "If you still use a legacy on-disk layout, see content/UPGRADING.md "
+        "for the two-step Go-bridge -> npm migration."
+    )
     return 0
 
 def cmd_reset(args: List[str]):

--- a/tests/cli/test_cmd_update.py
+++ b/tests/cli/test_cmd_update.py
@@ -1,0 +1,34 @@
+"""tests/cli/test_cmd_update.py -- vendored `run update` npm signpost (#1998).
+
+The vendored ``run update`` command must not dead-end with a manual
+"replace the deft directory" message post-freeze (#1912). It signposts
+the canonical npm upgrade path instead.
+"""
+
+from __future__ import annotations
+
+_DEAD_END = "Replace deft directory with latest version from repository"
+_NOT_IMPLEMENTED = "Deft update functionality not yet implemented"
+
+
+class TestCmdUpdateNpmSignpost:
+    """#1998: cmd_update emits npm-canonical guidance, not the legacy dead-end."""
+
+    def test_emits_npm_global_upgrade_command(self, run_command):
+        result = run_command("cmd_update", [])
+        assert result.return_code == 0
+        assert "npm i -g @deftai/directive@latest" in result.stdout
+
+    def test_emits_npx_project_refresh_command(self, run_command):
+        result = run_command("cmd_update", [])
+        assert result.return_code == 0
+        assert "npx @deftai/directive update" in result.stdout
+
+    def test_does_not_emit_replace_directory_dead_end(self, run_command):
+        result = run_command("cmd_update", [])
+        assert _DEAD_END not in result.stdout
+        assert _NOT_IMPLEMENTED not in result.stdout
+
+    def test_explains_run_update_does_not_replace_payload(self, run_command):
+        result = run_command("cmd_update", [])
+        assert "does not replace the payload" in result.stdout

--- a/vbrief/completed/2026-06-25-1998-vendored-run-update-stub-dead-ends-post-freeze-redirect-to-t.vbrief.json
+++ b/vbrief/completed/2026-06-25-1998-vendored-run-update-stub-dead-ends-post-freeze-redirect-to-t.vbrief.json
@@ -1,0 +1,37 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1998"
+  },
+  "plan": {
+    "title": "Vendored `run update` stub dead-ends post-freeze — redirect to the canonical npm path (template fix)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Vendored `run update` stub dead-ends post-freeze — redirect to the canonical npm path (template fix)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1998",
+      "Overview": "Child of #1993 (sub-problem 4). Split out from the live Cartograph consumer report.\n\nThe vendored `run update` (`run:3944-3950`, registered at `run:5398`) prints \"Deft update functionality not yet implemented / Manual update: Replace deft directory with latest version from repository\" — a first-class command that dead-ends.\n\nVendored-only artifact: we can't fix it on existing v0.56.0 installs (the payload is frozen), but the template should be corrected so future deposits print the exact canonical next step (`npx @deftai/directive update`, or `npm i -g @deftai/directive@latest` then the migration step) instead of \"replace the directory\". Lowest priority of the #1993 children.\n\nRefs #1993.",
+      "Labels": "installer"
+    },
+    "items": [],
+    "tags": [
+      "installer"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1998",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1998: Vendored `run update` stub dead-ends post-freeze — redirect to the canonical npm path (template fix)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1993",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1993"
+      }
+    ],
+    "updated": "2026-06-25T20:15:40Z",
+    "metadata": {
+      "completedAt": "2026-06-25T20:15:40Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Redirect the vendored `run update` stub from the dead-end "replace the deft directory" message to the post-freeze npm upgrade path.
- Signpost `npm i -g @deftai/directive@latest` for global CLI upgrades and `npx @deftai/directive update` for refreshing the project's vendored payload.
- Add regression tests asserting the npm guidance is emitted and the legacy dead-end text is absent.

## Test plan

- [x] `uv run pytest tests/cli/test_cmd_update.py`
- [x] `TMPDIR=$(mktemp -d) task check`

Closes #1998
