### PR TITLE
fix(installer): update Go installer for xbrief layout (#2134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Go installer test and next-steps output updated for `xbrief` layout (#2134).** After the `vbrief/`→`xbrief/` rename (#2109), the Go installer's generated AGENTS.md referenced `PROJECT-DEFINITION.xbrief.json` but the test still asserted the legacy name, causing the Go CI job to fail on master. The stale test assertion and the post-install next-steps message are now consistent with the `xbrief` layout. Closes #2134.
+
 - **Engine emit sites now produce canonical `x-xbrief/` reference tokens (#2128).** The intake, build, speckit, decompose, and reconcile paths previously minted legacy `x-vbrief/` tokens, causing freshly ingested or built artifacts committed under `xbrief/` to trip the `verify:xbrief-drift` pre-commit gate. All emit constants are flipped to `x-xbrief/` and reader matchers in capacity, scope, swarm, and lifecycle modules are made dual-namespace (accepting both prefixes) via a new shared `referenceTypeMatches` helper in `@deftai/directive-types`. `x-vbrief/` remains read-accepted for consumer back-compat. Closes #2128.
 
 ### Changed

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -493,9 +493,9 @@ func TestWriteAgentsMD_CreateNew(t *testing.T) {
 	if strings.Contains(content, "deft/skills/deft-setup/") {
 		t.Error("AGENTS.md should not reference legacy deft-setup path")
 	}
-	// Verify vBRIEF-centric references.
-	if !strings.Contains(content, "PROJECT-DEFINITION.vbrief.json") {
-		t.Error("AGENTS.md should reference PROJECT-DEFINITION.vbrief.json")
+	// Verify xBRIEF-centric references (post vbrief->xbrief rename, #2109).
+	if !strings.Contains(content, "PROJECT-DEFINITION.xbrief.json") {
+		t.Error("AGENTS.md should reference PROJECT-DEFINITION.xbrief.json")
 	}
 }
 
@@ -841,7 +841,7 @@ func TestPrintNextSteps(t *testing.T) {
 		"AGENTS.md",
 		"User config",
 		"Use AGENTS.md",
-		"USER.md and PROJECT-DEFINITION.vbrief.json",
+		"USER.md and PROJECT-DEFINITION.xbrief.json",
 		"created",
 	} {
 		if !strings.Contains(out, want) {

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -1813,7 +1813,7 @@ func PrintNextSteps(w *Wizard, result *WizardResult, configDir string, skillsCre
 	w.printf("  1. Open your AI coding assistant in %s%c\n", result.ProjectDir, os.PathSeparator)
 	w.printf("  2. Deft skill auto-discovery is partially implemented — if your agent doesn't\n")
 	w.printf("     start setup automatically, tell it: \"Use AGENTS.md\"\n")
-	w.printf("  3. On first session, the agent will guide you through creating USER.md and PROJECT-DEFINITION.vbrief.json\n")
+	w.printf("  3. On first session, the agent will guide you through creating USER.md and PROJECT-DEFINITION.xbrief.json\n")
 	w.printf("\n")
 }
 

--- a/xbrief/completed/2026-07-01-2134-go-installer-xbrief.xbrief.json
+++ b/xbrief/completed/2026-07-01-2134-go-installer-xbrief.xbrief.json
@@ -1,0 +1,77 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2134: update Go installer test and next-steps output for xbrief layout after vbrief->xbrief rename.",
+    "created": "2026-07-01T16:33:00Z",
+    "updated": "2026-07-01T16:33:00Z"
+  },
+  "plan": {
+    "id": "2134-go-installer-xbrief",
+    "title": "Fix Go installer test and next-steps for xbrief layout (fixes master CI red)",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2134",
+    "narratives": {
+      "Description": "After the vbrief/->xbrief/ rename (#2109), the Go installer's AGENTS.md template now references PROJECT-DEFINITION.xbrief.json, but main_test.go:497-498 still asserts the legacy 'vbrief.json' string. Additionally, setup.go:1816 emits 'PROJECT-DEFINITION.vbrief.json' in its next-steps user-facing output. Fix the stale test assertion and the next-steps output string to match the current xbrief layout, making the Go (test + build) CI job pass on master.",
+      "ImplementationPlan": "1. Update main_test.go:497-498 to assert PROJECT-DEFINITION.xbrief.json instead of vbrief.json. 2. Update setup.go:1816 next-steps printf to reference PROJECT-DEFINITION.xbrief.json. 3. Update main_test.go:844 to assert the updated next-steps string. 4. Verify with 'go test ./cmd/deft-install/' that all tests pass. Leave the deposit directory name (vbrief/) and all related deposit tests unchanged -- the installer still deposits vbrief/ for back-compat, and consumers run 'deft migrate:xbrief' to rename.",
+      "UserStory": "As a framework maintainer, I want the Go installer test and next-steps output to reflect the xbrief layout so that the Go CI job is green on master and new consumers see accurate post-install guidance.",
+      "Traces": "#2134"
+    },
+    "items": [
+      {
+        "id": "2134-a1",
+        "title": "main_test.go asserts PROJECT-DEFINITION.xbrief.json in generated AGENTS.md",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the Go installer test suite, when TestWriteAgentsMD_CreateNew runs, then it passes because the AGENTS.md template now references xbrief not vbrief."
+        }
+      },
+      {
+        "id": "2134-a2",
+        "title": "setup.go next-steps output references PROJECT-DEFINITION.xbrief.json",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a fresh deft install, when PrintNextSteps runs, then the user-facing step 3 message references PROJECT-DEFINITION.xbrief.json."
+        }
+      },
+      {
+        "id": "2134-a3",
+        "title": "All Go installer tests pass with 'go test ./cmd/deft-install/'",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the fixes applied, when 'go test ./cmd/deft-install/' runs, then the exit code is 0 with no FAIL lines."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "cmd/deft-install/main_test.go",
+          "cmd/deft-install/setup.go"
+        ],
+        "verify_commands": [
+          "go test ./cmd/deft-install/"
+        ],
+        "expected_outputs": [
+          "Go installer test suite passes; TestWriteAgentsMD_CreateNew green"
+        ],
+        "depends_on": [],
+        "conflict_group": "go-installer",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "small"
+      },
+      "completedAt": "2026-07-01T16:37:11Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2134",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2134: Go installer test asserts vbrief after xbrief rename -- master CI red (Go job)"
+      }
+    ],
+    "updated": "2026-07-01T16:37:11Z"
+  }
+}


### PR DESCRIPTION
## Summary

Completes the `vbrief/` → `xbrief/` rename (#2109) on the Go installer surface. After the rename, the AGENTS.md template was updated to reference `xbrief/PROJECT-DEFINITION.xbrief.json`, but two Go installer files were not updated:

- `cmd/deft-install/main_test.go:497-498` — `TestWriteAgentsMD_CreateNew` still asserted `PROJECT-DEFINITION.vbrief.json`, causing the **Go (test + build)** required CI check to fail on master HEAD.
- `cmd/deft-install/setup.go:1816` — `PrintNextSteps` still emitted `PROJECT-DEFINITION.vbrief.json` in the user-facing step 3 post-install message.

## Root cause (option a — stale test + stale next-steps output)

The Go installer's deposit directory (`vbrief/`) and all its related lifecycle tests are unchanged — those represent intentional back-compat (consumers migrate via `deft migrate:xbrief`). Only the AGENTS.md content assertion and the user-facing next-steps string were stale.

## Verification

```
go test ./cmd/deft-install/
# ok  github.com/deftai/directive/cmd/deft-install  2.2s
```

- `TestWriteAgentsMD_CreateNew` now passes (was the only failing test on master).
- `TestPrintNextSteps` continues to pass with the updated expected string.
- `task check` / `go build ./...` both green.

The TypeScript coverage red on master is the pre-existing #2135 failure being fixed in a parallel PR and is NOT caused by this change.

## Related Issues

Closes #2134

## Checklist

- [x] `/deft:change <name>` — N/A (< 3 file changes: main_test.go + setup.go only)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (not a tracked roadmap issue)
- [x] Tests pass locally (`go test ./cmd/deft-install/` + `task check`)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm #2134 actually closed — `gh issue view 2134 --json state --jq .state`. If still open, close manually.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)