### PR TITLE
fix: migrate:vbrief stamps .deft-version and lifecycle .gitkeep sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Post-upgrade doctor no longer fails on stale skill paths or doc-only redirect mentions** — `deft agents:refresh` now writes runtime skill routes under `.deft/core/.agents/skills/` instead of legacy stub paths, adds missing decompose/probe runtime pointers, and `deft doctor` skill-paths-resolve ignores deprecation sentinels that appear only in skill documentation prose. Closes #1404, #1408.
-<<<<<<< HEAD
 - **npm upgrade path surfaces `deft migrate` before doctor warns** — UPGRADING.md, README, and release upgrade banners now document the full npm path (`npm i -g`, `deft update`, `deft migrate`, `deft doctor`) with a disambiguation table vs `migrate:vbrief`; `directive init` / `directive update` and session start emit a one-line migrate nudge when `managed_by: npm` is absent. Closes #2059, #2012, #1995. Refs #2057.
  4b2cffd2 (fix: surface deft migrate on npm upgrade path (#2059))
-=======
 - `task migrate:vbrief` now stamps `vbrief/.deft-version` from the installed framework VERSION manifest so greenfield and post-cutover projects no longer report `recorded=unknown` until a separate upgrade step runs. Closes #1157.
 - `task migrate:vbrief` now writes tracked `.gitkeep` sentinels in each lifecycle folder and records them in the safety manifest so empty `vbrief/{proposed,pending,active,completed,cancelled}/` directories survive clone and worktree checkout. Closes #1159.
  ff6d5872 (fix: migrate:vbrief stamps version marker and lifecycle gitkeep)
->>>>>>> 4a110a80 (fix: migrate:vbrief stamps version marker and lifecycle gitkeep)
+ 4a110a80 (fix: migrate:vbrief stamps version marker and lifecycle gitkeep)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Post-upgrade doctor no longer fails on stale skill paths or doc-only redirect mentions** — `deft agents:refresh` now writes runtime skill routes under `.deft/core/.agents/skills/` instead of legacy stub paths, adds missing decompose/probe runtime pointers, and `deft doctor` skill-paths-resolve ignores deprecation sentinels that appear only in skill documentation prose. Closes #1404, #1408.
+<<<<<<< HEAD
 - **npm upgrade path surfaces `deft migrate` before doctor warns** — UPGRADING.md, README, and release upgrade banners now document the full npm path (`npm i -g`, `deft update`, `deft migrate`, `deft doctor`) with a disambiguation table vs `migrate:vbrief`; `directive init` / `directive update` and session start emit a one-line migrate nudge when `managed_by: npm` is absent. Closes #2059, #2012, #1995. Refs #2057.
  4b2cffd2 (fix: surface deft migrate on npm upgrade path (#2059))
+=======
+- `task migrate:vbrief` now stamps `vbrief/.deft-version` from the installed framework VERSION manifest so greenfield and post-cutover projects no longer report `recorded=unknown` until a separate upgrade step runs. Closes #1157.
+- `task migrate:vbrief` now writes tracked `.gitkeep` sentinels in each lifecycle folder and records them in the safety manifest so empty `vbrief/{proposed,pending,active,completed,cancelled}/` directories survive clone and worktree checkout. Closes #1159.
+ ff6d5872 (fix: migrate:vbrief stamps version marker and lifecycle gitkeep)
+>>>>>>> 4a110a80 (fix: migrate:vbrief stamps version marker and lifecycle gitkeep)
 
 ### Removed
 

--- a/scripts/migrate_vbrief.py
+++ b/scripts/migrate_vbrief.py
@@ -227,6 +227,22 @@ _TRACES_SECTION_HEADER = "## Traces lines stripped from LegacyArtifacts (#529)"
 # Lifecycle folders per RFC #309 D13
 LIFECYCLE_FOLDERS = ("proposed", "pending", "active", "completed", "cancelled")
 
+# Tracked placeholder so empty lifecycle folders survive clone/worktree (#1159).
+# Content mirrors ``packages/core/src/init-deposit/scaffold.ts`` ``VBRIEF_LIFECYCLE_GITKEEP``.
+LIFECYCLE_GITKEEP_NAME = ".gitkeep"
+LIFECYCLE_GITKEEP_CONTENT = (
+    "# This file keeps the lifecycle directory present in version control and\n"
+    "# survives installer packaging so the deft-directive-setup pre-cutover guard\n"
+    "# (condition 3, see skills/deft-directive-setup/SKILL.md:32 and main.md:159)\n"
+    "# does not fire on a fresh install. See #1179.\n"
+)
+
+# Minimal YAML-ish manifest line parser for ``.deft-version`` stamping (#1157).
+# Mirrors ``scripts/doctor.py::_parse_manifest`` / ``_manifest_tag_to_version``.
+_MANIFEST_LINE_RE = re.compile(
+    r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?P<value>.*?)\s*$"
+)
+
 # Migrator-managed subdirectories under ``vbrief/`` that are created lazily by
 # sidecar emission (``vbrief/legacy/``, #505) and reporting (``vbrief/migration/``)
 # paths. Tracked in the safety manifest's ``created_dirs`` when the migrator
@@ -1143,6 +1159,131 @@ def _write_traces_stripped_note(
 # --- end traces strip helpers ---
 
 
+def _parse_install_manifest(text: str) -> dict[str, str]:
+    """Parse ``key: value`` lines from a framework VERSION manifest."""
+    parsed: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = _MANIFEST_LINE_RE.match(stripped)
+        if match is None:
+            continue
+        key = match.group("key").strip().lower()
+        value = match.group("value").strip().strip("'\"")
+        if key:
+            parsed[key] = value
+    return parsed
+
+
+def _bare_version_from_manifest(manifest: dict[str, str]) -> str | None:
+    """Derive the bare ``vbrief/.deft-version`` value from a manifest dict."""
+    for key in ("tag", "ref"):
+        raw = manifest.get(key)
+        if not isinstance(raw, str):
+            continue
+        candidate = raw.strip().lstrip("v")
+        if candidate:
+            return candidate
+    return None
+
+
+def _framework_version_manifest_path(project_root: Path) -> Path | None:
+    """Return the first existing framework VERSION manifest, canonical-first."""
+    for candidate in (
+        project_root / ".deft" / "core" / "VERSION",
+        project_root / ".deft" / "VERSION",
+        project_root / "deft" / "VERSION",
+    ):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _ensure_lifecycle_gitkeep(
+    project_root: Path,
+    folder_name: str,
+    *,
+    dry_run: bool,
+    created_files: list[str],
+    actions: list[str],
+) -> None:
+    """Write a tracked ``.gitkeep`` sentinel when a lifecycle folder is empty (#1159)."""
+    folder = project_root / "vbrief" / folder_name
+    gitkeep_rel = f"vbrief/{folder_name}/{LIFECYCLE_GITKEEP_NAME}"
+    gitkeep_path = folder / LIFECYCLE_GITKEEP_NAME
+
+    if gitkeep_path.is_file():
+        actions.append(f"SKIP  lifecycle gitkeep already exists: {gitkeep_rel}")
+        return
+
+    if folder.is_dir() and any(folder.iterdir()):
+        # Folder already carries tracked scope vBRIEFs -- no placeholder needed.
+        return
+
+    if dry_run:
+        actions.append(f"DRYRUN CREATE lifecycle gitkeep: {gitkeep_rel}")
+        return
+
+    folder.mkdir(parents=True, exist_ok=True)
+    gitkeep_path.write_text(LIFECYCLE_GITKEEP_CONTENT, encoding="utf-8")
+    created_files.append(gitkeep_rel)
+    actions.append(f"CREATE lifecycle gitkeep: {gitkeep_rel}")
+
+
+def _stamp_deft_version_marker(
+    project_root: Path,
+    vbrief_dir: Path,
+    *,
+    dry_run: bool,
+    created_files: list[str],
+    stub_hashes: dict[str, str],
+    actions: list[str],
+) -> None:
+    """Sync ``vbrief/.deft-version`` from the installed framework VERSION manifest (#1157)."""
+    rel = "vbrief/.deft-version"
+    marker_path = vbrief_dir / ".deft-version"
+    manifest_path = _framework_version_manifest_path(project_root)
+    if manifest_path is None:
+        actions.append(
+            "SKIP  vbrief/.deft-version (no framework VERSION manifest found)"
+        )
+        return
+
+    try:
+        manifest = _parse_install_manifest(
+            manifest_path.read_text(encoding="utf-8")
+        )
+    except OSError as exc:
+        actions.append(
+            f"SKIP  vbrief/.deft-version (cannot read {manifest_path}: {exc})"
+        )
+        return
+
+    bare = _bare_version_from_manifest(manifest)
+    if not bare or bare == "0.0.0-dev":
+        actions.append(
+            "SKIP  vbrief/.deft-version (manifest has no usable tag/ref)"
+        )
+        return
+
+    manifest_rel = manifest_path.relative_to(project_root).as_posix()
+    if dry_run:
+        actions.append(
+            f"DRYRUN STAMP vbrief/.deft-version from {manifest_rel} ({bare})"
+        )
+        return
+
+    already_exists = marker_path.is_file()
+    vbrief_dir.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text(f"{bare}\n", encoding="utf-8")
+    if not already_exists:
+        created_files.append(rel)
+    stub_hashes[rel] = sha256_of(marker_path)
+    verb = "UPDATE" if already_exists else "STAMP"
+    actions.append(f"{verb} vbrief/.deft-version ({bare}) from {manifest_rel}")
+
+
 def _track_managed_subdir(
     project_root: Path,
     subdir_name: str,
@@ -1342,6 +1483,13 @@ def migrate(
             folder.mkdir(parents=True, exist_ok=True)
             created_dirs.append(rel)
             actions.append(f"CREATE lifecycle folder: vbrief/{folder_name}/")
+        _ensure_lifecycle_gitkeep(
+            project_root,
+            folder_name,
+            dry_run=dry_run,
+            created_files=created_files,
+            actions=actions,
+        )
 
     # ---- Step 2: Read existing sources ----
     spec_vbrief_path = vbrief_dir / "specification.vbrief.json"
@@ -2209,6 +2357,15 @@ def migrate(
             managed_subdir_pre_existed,
             created_dirs,
         )
+
+    _stamp_deft_version_marker(
+        project_root,
+        vbrief_dir,
+        dry_run=dry_run,
+        created_files=created_files,
+        stub_hashes=stub_hashes,
+        actions=actions,
+    )
 
     # --- safety (Agent C, #497) ---
     # Persist a safety manifest for --rollback.  The manifest lives under

--- a/tests/cli/test_migrate_vbrief.py
+++ b/tests/cli/test_migrate_vbrief.py
@@ -23,6 +23,8 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from migrate_vbrief import (  # noqa: E402, I001
     DEPRECATION_SENTINEL,
     LIFECYCLE_FOLDERS,
+    LIFECYCLE_GITKEEP_CONTENT,
+    LIFECYCLE_GITKEEP_NAME,
     _PRETTIER_BREADCRUMB_MARKER,
     _PRETTIER_BREADCRUMB_PATHS,
     _build_project_definition,
@@ -81,6 +83,18 @@ def _make_project(tmp_path: Path, **kwargs) -> Path:
         (tmp_path / "PRD.md").write_text(kwargs["prd_md"], encoding="utf-8")
 
     return tmp_path
+
+
+def _write_framework_version_manifest(
+    project: Path, *, tag: str = "v0.61.1", sha: str = "abc123"
+) -> None:
+    """Lay down a minimal ``.deft/core/VERSION`` manifest for migration tests."""
+    manifest_dir = project / ".deft" / "core"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "VERSION").write_text(
+        f"tag: {tag}\nsha: {sha}\n",
+        encoding="utf-8",
+    )
 
 
 SAMPLE_SPEC_VBRIEF = {
@@ -614,6 +628,70 @@ class TestMigrateLifecycleFolders:
         assert ok
         skip_count = sum(1 for a in actions if "SKIP  lifecycle folder" in a)
         assert skip_count == 5
+
+    def test_creates_gitkeep_in_empty_lifecycle_folders(self, tmp_path):
+        project = _make_project(tmp_path)
+        ok, actions = migrate(project)
+        assert ok
+        for folder in LIFECYCLE_FOLDERS:
+            gitkeep = project / "vbrief" / folder / LIFECYCLE_GITKEEP_NAME
+            assert gitkeep.is_file(), f"missing gitkeep in vbrief/{folder}/"
+            assert gitkeep.read_text(encoding="utf-8") == LIFECYCLE_GITKEEP_CONTENT
+        assert any("CREATE lifecycle gitkeep" in a for a in actions)
+
+    def test_gitkeep_backfill_on_rerun_when_folder_exists(self, tmp_path):
+        project = _make_project(tmp_path)
+        for folder in LIFECYCLE_FOLDERS:
+            (project / "vbrief" / folder).mkdir(parents=True, exist_ok=True)
+        ok, actions = migrate(project)
+        assert ok
+        for folder in LIFECYCLE_FOLDERS:
+            assert (
+                project / "vbrief" / folder / LIFECYCLE_GITKEEP_NAME
+            ).is_file()
+        assert any("CREATE lifecycle gitkeep" in a for a in actions)
+
+    def test_dry_run_announces_gitkeep_creation(self, tmp_path):
+        project = _make_project(tmp_path)
+        ok, actions = migrate(project, dry_run=True)
+        assert ok
+        gitkeep_dryruns = [
+            a for a in actions if "DRYRUN CREATE lifecycle gitkeep" in a
+        ]
+        assert len(gitkeep_dryruns) == len(LIFECYCLE_FOLDERS)
+
+
+class TestMigrateDeftVersionStamp:
+    """Tests for vbrief/.deft-version stamping (#1157)."""
+
+    def test_stamps_deft_version_from_framework_manifest(self, tmp_path):
+        project = _make_project(tmp_path, spec_vbrief=SAMPLE_SPEC_VBRIEF)
+        _write_framework_version_manifest(project, tag="v0.61.1")
+        ok, actions = migrate(project)
+        assert ok
+        marker = project / "vbrief" / ".deft-version"
+        assert marker.is_file()
+        assert marker.read_text(encoding="utf-8") == "0.61.1\n"
+        assert any("STAMP vbrief/.deft-version" in a for a in actions)
+
+    def test_skips_deft_version_when_no_framework_manifest(self, tmp_path):
+        project = _make_project(tmp_path, spec_vbrief=SAMPLE_SPEC_VBRIEF)
+        ok, actions = migrate(project)
+        assert ok
+        assert not (project / "vbrief" / ".deft-version").exists()
+        assert any(
+            "SKIP  vbrief/.deft-version (no framework VERSION manifest found)"
+            in a
+            for a in actions
+        )
+
+    def test_dry_run_announces_deft_version_stamp(self, tmp_path):
+        project = _make_project(tmp_path, spec_vbrief=SAMPLE_SPEC_VBRIEF)
+        _write_framework_version_manifest(project, tag="v0.61.1")
+        ok, actions = migrate(project, dry_run=True)
+        assert ok
+        assert not (project / "vbrief" / ".deft-version").exists()
+        assert any("DRYRUN STAMP vbrief/.deft-version" in a for a in actions)
 
 
 class TestMigrateProjectDefinition:
@@ -2071,6 +2149,23 @@ class TestSafetyRollback:
         # Migrator-created lifecycle folders should also be gone -- they were
         # created by this run and are empty post-rollback.
         assert not (project / "vbrief" / "pending").exists()
+
+    def test_rollback_removes_lifecycle_gitkeep_sentinels(self, tmp_path):
+        project = _make_safety_project(tmp_path)
+        ok, _ = migrate(project)
+        assert ok
+        for folder in LIFECYCLE_FOLDERS:
+            gitkeep = project / "vbrief" / folder / LIFECYCLE_GITKEEP_NAME
+            folder_path = project / "vbrief" / folder
+            # Empty folders get gitkeep; pending may hold scope vBRIEFs only.
+            if folder_path.exists() and gitkeep.is_file():
+                assert gitkeep.read_text(encoding="utf-8") == LIFECYCLE_GITKEEP_CONTENT
+
+        ok, actions = safety_rollback(project, force=True)
+        assert ok, actions
+        for folder in LIFECYCLE_FOLDERS:
+            assert not (project / "vbrief" / folder / LIFECYCLE_GITKEEP_NAME).exists()
+        assert any("REMOVE vbrief/" in a and ".gitkeep" in a for a in actions)
 
     def test_rollback_removes_backup_files(self, tmp_path):
         project = _make_safety_project(tmp_path)

--- a/vbrief/active/2026-06-28-bug-pass-migrate-vbrief-hygiene.vbrief.json
+++ b/vbrief/active/2026-06-28-bug-pass-migrate-vbrief-hygiene.vbrief.json
@@ -51,11 +51,11 @@
         "parallel_safe": true,
         "file_scope": [
           "scripts/migrate_vbrief.py",
-          "tests/test_migrate_vbrief.py",
+          "tests/cli/test_migrate_vbrief.py",
           "CHANGELOG.md"
         ],
         "verify_commands": [
-          "uv run pytest tests/test_migrate_vbrief.py -q",
+          "uv run pytest tests/cli/test_migrate_vbrief.py -q",
           "task check"
         ],
         "expected_outputs": [

--- a/vbrief/completed/2026-06-28-bug-pass-migrate-vbrief-hygiene.vbrief.json
+++ b/vbrief/completed/2026-06-28-bug-pass-migrate-vbrief-hygiene.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "bug-pass-migrate-vbrief-hygiene",
     "title": "migrate:vbrief: stamp .deft-version and track lifecycle folders in git",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Greenfield and migrate:vbrief paths leave vbrief/.deft-version unstamped so gates report recorded=unknown (#1157). migrate:vbrief also creates empty lifecycle folders that git does not track, so fresh clones and swarm worktrees lack vbrief/proposed|pending|active|completed|cancelled (#1159). This story stamps the version marker during migration and adds tracked .gitkeep sentinels so lifecycle layout survives clone/worktree.",
       "ImplementationPlan": "1. In scripts/migrate_vbrief.py cmd_migrate path, after successful migration, write/sync vbrief/.deft-version from .deft/core/VERSION install manifest fields (#1157). 2. During lifecycle folder mkdir in migrate_vbrief.py, write tracked .gitkeep sentinel files in each vbrief lifecycle directory and record them in the safety manifest for rollback (#1159). 3. Add pytest cases in tests/test_migrate_vbrief.py asserting .deft-version content and .gitkeep files on disk. 4. Run uv run pytest tests/test_migrate_vbrief.py and task check as verification evidence.",
@@ -67,7 +67,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-28T22:35:30Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -81,6 +83,6 @@
         "title": "Issue #1159: empty lifecycle folders vanish in clones"
       }
     ],
-    "updated": "2026-06-28T22:24:12Z"
+    "updated": "2026-06-28T22:35:30Z"
   }
 }


### PR DESCRIPTION
## Summary
- `task migrate:vbrief` now writes `vbrief/.deft-version` from the installed framework VERSION manifest so post-cutover projects no longer report `recorded=unknown` until a separate upgrade step runs (#1157).
- Migration creates tracked `.gitkeep` placeholders in each lifecycle folder and records them in the safety manifest for rollback, so empty `vbrief/{proposed,pending,active,completed,cancelled}/` directories survive clone and worktree checkout (#1159).

## Test plan
- [x] `uv run pytest tests/cli/test_migrate_vbrief.py -q` (212 passed)
- [x] `uv run ruff check scripts/migrate_vbrief.py tests/cli/test_migrate_vbrief.py`
- [ ] CI green on PR

Closes #1157
Closes #1159


Made with [Cursor](https://cursor.com)