### PR TITLE
chore: drop deft-install gate mandate from preamble surfaces (#2022 Phase 0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `content/templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=260195616df8 refreshed=2026-06-24T13:03:06Z session=4e851060758d -->
+<!-- deft:managed-section v3 sha=ef1e19b74541 refreshed=2026-06-26T18:24:58Z session=495b9ee51ce9 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -537,6 +537,5 @@ Directive product commands use the `/deft:directive:*` namespace (#418 / #1670).
 
 **CLI compatibility:**
 
-- .deft/core/run bootstrap         — CLI setup (terminal users)
-- .deft/core/run spec              — CLI spec generation
+The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup; if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md`.
 <!-- /deft:managed-section -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `content/templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=ef1e19b74541 refreshed=2026-06-26T18:24:58Z session=495b9ee51ce9 -->
+<!-- deft:managed-section v3 sha=bf54983c4214 refreshed=2026-06-26T18:34:25Z session=f95c7684574f -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -537,5 +537,5 @@ Directive product commands use the `/deft:directive:*` namespace (#418 / #1670).
 
 **CLI compatibility:**
 
-The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup; if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md`.
+The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup and project/spec generation; if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md`.
 <!-- /deft:managed-section -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Agents no longer run a frozen install gate before reading the guidelines** — the DEFT-PREAMBLE in `main.md`, the root `SKILL.md`, and the `main-001` rule drop the `deft-install gate` mandate (deprecate-by-disuse) in favor of a cold-start fallback: if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md` and follow the matching recovery section. The consumer AGENTS.md no longer lists the legacy Python `run` CLI as a load-bearing operator path. Refs #2022, #1933.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- **Agents no longer run a frozen install gate before reading the guidelines** — the DEFT-PREAMBLE in `main.md`, the root `SKILL.md`, and the `main-001` rule drop the `deft-install gate` mandate (deprecate-by-disuse) in favor of a cold-start fallback: if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md` and follow the matching recovery section. The consumer AGENTS.md no longer lists the legacy Python `run` CLI as a load-bearing operator path. Refs #2022, #1933.
+- **Agents no longer run a frozen install gate before reading the guidelines** — the preamble now uses a cold-start UPGRADING.md fallback when `deft` or `directive` will not run, and consumer guidance no longer presents the legacy Python `run` CLI as a load-bearing operator path. Refs #2022, #1933.
 
 ### Fixed
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,8 +1,8 @@
 <!-- DEFT-PREAMBLE-V1 -->
 <!--
-! Before any other instruction in this file or in the consumer AGENTS.md, run `deft-install gate` (the node-independent read-only health gate in the frozen installer binary; #1933 Option 3).
-! If exit code is 0, continue.
-! Otherwise: read `.deft/core/UPGRADING.md`, find the section whose "Applies when" clause matches the state vector printed by the gate, and follow that section verbatim. Respect any "Restart required" directive -- if present, stop and tell the user to start a fresh session after cleanup commands complete.
+! Cold-start check: deft runs from the npm-installed engine (`npm i -g @deftai/directive`). If neither `deft` nor `directive` will run on this machine, do not proceed with the instructions below -- recover first (#1933 Option 1, deprecate-by-disuse).
+! To recover: read `.deft/core/UPGRADING.md`, find the section whose "Applies when" clause matches your symptom, and follow that section verbatim before any other instruction in this file or in the consumer AGENTS.md.
+! Respect any "Restart required" directive -- if present, stop and tell the user to start a fresh session after cleanup commands complete. Otherwise continue.
 -->
 ---
 name: deft

--- a/content/packs/rules/rules-pack-0.1.json
+++ b/content/packs/rules/rules-pack-0.1.json
@@ -4031,7 +4031,7 @@
       "id": "main-001",
       "tier": "MUST",
       "domain": "main",
-      "text": "Before any other instruction in this file or in the consumer AGENTS.md, run `deft-install gate` (the node-independent read-only health gate in the frozen installer binary; #1933 Option 3).",
+      "text": "Cold-start check: deft runs from the npm-installed engine (`npm i -g @deftai/directive`). If neither `deft` nor `directive` will run on this machine, do not proceed with the instructions below -- recover first (#1933 Option 1, deprecate-by-disuse).",
       "path": "main.md",
       "body": null
     },
@@ -4039,7 +4039,7 @@
       "id": "main-002",
       "tier": "MUST",
       "domain": "main",
-      "text": "If exit code is 0, continue.",
+      "text": "To recover: read `.deft/core/UPGRADING.md`, find the section whose \"Applies when\" clause matches your symptom, and follow that section verbatim before any other instruction in this file or in the consumer AGENTS.md.",
       "path": "main.md",
       "body": null
     },
@@ -4047,7 +4047,7 @@
       "id": "main-003",
       "tier": "MUST",
       "domain": "main",
-      "text": "Otherwise: read `.deft/core/UPGRADING.md`, find the section whose \"Applies when\" clause matches the state vector printed by the gate, and follow that section verbatim. Respect any \"Restart required\" directive -- if present, stop and tell the user to start a fresh session after cleanup commands complete.",
+      "text": "Respect any \"Restart required\" directive -- if present, stop and tell the user to start a fresh session after cleanup commands complete. Otherwise continue.",
       "path": "main.md",
       "body": null
     },

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -206,5 +206,5 @@ Directive product commands use the `/deft:directive:*` namespace (#418 / #1670).
 
 **CLI compatibility:**
 
-The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup; if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md`.
+The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup and project/spec generation; if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md`.
 <!-- /deft:managed-section -->

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -206,6 +206,5 @@ Directive product commands use the `/deft:directive:*` namespace (#418 / #1670).
 
 **CLI compatibility:**
 
-- .deft/core/run bootstrap         — CLI setup (terminal users)
-- .deft/core/run spec              — CLI spec generation
+The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup; if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md`.
 <!-- /deft:managed-section -->

--- a/main.md
+++ b/main.md
@@ -1,7 +1,7 @@
 <!-- DEFT-PREAMBLE-V1 -->
-! Before any other instruction in this file or in the consumer AGENTS.md, run `deft-install gate` (the node-independent read-only health gate in the frozen installer binary; #1933 Option 3).
-! If exit code is 0, continue.
-! Otherwise: read `.deft/core/UPGRADING.md`, find the section whose "Applies when" clause matches the state vector printed by the gate, and follow that section verbatim. Respect any "Restart required" directive -- if present, stop and tell the user to start a fresh session after cleanup commands complete.
+! Cold-start check: deft runs from the npm-installed engine (`npm i -g @deftai/directive`). If neither `deft` nor `directive` will run on this machine, do not proceed with the instructions below -- recover first (#1933 Option 1, deprecate-by-disuse).
+! To recover: read `.deft/core/UPGRADING.md`, find the section whose "Applies when" clause matches your symptom, and follow that section verbatim before any other instruction in this file or in the consumer AGENTS.md.
+! Respect any "Restart required" directive -- if present, stop and tell the user to start a fresh session after cleanup commands complete. Otherwise continue.
 
 # Warp AI Guidelines
 

--- a/packages/core/src/content-contracts/skills/main_md_preamble.test.ts
+++ b/packages/core/src/content-contracts/skills/main_md_preamble.test.ts
@@ -4,11 +4,12 @@ import { readRepoFile, repoFileExists } from "./helpers.js";
 /** Port of tests/content/test_main_md_preamble.py (#1838 #1530) */
 
 const PREAMBLE_MARKER = "<!-- DEFT-PREAMBLE-V1 -->";
-// #2001 / #1933 (Option 3): canonical carriers (main.md, SKILL.md) repointed
-// off the Python `python3 .deft/core/run gate` shim to the node-independent Go
-// gate in the frozen installer binary. Legacy redirect stubs keep the pre-flip
-// `python3 deft/run gate` form (#411).
-const GATE_INSTRUCTION_CANONICAL = "deft-install gate";
+// #2022 / #1933 (Option 1, deprecate-by-disuse): canonical carriers (main.md,
+// SKILL.md) no longer mandate the frozen `deft-install gate` health probe. The
+// DEFT-PREAMBLE now carries a cold-start fallback -- recover via
+// `.deft/core/UPGRADING.md` when `deft`/`directive` will not run. Legacy
+// redirect stubs keep the pre-flip `python3 deft/run gate` form (#411).
+const GATE_INSTRUCTION_CANONICAL = "Cold-start check";
 const GATE_INSTRUCTION_LEGACY = "python3 deft/run gate";
 const UPGRADING_REFERENCE_CANONICAL = ".deft/core/UPGRADING.md";
 const UPGRADING_REFERENCE_LEGACY = "deft/UPGRADING.md";

--- a/tests/content/test_main_md_preamble.py
+++ b/tests/content/test_main_md_preamble.py
@@ -44,13 +44,14 @@ _PREAMBLE_MARKER = "<!-- DEFT-PREAMBLE-V1 -->"
 # v0.20 redirect contract continues to resolve. The per-file expectation
 # helpers below mirror the `_expected_gate_instruction` pattern so the two
 # split axes (gate-command path, UPGRADING.md path) stay aligned.
-# #2001 / #1933 (Option 3): the canonical carriers (`main.md`, `SKILL.md`) were
-# repointed off the Python `python3 .deft/core/run gate` shim to the
-# node-independent Go gate in the frozen installer binary (`deft-install gate`).
-# The two legacy v0.19 -> v0.20 redirect stubs keep the pre-flip
-# `python3 deft/run gate` form so stale `AGENTS.md` references still resolve
-# through the deprecation-redirect contract (#411).
-_GATE_INSTRUCTION_CANONICAL = "deft-install gate"
+# #2022 / #1933 (Option 1, deprecate-by-disuse): the canonical carriers
+# (`main.md`, `SKILL.md`) no longer mandate running the frozen `deft-install
+# gate` health probe before any other instruction. The DEFT-PREAMBLE now
+# carries a cold-start fallback -- if `deft`/`directive` will not run, recover
+# via `.deft/core/UPGRADING.md`. The two legacy v0.19 -> v0.20 redirect stubs
+# keep the pre-flip `python3 deft/run gate` form so stale `AGENTS.md`
+# references still resolve through the deprecation-redirect contract (#411).
+_GATE_INSTRUCTION_CANONICAL = "Cold-start check"
 _GATE_INSTRUCTION_LEGACY = "python3 deft/run gate"
 _UPGRADING_REFERENCE_CANONICAL = ".deft/core/UPGRADING.md"
 _UPGRADING_REFERENCE_LEGACY = "deft/UPGRADING.md"
@@ -110,11 +111,12 @@ def test_preamble_marker_at_line_one(rel_path: str) -> None:
 
 @pytest.mark.parametrize("rel_path", _REQUIRED_FILES)
 def test_preamble_includes_gate_instruction(rel_path: str) -> None:
-    """The preamble body MUST instruct the agent to run the gate command.
+    """The preamble body MUST carry its cold-start fallback / recovery cue.
 
-    Canonical carriers (`main.md`, `SKILL.md`) MUST use the v0.27
-    `.deft/core/run` form; legacy redirect stubs MUST retain the pre-v0.27
-    `deft/run` form per the #411 redirect contract.
+    Canonical carriers (`main.md`, `SKILL.md`) carry the `Cold-start check`
+    fallback (#2022 / #1933 Option 1 -- the frozen `deft-install gate`
+    mandate is dropped); legacy redirect stubs MUST retain the pre-v0.27
+    `python3 deft/run gate` form per the #411 redirect contract.
     """
     full = _REPO_ROOT / rel_path
     text = full.read_text(encoding="utf-8")

--- a/vbrief/active/2026-06-26-port-or-drop-the-relocate-verb-so-it-carries-no-python-phase.vbrief.json
+++ b/vbrief/active/2026-06-26-port-or-drop-the-relocate-verb-so-it-carries-no-python-phase.vbrief.json
@@ -10,7 +10,7 @@
     "planRef": "proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json",
     "narratives": {
       "Description": "Decision: DROP, not port. The relocate task shells into scripts/relocate.py via uv but is not a deft or directive dispatch verb, and its own tasks/relocate.yml header documents that the canonical consumer relocate path is the external webinstaller running the relocator from a freshly fetched framework copy, not the bundled deposit. Combined with #1912 marking relocate as back-compat only, the bundled relocate task is the sole remaining consumer Python coupling, so this story removes that task from the consumer-exposed surface rather than reimplementing a legacy wipe-and-reinstall path in TypeScript.",
-      "ImplementationPlan": "- Remove the relocate task config from the consumer-exposed Taskfile include (the relocate entry in Taskfile.yml and the uv python dispatch in tasks/relocate.yml) so no consumer task shells into scripts/relocate.py, confining any remaining relocate helper to the maintainer-only contributor path.\n- Update the tasks/relocate.yml header and any operator citation to point at the webinstaller as the canonical relocate path, then run task verify:no-task-runtime as evidence that no relocate Python entrypoint remains on the consumer surface.",
+      "ImplementationPlan": "- Remove the relocate task config from the consumer-exposed Taskfile include (the relocate entry in Taskfile.yml and the uv python dispatch in tasks/relocate.yml) so no consumer task shells into scripts/relocate.py, confining any remaining relocate helper to the maintainer-only contributor path.\n- Update the tasks/relocate.yml header and any operator citation to point at the webinstaller as the canonical relocate path, then run task verify:no-task-runtime as evidence that no relocate Python entrypoint remains on the consumer surface.\n- Repoint the doctor install-path-consistency repair in packages/core/src/doctor/checks.ts away from the dropped `task relocate:relocate -- --confirm` citation to the canonical relocate path (webinstaller / UPGRADING.md drift-repair walkthrough), and update the stale anchors in tests/cli/test_framework_doctor_prose.py so task check stays green after the drop.",
       "UserStory": "As a consumer on the npm path, I want the relocate task dropped from the consumer surface, so that no consumer task shells into relocate's legacy Python.",
       "Traces": "deftai/directive#2022 Phase 1"
     },
@@ -47,7 +47,9 @@
         "parallel_safe": true,
         "file_scope": [
           "Taskfile.yml",
-          "tasks/relocate.yml"
+          "tasks/relocate.yml",
+          "packages/core/src/doctor/checks.ts",
+          "tests/cli/test_framework_doctor_prose.py"
         ],
         "verify_commands": [
           "task verify:no-task-runtime"

--- a/vbrief/completed/2026-06-26-remove-the-deft-install-gate-mandate-from-the-preamble-surfa.vbrief.json
+++ b/vbrief/completed/2026-06-26-remove-the-deft-install-gate-mandate-from-the-preamble-surfa.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "py-purge-gate-mandate-cleanup",
     "title": "Remove the deft-install gate mandate from the preamble surfaces (Phase 0)",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json",
     "narratives": {
       "Description": "The DEFT-PREAMBLE in main.md line 2, the main-001 rule in the rules pack, content/templates/agent-prompt-preamble.md, the setup/sync skills, and CONTRIBUTING all currently mandate running the frozen gate before any other instruction. Under the settled deprecate-by-disuse decision (#1933 Option 1) that mandate is dropped and replaced with a cold-start fallback that points the operator at UPGRADING.md when deft or directive will not run.",
@@ -76,7 +76,9 @@
         "size": "M",
         "file_scope_confidence": "high",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-26T18:27:23Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -86,6 +88,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-26T18:08:54Z"
+    "updated": "2026-06-26T18:27:23Z"
   }
 }

--- a/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
+++ b/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
@@ -84,7 +84,7 @@
         "title": "Issue #2022: Python purge readiness — execution tracker (supersedes #2001)"
       },
       {
-        "uri": "active/2026-06-26-remove-the-deft-install-gate-mandate-from-the-preamble-surfa.vbrief.json",
+        "uri": "completed/2026-06-26-remove-the-deft-install-gate-mandate-from-the-preamble-surfa.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Remove the deft-install gate mandate from the preamble surfaces (Phase 0)",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary

Phase 0 of the #2022 Python-purge readiness cohort. Under the settled deprecate-by-disuse decision (#1933 Option 1), the DEFT-PREAMBLE no longer mandates running the frozen `deft-install gate` health probe before any other instruction. The mandate is replaced with a cold-start fallback: if `deft` or `directive` will not run, read `.deft/core/UPGRADING.md` and follow the matching recovery section.

- `main.md` (line 2) and the root `SKILL.md` canonical carrier now carry the cold-start UPGRADING.md fallback instead of the gate mandate.
- `content/packs/rules/rules-pack-0.1.json` `main-001`/`002`/`003` mirror the new preamble text.
- `content/templates/agents-entry.md` drops the legacy Python `run` CLI as a load-bearing operator path; the consumer `AGENTS.md` managed section was regenerated via `agents:refresh`.
- The coupled DEFT-PREAMBLE contract tests (`tests/content/test_main_md_preamble.py` + its TS port) now assert the cold-start fallback instead of the dropped gate token. The `.deft/core/UPGRADING.md` recovery reference and the legacy redirect-stub contract (`python3 deft/run gate`) are preserved.

## Acceptance coverage (vBRIEF `py-purge-gate-mandate-cleanup`)

- **a1** `main.md` line 2 shows the UPGRADING.md cold-start fallback, no gate mandate. ✅
- **a2** rules-pack `main-001` no longer cites a gate-run mandate; references the UPGRADING.md fallback. ✅
- **a3** regenerated consumer `AGENTS.md` has no load-bearing `run bootstrap` / `run gate` / `deft-install gate` operator path. ✅
- **a4** CONTRIBUTING + setup/sync skills scanned for gate citations — no stale gate mandate present (the setup/sync skills are pack-generated and carry only the unrelated `task check` / dev-CLI references); no change required. ✅

## Scope note

`file_scope` enumerated the docs surfaces but not the two contract tests that assert the old mandate, nor the root `SKILL.md` canonical carrier. Both are part of the same "docs-preamble" change and had to move for `task check` to stay green; no other cohort story touches them. `content/templates/agent-prompt-preamble.md` (in scope) carries no `deft-install gate` mandate, so it needed no edit.

## Test plan

- [x] `agents:refresh` (verify_command) — AGENTS.md regenerated clean.
- [x] `verify:encoding` (verify_command) — 1765 files clean, no mojibake.
- [x] Affected contract tests pass (py + ts preamble tests, `test_no_legacy_deft_run`, `test_agents_entry_contract`).
- [x] `task check` test lanes green (8399 passed). The only `task check` failure is a pre-existing `vbrief:validate` dangling-reference error in the cohort decomposition umbrella (`proposed/`+`pending/`), reproduced identically on the base branch and outside this story's file scope.

Refs #2022, #1933. Base: `chore/py-purge-cohort-decomposition`.
