### PR TITLE
fix(cli): wire triage colon verbs to triage-actions (#1888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **verify:cache-fresh --for-issue reads canonical audit fields (#1887).** The cache-fresh gate now resolves per-issue triage decisions via the shared candidates audit-log reader (`issue_number` / `timestamp`), so a valid `triage:accept` no longer false-fails with "no triage decision" during the pre-dispatch gate stack. Closes #1887.
 
+- **`task triage:reset` and related colon verbs reach triage-actions (#1888).** `deft triage:reset`, `deft triage:needs-ac`, and the other documented triage colon aliases now register in the CLI dispatcher and pass the correct subcommand to triage-actions instead of failing with unknown verb. Closes #1888.
+
 - **D2 triage summary suppression includes discrepancy fields (#1279).** Session-start triage one-liner re-emits within the 4-hour D2 window when the `[triage:scope]` discrepancy line appears or resolves, because the suppression key now includes `in_flight_filesystem`, `in_flight_cache_scoped`, and `triage_scope_configured`. Existing operators may see one extra emission after upgrade as the hash key changes. Closes #1279.
 
 - **Content-standards scans skip `.deft-scratch` worktrees (#1656).** Markdown scanners no longer treat stale swarm worktrees under `.deft-scratch/` as framework docs, so leftover worktrees do not cause false `task check` failures during release CI. Closes #1656.

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -126,6 +126,13 @@ describe("taskKeyToDispatchArgv", () => {
     ]);
     expect(taskKeyToDispatchArgv("vbrief:preflight")).toEqual(["vbrief:preflight"]);
     expect(taskKeyToDispatchArgv("triage:welcome")).toEqual(["triage:welcome"]);
+    expect(taskKeyToDispatchArgv("triage:reset", ["--issue", "1"])).toEqual([
+      "triage-actions",
+      "reset",
+      "--issue",
+      "1",
+    ]);
+    expect(taskKeyToDispatchArgv("triage:needs-ac")).toEqual(["triage-actions", "needs-ac"]);
   });
 });
 

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -19,8 +19,8 @@ import {
   runDirectiveBootstrap,
   runSetupGhx,
   SETUP_SKILL_REL_PATH,
-  VERB_ALIASES,
   TRIAGE_ACTION_ALIAS_SUBCOMMANDS,
+  VERB_ALIASES,
 } from "./dispatch.js";
 
 const engineVersion = engineInfo().version;

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -20,6 +20,7 @@ import {
   runSetupGhx,
   SETUP_SKILL_REL_PATH,
   VERB_ALIASES,
+  TRIAGE_ACTION_ALIAS_SUBCOMMANDS,
 } from "./dispatch.js";
 
 const engineVersion = engineInfo().version;
@@ -301,6 +302,50 @@ describe("dispatch", () => {
     for (const [alias, canonical] of Object.entries(VERB_ALIASES)) {
       expect(resolveCanonicalVerb(alias)).toBe(canonical);
     }
+  });
+
+  it("registers all triage-actions colon aliases (#1888)", () => {
+    for (const alias of Object.keys(TRIAGE_ACTION_ALIAS_SUBCOMMANDS)) {
+      expect(resolveCanonicalVerb(alias)).toBe("triage-actions");
+    }
+    expect(resolveCanonicalVerb("triage:reset")).toBe("triage-actions");
+    expect(resolveCanonicalVerb("triage:needs-ac")).toBe("triage-actions");
+  });
+
+  it("injects triage-actions subcommand for colon aliases (#1888)", async () => {
+    const run = vi.fn(() => 0);
+    vi.doMock("./triage-actions.js", () => ({ run }));
+    resetHandlerCacheForTests();
+
+    await dispatch(["triage:reset", "--issue", "1", "--repo", "deftai/directive"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+    expect(run).toHaveBeenCalledWith(["reset", "--issue", "1", "--repo", "deftai/directive"]);
+
+    resetHandlerCacheForTests();
+    vi.doMock("./triage-actions.js", () => ({ run }));
+
+    await dispatch(["triage:needs-ac", "--issue", "2", "--repo", "deftai/directive"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+    expect(run).toHaveBeenCalledWith(["needs-ac", "--issue", "2", "--repo", "deftai/directive"]);
+
+    resetHandlerCacheForTests();
+    vi.doMock("./triage-actions.js", () => ({ run }));
+
+    await dispatch(["triage:mark-duplicate", "--issue", "3", "--repo", "deftai/directive"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+    expect(run).toHaveBeenCalledWith([
+      "mark-duplicate",
+      "--issue",
+      "3",
+      "--repo",
+      "deftai/directive",
+    ]);
   });
 });
 

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -2442,8 +2442,7 @@ export async function dispatch(argv: string[], io: DispatchIo = defaultIo()): Pr
 
   try {
     const handler = await loadHandler(canonical, io);
-    const triageSubcommand =
-      verb !== undefined ? TRIAGE_ACTION_ALIAS_SUBCOMMANDS[verb] : undefined;
+    const triageSubcommand = verb !== undefined ? TRIAGE_ACTION_ALIAS_SUBCOMMANDS[verb] : undefined;
     const handlerArgv =
       canonical === "framework-commands" && verb !== undefined && verb !== canonical
         ? [verb, ...rest]

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -183,6 +183,22 @@ export const CORE_MODULE_VERBS = [
   "architecture-preflight-sor",
 ] as const;
 
+/** Colon aliases for triage-actions (mirrors cli-router SUBCOMMAND_ROUTES). */
+export const TRIAGE_ACTION_ALIAS_SUBCOMMANDS: Readonly<Record<string, string>> = {
+  "triage:accept": "accept",
+  "triage:reject": "reject",
+  "triage:defer": "defer",
+  "triage:needs-ac": "needs-ac",
+  "triage:mark-duplicate": "mark-duplicate",
+  "triage:status": "status",
+  "triage:reset": "reset",
+  "triage:history": "history",
+};
+
+const TRIAGE_ACTION_COLON_ALIASES = Object.fromEntries(
+  Object.keys(TRIAGE_ACTION_ALIAS_SUBCOMMANDS).map((alias) => [alias, "triage-actions"]),
+) as Record<string, string>;
+
 /** Task-style aliases (framework_commands / Taskfile names). */
 export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "verify:encoding": "verify-encoding",
@@ -220,8 +236,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "triage:summary": "triage-summary",
   "triage:queue": "triage-queue",
   "triage:scope": "triage-scope",
-  "triage:accept": "triage-actions",
-  "triage:status": "triage-actions",
+  ...TRIAGE_ACTION_COLON_ALIASES,
   "agents:refresh": "agents-refresh",
   "migrate:preflight": "migrate-preflight",
   "framework:check-updates": "framework-check-updates",
@@ -2427,10 +2442,14 @@ export async function dispatch(argv: string[], io: DispatchIo = defaultIo()): Pr
 
   try {
     const handler = await loadHandler(canonical, io);
+    const triageSubcommand =
+      verb !== undefined ? TRIAGE_ACTION_ALIAS_SUBCOMMANDS[verb] : undefined;
     const handlerArgv =
       canonical === "framework-commands" && verb !== undefined && verb !== canonical
         ? [verb, ...rest]
-        : rest;
+        : triageSubcommand !== undefined && canonical === "triage-actions"
+          ? [triageSubcommand, ...rest]
+          : rest;
     return await invokeHandler(handler, handlerArgv);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Register all documented `triage:*` colon aliases in `dispatch.ts` VERB_ALIASES (reject, defer, needs-ac, mark-duplicate, reset, history).
- Inject the subcommand when routing colon aliases to `triage-actions`, matching `route-argv` SUBCOMMAND_ROUTES behavior.
- Add regression tests for alias resolution and argv injection.

## Test plan
- [x] `pnpm -w exec vitest run packages/cli/src/triage-actions.test.ts packages/cli/src/cli-router/router.test.ts packages/cli/src/dispatch.test.ts`
- [x] Manual: `node packages/cli/dist/bin.js triage:reset` returns triage_actions arg error (not unknown verb)

Closes #1888

Made with [Cursor](https://cursor.com)