### PR TITLE
feat(agents-md): advisory consumer AGENTS.md legibility signal (#2155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **AGENTS.md now has a line-budget ratchet that stops it silently bloating (#645).** A new `verify:agents-md-budget` gate (wired into `task check`) counts the managed section and the hand-maintained region of AGENTS.md separately and fails when either grows past the budget recorded in `PROJECT-DEFINITION` (`plan.policy.agentsMdBudget`). The budget is seeded at the current size, so it ships green and only flags future growth — reductions are always allowed and should tighten the budget toward the ~100–150 line ceiling that keeps AGENTS.md a map, not a manual. Refs #645, #1882.
+- **Consumer projects get a gentle, never-failing nudge when their AGENTS.md grows (#2155).** `deft doctor` now reports the size of your project-authored (unmanaged) region of AGENTS.md and, when it exceeds a soft budget, prints an advisory note pointing you at the "map, not a manual" guidance — but always exits 0, so it can never fail your build. The framework-owned managed section is excluded from the count. The soft budget is the typed field `plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines` (generous by default); raise it to accept intentional growth and silence the nudge. Consumers who want a hard cap can opt in with `deft verify:agents-md-advisory --enforce`. Refs #2155, #645, #1419, #1882.
 
 ### Changed
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -22,8 +22,24 @@
 AGENTS.md is the always-loaded front door. Empirical study (`content/docs/good-agents-md.md`) found agent-quality gains from AGENTS.md **reverse** once the file grows past ~100–150 lines: context is scarce, "everything important" becomes non-guidance, and stale rules accumulate.
 
 - **Default when adding content**: push the detail into a reference doc (`main.md` section, a content pack, or `docs/`) and leave a *pointer* from AGENTS.md — do **not** expand AGENTS.md itself.
-- **Enforced by a ratchet**: `task verify:agents-md-budget` (wired into `task check`) fails when the managed section or the unmanaged region grows past `plan.policy.agentsMdBudget` in `PROJECT-DEFINITION`. The budget is seeded at the current per-region size, so *growth* fails while *reductions* are always allowed.
+- **Enforced by a ratchet (maintainer repo only)**: `task verify:agents-md-budget` (wired into `check:framework-source`) fails when the managed section or the unmanaged region grows past `plan.policy.agentsMdBudget` in `PROJECT-DEFINITION`. The budget is seeded at the current per-region size, so *growth* fails while *reductions* are always allowed.
 - **Lowering the budget is free; raising it is a reviewed diff.** Each reduction should tighten the matching `managedMaxLines` / `unmanagedMaxLines` line so the ratchet only ever ratchets down toward the ceiling.
+
+### Consumer projects: an *advisory* signal, never a failing gate (#2155)
+
+Consumer projects (deft installed as `.deft/core`) get a **different** treatment than the maintainer repo, because your AGENTS.md has two regions with very different owners:
+
+- The **managed section** is rendered from the framework template — *we* own its size. It is never a consumer-actionable failure; at most `deft doctor` hints at `deft update`.
+- The **unmanaged region** (your project header + project-specific rules) is **yours**. The framework can't know what your project legitimately needs there — a compliance-heavy repo or a monorepo with real per-package rules may need more — so it has no business failing *your* build over it.
+
+So the consumer posture is **advise, don't enforce** (the `verify:capacity` / `verify:judgment-gates` advise → observe → enforce precedent, #1419):
+
+- `deft doctor` (and the `check:consumer` aggregate that depends on it) reports the unmanaged region size against a **soft budget** and, when over, prints an advisory note — but **always exits 0**. It can never fail-close your build.
+- The soft budget is the typed field `plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines` in `PROJECT-DEFINITION`, **generous by default** when unset. Raising it is the no-friction, self-service way to accept legitimate growth and silence the nudge — that edit *is* your "yes, this is intentional".
+- The framework-owned managed section is **excluded** from the count (it reuses the #645 region counter).
+- Want a hard cap on your own file anyway? Run `task verify:agents-md-advisory -- --enforce` (or `deft verify:agents-md-advisory --enforce`) — the opt-in enforce tier exits non-zero when over. It is deliberately **not** wired into `check:consumer`; you invoke it yourself.
+
+The honest caveat: because it is advisory-and-generous-by-default, the value is the *nudge at the right moment* (a growing header caught during `doctor` / session start / pre-pr), not a blocking number we made up.
 
 ## 🧭 Skills Index
 

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -148,6 +148,7 @@ export const CLI_MODULE_VERBS = [
   "verify-tools",
   "verify-wip-cap",
   "verify-agents-md-budget",
+  "verify-agents-md-advisory",
 ] as const;
 
 /** Core-only CLI entrypoints without a packages/cli wrapper. */
@@ -212,6 +213,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "verify:vbrief-conformance": "vbrief-validate",
   "verify:wip-cap": "verify-wip-cap",
   "verify:agents-md-budget": "verify-agents-md-budget",
+  "verify:agents-md-advisory": "verify-agents-md-advisory",
   "verify:hooks-installed": "verify-hooks-installed",
   "verify:no-task-runtime": "verify-no-task-runtime",
   "vbrief:validate": "vbrief-validate",

--- a/packages/cli/src/verify-agents-md-advisory.test.ts
+++ b/packages/cli/src/verify-agents-md-advisory.test.ts
@@ -16,11 +16,13 @@ function agentsWith(unmanaged: number, managed: number): string {
   for (let i = 0; i < unmanaged; i += 1) {
     lines.push(`unmanaged ${i}`);
   }
-  lines.push("<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->");
-  for (let i = 0; i < managed - 2; i += 1) {
-    lines.push(`managed ${i}`);
+  if (managed > 0) {
+    lines.push("<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->");
+    for (let i = 0; i < managed - 2; i += 1) {
+      lines.push(`managed ${i}`);
+    }
+    lines.push("<!-- /deft:managed-section -->");
   }
-  lines.push("<!-- /deft:managed-section -->");
   return lines.join("\n");
 }
 

--- a/packages/cli/src/verify-agents-md-advisory.test.ts
+++ b/packages/cli/src/verify-agents-md-advisory.test.ts
@@ -1,0 +1,125 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { parseArgs, run } from "./verify-agents-md-advisory.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function agentsWith(unmanaged: number, managed: number): string {
+  const lines: string[] = [];
+  for (let i = 0; i < unmanaged; i += 1) {
+    lines.push(`unmanaged ${i}`);
+  }
+  lines.push("<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->");
+  for (let i = 0; i < managed - 2; i += 1) {
+    lines.push(`managed ${i}`);
+  }
+  lines.push("<!-- /deft:managed-section -->");
+  return lines.join("\n");
+}
+
+function buildRepo(options: { plan?: Record<string, unknown>; agents?: string }): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-cli-agents-advisory-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  if (options.plan !== undefined) {
+    writeFileSync(
+      join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "running", items: [], ...options.plan },
+      }),
+      "utf8",
+    );
+  }
+  if (options.agents !== undefined) {
+    writeFileSync(join(root, "AGENTS.md"), options.agents, "utf8");
+  }
+  return root;
+}
+
+function silentRun(argv: string[]): number {
+  const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  try {
+    return run(argv);
+  } finally {
+    out.mockRestore();
+    err.mockRestore();
+  }
+}
+
+const softPlan = (n: number) => ({ policy: { agentsMdAdvisory: { unmanagedSoftMaxLines: n } } });
+
+describe("parseArgs", () => {
+  it("parses defaults", () => {
+    expect(parseArgs([])).toMatchObject({ projectRoot: ".", quiet: false, enforce: false });
+  });
+
+  it("parses flags and = form", () => {
+    expect(parseArgs(["--project-root", "/root", "--quiet", "--enforce"])).toMatchObject({
+      projectRoot: "/root",
+      quiet: true,
+      enforce: true,
+    });
+    expect(parseArgs(["--project-root=/tmp/x"]).projectRoot).toBe("/tmp/x");
+  });
+
+  it("errors on unknown flags and missing values", () => {
+    expect(parseArgs(["--bogus"]).error).toBeDefined();
+    expect(parseArgs(["--project-root"]).error).toBeDefined();
+  });
+});
+
+describe("run (advisory posture)", () => {
+  it("returns 0 when within the soft budget", () => {
+    const root = buildRepo({ plan: softPlan(10), agents: agentsWith(5, 5) });
+    expect(silentRun(["--project-root", root])).toBe(0);
+  });
+
+  it("returns 0 EVEN WHEN over budget (never fail-closes)", () => {
+    const root = buildRepo({ plan: softPlan(10), agents: agentsWith(50, 5) });
+    expect(silentRun(["--project-root", root])).toBe(0);
+  });
+
+  it("returns 0 when AGENTS.md is missing (advisory skip)", () => {
+    const root = buildRepo({ plan: softPlan(10) });
+    expect(silentRun(["--project-root", root])).toBe(0);
+  });
+
+  it("returns 2 for bad args", () => {
+    expect(silentRun(["--bogus"])).toBe(2);
+  });
+
+  it("suppresses output when --quiet at baseline", () => {
+    const root = buildRepo({ plan: softPlan(10), agents: agentsWith(3, 5) });
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(run(["--project-root", root, "--quiet"])).toBe(0);
+      expect(out.mock.calls.length).toBe(0);
+      expect(err.mock.calls.length).toBe(0);
+    } finally {
+      out.mockRestore();
+      err.mockRestore();
+    }
+  });
+});
+
+describe("run (--enforce opt-in)", () => {
+  it("returns 1 when over budget under --enforce", () => {
+    const root = buildRepo({ plan: softPlan(10), agents: agentsWith(50, 5) });
+    expect(silentRun(["--project-root", root, "--enforce"])).toBe(1);
+  });
+
+  it("returns 0 when within budget under --enforce", () => {
+    const root = buildRepo({ plan: softPlan(10), agents: agentsWith(5, 5) });
+    expect(silentRun(["--project-root", root, "--enforce"])).toBe(0);
+  });
+});

--- a/packages/cli/src/verify-agents-md-advisory.ts
+++ b/packages/cli/src/verify-agents-md-advisory.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluate } from "@deftai/directive-core/agents-md-advisory";
+
+interface ParsedArgs {
+  projectRoot: string;
+  quiet: boolean;
+  enforce: boolean;
+  error?: string;
+}
+
+/** Parse verify-agents-md-advisory CLI args. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    projectRoot: ".",
+    quiet: false,
+    enforce: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--quiet") {
+      parsed.quiet = true;
+    } else if (arg === "--enforce") {
+      parsed.enforce = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Run the advisory and return the process exit code.
+ *
+ * Default posture is advisory: the command ALWAYS exits 0 (it never
+ * fail-closes a consumer build). The opt-in `--enforce` flag promotes an
+ * over-budget unmanaged region to exit 1 for consumers who want a hard cap.
+ */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify_agents_md_advisory: ${args.error}\n`);
+    return 2;
+  }
+
+  const projectRoot = resolve(args.projectRoot);
+  const result = evaluate(projectRoot, { quiet: args.quiet, enforce: args.enforce });
+
+  if (result.message.length > 0) {
+    if (result.stream === "stdout") {
+      process.stdout.write(`${result.message}\n`);
+    } else if (result.stream === "stderr") {
+      process.stderr.write(`${result.message}\n`);
+    }
+  }
+
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/agents-md-budget/index.d.ts",
       "default": "./dist/agents-md-budget/index.js"
     },
+    "./agents-md-advisory": {
+      "types": "./dist/agents-md-advisory/index.d.ts",
+      "default": "./dist/agents-md-advisory/index.js"
+    },
     "./xbrief-migrate": {
       "types": "./dist/xbrief-migrate/index.d.ts",
       "default": "./dist/xbrief-migrate/index.js"

--- a/packages/core/src/agents-md-advisory/evaluate.test.ts
+++ b/packages/core/src/agents-md-advisory/evaluate.test.ts
@@ -1,0 +1,177 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { evaluate } from "./evaluate.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function writeProjectDefinition(root: string, plan: Record<string, unknown>): void {
+  const dir = join(root, "vbrief");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "PROJECT-DEFINITION.vbrief.json"),
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6" },
+      plan: { title: "T", status: "running", items: [], ...plan },
+    }),
+    "utf8",
+  );
+}
+
+/** Build an AGENTS.md with `unmanaged` leading lines then a managed block of `managed` lines. */
+function agentsWith(unmanaged: number, managed: number): string {
+  const lines: string[] = [];
+  for (let i = 0; i < unmanaged; i += 1) {
+    lines.push(`unmanaged line ${i}`);
+  }
+  if (managed > 0) {
+    lines.push("<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->");
+    for (let i = 0; i < managed - 2; i += 1) {
+      lines.push(`managed line ${i}`);
+    }
+    lines.push("<!-- /deft:managed-section -->");
+  }
+  return lines.join("\n");
+}
+
+function makeRepo(options: { plan?: Record<string, unknown>; agents?: string }): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-agents-advisory-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  if (options.plan !== undefined) {
+    writeProjectDefinition(root, options.plan);
+  }
+  if (options.agents !== undefined) {
+    writeFileSync(join(root, "AGENTS.md"), options.agents, "utf8");
+  }
+  return root;
+}
+
+const softPlan = (n: number) => ({ policy: { agentsMdAdvisory: { unmanagedSoftMaxLines: n } } });
+
+describe("agents-md-advisory evaluate (advisory posture)", () => {
+  it("is silent-friendly and exits 0 when the unmanaged region is within budget", () => {
+    const root = makeRepo({ plan: softPlan(10), agents: agentsWith(8, 30) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.over).toBe(false);
+    expect(result.stream).toBe("stdout");
+    expect(result.message).toContain("within soft budget");
+    expect(result.source).toBe("typed");
+  });
+
+  it("EXCLUDES the managed section from the count (managed size never triggers)", () => {
+    // 8 unmanaged, but a huge 100-line managed block. Budget is 10 unmanaged.
+    const root = makeRepo({ plan: softPlan(10), agents: agentsWith(8, 100) });
+    const result = evaluate(root);
+    expect(result.over).toBe(false);
+    expect(result.code).toBe(0);
+    expect(result.counts?.unmanaged).toBe(8);
+    expect(result.counts?.managed).toBe(100);
+  });
+
+  it("emits an advisory message but STILL EXITS 0 when over the soft budget", () => {
+    const root = makeRepo({ plan: softPlan(10), agents: agentsWith(25, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0); // never fail-closes in advisory posture
+    expect(result.over).toBe(true);
+    expect(result.stream).toBe("stderr");
+    expect(result.message).toContain("advisory only");
+    expect(result.message).toContain("plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines");
+  });
+
+  it("is silenced when the operator raises the soft budget (configurable-raise honored)", () => {
+    const agents = agentsWith(25, 5);
+    const strict = evaluate(makeRepo({ plan: softPlan(10), agents }));
+    expect(strict.over).toBe(true);
+    const raised = evaluate(makeRepo({ plan: softPlan(100), agents }));
+    expect(raised.over).toBe(false);
+    expect(raised.code).toBe(0);
+  });
+
+  it("uses the generous default (300) when no advisory field is configured", () => {
+    const root = makeRepo({ plan: { title: "T" }, agents: agentsWith(50, 20) });
+    const result = evaluate(root);
+    expect(result.softMaxLines).toBe(300);
+    expect(result.over).toBe(false);
+    expect(result.source).toBe("default");
+  });
+
+  it("degrades to the generous default (never fails) on a malformed advisory field", () => {
+    const plan = { policy: { agentsMdAdvisory: { unmanagedSoftMaxLines: -5 } } };
+    const root = makeRepo({ plan, agents: agentsWith(50, 20) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.softMaxLines).toBe(300);
+    expect(result.source).toBe("default-on-error");
+  });
+
+  it("stays silent (exit 0, no message) when quiet and within budget", () => {
+    const root = makeRepo({ plan: softPlan(10), agents: agentsWith(3, 5) });
+    const result = evaluate(root, { quiet: true });
+    expect(result.code).toBe(0);
+    expect(result.message).toBe("");
+    expect(result.stream).toBe("none");
+  });
+
+  it("exits 0 and skips gracefully when AGENTS.md is missing", () => {
+    const root = makeRepo({ plan: softPlan(10) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.counts).toBeNull();
+    expect(result.message).toContain("no AGENTS.md found");
+  });
+
+  it("exits 0 when the managed markers are malformed (advisory never fails)", () => {
+    const root = makeRepo({
+      plan: softPlan(10),
+      agents: "x\n<!-- deft:managed-section v3 -->\nno close here",
+    });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.counts).toBeNull();
+  });
+});
+
+describe("agents-md-advisory evaluate (--enforce opt-in)", () => {
+  it("exits 1 when over budget under --enforce (hard cap)", () => {
+    const root = makeRepo({ plan: softPlan(10), agents: agentsWith(25, 5) });
+    const result = evaluate(root, { enforce: true });
+    expect(result.code).toBe(1);
+    expect(result.over).toBe(true);
+    expect(result.message).toContain("over the enforced cap");
+  });
+
+  it("exits 0 when within budget under --enforce", () => {
+    const root = makeRepo({ plan: softPlan(10), agents: agentsWith(5, 5) });
+    expect(evaluate(root, { enforce: true }).code).toBe(0);
+  });
+
+  it("exits 2 on a config problem (missing AGENTS.md) under --enforce", () => {
+    const root = makeRepo({ plan: softPlan(10) });
+    const result = evaluate(root, { enforce: true });
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("no AGENTS.md found");
+  });
+
+  it("exits 2 on malformed markers under --enforce", () => {
+    const root = makeRepo({
+      plan: softPlan(10),
+      agents: "x\n<!-- deft:managed-section v3 -->\nno close",
+    });
+    expect(evaluate(root, { enforce: true }).code).toBe(2);
+  });
+});
+
+describe("agents-md-advisory index re-exports", () => {
+  it("exports evaluate from the barrel", async () => {
+    const mod = await import("./index.js");
+    expect(typeof mod.evaluate).toBe("function");
+  });
+});

--- a/packages/core/src/agents-md-advisory/evaluate.ts
+++ b/packages/core/src/agents-md-advisory/evaluate.ts
@@ -1,0 +1,176 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { countRegions, type RegionCounts } from "../agents-md-budget/evaluate.js";
+import {
+  type AgentsMdAdvisorySource,
+  resolveAgentsMdAdvisory,
+} from "../policy/agents-md-advisory.js";
+
+export type OutputStream = "stdout" | "stderr" | "none";
+
+/**
+ * Result of the consumer AGENTS.md advisory evaluation (#2155).
+ *
+ * `code` is 0 in the DEFAULT advisory posture no matter what -- the advisory
+ * MUST NEVER fail-close a consumer build. Non-zero codes are only ever produced
+ * in the explicit `--enforce` opt-in posture (1 = over the hard cap the
+ * consumer asked for; 2 = a config problem that blocks an enforced check).
+ */
+export interface AdvisoryEvaluateResult {
+  readonly code: 0 | 1 | 2;
+  readonly message: string;
+  readonly stream: OutputStream;
+  /** True when the unmanaged region exceeds the soft budget. */
+  readonly over: boolean;
+  /** Region counts, or null when AGENTS.md was missing / unreadable / malformed. */
+  readonly counts: RegionCounts | null;
+  /** The resolved soft budget the unmanaged region was compared against. */
+  readonly softMaxLines: number;
+  /** Provenance of the soft budget (typed / default / default-on-error). */
+  readonly source: AgentsMdAdvisorySource;
+}
+
+export interface AdvisoryEvaluateOptions {
+  /**
+   * Opt-in hard-cap posture (#1419 enforce tier). When true, an over-budget
+   * unmanaged region exits 1 and a config problem exits 2. Default (false) is
+   * the advisory posture that always exits 0.
+   */
+  readonly enforce?: boolean;
+  /** Suppress the within-budget "OK" line (used by aggregate callers). */
+  readonly quiet?: boolean;
+}
+
+const GUIDANCE_LINE =
+  "  AGENTS.md is a map, not a manual (#1882): push project detail into a\n" +
+  "  reference doc and leave a pointer, rather than growing AGENTS.md. See\n" +
+  "  content/docs/good-agents-md.md.";
+
+function overMessage(
+  counts: RegionCounts,
+  softMax: number,
+  enforce: boolean,
+  fieldName: string,
+): string {
+  const over = counts.unmanaged - softMax;
+  if (enforce) {
+    return (
+      `❌ agents-md-advisory: AGENTS.md unmanaged (project-authored) region is ` +
+      `${counts.unmanaged} lines, over the enforced cap of ${softMax} (OVER by ${over}).\n` +
+      `${GUIDANCE_LINE}\n` +
+      `  Raise ${fieldName} in PROJECT-DEFINITION to accept the growth.`
+    );
+  }
+  return (
+    `⚠ agents-md-advisory: AGENTS.md unmanaged (project-authored) region is ` +
+    `${counts.unmanaged} lines, over the soft budget of ${softMax} (OVER by ${over}). ` +
+    "This is advisory only -- your build is NOT affected.\n" +
+    `${GUIDANCE_LINE}\n` +
+    `  This is your knob: raise ${fieldName} in PROJECT-DEFINITION to accept the\n` +
+    "  growth and silence this note."
+  );
+}
+
+const FIELD_NAME = "plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines";
+
+/**
+ * Evaluate the consumer AGENTS.md against its soft, unmanaged-focused budget.
+ *
+ * Reuses the #645 region counter (`countRegions`) so the framework-owned
+ * managed section is EXCLUDED from the comparison -- only the consumer-authored
+ * unmanaged region is measured. In the default advisory posture the result code
+ * is always 0; `--enforce` promotes over-budget / config problems to non-zero.
+ */
+export function evaluate(
+  projectRoot: string,
+  options: AdvisoryEvaluateOptions = {},
+): AdvisoryEvaluateResult {
+  const root = resolve(projectRoot);
+  const enforce = options.enforce ?? false;
+  const quiet = options.quiet ?? false;
+
+  const advisory = resolveAgentsMdAdvisory(root);
+  const softMax = advisory.config.unmanagedSoftMaxLines;
+
+  const agentsPath = join(root, "AGENTS.md");
+  if (!existsSync(agentsPath)) {
+    const message = `agents-md-advisory: no AGENTS.md found at ${agentsPath}`;
+    return {
+      code: enforce ? 2 : 0,
+      message: enforce ? `❌ ${message}` : quiet ? "" : `${message} (advisory; skipped).`,
+      stream: enforce ? "stderr" : quiet ? "none" : "stdout",
+      over: false,
+      counts: null,
+      softMaxLines: softMax,
+      source: advisory.source,
+    };
+  }
+
+  let text: string;
+  try {
+    text = readFileSync(agentsPath, { encoding: "utf8" });
+  } catch (err: unknown) {
+    const message = `agents-md-advisory: AGENTS.md at ${agentsPath} cannot be read: ${String(err)}`;
+    return {
+      code: enforce ? 2 : 0,
+      message: enforce ? `❌ ${message}` : quiet ? "" : `${message} (advisory; skipped).`,
+      stream: enforce ? "stderr" : quiet ? "none" : "stdout",
+      over: false,
+      counts: null,
+      softMaxLines: softMax,
+      source: advisory.source,
+    };
+  }
+
+  const regionResult = countRegions(text);
+  if ("error" in regionResult) {
+    const message = `agents-md-advisory: ${regionResult.error}`;
+    return {
+      code: enforce ? 2 : 0,
+      message: enforce ? `❌ ${message}` : quiet ? "" : `${message} (advisory; skipped).`,
+      stream: enforce ? "stderr" : quiet ? "none" : "stdout",
+      over: false,
+      counts: null,
+      softMaxLines: softMax,
+      source: advisory.source,
+    };
+  }
+
+  const counts = regionResult.counts;
+  const over = counts.unmanaged > softMax;
+
+  if (!over) {
+    if (quiet) {
+      return {
+        code: 0,
+        message: "",
+        stream: "none",
+        over: false,
+        counts,
+        softMaxLines: softMax,
+        source: advisory.source,
+      };
+    }
+    return {
+      code: 0,
+      message:
+        `✓ agents-md-advisory: AGENTS.md unmanaged region ${counts.unmanaged}/${softMax} lines ` +
+        `within soft budget (managed ${counts.managed} excluded; advisory).`,
+      stream: "stdout",
+      over: false,
+      counts,
+      softMaxLines: softMax,
+      source: advisory.source,
+    };
+  }
+
+  return {
+    code: enforce ? 1 : 0,
+    message: overMessage(counts, softMax, enforce, FIELD_NAME),
+    stream: "stderr",
+    over: true,
+    counts,
+    softMaxLines: softMax,
+    source: advisory.source,
+  };
+}

--- a/packages/core/src/agents-md-advisory/index.ts
+++ b/packages/core/src/agents-md-advisory/index.ts
@@ -1,0 +1,1 @@
+export * from "./evaluate.js";

--- a/packages/core/src/doctor/agents-md-advisory.test.ts
+++ b/packages/core/src/doctor/agents-md-advisory.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cmdDoctor } from "./main.js";
+
+/**
+ * Consumer-side advisory AGENTS.md legibility finding in `deft doctor` (#2155).
+ *
+ * The advisory MUST never turn `deft doctor` (and the `check:consumer`
+ * aggregate that depends on it) into a fail-close: it emits at most a
+ * `warning` finding, so the exit code stays 0 even when the unmanaged region
+ * is over the soft budget.
+ */
+const temps: string[] = [];
+afterEach(() => {
+  for (const t of temps.splice(0)) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function makeConsumerDeposit(options: {
+  advisory?: Record<string, unknown>;
+  unmanagedLines: number;
+  markers?: boolean;
+}): { root: string; framework: string } {
+  const root = mkdtempSync(join(tmpdir(), "deft-doc-advisory-"));
+  const framework = mkdtempSync(join(tmpdir(), "deft-doc-advisory-fw-"));
+  temps.push(root, framework);
+  const deposit = join(root, ".deft", "core");
+  for (const dir of ["languages", "strategies", "skills", "templates", "tasks", "vbrief"]) {
+    mkdirSync(join(deposit, dir), { recursive: true });
+  }
+  const lines: string[] = [];
+  for (let i = 0; i < options.unmanagedLines; i += 1) {
+    lines.push(`project rule ${i}`);
+  }
+  if (options.markers !== false) {
+    lines.push("<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->");
+    lines.push("managed body");
+    lines.push("<!-- /deft:managed-section -->");
+  }
+  writeFileSync(join(root, "AGENTS.md"), `${lines.join("\n")}\n`, "utf8");
+  writeFileSync(join(root, "Taskfile.yml"), "version: '3'\n", "utf8");
+  if (options.advisory !== undefined) {
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: {
+          title: "T",
+          status: "running",
+          items: [],
+          policy: { agentsMdAdvisory: options.advisory },
+        },
+      }),
+      "utf8",
+    );
+  }
+  return { root, framework };
+}
+
+type DoctorJsonPayload = { findings: Array<Record<string, unknown>> };
+
+function runDoctorJson(
+  root: string,
+  framework: string,
+): { code: number; payload: DoctorJsonPayload } {
+  const stdout: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((s: string | Uint8Array) => {
+    stdout.push(String(s));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const code = cmdDoctor(["--full", "--json", "--project-root", root], {
+      frameworkRoot: framework,
+      whichFn: () => "/bin/x",
+      agentsRefreshPlan: () => ({ state: "current" }),
+    });
+    return { code, payload: JSON.parse(stdout.join("")) };
+  } finally {
+    process.stdout.write = orig;
+  }
+}
+
+describe("doctor agents-md advisory finding", () => {
+  it("emits a non-failing warning (exit 0) when the unmanaged region is over the soft budget", () => {
+    const { root, framework } = makeConsumerDeposit({
+      advisory: { unmanagedSoftMaxLines: 0 },
+      unmanagedLines: 5,
+    });
+    const { code, payload } = runDoctorJson(root, framework);
+    expect(code).toBe(0);
+    const finding = payload.findings.find((f) => f.check === "agents-md-advisory");
+    expect(finding?.severity).toBe("warning");
+    expect(finding?.status).toBe("over-soft-budget");
+    expect(String(finding?.message)).toContain("advisory only");
+  });
+
+  it("reports success (no warning, exit 0) when within the soft budget", () => {
+    const { root, framework } = makeConsumerDeposit({
+      advisory: { unmanagedSoftMaxLines: 500 },
+      unmanagedLines: 5,
+    });
+    const { code, payload } = runDoctorJson(root, framework);
+    expect(code).toBe(0);
+    const finding = payload.findings.find(
+      (f) => f.check === "agents-md-advisory" && f.severity === "warning",
+    );
+    expect(finding).toBeUndefined();
+  });
+
+  it("skips (does not warn) in the maintainer repo / when no managed markers exist", () => {
+    const { root, framework } = makeConsumerDeposit({
+      advisory: { unmanagedSoftMaxLines: 0 },
+      unmanagedLines: 5,
+      markers: false,
+    });
+    const { code, payload } = runDoctorJson(root, framework);
+    expect(code).toBe(0);
+    const warning = payload.findings.find(
+      (f) => f.check === "agents-md-advisory" && f.severity === "warning",
+    );
+    expect(warning).toBeUndefined();
+  });
+});

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -473,9 +473,17 @@ function runAgentsMdAdvisoryCheck(
     // No counts (missing / unreadable / malformed AGENTS.md): advisory stays
     // silent-but-informational; never a doctor error.
     sink.info(`${checkName}: skip -- AGENTS.md not measurable`);
-    addFinding({ severity: "skip", message: "AGENTS.md not measurable", check: checkName });
+    addFinding({
+      severity: "skip",
+      message: "AGENTS.md not measurable",
+      check: checkName,
+      status: "skip",
+    });
   } catch (exc) {
-    const message = `${checkName}: probe failed -- ${exc instanceof Error ? exc.name : "Error"}: ${exc}`;
+    // Sanitize newlines so an error string can't break out of the markdown
+    // bullet when findings are rendered (CWE-116).
+    const detail = `${exc instanceof Error ? exc.name : "Error"}: ${exc}`.replace(/\r?\n/g, " ");
+    const message = `${checkName}: probe failed -- ${detail}`;
     sink.warn(message);
     addFinding({ severity: "warning", message, check: checkName });
   }

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { evaluate as evaluateAgentsMdAdvisory } from "../agents-md-advisory/evaluate.js";
 import { contentRoot } from "../content-root.js";
 import { agentsRefreshPlan, hasV3ManagedMarker } from "./agents-md.js";
 import { runChecks } from "./checks.js";
@@ -165,6 +166,12 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
   }
   sink.info("Checking AGENTS.md managed-section freshness...");
   runAgentsMdFreshnessCheck(projectRoot, sink, addFinding, seams);
+
+  if (!jsonMode) {
+    sink.blank();
+  }
+  sink.info("Checking AGENTS.md legibility (advisory)...");
+  runAgentsMdAdvisoryCheck(projectRoot, sink, addFinding, seams);
 
   if (!jsonMode) {
     sink.blank();
@@ -399,6 +406,74 @@ function runAgentsMdFreshnessCheck(
     const message = `AGENTS.md freshness check could not run (state='${state}'). Inspect the framework template or AGENTS.md file permissions.`;
     sink.warn(message);
     addFinding({ severity: "warning", message, check: checkName, status: state });
+  } catch (exc) {
+    const message = `${checkName}: probe failed -- ${exc instanceof Error ? exc.name : "Error"}: ${exc}`;
+    sink.warn(message);
+    addFinding({ severity: "warning", message, check: checkName });
+  }
+}
+
+/**
+ * Advisory (never-failing) consumer AGENTS.md legibility signal (#2155).
+ *
+ * Reports the unmanaged (project-authored) region size against the soft budget
+ * (`plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines`, generous by default).
+ * The managed section is EXCLUDED. This is the consumer companion to the
+ * maintainer-only #645 ratchet and follows the advise -> observe -> enforce
+ * posture (#1419): it emits at most a `warning` finding, NEVER an `error`, so
+ * `deft doctor` (and the `check:consumer` aggregate that depends on it) can
+ * never fail-close on a judgment call about the consumer's own file.
+ */
+function runAgentsMdAdvisoryCheck(
+  projectRoot: string,
+  sink: ReturnType<typeof createPlainSink>,
+  addFinding: (f: Finding) => void,
+  seams: DoctorSeams,
+): void {
+  const checkName = "agents-md-advisory";
+  // Only meaningful for consumer installs (managed markers present). In the
+  // maintainer repo the #645 ratchet owns this file, so skip -- mirrors the
+  // freshness check's guard above.
+  if (
+    runningInsideDeftRepo(projectRoot, seams) ||
+    !hasV3ManagedMarker(projectRoot, seams.readText)
+  ) {
+    const skipReason = "no managed-section markers (likely maintainer repo)";
+    sink.info(`${checkName}: skip -- ${skipReason}`);
+    addFinding({ severity: "skip", message: skipReason, check: checkName, status: "skip" });
+    return;
+  }
+  try {
+    const evalFn =
+      seams.agentsMdAdvisoryEvaluate ?? ((root: string) => evaluateAgentsMdAdvisory(root));
+    const result = evalFn(projectRoot);
+    if (result.over && result.counts !== null) {
+      const message =
+        `AGENTS.md unmanaged (project-authored) region is ${result.counts.unmanaged} lines, ` +
+        `over the soft budget of ${result.softMaxLines} (advisory only -- your build is NOT ` +
+        "affected). AGENTS.md is a map, not a manual (#1882): push detail into a reference doc " +
+        "and leave a pointer (see content/docs/good-agents-md.md). Raise " +
+        "plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines to accept the growth and silence this.";
+      sink.warn(message);
+      addFinding({
+        severity: "warning",
+        message,
+        check: checkName,
+        status: "over-soft-budget",
+        suggestion: "content/docs/good-agents-md.md",
+      });
+      return;
+    }
+    if (result.counts !== null) {
+      sink.success(
+        `${checkName}: unmanaged region ${result.counts.unmanaged}/${result.softMaxLines} lines (within soft budget)`,
+      );
+      return;
+    }
+    // No counts (missing / unreadable / malformed AGENTS.md): advisory stays
+    // silent-but-informational; never a doctor error.
+    sink.info(`${checkName}: skip -- AGENTS.md not measurable`);
+    addFinding({ severity: "skip", message: "AGENTS.md not measurable", check: checkName });
   } catch (exc) {
     const message = `${checkName}: probe failed -- ${exc instanceof Error ? exc.name : "Error"}: ${exc}`;
     sink.warn(message);

--- a/packages/core/src/doctor/types.ts
+++ b/packages/core/src/doctor/types.ts
@@ -1,3 +1,5 @@
+import type { AdvisoryEvaluateResult } from "../agents-md-advisory/evaluate.js";
+
 export const EXIT_CLEAN = 0;
 export const EXIT_DRIFT = 1;
 export const EXIT_CONFIG_ERROR = 2;
@@ -66,6 +68,7 @@ export interface DoctorSeams {
   readonly isFile?: (path: string) => boolean;
   readonly runGitLsRemote?: (deftDir: string, ref: string) => { ok: boolean; stdout: string };
   readonly agentsRefreshPlan?: (projectRoot: string) => Record<string, unknown>;
+  readonly agentsMdAdvisoryEvaluate?: (projectRoot: string) => AdvisoryEvaluateResult;
   readonly readState?: (projectRoot: string) => DoctorState | null;
   readonly writeState?: (
     projectRoot: string,

--- a/packages/core/src/policy/agents-md-advisory.test.ts
+++ b/packages/core/src/policy/agents-md-advisory.test.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  DEFAULT_UNMANAGED_SOFT_MAX_LINES,
+  FIELD_AGENTS_MD_ADVISORY_UNMANAGED_SOFT_MAX_LINES,
+  resolveAgentsMdAdvisory,
+} from "./agents-md-advisory.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function makeRepo(plan?: Record<string, unknown>): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-advisory-policy-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  if (plan !== undefined) {
+    writeFileSync(
+      join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "running", items: [], ...plan },
+      }),
+      "utf8",
+    );
+  }
+  return root;
+}
+
+describe("resolveAgentsMdAdvisory", () => {
+  it("returns the generous default when no PROJECT-DEFINITION exists", () => {
+    const root = makeRepo();
+    const result = resolveAgentsMdAdvisory(root);
+    expect(result.config.unmanagedSoftMaxLines).toBe(DEFAULT_UNMANAGED_SOFT_MAX_LINES);
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).not.toBeNull();
+  });
+
+  it("returns the generous default when the advisory field is unset", () => {
+    const root = makeRepo({ policy: { wipCap: 10 } });
+    const result = resolveAgentsMdAdvisory(root);
+    expect(result.config.unmanagedSoftMaxLines).toBe(DEFAULT_UNMANAGED_SOFT_MAX_LINES);
+    expect(result.source).toBe("default");
+    expect(result.error).toBeNull();
+  });
+
+  it("reads the typed soft budget when configured", () => {
+    const root = makeRepo({ policy: { agentsMdAdvisory: { unmanagedSoftMaxLines: 42 } } });
+    const result = resolveAgentsMdAdvisory(root);
+    expect(result.config.unmanagedSoftMaxLines).toBe(42);
+    expect(result.source).toBe("typed");
+  });
+
+  it("degrades to the default when agentsMdAdvisory is not an object", () => {
+    const root = makeRepo({ policy: { agentsMdAdvisory: 99 } });
+    const result = resolveAgentsMdAdvisory(root);
+    expect(result.config.unmanagedSoftMaxLines).toBe(DEFAULT_UNMANAGED_SOFT_MAX_LINES);
+    expect(result.source).toBe("default-on-error");
+  });
+
+  it("treats an advisory object without the field as unset (default, no error)", () => {
+    const root = makeRepo({ policy: { agentsMdAdvisory: {} } });
+    const result = resolveAgentsMdAdvisory(root);
+    expect(result.config.unmanagedSoftMaxLines).toBe(DEFAULT_UNMANAGED_SOFT_MAX_LINES);
+    expect(result.source).toBe("default");
+    expect(result.error).toBeNull();
+  });
+
+  it("degrades to the default (never throws) on a non-integer soft budget", () => {
+    const root = makeRepo({ policy: { agentsMdAdvisory: { unmanagedSoftMaxLines: -1 } } });
+    const result = resolveAgentsMdAdvisory(root);
+    expect(result.config.unmanagedSoftMaxLines).toBe(DEFAULT_UNMANAGED_SOFT_MAX_LINES);
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain(FIELD_AGENTS_MD_ADVISORY_UNMANAGED_SOFT_MAX_LINES);
+  });
+
+  it("accepts zero as a valid (tightest) soft budget", () => {
+    const root = makeRepo({ policy: { agentsMdAdvisory: { unmanagedSoftMaxLines: 0 } } });
+    const result = resolveAgentsMdAdvisory(root);
+    expect(result.config.unmanagedSoftMaxLines).toBe(0);
+    expect(result.source).toBe("typed");
+  });
+});

--- a/packages/core/src/policy/agents-md-advisory.ts
+++ b/packages/core/src/policy/agents-md-advisory.ts
@@ -1,0 +1,107 @@
+import { readPlanPolicy } from "./plan-extensions.js";
+import { loadProjectDefinition } from "./resolve.js";
+
+/**
+ * Advisory (consumer-side) AGENTS.md legibility budget (#2155).
+ *
+ * This is the consumer companion to the maintainer-only #645 ratchet
+ * (`plan.policy.agentsMdBudget`, fail-closed via `check:framework-source`). A
+ * consumer's AGENTS.md has a framework-owned managed section (rendered from the
+ * template; the consumer cannot act on its size) and an UNMANAGED region
+ * (project header + project-specific rules) that is theirs. Because we cannot
+ * know what a given project legitimately needs in that region, the framework
+ * has no business failing THEIR build over it. So this budget is:
+ *
+ * - unmanaged-focused (the managed section is excluded from the count),
+ * - a SOFT, operator-adjustable knob, generous by DEFAULT when unset, and
+ * - never fail-closing in the default advisory posture (advise -> observe ->
+ *   enforce per #1419).
+ *
+ * Raising `unmanagedSoftMaxLines` is the no-friction, documented way a consumer
+ * accepts legitimate growth and silences the advisory nudge.
+ */
+export interface AgentsMdAdvisoryConfig {
+  readonly unmanagedSoftMaxLines: number;
+}
+
+export type AgentsMdAdvisorySource = "typed" | "default" | "default-on-error";
+
+export interface AgentsMdAdvisoryResult {
+  readonly config: AgentsMdAdvisoryConfig;
+  readonly source: AgentsMdAdvisorySource;
+  /** Populated only when a malformed field forced a fallback to the default. */
+  readonly error: string | null;
+}
+
+/**
+ * Generous default soft budget for the consumer-authored (unmanaged) region.
+ *
+ * Deliberately generous: the empirical "map, not a manual" guidance
+ * (`content/docs/good-agents-md.md`) is about the whole file's front-door cost,
+ * but a compliance-heavy repo or a monorepo with real per-package rules may
+ * legitimately need a larger project section. This default only nudges once the
+ * unmanaged region gets genuinely large; the consumer raises the field to
+ * accept their own trade-off.
+ */
+export const DEFAULT_UNMANAGED_SOFT_MAX_LINES = 300;
+
+/** Canonical dotted-path name of the typed advisory soft-budget field. */
+export const FIELD_AGENTS_MD_ADVISORY_UNMANAGED_SOFT_MAX_LINES =
+  "plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines";
+
+function defaultConfig(): AgentsMdAdvisoryConfig {
+  return { unmanagedSoftMaxLines: DEFAULT_UNMANAGED_SOFT_MAX_LINES };
+}
+
+/**
+ * Resolve the advisory soft budget from PROJECT-DEFINITION (#2155).
+ *
+ * NEVER throws and NEVER surfaces a hard config error: because the advisory is
+ * non-blocking by contract, any malformed input degrades gracefully to the
+ * generous default (`source: "default-on-error"`, `error` populated for
+ * optional display) rather than failing the caller.
+ */
+export function resolveAgentsMdAdvisory(projectRoot: string): AgentsMdAdvisoryResult {
+  const [data, err] = loadProjectDefinition(projectRoot);
+  if (data === null) {
+    return { config: defaultConfig(), source: "default-on-error", error: err };
+  }
+
+  const policyBlock = readPlanPolicy(data.plan);
+  if (
+    typeof policyBlock !== "object" ||
+    policyBlock === null ||
+    Array.isArray(policyBlock) ||
+    !("agentsMdAdvisory" in (policyBlock as Record<string, unknown>))
+  ) {
+    return { config: defaultConfig(), source: "default", error: null };
+  }
+
+  const rawAdvisory = (policyBlock as Record<string, unknown>).agentsMdAdvisory;
+  if (typeof rawAdvisory !== "object" || rawAdvisory === null || Array.isArray(rawAdvisory)) {
+    return {
+      config: defaultConfig(),
+      source: "default-on-error",
+      error: "plan.policy.agentsMdAdvisory must be an object with unmanagedSoftMaxLines",
+    };
+  }
+
+  const block = rawAdvisory as Record<string, unknown>;
+  if (!("unmanagedSoftMaxLines" in block)) {
+    // Object present but the field unset: treat as unset -> generous default.
+    return { config: defaultConfig(), source: "default", error: null };
+  }
+
+  const raw = block.unmanagedSoftMaxLines;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) {
+    return {
+      config: defaultConfig(),
+      source: "default-on-error",
+      error:
+        `${FIELD_AGENTS_MD_ADVISORY_UNMANAGED_SOFT_MAX_LINES} must be a non-negative integer; ` +
+        "falling back to the generous default",
+    };
+  }
+
+  return { config: { unmanagedSoftMaxLines: raw }, source: "typed", error: null };
+}

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -2,6 +2,7 @@ import { readPlanPolicy } from "./plan-extensions.js";
 import { coerceLegacyNarrative, LEGACY_NARRATIVE_KEY, loadProjectDefinition } from "./resolve.js";
 import { DEFAULT_WIP_CAP } from "./wip.js";
 
+export * from "./agents-md-advisory.js";
 export * from "./autonomy.js";
 export * from "./capacity.js";
 export * from "./decisions.js";

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -370,3 +370,15 @@ tasks:
       - task: :engine:invoke
         vars:
           ENGINE_CMD: 'verify:agents-md-budget --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
+
+  agents-md-advisory:
+    desc: "ADVISORY (never fail-closing) consumer AGENTS.md legibility signal (#2155). Counts the UNMANAGED (project-authored) region only -- the framework-owned managed section is excluded -- and compares it against the SOFT, operator-adjustable budget plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines (generous default when unset). Consumer companion to the maintainer-only #645 ratchet; deliberately NOT a check:consumer dependency (advise->observe->enforce per #1419). Default posture ALWAYS exits 0; the opt-in --enforce flag promotes an over-budget region to a hard cap (exit 1). Raising the field is the documented, no-friction way to accept growth and silence the nudge."
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    # Per `conventions/task-caching.md` (#574): NO `sources:` / `generates:`
+    # because the gate forwards user-facing flags via {{.CLI_ARGS}} (--quiet / --enforce).
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:agents-md-advisory --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ const subpathAliases: Record<string, string> = {
   "@deftai/directive-core/branch": sub("core", "branch"),
   "@deftai/directive-core/wip-cap": sub("core", "wip-cap"),
   "@deftai/directive-core/agents-md-budget": sub("core", "agents-md-budget"),
+  "@deftai/directive-core/agents-md-advisory": sub("core", "agents-md-advisory"),
   "@deftai/directive-core/scm": sub("core", "scm"),
   "@deftai/directive-core/scope": sub("core", "scope"),
   "@deftai/directive-core/session": sub("core", "session"),

--- a/xbrief/completed/2026-07-02-2155-consumer-agents-md-advisory.xbrief.json
+++ b/xbrief/completed/2026-07-02-2155-consumer-agents-md-advisory.xbrief.json
@@ -1,0 +1,89 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2155: advisory consumer-side AGENTS.md legibility signal (unmanaged-focused, advise->observe->enforce per #1419; never fail-closes check:consumer). Consumer companion to the maintainer-only #645 ratchet. Child of #1882.",
+    "created": "2026-07-02T00:00:00Z",
+    "updated": "2026-07-02T00:00:00Z"
+  },
+  "plan": {
+    "id": "2155-consumer-agents-md-advisory",
+    "title": "Advisory consumer AGENTS.md legibility signal (unmanaged-focused, non-failing)",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2155",
+    "narratives": {
+      "Description": "The #645 ratchet governs the MAINTAINER (deftai/directive) AGENTS.md and is fail-closed for this repo only. Consumers get the managed section propagated but their UNMANAGED section is theirs -- we cannot know their real needs, so we must not fail-close their build on size. This story adds an ADVISORY consumer-side legibility signal: it measures the consumer AGENTS.md (focused on the unmanaged region, since the managed section is framework-owned) against a soft, operator-adjustable budget and SURFACES guidance without failing the gate. It follows the advise->observe->enforce posture (#1419): advisory-only in v1, operator can raise/configure the soft budget, and it never fail-closes check:consumer.",
+      "ImplementationPlan": "1. Study the consumer check surface (check:consumer / doctor consumer path) and the #645 evaluate module (packages/core agents-md-budget) for the region-counting helper to reuse. 2. Add an advisory evaluator that counts the consumer AGENTS.md unmanaged region and compares against a soft, operator-configurable budget (typed policy field, default generous; document how to raise it). It returns an advisory message, never a non-zero fail. 3. Wire it as advisory output in check:consumer / doctor (informational line, exit 0 always). Make the soft budget configurable via a typed plan.policy field and documented override. 4. Tests: at/under budget (silent or gentle), over budget (advisory message, still exit 0), configurable-raise honored, managed section excluded from the count. 5. Docs: consumer-facing note (REFERENCES.md or docs) explaining the advisory signal, why it's advisory, and how to adjust. CHANGELOG [Unreleased] entry. Run `task check` green.",
+      "UserStory": "As a consumer of directive, I want an ADVISORY signal when my AGENTS.md unmanaged section grows large (with an easy way to raise the threshold), so that I get legibility guidance without my build ever failing on a judgment call about my own file.",
+      "Traces": "#2155, #645, #1419, #1882"
+    },
+    "items": [
+      {
+        "id": "ca-a1",
+        "title": "Advisory-only: never fail-closes check:consumer",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a consumer AGENTS.md over the soft budget, when check:consumer / doctor runs, then an advisory message is surfaced and the command still exits 0 (never fail-closed)."
+        }
+      },
+      {
+        "id": "ca-a2",
+        "title": "Unmanaged-focused count with configurable soft budget",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the consumer AGENTS.md, when measured, then the framework-owned managed section is excluded and the soft budget is an operator-adjustable typed policy field with a documented override to raise it."
+        }
+      },
+      {
+        "id": "ca-a3",
+        "title": "Tests + docs + task check",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given tests for at/under/over budget + configurable-raise + managed-excluded, and a consumer-facing doc note, then `task check` passes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1882",
+        "child_issue": "#2155"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src (advisory evaluator, reuse agents-md-budget region helper)",
+          "packages/cli/src (check:consumer / doctor wiring)",
+          "tests",
+          "docs/REFERENCES.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task check"
+        ],
+        "expected_outputs": [
+          "Advisory (non-failing) consumer AGENTS.md unmanaged-region legibility signal with operator-adjustable soft budget; advise->observe->enforce posture; tests + docs"
+        ],
+        "depends_on": [],
+        "conflict_group": "consumer-legibility",
+        "size": "medium",
+        "file_scope_confidence": "low",
+        "model_tier": "high"
+      },
+      "completedAt": "2026-07-02T13:51:30Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2155",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2155: advisory consumer AGENTS.md legibility signal"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1882",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1882: AGENTS.md map-not-manual umbrella"
+      }
+    ],
+    "updated": "2026-07-02T13:51:30Z"
+  }
+}


### PR DESCRIPTION
## Summary

Adds an **advisory** consumer-side AGENTS.md legibility signal, focused on the **unmanaged** (project-authored) region, that **never fail-closes** a consumer's build. This is the consumer companion to the maintainer-only #645 ratchet (`check:framework-source`), following the `verify:capacity` / `verify:judgment-gates` **advise → observe → enforce** posture (#1419).

- **New pure evaluator** (`packages/core/src/agents-md-advisory`) reuses the #645 region counter (`countRegions`) so the framework-owned **managed section is excluded** — only the consumer-authored unmanaged region is measured. In the default advisory posture it **always returns exit 0**.
- **New typed policy field** `plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines` — a soft, operator-adjustable budget, **generous by default (300)** when unset. Raising it is the no-friction, self-service way to accept legitimate growth and silence the nudge.
- **Wired into `deft doctor`** as a non-failing `warning` finding (never an `error`), so `deft doctor` and the `check:consumer` aggregate that depends on it **always exit 0** — it can never fail-close on a judgment call about the consumer's own file. Managed-section growth is not surfaced as consumer-actionable.
- **Opt-in `--enforce` tier**: `deft verify:agents-md-advisory --enforce` (also `task verify:agents-md-advisory -- --enforce`) exits non-zero over budget for consumers who want a hard cap. It is deliberately **not** a `check:consumer` dependency.
- **Docs**: `REFERENCES.md` consumer section explaining why it's advisory, unmanaged-focused, and how to adjust; `CHANGELOG.md` `[Unreleased]` entry.

## Acceptance mapping (#2155)

- ✅ Advisory surface reports managed/unmanaged counts + "map not manual" guidance and exits 0 by default.
- ✅ NOT a `check:consumer` dependency that can fail-close in the default posture (wired as a non-failing doctor finding; standalone `--enforce` verb is opt-in only).
- ✅ With a seeded budget, warns (non-blocking) when unmanaged exceeds `unmanagedSoftMaxLines`; raising the field silences it.
- ✅ Managed-section growth is not a consumer-actionable failure (excluded from the count).
- ✅ Opt-in `--enforce` hard-cap posture exists.
- ✅ Docs state the budget is self-service and cite the empirical basis (`content/docs/good-agents-md.md`).

## Related Issues

Closes #2155. Refs #645, #1419, #1882.

## Checklist

- [x] `/deft:change` — N/A: covered by scope xBRIEF for #2155 (child of umbrella #1882).
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`.
- [x] `ROADMAP.md` — N/A (batch-moved at release time).
- [x] Tests pass locally (`task check` green; new evaluator, policy resolver, CLI verb, and doctor-wiring tests added).

## Test plan

- [x] `task check` green (build + biome + full vitest + coverage ≥ 85%).
- [x] Advisory over-budget → exit 0 (verified against the framework AGENTS.md: unmanaged 327 > default 300 → advisory note, exit 0).
- [x] `--enforce` over-budget → exit 1.
- [x] Unit tests: at/under budget, over budget (exit 0), configurable-raise silences, managed section excluded, missing/malformed AGENTS.md, `--enforce` tiers, doctor non-failing warning.

## Post-Merge

- [ ] **Verify issue auto-close**: after squash merge, confirm #2155 closed — `gh issue view 2155 --json state --jq .state`.
