### PR TITLE
fix(install): harden _ts-build guard for stray packages/ deposits (#2142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`task deft:*` no longer fails on git-vendored deposits with a stray `packages/` tree (#2142).** The v0.66.0 `_ts-build` guard treated any `packages/cli/package.json` as a build signal and ran `pnpm run build` at deposits that lack a root `build` script, breaking `task check` for repos that committed framework source under `.deft/core`. The guard now requires a root `build` script before building, and `deft doctor` warns when `.deft/core/packages/` is present. Closes #2142.
+
 ### Removed
 
 ## [0.66.0] - 2026-07-01

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -8,7 +8,7 @@ vi.mock("@deftai/directive-core/dist/doctor/main.js", () => ({
 }));
 
 import { cmdDoctor } from "@deftai/directive-core/dist/doctor/main.js";
-import { run } from "./doctor.js";
+import { renderStrayPackagesAdvisoryLine, run } from "./doctor.js";
 
 const LIFECYCLE_FOLDERS = ["proposed", "pending", "active", "completed", "cancelled"] as const;
 
@@ -189,6 +189,29 @@ describe("doctor CLI", () => {
     expect(out).toContain("migrate:xbrief");
   });
 
+  it("reports clean deposit hygiene when .deft/core has no packages/ (#2142)", () => {
+    const root = makeRoot("doctor-deposit-clean-");
+    makeLifecycleDirs(root);
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("Deposit hygiene: none");
+    expect(renderStrayPackagesAdvisoryLine(root)).toContain("Deposit hygiene: none");
+  });
+
+  it("flags stray packages/ under .deft/core (#2142)", () => {
+    const root = makeRoot("doctor-stray-packages-");
+    makeLifecycleDirs(root);
+    mkdirSync(join(root, ".deft", "core", "packages", "cli"), { recursive: true });
+    writeFileSync(join(root, ".deft", "core", "packages", "cli", "package.json"), "{}\n", "utf8");
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("Deposit hygiene: advisory");
+    expect(out).toContain(".deft/core/packages/");
+    expect(renderStrayPackagesAdvisoryLine(root)).toContain("advisory");
+  });
+
   it("defaults projectRoot to process.cwd() when --project-root is omitted", () => {
     // Exercises the `flags.projectRoot ?? process.cwd()` false branch in doctor.ts.
     const out = captureStdout(() => {
@@ -199,5 +222,6 @@ describe("doctor CLI", () => {
     // since process.cwd() varies by environment).
     expect(out).toContain("Pre-cutover:");
     expect(out).toContain("xBrief migration:");
+    expect(out).toContain("Deposit hygiene:");
   });
 });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,9 +1,24 @@
 #!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseDoctorFlags } from "@deftai/directive-core/dist/doctor/flags.js";
 import { cmdDoctor } from "@deftai/directive-core/dist/doctor/main.js";
 import { renderPrecutoverLine } from "@deftai/directive-core/dist/vbrief-validate/precutover.js";
 import { renderXbriefMigrationLine } from "@deftai/directive-core/xbrief-migrate";
+
+/** Advisory when a consumer deposit carries git-vendored framework source (#2142). */
+export function renderStrayPackagesAdvisoryLine(projectRoot: string): string {
+  const packagesDir = join(projectRoot, ".deft", "core", "packages");
+  if (!existsSync(packagesDir)) {
+    return "Deposit hygiene: none -- .deft/core contains no stray packages/ source tree.";
+  }
+  return (
+    "Deposit hygiene: advisory -- .deft/core/packages/ is present (git-vendored framework source, " +
+    "not shipped by npm @deftai/directive-content). Upgrade directive to pick up task guard fixes; " +
+    "consider removing the stray tree from version control."
+  );
+}
 
 export function run(argv: string[]): number {
   // #2022: surface pre-cutover (pre-v0.20 document model) migration state alongside the
@@ -15,6 +30,7 @@ export function run(argv: string[]): number {
     const projectRoot = flags.projectRoot ?? process.cwd();
     process.stdout.write(`${renderPrecutoverLine(projectRoot)}\n`);
     process.stdout.write(`${renderXbriefMigrationLine(projectRoot)}\n`);
+    process.stdout.write(`${renderStrayPackagesAdvisoryLine(projectRoot)}\n`);
   }
   return cmdDoctor(argv);
 }

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -19,10 +19,11 @@ import { repoRoot } from "./_helpers.js";
  * would miss: a local `_ts-build`, a local `_ensure-ts` (`pnpm --dir DEFT_ROOT
  * run build`), and a `deps: [:ts:build]` on the unconditional maintainer build
  * primitive. The canonical guarded pattern lives in tasks/engine.yml:
- *   - `:engine:_ts-build` guards the build behind `[ -f {{.DEFT_ROOT}}/packages/
- *     cli/package.json ]` -- SOURCE presence, so it builds on a cold framework
- *     checkout (dist/ is gitignored) yet no-ops on a consumer deposit -- and
- *     runs from `{{.USER_WORKING_DIR}}` so an absolute `dir:` cannot double on a
+ *   - `:engine:_ts-build` guards the build behind packages/cli/package.json
+ *     AND a root `build` script (#2142) so it builds on a cold framework
+ *     checkout (dist/ is gitignored) yet no-ops on a consumer deposit or a
+ *     git-vendored stray packages/ tree without a root build script -- and runs
+ *     from `{{.USER_WORKING_DIR}}` so an absolute `dir:` cannot double on a
  *     Windows `task -t <abs>` invocation (#2126), and
  *   - `:engine:invoke` runs the vendored bin.js when present, else falls back to
  *     the globally-installed `deft` command.
@@ -103,15 +104,26 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
   it("engine.yml still owns the guarded build + global-deft fallback", () => {
     const engine = readTask(ENGINE_FILE);
     expect(engine).toMatch(/_ts-build:/);
-    // Guard is SOURCE presence (packages/cli/package.json), referenced by
-    // absolute path so the check stays cwd-independent on Windows
-    // `task -t <abs>` invocations AND still builds on a cold framework checkout
-    // where dist/ is gitignored/absent (#2126).
+    // Guard requires packages/cli/package.json AND a root build script (#2142)
+    // so cold framework checkouts still build while stray consumer packages/
+    // trees without a root build script no-op instead of ERR_PNPM_NO_SCRIPT.
     expect(engine).toMatch(/\[ -f "\{\{\.DEFT_ROOT\}\}\/packages\/cli\/package\.json" \]/);
+    expect(engine).toMatch(/p\.scripts&&p\.scripts\.build/);
     expect(engine).toMatch(RAW_PNPM_BUILD);
     expect(engine).toMatch(/invoke:/);
     expect(engine).toMatch(/command -v deft/);
     expect(engine).toMatch(/deft \{\{\.ENGINE_CMD\}\}/);
+  });
+
+  it("_ts-build guard no-ops on stray packages/ without root build script (#2142)", () => {
+    const engine = readTask(ENGINE_FILE);
+    const scriptMatch = engine.match(
+      /if \[ -f "\{\{\.DEFT_ROOT\}\}\/packages\/cli\/package\.json" \][\s\S]*?fi/m,
+    );
+    expect(scriptMatch, "engine _ts-build guard block").not.toBeNull();
+    const guardBlock = scriptMatch?.[0] ?? "";
+    expect(guardBlock).toMatch(/node -e "p=require/);
+    expect(guardBlock).not.toMatch(/\[ -f "\{\{\.DEFT_ROOT\}\}\/packages\/cli\/dist\/bin\.js" \]/);
   });
 
   it("TS_BUILD_DEP catches all three :ts:build spellings (regex self-test, #2126 Greptile P1)", () => {

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -108,7 +108,8 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
     // so cold framework checkouts still build while stray consumer packages/
     // trees without a root build script no-op instead of ERR_PNPM_NO_SCRIPT.
     expect(engine).toMatch(/\[ -f "\{\{\.DEFT_ROOT\}\}\/packages\/cli\/package\.json" \]/);
-    expect(engine).toMatch(/p\.scripts&&p\.scripts\.build/);
+    expect(engine).toMatch(/process\.argv\[1\]/);
+    expect(engine).toMatch(/readFileSync\(process\.argv\[1\]/);
     expect(engine).toMatch(RAW_PNPM_BUILD);
     expect(engine).toMatch(/invoke:/);
     expect(engine).toMatch(/command -v deft/);
@@ -122,7 +123,7 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
     );
     expect(scriptMatch, "engine _ts-build guard block").not.toBeNull();
     const guardBlock = scriptMatch?.[0] ?? "";
-    expect(guardBlock).toMatch(/node -e "p=require/);
+    expect(guardBlock).toMatch(/process\.argv\[1\]/);
     expect(guardBlock).not.toMatch(/\[ -f "\{\{\.DEFT_ROOT\}\}\/packages\/cli\/dist\/bin\.js" \]/);
   });
 

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -19,17 +19,18 @@ tasks:
     # `D:\a\directive\directive\D:\a\directive\directive`, #2126). Reference the
     # build root by absolute path so the guard stays cwd-independent.
     #
-    # Guard on SOURCE presence (packages/cli/package.json), NOT the dist/
-    # artifact: dist/ is gitignored, so a cold framework checkout (e.g. CI after
-    # a bare `pnpm install`) has source but no dist and MUST still build. A
-    # consumer deposit (`.deft/core` = @deftai/directive-content) ships no
-    # packages/ tree, so the guard is false and the build is a clean no-op --
-    # this is the #2126 fix (avoids `pnpm run build` -> Missing script: build).
+    # Guard on buildability, not source presence alone (#2142): a cold framework
+    # checkout has packages/cli/package.json AND a root `build` script, so it
+    # still builds when dist/ is gitignored/absent. A clean npm consumer deposit
+    # ships no packages/ tree (guard false -> no-op, #2126). Git-vendored-payload
+    # repos may carry a stray packages/ under .deft/core without a root `build`
+    # script — source-only presence must NOT run `pnpm run build` there.
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - |
         set -eu
-        if [ -f "{{.DEFT_ROOT}}/packages/cli/package.json" ]; then
+        if [ -f "{{.DEFT_ROOT}}/packages/cli/package.json" ] \
+           && node -e "p=require('{{.DEFT_ROOT}}/package.json');process.exit(p.scripts&&p.scripts.build?0:1)"; then
           pnpm --dir "{{.DEFT_ROOT}}" run build
         fi
 

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -30,7 +30,8 @@ tasks:
       - |
         set -eu
         if [ -f "{{.DEFT_ROOT}}/packages/cli/package.json" ] \
-           && node -e "p=require('{{.DEFT_ROOT}}/package.json');process.exit(p.scripts&&p.scripts.build?0:1)"; then
+           && [ -f "{{.DEFT_ROOT}}/package.json" ] \
+           && node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.exit(j.scripts&&j.scripts.build?0:1)" "{{.DEFT_ROOT}}/package.json"; then
           pnpm --dir "{{.DEFT_ROOT}}" run build
         fi
 


### PR DESCRIPTION
## Summary

- Harden `:engine:_ts-build` to require both `packages/cli/package.json` and a root `build` script before running `pnpm run build`, so git-vendored `.deft/core` deposits with stray `packages/` no longer hit `[ERR_PNPM_NO_SCRIPT]`.
- Add a `deft doctor` deposit-hygiene advisory when `.deft/core/packages/` is present.
- Regression tests in `doctor.test.ts` and `taskfile_engine_dispatch.test.ts`.

## Related Issues

Closes #2142

## Checklist

- [x] `/deft:change <name>` — N/A (focused adoption-blocker fix; 5 files, single issue scope)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (release-time batch)
- [x] Tests pass locally (`task check`)

## Test plan

- [x] `pnpm exec vitest run packages/cli/src/doctor.test.ts`
- [x] `pnpm exec vitest run packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts`
- [x] `task check`


Made with [Cursor](https://cursor.com)