### PR TITLE
feat: doc-CLI parity gate + npm install+run release-e2e smoke (#1996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Doc and release rehearsals now catch npm CLI drift before publish** — a new check compares every `directive` / `deft` command cited in UPGRADING.md and the AGENTS.md managed section against the live CLI router so documented verbs cannot outpace registration, and the release end-to-end rehearsal packs all four npm packages, installs them into a clean layout, and runs `directive doctor` to fail on module-not-found import bugs like the #1993 regression. Closes #1996.
 
 ### Changed
 

--- a/packages/cli/src/agents-refresh.test.ts
+++ b/packages/cli/src/agents-refresh.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseAgentsRefreshArgs, runAgentsRefresh } from "./agents-refresh.js";
+
+describe("agents-refresh CLI (#1996)", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshProject(): string {
+    const root = mkdtempSync(join(tmpdir(), "agents-refresh-"));
+    created.push(root);
+    return root;
+  }
+
+  it("parseAgentsRefreshArgs rejects unknown flags", () => {
+    expect(parseAgentsRefreshArgs(["--nope"]).error).toContain("unrecognized");
+  });
+
+  it("creates AGENTS.md when absent", () => {
+    const project = freshProject();
+    const code = runAgentsRefresh(["--project-root", project]);
+    expect(code).toBe(0);
+    const text = readFileSync(join(project, "AGENTS.md"), "utf8");
+    expect(text).toContain("deft:managed-section");
+  });
+
+  it("--check exits 0 when current", () => {
+    const project = freshProject();
+    expect(runAgentsRefresh(["--project-root", project])).toBe(0);
+    expect(runAgentsRefresh(["--project-root", project, "--check"])).toBe(0);
+  });
+
+  it("--dry-run does not write", () => {
+    const project = freshProject();
+    writeFileSync(join(project, "AGENTS.md"), "# stale\n", "utf8");
+    const code = runAgentsRefresh(["--project-root", project, "--dry-run"]);
+    expect(code).toBe(0);
+    expect(readFileSync(join(project, "AGENTS.md"), "utf8")).toBe("# stale\n");
+  });
+});

--- a/packages/cli/src/agents-refresh.ts
+++ b/packages/cli/src/agents-refresh.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * agents:refresh — rewrite AGENTS.md managed section from the canonical template (#768 / #1996).
+ */
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { agentsRefreshPlan } from "@deftai/directive-core/platform";
+
+export interface AgentsRefreshArgs {
+  projectRoot: string;
+  check: boolean;
+  dryRun: boolean;
+  error?: string;
+}
+
+export function parseAgentsRefreshArgs(argv: readonly string[]): AgentsRefreshArgs {
+  let projectRoot = process.cwd();
+  let check = false;
+  let dryRun = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i] ?? "";
+    if (arg === "--check") {
+      check = true;
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--project-root") {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        return { projectRoot, check, dryRun, error: "missing --project-root value" };
+      }
+      projectRoot = next;
+      i += 1;
+    } else if (arg.startsWith("--project-root=")) {
+      projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { projectRoot, check, dryRun, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return { projectRoot: resolve(projectRoot), check, dryRun };
+}
+
+export function runAgentsRefresh(argv: readonly string[]): number {
+  const args = parseAgentsRefreshArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`agents:refresh: ${args.error}\n`);
+    return 2;
+  }
+
+  const plan = agentsRefreshPlan(args.projectRoot) as Record<string, unknown>;
+  const state = String(plan.state ?? "unknown");
+
+  if (args.check) {
+    if (state === "current") return 0;
+    process.stderr.write(`agents:refresh --check: AGENTS.md state is ${state}\n`);
+    return 1;
+  }
+
+  if (state === "current") {
+    process.stdout.write("AGENTS.md managed section is current — no changes.\n");
+    return 0;
+  }
+
+  if (state === "template-missing" || state === "template-malformed" || state === "unreadable") {
+    process.stderr.write(`agents:refresh failed: ${state}\n`);
+    return 2;
+  }
+
+  const newContent = plan.new_content;
+  if (typeof newContent !== "string") {
+    process.stderr.write("agents:refresh failed: plan produced no new_content\n");
+    return 2;
+  }
+
+  const path = String(plan.path ?? resolve(args.projectRoot, "AGENTS.md"));
+  if (args.dryRun) {
+    process.stdout.write(`[dry-run] would write ${path} (state=${state})\n`);
+    return 0;
+  }
+
+  writeFileSync(path, newContent, "utf8");
+  process.stdout.write(`AGENTS.md updated (state=${state}).\n`);
+  return 0;
+}
+
+export function run(argv: readonly string[]): number {
+  return runAgentsRefresh(argv);
+}
+
+/* v8 ignore start -- entry guard */
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}
+/* v8 ignore stop */

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -148,6 +148,14 @@ function routeNamespaceVerb(ns: string, verb: string, rest: string[]): RoutedArg
     return { kind: "dispatch", argv: [colonKey, ...rest] };
   }
 
+  if (ns === "framework" && verb === "doctor") {
+    return { kind: "dispatch", argv: ["doctor", ...rest] };
+  }
+
+  if (ns === "agents" && verb === "refresh") {
+    return { kind: "dispatch", argv: ["agents-refresh", ...rest] };
+  }
+
   if (ns === "scope") {
     if (SCOPE_LIFECYCLE_VERBS.has(verb)) {
       return { kind: "dispatch", argv: ["scope-lifecycle", verb, ...rest] };

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -33,6 +33,7 @@ const HANDLER_KEYS = [
 
 /** CLI modules in packages/cli/src (excluding parity harnesses and bin/index). */
 export const CLI_MODULE_VERBS = [
+  "agents-refresh",
   "cache",
   "check",
   "capacity-backfill",
@@ -176,6 +177,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "triage:scope": "triage-scope",
   "triage:accept": "triage-actions",
   "triage:status": "triage-actions",
+  "agents:refresh": "agents-refresh",
   "session:start": "framework-commands",
   "toolchain:check": "toolchain-check",
   "ts:check-lane": "ts-check-lane",

--- a/packages/cli/src/doc-cli-parity.test.ts
+++ b/packages/cli/src/doc-cli-parity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectDocCliParityFailures,
+  extractDocCliReferences,
+  LEGACY_DOC_VERB_KEYS,
+  normalizeDocCommand,
+  validateDocCliCommand,
+} from "./doc-cli-parity.js";
+
+describe("normalizeDocCommand", () => {
+  it("strips flags and placeholders", () => {
+    expect(normalizeDocCommand("deft scope:promote -- <path>")).toBe("scope:promote");
+    expect(normalizeDocCommand("deft verify:session-ritual -- --tier=gated")).toBe(
+      "verify:session-ritual",
+    );
+    expect(normalizeDocCommand("deft packs:slice <pack> <slice> [-- <filters>]")).toBe(
+      "packs:slice",
+    );
+  });
+
+  it("returns null for paths, globs, and legacy installer literals", () => {
+    expect(normalizeDocCommand("deft/QUICK-START.md")).toBeNull();
+    expect(normalizeDocCommand("deft-directive-sync")).toBeNull();
+    expect(normalizeDocCommand("deft-install --yes --upgrade")).toBeNull();
+    expect(normalizeDocCommand("deftai/directive")).toBeNull();
+  });
+});
+
+describe("doc ↔ CLI parity gate (#1996)", () => {
+  it("extracts npm/directive/deft references from UPGRADING and agents-entry", () => {
+    const refs = extractDocCliReferences();
+    expect(refs.some((r) => r.source === "content/UPGRADING.md" && r.normalized === "doctor")).toBe(
+      true,
+    );
+    expect(
+      refs.some((r) => r.source === "content/UPGRADING.md" && r.normalized === "agents:refresh"),
+    ).toBe(true);
+    expect(
+      refs.some(
+        (r) => r.source === "content/templates/agents-entry.md" && r.normalized === "triage:queue",
+      ),
+    ).toBe(true);
+  });
+
+  it("validates every extracted command against registeredVerbs + router", () => {
+    const failures = collectDocCliParityFailures();
+    expect(
+      failures,
+      failures.map((f) => `${f.source}: \`${f.raw}\` -> ${f.reason}`).join("\n"),
+    ).toEqual([]);
+  });
+
+  it("fails loudly when a doc verb is not registered", () => {
+    expect(validateDocCliCommand("totally-fake-verb")).toMatch(/unregistered handler/);
+  });
+
+  it("allowlists documented legacy back-compat verbs", () => {
+    for (const key of LEGACY_DOC_VERB_KEYS) {
+      expect(validateDocCliCommand(key)).toBeNull();
+    }
+  });
+
+  it("accepts npm top-level init/update/migrate invocations", () => {
+    expect(validateDocCliCommand("init")).toBeNull();
+    expect(validateDocCliCommand("update")).toBeNull();
+  });
+});

--- a/packages/cli/src/doc-cli-parity.test.ts
+++ b/packages/cli/src/doc-cli-parity.test.ts
@@ -60,6 +60,12 @@ describe("doc ↔ CLI parity gate (#1996)", () => {
     }
   });
 
+  it("does not allowlist colon-verbs whose stem matches a legacy key", () => {
+    const reason = validateDocCliCommand("core:upgrade");
+    expect(reason).not.toBeNull();
+    expect(reason).toContain("unregistered handler");
+  });
+
   it("accepts npm top-level init/update/migrate invocations", () => {
     expect(validateDocCliCommand("init")).toBeNull();
     expect(validateDocCliCommand("update")).toBeNull();

--- a/packages/cli/src/doc-cli-parity.ts
+++ b/packages/cli/src/doc-cli-parity.ts
@@ -1,0 +1,175 @@
+/**
+ * Doc ↔ CLI parity gate (#1996).
+ *
+ * Extracts npm-canonical CLI invocations from UPGRADING.md and the AGENTS.md
+ * managed-section template, then asserts each resolves through the top-level
+ * router to a registered dispatcher verb (or an explicitly allowlisted legacy
+ * back-compat surface documented post-#1912).
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { hasCommand } from "@deftai/directive-core/render";
+import { routeArgv } from "./cli-router/route-argv.js";
+import { registeredVerbs, resolveCanonicalVerb, VERB_ALIASES } from "./dispatch.js";
+
+/** Documented legacy surfaces that remain in prose but are not npm-router verbs. */
+export const LEGACY_DOC_VERB_KEYS = new Set(["setup", "upgrade", "relocate"]);
+
+const CLI_PREFIX_RE = /^(?:directive|deft|npx @deftai\/directive)\s+/;
+const BACKTICK_COMMAND_RE = /`((?:directive|deft|npx @deftai\/directive)\s+[^`]+)`/g;
+
+const TOP_LEVEL_UX = new Set(["init", "update", "migrate"]);
+
+export interface DocCliReference {
+  readonly source: string;
+  readonly raw: string;
+  readonly normalized: string;
+}
+
+export interface DocCliParityFailure {
+  readonly source: string;
+  readonly raw: string;
+  readonly reason: string;
+}
+
+function repoRootFromModule(): string {
+  return resolve(import.meta.dirname, "..", "..", "..");
+}
+
+function extractManagedSection(text: string): string {
+  const open = text.indexOf("<!-- deft:managed-section");
+  if (open < 0) return text;
+  const close = text.indexOf("<!-- /deft:managed-section -->", open);
+  if (close < 0) return text.slice(open);
+  return text.slice(open, close);
+}
+
+/** Pull CLI command references from UPGRADING.md + agents-entry managed section. */
+export function extractDocCliReferences(
+  repoRoot: string = repoRootFromModule(),
+): DocCliReference[] {
+  const sources: Array<[string, string]> = [
+    ["content/UPGRADING.md", readFileSync(join(repoRoot, "content/UPGRADING.md"), "utf8")],
+    [
+      "content/templates/agents-entry.md",
+      extractManagedSection(
+        readFileSync(join(repoRoot, "content/templates/agents-entry.md"), "utf8"),
+      ),
+    ],
+  ];
+  const seen = new Set<string>();
+  const out: DocCliReference[] = [];
+  for (const [source, text] of sources) {
+    for (const match of text.matchAll(BACKTICK_COMMAND_RE)) {
+      const raw = match[1]?.trim() ?? "";
+      if (!CLI_PREFIX_RE.test(raw)) continue;
+      const normalized = normalizeDocCommand(raw);
+      if (normalized === null) continue;
+      const key = `${source}\0${normalized}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ source, raw, normalized });
+    }
+  }
+  return out.sort(
+    (a, b) => a.source.localeCompare(b.source) || a.normalized.localeCompare(b.normalized),
+  );
+}
+
+/** Strip flags/placeholders; return null when the literal is not a CLI verb invocation. */
+export function normalizeDocCommand(raw: string): string | null {
+  let rest = raw.replace(CLI_PREFIX_RE, "").trim();
+  if (rest.length === 0) return null;
+
+  const dd = rest.indexOf(" --");
+  if (dd >= 0) rest = rest.slice(0, dd).trim();
+
+  rest = rest.replace(/\s+\[[^\]]*\]/g, "").trim();
+  rest = rest.replace(/\s+--[^\s]+(\s+[^\s]+)?/g, "").trim();
+  rest = rest.replace(/<[^>]+>/g, "").trim();
+
+  if (rest.includes("/") || rest.includes(".md") || rest.includes("*")) return null;
+  if (/^deft-install\b/.test(rest)) return null;
+  if (/^deft-directive\b/.test(rest)) return null;
+  if (/^deftai\b/.test(rest)) return null;
+
+  const first = rest.split(/\s+/)[0] ?? "";
+  if (!/^[\w:-]+$/.test(first)) return null;
+
+  if (first.includes(":")) {
+    return first;
+  }
+  return first;
+}
+
+function tokenizeDocVerb(normalized: string): string[] {
+  if (normalized.includes(":")) {
+    const colon = normalized.indexOf(":");
+    return [normalized.slice(0, colon), normalized.slice(colon + 1)];
+  }
+  return [normalized];
+}
+
+function colonKeyFromNormalized(normalized: string): string | null {
+  if (normalized.includes(":")) return normalized;
+  return null;
+}
+
+function isRegisteredHandler(flatVerb: string): boolean {
+  const verbs = new Set(registeredVerbs());
+  if (verbs.has(flatVerb)) return true;
+  const canon = resolveCanonicalVerb(flatVerb);
+  return canon !== null && verbs.has(canon);
+}
+
+/** Validate one normalized doc command against the router + registeredVerbs(). */
+export function validateDocCliCommand(normalized: string): string | null {
+  const colonKey = colonKeyFromNormalized(normalized);
+  if (colonKey !== null) {
+    const legacyStem = colonKey.includes(":") ? colonKey.split(":")[1] : colonKey;
+    if (LEGACY_DOC_VERB_KEYS.has(colonKey) || LEGACY_DOC_VERB_KEYS.has(legacyStem ?? "")) {
+      return null;
+    }
+    if (colonKey in VERB_ALIASES || hasCommand(colonKey)) {
+      return null;
+    }
+  } else if (LEGACY_DOC_VERB_KEYS.has(normalized)) {
+    return null;
+  }
+
+  const tokens = tokenizeDocVerb(normalized);
+  const routed = routeArgv(tokens);
+  if (routed.kind === "stub") {
+    return routed.stubMessage ?? "routes to stub handler";
+  }
+
+  const head = routed.argv[0];
+  if (head === undefined || head.length === 0) {
+    return "router produced empty argv";
+  }
+
+  if (TOP_LEVEL_UX.has(head)) {
+    return null;
+  }
+
+  if (isRegisteredHandler(head)) {
+    return null;
+  }
+
+  return `unregistered handler '${head}' (tokens=${JSON.stringify(tokens)}, routed=${JSON.stringify(routed.argv.slice(0, 3))})`;
+}
+
+/** Run the parity gate; returns failure rows (empty == pass). */
+export function collectDocCliParityFailures(
+  repoRoot: string = repoRootFromModule(),
+): DocCliParityFailure[] {
+  const failures: DocCliParityFailure[] = [];
+  for (const ref of extractDocCliReferences(repoRoot)) {
+    const reason = validateDocCliCommand(ref.normalized);
+    if (reason !== null) {
+      failures.push({ source: ref.source, raw: ref.raw, reason });
+    }
+  }
+  return failures;
+}

--- a/packages/cli/src/doc-cli-parity.ts
+++ b/packages/cli/src/doc-cli-parity.ts
@@ -77,6 +77,18 @@ export function extractDocCliReferences(
   );
 }
 
+function stripAnglePlaceholders(text: string): string {
+  let out = text;
+  let start = out.indexOf("<");
+  while (start >= 0) {
+    const end = out.indexOf(">", start + 1);
+    if (end < 0) break;
+    out = `${out.slice(0, start)}${out.slice(end + 1)}`;
+    start = out.indexOf("<");
+  }
+  return out.trim();
+}
+
 /** Strip flags/placeholders; return null when the literal is not a CLI verb invocation. */
 export function normalizeDocCommand(raw: string): string | null {
   let rest = raw.replace(CLI_PREFIX_RE, "").trim();
@@ -87,7 +99,7 @@ export function normalizeDocCommand(raw: string): string | null {
 
   rest = rest.replace(/\s+\[[^\]]*\]/g, "").trim();
   rest = rest.replace(/\s+--[^\s]+(\s+[^\s]+)?/g, "").trim();
-  rest = rest.replace(/<[^>]+>/g, "").trim();
+  rest = stripAnglePlaceholders(rest);
 
   if (rest.includes("/") || rest.includes(".md") || rest.includes("*")) return null;
   if (/^deft-install\b/.test(rest)) return null;
@@ -127,8 +139,7 @@ function isRegisteredHandler(flatVerb: string): boolean {
 export function validateDocCliCommand(normalized: string): string | null {
   const colonKey = colonKeyFromNormalized(normalized);
   if (colonKey !== null) {
-    const legacyStem = colonKey.includes(":") ? colonKey.split(":")[1] : colonKey;
-    if (LEGACY_DOC_VERB_KEYS.has(colonKey) || LEGACY_DOC_VERB_KEYS.has(legacyStem ?? "")) {
+    if (LEGACY_DOC_VERB_KEYS.has(colonKey)) {
       return null;
     }
     if (colonKey in VERB_ALIASES || hasCommand(colonKey)) {

--- a/packages/core/src/release-e2e/constants.ts
+++ b/packages/core/src/release-e2e/constants.ts
@@ -19,6 +19,14 @@ export const NPM_E2E_REHEARSAL_TAG = "e2e-rehearsal";
 export const NPM_INSTALL_TIMEOUT_SECONDS = 600;
 export const NPM_BUILD_TIMEOUT_SECONDS = 600;
 export const NPM_PUBLISH_DRYRUN_TIMEOUT_SECONDS = 180;
+export const NPM_PACK_TIMEOUT_SECONDS = 300;
+export const NPM_INSTALL_RUN_TIMEOUT_SECONDS = 300;
+/** Fail the install+run smoke when stderr/stdout carries a module-resolution error. */
+export const MODULE_NOT_FOUND_MARKERS = [
+  "Cannot find module",
+  "ERR_MODULE_NOT_FOUND",
+  "MODULE_NOT_FOUND",
+] as const;
 
 export const RELEASE_ENTRYPOINT_TIMEOUT_SECONDS = 600.0;
 export const ROLLBACK_ENTRYPOINT_TIMEOUT_SECONDS = 300.0;

--- a/packages/core/src/release-e2e/main.test.ts
+++ b/packages/core/src/release-e2e/main.test.ts
@@ -426,6 +426,10 @@ describe("runRehearsal", () => {
       order.push("npm");
       return [true, "ok"];
     });
+    vi.spyOn(npmOps, "rehearseNpmInstallAndRun").mockImplementation(() => {
+      order.push("npm-install-run");
+      return [true, "ok"];
+    });
     const seams: E2ESeams = {
       mkdtemp: () => mkdtempSync(join(tmpdir(), "deft-e2e-")),
       releaseEntrypoint: () => 0,
@@ -437,8 +441,8 @@ describe("runRehearsal", () => {
     const [ok, reason] = runRehearsal("deftai", "x", "/proj", REHEARSAL_VERSION, seams);
     expect(ok).toBe(true);
     expect(reason).toContain("npm publish dry-run");
-    // npm step lands between verify tag and rollback.
-    expect(order).toEqual(["clone", "verify tag", "npm", "rollback"]);
+    // npm steps land between verify tag and rollback.
+    expect(order).toEqual(["clone", "verify tag", "npm", "npm-install-run", "rollback"]);
   });
 
   it("task release failure short-circuits before verify", () => {

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -16,7 +16,12 @@ import { CONTENT_PACKAGE_NAME } from "../deposit/resolve-content.js";
 import { runInitDeposit } from "../init-deposit/init-deposit.js";
 import { runRefreshDeposit } from "../init-deposit/refresh.js";
 import type { SpawnResult } from "../release/types.js";
-import { alignNpmPackageVersions, rehearseNpmPublish, resolvePnpm } from "./npm-ops.js";
+import {
+  alignNpmPackageVersions,
+  rehearseNpmInstallAndRun,
+  rehearseNpmPublish,
+  resolvePnpm,
+} from "./npm-ops.js";
 import type { E2ESeams } from "./types.js";
 
 function installFakeContentPackage(projectRoot: string, version = "0.53.0"): string {
@@ -313,5 +318,59 @@ describe("rehearseNpmPublish", () => {
     expect(reason).toContain("packages/core");
     expect(publishCwds).not.toContain(join(clone, "packages", "content"));
     expect(publishCwds).not.toContain(join(clone, "packages", "cli"));
+  });
+});
+
+describe("rehearseNpmInstallAndRun (#1996)", () => {
+  it("soft-skips when npm is absent", () => {
+    const [okFlag, reason] = rehearseNpmInstallAndRun("/proj", "0.0.1", { which: () => null });
+    expect(okFlag).toBe(true);
+    expect(reason).toContain("SKIP");
+  });
+
+  it("packs, installs, and runs doctor without module-not-found", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-install-run-"));
+    scaffoldPackages(clone);
+    const calls: Array<{ cmd: string[]; cwd?: string }> = [];
+    const seams: E2ESeams = {
+      which: (n) => `/usr/bin/${n}`,
+      spawnText: (cmd, args, options) => {
+        calls.push({ cmd: [cmd, ...args], cwd: options?.cwd });
+        const full = [cmd, ...args];
+        if (full.some((part) => String(part).includes("bin.js"))) {
+          return { status: 0, stdout: "Usage: directive doctor\n", stderr: "" };
+        }
+        return ok();
+      },
+    };
+    const [okFlag, reason] = rehearseNpmInstallAndRun(clone, "0.0.1", seams);
+    expect(okFlag).toBe(true);
+    expect(reason).toContain("without module-not-found");
+    expect(calls.some((c) => c.cmd.includes("pack"))).toBe(true);
+    expect(calls.some((c) => c.cmd.includes("install"))).toBe(true);
+    expect(calls.some((c) => c.cmd.some((part) => String(part).includes("bin.js")))).toBe(true);
+  });
+
+  it("fails loudly on ERR_MODULE_NOT_FOUND from the installed CLI", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-install-run-fail-"));
+    scaffoldPackages(clone);
+    const seams: E2ESeams = {
+      which: (n) => `/usr/bin/${n}`,
+      spawnText: (cmd, args) => {
+        const full = [cmd, ...args];
+        if (full.some((part) => String(part).includes("bin.js"))) {
+          return {
+            status: 1,
+            stdout: "",
+            stderr: "Error [ERR_MODULE_NOT_FOUND]: Cannot find module '@deftai/missing'",
+          };
+        }
+        return ok();
+      },
+    };
+    const [okFlag, reason] = rehearseNpmInstallAndRun(clone, "0.0.1", seams);
+    expect(okFlag).toBe(false);
+    expect(reason).toContain("module resolution error");
+    expect(reason).toContain("ERR_MODULE_NOT_FOUND");
   });
 });

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -351,6 +351,27 @@ describe("rehearseNpmInstallAndRun (#1996)", () => {
     expect(calls.some((c) => c.cmd.some((part) => String(part).includes("bin.js")))).toBe(true);
   });
 
+  it("skipWorkspacePrep omits pnpm install/build when publish dry-run already prepared", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-install-run-skip-"));
+    scaffoldPackages(clone);
+    const calls: string[][] = [];
+    const seams: E2ESeams = {
+      which: (n) => `/usr/bin/${n}`,
+      spawnText: (cmd, args) => {
+        const full = [cmd, ...args];
+        calls.push(full);
+        if (full.some((part) => String(part).includes("bin.js"))) {
+          return { status: 0, stdout: "Usage: directive doctor\n", stderr: "" };
+        }
+        return ok();
+      },
+    };
+    const [okFlag] = rehearseNpmInstallAndRun(clone, "0.0.1", seams, { skipWorkspacePrep: true });
+    expect(okFlag).toBe(true);
+    expect(calls.some((c) => c.includes("build"))).toBe(false);
+    expect(calls.some((c) => c.includes("frozen-lockfile"))).toBe(false);
+  });
+
   it("fails loudly on ERR_MODULE_NOT_FOUND from the installed CLI", () => {
     const clone = mkdtempSync(join(tmpdir(), "deft-npm-install-run-fail-"));
     scaffoldPackages(clone);

--- a/packages/core/src/release-e2e/npm-ops.ts
+++ b/packages/core/src/release-e2e/npm-ops.ts
@@ -214,6 +214,7 @@ export function rehearseNpmInstallAndRun(
   cloneDir: string,
   version: string,
   seams: E2ESeams = {},
+  options: { skipWorkspacePrep?: boolean } = {},
 ): [boolean, string] {
   const which = resolveWhich(seams);
   const npmPath = which("npm");
@@ -231,26 +232,31 @@ export function rehearseNpmInstallAndRun(
   }
 
   const env: NodeJS.ProcessEnv = { ...process.env, DEFT_PROJECT_ROOT: cloneDir };
-  let [ok, reason] = runNpmStep(
-    [...pnpmCmd, "install", "--frozen-lockfile"],
-    cloneDir,
-    env,
-    "pnpm install",
-    NPM_INSTALL_TIMEOUT_SECONDS,
-    seams,
-  );
-  if (!ok) return [false, reason];
-  [ok, reason] = runNpmStep(
-    [...pnpmCmd, "-w", "run", "build"],
-    cloneDir,
-    env,
-    "pnpm build",
-    NPM_BUILD_TIMEOUT_SECONDS,
-    seams,
-  );
-  if (!ok) return [false, reason];
-  [ok, reason] = alignNpmPackageVersions(cloneDir, version);
-  if (!ok) return [false, reason];
+  let ok = true;
+  let reason = "";
+
+  if (!options.skipWorkspacePrep) {
+    let [ok, reason] = runNpmStep(
+      [...pnpmCmd, "install", "--frozen-lockfile"],
+      cloneDir,
+      env,
+      "pnpm install",
+      NPM_INSTALL_TIMEOUT_SECONDS,
+      seams,
+    );
+    if (!ok) return [false, reason];
+    [ok, reason] = runNpmStep(
+      [...pnpmCmd, "-w", "run", "build"],
+      cloneDir,
+      env,
+      "pnpm build",
+      NPM_BUILD_TIMEOUT_SECONDS,
+      seams,
+    );
+    if (!ok) return [false, reason];
+    [ok, reason] = alignNpmPackageVersions(cloneDir, version);
+    if (!ok) return [false, reason];
+  }
 
   const packDir = join(cloneDir, ".deft-e2e-packs");
   mkdirSync(packDir, { recursive: true });
@@ -267,10 +273,17 @@ export function rehearseNpmInstallAndRun(
     );
     if (!ok) return [false, reason];
     const manifest = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8")) as {
-      name: string;
-      version: string;
-    };
-    const scoped = manifest.name.replace("@", "").replace("/", "-");
+      name?: string;
+      version?: string;
+    } | null;
+    if (
+      manifest === null ||
+      typeof manifest.name !== "string" ||
+      typeof manifest.version !== "string"
+    ) {
+      return [false, `version-align FAIL: invalid manifest in packages/${pkg}`];
+    }
+    const scoped = manifest.name.replaceAll("@", "").replaceAll("/", "-");
     tgzPaths.push(join(packDir, `${scoped}-${manifest.version}.tgz`));
   }
 
@@ -308,7 +321,7 @@ export function rehearseNpmInstallAndRun(
       `install+run smoke: module resolution error (${resolutionHit}): ${doctorOut.trim().slice(-800)}`,
     ];
   }
-  if (doctor.status !== 0 && doctor.status !== 1) {
+  if (doctor.status !== 0) {
     return [
       false,
       `install+run smoke: directive doctor --help exited ${doctor.status}: ${doctorOut.trim().slice(-500)}`,

--- a/packages/core/src/release-e2e/npm-ops.ts
+++ b/packages/core/src/release-e2e/npm-ops.ts
@@ -1,10 +1,13 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { defaultWhich, spawnText } from "../release/spawn.js";
 import {
+  MODULE_NOT_FOUND_MARKERS,
   NPM_BUILD_TIMEOUT_SECONDS,
   NPM_E2E_REHEARSAL_TAG,
+  NPM_INSTALL_RUN_TIMEOUT_SECONDS,
   NPM_INSTALL_TIMEOUT_SECONDS,
+  NPM_PACK_TIMEOUT_SECONDS,
   NPM_PUBLISH_DRYRUN_TIMEOUT_SECONDS,
   NPM_PUBLISH_PACKAGES,
 } from "./constants.js";
@@ -191,5 +194,129 @@ export function rehearseNpmPublish(
     true,
     "npm publish --dry-run clean for 4 packages " +
       `(types -> core -> content -> cli) at v${version}`,
+  ];
+}
+
+function moduleResolutionFailure(output: string): string | null {
+  for (const marker of MODULE_NOT_FOUND_MARKERS) {
+    if (output.includes(marker)) return marker;
+  }
+  return null;
+}
+
+/**
+ * Publish-layout install+run smoke (#1996): pack the four @deftai/directive*
+ * packages, install the tarballs into a clean flat node_modules, and run
+ * `directive doctor --help` so import-resolution bugs like #1993 sub-problem 1
+ * surface before a real npm publish.
+ */
+export function rehearseNpmInstallAndRun(
+  cloneDir: string,
+  version: string,
+  seams: E2ESeams = {},
+): [boolean, string] {
+  const which = resolveWhich(seams);
+  const npmPath = which("npm");
+  if (npmPath === null) {
+    return [true, "SKIP (npm not on PATH; Node-less operator)"];
+  }
+
+  const pnpmCmd = resolvePnpm(seams);
+  if (pnpmCmd === null) {
+    return [
+      false,
+      "npm present but neither pnpm nor corepack is on PATH -- " +
+        "cannot build the workspace for install+run smoke",
+    ];
+  }
+
+  const env: NodeJS.ProcessEnv = { ...process.env, DEFT_PROJECT_ROOT: cloneDir };
+  let [ok, reason] = runNpmStep(
+    [...pnpmCmd, "install", "--frozen-lockfile"],
+    cloneDir,
+    env,
+    "pnpm install",
+    NPM_INSTALL_TIMEOUT_SECONDS,
+    seams,
+  );
+  if (!ok) return [false, reason];
+  [ok, reason] = runNpmStep(
+    [...pnpmCmd, "-w", "run", "build"],
+    cloneDir,
+    env,
+    "pnpm build",
+    NPM_BUILD_TIMEOUT_SECONDS,
+    seams,
+  );
+  if (!ok) return [false, reason];
+  [ok, reason] = alignNpmPackageVersions(cloneDir, version);
+  if (!ok) return [false, reason];
+
+  const packDir = join(cloneDir, ".deft-e2e-packs");
+  mkdirSync(packDir, { recursive: true });
+  const tgzPaths: string[] = [];
+  for (const pkg of NPM_PUBLISH_PACKAGES) {
+    const pkgDir = join(cloneDir, "packages", pkg);
+    [ok, reason] = runNpmStep(
+      [npmPath, "pack", "--pack-destination", packDir],
+      pkgDir,
+      env,
+      `npm pack packages/${pkg}`,
+      NPM_PACK_TIMEOUT_SECONDS,
+      seams,
+    );
+    if (!ok) return [false, reason];
+    const manifest = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8")) as {
+      name: string;
+      version: string;
+    };
+    const scoped = manifest.name.replace("@", "").replace("/", "-");
+    tgzPaths.push(join(packDir, `${scoped}-${manifest.version}.tgz`));
+  }
+
+  const consumerDir = join(cloneDir, ".deft-e2e-consumer");
+  mkdirSync(consumerDir, { recursive: true });
+  writeFileSync(
+    join(consumerDir, "package.json"),
+    `${JSON.stringify({ name: "deft-e2e-consumer", private: true, version: "0.0.0" }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const installArgs = [npmPath, "install", ...tgzPaths];
+  [ok, reason] = runNpmStep(
+    installArgs,
+    consumerDir,
+    env,
+    "npm install packed tarballs",
+    NPM_INSTALL_RUN_TIMEOUT_SECONDS,
+    seams,
+  );
+  if (!ok) return [false, reason];
+
+  const spawn = seams.spawnText ?? spawnText;
+  const cliBin = join(consumerDir, "node_modules", "@deftai", "directive", "dist", "bin.js");
+  const doctor = spawn(process.execPath, [cliBin, "doctor", "--help"], {
+    cwd: consumerDir,
+    env,
+    timeoutMs: NPM_INSTALL_RUN_TIMEOUT_SECONDS * 1000,
+  });
+  const doctorOut = `${doctor.stdout ?? ""}\n${doctor.stderr ?? ""}`;
+  const resolutionHit = moduleResolutionFailure(doctorOut);
+  if (resolutionHit !== null) {
+    return [
+      false,
+      `install+run smoke: module resolution error (${resolutionHit}): ${doctorOut.trim().slice(-800)}`,
+    ];
+  }
+  if (doctor.status !== 0 && doctor.status !== 1) {
+    return [
+      false,
+      `install+run smoke: directive doctor --help exited ${doctor.status}: ${doctorOut.trim().slice(-500)}`,
+    ];
+  }
+
+  return [
+    true,
+    `packed + installed 4 packages at v${version} and ran directive doctor without module-not-found`,
   ];
 }

--- a/packages/core/src/release-e2e/rehearsal.ts
+++ b/packages/core/src/release-e2e/rehearsal.ts
@@ -6,7 +6,7 @@ import { dispatchTaskRelease, dispatchTaskReleaseRollback } from "./entrypoint.j
 import { emit } from "./flags.js";
 import { verifyDraftRelease } from "./gh-ops.js";
 import { cloneRepoToTemp, pushMirror, setOriginToTempRepo, verifyTag } from "./git-ops.js";
-import { rehearseNpmPublish } from "./npm-ops.js";
+import { rehearseNpmInstallAndRun, rehearseNpmPublish } from "./npm-ops.js";
 import type { E2ESeams } from "./types.js";
 
 export function runRehearsal(
@@ -34,6 +34,10 @@ export function runRehearsal(
     ];
     if (!skipNpm) {
       steps.push(["npm publish dry-run", () => rehearseNpmPublish(cloneDir, version, seams)]);
+      steps.push([
+        "npm install+run smoke",
+        () => rehearseNpmInstallAndRun(cloneDir, version, seams),
+      ]);
     }
     steps.push([
       "task release:rollback",
@@ -48,7 +52,9 @@ export function runRehearsal(
       }
     }
 
-    const npmNote = skipNpm ? " (npm dry-run skipped)" : " -> npm publish dry-run";
+    const npmNote = skipNpm
+      ? " (npm dry-run skipped)"
+      : " -> npm publish dry-run -> npm install+run smoke";
     return [
       true,
       `pipeline-mirror rehearsal succeeded against ${repoFull} ` +

--- a/packages/core/src/release-e2e/rehearsal.ts
+++ b/packages/core/src/release-e2e/rehearsal.ts
@@ -36,7 +36,7 @@ export function runRehearsal(
       steps.push(["npm publish dry-run", () => rehearseNpmPublish(cloneDir, version, seams)]);
       steps.push([
         "npm install+run smoke",
-        () => rehearseNpmInstallAndRun(cloneDir, version, seams),
+        () => rehearseNpmInstallAndRun(cloneDir, version, seams, { skipWorkspacePrep: true }),
       ]);
     }
     steps.push([

--- a/vbrief/completed/2026-06-25-1996-add-doc-cli-parity-gate-upgrading-npm-verbs-subset-of-regist.vbrief.json
+++ b/vbrief/completed/2026-06-25-1996-add-doc-cli-parity-gate-upgrading-npm-verbs-subset-of-regist.vbrief.json
@@ -1,0 +1,38 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1996"
+  },
+  "plan": {
+    "title": "Add doc<->CLI parity gate (UPGRADING npm verbs subset of registered verbs) + install+run smoke in release-e2e",
+    "status": "completed",
+    "narratives": {
+      "Description": "Add doc<->CLI parity gate (UPGRADING npm verbs subset of registered verbs) + install+run smoke in release-e2e",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1996",
+      "Overview": "Child of #1993 (sub-problems 1 + 6). Hardening so the npm-CLI breakage and doc drift can't recur.\n\nTwo complementary gates:\n1. **Doc<->CLI parity**: extract `directive <verb>` / `npx @deftai/directive <verb>` references from `content/UPGRADING.md` (and the AGENTS.md managed section) and assert each is in `registeredVerbs()` (`packages/cli/src/dispatch.ts:553`) + the top-level router. No existing gate does this (`tests/cli/test_framework_doctor_prose.py` is partial).\n2. **Install+run smoke in release-e2e**: the v0.56.2 fix added a static lint (`packages/cli/src/cross-package-imports.test.ts`) that catches the specific `../../core/dist` pattern. Add a broader publish-layout smoke to `release-e2e`: pack the 4 packages, install into a clean flat `node_modules`, and run a verb (e.g. `doctor`) asserting no module-not-found. `npm publish --dry-run` (current e2e) validates packaging but does NOT install+run, so it cannot catch import-resolution bugs like #1993 sub-problem 1.\n\nRefs #1993.",
+      "Labels": "enhancement, installer"
+    },
+    "items": [],
+    "tags": [
+      "enhancement",
+      "installer"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1996",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1996: Add doc<->CLI parity gate (UPGRADING npm verbs subset of registered verbs) + install+run smoke in release-e2e"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1993",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1993"
+      }
+    ],
+    "updated": "2026-06-25T20:18:47Z",
+    "metadata": {
+      "completedAt": "2026-06-25T20:18:47Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a deterministic doc↔CLI parity gate that extracts `directive` / `deft` / `npx @deftai/directive` invocations from `content/UPGRADING.md` and the AGENTS.md managed-section template, then asserts each resolves through the top-level router to a registered verb (with an explicit legacy allowlist for documented back-compat surfaces).
- Wires a TypeScript `agents:refresh` verb so UPGRADING/agents-entry citations for AGENTS.md refresh are routable on the npm CLI path.
- Extends `release:e2e` with a pack → flat install → `directive doctor --help` smoke that fails loudly on module-not-found import errors (complements the existing dry-run step).

## Test plan

- [x] `pnpm run test -- packages/cli/src/doc-cli-parity.test.ts packages/cli/src/agents-refresh.test.ts packages/core/src/release-e2e/npm-ops.test.ts`
- [x] `TMPDIR=$(mktemp -d) task check`

Closes #1996
