### PR TITLE
fix: make the npm consumer upgrade path complete atomically (#2057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **npm consumer upgrades complete in one consistent path** — On a vendored `.deft/core/` install, `directive update` now also syncs the bare `.deft-version` marker and keeps the `managed_by: npm` provenance stamp, so `deft doctor` no longer reports version drift or re-nudges a migrate step after each upgrade. `deft install-upgrade` resolves the real version from the project's install manifest (instead of misreporting `0.0.0-dev`) when run from a global npm install, and `task upgrade` now works on vendored installs instead of failing on a missing build script. Closes #2053, #2054, #2055, #2056. Refs #2057.
+
 ### Removed
 
 ## [0.61.0] - 2026-06-28

--- a/packages/cli/src/migrate-task-surface.test.ts
+++ b/packages/cli/src/migrate-task-surface.test.ts
@@ -18,9 +18,13 @@ describe("migrate/install task surface (#2022 Phase 2)", () => {
     expect(text).not.toContain("migrate_preflight.py");
   });
 
-  it("install.yml upgrade avoids scripts/run.py", () => {
+  it("install.yml upgrade avoids scripts/run.py and routes through the consumer-aware engine dispatch (#2054)", () => {
     const text = readFileSync(join(repoRoot(), "tasks", "install.yml"), "utf8");
-    expect(text).toContain('bin.js" install-upgrade');
+    // #2054: dispatch goes through :engine:invoke (vendored bin.js in source
+    // checkouts, global `deft` on npm consumer deposits) rather than an
+    // unconditional `node bin.js` that fails on vendored installs.
+    expect(text).toContain(":engine:invoke");
+    expect(text).toContain("ENGINE_CMD: 'install-upgrade");
     expect(text).not.toContain('run" upgrade');
     expect(text).not.toContain("scripts/run.py");
   });

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -250,6 +250,53 @@ describe("runRefreshDeposit", () => {
     expect(lines.join("")).toContain("directive-content is v0.52.0");
   });
 
+  it("syncs vbrief/.deft-version to the deposited content version (#2055)", async () => {
+    const project = freshRoot("refresh-marker-");
+    const contentRoot = installFakeContentPackage(project, "0.61.0");
+    mkdirSync(join(project, "vbrief"), { recursive: true });
+    writeFileSync(join(project, "vbrief", ".deft-version"), "0.60.0\n", "utf8");
+
+    await runRefreshDeposit(
+      { projectDir: project, jsonOut: false, nonInteractive: true, upgrade: true },
+      { printf: () => {} },
+      {
+        resolveContentRoot: async () => contentRoot,
+        readEngineVersion: () => "0.61.0",
+        nowIso: () => "2026-06-28T12:00:00Z",
+        gitPorcelain: () => null,
+      },
+    );
+
+    expect(readFileSync(join(project, "vbrief", ".deft-version"), "utf8").trim()).toBe("0.61.0");
+  });
+
+  it("preserves managed_by: npm across a payload refresh (#2056)", async () => {
+    const project = freshRoot("refresh-managed-");
+    const contentRoot = installFakeContentPackage(project, "0.61.0");
+    const deftDir = join(project, ".deft", "core");
+    mkdirSync(deftDir, { recursive: true });
+    writeFileSync(
+      join(deftDir, "VERSION"),
+      "ref: 'v0.60.0'\ntag: 'v0.60.0'\nsha: 'content-package'\ninstall_root: '.deft/core'\nmanaged_by: 'npm'\n",
+      "utf8",
+    );
+
+    await runRefreshDeposit(
+      { projectDir: project, jsonOut: false, nonInteractive: true, upgrade: true },
+      { printf: () => {} },
+      {
+        resolveContentRoot: async () => contentRoot,
+        readEngineVersion: () => "0.61.0",
+        nowIso: () => "2026-06-28T12:00:00Z",
+        gitPorcelain: () => null,
+      },
+    );
+
+    const manifest = readFileSync(join(deftDir, "VERSION"), "utf8");
+    expect(manifest).toContain("tag: 'v0.61.0'");
+    expect(manifest).toContain("managed_by: 'npm'");
+  });
+
   it("throws LegacyLayoutRefusedError on a legacy layout (no refresh)", async () => {
     await expect(
       runRefreshDeposit(

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -8,13 +8,14 @@
  * Refs #1942, #1430, #1671.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { copyTree } from "../deposit/copy-tree.js";
 import { prunePythonArtifactsFromDeposit } from "../deposit/python-free.js";
 import { resolveInstalledContentRoot } from "../deposit/resolve-content.js";
 import { manifestTagToVersion, parseInstallManifest } from "../doctor/manifest.js";
 import { readCorePackageVersion } from "../engine-version.js";
+import { DEV_FALLBACK } from "../platform/constants.js";
 import { gitPorcelain } from "../story-ready/git.js";
 import { type InitDepositArgs, parseInitArgv } from "./init-deposit.js";
 import {
@@ -106,6 +107,44 @@ function readRecordedDepositVersion(deftDir: string): string | null {
     return manifestTagToVersion(parseInstallManifest(readFileSync(manifestPath, "utf8")));
   } catch {
     return null;
+  }
+}
+
+/** Prior `managed_by` provenance sentinel from the deposit manifest, if any (#2056). */
+function readRecordedManagedBy(deftDir: string): string | null {
+  const manifestPath = join(deftDir, "VERSION");
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const value = (
+      parseInstallManifest(readFileSync(manifestPath, "utf8")).managed_by ?? ""
+    ).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Regenerate the bare `.deft-version` derivative from the deposited content
+ * version in the same transaction as the payload swap (#2055). The canonical
+ * marker lives at `vbrief/.deft-version`; fall back to the project root only
+ * when `vbrief/` is absent. Never persist the dev fallback.
+ */
+function syncBareVersionMarker(projectDir: string, version: string): void {
+  const normalized = normalizeVersion(version);
+  if (!normalized || normalized === DEV_FALLBACK) return;
+  const vbriefDir = join(projectDir, "vbrief");
+  let targetDir = projectDir;
+  try {
+    if (statSync(vbriefDir).isDirectory()) targetDir = vbriefDir;
+  } catch {
+    // vbrief/ absent — write the root-level derivative instead
+  }
+  try {
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(targetDir, ".deft-version"), `${normalized}\n`, "utf8");
+  } catch {
+    // best-effort, mirrors install-upgrade marker write
   }
 }
 
@@ -274,6 +313,7 @@ export async function runRefreshDeposit(
 
   const contentRoot = await resolveContent();
   const previousDepositVersion = readRecordedDepositVersion(deftDir);
+  const previousManagedBy = readRecordedManagedBy(deftDir);
   const engineVersion = readEngine();
   const contentVersion = readContentPackageVersion(contentRoot, readPackageVersion);
   const versionSkewNotice = buildVersionSkewNotice(
@@ -293,8 +333,14 @@ export async function runRefreshDeposit(
     installRoot: CANONICAL_INSTALL_ROOT,
     fetchedAt: nowIso(),
     fetchedBy: "directive-update",
+    ...(previousManagedBy ? { managedBy: previousManagedBy } : {}),
   };
   writeInstallManifest(projectDir, deftDir, manifestFields);
+
+  // #2055: regenerate the bare .deft-version derivative so it agrees with the
+  // freshly written manifest tag (otherwise doctor's manifest-agreement check
+  // fails and the operator must hand-edit the marker).
+  syncBareVersionMarker(projectDir, contentVersion);
 
   const agentsMdUpdated = writeAgentsMd(projectDir, deftDir, io);
 

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -213,6 +213,13 @@ export interface InstallManifestFields {
   installRoot: string;
   fetchedAt: string;
   fetchedBy: string;
+  /**
+   * Provenance sentinel (#2056). When the prior manifest was stamped
+   * `managed_by: 'npm'` by the npm-migration path, callers thread it through a
+   * manifest rebuild so a routine `directive update` / `install-upgrade` does not
+   * regress provenance and re-arm the doctor signpost.
+   */
+  managedBy?: string;
 }
 
 const BARE_SEMVER = /^\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?$/;
@@ -223,14 +230,18 @@ export function buildInstallManifestText(fields: InstallManifestFields): string 
     effectiveTag = `v${effectiveTag}`;
   }
   const effectiveRef = fields.ref || effectiveTag;
-  return (
+  let body =
     `ref: '${effectiveRef}'\n` +
     `sha: '${fields.sha}'\n` +
     `tag: '${effectiveTag}'\n` +
     `install_root: '${fields.installRoot}'\n` +
     `fetched_at: '${fields.fetchedAt}'\n` +
-    `fetched_by: '${fields.fetchedBy}'\n`
-  );
+    `fetched_by: '${fields.fetchedBy}'\n`;
+  const managedBy = fields.managedBy?.trim();
+  if (managedBy) {
+    body += `managed_by: '${managedBy}'\n`;
+  }
+  return body;
 }
 
 export function writeInstallManifest(

--- a/packages/core/src/install-upgrade/index.test.ts
+++ b/packages/core/src/install-upgrade/index.test.ts
@@ -11,7 +11,10 @@ afterEach(() => {
   }
 });
 
-function scaffoldProject(base: string): { project: string; deftDir: string } {
+function scaffoldProject(
+  base: string,
+  version = "0.0.0-dev",
+): { project: string; deftDir: string } {
   const project = join(base, "consumer");
   const deftDir = join(project, ".deft", "core");
   mkdirSync(join(deftDir, "templates"), { recursive: true });
@@ -20,7 +23,7 @@ function scaffoldProject(base: string): { project: string; deftDir: string } {
     "<!-- deft:managed-section v3 -->\nbody\n<!-- /deft:managed-section -->\n",
     "utf8",
   );
-  writeFileSync(join(deftDir, "VERSION"), "tag: v0.0.0-dev\n", "utf8");
+  writeFileSync(join(deftDir, "VERSION"), `tag: v${version}\n`, "utf8");
   mkdirSync(join(project, "vbrief"), { recursive: true });
   return { project, deftDir };
 }
@@ -44,7 +47,7 @@ describe("install-upgrade", () => {
   it("records a new version marker when recorded version differs", () => {
     const base = mkdtempSync(join(tmpdir(), "deft-upgrade-"));
     temps.push(base);
-    const { project, deftDir } = scaffoldProject(base);
+    const { project, deftDir } = scaffoldProject(base, "1.2.3");
     writeFileSync(join(project, "vbrief", ".deft-version"), "0.0.0-old\n", "utf8");
 
     const lines: string[] = [];
@@ -53,7 +56,7 @@ describe("install-upgrade", () => {
       { writeOut: (t) => lines.push(t), writeErr: (t) => lines.push(t) },
     );
     expect([0, 2]).toContain(code);
-    expect(lines.join("")).toContain("Updated .deft-version from 0.0.0-old to 0.0.0-dev");
+    expect(lines.join("")).toContain("Updated .deft-version from 0.0.0-old to 1.2.3");
   });
 
   it("surfaces pre-cutover legacy guidance", () => {
@@ -74,7 +77,7 @@ describe("install-upgrade", () => {
   it("records first-time version marker when none exists", () => {
     const base = mkdtempSync(join(tmpdir(), "deft-upgrade-"));
     temps.push(base);
-    const { project, deftDir } = scaffoldProject(base);
+    const { project, deftDir } = scaffoldProject(base, "1.2.3");
 
     const lines: string[] = [];
     const code = runInstallUpgrade(
@@ -82,7 +85,74 @@ describe("install-upgrade", () => {
       { writeOut: (t) => lines.push(t), writeErr: (t) => lines.push(t) },
     );
     expect([0, 2]).toContain(code);
-    expect(lines.join("")).toContain("Recorded framework version");
+    expect(lines.join("")).toContain("Recorded framework version 1.2.3");
+  });
+
+  it("auto-detects the consumer .deft/core manifest when framework-root has no version (#2053)", () => {
+    const base = mkdtempSync(join(tmpdir(), "deft-upgrade-"));
+    temps.push(base);
+    const { project } = scaffoldProject(base, "0.61.0");
+    writeFileSync(join(project, "vbrief", ".deft-version"), "0.60.0\n", "utf8");
+
+    // Simulate an npm-global engine root: has the AGENTS.md template but no
+    // install manifest / .deft-version / git — so resolveVersion dead-ends at
+    // the dev fallback and the consumer-manifest auto-detect must recover it.
+    const fakeGlobal = join(base, "global-npm");
+    mkdirSync(join(fakeGlobal, "templates"), { recursive: true });
+    writeFileSync(
+      join(fakeGlobal, "templates", "agents-entry.md"),
+      "<!-- deft:managed-section v3 -->\nbody\n<!-- /deft:managed-section -->\n",
+      "utf8",
+    );
+
+    const lines: string[] = [];
+    runInstallUpgrade(
+      { projectRoot: project, frameworkRoot: fakeGlobal },
+      { writeOut: (t) => lines.push(t), writeErr: (t) => lines.push(t) },
+    );
+    const out = lines.join("");
+    expect(out).toContain("Deft CLI v0.61.0 - Upgrade");
+    expect(out).toContain("Updated .deft-version from 0.60.0 to 0.61.0");
+    expect(out).not.toContain("0.0.0-dev");
+    expect(readFileSync(join(project, "vbrief", ".deft-version"), "utf8").trim()).toBe("0.61.0");
+  });
+
+  it("does not claim a marker update when the version stays at the dev fallback (#2053)", () => {
+    const base = mkdtempSync(join(tmpdir(), "deft-upgrade-"));
+    temps.push(base);
+    const { project, deftDir } = scaffoldProject(base, "0.0.0-dev");
+    writeFileSync(join(project, "vbrief", ".deft-version"), "0.0.0-old\n", "utf8");
+
+    const lines: string[] = [];
+    runInstallUpgrade(
+      { projectRoot: project, frameworkRoot: deftDir },
+      { writeOut: (t) => lines.push(t), writeErr: (t) => lines.push(t) },
+    );
+    const out = lines.join("");
+    expect(out).toContain("Could not resolve a published framework version");
+    expect(out).not.toContain("Updated .deft-version from 0.0.0-old to 0.0.0-dev");
+    // The marker write is a no-op on the dev fallback, so the stale value remains.
+    expect(readFileSync(join(project, "vbrief", ".deft-version"), "utf8").trim()).toBe("0.0.0-old");
+  });
+
+  it("preserves managed_by: npm in the rewritten install manifest (#2056)", () => {
+    const base = mkdtempSync(join(tmpdir(), "deft-upgrade-"));
+    temps.push(base);
+    const { project, deftDir } = scaffoldProject(base, "1.2.3");
+    writeFileSync(
+      join(deftDir, "VERSION"),
+      "ref: 'v1.2.3'\ntag: 'v1.2.3'\nsha: 'content-package'\ninstall_root: '.deft/core'\nmanaged_by: 'npm'\n",
+      "utf8",
+    );
+    writeFileSync(join(project, "vbrief", ".deft-version"), "1.0.0\n", "utf8");
+
+    runInstallUpgrade(
+      { projectRoot: project, frameworkRoot: deftDir },
+      { writeOut: () => {}, writeErr: () => {} },
+    );
+    const manifest = readFileSync(join(deftDir, "VERSION"), "utf8");
+    expect(manifest).toContain("fetched_by: 'deft-upgrade'");
+    expect(manifest).toContain("managed_by: 'npm'");
   });
 
   it("writes install manifest under legacy deft/ deposit", () => {

--- a/packages/core/src/install-upgrade/index.test.ts
+++ b/packages/core/src/install-upgrade/index.test.ts
@@ -117,6 +117,36 @@ describe("install-upgrade", () => {
     expect(readFileSync(join(project, "vbrief", ".deft-version"), "utf8").trim()).toBe("0.61.0");
   });
 
+  it("renders AGENTS.md from the deposited .deft/core templates, not the engine root (#2057)", () => {
+    const base = mkdtempSync(join(tmpdir(), "deft-upgrade-"));
+    temps.push(base);
+    const { project, deftDir } = scaffoldProject(base, "0.61.0");
+    writeFileSync(
+      join(deftDir, "templates", "agents-entry.md"),
+      "<!-- deft:managed-section v3 -->\nDEPOSITED-TEMPLATE-BODY\n<!-- /deft:managed-section -->\n",
+      "utf8",
+    );
+    writeFileSync(join(project, "vbrief", ".deft-version"), "0.60.0\n", "utf8");
+
+    // Engine root carries a DIFFERENT template body, simulating a global npm
+    // engine at a newer content version than the deposited payload.
+    const fakeGlobal = join(base, "global-npm");
+    mkdirSync(join(fakeGlobal, "templates"), { recursive: true });
+    writeFileSync(
+      join(fakeGlobal, "templates", "agents-entry.md"),
+      "<!-- deft:managed-section v3 -->\nGLOBAL-ENGINE-BODY\n<!-- /deft:managed-section -->\n",
+      "utf8",
+    );
+
+    runInstallUpgrade(
+      { projectRoot: project, frameworkRoot: fakeGlobal },
+      { writeOut: () => {}, writeErr: () => {} },
+    );
+    const agents = readFileSync(join(project, "AGENTS.md"), "utf8");
+    expect(agents).toContain("DEPOSITED-TEMPLATE-BODY");
+    expect(agents).not.toContain("GLOBAL-ENGINE-BODY");
+  });
+
   it("does not claim a marker update when the version stays at the dev fallback (#2053)", () => {
     const base = mkdtempSync(join(tmpdir(), "deft-upgrade-"));
     temps.push(base);

--- a/packages/core/src/install-upgrade/index.ts
+++ b/packages/core/src/install-upgrade/index.ts
@@ -45,6 +45,23 @@ function resolveUpgradeVersion(frameworkRoot: string, projectRoot: string): stri
   return DEV_FALLBACK;
 }
 
+/**
+ * The consumer's deposited framework install root (`.deft/core`, then legacy
+ * `deft/`), if present. Used as the AGENTS.md render root and manifest target so
+ * the refresh renders from the *deposited* templates that match the installed
+ * payload -- not the (possibly newer) templates bundled in a global npm engine.
+ */
+function resolveInstallRoot(projectRoot: string): string | null {
+  for (const candidate of [join(projectRoot, ".deft", "core"), join(projectRoot, "deft")]) {
+    try {
+      if (statSync(candidate).isDirectory()) return candidate;
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
 /** Prior `managed_by` provenance sentinel from an install manifest, if any (#2056). */
 function readManagedByAt(installRoot: string): string | null {
   const manifestPath = join(installRoot, "VERSION");
@@ -188,13 +205,19 @@ export function runInstallUpgrade(args: InstallUpgradeArgs, io: InstallUpgradeIo
   const frameworkRoot = resolve(args.frameworkRoot);
   const version = resolveUpgradeVersion(frameworkRoot, projectRoot);
   const normalizedVersion = version.startsWith("v") ? version.slice(1) : version;
+  // Render AGENTS.md from the deposited install root so the managed section
+  // matches the installed payload, not the engine's bundled templates (which a
+  // global npm `deft` may carry at a different version). Falls back to the engine
+  // framework root when no deposit is present.
+  const installRoot = resolveInstallRoot(projectRoot);
+  const agentsRoot = installRoot ?? frameworkRoot;
 
   io.writeOut(`Deft CLI v${normalizedVersion} - Upgrade\n\n`);
 
   const recorded = readVersionMarker(projectRoot);
   if (recorded === normalizedVersion) {
     io.writeOut(`Project already at ${normalizedVersion}. Nothing to do.\n`);
-    return runAgentsRefresh(projectRoot, frameworkRoot, io);
+    return runAgentsRefresh(projectRoot, agentsRoot, io);
   }
 
   const legacy = detectPreCutoverLegacy(projectRoot);
@@ -209,17 +232,10 @@ export function runInstallUpgrade(args: InstallUpgradeArgs, io: InstallUpgradeIo
     existsSync(vbriefDir) && statSync(vbriefDir).isDirectory() ? vbriefDir : projectRoot;
   writeVersionMarker(targetDir, normalizedVersion);
 
-  let writtenManifestPath: string | null = null;
-  for (const installCandidate of [join(projectRoot, ".deft", "core"), join(projectRoot, "deft")]) {
-    if (existsSync(installCandidate) && statSync(installCandidate).isDirectory()) {
-      writtenManifestPath = writeInstallManifestAt(
-        installCandidate,
-        projectRoot,
-        normalizedVersion,
-      );
-      break;
-    }
-  }
+  const writtenManifestPath =
+    installRoot !== null
+      ? writeInstallManifestAt(installRoot, projectRoot, normalizedVersion)
+      : null;
   migrateLegacyInstallManifest(projectRoot, writtenManifestPath);
 
   if (normalizedVersion === DEV_FALLBACK) {
@@ -240,5 +256,5 @@ export function runInstallUpgrade(args: InstallUpgradeArgs, io: InstallUpgradeIo
     "If legacy SPECIFICATION.md or PROJECT.md content remains, run `task migrate:vbrief` to complete the upgrade.\n",
   );
 
-  return runAgentsRefresh(projectRoot, frameworkRoot, io);
+  return runAgentsRefresh(projectRoot, agentsRoot, io);
 }

--- a/packages/core/src/install-upgrade/index.ts
+++ b/packages/core/src/install-upgrade/index.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
-import { manifestTagToVersion, parseInstallManifest } from "../doctor/manifest.js";
+import { locateManifest, manifestTagToVersion, parseInstallManifest } from "../doctor/manifest.js";
+import { readCorePackageVersion } from "../engine-version.js";
 import {
   buildInstallManifestText,
   CANONICAL_INSTALL_ROOT,
@@ -10,6 +11,53 @@ import { agentsRefreshPlan } from "../platform/agents-md.js";
 import { DEV_FALLBACK } from "../platform/constants.js";
 import { resolveVersion } from "../platform/resolve-version.js";
 import { detectPreCutoverLegacy } from "../vbrief-validate/precutover.js";
+
+const ENGINE_PACKAGE_FALLBACK = "0.0.0";
+
+/**
+ * Resolve the framework version for an upgrade (#2053).
+ *
+ * `resolveVersion({ frameworkRoot })` reads env / install-manifest / .deft-version
+ * / git against the *engine* framework root. When `deft install-upgrade` runs from
+ * a global npm install, that root is the npm package directory — which carries no
+ * install manifest, no bare marker, and is not its own git repo — so the chain
+ * dead-ends at `0.0.0-dev`. Recover by auto-detecting the *consumer project's*
+ * deposited manifest, then fall back to the engine package.json version, before
+ * surrendering to the dev fallback.
+ */
+function resolveUpgradeVersion(frameworkRoot: string, projectRoot: string): string {
+  const primary = resolveVersion({ frameworkRoot });
+  if (primary !== DEV_FALLBACK) return primary;
+
+  const manifestPath = locateManifest(projectRoot, null);
+  if (manifestPath) {
+    try {
+      const tag = manifestTagToVersion(parseInstallManifest(readFileSync(manifestPath, "utf8")));
+      if (tag) return tag;
+    } catch {
+      // fall through to package.json fallback
+    }
+  }
+
+  const pkgVersion = readCorePackageVersion();
+  if (pkgVersion && pkgVersion !== ENGINE_PACKAGE_FALLBACK) return pkgVersion;
+
+  return DEV_FALLBACK;
+}
+
+/** Prior `managed_by` provenance sentinel from an install manifest, if any (#2056). */
+function readManagedByAt(installRoot: string): string | null {
+  const manifestPath = join(installRoot, "VERSION");
+  if (!existsSync(manifestPath) || !statSync(manifestPath).isFile()) return null;
+  try {
+    const value = (
+      parseInstallManifest(readFileSync(manifestPath, "utf8")).managed_by ?? ""
+    ).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
 
 export interface InstallUpgradeArgs {
   readonly projectRoot: string;
@@ -62,6 +110,7 @@ function writeInstallManifestAt(
   version: string,
 ): string | null {
   if (version.replace(/^v/, "") === DEV_FALLBACK) return null;
+  const priorManagedBy = readManagedByAt(installRoot);
   const fields: InstallManifestFields = {
     ref: version.startsWith("v") ? version : `v${version}`,
     sha: "content-package",
@@ -69,6 +118,7 @@ function writeInstallManifestAt(
     installRoot: deriveInstallRootString(installRoot, projectRoot),
     fetchedAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
     fetchedBy: "deft-upgrade",
+    ...(priorManagedBy ? { managedBy: priorManagedBy } : {}),
   };
   try {
     mkdirSync(installRoot, { recursive: true });
@@ -136,7 +186,7 @@ function runAgentsRefresh(
 export function runInstallUpgrade(args: InstallUpgradeArgs, io: InstallUpgradeIo): number {
   const projectRoot = resolve(args.projectRoot);
   const frameworkRoot = resolve(args.frameworkRoot);
-  const version = resolveVersion({ frameworkRoot });
+  const version = resolveUpgradeVersion(frameworkRoot, projectRoot);
   const normalizedVersion = version.startsWith("v") ? version.slice(1) : version;
 
   io.writeOut(`Deft CLI v${normalizedVersion} - Upgrade\n\n`);
@@ -172,7 +222,16 @@ export function runInstallUpgrade(args: InstallUpgradeArgs, io: InstallUpgradeIo
   }
   migrateLegacyInstallManifest(projectRoot, writtenManifestPath);
 
-  if (recorded === null) {
+  if (normalizedVersion === DEV_FALLBACK) {
+    // #2053: the marker + manifest writers above no-op on the dev fallback, so do
+    // not claim a marker update that never happened.
+    io.writeOut(
+      "Could not resolve a published framework version (resolved 0.0.0-dev); " +
+        ".deft-version marker and install manifest were left unchanged. On a consumer " +
+        "install, ensure <project>/.deft/core/VERSION carries a real tag, or upgrade the " +
+        "engine with `npm i -g @deftai/directive@latest`.\n",
+    );
+  } else if (recorded === null) {
     io.writeOut(`Recorded framework version ${normalizedVersion} in .deft-version.\n`);
   } else {
     io.writeOut(`Updated .deft-version from ${recorded} to ${normalizedVersion}.\n`);

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -51,11 +51,20 @@ tasks:
   # on PR #1067 -- the upgrade handler does not currently accept flags; future
   # flag additions land deliberately, not implicitly via Taskfile drift).
   upgrade:
-    desc: "Upgrade deft framework: refresh AGENTS.md to current marker, write canonical install manifest, regenerate .deft-version derivative (#1061). Dispatches via deft-ts install-upgrade."
+    desc: "Upgrade deft framework: refresh AGENTS.md to current marker, write canonical install manifest, regenerate .deft-version derivative (#1061). Dispatches via deft-ts install-upgrade (vendored bin.js in source checkouts, global deft on npm consumer deposits -- #2054)."
     dir: '{{.USER_WORKING_DIR}}'
     vars:
       CLI_ARGS: ""
+    # #2054: route through the consumer-aware engine dispatch (engine:_ts-build is a
+    # no-op on vendored deposits; engine:invoke falls back to global `deft`). The
+    # previous `_ts-build` dep unconditionally ran `pnpm run build` inside the
+    # `@deftai/directive-content` payload -- which has no `build` script -- so
+    # `task upgrade` failed on the primary npm consumer workflow. Framework-root is
+    # intentionally omitted: install-upgrade auto-detects the consumer's
+    # `.deft/core/VERSION` (#2053) when run from the global engine.
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" install-upgrade --project-root "{{.USER_WORKING_DIR}}" --framework-root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'install-upgrade --project-root "{{.USER_WORKING_DIR}}"'

--- a/tests/content/test_taskfile_uv_project_pin.py
+++ b/tests/content/test_taskfile_uv_project_pin.py
@@ -155,9 +155,13 @@ def test_migrate_preflight_uses_deft_ts_not_python() -> None:
 
 
 def test_install_upgrade_uses_deft_ts_not_run_py() -> None:
-    """install:upgrade must not shell into scripts/run.py (#2022)."""
+    """install:upgrade must route through the consumer-aware engine dispatch, not run.py (#2054)."""
     install_text = (TASKS_DIR / "install.yml").read_text(encoding="utf-8")
-    assert 'node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" install-upgrade' in install_text
+    # #2054: dispatch goes through :engine:invoke (vendored bin.js in source
+    # checkouts, global `deft` on npm consumer deposits) so `task upgrade` no
+    # longer fails on vendored installs that lack a buildable source tree.
+    assert ":engine:invoke" in install_text
+    assert "ENGINE_CMD: 'install-upgrade" in install_text
     assert 'run" upgrade' not in install_text
     assert "scripts/run.py" not in install_text
 


### PR DESCRIPTION
## Summary

Fixes the four root causes (umbrella #2057) behind the fragmented consumer npm upgrade experience, so `npm i -g @deftai/directive@latest` + `directive update` is a self-consistent happy path on a vendored `.deft/core/` install — no manifest drift, no provenance regression, no broken repair commands.

- **#2053** — `install-upgrade` now resolves a real version by auto-detecting the consumer's `.deft/core/VERSION` (with a `package.json` fallback) instead of dead-ending at `0.0.0-dev` when run from a global npm install, and no longer prints a `.deft-version` "update" that never happened.
- **#2054** — `task upgrade` routes through the consumer-aware `:engine:invoke` / `:engine:_ts-build` dispatch (the same pattern `task doctor` uses) rather than the unconditional `pnpm run build` that fails on vendored payloads (no `build` script / no `bin.js`).
- **#2055** — `directive update` regenerates the bare `vbrief/.deft-version` marker in the same transaction as the payload swap, so `deft doctor`'s manifest-agreement check no longer fails.
- **#2056** — both `directive update` and `install-upgrade` preserve the `managed_by: npm` provenance stamp across a manifest rebuild, so the doctor signpost / migrate nudge does not re-arm on every upgrade.

## Changes

- `packages/core/src/install-upgrade/index.ts` — `resolveUpgradeVersion()` + reworded dev-fallback output + `managed_by` preservation.
- `packages/core/src/init-deposit/refresh.ts` — bare-marker sync + `managed_by` preservation in the refresh transaction.
- `packages/core/src/init-deposit/scaffold.ts` — optional `managedBy` field on the install manifest builder.
- `tasks/install.yml` — consumer-aware `upgrade` dispatch.
- Tests: 6 new cases (auto-detect, dev-fallback no-op messaging, provenance preservation across both surfaces); updated 3 existing tests (TS + Python) that encoded the old behavior.

## Test plan

- [x] `task check` — full gate green (8388 passed, 10 skipped)
- [x] `npx vitest run` — 7501/7501 TS tests pass
- [x] biome clean on all touched files
- [x] CHANGELOG `[Unreleased]` entry added
- [ ] Bot/subagent review clean (P0/P1)

Closes #2053, #2054, #2055, #2056. Refs #2057.

Made with [Cursor](https://cursor.com)