### PR TITLE
chore(policy): restore branch protection post v0.65.0

### DIFF
--- a/meta/policy-changes.log
+++ b/meta/policy-changes.log
@@ -63,3 +63,4 @@
 2026-06-29T20:33:18Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
 2026-06-29T20:33:26Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True
 2026-06-30T00:41:03Z actor=task policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
+2026-06-30T00:44:43Z actor=task policy:enforce-branches allowDirectCommitsToMaster=false previous=True

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -16780,7 +16780,7 @@
           }
         ]
       },
-      "allowDirectCommitsToMaster": true
+      "allowDirectCommitsToMaster": false
     },
     "updated": "2026-06-12T20:26:00Z"
   }


### PR DESCRIPTION
Restore typed branch policy after release cut.

Made with [Cursor](https://cursor.com)