### PR TITLE
fix: biome format for setup:ghx dispatch (#2022 follow-up)

### DIFF
--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -1011,7 +1011,11 @@ describe("native policy-set handler (#2022)", () => {
 // ---------------------------------------------------------------------------
 
 describe("native setup:ghx handler (#2022)", () => {
-  function captureIo(): { io: { writeOut: (t: string) => void; writeErr: (t: string) => void }; out: string[]; err: string[] } {
+  function captureIo(): {
+    io: { writeOut: (t: string) => void; writeErr: (t: string) => void };
+    out: string[];
+    err: string[];
+  } {
     const out: string[] = [];
     const err: string[] = [];
     return {

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -16,7 +16,6 @@ import {
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { engineInfo } from "@deftai/directive-core";
-import { defaultWhich, type WhichFn } from "@deftai/directive-core/scm";
 import {
   appendAuditLog,
   disclosureLine,
@@ -25,6 +24,7 @@ import {
   resolveWipCap,
   setPolicy,
 } from "@deftai/directive-core/policy";
+import { defaultWhich, type WhichFn } from "@deftai/directive-core/scm";
 import {
   KNOWN_SUBAGENT_BACKEND_IDS,
   probeSubagentBackends,
@@ -1283,7 +1283,10 @@ export function promptSetupGhxConsent(
   return answer === "y" || answer === "yes";
 }
 
-export function buildSetupGhxInstallCommand(host: SetupGhxHost, whichFn: WhichFn = defaultWhich): string[] {
+export function buildSetupGhxInstallCommand(
+  host: SetupGhxHost,
+  whichFn: WhichFn = defaultWhich,
+): string[] {
   if (host === "windows") {
     const psBin = whichFn("pwsh") ?? whichFn("powershell") ?? "powershell";
     return [


### PR DESCRIPTION
## Summary
- Applies biome import ordering and formatting fixes for the setup:ghx TS port landed in #2038
- Unblocks master CI (TypeScript build + lint + test was failing on biome check)

Refs #2022

## Test plan
- [x] `pnpm exec biome check packages/cli/src/dispatch.ts packages/cli/src/dispatch.test.ts`
- [ ] CI green


Made with [Cursor](https://cursor.com)