### PR TITLE
feat(layout): xbrief-aware resolution (rename part 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Layout-aware lifecycle resolution -- xbrief or vbrief (#2109, part 1 of 2).** The engine now resolves either an `xbrief/` layout (with `*.xbrief.json` artifacts) or the legacy `vbrief/` layout, preferring `xbrief/` only when both the directory and its artifacts are present. A shared resolver routes validation, conformance scanning, swarm-readiness globs, and project-root detection, and file matching accepts both `.vbrief.json` and `.xbrief.json` suffixes. This is purely additive: with only `vbrief/` present (today's tree) behavior is unchanged, and nothing is moved or renamed. Refs #2109 (part 1/2), #2034.
+
 - **Consumer xbrief migration surface (#2110).** `deft migrate:xbrief` converts a legacy `vbrief/` tree to `xbrief/` with v0.6→v0.8 semantic transforms behind a clean-working-tree gate (`--force` to override). `deft doctor` signposts unmigrated layouts, and `deft update` signposts by default with opt-in `--migrate` on non-patch upgrades — patch releases stay migration-inert per #2034. Refs #2034. Closes #2110.
 
 - **Extension round-trip conformance fixtures and gate (#715).** Packaged conformance fixtures exercise `x-<consumer>/` keys at document, plan, item, and nested value levels; the vBRIEF validator now proves those keys survive load→re-emit with JSON-structural equality and fails the conformance gate when a key is dropped or mutated. Refs #2034. Closes #715.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * as codebase from "./codebase/index.js";
 export * as doctor from "./doctor/index.js";
 export * from "./encoding/index.js";
 export * as intake from "./intake/index.js";
+export * as layout from "./layout/index.js";
 export * as legacyBridge from "./legacy-bridge/index.js";
 export * as lifecycle from "./lifecycle/index.js";
 export * as orchestration from "./orchestration/index.js";

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -1,0 +1,16 @@
+export {
+  ARTIFACT_SUFFIXES,
+  hasArtifactSuffix,
+  isLifecycleArtifactPath,
+  LEGACY_ARTIFACT_DIR,
+  LEGACY_ARTIFACT_SUFFIX,
+  LEGACY_INFO_ROOT_KEY,
+  LIFECYCLE_DIR_NAMES,
+  type LifecycleLayout,
+  MIGRATED_ARTIFACT_DIR,
+  MIGRATED_ARTIFACT_SUFFIX,
+  MIGRATED_INFO_ROOT_KEY,
+  resolveLifecycleLayout,
+  resolveLifecycleRoot,
+  stripArtifactSuffix,
+} from "./resolve.js";

--- a/packages/core/src/layout/layout-callsites.test.ts
+++ b/packages/core/src/layout/layout-callsites.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { expandReadinessPaths } from "../swarm/readiness.js";
+import { matchesFilenameConvention, validateFilename } from "../vbrief-validate/filename.js";
+import { discoverVbriefs } from "../vbrief-validate/validate-all.js";
+
+const STORY = JSON.stringify({ plan: { id: "s", status: "running", items: [] } });
+
+describe("layout-aware call sites accept the xbrief layout (#2109 part 1)", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "layout-cs-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("readiness default glob resolves an xbrief/ tree", () => {
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(join(root, "xbrief", "active", "2026-06-30-x.xbrief.json"), STORY, "utf8");
+    const paths = expandReadinessPaths(root, []);
+    expect(paths.some((p) => p.endsWith("2026-06-30-x.xbrief.json"))).toBe(true);
+  });
+
+  it("readiness default glob still resolves a vbrief/ tree unchanged", () => {
+    mkdirSync(join(root, "vbrief", "active"), { recursive: true });
+    writeFileSync(join(root, "vbrief", "active", "2026-06-30-v.vbrief.json"), STORY, "utf8");
+    const paths = expandReadinessPaths(root, []);
+    expect(paths.some((p) => p.endsWith("2026-06-30-v.vbrief.json"))).toBe(true);
+  });
+
+  it("validate discovery picks up .xbrief.json artifacts", () => {
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(join(root, "xbrief", "active", "2026-06-30-x.xbrief.json"), STORY, "utf8");
+    const found = discoverVbriefs(join(root, "xbrief"));
+    expect(found.length).toBe(1);
+    expect(found[0]?.display.endsWith("2026-06-30-x.xbrief.json")).toBe(true);
+  });
+
+  it("filename convention accepts both artifact suffixes", () => {
+    expect(matchesFilenameConvention("2026-01-01-abc-def.vbrief.json")).toBe(true);
+    expect(matchesFilenameConvention("2026-01-01-abc-def.xbrief.json")).toBe(true);
+    expect(validateFilename("xbrief/PROJECT-DEFINITION.xbrief.json")).toEqual([]);
+    expect(validateFilename("vbrief/PROJECT-DEFINITION.vbrief.json")).toEqual([]);
+  });
+});

--- a/packages/core/src/layout/resolve.test.ts
+++ b/packages/core/src/layout/resolve.test.ts
@@ -1,0 +1,120 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ARTIFACT_SUFFIXES,
+  hasArtifactSuffix,
+  isLifecycleArtifactPath,
+  LIFECYCLE_DIR_NAMES,
+  resolveLifecycleLayout,
+  resolveLifecycleRoot,
+  stripArtifactSuffix,
+} from "./resolve.js";
+
+describe("layout resolution (#2109 part 1)", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "layout-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function seedVbrief(): void {
+    mkdirSync(join(root, "vbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "vbrief", "active", "2026-06-30-story.vbrief.json"),
+      JSON.stringify({ plan: { id: "s", status: "running", items: [] } }),
+      "utf8",
+    );
+  }
+
+  function seedXbrief(): void {
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "2026-06-30-story.xbrief.json"),
+      JSON.stringify({ plan: { id: "s", status: "running", items: [] } }),
+      "utf8",
+    );
+  }
+
+  it("returns the legacy vbrief layout when only vbrief/ is present (unchanged)", () => {
+    seedVbrief();
+    const layout = resolveLifecycleLayout(root);
+    expect(layout.artifactDir).toBe("vbrief");
+    expect(layout.artifactSuffix).toBe(".vbrief.json");
+    expect(layout.infoRootKey).toBe("vBRIEFInfo");
+    expect(layout.migrated).toBe(false);
+    expect(layout.root).toBe(join(root, "vbrief"));
+    expect(resolveLifecycleRoot(root)).toBe(join(root, "vbrief"));
+  });
+
+  it("returns the xbrief layout when an xbrief/ tree with .xbrief.json files exists", () => {
+    seedXbrief();
+    const layout = resolveLifecycleLayout(root);
+    expect(layout.artifactDir).toBe("xbrief");
+    expect(layout.artifactSuffix).toBe(".xbrief.json");
+    expect(layout.infoRootKey).toBe("xBRIEFInfo");
+    expect(layout.migrated).toBe(true);
+    expect(layout.root).toBe(join(root, "xbrief"));
+  });
+
+  it("prefers xbrief/ when BOTH layouts are present", () => {
+    seedVbrief();
+    seedXbrief();
+    const layout = resolveLifecycleLayout(root);
+    expect(layout.artifactDir).toBe("xbrief");
+    expect(layout.migrated).toBe(true);
+  });
+
+  it("falls back to vbrief when xbrief/ exists but has no .xbrief.json artifacts", () => {
+    seedVbrief();
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    // Only a legacy-suffixed file under xbrief/ -- not a migrated artifact.
+    writeFileSync(join(root, "xbrief", "active", "stray.vbrief.json"), "{}", "utf8");
+    const layout = resolveLifecycleLayout(root);
+    expect(layout.artifactDir).toBe("vbrief");
+    expect(layout.migrated).toBe(false);
+  });
+
+  it("defaults to vbrief when neither layout is present", () => {
+    const layout = resolveLifecycleLayout(root);
+    expect(layout.artifactDir).toBe("vbrief");
+    expect(layout.migrated).toBe(false);
+  });
+});
+
+describe("artifact suffix helpers (#2109 part 1)", () => {
+  it("recognizes both artifact suffixes", () => {
+    expect(hasArtifactSuffix("2026-06-30-x.vbrief.json")).toBe(true);
+    expect(hasArtifactSuffix("2026-06-30-x.xbrief.json")).toBe(true);
+    expect(hasArtifactSuffix("README.md")).toBe(false);
+    expect(hasArtifactSuffix("plan.json")).toBe(false);
+  });
+
+  it("strips whichever artifact suffix is present", () => {
+    expect(stripArtifactSuffix("2026-06-30-x.vbrief.json")).toBe("2026-06-30-x");
+    expect(stripArtifactSuffix("2026-06-30-x.xbrief.json")).toBe("2026-06-30-x");
+    expect(stripArtifactSuffix("PROJECT-DEFINITION.xbrief.json")).toBe("PROJECT-DEFINITION");
+    expect(stripArtifactSuffix("no-suffix.json")).toBe("no-suffix.json");
+  });
+
+  it("accepts both lifecycle roots and both suffixes for artifact paths", () => {
+    expect(isLifecycleArtifactPath("vbrief/active/2026-06-30-x.vbrief.json")).toBe(true);
+    expect(isLifecycleArtifactPath("xbrief/active/2026-06-30-x.xbrief.json")).toBe(true);
+    // Mixed tree: either suffix under either root validates.
+    expect(isLifecycleArtifactPath("xbrief/active/2026-06-30-x.vbrief.json")).toBe(true);
+    expect(isLifecycleArtifactPath("vbrief/active/2026-06-30-x.xbrief.json")).toBe(true);
+    // Not a lifecycle artifact.
+    expect(isLifecycleArtifactPath("docs/notes.vbrief.json")).toBe(false);
+    expect(isLifecycleArtifactPath("vbrief/active/README.md")).toBe(false);
+  });
+
+  it("exposes stable preference-ordered constants", () => {
+    expect([...LIFECYCLE_DIR_NAMES]).toEqual(["xbrief", "vbrief"]);
+    expect([...ARTIFACT_SUFFIXES]).toEqual([".xbrief.json", ".vbrief.json"]);
+  });
+});

--- a/packages/core/src/layout/resolve.ts
+++ b/packages/core/src/layout/resolve.ts
@@ -1,0 +1,132 @@
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  LEGACY_ARTIFACT_DIR,
+  LEGACY_ARTIFACT_SUFFIX,
+  LEGACY_INFO_ROOT_KEY,
+  MIGRATED_ARTIFACT_DIR,
+  MIGRATED_ARTIFACT_SUFFIX,
+  MIGRATED_INFO_ROOT_KEY,
+} from "../xbrief-migrate/constants.js";
+
+export {
+  LEGACY_ARTIFACT_DIR,
+  LEGACY_ARTIFACT_SUFFIX,
+  LEGACY_INFO_ROOT_KEY,
+  MIGRATED_ARTIFACT_DIR,
+  MIGRATED_ARTIFACT_SUFFIX,
+  MIGRATED_INFO_ROOT_KEY,
+};
+
+/**
+ * Lifecycle directory names recognized by the layout-aware resolver, in
+ * preference order (migrated `xbrief` first, legacy `vbrief` second).
+ */
+export const LIFECYCLE_DIR_NAMES = [MIGRATED_ARTIFACT_DIR, LEGACY_ARTIFACT_DIR] as const;
+
+/**
+ * Artifact filename suffixes recognized by the layout-aware resolver, in
+ * preference order (`.xbrief.json` first, `.vbrief.json` second).
+ */
+export const ARTIFACT_SUFFIXES = [MIGRATED_ARTIFACT_SUFFIX, LEGACY_ARTIFACT_SUFFIX] as const;
+
+/** The on-disk lifecycle layout an engine call site should resolve against (#2109). */
+export interface LifecycleLayout {
+  /** The lifecycle directory name -- `xbrief` when migrated, else `vbrief`. */
+  readonly artifactDir: typeof MIGRATED_ARTIFACT_DIR | typeof LEGACY_ARTIFACT_DIR;
+  /** The artifact filename suffix matching `artifactDir`. */
+  readonly artifactSuffix: typeof MIGRATED_ARTIFACT_SUFFIX | typeof LEGACY_ARTIFACT_SUFFIX;
+  /** The `*BRIEFInfo` root key matching `artifactDir`. */
+  readonly infoRootKey: typeof MIGRATED_INFO_ROOT_KEY | typeof LEGACY_INFO_ROOT_KEY;
+  /** Absolute path to the resolved lifecycle root (`<projectRoot>/<artifactDir>`). */
+  readonly root: string;
+  /** True when the resolved layout is the migrated `xbrief` layout. */
+  readonly migrated: boolean;
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** True when `name` ends with any recognized artifact suffix (.xbrief.json or .vbrief.json). */
+export function hasArtifactSuffix(name: string): boolean {
+  return ARTIFACT_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+
+/**
+ * Strip whichever recognized artifact suffix `name` ends with. Returns `name`
+ * unchanged when it carries no recognized suffix.
+ */
+export function stripArtifactSuffix(name: string): string {
+  for (const suffix of ARTIFACT_SUFFIXES) {
+    if (name.endsWith(suffix)) {
+      return name.slice(0, -suffix.length);
+    }
+  }
+  return name;
+}
+
+/**
+ * True when a POSIX-style path is a lifecycle artifact under either layout
+ * root (`xbrief/` or `vbrief/`) carrying either artifact suffix.
+ */
+export function isLifecycleArtifactPath(posix: string): boolean {
+  const underLifecycleDir = LIFECYCLE_DIR_NAMES.some((dir) => posix.startsWith(`${dir}/`));
+  return underLifecycleDir && hasArtifactSuffix(posix);
+}
+
+/** Walk `root` looking for any `.xbrief.json` file (bounded iterative scan). */
+function containsMigratedArtifact(root: string): boolean {
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (dir === undefined || !isDirectory(dir)) {
+      continue;
+    }
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        stack.push(join(dir, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith(MIGRATED_ARTIFACT_SUFFIX)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve the active lifecycle layout for `projectRoot` (#2109 part 1).
+ *
+ * Prefers the migrated `xbrief/` layout only when BOTH the `xbrief/` directory
+ * exists AND it contains at least one `.xbrief.json` artifact; otherwise falls
+ * back to the legacy `vbrief/` layout. With only `vbrief/` present (today's
+ * repo) the result is the legacy layout, so existing behavior is unchanged.
+ */
+export function resolveLifecycleLayout(projectRoot: string): LifecycleLayout {
+  const migratedRoot = join(projectRoot, MIGRATED_ARTIFACT_DIR);
+  if (isDirectory(migratedRoot) && containsMigratedArtifact(migratedRoot)) {
+    return {
+      artifactDir: MIGRATED_ARTIFACT_DIR,
+      artifactSuffix: MIGRATED_ARTIFACT_SUFFIX,
+      infoRootKey: MIGRATED_INFO_ROOT_KEY,
+      root: migratedRoot,
+      migrated: true,
+    };
+  }
+  return {
+    artifactDir: LEGACY_ARTIFACT_DIR,
+    artifactSuffix: LEGACY_ARTIFACT_SUFFIX,
+    infoRootKey: LEGACY_INFO_ROOT_KEY,
+    root: join(projectRoot, LEGACY_ARTIFACT_DIR),
+    migrated: false,
+  };
+}
+
+/** Convenience accessor for the absolute resolved lifecycle root directory. */
+export function resolveLifecycleRoot(projectRoot: string): string {
+  return resolveLifecycleLayout(projectRoot).root;
+}

--- a/packages/core/src/scope/project-context.ts
+++ b/packages/core/src/scope/project-context.ts
@@ -1,7 +1,8 @@
 import { existsSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
-const PROJECT_ROOT_SENTINELS = ["vbrief", ".git"] as const;
+// Layout-aware (#2109 part 1): an xbrief-only tree is also a valid project root.
+const PROJECT_ROOT_SENTINELS = ["xbrief", "vbrief", ".git"] as const;
 
 function isProjectRoot(candidate: string): boolean {
   return PROJECT_ROOT_SENTINELS.some((sentinel) => existsSync(join(candidate, sentinel)));

--- a/packages/core/src/swarm/readiness.ts
+++ b/packages/core/src/swarm/readiness.ts
@@ -1,6 +1,14 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import {
+  ARTIFACT_SUFFIXES,
+  hasArtifactSuffix,
+  LIFECYCLE_DIR_NAMES,
+  resolveLifecycleLayout,
+  resolveLifecycleRoot,
+  stripArtifactSuffix,
+} from "../layout/resolve.js";
+import {
   acceptanceTextsFromItems,
   asStrList,
   deprecatedSubitemsIssues,
@@ -49,7 +57,9 @@ function projectRel(projectRoot: string, path: string): string {
 }
 
 function expandPaths(projectRoot: string, patterns: readonly string[]): string[] {
-  const usePatterns = patterns.length > 0 ? patterns : ["vbrief/active/*.vbrief.json"];
+  const layout = resolveLifecycleLayout(projectRoot);
+  const usePatterns =
+    patterns.length > 0 ? patterns : [`${layout.artifactDir}/active/*${layout.artifactSuffix}`];
   const out: string[] = [];
   const seen = new Set<string>();
 
@@ -59,12 +69,11 @@ function expandPaths(projectRoot: string, patterns: readonly string[]): string[]
       const globPart = pattern.includes("/")
         ? pattern.slice(pattern.lastIndexOf("/") + 1)
         : pattern;
-      if (existsSync(join(projectRoot, "vbrief", "active")) && pattern.startsWith("vbrief/")) {
-        const activeDir = join(
-          projectRoot,
-          pattern.split("/")[0] ?? "vbrief",
-          pattern.split("/")[1] ?? "active",
-        );
+      const firstSeg = pattern.split("/")[0] ?? "";
+      const secondSeg = pattern.split("/")[1] ?? "";
+      const lifecyclePattern = (LIFECYCLE_DIR_NAMES as readonly string[]).includes(firstSeg);
+      if (lifecyclePattern && existsSync(join(projectRoot, firstSeg, secondSeg))) {
+        const activeDir = join(projectRoot, firstSeg, secondSeg);
         if (existsSync(activeDir)) {
           for (const name of readdirSync(activeDir)) {
             if (matchGlob(name, globPart)) {
@@ -99,8 +108,10 @@ function dirnamePattern(projectRoot: string, pattern: string): string {
 }
 
 function matchGlob(name: string, glob: string): boolean {
-  if (glob === "*.vbrief.json") {
-    return name.endsWith(".vbrief.json");
+  // Layout-aware (#2109 part 1): an artifact-suffix glob matches either suffix,
+  // so a mixed/either lifecycle tree resolves the same way.
+  if (ARTIFACT_SUFFIXES.some((suffix) => glob === `*${suffix}`)) {
+    return hasArtifactSuffix(name);
   }
   if (glob.startsWith("*.")) {
     return name.endsWith(glob.slice(1));
@@ -197,9 +208,7 @@ function storyId(path: string, plan: Record<string, unknown>): string {
     return value.trim();
   }
   const name = basename(path);
-  return name.endsWith(".vbrief.json")
-    ? name.slice(0, -".vbrief.json".length)
-    : name.replace(/\.[^.]+$/, "");
+  return hasArtifactSuffix(name) ? stripArtifactSuffix(name) : name.replace(/\.[^.]+$/, "");
 }
 
 function hasTraces(plan: Record<string, unknown>, swarm: Record<string, unknown>): boolean {
@@ -261,14 +270,14 @@ function acceptanceCountJustification(
 
 function allScopeIds(projectRoot: string): Map<string, [string, string]> {
   const ids = new Map<string, [string, string]>();
-  const vbriefDir = join(projectRoot, "vbrief");
+  const vbriefDir = resolveLifecycleRoot(projectRoot);
   for (const folder of LIFECYCLE_FOLDERS) {
     const dir = join(vbriefDir, folder);
     if (!existsSync(dir)) {
       continue;
     }
     for (const name of readdirSync(dir).sort()) {
-      if (!name.endsWith(".vbrief.json")) {
+      if (!hasArtifactSuffix(name)) {
         continue;
       }
       const path = join(dir, name);
@@ -279,9 +288,7 @@ function allScopeIds(projectRoot: string): Map<string, [string, string]> {
       const plan = planOf(data);
       const sid = storyId(path, plan);
       ids.set(sid, [path, String(plan.status ?? "")]);
-      const stem = name.endsWith(".vbrief.json")
-        ? name.slice(0, -".vbrief.json".length)
-        : name.replace(/\.[^.]+$/, "");
+      const stem = stripArtifactSuffix(name);
       if (!ids.has(stem)) {
         ids.set(stem, [path, String(plan.status ?? "")]);
       }

--- a/packages/core/src/swarm/readiness.ts
+++ b/packages/core/src/swarm/readiness.ts
@@ -74,11 +74,9 @@ function expandPaths(projectRoot: string, patterns: readonly string[]): string[]
       const lifecyclePattern = (LIFECYCLE_DIR_NAMES as readonly string[]).includes(firstSeg);
       if (lifecyclePattern && existsSync(join(projectRoot, firstSeg, secondSeg))) {
         const activeDir = join(projectRoot, firstSeg, secondSeg);
-        if (existsSync(activeDir)) {
-          for (const name of readdirSync(activeDir)) {
-            if (matchGlob(name, globPart)) {
-              addPath(join(activeDir, name), seen, out);
-            }
+        for (const name of readdirSync(activeDir)) {
+          if (matchGlob(name, globPart)) {
+            addPath(join(activeDir, name), seen, out);
           }
         }
       } else {

--- a/packages/core/src/vbrief-validate/conformance.ts
+++ b/packages/core/src/vbrief-validate/conformance.ts
@@ -7,6 +7,7 @@ import {
   gitTrackedFiles,
 } from "../encoding/git.js";
 import { fnmatchCase } from "../encoding/text.js";
+import { isLifecycleArtifactPath, LIFECYCLE_DIR_NAMES } from "../layout/resolve.js";
 import { evaluateExtensionRoundtrip } from "./roundtrip.js";
 import type { JsonObject } from "./schema.js";
 
@@ -200,7 +201,8 @@ function isAllowListed(relPath: string, patterns: readonly string[]): boolean {
 }
 
 function isVbriefPath(posix: string): boolean {
-  return posix.startsWith("vbrief/") && posix.endsWith(".vbrief.json");
+  // Layout-aware (#2109 part 1): accept either lifecycle root + either suffix.
+  return isLifecycleArtifactPath(posix);
 }
 
 export type ConformanceMode = "all" | "staged";
@@ -229,7 +231,7 @@ export function evaluateConformance(
     };
   }
 
-  if (!existsSync(join(root, "vbrief"))) {
+  if (!LIFECYCLE_DIR_NAMES.some((dir) => existsSync(join(root, dir)))) {
     return {
       exitCode: 2,
       findings: [],

--- a/packages/core/src/vbrief-validate/filename.ts
+++ b/packages/core/src/vbrief-validate/filename.ts
@@ -1,9 +1,12 @@
+import { ARTIFACT_SUFFIXES, hasArtifactSuffix, stripArtifactSuffix } from "../layout/resolve.js";
+
 /** D7: filename convention without polynomial regex (#1782 s3). */
 export function matchesFilenameConvention(name: string): boolean {
-  if (!name.endsWith(".vbrief.json")) {
+  // Layout-aware (#2109 part 1): accept either .vbrief.json or .xbrief.json.
+  if (!ARTIFACT_SUFFIXES.some((suffix) => name.endsWith(suffix))) {
     return false;
   }
-  const stem = name.slice(0, -".vbrief.json".length);
+  const stem = stripArtifactSuffix(name);
   if (stem.length < 12) {
     return false;
   }
@@ -49,7 +52,7 @@ export function matchesFilenameConvention(name: string): boolean {
 /** Check filename matches YYYY-MM-DD-descriptive-slug.vbrief.json (D7). */
 export function validateFilename(filepath: string): string[] {
   const name = filepath.split("/").pop() ?? filepath;
-  if (name === "PROJECT-DEFINITION.vbrief.json") {
+  if (hasArtifactSuffix(name) && stripArtifactSuffix(name) === "PROJECT-DEFINITION") {
     return [];
   }
   if (!matchesFilenameConvention(name)) {

--- a/packages/core/src/vbrief-validate/main.ts
+++ b/packages/core/src/vbrief-validate/main.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { resolveLifecycleLayout } from "../layout/resolve.js";
 import { evaluateConformance } from "./conformance.js";
 import { USAGE } from "./constants.js";
 import { validateAll } from "./validate-all.js";
@@ -19,7 +20,9 @@ export interface ConformanceCliOptions {
 
 /** CLI entry for vbrief_validate.py parity. */
 export function runValidate(argv: string[]): number {
-  let vbriefDir = "vbrief";
+  // Layout-aware (#2109 part 1): default to the resolved lifecycle dir name
+  // (xbrief when migrated, else vbrief -- unchanged on today's repo).
+  let vbriefDir: string | null = null;
   let strictOriginTypes = false;
   let warningsAsErrors = false;
 
@@ -45,12 +48,14 @@ export function runValidate(argv: string[]): number {
     }
   }
 
-  if (!existsSync(vbriefDir)) {
-    process.stdout.write(`OK: No vbrief directory at ${vbriefDir} -- skipping validation\n`);
+  const resolvedDir = vbriefDir ?? resolveLifecycleLayout(process.cwd()).artifactDir;
+
+  if (!existsSync(resolvedDir)) {
+    process.stdout.write(`OK: No vbrief directory at ${resolvedDir} -- skipping validation\n`);
     return 0;
   }
 
-  const { errors, warnings, scopeCount } = validateAll(vbriefDir, { strictOriginTypes });
+  const { errors, warnings, scopeCount } = validateAll(resolvedDir, { strictOriginTypes });
 
   for (const w of warnings) {
     process.stdout.write(`WARN: ${w}\n`);
@@ -67,8 +72,9 @@ export function runValidate(argv: string[]): number {
     if (scopeCount > 0) {
       parts.push(`${scopeCount} scope vBRIEF(s)`);
     }
-    const projectDef = resolve(vbriefDir, "PROJECT-DEFINITION.vbrief.json");
-    if (existsSync(projectDef)) {
+    const projectDef = resolve(resolvedDir, "PROJECT-DEFINITION.vbrief.json");
+    const projectDefXbrief = resolve(resolvedDir, "PROJECT-DEFINITION.xbrief.json");
+    if (existsSync(projectDef) || existsSync(projectDefXbrief)) {
       parts.push("PROJECT-DEFINITION");
     }
     const summary = parts.length > 0 ? parts.join(", ") : "no vBRIEF files";

--- a/packages/core/src/vbrief-validate/validate-all.ts
+++ b/packages/core/src/vbrief-validate/validate-all.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { hasArtifactSuffix } from "../layout/resolve.js";
+import { basename, join, resolve } from "node:path";
+import { hasArtifactSuffix, MIGRATED_ARTIFACT_DIR } from "../layout/resolve.js";
 import { LIFECYCLE_FOLDERS } from "./constants.js";
 import { validateNoRootDecompositionDrafts } from "./decomposition.js";
 import { validateEpicStoryLinks } from "./epic-links.js";
@@ -109,11 +109,14 @@ export function validateAll(
   }
 
   const normalizedDir = normalizeVbriefDir(vbriefDir);
-  // Layout-aware (#2109 part 1): prefer an xbrief-named project definition when
-  // present, else fall back to the legacy vbrief-named file (unchanged default).
-  const projectDefName = existsSync(join(vbriefDir, "PROJECT-DEFINITION.xbrief.json"))
-    ? "PROJECT-DEFINITION.xbrief.json"
-    : "PROJECT-DEFINITION.vbrief.json";
+  // Layout-aware (#2109 part 1): key the project-definition suffix to the
+  // resolved lifecycle directory's identity (its basename) rather than probing
+  // the filesystem, so a stray xbrief-named file in a legacy tree cannot flip
+  // selection -- this stays consistent with resolveLifecycleLayout's output.
+  const projectDefName =
+    basename(normalizedDir) === MIGRATED_ARTIFACT_DIR
+      ? "PROJECT-DEFINITION.xbrief.json"
+      : "PROJECT-DEFINITION.vbrief.json";
   const projectDefDisplay = `${normalizedDir}/${projectDefName}`;
   const projectDefAbsolute = join(vbriefDir, projectDefName);
   if (existsSync(projectDefAbsolute)) {

--- a/packages/core/src/vbrief-validate/validate-all.ts
+++ b/packages/core/src/vbrief-validate/validate-all.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { hasArtifactSuffix } from "../layout/resolve.js";
 import { LIFECYCLE_FOLDERS } from "./constants.js";
 import { validateNoRootDecompositionDrafts } from "./decomposition.js";
 import { validateEpicStoryLinks } from "./epic-links.js";
@@ -46,7 +47,7 @@ export function discoverVbriefs(vbriefDir: string): Array<{ display: string; abs
       continue;
     }
     const names = readdirSync(folderPath)
-      .filter((name) => name.endsWith(".vbrief.json"))
+      .filter((name) => hasArtifactSuffix(name))
       .sort();
     for (const name of names) {
       files.push({
@@ -108,8 +109,13 @@ export function validateAll(
   }
 
   const normalizedDir = normalizeVbriefDir(vbriefDir);
-  const projectDefDisplay = `${normalizedDir}/PROJECT-DEFINITION.vbrief.json`;
-  const projectDefAbsolute = join(vbriefDir, "PROJECT-DEFINITION.vbrief.json");
+  // Layout-aware (#2109 part 1): prefer an xbrief-named project definition when
+  // present, else fall back to the legacy vbrief-named file (unchanged default).
+  const projectDefName = existsSync(join(vbriefDir, "PROJECT-DEFINITION.xbrief.json"))
+    ? "PROJECT-DEFINITION.xbrief.json"
+    : "PROJECT-DEFINITION.vbrief.json";
+  const projectDefDisplay = `${normalizedDir}/${projectDefName}`;
+  const projectDefAbsolute = join(vbriefDir, projectDefName);
   if (existsSync(projectDefAbsolute)) {
     const { data, error } = loadVbrief(projectDefAbsolute);
     if (error !== null) {

--- a/vbrief/active/2026-06-30-2109-maintainer-xbrief-rename.vbrief.json
+++ b/vbrief/active/2026-06-30-2109-maintainer-xbrief-rename.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "2109-maintainer-xbrief-rename",
     "title": "Maintainer-repo mechanical vbrief->xbrief rename plus drift gate",
-    "status": "proposed",
+    "status": "running",
     "planRef": "https://github.com/deftai/directive/issues/2034",
     "narratives": {
       "Description": "Run the one-shot mechanical rename of the directive repo itself from the vbrief layout and tokens to xbrief, then add a gate that blocks reintroduction of the old tokens. This is a repo-wide atomic change that cannot be parallelized, so it is marked sequential and run solo as its own wave.",
@@ -85,6 +85,7 @@
         "type": "x-vbrief/github-issue",
         "title": "Issue #2034: Adopt latest xBRIEF spec (umbrella)"
       }
-    ]
+    ],
+    "updated": "2026-06-30T17:53:38Z"
   }
 }


### PR DESCRIPTION
## Summary

Part 1 of 2 for #2109 — additive layout resolution, no move/rename.

This teaches the engine to resolve **either** an `xbrief/` layout (with `*.xbrief.json` artifacts) or the legacy `vbrief/` layout, preferring `xbrief/` only when **both** the directory and its artifacts are present, and otherwise falling back to `vbrief/`. It is purely additive: with only `vbrief/` present (today's repo), behavior is **unchanged** and nothing is moved or renamed. This lands first so the Part 2 mechanical move/token-rewrite cannot break the tooling.

This PR deliberately does **NOT** do the directory move, the `*.vbrief.json` → `*.xbrief.json` rename, the `x-vbrief/` / `vbrief:*` token rewrite, or the drift gate — those are all Part 2 (a separate later PR). Issue #2109 stays **OPEN** for Part 2.

### What changed

- **New shared helper** `packages/core/src/layout/` — `resolveLifecycleLayout(projectRoot)` returns the active lifecycle root (`xbrief` vs `vbrief`), artifact suffix (`.xbrief.json` vs `.vbrief.json`), and info-root key, preferring `xbrief` when present. Plus `hasArtifactSuffix` / `stripArtifactSuffix` / `isLifecycleArtifactPath` predicates that accept both layouts. Reuses the #2108 `xbrief-migrate` constants.
- **Routed call sites** through the helper instead of hardcoded literals:
  - conformance scan `isVbriefPath` + lifecycle-dir existence guard
  - swarm-readiness default glob, glob matcher, and scope listing
  - `vbrief:validate` discovery, default dir, and PROJECT-DEFINITION lookup
  - filename convention (`matchesFilenameConvention` / `validateFilename`)
  - project-root sentinel detection (`xbrief` is now a valid root)
- **Dual-suffix acceptance** where files are matched/scanned, so a mixed/either tree validates.
- The lifecycle **write** side is untouched — it keeps writing to the detected layout (still `vbrief/` today); the helper only makes `xbrief/` *also* resolvable for when Part 2 flips it.

## Test plan

- [x] New unit tests: `vbrief/`-only resolves `vbrief/.vbrief.json` (unchanged); an `xbrief/` tree resolves `xbrief/.xbrief.json`; both present → `xbrief/` wins; `xbrief/` dir without `.xbrief.json` artifacts falls back to `vbrief/`.
- [x] New call-site tests: readiness default glob + validate discovery + filename convention accept the `xbrief` layout and both suffixes.
- [x] `task check` fully green (runs on today's `vbrief/` tree — green proves no regression).

Refs #2109 (part 1/2), #2034
