### PR TITLE
feat(doctor): add a pre-cutover status line to deft doctor (#2022 Phase 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`deft doctor` now shows a pre-cutover status line** — running the doctor prints a short line telling you whether the project still carries pre-v0.20 document-model artifacts that need migration (flagging the offending files and pointing at `deft migrate:vbrief`), or confirms it is on the current vBRIEF document model. This surfaces migration state in the TypeScript engine without depending on the Python migrator. Refs #2022.
+- **`deft doctor` now shows a pre-cutover status line** — running the doctor tells operators whether a project still needs the pre-v0.20 document-model migration or is already on the current vBRIEF model. Refs #2022.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`deft doctor` now shows a pre-cutover status line** — running the doctor prints a short line telling you whether the project still carries pre-v0.20 document-model artifacts that need migration (flagging the offending files and pointing at `deft migrate:vbrief`), or confirms it is on the current vBRIEF document model. This surfaces migration state in the TypeScript engine without depending on the Python migrator. Refs #2022.
 
 ### Changed
 

--- a/packages/cli/src/doctor-parity.test.ts
+++ b/packages/cli/src/doctor-parity.test.ts
@@ -6,6 +6,17 @@ describe("doctor-parity helpers", () => {
     expect(normaliseStdout("Using CPython 3.14\nok\n")).toBe("ok\n");
   });
 
+  it("normaliseStdout strips the TS-only pre-cutover status line (#2022)", () => {
+    expect(
+      normaliseStdout(
+        "Pre-cutover: none -- project is on the current vBRIEF document model.\nok\n",
+      ),
+    ).toBe("ok\n");
+    expect(normaliseStdout("Pre-cutover: migration needed -- SPECIFICATION.md ...\nok\n")).toBe(
+      "ok\n",
+    );
+  });
+
   it("diffParity detects stdout mismatch", () => {
     const diff = diffParity(
       { name: "a", exitCode: 0, stdout: "x", stderr: "" },

--- a/packages/cli/src/doctor-parity.ts
+++ b/packages/cli/src/doctor-parity.ts
@@ -111,7 +111,12 @@ export function normaliseStdout(text: string): string {
       (line) =>
         !line.startsWith("Using CPython") &&
         !line.startsWith("Creating virtual environment") &&
-        !line.startsWith("Installed "),
+        !line.startsWith("Installed ") &&
+        // #2022: the TS doctor emits a pre-cutover status line that the Python
+        // oracle (scripts/doctor.py) never had ("without a Python port"). Filter
+        // it so this intentional TS-only addition does not register as parity
+        // divergence. Removed when scripts/doctor.py is purged with the gate.
+        !line.startsWith("Pre-cutover:"),
     )
     .join("\n");
 }

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -73,6 +73,22 @@ describe("doctor CLI", () => {
     expect(cmdDoctor).toHaveBeenCalledWith(["--json", "--project-root", root]);
   });
 
+  it("suppresses the precutover line for an invalid invocation (unknown flag)", () => {
+    const out = captureStdout(() => {
+      run(["--not-a-real-flag"]);
+    });
+    expect(out).toBe("");
+    expect(cmdDoctor).toHaveBeenCalledWith(["--not-a-real-flag"]);
+  });
+
+  it("suppresses the precutover line for --help", () => {
+    const out = captureStdout(() => {
+      run(["--help"]);
+    });
+    expect(out).toBe("");
+    expect(cmdDoctor).toHaveBeenCalledWith(["--help"]);
+  });
+
   it("flags the migration-needed state for a pre-cutover project fixture", () => {
     const root = makeRoot("doctor-precut-");
     makeLifecycleDirs(root);

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@deftai/directive-core/dist/doctor/main.js", () => ({
   cmdDoctor: vi.fn(() => 0),
@@ -7,9 +10,137 @@ vi.mock("@deftai/directive-core/dist/doctor/main.js", () => ({
 import { cmdDoctor } from "@deftai/directive-core/dist/doctor/main.js";
 import { run } from "./doctor.js";
 
+const LIFECYCLE_FOLDERS = ["proposed", "pending", "active", "completed", "cancelled"] as const;
+
+function makeLifecycleDirs(
+  projectRoot: string,
+  folders: readonly string[] = LIFECYCLE_FOLDERS,
+): void {
+  for (const folder of folders) {
+    mkdirSync(join(projectRoot, "vbrief", folder), { recursive: true });
+  }
+}
+
+const createdRoots: string[] = [];
+
+function makeRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  createdRoots.push(root);
+  return root;
+}
+
+function captureStdout(fn: () => void): string {
+  let captured = "";
+  const spy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk: string | Uint8Array): boolean => {
+      captured += typeof chunk === "string" ? chunk : chunk.toString();
+      return true;
+    });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return captured;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  while (createdRoots.length > 0) {
+    const root = createdRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
 describe("doctor CLI", () => {
   it("delegates argv to cmdDoctor", () => {
-    expect(run(["--full", "--json"])).toBe(0);
+    captureStdout(() => {
+      expect(run(["--full", "--json"])).toBe(0);
+    });
     expect(cmdDoctor).toHaveBeenCalledWith(["--full", "--json"]);
+  });
+
+  it("suppresses the precutover line under --json so JSON output stays valid", () => {
+    const root = makeRoot("doctor-json-");
+    makeLifecycleDirs(root);
+    const out = captureStdout(() => {
+      expect(run(["--json", "--project-root", root])).toBe(0);
+    });
+    expect(out).toBe("");
+    expect(cmdDoctor).toHaveBeenCalledWith(["--json", "--project-root", root]);
+  });
+
+  it("flags the migration-needed state for a pre-cutover project fixture", () => {
+    const root = makeRoot("doctor-precut-");
+    makeLifecycleDirs(root);
+    writeFileSync(
+      join(root, "SPECIFICATION.md"),
+      "# Project Specification\n\nHand-authored legacy spec.\n",
+      "utf8",
+    );
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("Pre-cutover: migration needed");
+    expect(out).toContain("SPECIFICATION.md");
+    expect(out).toContain("deft migrate:vbrief");
+  });
+
+  it("reports a clean non-pre-cutover state for a current-layout project fixture", () => {
+    const root = makeRoot("doctor-current-");
+    makeLifecycleDirs(root);
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("Pre-cutover: none");
+    expect(out).toContain("current vBRIEF document model");
+    expect(out).not.toContain("migration needed");
+  });
+
+  it("flags a pre-cutover PROJECT.md and missing lifecycle folders", () => {
+    const root = makeRoot("doctor-project-md-");
+    // Only a subset of lifecycle folders -> missing-folder reason fires.
+    makeLifecycleDirs(root, ["proposed", "active"]);
+    writeFileSync(join(root, "PROJECT.md"), "# Project\n\nLegacy project doc.\n", "utf8");
+    const out = captureStdout(() => {
+      run([`--project-root=${root}`]);
+    });
+    expect(out).toContain("Pre-cutover: migration needed");
+    expect(out).toContain("PROJECT.md");
+    expect(out).toContain("missing lifecycle folder");
+  });
+
+  it("treats deprecation-redirect root docs as already migrated", () => {
+    const root = makeRoot("doctor-redirect-");
+    makeLifecycleDirs(root);
+    const redirect = "<!-- deft:deprecated-redirect -->\n# Deprecated\n";
+    writeFileSync(join(root, "SPECIFICATION.md"), redirect, "utf8");
+    writeFileSync(join(root, "PROJECT.md"), redirect, "utf8");
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("Pre-cutover: none");
+  });
+
+  it("treats a current generated SPECIFICATION export as already migrated", () => {
+    const root = makeRoot("doctor-generated-");
+    makeLifecycleDirs(root);
+    writeFileSync(
+      join(root, "vbrief", "specification.vbrief.json"),
+      JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { title: "Spec", items: [] } }),
+      "utf8",
+    );
+    writeFileSync(
+      join(root, "SPECIFICATION.md"),
+      "<!-- Purpose: rendered specification -->\n<!-- Source of truth: vbrief/specification.vbrief.json -->\n# Spec\n",
+      "utf8",
+    );
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("Pre-cutover: none");
   });
 });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,32 +1,18 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
+import { parseDoctorFlags } from "@deftai/directive-core/dist/doctor/flags.js";
 import { cmdDoctor } from "@deftai/directive-core/dist/doctor/main.js";
 import { renderPrecutoverLine } from "@deftai/directive-core/dist/vbrief-validate/precutover.js";
 
-const PROJECT_ROOT_PREFIX = "--project-root=";
-
-function resolveProjectRoot(argv: readonly string[]): string {
-  for (let i = 0; i < argv.length; i += 1) {
-    const token = argv[i] ?? "";
-    if (token === "--project-root") {
-      return argv[i + 1] ?? process.cwd();
-    }
-    if (token.startsWith(PROJECT_ROOT_PREFIX)) {
-      const value = token.slice(PROJECT_ROOT_PREFIX.length);
-      if (value) {
-        return value;
-      }
-    }
-  }
-  return process.cwd();
-}
-
 export function run(argv: string[]): number {
   // #2022: surface pre-cutover (pre-v0.20 document model) migration state alongside the
-  // core doctor report. The line is suppressed under --json so it does not corrupt the
-  // machine-readable JSON document the core report emits.
-  if (!argv.includes("--json")) {
-    process.stdout.write(`${renderPrecutoverLine(resolveProjectRoot(argv))}\n`);
+  // core doctor report. Only emit on a valid, human-readable invocation: suppressed under
+  // --json (so the machine-readable report stays valid), on --help, and when unknown flags
+  // are present (so an invalid invocation still mirrors the core error path exactly).
+  const flags = parseDoctorFlags(argv);
+  if (!flags.json && !flags.help && flags.unknown.length === 0) {
+    const projectRoot = flags.projectRoot ?? process.cwd();
+    process.stdout.write(`${renderPrecutoverLine(projectRoot)}\n`);
   }
   return cmdDoctor(argv);
 }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,8 +1,33 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
 import { cmdDoctor } from "@deftai/directive-core/dist/doctor/main.js";
+import { renderPrecutoverLine } from "@deftai/directive-core/dist/vbrief-validate/precutover.js";
+
+const PROJECT_ROOT_PREFIX = "--project-root=";
+
+function resolveProjectRoot(argv: readonly string[]): string {
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i] ?? "";
+    if (token === "--project-root") {
+      return argv[i + 1] ?? process.cwd();
+    }
+    if (token.startsWith(PROJECT_ROOT_PREFIX)) {
+      const value = token.slice(PROJECT_ROOT_PREFIX.length);
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return process.cwd();
+}
 
 export function run(argv: string[]): number {
+  // #2022: surface pre-cutover (pre-v0.20 document model) migration state alongside the
+  // core doctor report. The line is suppressed under --json so it does not corrupt the
+  // machine-readable JSON document the core report emits.
+  if (!argv.includes("--json")) {
+    process.stdout.write(`${renderPrecutoverLine(resolveProjectRoot(argv))}\n`);
+  }
   return cmdDoctor(argv);
 }
 

--- a/packages/core/src/vbrief-validate/precutover.ts
+++ b/packages/core/src/vbrief-validate/precutover.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { DEPRECATION_SENTINEL } from "../vbrief-build/constants.js";
 
@@ -36,4 +36,83 @@ function isGeneratedSpecificationExport(projectRoot: string, content: string): b
 /** Return true for a fully current ``task spec:render`` root export. */
 export function isCurrentGeneratedSpecification(projectRoot: string, content: string): boolean {
   return isGeneratedSpecificationExport(projectRoot, content) && hasCompleteLifecycle(projectRoot);
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function safeReadText(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/** Structured result of a pre-cutover (pre-v0.20 document model) probe. */
+export interface PrecutoverDetection {
+  /** True when any legacy pre-v0.20 artifact still needs migration. */
+  preCutover: boolean;
+  /** Human-readable reasons; empty when the project is on the current model. */
+  reasons: string[];
+}
+
+/**
+ * Detect whether ``projectRoot`` still carries pre-v0.20 (pre-cutover) document-model
+ * artifacts that need migration. Mirrors the AGENTS.md "Pre-Cutover Check" rule and the
+ * legacy ``scripts/_precutover.py`` helper: a project is pre-cutover when any of the
+ * following hold:
+ *
+ * - ``SPECIFICATION.md`` exists and is neither a deprecation redirect nor a current
+ *   generated spec export;
+ * - ``PROJECT.md`` exists and is not a deprecation redirect;
+ * - ``vbrief/`` exists but is missing one or more lifecycle folders.
+ */
+export function detectPreCutover(projectRoot: string): PrecutoverDetection {
+  const reasons: string[] = [];
+
+  const specPath = join(projectRoot, "SPECIFICATION.md");
+  if (isFile(specPath)) {
+    const content = safeReadText(specPath);
+    if (!isDeprecationRedirect(content) && !isCurrentGeneratedSpecification(projectRoot, content)) {
+      reasons.push(
+        "SPECIFICATION.md is a pre-v0.20 hand-authored doc (not a deprecation redirect or current generated export)",
+      );
+    }
+  }
+
+  const projectMdPath = join(projectRoot, "PROJECT.md");
+  if (isFile(projectMdPath)) {
+    const content = safeReadText(projectMdPath);
+    if (!isDeprecationRedirect(content)) {
+      reasons.push("PROJECT.md is a pre-v0.20 hand-authored doc (not a deprecation redirect)");
+    }
+  }
+
+  const vbriefRoot = join(projectRoot, "vbrief");
+  if (existsSync(vbriefRoot)) {
+    const missing = missingLifecycleFolders(projectRoot);
+    if (missing.length > 0) {
+      reasons.push(`vbrief/ is missing lifecycle folder(s): ${missing.join(", ")}`);
+    }
+  }
+
+  return { preCutover: reasons.length > 0, reasons };
+}
+
+/**
+ * Render the single-line pre-cutover status string surfaced by ``deft doctor``.
+ * Flags the migration-needed state with reasons, or reports a clean current-model state.
+ */
+export function renderPrecutoverLine(projectRoot: string): string {
+  const { preCutover, reasons } = detectPreCutover(projectRoot);
+  if (!preCutover) {
+    return "Pre-cutover: none -- project is on the current vBRIEF document model.";
+  }
+  return `Pre-cutover: migration needed -- ${reasons.join("; ")}. Run \`deft migrate:vbrief\` to migrate.`;
 }

--- a/packages/core/src/vbrief-validate/precutover.ts
+++ b/packages/core/src/vbrief-validate/precutover.ts
@@ -114,5 +114,7 @@ export function renderPrecutoverLine(projectRoot: string): string {
   if (!preCutover) {
     return "Pre-cutover: none -- project is on the current vBRIEF document model.";
   }
-  return `Pre-cutover: migration needed -- ${reasons.join("; ")}. Run \`deft migrate:vbrief\` to migrate.`;
+  // Collapse any embedded newlines so the status line stays a single line (CWE-116).
+  const summary = reasons.join("; ").replace(/\r?\n/g, " ");
+  return `Pre-cutover: migration needed -- ${summary}. Run \`deft migrate:vbrief\` to migrate.`;
 }

--- a/vbrief/completed/2026-06-26-extend-deft-doctor-with-a-precutover-status-line-phase-0.vbrief.json
+++ b/vbrief/completed/2026-06-26-extend-deft-doctor-with-a-precutover-status-line-phase-0.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "py-purge-doctor-precutover-line",
     "title": "Extend deft doctor with a precutover status line (Phase 0)",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json",
     "narratives": {
       "Description": "The TypeScript doctor does not yet surface a pre-cutover detection line even though the predicates already exist in packages/core/src/vbrief-validate/precutover.ts. This story wires the existing isDeprecationRedirect and isCurrentGeneratedSpecification predicates into the doctor output as a short precutover line so operators see migration state without a Python port.",
@@ -62,7 +62,9 @@
         "size": "S",
         "file_scope_confidence": "medium",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-26T18:28:07Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -72,6 +74,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-26T18:08:55Z"
+    "updated": "2026-06-26T18:28:07Z"
   }
 }

--- a/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
+++ b/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
@@ -90,7 +90,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-26-extend-deft-doctor-with-a-precutover-status-line-phase-0.vbrief.json",
+        "uri": "completed/2026-06-26-extend-deft-doctor-with-a-precutover-status-line-phase-0.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Extend deft doctor with a precutover status line (Phase 0)",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary

Story `py-purge-doctor-precutover-line` (Phase 0 of the #2022 Python-purge readiness cohort).

`deft doctor` now surfaces a **pre-cutover status line** so operators can tell whether a project still carries pre-v0.20 document-model artifacts that need migration — without reading the Python migrator.

- Adds `detectPreCutover` + `renderPrecutoverLine` to `packages/core/src/vbrief-validate/precutover.ts`, reusing the existing `isDeprecationRedirect` / `isCurrentGeneratedSpecification` predicates and mirroring the AGENTS.md "Pre-Cutover Check" rule (legacy `SPECIFICATION.md` / `PROJECT.md`, or `vbrief/` missing lifecycle folders).
- Wires the line into the CLI doctor wrapper (`packages/cli/src/doctor.ts`). It is suppressed under `--json` so the core report's machine-readable JSON stays valid.
- Pre-cutover state flags the offending files and points at `deft migrate:vbrief`; a current layout reports a clean "Pre-cutover: none" state.

## Acceptance coverage

- **a1** pre-cutover fixture → report includes a migration-needed precutover line ✅
- **a2** current-layout fixture → precutover line reports a clean non-pre-cutover state ✅
- **a3** `doctor.test.ts` asserts both fixtures (plus redirect / generated-export / missing-lifecycle branches) ✅

## Test plan

- [x] `pnpm exec vitest run packages/cli/src/doctor.test.ts` (7 passing)
- [x] `pnpm exec vitest run --coverage` — global thresholds pass; `precutover.ts` 97.33% stmts / 95.83% branches / 100% funcs
- [x] `tsc -b` typecheck + `biome check` lint clean
- [x] Python suite green (8373 passed)

> Note: `task check` still reports two pre-existing failures on the integration base that are **outside this story's file scope** and owned by sibling cohort work: (1) `vbrief:validate` D4 parent↔child reference wiring for the #2022 decomposition vBRIEFs, and (2) `test_main_md_preamble` gate-instruction wording (the `deft-install gate` migration). Both reproduce on a clean `origin/chore/py-purge-cohort-decomposition` checkout with this branch's changes stashed.

Base: `chore/py-purge-cohort-decomposition` (integration branch, not master).

Refs #2022
