### PR TITLE
fix(installer): route task surface through guarded :engine:* dispatch (#2126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`task check` and the `task <verb>` surface work again on vendored installs (#2126).** A half-finished v0.65.0 flatten left dozens of task fragments running a raw `pnpm run build` at the deposit root and calling the bundled CLI directly — both fail on a vendored `.deft/core` deposit, which has no `build` script and ships no `packages/`/`dist/`, so consumers refreshing to v0.65.0 hit `[ERR_PNPM_NO_SCRIPT] Missing script: build`. Every straggler now routes through the guarded `:engine:_ts-build` (a no-op on consumer deposits) and `:engine:invoke` (falls back to the globally-installed `deft`), matching the pattern already used by the branch/cache/wip-cap gates. A new deterministic gate keeps any task from re-introducing the broken pattern. Closes #2126.
+
 - **Go installer test and next-steps output updated for `xbrief` layout (#2134).** After the `vbrief/`→`xbrief/` rename (#2109), the Go installer's generated AGENTS.md referenced `PROJECT-DEFINITION.xbrief.json` but the test still asserted the legacy name, causing the Go CI job to fail on master. The stale test assertion and the post-install next-steps message are now consistent with the `xbrief` layout. Closes #2134.
 
 - **Global branch coverage restored above the 85% CI threshold (#2135).** Added targeted unit tests for uncovered branches in `xbrief-migrate` (detect, drift-gate, migrate-project) and the doctor CLI entry point — covering the quiet mode, non-git-repo error path, `emitXbriefMigration` outcome variants, `runAgentsRefresh` template-missing branch, root-level artifact detection, and legacy version string detection. No production code changes. Closes #2135.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -430,12 +430,12 @@ tasks:
   verify:no-task-runtime:
     desc: "Fail when runtime Python code hard-depends on go-task (#1659)."
     deps:
-      - task: verify:_ts-build
-        vars:
-          DEFT_ROOT: "{{.TASKFILE_DIR}}"
+      - task: engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/verify_no_task_runtime.py (#1854 s3).
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" verify-no-task-runtime
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-no-task-runtime'
 
   # Maintainer-only packaging aliases (#1860). `core:*` is internal;
   # these root aliases remain callable for release Step 8 (`task build`) and
@@ -490,7 +490,7 @@ tasks:
     desc: "Idempotent local-dev setup: configure git hooks (#747); detect-and-prompt ghx (#884). Sets core.hooksPath=.githooks so .githooks/pre-commit + .githooks/pre-push run."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - verify:_ts-build
+      - task: engine:_ts-build
     env:
       PYTHONUTF8: "1"
     cmds:
@@ -548,18 +548,22 @@ tasks:
       # `task setup` never prompts on a clean re-run; operators wanting to
       # opt in run `task setup:ghx` (defined below) which is the
       # interactive entry point. Native TypeScript handler (#2022 Phase 1).
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" setup:ghx --check
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'setup:ghx --check'
 
   setup:ghx:
     desc: "Consent-gated ghx (brunoborges/ghx) installer (#884) -- task setup:ghx [-- --yes]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - verify:_ts-build
+      - task: engine:_ts-build
     # Per `conventions/task-caching.md` (#574): no `sources:` / `generates:`
     # because the script forwards user-facing flags via {{.CLI_ARGS}}
     # (notably --yes for non-interactive CI / scripted approval).
     cmds:
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" setup:ghx {{.CLI_ARGS}}
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'setup:ghx {{.CLI_ARGS}}'
 
   # Release pipeline tasks (#74 + #716 safety hardening, namespace flatten #718).
   #
@@ -597,28 +601,36 @@ tasks:
     deps: [ts:build]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" release {{.CLI_ARGS}}
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'release {{.CLI_ARGS}}'
 
   release:publish:
     desc: "Flip a draft GitHub release to public (#716) -- task release:publish -- <version> [--dry-run] [--repo OWNER/REPO]"
     deps: [ts:build]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" release-publish {{.CLI_ARGS}}
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'release-publish {{.CLI_ARGS}}'
 
   release:rollback:
     desc: "State-aware release unwind (#716) -- task release:rollback -- <version> [--dry-run] [--allow-low-downloads N] [--allow-data-loss] [--force-strict-0]"
     deps: [ts:build]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" release-rollback {{.CLI_ARGS}}
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'release-rollback {{.CLI_ARGS}}'
 
   release:e2e:
     desc: "End-to-end release rehearsal against an auto-created+destroyed temp repo (#716) -- task release:e2e [-- --dry-run] [--owner OWNER] [--keep-repo]"
     deps: [ts:build]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" release-e2e {{.CLI_ARGS}}
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'release-e2e {{.CLI_ARGS}}'
 
   # ------------------------------------------------------------------
   # Triage v1 user-facing alias tasks (#845, #913).
@@ -676,7 +688,9 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" triage-help triage
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-help triage'
 
   scope:
     desc: "Print the categorized scope verb list (#1150 / N10). Run `task scope:<verb> --help` for usage examples."
@@ -684,7 +698,9 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - node "{{.TASKFILE_DIR}}/packages/cli/dist/bin.js" triage-help scope
+      - task: engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-help scope'
 
   triage:accept:
     desc: "Accept an issue for triage. Records an audit entry. (#845 Story 3)"

--- a/packages/cli/src/migrate-task-surface.test.ts
+++ b/packages/cli/src/migrate-task-surface.test.ts
@@ -13,8 +13,10 @@ describe("migrate/install task surface (#2022 Phase 2 / #2068 cutoff)", () => {
 
   it("migrate.yml uses deft-ts preflight and xbrief migration handlers", () => {
     const text = readFileSync(join(repoRoot(), "tasks", "migrate.yml"), "utf8");
-    expect(text).toContain('bin.js" migrate-preflight');
-    expect(text).toContain('bin.js" migrate-xbrief');
+    // #2126: migrate.yml dispatches through the guarded :engine:invoke pattern
+    // (global-deft fallback on consumer deposits), not a direct dist/bin.js call.
+    expect(text).toContain("ENGINE_CMD: 'migrate-preflight");
+    expect(text).toContain("ENGINE_CMD: 'migrate-xbrief");
     expect(text).not.toContain("migrate_vbrief.py");
     expect(text).not.toContain("\n  vbrief:");
     expect(text).not.toContain("migrate_preflight.py");

--- a/packages/cli/src/umbrella-current-shape-task-surface.test.ts
+++ b/packages/cli/src/umbrella-current-shape-task-surface.test.ts
@@ -10,10 +10,11 @@ describe("umbrella:current-shape task surface (#2066)", () => {
     expect(resolveCanonicalVerb("umbrella:current-shape")).toBe("umbrella-current-shape");
   });
 
-  it("umbrella.yml uses engine:invoke with _ensure-ts rebuild", () => {
+  it("umbrella.yml uses engine:invoke with the guarded :engine:_ts-build rebuild", () => {
     const text = readFileSync(join(repoRoot(), "tasks", "umbrella.yml"), "utf8");
     expect(text).toContain(":engine:invoke");
-    expect(text).toContain("_ensure-ts");
+    // #2126: guarded build dep (no-op on consumer deposits), not the old unguarded _ensure-ts.
+    expect(text).toContain(":engine:_ts-build");
     expect(text).toContain("umbrella:current-shape");
     expect(text).not.toContain("uv run python");
     expect(text).not.toContain("run umbrella");

--- a/packages/core/src/content-contracts/standards/branch_gate.test.ts
+++ b/packages/core/src/content-contracts/standards/branch_gate.test.ts
@@ -49,7 +49,9 @@ describe("test_branch_gate.py", () => {
     expect(text).toContain("show:");
     expect(text).toContain("enforce-branches:");
     expect(text).toContain("allow-direct-commits:");
-    expect(text).toContain("packages/cli/dist/bin.js");
+    // #2126: policy.yml dispatches through the guarded :engine:invoke pattern
+    // (global-deft fallback on consumer deposits), not a direct dist/bin.js call.
+    expect(text).toContain(":engine:invoke");
     expect(text).toContain("policy show");
     expect(text).toContain("policy-set");
   });

--- a/packages/core/src/content-contracts/standards/code_structure_profile.test.ts
+++ b/packages/core/src/content-contracts/standards/code_structure_profile.test.ts
@@ -49,7 +49,9 @@ describe("test_code_structure_profile.py", () => {
     expect(codebaseTasks).toContain("extract-default:");
     expect(codebaseTasks).toContain("provider-map:");
     expect(codebaseTasks).toContain("projection-registry:");
-    expect(codebaseTasks).toContain("packages/cli/dist/bin.js");
+    // #2126: codebase.yml dispatches through the guarded :engine:invoke pattern
+    // (global-deft fallback on consumer deposits), not a direct dist/bin.js call.
+    expect(codebaseTasks).toContain(":engine:invoke");
     expect(codebaseTasks).toContain("code-structure-validate");
   });
   it("test_profile_doc_names_physical_home_and_later_slices", () => {

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -19,8 +19,11 @@ import { repoRoot } from "./_helpers.js";
  * would miss: a local `_ts-build`, a local `_ensure-ts` (`pnpm --dir DEFT_ROOT
  * run build`), and a `deps: [:ts:build]` on the unconditional maintainer build
  * primitive. The canonical guarded pattern lives in tasks/engine.yml:
- *   - `:engine:_ts-build` guards the build behind `[ -f packages/cli/dist/bin.js ]`
- *     (a no-op on a consumer deposit), and
+ *   - `:engine:_ts-build` guards the build behind `[ -f {{.DEFT_ROOT}}/packages/
+ *     cli/package.json ]` -- SOURCE presence, so it builds on a cold framework
+ *     checkout (dist/ is gitignored) yet no-ops on a consumer deposit -- and
+ *     runs from `{{.USER_WORKING_DIR}}` so an absolute `dir:` cannot double on a
+ *     Windows `task -t <abs>` invocation (#2126), and
  *   - `:engine:invoke` runs the vendored bin.js when present, else falls back to
  *     the globally-installed `deft` command.
  *
@@ -94,8 +97,12 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
   it("engine.yml still owns the guarded build + global-deft fallback", () => {
     const engine = readTask(ENGINE_FILE);
     expect(engine).toMatch(/_ts-build:/);
-    expect(engine).toMatch(/\[ -f packages\/cli\/dist\/bin\.js \]/);
-    expect(engine).toMatch(/pnpm run build/);
+    // Guard is SOURCE presence (packages/cli/package.json), referenced by
+    // absolute path so the check stays cwd-independent on Windows
+    // `task -t <abs>` invocations AND still builds on a cold framework checkout
+    // where dist/ is gitignored/absent (#2126).
+    expect(engine).toMatch(/\[ -f "\{\{\.DEFT_ROOT\}\}\/packages\/cli\/package\.json" \]/);
+    expect(engine).toMatch(RAW_PNPM_BUILD);
     expect(engine).toMatch(/invoke:/);
     expect(engine).toMatch(/command -v deft/);
     expect(engine).toMatch(/deft \{\{\.ENGINE_CMD\}\}/);

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -1,0 +1,140 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./_helpers.js";
+
+/**
+ * Consumer-safe engine-dispatch contract for the task surface (#2126).
+ *
+ * v0.65.0 shipped a half-finished #2022 Phase 3 flatten: dozens of task
+ * fragments reached an UNGUARDED build or a direct vendored-CLI call. On a
+ * vendored consumer install DEFT_ROOT is `.deft/core` = `@deftai/directive-
+ * content`, which has NO `build` script and ships NO `packages/`/`dist/`, so any
+ * consumer/operator task that reached one of those fragments died -- first with
+ * `[ERR_PNPM_NO_SCRIPT] Missing script: build`, then (once guarded) with
+ * `MODULE_NOT_FOUND` on the absent dist/bin.js. That broke `task check` for every
+ * consumer refreshing to v0.65.0.
+ *
+ * The unguarded build appeared under several spellings that a name-scoped fix
+ * would miss: a local `_ts-build`, a local `_ensure-ts` (`pnpm --dir DEFT_ROOT
+ * run build`), and a `deps: [:ts:build]` on the unconditional maintainer build
+ * primitive. The canonical guarded pattern lives in tasks/engine.yml:
+ *   - `:engine:_ts-build` guards the build behind `[ -f packages/cli/dist/bin.js ]`
+ *     (a no-op on a consumer deposit), and
+ *   - `:engine:invoke` runs the vendored bin.js when present, else falls back to
+ *     the globally-installed `deft` command.
+ *
+ * Build PRIMITIVES are allowlisted: engine.yml owns the guard; ts.yml owns the
+ * maintainer monorepo `ts:build`/`ts:test`/`ts:lint`; core.yml owns maintainer
+ * packaging. Every OTHER task-verb must depend on the guarded `:engine:_ts-build`
+ * and dispatch through `:engine:invoke`.
+ */
+
+// Build primitives + maintainer packaging -- allowed to run a real `pnpm build`.
+const BUILD_PRIMITIVE_FILES = new Set(["engine.yml", "ts.yml", "core.yml"]);
+// Only engine.yml may define/own a local build task + the direct dist/bin.js call.
+const ENGINE_FILE = "engine.yml";
+// Only core.yml may depend on the unconditional :ts:build primitive (packaging).
+const TS_BUILD_DEP_ALLOWED = new Set(["core.yml"]);
+
+function taskYmlNames(): string[] {
+  return readdirSync(join(repoRoot(), "tasks"))
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .sort();
+}
+
+function readTask(name: string): string {
+  return readFileSync(join(repoRoot(), "tasks", name), { encoding: "utf8" });
+}
+
+function nonCommentLines(text: string): string[] {
+  return text.split("\n").filter((l) => !l.trim().startsWith("#"));
+}
+
+const DIRECT_NODE_CALL = /-\s*node\s+"\{\{\.[A-Z_]+\}\}\/packages\/cli\/dist\/bin\.js"/;
+const LOCAL_BUILD_DEF = /^ {2}(_ts-build|_ensure-ts):/m;
+const RAW_PNPM_BUILD = /pnpm\s+(?:--dir\s+"[^"]*"\s+|-C\s+"[^"]*"\s+)?run build/;
+const TS_BUILD_DEP = /-\s*task:\s*:ts:build\b/;
+const BARE_TS_BUILD_DEP = /^\s*-\s*(_ts-build|_ensure-ts)\s*$/m;
+
+describe("task surface routes through the guarded :engine:* pattern (#2126)", () => {
+  const names = taskYmlNames();
+
+  for (const name of names) {
+    describe(`tasks/${name}`, () => {
+      const text = readTask(name);
+      const body = nonCommentLines(text).join("\n");
+
+      it("has no direct dist/bin.js node call (use :engine:invoke)", () => {
+        if (name === ENGINE_FILE) return;
+        expect(DIRECT_NODE_CALL.test(body)).toBe(false);
+      });
+
+      it("defines no local build task (use :engine:_ts-build)", () => {
+        if (name === ENGINE_FILE) return;
+        expect(LOCAL_BUILD_DEF.test(text)).toBe(false);
+      });
+
+      it("carries no bare local-build dependency", () => {
+        expect(BARE_TS_BUILD_DEP.test(body)).toBe(false);
+      });
+
+      it("runs no unguarded `pnpm run build` (build primitives excepted)", () => {
+        if (BUILD_PRIMITIVE_FILES.has(name)) return;
+        expect(RAW_PNPM_BUILD.test(body)).toBe(false);
+      });
+
+      it("does not depend on the unconditional :ts:build (use :engine:_ts-build)", () => {
+        if (TS_BUILD_DEP_ALLOWED.has(name)) return;
+        expect(TS_BUILD_DEP.test(body)).toBe(false);
+      });
+    });
+  }
+
+  it("engine.yml still owns the guarded build + global-deft fallback", () => {
+    const engine = readTask(ENGINE_FILE);
+    expect(engine).toMatch(/_ts-build:/);
+    expect(engine).toMatch(/\[ -f packages\/cli\/dist\/bin\.js \]/);
+    expect(engine).toMatch(/pnpm run build/);
+    expect(engine).toMatch(/invoke:/);
+    expect(engine).toMatch(/command -v deft/);
+    expect(engine).toMatch(/deft \{\{\.ENGINE_CMD\}\}/);
+  });
+
+  it("root Taskfile.yml carries no straggler build/dispatch fragments", () => {
+    const root = readFileSync(join(repoRoot(), "Taskfile.yml"), { encoding: "utf8" });
+    const body = nonCommentLines(root).join("\n");
+    // No direct vendored-CLI call and no reference to the deleted verify:_ts-build.
+    expect(DIRECT_NODE_CALL.test(body)).toBe(false);
+    expect(/verify:_ts-build/.test(body)).toBe(false);
+  });
+
+  it("the known straggler files were migrated (regression floor)", () => {
+    // The #2126 maintainer comment + the wider audit named these families; assert
+    // none re-introduces an unguarded build or a direct dist/bin.js call.
+    const named = [
+      "verify.yml",
+      "vbrief.yml",
+      "commit.yml",
+      "prd.yml",
+      "project.yml",
+      "spec.yml",
+      "scope.yml",
+      "policy.yml",
+      "scm.yml",
+      "cache.yml",
+      "codebase.yml",
+      "issue.yml",
+      "reconcile.yml",
+      "umbrella.yml",
+    ];
+    for (const name of named) {
+      expect(names, `${name} should exist`).toContain(name);
+      const body = nonCommentLines(readTask(name)).join("\n");
+      expect(DIRECT_NODE_CALL.test(body), `${name} has a direct node call`).toBe(false);
+      expect(RAW_PNPM_BUILD.test(body), `${name} has raw pnpm build`).toBe(false);
+      expect(TS_BUILD_DEP.test(body), `${name} deps on :ts:build`).toBe(false);
+      expect(LOCAL_BUILD_DEF.test(readTask(name)), `${name} defines local build`).toBe(false);
+    }
+  });
+});

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -57,7 +57,13 @@ function nonCommentLines(text: string): string[] {
 const DIRECT_NODE_CALL = /-\s*node\s+"\{\{\.[A-Z_]+\}\}\/packages\/cli\/dist\/bin\.js"/;
 const LOCAL_BUILD_DEF = /^ {2}(_ts-build|_ensure-ts):/m;
 const RAW_PNPM_BUILD = /pnpm\s+(?:--dir\s+"[^"]*"\s+|-C\s+"[^"]*"\s+)?run build/;
-const TS_BUILD_DEP = /-\s*task:\s*:ts:build\b/;
+// The unconditional :ts:build primitive appears as a dep in THREE spellings that
+// all break consumers (`:ts:build` = unguarded `pnpm run build` at DEFT_ROOT):
+//   1. bare long form   `- task: :ts:build`
+//   2. quoted long form `- task: ":ts:build"`   (packs.yml)
+//   3. inline array      `deps: [":ts:build"]`   (swarm/triage/pr/session/issue)
+// A name-scoped fix that only caught (1) left ~45 stragglers hidden (#2126, Greptile P1).
+const TS_BUILD_DEP = /(?:-\s*task:\s*"?:ts:build\b)|(?:deps:\s*\[[^\]]*":ts:build"[^\]]*\])/;
 const BARE_TS_BUILD_DEP = /^\s*-\s*(_ts-build|_ensure-ts)\s*$/m;
 
 describe("task surface routes through the guarded :engine:* pattern (#2126)", () => {
@@ -108,6 +114,17 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
     expect(engine).toMatch(/deft \{\{\.ENGINE_CMD\}\}/);
   });
 
+  it("TS_BUILD_DEP catches all three :ts:build spellings (regex self-test, #2126 Greptile P1)", () => {
+    // Guards against the first-pass regex that only matched the bare long form
+    // and silently let ~45 inline-array / quoted stragglers through.
+    expect(TS_BUILD_DEP.test("      - task: :ts:build")).toBe(true);
+    expect(TS_BUILD_DEP.test('      - task: ":ts:build"')).toBe(true);
+    expect(TS_BUILD_DEP.test('    deps: [":ts:build"]')).toBe(true);
+    // Must NOT false-positive on the guarded engine build.
+    expect(TS_BUILD_DEP.test('    deps: [":engine:_ts-build"]')).toBe(false);
+    expect(TS_BUILD_DEP.test("      - task: :engine:_ts-build")).toBe(false);
+  });
+
   it("root Taskfile.yml carries no straggler build/dispatch fragments", () => {
     const root = readFileSync(join(repoRoot(), "Taskfile.yml"), { encoding: "utf8" });
     const body = nonCommentLines(root).join("\n");
@@ -134,6 +151,24 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
       "issue.yml",
       "reconcile.yml",
       "umbrella.yml",
+      // Second wave: the inline-array `deps: [":ts:build"]` + quoted long-form
+      // `- task: ":ts:build"` families the first-pass regex missed (#2126, Greptile P1).
+      "swarm.yml",
+      "packs.yml",
+      "session.yml",
+      "pr.yml",
+      "triage-actions.yml",
+      "triage-queue.yml",
+      "triage-bulk.yml",
+      "triage-bootstrap.yml",
+      "triage-classify.yml",
+      "triage-reconcile.yml",
+      "triage-scope.yml",
+      "triage-scope-drift.yml",
+      "triage-smoketest.yml",
+      "triage-subscribe.yml",
+      "triage-summary.yml",
+      "triage-welcome.yml",
     ];
     for (const name of named) {
       expect(names, `${name} should exist`).toContain(name);

--- a/tasks/architecture.yml
+++ b/tasks/architecture.yml
@@ -10,4 +10,6 @@ tasks:
     # Per conventions/task-caching.md: no sources/generates because this target
     # forwards user-supplied story paths and flags via CLI_ARGS.
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" architecture-preflight-sor {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'architecture-preflight-sor {{.CLI_ARGS}}'

--- a/tasks/cache.yml
+++ b/tasks/cache.yml
@@ -32,38 +32,48 @@ tasks:
     desc: "Cache an entry -- task cache:put -- <source> <key> --raw-file PATH [--ttl-seconds N]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" cache put {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'cache put {{.CLI_ARGS}}'
 
   get:
     desc: "Read an entry -- task cache:get -- <source> <key> [--allow-stale | --no-stale]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" cache get {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'cache get {{.CLI_ARGS}}'
 
   invalidate:
     desc: "Drop an entry -- task cache:invalidate -- <source> <key> [--reason TEXT]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" cache invalidate {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'cache invalidate {{.CLI_ARGS}}'
 
   fetch-all:
     desc: "Bulk populate -- task cache:fetch-all -- --source github-issue --repo OWNER/NAME [--batch-size N] [--delay-ms N] [--ttl-seconds N] [--no-refresh-closed to skip open→closed reconcile]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" cache fetch-all {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'cache fetch-all {{.CLI_ARGS}}'
 
   prune:
     desc: "Drop expired or LRU-evict -- task cache:prune -- [--older-than-days 30] [--source github-issue] [--dry-run] [--to-cap]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" cache prune {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'cache prune {{.CLI_ARGS}}'

--- a/tasks/capacity.yml
+++ b/tasks/capacity.yml
@@ -25,14 +25,18 @@ tasks:
     desc: "Capacity allocation target-vs-actual mix (advisory, offline). task capacity:show [-- --project-root <path>]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" capacity-show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'capacity-show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   backfill:
     desc: "One-time capacity-bucket backfill for completed vBRIEFs (#1606): infer capacityBucket from origin-issue labels + stamp completedAt from git. Dry-run by default; idempotent; never touches cost. -- task capacity:backfill [-- --apply] [--window-only] [--cache-dir <path>] [--json]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" capacity-backfill --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'capacity-backfill --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/change.yml
+++ b/tasks/change.yml
@@ -7,25 +7,23 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed gates run (#1828 s2)."
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   changelog:check:
     desc: Verify CHANGELOG.md has an [Unreleased] section with at least one entry
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" changelog-check --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'changelog-check --project-root "{{.USER_WORKING_DIR}}"'
 
   change:init:
     desc: Create a new change proposal directory structure in history/changes/<name>/
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" change-init --project-root "{{.USER_WORKING_DIR}}" --name {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'change-init --project-root "{{.USER_WORKING_DIR}}" --name {{.CLI_ARGS}}'

--- a/tasks/changelog.yml
+++ b/tasks/changelog.yml
@@ -21,4 +21,6 @@ tasks:
     desc: "Union-merge CHANGELOG.md [Unreleased] conflicts (#911) -- task changelog:resolve-unreleased [-- --changelog-path PATH] [--dry-run]"
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" changelog-resolve-unreleased {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'changelog-resolve-unreleased {{.CLI_ARGS}}'

--- a/tasks/codebase.yml
+++ b/tasks/codebase.yml
@@ -10,38 +10,48 @@ tasks:
     # Per conventions/task-caching.md: no sources/generates because this task
     # forwards user-supplied paths and project-root flags via CLI_ARGS.
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" code-structure-validate --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'code-structure-validate --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   extract-default:
     desc: "Emit the dependency-free default codebase-map artifact to stdout (#1595 PR3)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" codebase-default-extractor --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'codebase-default-extractor --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   provider-map:
     desc: "Select an external codebase-map provider or fall back to the default artifact (#1595 PR3)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" codebase-provider --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'codebase-provider --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   map:
     desc: "Generate .planning/codebase/MAP.md from the selected codebase-map artifact (#1595 PR4)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" codebase-map --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'codebase-map --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   projection-registry:
     desc: "Inspect registered codebase projection kinds (#1595 PR3)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" codebase-projection-registry {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'codebase-projection-registry {{.CLI_ARGS}}'

--- a/tasks/commit.yml
+++ b/tasks/commit.yml
@@ -7,17 +7,13 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed gates run (#1828 s2)."
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   commit:lint:
     desc: Validate HEAD commit message against conventional commit format
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" commit-lint --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'commit-lint --project-root "{{.USER_WORKING_DIR}}"'

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -12,13 +12,25 @@ vars:
 tasks:
   _ts-build:
     internal: true
-    desc: "Build CLI dist when running from the framework source checkout; no-op on npm consumer deposits (#2022 Phase 3)."
-    dir: '{{.DEFT_ROOT}}'
+    desc: "Build CLI dist from the framework source checkout; no-op on npm consumer deposits that ship no packages/ source (#2022 Phase 3 / #2126)."
+    # Run from the operator project root (USER_WORKING_DIR), NOT an absolute
+    # DEFT_ROOT: an absolute `dir:` doubles onto the invocation cwd on Windows
+    # when the Taskfile is invoked via `task -t <absolute-path>` (observed as
+    # `D:\a\directive\directive\D:\a\directive\directive`, #2126). Reference the
+    # build root by absolute path so the guard stays cwd-independent.
+    #
+    # Guard on SOURCE presence (packages/cli/package.json), NOT the dist/
+    # artifact: dist/ is gitignored, so a cold framework checkout (e.g. CI after
+    # a bare `pnpm install`) has source but no dist and MUST still build. A
+    # consumer deposit (`.deft/core` = @deftai/directive-content) ships no
+    # packages/ tree, so the guard is false and the build is a clean no-op --
+    # this is the #2126 fix (avoids `pnpm run build` -> Missing script: build).
+    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - |
         set -eu
-        if [ -f packages/cli/dist/bin.js ]; then
-          pnpm run build
+        if [ -f "{{.DEFT_ROOT}}/packages/cli/package.json" ]; then
+          pnpm --dir "{{.DEFT_ROOT}}" run build
         fi
 
   invoke:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,12 +7,6 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed gates run (#1828 s2)."
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   install:
     desc: Install deft (dev convenience -- end users should use the compiled binary from GitHub Releases)
@@ -23,9 +17,11 @@ tasks:
     desc: Remove deft entry from AGENTS.md
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" install-uninstall --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'install-uninstall --project-root "{{.USER_WORKING_DIR}}"'
 
   # User-facing upgrade entrypoint (#1061). Native deft-ts handler (#2022 Phase 2):
   #   1. Writes / refreshes the bare ``.deft-version`` marker.

--- a/tasks/issue.yml
+++ b/tasks/issue.yml
@@ -18,20 +18,16 @@ vars:
 # `uv --project "{{.DEFT_ROOT}}" run python` (#566).
 
 tasks:
-  _ensure-ts:
-    internal: true
-    desc: "Build the TS engine before issue gates (#1828 s4)"
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   ingest:
     desc: "Ingest GitHub issues as scope vBRIEFs (single <N> or --all [--label L] [--status S] [--dry-run])"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" issue-ingest --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'issue-ingest --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   # issue emit task -- the write-direction counterpart to issue:ingest
   # (#1274 Change 2). Files GitHub issue(s) from scope vBRIEFs and records
@@ -47,4 +43,6 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" issue-emit --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'issue-emit --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/issue.yml
+++ b/tasks/issue.yml
@@ -39,7 +39,7 @@ tasks:
   emit:
     desc: "File GitHub issue(s) from scope vBRIEF(s) (<path> | --umbrella <glob> | --per-vbrief <glob> [--dry-run])"
     dir: '{{.USER_WORKING_DIR}}'
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     env:
       PYTHONUTF8: "1"
     cmds:

--- a/tasks/migrate.yml
+++ b/tasks/migrate.yml
@@ -7,12 +7,6 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed gates run (#1828 s2)."
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   preflight:
     # Pre-v0.20 document-model probe (#793, #2068 cutoff). Detects legacy
@@ -22,22 +16,28 @@ tasks:
     desc: "Detect pre-v0.20 document model and report the frozen-release migration path (#2068). Three-state exit (#793)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" migrate-preflight --project-root "{{.USER_WORKING_DIR}}" --deft-root "{{.DEFT_ROOT}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'migrate-preflight --project-root "{{.USER_WORKING_DIR}}" --deft-root "{{.DEFT_ROOT}}" {{.CLI_ARGS}}'
 
   xbrief:
     desc: "Migrate consumer vbrief/ layout to xbrief/ with semantic v0.6->v0.8 transforms (#2110 / #2034)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" migrate-xbrief --project-root "{{.USER_WORKING_DIR}}" --framework-root "{{.DEFT_ROOT}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'migrate-xbrief --project-root "{{.USER_WORKING_DIR}}" --framework-root "{{.DEFT_ROOT}}" {{.CLI_ARGS}}'
 
   category-b:
     desc: "Namespace Category B bare plan keys (policy / completedNote) under x-directive/ across the corpus (#1650 / #2034)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" migrate-category-b --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'migrate-category-b --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/packs.yml
+++ b/tasks/packs.yml
@@ -31,7 +31,7 @@ tasks:
     desc: "Named, structured slice access to a content pack (#1283, #1295). -- task packs:slice <pack> <name> [-- --since YYYY-MM | --tag T | --trigger KW] [--list] [--list-packs] [--json]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:
@@ -41,7 +41,7 @@ tasks:
     desc: "Regenerate every content-pack projection from its canonical source (ADR-001): meta/lessons.md (lessons), the proof SKILL.md (skills), coding/testing.md (rules), strategies/yolo.md (strategies). -- task packs:render [-- --pack rules] [--check]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:
@@ -51,7 +51,7 @@ tasks:
     desc: "One-shot migration: rebuild packs/skills/skills-pack-0.1.json from skills/*/SKILL.md + the AGENTS.md Skill Routing table (#1295)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:
@@ -61,7 +61,7 @@ tasks:
     desc: "One-shot migration: rebuild packs/rules/rules-pack-0.1.json from the RFC2119 directives in coding/*.md (#1296)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:
@@ -71,7 +71,7 @@ tasks:
     desc: "One-shot migration: rebuild packs/strategies/strategies-pack-0.1.json from strategies/*.md (#1296)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:
@@ -81,7 +81,7 @@ tasks:
     desc: "One-shot migration: rebuild packs/patterns/patterns-pack-0.1.json from patterns/*.md (#1637)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:
@@ -91,7 +91,7 @@ tasks:
     desc: "One-shot migration: rebuild packs/swarm-spec/swarm-spec-pack-0.1.json from swarm/*.md (#1637)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:
@@ -101,7 +101,7 @@ tasks:
     desc: "Drift gate: fail (exit 1) when ANY pack projection (meta/lessons.md, the skills proof SKILL.md, coding/testing.md, strategies/yolo.md) diverges from a freshly rendered buffer. Wired into `task check` and surfaced as `task verify:pack-drift`."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: ":ts:build"
+      - task: ":engine:_ts-build"
     cmds:
       - task: :engine:invoke
         vars:

--- a/tasks/packs.yml
+++ b/tasks/packs.yml
@@ -33,7 +33,9 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" packs-slice {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'packs-slice {{.CLI_ARGS}}'
 
   render:
     desc: "Regenerate every content-pack projection from its canonical source (ADR-001): meta/lessons.md (lessons), the proof SKILL.md (skills), coding/testing.md (rules), strategies/yolo.md (strategies). -- task packs:render [-- --pack rules] [--check]"
@@ -41,7 +43,9 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pack-render {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pack-render {{.CLI_ARGS}}'
 
   render-skills:
     desc: "One-shot migration: rebuild packs/skills/skills-pack-0.1.json from skills/*/SKILL.md + the AGENTS.md Skill Routing table (#1295)."
@@ -49,7 +53,9 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pack-migrate-skills {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pack-migrate-skills {{.CLI_ARGS}}'
 
   render-rules:
     desc: "One-shot migration: rebuild packs/rules/rules-pack-0.1.json from the RFC2119 directives in coding/*.md (#1296)."
@@ -57,7 +63,9 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pack-migrate-rules {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pack-migrate-rules {{.CLI_ARGS}}'
 
   render-strategies:
     desc: "One-shot migration: rebuild packs/strategies/strategies-pack-0.1.json from strategies/*.md (#1296)."
@@ -65,7 +73,9 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pack-migrate-strategies {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pack-migrate-strategies {{.CLI_ARGS}}'
 
   render-patterns:
     desc: "One-shot migration: rebuild packs/patterns/patterns-pack-0.1.json from patterns/*.md (#1637)."
@@ -73,7 +83,9 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pack-migrate-patterns {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pack-migrate-patterns {{.CLI_ARGS}}'
 
   render-swarm-spec:
     desc: "One-shot migration: rebuild packs/swarm-spec/swarm-spec-pack-0.1.json from swarm/*.md (#1637)."
@@ -81,7 +93,9 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pack-migrate-swarm-spec {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pack-migrate-swarm-spec {{.CLI_ARGS}}'
 
   verify-drift:
     desc: "Drift gate: fail (exit 1) when ANY pack projection (meta/lessons.md, the skills proof SKILL.md, coding/testing.md, strategies/yolo.md) diverges from a freshly rendered buffer. Wired into `task check` and surfaced as `task verify:pack-drift`."
@@ -89,4 +103,6 @@ tasks:
     deps:
       - task: ":ts:build"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pack-render --check {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pack-render --check {{.CLI_ARGS}}'

--- a/tasks/policy.yml
+++ b/tasks/policy.yml
@@ -26,50 +26,62 @@ tasks:
     desc: "Inspect every registered typed-policy field on vbrief/PROJECT-DEFINITION.vbrief.json (#1148 / N8). -- task policy:show [-- --format=json] [--changed-only] [--field=<name>]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" policy show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'policy show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   enforce-branches:
     desc: "Set plan.policy.allowDirectCommitsToMaster=false (enforce feature branches). Audits to meta/policy-changes.log. (#746)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" policy enforce-branches --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'policy enforce-branches --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   allow-direct-commits:
     desc: "Set plan.policy.allowDirectCommitsToMaster=true (capability-cost: branch-protection OFF). Requires --confirm to apply. (#746)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" policy allow-direct-commits --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'policy allow-direct-commits --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   wip-cap:
     desc: "Set plan.policy.wipCap=N (#1124 / D4 of #1119). Requires --set N --confirm. Default cap is 10 per umbrella #1119 Current Shape v3."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" policy-set wip-cap {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'policy-set wip-cap {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   subagent-backend:
     desc: "DEPRECATED (superseded by `task swarm:routing-set`, #1739). Was: Set plan.policy.swarmSubagentBackend (#1531a). -- task policy:subagent-backend -- --set composer|grok-build|cursor-cloud"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
       - cmd: echo "[deft deprecation] task policy:subagent-backend is superseded by 'task swarm:routing-set' (#1739). The swarmSubagentBackend enum is no longer the active routing surface." 1>&2
         silent: true
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" policy-set subagent-backend {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'policy-set subagent-backend {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   subagent-backends:
     desc: "DEPRECATED (superseded by `task swarm:routing-set` / `task verify:routing`, #1739). Was: Probe sub-agent backend ids, role capabilities, and availability (#1531a). -- task policy:subagent-backends [-- --format=json]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
       - cmd: echo "[deft deprecation] task policy:subagent-backends is superseded by 'task verify:routing -- --advise' and 'task swarm:routing-set' (#1739). The swarmSubagentBackend enum is no longer the active routing surface." 1>&2
         silent: true
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" policy-set subagent-backends {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'policy-set subagent-backends {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'

--- a/tasks/pr.yml
+++ b/tasks/pr.yml
@@ -24,7 +24,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pr-protected-issues {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pr-protected-issues {{.CLI_ARGS}}'
 
   # pr:check-closing-keywords -- Layer 0 (prevention) closing-keyword
   # negation-context lint introduced by #737. Refuses to push when the
@@ -43,7 +45,9 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pr-closing-keywords {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pr-closing-keywords {{.CLI_ARGS}}'
 
   # pr:merge-ready -- programmatic Greptile-body verdict gate. Closes the
   # SUCCESS-with-findings blind spot in the Phase 5 -> 6 merge-readiness
@@ -59,7 +63,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pr-merge-readiness {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pr-merge-readiness {{.CLI_ARGS}}'
 
   # pr:wait-mergeable-and-merge -- cascade automation surface (#1369).
   # Wraps scripts/pr_wait_mergeable.py which composes the resilient
@@ -86,4 +92,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" pr-wait-mergeable {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'pr-wait-mergeable {{.CLI_ARGS}}'

--- a/tasks/pr.yml
+++ b/tasks/pr.yml
@@ -21,7 +21,7 @@ vars:
 tasks:
   check-protected-issues:
     desc: "Verify NO protected (umbrella / staying-OPEN) issue is GitHub-side linked to a PR before squash merge (#701)"
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -41,7 +41,7 @@ tasks:
   check-closing-keywords:
     desc: "Scan PR body + commit messages for closing-keyword substrings in negation/quotation/example contexts that would trigger Layer 0 false-positive auto-closes (#737)"
     dir: '{{.USER_WORKING_DIR}}'
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     env:
       PYTHONUTF8: "1"
     cmds:
@@ -60,7 +60,7 @@ tasks:
   # Companion test:   tests/cli/test_pr_merge_readiness.py
   merge-ready:
     desc: "Verify a PR's Greptile review body satisfies the merge exit condition (confidence >3, no P0/P1, HEAD-SHA fresh, not errored)"
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -89,7 +89,7 @@ tasks:
   # Companion test:   tests/cli/test_pr_wait_mergeable.py
   wait-mergeable-and-merge:
     desc: "Wait until PR is mergeable (resilient cascade, #1368) and squash-merge with admin (#1369); Layer-3 protected-issue check (#701) chains before any merge call"
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/prd.yml
+++ b/tasks/prd.yml
@@ -13,12 +13,6 @@ vars:
 # caused sporadic PATH issues on Windows.
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed render gates run (#1854 s2)."
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   render:
     # Caching: intentionally absent. `prd:render` runs in <30ms and its
@@ -34,6 +28,8 @@ tasks:
       authoritative -- the vBRIEF is the source of truth.
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" prd-render --spec "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" --output "{{.USER_WORKING_DIR}}/PRD.md" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'prd-render --spec "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" --output "{{.USER_WORKING_DIR}}/PRD.md" {{.CLI_ARGS}}'

--- a/tasks/project.yml
+++ b/tasks/project.yml
@@ -17,20 +17,16 @@ vars:
 # origin freshness on scope vBRIEFs — not PROJECT-DEFINITION narrative heuristics.
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed render gates run (#1854 s2)."
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   render:
     desc: Regenerate PROJECT-DEFINITION.vbrief.json items registry from lifecycle folders
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" project-render "{{.USER_WORKING_DIR}}/vbrief"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'project-render "{{.USER_WORKING_DIR}}/vbrief"'
 
   ack-staleness:
     desc: >-
@@ -38,9 +34,11 @@ tasks:
       Distinct from task reconcile:issues (scope origin freshness).
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" project-render --acknowledge-staleness "{{.USER_WORKING_DIR}}/vbrief"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'project-render --acknowledge-staleness "{{.USER_WORKING_DIR}}/vbrief"'
 
   export-spec:
     desc: >-
@@ -48,6 +46,8 @@ tasks:
       Use --audience=internal to include proposed scopes (#2013 / #1502).
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" export-spec {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'export-spec {{.CLI_ARGS}}'

--- a/tasks/reconcile.yml
+++ b/tasks/reconcile.yml
@@ -16,17 +16,13 @@ vars:
 # `uv --project "{{.DEFT_ROOT}}" run python` (#566).
 
 tasks:
-  _ensure-ts:
-    internal: true
-    desc: "Build the TS engine before reconcile gates (#1828 s4)"
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   issues:
     desc: "Reconcile GitHub issues against vBRIEF references -- report linked, unlinked, and resolved"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" reconcile-issues --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'reconcile-issues --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/roadmap.yml
+++ b/tasks/roadmap.yml
@@ -15,14 +15,18 @@ tasks:
     desc: Render ROADMAP.md from vbrief/pending/ (Active) and vbrief/completed/ (Completed) lifecycle folders
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" roadmap-render "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'roadmap-render "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md"'
 
   check:
     desc: Verify ROADMAP.md matches what roadmap:render would produce
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" roadmap-render "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md" --check
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'roadmap-render "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md" --check'

--- a/tasks/scm.yml
+++ b/tasks/scm.yml
@@ -57,70 +57,88 @@ tasks:
     desc: "[#883 stub] List issues -- task scm:issue:list -- [--rest] --repo OWNER/NAME --json number,title,state,updatedAt [--state ...] (#976 --rest routes via REST helpers; default forwards to ghx|gh)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scm issue list {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scm issue list {{.CLI_ARGS}}'
 
   issue:view:
     desc: "[#883 stub] View an issue -- task scm:issue:view -- [--rest] <N> --repo OWNER/NAME --json number,title,body,state,author,createdAt,updatedAt,labels,comments (#976 --rest routes via REST helpers and emits REST shape; default forwards to ghx|gh GraphQL shape)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scm issue view {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scm issue view {{.CLI_ARGS}}'
 
   issue:close:
     desc: "[#883 stub] Close an issue -- task scm:issue:close -- <N> --repo OWNER/NAME [--comment ...]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scm issue close {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scm issue close {{.CLI_ARGS}}'
 
   issue:edit:
     desc: "[#883 stub] Edit an issue -- task scm:issue:edit -- <N> --repo OWNER/NAME [--add-label ...] [--body ...]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scm issue edit {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scm issue edit {{.CLI_ARGS}}'
 
   body:issue:create:
     desc: "[#1555] Safely create an issue body from --body-file without shell Markdown interpolation"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" github-body issue-create {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'github-body issue-create {{.CLI_ARGS}}'
 
   body:issue:edit:
     desc: "[#1555] Safely edit an issue body from --body-file and live gh read-back"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" github-body issue-edit {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'github-body issue-edit {{.CLI_ARGS}}'
 
   body:comment:create:
     desc: "[#1555] Safely create an issue/PR comment body from --body-file and live gh read-back"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" github-body comment-create {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'github-body comment-create {{.CLI_ARGS}}'
 
   body:comment:edit:
     desc: "[#1555] Safely edit an issue comment body from --body-file and live gh read-back"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" github-body comment-edit {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'github-body comment-edit {{.CLI_ARGS}}'
 
   body:pr:edit:
     desc: "[#1555] Safely edit a PR body from --body-file and live gh read-back"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - task: :ts:build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" github-body pr-edit {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'github-body pr-edit {{.CLI_ARGS}}'

--- a/tasks/scope-undo.yml
+++ b/tasks/scope-undo.yml
@@ -33,4 +33,6 @@ tasks:
     desc: "Reverse a scope-lifecycle audit entry (#1134). Single: `task scope:undo -- <decision_id>` / `task scope:undo -- --decision-id=<uuid>`. Batch: `task scope:undo -- --batch-id=<uuid>`. Optional `--dry-run`."
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-undo {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-undo {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -34,36 +34,36 @@ vars:
 # Taskfile.yml also sets this (#540).
 
 tasks:
-  _ensure-ts:
-    internal: true
-    desc: "Build the TS engine before lifecycle gates (#1828 s4)"
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   promote:
     desc: "Promote a vBRIEF scope: proposed/ -> pending/ (status: pending)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle promote {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle promote {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   activate:
     desc: "Activate a vBRIEF scope: pending/ -> active/ (status: running)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle activate {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle activate {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   complete:
     desc: "Complete a vBRIEF scope: active/ -> completed/ (status: completed)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle complete {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle complete {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   fail:
     # Terminal ``failed`` transition (#614). Parallels ``scope:complete``
@@ -79,49 +79,61 @@ tasks:
     desc: "Fail a vBRIEF scope: active/ -> completed/ (status: failed)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle fail {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle fail {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   cancel:
     desc: "Cancel a vBRIEF scope: any folder -> cancelled/ (status: cancelled)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle cancel {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle cancel {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   restore:
     desc: "Restore a cancelled vBRIEF scope: cancelled/ -> proposed/ (status: proposed)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle restore {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle restore {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   block:
     desc: "Block a vBRIEF scope: stays in active/ (status: blocked)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle block {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle block {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   unblock:
     desc: "Unblock a vBRIEF scope: stays in active/ (status: running)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-lifecycle unblock {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-lifecycle unblock {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   decompose:
     desc: "Apply/check an approved epic/phase -> story decomposition draft"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-decompose {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-decompose {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   # Operator-driven demote (D1 / #1121). Moves a vBRIEF scope from
   # vbrief/pending/ back to vbrief/proposed/ and appends a structured
@@ -136,6 +148,8 @@ tasks:
     desc: "Demote a vBRIEF scope: pending/ -> proposed/ (#1121). Single-file or --batch --older-than-days N (default 45)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" scope-demote {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'scope-demote {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'

--- a/tasks/session.yml
+++ b/tasks/session.yml
@@ -16,4 +16,6 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" session:start --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'session:start --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/session.yml
+++ b/tasks/session.yml
@@ -12,7 +12,7 @@ tasks:
   start:
     desc: "Run quick-tier session-start ritual and write .deft/ritual-state.json (#1348). Flags: --defer step=reason / --json"
     dir: '{{.USER_WORKING_DIR}}'
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     env:
       PYTHONUTF8: "1"
     cmds:

--- a/tasks/slice.yml
+++ b/tasks/slice.yml
@@ -43,27 +43,25 @@ vars:
 # `--wave-N=<csv>`, `--actor`, etc.) via {{.CLI_ARGS}}.
 
 tasks:
-  _ensure-ts:
-    internal: true
-    desc: "Build the TS engine before slice gates (#1828 s4)"
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   record-existing:
     desc: "Retrofit a slices.jsonl entry for a hand-filed cohort (#1147 / N7). Windows note (#1231): CLI_ARGS is forwarded bare to argparse so values containing spaces (e.g. --notes \"A note with spaces\") may be re-split by the shell -- prefer hyphenated single-token values like --notes=backfill-after-N7. -- task slice:record-existing -- --umbrella=N --children=A,B,C [--wave-1=A,B] [--wave-2=C] [--actor=manual:operator] [--expected-close-signal=all-children-merged] [--sliced-at=ISO] [--notes=TEXT] [--dry-run] [--force] [--skip-validation] [--repo OWNER/NAME]"
     internal: true
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" slice record-existing {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'slice record-existing {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   list:
     desc: "List recorded slices in vbrief/.eval/slices.jsonl (umbrella + child count + actor + sliced_at). -- task slice:list [-- --json]"
     internal: true
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" slice list {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'slice list {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'

--- a/tasks/spec.yml
+++ b/tasks/spec.yml
@@ -11,28 +11,26 @@ vars:
 # on Windows under `uv --project "{{.DEFT_ROOT}}" run python` (#566).
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed render gates run (#1854 s2)."
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   validate:
     desc: Validate that vbrief/specification.vbrief.json exists and is well-formed JSON
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" spec-validate "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'spec-validate "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json"'
 
   render:
     desc: Render vbrief/specification.vbrief.json to SPECIFICATION.md
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" spec-render "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" "{{.USER_WORKING_DIR}}/SPECIFICATION.md"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'spec-render "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" "{{.USER_WORKING_DIR}}/SPECIFICATION.md"'
 
   pipeline:
     desc: Run full spec pipeline (validate then render)

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -12,7 +12,9 @@ tasks:
       PYTHONUTF8: "1"
     cmds:
       # Keep CLI_ARGS bare; go-task shell-escapes pass-through args and quoting breaks globs/multi-arg calls.
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-readiness {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'swarm-readiness {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   # swarm:launch -- deterministic headless launch engine (#1387). Turns an
   # operator-supplied, pre-approved cohort into a ready-to-spawn launch
@@ -32,7 +34,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-launch {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'swarm-launch {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   # swarm:routing-set -- record an operator coding sub-agent model decision
   # (#1739) into the gitignored, per-machine .deft/routing.local.json keyed by
@@ -44,7 +48,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-routing-set {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'swarm-routing-set {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'
 
   # swarm:verify-review-clean -- cohort-level CLEAN verification gate (#1364).
   # Mandate the monitor invokes this after Phase 6 pollers report and BEFORE
@@ -62,7 +68,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-verify-review-clean {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'swarm-verify-review-clean {{.CLI_ARGS}}'
 
   # swarm:complete-cohort -- deterministic cohort completion sweep (#1487).
   # The REQUIRED Phase 6 step that moves a finished cohort's story vBRIEFs
@@ -82,4 +90,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-complete-cohort {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'swarm-complete-cohort {{.CLI_ARGS}} --project-root "{{.USER_WORKING_DIR}}"'

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -7,7 +7,7 @@ tasks:
   readiness:
     desc: "Report whether story vBRIEFs are ready for concurrent swarm allocation"
     dir: '{{.USER_WORKING_DIR}}'
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     env:
       PYTHONUTF8: "1"
     cmds:
@@ -31,7 +31,7 @@ tasks:
   # Companion test:   tests/cli/test_swarm_launch.py
   launch:
     desc: "Resolve a pre-approved cohort, enforce the #810 + swarm:readiness gates and sub-agent backend policy per story, and emit the launch-manifest JSON (#1387, #1531e)"
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -45,7 +45,7 @@ tasks:
   # (resolved_model / model_source) so dispatch can actually honor it.
   routing-set:
     desc: "Record an operator coding sub-agent model decision (#1739): --role <role> (--model <slug> | --harness-default) [--provider <p>]. Writes the gitignored, per-machine .deft/routing.local.json."
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -65,7 +65,7 @@ tasks:
   # Skill citation:   skills/deft-directive-swarm/SKILL.md Phase 5 Exit Condition + Phase 5 -> 6 gate
   verify-review-clean:
     desc: "Verify EVERY PR in a swarm cohort is CLEAN on current HEAD (confidence > 3, no P0/P1, not errored) before raising the Phase 5 -> 6 merge gate (#1364)"
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -87,7 +87,7 @@ tasks:
   # Skill citation:   skills/deft-directive-swarm/SKILL.md Phase 6 cohort completion sweep
   complete-cohort:
     desc: "Sweep a finished swarm cohort's stories active/ -> completed/ and complete their epic parents, keeping vbrief:validate green (#1487)"
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-actions.yml
+++ b/tasks/triage-actions.yml
@@ -35,7 +35,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions accept {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions accept {{.CLI_ARGS}}'
 
   reject:
     desc: "Reject an issue. Closes upstream via gh + applies triage-rejected label; rolls audit back on gh failure. (#845 Story 3)"
@@ -43,7 +45,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions reject {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions reject {{.CLI_ARGS}}'
 
   defer:
     desc: "Defer an issue. Records an audit entry. (#845 Story 3)"
@@ -51,7 +55,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions defer {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions defer {{.CLI_ARGS}}'
 
   needs-ac:
     desc: "Mark an issue as needing acceptance criteria + post AC-request comment upstream. (#845 Story 3)"
@@ -59,7 +65,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions needs-ac {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions needs-ac {{.CLI_ARGS}}'
 
   mark-duplicate:
     desc: "Link an issue as a duplicate of another (validated against Story 1 cache). (#845 Story 3)"
@@ -67,7 +75,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions mark-duplicate {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions mark-duplicate {{.CLI_ARGS}}'
 
   status:
     desc: "Print the latest triage decision for an issue. Read-only. (#845 Story 3)"
@@ -75,7 +85,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions status {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions status {{.CLI_ARGS}}'
 
   reset:
     desc: "Reset an issue's triage state. Appends a reset audit entry referencing prior; does NOT delete history. (#845 Story 3)"
@@ -83,7 +95,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions reset {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions reset {{.CLI_ARGS}}'
 
   history:
     desc: "Print the full triage timeline for an issue, ordered by timestamp. Read-only. (#845 Story 3)"
@@ -91,4 +105,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-actions history {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-actions history {{.CLI_ARGS}}'

--- a/tasks/triage-actions.yml
+++ b/tasks/triage-actions.yml
@@ -32,7 +32,7 @@ tasks:
   accept:
     desc: "Accept an issue for triage. Records an audit entry. (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -42,7 +42,7 @@ tasks:
   reject:
     desc: "Reject an issue. Closes upstream via gh + applies triage-rejected label; rolls audit back on gh failure. (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -52,7 +52,7 @@ tasks:
   defer:
     desc: "Defer an issue. Records an audit entry. (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -62,7 +62,7 @@ tasks:
   needs-ac:
     desc: "Mark an issue as needing acceptance criteria + post AC-request comment upstream. (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -72,7 +72,7 @@ tasks:
   mark-duplicate:
     desc: "Link an issue as a duplicate of another (validated against Story 1 cache). (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -82,7 +82,7 @@ tasks:
   status:
     desc: "Print the latest triage decision for an issue. Read-only. (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -92,7 +92,7 @@ tasks:
   reset:
     desc: "Reset an issue's triage state. Appends a reset audit entry referencing prior; does NOT delete history. (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -102,7 +102,7 @@ tasks:
   history:
     desc: "Print the full triage timeline for an issue, ordered by timestamp. Read-only. (#845 Story 3)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-bootstrap.yml
+++ b/tasks/triage-bootstrap.yml
@@ -40,4 +40,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bootstrap --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-bootstrap --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-bootstrap.yml
+++ b/tasks/triage-bootstrap.yml
@@ -37,7 +37,7 @@ tasks:
   bootstrap:
     desc: "Idempotent triage v1 installer (#845): populate cache, backfill audit log, ensure gitignore for .deft-cache/ and vbrief/.eval/. Re-runnable; per-step progress on stderr; cache:fetch-all wall-clock cap (#952). -- task triage:bootstrap [-- --repo OWNER/NAME] [--limit N] [--state open|closed|all] [--fetch-timeout-s N] [--quiet] [--json]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-bulk.yml
+++ b/tasks/triage-bulk.yml
@@ -40,7 +40,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk accept {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-bulk accept {{.CLI_ARGS}}'
 
   bulk-reject:
     desc: "Bulk reject candidates (#845 Story 4) -- task triage:bulk-reject -- --repo OWNER/NAME --reason 'why' [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
@@ -48,7 +50,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk reject {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-bulk reject {{.CLI_ARGS}}'
 
   bulk-defer:
     desc: "Bulk defer candidates (#845 Story 4) -- task triage:bulk-defer -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
@@ -56,7 +60,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk defer {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-bulk defer {{.CLI_ARGS}}'
 
   bulk-needs-ac:
     desc: "Bulk needs-ac candidates (#845 Story 4) -- task triage:bulk-needs-ac -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
@@ -64,7 +70,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-bulk needs-ac {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-bulk needs-ac {{.CLI_ARGS}}'
 
   refresh-active:
     desc: "Pre-swarm freshness gate (#845 Story 4) -- detects drift between cached and live `gh issue view` for every issue referenced in vbrief/active/*.vbrief.json"
@@ -72,4 +80,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-refresh --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-refresh --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-bulk.yml
+++ b/tasks/triage-bulk.yml
@@ -37,7 +37,7 @@ tasks:
   bulk-accept:
     desc: "Bulk accept candidates (#845 Story 4) -- task triage:bulk-accept -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -47,7 +47,7 @@ tasks:
   bulk-reject:
     desc: "Bulk reject candidates (#845 Story 4) -- task triage:bulk-reject -- --repo OWNER/NAME --reason 'why' [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -57,7 +57,7 @@ tasks:
   bulk-defer:
     desc: "Bulk defer candidates (#845 Story 4) -- task triage:bulk-defer -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -67,7 +67,7 @@ tasks:
   bulk-needs-ac:
     desc: "Bulk needs-ac candidates (#845 Story 4) -- task triage:bulk-needs-ac -- --repo OWNER/NAME [--label L] [--author A] [--age-days N] [--cluster C] [--re-action]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -77,7 +77,7 @@ tasks:
   refresh-active:
     desc: "Pre-swarm freshness gate (#845 Story 4) -- detects drift between cached and live `gh issue view` for every issue referenced in vbrief/active/*.vbrief.json"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-classify.yml
+++ b/tasks/triage-classify.yml
@@ -24,7 +24,7 @@ tasks:
   classify:
     desc: "Inspect / validate plan.policy.triageAutoClassify[] + triageHoldMarkers[] (#1129 / D10). -- task triage:classify -- [--list | --validate]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-classify.yml
+++ b/tasks/triage-classify.yml
@@ -27,4 +27,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-classify --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-classify --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-queue.yml
+++ b/tasks/triage-queue.yml
@@ -28,7 +28,7 @@ tasks:
   queue:
     desc: "Print the ranked triage queue (#1128 / D11). -- task triage:queue [-- --repo OWNER/NAME] [--limit N]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -38,7 +38,7 @@ tasks:
   show:
     desc: "Per-issue triage detail (#1128 / D11). -- task triage:show -- <N> [--repo OWNER/NAME]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -48,7 +48,7 @@ tasks:
   audit:
     desc: "Audit-log surface (#1128 / D11, #1180). -- task triage:audit [-- --format=text|json] [--vbrief-staleness] [--since=<window>] [--action=<verb>] [--repo OWNER/NAME]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-queue.yml
+++ b/tasks/triage-queue.yml
@@ -31,7 +31,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-queue queue --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-queue queue --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   show:
     desc: "Per-issue triage detail (#1128 / D11). -- task triage:show -- <N> [--repo OWNER/NAME]"
@@ -39,7 +41,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-queue show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-queue show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   audit:
     desc: "Audit-log surface (#1128 / D11, #1180). -- task triage:audit [-- --format=text|json] [--vbrief-staleness] [--since=<window>] [--action=<verb>] [--repo OWNER/NAME]"
@@ -47,4 +51,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-queue audit --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-queue audit --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-reconcile.yml
+++ b/tasks/triage-reconcile.yml
@@ -23,7 +23,7 @@ tasks:
   reconcile:
     desc: "Self-heal the triage audit log (#1468): backfill missing `accept` decisions for proposed/pending/active vBRIEFs carrying an x-vbrief/github-issue reference, without a cache re-fetch. Idempotent. -- task triage:reconcile [-- --repo OWNER/NAME] [--dry-run] [--json]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-reconcile.yml
+++ b/tasks/triage-reconcile.yml
@@ -26,4 +26,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-reconcile --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-reconcile --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-scope-drift.yml
+++ b/tasks/triage-scope-drift.yml
@@ -26,4 +26,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-scope-drift --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-scope-drift --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-scope-drift.yml
+++ b/tasks/triage-scope-drift.yml
@@ -23,7 +23,7 @@ tasks:
   scope-drift:
     desc: "Detect subscription drift -- unsubscribed labels/milestones on cached open issues (#1133 / D14). -- task triage:scope-drift [-- --ignore-label=L | --ignore-milestone=M]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-scope.yml
+++ b/tasks/triage-scope.yml
@@ -28,4 +28,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-scope --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-scope --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-scope.yml
+++ b/tasks/triage-scope.yml
@@ -25,7 +25,7 @@ tasks:
   scope:
     desc: "Inspect / mutate / diff the typed plan.policy.triageScope[] subscription + triageScopeIgnores[] (#1131 / D12, #1133 / D14, #1182 / D14c). -- task triage:scope -- [--list] [--add-label=L | --add-milestone=M | --ignore-label=L] [--diff-from-upstream --repo OWNER/NAME] [--refresh-denominator --repo OWNER/NAME --count N]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-smoketest.yml
+++ b/tasks/triage-smoketest.yml
@@ -25,7 +25,7 @@ tasks:
   smoketest:
     desc: "Run the N6 (#1146) end-to-end smoketest against the hermetic 20-issue fixture. Exits 0 on PASS / 1 on first failure. -- task triage:smoketest [-- --verbose] [--keep-tempdir] [--cache-only]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     env:
       DEFT_ROOT: '{{.DEFT_ROOT}}'

--- a/tasks/triage-smoketest.yml
+++ b/tasks/triage-smoketest.yml
@@ -30,4 +30,6 @@ tasks:
     env:
       DEFT_ROOT: '{{.DEFT_ROOT}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-smoketest {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-smoketest {{.CLI_ARGS}}'

--- a/tasks/triage-subscribe.yml
+++ b/tasks/triage-subscribe.yml
@@ -22,7 +22,7 @@ tasks:
   subscribe:
     desc: "Subscribe to a label / milestone / issue on plan.policy.triageScope[] (#1133 / D14). -- task triage:subscribe -- (--label=L | --milestone=M | --issue=N)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke
@@ -32,7 +32,7 @@ tasks:
   unsubscribe:
     desc: "Unsubscribe a label / milestone / issue from plan.policy.triageScope[] (#1133 / D14). -- task triage:unsubscribe -- (--label=L | --milestone=M | --issue=N)"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-subscribe.yml
+++ b/tasks/triage-subscribe.yml
@@ -25,7 +25,9 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-subscribe subscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-subscribe subscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   unsubscribe:
     desc: "Unsubscribe a label / milestone / issue from plan.policy.triageScope[] (#1133 / D14). -- task triage:unsubscribe -- (--label=L | --milestone=M | --issue=N)"
@@ -33,4 +35,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-subscribe unsubscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-subscribe unsubscribe --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-summary.yml
+++ b/tasks/triage-summary.yml
@@ -26,4 +26,6 @@ tasks:
     deps: [":ts:build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-summary --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-summary --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/triage-summary.yml
+++ b/tasks/triage-summary.yml
@@ -23,7 +23,7 @@ tasks:
   summary:
     desc: "Emit the D2 (#1122) one-line triage state for the session-start ritual (N9 / #1149). Always exits 0; appends a JSONL record to vbrief/.eval/summary-history.jsonl. -- task triage:summary -- [--json] [--no-history]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: :engine:invoke

--- a/tasks/triage-welcome.yml
+++ b/tasks/triage-welcome.yml
@@ -24,7 +24,7 @@ tasks:
   welcome:
     desc: "Run the 6-phase onboarding ritual (N3 / #1143): detect prior state, prompt subscription scope, run triage:bootstrap, prompt wipCap, offer WIP relief, print triage:summary. Idempotent; re-run resumes cleanly. -- task triage:welcome -- [--no-subprocess]"
     internal: true
-    deps: [":ts:build"]
+    deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'
     env:
       DEFT_TASK_PREFIX: '{{.DEFT_TASK_PREFIX | default ""}}'

--- a/tasks/triage-welcome.yml
+++ b/tasks/triage-welcome.yml
@@ -29,4 +29,6 @@ tasks:
     env:
       DEFT_TASK_PREFIX: '{{.DEFT_TASK_PREFIX | default ""}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" triage-welcome --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage-welcome --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/ts.yml
+++ b/tasks/ts.yml
@@ -28,7 +28,9 @@ tasks:
     desc: "Run the TS lane (lint+build+test) when a Node toolchain is present; skip with a notice otherwise (#1530, #1790)."
     dir: '{{.DEFT_ROOT}}'
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" ts-check-lane --project-root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'ts-check-lane --project-root "{{.DEFT_ROOT}}"'
 
   encoding:
     desc: "Run the ported verify:encoding gate (TS @deftai/core port, #1718)"

--- a/tasks/umbrella.yml
+++ b/tasks/umbrella.yml
@@ -10,18 +10,12 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  _ensure-ts:
-    internal: true
-    desc: "Build the TS engine before umbrella gates (#2066)"
-    dir: '{{.USER_WORKING_DIR}}'
-    cmds:
-      - pnpm --dir "{{.DEFT_ROOT}}" run build
 
   current-shape:
     desc: "Fetch umbrella ## Current shape comment (#1152) — task umbrella:current-shape <N> [-- --repo OWNER/REPO | --json | --strict]. Does NOT read the issue body."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ensure-ts
+      - task: :engine:_ts-build
     cmds:
       - task: :engine:invoke
         vars:

--- a/tasks/vbrief.yml
+++ b/tasks/vbrief.yml
@@ -4,12 +4,6 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed gates run (#1828 s2)."
-    dir: '{{.DEFT_ROOT}}'
-    cmds:
-      - pnpm run build
 
   validate:
     desc: Validate vBRIEF lifecycle folder structure and cross-file consistency
@@ -77,10 +71,12 @@ tasks:
     desc: "Preflight an implementation-intent gate (#810): exits 0 only when vBRIEF is in vbrief/active/ AND plan.status == 'running'. Fails closed (#1046 PR-C / #1047) if the wrapped script cannot be resolved."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/preflight_implementation.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" vbrief:preflight --vbrief-path {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'vbrief:preflight --vbrief-path {{.CLI_ARGS}}'
 
   reconcile:graph:
     # Cascade-unblock walker (#1287). Walks vbrief/proposed/, resolves each
@@ -105,10 +101,12 @@ tasks:
     desc: "Reconcile dep graph: promote proposed/ vBRIEFs whose swarm.depends_on[] all resolve to completed/ or cancelled/ (#1287). Flags: --force --dry-run --json."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/vbrief_reconcile_graph.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" vbrief-reconcile graph --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'vbrief-reconcile graph --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   reconcile:labels:
     # SCM label reconciliation (#1288). Walks vbrief/proposed/ + pending/ +
@@ -136,10 +134,12 @@ tasks:
     desc: "Reconcile SCM labels to mirror vBRIEF state: status:blocked / epic+status:tracker / rfc (#1288). Routes through scripts/scm.py. Flags: --repo --dry-run --json."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/vbrief_reconcile_labels.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" vbrief-reconcile labels --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'vbrief-reconcile labels --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   reconcile:umbrellas:
     # Umbrella current-shape auto-update (#1289). Walks every kind=epic
@@ -171,10 +171,12 @@ tasks:
     desc: "Reconcile epic umbrella current-shape comments to vBRIEF state per AGENTS.md #1152: edit in place (preserve permalink). Routes through scripts/scm.py. Flags: --repo --dry-run --json."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/vbrief_reconcile_umbrellas.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" vbrief-reconcile umbrellas --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'vbrief-reconcile umbrellas --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   activate:
     # Implementation-intent activation gate companion (#810). Idempotent:
@@ -205,7 +207,9 @@ tasks:
     desc: "Activate a vBRIEF: pending/ -> active/ (status: running). Idempotent. (#810)"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/vbrief_activate.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" vbrief:activate {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'vbrief:activate {{.CLI_ARGS}}'

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -4,85 +4,95 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 tasks:
-  _ts-build:
-    internal: true
-    desc: "Build @deftai/cli dist/ before TS-backed gates run (#1828 s2)."
-    dir: '{{.DEFT_ROOT}}'
-    cmds:
-      - pnpm run build
 
   stubs:
     desc: Scan source files for stub patterns (TODO, FIXME, HACK, return null, bare pass)
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/verify-stubs.py (#1828 Wave 8 / #1854 s3).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-stubs
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-stubs'
 
   links:
     desc: Validate internal links in markdown files
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/validate-links.py (#1828 Wave 8 / #1854 s3).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" validate-links
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'validate-links'
 
   rule-ownership:
     desc: "Verify the Rule Ownership Map (conventions/rule-ownership.json) is in sync with its owner files (#635)"
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/rule_ownership_lint.py (#1828 Wave 8 / #1854 s3).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" rule-ownership-lint --root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'rule-ownership-lint --root "{{.DEFT_ROOT}}"'
 
   content-manifest:
     desc: "Verify the Content Manifest (conventions/content-manifest.json) classifies every git-tracked top-level entry (#1821). Fails on an unclassified entry, a stale classified path, an invalid bucket, or a duplicate path. Wave-1 shippability audit for the engine/content split (#1669)."
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Framework-source-only gate: it classifies THIS repo's top-level tree, so it
     # targets DEFT_ROOT (not USER_WORKING_DIR) -- a consumer install has no
     # content/ + engine/ top-level split to audit. Mirrors verify:rule-ownership.
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-content-manifest --project-root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-content-manifest --project-root "{{.DEFT_ROOT}}"'
 
   contract-drift:
     desc: "Drift gate for the public contract layer (#1799). Asserts packages/types/schemas/vbrief-core-0.6.schema.json matches content/vbrief/schemas/vbrief-core.schema.json and that @deftai/directive-types Status/version constants align with the schema. Three-state exit (0 clean / 1 drift / 2 config error)."
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-contract-drift --project-root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-contract-drift --project-root "{{.DEFT_ROOT}}"'
 
   cursor-tier1:
     desc: "Framework-source content gate (#1877): assert Cursor (cursor-composer / cursor-cloud-agent, Task-tool primitive) is enumerated as a Tier-1 descriptor in the swarm Phase 3 capability matrix AND the review-cycle monitoring tier table. Fails when a doc edit drops the Cursor descriptor and silently re-opens the Tier-3 blocking-poll misclassification. Three-state exit (0 clean / 1 missing marker / 2 config error)."
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Framework-source-only gate: it scans THIS repo's two skill docs, so it
     # targets DEFT_ROOT (not USER_WORKING_DIR) -- a consumer install renders
     # these skills under .deft/core and does not author them. Mirrors
     # verify:content-manifest / verify:rule-ownership.
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-cursor-tier1 --project-root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-cursor-tier1 --project-root "{{.DEFT_ROOT}}"'
 
   go-freeze:
     desc: "Tier-1 freeze gate for the legacy Go-installer bridge (#1912). Advisory while the Tier-0 SoT (lastGoInstaller) is null; once the operator pins it, fails when cmd/deft-install is bumped above the frozen tag. Three-state exit (0 ok / 1 violation / 2 config error). Emergency bypass: DEFT_ALLOW_GO_INSTALLER_BUMP=1."
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Framework-source-only gate: it inspects THIS repo's cmd/deft-install
     # version constant + the Tier-0 SoT, so it targets DEFT_ROOT (not
     # USER_WORKING_DIR) -- a consumer install has no Go-installer source to
     # freeze. Mirrors verify:content-manifest.
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-go-freeze --project-root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-go-freeze --project-root "{{.DEFT_ROOT}}"'
 
   bridge-drift:
     desc: "Tier-1 cross-surface drift gate for the legacy Go-installer bridge (#1912). Asserts no surface marked with the bridge sentinel hardcodes a Go-installer version instead of reading the Tier-0 SoT (lastGoInstaller). Three-state exit (0 clean / 1 drift / 2 config error). Passes whether or not the UPGRADING/doctor surfaces exist yet."
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Framework-source-only gate: it scans THIS repo's bridge-version surfaces
     # against the Tier-0 SoT, so it targets DEFT_ROOT. Mirrors
     # verify:content-manifest / verify:scm-boundary.
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-bridge-drift --project-root "{{.DEFT_ROOT}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-bridge-drift --project-root "{{.DEFT_ROOT}}"'
 
   branch:
     desc: "Detection-bound branch-protection gate (#747). Reads plan.policy.allowDirectCommitsToMaster from PROJECT-DEFINITION."
@@ -98,27 +108,31 @@ tasks:
     desc: "Operator coding sub-agent model routing gate (#1739). Pre-dispatch (default): fails when a dispatched worker role has no decision in .deft/routing.local.json. Pass --advise for the non-blocking session-start disclosure; --roles a,b to widen the gated set; --provider to override the runtime."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Bare CLI_ARGS per the verify:encoding convention -- go-task shell-escapes pass-through args.
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" swarm-routing-verify --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'swarm-routing-verify --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   hooks-installed:
     desc: "Assert the deft git hooks are installed AND functional -- core.hooksPath set, hooks dir + pre-commit/pre-push present, and the gate scripts resolve in this layout (own-repo or vendored). Fails loud on the #1463 false-green (wired but non-functional). Run `task setup` / re-run the installer if this fails (#747, #1463)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # No sources:/generates: -- a cached cmds skip would mask a hooks dir /
     # gate-script that was deleted after the last run.
     cmds:
       # Oracle/fallback (parity): scripts/verify_hooks_installed.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify:hooks-installed --project-root "{{.USER_WORKING_DIR}}"
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:hooks-installed --project-root "{{.USER_WORKING_DIR}}"'
 
   encoding:
     desc: "Detect PS 5.1 non-ASCII round-trip corruption (#798). Scans tracked text files for U+FFFD, CP1252/CP437-as-UTF-8 mojibake, and unexpected BOM. Defaults to --all; pass --staged for the pre-commit invocation."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md`: NO `sources:` / `generates:` because
     # user-facing flags (--staged / --all / --allow-list <path>) MUST NOT be
     # silently swallowed by go-task's incremental-build cache. The same
@@ -127,33 +141,39 @@ tasks:
     # layer would otherwise discard.
     cmds:
       # Oracle/fallback (parity): scripts/verify_encoding.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify:encoding --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:encoding --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   vbrief-conformance:
     desc: "Detect bare non-conformant vBRIEF keys (#1620). Scans tracked vbrief/**/*.vbrief.json and flags any document/plan/item key that is not 0.6 spec-core, x-directive/-namespaced, or x-vbrief/-namespaced. plan.policy + plan.completedNote carry a TEMPORARY allow-list pending vBRIEF #12. Defaults to --all; pass --staged for the pre-commit invocation."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md`: NO `sources:` / `generates:` because
     # user-facing flags (--staged / --all / --allow-list <path>) MUST NOT be
     # silently swallowed by go-task's incremental-build cache (same rationale
     # as verify:encoding above).
     cmds:
       # Oracle/fallback (parity): scripts/verify_vbrief_conformance.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" vbrief-validate conformance --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'vbrief-validate conformance --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   destructive-gh-verbs:
     desc: "Detection-bound gate for destructive gh verbs (#1019). Runs preflight-gh --self-test so the fixture-vs-classifier contract fails CI on drift. Override via DEFT_ALLOW_DESTRUCTIVE_GH_VERBS=1 (per-shell emergency bypass)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # No sources:/generates: -- the self-test fixture table is the
     # invariant under test; we want the gate to re-run on every
     # `task check` invocation regardless of whether the classifier file
     # mtime moved. Caching here would silently mask a regression.
     cmds:
       # Oracle/fallback (parity): scripts/preflight_gh.py --self-test (#1854 s5).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" preflight-gh --self-test {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'preflight-gh --self-test {{.CLI_ARGS}}'
 
   cache-fresh:
     desc: "Pre-`start_agent` cache-freshness gate (#1127). Refuses implementation dispatch when the triage cache is stale, missing, or the target issue's latest decision is not `accept`. Subscription-aware via plan.policy.triageScope[] (D12 / #1131). Flags: --for-issue N / --max-age-hours N / --allow-stale / --repo OWNER/NAME / --allow-missing-bootstrap (consumed by the framework's own `task check` so a fresh checkout passes -- consumers leave it OFF)."
@@ -177,61 +197,71 @@ tasks:
     desc: "Drift gate for the generated .planning/codebase/MAP.md projection (#1595 PR4)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per conventions/task-caching.md: no sources/generates because this gate
     # forwards output/artifact overrides through CLI_ARGS.
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" codebase-map-fresh --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'codebase-map-fresh --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   session-ritual:
     desc: "Fail-closed session ritual verifier (#1348). Flags: --tier quick|gated / --json. Set DEFT_SESSION_RITUAL_SKIP=1 for headless workers and CI."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # No sources/generates: this gate is time-, HEAD-, and worktree-sensitive.
     cmds:
       # Oracle/fallback (parity): scripts/verify_session_ritual.py (#1828 Wave 8 / #1854 s3).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-session-ritual --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-session-ritual --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   tools:
     desc: "Detect required Deft host tools and print install or manual guidance (#1187). Flags: --install / --yes / --json"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     cmds:
       # Oracle/fallback (parity): scripts/verify_tools.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify:tools {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:tools {{.CLI_ARGS}}'
 
   scm-boundary:
     desc: "Detection-bound gate against raw `gh` / `ghx` subprocess calls outside `scripts/scm.py` (#1145 / N5). Scans verb-layer Python files (`scripts/triage_*.py`, `scripts/scope_*.py`, `scripts/slice_*.py`, `scripts/_triage_*.py`, `scripts/_scope_*.py`, `scripts/resume_conditions.py`, `scripts/issue_ingest.py`) and fails loud when any of them invoke `gh` directly instead of going through `scm.call(source, verb, args)`. Three-state exit (0 clean / 1 violations / 2 config error). Document an exception via `--allow-list <path>` (file with newline-separated glob patterns)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (`--allow-list <path>` / `--quiet`) that go-task's incremental-build
     # cache would silently swallow.
     cmds:
       # Oracle/fallback (parity): scripts/verify_scm_boundary.py (#1828 Wave 8 / #1854 s3).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-scm-boundary --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-scm-boundary --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   xbrief-drift:
     desc: "Data-plane drift gate for the #2109 vbrief->xbrief rename. FAILS when a NEW legacy-layout token is reintroduced: a tracked `*.vbrief.json` artifact, a tracked file under a top-level `vbrief/` lifecycle dir, or a bare `x-vbrief/` reference type inside a canonical `xbrief/**/*.xbrief.json` corpus artifact. Sanctioned back-compat shims (the Part 1 layout-resolver fallback, the EXTENSION_PREFIXES legacy entry, the #2110 migrate path, the #1650 policy fallback) are TS source -- outside the scanned data plane -- and the legacy fixture trees (tests/, content/vbrief/, docs/, history/, xbrief/migration/) are allowlisted. Three-state exit (0 clean / 1 drift / 2 config error). Document an exception via `--allow-list <path>`."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (`--allow-list <path>` / `--staged` / `--quiet`) that go-task's
     # incremental-build cache would silently swallow.
     cmds:
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify:xbrief-drift --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:xbrief-drift --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   story-ready:
     desc: "Deterministic story-start Gate 0 (#1378 Story C). Inspects working-tree cleanliness, the target vBRIEF lifecycle (active/ + plan.status==running), and the dispatch envelope's `## Allocation context` consent token (Story A schema). Three-state exit (0 ready / 1 not ready / 2 config error). -- task verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>] [--allow-dirty] [--json]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (--vbrief-path / --allocation-context / --allow-dirty / --json) that
@@ -241,37 +271,43 @@ tasks:
     # `task check` run has no way to supply.
     cmds:
       # Oracle/fallback (parity): scripts/preflight_story_start.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify:story-ready --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:story-ready --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   investigation:
     desc: "Validate a forensic investigation ledger (#1621). Promotes the forensic-research validator into a deterministic gate: the close check before Wave 5 / any causal chat. Three-state exit (0 close-ready / 1 hard failures / 2 config error). Intentionally NOT in the `task check` aggregate -- it requires a concrete --ledger path. -- task verify:investigation -- --ledger .tmp/investigations/<id>/investigation.vbrief.json [--json]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (--ledger / --json) that go-task's incremental-build cache would
     # silently swallow.
     cmds:
       # Oracle/fallback (parity): scripts/verify_investigation.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify:investigation --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:investigation --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   architecture-sor:
     desc: "Diff-time system-of-record architecture gate. Scans stateful persistence signals and requires a matching architecture.systemOfRecord record. Example: task verify:architecture-sor -- --base-ref origin/main [--story-path <path>]"
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per conventions/task-caching.md: no sources/generates because this gate
     # forwards --base-ref, --story-path, and --json through CLI_ARGS.
     cmds:
       # Oracle/fallback (parity): scripts/preflight_architecture_sor.py (#1854 s5).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" architecture-preflight-sor --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'architecture-preflight-sor --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   capacity:
     desc: "Three-state ADVISORY capacity gate (#1419 Slice 4). Reports trailing-window target-vs-actual bucket mix from plan.policy.capacityAllocation; exits 0 in the default advise posture (and on insufficient sample / unconfigured policy), 1 only under an explicit enforce posture with a sampled deficit, 2 on config error. DELIBERATELY NOT in the `task check` aggregate -- capacity must never fail-closed on the framework tree."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (--project-root / --quiet) that go-task's incremental-build cache would
@@ -280,13 +316,15 @@ tasks:
     # framework's own self-check (advise-mode discipline, #1419).
     cmds:
       # Oracle/fallback (parity): scripts/verify_capacity.py (#1828 Wave 8 / #1854 s3).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify-capacity --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify-capacity --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   judgment-gates:
     desc: "Three-state ADVISORY judgment-gate engine (#1419 Slice 3). Evaluates a candidate change (diff paths / labels / body) against plan.policy.judgmentGates + four default-on universal safety gates (secrets / infra / AGENTS.md+skills / installer). Advisory by default (always exits 0); opt-in --enforce fails closed (exit 1) when a mechanical block-tier gate fires without a recorded clearance; exit 2 on config error. -- task verify:judgment-gates [-- --base-ref <ref>] [--path P] [--label L] [--enforce] [--json]. DELIBERATELY NOT in the `task check` aggregate -- judgment gates must never fail-closed on the framework tree (advise -> observe -> block rollout, #1419)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
-      - _ts-build
+      - task: :engine:_ts-build
     # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
     # because the gate forwards user-facing flags via {{.CLI_ARGS}}
     # (--base-ref / --path / --label / --body / --state / --enforce / --json /
@@ -297,7 +335,9 @@ tasks:
     # advisory on the framework's own tree (advise-mode discipline, #1419).
     cmds:
       # Oracle/fallback (parity): scripts/verify_judgment_gates.py (#1828 Wave 8).
-      - node "{{.DEFT_ROOT}}/packages/cli/dist/bin.js" verify:judgment-gates --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:judgment-gates --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   wip-cap:
     desc: "Pre-merge re-validation that pending/+active/ count is within plan.policy.wipCap (#1124 / D4 of #1119). Catches stale-branch merges + --force overrides. Default cap is 10 per umbrella #1119 Current Shape v3. The framework's own task check passes --allow-over-cap during landing-day overage; consumer projects MUST NOT pass that flag."

--- a/xbrief/completed/2026-07-01-2126-vendored-ts-build-fix.xbrief.json
+++ b/xbrief/completed/2026-07-01-2126-vendored-ts-build-fix.xbrief.json
@@ -1,0 +1,103 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2126 (v0.65.0 adoption-blocker): route straggler task fragments through the guarded :engine:_ts-build / :engine:invoke pattern so `task check` and every `task <verb>` work on a vendored .deft/core consumer deposit.",
+    "created": "2026-07-01T15:00:00Z",
+    "updated": "2026-07-01T15:00:00Z"
+  },
+  "plan": {
+    "id": "2126-vendored-ts-build-fix",
+    "title": "Vendored task dispatch: route straggler _ts-build + direct node calls through :engine:* (fix #2126)",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2126",
+    "narratives": {
+      "Description": "v0.65.0 shipped a half-finished #2022 Phase 3 flatten. Dozens of tasks/*.yml fragments carried their own local, unguarded `_ts-build` (raw `pnpm run build` at DEFT_ROOT) plus direct `node .../packages/cli/dist/bin.js` calls. In a vendored consumer install DEFT_ROOT is `.deft/core` = `@deftai/directive-content`, which has NO `build` script and ships NO `packages/`/`dist/`. So `task check` -> `deft:verify:encoding` -> `_ts-build` failed with `[ERR_PNPM_NO_SCRIPT] Missing script: build`, and even once that step is guarded, the direct `node .../dist/bin.js` verb call fails with MODULE_NOT_FOUND. This broke `task check` (and the operator verb surface) for every consumer refreshing to v0.65.0. The canonical guarded pattern already exists in tasks/engine.yml: `:engine:_ts-build` guards the build behind `[ -f packages/cli/dist/bin.js ]` (no-op on a consumer deposit) and `:engine:invoke` runs the vendored bin.js when present, else falls back to the globally-installed `deft`. Only three gates (branch/cache-fresh/wip-cap, #2046) had been migrated; the rest were stragglers.",
+      "ImplementationPlan": "1. Point every straggler task at the shared guarded pattern: bare `- _ts-build` deps -> `- task: :engine:_ts-build`; direct `- node \"{{.DEFT_ROOT}}/packages/cli/dist/bin.js\" <verb+args>` -> `- task: :engine:invoke` with `vars.ENGINE_CMD: '<verb+args>'`; delete the now-unused local `_ts-build` definitions. Applied across all tasks/*.yml except engine.yml (39 files, 133 verb calls, 41 deps, 9 local defs). 2. Add a content-contract regression test (packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts) asserting no task file (except engine.yml) defines a local `_ts-build`, carries a bare `- _ts-build` dep, or calls dist/bin.js directly, and that engine.yml still owns the guarded build + global-deft fallback. 3. Update the three existing tests that pinned the old direct-node pattern (policy.yml, migrate.yml, codebase.yml) to assert the engine pattern. Verify: `task check:framework-source` + full vitest suite stay green; simulate a .deft/core deposit with no packages/dist and confirm `task verify:encoding` succeeds via global-deft fallback instead of `Missing script: build` / MODULE_NOT_FOUND.",
+      "UserStory": "As a Deft consumer who refreshed to v0.65.0, I want `task check` and the operator `task <verb>` surface to run against my vendored .deft/core deposit, so that I am not blocked by `Missing script: build` / MODULE_NOT_FOUND errors from tasks that assume a framework-source layout.",
+      "Traces": "#2126, #2022, #2046"
+    },
+    "items": [
+      {
+        "id": "2126-a1",
+        "title": "Given a vendored .deft/core deposit, when `task check` runs a TS-backed gate, then it no longer fails with `Missing script: build`",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a consumer deposit whose root package.json is @deftai/directive-content (no `build` script), when a gate's `_ts-build` dependency runs, then it is a guarded no-op (`:engine:_ts-build`) rather than `[ERR_PNPM_NO_SCRIPT] Missing script: build`."
+        }
+      },
+      {
+        "id": "2126-a2",
+        "title": "Given a deposit with no packages/dist, when a task dispatches a deft verb, then it falls back to the global `deft` instead of MODULE_NOT_FOUND",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a consumer deposit that ships no `packages/cli/dist/bin.js`, when a task runs its verb, then `:engine:invoke` dispatches through the globally-installed `deft` command (or exits 2 with an install hint), never MODULE_NOT_FOUND."
+        }
+      },
+      {
+        "id": "2126-a3",
+        "title": "Given a future edit, when a task re-introduces a local _ts-build or direct dist/bin.js call, then a deterministic test fails",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a regression that re-adds a local unguarded `_ts-build` or a direct `node .../dist/bin.js` call to any tasks/*.yml (except engine.yml), when the content-contract suite runs, then taskfile_engine_dispatch.test.ts fails."
+        }
+      },
+      {
+        "id": "2126-a4",
+        "title": "Given the framework-source checkout, when `task check:framework-source` runs, then it stays green",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the framework-source layout (deft-engine root with a `build` script and a built dist), when the migrated gates run via `:engine:invoke`, then they execute against the vendored bin.js exactly as before and the full test suite passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "child_issue": "#2126"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/verify.yml",
+          "tasks/vbrief.yml",
+          "tasks/commit.yml",
+          "tasks/prd.yml",
+          "tasks/project.yml",
+          "tasks/spec.yml",
+          "tasks/scope.yml",
+          "tasks/scm.yml",
+          "tasks/packs.yml",
+          "tasks/policy.yml",
+          "tasks/triage-actions.yml",
+          "packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts"
+        ],
+        "verify_commands": [
+          "task check:framework-source"
+        ],
+        "expected_outputs": [
+          "all tasks/*.yml (except engine.yml) route through :engine:_ts-build / :engine:invoke; consumer deposit runs task check via global-deft fallback; framework-source stays green"
+        ],
+        "depends_on": [],
+        "conflict_group": "vendored-task-dispatch",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completedAt": "2026-07-01T15:53:49Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2126",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2126: v0.65.0 vendored `task check` fails -- _ts-build runs `pnpm run build` in a consumer deposit with no build script"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2022",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2022: Python-free npm deposit / Phase 3 flatten (source of the half-finished migration)"
+      }
+    ],
+    "updated": "2026-07-01T15:53:49Z"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the v0.65.0 **adoption blocker** #2126: `task check` (and the operator `task <verb>` surface) failed on every vendored `.deft/core` consumer install with `[ERR_PNPM_NO_SCRIPT] Missing script: build`.

Root cause: a half-finished #2022 Phase 3 flatten left dozens of task fragments reaching an **unguarded build** or a **direct vendored-CLI call**. On a consumer deposit `DEFT_ROOT` is `.deft/core` = `@deftai/directive-content`, which has no `build` script and ships no `packages/`/`dist/` — so the build step dies with `Missing script: build`, and (once guarded) the direct `node .../packages/cli/dist/bin.js` call dies with `MODULE_NOT_FOUND`.

The canonical guarded pattern already existed in `tasks/engine.yml` (only branch/cache-fresh/wip-cap had been migrated, #2046). This PR routes **every** straggler through it.

## The fix

The unguarded build hid under **four spellings** — an `rg`-driven audit found all of them (the maintainer comment named the first two families; the last two were discovered during the fix and are the same #2126 bug):

1. **Local `_ts-build`** (`verify`, `vbrief`, `commit`, `prd`, `project`, `spec`, `change`, `install`, `migrate`) → deleted; deps point at `:engine:_ts-build`.
2. **Direct `node "{{.DEFT_ROOT|.TASKFILE_DIR}}/packages/cli/dist/bin.js"`** (39 `tasks/*.yml` + the root `Taskfile.yml`, ~140 call sites) → `:engine:invoke` with `ENGINE_CMD`.
3. **Local `_ensure-ts`** (`scope`, `slice`, `issue`, `reconcile`, `umbrella`) — `pnpm --dir DEFT_ROOT run build`, unguarded → deleted; deps point at `:engine:_ts-build`.
4. **`deps: [:ts:build]`** on the unconditional maintainer build primitive (`policy`, `capacity`, `scm`, `cache`, `codebase`, `roadmap`) → `:engine:_ts-build`.

`:engine:_ts-build` guards `pnpm run build` behind `[ -f packages/cli/dist/bin.js ]` (a no-op on a consumer deposit); `:engine:invoke` runs the vendored bin.js when present, else falls back to the globally-installed `deft`.

**Build primitives left intact (by design):** `tasks/engine.yml` (the guard), `tasks/ts.yml` (`ts:build`/`ts:test`/`ts:lint` maintainer monorepo verbs), and `tasks/core.yml` (maintainer packaging) must run a real build and are never invoked by a consumer.

A new deterministic gate `packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts` fails if any task file re-introduces any of the four broken spellings (build primitives allowlisted). Three existing task-surface tests that pinned the old shape were updated to pin the engine pattern.

## How I verified the consumer path (the whole point)

Simulated a faithful consumer: a git project whose `Taskfile.yml` includes `./.deft/core/Taskfile.yml` under the `deft:` namespace, where `.deft/core/package.json` is `@deftai/directive-content` (no `build` script) with **no `packages/`/`dist/`**.

- `task deft:verify:encoding` (the reporter's exact wiring) → **exit 0** via global-`deft` fallback (was `Missing script: build`).
- `task deft:check` → routes to `check:consumer` (not framework-source), **no `Missing script: build`, no `MODULE_NOT_FOUND`**.
- Wave-2 verbs `task deft:policy:show` (former `:ts:build`) and `task deft:scope:promote` (former `_ensure-ts`) → run via fallback with no build errors.

Framework-source stays green: `task check:framework-source` passes; full vitest suite **7935 passed**.

## Out-of-scope findings filed (not dropped)

- **#2132** — `spec`/`prd` render tasks still hardcode legacy `vbrief/specification.vbrief.json` paths after the #2109 xbrief rename (pre-existing; this PR preserved the verb args verbatim).

## Lifecycle

xBRIEF `xbrief/completed/2026-07-01-2126-vendored-ts-build-fix.xbrief.json` (swarm-ready, gate stack + `scope:complete` run). CHANGELOG `[Unreleased]` entry added.

Closes #2126

Made with [Cursor](https://cursor.com)