### PR TITLE
fix: agents:refresh runtime skill paths and doctor false positives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,12 +329,12 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `content/templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=92832175b924 refreshed=2026-06-28T19:43:45Z session=67db549eeb36 -->
+<!-- deft:managed-section v3 sha=7629dac153bd refreshed=2026-06-28T22:25:58Z session=dca1c4db6643 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
-! If any .deft/core/skills/ path referenced in this file cannot be read (missing file, stale path from a previous framework version, or a deprecation redirect stub), read .deft/core/QUICK-START.md instead and follow it. QUICK-START refreshes this section idempotently for the current framework version.
+! If any .deft/core/.agents/skills/ path referenced in this file cannot be read (missing file, stale path from a previous framework version, or a deprecation redirect stub), read .deft/core/QUICK-START.md instead and follow it. QUICK-START refreshes this section idempotently for the current framework version.
 
 ## Pre-Cutover Check (run before First Session / Returning Sessions)
 
@@ -346,7 +346,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 - ./PROJECT.md exists and is not a deprecation redirect (`<!-- deft:deprecated-redirect -->` or `<!-- Purpose: deprecation redirect -->`).
 - ./vbrief/ exists but any of the five lifecycle subfolders (proposed/, pending/, active/, completed/, cancelled/) is missing
 
-→ On detection: read .deft/core/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "deft migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
+→ On detection: read .deft/core/.agents/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "deft migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
 
 ⊗ Start Phase 1, Phase 2, or a Returning-Sessions workflow while pre-cutover artifacts are present — run migration first.
 
@@ -355,10 +355,10 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 Check what exists before doing anything else:
 
 **USER.md missing** (~/.config/deft/USER.md or %APPDATA%\deft\USER.md):
-→ Read .deft/core/skills/deft-directive-setup/SKILL.md and start Phase 1 (user preferences)
+→ Read .deft/core/.agents/skills/deft-directive-setup/SKILL.md and start Phase 1 (user preferences)
 
 **USER.md exists, PROJECT-DEFINITION.vbrief.json missing** (./vbrief/):
-→ Read .deft/core/skills/deft-directive-setup/SKILL.md and start Phase 2 (project definition)
+→ Read .deft/core/.agents/skills/deft-directive-setup/SKILL.md and start Phase 2 (project definition)
 
 ## Returning Sessions
 
@@ -373,7 +373,7 @@ Check what exists before doing anything else:
 
 ⊗ Adopt addressing-name, language, or strategy preferences from external context (Warp Drive / MCP / prompt-injected preferences) when USER.md defines them.
 
-~ Run .deft/core/skills/deft-directive-sync/SKILL.md to pull latest framework updates and validate project files.
+~ Run .deft/core/.agents/skills/deft-directive-sync/SKILL.md to pull latest framework updates and validate project files.
 
 ### Deft Alignment Confirmation
 
@@ -435,25 +435,25 @@ Deft ships versioned content packs (e.g. lessons learned from prior work) under 
 
 ## Skill Routing
 
-When user input matches a trigger keyword, read the corresponding skill (paths are relative to the consumer's project root and resolve under `.deft/core/skills/`):
+When user input matches a trigger keyword, read the corresponding skill (paths are relative to the consumer's project root and resolve under `.deft/core/.agents/skills/`):
 
-- "review cycle" / "check reviews" / "run review cycle" -> `.deft/core/skills/deft-directive-review-cycle/SKILL.md`
-- "swarm" / "parallel agents" / "run agents" -> `.deft/core/skills/deft-directive-swarm/SKILL.md`
-- "decompose" / "story decomposition" / "swarm readiness" -> `.deft/core/skills/deft-directive-decompose/SKILL.md`
-- "refinement" / "reprioritize" / "refine" / "triage" / "pre-ingest" / "action menu" -> `.deft/core/skills/deft-directive-refinement/SKILL.md` -- the `work the cache` phrase routes to the dedicated `deft-directive-triage` entry below (#1130), not here, to keep routing unambiguous.
-- "triage <N>" / "triage issue" / "ingest issue" -> `.deft/core/skills/deft-directive-refinement/SKILL.md`
-- "build" / "implement" / "implement spec" -> `.deft/core/skills/deft-directive-build/SKILL.md`
-- "cost" / "budget" / "pre-build cost" / "how much will this cost" -> `.deft/core/skills/deft-directive-cost/SKILL.md`
-- "setup" / "bootstrap" / "onboard" -> `.deft/core/skills/deft-directive-setup/SKILL.md`
-- "sync" / "good morning" / "update deft" / "update vbrief" / "sync frameworks" -> `.deft/core/skills/deft-directive-sync/SKILL.md`
-- "pre-pr" / "quality loop" / "rwldl" / "self-review" -> `.deft/core/skills/deft-directive-pre-pr/SKILL.md`
-- "interview loop" / "q&a loop" / "run interview loop" -> `.deft/core/skills/deft-directive-interview/SKILL.md`
-- "run probe" / "/deft:directive:run:probe" / "probe" -> `.deft/core/skills/deft-directive-probe/SKILL.md` (deprecated alias: `/deft:run:probe`)
-- "glossary" / "ubiquitous language" / "domain model" / "DDD" / "define terms" -> `.deft/core/skills/deft-directive-glossary/SKILL.md`
-- "improve architecture" / "deep modules" / "interface design" / "refactor RFC" -> `.deft/core/skills/deft-directive-gh-arch/SKILL.md`
-- "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/skills/deft-directive-debug/SKILL.md`
-- "triage hygiene" / "work the cache" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
-- "what's next" / "queue" / "build a cohort" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
+- "review cycle" / "check reviews" / "run review cycle" -> `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`
+- "swarm" / "parallel agents" / "run agents" -> `.deft/core/.agents/skills/deft-directive-swarm/SKILL.md`
+- "decompose" / "story decomposition" / "swarm readiness" -> `.deft/core/.agents/skills/deft-directive-decompose/SKILL.md`
+- "refinement" / "reprioritize" / "refine" / "triage" / "pre-ingest" / "action menu" -> `.deft/core/.agents/skills/deft-directive-refinement/SKILL.md` -- the `work the cache` phrase routes to the dedicated `deft-directive-triage` entry below (#1130), not here, to keep routing unambiguous.
+- "triage <N>" / "triage issue" / "ingest issue" -> `.deft/core/.agents/skills/deft-directive-refinement/SKILL.md`
+- "build" / "implement" / "implement spec" -> `.deft/core/.agents/skills/deft-directive-build/SKILL.md`
+- "cost" / "budget" / "pre-build cost" / "how much will this cost" -> `.deft/core/.agents/skills/deft-directive-cost/SKILL.md`
+- "setup" / "bootstrap" / "onboard" -> `.deft/core/.agents/skills/deft-directive-setup/SKILL.md`
+- "sync" / "good morning" / "update deft" / "update vbrief" / "sync frameworks" -> `.deft/core/.agents/skills/deft-directive-sync/SKILL.md`
+- "pre-pr" / "quality loop" / "rwldl" / "self-review" -> `.deft/core/.agents/skills/deft-directive-pre-pr/SKILL.md`
+- "interview loop" / "q&a loop" / "run interview loop" -> `.deft/core/.agents/skills/deft-directive-interview/SKILL.md`
+- "run probe" / "/deft:directive:run:probe" / "probe" -> `.deft/core/.agents/skills/deft-directive-probe/SKILL.md` (deprecated alias: `/deft:run:probe`)
+- "glossary" / "ubiquitous language" / "domain model" / "DDD" / "define terms" -> `.deft/core/.agents/skills/deft-directive-glossary/SKILL.md`
+- "improve architecture" / "deep modules" / "interface design" / "refactor RFC" -> `.deft/core/.agents/skills/deft-directive-gh-arch/SKILL.md`
+- "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/.agents/skills/deft-directive-debug/SKILL.md`
+- "triage hygiene" / "work the cache" -> `.deft/core/.agents/skills/deft-directive-triage/SKILL.md`
+- "what's next" / "queue" / "build a cohort" -> `.deft/core/.agents/skills/deft-directive-triage/SKILL.md`
 - "welcome" / "onboard triage" -> invokes `deft triage:welcome --onboard` (N3 / #1143)
 - "lessons" / "prior art" / "what have we learned about X" -> discover packs with `deft packs:slice --list-packs`, then `deft packs:slice <pack> --list` and load the relevant slice before improvising (see Content packs above)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Post-upgrade doctor no longer fails on stale skill paths or doc-only redirect mentions** — `deft agents:refresh` now writes runtime skill routes under `.deft/core/.agents/skills/` instead of legacy stub paths, and `deft doctor` skill-paths-resolve ignores deprecation sentinels that appear only in skill documentation prose. Closes #1404, #1408.
+- **Post-upgrade doctor no longer fails on stale skill paths or doc-only redirect mentions** — `deft agents:refresh` now writes runtime skill routes under `.deft/core/.agents/skills/` instead of legacy stub paths, adds missing decompose/probe runtime pointers, and `deft doctor` skill-paths-resolve ignores deprecation sentinels that appear only in skill documentation prose. Closes #1404, #1408.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-upgrade doctor no longer fails on stale skill paths or doc-only redirect mentions** — `deft agents:refresh` now writes runtime skill routes under `.deft/core/.agents/skills/` instead of legacy stub paths, and `deft doctor` skill-paths-resolve ignores deprecation sentinels that appear only in skill documentation prose. Closes #1404, #1408.
+
 ### Removed
 
-## [0.61.1] - 2026-06-28
 
 > Consumer npm upgrades now complete in one consistent path: version markers and managed_by provenance stay in sync, and task upgrade works on vendored installs.
 

--- a/content/.agents/skills/deft-directive-decompose/SKILL.md
+++ b/content/.agents/skills/deft-directive-decompose/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: deft-directive-decompose
+description: >-
+  Convert phase/epic scope vBRIEFs into swarm-ready story vBRIEFs before swarm
+  allocation. Use when the operator asks to decompose, split stories, or assess
+  swarm readiness.
+---
+
+Read and follow: skills/deft-directive-decompose/SKILL.md

--- a/content/.agents/skills/deft-directive-probe/SKILL.md
+++ b/content/.agents/skills/deft-directive-probe/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: deft-directive-probe
+description: >-
+  Adversarial one-question-per-turn plan stress-testing before vBRIEF or plan
+  artifacts. Use when the operator asks to run probe or stress-test a plan.
+---
+
+Read and follow: skills/deft-directive-probe/SKILL.md

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -3,7 +3,7 @@
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
-! If any .deft/core/skills/ path referenced in this file cannot be read (missing file, stale path from a previous framework version, or a deprecation redirect stub), read .deft/core/QUICK-START.md instead and follow it. QUICK-START refreshes this section idempotently for the current framework version.
+! If any .deft/core/.agents/skills/ path referenced in this file cannot be read (missing file, stale path from a previous framework version, or a deprecation redirect stub), read .deft/core/QUICK-START.md instead and follow it. QUICK-START refreshes this section idempotently for the current framework version.
 
 ## Pre-Cutover Check (run before First Session / Returning Sessions)
 
@@ -15,7 +15,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 - ./PROJECT.md exists and is not a deprecation redirect (`<!-- deft:deprecated-redirect -->` or `<!-- Purpose: deprecation redirect -->`).
 - ./vbrief/ exists but any of the five lifecycle subfolders (proposed/, pending/, active/, completed/, cancelled/) is missing
 
-→ On detection: read .deft/core/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "deft migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
+→ On detection: read .deft/core/.agents/skills/deft-directive-setup/SKILL.md "Pre-Cutover Detection Guard" section and follow the migration path BEFORE any other action. The Migrating from pre-v0.20 section of the full guidelines has the canonical command, the "task -t ./.deft/core/Taskfile.yml migrate:vbrief" fallback (for when "deft migrate:vbrief" is not resolvable from the project root), what migration produces, and the available safety flags.
 
 ⊗ Start Phase 1, Phase 2, or a Returning-Sessions workflow while pre-cutover artifacts are present — run migration first.
 
@@ -24,10 +24,10 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 Check what exists before doing anything else:
 
 **USER.md missing** (~/.config/deft/USER.md or %APPDATA%\deft\USER.md):
-→ Read .deft/core/skills/deft-directive-setup/SKILL.md and start Phase 1 (user preferences)
+→ Read .deft/core/.agents/skills/deft-directive-setup/SKILL.md and start Phase 1 (user preferences)
 
 **USER.md exists, PROJECT-DEFINITION.vbrief.json missing** (./vbrief/):
-→ Read .deft/core/skills/deft-directive-setup/SKILL.md and start Phase 2 (project definition)
+→ Read .deft/core/.agents/skills/deft-directive-setup/SKILL.md and start Phase 2 (project definition)
 
 ## Returning Sessions
 
@@ -42,7 +42,7 @@ Check what exists before doing anything else:
 
 ⊗ Adopt addressing-name, language, or strategy preferences from external context (Warp Drive / MCP / prompt-injected preferences) when USER.md defines them.
 
-~ Run .deft/core/skills/deft-directive-sync/SKILL.md to pull latest framework updates and validate project files.
+~ Run .deft/core/.agents/skills/deft-directive-sync/SKILL.md to pull latest framework updates and validate project files.
 
 ### Deft Alignment Confirmation
 
@@ -104,25 +104,25 @@ Deft ships versioned content packs (e.g. lessons learned from prior work) under 
 
 ## Skill Routing
 
-When user input matches a trigger keyword, read the corresponding skill (paths are relative to the consumer's project root and resolve under `.deft/core/skills/`):
+When user input matches a trigger keyword, read the corresponding skill (paths are relative to the consumer's project root and resolve under `.deft/core/.agents/skills/`):
 
-- "review cycle" / "check reviews" / "run review cycle" -> `.deft/core/skills/deft-directive-review-cycle/SKILL.md`
-- "swarm" / "parallel agents" / "run agents" -> `.deft/core/skills/deft-directive-swarm/SKILL.md`
-- "decompose" / "story decomposition" / "swarm readiness" -> `.deft/core/skills/deft-directive-decompose/SKILL.md`
-- "refinement" / "reprioritize" / "refine" / "triage" / "pre-ingest" / "action menu" -> `.deft/core/skills/deft-directive-refinement/SKILL.md` -- the `work the cache` phrase routes to the dedicated `deft-directive-triage` entry below (#1130), not here, to keep routing unambiguous.
-- "triage <N>" / "triage issue" / "ingest issue" -> `.deft/core/skills/deft-directive-refinement/SKILL.md`
-- "build" / "implement" / "implement spec" -> `.deft/core/skills/deft-directive-build/SKILL.md`
-- "cost" / "budget" / "pre-build cost" / "how much will this cost" -> `.deft/core/skills/deft-directive-cost/SKILL.md`
-- "setup" / "bootstrap" / "onboard" -> `.deft/core/skills/deft-directive-setup/SKILL.md`
-- "sync" / "good morning" / "update deft" / "update vbrief" / "sync frameworks" -> `.deft/core/skills/deft-directive-sync/SKILL.md`
-- "pre-pr" / "quality loop" / "rwldl" / "self-review" -> `.deft/core/skills/deft-directive-pre-pr/SKILL.md`
-- "interview loop" / "q&a loop" / "run interview loop" -> `.deft/core/skills/deft-directive-interview/SKILL.md`
-- "run probe" / "/deft:directive:run:probe" / "probe" -> `.deft/core/skills/deft-directive-probe/SKILL.md` (deprecated alias: `/deft:run:probe`)
-- "glossary" / "ubiquitous language" / "domain model" / "DDD" / "define terms" -> `.deft/core/skills/deft-directive-glossary/SKILL.md`
-- "improve architecture" / "deep modules" / "interface design" / "refactor RFC" -> `.deft/core/skills/deft-directive-gh-arch/SKILL.md`
-- "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/skills/deft-directive-debug/SKILL.md`
-- "triage hygiene" / "work the cache" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
-- "what's next" / "queue" / "build a cohort" -> `.deft/core/skills/deft-directive-triage/SKILL.md`
+- "review cycle" / "check reviews" / "run review cycle" -> `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`
+- "swarm" / "parallel agents" / "run agents" -> `.deft/core/.agents/skills/deft-directive-swarm/SKILL.md`
+- "decompose" / "story decomposition" / "swarm readiness" -> `.deft/core/.agents/skills/deft-directive-decompose/SKILL.md`
+- "refinement" / "reprioritize" / "refine" / "triage" / "pre-ingest" / "action menu" -> `.deft/core/.agents/skills/deft-directive-refinement/SKILL.md` -- the `work the cache` phrase routes to the dedicated `deft-directive-triage` entry below (#1130), not here, to keep routing unambiguous.
+- "triage <N>" / "triage issue" / "ingest issue" -> `.deft/core/.agents/skills/deft-directive-refinement/SKILL.md`
+- "build" / "implement" / "implement spec" -> `.deft/core/.agents/skills/deft-directive-build/SKILL.md`
+- "cost" / "budget" / "pre-build cost" / "how much will this cost" -> `.deft/core/.agents/skills/deft-directive-cost/SKILL.md`
+- "setup" / "bootstrap" / "onboard" -> `.deft/core/.agents/skills/deft-directive-setup/SKILL.md`
+- "sync" / "good morning" / "update deft" / "update vbrief" / "sync frameworks" -> `.deft/core/.agents/skills/deft-directive-sync/SKILL.md`
+- "pre-pr" / "quality loop" / "rwldl" / "self-review" -> `.deft/core/.agents/skills/deft-directive-pre-pr/SKILL.md`
+- "interview loop" / "q&a loop" / "run interview loop" -> `.deft/core/.agents/skills/deft-directive-interview/SKILL.md`
+- "run probe" / "/deft:directive:run:probe" / "probe" -> `.deft/core/.agents/skills/deft-directive-probe/SKILL.md` (deprecated alias: `/deft:run:probe`)
+- "glossary" / "ubiquitous language" / "domain model" / "DDD" / "define terms" -> `.deft/core/.agents/skills/deft-directive-glossary/SKILL.md`
+- "improve architecture" / "deep modules" / "interface design" / "refactor RFC" -> `.deft/core/.agents/skills/deft-directive-gh-arch/SKILL.md`
+- "debug" / "root cause" / "investigate" / "why did X break" / "why is X slow" / "systematic debugging" / "forensic" -> `.deft/core/.agents/skills/deft-directive-debug/SKILL.md`
+- "triage hygiene" / "work the cache" -> `.deft/core/.agents/skills/deft-directive-triage/SKILL.md`
+- "what's next" / "queue" / "build a cohort" -> `.deft/core/.agents/skills/deft-directive-triage/SKILL.md`
 - "welcome" / "onboard triage" -> invokes `deft triage:welcome --onboard` (N3 / #1143)
 - "lessons" / "prior art" / "what have we learned about X" -> discover packs with `deft packs:slice --list-packs`, then `deft packs:slice <pack> --list` and load the relevant slice before improvising (see Content packs above)
 

--- a/packages/cli/src/agents-refresh.test.ts
+++ b/packages/cli/src/agents-refresh.test.ts
@@ -31,6 +31,14 @@ describe("agents-refresh CLI (#1996)", () => {
     expect(text).toContain("deft:managed-section");
   });
 
+  it("emits runtime .agents/skills paths not legacy stubs (#1404)", () => {
+    const project = freshProject();
+    expect(runAgentsRefresh(["--project-root", project])).toBe(0);
+    const text = readFileSync(join(project, "AGENTS.md"), "utf8");
+    expect(text).toContain(".deft/core/.agents/skills/deft-directive-build/SKILL.md");
+    expect(text).not.toMatch(/-> `\.deft\/core\/skills\/deft-directive-/);
+  });
+
   it("--check exits 0 when current", () => {
     const project = freshProject();
     expect(runAgentsRefresh(["--project-root", project])).toBe(0);

--- a/packages/core/src/content-contracts/skills/500_discoverability.test.ts
+++ b/packages/core/src/content-contracts/skills/500_discoverability.test.ts
@@ -102,7 +102,7 @@ describe("test_500_discoverability", () => {
 
   it("agents_entry_template_routes_to_setup_skill", () => {
     const text = readRepoFile(AGENTS_ENTRY_TEMPLATE);
-    expect(text).toContain(".deft/core/skills/deft-directive-setup/SKILL.md");
+    expect(text).toContain(".deft/core/.agents/skills/deft-directive-setup/SKILL.md");
     expect(text).toContain("Pre-Cutover Detection Guard");
   });
 

--- a/packages/core/src/content-contracts/standards/debugging.test.ts
+++ b/packages/core/src/content-contracts/standards/debugging.test.ts
@@ -121,7 +121,7 @@ describe("test_debugging.py", () => {
     });
     it("test_template_routing", () => {
       expect(readText("templates/agents-entry.md")).toContain(
-        ".deft/core/skills/deft-directive-debug/SKILL.md",
+        ".deft/core/.agents/skills/deft-directive-debug/SKILL.md",
       );
     });
   });

--- a/packages/core/src/doctor/branches.test.ts
+++ b/packages/core/src/doctor/branches.test.ts
@@ -34,6 +34,15 @@ describe("manifest helpers", () => {
   it("isDeprecationRedirectStub", () => {
     expect(isDeprecationRedirectStub("<!-- deft:deprecated-redirect -->\n")).toBe(true);
     expect(isDeprecationRedirectStub("# real skill\n")).toBe(false);
+    const docWithSentinelInBody = [
+      "---",
+      "name: deft-directive-setup",
+      "---",
+      "# Setup",
+      "",
+      "Docs mention `<!-- deft:deprecated-redirect -->` in pre-cutover guard prose.",
+    ].join("\n");
+    expect(isDeprecationRedirectStub(docWithSentinelInBody)).toBe(false);
   });
 
   it("locateManifest canonical-first", () => {

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -73,6 +73,32 @@ describe("checks", () => {
     expect(result.status).toBe("pass");
   });
 
+  it("passes when deprecated-redirect sentinel appears only in documentation (#1408)", () => {
+    const text = "see .deft/core/skills/deft-directive-build/SKILL.md\n";
+    const docBody = [
+      "---",
+      "name: deft-directive-build",
+      "---",
+      "# Skill",
+      "",
+      "Pre-cutover docs mention `<!-- deft:deprecated-redirect -->` in prose.",
+    ].join("\n");
+    const result = checkSkillPathsResolve("/tmp", text, {
+      isFile: () => true,
+      readText: () => docBody,
+    });
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes .agents/skills runtime paths when files resolve (#1404)", () => {
+    const text = "-> `.deft/core/.agents/skills/deft-directive-build/SKILL.md`\n";
+    const result = checkSkillPathsResolve("/tmp", text, {
+      isFile: () => true,
+      readText: () => "Read and follow: skills/deft-directive-build/SKILL.md\n",
+    });
+    expect(result.status).toBe("pass");
+  });
+
   it("manifest agreement skip on greenfield", () => {
     const result = checkManifestAgreement("/tmp", null, { isFile: () => false });
     expect(result.status).toBe("skip");

--- a/tests/content/test_500_discoverability.py
+++ b/tests/content/test_500_discoverability.py
@@ -232,9 +232,9 @@ def test_agents_entry_template_routes_to_setup_skill() -> None:
     guard section. Path is the canonical .deft/core/ install layout (#1020,
     flipped from the legacy deft/ path)."""
     text = _AGENTS_ENTRY_TEMPLATE.read_text(encoding="utf-8")
-    assert ".deft/core/skills/deft-directive-setup/SKILL.md" in text, (
+    assert ".deft/core/.agents/skills/deft-directive-setup/SKILL.md" in text, (
         "templates/agents-entry.md: pre-cutover branch must route agents "
-        "to .deft/core/skills/deft-directive-setup/SKILL.md (#1020)"
+        "to .deft/core/.agents/skills/deft-directive-setup/SKILL.md (#1404)"
     )
     assert "Pre-Cutover Detection Guard" in text, (
         "templates/agents-entry.md: pre-cutover branch must name the "

--- a/tests/content/test_debugging.py
+++ b/tests/content/test_debugging.py
@@ -257,7 +257,7 @@ class TestDebugSkillRouting1621:
 
     def test_template_routing(self) -> None:
         text = _read(AGENTS_ENTRY)
-        assert ".deft/core/skills/deft-directive-debug/SKILL.md" in text, (
+        assert ".deft/core/.agents/skills/deft-directive-debug/SKILL.md" in text, (
             "templates/agents-entry.md Skill Routing must route to "
-            "deft-directive-debug (#1309 propagation)"
+            "deft-directive-debug (#1309 propagation, #1404 runtime paths)"
         )

--- a/tests/content/test_deprecated_skill_redirects.py
+++ b/tests/content/test_deprecated_skill_redirects.py
@@ -286,7 +286,7 @@ class TestQuickStartUpgradeDetection:
 class TestAgentsEntryFallbackRule:
     """templates/agents-entry.md and setup.go agentsMDEntry must carry the
     fallback rule that redirects agents to QUICK-START.md when a
-    .deft/core/skills/ path is unreadable (#411 item 2, paths flipped to
+    .deft/core/.agents/skills/ path is unreadable (#411 item 2, paths flipped to
     canonical layout in #1020)."""
 
     TEMPLATE = _REPO_ROOT / "content/templates/agents-entry.md"
@@ -294,9 +294,9 @@ class TestAgentsEntryFallbackRule:
 
     def test_template_has_fallback_rule(self) -> None:
         content = self.TEMPLATE.read_text(encoding="utf-8")
-        assert ".deft/core/skills/" in content, (
-            "templates/agents-entry.md must mention .deft/core/skills/ in the "
-            "fallback rule (#1020)."
+        assert ".deft/core/.agents/skills/" in content, (
+            "templates/agents-entry.md must mention .deft/core/.agents/skills/ in the "
+            "fallback rule (#1404)."
         )
         assert ".deft/core/QUICK-START.md" in content, (
             "templates/agents-entry.md must tell agents to read "
@@ -326,9 +326,9 @@ class TestAgentsEntryFallbackRule:
         # Assert the fallback rule exists in the canonical template, which
         # IS the body the installer writes into consumer AGENTS.md.
         template = self.TEMPLATE.read_text(encoding="utf-8")
-        assert ".deft/core/skills/" in template, (
+        assert ".deft/core/.agents/skills/" in template, (
             "templates/agents-entry.md must carry the fallback rule "
-            "(mentions .deft/core/skills/)."
+            "(mentions .deft/core/.agents/skills/)."
         )
         assert ".deft/core/QUICK-START.md" in template, (
             "templates/agents-entry.md fallback rule must point at "

--- a/tests/contract/test_no_legacy_deft_paths_in_agents_template.py
+++ b/tests/contract/test_no_legacy_deft_paths_in_agents_template.py
@@ -168,7 +168,7 @@ def test_canonical_install_path_tokens_present() -> None:
     text = _TEMPLATE_PATH.read_text(encoding="utf-8")
     canonical_tokens = (
         ".deft/core/main.md",
-        ".deft/core/skills/",
+        ".deft/core/.agents/skills/",
         ".deft/core/run",
     )
     missing = [token for token in canonical_tokens if token not in text]

--- a/vbrief/active/2026-06-28-bug-pass-doctor-agents-refresh.vbrief.json
+++ b/vbrief/active/2026-06-28-bug-pass-doctor-agents-refresh.vbrief.json
@@ -1,0 +1,91 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Bug-pass story: doctor and agents:refresh hygiene after upgrade (#1404, #1408).",
+    "created": "2026-06-28T23:00:00Z",
+    "updated": "2026-06-28T23:00:00Z"
+  },
+  "plan": {
+    "id": "bug-pass-doctor-agents-refresh",
+    "title": "doctor and agents:refresh: fix legacy skill paths and false-positive checks",
+    "status": "running",
+    "narratives": {
+      "Description": "After upgrade or agents:refresh, consumers see doctor failures: agents:refresh can restore legacy .deft/core/skills/ paths that doctor rejects as stubs (#1404), and skill-paths-resolve false-positives on documentation text containing sentinel substrings (#1408). This story fixes refresh output paths and tightens doctor matching so post-upgrade verification is trustworthy.",
+      "ImplementationPlan": "1. Fix agents:refresh / template rendering so skill symlinks or paths point to current .deft/core/skills/ layout, not legacy stub paths (#1404). 2. Fix doctor skill-paths-resolve check to match actual skill file paths, not arbitrary documentation substrings (#1408). 3. Add regression tests in packages/core/src/doctor/ and packages/cli/src/agents-refresh.test.ts. 4. Run task agents:refresh only if maintainer AGENTS.md template changes require it.",
+      "UserStory": "As a consumer who ran deft update or agents:refresh, I want deft doctor to pass when my install is healthy, so that I am not sent on a false repair loop after every upgrade.",
+      "Traces": "Refs #1404 #1408; upgrade path #2057 #1993."
+    },
+    "items": [
+      {
+        "id": "agents-refresh-paths",
+        "title": "agents:refresh emits current skill paths not legacy stubs",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a consumer runs deft agents:refresh on a canonical-vendored install, when AGENTS.md managed section is rewritten, then referenced skill paths resolve to live .deft/core/skills/ entries and doctor skill-paths-resolve does not FAIL due to legacy .deft/core/skills/ stub paths.",
+          "Traces": "#1404"
+        }
+      },
+      {
+        "id": "doctor-false-positive",
+        "title": "skill-paths-resolve ignores doc-only sentinel matches",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given AGENTS.md or templates contain documentation prose mentioning skill path patterns, when deft doctor runs skill-paths-resolve, then the check does not FAIL on substring matches in non-path documentation text; real missing skill files still FAIL.",
+          "Traces": "#1408"
+        }
+      },
+      {
+        "id": "tests-changelog",
+        "title": "Regression tests and CHANGELOG",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given regression tests cover agents:refresh path output and doctor skill-paths-resolve edge cases, when uv run pytest on those tests passes and task check passes, then CHANGELOG records the fix with Closes #1404 #1408.",
+          "Traces": "#1404 #1408"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/agents-refresh.ts",
+          "packages/core/src/doctor/checks.ts",
+          "packages/core/src/agents-refresh/",
+          "content/templates/agents-entry.md",
+          "tests/cli/test_agents_refresh.py",
+          "packages/cli/src/agents-refresh.test.ts",
+          "packages/core/src/doctor/checks.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "uv run pytest packages/cli/src/agents-refresh.test.ts packages/core/src/doctor/ -q",
+          "task check"
+        ],
+        "expected_outputs": [
+          "agents:refresh no longer writes legacy stub skill paths",
+          "doctor skill-paths-resolve passes on doc prose false-positive fixture"
+        ],
+        "depends_on": [],
+        "conflict_group": "doctor-agents-refresh",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1404",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1404: agents:refresh legacy skill paths"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1408",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1408: doctor skill-paths false positive"
+      }
+    ],
+    "updated": "2026-06-28T22:24:10Z"
+  }
+}

--- a/vbrief/active/2026-06-28-bug-pass-migrate-vbrief-hygiene.vbrief.json
+++ b/vbrief/active/2026-06-28-bug-pass-migrate-vbrief-hygiene.vbrief.json
@@ -1,0 +1,86 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Bug-pass story: migrate:vbrief version marker and lifecycle folder hygiene (#1157, #1159).",
+    "created": "2026-06-28T23:00:00Z",
+    "updated": "2026-06-28T23:00:00Z"
+  },
+  "plan": {
+    "id": "bug-pass-migrate-vbrief-hygiene",
+    "title": "migrate:vbrief: stamp .deft-version and track lifecycle folders in git",
+    "status": "running",
+    "narratives": {
+      "Description": "Greenfield and migrate:vbrief paths leave vbrief/.deft-version unstamped so gates report recorded=unknown (#1157). migrate:vbrief also creates empty lifecycle folders that git does not track, so fresh clones and swarm worktrees lack vbrief/proposed|pending|active|completed|cancelled (#1159). This story stamps the version marker during migration and adds tracked .gitkeep sentinels so lifecycle layout survives clone/worktree.",
+      "ImplementationPlan": "1. In scripts/migrate_vbrief.py cmd_migrate path, after successful migration, write/sync vbrief/.deft-version from .deft/core/VERSION install manifest fields (#1157). 2. During lifecycle folder mkdir in migrate_vbrief.py, write tracked .gitkeep sentinel files in each vbrief lifecycle directory and record them in the safety manifest for rollback (#1159). 3. Add pytest cases in tests/test_migrate_vbrief.py asserting .deft-version content and .gitkeep files on disk. 4. Run uv run pytest tests/test_migrate_vbrief.py and task check as verification evidence.",
+      "UserStory": "As an operator who ran migrate:vbrief, I want lifecycle folders and .deft-version to exist in every clone and worktree, so that swarm agents and preflight gates do not block on missing directories or unknown version.",
+      "Traces": "Refs #1157 #1159; swarm worktree recurrence."
+    },
+    "items": [
+      {
+        "id": "deft-version-stamp",
+        "title": "migrate:vbrief stamps vbrief/.deft-version",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a project completes task migrate:vbrief successfully, when vbrief/.deft-version is read, then it records the current framework version ref/sha consistent with .deft/core/VERSION and gates no longer report recorded=unknown for greenfield-migrated projects.",
+          "Traces": "#1157"
+        }
+      },
+      {
+        "id": "lifecycle-gitkeep",
+        "title": "Lifecycle folders survive clone via tracked placeholders",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given migrate:vbrief creates the five lifecycle folders, when the project is cloned or a git worktree is added, then vbrief/proposed pending active completed cancelled directories exist on disk because each contains a tracked .gitkeep sentinel file; rollback removes those sentinels per safety manifest.",
+          "Traces": "#1159"
+        }
+      },
+      {
+        "id": "migrate-tests-changelog",
+        "title": "migrate_vbrief tests and CHANGELOG",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given tests in tests/test_migrate_vbrief.py cover version stamp and gitkeep creation, when uv run pytest tests/test_migrate_vbrief.py passes and task check passes, then CHANGELOG records fixes with Closes #1157 #1159.",
+          "Traces": "#1157 #1159"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "scripts/migrate_vbrief.py",
+          "tests/test_migrate_vbrief.py",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "uv run pytest tests/test_migrate_vbrief.py -q",
+          "task check"
+        ],
+        "expected_outputs": [
+          "migrate:vbrief writes vbrief/.deft-version",
+          "lifecycle folders contain tracked .gitkeep after migration"
+        ],
+        "depends_on": [],
+        "conflict_group": "migrate-vbrief-hygiene",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1157",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1157: migrate:vbrief leaves .deft-version unstamped"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1159",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1159: empty lifecycle folders vanish in clones"
+      }
+    ],
+    "updated": "2026-06-28T22:24:12Z"
+  }
+}

--- a/vbrief/active/2026-06-28-bug-pass-npm-upgrade-discoverability.vbrief.json
+++ b/vbrief/active/2026-06-28-bug-pass-npm-upgrade-discoverability.vbrief.json
@@ -1,0 +1,112 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Bug-pass story: npm consumer upgrade discoverability (#2059, #2012, #1995). Closes #2057 cluster discoverability gap.",
+    "created": "2026-06-28T23:00:00Z",
+    "updated": "2026-06-28T23:00:00Z"
+  },
+  "plan": {
+    "id": "bug-pass-npm-upgrade-discoverability",
+    "title": "npm upgrade happy path: surface deft migrate in docs and CLI output",
+    "status": "running",
+    "narratives": {
+      "Description": "Operators following README and UPGRADING.md never encounter `deft migrate` until `deft doctor` warns them. This story adds the one-time npm provenance stamp to the canonical upgrade path, fixes the release upgrade banner that still cites legacy deft-install, and reconciles UPGRADING.md npm-migration steps with the shipped CLI. Includes a one-line disambiguation between `deft migrate` (npm handshake) and `migrate:vbrief` (pre-v0.20 cutover).",
+      "ImplementationPlan": "1. Update content/UPGRADING.md canonical npm section and Go-to-npm one-time migration to document npm i -g, deft update, deft migrate (idempotent), deft doctor; add migrate verb disambiguation table. 2. Update README Getting Started upgrade note if needed. 3. Replace .github/release-notes/upgrade-banner.md with npm canonical path (#2012). 4. Add migrate nudge to directive init/update completion output when managed_by is absent (packages/core/src/init-deposit/). 5. Optionally add non-blocking session:start line when signpost would fire. 6. Extend doc-cli-parity or content tests so UPGRADING cites only registered verbs; verify #1994 closable.",
+      "UserStory": "As a consumer who upgraded via npm, I want the documented upgrade path to include deft migrate before I need doctor, so that my vendored .deft/core install completes the npm hybrid handshake without guesswork.",
+      "Traces": "Refs #2059 #2012 #1995 #2057 #1993; related #1941 #2009 #2056 (fixed)."
+    },
+    "items": [
+      {
+        "id": "upgrading-migrate-step",
+        "title": "UPGRADING.md documents full npm path including migrate",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a reader follows content/UPGRADING.md canonical npm upgrade section, when they complete the documented steps, then they run deft migrate as an explicit step before or immediately after first deft update, and a table distinguishes deft migrate from migrate:vbrief.",
+          "Traces": "#2059 #1995"
+        }
+      },
+      {
+        "id": "release-banner-npm",
+        "title": "Release upgrade banner cites npm not deft-install",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given .github/release-notes/upgrade-banner.md is rendered into a release body, when an operator reads the banner, then it recommends npm i -g @deftai/directive@latest and deft update/migrate path, not deft-install --yes --upgrade.",
+          "Traces": "#2012"
+        }
+      },
+      {
+        "id": "cli-init-update-nudge",
+        "title": "init and update output nudge migrate when needed",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a canonical-vendored deposit without managed_by npm in VERSION, when directive init or directive update completes successfully, then stdout includes a one-line nudge to run deft migrate once (idempotent); when already npm-managed, no nudge is emitted.",
+          "Traces": "#2059"
+        }
+      },
+      {
+        "id": "tests-and-changelog",
+        "title": "Tests and CHANGELOG for discoverability fixes",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the implementation lands, when uv run pytest targets new or updated tests for init/update output and doc parity pass, then task check passes and CHANGELOG [Unreleased] records the user-visible discoverability fix with Closes #2059 #2012 #1995.",
+          "Traces": "#2059"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/UPGRADING.md",
+          "README.md",
+          ".github/release-notes/upgrade-banner.md",
+          "packages/core/src/init-deposit/refresh.ts",
+          "packages/core/src/init-deposit/init-deposit.ts",
+          "packages/core/src/session/session-start.ts",
+          "packages/cli/src/doc-cli-parity.test.ts",
+          "tests/cli/test_init_deposit_cli.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "uv run pytest packages/cli/src/doc-cli-parity.test.ts packages/core/src/init-deposit/init-deposit.test.ts -q",
+          "task check"
+        ],
+        "expected_outputs": [
+          "UPGRADING.md lists deft migrate on canonical npm path",
+          "upgrade-banner.md cites npm upgrade command",
+          "init/update print migrate nudge when managed_by absent"
+        ],
+        "depends_on": [],
+        "conflict_group": "npm-upgrade-discoverability",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2059",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2059: directive migrate undiscoverable"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2012",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2012: release banner cites legacy installer"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1995",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1995: reconcile UPGRADING npm commands"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2057",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2057: consumer npm upgrade path fragmented (umbrella)"
+      }
+    ],
+    "updated": "2026-06-28T22:24:09Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Update `content/templates/agents-entry.md` so `deft agents:refresh` writes skill routes under `.deft/core/.agents/skills/` instead of legacy `.deft/core/skills/` stub paths (#1404).
- Pin doctor `skill-paths-resolve` regressions so deprecation sentinels mentioned only in skill documentation prose do not fail the check (#1408; behavior already enforced via top-of-file sentinel detection in `isDeprecationRedirectStub`).
- Regenerate maintainer `AGENTS.md` managed section from the updated template.

## Test plan
- [x] `pnpm exec vitest run packages/cli/src/agents-refresh.test.ts packages/core/src/doctor/`
- [x] `task ts:check-lane`
- [x] Targeted content/contract pytest for template path assertions

Closes #1404
Closes #1408

Made with [Cursor](https://cursor.com)