### PR TITLE
fix: exclude closed cached issues from triage summary (#1705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Triage summary excludes closed cached issues (#1705).** Session-start `computeSummary` no longer counts closed github-issue cache entries toward untriaged or in-flight cache-scoped totals, so accepted-then-closed issues stop inflating the triage one-liner. Closes #1705.
+
 - **Git hooks resolve local deft CLI when not on PATH (#2067).** Pre-commit and pre-push now fall back to `node packages/cli/dist/bin.js` in the maintainer monorepo (and any repo with a built local CLI) instead of aborting when global `deft` is missing. Closes #2067.
 
 - **`task triage:queue` honors triageScopeIgnores (#1800).** Issues matching label, milestone, or author entries in `plan.policy.triageScopeIgnores[]` are now excluded from the ranked queue, consistent with the scope-drift detector. Closes #1800.

--- a/packages/core/src/triage/summary/index.test.ts
+++ b/packages/core/src/triage/summary/index.test.ts
@@ -40,11 +40,17 @@ function mkRoot(): string {
   return root;
 }
 
-function makeCachedIssue(cacheRoot: string, repo: string, number: number): void {
+function makeCachedIssue(
+  cacheRoot: string,
+  repo: string,
+  number: number,
+  raw: Record<string, unknown> = { number, state: "open" },
+): void {
   const [owner, name] = repo.split("/", 2);
   const entry = join(cacheRoot, "github-issue", owner ?? "", name ?? "", String(number));
   mkdirSync(entry, { recursive: true });
   writeFileSync(join(entry, "meta.json"), "{}", "utf8");
+  writeFileSync(join(entry, "raw.json"), `${JSON.stringify(raw)}\n`, "utf8");
 }
 
 function writeAuditLog(root: string, entries: Record<string, unknown>[]): void {
@@ -166,6 +172,30 @@ describe("populated cache", () => {
     const result = computeSummary(root);
     expect(result.untriaged).toBe(0);
     expect(formatOneLiner(result)).toContain("0 untriaged");
+  });
+
+  it("excludes closed accepted issues from in-flight cache scope (#1705)", () => {
+    const root = mkRoot();
+    const cacheRoot = join(root, ".deft-cache");
+    makeCachedIssue(cacheRoot, "deftai/directive", 701, { number: 701, state: "closed" });
+    makeCachedIssue(cacheRoot, "deftai/directive", 702, { number: 702, state: "open" });
+    writeAuditLog(root, [
+      auditEntry("deftai/directive", 701, "accept", "77777777-7777-7777-7777-777777777701"),
+      auditEntry("deftai/directive", 702, "accept", "77777777-7777-7777-7777-777777777702"),
+    ]);
+    const result = computeSummary(root);
+    expect(result.inFlightCacheScoped).toBe(1);
+    expect(result.untriaged).toBe(0);
+  });
+
+  it("excludes closed untriaged issues from untriaged count (#1705)", () => {
+    const root = mkRoot();
+    const cacheRoot = join(root, ".deft-cache");
+    makeCachedIssue(cacheRoot, "deftai/directive", 801, { number: 801, state: "closed" });
+    makeCachedIssue(cacheRoot, "deftai/directive", 802, { number: 802, state: "open" });
+    const result = computeSummary(root);
+    expect(result.untriaged).toBe(1);
+    expect(result.inFlightCacheScoped).toBe(0);
   });
 
   it("counts backfilled accept toward in-flight cache scope (#1698)", () => {

--- a/packages/core/src/triage/summary/index.ts
+++ b/packages/core/src/triage/summary/index.ts
@@ -200,6 +200,45 @@ function decisionKey(repo: string, issueNumber: number): string {
   return `${repo}\0${issueNumber}`;
 }
 
+/** Read `raw.json` state for a cached github-issue entry; defaults to open when absent. */
+export function readCachedIssueState(
+  cacheRoot: string,
+  repo: string,
+  issueNumber: number,
+): string {
+  const [owner, name] = repo.split("/", 2);
+  const rawPath = join(
+    cacheRoot,
+    CACHE_SOURCE,
+    owner ?? "",
+    name ?? "",
+    String(issueNumber),
+    "raw.json",
+  );
+  if (!existsSync(rawPath)) {
+    return "open";
+  }
+  try {
+    const raw = JSON.parse(readFileSync(rawPath, { encoding: "utf8" })) as unknown;
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      return "open";
+    }
+    const stateRaw = (raw as Record<string, unknown>).state ?? "open";
+    return typeof stateRaw === "string" ? stateRaw.toLowerCase() : "open";
+  } catch {
+    return "open";
+  }
+}
+
+/** True when a cached issue should participate in summary classification counts. */
+export function isCachedIssueOpen(
+  cacheRoot: string,
+  repo: string,
+  issueNumber: number,
+): boolean {
+  return readCachedIssueState(cacheRoot, repo, issueNumber) !== "closed";
+}
+
 // ---------------------------------------------------------------------------
 // compute / format / persist
 // ---------------------------------------------------------------------------
@@ -245,6 +284,9 @@ export function computeSummary(
   const noDecisionKeys: Array<[string, number]> = [];
 
   for (const [repo, issueNumber] of cached) {
+    if (!isCachedIssueOpen(resolvedCacheRoot, repo, issueNumber)) {
+      continue;
+    }
     const decision = decisions.get(decisionKey(repo, issueNumber));
     if (decision === undefined || decision === "reset" || !TRIAGED_DECISIONS.has(decision)) {
       untriaged += 1;

--- a/vbrief/active/2026-06-30-1667-reconcileissues-apply-lifecycle-fixes-moves-parent-vbrief-bu.vbrief.json
+++ b/vbrief/active/2026-06-30-1667-reconcileissues-apply-lifecycle-fixes-moves-parent-vbrief-bu.vbrief.json
@@ -1,0 +1,64 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1667 — reconcile lifecycle fixes update child planRefs"
+  },
+  "plan": {
+    "id": "1667-reconcile-planref",
+    "title": "reconcile:issues lifecycle fix rewrites child planRefs when parent moves",
+    "status": "running",
+    "narratives": {
+      "Description": "`applyLifecycleFixes` in packages/core/src/intake/reconcile-issues.ts moves closed-issue vBRIEFs to completed/ but leaves child story vBRIEFs pointing at the old proposed/ path in planRef/items[].planRef. D4 validation then fails and blocks release.",
+      "ImplementationPlan": "1. After moving a parent/epic vBRIEF in applyLifecycleFixes, scan vbrief/ for children referencing the old relative path and rewrite planRef to the new completed/ (or cancelled/) path.\n2. Update propagateItemStatus or add rewriteChildPlanRefs helper; cover epic items[] back-links.\n3. Add regression tests in packages/core/src/intake/intake-cli-and-branches.test.ts or reconcile-issues dedicated test.\n4. CHANGELOG entry. Closes #1667.",
+      "UserStory": "As a release operator running reconcile:issues --apply-lifecycle-fixes, I want child vBRIEF planRefs to follow moved parents, so that vbrief:validate passes without hand-editing six files.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1667",
+      "Overview": "v0.49.0 release cut blocker — dangling planRef after parent git mv.",
+      "Labels": "bug, triage"
+    },
+    "items": [
+      {
+        "id": "1667-a1",
+        "title": "Child planRefs rewritten on parent move",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a parent moved proposed/X -> completed/X, when applyLifecycleFixes completes, then children referencing proposed/X have planRef updated to completed/X."
+        }
+      },
+      {
+        "id": "1667-a2",
+        "title": "Regression test for dangling planRef",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given fixture parent+child vBRIEFs and closed upstream issue, when applyLifecycleFixes runs, then vbrief:validate reports no D4 planRef errors."
+        }
+      }
+    ],
+    "tags": ["bug", "triage"],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": { "parent_issue": "#1667" },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/intake/reconcile-issues.ts",
+          "packages/core/src/intake/intake-cli-and-branches.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm -w exec vitest run packages/core/src/intake/intake-cli-and-branches.test.ts",
+          "pnpm -w run build"
+        ],
+        "expected_outputs": ["planRef rewrite on parent move", "Regression test", "CHANGELOG"],
+        "depends_on": [],
+        "conflict_group": "bug-cohort-reconcile",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "strong",
+        "missing_traces_justification": "Release blocker from issue #1667."
+      },
+      "capacityBucket": "bugfix"
+    },
+    "references": [{ "type": "github-issue", "uri": "https://github.com/deftai/directive/issues/1667" }]
+  }
+}

--- a/vbrief/active/2026-06-30-1705-floating-accepted-then-closed-issues-never-reconcile-filter.vbrief.json
+++ b/vbrief/active/2026-06-30-1705-floating-accepted-then-closed-issues-never-reconcile-filter.vbrief.json
@@ -1,0 +1,64 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1705 — triage summary excludes closed cached issues"
+  },
+  "plan": {
+    "id": "1705-summary-closed-filter",
+    "title": "Triage summary counts exclude closed upstream issues",
+    "status": "running",
+    "narratives": {
+      "Description": "computeSummary in packages/core/src/triage/summary/index.ts classifies every cached github-issue by audit decision alone. Closed issues with accept still inflate in_flight_cache_scoped; closed issues with no decision still count as untriaged.",
+      "ImplementationPlan": "1. When iterating cached issues in computeSummary, read raw.json state (or equivalent cache payload) and skip closed issues from untriaged / in_flight_cache_scoped / stale_defer counts.\n2. Optionally expose closed-issue skip in iterCachedIssues or a filter helper; keep reconcilable logic consistent.\n3. Add regression tests in packages/core/src/triage/summary/index.test.ts with closed+accepted and closed+untriaged fixtures.\n4. CHANGELOG entry. Closes #1705.",
+      "UserStory": "As an operator reading the session-start triage one-liner, I want counts to reflect only open upstream issues, so that accepted-then-closed issues do not inflate in-flight numbers.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1705",
+      "Overview": "Cache-scoped summary ignores GitHub state field.",
+      "Labels": "bug, triage"
+    },
+    "items": [
+      {
+        "id": "1705-a1",
+        "title": "Closed issues excluded from summary counts",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a cached issue with state=closed and latest decision accept, when computeSummary runs, then in_flight_cache_scoped does not include it."
+        }
+      },
+      {
+        "id": "1705-a2",
+        "title": "Regression tests for closed cache entries",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given index.test.ts fixtures for closed accepted and closed untriaged entries, when vitest runs, then counts match open-issue-only semantics."
+        }
+      }
+    ],
+    "tags": ["bug", "triage"],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": { "parent_issue": "#1705" },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/summary/index.ts",
+          "packages/core/src/triage/summary/index.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm -w exec vitest run packages/core/src/triage/summary/index.test.ts",
+          "pnpm -w run build"
+        ],
+        "expected_outputs": ["Closed-issue filter in computeSummary", "Regression tests", "CHANGELOG"],
+        "depends_on": [],
+        "conflict_group": "bug-cohort-summary",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "strong",
+        "missing_traces_justification": "Summary lie from issue #1705 evidence."
+      },
+      "capacityBucket": "bugfix"
+    },
+    "references": [{ "type": "github-issue", "uri": "https://github.com/deftai/directive/issues/1705" }]
+  }
+}

--- a/vbrief/active/2026-06-30-1888-triage-actions-ts-cli-missing-needs-ac-mark-duplicate-reset.vbrief.json
+++ b/vbrief/active/2026-06-30-1888-triage-actions-ts-cli-missing-needs-ac-mark-duplicate-reset.vbrief.json
@@ -1,0 +1,65 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1888 — task/deft triage colon verbs route to triage-actions"
+  },
+  "plan": {
+    "id": "1888-triage-actions-verbs",
+    "title": "Wire task triage:* colon verbs to triage-actions subcommands",
+    "status": "running",
+    "narratives": {
+      "Description": "The triage-actions module implements accept/reject/defer/needs-ac/mark-duplicate/reset/history, and route-argv maps `deft triage reset` correctly. But `task triage:reset`, `task triage:needs-ac`, etc. fail with `unknown verb` because dispatch.ts VERB_ALIASES only registers triage:accept and triage:status, and does not inject the subcommand when invoking triage-actions.",
+      "ImplementationPlan": "1. Extend packages/cli/src/dispatch.ts VERB_ALIASES with triage:reject, triage:defer, triage:needs-ac, triage:mark-duplicate, triage:reset, triage:history.\n2. When dispatch resolves a colon alias to triage-actions, prepend the subcommand (e.g. reset) to handler argv — mirror route-argv SUBCOMMAND_ROUTES behavior.\n3. Add regression tests in packages/cli/src/dispatch.test.ts or triage-actions.test.ts proving `deft triage:reset` and `deft triage:needs-ac` reach the handler.\n4. CHANGELOG entry. Closes #1888.",
+      "UserStory": "As an operator running `task triage:reset`, I want the command to append a reset audit entry, so that Layer-5 triage reversibility works from the documented task surface.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1888",
+      "Overview": "Partial TS port: module has verbs; task/deft colon aliases missing.",
+      "Labels": "bug, triage, ts-migration"
+    },
+    "items": [
+      {
+        "id": "1888-a1",
+        "title": "Colon verbs dispatch to triage-actions",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given `deft triage:reset --issue N --repo R`, when invoked, then triage-actions reset runs (not unknown verb)."
+        }
+      },
+      {
+        "id": "1888-a2",
+        "title": "Regression tests for colon routing",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given vitest covering dispatch alias + subcommand injection, when run, then needs-ac/reset/mark-duplicate colon forms pass."
+        }
+      }
+    ],
+    "tags": ["bug", "triage"],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": { "parent_issue": "#1888" },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/dispatch.ts",
+          "packages/cli/src/triage-actions.test.ts",
+          "packages/cli/src/cli-router/route-argv.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm -w exec vitest run packages/cli/src/triage-actions.test.ts packages/cli/src/cli-router/router.test.ts",
+          "pnpm -w run build"
+        ],
+        "expected_outputs": ["VERB_ALIASES + subcommand injection", "Regression tests", "CHANGELOG"],
+        "depends_on": [],
+        "conflict_group": "bug-cohort-cli",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "strong",
+        "missing_traces_justification": "Dispatch gap from issue #1888 evidence."
+      },
+      "capacityBucket": "bugfix"
+    },
+    "references": [{ "type": "github-issue", "uri": "https://github.com/deftai/directive/issues/1888" }]
+  }
+}

--- a/vbrief/completed/2026-06-29-1800-triagescopeignores-not-honored-by-triagequeue-only-the-drift.vbrief.json
+++ b/vbrief/completed/2026-06-29-1800-triagescopeignores-not-honored-by-triagequeue-only-the-drift.vbrief.json
@@ -1,9 +1,12 @@
 {
-  "vBRIEFInfo": { "version": "0.6", "description": "Story vBRIEF for #1800 — triage:queue honors triageScopeIgnores" },
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #1800 — triage:queue honors triageScopeIgnores"
+  },
   "plan": {
     "id": "1800-queue-ignores",
     "title": "triage:queue honors plan.policy.triageScopeIgnores",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "`plan.policy.triageScopeIgnores[]` suppresses issues in the drift detector but not in `task triage:queue`. Operators who add ignore entries still see those issues ranked as actionable untriaged work.",
       "ImplementationPlan": "1. Reuse `resolveScopeIgnores` from `packages/core/src/triage/scope-drift/scope-rules.ts` (or shared scope resolver) inside queue build path — filter cached issues in `packages/core/src/triage/queue/build-queue.ts` or `cache.ts` before ranking.\n2. Add regression test in `packages/core/src/triage/queue/queue.test.ts` with a PROJECT-DEFINITION ignore label and assert the issue is excluded from queue output.\n3. Run `pnpm -w exec vitest run packages/core/src/triage/queue/queue.test.ts` as verification evidence; CHANGELOG entry. Closes #1800.",
@@ -38,10 +41,15 @@
         }
       }
     ],
-    "tags": ["bug", "triage"],
+    "tags": [
+      "bug",
+      "triage"
+    ],
     "metadata": {
       "kind": "story",
-      "x-tracking": { "parent_issue": "#1800" },
+      "x-tracking": {
+        "parent_issue": "#1800"
+      },
       "swarm": {
         "readiness": "ready",
         "parallel_safe": true,
@@ -55,7 +63,11 @@
           "pnpm -w exec vitest run packages/core/src/triage/queue/queue.test.ts",
           "pnpm -w run build"
         ],
-        "expected_outputs": ["Queue filters triageScopeIgnores", "Regression test", "CHANGELOG entry"],
+        "expected_outputs": [
+          "Queue filters triageScopeIgnores",
+          "Regression test",
+          "CHANGELOG entry"
+        ],
         "depends_on": [],
         "conflict_group": "bug-cohort-queue",
         "size": "medium",
@@ -63,9 +75,16 @@
         "model_tier": "default",
         "missing_traces_justification": "Queue/policy mismatch from issue #1800."
       },
-      "capacityBucket": "bugfix"
+      "capacityBucket": "bugfix",
+      "completedAt": "2026-06-29T23:58:19Z"
     },
-    "references": [{ "uri": "https://github.com/deftai/directive/issues/1800", "type": "x-vbrief/github-issue", "title": "Issue #1800" }],
-    "updated": "2026-06-29T23:45:00Z"
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1800",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #1800"
+      }
+    ],
+    "updated": "2026-06-29T23:58:19Z"
   }
 }

--- a/vbrief/completed/2026-06-29-2067-git-hooks-fail-when-deft-is-absent-from-the-hook-path-mainta.vbrief.json
+++ b/vbrief/completed/2026-06-29-2067-git-hooks-fail-when-deft-is-absent-from-the-hook-path-mainta.vbrief.json
@@ -1,9 +1,12 @@
 {
-  "vBRIEFInfo": { "version": "0.6", "description": "Story vBRIEF for #2067 — git hooks resolve local deft CLI" },
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2067 — git hooks resolve local deft CLI"
+  },
   "plan": {
     "id": "2067-hooks-deft-path",
     "title": "Git hooks resolve local deft CLI when not on PATH",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Consumer git hooks (`.githooks/pre-commit`, `pre-push`) hard-require global `deft` on PATH. In the maintainer monorepo and other layouts where the runnable CLI lives at `packages/cli/dist/bin.js`, commits and pushes fail even though a local CLI exists.",
       "ImplementationPlan": "1. Add a POSIX hook helper (or inline resolver in `.githooks/pre-commit` and `.githooks/pre-push`) that falls back to `node \"$REPO_ROOT/packages/cli/dist/bin.js\"` (or equivalent) when `command -v deft` fails.\n2. Mirror the resolver in deposited hook templates under `packages/core/src/init-deposit/` if consumer hooks are generated from there.\n3. Add tests in `packages/core/src/content-contracts/standards/branch_gate.test.ts` or a focused hook-resolver test asserting maintainer-monorepo fallback; run `pnpm -w exec vitest run packages/core/src/content-contracts/standards/branch_gate.test.ts` as verification evidence. CHANGELOG entry. Closes #2067.",
@@ -38,10 +41,15 @@
         }
       }
     ],
-    "tags": ["bug", "tooling"],
+    "tags": [
+      "bug",
+      "tooling"
+    ],
     "metadata": {
       "kind": "story",
-      "x-tracking": { "parent_issue": "#2067" },
+      "x-tracking": {
+        "parent_issue": "#2067"
+      },
       "swarm": {
         "readiness": "ready",
         "parallel_safe": true,
@@ -55,7 +63,11 @@
           "pnpm -w exec vitest run packages/core/src/content-contracts/standards/branch_gate.test.ts",
           "pnpm -w run build"
         ],
-        "expected_outputs": ["Hook local deft resolver", "pre-commit/pre-push fallback", "CHANGELOG entry"],
+        "expected_outputs": [
+          "Hook local deft resolver",
+          "pre-commit/pre-push fallback",
+          "CHANGELOG entry"
+        ],
         "depends_on": [],
         "conflict_group": "bug-cohort-hooks",
         "size": "small",
@@ -63,9 +75,16 @@
         "model_tier": "default",
         "missing_traces_justification": "Release-blocker from ingested issue #2067."
       },
-      "capacityBucket": "bugfix"
+      "capacityBucket": "bugfix",
+      "completedAt": "2026-06-29T23:59:58Z"
     },
-    "references": [{ "uri": "https://github.com/deftai/directive/issues/2067", "type": "x-vbrief/github-issue", "title": "Issue #2067" }],
-    "updated": "2026-06-29T23:45:00Z"
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2067",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #2067"
+      }
+    ],
+    "updated": "2026-06-29T23:59:58Z"
   }
 }


### PR DESCRIPTION
## Summary
- `computeSummary` reads each cached github-issue `raw.json` state and skips closed entries when classifying untriaged, in-flight cache-scoped, and stale-defer counts
- Adds regression tests for closed+accepted and closed+untriaged fixtures

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/triage/summary/index.test.ts`
- [x] `pnpm -w run build`

Closes #1705

Made with [Cursor](https://cursor.com)