### PR TITLE
feat: convert the policy-set write path to native TypeScript (#2022 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **`deft pack-migrate` now runs without Python installed** — the five pack-migrate verbs (skills, rules, strategies, patterns, swarm-spec) are now served by native TypeScript handlers instead of shelling out to bundled Python scripts, so pack rendering works on a machine that has no Python. Output is byte-for-byte identical to the previous Python contract. Refs #2022.
+- **Editing a typed policy field no longer needs Python** — the `policy-set` write path (`task policy:wip-cap`, `task policy:enforce-branches` / `allow-direct-commits`, and the `subagent-backend(s)` surfaces) is now a native TypeScript handler instead of shelling into a bundled Python script, so changing a policy and recording its `meta/policy-changes.log` audit row works on a machine with no Python. Output and the audit trail are byte-for-byte identical to the previous Python contract. Refs #2022.
 
 ### Fixed
 

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -711,9 +711,12 @@ describe("native policy-set handler (#2022)", () => {
   }
 
   function readPolicyBlock(): Record<string, unknown> {
-    const parsed = JSON.parse(readFileSync(projectDefPath(), "utf8")) as Record<string, unknown>;
-    const plan = parsed.plan as Record<string, unknown>;
-    return (plan.policy ?? {}) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(readFileSync(projectDefPath(), "utf8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new Error("PROJECT-DEFINITION did not parse to an object");
+    }
+    const plan = (parsed as Record<string, unknown>).plan as Record<string, unknown> | undefined;
+    return (plan?.policy ?? {}) as Record<string, unknown>;
   }
 
   beforeEach(() => {
@@ -806,6 +809,19 @@ describe("native policy-set handler (#2022)", () => {
     expect(result.err).toContain("--set must be >= 0; got -1.");
   });
 
+  it("wip-cap accepts a whitespace-padded value (Python int() parity)", async () => {
+    const result = await runPolicy([
+      "wip-cap",
+      "--set",
+      " 7 ",
+      "--confirm",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(0);
+    expect(readPolicyBlock().wipCap).toBe(7);
+  });
+
   it("subagent-backend writes the typed field and appends an audit row", async () => {
     const result = await runPolicy([
       "subagent-backend",
@@ -888,7 +904,11 @@ describe("native policy-set handler (#2022)", () => {
       root,
     ]);
     expect(result.code).toBe(0);
-    const payload = JSON.parse(result.out) as { backends: Array<Record<string, unknown>> };
+    const parsed: unknown = JSON.parse(result.out);
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new Error("subagent-backends --format json did not emit an object");
+    }
+    const payload = parsed as { backends: Array<Record<string, unknown>> };
     expect(payload.backends).toHaveLength(3);
     expect(payload.backends.every((row) => "id" in row && "roles" in row)).toBe(true);
     expect(payload.backends.map((row) => row.id).sort()).toEqual([

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -1,8 +1,8 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { engineInfo } from "@deftai/directive-core";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CLI_MODULE_VERBS,
   CORE_MODULE_VERBS,
@@ -687,5 +687,294 @@ describe("native pack-migrate handlers (#2022)", () => {
     const byId = bodyById(readFileSync(out, "utf8"), "strategies");
     expect(byId.a).not.toBeNull();
     expect(byId.b).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Native policy-set handler (#2022 Phase 1).
+//
+// Verifies the typed-policy write path (formerly scripts/policy_set.py shelled
+// in via loadPythonScriptHandler) now routes to a native TypeScript handler:
+// the typed field updates and an audit row is appended to
+// meta/policy-changes.log, with output parity preserved.
+// ---------------------------------------------------------------------------
+
+describe("native policy-set handler (#2022)", () => {
+  let root: string;
+
+  function projectDefPath(): string {
+    return join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json");
+  }
+
+  function auditLogPath(): string {
+    return join(root, "meta", "policy-changes.log");
+  }
+
+  function readPolicyBlock(): Record<string, unknown> {
+    const parsed = JSON.parse(readFileSync(projectDefPath(), "utf8")) as Record<string, unknown>;
+    const plan = parsed.plan as Record<string, unknown>;
+    return (plan.policy ?? {}) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "deft-policy-set-"));
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+    const payload = {
+      vBRIEFInfo: { version: "0.6" },
+      plan: { title: "T", status: "running", items: [] },
+    };
+    writeFileSync(projectDefPath(), JSON.stringify(payload), "utf8");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  async function runPolicy(argv: string[]): Promise<{ code: number; out: string; err: string }> {
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = await dispatch(["policy-set", ...argv], {
+      writeOut: (t) => out.push(t),
+      writeErr: (t) => err.push(t),
+    });
+    return { code, out: out.join(""), err: err.join("") };
+  }
+
+  // a1: policy-set is a registered core (TypeScript) verb that routes to a
+  // native handler -- the removed loadPythonScriptHandler route used
+  // stdio:"inherit" and would never populate io.writeOut.
+  it("registers policy-set as a native core handler", () => {
+    expect(CORE_MODULE_VERBS).toContain("policy-set");
+    expect(resolveCanonicalVerb("policy-set")).toBe("policy-set");
+  });
+
+  it("routes subagent-backends through the native handler (output via DispatchIo)", async () => {
+    const result = await runPolicy(["subagent-backends", "--project-root", root]);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("composer");
+    expect(result.out).toContain("grok-build");
+    expect(result.out).toContain("cursor-cloud");
+    expect(result.out).toContain("leaf-implementation");
+    expect(result.err).toBe("");
+  });
+
+  // a2 + a3: a typed field write updates the field AND appends an audit row.
+  it("wip-cap writes the typed field and appends an audit row", async () => {
+    const result = await runPolicy(["wip-cap", "--set", "5", "--confirm", "--project-root", root]);
+    expect(result.code).toBe(0);
+    expect(result.out).toBe(
+      "\u2713 plan.policy.wipCap=5.\n" +
+        "  audit: meta/policy-changes.log :: actor=task policy:wip-cap wipCap=5 previous=None\n" +
+        "[deft policy] plan.policy.wipCap=5 (source: typed).\n",
+    );
+    expect(readPolicyBlock().wipCap).toBe(5);
+    expect(existsSync(auditLogPath())).toBe(true);
+    expect(readFileSync(auditLogPath(), "utf8")).toContain("wipCap=5 previous=None");
+  });
+
+  it("wip-cap honors --actor / --note in the audit row", async () => {
+    const result = await runPolicy([
+      "wip-cap",
+      "--set",
+      "3",
+      "--confirm",
+      "--actor",
+      "tester",
+      "--note",
+      "freeze window",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(0);
+    const log = readFileSync(auditLogPath(), "utf8");
+    expect(log).toContain("actor=tester wipCap=3 previous=None note=freeze window");
+  });
+
+  it("wip-cap without --confirm refuses with the capability-cost disclosure", async () => {
+    const result = await runPolicy(["wip-cap", "--set", "5", "--project-root", root]);
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("Capability-cost disclosure");
+    expect(result.out).toContain("Re-run with --confirm to apply: task policy:wip-cap -- --set 5");
+    // No write happened.
+    expect("wipCap" in readPolicyBlock()).toBe(false);
+    expect(existsSync(auditLogPath())).toBe(false);
+  });
+
+  it("wip-cap rejects a negative cap on stderr", async () => {
+    const result = await runPolicy(["wip-cap", "--set", "-1", "--confirm", "--project-root", root]);
+    expect(result.code).toBe(1);
+    expect(result.err).toContain("--set must be >= 0; got -1.");
+  });
+
+  it("subagent-backend writes the typed field and appends an audit row", async () => {
+    const result = await runPolicy([
+      "subagent-backend",
+      "--set",
+      "composer",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(0);
+    expect(result.out).toBe(
+      "\u2713 plan.policy.swarmSubagentBackend=composer.\n" +
+        "  audit: meta/policy-changes.log :: actor=task policy:subagent-backend " +
+        "swarmSubagentBackend=composer previous=None\n" +
+        "[deft policy] plan.policy.swarmSubagentBackend='composer' (source: typed).\n",
+    );
+    expect(readPolicyBlock().swarmSubagentBackend).toBe("composer");
+    expect(readFileSync(auditLogPath(), "utf8")).toContain("swarmSubagentBackend=composer");
+  });
+
+  it("subagent-backend rerun updates the stored value (changed audit row)", async () => {
+    await runPolicy(["subagent-backend", "--set", "grok-build", "--project-root", root]);
+    // dispatch caches the handler (bound to the first call's DispatchIo); reset so
+    // the second invocation writes to a fresh capture buffer.
+    resetHandlerCacheForTests();
+    const result = await runPolicy([
+      "subagent-backend",
+      "--set",
+      "composer",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(0);
+    expect(readPolicyBlock().swarmSubagentBackend).toBe("composer");
+    expect(result.out).toContain("swarmSubagentBackend=composer previous='grok-build'");
+  });
+
+  it("enforce-branches writes the typed flag false and audits", async () => {
+    const result = await runPolicy([
+      "enforce-branches",
+      "--actor",
+      "tester",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("branch-protection ON");
+    expect(readPolicyBlock().allowDirectCommitsToMaster).toBe(false);
+    expect(readFileSync(auditLogPath(), "utf8")).toContain("allowDirectCommitsToMaster=false");
+  });
+
+  it("allow-direct-commits with --confirm writes true and audits the note", async () => {
+    const result = await runPolicy([
+      "allow-direct-commits",
+      "--confirm",
+      "--note",
+      "solo project",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("branch-protection OFF");
+    expect(readPolicyBlock().allowDirectCommitsToMaster).toBe(true);
+    expect(readFileSync(auditLogPath(), "utf8")).toContain("note=solo project");
+  });
+
+  it("allow-direct-commits without --confirm refuses", async () => {
+    const result = await runPolicy(["allow-direct-commits", "--project-root", root]);
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("Capability-cost disclosure");
+    expect(result.out).toContain("--confirm");
+    expect("allowDirectCommitsToMaster" in readPolicyBlock()).toBe(false);
+  });
+
+  it("subagent-backends --format json emits the catalog envelope", async () => {
+    const result = await runPolicy([
+      "subagent-backends",
+      "--format",
+      "json",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(0);
+    const payload = JSON.parse(result.out) as { backends: Array<Record<string, unknown>> };
+    expect(payload.backends).toHaveLength(3);
+    expect(payload.backends.every((row) => "id" in row && "roles" in row)).toBe(true);
+    expect(payload.backends.map((row) => row.id).sort()).toEqual([
+      "composer",
+      "cursor-cloud",
+      "grok-build",
+    ]);
+  });
+
+  it("reports a missing PROJECT-DEFINITION as a config error with recovery", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "deft-policy-set-empty-"));
+    try {
+      const result = await runPolicy(["enforce-branches", "--project-root", empty]);
+      expect(result.code).toBe(2);
+      expect(result.err).toContain("not found");
+      expect(result.err).toContain("task setup");
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a missing PROJECT-DEFINITION on the wip-cap write path", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "deft-policy-set-empty-"));
+    try {
+      const result = await runPolicy([
+        "wip-cap",
+        "--set",
+        "2",
+        "--confirm",
+        "--project-root",
+        empty,
+      ]);
+      expect(result.code).toBe(2);
+      expect(result.err).toContain("not found");
+      expect(result.err).toContain("task setup");
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a missing subcommand with exit code 2", async () => {
+    const result = await runPolicy([]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("required: cmd");
+  });
+
+  it("rejects an unknown subcommand with exit code 2", async () => {
+    const result = await runPolicy(["bogus", "--project-root", root]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("invalid choice: 'bogus'");
+  });
+
+  it("rejects an unrecognized flag with exit code 2", async () => {
+    const result = await runPolicy(["wip-cap", "--nope", "x", "--project-root", root]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("unrecognized arguments");
+  });
+
+  it("rejects a non-integer wip-cap value with exit code 2", async () => {
+    const result = await runPolicy([
+      "wip-cap",
+      "--set",
+      "abc",
+      "--confirm",
+      "--project-root",
+      root,
+    ]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("invalid int value: 'abc'");
+  });
+
+  it("rejects an invalid subagent backend choice with exit code 2", async () => {
+    const result = await runPolicy(["subagent-backend", "--set", "bogus", "--project-root", root]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("invalid choice: 'bogus'");
+  });
+
+  it("rejects a flag missing its value with exit code 2", async () => {
+    const result = await runPolicy(["wip-cap", "--set"]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("expected one argument");
+  });
+
+  it("requires --set for wip-cap with exit code 2", async () => {
+    const result = await runPolicy(["wip-cap", "--confirm", "--project-root", root]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("required: --set");
   });
 });

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -3,10 +3,23 @@
  * Routes to ported command modules in packages/cli and packages/core.
  */
 
-import { execFileSync } from "node:child_process";
-import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { engineInfo } from "@deftai/directive-core";
+import {
+  appendAuditLog,
+  disclosureLine,
+  projectDefinitionPath,
+  resolvePolicy,
+  resolveWipCap,
+  setPolicy,
+} from "@deftai/directive-core/policy";
+import {
+  KNOWN_SUBAGENT_BACKEND_IDS,
+  probeSubagentBackends,
+  resolveSwarmSubagentBackend,
+  type SubagentBackendDescriptor,
+} from "@deftai/directive-core/swarm";
 
 export type CommandHandler = (argv: string[]) => number | Promise<number>;
 
@@ -1178,26 +1191,459 @@ function runPackMigrateSwarmSpec(argv: string[], io: DispatchIo): number {
   return 0;
 }
 
-function loadPythonScriptHandler(scriptName: string): CommandHandler {
-  return (argv) => {
-    const deftRoot = resolveDeftRoot();
-    try {
-      execFileSync(
-        "uv",
-        ["--project", deftRoot, "run", "python", join(deftRoot, "scripts", scriptName), ...argv],
-        {
-          cwd: deftRoot,
-          encoding: "utf8",
-          env: { ...process.env, PYTHONUTF8: "1", DEFT_CACHE_DISABLE: "1" },
-          stdio: "inherit",
-        },
-      );
-      return 0;
-    } catch (err) {
-      const e = err as { status?: number };
-      return typeof e.status === "number" ? e.status : 1;
-    }
+// ===========================================================================
+// Native policy-set handler (#2022 Phase 1).
+//
+// Port of scripts/policy_set.py to native TypeScript so the typed-policy write
+// path (enforce-branches / allow-direct-commits / wip-cap / subagent-backend)
+// and the subagent-backends probe surface no longer shell into bundled Python.
+// Behaviour parity with the Python script is preserved: the audit row appended
+// to meta/policy-changes.log, the json.dumps(..., indent=2, ensure_ascii=False)
+// + "\n" serialization, the disclosure text, and the exit codes
+// (0 success / 1 refusal / 2 config-or-parse error).
+// ===========================================================================
+
+const POLICY_CAPABILITY_COST_DISCLOSURE =
+  "\u26a0 Capability-cost disclosure -- enabling direct commits to the default " +
+  "branch turns OFF the deft branch-protection policy.\n" +
+  "  \u2022 Pre-commit + pre-push hooks will no longer block default-branch " +
+  "commits.\n" +
+  "  \u2022 verify:branch will pass on the default branch.\n" +
+  "  \u2022 The CI sanity check (head_ref != base_ref) is still independent and " +
+  "will continue to flag master->master PRs.\n" +
+  "  \u2022 This change is reversible: run `task policy:enforce-branches` to " +
+  "re-enable the gate.\n" +
+  "  \u2022 The change is recorded to meta/policy-changes.log for auditability.";
+
+const POLICY_WIP_CAP_DISCLOSURE =
+  "\u26a0 Capability-cost disclosure -- changing plan.policy.wipCap " +
+  "alters the refusal threshold on task scope:promote (#1124 / D4 of #1119).\n" +
+  "  \u2022 Raising the cap lets more vBRIEFs sit in pending/+active/ " +
+  "before promotion is refused.\n" +
+  "  \u2022 Lowering the cap may put the project over cap immediately; " +
+  "use `task scope:demote` / `task scope:demote --batch --older-than-days 30` " +
+  "to drain.\n" +
+  "  \u2022 cap=0 freezes promotion entirely (useful for code-freeze " +
+  "windows; restore by setting a positive value).\n" +
+  "  \u2022 This change is reversible and recorded to " +
+  "meta/policy-changes.log for auditability.";
+
+type PolicySetCmd =
+  | "enforce-branches"
+  | "allow-direct-commits"
+  | "wip-cap"
+  | "subagent-backend"
+  | "subagent-backends";
+
+const POLICY_SET_COMMANDS: readonly PolicySetCmd[] = [
+  "enforce-branches",
+  "allow-direct-commits",
+  "wip-cap",
+  "subagent-backend",
+  "subagent-backends",
+] as const;
+
+/** Flags each subcommand accepts (mirrors the policy_set.py argparse subparsers). */
+const POLICY_SET_ALLOWED_FLAGS: Readonly<Record<PolicySetCmd, ReadonlySet<string>>> = {
+  "enforce-branches": new Set(["--actor", "--note", "--project-root"]),
+  "allow-direct-commits": new Set(["--confirm", "--actor", "--note", "--project-root"]),
+  "wip-cap": new Set(["--set", "--confirm", "--actor", "--note", "--project-root"]),
+  "subagent-backend": new Set(["--set", "--actor", "--note", "--project-root"]),
+  "subagent-backends": new Set(["--format", "--project-root"]),
+};
+
+interface PolicySetArgs {
+  cmd: PolicySetCmd;
+  confirm: boolean;
+  actor: string;
+  note: string;
+  projectRoot: string;
+  cap?: number;
+  backendId?: string;
+  format: "text" | "json";
+  error?: string;
+}
+
+/** Custom error so write helpers can distinguish a missing file from a config fault. */
+class PolicySetError extends Error {
+  readonly kind: "not-found" | "config";
+  constructor(message: string, kind: "not-found" | "config") {
+    super(message);
+    this.name = "PolicySetError";
+    this.kind = kind;
+  }
+}
+
+/** Python repr() for the audit-trail `previous=` field (None / 'str' / int / bool). */
+function pyRepr(value: unknown): string {
+  if (value === undefined || value === null) return "None";
+  if (typeof value === "string") return `'${value}'`;
+  if (typeof value === "boolean") return value ? "True" : "False";
+  return String(value);
+}
+
+/** Strip newlines so an audit note stays a single log line (mirrors policy_set.py). */
+function sanitizeNote(note: string): string {
+  return note.replace(/\n/g, " ").replace(/\r/g, " ");
+}
+
+function defaultPolicySetActor(cmd: PolicySetCmd): string {
+  switch (cmd) {
+    case "enforce-branches":
+      return "task policy:enforce-branches";
+    case "allow-direct-commits":
+      return "task policy:allow-direct-commits";
+    case "wip-cap":
+      return "task policy:wip-cap";
+    case "subagent-backend":
+      return "task policy:subagent-backend";
+    case "subagent-backends":
+      return "task policy:subagent-backends";
+  }
+}
+
+function policySetError(message: string): PolicySetArgs {
+  return {
+    cmd: "enforce-branches",
+    confirm: false,
+    actor: "",
+    note: "",
+    projectRoot: ".",
+    format: "text",
+    error: message,
   };
+}
+
+/** Parse `policy-set <cmd> [flags]` (mirrors the policy_set.py argparse surface). */
+function parsePolicySetArgs(argv: readonly string[]): PolicySetArgs {
+  const cmd = argv[0];
+  if (cmd === undefined) {
+    return policySetError("the following arguments are required: cmd");
+  }
+  if (!(POLICY_SET_COMMANDS as readonly string[]).includes(cmd)) {
+    return policySetError(`argument cmd: invalid choice: '${cmd}'`);
+  }
+  const command = cmd as PolicySetCmd;
+  const allowed = POLICY_SET_ALLOWED_FLAGS[command];
+  const args: PolicySetArgs = {
+    cmd: command,
+    confirm: false,
+    actor: defaultPolicySetActor(command),
+    note: "",
+    projectRoot: ".",
+    format: "text",
+  };
+
+  const rest = argv.slice(1);
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (token === undefined) continue;
+    let flag = token;
+    let inlineValue: string | undefined;
+    if (token.startsWith("--") && token.includes("=")) {
+      const eq = token.indexOf("=");
+      flag = token.slice(0, eq);
+      inlineValue = token.slice(eq + 1);
+    }
+    if (!allowed.has(flag)) {
+      return policySetError(`unrecognized arguments: ${token}`);
+    }
+    const takeValue = (): string | undefined => {
+      if (inlineValue !== undefined) return inlineValue;
+      i += 1;
+      return rest[i];
+    };
+
+    if (flag === "--confirm") {
+      args.confirm = true;
+      continue;
+    }
+    const value = takeValue();
+    if (value === undefined) {
+      return policySetError(`argument ${flag}: expected one argument`);
+    }
+    if (flag === "--actor") {
+      args.actor = value;
+    } else if (flag === "--note") {
+      args.note = value;
+    } else if (flag === "--project-root") {
+      args.projectRoot = value;
+    } else if (flag === "--format") {
+      if (value !== "text" && value !== "json") {
+        return policySetError(`argument --format: invalid choice: '${value}'`);
+      }
+      args.format = value;
+    } else if (flag === "--set") {
+      if (command === "wip-cap") {
+        if (!/^[+-]?\d+$/.test(value)) {
+          return policySetError(`argument --set: invalid int value: '${value}'`);
+        }
+        args.cap = Number.parseInt(value, 10);
+      } else {
+        // subagent-backend --set <choice>
+        if (!KNOWN_SUBAGENT_BACKEND_IDS.has(value)) {
+          const choices = [...KNOWN_SUBAGENT_BACKEND_IDS].sort().join(", ");
+          return policySetError(
+            `argument --set: invalid choice: '${value}' (choose from ${choices})`,
+          );
+        }
+        args.backendId = value;
+      }
+    }
+  }
+
+  if (command === "wip-cap" && args.cap === undefined) {
+    return policySetError("the following arguments are required: --set");
+  }
+  if (command === "subagent-backend" && args.backendId === undefined) {
+    return policySetError("the following arguments are required: --set");
+  }
+  return args;
+}
+
+interface PdWriteContext {
+  path: string;
+  data: Record<string, unknown>;
+  policyBlock: Record<string, unknown>;
+}
+
+/** Load PROJECT-DEFINITION for an in-place typed-field write (mirrors the .setdefault chain). */
+function loadProjectDefinitionForWrite(projectRoot: string): PdWriteContext {
+  const path = projectDefinitionPath(projectRoot);
+  if (!existsSync(path)) {
+    throw new PolicySetError(`PROJECT-DEFINITION not found at ${path}`, "not-found");
+  }
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+  } catch (err) {
+    throw new PolicySetError(
+      `PROJECT-DEFINITION at ${path} is not valid JSON: ${String(err)}`,
+      "config",
+    );
+  }
+  let plan = data.plan;
+  if (plan === undefined) {
+    plan = {};
+    data.plan = plan;
+  }
+  if (typeof plan !== "object" || plan === null || Array.isArray(plan)) {
+    throw new PolicySetError("PROJECT-DEFINITION 'plan' is not an object", "config");
+  }
+  const planObj = plan as Record<string, unknown>;
+  let policy = planObj.policy;
+  if (policy === undefined) {
+    policy = {};
+    planObj.policy = policy;
+  }
+  if (typeof policy !== "object" || policy === null || Array.isArray(policy)) {
+    throw new PolicySetError("plan.policy is not an object", "config");
+  }
+  return { path, data, policyBlock: policy as Record<string, unknown> };
+}
+
+/** Write plan.policy.wipCap in place + append the audit row (mirrors set_wip_cap). */
+function writeWipCap(
+  projectRoot: string,
+  cap: number,
+  actor: string,
+  note: string,
+): { changed: boolean; auditEntry: string } {
+  const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
+  const previous = policyBlock.wipCap;
+  policyBlock.wipCap = cap;
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  const changed = previous !== cap;
+  const parts = [`actor=${actor}`, `wipCap=${cap}`, `previous=${pyRepr(previous)}`];
+  if (note) parts.push(`note=${sanitizeNote(note)}`);
+  const auditEntry = parts.join(" ");
+  appendAuditLog(projectRoot, auditEntry);
+  return { changed, auditEntry };
+}
+
+/** Write plan.policy.swarmSubagentBackend in place + append the audit row. */
+function writeSubagentBackend(
+  projectRoot: string,
+  backendId: string,
+  actor: string,
+  note: string,
+): { changed: boolean; auditEntry: string } {
+  const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
+  const previous = policyBlock.swarmSubagentBackend;
+  policyBlock.swarmSubagentBackend = backendId;
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  const changed = previous !== backendId;
+  const parts = [
+    `actor=${actor}`,
+    `swarmSubagentBackend=${backendId}`,
+    `previous=${pyRepr(previous)}`,
+  ];
+  if (note) parts.push(`note=${sanitizeNote(note)}`);
+  const auditEntry = parts.join(" ");
+  appendAuditLog(projectRoot, auditEntry);
+  return { changed, auditEntry };
+}
+
+/** Serialise the probe output for `subagent-backends --format json`. */
+function subagentBackendsToJson(backends: readonly SubagentBackendDescriptor[]): string {
+  const payload = {
+    backends: backends.map((entry) => ({
+      id: entry.backend_id,
+      display_name: entry.display_name,
+      roles: [...entry.roles],
+      available: entry.available,
+    })),
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+/** Map a write-path error to its fail-closed message + exit code (mirrors the except blocks). */
+function reportPolicyWriteError(err: unknown, io: DispatchIo): number {
+  const message = err instanceof Error ? err.message : String(err);
+  if (err instanceof PolicySetError && err.kind === "not-found") {
+    io.writeErr(`\u274c ${message}\n`);
+    io.writeErr(
+      "  Recovery: run `task setup` to generate vbrief/PROJECT-DEFINITION.vbrief.json.\n",
+    );
+    return 2;
+  }
+  io.writeErr(`\u274c Config error: ${message}\n`);
+  return 2;
+}
+
+function applyBranchPolicy(args: PolicySetArgs, io: DispatchIo): number {
+  let target: boolean;
+  if (args.cmd === "enforce-branches") {
+    target = false;
+  } else {
+    if (!args.confirm) {
+      io.writeOut(`${POLICY_CAPABILITY_COST_DISCLOSURE}\n`);
+      io.writeOut("\n");
+      io.writeOut(
+        "Re-run with --confirm to apply: task policy:allow-direct-commits -- --confirm\n",
+      );
+      return 1;
+    }
+    target = true;
+  }
+
+  let result: { changed: boolean; auditEntry: string };
+  try {
+    result = setPolicy(args.projectRoot, {
+      allowDirectCommits: target,
+      actor: args.actor,
+      note: args.note,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("PROJECT-DEFINITION not found")) {
+      io.writeErr(`\u274c ${message}\n`);
+      io.writeErr(
+        "  Recovery: run `task setup` to generate vbrief/PROJECT-DEFINITION.vbrief.json.\n",
+      );
+      return 2;
+    }
+    io.writeErr(`\u274c Config error: ${message}\n`);
+    return 2;
+  }
+
+  const state = target ? "OFF" : "ON";
+  io.writeOut(
+    `\u2713 plan.policy.allowDirectCommitsToMaster=${target ? "true" : "false"} ` +
+      `(branch-protection ${state}).\n`,
+  );
+  if (result.changed) {
+    io.writeOut(`  audit: meta/policy-changes.log :: ${result.auditEntry}\n`);
+  } else {
+    io.writeOut("  no-op: value already matched (audit entry still appended for trail).\n");
+  }
+  io.writeOut(`${disclosureLine(resolvePolicy(args.projectRoot))}\n`);
+  return 0;
+}
+
+function applyWipCap(args: PolicySetArgs, io: DispatchIo): number {
+  const cap = args.cap ?? 0;
+  if (cap < 0) {
+    io.writeErr(`\u274c --set must be >= 0; got ${cap}.\n`);
+    return 1;
+  }
+  if (!args.confirm) {
+    io.writeOut(`${POLICY_WIP_CAP_DISCLOSURE}\n`);
+    io.writeOut("\n");
+    io.writeOut(`Re-run with --confirm to apply: task policy:wip-cap -- --set ${cap} --confirm\n`);
+    return 1;
+  }
+  let res: { changed: boolean; auditEntry: string };
+  try {
+    res = writeWipCap(args.projectRoot, cap, args.actor, args.note);
+  } catch (err) {
+    return reportPolicyWriteError(err, io);
+  }
+  io.writeOut(`\u2713 plan.policy.wipCap=${cap}.\n`);
+  if (res.changed) {
+    io.writeOut(`  audit: meta/policy-changes.log :: ${res.auditEntry}\n`);
+  } else {
+    io.writeOut("  no-op: value already matched (audit entry still appended for trail).\n");
+  }
+  const result = resolveWipCap(args.projectRoot);
+  io.writeOut(`[deft policy] plan.policy.wipCap=${result.cap} (source: ${result.source}).\n`);
+  return 0;
+}
+
+function applySubagentBackend(args: PolicySetArgs, io: DispatchIo): number {
+  const backendId = args.backendId ?? "";
+  let res: { changed: boolean; auditEntry: string };
+  try {
+    res = writeSubagentBackend(args.projectRoot, backendId, args.actor, args.note);
+  } catch (err) {
+    return reportPolicyWriteError(err, io);
+  }
+  io.writeOut(`\u2713 plan.policy.swarmSubagentBackend=${backendId}.\n`);
+  if (res.changed) {
+    io.writeOut(`  audit: meta/policy-changes.log :: ${res.auditEntry}\n`);
+  } else {
+    io.writeOut("  no-op: value already matched (audit entry still appended for trail).\n");
+  }
+  const result = resolveSwarmSubagentBackend(args.projectRoot);
+  io.writeOut(
+    `[deft policy] plan.policy.swarmSubagentBackend=${pyRepr(result.backend_id)} ` +
+      `(source: ${result.source}).\n`,
+  );
+  return 0;
+}
+
+function applySubagentBackends(args: PolicySetArgs, io: DispatchIo): number {
+  const entries = probeSubagentBackends();
+  if (args.format === "json") {
+    io.writeOut(`${subagentBackendsToJson(entries)}\n`);
+    return 0;
+  }
+  for (const entry of entries) {
+    const roles = entry.roles.join(", ");
+    const avail = entry.available ? "available" : "unavailable";
+    io.writeOut(`${entry.backend_id}\t${entry.display_name}\troles=[${roles}]\t${avail}\n`);
+  }
+  return 0;
+}
+
+/** Native `policy-set` dispatcher (replaces the policy_set.py shell-out, #2022 Phase 1). */
+export function runPolicySet(argv: string[], io: DispatchIo): number {
+  const args = parsePolicySetArgs(argv);
+  if (args.error !== undefined) {
+    io.writeErr(`policy-set: ${args.error}\n`);
+    return 2;
+  }
+  switch (args.cmd) {
+    case "enforce-branches":
+    case "allow-direct-commits":
+      return applyBranchPolicy(args, io);
+    case "wip-cap":
+      return applyWipCap(args, io);
+    case "subagent-backend":
+      return applySubagentBackend(args, io);
+    case "subagent-backends":
+      return applySubagentBackends(args, io);
+  }
 }
 
 async function loadCoreModuleHandler(verb: string, io: DispatchIo): Promise<CommandHandler> {
@@ -1327,7 +1773,7 @@ async function loadCoreModuleHandler(verb: string, io: DispatchIo): Promise<Comm
     case "pack-migrate-swarm-spec":
       return (argv) => runPackMigrateSwarmSpec(argv, io);
     case "policy-set":
-      return loadPythonScriptHandler("policy_set.py");
+      return (argv) => runPolicySet(argv, io);
     case "scope-undo": {
       const { undoMain } = await import("@deftai/directive-core/dist/scope/main.js");
       return undoMain;

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -4,6 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { engineInfo } from "@deftai/directive-core";
 import {
@@ -1302,6 +1303,15 @@ function defaultPolicySetActor(cmd: PolicySetCmd): string {
   }
 }
 
+/** Mirror Python `Path(...).expanduser()` for a leading `~` / `~/` segment. */
+function expandUser(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return join(homedir(), p.slice(2));
+  }
+  return p;
+}
+
 function policySetError(message: string): PolicySetArgs {
   return {
     cmd: "enforce-branches",
@@ -1367,7 +1377,7 @@ function parsePolicySetArgs(argv: readonly string[]): PolicySetArgs {
     } else if (flag === "--note") {
       args.note = value;
     } else if (flag === "--project-root") {
-      args.projectRoot = value;
+      args.projectRoot = expandUser(value);
     } else if (flag === "--format") {
       if (value !== "text" && value !== "json") {
         return policySetError(`argument --format: invalid choice: '${value}'`);
@@ -1375,10 +1385,13 @@ function parsePolicySetArgs(argv: readonly string[]): PolicySetArgs {
       args.format = value;
     } else if (flag === "--set") {
       if (command === "wip-cap") {
-        if (!/^[+-]?\d+$/.test(value)) {
+        // Python int() strips surrounding whitespace, so "--set ' 5'" parsed
+        // cleanly; trim before the integer check to preserve that contract.
+        const capText = value.trim();
+        if (!/^[+-]?\d+$/.test(capText)) {
           return policySetError(`argument --set: invalid int value: '${value}'`);
         }
-        args.cap = Number.parseInt(value, 10);
+        args.cap = Number.parseInt(capText, 10);
       } else {
         // subagent-backend --set <choice>
         if (!KNOWN_SUBAGENT_BACKEND_IDS.has(value)) {
@@ -1413,15 +1426,21 @@ function loadProjectDefinitionForWrite(projectRoot: string): PdWriteContext {
   if (!existsSync(path)) {
     throw new PolicySetError(`PROJECT-DEFINITION not found at ${path}`, "not-found");
   }
-  let data: Record<string, unknown>;
+  let parsed: unknown;
   try {
-    data = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    parsed = JSON.parse(readFileSync(path, "utf8"));
   } catch (err) {
     throw new PolicySetError(
       `PROJECT-DEFINITION at ${path} is not valid JSON: ${String(err)}`,
       "config",
     );
   }
+  // JSON.parse can yield a non-object top level (null / array / scalar) without
+  // throwing; reject it before the .plan/.policy property chain dereferences it.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new PolicySetError(`PROJECT-DEFINITION at ${path} is not a JSON object`, "config");
+  }
+  const data = parsed as Record<string, unknown>;
   let plan = data.plan;
   if (plan === undefined) {
     plan = {};

--- a/vbrief/completed/2026-06-26-convert-the-policy-set-write-path-to-native-typescript-phase.vbrief.json
+++ b/vbrief/completed/2026-06-26-convert-the-policy-set-write-path-to-native-typescript-phase.vbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "py-purge-policy-set-ts",
     "title": "Convert the policy-set write path to native TypeScript (Phase 1)",
-    "status": "running",
+    "status": "completed",
     "planRef": "proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json",
     "narratives": {
       "Description": "The policy-set write path is still served by a loadPythonScriptHandler route in packages/cli/src/dispatch.ts (~line 501) that shells into scripts/policy_set.py, while the policy read path is already native TypeScript. This story ports the policy write path to TypeScript so editing a typed policy field no longer requires Python.",
@@ -61,7 +61,9 @@
         "size": "M",
         "file_scope_confidence": "medium",
         "model_tier": "high"
-      }
+      },
+      "completedAt": "2026-06-26T19:27:20Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -71,6 +73,6 @@
         "TrustLevel": "external"
       }
     ],
-    "updated": "2026-06-26T18:08:57Z"
+    "updated": "2026-06-26T19:27:20Z"
   }
 }

--- a/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
+++ b/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
@@ -102,7 +102,7 @@
         "TrustLevel": "internal"
       },
       {
-        "uri": "active/2026-06-26-convert-the-policy-set-write-path-to-native-typescript-phase.vbrief.json",
+        "uri": "completed/2026-06-26-convert-the-policy-set-write-path-to-native-typescript-phase.vbrief.json",
         "type": "x-vbrief/plan",
         "title": "Convert the policy-set write path to native TypeScript (Phase 1)",
         "TrustLevel": "internal"


### PR DESCRIPTION
## Summary
- Converts the `policy-set` write path from a `policy_set.py` shell-out to a native TypeScript handler in `packages/cli/src/dispatch.ts` (#2022 Phase 1 — Python purge). The route no longer uses `loadPythonScriptHandler`; the now-dead `execFileSync` path is removed.
- Ports every `policy_set.py` subcommand: `wip-cap`, `subagent-backend`, `subagent-backends`, and `enforce-branches` / `allow-direct-commits`. Typed-field writes update `PROJECT-DEFINITION.vbrief.json` in place and append the `meta/policy-changes.log` audit row.
- Output, JSON serialization, audit trail, and exit codes are **byte-for-byte identical to the Python oracle** (verified against `scripts/policy_set.py` for every subcommand, including the no-confirm refusal paths).
- Builds on the already-merged pack-migrate dispatch.ts conversion (#2030); pack-migrate routes are untouched.

## Acceptance coverage (story py-purge-policy-set-ts)
- **a1** — `policy-set` routes to a native TS handler with no `loadPythonScriptHandler` call. ✓
- **a2** — a typed field write updates the field and appends an audit row to `meta/policy-changes.log`. ✓
- **a3** — `dispatch.test.ts` asserts the write path updates the field and records the audit row. ✓ (57 dispatch tests; new `native policy-set handler (#2022)` describe block)

## Test plan
- [x] `pnpm exec vitest run packages/cli/src/dispatch.test.ts` — 57 passed
- [x] Full TS suite `pnpm exec vitest run` — 7337 passed (513 files)
- [x] Python suite via `task check` — 8373 passed
- [x] Byte-exact Python-oracle parity diff for every subcommand (stdout + PROJECT-DEFINITION + audit log)
- [x] `biome check` clean on edited files

> Note: `task check` reports a pre-existing `vbrief:validate` drift on the `#2022` tracker's child references (setupghx / rewire-consumer / npm-deposit / bootstrap-launcher). That drift is orchestrator-owned and outside this story's file scope; it is unrelated to this change.

Refs #2022.
