### PR TITLE
fix(intake): preserve inline code in ingested item titles (#1276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CI fails closed on ghx installer checksum mismatch (#1328).** The Windows ghx pre-install workflow now splits download/verify from execution: SHA256 mismatch on `install.ps1` fails the verify step (no `continue-on-error`), while the dot-source install step keeps the #884 best-effort soft-fail contract. Closes #1328.
 
+- **Issue ingest preserves inline code in acceptance-criteria titles (#1276).** `task issue:ingest` no longer strips backtick-delimited inline code from `plan.items[].title` when parsing acceptance criteria; narrative Overview was already correct. Closes #1276.
+
 - **Biome export-order lint on verify-source barrel (#2091).** Reorders named `contract-drift` re-exports so `task ts:check-lane` passes. Closes #2091.
 
 ### Removed

--- a/packages/core/src/intake/issue-ingest.test.ts
+++ b/packages/core/src/intake/issue-ingest.test.ts
@@ -45,6 +45,48 @@ describe("extractPlanItems", () => {
   it("returns empty for body without structure", () => {
     expect(extractPlanItems("Just prose, no checklist.")).toEqual([]);
   });
+
+  it("preserves inline code in acceptance-criteria checkbox titles (#1269 shape)", () => {
+    const body = [
+      "## Acceptance criteria",
+      "",
+      "- [ ] `.deft/` added to `.gitignore`",
+      "- [ ] Sentinel reader + writer module (e.g. `scripts/ritual_sentinel.py`) with `read()` / `write()` / `compute_delta()` functions",
+      "- [ ] `task check` passes",
+    ].join("\n");
+    expect(extractPlanItems(body)).toEqual([
+      { title: "`.deft/` added to `.gitignore`", status: "proposed" },
+      {
+        title:
+          "Sentinel reader + writer module (e.g. `scripts/ritual_sentinel.py`) with `read()` / `write()` / `compute_delta()` functions",
+        status: "proposed",
+      },
+      { title: "`task check` passes", status: "proposed" },
+    ]);
+  });
+
+  it("preserves inline code in acceptance-criteria checkbox titles (#1270 shape)", () => {
+    const body = [
+      "## Acceptance criteria",
+      "",
+      '- [ ] `scripts/triage_summary.py` `in-flight` count reads `len(glob("vbrief/active/*.vbrief.json"))` filtered by `plan.status == "running"` (filesystem-truth)',
+      "- [ ] When `filesystem_count != cache_scoped_count`, append `[triage:scope] N in-flight outside plan.policy.triageScope[] (uncounted in queue ranking)` (loud discrepancy line)",
+      "- [ ] `task check` passes",
+    ].join("\n");
+    expect(extractPlanItems(body)).toEqual([
+      {
+        title:
+          '`scripts/triage_summary.py` `in-flight` count reads `len(glob("vbrief/active/*.vbrief.json"))` filtered by `plan.status == "running"` (filesystem-truth)',
+        status: "proposed",
+      },
+      {
+        title:
+          "When `filesystem_count != cache_scoped_count`, append `[triage:scope] N in-flight outside plan.policy.triageScope[] (uncounted in queue ranking)` (loud discrepancy line)",
+        status: "proposed",
+      },
+      { title: "`task check` passes", status: "proposed" },
+    ]);
+  });
 });
 
 describe("provenanceIssueNumber", () => {

--- a/packages/core/src/intake/issue-ingest.ts
+++ b/packages/core/src/intake/issue-ingest.ts
@@ -12,6 +12,7 @@ import {
   parseListItems,
   sliceAcSection,
   stripCodeBlocks,
+  stripFencedCodeBlocks,
 } from "./markdown-scanners.js";
 import {
   detectRepo,
@@ -96,7 +97,7 @@ export function extractPlanItems(body: string): Record<string, string>[] {
   if (body.length === 0) {
     return [];
   }
-  const text = stripCodeBlocks(body);
+  const text = stripFencedCodeBlocks(body);
   const checkboxItems = parseCheckboxItems(text);
   if (checkboxItems.length > 0) {
     return checkboxItems.map((item) => ({ title: item.title, status: item.status }));

--- a/packages/core/src/intake/markdown-scanners.test.ts
+++ b/packages/core/src/intake/markdown-scanners.test.ts
@@ -5,12 +5,20 @@ import {
   parseListItems,
   sliceAcSection,
   stripCodeBlocks,
+  stripFencedCodeBlocks,
 } from "./markdown-scanners.js";
 
 describe("stripCodeBlocks", () => {
   it("removes fenced and inline code", () => {
     const body = "Closes #1 in prose\n```\nCloses #99\n```\n`Closes #2` ok";
     expect(stripCodeBlocks(body)).toBe("Closes #1 in prose\n\n ok");
+  });
+});
+
+describe("stripFencedCodeBlocks", () => {
+  it("removes fenced blocks but preserves inline backticks", () => {
+    const body = "`.deft/` added\n```\nCloses #99\n```\n`task check` passes";
+    expect(stripFencedCodeBlocks(body)).toBe("`.deft/` added\n\n`task check` passes");
   });
 });
 

--- a/packages/core/src/intake/markdown-scanners.ts
+++ b/packages/core/src/intake/markdown-scanners.ts
@@ -3,17 +3,25 @@
  * Avoids nested/polynomial regex on issue bodies (ReDoS-safe).
  */
 
-/** Strip fenced and inline code spans before cross-ref / plan-item extraction. */
+/** Strip fenced code blocks only (preserves inline backtick spans). */
+export function stripFencedCodeBlocks(body: string): string {
+  if (body.length === 0) {
+    return "";
+  }
+  return stripFencedCodeBlocksInner(body);
+}
+
+/** Strip fenced and inline code spans before cross-ref extraction. */
 export function stripCodeBlocks(body: string): string {
   if (body.length === 0) {
     return "";
   }
-  let text = stripFencedCodeBlocks(body);
+  let text = stripFencedCodeBlocksInner(body);
   text = stripInlineCode(text);
   return text;
 }
 
-function stripFencedCodeBlocks(text: string): string {
+function stripFencedCodeBlocksInner(text: string): string {
   let out = "";
   let i = 0;
   while (i < text.length) {


### PR DESCRIPTION
## Summary

- Plan-item extraction (`extractPlanItems`) now strips fenced code blocks only via new exported `stripFencedCodeBlocks`, preserving backtick-delimited inline code in `plan.items[].title`.
- Cross-ref extraction (`extractCrossRefs`) continues using full `stripCodeBlocks` so issue references inside inline code are not falsely captured.
- Regression tests cover #1269 and #1270 acceptance-criteria checkbox shapes.

## Test plan

- [x] `pnpm -w exec vitest run packages/core/src/intake/markdown-scanners.test.ts packages/core/src/intake/issue-ingest.test.ts`
- [x] `task check`

Closes #1276


Made with [Cursor](https://cursor.com)