### PR TITLE
fix(doctor): npm canonical upgrade path and post-freeze signpost hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Vendored `run update` now points at npm instead of dead-ending** — the compatibility `run update` stub no longer tells operators to manually replace the deft directory; it signposts `npm i -g @deftai/directive@latest` and `npx @deftai/directive update` so future deposits steer consumers to the post-freeze upgrade path. Closes #1998.
+- **Doctor now recommends npm upgrades and surfaces layout advisories on throttled runs** — payload-staleness emits `npm i -g @deftai/directive@latest` (matching AGENTS.md), falls back to the npm registry when GitHub `ls-remote` is unreachable, and warns when payload currency is UNVERIFIED instead of silently passing; legacy-layout and canonical-vendored npm-migration signposts run on normal throttled doctor runs and in the Python doctor. Closes #1997, #2003, #2004.
 
 ### Removed
 

--- a/packages/cli/src/triage-cli.test.ts
+++ b/packages/cli/src/triage-cli.test.ts
@@ -6,7 +6,6 @@ import {
   buildFixtureRepo,
   diffCase,
   normalizeOutput,
-  PARITY_CASES,
   renderReport,
   resolveDeftRoot,
   runParity,

--- a/packages/core/src/doctor/branches.test.ts
+++ b/packages/core/src/doctor/branches.test.ts
@@ -106,7 +106,7 @@ describe("payload staleness", () => {
         stdout: "cafebabe refs/heads/main\n",
       }),
     });
-    expect(lines.join("")).toContain("deft-install --yes --upgrade");
+    expect(lines.join("")).toContain("npm i -g @deftai/directive@latest");
   });
 });
 

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -4,13 +4,24 @@ import {
   type LegacyDetectSeams,
   legacyLayoutSignpostLine,
 } from "../init-deposit/legacy-detect.js";
+import {
+  detectCanonicalVendoredManifest,
+  isNpmManaged,
+  NPM_MANAGED_SENTINEL_KEY,
+  NPM_MANAGED_SENTINEL_VALUE,
+} from "../init-deposit/migrate.js";
 import { findSkillPathsInText } from "../text/redos-safe.js";
-import { GO_BRIDGE_RELEASES_URL, UPGRADING_DOC_URL } from "./constants.js";
+import {
+  CANONICAL_UPGRADE_COMMAND,
+  GO_BRIDGE_RELEASES_URL,
+  UPGRADING_DOC_URL,
+} from "./constants.js";
 import {
   isDeprecationRedirectStub,
   locateManifest,
   manifestCandidatePaths,
   manifestTagToVersion,
+  parseInstallManifest,
   parseInstallRootFromAgentsMd,
   parseManifest,
 } from "./manifest.js";
@@ -357,11 +368,68 @@ export function checkLegacyLayout(projectRoot: string, seams: CheckSeams = {}): 
   };
 }
 
+/**
+ * #1997: signpost a canonical-vendored `.deft/core/` deposit that has not yet
+ * been stamped npm-managed. Local-only (no network).
+ */
+export function checkCanonicalVendoredNpmSignpost(
+  projectRoot: string,
+  seams: CheckSeams = {},
+): CheckResult {
+  const readText = seams.readText ?? readTextSafe;
+  const isFile = seams.isFile ?? ((p: string) => readText(p) !== null);
+  const manifestPath = detectCanonicalVendoredManifest(projectRoot, isFile);
+  if (manifestPath === null) {
+    return {
+      name: "canonical-vendored-npm-signpost",
+      status: "skip",
+      detail: "No canonical-vendored .deft/core/ deposit (nothing to signpost).",
+      data: { canonical_vendored: false },
+    };
+  }
+  const text = readText(manifestPath);
+  if (text === null) {
+    return {
+      name: "canonical-vendored-npm-signpost",
+      status: "skip",
+      detail: "Canonical-vendored manifest unreadable.",
+      data: { canonical_vendored: true },
+    };
+  }
+  const manifest = parseInstallManifest(text);
+  if (isNpmManaged(manifest)) {
+    return {
+      name: "canonical-vendored-npm-signpost",
+      status: "skip",
+      detail: "Deposit is already npm-managed (hybrid).",
+      data: { canonical_vendored: true, npm_managed: true },
+    };
+  }
+  const detail =
+    "Canonical-vendored install (.deft/core/) is not yet npm-managed. " +
+    "Post-freeze upgrades run via npm: install the engine with " +
+    `\`${CANONICAL_UPGRADE_COMMAND}\`, then run \`directive migrate\` ` +
+    `to stamp provenance. See ${UPGRADING_DOC_URL}.`;
+  return {
+    name: "canonical-vendored-npm-signpost",
+    status: "fail",
+    detail,
+    data: {
+      canonical_vendored: true,
+      npm_managed: false,
+      manifest_path: manifestPath,
+      sentinel_key: NPM_MANAGED_SENTINEL_KEY,
+      sentinel_value: NPM_MANAGED_SENTINEL_VALUE,
+      upgrading_doc_url: UPGRADING_DOC_URL,
+    },
+  };
+}
+
 export function deriveExitCode(checks: readonly CheckResult[], errors: readonly string[]): number {
   if (errors.length > 0 || checks.some((c) => c.status === "error")) {
     return 2;
   }
-  if (checks.some((c) => c.status === "fail")) {
+  if (checks.some((c) => c.status === "fail" && c.name !== "canonical-vendored-npm-signpost")) {
     return 1;
   }
   return 0;
@@ -399,6 +467,7 @@ export function runChecksImpl(
     });
     checks.push(checkManifestAgreement(projectRoot, null, seams));
     checks.push(checkLegacyLayout(projectRoot, seams));
+    checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));
     return {
       projectRoot,
       installRoot: null,
@@ -412,6 +481,7 @@ export function runChecksImpl(
   checks.push(checkManifestAgreement(projectRoot, installRoot, seams));
   checks.push(checkInstallPathConsistency(projectRoot, installRoot, seams));
   checks.push(checkLegacyLayout(projectRoot, seams));
+  checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));
   return {
     projectRoot,
     installRoot,

--- a/packages/core/src/doctor/constants.test.ts
+++ b/packages/core/src/doctor/constants.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { CANONICAL_UPGRADE_COMMAND } from "./constants.js";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+describe("doctor constants (#2003)", () => {
+  it("CANONICAL_UPGRADE_COMMAND matches agents-entry.md narrative", () => {
+    const agentsEntry = readFileSync(join(repoRoot, "content/templates/agents-entry.md"), "utf8");
+    expect(agentsEntry).toContain(CANONICAL_UPGRADE_COMMAND);
+    expect(CANONICAL_UPGRADE_COMMAND).toBe("npm i -g @deftai/directive@latest");
+  });
+});

--- a/packages/core/src/doctor/constants.ts
+++ b/packages/core/src/doctor/constants.ts
@@ -52,7 +52,10 @@ export const DEFT_REPO_POSITIVE_MARKERS = [
 // consumer deposit (<dir>).
 export const EXPECTED_CONTENT_DIRS = ["languages", "strategies", "skills", "templates"] as const;
 
-export const CANONICAL_UPGRADE_COMMAND = "deft-install --yes --upgrade --repo-root . --json";
+/** Post-freeze canonical upgrade path (#1997 / #2003 / #1912). */
+export const CANONICAL_UPGRADE_COMMAND = "npm i -g @deftai/directive@latest";
+
+export const NPM_PACKAGE_NAME = "@deftai/directive";
 
 export const CLEAN_WINDOW_HOURS = 24;
 export const DIRTY_WINDOW_HOURS = 4;

--- a/packages/core/src/doctor/index.test.ts
+++ b/packages/core/src/doctor/index.test.ts
@@ -5,6 +5,6 @@ describe("doctor barrel", () => {
   it("re-exports cmdDoctor", () => {
     expect(typeof doctor.cmdDoctor).toBe("function");
     expect(typeof doctor.runChecks).toBe("function");
-    expect(doctor.CANONICAL_UPGRADE_COMMAND).toContain("deft-install");
+    expect(doctor.CANONICAL_UPGRADE_COMMAND).toBe("npm i -g @deftai/directive@latest");
   });
 });

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -26,6 +26,7 @@ import {
   runningInsideDeftRepo,
 } from "./paths.js";
 import { runPayloadStalenessCheck } from "./payload-staleness.js";
+import { runLocalSignpostChecks } from "./signpost-checks.js";
 import {
   classifyTaskfileInclude,
   formatMissingIncludeSnippet,
@@ -57,6 +58,16 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
     const state = (seams.readState ?? readState)(projectRoot);
     const decision = decideThrottle(state, nowFn());
     if (decision.skip) {
+      const throttleFindings: Finding[] = [];
+      const throttleSink = createPlainSink({ jsonMode, quietMode });
+      runLocalSignpostChecks(
+        projectRoot,
+        throttleSink,
+        (finding) => {
+          throttleFindings.push(finding);
+        },
+        seams,
+      );
       const hint = decision.dirty
         ? "run `deft doctor --full` to re-probe or address findings"
         : "--full forces";
@@ -69,10 +80,17 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
           last_error_count: decision.lastErrorCount,
           next_eligible_at: formatIsoZ(decision.nextEligibleAt),
           hint,
+          signpost_findings: throttleFindings,
         };
         process.stdout.write(`${pythonJsonDump(payload)}\n`);
       } else {
         process.stdout.write(`${renderDoctorStatusLine(decision, nowFn())}\n`);
+      }
+      const signpostWarnings = throttleFindings.filter((f) => f.severity === "warning").length;
+      if (signpostWarnings > 0 && !jsonMode) {
+        throttleSink.finalWarn(
+          `Signpost advisory: ${signpostWarnings} local layout / npm-migration note(s) above (throttle-skipped full probe).`,
+        );
       }
       return decision.dirty ? 1 : 0;
     }
@@ -282,6 +300,21 @@ function runInstallIntegrityChecks(
       }
       if (status === "skip") {
         sink.info(`${name}: skip -- ${detail}`);
+        continue;
+      }
+      if (
+        (name === "legacy-layout" || name === "canonical-vendored-npm-signpost") &&
+        status === "fail"
+      ) {
+        sink.warn(`${name}: ${detail}`);
+        addFinding({
+          severity: "warning",
+          message: detail || `${name} ${status}`,
+          check: `install-integrity:${name}`,
+          install_check: name,
+          status,
+          data: (entry.data as Record<string, unknown>) ?? {},
+        });
         continue;
       }
       if (status === "error") {

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -80,7 +80,7 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
           last_error_count: decision.lastErrorCount,
           next_eligible_at: formatIsoZ(decision.nextEligibleAt),
           hint,
-          signpost_findings: throttleFindings,
+          ...(throttleFindings.length > 0 ? { signpost_findings: throttleFindings } : {}),
         };
         process.stdout.write(`${pythonJsonDump(payload)}\n`);
       } else {

--- a/packages/core/src/doctor/payload-staleness.test.ts
+++ b/packages/core/src/doctor/payload-staleness.test.ts
@@ -53,6 +53,26 @@ describe("payload-staleness (#2003 / #2004)", () => {
     }
   });
 
+  it("does not npm-compare branch-pinned refs like master", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-ps-"));
+    try {
+      seedManifest(root, "c".repeat(40), "master");
+      const findings: Finding[] = [];
+      const sink = createPlainSink();
+      runPayloadStalenessCheck(root, sink, (f) => findings.push(f), {
+        isFile: (p) => p.includes("VERSION"),
+        readText: (p) =>
+          p.includes("VERSION") ? `sha: ${"c".repeat(40)}\nref: master\n` : null,
+        runGitLsRemote: () => ({ ok: true, stdout: "" }),
+        runNpmViewVersion: () => ({ ok: true, version: "0.56.2" }),
+      });
+      expect(findings.find((f) => f.status === "stale")).toBeUndefined();
+      expect(findings.find((f) => f.status === "unverified")).toBeDefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces unverified advisory when both resolvers fail", () => {
     const root = mkdtempSync(join(tmpdir(), "deft-ps-"));
     try {

--- a/packages/core/src/doctor/payload-staleness.test.ts
+++ b/packages/core/src/doctor/payload-staleness.test.ts
@@ -61,8 +61,7 @@ describe("payload-staleness (#2003 / #2004)", () => {
       const sink = createPlainSink();
       runPayloadStalenessCheck(root, sink, (f) => findings.push(f), {
         isFile: (p) => p.includes("VERSION"),
-        readText: (p) =>
-          p.includes("VERSION") ? `sha: ${"c".repeat(40)}\nref: master\n` : null,
+        readText: (p) => (p.includes("VERSION") ? `sha: ${"c".repeat(40)}\nref: master\n` : null),
         runGitLsRemote: () => ({ ok: true, stdout: "" }),
         runNpmViewVersion: () => ({ ok: true, version: "0.56.2" }),
       });

--- a/packages/core/src/doctor/payload-staleness.test.ts
+++ b/packages/core/src/doctor/payload-staleness.test.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CANONICAL_UPGRADE_COMMAND } from "./constants.js";
+import { createPlainSink } from "./output.js";
+import { runPayloadStalenessCheck } from "./payload-staleness.js";
+import type { Finding } from "./types.js";
+
+function seedManifest(root: string, sha: string, ref = "v0.56.0"): void {
+  const core = join(root, ".deft", "core");
+  mkdirSync(core, { recursive: true });
+  writeFileSync(join(core, "VERSION"), `sha: ${sha}\nref: ${ref}\ntag: ${ref}\n`, "utf8");
+}
+
+describe("payload-staleness (#2003 / #2004)", () => {
+  it("stale via git ls-remote emits npm upgrade command", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-ps-"));
+    try {
+      seedManifest(root, "1".repeat(40));
+      const findings: Finding[] = [];
+      const sink = createPlainSink();
+      runPayloadStalenessCheck(root, sink, (f) => findings.push(f), {
+        isFile: (p) => p.endsWith("VERSION") || p.endsWith("AGENTS.md"),
+        readText: (p) => (p.endsWith("VERSION") ? `sha: ${"1".repeat(40)}\nref: v0.56.0\n` : null),
+        runGitLsRemote: () => ({ ok: true, stdout: `${"2".repeat(40)}\trefs/tags/v0.56.0\n` }),
+      });
+      const stale = findings.find((f) => f.status === "stale");
+      expect(stale?.suggestion).toBe(CANONICAL_UPGRADE_COMMAND);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to npm view when ls-remote yields no sha", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-ps-"));
+    try {
+      seedManifest(root, "a".repeat(40), "v0.56.0");
+      const findings: Finding[] = [];
+      const sink = createPlainSink();
+      runPayloadStalenessCheck(root, sink, (f) => findings.push(f), {
+        isFile: (p) => p.includes("VERSION"),
+        readText: (p) =>
+          p.includes("VERSION") ? `sha: ${"a".repeat(40)}\nref: v0.56.0\ntag: v0.56.0\n` : null,
+        runGitLsRemote: () => ({ ok: true, stdout: "" }),
+        runNpmViewVersion: () => ({ ok: true, version: "0.56.2" }),
+      });
+      const stale = findings.find((f) => f.status === "stale");
+      expect(stale?.resolver).toBe("npm-view");
+      expect(stale?.suggestion).toBe(CANONICAL_UPGRADE_COMMAND);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces unverified advisory when both resolvers fail", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-ps-"));
+    try {
+      seedManifest(root, "b".repeat(40));
+      const findings: Finding[] = [];
+      const sink = createPlainSink();
+      runPayloadStalenessCheck(root, sink, (f) => findings.push(f), {
+        isFile: (p) => p.includes("VERSION"),
+        readText: (p) =>
+          p.includes("VERSION") ? `sha: ${"b".repeat(40)}\nref: v0.56.0\ntag: v0.56.0\n` : null,
+        runGitLsRemote: () => ({ ok: false, stdout: "" }),
+        runNpmViewVersion: () => ({ ok: false, version: "" }),
+      });
+      const unverified = findings.find((f) => f.status === "unverified");
+      expect(unverified?.severity).toBe("warning");
+      expect(String(unverified?.message)).toContain("UNVERIFIED");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/doctor/payload-staleness.ts
+++ b/packages/core/src/doctor/payload-staleness.ts
@@ -80,7 +80,11 @@ function semverLessThan(left: string, right: string): boolean {
 
 function manifestVersion(ref: string, tag: string): string {
   const candidate = (tag || ref).trim().replace(/^refs\/tags\//, "");
-  return candidate.replace(/^v/i, "");
+  const normalized = candidate.replace(/^v/i, "");
+  if (!/^\d+(?:\.\d+)*/.test(normalized)) {
+    return "";
+  }
+  return normalized;
 }
 
 function defaultNpmViewVersion(): { ok: boolean; version: string } {

--- a/packages/core/src/doctor/payload-staleness.ts
+++ b/packages/core/src/doctor/payload-staleness.ts
@@ -265,11 +265,20 @@ export function runPayloadStalenessCheck(
   const installedVersion = manifestVersion(ref, tag);
   if (npmResult.ok && installedVersion) {
     if (semverLessThan(installedVersion, npmResult.version)) {
-      emitStale(checkName, `v${installedVersion}`, `v${npmResult.version}`, ref, sink, addFinding, {
-        installed_version: installedVersion,
-        remote_version: npmResult.version,
-        resolver: "npm-view",
-      }, "npm registry");
+      emitStale(
+        checkName,
+        `v${installedVersion}`,
+        `v${npmResult.version}`,
+        ref,
+        sink,
+        addFinding,
+        {
+          installed_version: installedVersion,
+          remote_version: npmResult.version,
+          resolver: "npm-view",
+        },
+        "npm registry",
+      );
       return;
     }
     if (installedVersion === npmResult.version.replace(/^v/i, "")) {

--- a/packages/core/src/doctor/payload-staleness.ts
+++ b/packages/core/src/doctor/payload-staleness.ts
@@ -120,10 +120,11 @@ function emitStale(
   sink: OutputSink,
   addFinding: (finding: Finding) => void,
   extras: Record<string, unknown> = {},
+  behindWord: "remote" | "npm registry" = "remote",
 ): void {
   const msg =
-    `Framework payload is stale (installed ${installedLabel} behind remote ${remoteLabel} for ref '${ref}'). ` +
-    `Recommendation: run \`${CANONICAL_UPGRADE_COMMAND}\` from any shell with Node ≥ 20, then start a fresh agent session.`;
+    `Framework payload is stale (installed ${installedLabel} behind ${behindWord} ${remoteLabel} for ref '${ref}'). ` +
+    `Recommendation: run \`${CANONICAL_UPGRADE_COMMAND}\` from any shell with Node ≥ 20.`;
   sink.warn(msg);
   addFinding({
     severity: "warning",
@@ -268,7 +269,7 @@ export function runPayloadStalenessCheck(
         installed_version: installedVersion,
         remote_version: npmResult.version,
         resolver: "npm-view",
-      });
+      }, "npm registry");
       return;
     }
     if (installedVersion === npmResult.version.replace(/^v/i, "")) {

--- a/packages/core/src/doctor/payload-staleness.ts
+++ b/packages/core/src/doctor/payload-staleness.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
-import { CANONICAL_UPGRADE_COMMAND } from "./constants.js";
+import { CANONICAL_UPGRADE_COMMAND, NPM_PACKAGE_NAME } from "./constants.js";
 import { locateManifest, parseInstallManifest } from "./manifest.js";
 import type { OutputSink } from "./output.js";
 import { readTextSafe, resolveDefaultFrameworkRoot } from "./paths.js";
@@ -11,13 +11,14 @@ export interface PayloadStalenessSeams {
   readonly isFile?: (path: string) => boolean;
   readonly frameworkRoot?: string;
   readonly runGitLsRemote?: (deftDir: string, ref: string) => { ok: boolean; stdout: string };
+  readonly runNpmViewVersion?: () => { ok: boolean; version: string };
 }
 
 function isDeftFrameworkRepo(projectRoot: string, readText = readTextSafe): boolean {
   try {
     const agents = join(projectRoot, "AGENTS.md");
     const text = readText(agents);
-    return text !== null && text.includes("Deft — Development Framework (deft repo)");
+    return text?.includes("Deft — Development Framework (deft repo)") ?? false;
   } catch {
     return false;
   }
@@ -47,6 +48,90 @@ function parseRemoteSha(stdout: string): string {
   return firstLine.trim().split(/\s+/)[0] ?? "";
 }
 
+function parseSemver(version: string): number[] {
+  const normalized = version.trim().replace(/^v/i, "");
+  const parts: number[] = [];
+  for (const segment of normalized.split(".")) {
+    const numeric = Number.parseInt(segment.split("-")[0] ?? "", 10);
+    if (Number.isNaN(numeric)) {
+      break;
+    }
+    parts.push(numeric);
+  }
+  return parts.length > 0 ? parts : [0];
+}
+
+function semverLessThan(left: string, right: string): boolean {
+  const a = parseSemver(left);
+  const b = parseSemver(right);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av < bv) {
+      return true;
+    }
+    if (av > bv) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function manifestVersion(ref: string, tag: string): string {
+  const candidate = (tag || ref).trim().replace(/^refs\/tags\//, "");
+  return candidate.replace(/^v/i, "");
+}
+
+function defaultNpmViewVersion(): { ok: boolean; version: string } {
+  const proc = spawnSync("npm", ["view", NPM_PACKAGE_NAME, "version"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  const version = (proc.stdout ?? "").trim().split("\n")[0]?.trim() ?? "";
+  return { ok: proc.status === 0 && version.length > 0, version };
+}
+
+function emitUnverified(
+  checkName: string,
+  reason: string,
+  sink: OutputSink,
+  addFinding: (finding: Finding) => void,
+): void {
+  const msg = `payload currency UNVERIFIED — ${reason}`;
+  sink.warn(msg);
+  addFinding({
+    severity: "warning",
+    message: msg,
+    check: checkName,
+    status: "unverified",
+  });
+}
+
+function emitStale(
+  checkName: string,
+  installedLabel: string,
+  remoteLabel: string,
+  ref: string,
+  sink: OutputSink,
+  addFinding: (finding: Finding) => void,
+  extras: Record<string, unknown> = {},
+): void {
+  const msg =
+    `Framework payload is stale (installed ${installedLabel} behind remote ${remoteLabel} for ref '${ref}'). ` +
+    `Recommendation: run \`${CANONICAL_UPGRADE_COMMAND}\` from any shell with Node ≥ 20, then start a fresh agent session.`;
+  sink.warn(msg);
+  addFinding({
+    severity: "warning",
+    message: msg,
+    check: checkName,
+    status: "stale",
+    ref,
+    suggestion: CANONICAL_UPGRADE_COMMAND,
+    ...extras,
+  });
+}
+
 export function runPayloadStalenessCheck(
   projectRoot: string,
   sink: OutputSink,
@@ -64,6 +149,7 @@ export function runPayloadStalenessCheck(
       message: "inside framework repo (no install manifest)",
       check: checkName,
       status: "skip",
+      reason: "not-applicable",
     });
     return;
   }
@@ -81,7 +167,13 @@ export function runPayloadStalenessCheck(
   }
   if (manifestPath === null || !isFile(manifestPath)) {
     sink.info(`${checkName}: skip -- no install manifest found (pre-v0.28 or legacy state)`);
-    addFinding({ severity: "skip", message: "no manifest", check: checkName, status: "skip" });
+    addFinding({
+      severity: "skip",
+      message: "no manifest",
+      check: checkName,
+      status: "skip",
+      reason: "not-applicable",
+    });
     return;
   }
 
@@ -93,6 +185,7 @@ export function runPayloadStalenessCheck(
       message: "manifest unreadable",
       check: checkName,
       status: "skip",
+      reason: "not-applicable",
     });
     return;
   }
@@ -100,6 +193,7 @@ export function runPayloadStalenessCheck(
   const manifest = parseInstallManifest(text);
   const installedSha = (manifest.sha ?? "").trim();
   const ref = (manifest.ref ?? manifest.tag ?? "").trim();
+  const tag = (manifest.tag ?? "").trim();
   if (!installedSha) {
     sink.info(`${checkName}: skip -- manifest has no sha (incomplete provenance)`);
     addFinding({
@@ -107,6 +201,7 @@ export function runPayloadStalenessCheck(
       message: "no sha in manifest",
       check: checkName,
       status: "skip",
+      reason: "not-applicable",
     });
     return;
   }
@@ -117,6 +212,7 @@ export function runPayloadStalenessCheck(
       message: "no ref/tag in manifest",
       check: checkName,
       status: "skip",
+      reason: "not-applicable",
     });
     return;
   }
@@ -131,59 +227,57 @@ export function runPayloadStalenessCheck(
       });
       return { ok: proc.status === 0, stdout: proc.stdout ?? "" };
     });
+  const runNpmView = seams.runNpmViewVersion ?? defaultNpmViewVersion;
 
   let remoteResult: { ok: boolean; stdout: string };
   try {
     remoteResult = runLsRemote(deftDir, ref);
   } catch {
-    sink.info(`${checkName}: skip -- could not probe remote (Error)`);
-    addFinding({
-      severity: "skip",
-      message: "remote probe failed",
-      check: checkName,
-      status: "skip",
-    });
+    remoteResult = { ok: false, stdout: "" };
+  }
+
+  if (remoteResult.ok) {
+    const remoteSha = parseRemoteSha(remoteResult.stdout);
+    if (remoteSha) {
+      if (installedSha === remoteSha) {
+        sink.info(`${checkName}: current (sha matches remote)`);
+        return;
+      }
+      emitStale(
+        checkName,
+        `sha ${installedSha.slice(0, 8)}...`,
+        `sha ${remoteSha.slice(0, 8)}...`,
+        ref,
+        sink,
+        addFinding,
+        { installed_sha: installedSha, remote_sha: remoteSha, resolver: "git-ls-remote" },
+      );
+      return;
+    }
+  }
+
+  const npmResult = runNpmView();
+  const installedVersion = manifestVersion(ref, tag);
+  if (npmResult.ok && installedVersion) {
+    if (semverLessThan(installedVersion, npmResult.version)) {
+      emitStale(checkName, `v${installedVersion}`, `v${npmResult.version}`, ref, sink, addFinding, {
+        installed_version: installedVersion,
+        remote_version: npmResult.version,
+        resolver: "npm-view",
+      });
+      return;
+    }
+    if (installedVersion === npmResult.version.replace(/^v/i, "")) {
+      sink.info(`${checkName}: current (version matches npm registry)`);
+      return;
+    }
+    sink.info(`${checkName}: current (installed version >= npm registry)`);
     return;
   }
 
-  if (!remoteResult.ok) {
-    sink.info(`${checkName}: skip -- git ls-remote failed (no network or no origin)`);
-    addFinding({
-      severity: "skip",
-      message: "ls-remote unavailable",
-      check: checkName,
-      status: "skip",
-    });
-    return;
-  }
-
-  const remoteSha = parseRemoteSha(remoteResult.stdout);
-  if (!remoteSha) {
-    sink.info(`${checkName}: skip -- ls-remote produced no sha`);
-    addFinding({
-      severity: "skip",
-      message: "no remote sha",
-      check: checkName,
-      status: "skip",
-    });
-    return;
-  }
-
-  if (installedSha === remoteSha) {
-    sink.info(`${checkName}: current (sha matches remote)`);
-    return;
-  }
-
-  const msg = `Framework payload is stale (installed sha ${installedSha.slice(0, 8)}... behind remote ${remoteSha.slice(0, 8)}... for ref '${ref}'). Recommendation: run the canonical headless upgrader \`${CANONICAL_UPGRADE_COMMAND}\` from your project root to pull the latest payload (drop \`--json\` for human-readable output). On an installer binary predating the headless flags, download the latest deft-install from GitHub Releases first.`;
-  sink.warn(msg);
-  addFinding({
-    severity: "warning",
-    message: msg,
-    check: checkName,
-    status: "stale",
-    installed_sha: installedSha,
-    remote_sha: remoteSha,
-    ref,
-    suggestion: CANONICAL_UPGRADE_COMMAND,
-  });
+  const reason = remoteResult.ok
+    ? "ls-remote produced no sha and npm registry fallback unavailable"
+    : "could not reach remote (git ls-remote / npm view both unavailable)";
+  sink.info(`${checkName}: skip -- ${reason}`);
+  emitUnverified(checkName, reason, sink, addFinding);
 }

--- a/packages/core/src/doctor/signpost-checks.test.ts
+++ b/packages/core/src/doctor/signpost-checks.test.ts
@@ -1,0 +1,37 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createPlainSink } from "./output.js";
+import { runLocalSignpostChecks } from "./signpost-checks.js";
+import type { Finding } from "./types.js";
+
+describe("runLocalSignpostChecks (#1997)", () => {
+  it("warns on canonical-vendored deposit without npm-managed sentinel", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-sp-"));
+    try {
+      const core = join(root, ".deft", "core");
+      mkdirSync(core, { recursive: true });
+      writeFileSync(join(core, "VERSION"), "tag: v0.56.0\nsha: abc\n", "utf8");
+      writeFileSync(join(root, "AGENTS.md"), "Deft is installed in .deft/core/.\n", "utf8");
+      const findings: Finding[] = [];
+      runLocalSignpostChecks(root, createPlainSink(), (f) => findings.push(f));
+      expect(findings.some((f) => f.check === "canonical-vendored-npm-signpost")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("warns on orphan .deft/VERSION legacy layout", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-sp-"));
+    try {
+      mkdirSync(join(root, ".deft"), { recursive: true });
+      writeFileSync(join(root, ".deft", "VERSION"), "tag: v0.26.0\n", "utf8");
+      const findings: Finding[] = [];
+      runLocalSignpostChecks(root, createPlainSink(), (f) => findings.push(f));
+      expect(findings.some((f) => f.check === "legacy-layout")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/doctor/signpost-checks.ts
+++ b/packages/core/src/doctor/signpost-checks.ts
@@ -1,0 +1,40 @@
+import { type CheckSeams, checkCanonicalVendoredNpmSignpost, checkLegacyLayout } from "./checks.js";
+import type { OutputSink } from "./output.js";
+import { runningInsideDeftRepo } from "./paths.js";
+import type { Finding } from "./types.js";
+
+export interface LocalSignpostSeams extends CheckSeams {
+  readonly runningInsideDeftRepo?: (root: string) => boolean;
+}
+
+/** Lightweight, local-only signpost probes for the throttle-skip path (#1997). */
+export function runLocalSignpostChecks(
+  projectRoot: string,
+  sink: OutputSink,
+  addFinding: (finding: Finding) => void,
+  seams: LocalSignpostSeams = {},
+): void {
+  const insideDeft =
+    seams.runningInsideDeftRepo?.(projectRoot) ?? runningInsideDeftRepo(projectRoot, seams);
+  if (insideDeft) {
+    return;
+  }
+  for (const result of [
+    checkLegacyLayout(projectRoot, seams),
+    checkCanonicalVendoredNpmSignpost(projectRoot, seams),
+  ]) {
+    if (result.status === "skip") {
+      continue;
+    }
+    if (result.status === "fail") {
+      sink.warn(result.detail);
+      addFinding({
+        severity: "warning",
+        message: result.detail,
+        check: result.name,
+        status: result.status,
+        data: result.data ?? {},
+      });
+    }
+  }
+}

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -1535,12 +1535,11 @@ def _emit_doctor_throttle_skip(decision, *, json_mode: bool, project_root: Path)
         entry.update(extras)
         signpost_findings.append(entry)
 
-    if not json_mode:
-        _run_local_signpost_checks(
-            project_root,
-            emit_warn=warn,
-            add_finding=_add_signpost,
-        )
+    _run_local_signpost_checks(
+        project_root,
+        emit_warn=warn if not json_mode else (lambda _m: None),
+        add_finding=_add_signpost,
+    )
 
     hint = (
         "run `deft doctor --full` to re-probe or address findings"
@@ -1556,8 +1555,9 @@ def _emit_doctor_throttle_skip(decision, *, json_mode: bool, project_root: Path)
             "last_finding_count": decision.last_finding_count,
             "next_eligible_at": _format_iso_z(decision.next_eligible_at),
             "hint": hint,
-            "signpost_findings": signpost_findings,
         }
+        if signpost_findings:
+            payload["signpost_findings"] = signpost_findings
         print(json.dumps(payload, sort_keys=True))
     else:
         print(_render_doctor_status_line(decision))
@@ -1751,11 +1751,6 @@ def _semver_less_than(left: str, right: str) -> bool:
     return _parse_semver(left) < _parse_semver(right)
 
 
-def _manifest_version(ref: str, tag: str) -> str:
-    candidate = (tag or ref).strip().replace("refs/tags/", "")
-    return candidate.lstrip("vV")
-
-
 def _npm_view_version() -> tuple[bool, str]:
     try:
         proc = subprocess.run(
@@ -1768,6 +1763,14 @@ def _npm_view_version() -> tuple[bool, str]:
         return False, ""
     version = (proc.stdout or "").strip().splitlines()[0].strip() if proc.stdout else ""
     return proc.returncode == 0 and bool(version), version
+
+
+def _manifest_version(ref: str, tag: str) -> str:
+    candidate = (tag or ref).strip().replace("refs/tags/", "")
+    normalized = candidate.lstrip("vV")
+    if not re.match(r"^\d+(?:\.\d+)*", normalized):
+        return ""
+    return normalized
 
 
 def _run_payload_staleness_check(

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -1558,7 +1558,7 @@ def _emit_doctor_throttle_skip(decision, *, json_mode: bool, project_root: Path)
         }
         if signpost_findings:
             payload["signpost_findings"] = signpost_findings
-        print(json.dumps(payload, sort_keys=True))
+        print(json.dumps(payload, sort_keys=True, ensure_ascii=False))
     else:
         print(_render_doctor_status_line(decision))
         signpost_warnings = sum(1 for f in signpost_findings if f.get("severity") == "warning")
@@ -2426,7 +2426,7 @@ def cmd_doctor(args: list[str]):
             },
             "project_root": str(project_root),
         }
-        print(json.dumps(payload, sort_keys=True))
+        print(json.dumps(payload, sort_keys=True, ensure_ascii=False))
         return exit_code
 
     print()
@@ -2536,7 +2536,7 @@ def main(argv: list[str] | None = None) -> int:
     project_root = Path(args.project_root).resolve()
     result = _run_checks_impl(project_root)
     if args.json:
-        print(json.dumps(result.to_dict(), sort_keys=True))
+        print(json.dumps(result.to_dict(), sort_keys=True, ensure_ascii=False))
     else:
         if not (args.quiet and result.exit_code == EXIT_CLEAN):
             print(_format_text_report(result))

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -131,6 +131,14 @@ VERSION = _resolve_version()
 # UV url constant (the _check_uv_available helper remains in run for other callers)
 UV_INSTALL_URL = "https://docs.astral.sh/uv/"
 
+# Post-freeze npm canonical path (#1997 / #2003 / #1912).
+CANONICAL_UPGRADE_COMMAND = "npm i -g @deftai/directive@latest"
+NPM_PACKAGE_NAME = "@deftai/directive"
+UPGRADING_DOC_URL = "https://github.com/deftai/directive/blob/master/content/UPGRADING.md"
+GO_BRIDGE_RELEASES_URL = "https://github.com/deftai/directive/releases"
+NPM_MANAGED_SENTINEL_KEY = "managed_by"
+NPM_MANAGED_SENTINEL_VALUE = "npm"
+
 # --- Install-integrity checks (ported from retired framework_doctor.py #1336) ---
 # Symbols (EXIT_*, run_checks, main, CheckResult, DoctorResult + 4 checks + impl)
 # are inserted below in small batches. Once complete, _run_install_integrity_checks
@@ -766,6 +774,207 @@ def _check_install_path_consistency(project_root: Path, install_root: str | None
 
 
 # ---------------------------------------------------------------------------
+# Legacy-layout + canonical-vendored npm signpost (#1912 / #1997)
+# ---------------------------------------------------------------------------
+
+
+def _gitmodules_references_framework(text: str) -> bool:
+    normalized = text.replace("\r\n", "\n").lower()
+    if "deftai/directive" in normalized:
+        return True
+    return bool(re.search(r"(^|\n)\s*path\s*=\s*\.?deft(/|\s|$)", normalized))
+
+
+def _detect_legacy_layout(project_root: Path) -> tuple[bool, str | None, str, list[str]]:
+    """Mirror packages/core/src/init-deposit/legacy-detect.ts heuristics."""
+    if (project_root / ".deft" / "core").is_dir():
+        return False, None, "", []
+    orphan = project_root / ".deft" / "VERSION"
+    if orphan.is_file():
+        return (
+            True,
+            "orphan-deft-version",
+            "Found an orphan .deft/VERSION manifest with no .deft/core/ directory -- "
+            "this is a pre-.deft/core/ layout the npm CLI does not migrate.",
+            [".deft/VERSION"],
+        )
+    deft_dir = project_root / "deft"
+    deft_markers = [
+        deft_dir / "VERSION",
+        deft_dir / "main.md",
+        deft_dir / "Taskfile.yml",
+    ]
+    deft_is_framework = deft_dir.is_dir() and (
+        any(p.is_file() for p in deft_markers) or (deft_dir / "skills").is_dir()
+    )
+    if deft_is_framework:
+        if (deft_dir / ".git").exists():
+            return (
+                True,
+                "git-clone-or-submodule",
+                "Found a deft/ framework directory backed by its own .git (clone or "
+                "git submodule) -- the npm CLI does not migrate a clone/submodule deposit.",
+                ["deft/", "deft/.git"],
+            )
+        return (
+            True,
+            "legacy-deft-prefixed",
+            "Found a legacy deft/-prefixed framework install -- the canonical layout "
+            "is .deft/core/. The npm CLI does not migrate the deft/ -> .deft/core/ move.",
+            ["deft/"],
+        )
+    gitmodules = project_root / ".gitmodules"
+    if gitmodules.is_file():
+        text = _read_text_safe(gitmodules)
+        if text is not None and _gitmodules_references_framework(text):
+            return (
+                True,
+                "git-clone-or-submodule",
+                "Found a .gitmodules entry referencing the Deft framework -- a submodule "
+                "deposit the npm CLI does not migrate.",
+                [".gitmodules"],
+            )
+    agents_text = _read_text_safe(project_root / "AGENTS.md")
+    if agents_text is not None:
+        install_root = _parse_install_root_from_agents_md(agents_text)
+        if install_root == "deft":
+            return (
+                True,
+                "legacy-deft-prefixed",
+                "AGENTS.md declares the legacy deft/ install root -- the canonical layout "
+                "is .deft/core/. The npm CLI does not migrate the deft/ -> .deft/core/ move.",
+                ["AGENTS.md (install root: deft)"],
+            )
+        if (
+            "<!-- deft:managed-section" in agents_text
+            and _extract_managed_section(agents_text) is None
+        ):
+            return (
+                True,
+                "pre-v0.27-sentinel-agents-md",
+                "AGENTS.md carries a pre-v0.27 sentinel-only managed-section (no v2/v3 "
+                "managed-section markers) -- run the Go bridge to migrate before the npm CLI.",
+                ["AGENTS.md (sentinel-only managed-section)"],
+            )
+    return False, None, "", []
+
+
+def _legacy_layout_signpost_line(kind: str | None, detail: str) -> str:
+    return (
+        f"Legacy Deft layout detected ({kind or 'unknown'}): {detail} "
+        "Run the frozen Go bridge installer to migrate to .deft/core/, then use the npm "
+        f"CLI (`npx @deftai/directive update`). See {UPGRADING_DOC_URL} "
+        f"(frozen bridge: {GO_BRIDGE_RELEASES_URL})."
+    )
+
+
+def _check_legacy_layout(project_root: Path) -> CheckResult:
+    legacy, kind, detail, evidence = _detect_legacy_layout(project_root)
+    if not legacy:
+        return CheckResult(
+            name="legacy-layout",
+            status="skip",
+            detail="No legacy Deft layout detected (canonical .deft/core/ or greenfield).",
+            data={"legacy_layout": False},
+        )
+    signpost = _legacy_layout_signpost_line(kind, detail)
+    return CheckResult(
+        name="legacy-layout",
+        status="fail",
+        detail=signpost,
+        data={
+            "legacy_layout": True,
+            "legacy_layout_kind": kind,
+            "evidence": evidence,
+            "upgrading_doc_url": UPGRADING_DOC_URL,
+            "go_bridge_releases_url": GO_BRIDGE_RELEASES_URL,
+        },
+    )
+
+
+def _detect_canonical_vendored_manifest(project_root: Path) -> Path | None:
+    canonical = project_root / ".deft" / "core" / "VERSION"
+    located = _locate_manifest(project_root, ".deft/core")
+    return located if located == canonical else None
+
+
+def _is_npm_managed(manifest: dict) -> bool:
+    return manifest.get(NPM_MANAGED_SENTINEL_KEY) == NPM_MANAGED_SENTINEL_VALUE
+
+
+def _check_canonical_vendored_npm_signpost(project_root: Path) -> CheckResult:
+    manifest_path = _detect_canonical_vendored_manifest(project_root)
+    if manifest_path is None:
+        return CheckResult(
+            name="canonical-vendored-npm-signpost",
+            status="skip",
+            detail="No canonical-vendored .deft/core/ deposit (nothing to signpost).",
+            data={"canonical_vendored": False},
+        )
+    text = _read_text_safe(manifest_path)
+    if text is None:
+        return CheckResult(
+            name="canonical-vendored-npm-signpost",
+            status="skip",
+            detail="Canonical-vendored manifest unreadable.",
+            data={"canonical_vendored": True},
+        )
+    manifest = _parse_manifest(text)
+    if _is_npm_managed(manifest):
+        return CheckResult(
+            name="canonical-vendored-npm-signpost",
+            status="skip",
+            detail="Deposit is already npm-managed (hybrid).",
+            data={"canonical_vendored": True, "npm_managed": True},
+        )
+    detail = (
+        "Canonical-vendored install (.deft/core/) is not yet npm-managed. "
+        "Post-freeze upgrades run via npm: install the engine with "
+        f"`{CANONICAL_UPGRADE_COMMAND}`, then run `directive migrate` "
+        f"to stamp provenance. See {UPGRADING_DOC_URL}."
+    )
+    return CheckResult(
+        name="canonical-vendored-npm-signpost",
+        status="fail",
+        detail=detail,
+        data={
+            "canonical_vendored": True,
+            "npm_managed": False,
+            "manifest_path": str(manifest_path),
+            "sentinel_key": NPM_MANAGED_SENTINEL_KEY,
+            "sentinel_value": NPM_MANAGED_SENTINEL_VALUE,
+            "upgrading_doc_url": UPGRADING_DOC_URL,
+        },
+    )
+
+
+def _run_local_signpost_checks(
+    project_root: Path,
+    *,
+    emit_warn,
+    add_finding,
+) -> None:
+    """Lightweight local signposts on throttle-skip (#1997)."""
+    if _running_inside_deft_repo(project_root):
+        return
+    for check in (
+        _check_legacy_layout(project_root),
+        _check_canonical_vendored_npm_signpost(project_root),
+    ):
+        if check.status == "skip":
+            continue
+        if check.status == "fail":
+            emit_warn(check.detail)
+            add_finding(
+                "warning",
+                check.detail,
+                check=check.name,
+                status=check.status,
+                data=check.data,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Top-level driver (ported) -- provides run_checks for tests + internal use
 # ---------------------------------------------------------------------------
 
@@ -820,6 +1029,8 @@ def _run_checks_impl(project_root: Path) -> DoctorResult:
         # Still attempt the manifest agreement check (it can run without
         # AGENTS.md for the greenfield case).
         checks.append(_check_manifest_agreement(project_root, None))
+        checks.append(_check_legacy_layout(project_root))
+        checks.append(_check_canonical_vendored_npm_signpost(project_root))
         return DoctorResult(
             project_root=str(project_root),
             install_root=None,
@@ -832,6 +1043,8 @@ def _run_checks_impl(project_root: Path) -> DoctorResult:
     checks.append(_check_skill_paths_resolve(project_root, agents_md_text))
     checks.append(_check_manifest_agreement(project_root, install_root))
     checks.append(_check_install_path_consistency(project_root, install_root))
+    checks.append(_check_legacy_layout(project_root))
+    checks.append(_check_canonical_vendored_npm_signpost(project_root))
 
     return DoctorResult(
         project_root=str(project_root),
@@ -846,7 +1059,10 @@ def _derive_exit_code(checks: list[CheckResult], errors: list[str]) -> int:
     """Three-state exit code from check results + errors."""
     if errors or any(c.status == "error" for c in checks):
         return EXIT_CONFIG_ERROR
-    if any(c.status == "fail" for c in checks):
+    if any(
+        c.status == "fail" and c.name != "canonical-vendored-npm-signpost"
+        for c in checks
+    ):
         return EXIT_DRIFT
     return EXIT_CLEAN
 
@@ -1310,8 +1526,22 @@ def _render_doctor_status_line(decision) -> str:
     )
 
 
-def _emit_doctor_throttle_skip(decision, *, json_mode: bool) -> int:
+def _emit_doctor_throttle_skip(decision, *, json_mode: bool, project_root: Path) -> int:
     """Print the throttle-skip surface and return the gated exit code (#1308)."""
+    signpost_findings: list[dict] = []
+
+    def _add_signpost(severity: str, message: str, **extras: object) -> None:
+        entry: dict = {"severity": severity, "message": message}
+        entry.update(extras)
+        signpost_findings.append(entry)
+
+    if not json_mode:
+        _run_local_signpost_checks(
+            project_root,
+            emit_warn=warn,
+            add_finding=_add_signpost,
+        )
+
     hint = (
         "run `deft doctor --full` to re-probe or address findings"
         if decision.dirty
@@ -1326,10 +1556,17 @@ def _emit_doctor_throttle_skip(decision, *, json_mode: bool) -> int:
             "last_finding_count": decision.last_finding_count,
             "next_eligible_at": _format_iso_z(decision.next_eligible_at),
             "hint": hint,
+            "signpost_findings": signpost_findings,
         }
         print(json.dumps(payload, sort_keys=True))
     else:
         print(_render_doctor_status_line(decision))
+        signpost_warnings = sum(1 for f in signpost_findings if f.get("severity") == "warning")
+        if signpost_warnings:
+            warn(
+                f"Signpost advisory: {signpost_warnings} local layout / npm-migration "
+                "note(s) above (throttle-skipped full probe)."
+            )
     return 1 if decision.dirty else 0
 
 
@@ -1403,6 +1640,17 @@ def _run_install_integrity_checks(
             continue
         if status == "skip":
             emit_info(f"{name}: skip -- {detail}")
+            continue
+        if name in ("legacy-layout", "canonical-vendored-npm-signpost") and status == "fail":
+            emit_warn(f"{name}: {detail}")
+            add_finding(
+                "warning",
+                detail or f"{name} {status}",
+                check=f"install-integrity:{name}",
+                install_check=name,
+                status=status,
+                data=entry.get("data", {}),
+            )
             continue
         if status == "error":
             emit_error(f"{name}: error -- {detail}")
@@ -1488,6 +1736,40 @@ def _run_agents_md_freshness_check(
     add_finding("warning", message, check=check_name, status=state)
 
 
+def _parse_semver(version: str) -> tuple[int, ...]:
+    normalized = version.strip().lstrip("vV")
+    parts: list[int] = []
+    for segment in normalized.split("."):
+        try:
+            parts.append(int(segment.split("-")[0]))
+        except ValueError:
+            break
+    return tuple(parts) if parts else (0,)
+
+
+def _semver_less_than(left: str, right: str) -> bool:
+    return _parse_semver(left) < _parse_semver(right)
+
+
+def _manifest_version(ref: str, tag: str) -> str:
+    candidate = (tag or ref).strip().replace("refs/tags/", "")
+    return candidate.lstrip("vV")
+
+
+def _npm_view_version() -> tuple[bool, str]:
+    try:
+        proc = subprocess.run(
+            ["npm", "view", NPM_PACKAGE_NAME, "version"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception:  # noqa: BLE001
+        return False, ""
+    version = (proc.stdout or "").strip().splitlines()[0].strip() if proc.stdout else ""
+    return proc.returncode == 0 and bool(version), version
+
+
 def _run_payload_staleness_check(
     project_root: Path,
     *,
@@ -1495,17 +1777,8 @@ def _run_payload_staleness_check(
     emit_info,
     add_finding,
 ) -> None:
-    """#1339 (Epic-5): Detect when the installed framework payload is behind its
-    manifest-recorded ref/sha. Reads the canonical <deftDir>/VERSION manifest
-    (single source of truth per #1062), resolves the corresponding remote SHA
-    via git ls-remote, and surfaces the canonical headless upgrade command
-    `deft-install --yes --upgrade --repo-root . --json` (#1409) when the shas
-    diverge. Skips gracefully inside the deft repo or when git / network /
-    manifest unavailable (non-fatal, best-effort).
-    """
+    """#1339 / #2003 / #2004: payload staleness with npm canonical upgrade path."""
     check_name = "payload-staleness"
-    # Self-contained "inside deft repo" probe (avoids dependency on private
-    # _running_inside_deft_repo helper that may be scoped inside cmd_doctor).
     try:
         agents = project_root / "AGENTS.md"
         is_deft = agents.exists() and (
@@ -1516,40 +1789,28 @@ def _run_payload_staleness_check(
             emit_info(f"{check_name}: skip -- running inside deft framework repo")
             add_finding(
                 "skip", "inside framework repo (no install manifest)",
-                check=check_name, status="skip",
+                check=check_name, status="skip", reason="not-applicable",
             )
             return
     except Exception:
         pass
 
-    # Locate a plausible manifest. Prefer the one next to the scripts/doctor.py
-    # we are running from (when invoked via the installed layout); fall back to
-    # common canonical/legacy locations under project_root.
     manifest_path = None
     try:
-        # When doctor.py lives at <deftDir>/scripts/doctor.py the manifest is at <deftDir>/VERSION
         candidate = get_script_dir().parent / "VERSION"
         if candidate.exists():
             manifest_path = candidate
     except Exception:
         pass
     if manifest_path is None:
-        # #1427: probe canonical-first via the shared helper so a
-        # webinstaller-vendored ``.deft/VERSION`` manifest is found too
-        # (the prior list probed only ``.deft/core/VERSION`` and legacy
-        # ``deft/VERSION``).
         manifest_path = _locate_manifest(project_root, None)
     if manifest_path is None:
-        # Legacy bare marker -- not a full manifest, but the last-resort
-        # provenance source for a pre-v0.28 install. Kept out of
-        # ``_locate_manifest`` because that helper returns VERSION-manifest
-        # paths only.
         legacy_marker = project_root / ".deft-version"
         if legacy_marker.exists():
             manifest_path = legacy_marker
     if manifest_path is None or not manifest_path.exists():
         emit_info(f"{check_name}: skip -- no install manifest found (pre-v0.28 or legacy state)")
-        add_finding("skip", "no manifest", check=check_name, status="skip")
+        add_finding("skip", "no manifest", check=check_name, status="skip", reason="not-applicable")
         return
 
     try:
@@ -1557,106 +1818,134 @@ def _run_payload_staleness_check(
         manifest = _parse_install_manifest(text)
     except Exception as exc:  # noqa: BLE001
         emit_info(f"{check_name}: skip -- could not read manifest: {exc}")
-        add_finding("skip", f"manifest unreadable: {exc}", check=check_name, status="skip")
+        add_finding(
+            "skip",
+            f"manifest unreadable: {exc}",
+            check=check_name,
+            status="skip",
+            reason="not-applicable",
+        )
         return
 
     installed_sha = manifest.get("sha", "").strip()
-    # Greptile P1 on #1384: do NOT fall back to "HEAD" when ref/tag are
-    # absent. `git ls-remote origin HEAD` returns the current remote
-    # default-branch tip, which almost certainly differs from the locally
-    # installed sha for development builds without a ref/tag pinned, and
-    # the check would then emit a permanent false-stale warning. Skip
-    # cleanly when the manifest does not declare a ref/tag.
     ref = (manifest.get("ref") or manifest.get("tag") or "").strip()
+    tag = (manifest.get("tag") or "").strip()
     if not installed_sha:
         emit_info(f"{check_name}: skip -- manifest has no sha (incomplete provenance)")
-        add_finding("skip", "no sha in manifest", check=check_name, status="skip")
+        add_finding(
+            "skip",
+            "no sha in manifest",
+            check=check_name,
+            status="skip",
+            reason="not-applicable",
+        )
         return
     if not ref:
         emit_info(
             f"{check_name}: skip -- manifest has no ref or tag (cannot resolve remote sha)"
         )
-        add_finding("skip", "no ref/tag in manifest", check=check_name, status="skip")
+        add_finding(
+            "skip",
+            "no ref/tag in manifest",
+            check=check_name,
+            status="skip",
+            reason="not-applicable",
+        )
         return
 
-    # Resolve current remote SHA for the ref (best effort, may be tag or branch).
-    # Use ls-remote to avoid needing a local fetch or modifying state.
+    deft_dir = manifest_path.parent
+    ls_remote_ok = False
+    remote_sha = ""
     try:
-        # Determine the deft dir from manifest location (parent of VERSION)
-        deft_dir = manifest_path.parent
-        # ls-remote origin <ref> (works for branches and tags)
         proc = subprocess.run(
             ["git", "-C", str(deft_dir), "ls-remote", "origin", ref],
             capture_output=True,
             text=True,
             timeout=15,
         )
-        if proc.returncode != 0:
-            emit_info(f"{check_name}: skip -- git ls-remote failed (no network or no origin)")
-            add_finding("skip", "ls-remote unavailable", check=check_name, status="skip")
-            return
-        # Output is "<sha>\t<refname>"
-        # For annotated tags, ls-remote returns TWO lines:
-        #   <tag-object-sha>	refs/tags/<tag>
-        #   <commit-sha>	refs/tags/<tag>^{}
-        # Prefer the peeled ^{} commit SHA when present (the one that matches
-        # what the installer recorded in the manifest). Fall back to first line.
-        # See Greptile P1 on #1384 (annotated-tag false-positive staleness).
-        remote_sha = ""
-        peeled_sha = ""
-        for line in proc.stdout.splitlines():
-            parts = line.strip().split()
-            if len(parts) >= 2:
-                refname = parts[1]
-                if refname.endswith("^{}"):
-                    peeled_sha = parts[0]
-                elif not remote_sha:
+        ls_remote_ok = proc.returncode == 0
+        if ls_remote_ok:
+            peeled_sha = ""
+            for line in proc.stdout.splitlines():
+                parts = line.strip().split()
+                if len(parts) >= 2:
+                    refname = parts[1]
+                    if refname.endswith("^{}"):
+                        peeled_sha = parts[0]
+                    elif not remote_sha:
+                        remote_sha = parts[0]
+            if peeled_sha:
+                remote_sha = peeled_sha
+            elif not remote_sha:
+                first_line = next((ln for ln in proc.stdout.splitlines() if ln.strip()), "")
+                parts = first_line.strip().split()
+                if parts:
                     remote_sha = parts[0]
-        if peeled_sha:
-            remote_sha = peeled_sha
-        elif not remote_sha:
-            # last-resort: first token of first line
-            first_line = next((ln for ln in proc.stdout.splitlines() if ln.strip()), "")
-            parts = first_line.strip().split()
-            if parts:
-                remote_sha = parts[0]
-        if not remote_sha:
-            emit_info(f"{check_name}: skip -- ls-remote produced no sha")
-            add_finding("skip", "no remote sha", check=check_name, status="skip")
+    except Exception:  # noqa: BLE001
+        ls_remote_ok = False
+
+    if ls_remote_ok and remote_sha:
+        if installed_sha == remote_sha:
+            emit_info(f"{check_name}: current (sha matches remote)")
             return
-    except Exception as exc:  # noqa: BLE001 -- network/git optional
-        emit_info(f"{check_name}: skip -- could not probe remote ({type(exc).__name__})")
-        add_finding("skip", f"remote probe failed: {exc}", check=check_name, status="skip")
+        msg = (
+            f"Framework payload is stale (installed sha {installed_sha[:8]}... "
+            f"behind remote {remote_sha[:8]}... for ref '{ref}'). "
+            f"Recommendation: run `{CANONICAL_UPGRADE_COMMAND}` from any shell with Node ≥ 20."
+        )
+        emit_warn(msg)
+        add_finding(
+            "warning",
+            msg,
+            check=check_name,
+            status="stale",
+            installed_sha=installed_sha,
+            remote_sha=remote_sha,
+            ref=ref,
+            suggestion=CANONICAL_UPGRADE_COMMAND,
+            resolver="git-ls-remote",
+        )
         return
 
-    if installed_sha == remote_sha:
-        # Current
-        emit_info(f"{check_name}: current (sha matches remote)")
+    npm_ok, npm_version = _npm_view_version()
+    installed_version = _manifest_version(ref, tag)
+    if npm_ok and installed_version:
+        if _semver_less_than(installed_version, npm_version):
+            msg = (
+                f"Framework payload is stale (installed v{installed_version} "
+                f"behind npm registry v{npm_version} for ref '{ref}'). "
+                f"Recommendation: run `{CANONICAL_UPGRADE_COMMAND}` from any shell with Node ≥ 20."
+            )
+            emit_warn(msg)
+            add_finding(
+                "warning",
+                msg,
+                check=check_name,
+                status="stale",
+                installed_version=installed_version,
+                remote_version=npm_version,
+                ref=ref,
+                suggestion=CANONICAL_UPGRADE_COMMAND,
+                resolver="npm-view",
+            )
+            return
+        emit_info(f"{check_name}: current (version matches npm registry)")
         return
 
-    # Stale! Emit the EXACT canonical headless upgrade command (#1409) so a
-    # normal consumer can copy-paste one line and end up with a fresh payload
-    # plus updated metadata -- not just the metadata-only `task upgrade` ack.
-    recommended_command = "deft-install --yes --upgrade --repo-root . --json"
-    msg = (
-        f"Framework payload is stale (installed sha {installed_sha[:8]}... "
-        f"behind remote {remote_sha[:8]}... for ref '{ref}'). "
-        f"Recommendation: run the canonical headless upgrader "
-        f"`{recommended_command}` from your project root to pull the latest "
-        f"payload (drop `--json` for human-readable output). On an installer "
-        f"binary predating the headless flags, download the latest deft-install "
-        f"from GitHub Releases first."
+    reason = (
+        "ls-remote produced no sha and npm registry fallback unavailable"
+        if ls_remote_ok
+        else "could not reach remote (git ls-remote / npm view both unavailable)"
     )
-    emit_warn(msg)
+    emit_info(f"{check_name}: skip -- {reason}")
+    unverified_msg = f"payload currency UNVERIFIED — {reason}"
+    emit_warn(unverified_msg)
     add_finding(
         "warning",
-        msg,
+        unverified_msg,
         check=check_name,
-        status="stale",
-        installed_sha=installed_sha,
-        remote_sha=remote_sha,
-        ref=ref,
-        suggestion=recommended_command,
+        status="unverified",
+        reason=reason,
     )
 
 
@@ -1791,7 +2080,9 @@ def cmd_doctor(args: list[str]):
     if not full_mode:
         decision = _evaluate_doctor_throttle(project_root)
         if decision is not None and decision.skip:
-            return _emit_doctor_throttle_skip(decision, json_mode=json_mode)
+            return _emit_doctor_throttle_skip(
+                decision, json_mode=json_mode, project_root=project_root
+            )
 
     # Findings are the single source of truth for the summary, the
     # JSON payload, and the exit code (#1303 review #1 / #4). Replaces

--- a/tests/cli/test_doctor_locate_manifest.py
+++ b/tests/cli/test_doctor_locate_manifest.py
@@ -289,7 +289,7 @@ class TestPayloadStalenessDeftVersion:
         )
         warnings, findings = _collect_staleness(doctor_module, tmp_path)
         assert [f for f in findings if f.get("status") == "stale"], findings
-        assert any("deft-install" in w for w in warnings), warnings
+        assert any("npm i -g @deftai/directive@latest" in w for w in warnings), warnings
 
     def test_current_from_deft_version_emits_no_stale(
         self, doctor_module, tmp_path, monkeypatch

--- a/tests/cli/test_doctor_payload_staleness.py
+++ b/tests/cli/test_doctor_payload_staleness.py
@@ -1,35 +1,19 @@
-"""tests/cli/test_doctor_payload_staleness.py -- payload-staleness remediation (#1409).
+"""tests/cli/test_doctor_payload_staleness.py -- payload-staleness remediation (#1409 / #2003).
 
 `_run_payload_staleness_check` (scripts/doctor.py) is the deterministic surface
 the installer -> doctor handoff (#1339) uses to tell a consumer their framework
-payload is behind the remote. #1409 makes that remediation actionable by
-emitting the EXACT canonical headless upgrade command -- so a normal consumer
-following doctor guidance can copy-paste one line and end up with a fresh
-payload + updated metadata, instead of the vague "re-run the installer" prose.
-
-These tests pin the contract:
-  * Stale state -> the warn message AND the structured `suggestion` finding
-    BOTH carry the exact `deft-install --yes --upgrade --repo-root . --json`.
-  * Current state (installed sha == remote sha) -> no stale finding, no command.
-
-The check is exercised directly (rather than via `cmd_doctor`) so the test is
-hermetic: it stubs `git ls-remote` via the module-level `subprocess` and points
-the manifest probe at a tmp `.deft/core/VERSION` we control. Refs #1409, #1339.
+payload is behind the remote. Post-freeze (#2003) the remediation is the npm
+canonical upgrade command, not the Go bridge installer.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-# The exact canonical headless upgrade command #1409 standardises on. This
-# literal MUST stay byte-identical to the string emitted by
-# `scripts/doctor.py::_run_payload_staleness_check` and documented in
-# README.md / UPGRADING.md / the deft-directive-sync skill / AGENTS.md.
-CANONICAL_HEADLESS_UPGRADE = "deft-install --yes --upgrade --repo-root . --json"
+CANONICAL_NPM_UPGRADE = "npm i -g @deftai/directive@latest"
 
 
 def _seed_manifest(project_root: Path, *, sha: str, ref: str = "master") -> None:
-    """Write a canonical `.deft/core/VERSION` manifest with sha + ref provenance."""
     deft_core = project_root / ".deft" / "core"
     deft_core.mkdir(parents=True, exist_ok=True)
     (deft_core / "VERSION").write_text(
@@ -39,28 +23,18 @@ def _seed_manifest(project_root: Path, *, sha: str, ref: str = "master") -> None
 
 
 def _force_manifest_fallback(doctor_module, tmp_path: Path, monkeypatch) -> None:
-    """Make the "manifest next to doctor.py" probe miss.
-
-    `_run_payload_staleness_check` first looks for `<get_script_dir()>/../VERSION`
-    (the installed layout). Point `get_script_dir` at a non-existent dir so the
-    function falls back to the `project_root / .deft/core/VERSION` manifest the
-    test controls.
-    """
     monkeypatch.setattr(
         doctor_module, "get_script_dir", lambda: tmp_path / "no-such-scripts"
     )
 
 
 class _FakeProc:
-    """Minimal stand-in for `subprocess.run` output (returncode + stdout)."""
-
     def __init__(self, stdout: str, returncode: int = 0) -> None:
         self.stdout = stdout
         self.returncode = returncode
 
 
 def _collect(doctor_module, project_root: Path):
-    """Invoke the check, returning (warnings, infos, findings)."""
     warnings: list[str] = []
     infos: list[str] = []
     findings: list[dict] = []
@@ -79,14 +53,12 @@ def _collect(doctor_module, project_root: Path):
     return warnings, infos, findings
 
 
-def test_stale_payload_emits_canonical_headless_command(
+def test_stale_payload_emits_canonical_npm_command(
     doctor_module, tmp_path, monkeypatch
 ):
-    """A stale payload surfaces the exact headless upgrade command (#1409)."""
     project_root = tmp_path
     _seed_manifest(project_root, sha="1" * 40)
     _force_manifest_fallback(doctor_module, tmp_path, monkeypatch)
-    # git ls-remote returns a DIFFERENT remote sha -> stale.
     monkeypatch.setattr(
         doctor_module.subprocess,
         "run",
@@ -98,26 +70,15 @@ def test_stale_payload_emits_canonical_headless_command(
     stale = [f for f in findings if f.get("status") == "stale"]
     assert stale, f"expected a stale finding; got findings={findings}"
     finding = stale[0]
-    assert CANONICAL_HEADLESS_UPGRADE in finding["message"], (
-        "stale remediation message MUST name the exact canonical headless "
-        f"upgrade command. Got: {finding['message']!r}"
-    )
-    assert finding.get("suggestion") == CANONICAL_HEADLESS_UPGRADE, (
-        "the structured `suggestion` finding MUST be the exact canonical "
-        f"command so agents/CI can act on it. Got: {finding.get('suggestion')!r}"
-    )
-    assert any(CANONICAL_HEADLESS_UPGRADE in w for w in warnings), (
-        "the human-facing warn line MUST also carry the exact command. "
-        f"Warnings: {warnings!r}"
-    )
+    assert CANONICAL_NPM_UPGRADE in finding["message"]
+    assert finding.get("suggestion") == CANONICAL_NPM_UPGRADE
+    assert any(CANONICAL_NPM_UPGRADE in w for w in warnings)
 
 
 def test_current_payload_emits_no_command(doctor_module, tmp_path, monkeypatch):
-    """When installed sha == remote sha, no stale finding / command surfaces."""
     project_root = tmp_path
     _seed_manifest(project_root, sha="a" * 40)
     _force_manifest_fallback(doctor_module, tmp_path, monkeypatch)
-    # Remote sha matches the installed sha -> current, not stale.
     monkeypatch.setattr(
         doctor_module.subprocess,
         "run",
@@ -126,37 +87,26 @@ def test_current_payload_emits_no_command(doctor_module, tmp_path, monkeypatch):
 
     warnings, _infos, findings = _collect(doctor_module, project_root)
 
-    assert not [f for f in findings if f.get("status") == "stale"], (
-        "a current payload MUST NOT produce a stale finding."
-    )
-    assert not any(CANONICAL_HEADLESS_UPGRADE in w for w in warnings), (
-        "a current payload MUST NOT recommend the headless upgrade command."
-    )
+    assert not [f for f in findings if f.get("status") == "stale"]
+    assert not any(CANONICAL_NPM_UPGRADE in w for w in warnings)
 
 
-def test_stale_message_notes_json_and_version_skew(
-    doctor_module, tmp_path, monkeypatch
-):
-    """The remediation explains `--json` is optional and covers version skew (#1409)."""
+def test_npm_fallback_when_ls_remote_empty(doctor_module, tmp_path, monkeypatch):
     project_root = tmp_path
-    _seed_manifest(project_root, sha="1" * 40)
+    _seed_manifest(project_root, sha="1" * 40, ref="v0.56.0")
     _force_manifest_fallback(doctor_module, tmp_path, monkeypatch)
     monkeypatch.setattr(
         doctor_module.subprocess,
         "run",
-        lambda *a, **k: _FakeProc("3" * 40 + "\trefs/heads/master\n"),
+        lambda *a, **k: _FakeProc(""),
+    )
+    monkeypatch.setattr(
+        doctor_module, "_npm_view_version", lambda: (True, "0.56.2")
     )
 
     _warnings, _infos, findings = _collect(doctor_module, project_root)
 
     stale = [f for f in findings if f.get("status") == "stale"]
-    assert stale, f"expected a stale finding; got findings={findings}"
-    message = stale[0]["message"]
-    assert "--json" in message and "human-readable" in message, (
-        "the remediation SHOULD note that `--json` can be dropped for "
-        f"human-readable output. Got: {message!r}"
-    )
-    assert "GitHub Releases" in message, (
-        "the remediation SHOULD cover the version-skew case (download the "
-        f"latest deft-install binary first). Got: {message!r}"
-    )
+    assert stale
+    assert stale[0].get("resolver") == "npm-view"
+    assert stale[0].get("suggestion") == CANONICAL_NPM_UPGRADE

--- a/tests/cli/test_doctor_throttle.py
+++ b/tests/cli/test_doctor_throttle.py
@@ -421,6 +421,38 @@ def test_cmd_doctor_corrupt_state_runs_full(
     assert "Checking system dependencies" in result.stdout
 
 
+def test_cmd_doctor_throttle_skip_surfaces_local_signpost(
+    run_command, doctor_env, doctor_state_module, monkeypatch, deft_run_module
+):
+    """#1997: throttle skip still emits legacy/npm signposts without --full."""
+    orphan = doctor_env.project / ".deft"
+    orphan.mkdir(parents=True, exist_ok=True)
+    (orphan / "VERSION").write_text("tag: v0.26.0\n", encoding="utf-8")
+    _seed_state(
+        doctor_state_module,
+        doctor_env.project,
+        last_error_count=0,
+        age_hours=1.0,
+    )
+    monkeypatch.setattr(
+        deft_run_module,
+        "_run_install_integrity_checks",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        deft_run_module,
+        "_run_agents_md_freshness_check",
+        lambda *a, **kw: None,
+        raising=False,
+    )
+    result = run_command("cmd_doctor", [])
+    assert result.return_code == 0
+    assert "[doctor]" in result.stdout
+    assert "Legacy Deft layout detected" in result.stdout
+    assert "Signpost advisory" in result.stdout
+
+
 # ---------------------------------------------------------------------------
 # #1316 -- skip-severity findings must not inflate the persisted warning tally
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_doctor_upgrade_command_contract.py
+++ b/tests/cli/test_doctor_upgrade_command_contract.py
@@ -1,0 +1,102 @@
+"""tests/cli/test_doctor_upgrade_command_contract.py -- doctor vs AGENTS.md (#2003)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_AGENTS_ENTRY = _REPO_ROOT / "content/templates/agents-entry.md"
+_CANONICAL_NPM_UPGRADE = "npm i -g @deftai/directive@latest"
+
+
+def test_doctor_module_emits_agents_entry_upgrade_command(doctor_module) -> None:
+    assert doctor_module.CANONICAL_UPGRADE_COMMAND == _CANONICAL_NPM_UPGRADE
+    agents_entry = _AGENTS_ENTRY.read_text(encoding="utf-8")
+    assert _CANONICAL_NPM_UPGRADE in agents_entry, (
+        "agents-entry.md MUST document the same canonical upgrade command "
+        "the doctor emits (#2003)."
+    )
+
+
+def test_payload_staleness_stale_finding_uses_npm_command(
+    doctor_module, tmp_path, monkeypatch
+):
+    """Stale payload surfaces npm upgrade in message + suggestion (#2003)."""
+    deft_core = tmp_path / ".deft" / "core"
+    deft_core.mkdir(parents=True)
+    (deft_core / "VERSION").write_text(
+        f"sha: {'1' * 40}\nref: master\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        doctor_module, "get_script_dir", lambda: tmp_path / "no-scripts"
+    )
+
+    class _FakeProc:
+        stdout = f"{'2' * 40}\trefs/heads/master\n"
+        returncode = 0
+
+    monkeypatch.setattr(
+        doctor_module.subprocess, "run", lambda *a, **k: _FakeProc()
+    )
+
+    warnings: list[str] = []
+    findings: list[dict] = []
+
+    doctor_module._run_payload_staleness_check(
+        tmp_path,
+        emit_warn=warnings.append,
+        emit_info=lambda _m: None,
+        add_finding=lambda severity, message, **extras: findings.append(
+            {"severity": severity, "message": message, **extras}
+        ),
+    )
+
+    stale = [f for f in findings if f.get("status") == "stale"]
+    assert stale, findings
+    assert _CANONICAL_NPM_UPGRADE in stale[0]["message"]
+    assert stale[0].get("suggestion") == _CANONICAL_NPM_UPGRADE
+
+
+def test_payload_staleness_unverified_surfaces_warning_not_silent_green(
+    doctor_module, tmp_path, monkeypatch
+):
+    """When currency cannot be verified, emit a warning advisory (#2004)."""
+    deft_core = tmp_path / ".deft" / "core"
+    deft_core.mkdir(parents=True)
+    (deft_core / "VERSION").write_text(
+        f"sha: {'3' * 40}\nref: v0.56.0\ntag: v0.56.0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        doctor_module, "get_script_dir", lambda: tmp_path / "no-scripts"
+    )
+    monkeypatch.setattr(
+        doctor_module, "_npm_view_version", lambda: (False, "")
+    )
+
+    class _FailProc:
+        stdout = ""
+        returncode = 1
+
+    monkeypatch.setattr(
+        doctor_module.subprocess, "run", lambda *a, **k: _FailProc()
+    )
+
+    warnings: list[str] = []
+    findings: list[dict] = []
+
+    doctor_module._run_payload_staleness_check(
+        tmp_path,
+        emit_warn=warnings.append,
+        emit_info=lambda _m: None,
+        add_finding=lambda severity, message, **extras: findings.append(
+            {"severity": severity, "message": message, **extras}
+        ),
+    )
+
+    unverified = [f for f in findings if f.get("status") == "unverified"]
+    assert unverified, findings
+    assert unverified[0]["severity"] == "warning"
+    assert "UNVERIFIED" in unverified[0]["message"]
+    assert any("UNVERIFIED" in w for w in warnings)

--- a/tests/cli/test_framework_doctor.py
+++ b/tests/cli/test_framework_doctor.py
@@ -97,6 +97,7 @@ def _write_manifest(install_root_path: Path, tag: str = "0.27.1") -> None:
         f"tag: 'v{tag}'\n"
         "fetched_at: '2026-05-11T15:30:52Z'\n"
         "fetched_by: 'run-install'\n"
+        "managed_by: 'npm'\n"
     )
     (install_root_path / "VERSION").write_text(body, encoding="utf-8")
 

--- a/tests/cli/test_framework_doctor_prose.py
+++ b/tests/cli/test_framework_doctor_prose.py
@@ -363,6 +363,15 @@ def _classify_command(
             return True, f"run subcommand `{subcmd}`"
         return False, f"unknown run subcommand `{subcmd}`"
 
+    if cmd.startswith("npm i -g @deftai/directive"):
+        return True, "canonical npm upgrade command (#2003)"
+
+    if cmd.startswith("npx @deftai/directive "):
+        return True, "canonical npx npm CLI invocation (#1912)"
+
+    if head == "directive":
+        return True, "directive CLI verb (#2003)"
+
     # Not a command shape we recognise -- the regex picked up something
     # else (an inline-code literal like `v0.27.1` or a file path). The
     # caller filters these out via the explicit-command-prefixes check.
@@ -372,16 +381,18 @@ def _classify_command(
 def _looks_like_command(cmd: str) -> bool:
     """Heuristic: does this backticked literal LOOK like a command vs a value?
 
-    Commands always start with ``task ``, ``.deft/core/run ``,
-    ``.deft\\core\\run ``, or ``run ``. Anything else (e.g. inline-code
-    literals citing a version string, a file path, or a YAML field name)
-    is excluded from the command-string contract.
+    Commands start with ``task ``, ``.deft/core/run ``,
+    ``.deft\\core\\run ``, ``run ``, the post-freeze npm upgrade one-liner,
+    ``npx @deftai/directive ...``, or ``directive ...`` CLI verbs.
     """
     return cmd.startswith((
         "task ",
         ".deft/core/run ",
         ".deft\\core\\run ",
         "run ",
+        "npm i -g ",
+        "npx @deftai/directive ",
+        "directive ",
     ))
 
 

--- a/vbrief/completed/2026-06-25-1997-post-freeze-doctor-surface-npm-migration-signpost-on-a-norma.vbrief.json
+++ b/vbrief/completed/2026-06-25-1997-post-freeze-doctor-surface-npm-migration-signpost-on-a-norma.vbrief.json
@@ -1,0 +1,38 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #1997"
+  },
+  "plan": {
+    "title": "Post-freeze doctor: surface npm-migration signpost on a normal run + npm payload-staleness command + Python doctor legacy-layout parity",
+    "status": "completed",
+    "narratives": {
+      "Description": "Post-freeze doctor: surface npm-migration signpost on a normal run + npm payload-staleness command + Python doctor legacy-layout parity",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1997",
+      "Overview": "Child of #1993 (sub-problem 5). Split out from the live Cartograph consumer report.\n\nThree doctor gaps post-freeze:\n- **Throttle hides the signpost**: on a normal (non-`--full`) run the 24h clean-window throttle (`packages/core/src/doctor/main.ts:56-78`, `constants.ts` CLEAN_WINDOW_HOURS) can skip the legacy-layout signpost entirely. The frozen-final v0.56.0 canonical-vendored layout is a known terminal state and should be detectable/surfaced without a networked `--full` run.\n- **Payload-staleness still recommends the Go bridge**: `CANONICAL_UPGRADE_COMMAND` (`doctor/constants.ts:55`) / `payload-staleness.ts:177` emit `deft-install --yes --upgrade ...`. Post-freeze the canonical path is npm — update the recommendation.\n- **Python doctor lacks legacy-layout**: `scripts/doctor.py` has no `legacy-layout` check, so the vendored Python doctor never emits the npm signpost (only the TS doctor does). UPGRADING claims parity; close the gap or adjust the claim.\n\nRefs #1993, #1912, #1411.",
+      "Labels": "enhancement, installer"
+    },
+    "items": [],
+    "tags": [
+      "enhancement",
+      "installer"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1997",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1997: Post-freeze doctor: surface npm-migration signpost on a normal run + npm payload-staleness command + Python doctor legacy-layout parity"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1993",
+        "type": "x-vbrief/refs",
+        "title": "Issue #1993"
+      }
+    ],
+    "updated": "2026-06-25T20:23:04Z",
+    "metadata": {
+      "completedAt": "2026-06-25T20:23:04Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}

--- a/vbrief/completed/2026-06-25-2003-doctor-payload-staleness-command-diverges-from-agentsmd-mana.vbrief.json
+++ b/vbrief/completed/2026-06-25-2003-doctor-payload-staleness-command-diverges-from-agentsmd-mana.vbrief.json
@@ -1,0 +1,28 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #2003"
+  },
+  "plan": {
+    "title": "doctor payload-staleness command diverges from AGENTS.md / managed-section docs",
+    "status": "completed",
+    "narratives": {
+      "Description": "doctor payload-staleness command diverges from AGENTS.md / managed-section docs",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2003",
+      "Overview": "## Summary\n\nTwo different \"canonical upgrade command\" strings are live across surfaces, and the AGENTS.md / managed-section narrative attributes the **wrong** one to `scripts/doctor.py`.\n\nThe managed-section template (and therefore every consumer-installed `AGENTS.md`) states:\n\n> The canonical `scripts/doctor.py` ... when behind, emits the canonical upgrade command `npm i -g @deftai/directive@latest` (#1339 / #1409 / #1912).\n\nBut the doctor's payload-staleness path actually emits a **different** command.\n\n## Evidence\n\nDocumentation side (claims `npm i -g @deftai/directive@latest`):\n- `templates/agents-entry.md` (managed-section source) → propagates to every consumer `AGENTS.md`\n- `AGENTS.md` (maintainer copy)\n- `skills/deft-directive-sync/SKILL.md`, `README.md`\n\nSource side (actually emits `deft-install --yes --upgrade --repo-root . --json`):\n- `scripts/doctor.py:1640` — `recommended_command = \"deft-install --yes --upgrade --repo-root . --json\"` (docstring at :1502 confirms this is the payload-staleness emission, #1409)\n- `packages/core/src/doctor/constants.ts:55` — `CANONICAL_UPGRADE_COMMAND = \"deft-install --yes --upgrade --repo-root . --json\"`\n- Release notes for v0.56.1 / v0.56.2 also cite `deft-install --yes --upgrade --repo-root . --json`\n\n## Why it matters\n\n`npm i -g ...` and `deft-install --yes --upgrade ...` are **different operations**: the former refreshes the globally-installed CLI, the latter refreshes the *vendored* `.deft/core` payload in a project. The doctor's payload-staleness check is specifically about the vendored payload, so the source command (`deft-install --yes --upgrade`) is the correct one for that emission — which means the AGENTS.md narrative citing the npm command for that exact code path is inaccurate. A consumer who copy-pastes the npm command after a payload-staleness warning updates the wrong thing and the warning persists.\n\n## Suggested resolution\n\nReconcile the managed-section narrative with the doctor source. Either:\n1. Correct `templates/agents-entry.md` (and re-run `task agents:refresh`) so the doctor-attributed command matches `CANONICAL_UPGRADE_COMMAND` (`deft-install --yes --upgrade --repo-root . --json`), keeping `npm i -g @deftai/directive@latest` only where it correctly refers to refreshing the global CLI; or\n2. If npm is intended to be the single canonical path post-freeze, update `doctor.py` + `constants.ts` to emit the npm command and adjust the release-notes template accordingly.\n\nA small contract test asserting the doctor-emitted command string matches the string quoted in `templates/agents-entry.md` would prevent regression (cf. the existing `tests/content/test_agents_entry_contract.py` marker mechanism).\n\n## Discovered\n\nFound during a routine version-staleness investigation on a vendored install (cartograph, payload `v0.56.0`)."
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2003",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2003: doctor payload-staleness command diverges from AGENTS.md / managed-section docs"
+      }
+    ],
+    "updated": "2026-06-25T20:23:05Z",
+    "metadata": {
+      "completedAt": "2026-06-25T20:23:05Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}

--- a/vbrief/completed/2026-06-25-2004-doctor-payload-staleness-silently-green-when-ls-remote-unava.vbrief.json
+++ b/vbrief/completed/2026-06-25-2004-doctor-payload-staleness-silently-green-when-ls-remote-unava.vbrief.json
@@ -1,0 +1,28 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #2004"
+  },
+  "plan": {
+    "title": "doctor payload-staleness silently green when ls-remote unavailable (false 'System check passed!')",
+    "status": "completed",
+    "narratives": {
+      "Description": "doctor payload-staleness silently green when ls-remote unavailable (false 'System check passed!')",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2004",
+      "Overview": "## Summary\n\n`scripts/doctor.py`'s payload-staleness check degrades to a silent, invisible `skip` whenever its `git ls-remote` probe can't resolve a remote SHA (no network, no origin, restricted/allowlist network, or empty output). Because `skip` findings do not affect the doctor's overall verdict, the doctor prints `✓ System check passed!` even when the installed payload is genuinely behind. In any network-restricted environment (CI, sandboxed agents, corporate egress filtering) the staleness guard is effectively blind and reports a false \"all clear\".\n\n## Reproduction (observed live)\n\nVendored install on a project (cartograph), payload `v0.56.0`; latest published was `v0.56.2` (two patches behind, same day). `doctor.py --full` output:\n\n```\nℹ Checking payload staleness from install manifest...\nℹ payload-staleness: skip -- ls-remote produced no sha\n...\n✓ System check passed!\n```\n\nThe only reason the staleness was caught at all was an independent `npm view @deftai/directive version` (the npm registry was reachable in the same environment where `git ls-remote origin <ref>` to GitHub was not).\n\n## Root cause\n\nAll network/resolution failure branches emit `add_finding(..., status=\"skip\")` and `return`, which is non-fatal and does not downgrade the green summary:\n\n- `scripts/doctor.py:1594-1597` — `git ls-remote failed (no network or no origin)`\n- `scripts/doctor.py:1624-1626` — `ls-remote produced no sha` (the branch hit here)\n- `scripts/doctor.py:1627-1630` — `could not probe remote (<Exc>)`\n\nThe docstring (`:1503-1504`) documents this as intentional best-effort behavior (\"Skips gracefully ... when git / network / manifest unavailable (non-fatal)\"). The problem is the *consequence*: a skip is indistinguishable from a confirmed-current result in the headline verdict, so \"couldn't verify\" reads as \"verified fresh\".\n\n## Why it matters\n\n- The payload-staleness guard is the canonical surface that tells consumers they're behind. When it silent-skips, consumers (and headless agents that key off doctor's exit/verdict) believe they're current when they're not.\n- This is most likely to fire exactly where it's most dangerous: automated/sandboxed/CI contexts that can't reach GitHub directly.\n\n## Suggested resolution\n\n1. **Make the skip visible in the summary.** When payload-staleness can't verify, surface a distinct advisory line in the final summary (e.g. `⚠ payload currency UNVERIFIED — could not reach remote`) rather than folding into a clean `✓ System check passed!`. Keep it non-fatal, but not invisible.\n2. **Add a network-independent fallback resolver.** Post-freeze the canonical distribution is npm, and the npm registry is often reachable when GitHub `ls-remote` is not (demonstrated above). The doctor could compare the manifest `ref`/`tag` against `npm view @deftai/directive version` as a fallback when `ls-remote` yields nothing — which would have caught the `v0.56.0` vs `v0.56.2` gap.\n3. Optionally distinguish \"skip: no manifest / inside repo\" (genuinely not applicable) from \"skip: could not verify currency\" (applicable but unverifiable) so only the latter raises the advisory.\n\n## Related\n\nSurfaced alongside #2003 (doctor-emitted upgrade-command string diverging from AGENTS.md docs) during the same version-staleness investigation."
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2004",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2004: doctor payload-staleness silently green when ls-remote unavailable (false 'System check passed!')"
+      }
+    ],
+    "updated": "2026-06-25T20:23:06Z",
+    "metadata": {
+      "completedAt": "2026-06-25T20:23:06Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Align doctor payload-staleness remediation with the post-freeze npm path: both TS and Python doctors now recommend `npm i -g @deftai/directive@latest`, matching `agents-entry.md` / AGENTS.md (#2003).
- When `git ls-remote` cannot verify currency, fall back to `npm view @deftai/directive version` and surface a non-fatal **UNVERIFIED** advisory instead of a silent green pass (#2004).
- Surface legacy-layout and canonical-vendored npm-migration signposts on throttled (non-`--full`) doctor runs; add Python doctor parity for legacy-layout detection (#1997).

Closes #1997
Closes #2003
Closes #2004

## Test plan

- [x] `TMPDIR=$(mktemp -d) task check`
- [x] New contract test: `tests/cli/test_doctor_upgrade_command_contract.py`
- [x] TS unit tests under `packages/core/src/doctor/*.test.ts`
- [x] Throttle signpost integration: `tests/cli/test_doctor_throttle.py`


Made with [Cursor](https://cursor.com)