### PR TITLE
feat: port setup:ghx to native TypeScript (#2022 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Supported ghx install verb** — `directive setup:ghx` (and `task setup:ghx`) is now a native TypeScript command with consent-gated install (default deny); `task setup` nudges when `gh` is present but ghx is missing. Refs #2022.
 
 ### Changed
 - **The conception-to-ship lifecycle diagram now ships with your install** — the single-picture overview of how Directive turns an idea into shipped work (inception strategy analysis feeding the recurring per-session triage→slice→swarm→review→ship loop) moved into the installed `.deft/core/docs/` payload and is cross-linked from the getting-started guide, so adopters can see the framework's overall shape without visiting the upstream repo. Documentation only.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Security posture, audit cadence, and vulnerability-reporting flow live in [`docs
 
 **GitHub** is the primary supported SCM platform. Skills that interact with issues and PRs (`deft-directive-sync`, `deft-directive-swarm`, `deft-directive-review-cycle`, `deft-directive-refinement`, `deft-directive-release`, `deft-directive-gh-slice`, `deft-directive-gh-arch`) require the [GitHub CLI (`gh`)](https://cli.github.com/) to be installed and authenticated. Core framework features (setup, build, rendering, validation) work independently of any SCM platform.
 
+**ghx (recommended proxy):** When `gh` is on PATH, Deft automatically prefers [ghx](https://github.com/brunoborges/ghx) — a read-only cache proxy for `gh` — if it is installed. ghx speeds up repeated GitHub API reads and helps multi-agent swarms stay under rate limits. Install it with consent via `directive setup:ghx` (or `task setup:ghx`); `task setup` nudges you when `gh` is present but `ghx` is missing. Consumer projects only require `gh`; ghx is optional but supported.
+
 The migration script (`task migrate:vbrief`) defaults origin provenance to `x-vbrief/github-issue` type. Non-GitHub users should manually adjust `references[].type` in generated vBRIEFs after migration.
 
 ## 📦 Content packs

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -512,6 +512,8 @@ tasks:
   setup:
     desc: "Idempotent local-dev setup: configure git hooks (#747); detect-and-prompt ghx (#884). Sets core.hooksPath=.githooks so .githooks/pre-commit + .githooks/pre-push run."
     dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - verify:_ts-build
     env:
       PYTHONUTF8: "1"
     cmds:
@@ -568,24 +570,19 @@ tasks:
       # GitHub CLI cache proxy. Default invocation here passes --check so
       # `task setup` never prompts on a clean re-run; operators wanting to
       # opt in run `task setup:ghx` (defined below) which is the
-      # interactive entry point. The script is pure-stdlib so it works
-      # before `uv sync` has run on a fresh worktree; `uv run` is still
-      # the canonical dispatcher to keep the python interpreter consistent
-      # with every other Taskfile-dispatched script. `--project` pins uv
-      # to the framework root so ancestor pyproject.toml files cannot
-      # hijack the resolver via uv's upward walk (#1011).
-      - uv --project "{{.TASKFILE_DIR}}" run python "{{.TASKFILE_DIR}}/scripts/setup_ghx.py" --check
+      # interactive entry point. Native TypeScript handler (#2022 Phase 1).
+      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" setup:ghx --check
 
   setup:ghx:
     desc: "Consent-gated ghx (brunoborges/ghx) installer (#884) -- task setup:ghx [-- --yes]"
     dir: '{{.USER_WORKING_DIR}}'
-    env:
-      PYTHONUTF8: "1"
+    deps:
+      - verify:_ts-build
     # Per `conventions/task-caching.md` (#574): no `sources:` / `generates:`
     # because the script forwards user-facing flags via {{.CLI_ARGS}}
     # (notably --yes for non-interactive CI / scripted approval).
     cmds:
-      - uv --project "{{.TASKFILE_DIR}}" run python "{{.TASKFILE_DIR}}/scripts/setup_ghx.py" {{.CLI_ARGS}}
+      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" setup:ghx {{.CLI_ARGS}}
 
   # Release pipeline tasks (#74 + #716 safety hardening, namespace flatten #718).
   #

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -214,6 +214,26 @@ Following a v1.0.0 release, commits:
 - ⊗ Allow force pushes
 - ⊗ Allow deletions
 
+## ghx cache proxy (#884)
+
+[ghx](https://github.com/brunoborges/ghx) is a **supported, recommended** read-only cache proxy for the GitHub CLI. Deft's SCM layer (`resolveBinary` in `@deftai/directive-core/scm`) prefers `ghx` over `gh` when both are on PATH, so consumers benefit automatically once ghx is installed. ghx is optional for consumer projects — only `gh` is required — but strongly recommended for maintainers and multi-agent swarms that issue many read-only `gh api` / `gh issue view` calls.
+
+**Install (consent-gated, default deny):**
+
+```bash
+directive setup:ghx          # interactive y/N prompt (default: no)
+task setup:ghx               # same via Taskfile
+task setup:ghx -- --yes      # non-interactive CI / scripted approval
+```
+
+`task setup` runs a detection-only `--check` pass and nudges when `gh` is present but `ghx` is missing. Set `DEFT_SETUP_GHX_SKIP=1` to suppress the interactive install path in non-interactive shells.
+
+**Surface rules:**
+
+- ! Prefer `ghx` over `gh` for read-only GET operations when ghx is on PATH
+- ! Use live `gh` for mutations (POST/PATCH/PUT/DELETE) and for immediate read-back after a mutation — ghx is a cached GET proxy only
+- ⊗ Use `ghx api` for multi-arg write invocations — ghx accepts a single positional path arg; writes fall through to `gh`
+
 ## Destructive gh verbs (#1019)
 
 A detection-bound gate (`scripts/preflight_gh.py`) refuses three classes of destructive surface before they execute, complementing the #747 branch-protection gate which already refuses commits to the default branch:
@@ -233,8 +253,6 @@ Three enforcement surfaces back the gate:
 - `DEFT_ALLOW_DESTRUCTIVE_GH_VERBS=1` -- per-shell emergency env-var bypass. Mirrors `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT` (#747). The gate prints an explicit `policy bypassed for this session` line so the bypass is auditable after the fact.
 - For repo deletion specifically: prefer the GitHub web UI's archive-or-delete prompt -- archiving is reversible, the gate is not opining on it.
 - For an admin merge: the canonical recovery is to request review through the normal flow. The `--admin` flag is gated because the most-common legitimate use case (release hot-fix) is rare enough that documenting an explicit bypass is cheaper than letting the verb pass by default.
-
-**Out of scope (v1):** a PATH-shim that intercepts `gh` at the command layer is deferred -- the consent-gated install path mirrors `setup_ghx.py` (#884) and lands additively when a follow-up issue is opened. The current gate is detection-bound (pre-push hook + agent-side `--command` classifier + self-test contract) rather than execution-bound, which is sufficient to refuse the recurring failure mode that motivated #1019 (an agent with an unrestricted `gh` token executing a destructive verb).
 
 ## Release Workflow (UCCPR)
 

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -7,10 +7,14 @@ import {
   CLI_MODULE_VERBS,
   CORE_MODULE_VERBS,
   dispatch,
+  GHX_VERSION,
+  INSTALL_PS1_URL,
+  INSTALL_SH_URL,
   printHelp,
   registeredVerbs,
   resetHandlerCacheForTests,
   resolveCanonicalVerb,
+  runSetupGhx,
   VERB_ALIASES,
 } from "./dispatch.js";
 
@@ -996,5 +1000,100 @@ describe("native policy-set handler (#2022)", () => {
     const result = await runPolicy(["wip-cap", "--confirm", "--project-root", root]);
     expect(result.code).toBe(2);
     expect(result.err).toContain("required: --set");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Native setup:ghx handler (#2022 Phase 1).
+//
+// Verifies the consent-gated ghx installer (formerly scripts/setup_ghx.py)
+// routes to a native TypeScript handler with default-deny consent.
+// ---------------------------------------------------------------------------
+
+describe("native setup:ghx handler (#2022)", () => {
+  function captureIo(): { io: { writeOut: (t: string) => void; writeErr: (t: string) => void }; out: string[]; err: string[] } {
+    const out: string[] = [];
+    const err: string[] = [];
+    return {
+      io: {
+        writeOut: (t) => out.push(t),
+        writeErr: (t) => err.push(t),
+      },
+      out,
+      err,
+    };
+  }
+
+  async function runSetup(argv: string[]): Promise<{
+    code: number;
+    out: string;
+    err: string;
+  }> {
+    const { io, out, err } = captureIo();
+    const code = await dispatch(["setup:ghx", ...argv], io);
+    return { code, out: out.join(""), err: err.join("") };
+  }
+
+  it("registers setup:ghx as a native core handler", () => {
+    expect(CORE_MODULE_VERBS).toContain("setup-ghx");
+    expect(resolveCanonicalVerb("setup:ghx")).toBe("setup-ghx");
+    expect(VERB_ALIASES["setup:ghx"]).toBe("setup-ghx");
+  });
+
+  it("skips install when ghx is already on PATH", () => {
+    const { io, out } = captureIo();
+    const code = runSetupGhx([], io, {
+      whichFn: (name) => (name === "ghx" ? "/usr/local/bin/ghx" : null),
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("ghx already on PATH");
+  });
+
+  it("--check nudges directive setup:ghx when gh is present but ghx is missing", () => {
+    const { io, out } = captureIo();
+    const code = runSetupGhx(["--check"], io, {
+      whichFn: (name) => (name === "gh" ? "/usr/bin/gh" : null),
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("gh is on PATH but ghx is not");
+    expect(out.join("")).toContain("directive setup:ghx");
+  });
+
+  it("declines install by default when consent is empty (default deny)", () => {
+    const { io, out } = captureIo();
+    const code = runSetupGhx([], io, {
+      whichFn: () => null,
+      readConsentLine: () => "\n",
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("Skipping ghx install");
+  });
+
+  it("installs only when consent is explicitly yes", () => {
+    const { io, out } = captureIo();
+    let installed = false;
+    const code = runSetupGhx([], io, {
+      whichFn: () => null,
+      readConsentLine: () => "yes\n",
+      runInstall: () => {
+        installed = true;
+        return 0;
+      },
+    });
+    expect(code).toBe(0);
+    expect(installed).toBe(true);
+    expect(out.join("")).toContain("ghx installed");
+  });
+
+  it("rejects --yes and --check together with exit code 2", async () => {
+    const result = await runSetup(["--yes", "--check"]);
+    expect(result.code).toBe(2);
+    expect(result.err).toContain("mutually exclusive");
+  });
+
+  it("pins installer URLs to GHX_VERSION", () => {
+    expect(INSTALL_PS1_URL).toContain(`/${GHX_VERSION}/`);
+    expect(INSTALL_SH_URL).toContain(`/${GHX_VERSION}/`);
+    expect(INSTALL_PS1_URL).not.toContain("/main/");
   });
 });

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -3,10 +3,20 @@
  * Routes to ported command modules in packages/cli and packages/core.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { engineInfo } from "@deftai/directive-core";
+import { defaultWhich, type WhichFn } from "@deftai/directive-core/scm";
 import {
   appendAuditLog,
   disclosureLine,
@@ -149,6 +159,7 @@ export const CORE_MODULE_VERBS = [
   "pack-migrate-patterns",
   "pack-migrate-swarm-spec",
   "policy-set",
+  "setup-ghx",
   "scope-undo",
   "scope-demote",
   "scope-decompose",
@@ -202,6 +213,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "project:render": "project-render",
   doctor: "doctor",
   build: "framework-commands",
+  "setup:ghx": "setup-ghx",
 };
 
 /** CLI modules living under verify-source-cli/ or content-validate-cli/ subdirs. */
@@ -1193,6 +1205,200 @@ function runPackMigrateSwarmSpec(argv: string[], io: DispatchIo): number {
 }
 
 // ===========================================================================
+// Native setup:ghx handler (#2022 Phase 1).
+//
+// Port of scripts/setup_ghx.py to native TypeScript: consent-gated ghx proxy
+// installer with three-state exit (0 ok / 1 install failure / 2 config error).
+// ===========================================================================
+
+/** Pinned ghx version — keep in lockstep with .github/workflows/ci.yml env.GHX_VERSION. */
+export const GHX_VERSION = "v1.5.1";
+
+export const INSTALL_PS1_URL = `https://raw.githubusercontent.com/brunoborges/ghx/${GHX_VERSION}/install.ps1`;
+export const INSTALL_SH_URL = `https://raw.githubusercontent.com/brunoborges/ghx/${GHX_VERSION}/install.sh`;
+
+export type SetupGhxHost = "windows" | "darwin" | "linux" | string;
+
+export interface SetupGhxDeps {
+  whichFn?: WhichFn;
+  readConsentLine?: () => string;
+  runInstall?: (host: SetupGhxHost) => number;
+}
+
+interface SetupGhxArgs {
+  yes: boolean;
+  check: boolean;
+  error?: string;
+}
+
+function parseSetupGhxArgs(argv: readonly string[]): SetupGhxArgs {
+  let yes = false;
+  let check = false;
+  for (const arg of argv) {
+    if (arg === "--yes") {
+      yes = true;
+    } else if (arg === "--check") {
+      check = true;
+    } else {
+      return { yes, check, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return { yes, check };
+}
+
+export function ghxPresent(whichFn: WhichFn = defaultWhich): boolean {
+  return whichFn("ghx") !== null;
+}
+
+export function detectSetupGhxHost(): SetupGhxHost {
+  if (process.platform === "win32") return "windows";
+  if (process.platform === "darwin") return "darwin";
+  if (process.platform === "linux") return "linux";
+  return process.platform;
+}
+
+function readConsentLineFromStdin(): string {
+  const buf = Buffer.alloc(256);
+  try {
+    const n = readSync(0, buf, 0, 256, null);
+    if (n === null || n <= 0) return "";
+    return buf.toString("utf8", 0, n);
+  } catch {
+    return "";
+  }
+}
+
+export function promptSetupGhxConsent(
+  io: DispatchIo,
+  readLine: () => string = readConsentLineFromStdin,
+): boolean {
+  io.writeOut(
+    "\n[setup_ghx] ghx is the recommended GitHub CLI cache proxy for deft " +
+      "maintainers (prevents rate-limiting in multi-agent swarms; speeds up " +
+      "scm:* calls). Consumer projects only require gh.\n",
+  );
+  io.writeOut(`[setup_ghx] Upstream: https://github.com/brunoborges/ghx (${GHX_VERSION})\n`);
+  io.writeOut("[setup_ghx] Install ghx via the upstream installer? [y/N]: ");
+  const answer = readLine().trim().toLowerCase();
+  return answer === "y" || answer === "yes";
+}
+
+export function buildSetupGhxInstallCommand(host: SetupGhxHost, whichFn: WhichFn = defaultWhich): string[] {
+  if (host === "windows") {
+    const psBin = whichFn("pwsh") ?? whichFn("powershell") ?? "powershell";
+    return [
+      psBin,
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      `irm ${INSTALL_PS1_URL} | iex`,
+    ];
+  }
+  if (host === "darwin" || host === "linux") {
+    return ["bash", "-c", `curl -fsSL ${INSTALL_SH_URL} | bash`];
+  }
+  throw new Error(
+    `no upstream ghx installer available for host '${host}'; ` +
+      "see https://github.com/brunoborges/ghx#install for manual options",
+  );
+}
+
+export function installSetupGhx(
+  host: SetupGhxHost,
+  whichFn: WhichFn = defaultWhich,
+  runner: typeof spawnSync = spawnSync,
+): number {
+  const cmd = buildSetupGhxInstallCommand(host, whichFn);
+  const proc = runner(cmd[0] ?? "", cmd.slice(1), {
+    env: { ...process.env, GHX_VERSION },
+    stdio: "inherit",
+  });
+  return proc.status ?? 1;
+}
+
+/** Native `setup:ghx` handler (replaces scripts/setup_ghx.py shell-out, #2022 Phase 1). */
+export function runSetupGhx(argv: string[], io: DispatchIo, deps: SetupGhxDeps = {}): number {
+  const args = parseSetupGhxArgs(argv);
+  if (args.error !== undefined) {
+    io.writeErr(`setup-ghx: ${args.error}\n`);
+    return 2;
+  }
+
+  if (args.yes && args.check) {
+    io.writeErr("[setup_ghx] error: --yes and --check are mutually exclusive.\n");
+    return 2;
+  }
+
+  const whichFn = deps.whichFn ?? defaultWhich;
+
+  if (ghxPresent(whichFn)) {
+    io.writeOut("[setup_ghx] ghx already on PATH -- skipping install.\n");
+    return 0;
+  }
+
+  if (args.check) {
+    if (whichFn("gh") !== null) {
+      io.writeOut(
+        "[setup_ghx] gh is on PATH but ghx is not; ghx is the recommended GitHub CLI " +
+          "cache proxy. Install with `directive setup:ghx` (or `task setup:ghx`). Refs #884.\n",
+      );
+    } else {
+      io.writeOut(
+        "[setup_ghx] ghx not on PATH; recommended for speed -- run `directive setup:ghx` " +
+          "to opt in. Consumer projects only require gh. Refs #884.\n",
+      );
+    }
+    return 0;
+  }
+
+  let consent: boolean;
+  if (args.yes) {
+    consent = true;
+    io.writeOut("[setup_ghx] --yes provided; skipping interactive consent prompt.\n");
+  } else {
+    const skip = (process.env.DEFT_SETUP_GHX_SKIP ?? "").trim();
+    if (skip === "1" || skip.toLowerCase() === "true" || skip.toLowerCase() === "yes") {
+      io.writeOut("[setup_ghx] DEFT_SETUP_GHX_SKIP set; skipping ghx install. Refs #884.\n");
+      return 0;
+    }
+    const readLine = deps.readConsentLine ?? readConsentLineFromStdin;
+    consent = promptSetupGhxConsent(io, readLine);
+  }
+
+  if (!consent) {
+    io.writeOut(
+      "[setup_ghx] Skipping ghx install. ghx is recommended for speed for maintainers and " +
+        "swarm runs; consumer projects only require gh " +
+        "(see https://github.com/brunoborges/ghx, #884).\n",
+    );
+    return 0;
+  }
+
+  const host = detectSetupGhxHost();
+  const runInstall = deps.runInstall ?? ((h) => installSetupGhx(h, whichFn));
+  try {
+    const rc = runInstall(host);
+    if (rc !== 0) {
+      io.writeErr(
+        `[setup_ghx] error: upstream installer exited ${rc}. ` +
+          "See https://github.com/brunoborges/ghx#install for manual options.\n",
+      );
+      return 1;
+    }
+    io.writeOut(
+      "[setup_ghx] ghx installed. Open a fresh shell so the updated PATH takes effect, " +
+        "then re-run `task setup` to verify.\n",
+    );
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    io.writeErr(`[setup_ghx] error: ${message}\n`);
+    return 1;
+  }
+}
+
+// ===========================================================================
 // Native policy-set handler (#2022 Phase 1).
 //
 // Port of scripts/policy_set.py to native TypeScript so the typed-policy write
@@ -1793,6 +1999,8 @@ async function loadCoreModuleHandler(verb: string, io: DispatchIo): Promise<Comm
       return (argv) => runPackMigrateSwarmSpec(argv, io);
     case "policy-set":
       return (argv) => runPolicySet(argv, io);
+    case "setup-ghx":
+      return (argv) => runSetupGhx(argv, io);
     case "scope-undo": {
       const { undoMain } = await import("@deftai/directive-core/dist/scope/main.js");
       return undoMain;


### PR DESCRIPTION
## Summary
- Adds a native TypeScript `setup:ghx` / `setup-ghx` dispatch handler with consent-gated install (default deny) and three-state exit codes
- Repoints `task setup` and `task setup:ghx` from `scripts/setup_ghx.py` to the TS CLI
- Emits a setup-time nudge when `gh` is on PATH but `ghx` is missing, pointing operators at `directive setup:ghx`
- Documents ghx as a supported recommended proxy in README and `content/scm/github.md`

Refs #2022 (Phase 1 setup:ghx TS port)

## Test plan
- [x] `pnpm exec vitest run packages/cli/src/dispatch.test.ts` (65 passed)
- [x] Pre-commit hooks (branch gate, encoding, vbrief conformance on staged files)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)