### PR TITLE
fix: canonicalize emit-site reference tokens to x-xbrief/ + dual-namespace readers (#2128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Engine emit sites now produce canonical `x-xbrief/` reference tokens (#2128).** The intake, build, speckit, decompose, and reconcile paths previously minted legacy `x-vbrief/` tokens, causing freshly ingested or built artifacts committed under `xbrief/` to trip the `verify:xbrief-drift` pre-commit gate. All emit constants are flipped to `x-xbrief/` and reader matchers in capacity, scope, swarm, and lifecycle modules are made dual-namespace (accepting both prefixes) via a new shared `referenceTypeMatches` helper in `@deftai/directive-types`. `x-vbrief/` remains read-accepted for consumer back-compat. Closes #2128.
+
 ### Changed
 
 - **Docs and skills now describe the xBRIEF layout and migration path (#2111).** Agent-facing guidance (skills, templates, commands, and key docs) uses xBRIEF prose, `xbrief/` lifecycle paths, `*.xbrief.json` artifacts, and `deft migrate:xbrief` for legacy trees still read-accepted under `vbrief/` / `x-vbrief/`. The consumer AGENTS.md managed section and propagation contract tests were refreshed to match. Closes #2111.

--- a/packages/core/src/capacity/backfill.ts
+++ b/packages/core/src/capacity/backfill.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { sortedStringifyCompact } from "../codebase/json.js";
 import { hasArtifactSuffix, resolveLifecycleFolder } from "../layout/resolve.js";
 import {
@@ -71,7 +72,7 @@ export function extractIssueRef(plan: Record<string, unknown>): [string | null, 
       continue;
     }
     const rec = ref as Record<string, unknown>;
-    if (rec.type !== "x-vbrief/github-issue") {
+    if (!referenceTypeMatches(String(rec.type ?? ""), "github-issue")) {
       continue;
     }
     const uri = rec.uri;

--- a/packages/core/src/capacity/show.ts
+++ b/packages/core/src/capacity/show.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../layout/resolve.js";
 import { recommendAutonomyLevel, resolveAutonomy } from "../policy/autonomy.js";
 import {
@@ -86,7 +87,7 @@ function planHasChildren(plan: Record<string, unknown>): boolean {
     (ref) =>
       typeof ref === "object" &&
       ref !== null &&
-      (ref as Record<string, unknown>).type === "x-vbrief/plan",
+      referenceTypeMatches(String((ref as Record<string, unknown>).type ?? ""), "plan"),
   );
 }
 

--- a/packages/core/src/intake/issue-emit.ts
+++ b/packages/core/src/intake/issue-emit.ts
@@ -1,12 +1,13 @@
 import { globSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { call } from "../scm/call.js";
 import { resolveProjectRoot } from "../scope/project-context.js";
 import { resolveProjectRepo } from "../slice/project-context.js";
 import type { ScmCallFn } from "./reconcile-issues.js";
 
-export const GITHUB_ISSUE_REF_TYPE = "x-vbrief/github-issue";
+export const GITHUB_ISSUE_REF_TYPE = "x-xbrief/github-issue";
 export const EXTERNAL_TRUST_LEVEL = "external";
 
 const ISSUE_URL_PATTERN = /https?:\/\/\S+?\/issues\/\d+/;
@@ -52,7 +53,7 @@ export function existingGithubIssueRef(data: Record<string, unknown>): string | 
   for (const ref of refs) {
     if (ref !== null && typeof ref === "object" && !Array.isArray(ref)) {
       const obj = ref as Record<string, unknown>;
-      if (obj.type === GITHUB_ISSUE_REF_TYPE) {
+      if (referenceTypeMatches(String(obj.type ?? ""), "github-issue")) {
         const uri = obj.uri ?? obj.url;
         return typeof uri === "string" && uri.length > 0 ? uri : "";
       }

--- a/packages/core/src/intake/issue-ingest.test.ts
+++ b/packages/core/src/intake/issue-ingest.test.ts
@@ -46,9 +46,9 @@ describe("extractCrossRefs", () => {
     const body = "Closes #10\nRefs #11\nBlocked by #12\n```\nCloses #99\n```";
     const refs = extractCrossRefs(body, "https://github.com/o/r", new Set());
     expect(refs.map((r) => r.type)).toEqual([
-      "x-vbrief/closes",
-      "x-vbrief/blocks",
-      "x-vbrief/refs",
+      "x-xbrief/closes",
+      "x-xbrief/blocks",
+      "x-xbrief/refs",
     ]);
   });
 });

--- a/packages/core/src/intake/issue-ingest.ts
+++ b/packages/core/src/intake/issue-ingest.ts
@@ -45,9 +45,9 @@ const ORIGIN_URL_PATTERN = /https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\
 const ORIGIN_BARE_PATTERN = /issue\s*#(\d+)/i;
 
 const CROSS_REF_PATTERNS: readonly [string, RegExp][] = [
-  ["x-vbrief/closes", /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/i],
-  ["x-vbrief/blocks", /\bblocked[\s-]+by\s+#(\d+)\b/i],
-  ["x-vbrief/refs", /\b(?:refs?|references?|see\s+also|related(?:\s+to)?)\s+#(\d+)\b/i],
+  ["x-xbrief/closes", /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/i],
+  ["x-xbrief/blocks", /\bblocked[\s-]+by\s+#(\d+)\b/i],
+  ["x-xbrief/refs", /\b(?:refs?|references?|see\s+also|related(?:\s+to)?)\s+#(\d+)\b/i],
 ];
 
 function hasNonIndentationPrefix(text: string, index: number): boolean {
@@ -292,7 +292,7 @@ export function buildIssueVbrief(
     const references: Record<string, string>[] = [
       {
         uri: url,
-        type: "x-vbrief/github-issue",
+        type: "x-xbrief/github-issue",
         title: `Issue #${number}: ${title}`,
       },
     ];

--- a/packages/core/src/intake/reconcile-issues.ts
+++ b/packages/core/src/intake/reconcile-issues.ts
@@ -17,7 +17,11 @@ export const LIFECYCLE_FOLDERS = [
 
 export const TERMINAL_LIFECYCLE_FOLDERS = new Set<string>(["completed", "cancelled"]);
 
-export const GITHUB_ISSUE_REF_TYPES = new Set<string>(["github-issue", "x-vbrief/github-issue"]);
+export const GITHUB_ISSUE_REF_TYPES = new Set<string>([
+  "github-issue",
+  "x-vbrief/github-issue",
+  "x-xbrief/github-issue",
+]);
 
 export const CANCELLED_STATE_REASONS = new Set<string>(["NOT_PLANNED", "DUPLICATE"]);
 

--- a/packages/core/src/integration-e2e/consumer-tasks.test.ts
+++ b/packages/core/src/integration-e2e/consumer-tasks.test.ts
@@ -169,7 +169,7 @@ describe("integration-e2e consumer tasks (mirrors test_consumer_tasks.py)", () =
     expect(payload.vBRIEFInfo.version).toBe("0.6");
     const ref = payload.plan.references[0];
     expect(ref?.uri).toBe("https://github.com/owner/consumer/issues/101");
-    expect(ref?.type).toBe("x-vbrief/github-issue");
+    expect(ref?.type).toBe("x-xbrief/github-issue");
     expect(ref?.title).toBe("Issue #101: Consumer fixture issue");
     expect(ref).not.toHaveProperty("url");
     expect(ref).not.toHaveProperty("id");

--- a/packages/core/src/lifecycle/lifecycle-hygiene.ts
+++ b/packages/core/src/lifecycle/lifecycle-hygiene.ts
@@ -7,6 +7,7 @@ import {
   statSync,
 } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { computeReport } from "../capacity/show.js";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../layout/resolve.js";
 import { resolveCapacityAllocation } from "../policy/capacity.js";
@@ -35,7 +36,7 @@ export const LIFECYCLE_FOLDERS = [
 export const TERMINAL_STATUSES = new Set(["completed", "cancelled", "failed"]);
 
 /** Child reference type that marks an epic as decomposed. */
-export const CHILD_REF_TYPE = "x-vbrief/plan";
+export const CHILD_REF_TYPE = "x-xbrief/plan";
 
 /** Durable tech-debt acceptance ledger relative path segments. */
 export const TECH_DEBT_LEDGER_RELPATH = [
@@ -177,7 +178,7 @@ function childRefNames(plan: Record<string, unknown>): string[] {
       continue;
     }
     const rec = ref as Record<string, unknown>;
-    if (rec.type !== CHILD_REF_TYPE) {
+    if (!referenceTypeMatches(String(rec.type ?? ""), "plan")) {
       continue;
     }
     const uri = rec.uri;

--- a/packages/core/src/scope/decompose.test.ts
+++ b/packages/core/src/scope/decompose.test.ts
@@ -343,7 +343,7 @@ describe("applyDecomposition", () => {
     const updatedParent = JSON.parse(readFileSync(parentPath, "utf8")) as Record<string, unknown>;
     const plan = updatedParent.plan as Record<string, unknown>;
     const refs = plan.references as unknown[];
-    expect(refs.some((r) => (r as Record<string, unknown>).type === "x-vbrief/plan")).toBe(true);
+    expect(refs.some((r) => (r as Record<string, unknown>).type === "x-xbrief/plan")).toBe(true);
   });
 
   it("throws when output_dir is active", () => {

--- a/packages/core/src/scope/decompose.ts
+++ b/packages/core/src/scope/decompose.ts
@@ -9,6 +9,7 @@
 
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../layout/resolve.js";
 import { referenceWithDefaultTrust, slugify } from "../vbrief-build/build.js";
 import { EMITTED_VBRIEF_VERSION } from "../vbrief-build/constants.js";
@@ -580,7 +581,7 @@ function storyHasTraces(story: JsonObj, items: unknown[], sw: JsonObj): boolean 
   if (Array.isArray(refs)) {
     for (const ref of refs) {
       if (typeof ref === "object" && ref !== null && !Array.isArray(ref)) {
-        if ((ref as JsonObj).type === "x-vbrief/spec-section") return true;
+        if (referenceTypeMatches(String((ref as JsonObj).type ?? ""), "spec-section")) return true;
       }
     }
   }
@@ -1016,7 +1017,7 @@ export function applyDecomposition(opts: ApplyDecompositionOptions): string[] {
     (references as JsonObj[]).push(
       referenceWithDefaultTrust({
         uri: relToVbrief(vbriefDirPath, target),
-        type: "x-vbrief/plan",
+        type: "x-xbrief/plan",
         title,
       }),
     );

--- a/packages/core/src/scope/decomposed-refs.ts
+++ b/packages/core/src/scope/decomposed-refs.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { formatVbriefJson } from "./vbrief-json.js";
 import { collectChildUris, collectPlanRefs, resolveVbriefRef } from "./vbrief-ref.js";
 
@@ -47,7 +48,7 @@ function rewriteParentChildReference(
       continue;
     }
     const r = ref as Record<string, unknown>;
-    if (r.type !== "x-vbrief/plan") {
+    if (!referenceTypeMatches(String(r.type ?? ""), "plan")) {
       continue;
     }
     const resolved = resolveVbriefRef(r.uri, vbriefDir);

--- a/packages/core/src/scope/project-definition-sync.ts
+++ b/packages/core/src/scope/project-definition-sync.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { PROJECT_DEFINITION_REL_PATH } from "../policy/resolve.js";
 import { formatVbriefJson } from "./vbrief-json.js";
 import { relativeToVbrief, resolveVbriefRef, scopeIdsForFilename } from "./vbrief-ref.js";
@@ -14,7 +15,7 @@ function rewriteProjectDefinitionPlanReference(
     return false;
   }
   const r = ref as Record<string, unknown>;
-  if (r.type !== "x-vbrief/plan") {
+  if (!referenceTypeMatches(String(r.type ?? ""), "plan")) {
     return false;
   }
   const resolved = resolveVbriefRef(r.uri, vbriefRoot);
@@ -53,7 +54,7 @@ function projectItemReferencesScope(
           continue;
         }
         const r = ref as Record<string, unknown>;
-        if (r.type !== "x-vbrief/plan") {
+        if (!referenceTypeMatches(String(r.type ?? ""), "plan")) {
           continue;
         }
         const resolved = resolveVbriefRef(r.uri, vbriefRoot);
@@ -70,7 +71,7 @@ function projectItemReferencesScope(
         continue;
       }
       const r = ref as Record<string, unknown>;
-      if (r.type !== "x-vbrief/plan") {
+      if (!referenceTypeMatches(String(r.type ?? ""), "plan")) {
         continue;
       }
       const resolved = resolveVbriefRef(r.uri, vbriefRoot);

--- a/packages/core/src/scope/vbrief-ref.ts
+++ b/packages/core/src/scope/vbrief-ref.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix, stripArtifactSuffix } from "../layout/resolve.js";
 
 /** Resolve a vBRIEF reference URI to an absolute path, or null. */
@@ -50,7 +51,7 @@ export function collectChildUris(plan: Record<string, unknown>): string[] {
       continue;
     }
     const r = ref as Record<string, unknown>;
-    if (r.type !== "x-vbrief/plan") {
+    if (!referenceTypeMatches(String(r.type ?? ""), "plan")) {
       continue;
     }
     const uri = r.uri;

--- a/packages/core/src/swarm/readiness.ts
+++ b/packages/core/src/swarm/readiness.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import {
   ARTIFACT_SUFFIXES,
   hasArtifactSuffix,
@@ -162,7 +163,7 @@ function hasChildPlanRefs(plan: Record<string, unknown>): boolean {
       typeof ref === "object" &&
       ref !== null &&
       !Array.isArray(ref) &&
-      (ref as Record<string, unknown>).type === "x-vbrief/plan",
+      referenceTypeMatches(String((ref as Record<string, unknown>).type ?? ""), "plan"),
   );
 }
 

--- a/packages/core/src/swarm/readiness.ts
+++ b/packages/core/src/swarm/readiness.ts
@@ -238,7 +238,7 @@ function hasTraces(plan: Record<string, unknown>, swarm: Record<string, unknown>
         typeof ref === "object" &&
         ref !== null &&
         !Array.isArray(ref) &&
-        (ref as Record<string, unknown>).type === "x-vbrief/spec-section"
+        referenceTypeMatches(String((ref as Record<string, unknown>).type ?? ""), "spec-section")
       ) {
         return true;
       }

--- a/packages/core/src/triage/classify/index.ts
+++ b/packages/core/src/triage/classify/index.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import {
   hasArtifactSuffix,
   resolveLifecycleRoot,
@@ -688,7 +689,7 @@ export function extractReferencedIssues(
             continue;
           }
           const r = ref as Record<string, unknown>;
-          if (r.type !== "x-vbrief/github-issue") {
+          if (!referenceTypeMatches(String(r.type ?? ""), "github-issue")) {
             continue;
           }
           const uri = r.uri;

--- a/packages/core/src/triage/queue/scope-walk.ts
+++ b/packages/core/src/triage/queue/scope-walk.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import {
   hasArtifactSuffix,
   resolveLifecycleFolder,
@@ -31,7 +32,7 @@ export function issueNumbersFromPlan(plan: Record<string, unknown>): ReadonlySet
       continue;
     }
     const typed = ref as Record<string, unknown>;
-    if (typed.type !== "x-vbrief/github-issue") {
+    if (!referenceTypeMatches(String(typed.type ?? ""), "github-issue")) {
       continue;
     }
     const uri = typed.uri;

--- a/packages/core/src/triage/reconcile/parse-uri.ts
+++ b/packages/core/src/triage/reconcile/parse-uri.ts
@@ -1,3 +1,5 @@
+import { referenceTypeMatches } from "@deftai/directive-types";
+
 /** Parse (repo, issue_number) from a github-issue reference URI. */
 export function parseGithubIssueUri(uri: unknown): [string | null, number | null] {
   if (typeof uri !== "string") return [null, null];
@@ -26,7 +28,7 @@ export function extractIssueRef(data: Record<string, unknown>): [string | null, 
   for (const ref of refs) {
     if (typeof ref !== "object" || ref === null || Array.isArray(ref)) continue;
     const rec = ref as Record<string, unknown>;
-    if (rec.type !== "x-vbrief/github-issue") continue;
+    if (!referenceTypeMatches(String(rec.type ?? ""), "github-issue")) continue;
     const [repo, number] = parseGithubIssueUri(rec.uri);
     if (number !== null) return [repo, number];
   }

--- a/packages/core/src/triage/refresh/extract.ts
+++ b/packages/core/src/triage/refresh/extract.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix } from "../../layout/resolve.js";
 
 const ISSUE_URL_RE = /github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/i;
@@ -28,7 +29,7 @@ export function extractIssueRefs(vbriefPath: string): Array<[string, number]> {
   for (const ref of refs) {
     if (typeof ref !== "object" || ref === null || Array.isArray(ref)) continue;
     const rec = ref as Record<string, unknown>;
-    if (rec.type !== "x-vbrief/github-issue") continue;
+    if (!referenceTypeMatches(String(rec.type ?? ""), "github-issue")) continue;
     const uri = String(rec.uri ?? "");
     const match = ISSUE_URL_RE.exec(uri);
     if (!match) continue;

--- a/packages/core/src/triage/scope/renderers.ts
+++ b/packages/core/src/triage/scope/renderers.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../../layout/resolve.js";
 import { subscriptionHash } from "./normalize.js";
 import { pyListRepr } from "./python-repr.js";
@@ -35,7 +36,7 @@ export function extractReferencedIssues(
       for (const ref of refs) {
         if (typeof ref !== "object" || ref === null || Array.isArray(ref)) continue;
         const rec = ref as Record<string, unknown>;
-        if (rec.type !== "x-vbrief/github-issue") continue;
+        if (!referenceTypeMatches(String(rec.type ?? ""), "github-issue")) continue;
         const uri = rec.uri;
         if (typeof uri !== "string") continue;
         const tail = uri.replace(/\/$/, "").split("/").pop() ?? "";

--- a/packages/core/src/triage/summary/reconcilable.ts
+++ b/packages/core/src/triage/summary/reconcilable.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix, resolveEvalPath, resolveLifecycleRoot } from "../../layout/resolve.js";
 import { AUDIT_LOG_REL_PATH, readAuditLog } from "../actions/candidates-log.js";
 
@@ -41,7 +42,7 @@ function extractIssueRef(data: Record<string, unknown>): [string | null, number 
       continue;
     }
     const obj = ref as Record<string, unknown>;
-    if (obj.type !== "x-vbrief/github-issue") {
+    if (!referenceTypeMatches(String(obj.type ?? ""), "github-issue")) {
       continue;
     }
     const [repo, number] = parseGithubIssueUri(obj.uri);

--- a/packages/core/src/validate-content/capacity-show.ts
+++ b/packages/core/src/validate-content/capacity-show.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../layout/resolve.js";
 import {
   type AutonomyRecommendation,
@@ -85,7 +86,7 @@ function planHasChildren(plan: Record<string, unknown>): boolean {
     (ref) =>
       typeof ref === "object" &&
       ref !== null &&
-      (ref as Record<string, unknown>).type === "x-vbrief/plan",
+      referenceTypeMatches(String((ref as Record<string, unknown>).type ?? ""), "plan"),
   );
 }
 

--- a/packages/core/src/vbrief-build/build.ts
+++ b/packages/core/src/vbrief-build/build.ts
@@ -73,7 +73,7 @@ function githubIssueReference(params: {
       : `Issue #${cleanedNumber}`;
   return {
     uri: `${cleanedRepo}/issues/${cleanedNumber}`,
-    type: "x-vbrief/github-issue",
+    type: "x-xbrief/github-issue",
     title: refTitle,
   };
 }

--- a/packages/core/src/vbrief-build/constants.ts
+++ b/packages/core/src/vbrief-build/constants.ts
@@ -12,6 +12,9 @@ export const INTERNAL_REFERENCE_TYPES = new Set([
   "x-vbrief/plan",
   "x-vbrief/spec-section",
   "x-vbrief/user-request",
+  "x-xbrief/plan",
+  "x-xbrief/spec-section",
+  "x-xbrief/user-request",
 ]);
 
 export const EXTERNAL_REFERENCE_TYPES = new Set([
@@ -19,6 +22,10 @@ export const EXTERNAL_REFERENCE_TYPES = new Set([
   "x-vbrief/github-pr",
   "x-vbrief/jira-ticket",
   "x-vbrief/web-page",
+  "x-xbrief/github-issue",
+  "x-xbrief/github-pr",
+  "x-xbrief/jira-ticket",
+  "x-xbrief/web-page",
 ]);
 
 export const FOLDER_TO_STATUSES: Readonly<Record<string, readonly string[]>> = {

--- a/packages/core/src/vbrief-build/speckit.ts
+++ b/packages/core/src/vbrief-build/speckit.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { referenceWithDefaultTrust, slugify } from "./build.js";
 import { EMITTED_VBRIEF_VERSION } from "./constants.js";
 import { pythonJsonPretty } from "./json.js";
@@ -120,7 +121,7 @@ export function createSpeckitScopeVbrief(
   }
 
   const references: JsonObject[] = [
-    referenceWithDefaultTrust({ type: "x-vbrief/plan", uri: specRef }),
+    referenceWithDefaultTrust({ type: "x-xbrief/plan", uri: specRef }),
   ];
   const itemRefs = item.references;
   if (Array.isArray(itemRefs)) {
@@ -129,7 +130,7 @@ export function createSpeckitScopeVbrief(
         typeof ref === "object" &&
         ref !== null &&
         !Array.isArray(ref) &&
-        (ref as JsonObject).type !== "x-vbrief/plan"
+        !referenceTypeMatches(String((ref as JsonObject).type ?? ""), "plan")
       ) {
         references.push(referenceWithDefaultTrust(ref as JsonObject));
       }

--- a/packages/core/src/vbrief-reconcile/reconciliation.ts
+++ b/packages/core/src/vbrief-reconcile/reconciliation.ts
@@ -15,7 +15,11 @@ const CANCELLED_MARKERS = ["[cancelled]", "[canceled]"] as const;
 
 export const OVERRIDES_FILENAME = "migration-overrides.yaml";
 
-const GITHUB_ISSUE_REF_TYPES = new Set(["github-issue", "x-vbrief/github-issue"]);
+const GITHUB_ISSUE_REF_TYPES = new Set([
+  "github-issue",
+  "x-vbrief/github-issue",
+  "x-xbrief/github-issue",
+]);
 const GITHUB_ISSUE_URI_RE = /https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/;
 
 const PHASE_TITLE_RE = /^(Phase\s+\d|IP[-\s]\d|Milestone\s+\d)/i;

--- a/packages/core/src/vbrief-reconcile/umbrellas.ts
+++ b/packages/core/src/vbrief-reconcile/umbrellas.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
 import { hasArtifactSuffix, resolveLifecycleRoot, stripArtifactSuffix } from "../layout/resolve.js";
 import { call } from "../scm/call.js";
 import { extractIssueRef } from "../triage/reconcile/parse-uri.js";
@@ -8,7 +9,7 @@ import type { Child, ReconcileUmbrellasOutcome, UmbrellaChange, UmbrellaClient }
 export const OPEN_FOLDERS = ["proposed", "pending", "active"] as const;
 export const CLOSED_FOLDERS = ["completed", "cancelled"] as const;
 export const LIFECYCLE_FOLDERS = [...OPEN_FOLDERS, ...CLOSED_FOLDERS] as const;
-export const CHILD_REF_TYPE = "x-vbrief/plan";
+export const CHILD_REF_TYPE = "x-xbrief/plan";
 const SCM_SOURCE = "github-issue";
 
 const HEADER_RE = /^## Current shape \(as of pass-(\d+)\)/m;
@@ -106,7 +107,7 @@ export function computeChildren(
   for (const ref of refs) {
     if (typeof ref !== "object" || ref === null || Array.isArray(ref)) continue;
     const rec = ref as Record<string, unknown>;
-    if (rec.type !== CHILD_REF_TYPE) continue;
+    if (!referenceTypeMatches(String(rec.type ?? ""), "plan")) continue;
     const name = basename(String(rec.uri ?? ""));
     const child = index[name];
     if (!child || seen.has(child.story_id)) continue;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -42,6 +42,7 @@ export {
   isVBriefReferenceType,
   KNOWN_REFERENCE_TYPES,
   type KnownReferenceType,
+  referenceTypeMatches,
   type TrustLevel,
   type VBriefReference,
 } from "./reference.js";

--- a/packages/types/src/reference.test.ts
+++ b/packages/types/src/reference.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isVBriefReferenceType, referenceTypeMatches } from "./reference.js";
+
+describe("referenceTypeMatches", () => {
+  it("matches the legacy x-vbrief/ prefix", () => {
+    expect(referenceTypeMatches("x-vbrief/plan", "plan")).toBe(true);
+    expect(referenceTypeMatches("x-vbrief/github-issue", "github-issue")).toBe(true);
+    expect(referenceTypeMatches("x-vbrief/closes", "closes")).toBe(true);
+  });
+
+  it("matches the canonical x-xbrief/ prefix", () => {
+    expect(referenceTypeMatches("x-xbrief/plan", "plan")).toBe(true);
+    expect(referenceTypeMatches("x-xbrief/github-issue", "github-issue")).toBe(true);
+    expect(referenceTypeMatches("x-xbrief/closes", "closes")).toBe(true);
+  });
+
+  it("does not match an unrelated type", () => {
+    expect(referenceTypeMatches("x-vbrief/github-issue", "plan")).toBe(false);
+    expect(referenceTypeMatches("x-xbrief/github-issue", "plan")).toBe(false);
+    expect(referenceTypeMatches("github-issue", "github-issue")).toBe(false);
+    expect(referenceTypeMatches("", "plan")).toBe(false);
+  });
+
+  it("does not match a prefix extension of bareType", () => {
+    expect(referenceTypeMatches("x-vbrief/plan-extended", "plan")).toBe(false);
+    expect(referenceTypeMatches("x-xbrief/plan-extra", "plan")).toBe(false);
+  });
+});
+
+describe("isVBriefReferenceType", () => {
+  it("accepts x-vbrief/ types", () => {
+    expect(isVBriefReferenceType("x-vbrief/plan")).toBe(true);
+    expect(isVBriefReferenceType("x-vbrief/github-issue")).toBe(true);
+  });
+
+  it("accepts x-xbrief/ types", () => {
+    expect(isVBriefReferenceType("x-xbrief/plan")).toBe(true);
+    expect(isVBriefReferenceType("x-xbrief/github-issue")).toBe(true);
+  });
+
+  it("rejects unrecognized types", () => {
+    expect(isVBriefReferenceType("github-issue")).toBe(false);
+    expect(isVBriefReferenceType("")).toBe(false);
+  });
+});

--- a/packages/types/src/reference.ts
+++ b/packages/types/src/reference.ts
@@ -45,3 +45,16 @@ export interface VBriefReference {
 export function isVBriefReferenceType(type: string): boolean {
   return type.startsWith(VBRIEF_REFERENCE_PREFIX) || type.startsWith(XBRIEF_REFERENCE_PREFIX);
 }
+
+/**
+ * Return true when `value` matches either the legacy `x-vbrief/<bareType>` or
+ * the canonical `x-xbrief/<bareType>` form.  Use this for all reader/matcher
+ * comparisons so that both namespaces are accepted during the transition
+ * period while `x-vbrief/` remains read-accepted for consumer back-compat.
+ */
+export function referenceTypeMatches(value: string, bareType: string): boolean {
+  return (
+    value === `${VBRIEF_REFERENCE_PREFIX}${bareType}` ||
+    value === `${XBRIEF_REFERENCE_PREFIX}${bareType}`
+  );
+}

--- a/packages/types/src/reference.ts
+++ b/packages/types/src/reference.ts
@@ -17,6 +17,7 @@ export const KNOWN_REFERENCE_TYPES = [
   "x-xbrief/user-request",
   "x-xbrief/spec-section",
   "x-xbrief/commit",
+  "x-xbrief/context",
   "x-xbrief/external",
   "x-xbrief/research",
   "x-xbrief/adr",

--- a/xbrief/active/2026-07-01-2128-canonicalize-emit-tokens.xbrief.json
+++ b/xbrief/active/2026-07-01-2128-canonicalize-emit-tokens.xbrief.json
@@ -1,0 +1,97 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2128 (canonicalize emit-site reference tokens to x-xbrief/ and make non-validate reader matchers dual-namespace); follow-up to #2109.",
+    "created": "2026-07-01T13:00:00Z",
+    "updated": "2026-07-01T13:00:00Z"
+  },
+  "plan": {
+    "id": "2128-canonicalize-emit-tokens",
+    "title": "Canonicalize emit-site reference tokens to x-xbrief/ and dual-namespace reader matchers",
+    "status": "running",
+    "planRef": "https://github.com/deftai/directive/issues/2128",
+    "narratives": {
+      "Description": "After the vbrief->xbrief flip (#2109), the engine still mints legacy reference tokens at its emit sites, so a freshly ingested or built artifact committed under xbrief/ trips the new verify:xbrief-drift pre-commit gate. This story flips the canonical emit constants to x-xbrief/ and makes the remaining single-namespace reader matchers dual-namespace so migrated x-xbrief/ refs are no longer silently skipped, while keeping legacy reference tokens read-accepted for consumer back-compat.",
+      "ImplementationPlan": "1. Add a shared dual-namespace helper referenceTypeMatches(value, bareType) in packages/types/src/reference.ts (accepting both legacy and canonical prefixes), with unit tests. 2. Flip the canonical emit constants to x-xbrief/ at the emit sites (packages/core/src/intake/issue-emit.ts, intake/issue-ingest.ts, vbrief-build/build.ts, vbrief-build/speckit.ts, scope/decompose.ts, vbrief-reconcile/umbrellas.ts, lifecycle/lifecycle-hygiene.ts) and update their parity fixtures/tests. 3. Sweep the non-validate reader matchers (capacity/backfill.ts, capacity/show.ts, validate-content/capacity-show.ts, scope/project-definition-sync.ts, scope/decompose.ts, scope/decomposed-refs.ts, swarm/readiness.ts, vbrief-build/speckit.ts) to use the shared helper. Verify by running task check and confirming a freshly ingested artifact no longer trips verify:xbrief-drift.",
+      "UserStory": "As a directive maintainer, I want newly emitted artifacts to use x-xbrief/ reference tokens and all readers to accept both namespaces, so that fresh ingest/build output does not trip the drift gate and migrated refs are never silently skipped.",
+      "Traces": "#2128, #2109, #2034"
+    },
+    "items": [
+      {
+        "id": "2128-a1",
+        "title": "Given a freshly ingested or built artifact, when committed under xbrief/, then verify:xbrief-drift passes",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a newly ingested or built vBRIEF written under xbrief/, when the pre-commit drift gate runs, then it passes because the artifact carries x-xbrief/ reference tokens."
+        }
+      },
+      {
+        "id": "2128-a2",
+        "title": "Given a migrated x-xbrief/ reference, when a reader matcher evaluates it, then it is matched not skipped",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given an artifact using x-xbrief/ reference types, when capacity/scope/swarm reader matchers evaluate it, then they match it via the shared dual-namespace helper."
+        }
+      },
+      {
+        "id": "2128-a3",
+        "title": "Given a legacy reference, when a reader matcher evaluates it, then it is still accepted",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a legacy artifact using the old reference prefix, when the reader matchers evaluate it, then it is still accepted for consumer back-compat."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#2109",
+        "child_issue": "#2128"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/types/src/reference.ts",
+          "packages/core/src/intake/issue-emit.ts",
+          "packages/core/src/intake/issue-ingest.ts",
+          "packages/core/src/vbrief-build/build.ts",
+          "packages/core/src/vbrief-build/speckit.ts",
+          "packages/core/src/scope/decompose.ts",
+          "packages/core/src/scope/decomposed-refs.ts",
+          "packages/core/src/scope/project-definition-sync.ts",
+          "packages/core/src/vbrief-reconcile/umbrellas.ts",
+          "packages/core/src/lifecycle/lifecycle-hygiene.ts",
+          "packages/core/src/capacity/backfill.ts",
+          "packages/core/src/capacity/show.ts",
+          "packages/core/src/validate-content/capacity-show.ts",
+          "packages/core/src/swarm/readiness.ts"
+        ],
+        "verify_commands": [
+          "task check"
+        ],
+        "expected_outputs": [
+          "emit sites produce x-xbrief/ tokens; shared dual-namespace matcher accepts both; fresh ingest/build no longer trips verify:xbrief-drift; legacy prefix still read-accepted"
+        ],
+        "depends_on": [],
+        "conflict_group": "xbrief-cleanup",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2128",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2128: canonicalize emit-site reference tokens + audit non-validate reader matchers"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2109",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2109: maintainer xbrief rename"
+      }
+    ],
+    "updated": "2026-07-01T14:30:00Z"
+  }
+}


### PR DESCRIPTION
## Summary

After the `vbrief/` → `xbrief/` rename (#2109), the engine's emit sites were still minting legacy `x-vbrief/` reference tokens. Any freshly ingested or built artifact committed under `xbrief/` would immediately trip the `verify:xbrief-drift` pre-commit gate. This PR closes that regression by:

- **Flipping all canonical emit constants to `x-xbrief/`** across `issue-emit.ts`, `issue-ingest.ts`, `build.ts`, `speckit.ts`, `decompose.ts`, `umbrellas.ts`, and `lifecycle-hygiene.ts`.
- **Adding a shared `referenceTypeMatches(value, bareType)` helper** in `@deftai/directive-types` that accepts both `x-vbrief/<type>` and `x-xbrief/<type>`, exported from the package index with unit tests.
- **Dual-namespacing all non-validate reader matchers** in `capacity/backfill.ts`, `capacity/show.ts`, `validate-content/capacity-show.ts`, `scope/project-definition-sync.ts`, `scope/decomposed-refs.ts`, `scope/vbrief-ref.ts`, `scope/decompose.ts`, `swarm/readiness.ts`, `vbrief-build/speckit.ts`, `vbrief-reconcile/umbrellas.ts`, and `lifecycle/lifecycle-hygiene.ts` via the new helper, so migrated `x-xbrief/` refs are no longer silently skipped.
- **Extending `INTERNAL_REFERENCE_TYPES` / `EXTERNAL_REFERENCE_TYPES`** in `vbrief-build/constants.ts` to include the `x-xbrief/` variants, ensuring `referenceWithDefaultTrust` assigns TrustLevel correctly for newly emitted tokens.
- **Dual-namespacing `GITHUB_ISSUE_REF_TYPES`** sets in `reconcile-issues.ts` and `reconciliation.ts` to accept `x-xbrief/github-issue`.
- **Updating emit-side parity tests** (`extractCrossRefs`, `decompose` child refs, e2e `ingest`) to expect `x-xbrief/` tokens.

`x-vbrief/` remains read-accepted for consumer back-compat (`EXTENSION_PREFIXES` is unchanged); only what the engine EMITS changes.

## Test plan

- [x] `pnpm vitest run packages/types/src/reference.test.ts` — 7 new unit tests for `referenceTypeMatches`
- [x] `task check` — all tests green, TypeScript build clean, `verify:xbrief-drift` passes
- [x] Pre-commit hook passes with no drift finding on the `xbrief/active/` story artifact
- [x] `task pr:check-closing-keywords` — no negation-context hits

Closes #2128.

Made with [Cursor](https://cursor.com)