### PR TITLE
fix(release-e2e): stop install+run smoke false-failing on healthy install (#2010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Vendored `run update` now points at npm instead of dead-ending** — the compatibility `run update` stub no longer tells operators to manually replace the deft directory; it signposts `npm i -g @deftai/directive@latest` and `npx @deftai/directive update` so future deposits steer consumers to the post-freeze upgrade path. Closes #1998.
 - **Doctor now recommends npm upgrades and surfaces layout advisories on throttled runs** — payload-staleness emits `npm i -g @deftai/directive@latest` (matching AGENTS.md), falls back to the npm registry when GitHub `ls-remote` is unreachable, and warns when payload currency is UNVERIFIED instead of silently passing; legacy-layout and canonical-vendored npm-migration signposts run on normal throttled doctor runs and in the Python doctor. Closes #1997, #2003, #2004.
+- **Release rehearsal no longer false-fails on a healthy install** — the install+run smoke now uses `directive --version` as its exit-0 liveness check and gates `directive doctor` only on module-not-found, so a benign non-zero doctor verdict in a bare consumer layout stops blocking `task release:e2e`. Closes #2010.
 
 ### Removed
 

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -394,4 +394,51 @@ describe("rehearseNpmInstallAndRun (#1996)", () => {
     expect(reason).toContain("module resolution error");
     expect(reason).toContain("ERR_MODULE_NOT_FOUND");
   });
+
+  it("passes when doctor exits non-zero in a bare consumer layout but --version is clean (#2010)", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-install-run-benign-"));
+    scaffoldPackages(clone);
+    const seams: E2ESeams = {
+      which: (n) => `/usr/bin/${n}`,
+      spawnText: (cmd, args) => {
+        const full = [cmd, ...args];
+        if (full.some((part) => String(part).includes("bin.js"))) {
+          if (full.includes("--version")) {
+            return { status: 0, stdout: "@deftai/directive (engine: core@0.0.1)\n", stderr: "" };
+          }
+          // doctor: benign non-zero verdict in a bare consumer layout (#2010)
+          return {
+            status: 1,
+            stdout: "\u2717 System check failed with 1 error(s) and 1 warning(s).\n",
+            stderr: "",
+          };
+        }
+        return ok();
+      },
+    };
+    const [okFlag, reason] = rehearseNpmInstallAndRun(clone, "0.0.1", seams);
+    expect(okFlag).toBe(true);
+    expect(reason).toContain("without module-not-found");
+  });
+
+  it("fails when the --version liveness probe exits non-zero (#2010)", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-install-run-liveness-"));
+    scaffoldPackages(clone);
+    const seams: E2ESeams = {
+      which: (n) => `/usr/bin/${n}`,
+      spawnText: (cmd, args) => {
+        const full = [cmd, ...args];
+        if (full.some((part) => String(part).includes("bin.js")) && full.includes("--version")) {
+          return { status: 7, stdout: "", stderr: "boom" };
+        }
+        if (full.some((part) => String(part).includes("bin.js"))) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        return ok();
+      },
+    };
+    const [okFlag, reason] = rehearseNpmInstallAndRun(clone, "0.0.1", seams);
+    expect(okFlag).toBe(false);
+    expect(reason).toContain("directive --version exited 7");
+  });
 });

--- a/packages/core/src/release-e2e/npm-ops.ts
+++ b/packages/core/src/release-e2e/npm-ops.ts
@@ -205,10 +205,14 @@ function moduleResolutionFailure(output: string): string | null {
 }
 
 /**
- * Publish-layout install+run smoke (#1996): pack the four @deftai/directive*
- * packages, install the tarballs into a clean flat node_modules, and run
- * `directive doctor --help` so import-resolution bugs like #1993 sub-problem 1
- * surface before a real npm publish.
+ * Publish-layout install+run smoke (#1996, #2010): pack the four
+ * @deftai/directive* packages, install the tarballs into a clean flat
+ * node_modules, then run `directive --version` (exit-0 liveness) and
+ * `directive doctor` (deep-import coverage) so import-resolution bugs like
+ * #1993 sub-problem 1 surface before a real npm publish. The smoke gates on
+ * module-not-found markers, NOT on the doctor's pass/fail verdict -- a full
+ * doctor check exits non-zero in a bare consumer layout, which is benign
+ * (#2010).
  */
 export function rehearseNpmInstallAndRun(
   cloneDir: string,
@@ -308,28 +312,53 @@ export function rehearseNpmInstallAndRun(
 
   const spawn = seams.spawnText ?? spawnText;
   const cliBin = join(consumerDir, "node_modules", "@deftai", "directive", "dist", "bin.js");
-  const doctor = spawn(process.execPath, [cliBin, "doctor", "--help"], {
+
+  // Liveness probe (#2010): `--version` loads the cli + core engine via
+  // engineInfo(), exercising the cross-package import path that #1993 broke,
+  // and reliably exits 0 on a healthy install. This is the clean exit-0 gate;
+  // gating the smoke on the doctor's exit code instead is a false positive
+  // because a full doctor check exits non-zero in a bare consumer layout.
+  const versionRun = spawn(process.execPath, [cliBin, "--version"], {
     cwd: consumerDir,
     env,
     timeoutMs: NPM_INSTALL_RUN_TIMEOUT_SECONDS * 1000,
   });
-  const doctorOut = `${doctor.stdout ?? ""}\n${doctor.stderr ?? ""}`;
-  const resolutionHit = moduleResolutionFailure(doctorOut);
+  const versionOut = `${versionRun.stdout ?? ""}\n${versionRun.stderr ?? ""}`;
+  let resolutionHit = moduleResolutionFailure(versionOut);
   if (resolutionHit !== null) {
     return [
       false,
-      `install+run smoke: module resolution error (${resolutionHit}): ${doctorOut.trim().slice(-800)}`,
+      `install+run smoke: module resolution error on --version (${resolutionHit}): ${versionOut.trim().slice(-800)}`,
     ];
   }
-  if (doctor.status !== 0) {
+  if (versionRun.status !== 0) {
     return [
       false,
-      `install+run smoke: directive doctor --help exited ${doctor.status}: ${doctorOut.trim().slice(-500)}`,
+      `install+run smoke: directive --version exited ${versionRun.status}: ${versionOut.trim().slice(-500)}`,
+    ];
+  }
+
+  // Deep-import probe (#2010): run the doctor verb to exercise the deeper
+  // cross-package import graph that #1993 sub-problem 1 broke. The doctor
+  // legitimately exits non-zero in a bare consumer layout (e.g. no root
+  // Taskfile.yml), so gate ONLY on the module-not-found markers, NOT on the
+  // doctor's pass/fail verdict.
+  const doctorRun = spawn(process.execPath, [cliBin, "doctor"], {
+    cwd: consumerDir,
+    env,
+    timeoutMs: NPM_INSTALL_RUN_TIMEOUT_SECONDS * 1000,
+  });
+  const doctorOut = `${doctorRun.stdout ?? ""}\n${doctorRun.stderr ?? ""}`;
+  resolutionHit = moduleResolutionFailure(doctorOut);
+  if (resolutionHit !== null) {
+    return [
+      false,
+      `install+run smoke: module resolution error on doctor (${resolutionHit}): ${doctorOut.trim().slice(-800)}`,
     ];
   }
 
   return [
     true,
-    `packed + installed 4 packages at v${version} and ran directive doctor without module-not-found`,
+    `packed + installed 4 packages at v${version}; ran directive --version (exit 0) + doctor without module-not-found`,
   ];
 }

--- a/vbrief/completed/2026-06-25-2010-releasee2e-installrun-smoke-false-positive-doctor-help-exits.vbrief.json
+++ b/vbrief/completed/2026-06-25-2010-releasee2e-installrun-smoke-false-positive-doctor-help-exits.vbrief.json
@@ -1,0 +1,28 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #2010"
+  },
+  "plan": {
+    "title": "release:e2e install+run smoke false-positive: doctor --help exits 1 in bare consumer layout (#1996 follow-up)",
+    "status": "completed",
+    "narratives": {
+      "Description": "release:e2e install+run smoke false-positive: doctor --help exits 1 in bare consumer layout (#1996 follow-up)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2010",
+      "Overview": "## Summary\n\nThe `release:e2e` \"npm install+run smoke\" step added in #1996 (PR #2008) has a false-positive failure: it runs `directive doctor --help` against a freshly-installed clean consumer layout and asserts exit code 0, but the `doctor` subcommand ignores `--help`, runs the full system check, and legitimately exits 1 in a bare consumer dir (e.g. the expected \"no root Taskfile.yml\" warning + a benign error). This blocks `task release:e2e` even though packaging and import resolution are healthy.\n\n## Evidence\n\n`task release:e2e` output:\n\n```\n[e2e]   rehearsal step: npm publish dry-run... OK (4 packages)\n[e2e]   rehearsal step: npm install+run smoke... FAIL (install+run smoke: directive doctor --help exited 1: ... ✗ System check failed with 1 error(s) and 1 warning(s).)\n```\n\nThe module-not-found check (the actual goal of #1996, guarding the #1993 import-resolution regression) PASSED — no `Cannot find module` / `ERR_MODULE_NOT_FOUND` marker hit. Only the over-strict `doctor.status !== 0` assertion in `packages/core/src/release-e2e/npm-ops.ts` (`rehearseNpmInstallAndRun`) tripped.\n\n## Root cause\n\n`rehearseNpmInstallAndRun` invokes `directive doctor --help` as a liveness probe and treats any non-zero exit as a smoke failure. A full doctor system check in a throwaway consumer layout is *expected* to exit non-zero, so the gate fires on a benign verdict rather than a real import/packaging defect.\n\n## Suggested resolution\n\n- Use `directive --version` as the exit-0 liveness probe (it loads the cli + core engine via `engineInfo()`, exercising the cross-package import path that #1993 broke, and reliably exits 0 on a healthy install).\n- Keep running `directive doctor` for deeper import coverage, but gate ONLY on the module-not-found markers — do NOT assert the doctor's pass/fail verdict.\n- Add a regression test: doctor exits 1 with benign (non-module-not-found) output + `--version` exits 0 ⇒ smoke PASSES.\n\nTS-only (no Python parity for this smoke). Discovered while cutting v0.57.0; the e2e gate is currently red and blocking the release.\n"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2010",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2010: release:e2e install+run smoke false-positive: doctor --help exits 1 in bare consumer layout (#1996 follow-up)"
+      }
+    ],
+    "updated": "2026-06-25T21:47:35Z",
+    "metadata": {
+      "completedAt": "2026-06-25T21:47:35Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a false-positive in the `release:e2e` "npm install+run smoke" added in #1996: the smoke ran `directive doctor --help` and asserted exit 0, but `doctor` ignores `--help`, runs the full system check, and legitimately exits 1 in a bare consumer layout — blocking `task release:e2e` even on a healthy install. Caught while cutting v0.57.0.

## What changed

- `directive --version` is now the exit-0 liveness probe (loads the cli + core engine via `engineInfo()`, exercising the cross-package import path that #1993 broke, and reliably exits 0).
- `directive doctor` still runs for deeper import coverage, but the smoke gates ONLY on module-not-found markers — not on the doctor's pass/fail verdict.
- Regression tests: a benign non-zero doctor verdict (bare consumer layout) now passes; a `--version` liveness failure fails.

TS-only (no Python parity for this smoke).

## Test plan

- [x] `pnpm -w exec vitest run packages/core/src/release-e2e/npm-ops.test.ts` — 18 passed
- [x] `task check` — full suite green
- [ ] `task release:e2e` re-run green (verified by maintainer after merge, resuming the v0.57.0 cut)

Closes #2010.
