### PR TITLE
fix: route session:start through native TS runSessionStart (#2032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Pre-push no longer blocks branch hygiene on the default branch** — deleting merged feature branches or pushing non-default refs while checked out on `main`/`master` no longer hits a misleading default-branch refusal from the HEAD-only hook; pre-push now relies on refspec-aware protection so only pushes that actually touch the default branch are blocked. Closes #1814.
+- **`directive session:start` works on npm consumer projects** — the command now routes through native TypeScript `runSessionStart()` instead of the Python framework-commands bridge, so ritual state records correctly when `.deft/core` is deposited via `directive init` without requiring Python on PATH. Closes #2032.
 
 ### Removed
 

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -1011,7 +1011,11 @@ describe("native policy-set handler (#2022)", () => {
 // ---------------------------------------------------------------------------
 
 describe("native setup:ghx handler (#2022)", () => {
-  function captureIo(): { io: { writeOut: (t: string) => void; writeErr: (t: string) => void }; out: string[]; err: string[] } {
+  function captureIo(): {
+    io: { writeOut: (t: string) => void; writeErr: (t: string) => void };
+    out: string[];
+    err: string[];
+  } {
     const out: string[] = [];
     const err: string[] = [];
     return {

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -16,7 +16,6 @@ import {
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { engineInfo } from "@deftai/directive-core";
-import { defaultWhich, type WhichFn } from "@deftai/directive-core/scm";
 import {
   appendAuditLog,
   disclosureLine,
@@ -25,6 +24,7 @@ import {
   resolveWipCap,
   setPolicy,
 } from "@deftai/directive-core/policy";
+import { defaultWhich, type WhichFn } from "@deftai/directive-core/scm";
 import {
   KNOWN_SUBAGENT_BACKEND_IDS,
   probeSubagentBackends,
@@ -84,6 +84,7 @@ export const CLI_MODULE_VERBS = [
   "release-publish",
   "release-rollback",
   "scope-lifecycle",
+  "session-start",
   "slice",
   "subagent-monitor",
   "toolchain-check",
@@ -204,7 +205,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "triage:accept": "triage-actions",
   "triage:status": "triage-actions",
   "agents:refresh": "agents-refresh",
-  "session:start": "framework-commands",
+  "session:start": "session-start",
   "toolchain:check": "toolchain-check",
   "ts:check-lane": "ts-check-lane",
   "spec:validate": "spec-validate",
@@ -1283,7 +1284,10 @@ export function promptSetupGhxConsent(
   return answer === "y" || answer === "yes";
 }
 
-export function buildSetupGhxInstallCommand(host: SetupGhxHost, whichFn: WhichFn = defaultWhich): string[] {
+export function buildSetupGhxInstallCommand(
+  host: SetupGhxHost,
+  whichFn: WhichFn = defaultWhich,
+): string[] {
   if (host === "windows") {
     const psBin = whichFn("pwsh") ?? whichFn("powershell") ?? "powershell";
     return [

--- a/packages/cli/src/gates-cli/session-ritual-cli.test.ts
+++ b/packages/cli/src/gates-cli/session-ritual-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { runSessionStart, verifySessionRitual } from "@deftai/directive-core/session";
 import { afterAll, describe, expect, it } from "vitest";
@@ -61,11 +61,44 @@ describe("session:start TS module (maps tests/cli/test_session_start.py)", () =>
 });
 
 describe("deft-ts session:start dispatcher smoke", () => {
-  it("framework-commands session:start is registered (Python oracle path)", () => {
+  it("native session:start records ritual state without framework-commands bridge (#2032)", () => {
     const root = seedProject();
     roots.push(root);
-    const { exitCode } = runDeftTs("framework-commands", ["session:start", "--project-root", root]);
-    expect([0, 1, 2]).toContain(exitCode);
+    const { exitCode, stdout, stderr } = runDeftTs("session:start", [
+      "--project-root",
+      root,
+      "--no-history",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Deft Directive active");
+    expect(stdout).toContain("[deft] session ritual recorded at");
+    expect(stderr).toBe("");
+    const statePath = join(root, ".deft", "ritual-state.json");
+    expect(existsSync(statePath)).toBe(true);
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as {
+      quick_steps: Record<string, unknown>;
+    };
+    expect(Object.keys(state.quick_steps).sort()).toEqual(
+      ["alignment", "branch_policy", "triage_welcome"].sort(),
+    );
+  });
+
+  it("session:start alias resolves to session-start handler", () => {
+    const root = seedProject();
+    roots.push(root);
+    const { exitCode } = runDeftTs("session:start", ["--project-root", root, "--no-history"]);
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(root, ".deft", "ritual-state.json"))).toBe(true);
+  });
+
+  it("verify:session-ritual quick tier passes after native session:start", () => {
+    const root = seedProject({ sessionRitualStalenessHours: 4 });
+    roots.push(root);
+    const start = runDeftTs("session:start", ["--project-root", root, "--no-history"]);
+    expect(start.exitCode).toBe(0);
+    const verify = runDeftTs("verify:session-ritual", ["--project-root", root, "--tier=quick"]);
+    expect(verify.exitCode).toBe(0);
+    expect(verify.stdout + verify.stderr).toMatch(/session ritual/i);
   });
 });
 

--- a/packages/cli/src/install-cli/retarget-dispatch.test.ts
+++ b/packages/cli/src/install-cli/retarget-dispatch.test.ts
@@ -111,3 +111,34 @@ describe("retarget: doctor (tests/cli/test_cmd_doctor.py)", () => {
     expect(resolveCanonicalVerb("doctor")).toBe("doctor");
   });
 });
+
+describe("retarget: session:start (tests/cli/test_session_start.py dispatch path)", () => {
+  it("deft-ts session:start routes argv through the session-start CLI module", async () => {
+    const handler = vi.fn(() => 0);
+    vi.doMock("../session-start.js", () => ({ run: handler }));
+    resetHandlerCacheForTests();
+
+    const code = await dispatch(["session:start", "--project-root", "/tmp/x", "--no-history"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+    expect(code).toBe(0);
+    expect(handler).toHaveBeenCalledWith(["--project-root", "/tmp/x", "--no-history"]);
+  });
+
+  it("deft-ts session:start propagates non-zero exit codes", async () => {
+    const handler = vi.fn(() => 2);
+    vi.doMock("../session-start.js", () => ({ run: handler }));
+    resetHandlerCacheForTests();
+
+    const code = await dispatch(["session:start"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+    expect(code).toBe(2);
+  });
+
+  it("resolveCanonicalVerb maps session:start to session-start", () => {
+    expect(resolveCanonicalVerb("session:start")).toBe("session-start");
+  });
+});

--- a/packages/cli/src/session-start.test.ts
+++ b/packages/cli/src/session-start.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "./session-start.js";
+
+describe("session-start parseArgs", () => {
+  it("defaults project root to cwd", () => {
+    expect(parseArgs([])).toEqual({
+      projectRoot: ".",
+      deferValues: [],
+      emitJson: false,
+      noHistory: false,
+    });
+  });
+
+  it("parses --project-root, --defer, --json, and --no-history", () => {
+    expect(
+      parseArgs([
+        "--project-root",
+        "/tmp/proj",
+        "--defer",
+        "doctor=postponed",
+        "--json",
+        "--no-history",
+      ]),
+    ).toEqual({
+      projectRoot: "/tmp/proj",
+      deferValues: ["doctor=postponed"],
+      emitJson: true,
+      noHistory: true,
+    });
+  });
+
+  it("accepts equals-form flags", () => {
+    expect(parseArgs(["--project-root=/x", "--defer=cache_fresh=later"])).toEqual({
+      projectRoot: "/x",
+      deferValues: ["cache_fresh=later"],
+      emitJson: false,
+      noHistory: false,
+    });
+  });
+
+  it("rejects unknown flags", () => {
+    expect(parseArgs(["--nope"]).error).toContain("unrecognized argument");
+  });
+});

--- a/packages/cli/src/session-start.ts
+++ b/packages/cli/src/session-start.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseDeferrals, ritualStatePath, runSessionStart } from "@deftai/directive-core/session";
+
+export interface ParsedSessionStartArgs {
+  projectRoot: string;
+  deferValues: string[];
+  emitJson: boolean;
+  noHistory: boolean;
+  error?: string;
+}
+
+/** Parse session:start CLI args, mirroring scripts/session_start.py. */
+export function parseArgs(argv: readonly string[]): ParsedSessionStartArgs {
+  const parsed: ParsedSessionStartArgs = {
+    projectRoot: ".",
+    deferValues: [],
+    emitJson: false,
+    noHistory: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      parsed.emitJson = true;
+    } else if (arg === "--no-history") {
+      parsed.noHistory = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg === "--defer") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --defer: expected one argument" };
+      }
+      parsed.deferValues.push(value);
+      i += 1;
+    } else if (arg?.startsWith("--defer=")) {
+      parsed.deferValues.push(arg.slice("--defer=".length));
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Native session:start handler (#2032 — replaces framework-commands Python bridge). */
+export function run(argv: readonly string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`session_start: ${args.error}\n`);
+    return 2;
+  }
+
+  const projectRoot = resolve(args.projectRoot);
+  const { deferrals, errors } = parseDeferrals(args.deferValues);
+  if (errors.length > 0) {
+    for (const error of errors) {
+      process.stderr.write(`${error}\n`);
+    }
+    return 2;
+  }
+
+  const capturedStdout: string[] = [];
+  const prevWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encoding?: BufferEncoding | ((err?: Error | null) => void),
+    callback?: (err?: Error | null) => void,
+  ): boolean => {
+    capturedStdout.push(String(chunk));
+    const cb = typeof encoding === "function" ? encoding : callback;
+    if (typeof cb === "function") {
+      cb();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  let result: ReturnType<typeof runSessionStart>;
+  try {
+    result = runSessionStart(projectRoot, {
+      deferrals,
+      writeHistory: !args.noHistory,
+    });
+  } finally {
+    process.stdout.write = prevWrite;
+  }
+
+  const lines = [...result.lines];
+  const stray = capturedStdout.join("").trim();
+  if (stray) {
+    lines.push(stray);
+  }
+
+  if (args.emitJson) {
+    const sorted = Object.keys(result.payload)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = result.payload[key];
+        return acc;
+      }, {});
+    process.stdout.write(`${JSON.stringify(sorted)}\n`);
+    return result.code;
+  }
+
+  const sink = result.code === 0 ? process.stdout : process.stderr;
+  for (const line of lines) {
+    sink.write(`${line}\n`);
+  }
+  if (result.code === 0) {
+    process.stdout.write(`[deft] session ritual recorded at ${ritualStatePath(projectRoot)}\n`);
+  }
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/src/session/session-start-consumer-root.test.ts
+++ b/packages/core/src/session/session-start-consumer-root.test.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ritualStatePath, runSessionStart } from "./session-start.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+  temps.length = 0;
+});
+
+function seedConsumerProject(): string {
+  const root = mkdtempSync(join(tmpdir(), "session-start-consumer-"));
+  temps.push(root);
+  mkdirSync(join(root, ".deft", "core"), { recursive: true });
+  writeFileSync(join(root, ".deft", "core", "VERSION"), "0.59.0\n", "utf8");
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6" },
+      plan: { title: "Consumer", status: "running", items: [], policy: {} },
+    }),
+    "utf8",
+  );
+  writeFileSync(join(root, "README.md"), "consumer\n", "utf8");
+  execFileSync("git", ["init", "-q"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "c@c.local"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "consumer"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["add", "-A"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["commit", "-q", "-m", "init"], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "consumer",
+      GIT_AUTHOR_EMAIL: "c@c.local",
+      GIT_COMMITTER_NAME: "consumer",
+      GIT_COMMITTER_EMAIL: "c@c.local",
+    },
+  });
+  return root;
+}
+
+describe("runSessionStart consumer project root (#2032)", () => {
+  it("writes ritual-state.json under the consumer project root, not framework deposit", () => {
+    const root = seedConsumerProject();
+    const result = runSessionStart(root, { writeHistory: false });
+    expect(result.code).toBe(0);
+    const statePath = ritualStatePath(root);
+    expect(statePath).toBe(join(root, ".deft", "ritual-state.json"));
+    expect(existsSync(statePath)).toBe(true);
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as {
+      worktree_path: string;
+    };
+    expect(state.worktree_path).toBe(root);
+  });
+});


### PR DESCRIPTION
## Summary
- Route `directive session:start` (and `task session:start`) to a native TypeScript handler that calls `runSessionStart()` from `@deftai/directive-core/session`, replacing the `framework-commands` Python bridge that broke on npm consumer installs.
- Add CLI + integration tests covering ritual-state recording and `verify:session-ritual` quick-tier success after session start.

## Test plan
- [x] `pnpm -w exec vitest run packages/cli/src/gates-cli/session-ritual-cli.test.ts packages/cli/src/session-start.test.ts packages/core/src/session/session-start-consumer-root.test.ts`
- [x] `task check`

Closes #2032

Made with [Cursor](https://cursor.com)