### PR TITLE
feat: Cursor Tier-1 dispatch provider + single-dispatch routing gate (#1877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cursor is a first-class Tier-1 dispatch provider in routing and monitoring matrices (#1877).** `task verify:routing` now resolves the active provider as `cursor` when running under Cursor (instead of falling through to `cloud-headless`), the swarm and review-cycle tier matrices enumerate Cursor as Tier 1 → Approach 1, `task verify:story-ready` chains the routing gate for single Task dispatches, and a deterministic `verify:cursor-tier1` content gate guards the matrices. Closes #1877. Refs #935, #1880.
+
 - **AGENTS.md now has a line-budget ratchet that stops it silently bloating (#645).** A new `verify:agents-md-budget` gate (wired into `task check`) counts the managed section and the hand-maintained region of AGENTS.md separately and fails when either grows past the budget recorded in `PROJECT-DEFINITION` (`plan.policy.agentsMdBudget`). The budget is seeded at the current size, so it ships green and only flags future growth — reductions are always allowed and should tighten the budget toward the ~100–150 line ceiling that keeps AGENTS.md a map, not a manual. Refs #645, #1882.
 
 ### Changed

--- a/content/templates/agent-prompt-preamble.md
+++ b/content/templates/agent-prompt-preamble.md
@@ -96,7 +96,7 @@ Worked example (a tiered leaf worker on Composer):
 - model_source: cursor-route
 ```
 
-! Pre-dispatch gate (#1739): run `task verify:routing` before spawning a cohort -- it fails when a dispatched worker role has no decision (pinned model or explicit harness default) for the active provider. Session start runs `task verify:routing -- --advise` (non-blocking disclosure).
+! Pre-dispatch gate (#1739 / #1877): run `task verify:routing` before spawning ANY sub-agent (cohort OR solo) — it fails when a dispatched worker role has no decision (pinned model or explicit harness default) for the active provider. `task verify:story-ready` chains the same routing gate for single Cursor/Grok Task dispatches (#1877). Session start runs `task verify:routing -- --advise` (non-blocking disclosure).
 
 Reference: `.deft/routing.local.json` + `task swarm:routing-set` + `task verify:routing` (#1739, supersedes the `plan.policy.swarmSubagentBackend` enum of #1531a / #1735), `scripts/policy.py` `SWARM_WORKER_ROLES`, issue #1531 scope update (dispatch provider / worker role / model selection are three separate concerns).
 

--- a/docs/subagent-heartbeat.md
+++ b/docs/subagent-heartbeat.md
@@ -16,6 +16,25 @@ other two produced **zero** observable signals (no commits, no PR
 comments, no messages). The monitor could not tell whether they were
 working, stalled, or dead. This contract closes that visibility gap.
 
+## Cursor Task pollers (#1877)
+
+! Every long-running Cursor `Task` sub-agent (review-monitor poller,
+implementation worker whose tool loop is expected to exceed ~3 minutes,
+or any backgrounded `run_in_background: true` worker) MUST honour this
+heartbeat contract — same obligation as the `spawn_subagent` path above
+(#1166). The Cursor completion-notification channel does NOT replace
+periodic heartbeats; it only signals terminal completion.
+
+~ Cursor pollers write to the same `.deft-scratch/subagent-status/<agent-id>.json`
+path and schema documented below. The monitor helper
+(`scripts/subagent_monitor.py`) reads both Grok Build and Cursor poller
+records from that directory without a separate Cursor-specific surface.
+
+Cross-references: `skills/deft-directive-review-cycle/SKILL.md` Review
+Monitoring (Approach 1 / heartbeat contract for Cursor pollers),
+`skills/deft-directive-swarm/SKILL.md` Phase 3 Step 2e (Cursor launch).
+Refs #1877, #1166.
+
 ## Where heartbeats live
 
 ! Every long-running sub-agent (review-cycle poller, watchdog, or

--- a/packages/cli/src/lifecycle-cli/dispatch-preflight.test.ts
+++ b/packages/cli/src/lifecycle-cli/dispatch-preflight.test.ts
@@ -75,6 +75,7 @@ describe("deft-ts preflight / verify gates (#1838 s3)", () => {
       vbriefPath,
       "--project-root",
       root,
+      "--skip-routing",
     ]);
     const alias = await runDispatch([
       "verify:story-ready",
@@ -82,6 +83,7 @@ describe("deft-ts preflight / verify gates (#1838 s3)", () => {
       vbriefPath,
       "--project-root",
       root,
+      "--skip-routing",
     ]);
     expect(alias.exitCode).toBe(canonical.exitCode);
     expect(canonical.exitCode).toBe(0);

--- a/packages/cli/src/verify-story-ready.test.ts
+++ b/packages/cli/src/verify-story-ready.test.ts
@@ -51,8 +51,9 @@ function buildRepo(status = "running"): { root: string; vbriefPath: string } {
 function silentRun(argv: string[]): number {
   const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
   const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  const args = argv.includes("--skip-routing") ? argv : [...argv, "--skip-routing"];
   try {
-    return run(argv);
+    return run(args);
   } finally {
     out.mockRestore();
     err.mockRestore();
@@ -176,12 +177,63 @@ describe("run", () => {
     const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
     const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
     try {
-      expect(run(["--vbrief-path", vbriefPath, "--project-root", root, "--json"])).toBe(0);
+      expect(
+        run(["--vbrief-path", vbriefPath, "--project-root", root, "--json", "--skip-routing"]),
+      ).toBe(0);
       const written = out.mock.calls.map((c) => String(c[0])).join("");
       expect(written).toContain('"ready":true');
     } finally {
       out.mockRestore();
       err.mockRestore();
+    }
+  });
+
+  it("chains verify:routing for cursor provider when routing is undecided (#1877)", () => {
+    const saved = process.env.CURSOR_AGENT;
+    process.env.CURSOR_AGENT = "1";
+    const { root, vbriefPath } = buildRepo();
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(run(["--vbrief-path", vbriefPath, "--project-root", root])).toBe(1);
+    } finally {
+      out.mockRestore();
+      err.mockRestore();
+      if (saved === undefined) {
+        delete process.env.CURSOR_AGENT;
+      } else {
+        process.env.CURSOR_AGENT = saved;
+      }
+    }
+  });
+
+  it("passes routing gate for cursor when leaf-implementation is decided (#1877)", () => {
+    const savedAgent = process.env.CURSOR_AGENT;
+    const savedRouting = process.env.DEFT_ROUTING_PATH;
+    process.env.CURSOR_AGENT = "1";
+    const { root, vbriefPath } = buildRepo();
+    const routingPath = join(root, ".deft", "routing.local.json");
+    mkdirSync(join(root, ".deft"), { recursive: true });
+    writeFileSync(
+      routingPath,
+      JSON.stringify({
+        cursor: { "leaf-implementation": { model: "composer-2.5-fast", mode: "pinned" } },
+      }),
+    );
+    process.env.DEFT_ROUTING_PATH = routingPath;
+    try {
+      expect(run(["--vbrief-path", vbriefPath, "--project-root", root, "--allow-dirty"])).toBe(0);
+    } finally {
+      if (savedAgent === undefined) {
+        delete process.env.CURSOR_AGENT;
+      } else {
+        process.env.CURSOR_AGENT = savedAgent;
+      }
+      if (savedRouting === undefined) {
+        delete process.env.DEFT_ROUTING_PATH;
+      } else {
+        process.env.DEFT_ROUTING_PATH = savedRouting;
+      }
     }
   });
 });

--- a/packages/cli/src/verify-story-ready.ts
+++ b/packages/cli/src/verify-story-ready.ts
@@ -3,6 +3,11 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { evaluate, gitPorcelain, parseAllocationSection } from "@deftai/directive-core/story-ready";
+import {
+  ROUTING_GATED_DISPATCH_PROVIDERS,
+  resolveDispatchProvider,
+  verifyRouting,
+} from "@deftai/directive-core/swarm";
 
 interface ParsedArgs {
   vbriefPath: string | null;
@@ -10,6 +15,8 @@ interface ParsedArgs {
   allocationContext: string | null;
   allowDirty: boolean;
   emitJson: boolean;
+  skipRouting: boolean;
+  roles: string[];
   help?: boolean;
   error?: string;
 }
@@ -22,6 +29,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     allocationContext: null,
     allowDirty: false,
     emitJson: false,
+    skipRouting: false,
+    roles: [],
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -57,6 +66,25 @@ export function parseArgs(argv: string[]): ParsedArgs {
       i += 1;
     } else if (arg?.startsWith("--allocation-context=")) {
       parsed.allocationContext = arg.slice("--allocation-context=".length);
+    } else if (arg === "--skip-routing") {
+      parsed.skipRouting = true;
+    } else if (arg === "--roles") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --roles: expected one argument" };
+      }
+      for (const role of value.split(",")) {
+        if (role.trim().length > 0) {
+          parsed.roles.push(role.trim());
+        }
+      }
+      i += 1;
+    } else if (arg?.startsWith("--roles=")) {
+      for (const role of arg.slice("--roles=".length).split(",")) {
+        if (role.trim().length > 0) {
+          parsed.roles.push(role.trim());
+        }
+      }
     } else if (arg === "--help" || arg === "-h") {
       return { ...parsed, help: true };
     } else {
@@ -72,8 +100,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
 const HELP_TEXT = `usage: verify-story-ready [--vbrief-path PATH] [--project-root PATH]
                           [--allocation-context PATH] [--allow-dirty] [--json]
+                          [--skip-routing] [--roles ROLE[,ROLE...]]
 
-Deterministic story-start Gate 0 (#1378). Three-state exit: 0 ready / 1 not ready / 2 config error.
+Deterministic story-start Gate 0 (#1378). When the active dispatch provider is
+cursor or grok, chains verify:routing (#1877 single-dispatch enforcement).
+Three-state exit: 0 ready / 1 not ready / 2 config error.
 `;
 
 function emitJson(
@@ -136,6 +167,27 @@ export function run(argv: string[]): number {
     allowDirty: args.allowDirty,
     parsed,
   });
+
+  if (result.exitCode === 0 && !args.skipRouting) {
+    const provider = resolveDispatchProvider(process.env);
+    if (ROUTING_GATED_DISPATCH_PROVIDERS.has(provider)) {
+      const routingResult = verifyRouting({
+        projectRoot,
+        environ: process.env,
+        roles: args.roles.length > 0 ? args.roles : undefined,
+      });
+      if (routingResult.exitCode !== 0) {
+        if (args.emitJson) {
+          process.stdout.write(
+            `${emitJson(vbriefPath, routingResult.exitCode, routingResult.report, result.dispatchKind)}\n`,
+          );
+        } else {
+          process.stderr.write(`${routingResult.report}\n`);
+        }
+        return routingResult.exitCode;
+      }
+    }
+  }
 
   if (args.emitJson) {
     process.stdout.write(

--- a/packages/core/src/swarm/launch-routing.test.ts
+++ b/packages/core/src/swarm/launch-routing.test.ts
@@ -114,6 +114,12 @@ describe("swarmLaunch route-file integration (#1739)", () => {
       preflightGate: () => ({ exitCode: 0, message: "" }),
       readinessGate: () => ({ exitCode: 0, report: "" }),
       runtimeAuthProbe: () => ["cursor-cloud", "gh-cli"],
+      // Pin the routing-provider environ explicitly (#1877 Greptile follow-up)
+      // rather than relying on ambient process.env -- a headless CI runner has
+      // no CURSOR_AGENT/CURSOR_COMPOSER set, so the un-injected form resolved
+      // to "cloud-headless" there even though it resolved to "cursor" locally
+      // inside an actual Cursor session.
+      environ: { CURSOR_AGENT: "1" },
     });
 
     expect(result.exitCode).toBe(0);
@@ -143,6 +149,7 @@ describe("swarmLaunch route-file integration (#1739)", () => {
       preflightGate: () => ({ exitCode: 0, message: "" }),
       readinessGate: () => ({ exitCode: 0, report: "" }),
       runtimeAuthProbe: () => ["cursor-cloud", "gh-cli"],
+      environ: { CURSOR_AGENT: "1" },
     });
 
     expect(result.exitCode).toBe(2);

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -526,6 +526,12 @@ export interface LaunchArgs {
   readinessGate?: ReadinessGateFn;
   worktreeResolver?: WorktreeResolverFn;
   runtimeAuthProbe?: RuntimeAuthProbeFn;
+  /**
+   * Injection seam for the routing-provider environment lookup, mirroring
+   * `resolveRoutingPath`'s `environ` parameter (#1877 Greptile follow-up).
+   * Defaults to `process.env` when unset.
+   */
+  environ?: NodeJS.ProcessEnv;
 }
 
 export function swarmLaunch(args: LaunchArgs): {
@@ -679,7 +685,7 @@ export function swarmLaunch(args: LaunchArgs): {
   let modelSource: string | null = null;
   let routingProvider: string | null = null;
   if (routingFile !== null) {
-    routingProvider = resolveDispatchProvider(process.env);
+    routingProvider = resolveDispatchProvider(args.environ ?? process.env);
     const route = resolveModelRoute(routingFile, routingProvider, LEAF_CODING_WORKER_ROLE);
     // A malformed decision object must fail loud here: the legacy backend gate
     // was already bypassed above (routingFile !== null), so silently continuing

--- a/packages/core/src/swarm/launch.ts
+++ b/packages/core/src/swarm/launch.ts
@@ -21,8 +21,8 @@ import {
 } from "./constants.js";
 import { readinessReport } from "./readiness.js";
 import {
-  dispatchProviderFromRuntime,
   loadRoutingFile,
+  resolveDispatchProvider,
   resolveModelRoute,
   resolveRoutingPath,
 } from "./routing.js";
@@ -679,7 +679,7 @@ export function swarmLaunch(args: LaunchArgs): {
   let modelSource: string | null = null;
   let routingProvider: string | null = null;
   if (routingFile !== null) {
-    routingProvider = dispatchProviderFromRuntime(runtimeMode);
+    routingProvider = resolveDispatchProvider(process.env);
     const route = resolveModelRoute(routingFile, routingProvider, LEAF_CODING_WORKER_ROLE);
     // A malformed decision object must fail loud here: the legacy backend gate
     // was already bypassed above (routingFile !== null), so silently continuing

--- a/packages/core/src/swarm/routing-verify.test.ts
+++ b/packages/core/src/swarm/routing-verify.test.ts
@@ -123,6 +123,20 @@ describe("verifyRouting (advise posture, never blocks)", () => {
     expect(r.report).toContain("undecided");
   });
 
+  it("resolves provider cursor from CURSOR_AGENT without --provider override (#1877)", () => {
+    const { dir, env } = withRouteFile({
+      cursor: { "leaf-implementation": { model: "composer-2.5-fast", mode: "pinned" } },
+    });
+    cleanups.push(dir);
+    const r = verifyRouting({
+      projectRoot: dir,
+      environ: { ...env, CURSOR_AGENT: "1" },
+      advise: true,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.report).toContain("provider 'cursor'");
+  });
+
   it("exit 0 even on a malformed route file (advisory)", () => {
     const { dir, env } = withRouteFile("{not json");
     cleanups.push(dir);

--- a/packages/core/src/swarm/routing-verify.ts
+++ b/packages/core/src/swarm/routing-verify.ts
@@ -8,13 +8,13 @@
  *       1 = at least one in-scope role is undecided / not dispatchable
  *       2 = config error (unreadable / malformed route file)
  */
-import { getPlatformCapabilities } from "../intake/platform-capabilities.js";
 import { EXIT_CONFIG_ERROR, EXIT_GATE_FAILED, EXIT_OK } from "./constants.js";
 import {
   dispatchProviderFromRuntime,
   HARNESS_BOUND_PROVIDERS,
   loadRoutingFile,
   ROUTING_MODE_HARNESS_DEFAULT,
+  resolveDispatchProvider,
   resolveModelRoute,
   resolveRoutingPath,
 } from "./routing.js";
@@ -33,7 +33,7 @@ export interface VerifyRoutingOptions {
   advise?: boolean;
   /** Override the resolved provider (else derived from the runtime). */
   provider?: string | null;
-  /** Inject the runtime descriptor (else getPlatformCapabilities().runtimeMode). */
+  /** Inject the runtime descriptor (legacy test seam; else resolveDispatchProvider). */
   runtimeProbe?: () => string;
 }
 
@@ -46,14 +46,16 @@ function resolveProvider(options: VerifyRoutingOptions): string {
   if (options.provider !== undefined && options.provider !== null && options.provider.length > 0) {
     return options.provider;
   }
-  const probe = options.runtimeProbe ?? (() => getPlatformCapabilities().runtimeMode);
-  let runtimeMode = "";
-  try {
-    runtimeMode = probe();
-  } catch {
-    runtimeMode = "";
+  if (options.runtimeProbe !== undefined) {
+    let runtimeMode = "";
+    try {
+      runtimeMode = options.runtimeProbe();
+    } catch {
+      runtimeMode = "";
+    }
+    return dispatchProviderFromRuntime(runtimeMode);
   }
-  return dispatchProviderFromRuntime(runtimeMode);
+  return resolveDispatchProvider(options.environ ?? process.env);
 }
 
 export function verifyRouting(options: VerifyRoutingOptions): VerifyRoutingResult {

--- a/packages/core/src/swarm/routing.test.ts
+++ b/packages/core/src/swarm/routing.test.ts
@@ -9,6 +9,7 @@ import {
   ROUTING_MODE_HARNESS_DEFAULT,
   ROUTING_MODE_PINNED,
   type RoutingFile,
+  resolveDispatchProvider,
   resolveModelRoute,
   resolveRoutingPath,
   SWARM_WORKER_ROLES,
@@ -85,6 +86,27 @@ describe("dispatchProviderFromRuntime", () => {
   it("passes through unknown and defaults empty", () => {
     expect(dispatchProviderFromRuntime("warp")).toBe("warp");
     expect(dispatchProviderFromRuntime("")).toBe("unknown");
+  });
+});
+
+describe("resolveDispatchProvider (#1877)", () => {
+  it("maps Cursor env signals to cursor even when runtime_mode would be cloud-headless", () => {
+    expect(resolveDispatchProvider({ CURSOR_AGENT: "1", CI: "true" })).toBe("cursor");
+    expect(resolveDispatchProvider({ CURSOR_COMPOSER: "1" })).toBe("cursor");
+  });
+
+  it("maps grok-build signals to grok", () => {
+    expect(resolveDispatchProvider({ GROK_BUILD: "true" })).toBe("grok");
+    expect(resolveDispatchProvider({ DEFT_AGENT_RUNTIME: "grok-build" })).toBe("grok");
+  });
+
+  it("maps CI without Cursor composer to cloud-headless", () => {
+    expect(resolveDispatchProvider({ CI: "true" })).toBe("cloud-headless");
+    expect(resolveDispatchProvider({ GITHUB_ACTIONS: "true" })).toBe("cloud-headless");
+  });
+
+  it("returns unknown for a plain local shell", () => {
+    expect(resolveDispatchProvider({})).toBe("unknown");
   });
 });
 

--- a/packages/core/src/swarm/routing.ts
+++ b/packages/core/src/swarm/routing.ts
@@ -38,6 +38,15 @@ export const ROUTING_FILENAME = "routing.local.json";
 /** Providers whose model is harness-bound -- deft cannot pin or verify a slug. */
 export const HARNESS_BOUND_PROVIDERS = new Set<string>(["grok"]);
 
+/** Providers whose per-role model must be decided before sub-agent dispatch (#1739 / #1877). */
+export const ROUTING_GATED_DISPATCH_PROVIDERS = new Set<string>(["cursor", "grok"]);
+
+const TRUTHY_ENV = new Set(["1", "true", "yes", "on"]);
+
+function envTruthy(environ: NodeJS.ProcessEnv, name: string): boolean {
+  return TRUTHY_ENV.has((environ[name] ?? "").trim().toLowerCase());
+}
+
 export interface RouteDecision {
   model: string | null;
   mode?: string;
@@ -188,6 +197,33 @@ export function dispatchProviderFromRuntime(runtimeMode: string): string {
     return "cursor";
   }
   return normalized;
+}
+
+/**
+ * Resolve the `dispatch_provider` routing key from the active runtime envelope.
+ * Separate from `runtime_mode` (#1557): Cursor sessions may carry
+ * `runtime_mode=cloud-headless` for gh-auth purposes but route under provider
+ * `cursor` for model selection (#1877).
+ */
+export function resolveDispatchProvider(environ: NodeJS.ProcessEnv = process.env): string {
+  if (envTruthy(environ, "CURSOR_COMPOSER") || envTruthy(environ, "CURSOR_AGENT")) {
+    return "cursor";
+  }
+  const runtime = (environ.DEFT_AGENT_RUNTIME ?? "").trim().toLowerCase();
+  if (envTruthy(environ, "GROK_BUILD") || runtime === "grok-build") {
+    return "grok";
+  }
+  if (runtime === "cloud" || runtime === "headless") {
+    return "cloud-headless";
+  }
+  if (
+    envTruthy(environ, "GITHUB_ACTIONS") ||
+    envTruthy(environ, "BUILDKITE") ||
+    (envTruthy(environ, "CI") && !envTruthy(environ, "CURSOR_COMPOSER"))
+  ) {
+    return "cloud-headless";
+  }
+  return "unknown";
 }
 
 /**

--- a/packages/core/src/swarm/routing.ts
+++ b/packages/core/src/swarm/routing.ts
@@ -219,7 +219,9 @@ export function resolveDispatchProvider(environ: NodeJS.ProcessEnv = process.env
   if (
     envTruthy(environ, "GITHUB_ACTIONS") ||
     envTruthy(environ, "BUILDKITE") ||
-    (envTruthy(environ, "CI") && !envTruthy(environ, "CURSOR_COMPOSER"))
+    (envTruthy(environ, "CI") &&
+      !envTruthy(environ, "CURSOR_COMPOSER") &&
+      !envTruthy(environ, "CURSOR_AGENT"))
   ) {
     return "cloud-headless";
   }

--- a/xbrief/completed/2026-07-02-1877-cursor-tier1-descriptor-routing.xbrief.json
+++ b/xbrief/completed/2026-07-02-1877-cursor-tier1-descriptor-routing.xbrief.json
@@ -1,0 +1,108 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for the #1877 residual: add Cursor as an explicit Tier-1 descriptor in the swarm Phase 3 + review-cycle monitoring matrices, resolve verify:routing as 'cursor' (not cloud-headless) in Cursor, wire verify:routing into the single-dispatch pre-dispatch gate stack, and extend the #1166 heartbeat to Cursor pollers >3min. Parent #935.",
+    "created": "2026-07-02T00:00:00Z",
+    "updated": "2026-07-02T00:00:00Z"
+  },
+  "plan": {
+    "id": "1877-cursor-tier1-descriptor-routing",
+    "title": "Cursor Tier-1 descriptor + single-dispatch routing enforcement + cursor provider resolution",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/1877",
+    "narratives": {
+      "Description": "Cursor has a first-class backgroundable sub-agent primitive (the Task tool) and is therefore Tier 1, but the swarm Phase 3 Step 1 detection matrix and the review-cycle Review Monitoring tier table never probe for it, so a Cursor agent falls through to generic-terminal / a blocking poll. Separately, `task verify:routing` resolves the provider as 'cloud-headless' when running in Cursor (confirmed live), and the routing gate is only wired for swarm cohorts -- a single Cursor Task dispatch can silently inherit the parent model with no resolved-model enforcement (the exact miss observed in the #1882 Wave-3 swarm). This story delivers the documented #1877 residual (AC1 + AC3 + the #1880-folded single-dispatch + cursor-provider items + optional stretch verify check).",
+      "ImplementationPlan": "1. Cursor provider descriptor: make provider detection resolve 'cursor' (cursor-composer interactive / cursor-cloud-agent cloud, Task-tool dispatch primitive) when running under Cursor, so `task verify:routing` and the session advisory bucket routes under a Cursor provider rather than falling through to cloud-headless/generic-terminal. Find the provider-detection code path used by swarm-routing-verify / the routing resolver (packages/core / packages/cli). Preserve existing providers. 2. Tier-1 matrices: add the Cursor descriptor mapped to Tier 1 -> Approach 1 (backgrounded Task poller) in content/skills/deft-directive-swarm/SKILL.md Phase 3 Step 1 detection matrix AND content/skills/deft-directive-review-cycle/SKILL.md Review Monitoring tier table. 3. Single-dispatch routing enforcement (folded from #1880): wire `verify:routing` into the canonical single-dispatch pre-dispatch gate stack (not just cohorts) so any single Cursor Task implementation/monitor dispatch requires a resolved model for the dispatched role -- fail or prompt when undecided. 4. Heartbeat: extend the #1166 heartbeat contract (docs/subagent-heartbeat.md) requirement to Cursor pollers whose loop runs > ~3 min, same as the spawn_subagent path. 5. Stretch (include if low-cost): a deterministic verify:/detection helper so 'Cursor -> Tier 1' is machine-resolved rather than prose-trusted. 6. If any consumer-relevant managed-section rule changes, mirror into content/templates/agents-entry.md and run `task agents:refresh` (template-propagation discipline #1309). Update content contract tests (skills/preamble) as needed. 7. CHANGELOG [Unreleased] entry. New source files get tests. Run `task check` green.",
+      "UserStory": "As an agent orchestrating a swarm from Cursor, I want Cursor recognized as a Tier-1 dispatch provider so routing resolves under a Cursor bucket, monitoring uses a backgrounded Task poller (not a blocking loop), and even a single Task dispatch is gated on a resolved model -- so the parent-model-inheritance miss cannot recur silently.",
+      "Traces": "#1877, #1880, #1739, #1531, #1342, #1166, #935"
+    },
+    "items": [
+      {
+        "id": "c-a1",
+        "title": "verify:routing resolves as a Cursor provider in Cursor",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given an agent running under Cursor, when `task verify:routing` (and the session advisory) run, then the resolved provider is a Cursor descriptor (cursor-composer / cursor-cloud-agent), not cloud-headless / generic-terminal."
+        }
+      },
+      {
+        "id": "c-a2",
+        "title": "Cursor is a Tier-1 descriptor in both matrices",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the swarm Phase 3 Step 1 detection matrix and the review-cycle Review Monitoring tier table, when read, then each enumerates a Cursor descriptor (Task-tool primitive) mapped to Tier 1 -> Approach 1 (backgrounded Task poller); a content-contract test asserts it."
+        }
+      },
+      {
+        "id": "c-a3",
+        "title": "Single Cursor Task dispatch is gated on a resolved model",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a single (non-cohort) Cursor Task implementation/monitor dispatch, when the pre-dispatch gate stack runs, then `verify:routing` requires a resolved model for the dispatched role and fails/prompts when the role is undecided."
+        }
+      },
+      {
+        "id": "c-a4",
+        "title": "Heartbeat extended to Cursor pollers >3min",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a Cursor poller whose loop runs > ~3 min, when the guidance is read, then the #1166 heartbeat contract requirement explicitly applies to it, same as the spawn_subagent path."
+        }
+      },
+      {
+        "id": "c-a5",
+        "title": "task check green",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given `task check`, when it runs on the PR, then content-contract tests, any new verify check, verify:encoding, and the full suite pass; template propagation ran if a consumer-relevant rule changed."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#935",
+        "child_issue": "#1877"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src (provider detection / routing resolver)",
+          "packages/cli/src (verify:routing single-dispatch wiring)",
+          "content/skills/deft-directive-swarm/SKILL.md",
+          "content/skills/deft-directive-review-cycle/SKILL.md",
+          "content/templates/agent-prompt-preamble.md",
+          "docs/subagent-heartbeat.md",
+          "tests",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task check"
+        ],
+        "expected_outputs": [
+          "Cursor resolves as a Tier-1 provider in verify:routing + both monitoring matrices; single-dispatch routing gate enforces a resolved model; heartbeat extended to Cursor pollers >3min"
+        ],
+        "depends_on": [],
+        "conflict_group": "cursor-dispatch-wiring",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "high"
+      },
+      "completedAt": "2026-07-02T14:15:58Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1877",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1877: Cursor Tier-1 descriptor in swarm + review-cycle matrices"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/935",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #935: beta readiness — cross-agent compat (parent)"
+      }
+    ],
+    "updated": "2026-07-02T14:15:58Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `resolveDispatchProvider()` so `task verify:routing` and `task swarm:launch` resolve the active provider as **`cursor`** when running under Cursor (`CURSOR_AGENT` / `CURSOR_COMPOSER`), instead of falling through to `cloud-headless`.
- Chains `verify:routing` into `task verify:story-ready` for single Cursor/Grok Task dispatches (#1880 fold-in): undecided per-role model routing now fails the gate before dispatch.
- Extends `docs/subagent-heartbeat.md` with an explicit Cursor `Task` poller section (#1166 parity) and updates the agent preamble pre-dispatch gate wording.

This PR delivers the **#1877 residual** scoped in the 2026-06-29 status comment and 2026-07-02 reopen comment (parent umbrella #935). Tier-1 matrix content and the deterministic `verify:cursor-tier1` content gate were already on master; this PR closes the provider-resolution and single-dispatch enforcement gaps.

## Related Issues

Closes #1877

## Checklist

- [x] `/deft:change <name>` — N/A (scoped xBRIEF `2026-07-02-1877-cursor-tier1-descriptor-routing.xbrief.json` covers this story)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [ ] `ROADMAP.md` — N/A (release-time batch)
- [x] Tests pass locally (`task check` green)

## Test plan

- [x] `task verify:routing -- --advise` reports `provider 'cursor'` in Cursor
- [x] `task verify:cursor-tier1` passes (matrix markers present)
- [x] `pnpm -w exec vitest run` routing + verify-story-ready suites
- [x] Full `task check` green

## Post-Merge

- [ ] Verify issue auto-close: `gh issue view 1877 --json state --jq .state`


Made with [Cursor](https://cursor.com)