### PR TITLE
fix: triage subscribe hint drops bogus --resume flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Triage subscribe reconciliation hint (#1416).** After subscribe or unsubscribe, the stderr hint now points at `task triage:bootstrap` instead of the non-existent `--resume` flag, so operators can reconcile cached entries without an argparse failure. Closes #1416.
+
 - **Biome export-order lint on verify-source barrel (#2091).** Reorders named `contract-drift` re-exports so `task ts:check-lane` passes. Closes #2091.
 
 ### Removed

--- a/packages/core/src/triage/subscribe/index.test.ts
+++ b/packages/core/src/triage/subscribe/index.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { ProjectDefinitionIOError, subscribe, unsubscribe } from "./index.js";
+import { ProjectDefinitionIOError, RECONCILE_HINT, subscribe, unsubscribe } from "./index.js";
 
 const temps: string[] = [];
 afterAll(() => {
@@ -35,6 +35,13 @@ function makeRepo(policy?: Record<string, unknown>): string {
   writePd(root, policy);
   return root;
 }
+
+describe("RECONCILE_HINT", () => {
+  it("references task triage:bootstrap without bogus --resume", () => {
+    expect(RECONCILE_HINT).toContain("task triage:bootstrap");
+    expect(RECONCILE_HINT).not.toContain("--resume");
+  });
+});
 
 describe("subscribe", () => {
   it("creates a labels.any-of rule", () => {

--- a/packages/core/src/triage/subscribe/index.ts
+++ b/packages/core/src/triage/subscribe/index.ts
@@ -406,5 +406,5 @@ export function unsubscribe(
 }
 
 export const RECONCILE_HINT =
-  "  Reconciliation: run `task triage:bootstrap -- --resume` to " +
+  "  Reconciliation: run `task triage:bootstrap` to " +
   "backfill / mark out-of-scope cached entries.";


### PR DESCRIPTION
## Summary
- Updates `RECONCILE_HINT` so post-subscribe/unsubscribe stderr points at `task triage:bootstrap` instead of the non-existent `--resume` flag.
- Adds a unit test asserting the hint references a valid bootstrap invocation.

## User impact
- Operators following the reconciliation hint after scope changes no longer hit an argparse failure.
- The suggested next step matches the idempotent bootstrap command that actually exists.

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/triage/subscribe/index.test.ts`
- [x] `task check`

Closes #1416

Made with [Cursor](https://cursor.com)