### PR TITLE
feat(render): add PROJECT-DEFINITION staleness acknowledgement (#640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Supported ghx install verb** — `directive setup:ghx` (and `task setup:ghx`) is now a native TypeScript command with consent-gated install (default deny); `task setup` nudges when `gh` is present but ghx is missing. Refs #2022.
+- **PROJECT-DEFINITION staleness flags can be cleared after review** — `task project:ack-staleness` records a completed-scope watermark on `plan.metadata.staleness_review` so `task project:render` stops repeating the same narrative warnings until new completed work arrives. Distinct from `task reconcile:issues` (scope origin freshness). Closes #640.
 
 ### Changed
 - **The conception-to-ship lifecycle diagram now ships with your install** — the single-picture overview of how Directive turns an idea into shipped work (inception strategy analysis feeding the recurring per-session triage→slice→swarm→review→ship loop) moved into the installed `.deft/core/docs/` payload and is cross-linked from the getting-started guide, so adopters can see the framework's overall shape without visiting the upstream repo. Documentation only.

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -13,10 +13,15 @@ export * as prdRender from "./prd-render.js";
 export { main as prdRenderMain, parsePrdArgv, renderPrd } from "./prd-render.js";
 export * as projectRender from "./project-render.js";
 export {
+  acknowledgeProjectDefinitionStaleness,
+  buildStalenessAcknowledgement,
+  computeStalenessFlags,
   flagStaleNarratives,
   main as projectRenderMain,
+  parseStalenessReview,
   renderProjectDefinition,
   scanLifecycleFolders,
+  unacknowledgedCompletedItems,
 } from "./project-render.js";
 export * as roadmapRender from "./roadmap-render.js";
 export {

--- a/packages/core/src/render/project-render.test.ts
+++ b/packages/core/src/render/project-render.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { validateProjectDefinition } from "../vbrief-validate/project-definition.js";
-import { renderProjectDefinition } from "./project-render.js";
+import {
+  acknowledgeProjectDefinitionStaleness,
+  renderProjectDefinition,
+} from "./project-render.js";
 
 const ISSUE_REF = {
   type: "x-vbrief/github-issue",
@@ -26,7 +29,7 @@ function writeScope(
   );
 }
 
-function writeProjectDefinition(vbriefDir: string): void {
+function writeProjectDefinition(vbriefDir: string, narratives?: Record<string, string>): void {
   writeFileSync(
     join(vbriefDir, "PROJECT-DEFINITION.vbrief.json"),
     `${JSON.stringify(
@@ -35,7 +38,12 @@ function writeProjectDefinition(vbriefDir: string): void {
         plan: {
           title: "PROJECT-DEFINITION",
           status: "running",
-          narratives: { Overview: "Test", "tech stack": "TS" },
+          narratives: narratives ?? {
+            Overview: "Test",
+            "tech stack": "TS",
+            Architecture: "Monolith",
+            Configuration: "Defaults",
+          },
           items: [],
           metadata: { staleness_flags: [] },
         },
@@ -127,6 +135,100 @@ describe("project-render decompose round-trip", () => {
       vbrief,
     );
     expect(errors.filter((e) => e.includes("registry-status"))).toEqual([]);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("project-render staleness acknowledgement (#640)", () => {
+  const FIXED_NOW = new Date("2026-06-28T12:00:00Z");
+
+  it("emits staleness flags on first render when completed scopes overlap narratives", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-pr-640-"));
+    const vbrief = join(root, "vbrief");
+    mkdirSync(vbrief, { recursive: true });
+
+    writeScope(vbrief, "completed", "2026-06-28-architecture-story.vbrief.json", {
+      title: "Architecture migration story",
+      status: "completed",
+      items: [],
+    });
+    writeProjectDefinition(vbrief);
+
+    renderProjectDefinition(vbrief, { now: FIXED_NOW });
+
+    const parsed = JSON.parse(
+      readFileSync(join(vbrief, "PROJECT-DEFINITION.vbrief.json"), "utf8"),
+    ) as { plan: { metadata?: { staleness_flags?: string[] } } };
+    const flags = parsed.plan.metadata?.staleness_flags ?? [];
+    expect(flags.some((f) => f.includes("Architecture"))).toBe(true);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("suppresses repeat flags after acknowledgement when no new completed scopes land", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-pr-640-"));
+    const vbrief = join(root, "vbrief");
+    mkdirSync(vbrief, { recursive: true });
+
+    writeScope(vbrief, "completed", "2026-06-28-architecture-story.vbrief.json", {
+      title: "Architecture migration story",
+      status: "completed",
+      items: [],
+    });
+    writeProjectDefinition(vbrief);
+
+    renderProjectDefinition(vbrief, { now: FIXED_NOW });
+    const [ackOk] = acknowledgeProjectDefinitionStaleness(vbrief, { now: FIXED_NOW });
+    expect(ackOk).toBe(true);
+
+    renderProjectDefinition(vbrief, { now: new Date("2026-06-28T13:00:00Z") });
+    const parsed = JSON.parse(
+      readFileSync(join(vbrief, "PROJECT-DEFINITION.vbrief.json"), "utf8"),
+    ) as {
+      plan: {
+        metadata?: {
+          staleness_flags?: string[];
+          staleness_review?: { acknowledged_completed_scope_ids?: string[] };
+        };
+      };
+    };
+    expect(parsed.plan.metadata?.staleness_flags ?? []).toEqual([]);
+    expect(parsed.plan.metadata?.staleness_review?.acknowledged_completed_scope_ids).toContain(
+      "2026-06-28-architecture-story",
+    );
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("re-flags when a new completed scope lands after acknowledgement", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-pr-640-"));
+    const vbrief = join(root, "vbrief");
+    mkdirSync(vbrief, { recursive: true });
+
+    writeScope(vbrief, "completed", "2026-06-28-architecture-story.vbrief.json", {
+      title: "Architecture migration story",
+      status: "completed",
+      items: [],
+    });
+    writeProjectDefinition(vbrief);
+
+    renderProjectDefinition(vbrief, { now: FIXED_NOW });
+    acknowledgeProjectDefinitionStaleness(vbrief, { now: FIXED_NOW });
+
+    writeScope(vbrief, "completed", "2026-06-28-configuration-story.vbrief.json", {
+      title: "Configuration rollout story",
+      status: "completed",
+      items: [],
+    });
+
+    renderProjectDefinition(vbrief, { now: new Date("2026-06-28T14:00:00Z") });
+    const parsed = JSON.parse(
+      readFileSync(join(vbrief, "PROJECT-DEFINITION.vbrief.json"), "utf8"),
+    ) as { plan: { metadata?: { staleness_flags?: string[] } } };
+    const flags = parsed.plan.metadata?.staleness_flags ?? [];
+    expect(flags.some((f) => f.includes("Configuration"))).toBe(true);
+    expect(flags.some((f) => f.includes("Architecture migration story"))).toBe(false);
 
     rmSync(root, { recursive: true, force: true });
   });

--- a/packages/core/src/render/project-render.ts
+++ b/packages/core/src/render/project-render.ts
@@ -311,7 +311,6 @@ export function acknowledgeProjectDefinitionStaleness(
     completedItems,
     parseStalenessReview(planMetadata),
   );
-  plan.items = items;
   if (typeof projectDef.vBRIEFInfo !== "object" || projectDef.vBRIEFInfo === null) {
     projectDef.vBRIEFInfo = {};
   }

--- a/packages/core/src/render/project-render.ts
+++ b/packages/core/src/render/project-render.ts
@@ -10,6 +10,14 @@ import { splitCamel, splitWords } from "./text-utils.js";
 
 type JsonObject = Record<string, unknown>;
 
+/** Durable review state for PROJECT-DEFINITION narrative staleness (#640). */
+export interface StalenessReviewMetadata {
+  /** ISO-8601 UTC when narratives were last reviewed/acknowledged. */
+  acknowledged_at: string;
+  /** Completed scope IDs incorporated at acknowledgement time (watermark). */
+  acknowledged_completed_scope_ids: readonly string[];
+}
+
 export interface LifecycleItem {
   id: string;
   title: string;
@@ -109,9 +117,71 @@ export function flagStaleNarratives(
   return flags.sort();
 }
 
+function isoTimestamp(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/** Parse `plan.metadata.staleness_review` when present and well-formed. */
+export function parseStalenessReview(metadata: unknown): StalenessReviewMetadata | null {
+  if (typeof metadata !== "object" || metadata === null || Array.isArray(metadata)) {
+    return null;
+  }
+  const review = (metadata as JsonObject).staleness_review;
+  if (typeof review !== "object" || review === null || Array.isArray(review)) {
+    return null;
+  }
+  const acknowledgedAt = (review as JsonObject).acknowledged_at;
+  const scopeIds = (review as JsonObject).acknowledged_completed_scope_ids;
+  if (typeof acknowledgedAt !== "string" || acknowledgedAt.length === 0) {
+    return null;
+  }
+  if (!Array.isArray(scopeIds) || !scopeIds.every((id) => typeof id === "string")) {
+    return null;
+  }
+  return {
+    acknowledged_at: acknowledgedAt,
+    acknowledged_completed_scope_ids: [...scopeIds].sort(),
+  };
+}
+
+/** Completed scopes not yet covered by the acknowledgement watermark. */
+export function unacknowledgedCompletedItems(
+  completedItems: readonly LifecycleItem[],
+  review: StalenessReviewMetadata | null,
+): LifecycleItem[] {
+  if (!review) return [...completedItems];
+  const acknowledged = new Set(review.acknowledged_completed_scope_ids);
+  return completedItems.filter((item) => !acknowledged.has(item.id));
+}
+
+/** Build acknowledgement metadata for the current completed-scope set. */
+export function buildStalenessAcknowledgement(
+  completedItems: readonly LifecycleItem[],
+  options: { now?: Date; existing?: StalenessReviewMetadata | null } = {},
+): StalenessReviewMetadata {
+  const now = isoTimestamp(options.now ?? new Date());
+  const mergedIds = new Set([
+    ...(options.existing?.acknowledged_completed_scope_ids ?? []),
+    ...completedItems.map((item) => item.id),
+  ]);
+  return {
+    acknowledged_at: now,
+    acknowledged_completed_scope_ids: [...mergedIds].sort(),
+  };
+}
+
+export function computeStalenessFlags(
+  narratives: Record<string, string>,
+  completedItems: readonly LifecycleItem[],
+  review: StalenessReviewMetadata | null = null,
+): string[] {
+  const pending = unacknowledgedCompletedItems(completedItems, review);
+  return flagStaleNarratives(narratives, pending);
+}
+
 export function createSkeleton(items: LifecycleItem[], now: string): JsonObject {
   const completedItems = items.filter((i) => i.status === "completed");
-  const stalenessFlags = flagStaleNarratives({ ...SKELETON_NARRATIVES }, completedItems);
+  const stalenessFlags = computeStalenessFlags({ ...SKELETON_NARRATIVES }, completedItems);
   return {
     vBRIEFInfo: {
       version: EMITTED_VBRIEF_VERSION,
@@ -166,7 +236,6 @@ export function renderProjectDefinition(
         ? (plan.narratives as Record<string, string>)
         : {};
     const completedItems = items.filter((i) => i.status === "completed");
-    const flags = flagStaleNarratives(narratives, completedItems);
     if (
       typeof plan.metadata !== "object" ||
       plan.metadata === null ||
@@ -174,7 +243,10 @@ export function renderProjectDefinition(
     ) {
       plan.metadata = {};
     }
-    (plan.metadata as JsonObject).staleness_flags = flags;
+    const planMetadata = plan.metadata as JsonObject;
+    const review = parseStalenessReview(planMetadata);
+    const flags = computeStalenessFlags(narratives, completedItems, review);
+    planMetadata.staleness_flags = flags;
     projectDef.plan = plan;
   } else {
     projectDef = createSkeleton(items, now);
@@ -192,14 +264,80 @@ export function renderProjectDefinition(
   return [true, parts.join("\n")];
 }
 
+/**
+ * Mark current completed scopes as reviewed for PROJECT-DEFINITION narratives.
+ *
+ * Distinct from `task reconcile:issues`, which reconciles origin freshness on scope
+ * vBRIEFs — this path only clears narrative staleness heuristics on render.
+ */
+export function acknowledgeProjectDefinitionStaleness(
+  vbriefDir: string,
+  options: RenderProjectOptions = {},
+): RenderProjectResult {
+  const nowDate = options.now ?? new Date();
+  const now = isoTimestamp(nowDate);
+  const projectDefPath = join(vbriefDir, "PROJECT-DEFINITION.vbrief.json");
+  if (!existsSync(projectDefPath)) {
+    return [false, `✗ ${projectDefPath} not found — run project:render first`];
+  }
+
+  let projectDef: JsonObject;
+  try {
+    projectDef = JSON.parse(readFileSync(projectDefPath, "utf8")) as JsonObject;
+  } catch (exc) {
+    return [false, `✗ Failed to read ${projectDefPath}: ${String(exc)}`];
+  }
+
+  const plan = (projectDef.plan ?? {}) as JsonObject;
+  if (typeof plan.metadata !== "object" || plan.metadata === null || Array.isArray(plan.metadata)) {
+    plan.metadata = {};
+  }
+  const planMetadata = plan.metadata as JsonObject;
+  const items = scanLifecycleFolders(vbriefDir);
+  const completedItems = items.filter((i) => i.status === "completed");
+  const existing = parseStalenessReview(planMetadata);
+  planMetadata.staleness_review = buildStalenessAcknowledgement(completedItems, {
+    now: nowDate,
+    existing,
+  });
+  const narratives =
+    typeof plan.narratives === "object" &&
+    plan.narratives !== null &&
+    !Array.isArray(plan.narratives)
+      ? (plan.narratives as Record<string, string>)
+      : {};
+  planMetadata.staleness_flags = computeStalenessFlags(
+    narratives,
+    completedItems,
+    parseStalenessReview(planMetadata),
+  );
+  plan.items = items;
+  if (typeof projectDef.vBRIEFInfo !== "object" || projectDef.vBRIEFInfo === null) {
+    projectDef.vBRIEFInfo = {};
+  }
+  (projectDef.vBRIEFInfo as JsonObject).updated = now;
+  projectDef.plan = plan;
+
+  writeFileSync(projectDefPath, `${JSON.stringify(projectDef, null, 2)}\n`, "utf8");
+  const ackCount = completedItems.length;
+  return [
+    true,
+    `✓ PROJECT-DEFINITION staleness acknowledged (${ackCount} completed scope(s) watermarked)`,
+  ];
+}
+
 /** CLI entry (mirrors ``scripts/project_render.main``). */
 export function main(argv: readonly string[]): number {
-  if (argv.length > 1) {
-    process.stderr.write("Usage: project_render.py [vbrief_dir]\n");
+  const acknowledge = argv[0] === "--acknowledge-staleness";
+  const rest = acknowledge ? argv.slice(1) : argv;
+  if (rest.length > 1) {
+    process.stderr.write("Usage: project_render.py [--acknowledge-staleness] [vbrief_dir]\n");
     return 2;
   }
-  const vbriefDir = argv[0] ?? "vbrief";
-  const [ok, message] = renderProjectDefinition(vbriefDir);
+  const vbriefDir = rest[0] ?? "vbrief";
+  const [ok, message] = acknowledge
+    ? acknowledgeProjectDefinitionStaleness(vbriefDir)
+    : renderProjectDefinition(vbriefDir);
   process.stdout.write(`${message}\n`);
   return ok ? 0 : 1;
 }

--- a/tasks/project.yml
+++ b/tasks/project.yml
@@ -9,6 +9,12 @@ vars:
 # own repo root when invoked via ``includes:`` -- consumers got their data
 # scanned from ``deft/vbrief/``. Switched to ``{{.USER_WORKING_DIR}}`` to
 # match the convention used by roadmap:render / spec:render / migrate:vbrief.
+#
+# Staleness acknowledgement (#640): ``task project:ack-staleness`` records a
+# completed-scope watermark on PROJECT-DEFINITION ``plan.metadata.staleness_review``
+# so ``task project:render`` stops re-emitting the same narrative staleness flags
+# after review. This is distinct from ``task reconcile:issues``, which reconciles
+# origin freshness on scope vBRIEFs — not PROJECT-DEFINITION narrative heuristics.
 
 tasks:
   _ts-build:
@@ -25,3 +31,13 @@ tasks:
       - _ts-build
     cmds:
       - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" project-render "{{.USER_WORKING_DIR}}/vbrief"
+
+  ack-staleness:
+    desc: >-
+      Acknowledge reviewed PROJECT-DEFINITION narrative staleness (#640).
+      Distinct from task reconcile:issues (scope origin freshness).
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - _ts-build
+    cmds:
+      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" project-render --acknowledge-staleness "{{.USER_WORKING_DIR}}/vbrief"

--- a/vbrief/completed/2026-06-28-add-acknowledgementclear-path-for-project-definition-stalene.vbrief.json
+++ b/vbrief/completed/2026-06-28-add-acknowledgementclear-path-for-project-definition-stalene.vbrief.json
@@ -1,0 +1,91 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 1 decomposed from proposed/2026-06-28-640-projectrender-staleness-flags-need-an-acknowledgementclear-p.vbrief.json"
+  },
+  "plan": {
+    "id": "story-640-project-render-staleness-ack",
+    "title": "Add acknowledgement/clear path for PROJECT-DEFINITION staleness flags",
+    "status": "completed",
+    "planRef": "proposed/2026-06-28-640-projectrender-staleness-flags-need-an-acknowledgementclear-p.vbrief.json",
+    "narratives": {
+      "Description": "task project:render emits heuristic staleness_flags when completed scope titles overlap narrative keys, but re-rendering after manual review does not clear flags because no reviewed/acknowledged state is persisted. This story adds durable review metadata (watermark or per-narrative acknowledgement) so operators can mark narratives fresh after review and subsequent renders suppress repeat warnings until new completed work arrives.",
+      "ImplementationPlan": "Extend the project-render module in packages/core/src/render/project-render.ts to persist acknowledgement metadata on plan.metadata and filter staleness_flags using that watermark.\nAdd packages/core/src/render/project-render.test.ts cases for initial emission, acknowledgement, no-repeat after ack, and re-flag on new completed scopes; run pnpm test project-render as verify evidence.",
+      "UserStory": "As a maintainer updating PROJECT-DEFINITION narratives, I want staleness flags to clear after I review them, so that project:render stays actionable instead of noisy on every run.",
+      "Traces": "deftai/directive#640"
+    },
+    "items": [
+      {
+        "id": "story-640-project-render-staleness-ack-a1",
+        "title": "Given completed scopes trigger staleness_flags on first render, when the operator acknowledges reviewed narratives, then a subsequent project:render without new completed scopes emits zero repeat flags for those narratives.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given completed scopes trigger staleness_flags on first render, when the operator acknowledges reviewed narratives, then a subsequent project:render without new completed scopes emits zero repeat flags for those narratives.",
+          "Traces": "deftai/directive#640"
+        }
+      },
+      {
+        "id": "story-640-project-render-staleness-ack-a2",
+        "title": "Given new completed scopes land after acknowledgement, when project:render runs, then only the affected narratives are flagged again.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given new completed scopes land after acknowledgement, when project:render runs, then only the affected narratives are flagged again.",
+          "Traces": "deftai/directive#640"
+        }
+      },
+      {
+        "id": "story-640-project-render-staleness-ack-a3",
+        "title": "Given the acknowledgement path, when used, then it is documented as distinct from task reconcile:issues origin reconciliation.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the acknowledgement path, when used, then it is documented as distinct from task reconcile:issues origin reconciliation.",
+          "Traces": "deftai/directive#640"
+        }
+      },
+      {
+        "id": "story-640-project-render-staleness-ack-a4",
+        "title": "Given packages/core/src/render/project-render.test.ts, when it runs, then initial emission, acknowledgement, no-repeat, and re-flag scenarios pass.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given packages/core/src/render/project-render.test.ts, when it runs, then initial emission, acknowledgement, no-repeat, and re-flag scenarios pass.",
+          "Traces": "deftai/directive#640"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/render/project-render.ts",
+          "packages/core/src/render/project-render.test.ts",
+          "tasks/project.yml"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test project-render"
+        ],
+        "expected_outputs": [
+          "staleness acknowledgement metadata persisted",
+          "repeat flags suppressed after review"
+        ],
+        "depends_on": [],
+        "conflict_group": "project-render",
+        "size": "M",
+        "file_scope_confidence": "medium",
+        "model_tier": "high"
+      },
+      "completedAt": "2026-06-28T15:10:26Z",
+      "capacityBucket": "new-capability"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/640",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #640: project:render staleness flags need an acknowledgement/clear path after PROJECT-DEFINITION review",
+        "TrustLevel": "external"
+      }
+    ],
+    "updated": "2026-06-28T15:10:26Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `plan.metadata.staleness_review` watermark so `task project:render` suppresses repeat narrative staleness flags after operator review
- Expose `task project:ack-staleness` (and `--acknowledge-staleness` CLI flag) as the acknowledgement path, documented as distinct from `task reconcile:issues`
- Add unit tests for initial emission, acknowledgement, no-repeat, and re-flag on new completed scopes

Closes #640

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/render/project-render.test.ts`
- [x] `pnpm exec biome check` on changed render files
- [x] `pnpm run build`


Made with [Cursor](https://cursor.com)