### PR TITLE
fix(adoption): migrate:xbrief patches stale vbrief paths in AGENTS.md unmanaged header (#2154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`migrate:xbrief` now fixes stale `vbrief/` paths in your AGENTS.md header, not just the managed section (#2154).** Previously a crossover migration renamed the lifecycle tree and refreshed the managed Deft section but left the hand-maintained header pointing at the old `vbrief/` layout (`Session orientation`, `Lifecycle` examples, `test-single.vbrief.json`), so agents read the wrong paths every session while `deft doctor` still reported healthy. `migrate:xbrief` now rewrites the known crossover tokens (`vbrief/` → `xbrief/`, `*.vbrief.json` → `*.xbrief.json`, `vbrief:preflight` → `xbrief:preflight`) in the unmanaged header — idempotently and without touching the managed section — and prints a summary of what changed. `deft doctor` also gained a signpost that warns when an `xbrief/` tree still has a legacy header. Refs #2154, #2034, #2065, #1882.
+
 ### Removed
 
 ## [0.66.2] - 2026-07-01

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -56,6 +56,15 @@ deft migrate:xbrief
 
 (or `task migrate:xbrief` from a maintainer checkout). The command requires a clean working tree unless you pass `--force`. Legacy `vbrief/` paths and `x-vbrief/` tokens remain **read-accepted** until this migration runs; `deft update` may signpost the same guidance on non-patch upgrades.
 
+### AGENTS.md: managed vs unmanaged header (#2154)
+
+`migrate:xbrief` touches your `AGENTS.md` in two distinct regions:
+
+- **Managed section** (between the `<!-- deft:managed-section ... -->` / `<!-- /deft:managed-section -->` markers): regenerated wholesale by `agents:refresh`, so it always reflects the current framework layout. This region is rendered from the framework template — do not hand-edit it.
+- **Unmanaged header/tail** (everything outside those markers — your project-specific `Session orientation`, `Lifecycle` examples, `Local dev` notes): preserved verbatim across upgrades so your consumer notes survive. Because it is preserved, a rename migration would otherwise leave stale `vbrief/` path literals here. `migrate:xbrief` now applies a **bounded, idempotent** rewrite over the unmanaged region only, replacing the known crossover tokens (`vbrief/` → `xbrief/`, `*.vbrief.json` → `*.xbrief.json`, `vbrief:preflight` → `xbrief:preflight`) while leaving freeform prose untouched. It prints a summary of the replacements.
+
+If you upgraded before this fix landed and your header still points at `vbrief/`, `deft doctor` now emits an `AGENTS.md header drift:` signpost. Re-run `deft migrate:xbrief` (idempotent) to patch the header, or hand-edit the offending path literals.
+
 ## Public contract layer — `@deftai/directive-types` (#1799)
 
 Downstream TypeScript projects can import the canonical xBRIEF/policy contract instead of hand-mirroring JSON shapes:

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -189,6 +189,45 @@ describe("doctor CLI", () => {
     expect(out).toContain("migrate:xbrief");
   });
 
+  it("signposts a half-migrated AGENTS.md header (xbrief tree + vbrief header) (#2154)", () => {
+    const root = makeRoot("doctor-header-drift-");
+    for (const folder of LIFECYCLE_FOLDERS) {
+      mkdirSync(join(root, "xbrief", folder), { recursive: true });
+    }
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      [
+        "# Consumer",
+        "## Lifecycle",
+        "- `task vbrief:preflight -- vbrief/active/foo.vbrief.json`",
+        "",
+        "<!-- deft:managed-section v3 -->",
+        "managed body",
+        "<!-- /deft:managed-section -->",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("AGENTS.md header drift:");
+    expect(out).toContain("migrate:xbrief");
+    expect(out).toContain("vbrief/");
+  });
+
+  it("reports no AGENTS.md header drift for a clean xbrief header (#2154)", () => {
+    const root = makeRoot("doctor-header-clean-");
+    for (const folder of LIFECYCLE_FOLDERS) {
+      mkdirSync(join(root, "xbrief", folder), { recursive: true });
+    }
+    writeFileSync(join(root, "AGENTS.md"), "# Consumer\nAll on xbrief/ now.\n", "utf8");
+    const out = captureStdout(() => {
+      run(["--project-root", root]);
+    });
+    expect(out).toContain("AGENTS.md header drift: none");
+  });
+
   it("reports clean deposit hygiene when .deft/core has no packages/ (#2142)", () => {
     const root = makeRoot("doctor-deposit-clean-");
     makeLifecycleDirs(root);

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -5,7 +5,10 @@ import { fileURLToPath } from "node:url";
 import { parseDoctorFlags } from "@deftai/directive-core/dist/doctor/flags.js";
 import { cmdDoctor } from "@deftai/directive-core/dist/doctor/main.js";
 import { renderPrecutoverLine } from "@deftai/directive-core/dist/vbrief-validate/precutover.js";
-import { renderXbriefMigrationLine } from "@deftai/directive-core/xbrief-migrate";
+import {
+  renderStaleHeaderLine,
+  renderXbriefMigrationLine,
+} from "@deftai/directive-core/xbrief-migrate";
 
 /** Advisory when a consumer deposit carries git-vendored framework source (#2142). */
 export function renderStrayPackagesAdvisoryLine(projectRoot: string): string {
@@ -30,6 +33,7 @@ export function run(argv: string[]): number {
     const projectRoot = flags.projectRoot ?? process.cwd();
     process.stdout.write(`${renderPrecutoverLine(projectRoot)}\n`);
     process.stdout.write(`${renderXbriefMigrationLine(projectRoot)}\n`);
+    process.stdout.write(`${renderStaleHeaderLine(projectRoot)}\n`);
     process.stdout.write(`${renderStrayPackagesAdvisoryLine(projectRoot)}\n`);
   }
   return cmdDoctor(argv);

--- a/packages/core/src/xbrief-migrate/agents-header.test.ts
+++ b/packages/core/src/xbrief-migrate/agents-header.test.ts
@@ -1,0 +1,221 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  detectStaleUnmanagedHeader,
+  patchAgentsMdHeader,
+  renderHeaderPatchSummary,
+  renderStaleHeaderLine,
+  rewriteUnmanagedHeaderTokens,
+} from "./agents-header.js";
+import { MIGRATED_ARTIFACT_DIR } from "./constants.js";
+
+const MANAGED_BLOCK = [
+  "<!-- deft:managed-section v3 sha=abc123 refreshed=2026-07-02T00:00:00Z session=deadbeef -->",
+  "# Deft — AI Development Framework",
+  "Managed body deliberately mentions vbrief/active/x.vbrief.json and vbrief:preflight.",
+  "<!-- /deft:managed-section -->",
+].join("\n");
+
+const STALE_HEADER = [
+  "# Cartograph",
+  "",
+  "## Session orientation",
+  "Scoped work items live in `vbrief/`.",
+  "",
+  "## Local dev",
+  "Run the `test-single.vbrief.json` fixture.",
+  "",
+  "## Lifecycle",
+  "- `task scope:promote -- vbrief/proposed/foo.vbrief.json`",
+  "- `task vbrief:preflight -- vbrief/active/foo.vbrief.json`",
+  "",
+  MANAGED_BLOCK,
+  "",
+  "## Notes",
+  "Archive lives under vbrief/completed/.",
+  "",
+].join("\n");
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("rewriteUnmanagedHeaderTokens", () => {
+  it("rewrites legacy tokens in the unmanaged header and preserves the managed section verbatim", () => {
+    const result = rewriteUnmanagedHeaderTokens(STALE_HEADER);
+    expect(result.changed).toBe(true);
+
+    // Unmanaged header now references xbrief.
+    expect(result.content).toContain("Scoped work items live in `xbrief/`.");
+    expect(result.content).toContain("`test-single.xbrief.json`");
+    expect(result.content).toContain("scope:promote -- xbrief/proposed/foo.xbrief.json");
+    expect(result.content).toContain("xbrief:preflight -- xbrief/active/foo.xbrief.json");
+    expect(result.content).toContain("Archive lives under xbrief/completed/.");
+
+    // Managed block is byte-for-byte intact — its legacy tokens survive.
+    expect(result.content).toContain(MANAGED_BLOCK);
+    expect(result.content).toContain(
+      "Managed body deliberately mentions vbrief/active/x.vbrief.json and vbrief:preflight.",
+    );
+  });
+
+  it("reports per-token replacement counts", () => {
+    const result = rewriteUnmanagedHeaderTokens(STALE_HEADER);
+    const byToken = new Map(result.replacements.map((r) => [r.legacy, r.count]));
+    // vbrief/ appears in header lines: proposed/, active/, `vbrief/`, completed/ (4).
+    expect(byToken.get("vbrief/")).toBe(4);
+    // .vbrief.json appears in test-single, proposed/foo, active/foo (3).
+    expect(byToken.get(".vbrief.json")).toBe(3);
+    expect(byToken.get("vbrief:preflight")).toBe(1);
+  });
+
+  it("is idempotent — a second pass is a no-op", () => {
+    const first = rewriteUnmanagedHeaderTokens(STALE_HEADER);
+    const second = rewriteUnmanagedHeaderTokens(first.content);
+    expect(second.changed).toBe(false);
+    expect(second.replacements).toHaveLength(0);
+    expect(second.content).toBe(first.content);
+  });
+
+  it("rewrites the whole document when there is no managed section", () => {
+    const plain = "See vbrief/active/story.vbrief.json and run vbrief:preflight.\n";
+    const result = rewriteUnmanagedHeaderTokens(plain);
+    expect(result.content).toBe("See xbrief/active/story.xbrief.json and run xbrief:preflight.\n");
+    expect(result.changed).toBe(true);
+  });
+
+  it("preserves CRLF line endings and leaves clean content unchanged", () => {
+    const crlf = "line one on xbrief/\r\nline two\r\n";
+    const result = rewriteUnmanagedHeaderTokens(crlf);
+    expect(result.changed).toBe(false);
+    expect(result.content).toBe(crlf);
+  });
+});
+
+describe("patchAgentsMdHeader", () => {
+  it("patches an on-disk AGENTS.md and reports patched", () => {
+    const root = mkdtempSync(join(tmpdir(), "header-patch-"));
+    temps.push(root);
+    writeFileSync(join(root, "AGENTS.md"), STALE_HEADER, "utf8");
+
+    const outcome = patchAgentsMdHeader(root);
+    expect(outcome.kind).toBe("patched");
+    const written = readFileSync(join(root, "AGENTS.md"), "utf8");
+    expect(written).toContain("Scoped work items live in `xbrief/`.");
+    expect(written).toContain(MANAGED_BLOCK);
+  });
+
+  it("returns clean when the header has no legacy tokens", () => {
+    const root = mkdtempSync(join(tmpdir(), "header-clean-"));
+    temps.push(root);
+    writeFileSync(join(root, "AGENTS.md"), "# Clean\nAll xbrief/ here.\n", "utf8");
+    const outcome = patchAgentsMdHeader(root);
+    expect(outcome.kind).toBe("clean");
+    expect(outcome.replacements).toHaveLength(0);
+  });
+
+  it("returns absent when AGENTS.md does not exist", () => {
+    const root = mkdtempSync(join(tmpdir(), "header-absent-"));
+    temps.push(root);
+    const outcome = patchAgentsMdHeader(root);
+    expect(outcome.kind).toBe("absent");
+  });
+
+  it("honours read/write seams without touching disk", () => {
+    let written: string | null = null;
+    const outcome = patchAgentsMdHeader("/nowhere", {
+      readText: () => "run vbrief:preflight -- vbrief/active/x.vbrief.json\n",
+      writeText: (_path, text) => {
+        written = text;
+      },
+    });
+    expect(outcome.kind).toBe("patched");
+    expect(written).toBe("run xbrief:preflight -- xbrief/active/x.xbrief.json\n");
+  });
+});
+
+describe("renderHeaderPatchSummary", () => {
+  it("summarises a patched outcome with per-token detail", () => {
+    const outcome = patchAgentsMdHeader("/nowhere", {
+      readText: () => STALE_HEADER,
+      writeText: () => {},
+    });
+    const summary = renderHeaderPatchSummary(outcome);
+    expect(summary).toContain("rewrote 8 legacy vbrief token(s)");
+    expect(summary).toContain("vbrief/ ×4");
+    expect(summary).toContain("vbrief:preflight ×1");
+  });
+
+  it("summarises clean and absent outcomes", () => {
+    expect(
+      renderHeaderPatchSummary({ kind: "clean", path: "AGENTS.md", replacements: [] }),
+    ).toContain("no legacy vbrief tokens found");
+    expect(
+      renderHeaderPatchSummary({ kind: "absent", path: "AGENTS.md", replacements: [] }),
+    ).toContain("no AGENTS.md present");
+  });
+});
+
+describe("detectStaleUnmanagedHeader", () => {
+  function scaffold(withXbrief: boolean, agents: string | null): string {
+    const root = mkdtempSync(join(tmpdir(), "header-detect-"));
+    temps.push(root);
+    if (withXbrief) {
+      mkdirSync(join(root, MIGRATED_ARTIFACT_DIR, "active"), { recursive: true });
+    }
+    if (agents !== null) {
+      writeFileSync(join(root, "AGENTS.md"), agents, "utf8");
+    }
+    return root;
+  }
+
+  it("flags xbrief tree + stale unmanaged header", () => {
+    const root = scaffold(true, STALE_HEADER);
+    const detection = detectStaleUnmanagedHeader(root);
+    expect(detection.stale).toBe(true);
+    expect(detection.matches).toContain("vbrief/");
+    expect(detection.matches).toContain("vbrief:preflight");
+  });
+
+  it("does NOT flag legacy tokens that live only in the managed section", () => {
+    const managedOnly = ["# Clean header on xbrief/", "", MANAGED_BLOCK, ""].join("\n");
+    const root = scaffold(true, managedOnly);
+    expect(detectStaleUnmanagedHeader(root).stale).toBe(false);
+  });
+
+  it("does NOT flag when there is no xbrief tree yet", () => {
+    const root = scaffold(false, STALE_HEADER);
+    expect(detectStaleUnmanagedHeader(root).stale).toBe(false);
+  });
+
+  it("does NOT flag when AGENTS.md is absent", () => {
+    const root = scaffold(true, null);
+    expect(detectStaleUnmanagedHeader(root).stale).toBe(false);
+  });
+});
+
+describe("renderStaleHeaderLine", () => {
+  it("returns a clean line when no drift is present", () => {
+    const root = mkdtempSync(join(tmpdir(), "header-line-clean-"));
+    temps.push(root);
+    mkdirSync(join(root, MIGRATED_ARTIFACT_DIR), { recursive: true });
+    writeFileSync(join(root, "AGENTS.md"), "# Clean xbrief/ header\n", "utf8");
+    expect(renderStaleHeaderLine(root)).toContain("AGENTS.md header drift: none");
+  });
+
+  it("signposts the drift with remediation guidance", () => {
+    const root = mkdtempSync(join(tmpdir(), "header-line-stale-"));
+    temps.push(root);
+    mkdirSync(join(root, MIGRATED_ARTIFACT_DIR), { recursive: true });
+    writeFileSync(join(root, "AGENTS.md"), STALE_HEADER, "utf8");
+    const line = renderStaleHeaderLine(root);
+    expect(line).toContain("still");
+    expect(line).toContain("migrate:xbrief");
+    expect(line).toContain("vbrief/");
+  });
+});

--- a/packages/core/src/xbrief-migrate/agents-header.test.ts
+++ b/packages/core/src/xbrief-migrate/agents-header.test.ts
@@ -137,6 +137,19 @@ describe("patchAgentsMdHeader", () => {
     expect(outcome.kind).toBe("patched");
     expect(written).toBe("run xbrief:preflight -- xbrief/active/x.xbrief.json\n");
   });
+
+  it("captures a write failure as a non-fatal `failed` outcome instead of throwing", () => {
+    const outcome = patchAgentsMdHeader("/nowhere", {
+      readText: () => "run vbrief:preflight -- vbrief/active/x.vbrief.json\n",
+      writeText: () => {
+        throw new Error("EACCES: read-only AGENTS.md");
+      },
+    });
+    expect(outcome.kind).toBe("failed");
+    expect(outcome.error).toContain("EACCES");
+    expect(renderHeaderPatchSummary(outcome)).toContain("patch failed");
+    expect(renderHeaderPatchSummary(outcome)).toContain("migrate:xbrief");
+  });
 });
 
 describe("renderHeaderPatchSummary", () => {
@@ -217,5 +230,18 @@ describe("renderStaleHeaderLine", () => {
     expect(line).toContain("still");
     expect(line).toContain("migrate:xbrief");
     expect(line).toContain("vbrief/");
+  });
+
+  it("accepts an injected readText seam (no disk I/O for the AGENTS.md read)", () => {
+    const root = mkdtempSync(join(tmpdir(), "header-line-seam-"));
+    temps.push(root);
+    mkdirSync(join(root, MIGRATED_ARTIFACT_DIR), { recursive: true });
+    // No AGENTS.md on disk — the seam supplies a stale header in memory.
+    const line = renderStaleHeaderLine(
+      root,
+      () => "run vbrief:preflight -- vbrief/active/x.vbrief.json\n",
+    );
+    expect(line).toContain("migrate:xbrief");
+    expect(line).toContain("vbrief:preflight");
   });
 });

--- a/packages/core/src/xbrief-migrate/agents-header.ts
+++ b/packages/core/src/xbrief-migrate/agents-header.ts
@@ -1,7 +1,8 @@
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { iterManagedSections } from "../platform/agents-md.js";
 import { MIGRATED_ARTIFACT_DIR } from "./constants.js";
+import { isDirectory } from "./fs-helpers.js";
 
 /**
  * Bounded, ordered set of legacy crossover tokens rewritten in the UNMANAGED
@@ -94,15 +95,20 @@ export function rewriteUnmanagedHeaderTokens(content: string): HeaderRewriteResu
 }
 
 export interface HeaderPatchOutcome {
-  readonly kind: "patched" | "clean" | "absent";
+  readonly kind: "patched" | "clean" | "absent" | "failed";
   readonly path: string;
   readonly replacements: HeaderTokenReplacement[];
+  readonly error?: string;
 }
 
 /**
  * Read AGENTS.md at `projectRoot`, rewrite legacy tokens in the unmanaged
  * header, and write the result back only when something changed. Returns a
  * structured outcome so the caller can log a LEGACY-REPORT-style summary.
+ *
+ * Non-fatal: a write failure (read-only file, full disk) is captured as a
+ * `failed` outcome rather than thrown, so a post-migration header patch can
+ * never crash a migration that already succeeded.
  */
 export function patchAgentsMdHeader(
   projectRoot: string,
@@ -135,7 +141,16 @@ export function patchAgentsMdHeader(
     return { kind: "clean", path: agentsPath, replacements: [] };
   }
 
-  writeText(agentsPath, result.content);
+  try {
+    writeText(agentsPath, result.content);
+  } catch (err) {
+    return {
+      kind: "failed",
+      path: agentsPath,
+      replacements: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
   return { kind: "patched", path: agentsPath, replacements: result.replacements };
 }
 
@@ -147,17 +162,15 @@ export function renderHeaderPatchSummary(outcome: HeaderPatchOutcome): string {
   if (outcome.kind === "clean") {
     return "AGENTS.md unmanaged header: no legacy vbrief tokens found — nothing to patch.";
   }
+  if (outcome.kind === "failed") {
+    return (
+      `AGENTS.md unmanaged header: patch failed (${outcome.error ?? "unknown error"}) — ` +
+      "re-run `deft migrate:xbrief` (idempotent) or hand-edit the header."
+    );
+  }
   const total = outcome.replacements.reduce((sum, r) => sum + r.count, 0);
   const detail = outcome.replacements.map((r) => `${r.legacy} ×${r.count}`).join(", ");
   return `AGENTS.md unmanaged header: rewrote ${total} legacy vbrief token(s) -> xbrief (${detail}).`;
-}
-
-function isDirectory(path: string): boolean {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
-  }
 }
 
 export interface StaleHeaderDetection {
@@ -207,8 +220,11 @@ export function detectStaleUnmanagedHeader(
 }
 
 /** One-line doctor / ritual signpost for the #2154 stale-header regression. */
-export function renderStaleHeaderLine(projectRoot: string): string {
-  const { stale, matches } = detectStaleUnmanagedHeader(projectRoot);
+export function renderStaleHeaderLine(
+  projectRoot: string,
+  readText?: (path: string) => string | null,
+): string {
+  const { stale, matches } = detectStaleUnmanagedHeader(projectRoot, readText);
   if (!stale) {
     return "AGENTS.md header drift: none -- unmanaged header has no legacy vbrief path literals.";
   }

--- a/packages/core/src/xbrief-migrate/agents-header.ts
+++ b/packages/core/src/xbrief-migrate/agents-header.ts
@@ -1,0 +1,220 @@
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { iterManagedSections } from "../platform/agents-md.js";
+import { MIGRATED_ARTIFACT_DIR } from "./constants.js";
+
+/**
+ * Bounded, ordered set of legacy crossover tokens rewritten in the UNMANAGED
+ * region of a consumer AGENTS.md after `migrate:xbrief` (#2154 / Option A).
+ *
+ * Each entry is a mechanical path / verb literal — NOT freeform prose. The
+ * casing-only `vBRIEF format` product-description token from the issue table is
+ * intentionally excluded so freeform prose survives untouched. The tokens are
+ * disjoint substrings (`.vbrief.json` has no trailing slash, `vbrief:preflight`
+ * uses a colon, `vbrief/` requires a slash), so replacement order does not
+ * change the result and a second pass is a guaranteed no-op (idempotent).
+ */
+export const LEGACY_HEADER_TOKENS: ReadonlyArray<{
+  readonly legacy: string;
+  readonly migrated: string;
+}> = [
+  { legacy: ".vbrief.json", migrated: ".xbrief.json" },
+  { legacy: "vbrief:preflight", migrated: "xbrief:preflight" },
+  { legacy: "vbrief/", migrated: "xbrief/" },
+];
+
+export interface HeaderTokenReplacement {
+  readonly legacy: string;
+  readonly migrated: string;
+  readonly count: number;
+}
+
+export interface HeaderRewriteResult {
+  readonly content: string;
+  readonly changed: boolean;
+  readonly replacements: HeaderTokenReplacement[];
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+/** Rewrite the bounded legacy tokens inside a single unmanaged text slice. */
+function rewriteSlice(slice: string, tally: Map<string, number>): string {
+  let next = slice;
+  for (const { legacy, migrated } of LEGACY_HEADER_TOKENS) {
+    const occurrences = countOccurrences(next, legacy);
+    if (occurrences === 0) continue;
+    tally.set(legacy, (tally.get(legacy) ?? 0) + occurrences);
+    next = next.replaceAll(legacy, migrated);
+  }
+  return next;
+}
+
+/**
+ * Rewrite known legacy `vbrief` crossover tokens in the UNMANAGED region(s) of
+ * an AGENTS.md document, leaving every `<!-- deft:managed-section ... -->` block
+ * byte-for-byte intact. Idempotent: running on already-migrated content is a
+ * no-op. Managed sections are located by literal markers on the raw text so no
+ * line-ending normalisation is performed (UTF-8 / CRLF safe).
+ */
+export function rewriteUnmanagedHeaderTokens(content: string): HeaderRewriteResult {
+  const managed = iterManagedSections(content);
+  const tally = new Map<string, number>();
+
+  let out = "";
+  let cursor = 0;
+  for (const [start, end] of managed) {
+    // Unmanaged slice before this managed block: eligible for rewrite.
+    out += rewriteSlice(content.slice(cursor, start), tally);
+    // Managed block: preserved verbatim.
+    out += content.slice(start, end);
+    cursor = end;
+  }
+  // Trailing unmanaged slice after the last managed block (or the whole file
+  // when there is no managed section at all).
+  out += rewriteSlice(content.slice(cursor), tally);
+
+  const replacements: HeaderTokenReplacement[] = LEGACY_HEADER_TOKENS.filter((t) =>
+    tally.has(t.legacy),
+  ).map((t) => ({
+    legacy: t.legacy,
+    migrated: t.migrated,
+    count: tally.get(t.legacy) ?? 0,
+  }));
+
+  return { content: out, changed: out !== content, replacements };
+}
+
+export interface HeaderPatchOutcome {
+  readonly kind: "patched" | "clean" | "absent";
+  readonly path: string;
+  readonly replacements: HeaderTokenReplacement[];
+}
+
+/**
+ * Read AGENTS.md at `projectRoot`, rewrite legacy tokens in the unmanaged
+ * header, and write the result back only when something changed. Returns a
+ * structured outcome so the caller can log a LEGACY-REPORT-style summary.
+ */
+export function patchAgentsMdHeader(
+  projectRoot: string,
+  seams: {
+    readText?: (path: string) => string | null;
+    writeText?: (path: string, text: string) => void;
+  } = {},
+): HeaderPatchOutcome {
+  const agentsPath = join(projectRoot, "AGENTS.md");
+  const readText =
+    seams.readText ??
+    ((path: string) => {
+      try {
+        if (!existsSync(path)) return null;
+        return readFileSync(path, "utf8");
+      } catch {
+        return null;
+      }
+    });
+  const writeText =
+    seams.writeText ?? ((path: string, text: string) => writeFileSync(path, text, "utf8"));
+
+  const existing = readText(agentsPath);
+  if (existing === null) {
+    return { kind: "absent", path: agentsPath, replacements: [] };
+  }
+
+  const result = rewriteUnmanagedHeaderTokens(existing);
+  if (!result.changed) {
+    return { kind: "clean", path: agentsPath, replacements: [] };
+  }
+
+  writeText(agentsPath, result.content);
+  return { kind: "patched", path: agentsPath, replacements: result.replacements };
+}
+
+/** Human-readable one-line summary of a header patch outcome (LEGACY-REPORT style). */
+export function renderHeaderPatchSummary(outcome: HeaderPatchOutcome): string {
+  if (outcome.kind === "absent") {
+    return "AGENTS.md unmanaged header: no AGENTS.md present — nothing to patch.";
+  }
+  if (outcome.kind === "clean") {
+    return "AGENTS.md unmanaged header: no legacy vbrief tokens found — nothing to patch.";
+  }
+  const total = outcome.replacements.reduce((sum, r) => sum + r.count, 0);
+  const detail = outcome.replacements.map((r) => `${r.legacy} ×${r.count}`).join(", ");
+  return `AGENTS.md unmanaged header: rewrote ${total} legacy vbrief token(s) -> xbrief (${detail}).`;
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export interface StaleHeaderDetection {
+  readonly stale: boolean;
+  readonly matches: string[];
+}
+
+/**
+ * Detect the #2154 half-migrated state: the `xbrief/` tree exists (lifecycle
+ * migration + managed-section refresh already happened) yet the UNMANAGED
+ * AGENTS.md header still references legacy `vbrief` path / verb literals — a
+ * regression `deft doctor` cannot see because the managed-section byte compare
+ * passes (#1308). Returns the matched legacy tokens for the signpost.
+ */
+export function detectStaleUnmanagedHeader(
+  projectRoot: string,
+  readText: (path: string) => string | null = (path) => {
+    try {
+      if (!existsSync(path)) return null;
+      return readFileSync(path, "utf8");
+    } catch {
+      return null;
+    }
+  },
+): StaleHeaderDetection {
+  if (!isDirectory(join(projectRoot, MIGRATED_ARTIFACT_DIR))) {
+    return { stale: false, matches: [] };
+  }
+  const content = readText(join(projectRoot, "AGENTS.md"));
+  if (content === null) {
+    return { stale: false, matches: [] };
+  }
+
+  const managed = iterManagedSections(content);
+  let unmanaged = "";
+  let cursor = 0;
+  for (const [start, end] of managed) {
+    unmanaged += content.slice(cursor, start);
+    cursor = end;
+  }
+  unmanaged += content.slice(cursor);
+
+  const matches = LEGACY_HEADER_TOKENS.filter((t) => unmanaged.includes(t.legacy)).map(
+    (t) => t.legacy,
+  );
+  return { stale: matches.length > 0, matches };
+}
+
+/** One-line doctor / ritual signpost for the #2154 stale-header regression. */
+export function renderStaleHeaderLine(projectRoot: string): string {
+  const { stale, matches } = detectStaleUnmanagedHeader(projectRoot);
+  if (!stale) {
+    return "AGENTS.md header drift: none -- unmanaged header has no legacy vbrief path literals.";
+  }
+  return (
+    `AGENTS.md header drift: xbrief/ tree present but the unmanaged AGENTS.md header still ` +
+    `references legacy token(s) ${matches.join(", ")}. ` +
+    "Run `deft migrate:xbrief` (idempotent) to rewrite them, or hand-edit the header."
+  );
+}

--- a/packages/core/src/xbrief-migrate/fs-helpers.ts
+++ b/packages/core/src/xbrief-migrate/fs-helpers.ts
@@ -1,0 +1,10 @@
+import { statSync } from "node:fs";
+
+/** True when `path` exists and is a directory; false on any stat error. */
+export function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/xbrief-migrate/index.ts
+++ b/packages/core/src/xbrief-migrate/index.ts
@@ -1,4 +1,16 @@
 export {
+  detectStaleUnmanagedHeader,
+  type HeaderPatchOutcome,
+  type HeaderRewriteResult,
+  type HeaderTokenReplacement,
+  LEGACY_HEADER_TOKENS,
+  patchAgentsMdHeader,
+  renderHeaderPatchSummary,
+  renderStaleHeaderLine,
+  rewriteUnmanagedHeaderTokens,
+  type StaleHeaderDetection,
+} from "./agents-header.js";
+export {
   detectLegacyVbriefLayout,
   type LegacyVbriefLayoutDetection,
 } from "./detect.js";

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -267,6 +267,43 @@ describe("runXbriefMigrationCli", () => {
     expect(existsSync(join(project, "AGENTS.md"))).toBe(true);
   });
 
+  it("patches stale vbrief tokens in the pre-existing AGENTS.md unmanaged header (#2154)", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-cli-header-"));
+    temps.push(base);
+    const project = scaffoldLegacyProject(base);
+    // A consumer AGENTS.md whose unmanaged header still points at the legacy
+    // layout, wrapped around a managed section (which must survive untouched).
+    const staleAgents = [
+      "# Consumer",
+      "",
+      "## Lifecycle",
+      "- `task vbrief:preflight -- vbrief/active/foo.vbrief.json`",
+      "- Scoped work lives in `vbrief/`.",
+      "",
+      "<!-- deft:managed-section v3 -->",
+      "body mentions vbrief/active/x.vbrief.json",
+      "<!-- /deft:managed-section -->",
+      "",
+    ].join("\n");
+    writeFileSync(join(project, "AGENTS.md"), staleAgents, "utf8");
+
+    const lines: string[] = [];
+    const code = runXbriefMigrationCli(
+      { projectRoot: project, frameworkRoot: join(project, ".deft", "core"), force: true },
+      { writeOut: (t) => lines.push(t), writeErr: (t) => lines.push(t) },
+    );
+    expect(code).toBe(0);
+    expect(lines.join("")).toContain("rewrote");
+
+    const written = readFileSync(join(project, "AGENTS.md"), "utf8");
+    // Unmanaged header lifecycle examples now reference xbrief.
+    expect(written).toContain("xbrief:preflight -- xbrief/active/foo.xbrief.json");
+    expect(written).toContain("Scoped work lives in `xbrief/`.");
+    expect(written).not.toContain("vbrief/active/foo.vbrief.json");
+    // Managed section markers are still present.
+    expect(written).toContain("<!-- /deft:managed-section -->");
+  });
+
   it("returns exit code 2 when agents:refresh cannot find the framework template (template-missing)", () => {
     const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-cli-tmpl-"));
     temps.push(base);

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -11,6 +11,7 @@ import {
 import { dirname, join, relative, resolve } from "node:path";
 import { checkGitClean } from "../migrate-preflight/index.js";
 import { agentsRefreshPlan } from "../platform/agents-md.js";
+import { patchAgentsMdHeader, renderHeaderPatchSummary } from "./agents-header.js";
 import {
   LEGACY_ARTIFACT_DIR,
   LEGACY_ARTIFACT_SUFFIX,
@@ -243,6 +244,19 @@ export function emitXbriefMigration(
   }
 }
 
+/**
+ * Rewrite legacy `vbrief` crossover tokens in the UNMANAGED AGENTS.md header
+ * after lifecycle migration + agents:refresh (#2154). The managed section is
+ * left byte-for-byte intact; only the freeform header/tail path literals are
+ * patched. Idempotent and non-fatal — a header with no legacy tokens is a
+ * clean no-op. Always returns 0; the migration itself already succeeded.
+ */
+function runHeaderPatch(projectRoot: string, io: XbriefMigrationIo): number {
+  const outcome = patchAgentsMdHeader(projectRoot);
+  io.writeOut(`${renderHeaderPatchSummary(outcome)}\n`);
+  return 0;
+}
+
 /** End-to-end migrate:xbrief handler including optional agents:refresh (#2110). */
 export function runXbriefMigrationCli(args: XbriefMigrationArgs, io: XbriefMigrationIo): number {
   const outcome = runXbriefMigration(args, io);
@@ -250,5 +264,10 @@ export function runXbriefMigrationCli(args: XbriefMigrationArgs, io: XbriefMigra
   if (code !== 0 || outcome.kind !== "migrated") {
     return code;
   }
-  return runAgentsRefresh(resolve(args.projectRoot), args.frameworkRoot, io);
+  const projectRoot = resolve(args.projectRoot);
+  const refreshCode = runAgentsRefresh(projectRoot, args.frameworkRoot, io);
+  if (refreshCode !== 0) {
+    return refreshCode;
+  }
+  return runHeaderPatch(projectRoot, io);
 }

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -5,7 +5,6 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
@@ -19,6 +18,7 @@ import {
   MIGRATED_ARTIFACT_SUFFIX,
 } from "./constants.js";
 import { detectLegacyVbriefLayout } from "./detect.js";
+import { isDirectory } from "./fs-helpers.js";
 import { renderXbriefMigrationLine, xbriefMigrationGuidance } from "./signpost.js";
 import type { JsonObject } from "./transforms.js";
 import { rewriteEmbeddedTokens, transformArtifactV06ToV08Transactional } from "./transforms.js";
@@ -39,14 +39,6 @@ export type XbriefMigrationOutcome =
   | { readonly kind: "refused"; readonly message: string }
   | { readonly kind: "migrated"; readonly backupDir: string; readonly files: number }
   | { readonly kind: "config"; readonly message: string };
-
-function isDirectory(path: string): boolean {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
-  }
-}
 
 function collectFiles(root: string, acc: string[] = []): string[] {
   if (!isDirectory(root)) {
@@ -249,11 +241,18 @@ export function emitXbriefMigration(
  * after lifecycle migration + agents:refresh (#2154). The managed section is
  * left byte-for-byte intact; only the freeform header/tail path literals are
  * patched. Idempotent and non-fatal — a header with no legacy tokens is a
- * clean no-op. Always returns 0; the migration itself already succeeded.
+ * clean no-op, and a write failure surfaces as a `failed` outcome on stderr
+ * rather than an exception. Always returns 0; the migration itself already
+ * succeeded, so a header-patch hiccup must not fail the whole command.
  */
 function runHeaderPatch(projectRoot: string, io: XbriefMigrationIo): number {
   const outcome = patchAgentsMdHeader(projectRoot);
-  io.writeOut(`${renderHeaderPatchSummary(outcome)}\n`);
+  const summary = `${renderHeaderPatchSummary(outcome)}\n`;
+  if (outcome.kind === "failed") {
+    io.writeErr(summary);
+  } else {
+    io.writeOut(summary);
+  }
   return 0;
 }
 

--- a/xbrief/completed/2026-07-02-2154-migrate-xbrief-header-patch.xbrief.json
+++ b/xbrief/completed/2026-07-02-2154-migrate-xbrief-header-patch.xbrief.json
@@ -1,0 +1,97 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2154: migrate:xbrief leaves stale vbrief/ paths in the consumer AGENTS.md unmanaged header; doctor cannot see it. Child of #1882 (specific xbrief-crossover instance of the #2065 unmanaged-header-rot umbrella).",
+    "created": "2026-07-02T00:00:00Z",
+    "updated": "2026-07-02T00:00:00Z"
+  },
+  "plan": {
+    "id": "2154-migrate-xbrief-header-patch",
+    "title": "migrate:xbrief mechanically patches stale vbrief/ path literals in the AGENTS.md unmanaged header",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2154",
+    "narratives": {
+      "Description": "After a successful `deft migrate:xbrief` crossover, the consumer AGENTS.md UNMANAGED header can still reference the legacy vbrief/ layout (Session orientation, Lifecycle task examples, Local dev artifact names) while the lifecycle tree and managed section are already on xbrief/. Agents read AGENTS.md every session and get wrong path orientation, yet `deft doctor` reports healthy (managed-section byte compare passes, #1308). This story implements Option A from the issue (recommended minimum): after lifecycle migration + agents:refresh, apply a bounded, idempotent rewrite pass over the UNMANAGED header only, for known crossover tokens, preserving freeform prose and never touching the managed section. It also adds a detection signpost so the regression is catchable (Option B, lightweight).",
+      "ImplementationPlan": "1. In the migrate:xbrief implementation (packages/core migration module; find the migrate verb and the agents:refresh call site), add a bounded, idempotent header-rewrite pass scoped to the UNMANAGED region only (everything OUTSIDE the deft:managed-section markers). Replace known crossover tokens: 'vbrief/' path literals -> 'xbrief/', '*.vbrief.json' example artifacts -> '*.xbrief.json', 'vbrief:preflight' -> 'xbrief:preflight' (current canonical verb). Preserve prose; do not touch the managed section. 2. Emit a summary of replacements (LEGACY-REPORT.md-style or migration log) so the operator sees what changed. 3. Add a lightweight detection: when xbrief/ exists and the managed section is fresh but the unmanaged header still matches legacy patterns (vbrief/proposed, vbrief:preflight, test-single.vbrief.json), warn (doctor signpost or a verify gate) pointing at the fix. 4. Add tests: a fixture consumer AGENTS.md with a typical stale header; assert post-migrate the header lifecycle/path examples reference xbrief/, and the idempotency (running twice is a no-op), and that the managed section is untouched. 5. Document in UPGRADING.md (xBRIEF rename section) the managed vs unmanaged header expectations. 6. CHANGELOG [Unreleased] entry (user-visible: migrate:xbrief now fixes stale vbrief paths in your AGENTS.md header). Run `task check` green.",
+      "UserStory": "As an operator who ran `deft migrate:xbrief`, I want the migration to also fix the stale vbrief/ path literals in my AGENTS.md session-orientation header (or at least warn me), so that agents are not misdirected at session start while doctor reports healthy.",
+      "Traces": "#2154, #2034, #2065, #2110, #1882"
+    },
+    "items": [
+      {
+        "id": "m-a1",
+        "title": "migrate:xbrief rewrites known vbrief tokens in the unmanaged header",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a fixture consumer AGENTS.md with a typical stale unmanaged header, when `deft migrate:xbrief` runs, then header lifecycle/path examples reference xbrief/ (vbrief/ -> xbrief/, *.vbrief.json -> *.xbrief.json, vbrief:preflight -> xbrief:preflight), freeform prose is preserved, and the managed section is untouched."
+        }
+      },
+      {
+        "id": "m-a2",
+        "title": "Rewrite pass is idempotent",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a header already on xbrief/, when migrate runs again, then the header is unchanged (no double-rewrite, no corruption)."
+        }
+      },
+      {
+        "id": "m-a3",
+        "title": "Detection catches xbrief-tree + vbrief-header drift",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given xbrief/ exists and the managed section is fresh but the unmanaged header matches legacy vbrief patterns, when doctor or the dedicated verify gate runs, then it warns and points at the remediation."
+        }
+      },
+      {
+        "id": "m-a4",
+        "title": "Docs + task check",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given UPGRADING.md, then the managed vs unmanaged header expectation is documented; `task check` passes with the new tests."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1882",
+        "child_issue": "#2154"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src (migrate:xbrief module)",
+          "packages/cli/src (migrate verb if applicable)",
+          "tests",
+          "UPGRADING.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task check"
+        ],
+        "expected_outputs": [
+          "migrate:xbrief patches stale vbrief/ tokens in the unmanaged AGENTS.md header (idempotent, managed section untouched) + detection signpost + tests + docs"
+        ],
+        "depends_on": [],
+        "conflict_group": "migrate-xbrief",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "high"
+      },
+      "completedAt": "2026-07-02T13:46:30Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2154",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2154: migrate:xbrief leaves stale vbrief paths in AGENTS.md header"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1882",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1882: AGENTS.md map-not-manual umbrella"
+      }
+    ],
+    "updated": "2026-07-02T13:46:30Z"
+  }
+}


### PR DESCRIPTION
## Summary

`deft migrate:xbrief` renamed the lifecycle tree and refreshed the managed AGENTS.md section, but left the **unmanaged header** (Session orientation / Lifecycle examples / Local dev artifact names) pointing at the legacy `vbrief/` layout. Agents read that header every session and got the wrong path orientation while `deft doctor` still reported healthy (the managed-section byte compare passes, #1308).

This PR implements **Option A** from the issue (recommended minimum) plus a lightweight detection signpost (Option B):

- **Bounded, idempotent header rewrite.** After lifecycle migration + `agents:refresh`, `migrate:xbrief` rewrites the known crossover tokens in the **unmanaged region only** — `vbrief/` → `xbrief/`, `*.vbrief.json` → `*.xbrief.json`, `vbrief:preflight` → `xbrief:preflight`. The managed section is preserved byte-for-byte and freeform prose is untouched. Running twice is a no-op.
- **Replacement summary.** The migrate CLI prints a LEGACY-REPORT-style one-line summary of what was rewritten.
- **Doctor signpost.** `deft doctor` now emits an `AGENTS.md header drift:` line that warns when an `xbrief/` tree exists but the unmanaged header still references legacy `vbrief` literals, pointing at the (idempotent) remediation.
- **Docs.** UPGRADING.md now documents the managed vs unmanaged header expectation; CHANGELOG `[Unreleased]` has a user-visible entry.

New module: `packages/core/src/xbrief-migrate/agents-header.ts` (rewrite + detection + summary), wired into `runXbriefMigrationCli` and the doctor CLI.

## Test plan

- [x] `agents-header.test.ts`: unmanaged rewrite, managed section preserved verbatim, per-token counts, idempotency, no-managed-section whole-file rewrite, CRLF safety, patch/clean/absent outcomes, seams, detection (xbrief tree + stale header vs managed-only tokens vs no tree vs no AGENTS.md), signpost lines.
- [x] `migrate-project.test.ts`: end-to-end `migrate:xbrief` CLI patches a pre-existing stale AGENTS.md header, managed markers survive.
- [x] `doctor.test.ts`: doctor emits the drift signpost for a half-migrated fixture and `header drift: none` for a clean one.
- [x] `task check` GREEN (branch coverage 85.07%; new module ~97%).

Closes #2154
