### PR TITLE
Add an AGENTS.md line-budget ratchet so it can't silently bloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AGENTS.md now has a line-budget ratchet that stops it silently bloating (#645).** A new `verify:agents-md-budget` gate (wired into `task check`) counts the managed section and the hand-maintained region of AGENTS.md separately and fails when either grows past the budget recorded in `PROJECT-DEFINITION` (`plan.policy.agentsMdBudget`). The budget is seeded at the current size, so it ships green and only flags future growth — reductions are always allowed and should tighten the budget toward the ~100–150 line ceiling that keeps AGENTS.md a map, not a manual. Refs #645, #1882.
+
 ### Changed
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,14 @@ task check    # runs: validate + lint + test
 
 ⊗ Commit code that has not passed `task check`.
 
+### AGENTS.md line budget (#645)
+
+`task verify:agents-md-budget` (wired into `task check:framework-source`) is a **ratchet** that keeps AGENTS.md a map, not a manual (#1882). It counts the managed section and the unmanaged region separately and fails when either grows past `plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines}` in `PROJECT-DEFINITION`. The budget is seeded at the current per-region size, so the gate ships green; only *growth* fails.
+
+- ! When you need to add content, push the detail into a reference doc (`main.md` section, a content pack, or `docs/`) and leave a pointer from AGENTS.md — do not expand AGENTS.md itself. See `REFERENCES.md` § "AGENTS.md is a map, not a manual".
+- ! When you *reduce* AGENTS.md, lower the matching `managedMaxLines` / `unmanagedMaxLines` in the same PR so the ratchet tightens toward the ~150-line ceiling.
+- ? If growth is genuinely warranted (e.g. a new #1309-propagated consumer rule), raising the budget is an explicit, reviewed diff to the typed field — that diff is the "was this growth deliberate?" checkpoint.
+
 ### Slow tests (#975)
 
 Deft uses a `slow` pytest marker to keep `task check` fast on tight-loop iteration. Tests that exceed ~1s wall-clock (e.g. real `time.sleep` / thread-join waits in the watchdog regression suite) are marked with `@pytest.mark.slow` and **excluded by default** from `task check` via `addopts = "-m 'not slow'"` in `pyproject.toml`. The current marker users in `tests/integration/test_triage_bootstrap_at_scale.py` and `tests/test_triage_bootstrap.py` range from ~0.5s to ~1.9s; the **1s threshold is the contributor decision point**, not a hard floor on which existing tests qualify.

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -17,6 +17,14 @@
 - Load: When any term is undefined or used ambiguously; before introducing a new term
 - Contains: work decomposition hierarchy, hygiene terms, framework design terms, GSD → Deft mapping
 
+## 🗺️ AGENTS.md is a map, not a manual (#645 / #1882)
+
+AGENTS.md is the always-loaded front door. Empirical study (`content/docs/good-agents-md.md`) found agent-quality gains from AGENTS.md **reverse** once the file grows past ~100–150 lines: context is scarce, "everything important" becomes non-guidance, and stale rules accumulate.
+
+- **Default when adding content**: push the detail into a reference doc (`main.md` section, a content pack, or `docs/`) and leave a *pointer* from AGENTS.md — do **not** expand AGENTS.md itself.
+- **Enforced by a ratchet**: `task verify:agents-md-budget` (wired into `task check`) fails when the managed section or the unmanaged region grows past `plan.policy.agentsMdBudget` in `PROJECT-DEFINITION`. The budget is seeded at the current per-region size, so *growth* fails while *reductions* are always allowed.
+- **Lowering the budget is free; raising it is a reviewed diff.** Each reduction should tighten the matching `managedMaxLines` / `unmanagedMaxLines` line so the ratchet only ever ratchets down toward the ceiling.
+
 ## 📋 Task-Based Loading
 
 ### When Writing Code

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -360,6 +360,7 @@ tasks:
       - verify:cache-fresh
       - verify:pack-drift
       - verify-wip-cap-framework-self-check
+      - verify:agents-md-budget
       - vbrief:validate
       - codebase:validate-structure
       - verify:codebase-map-fresh

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -147,6 +147,7 @@ export const CLI_MODULE_VERBS = [
   "verify-story-ready",
   "verify-tools",
   "verify-wip-cap",
+  "verify-agents-md-budget",
 ] as const;
 
 /** Core-only CLI entrypoints without a packages/cli wrapper. */
@@ -210,6 +211,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "verify:branch": "verify-branch",
   "verify:vbrief-conformance": "vbrief-validate",
   "verify:wip-cap": "verify-wip-cap",
+  "verify:agents-md-budget": "verify-agents-md-budget",
   "verify:hooks-installed": "verify-hooks-installed",
   "verify:no-task-runtime": "verify-no-task-runtime",
   "vbrief:validate": "vbrief-validate",

--- a/packages/cli/src/gates-cli/verify-gates-cli.test.ts
+++ b/packages/cli/src/gates-cli/verify-gates-cli.test.ts
@@ -47,6 +47,20 @@ describe("deft-ts verify-wip-cap", () => {
   });
 });
 
+describe("deft-ts verify-agents-md-budget (#645)", () => {
+  it("passes against the framework repo (ratchet seeded at current size)", () => {
+    const { exitCode } = runDeftTs("verify-agents-md-budget", ["--project-root", repoRoot()]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("verify:agents-md-budget alias routes identically", () => {
+    const args = ["--project-root", repoRoot()];
+    expect(runDeftTs("verify:agents-md-budget", args).exitCode).toBe(
+      runDeftTs("verify-agents-md-budget", args).exitCode,
+    );
+  });
+});
+
 describe("deft-ts verify-judgment-gates (maps tests/cli/test_verify_judgment_gates.py)", () => {
   it("returns 2 when claim ledger path is missing", () => {
     const root = seedProject();

--- a/packages/cli/src/verify-agents-md-budget.test.ts
+++ b/packages/cli/src/verify-agents-md-budget.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { parseArgs, run } from "./verify-agents-md-budget.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function agentsWith(unmanaged: number, managed: number): string {
+  const lines: string[] = [];
+  for (let i = 0; i < unmanaged; i += 1) {
+    lines.push(`unmanaged ${i}`);
+  }
+  lines.push("<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->");
+  for (let i = 0; i < managed - 2; i += 1) {
+    lines.push(`managed ${i}`);
+  }
+  lines.push("<!-- /deft:managed-section -->");
+  return lines.join("\n");
+}
+
+function buildRepo(options: { plan?: Record<string, unknown>; agents?: string }): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-cli-agents-budget-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  if (options.plan !== undefined) {
+    writeFileSync(
+      join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "running", items: [], ...options.plan },
+      }),
+      "utf8",
+    );
+  }
+  if (options.agents !== undefined) {
+    writeFileSync(join(root, "AGENTS.md"), options.agents, "utf8");
+  }
+  return root;
+}
+
+function silentRun(argv: string[]): number {
+  const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  try {
+    return run(argv);
+  } finally {
+    out.mockRestore();
+    err.mockRestore();
+  }
+}
+
+describe("parseArgs", () => {
+  it("parses defaults", () => {
+    expect(parseArgs([])).toMatchObject({ projectRoot: ".", quiet: false });
+  });
+
+  it("parses flags and = form", () => {
+    expect(parseArgs(["--project-root", "/root", "--quiet"])).toMatchObject({
+      projectRoot: "/root",
+      quiet: true,
+    });
+    expect(parseArgs(["--project-root=/tmp/x"]).projectRoot).toBe("/tmp/x");
+  });
+
+  it("errors on unknown flags and missing values", () => {
+    expect(parseArgs(["--bogus"]).error).toBeDefined();
+    expect(parseArgs(["--project-root"]).error).toBeDefined();
+  });
+});
+
+describe("run", () => {
+  const plan = { policy: { agentsMdBudget: { managedMaxLines: 5, unmanagedMaxLines: 10 } } };
+
+  it("returns 0 at the seeded baseline", () => {
+    const root = buildRepo({ plan, agents: agentsWith(10, 5) });
+    expect(silentRun(["--project-root", root])).toBe(0);
+  });
+
+  it("returns 1 when a region grows past its ratchet", () => {
+    const root = buildRepo({ plan, agents: agentsWith(20, 5) });
+    expect(silentRun(["--project-root", root])).toBe(1);
+  });
+
+  it("returns 2 for a malformed budget field", () => {
+    const root = buildRepo({
+      plan: { policy: { agentsMdBudget: { managedMaxLines: "bad", unmanagedMaxLines: 10 } } },
+      agents: agentsWith(10, 5),
+    });
+    expect(silentRun(["--project-root", root])).toBe(2);
+  });
+
+  it("returns 2 for bad args", () => {
+    expect(silentRun(["--bogus"])).toBe(2);
+  });
+
+  it("suppresses stdout when --quiet at baseline", () => {
+    const root = buildRepo({ plan, agents: agentsWith(10, 5) });
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(run(["--project-root", root, "--quiet"])).toBe(0);
+      expect(out.mock.calls.length).toBe(0);
+      expect(err.mock.calls.length).toBe(0);
+    } finally {
+      out.mockRestore();
+      err.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/verify-agents-md-budget.ts
+++ b/packages/cli/src/verify-agents-md-budget.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluate } from "@deftai/directive-core/agents-md-budget";
+
+interface ParsedArgs {
+  projectRoot: string;
+  quiet: boolean;
+  error?: string;
+}
+
+/** Parse verify-agents-md-budget CLI args. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    projectRoot: ".",
+    quiet: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--quiet") {
+      parsed.quiet = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run the gate and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify_agents_md_budget: ${args.error}\n`);
+    return 2;
+  }
+
+  const projectRoot = resolve(args.projectRoot);
+  const result = evaluate(projectRoot, { quiet: args.quiet });
+
+  if (result.message.length > 0) {
+    if (result.stream === "stdout") {
+      process.stdout.write(`${result.message}\n`);
+    } else if (result.stream === "stderr") {
+      process.stderr.write(`${result.message}\n`);
+    }
+  }
+
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/wip-cap/index.d.ts",
       "default": "./dist/wip-cap/index.js"
     },
+    "./agents-md-budget": {
+      "types": "./dist/agents-md-budget/index.d.ts",
+      "default": "./dist/agents-md-budget/index.js"
+    },
     "./xbrief-migrate": {
       "types": "./dist/xbrief-migrate/index.d.ts",
       "default": "./dist/xbrief-migrate/index.js"

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -88,6 +88,34 @@ describe("countRegions", () => {
     const result = countRegions(text);
     expect("error" in result).toBe(true);
   });
+
+  it("errors when a second open marker is present (duplicate)", () => {
+    const text = [
+      "x",
+      "<!-- deft:managed-section v3 -->",
+      "managed",
+      "<!-- /deft:managed-section -->",
+      "<!-- deft:managed-section v3 -->",
+      "second block",
+    ].join("\n");
+    const result = countRegions(text);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain("malformed");
+    }
+  });
+
+  it("errors when a second close marker is present (duplicate)", () => {
+    const text = [
+      "x",
+      "<!-- deft:managed-section v3 -->",
+      "managed",
+      "<!-- /deft:managed-section -->",
+      "<!-- /deft:managed-section -->",
+    ].join("\n");
+    const result = countRegions(text);
+    expect("error" in result).toBe(true);
+  });
 });
 
 describe("evaluate", () => {
@@ -130,6 +158,19 @@ describe("evaluate", () => {
     expect(result.code).toBe(0);
     expect(result.stream).toBe("stderr");
     expect(result.message).toContain("no plan.policy.agentsMdBudget configured");
+  });
+
+  it("suppresses the unset-budget warning when quiet", () => {
+    const root = makeRepo({ plan: { title: "T" }, agents: agentsWith(10, 5) });
+    expect(evaluate(root, { quiet: true })).toEqual({ code: 0, message: "", stream: "none" });
+  });
+
+  it("returns exit 2 when AGENTS.md exists but cannot be read (is a directory)", () => {
+    const root = makeRepo({ plan: budgetPlan });
+    mkdirSync(join(root, "AGENTS.md"), { recursive: true });
+    const result = evaluate(root);
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("cannot be read");
   });
 
   it("returns exit 2 for a malformed budget field", () => {

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -1,0 +1,177 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { countRegions, evaluate } from "./evaluate.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function writeProjectDefinition(root: string, plan: Record<string, unknown>): void {
+  const dir = join(root, "vbrief");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "PROJECT-DEFINITION.vbrief.json"),
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6" },
+      plan: { title: "T", status: "running", items: [], ...plan },
+    }),
+    "utf8",
+  );
+}
+
+/** Build an AGENTS.md with `unmanaged` leading lines then a managed block of `managed` lines. */
+function agentsWith(unmanaged: number, managed: number): string {
+  const lines: string[] = [];
+  for (let i = 0; i < unmanaged; i += 1) {
+    lines.push(`unmanaged line ${i}`);
+  }
+  if (managed > 0) {
+    lines.push("<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->");
+    for (let i = 0; i < managed - 2; i += 1) {
+      lines.push(`managed line ${i}`);
+    }
+    lines.push("<!-- /deft:managed-section -->");
+  }
+  return lines.join("\n");
+}
+
+function makeRepo(options: { plan?: Record<string, unknown>; agents?: string }): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-agents-budget-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  if (options.plan !== undefined) {
+    writeProjectDefinition(root, options.plan);
+  }
+  if (options.agents !== undefined) {
+    writeFileSync(join(root, "AGENTS.md"), options.agents, "utf8");
+  }
+  return root;
+}
+
+describe("countRegions", () => {
+  it("splits managed and unmanaged line counts", () => {
+    const result = countRegions(agentsWith(10, 5));
+    expect("counts" in result).toBe(true);
+    if ("counts" in result) {
+      expect(result.counts).toEqual({ total: 15, managed: 5, unmanaged: 10 });
+    }
+  });
+
+  it("treats a file with no markers as entirely unmanaged", () => {
+    const result = countRegions("a\nb\nc");
+    expect("counts" in result).toBe(true);
+    if ("counts" in result) {
+      expect(result.counts).toEqual({ total: 3, managed: 0, unmanaged: 3 });
+    }
+  });
+
+  it("ignores a trailing final newline", () => {
+    const result = countRegions("a\nb\n");
+    if ("counts" in result) {
+      expect(result.counts.total).toBe(2);
+    }
+  });
+
+  it("errors when only an open marker is present (malformed)", () => {
+    const text = "x\n<!-- deft:managed-section v3 -->\nmanaged";
+    const result = countRegions(text);
+    expect("error" in result).toBe(true);
+  });
+
+  it("errors when only a close marker is present (malformed)", () => {
+    const text = "x\n<!-- /deft:managed-section -->\ny";
+    const result = countRegions(text);
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("evaluate", () => {
+  const budgetPlan = { policy: { agentsMdBudget: { managedMaxLines: 5, unmanagedMaxLines: 10 } } };
+
+  it("returns exit 0 at the seeded baseline (ratchet ships green)", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsWith(10, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.stream).toBe("stdout");
+    expect(result.message).toContain("managed 5/5, unmanaged 10/10");
+  });
+
+  it("returns exit 1 when the managed region grows past its ratchet", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsWith(10, 6) });
+    const result = evaluate(root);
+    expect(result.code).toBe(1);
+    expect(result.stream).toBe("stderr");
+    expect(result.message).toContain("managed region:   6/5");
+    expect(result.message).toContain("map, not a manual");
+  });
+
+  it("returns exit 1 when the unmanaged region grows past its ratchet", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsWith(11, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("unmanaged region: 11/10");
+  });
+
+  it("passes after a reduction re-seeds a tighter budget (ratchet lowers)", () => {
+    // File reduced to managed 3 / unmanaged 6; budget lowered to match.
+    const plan = { policy: { agentsMdBudget: { managedMaxLines: 3, unmanagedMaxLines: 6 } } };
+    const root = makeRepo({ plan, agents: agentsWith(6, 3) });
+    expect(evaluate(root).code).toBe(0);
+  });
+
+  it("warns (exit 0) when no budget is configured", () => {
+    const root = makeRepo({ plan: { title: "T" }, agents: agentsWith(10, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.stream).toBe("stderr");
+    expect(result.message).toContain("no plan.policy.agentsMdBudget configured");
+  });
+
+  it("returns exit 2 for a malformed budget field", () => {
+    const plan = { policy: { agentsMdBudget: { managedMaxLines: -1, unmanagedMaxLines: 10 } } };
+    const root = makeRepo({ plan, agents: agentsWith(10, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("must be a non-negative integer");
+  });
+
+  it("returns exit 2 when AGENTS.md is missing", () => {
+    const root = makeRepo({ plan: budgetPlan });
+    const result = evaluate(root);
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("AGENTS.md not found");
+  });
+
+  it("returns exit 2 when managed markers are malformed", () => {
+    const root = makeRepo({
+      plan: budgetPlan,
+      agents: "x\n<!-- deft:managed-section v3 -->\nno close here",
+    });
+    const result = evaluate(root);
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("malformed");
+  });
+
+  it("suppresses the success banner when quiet", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsWith(10, 5) });
+    expect(evaluate(root, { quiet: true })).toEqual({ code: 0, message: "", stream: "none" });
+  });
+
+  it("still emits the refusal when quiet and over budget", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsWith(20, 5) });
+    const result = evaluate(root, { quiet: true });
+    expect(result.code).toBe(1);
+  });
+});
+
+describe("agents-md-budget index re-exports", () => {
+  it("exports evaluate from the barrel", async () => {
+    const mod = await import("./index.js");
+    expect(typeof mod.evaluate).toBe("function");
+  });
+});

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -1,0 +1,182 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
+import { resolveAgentsMdBudget } from "../policy/agents-md-budget.js";
+
+export type OutputStream = "stdout" | "stderr" | "none";
+
+/** Result of verify:agents-md-budget evaluation; three-state exit contract. */
+export interface EvaluateResult {
+  readonly code: 0 | 1 | 2;
+  readonly message: string;
+  readonly stream: OutputStream;
+}
+
+export interface EvaluateOptions {
+  readonly quiet?: boolean;
+}
+
+/** Per-region line counts of an AGENTS.md file. */
+export interface RegionCounts {
+  readonly total: number;
+  readonly managed: number;
+  readonly unmanaged: number;
+}
+
+const OPEN_MARKER_PREFIX = "<!-- deft:managed-section";
+
+/**
+ * Split AGENTS.md into managed / unmanaged line counts.
+ *
+ * Returns `{ counts }` on success, or `{ error }` when the managed markers are
+ * malformed (exactly one marker present, or close-before-open). A file with no
+ * markers at all is valid: the whole file counts as unmanaged.
+ */
+export function countRegions(text: string): { counts: RegionCounts } | { error: string } {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  // Ignore the trailing empty element produced by a final newline.
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  const total = lines.length;
+
+  const openLine = lines.findIndex((l) => l.startsWith(OPEN_MARKER_PREFIX));
+  const closeLine = lines.findIndex((l) => l.trim().startsWith(AGENTS_MANAGED_CLOSE));
+
+  if (openLine === -1 && closeLine === -1) {
+    return { counts: { total, managed: 0, unmanaged: total } };
+  }
+  if (openLine === -1 || closeLine === -1 || closeLine < openLine) {
+    return {
+      error:
+        "AGENTS.md managed-section markers are malformed " +
+        `(open@${openLine === -1 ? "none" : openLine + 1}, ` +
+        `close@${closeLine === -1 ? "none" : closeLine + 1}); ` +
+        "expected a single <!-- deft:managed-section ... --> ... " +
+        "<!-- /deft:managed-section --> pair.",
+    };
+  }
+
+  const managed = closeLine - openLine + 1;
+  return { counts: { total, managed, unmanaged: total - managed } };
+}
+
+function formatRefusal(
+  counts: RegionCounts,
+  managedMax: number,
+  unmanagedMax: number,
+  projectRoot: string,
+): string {
+  const over: string[] = [];
+  if (counts.managed > managedMax) {
+    over.push(
+      `   managed region:   ${counts.managed}/${managedMax} lines (OVER by ${counts.managed - managedMax})`,
+    );
+  }
+  if (counts.unmanaged > unmanagedMax) {
+    over.push(
+      `   unmanaged region: ${counts.unmanaged}/${unmanagedMax} lines (OVER by ${counts.unmanaged - unmanagedMax})`,
+    );
+  }
+  return (
+    `❌ verify:agents-md-budget: AGENTS.md grew past its ratchet ` +
+    `(project_root=${projectRoot}).\n` +
+    `${over.join("\n")}\n` +
+    "   AGENTS.md is a map, not a manual (#1882): push detail into a\n" +
+    "   reference doc (main.md / a pack / docs/) and leave a pointer,\n" +
+    "   rather than expanding AGENTS.md. See REFERENCES.md.\n" +
+    "   If the growth is deliberate, raise the matching line in\n" +
+    "   plan.policy.agentsMdBudget in PROJECT-DEFINITION (a reviewed diff). (#645)"
+  );
+}
+
+/**
+ * Pure evaluator for the AGENTS.md line-budget ratchet gate (#645).
+ *
+ * Counts the managed section and the unmanaged region separately (the #1309
+ * propagation duplicates content across the marker) and fails when either
+ * region exceeds its typed per-region budget. Ships green because the budget is
+ * seeded at current size; growth past the ratchet fails.
+ */
+export function evaluate(projectRoot: string, options: EvaluateOptions = {}): EvaluateResult {
+  const root = resolve(projectRoot);
+  const quiet = options.quiet ?? false;
+
+  const budgetResult = resolveAgentsMdBudget(root);
+  if (budgetResult.source === "default-on-error") {
+    return {
+      code: 2,
+      message: `❌ verify:agents-md-budget: PROJECT-DEFINITION malformed: ${budgetResult.error}`,
+      stream: "stderr",
+    };
+  }
+
+  const agentsPath = join(root, "AGENTS.md");
+  if (!existsSync(agentsPath)) {
+    return {
+      code: 2,
+      message: `❌ verify:agents-md-budget: AGENTS.md not found at ${agentsPath}`,
+      stream: "stderr",
+    };
+  }
+
+  let text: string;
+  try {
+    text = readFileSync(agentsPath, { encoding: "utf8" });
+  } catch (err: unknown) {
+    return {
+      code: 2,
+      message: `❌ verify:agents-md-budget: AGENTS.md at ${agentsPath} cannot be read: ${String(err)}`,
+      stream: "stderr",
+    };
+  }
+
+  const regionResult = countRegions(text);
+  if ("error" in regionResult) {
+    return {
+      code: 2,
+      message: `❌ verify:agents-md-budget: ${regionResult.error}`,
+      stream: "stderr",
+    };
+  }
+  const counts = regionResult.counts;
+
+  if (budgetResult.source === "unset") {
+    if (quiet) {
+      return { code: 0, message: "", stream: "none" };
+    }
+    return {
+      code: 0,
+      message:
+        "⚠ verify:agents-md-budget: no plan.policy.agentsMdBudget configured " +
+        `(managed=${counts.managed}, unmanaged=${counts.unmanaged} lines).\n` +
+        "  Seed a ratchet at current size to freeze growth (#645): set\n" +
+        "  plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines} in " +
+        "PROJECT-DEFINITION.",
+      stream: "stderr",
+    };
+  }
+
+  const budget = budgetResult.budget as { managedMaxLines: number; unmanagedMaxLines: number };
+  const overManaged = counts.managed > budget.managedMaxLines;
+  const overUnmanaged = counts.unmanaged > budget.unmanagedMaxLines;
+
+  if (!overManaged && !overUnmanaged) {
+    if (quiet) {
+      return { code: 0, message: "", stream: "none" };
+    }
+    return {
+      code: 0,
+      message:
+        `✓ verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
+        `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet).`,
+      stream: "stdout",
+    };
+  }
+
+  return {
+    code: 1,
+    message: formatRefusal(counts, budget.managedMaxLines, budget.unmanagedMaxLines, root),
+    stream: "stderr",
+  };
+}

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -42,16 +42,26 @@ export function countRegions(text: string): { counts: RegionCounts } | { error: 
 
   const openLine = lines.findIndex((l) => l.startsWith(OPEN_MARKER_PREFIX));
   const closeLine = lines.findIndex((l) => l.trim().startsWith(AGENTS_MANAGED_CLOSE));
+  const openCount = lines.filter((l) => l.startsWith(OPEN_MARKER_PREFIX)).length;
+  const closeCount = lines.filter((l) => l.trim().startsWith(AGENTS_MANAGED_CLOSE)).length;
 
   if (openLine === -1 && closeLine === -1) {
     return { counts: { total, managed: 0, unmanaged: total } };
   }
-  if (openLine === -1 || closeLine === -1 || closeLine < openLine) {
+  // Malformed if a marker is missing, close precedes open, or either marker is
+  // duplicated -- the contract promises exactly one open/close pair.
+  if (
+    openLine === -1 ||
+    closeLine === -1 ||
+    closeLine < openLine ||
+    openCount > 1 ||
+    closeCount > 1
+  ) {
     return {
       error:
         "AGENTS.md managed-section markers are malformed " +
-        `(open@${openLine === -1 ? "none" : openLine + 1}, ` +
-        `close@${closeLine === -1 ? "none" : closeLine + 1}); ` +
+        `(open@${openLine === -1 ? "none" : openLine + 1}×${openCount}, ` +
+        `close@${closeLine === -1 ? "none" : closeLine + 1}×${closeCount}); ` +
         "expected a single <!-- deft:managed-section ... --> ... " +
         "<!-- /deft:managed-section --> pair.",
     };
@@ -157,7 +167,16 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     };
   }
 
-  const budget = budgetResult.budget as { managedMaxLines: number; unmanagedMaxLines: number };
+  /* v8 ignore start -- defensive: source "typed" always carries a non-null budget. */
+  if (budgetResult.budget === null) {
+    return {
+      code: 2,
+      message: "❌ verify:agents-md-budget: unexpected null budget for typed source",
+      stream: "stderr",
+    };
+  }
+  /* v8 ignore stop */
+  const budget = budgetResult.budget;
   const overManaged = counts.managed > budget.managedMaxLines;
   const overUnmanaged = counts.unmanaged > budget.unmanagedMaxLines;
 

--- a/packages/core/src/agents-md-budget/index.ts
+++ b/packages/core/src/agents-md-budget/index.ts
@@ -1,0 +1,1 @@
+export * from "./evaluate.js";

--- a/packages/core/src/policy/agents-md-budget.test.ts
+++ b/packages/core/src/policy/agents-md-budget.test.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolveAgentsMdBudget } from "./agents-md-budget.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+/** Create a temp project root; optionally write a PROJECT-DEFINITION with the given raw JSON text. */
+function makeRepo(raw?: string): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-agents-budget-policy-"));
+  temps.push(root);
+  if (raw !== undefined) {
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+    writeFileSync(join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"), raw, "utf8");
+  }
+  return root;
+}
+
+/** Serialize a plan object into a minimal valid PROJECT-DEFINITION envelope. */
+function withPlan(plan: unknown): string {
+  return JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan });
+}
+
+describe("resolveAgentsMdBudget", () => {
+  it("returns default-on-error when PROJECT-DEFINITION is absent", () => {
+    const result = resolveAgentsMdBudget(makeRepo());
+    expect(result.source).toBe("default-on-error");
+    expect(result.budget).toBeNull();
+    expect(result.error).toContain("PROJECT-DEFINITION not found");
+  });
+
+  it("returns default-on-error when PROJECT-DEFINITION is not valid JSON", () => {
+    const result = resolveAgentsMdBudget(makeRepo("{ not json"));
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("not valid JSON");
+  });
+
+  it("returns default-on-error when plan is not an object", () => {
+    const result = resolveAgentsMdBudget(makeRepo(withPlan("nope")));
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("'plan' is not an object");
+  });
+
+  it("returns unset when the plan has no policy block", () => {
+    const result = resolveAgentsMdBudget(makeRepo(withPlan({ title: "T" })));
+    expect(result.source).toBe("unset");
+    expect(result.budget).toBeNull();
+    expect(result.error).toBeNull();
+  });
+
+  it("returns unset when the policy block omits agentsMdBudget", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(withPlan({ policy: { allowDirectCommitsToMaster: false } })),
+    );
+    expect(result.source).toBe("unset");
+  });
+
+  it("returns unset when the policy block is not an object", () => {
+    const result = resolveAgentsMdBudget(makeRepo(withPlan({ policy: "nope" })));
+    expect(result.source).toBe("unset");
+  });
+
+  it("returns default-on-error when agentsMdBudget is a string", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(withPlan({ policy: { agentsMdBudget: "nope" } })),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("must be an object with managedMaxLines and unmanagedMaxLines");
+    expect(result.error).toContain("got str");
+  });
+
+  it("returns default-on-error when agentsMdBudget is an array", () => {
+    const result = resolveAgentsMdBudget(makeRepo(withPlan({ policy: { agentsMdBudget: [] } })));
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("got list");
+  });
+
+  it("returns default-on-error when managedMaxLines is missing", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(withPlan({ policy: { agentsMdBudget: { unmanagedMaxLines: 10 } } })),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("managedMaxLines is required");
+  });
+
+  it("returns default-on-error when unmanagedMaxLines is missing", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(withPlan({ policy: { agentsMdBudget: { managedMaxLines: 5 } } })),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("unmanagedMaxLines is required");
+  });
+
+  it("returns default-on-error when a region value is a non-integer float", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({ policy: { agentsMdBudget: { managedMaxLines: 5.5, unmanagedMaxLines: 10 } } }),
+      ),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("must be a non-negative integer");
+    expect(result.error).toContain("got float");
+  });
+
+  it("returns default-on-error when a region value is a string (reports str type)", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({ policy: { agentsMdBudget: { managedMaxLines: "5", unmanagedMaxLines: 10 } } }),
+      ),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("got str ('5')");
+  });
+
+  it("returns default-on-error when a region value is negative", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({ policy: { agentsMdBudget: { managedMaxLines: 5, unmanagedMaxLines: -1 } } }),
+      ),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("must be a non-negative integer");
+  });
+
+  it("resolves a typed budget when both regions are valid non-negative integers", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({ policy: { agentsMdBudget: { managedMaxLines: 223, unmanagedMaxLines: 347 } } }),
+      ),
+    );
+    expect(result.source).toBe("typed");
+    expect(result.error).toBeNull();
+    expect(result.budget).toEqual({ managedMaxLines: 223, unmanagedMaxLines: 347 });
+  });
+
+  it("reads the namespaced x-directive/policy block", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({
+          "x-directive/policy": { agentsMdBudget: { managedMaxLines: 1, unmanagedMaxLines: 2 } },
+        }),
+      ),
+    );
+    expect(result.source).toBe("typed");
+    expect(result.budget).toEqual({ managedMaxLines: 1, unmanagedMaxLines: 2 });
+  });
+});

--- a/packages/core/src/policy/agents-md-budget.ts
+++ b/packages/core/src/policy/agents-md-budget.ts
@@ -1,0 +1,116 @@
+import { readPlanPolicy } from "./plan-extensions.js";
+import { loadProjectDefinition } from "./resolve.js";
+
+/**
+ * Per-region line-budget ratchet for AGENTS.md (#645).
+ *
+ * The budget is seeded at the CURRENT per-region line counts and forbids
+ * INCREASE, rather than encoding a static absolute ceiling. This decouples the
+ * gate from the reduction work (#1882): the file is by definition within its
+ * own seeded baseline, so the gate ships green, while any growth past the
+ * ratchet fails. Lowering a budget (a reduction PR) is always allowed; raising
+ * it is an explicit, reviewed diff to this typed field -- that diff IS the
+ * "was this growth deliberate?" checkpoint.
+ */
+export interface AgentsMdBudget {
+  readonly managedMaxLines: number;
+  readonly unmanagedMaxLines: number;
+}
+
+export type AgentsMdBudgetSource = "typed" | "unset" | "default-on-error";
+
+export interface AgentsMdBudgetResult {
+  readonly budget: AgentsMdBudget | null;
+  readonly source: AgentsMdBudgetSource;
+  readonly error: string | null;
+}
+
+function pythonTypeName(value: unknown): string {
+  if (value === null) return "None";
+  if (Array.isArray(value)) return "list";
+  if (typeof value === "boolean") return "bool";
+  if (typeof value === "number") return Number.isInteger(value) ? "int" : "float";
+  if (typeof value === "string") return "str";
+  if (typeof value === "object") return "dict";
+  return typeof value;
+}
+
+function pythonRepr(value: unknown): string {
+  if (value === undefined) return "None";
+  if (typeof value === "string") return `'${value}'`;
+  if (value === null) return "None";
+  if (typeof value === "boolean") return value ? "True" : "False";
+  return String(value);
+}
+
+function readRegion(
+  block: Record<string, unknown>,
+  key: string,
+): { value: number | null; error: string | null } {
+  if (!(key in block)) {
+    return { value: null, error: `plan.policy.agentsMdBudget.${key} is required` };
+  }
+  const raw = block[key];
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) {
+    return {
+      value: null,
+      error: `plan.policy.agentsMdBudget.${key} must be a non-negative integer; got ${pythonTypeName(raw)} (${pythonRepr(raw)})`,
+    };
+  }
+  return { value: raw, error: null };
+}
+
+/** Resolve plan.policy.agentsMdBudget from PROJECT-DEFINITION (#645). */
+export function resolveAgentsMdBudget(projectRoot: string): AgentsMdBudgetResult {
+  const [data, err] = loadProjectDefinition(projectRoot);
+  if (data === null) {
+    return { budget: null, source: "default-on-error", error: err };
+  }
+
+  const plan = data.plan;
+  if (typeof plan !== "object" || plan === null || Array.isArray(plan)) {
+    return {
+      budget: null,
+      source: "default-on-error",
+      error: "PROJECT-DEFINITION 'plan' is not an object",
+    };
+  }
+
+  const policyBlock = readPlanPolicy(plan);
+  if (
+    typeof policyBlock !== "object" ||
+    policyBlock === null ||
+    Array.isArray(policyBlock) ||
+    !("agentsMdBudget" in policyBlock)
+  ) {
+    return { budget: null, source: "unset", error: null };
+  }
+
+  const rawBudget = (policyBlock as Record<string, unknown>).agentsMdBudget;
+  if (typeof rawBudget !== "object" || rawBudget === null || Array.isArray(rawBudget)) {
+    return {
+      budget: null,
+      source: "default-on-error",
+      error: `plan.policy.agentsMdBudget must be an object with managedMaxLines and unmanagedMaxLines; got ${pythonTypeName(rawBudget)}`,
+    };
+  }
+
+  const block = rawBudget as Record<string, unknown>;
+  const managed = readRegion(block, "managedMaxLines");
+  if (managed.error !== null) {
+    return { budget: null, source: "default-on-error", error: managed.error };
+  }
+  const unmanaged = readRegion(block, "unmanagedMaxLines");
+  if (unmanaged.error !== null) {
+    return { budget: null, source: "default-on-error", error: unmanaged.error };
+  }
+
+  return {
+    budget: {
+      managedMaxLines: managed.value as number,
+      unmanagedMaxLines: unmanaged.value as number,
+    },
+    source: "typed",
+    error: null,
+  };
+}

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -358,3 +358,15 @@ tasks:
       - task: :engine:invoke
         vars:
           ENGINE_CMD: 'verify:wip-cap --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
+
+  agents-md-budget:
+    desc: "Ratchet gate for AGENTS.md per-region line budgets (#645). Counts the managed section and the unmanaged region separately (the #1309 propagation duplicates content across the marker) and fails when either region grows past plan.policy.agentsMdBudget. Seeded at current size, so it ships green; growth past the ratchet fails. Lowering a budget (a reduction PR) is always allowed; raising it is a reviewed diff to the typed field. Three-state exit (0 within / 1 over / 2 config error)."
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
+    # because the gate forwards user-facing flags via {{.CLI_ARGS}} (--quiet).
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:agents-md-budget --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ const subpathAliases: Record<string, string> = {
   "@deftai/directive-core/story-ready": sub("core", "story-ready"),
   "@deftai/directive-core/branch": sub("core", "branch"),
   "@deftai/directive-core/wip-cap": sub("core", "wip-cap"),
+  "@deftai/directive-core/agents-md-budget": sub("core", "agents-md-budget"),
   "@deftai/directive-core/scm": sub("core", "scm"),
   "@deftai/directive-core/scope": sub("core", "scope"),
   "@deftai/directive-core/session": sub("core", "session"),

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16780,7 +16780,11 @@
           }
         ]
       },
-      "allowDirectCommitsToMaster": false
+      "allowDirectCommitsToMaster": false,
+      "agentsMdBudget": {
+        "managedMaxLines": 223,
+        "unmanagedMaxLines": 347
+      }
     },
     "updated": "2026-06-12T20:26:00Z"
   }

--- a/xbrief/completed/2026-07-01-645-agents-md-size-budget-gate.xbrief.json
+++ b/xbrief/completed/2026-07-01-645-agents-md-size-budget-gate.xbrief.json
@@ -1,0 +1,97 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #645 (encode + enforce the AGENTS.md line-budget ceiling with a deterministic gate); child of the #1882 map-not-manual umbrella.",
+    "created": "2026-07-01T00:00:00Z",
+    "updated": "2026-07-01T00:00:00Z"
+  },
+  "plan": {
+    "id": "645-agents-md-size-budget-gate",
+    "title": "Encode and enforce an AGENTS.md line-budget ceiling with a deterministic gate",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/645",
+    "narratives": {
+      "Description": "The maintainer AGENTS.md grew from 102 lines (when #645 was filed) to 569 lines (2026-07-01), 5.6x the empirically-supported 100-150 line ceiling in content/docs/good-agents-md.md. A prose-only ceiling demonstrably did not hold. Per main.md Rule Authority [AXIOM], a size budget that matters must be a deterministic gate, not a sentence. This story adds a verify:agents-md-budget gate that counts the managed section and the maintainer/unmanaged region separately (the #1309 propagation duplicates content across the deft:managed-section marker). CRITICAL DESIGN DECISION: the gate is a RATCHET seeded at the CURRENT per-region line counts, failing on INCREASE, not a static absolute ceiling. This decouples the story from #1882: a ratchet ships green today because the current file is by definition within its own seeded budget, and it immediately delivers the value (no further growth is possible without a deliberate, reviewed budget bump). A static 150-line ceiling would instead couple this story to #1882 -- it would warn/fail permanently until the reduction work lands. #1882 then LOWERS the ratchet: each reduction PR tightens the allowed max toward the 150 target. This story owns the ceiling mechanism and the freeze; #1882 owns the shrink that ratchets it down.",
+      "ImplementationPlan": "1. Add a size-budget verifier (TypeScript, packages/core, mirroring existing verify:* gates) that parses AGENTS.md, splits on the <!-- deft:managed-section --> / <!-- /deft:managed-section --> markers, and counts managed vs unmanaged line totals. 2. Read per-region budgets from a typed policy field (plan.policy) SEEDED AT THE CURRENT per-region line counts (the ratchet baseline), not a static 150; no magic numbers. A budget increase is an explicit, reviewed diff to the typed field -- that diff IS the 'was this growth deliberate?' checkpoint, and accommodates legitimate #1309-propagated consumer-rule additions. 3. Three-state exit (0 within budget / 1 over budget i.e. region exceeds its ratchet / 2 config error) with a remediation message pointing at REFERENCES.md and the push-to-reference pattern. 4. Wire into task check via a verify:agents-md-budget target; because it is a ratchet seeded at current size it can run at FAIL tier from day one without blocking (the file already satisfies its own baseline), though an advisory warn tier is acceptable if preferred (per the #1419 judgment-gate precedent). 5. Add the maintenance rule (push detail into a reference file + add a pointer; do not expand AGENTS.md; lowering a budget is always allowed, raising it requires justification) to REFERENCES.md / CONTRIBUTING.md with the empirical basis cited. 6. Add tests exercising within-budget (at baseline), over-budget (region grew past its ratchet), budget-lowered (reduction re-seeds tighter), missing-marker, and config-error paths.",
+      "UserStory": "As a directive maintainer, I want a deterministic gate that flags AGENTS.md growth past a configured line budget, so that the map-not-manual ceiling is enforced mechanically instead of eroding silently as it did from 102 to 569 lines.",
+      "Traces": "#645, #1882"
+    },
+    "items": [
+      {
+        "id": "645-a1",
+        "title": "Given an AGENTS.md region that grew past its ratchet baseline, when the gate runs, then it reports over-budget with a remediation hint",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an AGENTS.md whose managed or unmanaged region exceeds its ratchet-seeded line budget, when verify:agents-md-budget runs, then it exits non-zero and names the offending region plus the push-to-reference remediation. Given the file exactly at its seeded baseline, the gate passes (the ratchet ships green with no reduction required)."
+        }
+      },
+      {
+        "id": "645-a2",
+        "title": "Given the managed-section markers, when the gate counts lines, then managed and unmanaged regions are budgeted separately",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the deft:managed-section markers, when the gate parses AGENTS.md, then it counts the managed section and the maintainer/unmanaged region independently and applies each region's own budget."
+        }
+      },
+      {
+        "id": "645-a3",
+        "title": "Given a project Taskfile, when task check runs, then the budget gate participates at the configured tier",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given task check, when it runs on a PR touching AGENTS.md or the template, then verify:agents-md-budget participates at the configured (advisory by default) tier."
+        }
+      },
+      {
+        "id": "645-a4",
+        "title": "Given the docs, when a contributor reads REFERENCES.md/CONTRIBUTING.md, then the ceiling rule and remediation are documented",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given REFERENCES.md / CONTRIBUTING.md, when a contributor reads the AGENTS.md maintenance guidance, then the line-budget ceiling, the push-detail-to-references default, and the empirical basis (content/docs/good-agents-md.md) are stated."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1882",
+        "child_issue": "#645"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/**/agents-md-budget*.ts",
+          "packages/core/src/**/agents-md-budget*.test.ts",
+          "tasks/verify.yml",
+          "REFERENCES.md",
+          "CONTRIBUTING.md"
+        ],
+        "verify_commands": [
+          "task check"
+        ],
+        "expected_outputs": [
+          "verify:agents-md-budget gate flags AGENTS.md growth past a configured line budget, counting managed vs unmanaged regions separately; ceiling + remediation documented"
+        ],
+        "depends_on": [],
+        "conflict_group": "agents-md-legibility",
+        "size": "small",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      },
+      "completedAt": "2026-07-02T00:42:59Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/645",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #645: docs(agents-md): encode 100-150 line ceiling as an explicit AGENTS.md maintenance rule"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1882",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1882: design(agents-md): treat AGENTS.md as a map, not a manual"
+      }
+    ],
+    "updated": "2026-07-02T00:42:59Z"
+  }
+}

--- a/xbrief/completed/2026-07-01-645-agents-md-size-budget-gate.xbrief.json
+++ b/xbrief/completed/2026-07-01-645-agents-md-size-budget-gate.xbrief.json
@@ -20,7 +20,7 @@
       {
         "id": "645-a1",
         "title": "Given an AGENTS.md region that grew past its ratchet baseline, when the gate runs, then it reports over-budget with a remediation hint",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given an AGENTS.md whose managed or unmanaged region exceeds its ratchet-seeded line budget, when verify:agents-md-budget runs, then it exits non-zero and names the offending region plus the push-to-reference remediation. Given the file exactly at its seeded baseline, the gate passes (the ratchet ships green with no reduction required)."
         }
@@ -28,7 +28,7 @@
       {
         "id": "645-a2",
         "title": "Given the managed-section markers, when the gate counts lines, then managed and unmanaged regions are budgeted separately",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the deft:managed-section markers, when the gate parses AGENTS.md, then it counts the managed section and the maintainer/unmanaged region independently and applies each region's own budget."
         }
@@ -36,7 +36,7 @@
       {
         "id": "645-a3",
         "title": "Given a project Taskfile, when task check runs, then the budget gate participates at the configured tier",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given task check, when it runs on a PR touching AGENTS.md or the template, then verify:agents-md-budget participates at the configured (advisory by default) tier."
         }
@@ -44,7 +44,7 @@
       {
         "id": "645-a4",
         "title": "Given the docs, when a contributor reads REFERENCES.md/CONTRIBUTING.md, then the ceiling rule and remediation are documented",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given REFERENCES.md / CONTRIBUTING.md, when a contributor reads the AGENTS.md maintenance guidance, then the line-budget ceiling, the push-detail-to-references default, and the empirical basis (content/docs/good-agents-md.md) are stated."
         }


### PR DESCRIPTION
## Summary

- Adds a `verify:agents-md-budget` **ratchet gate** (wired into `task check`) that keeps AGENTS.md a map, not a manual (#1882): it counts the managed section and the hand-maintained region separately and fails when either grows past the budget recorded in `PROJECT-DEFINITION` (`plan.policy.agentsMdBudget`).
- The budget is **seeded at the current per-region size** (managed 223 / unmanaged 347), so the gate ships green today and only flags *future* growth — reductions are always allowed and should tighten the budget toward the ~100–150 line ceiling. This decouples the gate from the #1882 reduction work.
- Three-state exit (0 within / 1 over / 2 config error); an unset budget warns without failing. Registers the CLI verb + colon alias, adds a vitest subpath alias, and documents the map-not-manual rule in `REFERENCES.md` / `CONTRIBUTING.md`.

## Test plan

- [x] `task check` passes fully (532 test files, 8005 tests, all green)
- [x] New unit tests cover within-budget (at baseline), over-budget per region, budget-lowered re-seed, missing/malformed markers, unset budget, and config-error paths
- [x] Framework self-check confirms the ratchet passes against this repo's own AGENTS.md at its seeded size
- [x] CLI alias `verify:agents-md-budget` routes identically to `verify-agents-md-budget`

Closes #645
Refs #1882
