### PR TITLE
fix: resolve content package via package.json subpath (#2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **`deft update` / `deft init` no longer abort with `refresh_deposit_failed` on canonical-vendored installs** — the content-package resolver now locates `@deftai/directive-content` through its `package.json` subpath instead of its bare specifier. The content package ships no entry point, so the old bare-specifier resolve threw and stopped the deposit; resolving the always-present `package.json` restores the npm refresh path. Closes #2023.
 
 ### Removed
 

--- a/packages/core/src/deposit/resolve-content.test.ts
+++ b/packages/core/src/deposit/resolve-content.test.ts
@@ -44,6 +44,29 @@ describe("resolveInstalledContentRoot", () => {
     expect(root).toBe(pkgDir);
   });
 
+  it("resolves via the package.json subpath when the package ships no entry point (#2023)", async () => {
+    const project = freshRoot();
+    const pkgDir = installContentPackage(project);
+
+    // The content package ships no main, exports, or index.js, so a bare-specifier
+    // resolve throws (the #2023 abort). The package.json subpath always resolves.
+    const resolveSpecifier = async (specifier: string): Promise<string> => {
+      if (specifier === CONTENT_PACKAGE_NAME) {
+        throw new Error(
+          `Cannot find module '${CONTENT_PACKAGE_NAME}'. ` +
+            "The package has no main, exports, or index.js entry point.",
+        );
+      }
+      if (specifier === `${CONTENT_PACKAGE_NAME}/package.json`) {
+        return join(pkgDir, "package.json");
+      }
+      throw new Error(`unexpected specifier: ${specifier}`);
+    };
+
+    const root = await resolveInstalledContentRoot(resolveSpecifier);
+    expect(root).toBe(pkgDir);
+  });
+
   it("finds the package root when resolution lands on an nested entry file", async () => {
     const project = freshRoot();
     const pkgDir = installContentPackage(project);

--- a/packages/core/src/deposit/resolve-content.ts
+++ b/packages/core/src/deposit/resolve-content.ts
@@ -63,13 +63,19 @@ export function contentPackageRootFromResolvedEntry(resolvedEntry: string): stri
 /**
  * Resolve the installed {@link CONTENT_PACKAGE_NAME} package root via Node module
  * resolution (`import.meta.resolve`).
+ *
+ * Resolves the package's `package.json` subpath rather than its bare specifier:
+ * the content package ships no entry point (no `main`, `exports`, or `index.js`),
+ * so a bare-specifier resolve throws. The `package.json` subpath always resolves,
+ * and {@link contentPackageRootFromResolvedEntry} walks up from it to the package
+ * root. Refs #2023.
  */
 export async function resolveInstalledContentRoot(
   resolveSpecifier: ResolveSpecifier = defaultResolveSpecifier,
 ): Promise<string> {
   let resolvedEntry: string;
   try {
-    resolvedEntry = await resolveSpecifier(CONTENT_PACKAGE_NAME);
+    resolvedEntry = await resolveSpecifier(`${CONTENT_PACKAGE_NAME}/package.json`);
   } catch (cause) {
     const detail = cause instanceof Error ? cause.message : String(cause);
     throw new ContentPackageNotFoundError(

--- a/vbrief/completed/2026-06-26-2023-deft-updateinit-aborts-with-refresh-deposit-failed-content-p.vbrief.json
+++ b/vbrief/completed/2026-06-26-2023-deft-updateinit-aborts-with-refresh-deposit-failed-content-p.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "fix-2023-content-resolve",
     "title": "Fix deft update/init refresh_deposit_failed by resolving the content package via its package.json subpath",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "On v0.58.0, deft update and deft init against a canonical-vendored .deft/core install abort with refresh_deposit_failed and deposit nothing, because resolveInstalledContentRoot resolves @deftai/directive-content by its bare specifier and the content package ships no entry point (no main, no exports, no index.js). The fix resolves the package.json subpath instead and feeds it to the existing walk-up helper, restoring the npm refresh path for vendored deposits without shipping a dead entry module.",
       "ImplementationPlan": "- In the packages/core/src/deposit/resolve-content.ts source module, change resolveInstalledContentRoot to call resolveSpecifier with `${CONTENT_PACKAGE_NAME}/package.json` and feed the result to the existing contentPackageRootFromResolvedEntry walk-up, which already dirname()s and walks up to the package root, so the bare-specifier resolve that throws is removed.\n- Add a regression test in resolve-content.test.ts that asserts resolution succeeds when the content package fixture has no main, exports, or index.js, and run the deposit test suite as evidence the refresh path resolves.",
@@ -66,7 +66,9 @@
         "size": "S",
         "file_scope_confidence": "high",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-26T18:28:23Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -75,6 +77,6 @@
         "title": "Issue #2023: deft update/init aborts with refresh_deposit_failed: content package resolved by bare specifier has no entry point (v0.58.0)"
       }
     ],
-    "updated": "2026-06-26T18:08:58Z"
+    "updated": "2026-06-26T18:28:23Z"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2023 — `deft update` / `deft init` against a canonical-vendored `.deft/core/` install aborted with `refresh_deposit_failed` and deposited nothing.

**Root cause:** `resolveInstalledContentRoot()` resolved `@deftai/directive-content` by its **bare specifier** (`import.meta.resolve("@deftai/directive-content")`). The content package ships no entry point (no `main`, no `exports`, no `index.js`), so the bare-specifier resolve throws and the refresh path aborts.

**Fix (issue option 1):** resolve the `@deftai/directive-content/package.json` subpath instead — which always resolves — and feed the result to the existing `contentPackageRootFromResolvedEntry` walk-up, which already `dirname()`s and walks up to the package root. One-line behavioral change; no dead entry module shipped.

## Changes

- `packages/core/src/deposit/resolve-content.ts` — resolve the `package.json` subpath rather than the bare specifier; doc comment explains why.
- `packages/core/src/deposit/resolve-content.test.ts` — regression test asserting resolution succeeds when the bare specifier throws (no entry point) but the `package.json` subpath resolves.
- `CHANGELOG.md` — `[Unreleased]` user-facing entry.

## Acceptance criteria (vBRIEF `fix-2023-content-resolve`)

- a1 — content package with no `main`/`exports`/`index.js` resolves via the `package.json` subpath without throwing ✔ (new regression test)
- a2 — `deft update` deposits refreshed content instead of aborting with `refresh_deposit_failed` ✔ (resolver no longer throws on the no-entry-point package)
- a3 — `resolve-content.test.ts` covers the no-entry-point path and passes ✔

## Test plan

- `pnpm --filter @deftai/directive-core test deposit` — all deposit tests pass (7 in `resolve-content.test.ts`).
- `pnpm -w exec tsc -b` — clean build.
- `biome check` on changed files — clean.

> Base branch is the cohort integration branch `chore/py-purge-cohort-decomposition`, not `master`.
