### PR TITLE
feat(vbrief): extension round-trip conformance fixtures and gate (#715)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Extension round-trip conformance fixtures and gate (#715).** Packaged fixtures under `content/vbrief/conformance/extensions/valid/` exercise `x-<consumer>/` keys at document, plan, item, and nested value levels; a new round-trip preservation check in the vBRIEF validator proves those keys survive load→re-emit with JSON-structural equality and fails the conformance gate when a key is dropped or mutated. Refs #2034. Closes #715.
+
 - **xBRIEF v0.6→v0.8 semantic transforms and legacy-layout detection (#2108).** The core engine now ships a tested migration primitive that rewrites in-document v0.6 artifacts to v0.8 (info block, reference prefixes, embedded paths) idempotently, detects legacy `vbrief/` layouts, and enforces the locked safety rules that block v0.8-only feature emission into unmigrated files and prevent split `vbrief/` + `xbrief/` trees. Refs #2034. Closes #2108.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Extension round-trip conformance fixtures and gate (#715).** Packaged fixtures under `content/vbrief/conformance/extensions/valid/` exercise `x-<consumer>/` keys at document, plan, item, and nested value levels; a new round-trip preservation check in the vBRIEF validator proves those keys survive load→re-emit with JSON-structural equality and fails the conformance gate when a key is dropped or mutated. Refs #2034. Closes #715.
+- **Extension round-trip conformance fixtures and gate (#715).** Packaged conformance fixtures exercise `x-<consumer>/` keys at document, plan, item, and nested value levels; the vBRIEF validator now proves those keys survive load→re-emit with JSON-structural equality and fails the conformance gate when a key is dropped or mutated. Refs #2034. Closes #715.
 
 - **xBRIEF v0.6→v0.8 semantic transforms and legacy-layout detection (#2108).** The core engine now ships a tested migration primitive that rewrites in-document v0.6 artifacts to v0.8 (info block, reference prefixes, embedded paths) idempotently, detects legacy `vbrief/` layouts, and enforces the locked safety rules that block v0.8-only feature emission into unmigrated files and prevent split `vbrief/` + `xbrief/` trees. Refs #2034. Closes #2108.
 

--- a/content/vbrief/conformance/extensions/valid/extension-at-root.vbrief.json
+++ b/content/vbrief/conformance/extensions/valid/extension-at-root.vbrief.json
@@ -1,0 +1,31 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Conformance fixture: extension keys at document root, plan, and item (#715)."
+  },
+  "x-stream/runtime": {
+    "session": "fixture-715-root"
+  },
+  "x-directive/trace": {
+    "fixture": "extension-at-root"
+  },
+  "plan": {
+    "id": "715-extension-at-root",
+    "title": "Extension keys at root, plan, and item",
+    "status": "draft",
+    "items": [
+      {
+        "id": "715-item",
+        "title": "Item-level extension",
+        "status": "pending",
+        "x-acme/widget": {
+          "enabled": true,
+          "label": "nested-object"
+        }
+      }
+    ],
+    "x-directive/tracking": {
+      "issue": 715
+    }
+  }
+}

--- a/content/vbrief/conformance/extensions/valid/nested-extension-value.vbrief.json
+++ b/content/vbrief/conformance/extensions/valid/nested-extension-value.vbrief.json
@@ -1,0 +1,19 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Conformance fixture: extension value containing inner x-* key (#715)."
+  },
+  "plan": {
+    "id": "715-nested-extension-value",
+    "title": "Nested extension value preserves inner x-* keys",
+    "status": "draft",
+    "items": [],
+    "x-stream/container": {
+      "label": "outer",
+      "x-stream/inner": {
+        "token": "preserve-verbatim",
+        "depth": 2
+      }
+    }
+  }
+}

--- a/packages/core/src/vbrief-validate/conformance.ts
+++ b/packages/core/src/vbrief-validate/conformance.ts
@@ -7,6 +7,7 @@ import {
   gitTrackedFiles,
 } from "../encoding/git.js";
 import { fnmatchCase } from "../encoding/text.js";
+import { evaluateExtensionRoundtrip } from "./roundtrip.js";
 import type { JsonObject } from "./schema.js";
 
 export const DOC_CORE = new Set(["vBRIEFInfo", "xBRIEFInfo", "plan"]);
@@ -320,11 +321,22 @@ export function evaluateConformance(
     return { exitCode: 1, findings, message: `${header}\n${body}` };
   }
 
+  const extensionRoundtrip = evaluateExtensionRoundtrip(root);
+  if (extensionRoundtrip.exitCode !== 0) {
+    return {
+      exitCode: extensionRoundtrip.exitCode,
+      findings,
+      message: extensionRoundtrip.message,
+    };
+  }
+
+  const bareKeysMessage =
+    `\u2713 verify_vbrief_conformance: ${candidates.length} vBRIEF file(s) ` +
+    "clean -- no bare keys (#1620).";
+
   return {
     exitCode: 0,
     findings,
-    message:
-      `\u2713 verify_vbrief_conformance: ${candidates.length} vBRIEF file(s) ` +
-      "clean -- no bare keys (#1620).",
+    message: [extensionRoundtrip.message, bareKeysMessage].filter(Boolean).join("\n"),
   };
 }

--- a/packages/core/src/vbrief-validate/index.ts
+++ b/packages/core/src/vbrief-validate/index.ts
@@ -36,6 +36,7 @@ export {
   findExtensionPreservationViolations,
   reEmitVbriefArtifact,
   renderExtensionRoundtripFinding,
+  VbriefSchemaValidationError,
 } from "./roundtrip.js";
 export { normalizeNarrativeKey, validateVbriefSchema } from "./schema.js";
 export type { ValidateAllResult } from "./validate-all.js";

--- a/packages/core/src/vbrief-validate/index.ts
+++ b/packages/core/src/vbrief-validate/index.ts
@@ -24,6 +24,19 @@ export {
   validateWipCapOnPlan,
 } from "./plan-hooks.js";
 export { validateProjectDefinition } from "./project-definition.js";
+export type {
+  ExtensionEntry,
+  ExtensionRoundtripEvaluateResult,
+  ExtensionRoundtripFinding,
+} from "./roundtrip.js";
+export {
+  collectExtensionEntries,
+  EXTENSION_CONFORMANCE_FIXTURES_DIR,
+  evaluateExtensionRoundtrip,
+  findExtensionPreservationViolations,
+  reEmitVbriefArtifact,
+  renderExtensionRoundtripFinding,
+} from "./roundtrip.js";
 export { normalizeNarrativeKey, validateVbriefSchema } from "./schema.js";
 export type { ValidateAllResult } from "./validate-all.js";
 export {

--- a/packages/core/src/vbrief-validate/roundtrip.test.ts
+++ b/packages/core/src/vbrief-validate/roundtrip.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { EXTENSION_KEY_PATTERN, isExtensionKey } from "@deftai/directive-types";
+import { describe, expect, it } from "vitest";
+import { evaluateConformance } from "./conformance.js";
+import {
+  collectExtensionEntries,
+  EXTENSION_CONFORMANCE_FIXTURES_DIR,
+  evaluateExtensionRoundtrip,
+  findExtensionPreservationViolations,
+  reEmitVbriefArtifact,
+} from "./roundtrip.js";
+import type { JsonObject } from "./schema.js";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const FIXTURES_DIR = join(REPO_ROOT, EXTENSION_CONFORMANCE_FIXTURES_DIR);
+
+function loadFixture(name: string): JsonObject {
+  const text = readFileSync(join(FIXTURES_DIR, name), "utf8");
+  return JSON.parse(text) as JsonObject;
+}
+
+describe("extension round-trip preservation (#715)", () => {
+  it("uses EXTENSION_KEY_PATTERN from @deftai/directive-types as the namespace oracle", () => {
+    expect(isExtensionKey("x-stream/runtime")).toBe(true);
+    expect(isExtensionKey("x-directive/trace")).toBe(true);
+    expect(EXTENSION_KEY_PATTERN.test("x-stream/runtime")).toBe(true);
+    expect(isExtensionKey("x-stream-foo")).toBe(false);
+  });
+
+  it("collects extension keys at root, plan, item, and nested value levels", () => {
+    const artifact = loadFixture("extension-at-root.vbrief.json");
+    const keys = collectExtensionEntries(artifact).map((entry) => entry.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "x-stream/runtime",
+        "x-directive/trace",
+        "x-directive/tracking",
+        "x-acme/widget",
+      ]),
+    );
+  });
+
+  it("preserves nested extension keys inside extension values", () => {
+    const artifact = loadFixture("nested-extension-value.vbrief.json");
+    const roundtripped = reEmitVbriefArtifact(artifact, "nested-extension-value.vbrief.json");
+    expect(findExtensionPreservationViolations(artifact, roundtripped)).toEqual([]);
+    expect(
+      collectExtensionEntries(roundtripped).some((entry) => entry.key === "x-stream/inner"),
+    ).toBe(true);
+  });
+
+  it("round-trips every packaged fixture with JSON-structural extension equality", () => {
+    const result = evaluateExtensionRoundtrip(REPO_ROOT);
+    expect(result.exitCode).toBe(0);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("names dropped extension keys when preservation fails", () => {
+    const artifact = loadFixture("extension-at-root.vbrief.json");
+    const mutated = structuredClone(artifact) as JsonObject;
+    delete (mutated as Record<string, unknown>)["x-directive/trace"];
+    const violations = findExtensionPreservationViolations(artifact, mutated);
+    expect(violations.some((v) => v.includes("x-directive/trace"))).toBe(true);
+  });
+
+  it("wires extension round-trip into evaluateConformance on the maintainer repo", () => {
+    expect(existsSync(FIXTURES_DIR)).toBe(true);
+    const result = evaluateConformance(REPO_ROOT);
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toContain("extension fixture(s) round-trip clean (#715)");
+  });
+
+  it("skips extension round-trip when packaged fixtures are absent", () => {
+    const result = evaluateExtensionRoundtrip("/tmp/no-extension-fixtures-root");
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toBe("");
+  });
+});

--- a/packages/core/src/vbrief-validate/roundtrip.test.ts
+++ b/packages/core/src/vbrief-validate/roundtrip.test.ts
@@ -10,6 +10,7 @@ import {
   evaluateExtensionRoundtrip,
   findExtensionPreservationViolations,
   reEmitVbriefArtifact,
+  VbriefSchemaValidationError,
 } from "./roundtrip.js";
 import type { JsonObject } from "./schema.js";
 
@@ -70,6 +71,15 @@ describe("extension round-trip preservation (#715)", () => {
     const result = evaluateConformance(REPO_ROOT);
     expect(result.exitCode).toBe(0);
     expect(result.message).toContain("extension fixture(s) round-trip clean (#715)");
+  });
+
+  it("rejects invalid artifacts in reEmitVbriefArtifact before round-trip", () => {
+    expect(() =>
+      reEmitVbriefArtifact(
+        { xBRIEFInfo: { version: "0.8" }, plan: { title: "T", status: "auto", items: [] } },
+        "invalid-status.json",
+      ),
+    ).toThrow(VbriefSchemaValidationError);
   });
 
   it("skips extension round-trip when packaged fixtures are absent", () => {

--- a/packages/core/src/vbrief-validate/roundtrip.ts
+++ b/packages/core/src/vbrief-validate/roundtrip.ts
@@ -13,6 +13,11 @@ export interface ExtensionEntry {
   readonly value: unknown;
 }
 
+export interface ExtensionRoundtripFinding {
+  readonly path: string;
+  readonly message: string;
+}
+
 /** Thrown when `reEmitVbriefArtifact` rejects an artifact that fails schema validation. */
 export class VbriefSchemaValidationError extends Error {
   constructor(

--- a/packages/core/src/vbrief-validate/roundtrip.ts
+++ b/packages/core/src/vbrief-validate/roundtrip.ts
@@ -13,9 +13,15 @@ export interface ExtensionEntry {
   readonly value: unknown;
 }
 
-export interface ExtensionRoundtripFinding {
-  readonly path: string;
-  readonly message: string;
+/** Thrown when `reEmitVbriefArtifact` rejects an artifact that fails schema validation. */
+export class VbriefSchemaValidationError extends Error {
+  constructor(
+    readonly relPath: string,
+    readonly errors: readonly string[],
+  ) {
+    super(`schema validation failed for ${relPath}: ${errors.join("; ")}`);
+    this.name = "VbriefSchemaValidationError";
+  }
 }
 
 /** Recursively collect every `x-<consumer>/` key in `value` using the contract pattern. */
@@ -80,7 +86,10 @@ export function findExtensionPreservationViolations(
  * Extension properties MUST survive this path verbatim (xBRIEF v0.8 §7).
  */
 export function reEmitVbriefArtifact(artifact: JsonObject, relPath = "<roundtrip>"): JsonObject {
-  validateVbriefSchema(artifact, relPath);
+  const schemaErrors = validateVbriefSchema(artifact, relPath);
+  if (schemaErrors.length > 0) {
+    throw new VbriefSchemaValidationError(relPath, schemaErrors);
+  }
   const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
   return JSON.parse(serialized) as JsonObject;
 }
@@ -110,8 +119,9 @@ export function evaluateExtensionRoundtrip(projectRoot: string): ExtensionRoundt
 
   let fixtureNames: string[];
   try {
-    fixtureNames = readdirSync(fixturesDir)
-      .filter((name) => name.endsWith(".vbrief.json"))
+    fixtureNames = readdirSync(fixturesDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".vbrief.json"))
+      .map((entry) => entry.name)
       .sort();
   } catch (err: unknown) {
     const e = err as NodeJS.ErrnoException;

--- a/packages/core/src/vbrief-validate/roundtrip.ts
+++ b/packages/core/src/vbrief-validate/roundtrip.ts
@@ -1,0 +1,193 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { isExtensionKey } from "@deftai/directive-types";
+import type { JsonObject } from "./schema.js";
+import { validateVbriefSchema } from "./schema.js";
+
+/** Relative path to extension round-trip conformance fixtures (#715). */
+export const EXTENSION_CONFORMANCE_FIXTURES_DIR = "content/vbrief/conformance/extensions/valid";
+
+export interface ExtensionEntry {
+  readonly jsonPath: string;
+  readonly key: string;
+  readonly value: unknown;
+}
+
+export interface ExtensionRoundtripFinding {
+  readonly path: string;
+  readonly message: string;
+}
+
+/** Recursively collect every `x-<consumer>/` key in `value` using the contract pattern. */
+export function collectExtensionEntries(value: unknown, jsonPath = "$"): ExtensionEntry[] {
+  if (Array.isArray(value)) {
+    const entries: ExtensionEntry[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      entries.push(...collectExtensionEntries(value[index], `${jsonPath}[${index}]`));
+    }
+    return entries;
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return [];
+  }
+
+  const obj = value as Record<string, unknown>;
+  const entries: ExtensionEntry[] = [];
+  for (const [key, entryValue] of Object.entries(obj)) {
+    const childPath = `${jsonPath}.${JSON.stringify(key)}`;
+    if (isExtensionKey(key)) {
+      entries.push({ jsonPath: childPath, key, value: entryValue });
+    }
+    entries.push(...collectExtensionEntries(entryValue, childPath));
+  }
+  return entries;
+}
+
+function entriesByPath(entries: readonly ExtensionEntry[]): Map<string, unknown> {
+  const map = new Map<string, unknown>();
+  for (const entry of entries) {
+    map.set(entry.jsonPath, entry.value);
+  }
+  return map;
+}
+
+/** Compare extension keys/values between two parsed artifacts (JSON structural equality). */
+export function findExtensionPreservationViolations(
+  original: unknown,
+  roundtripped: unknown,
+): string[] {
+  const before = collectExtensionEntries(original);
+  const afterMap = entriesByPath(collectExtensionEntries(roundtripped));
+  const violations: string[] = [];
+
+  for (const entry of before) {
+    if (!afterMap.has(entry.jsonPath)) {
+      violations.push(`dropped extension key '${entry.key}' at ${entry.jsonPath}`);
+      continue;
+    }
+    const afterValue = afterMap.get(entry.jsonPath);
+    if (JSON.stringify(entry.value) !== JSON.stringify(afterValue)) {
+      violations.push(`mutated extension key '${entry.key}' at ${entry.jsonPath}`);
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Canonical reference-consumer read/write pipeline: validate, serialize, re-parse.
+ * Extension properties MUST survive this path verbatim (xBRIEF v0.8 §7).
+ */
+export function reEmitVbriefArtifact(artifact: JsonObject, relPath = "<roundtrip>"): JsonObject {
+  validateVbriefSchema(artifact, relPath);
+  const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
+  return JSON.parse(serialized) as JsonObject;
+}
+
+export function renderExtensionRoundtripFinding(finding: ExtensionRoundtripFinding): string {
+  return `  ${finding.path}: ${finding.message}`;
+}
+
+export interface ExtensionRoundtripEvaluateResult {
+  readonly exitCode: number;
+  readonly findings: readonly ExtensionRoundtripFinding[];
+  readonly message: string;
+}
+
+/** Run extension round-trip preservation over packaged conformance fixtures. */
+export function evaluateExtensionRoundtrip(projectRoot: string): ExtensionRoundtripEvaluateResult {
+  const root = resolve(projectRoot);
+  const fixturesDir = join(root, EXTENSION_CONFORMANCE_FIXTURES_DIR);
+
+  if (!existsSync(fixturesDir)) {
+    return {
+      exitCode: 0,
+      findings: [],
+      message: "",
+    };
+  }
+
+  let fixtureNames: string[];
+  try {
+    fixtureNames = readdirSync(fixturesDir)
+      .filter((name) => name.endsWith(".vbrief.json"))
+      .sort();
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException;
+    return {
+      exitCode: 2,
+      findings: [],
+      message: `\u274c verify_vbrief_conformance: cannot read extension fixtures: ${e.message ?? err}`,
+    };
+  }
+
+  if (fixtureNames.length === 0) {
+    return {
+      exitCode: 2,
+      findings: [],
+      message:
+        `\u274c verify_vbrief_conformance: no *.vbrief.json fixtures under ` +
+        `${EXTENSION_CONFORMANCE_FIXTURES_DIR}/.`,
+    };
+  }
+
+  const findings: ExtensionRoundtripFinding[] = [];
+  for (const name of fixtureNames) {
+    const relPath = `${EXTENSION_CONFORMANCE_FIXTURES_DIR}/${name}`;
+    const fullPath = join(fixturesDir, name);
+    let text: string;
+    try {
+      text = readFileSync(fullPath, "utf8");
+    } catch (err: unknown) {
+      const e = err as NodeJS.ErrnoException;
+      findings.push({
+        path: relPath,
+        message: `unreadable fixture: ${e.message ?? String(err)}`,
+      });
+      continue;
+    }
+
+    let parsed: JsonObject;
+    try {
+      parsed = JSON.parse(text) as JsonObject;
+    } catch (err: unknown) {
+      findings.push({
+        path: relPath,
+        message: `invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    const schemaErrors = validateVbriefSchema(parsed, relPath);
+    for (const error of schemaErrors) {
+      findings.push({ path: relPath, message: error });
+    }
+    if (schemaErrors.length > 0) {
+      continue;
+    }
+
+    const roundtripped = reEmitVbriefArtifact(parsed, relPath);
+    for (const violation of findExtensionPreservationViolations(parsed, roundtripped)) {
+      findings.push({ path: relPath, message: violation });
+    }
+  }
+
+  if (findings.length > 0) {
+    const header =
+      `\u274c verify_vbrief_conformance: extension round-trip preservation failed ` +
+      `(${findings.length} finding(s), #715).\n` +
+      "  Every key matching ^x-[a-z0-9-]+/ MUST survive load->re-emit verbatim at every object level.";
+    const body = findings.slice(0, 50).map(renderExtensionRoundtripFinding).join("\n");
+    const tail = findings.length > 50 ? `\n  ... and ${findings.length - 50} more` : "";
+    return { exitCode: 1, findings, message: `${header}\n${body}${tail}` };
+  }
+
+  return {
+    exitCode: 0,
+    findings,
+    message:
+      `\u2713 verify_vbrief_conformance: ${fixtureNames.length} extension fixture(s) ` +
+      "round-trip clean (#715).",
+  };
+}

--- a/vbrief/active/2026-06-30-715-extension-roundtrip-conformance.vbrief.json
+++ b/vbrief/active/2026-06-30-715-extension-roundtrip-conformance.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "715-extension-roundtrip-conformance",
     "title": "Extension round-trip conformance fixtures and validator preservation",
-    "status": "proposed",
+    "status": "running",
     "planRef": "https://github.com/deftai/directive/issues/2034",
     "narratives": {
       "Description": "Prove directive preserves x-consumer extension keys verbatim across a read and write, on the authority of xBRIEF v0.8 section 7. This story is independently buildable as a fixture set plus a round-trip test that does not depend on the rename or the corpus migration.",
@@ -82,6 +82,7 @@
         "type": "x-vbrief/github-issue",
         "title": "Issue #2034: Adopt latest xBRIEF spec (umbrella)"
       }
-    ]
+    ],
+    "updated": "2026-06-30T15:39:50Z"
   }
 }

--- a/vbrief/completed/2026-06-30-715-extension-roundtrip-conformance.vbrief.json
+++ b/vbrief/completed/2026-06-30-715-extension-roundtrip-conformance.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "715-extension-roundtrip-conformance",
     "title": "Extension round-trip conformance fixtures and validator preservation",
-    "status": "running",
+    "status": "completed",
     "planRef": "https://github.com/deftai/directive/issues/2034",
     "narratives": {
       "Description": "Prove directive preserves x-consumer extension keys verbatim across a read and write, on the authority of xBRIEF v0.8 section 7. This story is independently buildable as a fixture set plus a round-trip test that does not depend on the rename or the corpus migration.",
@@ -69,7 +69,9 @@
         "size": "small",
         "file_scope_confidence": "medium",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-06-30T15:48:04Z",
+      "capacityBucket": "new-capability"
     },
     "references": [
       {
@@ -83,6 +85,6 @@
         "title": "Issue #2034: Adopt latest xBRIEF spec (umbrella)"
       }
     ],
-    "updated": "2026-06-30T15:39:50Z"
+    "updated": "2026-06-30T15:48:04Z"
   }
 }


### PR DESCRIPTION
## Summary

- Add packaged conformance fixtures under `content/vbrief/conformance/extensions/valid/` covering `x-<consumer>/` keys at document root, plan, item, and nested extension values.
- Add `roundtrip.ts` with extension collection/comparison using `@deftai/directive-types` `isExtensionKey` / `EXTENSION_KEY_PATTERN` as the single namespace oracle.
- Wire extension round-trip preservation into `verify:vbrief-conformance` so a dropped or mutated extension key fails the gate and names the key.

## Test plan

- [x] `pnpm -w exec vitest run packages/core/src/vbrief-validate/roundtrip.test.ts`
- [x] `task verify:vbrief-conformance`
- [x] `task check`

Closes #715

Made with [Cursor](https://cursor.com)