### PR TITLE
fix(agents-md): de-drift Commands, drop placeholders + personal-rule leak, compress field list (Closes #2158 #2159 #2160 #2161)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,6 @@ Check what exists before doing anything else:
 
 ⊗ Confirm Deft alignment without first reading USER.md content -- a presence / `Test-Path` existence check is insufficient; the confirmation MUST echo the addressing-name read from inside USER.md.
 
-Note: A true UI indicator (e.g. Warp status bar) is deferred to Phase 5. This is a behavioral rule only.
-
 ## Session-start ritual (#1149)
 
 ! On every interactive session start, run `task session:start` after loading AGENTS.md. This records the quick-tier ritual in `.deft/ritual-state.json`: Deft alignment confirmation, branch-policy disclosure, required-tool guidance from `task verify:tools`, default-branch sync warnings, and `task triage:welcome` one-line state/nudge. The state is worktree- and HEAD-bound, and becomes stale after `plan.policy.sessionRitualStalenessHours` hours (default: 4).
@@ -52,16 +50,12 @@ Note: A true UI indicator (e.g. Warp status bar) is deferred to Phase 5. This is
 
 ⊗ Self-report the session-start ritual as complete without a fresh `task session:start` state, or bypass `task verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
 
+⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
+
 `task doctor` remains the install-integrity + toolchain + AGENTS.md managed-section freshness probe (#1308). When the managed-section is stale the doctor points the operator at `task agents:refresh` to regenerate AGENTS.md from `content/templates/agents-entry.md`. The canonical `scripts/doctor.py` (single owner post #1335/#1336) also detects payload staleness from the `<install>/VERSION` manifest and, when behind, emits the canonical upgrade command `npm i -g @deftai/directive@latest` (#1339 / #1409 / #1912). The installer itself calls `scripts/doctor.py --session --json` at the end of every run for the unified handoff.
 
 **Canonical bootstrap / update path:** Install and upgrade via npm: `npm i -g @deftai/directive` (install) or `npm i -g @deftai/directive@latest` (upgrade). Node ≥ 20 is required to run Deft (the live gates run on the TypeScript engine). On a machine without Node, install Node first, then use npm — the frozen legacy Go installer (GitHub Releases) is only a legacy/offline + layout-migration bridge (#1912), not a Node-free path. Legacy `task upgrade` / `run upgrade` are metadata-only acknowledgment (they do NOT replace the payload) and `task relocate -- --confirm` is back-compat only; git-clone / submodule / legacy doctor surfaces are de-emphasized in UPGRADING.md / README / skills. Agent example: after installing, start your session; the doctor output (or `task doctor`) tells you the exact state.
-`task triage:welcome` default mode remains non-interactive and emits the current triage-cache one-liner via the consolidated welcome surface (N3 / #1143). When state is incomplete (no `xbrief/.eval/candidates.jsonl`, no `triageScope`, no `wipCap` -- or any partial subset), an additional nudge line points the operator at `task triage:welcome --onboard` to set up or resume triage. D2's 4-hour suppression window still governs the headline; the canonical key compares structured fields from the latest `xbrief/.eval/summary-history.jsonl` record: `cache_empty`, `untriaged`, `stale_defer`, `in_flight`, `in_flight_filesystem`, `in_flight_cache_scoped`, `triage_scope_configured`, `wip_count`, `wip_cap`, `repos`, `scope_drift`, and `reconcilable` (#1279). Re-emission within the window occurs when any key field changes, including when the `[triage:scope]` discrepancy line appears or resolves. The headline `in-flight` count is **filesystem-truth** -- a live count of `xbrief/active/*.xbrief.json` files with `plan.status == "running"` (#1270). When that count diverges from the legacy audit-log-derived cache-scoped view, a second `[triage:scope]` line surfaces the gap; the wording distinguishes whether `plan.policy.triageScope[]` is explicitly configured (`outside plan.policy.triageScope[]`) or absent/empty/default (`not configured`). `task triage:summary` stays as a composable primitive for non-session-start callers (`deft-directive-sync`, scripts) -- not deprecated.
-
-## Resume nudge (conditional, #1269)
-
-Reserved placement for the optional 6th conditional step (resume nudge from the ritual sentinel) tracked by #1269. The substance lands with that PR; this anchor exists today so dispatched agents see the canonical placement once #1269 merges and the sentinel becomes available.
-
-⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
+`task triage:welcome` default mode remains non-interactive and emits the current triage-cache one-liner via the consolidated welcome surface (N3 / #1143); when triage state is incomplete it adds a nudge to `task triage:welcome --onboard`. D2's 4-hour suppression window governs re-emission: the headline re-emits only when a structured comparison-key field in the latest `xbrief/.eval/summary-history.jsonl` record changes (the canonical field set and the filesystem-truth in-flight count are owned by the `triage:welcome` implementation -- see #1279 / #1270, not enumerated here). `task triage:summary` stays as a composable primitive for non-session-start callers -- not deprecated.
 
 ## Template propagation discipline (#1309)
 
@@ -173,14 +167,7 @@ Canonical write-up + good / bad example: `CONTRIBUTING.md` `## CHANGELOG entry s
 
 ## Commands
 
-- /deft:change <name>        — Propose a scoped change
-- /deft:run:interview        — Structured spec interview
-- /deft:run:speckit          — Five-phase spec workflow (large projects)
-- /deft:run:discuss <topic>  — Feynman-style alignment
-- /deft:run:research <topic> — Research before planning
-- /deft:run:map              — Map an existing codebase
-- run bootstrap              — CLI setup (terminal users)
-- run spec                   — CLI spec generation
+Product commands use the `/deft:directive:*` namespace (#418 / #1670); the prior `/deft:*` product forms are deprecation-warning aliases, and cross-product session commands (`/deft:continue`, `/deft:checkpoint`) stay at the umbrella `/deft:*` level. The legacy Python `run` CLI is deprecated (#1933) -- use the agent-driven setup skill for first-time setup and spec generation. See `content/commands.md` for the full command + alias table and the managed `## Commands` section below for the rendered surface.
 
 ## PowerShell
 
@@ -188,7 +175,7 @@ Canonical write-up + good / bad example: `CONTRIBUTING.md` `## CHANGELOG entry s
 
 - ! On PS 5.1, MUST use Python `pathlib` for all file edits touching non-ASCII glyphs (em dashes, arrows, ⊗, ✓, …, smart quotes, etc.) -- never `Get-Content -Raw` / `Set-Content` / inline `-replace` / backtick-n interpolation
 - ! When writing files using PowerShell on PS 7+ where unavoidable, MUST use `New-Object System.Text.UTF8Encoding $false` -- never `[System.Text.Encoding]::UTF8` (writes BOM). See `content/scm/github.md` PS 5.1 section.
-- ! Personal rule `3MieNBQjwlObZM1If060iy` on the user's Warp profile encodes the same prohibition for the swarm cohort -- this AGENTS.md rule is the project-side mirror so consumer-installed copies of deft carry the rule even when the personal rule is not loaded
+- ! This AGENTS.md rule is the project-side mirror of the same prohibition maintained in the maintainer's personal agent profile, so consumer-installed copies of deft carry the rule even when that personal rule is not loaded
 - ⊗ Round-trip a file containing non-ASCII content through PS 5.1 commands (`Get-Content` → `-replace` → `Set-Content`, `Get-Content` → string concat → `WriteAllText`, here-strings interpolating non-ASCII) -- the read-side decode corrupts the bytes regardless of how the write side is encoded
 
 **Recurrence record:** four prior occurrences before the deterministic gate landed -- #236 (t1.11.1, content/scm/github.md), #240 (t1.11.2, multi-line here-string rule), #283 (t1.20.1, AGENTS.md UTF8Encoding rule), and PR #795 (2026-05-01, 132-line CHANGELOG mojibake on a maintainer with all three prose rules loaded; the read-side decode happened before any write).
@@ -325,7 +312,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `content/templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=4a455360697b refreshed=2026-07-02T02:16:47Z session=f1a7c4485a2e -->
+<!-- deft:managed-section v3 sha=7fa176f4718f refreshed=2026-07-02T13:40:18Z session=1ab0f05c9cbf -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -389,16 +376,12 @@ Check what exists before doing anything else:
 
 ⊗ Self-report the session-start ritual as complete without a fresh `deft session:start` state, or bypass `deft verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
 
+⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
+
 `deft doctor` remains the install-integrity + toolchain + AGENTS.md managed-section freshness probe (#1308). When the managed-section is stale, the doctor points the operator at `deft agents:refresh` to regenerate AGENTS.md from `templates/agents-entry.md`. The canonical `scripts/doctor.py` (single owner post #1335/#1336) also detects payload staleness from the `<install>/VERSION` manifest and, when behind, emits the canonical upgrade command `npm i -g @deftai/directive@latest` (#1339 / #1409 / #1912).
 
 **Canonical bootstrap / update path:** Install and upgrade via npm: `npm i -g @deftai/directive` (install) or `npm i -g @deftai/directive@latest` (upgrade). Node ≥ 20 is required to run Deft (the live gates run on the TypeScript engine). On a machine without Node, install Node first, then use npm — the frozen legacy Go installer (GitHub Releases) is only a legacy/offline + layout-migration bridge (#1912), not a Node-free path. Legacy `deft upgrade` / `run upgrade` are metadata-only acknowledgment and `deft relocate -- --confirm` is back-compat only; git-clone / submodule / legacy doctor surfaces are de-emphasized in UPGRADING.md / README / skills. Agent example: after installing, start your session; `deft doctor` tells you the exact state.
-`deft triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `deft triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual. D2's 4-hour suppression window governs repeat emission during session start; the canonical key compares structured fields from the latest `xbrief/.eval/summary-history.jsonl` record: `cache_empty`, `untriaged`, `stale_defer`, `in_flight`, `in_flight_filesystem`, `in_flight_cache_scoped`, `triage_scope_configured`, `wip_count`, `wip_cap`, `repos`, `scope_drift`, and `reconcilable` (#1279). Re-emission within the window occurs when any key field changes, including when the `[triage:scope]` discrepancy line appears or resolves.
-
-## Resume nudge (conditional, #1269)
-
-Reserved placement for the optional 6th conditional step (resume nudge from the ritual sentinel) tracked by #1269. The substance lands with that PR; this anchor exists today so consumers see the canonical placement once #1269 merges and the sentinel becomes available.
-
-⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
+`deft triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `deft triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual. D2's 4-hour suppression window governs repeat emission during session start: the headline re-emits only when a structured comparison-key field in the latest `xbrief/.eval/summary-history.jsonl` record changes (the canonical field set is owned by the `triage:welcome` implementation -- see #1279, not enumerated here).
 
 ## WIP cap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **One place to find the right skill.** Skill routing is now a unified Skills Index in `REFERENCES.md` that lists every skill with a one-sentence description and its trigger keywords, alongside the framework doc routing — so you scan a single Level-0 index to decide what to load instead of hunting through a table buried in `AGENTS.md`. `AGENTS.md` keeps only the "check the skills catalog before improvising" behavioral gate plus a pointer to the index, making the policy file leaner. Refs #838, #1882, #645.
 
+- **Leaner, more accurate always-loaded `AGENTS.md`.** The command reference no longer advertises retired commands as current — it now reflects the `/deft:directive:*` namespace and the deprecated `run` CLI, and points to the full alias table. Reserved placeholder sections and a verbatim internal field enumeration were dropped in favour of a one-line rule plus a pointer, and a leaked personal profile identifier was removed. The AGENTS.md size ratchet was tightened to the new, smaller line counts. Refs #2158, #2159, #2160, #2161, #1882, #645.
+
 ### Fixed
 
 ### Removed

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -62,16 +62,12 @@ Check what exists before doing anything else:
 
 ⊗ Self-report the session-start ritual as complete without a fresh `deft session:start` state, or bypass `deft verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
 
+⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
+
 `deft doctor` remains the install-integrity + toolchain + AGENTS.md managed-section freshness probe (#1308). When the managed-section is stale, the doctor points the operator at `deft agents:refresh` to regenerate AGENTS.md from `templates/agents-entry.md`. The canonical `scripts/doctor.py` (single owner post #1335/#1336) also detects payload staleness from the `<install>/VERSION` manifest and, when behind, emits the canonical upgrade command `npm i -g @deftai/directive@latest` (#1339 / #1409 / #1912).
 
 **Canonical bootstrap / update path:** Install and upgrade via npm: `npm i -g @deftai/directive` (install) or `npm i -g @deftai/directive@latest` (upgrade). Node ≥ 20 is required to run Deft (the live gates run on the TypeScript engine). On a machine without Node, install Node first, then use npm — the frozen legacy Go installer (GitHub Releases) is only a legacy/offline + layout-migration bridge (#1912), not a Node-free path. Legacy `deft upgrade` / `run upgrade` are metadata-only acknowledgment and `deft relocate -- --confirm` is back-compat only; git-clone / submodule / legacy doctor surfaces are de-emphasized in UPGRADING.md / README / skills. Agent example: after installing, start your session; `deft doctor` tells you the exact state.
-`deft triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `deft triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual. D2's 4-hour suppression window governs repeat emission during session start; the canonical key compares structured fields from the latest `xbrief/.eval/summary-history.jsonl` record: `cache_empty`, `untriaged`, `stale_defer`, `in_flight`, `in_flight_filesystem`, `in_flight_cache_scoped`, `triage_scope_configured`, `wip_count`, `wip_cap`, `repos`, `scope_drift`, and `reconcilable` (#1279). Re-emission within the window occurs when any key field changes, including when the `[triage:scope]` discrepancy line appears or resolves.
-
-## Resume nudge (conditional, #1269)
-
-Reserved placement for the optional 6th conditional step (resume nudge from the ritual sentinel) tracked by #1269. The substance lands with that PR; this anchor exists today so consumers see the canonical placement once #1269 merges and the sentinel becomes available.
-
-⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
+`deft triage:welcome` emits the triage one-liner and, when state is incomplete, nudges the operator at `deft triage:welcome --onboard` (#1143). Default mode is non-interactive; the `--onboard` flag runs the 6-phase interactive ritual. D2's 4-hour suppression window governs repeat emission during session start: the headline re-emits only when a structured comparison-key field in the latest `xbrief/.eval/summary-history.jsonl` record changes (the canonical field set is owned by the `triage:welcome` implementation -- see #1279, not enumerated here).
 
 ## WIP cap
 

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16782,8 +16782,8 @@
       },
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
-        "managedMaxLines": 211,
-        "unmanagedMaxLines": 327
+        "managedMaxLines": 207,
+        "unmanagedMaxLines": 314
       }
     },
     "updated": "2026-06-12T20:26:00Z"

--- a/xbrief/completed/2026-07-02-2158-2161-agents-md-quick-wins.xbrief.json
+++ b/xbrief/completed/2026-07-02-2158-2161-agents-md-quick-wins.xbrief.json
@@ -1,0 +1,105 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF batching four independent AGENTS.md quick-wins (#2158 Commands drift, #2159 personal-rule-ID leak, #2160 reserved placeholders, #2161 inlined field-list) into one PR; child of the #1882 map-not-manual umbrella. Batched because all four are small edits to the same hot files (AGENTS.md + content/templates/agents-entry.md + the #645 ratchet), so serializing into one PR avoids self-conflict.",
+    "created": "2026-07-02T00:00:00Z",
+    "updated": "2026-07-02T00:00:00Z"
+  },
+  "plan": {
+    "id": "2158-2161-agents-md-quick-wins",
+    "title": "AGENTS.md quick-wins batch: Commands drift + personal-rule leak + reserved placeholders + inlined field-list",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2158",
+    "narratives": {
+      "Description": "Four independent legibility/correctness fixes to the always-loaded AGENTS.md surface, batched into one PR because they all edit the same files and the #645 ratchet. (1) #2158: the maintainer-authored '## Commands' section still advertises deprecated command forms (/deft:change, /deft:run:*, run bootstrap, run spec) as current, drifted from its own managed section which already documents the /deft:directive:* namespace (#418/#1670) and the deprecated run CLI (#1933) -- update the maintainer Commands section to match the current surface (or reduce it to a pointer). (2) #2159: remove the hardcoded personal Warp-profile rule ID (3MieNBQjwlObZM1If060iy) from the shared PowerShell section -- keep the 'project-side mirror' intent without the opaque personal identifier. (3) #2160: drop the reserved placeholder sections (the '## Resume nudge (conditional, #1269)' anticipatory anchor and the 'Note: A true UI indicator ... deferred to Phase 5' line) from BOTH halves and the template -- they consume always-loaded budget for rules that do not exist yet. (4) #2161: compress the inlined triage:welcome summary-history field enumeration (~15 field names, #1279) in the Session-start ritual paragraph to a one-line behavioral rule + a pointer to the owning doc, in BOTH halves and the template. Because #2160 and #2161 reduce lines, this PR MUST lower the #645 ratchet (plan.policy.agentsMdBudget) to the new per-region counts after `task agents:refresh`.",
+      "ImplementationPlan": "1. #2158: rewrite the maintainer '## Commands' section in AGENTS.md so it matches the managed section (/deft:directive:* namespace; run CLI deprecated) or reduce it to a pointer to content/commands.md -- no deprecated form presented as current. 2. #2159: in the maintainer '## PowerShell' section, remove the personal Warp-profile rule ID reference; restate the mirror intent generically. 3. #2160: remove the '## Resume nudge (conditional, #1269)' reserved section and the Phase 5 UI-indicator deferral note from AGENTS.md (both maintainer half and, if mirrored, the managed section) AND from content/templates/agents-entry.md. 4. #2161: replace the verbatim summary-history field enumeration in the Session-start ritual with a one-line rule + pointer, in AGENTS.md and content/templates/agents-entry.md. 5. Run `task agents:refresh` so the rendered managed section inherits the template edits (#1309 propagation). 6. Update tests/content/test_agents_entry_contract.py curated marker list if any removed text was a marker. 7. Recompute managed vs unmanaged AGENTS.md line counts after refresh and LOWER plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines} in xbrief/PROJECT-DEFINITION.xbrief.json to the new counts. 8. Add a CHANGELOG [Unreleased] entry (user-visible: leaner, correct session-start guidance). Run `task check` green (includes verify:agents-md-budget, agents-entry contract, verify:encoding).",
+      "UserStory": "As an agent reading AGENTS.md every session, I want the always-loaded policy file to be correct (current command surface) and free of placeholder/reference-detail bloat, so that session-start orientation is accurate and the context budget is spent on real rules.",
+      "Traces": "#2158, #2159, #2160, #2161, #1882, #645, #2157"
+    },
+    "items": [
+      {
+        "id": "qw-a1",
+        "title": "Maintainer Commands section matches current surface (#2158)",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given AGENTS.md, when the maintainer '## Commands' section is read, then it no longer presents /deft:change, /deft:run:*, run bootstrap, or run spec as the current surface -- it agrees with the managed section (/deft:directive:* + run deprecated) or points at the single source."
+        }
+      },
+      {
+        "id": "qw-a2",
+        "title": "No personal Warp-profile rule ID in AGENTS.md/template (#2159)",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given AGENTS.md and the template, when the PowerShell section is read, then no personal Warp-profile rule ID appears; the PS 5.1 non-ASCII rule itself is unchanged and verify:encoding still passes."
+        }
+      },
+      {
+        "id": "qw-a3",
+        "title": "Reserved placeholders removed from always-loaded surface (#2160)",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given AGENTS.md and content/templates/agents-entry.md, when read, then the '## Resume nudge (#1269)' reserved anchor and the Phase 5 UI-indicator note are absent; `task agents:refresh` regenerates the managed section and the agents-entry contract test passes."
+        }
+      },
+      {
+        "id": "qw-a4",
+        "title": "Inlined triage:welcome field enumeration compressed to a pointer (#2161)",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the Session-start ritual section in both halves + the template, when read, then the verbatim summary-history.jsonl field enumeration is replaced by a one-line rule + pointer; the actionable 'run task session:start' rule is preserved."
+        }
+      },
+      {
+        "id": "qw-a5",
+        "title": "#645 ratchet lowered; task check green",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the smaller AGENTS.md after refresh, when the PR lands, then plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines} is lowered to the new counts and `task check` (verify:agents-md-budget, agents-entry contract, verify:encoding, full suite) passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1882",
+        "child_issue": "#2158"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": false,
+        "file_scope": [
+          "AGENTS.md",
+          "content/templates/agents-entry.md",
+          "xbrief/PROJECT-DEFINITION.xbrief.json",
+          "tests/content/test_agents_entry_contract.py",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task check"
+        ],
+        "expected_outputs": [
+          "Maintainer Commands section de-drifted; personal rule ID removed; reserved placeholders + inlined field-list removed from always-loaded surface; managed section refreshed; #645 ratchet lowered"
+        ],
+        "depends_on": [],
+        "conflict_group": "agents-md-legibility",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "high"
+      },
+      "completedAt": "2026-07-02T13:42:40Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2158",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2158: maintainer Commands drift"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1882",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1882: AGENTS.md map-not-manual umbrella"
+      }
+    ],
+    "updated": "2026-07-02T13:42:40Z"
+  }
+}

--- a/xbrief/completed/2026-07-02-2158-2161-agents-md-quick-wins.xbrief.json
+++ b/xbrief/completed/2026-07-02-2158-2161-agents-md-quick-wins.xbrief.json
@@ -3,7 +3,7 @@
     "version": "0.6",
     "description": "Story vBRIEF batching four independent AGENTS.md quick-wins (#2158 Commands drift, #2159 personal-rule-ID leak, #2160 reserved placeholders, #2161 inlined field-list) into one PR; child of the #1882 map-not-manual umbrella. Batched because all four are small edits to the same hot files (AGENTS.md + content/templates/agents-entry.md + the #645 ratchet), so serializing into one PR avoids self-conflict.",
     "created": "2026-07-02T00:00:00Z",
-    "updated": "2026-07-02T00:00:00Z"
+    "updated": "2026-07-02T13:42:40Z"
   },
   "plan": {
     "id": "2158-2161-agents-md-quick-wins",
@@ -20,7 +20,7 @@
       {
         "id": "qw-a1",
         "title": "Maintainer Commands section matches current surface (#2158)",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given AGENTS.md, when the maintainer '## Commands' section is read, then it no longer presents /deft:change, /deft:run:*, run bootstrap, or run spec as the current surface -- it agrees with the managed section (/deft:directive:* + run deprecated) or points at the single source."
         }
@@ -28,7 +28,7 @@
       {
         "id": "qw-a2",
         "title": "No personal Warp-profile rule ID in AGENTS.md/template (#2159)",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given AGENTS.md and the template, when the PowerShell section is read, then no personal Warp-profile rule ID appears; the PS 5.1 non-ASCII rule itself is unchanged and verify:encoding still passes."
         }
@@ -36,7 +36,7 @@
       {
         "id": "qw-a3",
         "title": "Reserved placeholders removed from always-loaded surface (#2160)",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given AGENTS.md and content/templates/agents-entry.md, when read, then the '## Resume nudge (#1269)' reserved anchor and the Phase 5 UI-indicator note are absent; `task agents:refresh` regenerates the managed section and the agents-entry contract test passes."
         }
@@ -44,7 +44,7 @@
       {
         "id": "qw-a4",
         "title": "Inlined triage:welcome field enumeration compressed to a pointer (#2161)",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the Session-start ritual section in both halves + the template, when read, then the verbatim summary-history.jsonl field enumeration is replaced by a one-line rule + pointer; the actionable 'run task session:start' rule is preserved."
         }
@@ -52,7 +52,7 @@
       {
         "id": "qw-a5",
         "title": "#645 ratchet lowered; task check green",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the smaller AGENTS.md after refresh, when the PR lands, then plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines} is lowered to the new counts and `task check` (verify:agents-md-budget, agents-entry contract, verify:encoding, full suite) passes."
         }


### PR DESCRIPTION
## Summary

Batch of four small legibility/correctness fixes to the always-loaded `AGENTS.md` surface (child of the #1882 "AGENTS.md is a map, not a manual" umbrella). All four touch the same hot files, so they are serialized into one PR to avoid self-conflict.

- **#2158** — the maintainer-authored `## Commands` section had drifted: it listed retired `/deft:change`, `/deft:run:*`, `run bootstrap`, and `run spec` forms as the current surface. Replaced with a concise pointer that reflects the `/deft:directive:*` namespace (#418/#1670), the deprecated `run` CLI (#1933), and `content/commands.md`.
- **#2159** — removed the hardcoded personal Warp-profile rule ID from the shared PowerShell section; the "project-side mirror" intent is preserved, stated generically.
- **#2160** — dropped the reserved `## Resume nudge (#1269)` placeholder anchor and the Phase 5 UI-indicator deferral note from both AGENTS.md halves and the template. The genuine ritual-tier-ordering rule that lived under that heading was preserved by relocating it into the Session-start ritual section.
- **#2161** — compressed the verbatim ~15-field `summary-history.jsonl` enumeration in the Session-start ritual paragraph to a one-line behavioral rule plus a pointer to the owning implementation, in both halves and the template.

The managed section was regenerated via `agents:refresh` (#1309 propagation) and the #645 `agentsMdBudget` ratchet was tightened to the new, smaller counts (managed 211→207, unmanaged 327→314). `task check` is green.

## Related Issues

Closes #2158
Closes #2159
Closes #2160
Closes #2161
Refs #1882, #2157, #645

## Checklist

- [x] `/deft:change <name>` — N/A (scoped xBRIEF created + activated via the swarm-cohort lifecycle; batching operator-approved under #1882 Wave-3)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [ ] `ROADMAP.md` — N/A (batch-moved at release time per repo convention)
- [x] Tests pass locally (`task check` green)

## Post-Merge

- [ ] **Verify issue auto-close**: confirm #2158/#2159/#2160/#2161 closed after squash merge; close manually if auto-close did not trigger (#167).
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57).
