### PR TITLE
test: restore branch coverage above 85% threshold (#2135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Go installer test and next-steps output updated for `xbrief` layout (#2134).** After the `vbrief/`→`xbrief/` rename (#2109), the Go installer's generated AGENTS.md referenced `PROJECT-DEFINITION.xbrief.json` but the test still asserted the legacy name, causing the Go CI job to fail on master. The stale test assertion and the post-install next-steps message are now consistent with the `xbrief` layout. Closes #2134.
 
+- **Global branch coverage restored above the 85% CI threshold (#2135).** Added targeted unit tests for uncovered branches in `xbrief-migrate` (detect, drift-gate, migrate-project) and the doctor CLI entry point — covering the quiet mode, non-git-repo error path, `emitXbriefMigration` outcome variants, `runAgentsRefresh` template-missing branch, root-level artifact detection, and legacy version string detection. No production code changes. Closes #2135.
+
 - **Engine emit sites now produce canonical `x-xbrief/` reference tokens (#2128).** The intake, build, speckit, decompose, and reconcile paths previously minted legacy `x-vbrief/` tokens, causing freshly ingested or built artifacts committed under `xbrief/` to trip the `verify:xbrief-drift` pre-commit gate. All emit constants are flipped to `x-xbrief/` and reader matchers in capacity, scope, swarm, and lifecycle modules are made dual-namespace (accepting both prefixes) via a new shared `referenceTypeMatches` helper in `@deftai/directive-types`. `x-vbrief/` remains read-accepted for consumer back-compat. Closes #2128.
 
 ### Changed

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -188,4 +188,16 @@ describe("doctor CLI", () => {
     expect(out).toContain("xBrief migration: legacy vbrief layout detected");
     expect(out).toContain("migrate:xbrief");
   });
+
+  it("defaults projectRoot to process.cwd() when --project-root is omitted", () => {
+    // Exercises the `flags.projectRoot ?? process.cwd()` false branch in doctor.ts.
+    const out = captureStdout(() => {
+      run([]);
+    });
+    // The pre-cutover and migration lines are rendered using process.cwd().
+    // We only assert that both lines were emitted (not their exact content,
+    // since process.cwd() varies by environment).
+    expect(out).toContain("Pre-cutover:");
+    expect(out).toContain("xBrief migration:");
+  });
 });

--- a/packages/core/src/xbrief-migrate/detect.test.ts
+++ b/packages/core/src/xbrief-migrate/detect.test.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LEGACY_ARTIFACT_DIR, LEGACY_ARTIFACT_SUFFIX } from "./constants.js";
+import { detectLegacyVbriefLayout } from "./detect.js";
+
+describe("detectLegacyVbriefLayout branch coverage", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "xbrief-detect-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("detects legacy version string in pretty-printed JSON (lines 57-58)", () => {
+    // Pretty-printed JSON contains `"version": "0.6"` (with space after colon),
+    // which triggers the LEGACY_VBRIEF_VERSION check in scanFileContent.
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    const artifact = JSON.stringify(
+      {
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "t", status: "proposed", items: [] },
+      },
+      null,
+      2,
+    );
+    writeFileSync(
+      join(root, LEGACY_ARTIFACT_DIR, "active", `story${LEGACY_ARTIFACT_SUFFIX}`),
+      artifact,
+      "utf8",
+    );
+
+    const result = detectLegacyVbriefLayout(root);
+    expect(result.legacyLayout).toBe(true);
+    expect(result.reasons.some((r) => r.includes("declared version 0.6"))).toBe(true);
+  });
+
+  it("detects a root-level .vbrief.json artifact (lines 88-95)", () => {
+    // Root-level *.vbrief.json files are scanned separately from the vbrief/ directory.
+    // This exercises the loop at lines 88-96 of detect.ts.
+    const artifact = JSON.stringify(
+      {
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "root", status: "proposed", items: [] },
+      },
+      null,
+      2,
+    );
+    writeFileSync(join(root, `root-artifact${LEGACY_ARTIFACT_SUFFIX}`), artifact, "utf8");
+
+    const result = detectLegacyVbriefLayout(root);
+    expect(result.legacyLayout).toBe(true);
+    expect(result.reasons.some((r) => r.includes("root-artifact"))).toBe(true);
+  });
+
+  it("returns legacyLayout=false for a project with no legacy artifacts", () => {
+    const result = detectLegacyVbriefLayout(root);
+    expect(result.legacyLayout).toBe(false);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it("scans xbrief/ dir for residual legacy tokens in mixed-state projects", () => {
+    // A project where xbrief/ exists but a file inside still has x-vbrief/ references.
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    const artifact = JSON.stringify(
+      {
+        xBRIEFInfo: { version: "0.8" },
+        plan: {
+          title: "mixed",
+          status: "running",
+          items: [],
+          references: [{ type: "x-vbrief/github-issue", uri: "https://example.com/1" }],
+        },
+      },
+      null,
+      2,
+    );
+    writeFileSync(join(root, "xbrief", "active", "story.xbrief.json"), artifact, "utf8");
+
+    const result = detectLegacyVbriefLayout(root);
+    expect(result.legacyLayout).toBe(true);
+    expect(result.reasons.some((r) => r.includes("x-vbrief/"))).toBe(true);
+  });
+});

--- a/packages/core/src/xbrief-migrate/drift-gate.test.ts
+++ b/packages/core/src/xbrief-migrate/drift-gate.test.ts
@@ -156,4 +156,29 @@ describe("evaluateXbriefDrift", () => {
     expect(staged.code).toBe(1);
     expect(staged.findings[0]?.kind).toBe("legacy-suffix");
   });
+
+  it("exits 0 with empty message when quiet option is true (lines 246-247)", () => {
+    // quiet: true suppresses the success message, returning an empty string.
+    root = initRepo();
+    writeTracked(root, "xbrief/active/2026-06-30-1-thing.xbrief.json", CANONICAL_ARTIFACT);
+    const result = evaluateXbriefDrift(root, { quiet: true });
+    expect(result.code).toBe(0);
+    expect(result.message).toBe("");
+    expect(result.stream).toBe("stdout");
+  });
+
+  it("exits 2 when project root is not inside a git repo (lines 192-193)", () => {
+    // A directory that exists but is not a git repo causes gitTrackedFiles to
+    // throw GitCommandError, which listFiles converts to an error object.
+    // evaluateXbriefDrift then returns code 2 via the !Array.isArray(listed) branch.
+    const nonGitDir = mkdtempSync(join(tmpdir(), "xbrief-drift-non-git-"));
+    try {
+      const result = evaluateXbriefDrift(nonGitDir);
+      expect(result.code).toBe(2);
+      expect(result.stream).toBe("stderr");
+      expect(result.message).toContain("verify_xbrief_drift:");
+    } finally {
+      rmSync(nonGitDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -189,6 +189,48 @@ describe("emitXbriefMigration", () => {
     ).toBe(0);
     expect(lines.join("")).toContain("migrate:xbrief");
   });
+
+  it("uses process.cwd() when signpostOnly=true and projectRoot is omitted", () => {
+    const outs: string[] = [];
+    const code = emitXbriefMigration(
+      { kind: "noop", message: "unused" },
+      { writeOut: (t) => outs.push(t), writeErr: () => {} },
+      { signpostOnly: true },
+    );
+    expect(code).toBe(0);
+    expect(outs.length).toBeGreaterThan(0);
+  });
+
+  it("returns exit code 2 and writes to stderr for config outcome (line 231-232)", () => {
+    const errs: string[] = [];
+    const code = emitXbriefMigration(
+      { kind: "config", message: "xbrief/ already exists alongside vbrief/" },
+      { writeOut: () => {}, writeErr: (t) => errs.push(t) },
+    );
+    expect(code).toBe(2);
+    expect(errs.join("")).toContain("xbrief/ already exists alongside vbrief/");
+  });
+
+  it("returns exit code 1 and writes to stderr for refused outcome", () => {
+    const errs: string[] = [];
+    const code = emitXbriefMigration(
+      { kind: "refused", message: "working tree is dirty" },
+      { writeOut: () => {}, writeErr: (t) => errs.push(t) },
+    );
+    expect(code).toBe(1);
+    expect(errs.join("")).toContain("working tree is dirty");
+  });
+
+  it("returns exit code 0 and writes to stdout for migrated outcome", () => {
+    const outs: string[] = [];
+    const code = emitXbriefMigration(
+      { kind: "migrated", backupDir: "/tmp/backup-xyz", files: 5 },
+      { writeOut: (t) => outs.push(t), writeErr: () => {} },
+    );
+    expect(code).toBe(0);
+    expect(outs.join("")).toContain("5 file(s)");
+    expect(outs.join("")).toContain("/tmp/backup-xyz");
+  });
 });
 
 describe("runXbriefMigrationCli", () => {
@@ -223,5 +265,23 @@ describe("runXbriefMigrationCli", () => {
     expect(code).toBe(0);
     expect(lines.join("")).toContain("Migrated 1 file(s)");
     expect(existsSync(join(project, "AGENTS.md"))).toBe(true);
+  });
+
+  it("returns exit code 2 when agents:refresh cannot find the framework template (template-missing)", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-cli-tmpl-"));
+    temps.push(base);
+    const project = scaffoldLegacyProject(base);
+    // An empty frameworkRoot has no templates/agents-entry.md so agentsRefreshPlan
+    // returns state="template-missing", causing runAgentsRefresh to return 2.
+    const emptyFwRoot = mkdtempSync(join(tmpdir(), "empty-fw-"));
+    temps.push(emptyFwRoot);
+
+    const errs: string[] = [];
+    const code = runXbriefMigrationCli(
+      { projectRoot: project, frameworkRoot: emptyFwRoot, force: true },
+      { writeOut: () => {}, writeErr: (t) => errs.push(t) },
+    );
+    expect(code).toBe(2);
+    expect(errs.join("")).toContain("agents:refresh failed");
   });
 });

--- a/xbrief/completed/2026-07-01-2135-branch-coverage.xbrief.json
+++ b/xbrief/completed/2026-07-01-2135-branch-coverage.xbrief.json
@@ -1,0 +1,41 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Restore global TypeScript branch coverage to >= 85% by adding targeted unit tests for uncovered branches in xbrief-migrate and related modules.",
+    "created": "2026-07-01T16:35:00Z",
+    "updated": "2026-07-01T16:35:00Z"
+  },
+  "plan": {
+    "id": "2135-branch-coverage",
+    "title": "Restore branch coverage above 85% threshold",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2135",
+    "narratives": {
+      "Description": "Global branch coverage sits at 84.99% (20922/24616) on master HEAD, just under the 85% threshold. Recent xbrief rename/layout PRs (#2109, #2110, #2119, #2122, #2125, #2127, #2128, #2130) added code branches (layout resolver, xbrief-migrate, dual-namespace readers, call-site wiring) without full branch coverage, tipping the global number just under the gate.",
+      "ImplementationPlan": "1. Run coverage locally; identify top uncovered branches in xbrief-migrate (drift-gate.ts, detect.ts, migrate-project.ts). 2. Add targeted unit tests for: (a) drift-gate.ts quiet mode and git-error path; (b) detect.ts root-level vbrief artifact detection and version-string detection; (c) migrate-project.ts emitXbriefMigration refused/config/migrated cases and runAgentsRefresh branches. 3. Re-run coverage and verify global branch coverage >= 85%.",
+      "UserStory": "As a directive CI maintainer, I want the TypeScript job to be green on master, so that merges are unblocked.",
+      "Traces": "#2135, #2130, #2109"
+    },
+    "items": [
+      {
+        "id": "2135-a1",
+        "title": "Given uncovered branches in xbrief-migrate modules, when targeted tests are added, then branch coverage >= 85%",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "pnpm -w test exits 0 with branch coverage >= 85% on master HEAD."
+        }
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2135",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2135: Global branch coverage 84.99% < 85% threshold"
+      }
+    ],
+    "updated": "2026-07-01T16:49:58Z",
+    "metadata": {
+      "completedAt": "2026-07-01T16:49:58Z"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Global branch coverage was at 84.99% on master HEAD (just under the 85% threshold), causing the `TypeScript (build + lint + test)` required CI check to fail. The recent xbrief rename/layout PRs (#2109, #2110, #2122, #2125, #2127, #2128, #2130) added code branches without matching tests, tipping the global number below the gate.

**Before:** 84.99% (CI), 85.01% (local baseline) — 1 branch above threshold  
**After:** 85.04% (20953/24637 branches covered) — ~9 branches above threshold

No production code was changed. Only targeted test additions.

## Branches covered

### `packages/core/src/xbrief-migrate/detect.test.ts` (new file)
- Root-level `*.vbrief.json` artifact detection (lines 88-95 in `detect.ts`)
- Legacy version string `"version": "0.6"` in pretty-printed JSON (lines 57-58)
- Scanning `xbrief/` directory for residual legacy reference tokens

### `packages/core/src/xbrief-migrate/drift-gate.test.ts` (additions)
- `quiet: true` option suppresses the success message and returns empty string (lines 246-247)
- Non-git-repo project root causes `listFiles` to return an error, returning code 2 (lines 192-193)

### `packages/core/src/xbrief-migrate/migrate-project.test.ts` (additions)
- `emitXbriefMigration` with `config` outcome → exits 2, writes to stderr (lines 231-232)
- `emitXbriefMigration` with `refused` outcome → exits 1, writes to stderr
- `emitXbriefMigration` with `migrated` outcome → exits 0, writes to stdout
- `emitXbriefMigration` with `signpostOnly=true` but no `projectRoot` → uses `process.cwd()` (line 218)
- `runXbriefMigrationCli` with empty `frameworkRoot` → `runAgentsRefresh` sees `template-missing` state → returns 2 (lines 153-155)

### `packages/cli/src/doctor.test.ts` (addition)
- `run([])` with no flags exercises the `flags.projectRoot ?? process.cwd()` false branch

## Related Issues

Closes #2135

## Checklist

- [x] `/deft:change <name>` — N/A (test-only fix, <3 file surfaces, solo fix story)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (test-only / CI-only fix)
- [x] Tests pass locally (527/527 test files pass, branch coverage 85.04%)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm `gh issue view 2135 --json state --jq .state` shows `CLOSED`