### PR TITLE
fix: skip .deft-scratch in content-standards scans (#1656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Content-standards scans skip `.deft-scratch` worktrees (#1656).** Markdown scanners no longer treat stale swarm worktrees under `.deft-scratch/` as framework docs, so leftover worktrees do not cause false `task check` failures during release CI. Closes #1656.
+
 - **Triage subscribe reconciliation hint (#1416).** After subscribe or unsubscribe, the stderr hint now points at `task triage:bootstrap` instead of the non-existent `--resume` flag, so operators can reconcile cached entries without an argparse failure. Closes #1416.
 
 - **CI fails closed on ghx installer checksum mismatch (#1328).** The Windows ghx pre-install workflow now splits download/verify from execution: SHA256 mismatch on `install.ps1` fails the verify step (no `continue-on-error`), while the dot-source install step keeps the #884 best-effort soft-fail contract. Closes #1328.

--- a/packages/core/src/content-contracts/standards/_helpers.ts
+++ b/packages/core/src/content-contracts/standards/_helpers.ts
@@ -87,6 +87,8 @@ const SKIP_DIRS = new Set([
   "dist",
   "tests",
   ".deft-cache",
+  // Swarm worktrees under .deft-scratch/ are not framework content (#1656).
+  ".deft-scratch",
   // node_modules holds third-party markdown (dependency READMEs) that is not
   // framework content; scanning it produced volatile, version-pinned cases that
   // broke CI when dependency versions drifted (#1993 follow-up).

--- a/packages/core/src/content-contracts/standards/standards.test.ts
+++ b/packages/core/src/content-contracts/standards/standards.test.ts
@@ -1,5 +1,7 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { readText } from "./_helpers.js";
+import { allMdFiles, readText, repoRoot } from "./_helpers.js";
 
 describe("test_standards.py", () => {
   it("languages/6502-DASM.md", () => {
@@ -2695,5 +2697,23 @@ describe("test_standards.py", () => {
     const text = readText("scm/github.md");
     expect(text).toContain("GetTempFileName");
     expect(text).toContain("mktemp");
+  });
+});
+
+describe("allMdFiles skip dirs", () => {
+  it("excludes markdown under .deft-scratch swarm worktrees (#1656)", () => {
+    const scratchDir = join(repoRoot(), ".deft-scratch", "worktrees", "standards-test-fixture");
+    const mdPath = join(scratchDir, "fixture.md");
+    mkdirSync(scratchDir, { recursive: true });
+    writeFileSync(mdPath, "# fixture\n", "utf8");
+    try {
+      const rel = ".deft-scratch/worktrees/standards-test-fixture/fixture.md";
+      expect(allMdFiles()).not.toContain(rel);
+    } finally {
+      rmSync(join(repoRoot(), ".deft-scratch", "worktrees", "standards-test-fixture"), {
+        recursive: true,
+        force: true,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add `.deft-scratch` to `SKIP_DIRS` in content-standards `allMdFiles()` so swarm worktrees are not scanned as framework markdown.
- Regression test creates a fixture under `.deft-scratch/worktrees/` and asserts it is excluded from the scan set.
- CHANGELOG entry under `[Unreleased]`.

Closes #1656

## Test plan

- [x] `pnpm -w exec vitest run packages/core/src/content-contracts/standards/standards.test.ts` (721 tests pass)
- [ ] `task check` (CI)


Made with [Cursor](https://cursor.com)