### PR TITLE
fix: skip HEAD-only branch gate on pre-push (#1814)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,17 @@
 #!/usr/bin/env sh
-# .githooks/pre-push -- detection-bound branch-protection gate (#747).
+# .githooks/pre-push -- refspec-aware default-branch push gate (#1019 / #1814).
 #
 # Activated by `git config core.hooksPath .githooks` -- idempotent setup
 # performed by `task setup` (the directive repo itself) OR by the deft
 # installer, which copies this hook to the consumer root .githooks/ and sets
-# core.hooksPath for vendored consumer projects (#1463). Mirrors the
-# pre-commit shape: pre-push defends against the case where a user opted out
-# at commit time (e.g. DEFT_ALLOW_DEFAULT_BRANCH_COMMIT in a single shell)
-# but still tries to push to the default branch in a fresh shell. The same
-# scripts run in both hooks so behavior stays consistent.
+# core.hooksPath for vendored consumer projects (#1463).
+#
+# Pre-push does NOT invoke preflight_branch.py (#747 gate #1). That gate
+# inspects HEAD only, so benign operations checked out on the default branch
+# (deleting a merged feature branch, pushing a non-default ref) false-positive
+# before the refspec-aware gate can approve them (#1814 Option A). HEAD-only
+# default-branch protection remains on pre-commit; pre-push relies on
+# preflight_gh --pre-push-stdin (gate #2) for refspec-aware protection.
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 if [ -z "$REPO_ROOT" ]; then
@@ -111,9 +114,7 @@ deft_py() {
     fi
 }
 
-deft_py "$SCRIPTS_DIR/preflight_branch.py" --project-root "$REPO_ROOT" || exit $?
-
-# Step 2: destructive-gh-verb gate (#1019). Reads per-ref stdin lines from
+# Refspec-aware default-branch push gate (#1019). Reads per-ref stdin lines from
 # git pre-push (one line per ref: <local_ref> <local_oid> <remote_ref> <remote_oid>)
 # and refuses pushes touching the default branch (force-push or otherwise).
 # DEFT_ALLOW_DESTRUCTIVE_GH_VERBS=1 is the per-shell emergency bypass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The conception-to-ship lifecycle diagram now ships with your install** — the single-picture overview of how Directive turns an idea into shipped work (inception strategy analysis feeding the recurring per-session triage→slice→swarm→review→ship loop) moved into the installed `.deft/core/docs/` payload and is cross-linked from the getting-started guide, so adopters can see the framework's overall shape without visiting the upstream repo. Documentation only.
 
 ### Fixed
+- **Pre-push no longer blocks branch hygiene on the default branch** — deleting merged feature branches or pushing non-default refs while checked out on `main`/`master` no longer hits a misleading default-branch refusal from the HEAD-only hook; pre-push now relies on refspec-aware protection so only pushes that actually touch the default branch are blocked. Closes #1814.
 
 ### Removed
 

--- a/packages/core/src/branch/evaluate.test.ts
+++ b/packages/core/src/branch/evaluate.test.ts
@@ -158,6 +158,24 @@ describe("evaluate", () => {
     expect(result.message).toContain("cannot determine current branch");
     expect(result.message).toContain("install git");
   });
+
+  describe("pre-commit HEAD gate unchanged (#1814)", () => {
+    it("still blocks commits on master when policy disallows direct commits", () => {
+      const r = root();
+      writeProjectDef(r, { policy: { allowDirectCommitsToMaster: false } });
+      const result = evaluate(r, { branchOverride: { branch: "master", detached: false } });
+      expect(result.exitCode).toBe(1);
+      expect(result.message).toContain("refusing to commit/push");
+    });
+
+    it("still passes on feature branches for pre-commit", () => {
+      const r = root();
+      writeProjectDef(r, { policy: { allowDirectCommitsToMaster: false } });
+      const result = evaluate(r, { branchOverride: { branch: "feat/hygiene", detached: false } });
+      expect(result.exitCode).toBe(0);
+      expect(result.message).toContain("feature branch");
+    });
+  });
 });
 
 describe("currentBranch", () => {

--- a/tests/cli/test_hooks_encoding.py
+++ b/tests/cli/test_hooks_encoding.py
@@ -77,9 +77,9 @@ HOOK_SCRIPTS: list[tuple[str, str, list[str], dict[str, str]]] = [
         {"_init_git_repo": "1"},
     ),
     (
-        # #1019: detection-bound gate for destructive ``gh`` verbs. Invoked
-        # from .githooks/pre-push AFTER preflight_branch via
-        # ``preflight_gh.py --pre-push-stdin``. Pinned to the same UTF-8
+        # #1019 / #1814: refspec-aware default-branch push gate. Invoked from
+        # .githooks/pre-push via ``preflight_gh.py --pre-push-stdin`` (the
+        # sole pre-push gate after #1814 Option A). Pinned to the same UTF-8
         # self-reconfigure contract; the --self-test mode is exercised here
         # because it deterministically prints the U+2713 success glyph
         # without depending on git pre-push stdin shape.
@@ -140,10 +140,11 @@ def test_audit_only_preflight_branch_is_hook_invoked():
     """Defence-in-depth: if a future hook script lands, this test fails loudly.
 
     The audit surface is the union of scripts under ``scripts/`` referenced
-    from any file in ``.githooks/``. Today that set is exactly
-    ``scripts/preflight_branch.py``. When a new hook script is added, the
-    HOOK_SCRIPTS registry above MUST grow a corresponding entry so the
-    contract test runs against it. This test detects the gap structurally
+    from any file in ``.githooks/``. Pre-commit invokes
+    ``scripts/preflight_branch.py``; pre-push invokes
+    ``scripts/preflight_gh.py`` (#1814 Option A). When a new hook script is
+    added, the HOOK_SCRIPTS registry above MUST grow a corresponding entry so
+    the contract test runs against it. This test detects the gap structurally
     by re-doing the audit at test time.
     """
     referenced: set[str] = set()

--- a/tests/cli/test_preflight_branch.py
+++ b/tests/cli/test_preflight_branch.py
@@ -278,3 +278,15 @@ def test_git_not_found_returns_config_error(preflight, tmp_path, monkeypatch):
     assert code == 2
     assert "cannot determine current branch" in msg
     assert "install git" in msg
+
+
+def test_pre_commit_blocks_master_unchanged_after_1814(preflight, tmp_path, monkeypatch):
+    """#1814: pre-commit still uses HEAD-only gate; master commits remain blocked."""
+    _write_project_def(tmp_path, {"policy": {"allowDirectCommitsToMaster": False}})
+    _stub_branch(monkeypatch, preflight, "master")
+    monkeypatch.delenv(preflight.ENV_SETUP_EXEMPTION, raising=False)
+    monkeypatch.delenv("DEFT_ALLOW_DEFAULT_BRANCH_COMMIT", raising=False)
+    code, msg = preflight.evaluate(tmp_path)
+    assert code == 1
+    assert "refusing to commit/push" in msg
+    assert "master" in msg

--- a/tests/cli/test_preflight_gh.py
+++ b/tests/cli/test_preflight_gh.py
@@ -255,6 +255,39 @@ def test_evaluate_pre_push_feature_branch_passes(preflight, monkeypatch):
     assert "no pushes to default branches" in msg
 
 
+def test_evaluate_pre_push_feature_branch_deletion_passes(preflight, monkeypatch):
+    """#1814: deleting a feature branch while HEAD is main must not block.
+
+    Simulates ``git push origin --delete feature-x`` checked out on main:
+    local OID is zero, remote_ref is the feature branch (not default).
+    """
+    monkeypatch.delenv(preflight.ENV_BYPASS, raising=False)
+    refs = [("(delete)", _ZERO, "refs/heads/feature-x", _SHA_B)]
+    code, msg = preflight.evaluate_pre_push(refs)
+    assert code == 0
+    assert "no pushes to default branches" in msg
+
+
+def test_evaluate_pre_push_main_update_from_main_head_blocks(preflight, monkeypatch):
+    """#1814: gate #2 still blocks pushing commits to refs/heads/main."""
+    monkeypatch.delenv(preflight.ENV_BYPASS, raising=False)
+    refs = [("refs/heads/main", _SHA_A, "refs/heads/main", _SHA_B)]
+    code, msg = preflight.evaluate_pre_push(refs)
+    assert code == 1
+    assert "refusing to push" in msg
+    assert "main" in msg
+
+
+def test_main_pre_push_stdin_feature_delete_passes(preflight, monkeypatch, capsys):
+    """End-to-end: --pre-push-stdin allows feature-branch deletion on default HEAD."""
+    monkeypatch.delenv(preflight.ENV_BYPASS, raising=False)
+    stdin = io.StringIO(f"(delete) {_ZERO} refs/heads/feature-x {_SHA_B}\n")
+    code = preflight.main(["--pre-push-stdin"], stdin=stdin)
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "no pushes to default branches" in out
+
+
 def test_evaluate_pre_push_default_branch_update_blocks(preflight, monkeypatch):
     monkeypatch.delenv(preflight.ENV_BYPASS, raising=False)
     refs = [("refs/heads/feat/x", _SHA_A, "refs/heads/master", _SHA_B)]

--- a/tests/cli/test_release_branch_gate.py
+++ b/tests/cli/test_release_branch_gate.py
@@ -1,9 +1,10 @@
 """test_release_branch_gate.py -- regression coverage for #867.
 
 The #747 detection-bound branch gate (`.githooks/pre-commit` ->
-`scripts/preflight_branch.py`, also `.githooks/pre-push`) refuses
-unauthorised commits / pushes on the default branch. The release
-pipeline (`scripts/release.py`) is the canonical authorised
+`scripts/preflight_branch.py`) refuses unauthorised commits on the
+default branch. Pre-push no longer invokes `preflight_branch.py` (#1814
+Option A); refspec-aware protection is `preflight_gh.py --pre-push-stdin`.
+The release pipeline (`scripts/release.py`) is the canonical authorised
 commit-on-master path: by design it commits release artifacts
 (CHANGELOG.md, ROADMAP.md, pyproject.toml, uv.lock) on master and then
 tags + pushes that commit.

--- a/tests/content/test_branch_gate.py
+++ b/tests/content/test_branch_gate.py
@@ -3,8 +3,8 @@
 Asserts the surfaces around `scripts/preflight_branch.py` exist and
 reference each other consistently:
 
-- ``.githooks/pre-commit`` and ``.githooks/pre-push`` exist and call the
-  preflight script.
+- ``.githooks/pre-commit`` calls ``preflight_branch.py``; ``.githooks/pre-push``
+  calls ``preflight_gh.py --pre-push-stdin`` only (#1814 Option A).
 - ``Taskfile.yml`` aggregate ``check`` task includes ``verify:branch``.
 - ``tasks/verify.yml`` declares ``branch`` and ``hooks-installed`` tasks.
 - ``tasks/policy.yml`` declares the policy:* surface.
@@ -39,10 +39,13 @@ def test_pre_commit_hook_exists_and_calls_script():
     assert ".deft/core/scripts" in text
 
 
-def test_pre_push_hook_exists_and_calls_script():
+def test_pre_push_hook_exists_and_calls_refspec_gate():
     text = _read(".githooks/pre-push")
-    # #1463: layout-aware resolution (see test_pre_commit_hook above).
-    assert "preflight_branch.py" in text
+    # #1814 Option A: pre-push skips HEAD-only preflight_branch invocation; gate #2
+    # is refspec-aware via preflight_gh --pre-push-stdin.
+    assert 'deft_py "$SCRIPTS_DIR/preflight_branch.py"' not in text
+    assert "preflight_gh.py" in text
+    assert "--pre-push-stdin" in text
     assert "SCRIPTS_DIR" in text
     assert ".deft/core/scripts" in text
 


### PR DESCRIPTION
## Summary
- Remove `preflight_branch.py` (gate #1) from `.githooks/pre-push` so HEAD-only default-branch checks no longer false-positive when checked out on `main`/`master`.
- Pre-push now relies solely on `preflight_gh.py --pre-push-stdin` for refspec-aware default-branch protection.
- Pre-commit `preflight_branch` behavior is unchanged.

## User impact
- Deleting merged feature branches while on the default branch no longer requires `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1`.
- Pushes that actually update the default branch remain blocked by gate #2.

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/branch/evaluate.test.ts`
- [x] `uv run pytest tests/cli/test_preflight_gh.py tests/cli/test_preflight_branch.py tests/content/test_branch_gate.py`
- [x] `task check`

Closes #1814

Made with [Cursor](https://cursor.com)