### PR TITLE
feat(intake): fetch issue comments by default on ingest (#2143)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,16 @@ v1 ships the read/render-and-validate command `task umbrella:current-shape <N>` 
 
 Cross-references: `content/skills/deft-directive-gh-slice/SKILL.md` (final phase -- file the umbrella, then file its current-shape comment per this convention), `content/skills/deft-directive-refinement/SKILL.md` and `content/skills/deft-directive-triage/SKILL.md` (before reporting umbrella status, read the current-shape comment + linked xBRIEF, not the body), `content/templates/agent-prompt-preamble.md` (canonical orchestrator preamble that consumers of this convention dispatch against). Refs #1140 (parent meta-umbrella -- design-pass churn), #1119 (companion umbrella whose pattern motivated this convention; its v3 current-shape comment is the seed example pre-dating this convention), #2066 (claim-cites-state-surface -- forbid body-only status conclusions).
 
+## Issue body→comments reading (#2143)
+
+**Why this rule exists:** the #2126 dispatch recurrence built a worker envelope from the issue body only; a maintainer comment on the same issue had already invalidated the body's suggested fix and named the correct approach. The umbrella current-shape convention (#1152) encodes the same principle for umbrellas — body is pass-1, comments supersede — but that discipline was not generalized to ordinary issues or enforced at ingest time.
+
+- ! Before ingesting or dispatching against any GitHub issue, fetch both the issue body AND `repos/<owner>/<repo>/issues/<N>/comments` via REST. Read body first, then the comment thread in chronological order.
+- ! The issue-ingest path (`packages/core/src/intake/issue-ingest.ts` / `task issue:ingest`) fetches `/comments` by default and folds the thread into the ingested overview so a body-only artifact is not the default.
+- ⊗ Build a dispatch envelope or conclude what an issue asks for from the issue body alone when the issue has comments (#2143).
+
+Cross-references: `content/templates/agent-prompt-preamble.md` § 5.6, issue #2143. Refs #1152, #2066, #2126.
+
 Note: paths here are root-relative — this repo IS the deft directory.
 Install-generated AGENTS.md uses deft/-prefixed paths.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Issue ingest now fetches GitHub issue comments by default and folds the thread into the ingested overview, so corrective maintainer comments reach workers instead of a body-only snapshot. Closes #2143.
+
 ### Changed
 
 ### Fixed

--- a/content/templates/agent-prompt-preamble.md
+++ b/content/templates/agent-prompt-preamble.md
@@ -233,19 +233,22 @@ task scm:body:pr:edit -- --repo OWNER/REPO --pr 42 --body-file "$bodyFile"
 
 The wrapper reads UTF-8 body text from a file or stdin, sends JSON to `gh api --input -` via `_safe_subprocess.run_text` with `shell=False`, and prints the live post-mutation read-back object. Use live `gh` for immediate verification after mutations; do not use `ghx` for the first read-back because it may serve a cached stale GET.
 
-## 5.6 Umbrella status — claim-cites-state-surface (#2066)
+## 5.6 Issue reading — body then comments (#2143 / #2066)
 
-Before stating an umbrella or epic's current status (what is done, what blocks, wave order), satisfy the claim-cites-state-surface rule:
+Before ingesting a GitHub issue, building a worker dispatch envelope, or concluding what an issue actually asks for, satisfy the body→comments reading discipline for **any** issue (not only umbrellas):
 
-1. ! Fetch issue comments via REST: `gh api repos/<owner>/<repo>/issues/<N>/comments` (or `ghx api ...` for cached read-only GET).
-2. ! Read the `## Current shape (as of pass-N)` comment and any linked context or `LockedDecisions` xBRIEF referenced there. Follow the AGENTS.md #1152 reading order: body -> current-shape comment -> amendment comments.
-3. ! Any "X is done" / "X is the blocker" assertion about an umbrella MUST cite the current-shape comment or another state artifact in the same message.
+1. ! Fetch the issue via REST: `gh api repos/<owner>/<repo>/issues/<N>` (or `ghx api ...` for cached read-only GET).
+2. ! Fetch the comment thread via REST: `gh api repos/<owner>/<repo>/issues/<N>/comments` (or `ghx api ...` for cached read-only GET). The issue-ingest path fetches `/comments` by default and folds the thread into the ingested overview (#2143).
+3. ! Read body first, then the comment thread in chronological order. Later maintainer comments may supersede the original body — the #2126 recurrence shipped the wrong fix because dispatch used a body-only fetch.
+4. ! Any scope, fix, or status conclusion about the issue MUST reflect the full thread, not the body alone.
 
-Anti-pattern: reading only the issue body (pass-1 plan, stale by design) and concluding umbrella status from it — e.g. `gh issue view <N> --json body` or REST `repos/.../issues/<N>` body field alone. The live recurrence on 2026-06-28 misread #2013 Wave 0 status this way despite #1152 being loaded.
+**Umbrellas and epics (#1152):** when the issue is an umbrella or epic, the reading order extends to body → `## Current shape (as of pass-N)` comment → amendment comments. Prefer `task umbrella:current-shape <N>` for the deterministic current-shape read path.
 
-⊗ Conclude umbrella or epic status from the issue body alone (#2066).
+Anti-pattern: reading only the issue body and building a dispatch envelope from it — e.g. `gh issue view <N> --json body` or REST `repos/.../issues/<N>` body field alone when `comments` count is greater than zero.
 
-Reference: AGENTS.md `## Umbrella current-shape convention (#1152)`, issue #2066.
+⊗ Conclude what an issue asks for, or build a dispatch envelope, from the issue body alone when the issue has comments (#2143 / #2066).
+
+Reference: AGENTS.md `## Issue body→comments reading (#2143)`, `## Umbrella current-shape convention (#1152)`, issue #2143.
 
 ## 6. No Draft re-toggling within a single review cycle
 

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -96,6 +96,16 @@ Umbrella and epic issues carry a pass-1 body (plan, stale by design) and a canon
 
 Cross-references: `.deft/core/.agents/skills/deft-directive-refinement/SKILL.md` and `.deft/core/.agents/skills/deft-directive-triage/SKILL.md` (before reporting umbrella status). Refs #1152, #2066.
 
+## Issue body→comments reading (#2143)
+
+When ingesting or dispatching against **any** GitHub issue (not only umbrellas), later maintainer comments may supersede the original body — the #2126 recurrence shipped the wrong fix from a body-only fetch.
+
+- ! Fetch both the issue body and `repos/<owner>/<repo>/issues/<N>/comments` via REST before concluding what the issue asks for or building a worker dispatch envelope. Read body first, then the comment thread in chronological order.
+- ! `deft issue:ingest` / `task issue:ingest` fetches `/comments` by default and folds the thread into the ingested overview (#2143).
+- ⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
+
+Cross-references: `.deft/core/content/templates/agent-prompt-preamble.md` § 5.6. Refs #2143, #1152, #2066, #2126.
+
 ## Content packs
 
 Deft ships versioned content packs (e.g. lessons learned from prior work) under `.deft/core/packs/`. Discover and LOAD pack content via the slice surface instead of reading whole pack files into context:

--- a/packages/core/src/intake/intake-coverage-boost.test.ts
+++ b/packages/core/src/intake/intake-coverage-boost.test.ts
@@ -46,13 +46,19 @@ import {
   writeVbrief,
 } from "./issue-emit.js";
 import {
+  attachIssueCommentThread,
   bodyControlCharacterLabels,
   buildIssueVbrief,
+  composeOverviewWithComments,
   extractAcSectionItems,
+  fetchIssue,
+  fetchIssueComments,
   fetchSingleIssue,
+  ISSUE_COMMENT_THREAD_KEY,
   ingestBulk,
   ingestOne,
   ingestSingleForAccept,
+  issueCommentThread,
   issueIngestMain,
   provenanceIssueNumber,
   resolveRepoUrl,
@@ -172,6 +178,58 @@ describe("intake coverage boost", () => {
           vBRIEFInfo: { description: "Scope vBRIEF ingested from GitHub issue #77" },
         }),
       ).toBe(77);
+    });
+
+    it("folds comment thread into overview so corrections supersede body-only fetch (#2143)", () => {
+      const bodyFix = "Use `pnpm -r run build` / `--filter @deftai/directive build`.";
+      const commentFix =
+        "Do NOT use pnpm -r run build for vendored deposits. Route through `:engine:_ts-build` + `:engine:invoke` instead.";
+      const issue = attachIssueCommentThread(
+        { number: 2126, title: "Vendored build", body: bodyFix, labels: [] },
+        [{ user: { login: "maintainer" }, body: commentFix, created_at: "2026-07-01T12:00:00Z" }],
+      );
+      const [vbrief] = buildIssueVbrief(issue, "proposed", "https://github.com/deftai/directive");
+      const overview = String(
+        (vbrief.plan as Record<string, unknown>).narratives &&
+          ((vbrief.plan as Record<string, unknown>).narratives as Record<string, string>).Overview,
+      );
+      expect(overview).toContain(bodyFix);
+      expect(overview).toContain("Issue comment thread");
+      expect(overview).toContain(":engine:_ts-build");
+      expect(overview).toContain(commentFix);
+      expect(issueCommentThread(issue)).toHaveLength(1);
+      expect(composeOverviewWithComments("", [{ body: "only comment" }])).toContain("only comment");
+    });
+
+    it("fetchIssue attaches comment thread from scm", () => {
+      const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[]) => {
+        if (args[0] === "repos/o/r/issues/99/comments") {
+          return completed(
+            JSON.stringify([
+              {
+                body: "Correct fix Y",
+                user: { login: "bot" },
+                created_at: "2026-07-01T00:00:00Z",
+              },
+            ]),
+          );
+        }
+        if (args[0] === "repos/o/r/issues/1/comments") {
+          return completed("[]");
+        }
+        return completed(
+          JSON.stringify({
+            number: 99,
+            title: "Issue",
+            body: "Wrong fix X",
+            html_url: "https://github.com/o/r/issues/99",
+          }),
+        );
+      });
+      expect(fetchIssueComments("o/r", 1, { scmCall })).toEqual([]);
+      const enriched = fetchIssue("o/r", 99, { scmCall });
+      expect(enriched?.[ISSUE_COMMENT_THREAD_KEY]).toHaveLength(1);
+      expect(String(enriched?.body ?? "")).toContain("Wrong fix X");
     });
 
     it("ingestOne handles duplicate and dry-run", () => {

--- a/packages/core/src/intake/issue-ingest.test.ts
+++ b/packages/core/src/intake/issue-ingest.test.ts
@@ -129,8 +129,11 @@ describe("fetchIssue", () => {
         { cacheRoot, clock, fetchedAt: clock.now() },
       );
 
-      const scmCall = vi.fn(() =>
-        completed(
+      const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[]) => {
+        if (args[0]?.endsWith("/comments")) {
+          return completed("[]", "", 0);
+        }
+        return completed(
           JSON.stringify({
             number: 1714,
             title: "Live rewritten title",
@@ -140,13 +143,13 @@ describe("fetchIssue", () => {
           }),
           "",
           0,
-        ),
-      );
+        );
+      });
 
       const issue = fetchIssue("o/r", 1714, { cacheRoot, scmCall });
       expect(issue?.title).toBe("Live rewritten title");
       expect(issue?.body).toBe("Live rewritten body");
-      expect(scmCall).toHaveBeenCalledTimes(1);
+      expect(scmCall).toHaveBeenCalledTimes(2);
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true });
     }
@@ -167,10 +170,15 @@ describe("fetchIssue", () => {
         { cacheRoot },
       );
 
-      const scmCall = vi.fn(() => completed("", "network error", 1));
+      const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[]) => {
+        if (args[0]?.endsWith("/comments")) {
+          return completed("[]", "", 0);
+        }
+        return completed("", "network error", 1);
+      });
       const issue = fetchIssue("o/r", 99, { cacheRoot, scmCall });
       expect(issue?.title).toBe("Cached fallback title");
-      expect(scmCall).toHaveBeenCalledTimes(1);
+      expect(scmCall).toHaveBeenCalledTimes(2);
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true });
     }

--- a/packages/core/src/intake/issue-ingest.test.ts
+++ b/packages/core/src/intake/issue-ingest.test.ts
@@ -7,9 +7,11 @@ import { FixedClock } from "../cache/test-helpers.js";
 import type { CompletedProcess } from "../scm/call.js";
 import {
   buildIssueVbrief,
+  enrichIssueWithComments,
   extractCrossRefs,
   extractPlanItems,
   fetchIssue,
+  ISSUE_COMMENT_THREAD_KEY,
   ingestOne,
   provenanceIssueNumber,
 } from "./issue-ingest.js";
@@ -181,6 +183,44 @@ describe("fetchIssue", () => {
       expect(scmCall).toHaveBeenCalledTimes(2);
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("marks empty comment threads fetched so ingestOne does not re-fetch", () => {
+    const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[]) => {
+      if (args[0]?.endsWith("/comments")) {
+        return completed("[]", "", 0);
+      }
+      return completed(
+        JSON.stringify({
+          number: 7,
+          title: "No comments",
+          body: "Body only",
+          html_url: "https://github.com/o/r/issues/7",
+        }),
+        "",
+        0,
+      );
+    });
+    const issue = fetchIssue("o/r", 7, { scmCall });
+    expect(issue?.[ISSUE_COMMENT_THREAD_KEY]).toEqual([]);
+    const dir = mkdtempSync(join(tmpdir(), "deft-ingest-nodup-"));
+    try {
+      ingestOne(issue as Record<string, unknown>, {
+        vbriefDir: dir,
+        status: "proposed",
+        repoUrl: "https://github.com/o/r",
+        dryRun: true,
+        scmCall,
+      });
+      expect(scmCall).toHaveBeenCalledTimes(2);
+      expect(
+        enrichIssueWithComments(issue as Record<string, unknown>, "https://github.com/o/r", {
+          scmCall,
+        }),
+      ).toBe(issue);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/core/src/intake/issue-ingest.ts
+++ b/packages/core/src/intake/issue-ingest.ts
@@ -286,6 +286,10 @@ export function issueCommentThread(issue: Record<string, unknown>): IssueComment
   return raw.filter((entry): entry is IssueComment => entry !== null && typeof entry === "object");
 }
 
+export function issueCommentsAlreadyFetched(issue: Record<string, unknown>): boolean {
+  return Object.hasOwn(issue, ISSUE_COMMENT_THREAD_KEY);
+}
+
 export function buildIssueVbrief(
   issue: Record<string, unknown>,
   status: IngestStatus,
@@ -332,7 +336,7 @@ export function buildIssueVbrief(
     narratives.Labels = labelNames.join(", ");
   }
 
-  const planItems = overviewSource.length > 0 ? extractPlanItems(overviewSource) : [];
+  const planItems = bodyStr.length > 0 ? extractPlanItems(bodyStr) : [];
   const plan: Record<string, unknown> = {
     title,
     status: planStatus,
@@ -432,9 +436,6 @@ export function attachIssueCommentThread(
   issue: Record<string, unknown>,
   comments: readonly IssueComment[],
 ): Record<string, unknown> {
-  if (comments.length === 0) {
-    return issue;
-  }
   return { ...issue, [ISSUE_COMMENT_THREAD_KEY]: [...comments] };
 }
 
@@ -448,7 +449,7 @@ export function enrichIssueWithComments(
   repoUrl: string,
   options: FetchIssueOptions = {},
 ): Record<string, unknown> {
-  if (issueCommentThread(issue).length > 0) {
+  if (issueCommentsAlreadyFetched(issue)) {
     return issue;
   }
   const repo = repoSlugFromUrl(repoUrl);
@@ -520,6 +521,9 @@ export function ingestOne(
     repoUrl: string;
     dryRun?: boolean;
     existingRefs?: Map<number, string[]>;
+    scmCall?: ScmCallFn;
+    cwd?: string | null;
+    cacheRoot?: string | null;
   },
 ): [IngestResult, string | null, string] {
   const number = Number(issue.number);
@@ -533,7 +537,11 @@ export function ingestOne(
     ];
   }
 
-  const enriched = enrichIssueWithComments(issue, options.repoUrl);
+  const enriched = enrichIssueWithComments(issue, options.repoUrl, {
+    scmCall: options.scmCall,
+    cwd: options.cwd,
+    cacheRoot: options.cacheRoot,
+  });
   const [vbrief, folder] = buildIssueVbrief(enriched, options.status, options.repoUrl);
   const filename = targetFilename(number, String(issue.title ?? ""));
   const target = join(options.vbriefDir, folder, filename);
@@ -555,6 +563,9 @@ export function ingestBulk(
     repoUrl: string;
     label?: string | null;
     dryRun?: boolean;
+    scmCall?: ScmCallFn;
+    cwd?: string | null;
+    cacheRoot?: string | null;
   },
 ): Record<string, string[] | number> {
   let filtered = issues;
@@ -664,6 +675,7 @@ export function issueIngestMain(args: IssueIngestCliArgs): number {
       repoUrl,
       label: args.label,
       dryRun: args.dryRun,
+      cwd: projectRoot,
     });
     const created = summary.created as string[];
     const duplicate = summary.duplicate as string[];
@@ -692,6 +704,7 @@ export function issueIngestMain(args: IssueIngestCliArgs): number {
     status,
     repoUrl,
     dryRun: args.dryRun,
+    cwd: projectRoot,
   });
   process.stdout.write(`${msg}\n`);
   return result === "duplicate" ? 1 : 0;

--- a/packages/core/src/intake/issue-ingest.ts
+++ b/packages/core/src/intake/issue-ingest.ts
@@ -28,6 +28,17 @@ import {
 export const INGEST_STATUSES = ["proposed", "pending", "active"] as const;
 export type IngestStatus = (typeof INGEST_STATUSES)[number];
 
+/** GitHub issue comment thread entry (REST `repos/.../issues/N/comments`). */
+export interface IssueComment {
+  readonly id?: number;
+  readonly body?: string;
+  readonly user?: { readonly login?: string };
+  readonly created_at?: string;
+}
+
+/** Enriched on issues after `fetchIssue` when the comment thread is non-empty (#2143). */
+export const ISSUE_COMMENT_THREAD_KEY = "issueCommentThread" as const;
+
 const STATUS_MAP: Record<IngestStatus, [string, string]> = {
   proposed: ["proposed", "proposed"],
   pending: ["pending", "pending"],
@@ -234,6 +245,47 @@ export function scanProvenanceRefs(vbriefDir: string): Map<number, string[]> {
   return issueToVbriefs;
 }
 
+export function composeOverviewWithComments(
+  body: string,
+  comments: readonly IssueComment[],
+): string {
+  if (comments.length === 0) {
+    return body;
+  }
+  const parts: string[] = [];
+  if (body.length > 0) {
+    parts.push(body);
+    parts.push("");
+    parts.push("---");
+    parts.push("");
+  }
+  parts.push("## Issue comment thread");
+  parts.push("");
+  parts.push(
+    "_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._",
+  );
+  parts.push("");
+  for (const comment of comments) {
+    const author = comment.user?.login ?? "unknown";
+    const when = comment.created_at ?? "";
+    const header =
+      when.length > 0 ? `### Comment by @${author} (${when})` : `### Comment by @${author}`;
+    parts.push(header);
+    parts.push("");
+    parts.push(typeof comment.body === "string" ? comment.body : "");
+    parts.push("");
+  }
+  return parts.join("\n").trimEnd();
+}
+
+export function issueCommentThread(issue: Record<string, unknown>): IssueComment[] {
+  const raw = issue[ISSUE_COMMENT_THREAD_KEY];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.filter((entry): entry is IssueComment => entry !== null && typeof entry === "object");
+}
+
 export function buildIssueVbrief(
   issue: Record<string, unknown>,
   status: IngestStatus,
@@ -249,6 +301,9 @@ export function buildIssueVbrief(
     (repoUrl.length > 0 ? `${repoUrl}/issues/${number}` : "");
   const bodyRaw = issue.body;
   const bodyStr = typeof bodyRaw === "string" && bodyRaw.length > 0 ? bodyRaw : "";
+  const commentThread = issueCommentThread(issue);
+  const overviewSource =
+    commentThread.length > 0 ? composeOverviewWithComments(bodyStr, commentThread) : bodyStr;
   const labelsRaw = issue.labels;
   const labelNames: string[] = [];
   if (Array.isArray(labelsRaw)) {
@@ -269,15 +324,15 @@ export function buildIssueVbrief(
     Description: title,
     Origin: url.length > 0 ? `Ingested from ${url}` : `Ingested from issue #${number}`,
   };
-  if (bodyStr.length > 0) {
-    warnBodyControlCharacters(number, bodyStr);
-    narratives.Overview = bodyStr;
+  if (overviewSource.length > 0) {
+    warnBodyControlCharacters(number, overviewSource);
+    narratives.Overview = overviewSource;
   }
   if (labelNames.length > 0) {
     narratives.Labels = labelNames.join(", ");
   }
 
-  const planItems = bodyStr.length > 0 ? extractPlanItems(bodyStr) : [];
+  const planItems = overviewSource.length > 0 ? extractPlanItems(overviewSource) : [];
   const plan: Record<string, unknown> = {
     title,
     status: planStatus,
@@ -296,8 +351,8 @@ export function buildIssueVbrief(
         title: `Issue #${number}: ${title}`,
       },
     ];
-    if (bodyStr.length > 0 && repoUrl.length > 0) {
-      references.push(...extractCrossRefs(bodyStr, repoUrl, new Set([number])));
+    if (overviewSource.length > 0 && repoUrl.length > 0) {
+      references.push(...extractCrossRefs(overviewSource, repoUrl, new Set([number])));
     }
     plan.references = references;
   }
@@ -347,6 +402,63 @@ export function fetchFromCache(
   }
 }
 
+export function fetchIssueComments(
+  repo: string,
+  number: number,
+  options: FetchIssueOptions = {},
+): IssueComment[] {
+  const scmCall = options.scmCall ?? call;
+  let result: CompletedProcess;
+  try {
+    result = scmCall("github-issue", "api", [`repos/${repo}/issues/${number}/comments`], {
+      timeout: 30,
+      cwd: options.cwd ?? undefined,
+    });
+  } catch {
+    return [];
+  }
+  if (result.returncode !== 0) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(result.stdout) as unknown;
+    return Array.isArray(parsed) ? (parsed as IssueComment[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function attachIssueCommentThread(
+  issue: Record<string, unknown>,
+  comments: readonly IssueComment[],
+): Record<string, unknown> {
+  if (comments.length === 0) {
+    return issue;
+  }
+  return { ...issue, [ISSUE_COMMENT_THREAD_KEY]: [...comments] };
+}
+
+export function repoSlugFromUrl(repoUrl: string): string | null {
+  const match = /github\.com\/([^/\s]+\/[^/\s]+)/.exec(repoUrl);
+  return match?.[1] ?? null;
+}
+
+export function enrichIssueWithComments(
+  issue: Record<string, unknown>,
+  repoUrl: string,
+  options: FetchIssueOptions = {},
+): Record<string, unknown> {
+  if (issueCommentThread(issue).length > 0) {
+    return issue;
+  }
+  const repo = repoSlugFromUrl(repoUrl);
+  const number = Number(issue.number);
+  if (repo === null || !Number.isFinite(number)) {
+    return issue;
+  }
+  return attachIssueCommentThread(issue, fetchIssueComments(repo, number, options));
+}
+
 export function fetchSingleIssue(
   repo: string,
   number: number,
@@ -387,9 +499,15 @@ export function fetchIssue(
 ): Record<string, unknown> | null {
   const live = fetchSingleIssue(repo, number, options);
   if (live !== null) {
-    return live;
+    const comments = fetchIssueComments(repo, number, options);
+    return attachIssueCommentThread(live, comments);
   }
-  return fetchFromCache(repo, number, options);
+  const cached = fetchFromCache(repo, number, options);
+  if (cached === null) {
+    return null;
+  }
+  const comments = fetchIssueComments(repo, number, options);
+  return attachIssueCommentThread(cached, comments);
 }
 
 export type IngestResult = "created" | "dryrun" | "duplicate";
@@ -415,7 +533,8 @@ export function ingestOne(
     ];
   }
 
-  const [vbrief, folder] = buildIssueVbrief(issue, options.status, options.repoUrl);
+  const enriched = enrichIssueWithComments(issue, options.repoUrl);
+  const [vbrief, folder] = buildIssueVbrief(enriched, options.status, options.repoUrl);
   const filename = targetFilename(number, String(issue.title ?? ""));
   const target = join(options.vbriefDir, folder, filename);
 


### PR DESCRIPTION
## Summary

- Issue ingest fetches `repos/.../issues/N/comments` by default and folds the comment thread into the ingested overview, so maintainer corrections supersede a body-only snapshot.
- Generalizes the body→comments reading discipline from umbrellas-only to any dispatched issue in the orchestrator preamble and consumer `agents-entry.md` template.
- Adds regression tests for body-vs-comment supersession (the #2126 failure mode).

Closes #2143

## Test plan

- [x] `pnpm vitest run packages/core/src/intake/intake-coverage-boost.test.ts`
- [x] `task check` (full framework source gate)

Made with [Cursor](https://cursor.com)