### PR TITLE
chore(vbrief): sync spec-authority state after #2013 Wave 1 close

### DIFF
--- a/vbrief/completed/2026-06-28-2013-wave-1-spec-export-and-fidelity-gate.vbrief.json
+++ b/vbrief/completed/2026-06-28-2013-wave-1-spec-export-and-fidelity-gate.vbrief.json
@@ -21,7 +21,7 @@
       {
         "id": "wave1-a1-export",
         "title": "Greenfield PROJECT-DEFINITION export produces SPECIFICATION.md with PD source banner and Scope outlook sections",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a v0.20 tree with PROJECT-DEFINITION, lifecycle folders, proposed+pending scopes, and no specification.vbrief.json, when project:export-spec runs, then SPECIFICATION.md is generated with the PD source-of-truth banner, filtered config narratives, and pending scopes; proposed scopes appear only with --audience=internal.",
           "Traces": "#1502"
@@ -30,7 +30,7 @@
       {
         "id": "wave1-a2-predicate",
         "title": "Three-class precutover and strategy-output predicates recognize full-spec and greenfield exports",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given full-spec and greenfield fixture trees, when verify-strategy-output and precutover helpers run, then each class is recognized without cross-classifying greenfield exports as legacy hand-authored SPECIFICATION.md.",
           "Traces": "#2013 Wave 0 decision 2"
@@ -39,7 +39,7 @@
       {
         "id": "wave1-a3-fidelity",
         "title": "Migration fidelity gate blocks silent spec deletion when premigrate snapshot narratives lack canonical landing",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given specification.premigrate.vbrief.json with narratives not present in PROJECT-DEFINITION or scope vBRIEFs and no specification.vbrief.json, when verify-strategy-output runs, then it fails with actionable recovery guidance referencing #2005.",
           "Traces": "#2005"
@@ -48,7 +48,7 @@
       {
         "id": "wave1-a4-parity",
         "title": "Python mirror surfaces stay aligned for maintainer task check paths",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given scripts/_precutover.py and scripts/validate_strategy_output.py, when run against the same fixtures as TS, then classification and fidelity outcomes match.",
           "Traces": "#2013 port checklist"
@@ -57,7 +57,7 @@
       {
         "id": "wave1-a5-hooks",
         "title": "Consumer deposit githooks invoke Node deft only (no Python scripts/)",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a Python-free 0.60.0-style consumer deposit (no scripts/), when git commit/push runs with core.hooksPath=.githooks, then branch/encoding/conformance/gh gates run via deft CLI; deft verify:hooks-installed passes; greenfield smoke succeeds with Python absent from PATH.",
           "Traces": "#2049, #2046, #2022"

--- a/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
+++ b/vbrief/proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json
@@ -142,6 +142,12 @@
         "type": "x-vbrief/plan",
         "title": "Implement the directive bootstrap launcher and repoint operator docs (Phase 4)",
         "TrustLevel": "internal"
+      },
+      {
+        "uri": "proposed/2026-06-28-2068-decide-migrate-vbrief-ts-port-or-pre-v020-cutoff.vbrief.json",
+        "type": "x-vbrief/plan",
+        "title": "Wave 2: migrate:vbrief disposition decision (#2068) — retires #1860 carve-out",
+        "TrustLevel": "internal"
       }
     ],
     "metadata": {

--- a/vbrief/proposed/2026-06-28-2068-decide-migrate-vbrief-ts-port-or-pre-v020-cutoff.vbrief.json
+++ b/vbrief/proposed/2026-06-28-2068-decide-migrate-vbrief-ts-port-or-pre-v020-cutoff.vbrief.json
@@ -1,0 +1,74 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Revived from cancelled/2026-06-26-decide-and-execute-migratevbrief-ts-port-or-pre-v020-cutoff.vbrief.json after parent gate #2001 was superseded by #2022; now tracked live as #2068."
+  },
+  "plan": {
+    "id": "migrate-vbrief-decision-2068",
+    "title": "Decide and execute migrate:vbrief -- TS port or pre-v0.20 cutoff (retires #1860 carve-out)",
+    "status": "proposed",
+    "planRef": "proposed/2026-06-26-2022-python-purge-readiness-execution-tracker-supersedes-2001.vbrief.json",
+    "narratives": {
+      "Description": "The migrate:vbrief verb still dispatches to scripts/migrate_vbrief.py -- the sole intentional consumer-path Python entrypoint carved out of #1860's bulk delete. This story resolves the open decision: either port the migrator to TypeScript behind the directive CLI, or document a hard pre-v0.20 legacy cutoff and remove the verb from the consumer surface. #2013 Wave 0 (locked) and Wave 1 (#1502 + #2005, closed 2026-06-28) settled the spec-authority output contract the migrator depends on, so the remaining unknown is exactly this port-vs-cutoff call.",
+      "ImplementationPlan": "- Evaluate the two options against pre-v0.20 consumer impact and record the operator-signed decision, identifying whether the TS module or the cutoff doc is the resulting source change.\n- If porting, implement the native directive migrate:vbrief module preserving the v0.20 cutover output contract + #2005 fidelity gate, plus a fixture migration test; rewire tasks/migrate.yml off `uv run python`.\n- If cutting, remove the verb from tasks/migrate.yml and the consumer task surface and document the pre-v0.20 cutoff in UPGRADING.md.\n- Verify with `task check` that no remaining code path shells out to scripts/migrate_vbrief.py; confirm the #1860 carve-out is removed and zero-Python-on-consumers is demonstrable.",
+      "UserStory": "As a deft maintainer, I want a resolved migrate:vbrief decision, so that the Python migrator carve-out can be removed without stranding pre-v0.20 consumers.",
+      "Traces": "deftai/directive#2068, deftai/directive#2013, deftai/directive#1860, deftai/directive#2022"
+    },
+    "items": [
+      {
+        "id": "migrate-vbrief-decision-2068-a1",
+        "title": "Given the TS-port path, when chosen, then `task migrate:vbrief` runs with no Python and a fixture migration test validates the output against the v0.20 cutover contract + #2005 fidelity gate.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the TS-port path, when chosen, then `task migrate:vbrief` runs with no Python and a fixture migration test validates the output against the v0.20 cutover contract + #2005 fidelity gate.",
+          "Traces": "deftai/directive#2068, deftai/directive#2005"
+        }
+      },
+      {
+        "id": "migrate-vbrief-decision-2068-a2",
+        "title": "Given the cutoff path, when chosen instead, then the consumer task surface no longer shows migrate:vbrief and UPGRADING.md documents a hard pre-v0.20 cutoff.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the cutoff path, when chosen instead, then the consumer task surface no longer shows migrate:vbrief and UPGRADING.md documents a hard pre-v0.20 cutoff.",
+          "Traces": "deftai/directive#2068"
+        }
+      },
+      {
+        "id": "migrate-vbrief-decision-2068-a3",
+        "title": "Given either resolution, when `task check` runs, then it exits zero, no code path invokes scripts/migrate_vbrief.py, and the #1860 Python carve-out is removed.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given either resolution, when `task check` runs, then it exits zero, no code path invokes scripts/migrate_vbrief.py, and the #1860 Python carve-out is removed.",
+          "Traces": "deftai/directive#2068, deftai/directive#1860"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "needs_refinement",
+        "parallel_safe": false,
+        "file_scope": ["scripts/migrate_vbrief.py", "tasks/migrate.yml"],
+        "verify_commands": ["task migrate:vbrief -- --dry-run", "task check"],
+        "expected_outputs": [
+          "recorded migrate:vbrief decision",
+          "either a TS migrate verb or a documented cutoff"
+        ],
+        "depends_on": [],
+        "conflict_group": "migrate",
+        "size": "L",
+        "file_scope_confidence": "medium",
+        "model_tier": "high"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2068",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2068: Decide migrate_vbrief.py disposition (TS port vs pre-v0.20 cutoff)",
+        "TrustLevel": "external"
+      }
+    ],
+    "updated": "2026-06-28T20:50:00Z"
+  }
+}


### PR DESCRIPTION
## Summary

vBRIEF + tracking bookkeeping after #2013 Wave 1 (#1502 + #2005) was implemented by PR #2051 and the children were closed manually (closing keywords stranded). No product code changes — vBRIEF state only.

- **Wave 1 item-status drift fixed** — `vbrief/completed/2026-06-28-2013-wave-1-spec-export-and-fidelity-gate.vbrief.json` had `plan.status: completed` but its five `items[]` were still `pending`. Marked completed to match reality.
- **Migrator-disposition story revived** — moved the `migrate:vbrief` port-vs-cutoff decision out of `cancelled/` (it was orphaned under the superseded #2001 gate) into `proposed/`, re-linked to the live #2022 tracker and tracked as the new issue **#2068**. This is the work that retires the #1860 Python carve-out.
- **#2022 tracker reference added** — registered the revived child (D4 bidirectional link).

## Companion GitHub updates (this session, not in this diff)

- **#2068** filed — migrate_vbrief.py disposition decision (retires #1860 carve-out).
- **#2069** filed — `framework:check-updates` last consumer-callable `run`+Python shim.
- **#2013 current-shape comment** edited in place → **pass-3** (both Wave 1 children closed; Wave 2 = #2068).
- **#1502 / #2005** closed earlier this session.

## Verification

- `deft vbrief:validate` → OK (826 scope vBRIEFs).
- Prettier-clean; encoding gate clean; vBRIEF conformance clean (pre-commit hooks passed).

## Refs

Refs #2013, #2068, #1860, #2022

Made with [Cursor](https://cursor.com)