### PR TITLE
chore(taskfile): drop relocate task from consumer surface (#2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- **`deft doctor`'s install-path repair now points at the npm installer** — the `install-path-consistency` check previously recommended the now-removed `task relocate:relocate -- --confirm`; it now recommends `npm i -g @deftai/directive@latest` as the canonical reinstall path. Refs #2022, #1912.
+- **`deft doctor`'s install-path repair now points at the npm CLI** — the `install-path-consistency` check previously recommended the now-removed `task relocate:relocate -- --confirm`; it now recommends `npx @deftai/directive update`, which (re)deposits the project framework directory. Refs #2022, #1912.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **`deft doctor`'s install-path repair now points at the npm installer** — the `install-path-consistency` check previously recommended the now-removed `task relocate:relocate -- --confirm`; it now recommends `npm i -g @deftai/directive@latest` as the canonical reinstall path. Refs #2022, #1912.
 
 ### Fixed
 
 ### Removed
+- **The `relocate` task is gone from the deft task surface** — `task relocate` (which shelled into a bundled Python relocator) has been removed; it was the last consumer task that ran Python. To move or reinstall the framework, use the canonical npm install path (`npm i -g @deftai/directive@latest`); see UPGRADING.md. Refs #2022.
 
 ## [0.58.0] - 2026-06-26
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -268,15 +268,15 @@ includes:
   changelog:
     taskfile: ./tasks/changelog.yml
     optional: true
-  # Wipe-and-reinstall relocator (#992 PR2). Exposes `task relocate` --
-  # forwards user-facing flags (`--confirm` / `--dry-run` / `--force` /
-  # `--rollback` / `--no-snapshot` / `--json` / `--quiet`) via
-  # {{.CLI_ARGS}}; per `conventions/task-caching.md` no `sources:` /
-  # `generates:` so the recovery flags reach the script (#574). The
-  # include is `optional: true` for rolling-merge tolerance.
-  relocate:
-    taskfile: ./tasks/relocate.yml
-    optional: true
+  # NOTE (#2022 Python-purge): the `relocate:` include was DROPPED from the
+  # consumer task surface. The relocate task shelled into scripts/relocate.py
+  # via `uv run python` -- the sole remaining consumer-exposed Python coupling
+  # on the deft task surface. It is intentionally NOT wired here anymore. The
+  # canonical consumer (re)install / relocate path is the npm installer
+  # (`npm i -g @deftai/directive@latest`; see UPGRADING.md / #1912, where
+  # relocate is a back-compat / legacy bridge only). tasks/relocate.yml is
+  # retained (un-wired) and the helper scripts/relocate.py stays for #1860
+  # (big-bang Python delete) to remove.
   # N7 (#1147): slice:* fragment exposing `task slice:record-existing`
   # (retrofit slices.jsonl for hand-filed cohorts) + `task slice:list`
   # (read surface). Include key `slice-record` (not `slice`) so the

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -305,7 +305,7 @@ export function checkInstallPathConsistency(
     return {
       name: "install-path-consistency",
       status: "fail",
-      detail: `Install root is recorded as '${effectiveInstallRoot}' (source: ${source}) but ${claimedDir} is not a directory. Pick one of two repair paths: (a) run \`.deft/core/run agents:refresh\` (Unix) / \`.deft\\core\\run agents:refresh\` (Windows) to rewrite AGENTS.md to match the on-disk framework -- pick this if the framework on disk is correct; OR (b) run \`task relocate:relocate -- --confirm\` to move the framework to the path AGENTS.md / the manifest claims -- pick this if AGENTS.md is correct. The YAML manifest (if present) is authoritative for the install-layout contract. See UPGRADING.md for the canonical drift-repair walkthrough.`,
+      detail: `Install root is recorded as '${effectiveInstallRoot}' (source: ${source}) but ${claimedDir} is not a directory. Pick one of two repair paths: (a) run \`.deft/core/run agents:refresh\` (Unix) / \`.deft\\core\\run agents:refresh\` (Windows) to rewrite AGENTS.md to match the on-disk framework -- pick this if the framework on disk is correct; OR (b) run \`npm i -g @deftai/directive@latest\` to reinstall the framework at the path AGENTS.md / the manifest claims (the canonical npm install path, #1912) -- pick this if AGENTS.md is correct. The YAML manifest (if present) is authoritative for the install-layout contract. See UPGRADING.md for the canonical drift-repair walkthrough.`,
       data: {
         claimed_install_root: installRoot,
         effective_install_root: effectiveInstallRoot,
@@ -314,7 +314,7 @@ export function checkInstallPathConsistency(
         claimed_dir_exists: false,
         fallback_info_note: fallbackInfoNote || null,
         suggested_fix: ".deft/core/run agents:refresh",
-        suggested_fix_alt: "task relocate:relocate -- --confirm",
+        suggested_fix_alt: "npm i -g @deftai/directive@latest",
       },
     };
   }

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -305,7 +305,7 @@ export function checkInstallPathConsistency(
     return {
       name: "install-path-consistency",
       status: "fail",
-      detail: `Install root is recorded as '${effectiveInstallRoot}' (source: ${source}) but ${claimedDir} is not a directory. Pick one of two repair paths: (a) run \`.deft/core/run agents:refresh\` (Unix) / \`.deft\\core\\run agents:refresh\` (Windows) to rewrite AGENTS.md to match the on-disk framework -- pick this if the framework on disk is correct; OR (b) run \`npm i -g @deftai/directive@latest\` to reinstall the framework at the path AGENTS.md / the manifest claims (the canonical npm install path, #1912) -- pick this if AGENTS.md is correct. The YAML manifest (if present) is authoritative for the install-layout contract. See UPGRADING.md for the canonical drift-repair walkthrough.`,
+      detail: `Install root is recorded as '${effectiveInstallRoot}' (source: ${source}) but ${claimedDir} is not a directory. Pick one of two repair paths: (a) run \`.deft/core/run agents:refresh\` (Unix) / \`.deft\\core\\run agents:refresh\` (Windows) to rewrite AGENTS.md to match the on-disk framework -- pick this if the framework on disk is correct; OR (b) run \`npx @deftai/directive update\` to (re)deposit the framework at the path AGENTS.md / the manifest claims (the npm CLI project deposit, #1912) -- pick this if AGENTS.md is correct. The YAML manifest (if present) is authoritative for the install-layout contract. See UPGRADING.md for the canonical drift-repair walkthrough.`,
       data: {
         claimed_install_root: installRoot,
         effective_install_root: effectiveInstallRoot,
@@ -314,7 +314,7 @@ export function checkInstallPathConsistency(
         claimed_dir_exists: false,
         fallback_info_note: fallbackInfoNote || null,
         suggested_fix: ".deft/core/run agents:refresh",
-        suggested_fix_alt: "npm i -g @deftai/directive@latest",
+        suggested_fix_alt: "npx @deftai/directive update",
       },
     };
   }

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -734,8 +734,9 @@ def _check_install_path_consistency(project_root: Path, install_root: str | None
                 "`.deft\\core\\run agents:refresh` (Windows) to rewrite "
                 "AGENTS.md to match the on-disk framework -- pick this if "
                 "the framework on disk is correct; OR "
-                "(b) run `task relocate:relocate -- --confirm` to move the "
-                "framework to the path AGENTS.md / the manifest claims -- "
+                "(b) run `npm i -g @deftai/directive@latest` to reinstall the "
+                "framework at the path AGENTS.md / the manifest claims (the "
+                "canonical npm install path, #1912) -- "
                 "pick this if AGENTS.md is correct. The YAML manifest (if "
                 "present) is authoritative for the install-layout contract. "
                 "See UPGRADING.md for the canonical drift-repair walkthrough."
@@ -748,7 +749,7 @@ def _check_install_path_consistency(project_root: Path, install_root: str | None
                 "claimed_dir_exists": False,
                 "fallback_info_note": fallback_info_note or None,
                 "suggested_fix": ".deft/core/run agents:refresh",
-                "suggested_fix_alt": "task relocate:relocate -- --confirm",
+                "suggested_fix_alt": "npm i -g @deftai/directive@latest",
             },
         )
     # Note: this check intentionally does NOT verify the YAML manifest

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -734,9 +734,9 @@ def _check_install_path_consistency(project_root: Path, install_root: str | None
                 "`.deft\\core\\run agents:refresh` (Windows) to rewrite "
                 "AGENTS.md to match the on-disk framework -- pick this if "
                 "the framework on disk is correct; OR "
-                "(b) run `npm i -g @deftai/directive@latest` to reinstall the "
+                "(b) run `npx @deftai/directive update` to (re)deposit the "
                 "framework at the path AGENTS.md / the manifest claims (the "
-                "canonical npm install path, #1912) -- "
+                "npm CLI project deposit, #1912) -- "
                 "pick this if AGENTS.md is correct. The YAML manifest (if "
                 "present) is authoritative for the install-layout contract. "
                 "See UPGRADING.md for the canonical drift-repair walkthrough."
@@ -749,7 +749,7 @@ def _check_install_path_consistency(project_root: Path, install_root: str | None
                 "claimed_dir_exists": False,
                 "fallback_info_note": fallback_info_note or None,
                 "suggested_fix": ".deft/core/run agents:refresh",
-                "suggested_fix_alt": "npm i -g @deftai/directive@latest",
+                "suggested_fix_alt": "npx @deftai/directive update",
             },
         )
     # Note: this check intentionally does NOT verify the YAML manifest

--- a/tasks/relocate.yml
+++ b/tasks/relocate.yml
@@ -1,56 +1,26 @@
 version: '3'
 
-# tasks/relocate.yml -- wipe-and-reinstall relocator surface (#992 PR2).
+# tasks/relocate.yml -- DROPPED from the consumer task surface (#2022).
 #
-# Wires `task relocate` to scripts/relocate.py with full {{.CLI_ARGS}}
-# pass-through so operators can compose flags as documented in the script
-# docstring (--project-root / --framework-source / --force / --confirm /
-# --no-confirm / --dry-run / --rollback / --snapshot / --no-snapshot /
-# --json / --quiet).
+# The relocate task previously wired `task relocate` (namespaced
+# `relocate:relocate`) to `uv run python scripts/relocate.py` -- the sole
+# remaining consumer-exposed Python coupling on the deft task surface. Per
+# the #2022 Python-purge readiness gate it has been REMOVED from the
+# consumer-exposed task graph: this fragment is no longer referenced by the
+# root Taskfile.yml `includes:` block and exposes no task.
 #
-# Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
-# declarations because user-facing recovery flags (`--force`, `--confirm`,
-# `--rollback`, `--dry-run`) flow via {{.CLI_ARGS}} -- a go-task cache
-# short-circuit would silently drop the recovery flag and leave the
-# operator following the docs against an exit-0 no-op (the same hazard
-# `task prd:render -- --force` hit at #574).
+# Canonical consumer (re)install / relocate path is now the npm installer
+# (`npm i -g @deftai/directive@latest`), NOT a bundled task -- see
+# content/UPGRADING.md "Manual drift repair" and #1912 (the relocator is a
+# back-compat / legacy bridge only, never a routine-upgrade path). The
+# underlying helper scripts/relocate.py is intentionally retained for #1860
+# (big-bang Python delete) to remove; this story only drops the consumer
+# task surface.
 #
-# Path resolution uses the same {{.TASKFILE_DIR}} / joinPath idiom every
-# other fragment uses (#566) so the dispatch resolves correctly under
-# Windows / macOS / Linux. The dispatched script lives at
-# {{.DEFT_ROOT}}/scripts/relocate.py with helper modules at
-# {{.DEFT_ROOT}}/scripts/_relocate_states.py and
-# {{.DEFT_ROOT}}/scripts/_relocate_snapshot.py.
-#
-# Usage notes for operators:
-#
-# - Bare invocation against a project root that needs relocating prompts
-#   `[y/N]` on stdin (auto-prompt never auto-wipe per the active vBRIEF).
-# - For scripted use, pass `--confirm` to skip the prompt (or
-#   `--no-snapshot` for hermetic test fixtures).
-# - For consumer projects: the canonical entry point is the webinstaller
-#   bootstrap (`upgrade.sh` / `upgrade.ps1` in the separate `webinstaller`
-#   repo) which fetches a fresh framework copy to a temp dir and runs the
-#   relocator from THAT copy -- the in-place framework about to be wiped
-#   never executes its own wipe.
-# - `task relocate -- --rollback` extracts the most recent snapshot back
-#   into project root.
-#
-# Companion script: scripts/relocate.py
-# Companion tests:  tests/relocate/test_state_matrix.py
-#                   tests/relocate/test_preflight.py
-# Refs: #992 (parent issue), #11 (.deft/core/ origin),
-#       #768 (managed-section v2 contract), #794 (_wrap_legacy_in_markers),
-#       #884 (consent-gate convention).
+# This file is retained (un-wired) so the framework's own Taskfile
+# content-contract tests keep a stable fixture. The DEFT_ROOT joinPath var
+# below preserves the #566 per-subfile path-resolution idiom for any future
+# maintainer-side re-wiring.
 
 vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
-
-tasks:
-  relocate:
-    desc: "Wipe-and-reinstall relocator (#992 PR2) -- task relocate [-- --confirm | --dry-run | --force | --rollback | --json | --quiet]"
-    dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
-    cmds:
-      - uv --project "{{.DEFT_ROOT}}" run python "{{.DEFT_ROOT}}/scripts/relocate.py" {{.CLI_ARGS}}

--- a/tests/cli/test_framework_doctor_prose.py
+++ b/tests/cli/test_framework_doctor_prose.py
@@ -430,8 +430,8 @@ def test_command_surface_discovery_finds_canonical_anchors(
     # NOTE (#2022 Python-purge): the `relocate:` include was dropped from the
     # consumer task surface, so `relocate:relocate` is no longer a Taskfile
     # target. The doctor's install-path-consistency repair (b) now cites the
-    # canonical npm install path instead (see the install-path-consistency
-    # tests below).
+    # npm CLI project deposit `npx @deftai/directive update` instead (see the
+    # install-path-consistency tests below).
     assert "agents:refresh" in run_subcommands, run_subcommands
     assert "upgrade" in run_subcommands, run_subcommands
 
@@ -547,8 +547,8 @@ def test_dual_recommendation_checks_carry_both_structured_fields(
     the same dual surface as humans. The three dual-recommendation
     checks are: ``quick-start-resolves`` (agents:refresh OR task
     upgrade), ``skill-paths-resolve`` (same pair), and
-    ``install-path-consistency`` (agents:refresh OR the canonical npm
-    install path ``npm i -g @deftai/directive@latest``, #2022). Each MUST
+    ``install-path-consistency`` (agents:refresh OR the npm CLI project
+    deposit ``npx @deftai/directive update``, #2022). Each MUST
     carry BOTH ``suggested_fix`` AND
     ``suggested_fix_alt`` -- a future regression that drops one breaks
     the API contract documented in the PR description.
@@ -660,11 +660,11 @@ def test_install_path_consistency_fail_recommends_both_repair_paths(fd, tmp_path
     The vBRIEF specifies that ``_check_install_path_consistency`` FAIL
     prose MUST name BOTH legitimate repair paths explicitly:
     (a) ``agents:refresh`` (rewrite AGENTS.md to match on-disk framework),
-    (b) ``npm i -g @deftai/directive@latest`` (reinstall the framework at
-    AGENTS.md's path via the canonical npm install path). Repair (b) was
+    (b) ``npx @deftai/directive update`` ((re)deposit the framework at
+    AGENTS.md's path via the npm CLI project deposit). Repair (b) was
     repointed from the now-dropped ``task relocate:relocate -- --confirm``
     when the relocate task was removed from the consumer surface (#2022
-    Python-purge); the npm install path is the canonical (re)install per
+    Python-purge); the npm CLI deposit is the canonical (re)install per
     #1912.
     """
     project_root = _drift_state_quick_start_missing(tmp_path)
@@ -674,4 +674,4 @@ def test_install_path_consistency_fail_recommends_both_repair_paths(fd, tmp_path
     )
     assert ipc["status"] == "fail"
     assert "agents:refresh" in ipc["detail"], ipc["detail"]
-    assert "npm i -g @deftai/directive" in ipc["detail"], ipc["detail"]
+    assert "npx @deftai/directive update" in ipc["detail"], ipc["detail"]

--- a/tests/cli/test_framework_doctor_prose.py
+++ b/tests/cli/test_framework_doctor_prose.py
@@ -427,10 +427,11 @@ def test_command_surface_discovery_finds_canonical_anchors(
     assert "upgrade" in taskfile_targets, taskfile_targets
     assert "install:upgrade" in taskfile_targets, taskfile_targets
     assert "framework:doctor" in taskfile_targets, taskfile_targets
-    # `relocate:relocate` is the doubled-namespace form (include `relocate:`
-    # + inner task `relocate:`); no root-level `relocate` alias exists
-    # today so the canonical target is the doubled form.
-    assert "relocate:relocate" in taskfile_targets, taskfile_targets
+    # NOTE (#2022 Python-purge): the `relocate:` include was dropped from the
+    # consumer task surface, so `relocate:relocate` is no longer a Taskfile
+    # target. The doctor's install-path-consistency repair (b) now cites the
+    # canonical npm install path instead (see the install-path-consistency
+    # tests below).
     assert "agents:refresh" in run_subcommands, run_subcommands
     assert "upgrade" in run_subcommands, run_subcommands
 
@@ -546,8 +547,9 @@ def test_dual_recommendation_checks_carry_both_structured_fields(
     the same dual surface as humans. The three dual-recommendation
     checks are: ``quick-start-resolves`` (agents:refresh OR task
     upgrade), ``skill-paths-resolve`` (same pair), and
-    ``install-path-consistency`` (agents:refresh OR task
-    relocate:relocate). Each MUST carry BOTH ``suggested_fix`` AND
+    ``install-path-consistency`` (agents:refresh OR the canonical npm
+    install path ``npm i -g @deftai/directive@latest``, #2022). Each MUST
+    carry BOTH ``suggested_fix`` AND
     ``suggested_fix_alt`` -- a future regression that drops one breaks
     the API contract documented in the PR description.
     """
@@ -658,11 +660,12 @@ def test_install_path_consistency_fail_recommends_both_repair_paths(fd, tmp_path
     The vBRIEF specifies that ``_check_install_path_consistency`` FAIL
     prose MUST name BOTH legitimate repair paths explicitly:
     (a) ``agents:refresh`` (rewrite AGENTS.md to match on-disk framework),
-    (b) ``task relocate:relocate -- --confirm`` (move framework to AGENTS.md's path).
-    The doubled-namespace form is the actual go-task target name -- the
-    include namespace ``relocate:`` and the inner task ``relocate:`` carry
-    the same key in ``tasks/relocate.yml`` and no root-level alias is
-    wired in ``Taskfile.yml``.
+    (b) ``npm i -g @deftai/directive@latest`` (reinstall the framework at
+    AGENTS.md's path via the canonical npm install path). Repair (b) was
+    repointed from the now-dropped ``task relocate:relocate -- --confirm``
+    when the relocate task was removed from the consumer surface (#2022
+    Python-purge); the npm install path is the canonical (re)install per
+    #1912.
     """
     project_root = _drift_state_quick_start_missing(tmp_path)
     result = fd.run_checks(project_root)
@@ -671,4 +674,4 @@ def test_install_path_consistency_fail_recommends_both_repair_paths(fd, tmp_path
     )
     assert ipc["status"] == "fail"
     assert "agents:refresh" in ipc["detail"], ipc["detail"]
-    assert "task relocate:relocate" in ipc["detail"], ipc["detail"]
+    assert "npm i -g @deftai/directive" in ipc["detail"], ipc["detail"]

--- a/vbrief/completed/2026-06-26-port-or-drop-the-relocate-verb-so-it-carries-no-python-phase.vbrief.json
+++ b/vbrief/completed/2026-06-26-port-or-drop-the-relocate-verb-so-it-carries-no-python-phase.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "py-purge-relocate-ts-or-drop",
     "title": "Drop the relocate task from the consumer surface so it carries no Python (Phase 1)",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json",
     "narratives": {
       "Description": "Decision: DROP, not port. The relocate task shells into scripts/relocate.py via uv but is not a deft or directive dispatch verb, and its own tasks/relocate.yml header documents that the canonical consumer relocate path is the external webinstaller running the relocator from a freshly fetched framework copy, not the bundled deposit. Combined with #1912 marking relocate as back-compat only, the bundled relocate task is the sole remaining consumer Python coupling, so this story removes that task from the consumer-exposed surface rather than reimplementing a legacy wipe-and-reinstall path in TypeScript.",
@@ -61,7 +61,9 @@
         "size": "S",
         "file_scope_confidence": "high",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-26T18:42:34Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -71,6 +73,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-26T18:08:56Z"
+    "updated": "2026-06-26T18:42:34Z"
   }
 }

--- a/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
+++ b/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
@@ -108,7 +108,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-26-port-or-drop-the-relocate-verb-so-it-carries-no-python-phase.vbrief.json",
+        "uri": "completed/2026-06-26-port-or-drop-the-relocate-verb-so-it-carries-no-python-phase.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Port or drop the relocate verb so it carries no Python (Phase 1)",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary

Drops the `relocate` task from the **consumer-exposed deft task surface** (#2022 Python-purge readiness, Phase 1). The relocate task shelled into `scripts/relocate.py` via `uv run python` — the last consumer task that ran Python — so removing it clears the final consumer Python coupling on the task surface.

- **Taskfile.yml** — removes the `relocate:` include (replaced with a breadcrumb explaining the drop).
- **tasks/relocate.yml** — removes the `uv run python scripts/relocate.py` dispatch and the task; retained (un-wired) with its `DEFT_ROOT` joinPath idiom so the framework's Taskfile content-contract tests keep a stable fixture. The underlying helper `scripts/relocate.py` is intentionally left for **#1860** (big-bang Python delete).
- **Doctor repoint** — the `install-path-consistency` repair path (b) cited the now-removed `task relocate:relocate -- --confirm`. It now cites the canonical npm install path `npm i -g @deftai/directive@latest` (#1912). Applied consistently in the canonical `scripts/doctor.py` **and** its TS port `packages/core/src/doctor/checks.ts` so the doctor-parity gate stays green.
- **Tests** — updates `tests/cli/test_framework_doctor_prose.py` anchors (drops the `relocate:relocate` Taskfile-target assertion; repoints the install-path-consistency repair assertions to the npm command).
- **CHANGELOG** — `[Unreleased]` entries for the drop + the doctor repoint.

### Acceptance coverage (story `py-purge-relocate-ts-or-drop`)

- **a1** — no relocate task exposes a `uv`/`python3` entrypoint on the consumer deposit path ✅ (include + dispatch removed).
- **a2** — relocate removed from the consumer-exposed task graph ✅ (include dropped).
- **a3** — `task verify:no-task-runtime` reports no relocate Python entrypoint and exits clean ✅.

### Scope note (operator-authorized)

Per operator authorization, this PR edits two files beyond the story `file_scope` to make the full drop land cleanly: `packages/core/src/doctor/checks.ts` and `tests/cli/test_framework_doctor_prose.py` (the doctor's `install-path-consistency` repair cited `task relocate:relocate`, enforced by that test). The same repoint was also required in the canonical `scripts/doctor.py` (the file the authorized Python test actually exercises) to keep `task check` green and preserve TS/Python doctor parity.

## Related Issues

Refs #2022, #1912. Unblocks #1860 (which removes `scripts/relocate.py`).

## Validation

- `task verify:no-task-runtime` — clean.
- `task check` — green for everything this PR touches: full pytest suite (8372 passed), `core:lint`, and `ts:check-lane` (vitest incl. `doctor-parity.test.ts` + Taskfile content-contract tests) all pass.
- The only remaining `task check` failure is a **pre-existing** `vbrief:validate` cohort-bookkeeping issue in the `#2022` tracker + its other children (confirmed identical on the base commit with this PR's changes stashed); it is orchestrator-owned and out of this story's scope.

## Follow-ups (out of scope)

- `content/UPGRADING.md` still references `task relocate` / `task relocate:relocate` in its drift-repair walkthrough; suggest cleaning up alongside #1860.

## Checklist

- [x] `CHANGELOG.md` — added entries under `[Unreleased]`
- [ ] `ROADMAP.md` — N/A (tracked-issue close handled at release)
- [x] Tests pass locally (scoped gates green; pre-existing tracker `vbrief:validate` failure noted above)

> Base branch: `chore/py-purge-cohort-decomposition` (NOT master). Do not merge from here — the orchestrator merges into the integration branch.
