### PR TITLE
chore(release): roll Go-installer freeze line to v0.58.0

### DIFF
--- a/packages/core/src/legacy-bridge/sot.test.ts
+++ b/packages/core/src/legacy-bridge/sot.test.ts
@@ -3,7 +3,7 @@ import { isFrozen, LAST_GO_INSTALLER, lastGoInstaller } from "./sot.js";
 
 describe("legacy-bridge SoT (lastGoInstaller)", () => {
   it("is pinned to the final Go-installer tag once frozen (#1912)", () => {
-    // The operator froze the SoT at v0.56.0; assert against the constant rather
+    // The operator froze the SoT at v0.58.0; assert against the constant rather
     // than a literal so this stays clear of the verify:bridge-drift gate.
     expect(LAST_GO_INSTALLER).not.toBeNull();
     expect(lastGoInstaller()).toBe(LAST_GO_INSTALLER);

--- a/packages/core/src/legacy-bridge/sot.ts
+++ b/packages/core/src/legacy-bridge/sot.ts
@@ -38,7 +38,7 @@
  * at freeze time. Leave it `null` otherwise. This is the only edit required to
  * pin the bridge version; the freeze + drift gates pick it up automatically.
  */
-export const LAST_GO_INSTALLER: string | null = "v0.56.0";
+export const LAST_GO_INSTALLER: string | null = "v0.58.0";
 
 /** Returns the frozen final Go-installer tag, or `null` while unfrozen. */
 export function lastGoInstaller(): string | null {


### PR DESCRIPTION
## Summary

Rolls the frozen Go-installer freeze line forward from `v0.56.0` to `v0.58.0` ahead of the `v0.58.0` release cut.

Per `docs/RELEASING.md` § Frozen Go-installer bridge, pinning `LAST_GO_INSTALLER` to the **exact tag being cut** does two things in one move:
- CI's `freeze-gate` job sees `tag (0.58.0) == pin (0.58.0)` → does **not** skip → the `build` matrix rebuilds all 6 Go binaries + the macOS universal asset (shipping the `deft-install gate` work from #2014 + the #2015 fix in a real frozen binary).
- The bridge stays frozen at the new line afterward (no separate post-release re-pin needed).

## What changed

- `packages/core/src/legacy-bridge/sot.ts` — `LAST_GO_INSTALLER`: `"v0.56.0"` → `"v0.58.0"` (the single Tier-0 source-of-truth edit).
- `packages/core/src/legacy-bridge/sot.test.ts` — stale comment updated to match.

## Verification

- `task verify:go-freeze` — OK (frozen at v0.58.0).
- `task verify:bridge-drift` — OK (4 surfaces scanned; every reference reads the SoT; no hardcoded competing literal).
- `pnpm vitest run packages/core/src/legacy-bridge` — 28 passed.
- `task check` — green (8397 passed).

This PR must merge to `master` before tagging `v0.58.0`. Refs #1912, #2001, #1933.
