### PR TITLE
fix: npm upgrade path surfaces deft migrate before doctor warns

### DIFF
--- a/.github/release-notes/upgrade-banner.md
+++ b/.github/release-notes/upgrade-banner.md
@@ -1,13 +1,13 @@
 ## Upgrading from an older version?
 
-If you are on an existing Deft installation and seeing warnings from `task doctor` about skill-path stubs, outdated surfaces, or payload staleness, run the canonical upgrade command:
+If you are on an existing Deft installation and seeing warnings from `deft doctor` about skill-path stubs, outdated surfaces, or payload staleness, run the canonical npm upgrade path:
 
 ```bash
-deft-install --yes --upgrade --repo-root . --json
+npm i -g @deftai/directive@latest
 ```
 
-(Drop `--json` for human-readable output. Download the latest installer from the [latest release](https://github.com/deftai/directive/releases/latest) if needed.)
+Then from your project root: `deft update`, `deft migrate` (one-time, idempotent), and `deft doctor`.
 
 After upgrading, start a completely new agent session.
 
-Full guidance: https://github.com/deftai/directive/issues/1411
+Full guidance: https://github.com/deftai/directive/blob/master/content/UPGRADING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Post-upgrade doctor no longer fails on stale skill paths or doc-only redirect mentions** — `deft agents:refresh` now writes runtime skill routes under `.deft/core/.agents/skills/` instead of legacy stub paths, adds missing decompose/probe runtime pointers, and `deft doctor` skill-paths-resolve ignores deprecation sentinels that appear only in skill documentation prose. Closes #1404, #1408.
+- **npm upgrade path surfaces `deft migrate` before doctor warns** — UPGRADING.md, README, and release upgrade banners now document the full npm path (`npm i -g`, `deft update`, `deft migrate`, `deft doctor`) with a disambiguation table vs `migrate:vbrief`; `directive init` / `directive update` and session start emit a one-line migrate nudge when `managed_by: npm` is absent. Closes #2059, #2012, #1995. Refs #2057.
+ 4b2cffd2 (fix: surface deft migrate on npm upgrade path (#2059))
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run `directive` (or the `deft` alias) from any project directory — for example
 
 **Node runtime (required):** Live deft gates run through the TypeScript engine. Install **Node 20+** (see `.nvmrc` in the framework payload) and **pnpm** (`corepack enable && corepack prepare pnpm@latest --activate`). Run `task toolchain:check` to confirm Node, pnpm, Python (`uv`), git, and gh are on PATH. See [UPGRADING.md § Node runtime](./content/UPGRADING.md#node-runtime-1828--1530) for details.
 
-> **🔄 Upgrading?** Run `npm i -g @deftai/directive@latest`. Read [UPGRADING.md](./content/UPGRADING.md) before proceeding if coming from a Go-installer install. **Agents:** ! Read [UPGRADING.md](./content/UPGRADING.md) on the first session after a framework update.
+> **🔄 Upgrading?** Run `npm i -g @deftai/directive@latest`, then `deft update`, `deft migrate` (one-time, idempotent), and `deft doctor` from your project root. Read [UPGRADING.md](./content/UPGRADING.md) before proceeding if coming from a Go-installer install. **Agents:** ! Read [UPGRADING.md](./content/UPGRADING.md) on the first session after a framework update.
 
 > **📦 Brownfield adoption:** Adding Deft to an existing project with pre-v0.20 `SPECIFICATION.md` / `PROJECT.md`? See [docs/BROWNFIELD.md](./content/docs/BROWNFIELD.md) for the migration path (`task migrate:vbrief`) and what to expect.
 

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -10,24 +10,59 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 ## Canonical upgrade — npm (v0.55.1+)
 
-From v0.55.1 onwards `@deftai/directive` is published on npm. The canonical upgrade command is:
+From v0.55.1 onwards `@deftai/directive` is published on npm. The canonical consumer upgrade path is:
 
-```bash
-npm i -g @deftai/directive@latest
-```
+1. **Upgrade the global engine** (Node ≥ 20):
 
-Run from any shell with Node ≥ 20. After upgrading, run `deft update` from your project root to refresh the vendored `.deft/core/` payload and project-root `.githooks/` (#2049), then start a new agent session so the refreshed AGENTS.md and skills load from a clean context. Run `deft doctor` to confirm the install state.
+   ```bash
+   npm i -g @deftai/directive@latest
+   ```
+
+2. **Refresh the project deposit** from your project root:
+
+   ```bash
+   deft update
+   ```
+
+   This re-copies the vendored `.deft/core/` payload and refreshes project-root `.githooks/` (#2049).
+
+3. **Stamp npm provenance (one-time, idempotent):**
+
+   ```bash
+   deft migrate
+   ```
+
+   Adds `managed_by: npm` to `.deft/core/VERSION` so doctor and future updates recognize the npm channel. Safe to re-run — when already hybrid, migrate is a no-op.
+
+4. **Verify:**
+
+   ```bash
+   deft doctor
+   ```
+
+Start a **new agent session** after steps 2–3 so the refreshed AGENTS.md and skills load from a clean context.
+
+### `deft migrate` vs `migrate:vbrief`
+
+These commands are unrelated — do not confuse them:
+
+| Command | When to use | What it does |
+| --- | --- | --- |
+| `deft migrate` / `directive migrate` | Canonical-vendored `.deft/core/` deposit after npm upgrade (#1941) | Stamps `managed_by: npm` into the install manifest. Idempotent; never downloads payload. |
+| `deft migrate:vbrief` / `task migrate:vbrief` | Pre-v0.20 cutover only (legacy `SPECIFICATION.md` / `PROJECT.md`) | Rewrites flat docs into deprecation redirects and creates vBRIEF lifecycle folders. See [From any pre-v0.20 version → v0.20.0](#from-any-pre-v020-version--v0200). |
 
 ### One-time migration from the Go installer (legacy → npm)
 
 If your current install uses the frozen Go installer (`deft-install`), migrate once:
 
 1. Install Node ≥ 20 if not already present.
-2. Run `npm i -g @deftai/directive` to install from npm.
-3. In your project, run `directive agents:refresh` to update AGENTS.md with the npm-based managed section.
-4. Verify with `directive doctor` — the install-integrity check confirms the npm payload is current.
+2. Run `npm i -g @deftai/directive@latest` to install the engine from npm.
+3. In your project, run `deft update` to refresh `.deft/core/` and `.githooks/`.
+4. Run `deft migrate` once to stamp npm provenance (idempotent).
+5. Run `deft agents:refresh` if the AGENTS.md managed section is stale.
+6. Verify with `deft doctor` — install integrity confirms the npm payload is current.
 
-The frozen Go installer remains available at [GitHub Releases](https://github.com/deftai/directive/releases) as a legacy / offline bridge but receives no further updates (#1912); Node ≥ 20 is still required to run Deft afterward. After this one-time step, `npm i -g @deftai/directive@latest` is the only upgrade command you need.
+The frozen Go installer remains available at [GitHub Releases](https://github.com/deftai/directive/releases) as a legacy / offline bridge but receives no further updates (#1912); Node ≥ 20 is still required to run Deft afterward. After this one-time step, the four-step npm path above is all you need for every future upgrade.
 
 ---
 
@@ -97,13 +132,16 @@ runs the doctor first gets pointed at this exact two-step before touching `init`
 - **From v0.60.x — manual (hook refresh).** After #2049, consumer `.githooks/` dispatch through the `deft` CLI only. Run [From v0.60.0 → v0.61.x (refresh project-root git hooks, #2049)](#from-v0600--v061x-refresh-project-root-git-hooks-2049) after every framework upgrade that touches hook templates.
 - **From v0.28–v0.36 (and the final hop to current) — auto-handled.** If still on the Go-installer layout, follow the [One-time migration from the Go installer](#one-time-migration-from-the-go-installer-legacy--npm) above, then `npm i -g @deftai/directive@latest` for all future upgrades.
 
-**Final step for every bucket.** Finish on the canonical upgrade command, then let the doctor confirm you are current:
+**Final step for every bucket.** Finish on the canonical npm upgrade path, then let the doctor confirm you are current:
 
 ```bash
 npm i -g @deftai/directive@latest
+deft update
+deft migrate
+deft doctor
 ```
 
-Then run `deft update` in your project root (refreshes `.deft/core/` and `.githooks/`), then `directive doctor`: it checks install integrity and tells you whether any further hop is still due. If still on a Go-installer layout, follow the [One-time migration from the Go installer](#one-time-migration-from-the-go-installer-legacy--npm) first.
+Run those from your project root after any bucket-specific hops (`deft update` refreshes `.deft/core/` and `.githooks/`; `deft migrate` stamps npm provenance once and is idempotent). If still on a Go-installer layout, follow the [One-time migration from the Go installer](#one-time-migration-from-the-go-installer-legacy--npm) first.
 
 ---
 

--- a/packages/cli/src/doc-cli-parity.test.ts
+++ b/packages/cli/src/doc-cli-parity.test.ts
@@ -36,6 +36,9 @@ describe("doc ↔ CLI parity gate (#1996)", () => {
       refs.some((r) => r.source === "content/UPGRADING.md" && r.normalized === "agents:refresh"),
     ).toBe(true);
     expect(
+      refs.some((r) => r.source === "content/UPGRADING.md" && r.normalized === "migrate"),
+    ).toBe(true);
+    expect(
       refs.some(
         (r) => r.source === "content/templates/agents-entry.md" && r.normalized === "triage:queue",
       ),
@@ -69,6 +72,7 @@ describe("doc ↔ CLI parity gate (#1996)", () => {
   it("accepts npm top-level init/update/migrate/bootstrap invocations", () => {
     expect(validateDocCliCommand("init")).toBeNull();
     expect(validateDocCliCommand("update")).toBeNull();
+    expect(validateDocCliCommand("migrate")).toBeNull();
     expect(validateDocCliCommand("bootstrap")).toBeNull();
   });
 });

--- a/packages/core/src/content-contracts/standards/upgrading_bigjump_triage.test.ts
+++ b/packages/core/src/content-contracts/standards/upgrading_bigjump_triage.test.ts
@@ -89,7 +89,7 @@ describe("test_upgrading_bigjump_triage.py", () => {
     expect(body).toContain("QUICK-START.md#");
     // npm is now the canonical upgrade command; Go installer is a frozen legacy bridge (#1912)
     expect(body).toContain("npm i -g @deftai/directive@latest");
-    expect(body).toContain("directive doctor");
+    expect(body).toContain("deft doctor");
   });
   it("test_doctor_anchor_actually_exists", () => {
     expect(anchorSet(readText("UPGRADING.md"))).toContain(DOCTOR_ANCHOR);

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -227,6 +227,54 @@ describe("runInitDeposit", () => {
     expect(lines.join("")).toContain("Next steps:");
   });
 
+  it("printNextSteps nudges migrate when deposit lacks npm provenance (#2059)", () => {
+    const root = makeProject(VENDORED_MANIFEST);
+    const lines: string[] = [];
+    printNextSteps(
+      {
+        projectDir: root,
+        deftDir: join(root, ".deft", "core"),
+        skillsCreated: true,
+        taskfileWired: true,
+        configDir: "/cfg",
+      },
+      { printf: (text) => lines.push(text) },
+    );
+    expect(lines.join("")).toContain("directive migrate");
+  });
+
+  it("printNextSteps omits migrate nudge when deposit is already npm-managed", () => {
+    const root = makeProject(`${VENDORED_MANIFEST}managed_by: 'npm'\n`);
+    const lines: string[] = [];
+    printNextSteps(
+      {
+        projectDir: root,
+        deftDir: join(root, ".deft", "core"),
+        skillsCreated: true,
+        taskfileWired: true,
+        configDir: "/cfg",
+      },
+      { printf: (text) => lines.push(text) },
+    );
+    expect(lines.join("")).not.toContain("directive migrate");
+  });
+
+  function makeProject(manifestBody: string): string {
+    const root = freshRoot("init-nudge-");
+    const coreDir = join(root, ".deft", "core");
+    mkdirSync(coreDir, { recursive: true });
+    writeFileSync(join(coreDir, "VERSION"), manifestBody, "utf8");
+    return root;
+  }
+
+  const VENDORED_MANIFEST = [
+    "ref: 'v0.40.0'",
+    "sha: 'deadbeef'",
+    "tag: 'v0.40.0'",
+    "install_root: '.deft/core'",
+    "",
+  ].join("\n");
+
   it("printNextSteps notes when skills were already present", () => {
     const lines: string[] = [];
     printNextSteps(

--- a/packages/core/src/init-deposit/init-deposit.ts
+++ b/packages/core/src/init-deposit/init-deposit.ts
@@ -22,6 +22,7 @@ import {
   type LegacyLayoutDetection,
   LegacyLayoutRefusedError,
 } from "./legacy-detect.js";
+import { printMigrateNudgeIfNeeded } from "./migrate.js";
 import {
   CANONICAL_INSTALL_ROOT,
   depositNeutralization,
@@ -166,6 +167,7 @@ export function printNextSteps(result: InitDepositResult, io: InitDepositIo): vo
   io.printf(
     "  3. On first session, the agent will guide you through creating USER.md and PROJECT-DEFINITION.vbrief.json\n",
   );
+  printMigrateNudgeIfNeeded(result.projectDir, io);
   io.printf("\n");
 }
 

--- a/packages/core/src/init-deposit/migrate.test.ts
+++ b/packages/core/src/init-deposit/migrate.test.ts
@@ -8,8 +8,10 @@ import {
   isNpmManaged,
   NPM_MANAGED_SENTINEL_KEY,
   NPM_MANAGED_SENTINEL_VALUE,
+  printMigrateNudgeIfNeeded,
   runMigrate,
   runMigrateCli,
+  shouldEmitMigrateNudge,
   stampManifestText,
 } from "./migrate.js";
 
@@ -224,5 +226,41 @@ describe("runMigrateCli", () => {
     expect(parsed.outcome).toBe("migrated");
     expect(parsed.sentinel_key).toBe(NPM_MANAGED_SENTINEL_KEY);
     expect(parsed.sentinel_value).toBe(NPM_MANAGED_SENTINEL_VALUE);
+  });
+});
+
+describe("shouldEmitMigrateNudge / printMigrateNudgeIfNeeded (#2059)", () => {
+  it("returns true for canonical-vendored deposit without npm sentinel", () => {
+    const root = makeProject(VENDORED_MANIFEST);
+    expect(shouldEmitMigrateNudge(root)).toBe(true);
+  });
+
+  it("returns false when deposit is already npm-managed", () => {
+    const root = makeProject(
+      `${VENDORED_MANIFEST}${NPM_MANAGED_SENTINEL_KEY}: '${NPM_MANAGED_SENTINEL_VALUE}'\n`,
+    );
+    expect(shouldEmitMigrateNudge(root)).toBe(false);
+  });
+
+  it("returns false when no canonical deposit exists", () => {
+    const root = makeProject(null);
+    expect(shouldEmitMigrateNudge(root)).toBe(false);
+  });
+
+  it("printMigrateNudgeIfNeeded emits the one-line nudge when needed", () => {
+    const root = makeProject(VENDORED_MANIFEST);
+    const lines: string[] = [];
+    printMigrateNudgeIfNeeded(root, { printf: (text) => lines.push(text) });
+    expect(lines.join("")).toContain("directive migrate");
+    expect(lines.join("")).toContain("idempotent");
+  });
+
+  it("printMigrateNudgeIfNeeded is silent when already hybrid", () => {
+    const root = makeProject(
+      `${VENDORED_MANIFEST}${NPM_MANAGED_SENTINEL_KEY}: '${NPM_MANAGED_SENTINEL_VALUE}'\n`,
+    );
+    const lines: string[] = [];
+    printMigrateNudgeIfNeeded(root, { printf: (text) => lines.push(text) });
+    expect(lines.join("")).toBe("");
   });
 });

--- a/packages/core/src/init-deposit/migrate.test.ts
+++ b/packages/core/src/init-deposit/migrate.test.ts
@@ -247,6 +247,14 @@ describe("shouldEmitMigrateNudge / printMigrateNudgeIfNeeded (#2059)", () => {
     expect(shouldEmitMigrateNudge(root)).toBe(false);
   });
 
+  it("returns false when manifest is empty or unreadable", () => {
+    const emptyRoot = makeProject("");
+    expect(shouldEmitMigrateNudge(emptyRoot)).toBe(false);
+
+    const root = makeProject(VENDORED_MANIFEST);
+    expect(shouldEmitMigrateNudge(root, { readText: () => null })).toBe(false);
+  });
+
   it("printMigrateNudgeIfNeeded emits the one-line nudge when needed", () => {
     const root = makeProject(VENDORED_MANIFEST);
     const lines: string[] = [];

--- a/packages/core/src/init-deposit/migrate.ts
+++ b/packages/core/src/init-deposit/migrate.ts
@@ -261,3 +261,38 @@ export function runMigrateCli(options: RunMigrateCliOptions): number {
   }
   return result.exitCode;
 }
+
+/** One-line nudge for init/update/session completion when provenance is unstamped (#2059). */
+export const MIGRATE_COMPLETION_NUDGE =
+  "[deft] One-time: run `directive migrate` to stamp npm provenance (idempotent). See content/UPGRADING.md.";
+
+/** True when a canonical-vendored deposit exists and lacks the npm-managed sentinel. */
+export function shouldEmitMigrateNudge(
+  projectRoot: string,
+  seams: Pick<MigrateSeams, "isFile" | "readText"> = {},
+): boolean {
+  const isFile = seams.isFile ?? existsSync;
+  const readText = seams.readText ?? defaultReadText;
+  const manifestPath = detectCanonicalVendoredManifest(projectRoot, isFile);
+  if (manifestPath === null) return false;
+  const text = readText(manifestPath);
+  if (text === null) return false;
+  const manifest = parseInstallManifest(text);
+  if (Object.keys(manifest).length === 0) return false;
+  return !isNpmManaged(manifest);
+}
+
+export interface MigrateNudgeIo {
+  printf: (text: string) => void;
+}
+
+/** Prints {@link MIGRATE_COMPLETION_NUDGE} when {@link shouldEmitMigrateNudge} is true. */
+export function printMigrateNudgeIfNeeded(
+  projectRoot: string,
+  io: MigrateNudgeIo,
+  seams: Pick<MigrateSeams, "isFile" | "readText"> = {},
+): void {
+  if (shouldEmitMigrateNudge(projectRoot, seams)) {
+    io.printf(`\n${MIGRATE_COMPLETION_NUDGE}\n`);
+  }
+}

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -19,6 +19,7 @@ import {
   frameworkRefreshSideEffects,
   parseUpdateArgv,
   printRefreshSideEffects,
+  printUpdateComplete,
   runRefreshDeposit,
   runRefreshDepositCli,
 } from "./refresh.js";
@@ -295,6 +296,58 @@ describe("runRefreshDeposit", () => {
     const manifest = readFileSync(join(deftDir, "VERSION"), "utf8");
     expect(manifest).toContain("tag: 'v0.61.0'");
     expect(manifest).toContain("managed_by: 'npm'");
+  });
+
+  it("printUpdateComplete nudges migrate when managed_by is absent (#2059)", () => {
+    const project = freshRoot("refresh-nudge-");
+    const deftDir = join(project, ".deft", "core");
+    mkdirSync(deftDir, { recursive: true });
+    writeFileSync(
+      join(deftDir, "VERSION"),
+      "tag: 'v0.61.0'\nsha: abc\ninstall_root: '.deft/core'\n",
+      "utf8",
+    );
+    const lines: string[] = [];
+    printUpdateComplete(
+      {
+        projectDir: project,
+        deftDir,
+        contentVersion: "0.61.0",
+        engineVersion: "0.61.0",
+        previousDepositVersion: "0.60.0",
+        agentsMdUpdated: true,
+        versionSkewNotice: null,
+        legacyLayout: false,
+      },
+      { printf: (text) => lines.push(text) },
+    );
+    expect(lines.join("")).toContain("directive migrate");
+  });
+
+  it("printUpdateComplete omits migrate nudge when deposit is npm-managed", () => {
+    const project = freshRoot("refresh-nudge-skip-");
+    const deftDir = join(project, ".deft", "core");
+    mkdirSync(deftDir, { recursive: true });
+    writeFileSync(
+      join(deftDir, "VERSION"),
+      "tag: 'v0.61.0'\nsha: abc\ninstall_root: '.deft/core'\nmanaged_by: 'npm'\n",
+      "utf8",
+    );
+    const lines: string[] = [];
+    printUpdateComplete(
+      {
+        projectDir: project,
+        deftDir,
+        contentVersion: "0.61.0",
+        engineVersion: "0.61.0",
+        previousDepositVersion: "0.60.0",
+        agentsMdUpdated: true,
+        versionSkewNotice: null,
+        legacyLayout: false,
+      },
+      { printf: (text) => lines.push(text) },
+    );
+    expect(lines.join("")).not.toContain("directive migrate");
   });
 
   it("throws LegacyLayoutRefusedError on a legacy layout (no refresh)", async () => {

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -26,6 +26,7 @@ import {
   type LegacyLayoutDetection,
   LegacyLayoutRefusedError,
 } from "./legacy-detect.js";
+import { printMigrateNudgeIfNeeded } from "./migrate.js";
 import {
   CANONICAL_INSTALL_ROOT,
   depositNeutralization,
@@ -287,6 +288,7 @@ export function printUpdateComplete(result: RefreshDepositResult, io: InitDeposi
   if (result.versionSkewNotice) {
     io.printf(`\n${result.versionSkewNotice}\n`);
   }
+  printMigrateNudgeIfNeeded(result.projectDir, io);
   io.printf("\n");
 }
 

--- a/packages/core/src/session/session-start-consumer-root.test.ts
+++ b/packages/core/src/session/session-start-consumer-root.test.ts
@@ -15,7 +15,11 @@ function seedConsumerProject(): string {
   const root = mkdtempSync(join(tmpdir(), "session-start-consumer-"));
   temps.push(root);
   mkdirSync(join(root, ".deft", "core"), { recursive: true });
-  writeFileSync(join(root, ".deft", "core", "VERSION"), "0.59.0\n", "utf8");
+  writeFileSync(
+    join(root, ".deft", "core", "VERSION"),
+    "tag: 'v0.59.0'\nsha: abc\ninstall_root: '.deft/core'\n",
+    "utf8",
+  );
   mkdirSync(join(root, "vbrief"), { recursive: true });
   writeFileSync(
     join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
@@ -56,5 +60,12 @@ describe("runSessionStart consumer project root (#2032)", () => {
       worktree_path: string;
     };
     expect(state.worktree_path).toBe(root);
+  });
+
+  it("emits a migrate nudge for unstamped canonical-vendored deposits (#2059)", () => {
+    const root = seedConsumerProject();
+    const result = runSessionStart(root, { writeHistory: false });
+    expect(result.code).toBe(0);
+    expect(result.lines.join("\n")).toContain("directive migrate");
   });
 });

--- a/packages/core/src/session/session-start-consumer-root.test.ts
+++ b/packages/core/src/session/session-start-consumer-root.test.ts
@@ -68,4 +68,16 @@ describe("runSessionStart consumer project root (#2032)", () => {
     expect(result.code).toBe(0);
     expect(result.lines.join("\n")).toContain("directive migrate");
   });
+
+  it("skips migrate nudge when deposit is already npm-managed", () => {
+    const root = seedConsumerProject();
+    writeFileSync(
+      join(root, ".deft", "core", "VERSION"),
+      "tag: 'v0.59.0'\nsha: abc\ninstall_root: '.deft/core'\nmanaged_by: 'npm'\n",
+      "utf8",
+    );
+    const result = runSessionStart(root, { writeHistory: false });
+    expect(result.code).toBe(0);
+    expect(result.lines.join("\n")).not.toContain("directive migrate");
+  });
 });

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { runningInsideDeftRepo } from "../doctor/paths.js";
+import { MIGRATE_COMPLETION_NUDGE, shouldEmitMigrateNudge } from "../init-deposit/migrate.js";
 import { disclosureLine } from "../policy/disclosure.js";
 import { resolvePolicy } from "../policy/resolve.js";
 import { runDefaultMode } from "../triage/welcome/default-mode.js";
@@ -332,6 +334,10 @@ export function runSessionStart(
       });
       lines.push(message);
     }
+  }
+
+  if (!runningInsideDeftRepo(projectRoot) && shouldEmitMigrateNudge(projectRoot)) {
+    lines.push(MIGRATE_COMPLETION_NUDGE);
   }
 
   const payload = newRitualStatePayload({

--- a/tests/cli/test_release_upgrade_banner.py
+++ b/tests/cli/test_release_upgrade_banner.py
@@ -17,8 +17,7 @@ Coverage:
 - CRLF templates are normalised to LF so the banner never injects
   mixed line endings into the release body.
 - The real committed template at the repo root is picked up and carries
-  the canonical ``deft-install --yes --upgrade --repo-root . --json``
-  command.
+  the canonical npm upgrade path (``npm i -g @deftai/directive@latest``).
 - Integration: ``run_pipeline`` Step 12 hands banner-led notes to
   ``create_github_release`` for the maintainer repo and unmodified notes
   for a consumer repo.
@@ -62,11 +61,16 @@ release = _load_module()
 BANNER_TEXT = (
     "## Upgrading from an older version?\n"
     "\n"
-    "Run the canonical upgrade command:\n"
+    "If you are on an existing Deft installation and seeing warnings from `deft doctor` "
+    "about skill-path stubs, outdated surfaces, or payload staleness, run the canonical "
+    "npm upgrade path:\n"
     "\n"
     "```bash\n"
-    "deft-install --yes --upgrade --repo-root . --json\n"
+    "npm i -g @deftai/directive@latest\n"
     "```\n"
+    "\n"
+    "Then from your project root: `deft update`, `deft migrate` (one-time, idempotent), "
+    "and `deft doctor`.\n"
 )
 
 NOTES = "### Added\n- A user-facing feature (#9999)\n"
@@ -98,8 +102,9 @@ class TestPrependUpgradeBanner:
         assert out.startswith("## Upgrading from an older version?")
         # The original notes survive verbatim, after the banner.
         assert out.endswith(NOTES)
-        # The canonical command rides through unchanged.
-        assert "deft-install --yes --upgrade --repo-root . --json" in out
+        # The canonical npm upgrade path rides through unchanged.
+        assert "npm i -g @deftai/directive@latest" in out
+        assert "deft migrate" in out
 
     def test_banner_joined_by_single_blank_line(self, tmp_path):
         """Banner + notes are separated by exactly one blank line."""
@@ -159,9 +164,10 @@ class TestPrependUpgradeBanner:
             NOTES, release.DEFAULT_REPO, REPO_ROOT
         )
         assert out.startswith("## Upgrading from an older version?")
-        assert "deft-install --yes --upgrade --repo-root . --json" in out
-        # The full-guidance pointer to #1411 rides through.
-        assert "issues/1411" in out
+        assert "npm i -g @deftai/directive@latest" in out
+        assert "deft migrate" in out
+        # Full guidance points at UPGRADING.md.
+        assert "content/UPGRADING.md" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/content/test_upgrading_bigjump_triage.py
+++ b/tests/content/test_upgrading_bigjump_triage.py
@@ -148,7 +148,7 @@ def test_triage_references_quickstart_and_doctor_surface() -> None:
         "The triage must name the canonical upgrade command as the "
         "final step (#1115 / #1912)."
     )
-    assert "directive doctor" in body, (
+    assert "deft doctor" in body, (
         "The triage must point multi-version upgraders at the doctor command "
         "surface (#1115)."
     )

--- a/vbrief/completed/2026-06-28-bug-pass-npm-upgrade-discoverability.vbrief.json
+++ b/vbrief/completed/2026-06-28-bug-pass-npm-upgrade-discoverability.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "bug-pass-npm-upgrade-discoverability",
     "title": "npm upgrade happy path: surface deft migrate in docs and CLI output",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Operators following README and UPGRADING.md never encounter `deft migrate` until `deft doctor` warns them. This story adds the one-time npm provenance stamp to the canonical upgrade path, fixes the release upgrade banner that still cites legacy deft-install, and reconciles UPGRADING.md npm-migration steps with the shipped CLI. Includes a one-line disambiguation between `deft migrate` (npm handshake) and `migrate:vbrief` (pre-v0.20 cutover).",
       "ImplementationPlan": "1. Update content/UPGRADING.md canonical npm section and Go-to-npm one-time migration to document npm i -g, deft update, deft migrate (idempotent), deft doctor; add migrate verb disambiguation table. 2. Update README Getting Started upgrade note if needed. 3. Replace .github/release-notes/upgrade-banner.md with npm canonical path (#2012). 4. Add migrate nudge to directive init/update completion output when managed_by is absent (packages/core/src/init-deposit/). 5. Optionally add non-blocking session:start line when signpost would fire. 6. Extend doc-cli-parity or content tests so UPGRADING cites only registered verbs; verify #1994 closable.",
@@ -83,7 +83,9 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-06-28T22:31:32Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -107,6 +109,6 @@
         "title": "Issue #2057: consumer npm upgrade path fragmented (umbrella)"
       }
     ],
-    "updated": "2026-06-28T22:24:09Z"
+    "updated": "2026-06-28T22:31:32Z"
   }
 }


### PR DESCRIPTION
## Summary
- Documents the full npm consumer upgrade path in UPGRADING.md (`npm i -g`, `deft update`, `deft migrate`, `deft doctor`) with a disambiguation table vs `migrate:vbrief`
- Replaces the release upgrade banner legacy `deft-install` command with the npm canonical path (#2012)
- Emits a one-line `directive migrate` nudge from `init`, `update`, and session start when `managed_by: npm` is absent

## Test plan
- [x] `task check` (8388 pytest + TS vitest + lint)
- [x] Targeted vitest for migrate nudge, doc-cli-parity, session-start, refresh/init completion output
- [x] Updated release upgrade banner and big-jump triage contract tests

Closes #2059
Closes #2012
Closes #1995
Refs #2057

Made with [Cursor](https://cursor.com)