### PR TITLE
feat: gate maintainer Python task lanes behind check:framework-source (#2022 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PROJECT-DEFINITION staleness flags can be cleared after review** — `task project:ack-staleness` records a completed-scope watermark on `plan.metadata.staleness_review` so `task project:render` stops repeating the same narrative warnings until new completed work arrives. Distinct from `task reconcile:issues` (scope origin freshness). Closes #640.
 
 ### Changed
+- **Maintainer Python self-test tasks are gated behind framework-source checks** — `tasks/core.yml` and `tasks/ci.yml` (pytest, ruff, ci_local.py) are now `internal: true` includes wired only through `task check:framework-source`; consumer `task check` continues to dispatch the TS/deft-verb `check:consumer` path with no uv/python subprocesses. Refs #2022.
 - **The conception-to-ship lifecycle diagram now ships with your install** — the single-picture overview of how Directive turns an idea into shipped work (inception strategy analysis feeding the recurring per-session triage→slice→swarm→review→ship loop) moved into the installed `.deft/core/docs/` payload and is cross-linked from the getting-started guide, so adopters can see the framework's overall shape without visiting the upstream repo. Documentation only.
 
 ### Fixed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,9 +70,6 @@ env:
   UV_PROJECT: '{{.TASKFILE_DIR}}'
 
 includes:
-  core:
-    taskfile: ./tasks/core.yml
-    optional: true
   ts:
     taskfile: ./tasks/ts.yml
     optional: true
@@ -140,9 +137,6 @@ includes:
     optional: true
   pr:
     taskfile: ./tasks/pr.yml
-    optional: true
-  ci:
-    taskfile: ./tasks/ci.yml
     optional: true
   policy:
     taskfile: ./tasks/policy.yml
@@ -307,6 +301,19 @@ includes:
   packs:
     taskfile: ./tasks/packs.yml
     optional: true
+  # Maintainer-only Python self-test lanes (#1813 contributor path / #2022
+  # Phase 2). `internal: true` hides `core:*` / `ci:*` from `task -l` and
+  # blocks direct CLI invocation on consumer installs; only
+  # `check:framework-source` below wires them as deps. Consumer `task check`
+  # dispatches to `check:consumer` (TS / deft verbs — no uv/python).
+  core:
+    taskfile: ./tasks/core.yml
+    optional: true
+    internal: true
+  ci:
+    taskfile: ./tasks/ci.yml
+    optional: true
+    internal: true
 
 tasks:
   default:
@@ -326,8 +333,9 @@ tasks:
       - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" check --framework-root "{{.TASKFILE_DIR}}" --project-root "{{.USER_WORKING_DIR}}"
 
   check:framework-source:
-    desc: "Run all framework source-repo pre-commit checks explicitly (skips @pytest.mark.slow tests via pyproject addopts -- run `task check:slow` for the slow lane, #975)."
+    desc: "Run all framework source-repo pre-commit checks explicitly (skips @pytest.mark.slow tests via pyproject addopts -- run `task check:slow` for the slow lane, #975). Sole wired consumer of maintainer-only core:* / ci:* Python lanes (#2022 Phase 2)."
     deps:
+      # Maintainer-only Python lanes (tasks/core.yml) — not on check:consumer.
       - core:validate
       - core:lint
       - core:test
@@ -434,40 +442,24 @@ tasks:
   # addopts=` reset overrides the pyproject default of `-m 'not slow'`
   # so the `-m slow` selector here actually picks up the marked tests.
   check:slow:
-    desc: "Run the @pytest.mark.slow test lane (watchdog regression suite excluded from `task check` by default, #975)"
+    desc: "Run the @pytest.mark.slow test lane (watchdog regression suite excluded from `task check` by default, #975). Maintainer-only Python lane — not part of `check:consumer`."
     cmds:
       # `--project` pins uv to the framework root so ancestor pyproject.toml
       # files cannot hijack the resolver via uv's upward walk (#1011).
       - uv --project "{{.TASKFILE_DIR}}" run pytest tests/ -o addopts= -m slow
 
-  test:
-    desc: Run test suite (alias for core:test)
-    cmds:
-      - task: core:test
-  test:coverage:
-    desc: Run tests with coverage (alias for core:test:coverage)
-    cmds:
-      - task: core:test:coverage
-  lint:
-    desc: Lint and type-check Python code (alias for core:lint)
-    cmds:
-      - task: core:lint
-  fmt:
-    desc: Format Python code (alias for core:fmt)
-    cmds:
-      - task: core:fmt
+  # Maintainer-only packaging aliases (#2022 Phase 2). `core:*` is internal;
+  # these root aliases remain callable for release Step 6 (`task build`) and
+  # local maintainer workflows. Not wired into `check:consumer`.
   build:
-    desc: Package framework for distribution (alias for core:build)
+    desc: Package framework for distribution (maintainer-only; alias for core:build)
     cmds:
       - task: core:build
   clean:
-    desc: Clean generated artifacts (alias for core:clean)
+    desc: Clean generated artifacts (maintainer-only; alias for core:clean)
     cmds:
       - task: core:clean
-  validate:
-    desc: Validate all markdown files (alias for core:validate)
-    cmds:
-      - task: core:validate
+
   install:
     desc: Install deft (alias for install:install)
     cmds:
@@ -485,10 +477,6 @@ tasks:
     desc: "Upgrade deft framework -- refresh AGENTS.md + write install manifest + regenerate .deft-version (alias for install:upgrade, #1061)"
     cmds:
       - task: install:upgrade
-  stats:
-    desc: Show framework statistics (alias for core:stats)
-    cmds:
-      - task: core:stats
 
   # #1272: canonical doctor surface -- thin shim that forwards to
   # ``.deft/core/run doctor``. The ``run`` CLI owns the diagnostic

--- a/tasks/ci.yml
+++ b/tasks/ci.yml
@@ -1,5 +1,13 @@
 version: '3'
 
+# Maintainer-only local CI mirror (#1813 contributor path / #2022 Phase 2).
+#
+# `ci:local` shells into scripts/ci_local.py via `uv run python`. Release
+# Step-5 pre-flight now uses the TS `task check` path (py-purge-ci-local-ts);
+# this fragment remains for explicit maintainer local CI only. Included from
+# the root Taskfile with `internal: true` — not wired into `check:consumer`
+# or the default `task check` aggregate.
+
 vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 

--- a/tasks/core.yml
+++ b/tasks/core.yml
@@ -1,5 +1,15 @@
 version: '3'
 
+# Maintainer-only Python self-test lane (#1813 contributor path / #2022 Phase 2).
+#
+# pytest, ruff, black, and mypy run here via `uv run` for framework-source-repo
+# pre-commit checks. This fragment is included from the root Taskfile with
+# `internal: true` so `core:*` tasks are NOT listed or callable from the CLI on
+# consumer installs — only `task check:framework-source` wires them as deps.
+#
+# Consumer `task check` dispatches to `check:consumer` (TS / deft verbs only).
+# Do NOT add these tasks to the consumer check aggregate.
+
 vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 

--- a/vbrief/completed/2026-06-28-move-maintainer-only-python-tasks-behind-checkframework-sour.vbrief.json
+++ b/vbrief/completed/2026-06-28-move-maintainer-only-python-tasks-behind-checkframework-sour.vbrief.json
@@ -1,0 +1,82 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF 2 decomposed from proposed/2026-06-26-rewire-the-consumer-task-surface-to-deft-verbs-with-zero-pyt.vbrief.json"
+  },
+  "plan": {
+    "id": "story-task-surface-maintainer-separation",
+    "title": "Move maintainer-only Python tasks behind check:framework-source",
+    "status": "completed",
+    "planRef": "proposed/2026-06-26-rewire-the-consumer-task-surface-to-deft-verbs-with-zero-pyt.vbrief.json",
+    "narratives": {
+      "Description": "tasks/core.yml and tasks/ci.yml still run pytest, ruff, and ci_local.py via uv on paths that ship to consumer installs. This story ensures those tasks are not reachable from the default consumer check aggregate — only from check:framework-source or an explicit maintainer include — so operators on npm installs never hit Python through task.",
+      "ImplementationPlan": "Confirm Taskfile.yml consumer check aggregate excludes core.yml and ci.yml Python lanes; wire maintainer-only includes to check:framework-source only.\nRemove or relocate tasks/ci.yml ci:local python bridge if still consumer-visible; align with completed py-purge-ci-local-ts release pre-flight story.\nRun task verify:no-task-runtime and task check on consumer projection paths.",
+      "UserStory": "As a framework maintainer, I want Python-heavy self-test tasks isolated from the consumer task surface, so that consumer installs never accidentally invoke pytest or ci_local.py.",
+      "Traces": "deftai/directive#2022 Phase 2, #1813"
+    },
+    "items": [
+      {
+        "id": "story-task-surface-maintainer-separation-a1",
+        "title": "Given task check on a consumer deposit layout, when it runs, then no subprocess invokes uv run python, pytest, ruff, or ci_local.py.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given task check on a consumer deposit layout, when it runs, then no subprocess invokes uv run python, pytest, ruff, or ci_local.py.",
+          "Traces": "deftai/directive#2022 Phase 2, #1813"
+        }
+      },
+      {
+        "id": "story-task-surface-maintainer-separation-a2",
+        "title": "Given task check:framework-source, when run from the framework repo, then maintainer Python self-test lanes remain available.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given task check:framework-source, when run from the framework repo, then maintainer Python self-test lanes remain available.",
+          "Traces": "deftai/directive#2022 Phase 2, #1813"
+        }
+      },
+      {
+        "id": "story-task-surface-maintainer-separation-a3",
+        "title": "Given tasks/core.yml and tasks/ci.yml, when included from Taskfile.yml, then they are optional/maintainer-only with clear comments.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given tasks/core.yml and tasks/ci.yml, when included from Taskfile.yml, then they are optional/maintainer-only with clear comments.",
+          "Traces": "deftai/directive#2022 Phase 2, #1813"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/core.yml",
+          "tasks/ci.yml",
+          "Taskfile.yml"
+        ],
+        "verify_commands": [
+          "task verify:no-task-runtime",
+          "task check:framework-source"
+        ],
+        "expected_outputs": [
+          "maintainer Python tasks gated behind framework-source"
+        ],
+        "depends_on": [],
+        "conflict_group": "task-surface-maintainer",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "high"
+      },
+      "completedAt": "2026-06-28T15:29:17Z",
+      "capacityBucket": "new-capability"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2022",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2022: Python purge readiness — execution tracker (supersedes #2001)",
+        "TrustLevel": "external"
+      }
+    ],
+    "updated": "2026-06-28T15:29:17Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Mark `tasks/core.yml` and `tasks/ci.yml` as maintainer-only via `internal: true` includes, wired exclusively through `check:framework-source` deps.
- Remove consumer-facing root aliases (`task test`, `task lint`, `task fmt`, etc.) that previously exposed pytest/ruff/mypy on the default task surface; retain `task build` / `task clean` for release Step 6.
- Document the #1813 contributor-path separation in Taskfile and fragment headers.

## Test plan
- [x] `task verify:no-task-runtime`
- [x] `task check:framework-source` (core:test lane — 8378 passed; full aggregate green on CI without sibling swarm vbrief noise)
- [x] `core:*` / `ci:*` hidden from `task -l`; direct `task core:test` blocked as internal
- [x] `task build` still dispatches `core:build` for release packaging

Refs #2022

Made with [Cursor](https://cursor.com)