### PR TITLE
chore: add minimal Greptile rules stub (app reinstall)

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,12 @@
+# Review Rules
+
+## Project Context
+
+- Maintainer repo for the deft Directive framework (`deftai/directive`).
+- Greptile setup and dashboard defaults: `content/tools/greptile.md`.
+- Review-cycle workflow: `content/skills/deft-directive-review-cycle/SKILL.md`.
+
+## Review Focus
+
+- Framework rules use RFC 2119 markers (`!`, `~`, `⊗`) — treat `!` / `⊗` as hard requirements.
+- Consumer-facing copy lives under `content/templates/` and `packages/content/`; maintainer-only rules stay in root `AGENTS.md`.


### PR DESCRIPTION
## Summary

Minimal PR to support reinstalling the Greptile GitHub app on `deftai/directive`.

Adds `.greptile/rules.md` with framework context pointers (per `content/tools/greptile.md` — repo-specific rules are additive with org dashboard defaults).

## Test plan

- [ ] Reinstall / reconnect Greptile on this PR in GitHub App settings
- [ ] Confirm `Greptile Review` check appears on the PR
- [ ] Merge or close after reinstall is verified — no product behavior change

Made with [Cursor](https://cursor.com)