### PR TITLE
test: remove real subprocess/network calls from flaky unit tests (#2166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mocked unit tests no longer depend on real network or subprocess latency (#2166).** Doctor payload-staleness branch tests, framework-command validation, and GitHub auth-mode CLI coverage now stub git-ls-remote, npm-view, filesystem-walk, and gh-auth seams so CI cannot spuriously hit 5s vitest timeouts under load. Closes #2166. Refs #1882, #644.
+
 ### Added
 
 - **Directive now teaches the empirically-grounded AGENTS.md structure — and surfaces doc sprawl before it degrades agents (#646, #647).** A new `content/docs/agent-docs.md` reference encodes the measured structure pattern for a project's AGENTS.md (100–150 line main file + focused reference docs, numbered workflows, decision tables, real snippets, paired don't/do rules, module-level over root files) and the measured overexploration failure modes, so projects directive creates get the "model-upgrade" version of agent docs instead of the "worse than nothing" version. The `deft-directive-sync` skill gains an advisory (never-blocking) doc-sprawl awareness step that flags orphan docs and large reachable doc volumes, and `deft-directive-pre-pr` reminds you to keep newly added docs in the reference chain. Refs #646, #647, #1882, #644.

--- a/packages/core/src/doctor/coverage-final.test.ts
+++ b/packages/core/src/doctor/coverage-final.test.ts
@@ -203,12 +203,18 @@ describe("doctor coverage final", () => {
 
   it("payload staleness skip when sha or ref missing", () => {
     const sink = createPlainSink({ write: () => {} });
+    const offlineSeams = {
+      runGitLsRemote: () => ({ ok: false, stdout: "" }),
+      runNpmViewVersion: () => ({ ok: false, version: "" }),
+    };
     runPayloadStalenessCheck("/tmp", sink, () => {}, {
+      ...offlineSeams,
       readText: (p) => (p.endsWith("VERSION") ? "ref: main\n" : "consumer\n"),
       isFile: (p) => p.endsWith("VERSION") || p.endsWith("AGENTS.md"),
       frameworkRoot: "/fw",
     });
     runPayloadStalenessCheck("/tmp", sink, () => {}, {
+      ...offlineSeams,
       readText: (p) => (p.endsWith("VERSION") ? "sha: abc\n" : "consumer\n"),
       isFile: (p) => p.endsWith("VERSION") || p.endsWith("AGENTS.md"),
       frameworkRoot: "/fw",

--- a/packages/core/src/doctor/main-branches.test.ts
+++ b/packages/core/src/doctor/main-branches.test.ts
@@ -440,24 +440,31 @@ describe("helpers branch sweep", () => {
   it("payload staleness skip branches", () => {
     const sink = createPlainSink({ write: () => {} });
     const add = vi.fn();
+    const offlineSeams = {
+      runGitLsRemote: () => ({ ok: false, stdout: "" }),
+      runNpmViewVersion: () => ({ ok: false, version: "" }),
+    };
     runPayloadStalenessCheck("/tmp", sink, add, {
+      ...offlineSeams,
       readText: () => "consumer",
       isFile: (p) => p.endsWith("VERSION"),
       frameworkRoot: "/fw",
-      runGitLsRemote: () => ({ ok: false, stdout: "" }),
     });
     runPayloadStalenessCheck("/tmp", sink, add, {
+      ...offlineSeams,
       readText: (p) => (p.endsWith("VERSION") ? "sha: abc\n" : "consumer"),
       isFile: () => true,
       frameworkRoot: "/fw",
     });
     runPayloadStalenessCheck("/tmp", sink, add, {
+      ...offlineSeams,
       readText: (p) => (p.endsWith("VERSION") ? "ref: main\nsha: abc\n" : "consumer"),
       isFile: () => true,
       frameworkRoot: "/fw",
       runGitLsRemote: () => ({ ok: true, stdout: "" }),
     });
     runPayloadStalenessCheck("/tmp", sink, add, {
+      ...offlineSeams,
       readText: (p) => (p.endsWith("VERSION") ? "ref: main\nsha: abc\n" : "consumer"),
       isFile: () => true,
       frameworkRoot: "/fw",
@@ -467,12 +474,14 @@ describe("helpers branch sweep", () => {
       }),
     });
     runPayloadStalenessCheck("/tmp", sink, add, {
+      ...offlineSeams,
       readText: (p) => (p.endsWith("VERSION") ? "ref: main\nsha: abc\n" : "consumer"),
       isFile: () => true,
       frameworkRoot: "/fw",
       runGitLsRemote: () => ({ ok: true, stdout: "abc refs/heads/main\n" }),
     });
     runPayloadStalenessCheck("/tmp", sink, add, {
+      ...offlineSeams,
       readText: (p) => (p.endsWith(".deft-version") ? "sha: x\nref: main\n" : null),
       isFile: (p) => p.endsWith(".deft-version"),
       frameworkRoot: "/fw",

--- a/packages/core/src/intake/github-auth-modes.ts
+++ b/packages/core/src/intake/github-auth-modes.ts
@@ -341,11 +341,13 @@ export interface GitHubAuthModesCliArgs {
   githubAuthMode?: string | null;
   repo?: string;
   json?: boolean;
+  runGh?: GhRunner;
 }
 
 export function githubAuthModesMain(args: GitHubAuthModesCliArgs): number {
   const result = validateGithubAuthForWorker(args.githubAuthMode ?? null, {
     repo: args.repo ?? DEFAULT_VALIDATION_REPO,
+    runGh: args.runGh,
   });
   if (args.json) {
     process.stdout.write(`${JSON.stringify(resultToDict(result), null, 2)}\n`);

--- a/packages/core/src/intake/intake-coverage-boost.test.ts
+++ b/packages/core/src/intake/intake-coverage-boost.test.ts
@@ -660,24 +660,21 @@ describe("intake coverage boost", () => {
     });
 
     it("validateGithubAuthForWorker and CLI output", () => {
+      const runner = ghRunner({
+        auth: completed(),
+        user: completed('"octo"'),
+        repo: completed("{}"),
+      });
       const result = validateGithubAuthForWorker("host-gh", {
-        runGh: ghRunner({
-          auth: completed(),
-          user: completed('"octo"'),
-          repo: completed("{}"),
-        }),
+        runGh: runner,
         runtimeReport: { runtimeMode: RUNTIME_MODE_LOCAL_UNSANDBOXED },
       });
       expect(resultToDict(result).ok).toBe(true);
       const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-      // githubAuthModesMain shells out to the real `gh` (no injectable runner), so its
-      // exit code depends on the host's auth state (0 authenticated / 1 not). Assert it
-      // returns a valid exit code while exercising both the JSON and text output branches
-      // so the test stays hermetic across local (authed) and CI (unauthed) environments.
-      const jsonExit = githubAuthModesMain({ githubAuthMode: "host-gh", json: true });
-      expect([0, 1]).toContain(jsonExit);
-      const textExit = githubAuthModesMain({ githubAuthMode: "host-gh", json: false });
-      expect([0, 1]).toContain(textExit);
+      expect(githubAuthModesMain({ githubAuthMode: "host-gh", json: true, runGh: runner })).toBe(0);
+      expect(githubAuthModesMain({ githubAuthMode: "host-gh", json: false, runGh: runner })).toBe(
+        0,
+      );
       expect(stdout).toHaveBeenCalled();
       stdout.mockRestore();
     });

--- a/packages/core/src/render/framework-commands-branches.test.ts
+++ b/packages/core/src/render/framework-commands-branches.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   cmdCoreLint,
@@ -20,9 +23,19 @@ describe("framework-commands branch coverage", () => {
   });
 
   it("cmdCoreValidate succeeds with capture", () => {
-    const result = runFrameworkCommand("core:validate", [], { capture: true });
-    expect(result.code).toBe(0);
-    expect(result.stdout).toContain("markdown files validated");
+    const root = mkdtempSync(join(tmpdir(), "fw-core-val-"));
+    writeFileSync(join(root, "sample.md"), "# sample\n", "utf8");
+    try {
+      const result = runFrameworkCommand("core:validate", [], {
+        capture: true,
+        frameworkRoot: root,
+        projectRoot: root,
+      });
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("markdown files validated");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("formatFrameworkCommand supports task surface prefix", () => {

--- a/xbrief/completed/2026-07-02-2166-flaky-subprocess-tests.xbrief.json
+++ b/xbrief/completed/2026-07-02-2166-flaky-subprocess-tests.xbrief.json
@@ -1,0 +1,61 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Remove real subprocess/network dependence from mocked unit tests that flake with 5s vitest timeouts (main-branches, framework-commands, intake-coverage-boost) by stubbing/injecting the subprocess seams (#2166).",
+    "created": "2026-07-02T00:00:00Z",
+    "updated": "2026-07-02T00:00:00Z"
+  },
+  "plan": {
+    "id": "2166-flaky-subprocess-tests",
+    "title": "test: remove real subprocess/network calls from mocked unit tests (flaky 5s timeouts)",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2166",
+    "narratives": {
+      "Description": "packages/core/src/doctor/main-branches.test.ts (\"payload staleness skip branches\") intermittently fails with a 5s vitest timeout because its default runGitLsRemote seam can perform a real network `git ls-remote`. Sibling tests (framework-commands, intake-coverage-boost, and the cmdCoreValidate / validateGithubAuthForWorker execFileSync tests folded in from #644/#2157 observations) share the same class of bug: a fully-mocked unit test depending on a real subprocess/network call. Fix by stubbing/injecting the seam, not by raising the timeout.",
+      "ImplementationPlan": "1. In main-branches.test.ts (and siblings sharing the seam), stub/inject runGitLsRemote so NO real network call is possible; optionally assert the seam is called with expected args. 2. Apply the same safe-injection pattern to the other flaky sites: framework-commands, intake-coverage-boost, and the execFileSync-backed cmdCoreValidate / validateGithubAuthForWorker tests. 3. Do NOT merely raise timeouts — remove the network/subprocess dependency. Follow the safe-injection pattern already used elsewhere in the doctor tests. 4. Confirm deterministic under a constrained/offline runner, well under the timeout. Test-only; no production behavior change. Run task check GREEN; CHANGELOG [Unreleased] entry (test hardening).",
+      "UserStory": "As a contributor, I want mocked unit tests to never depend on real subprocess/network latency, so CI doesn't spuriously fail with 5s timeouts on unrelated PRs.",
+      "Traces": "#2166, #1366, #975"
+    },
+    "items": [
+      {
+        "id": "fl1",
+        "title": "git-ls-remote seam stubbed in main-branches + siblings",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "The \"payload staleness skip branches\" test and siblings using the seam make no real network call; the seam is stubbed/injected."
+        }
+      },
+      {
+        "id": "fl2",
+        "title": "execFileSync-backed flaky sites hardened",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "framework-commands, intake-coverage-boost, cmdCoreValidate, validateGithubAuthForWorker tests inject/stub the subprocess seam; no real subprocess spawned."
+        }
+      },
+      {
+        "id": "fl3",
+        "title": "Deterministic + task check green",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Tests are deterministic under a constrained/offline runner and well under the timeout; task check passes; CHANGELOG entry added; no production change."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "child_issue": "#2166"
+      },
+      "completedAt": "2026-07-02T17:14:30Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2166",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2166"
+      }
+    ],
+    "updated": "2026-07-02T17:14:30Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Stub `runGitLsRemote` and `runNpmViewVersion` in doctor payload-staleness branch tests so skip/unverified paths never hit real git or npm
- Run `core:validate` coverage against a minimal temp framework root instead of walking the full repo tree under load
- Pass injectable `runGh` through `githubAuthModesMain` so GitHub auth CLI coverage stays hermetic in CI

## Test plan

- [x] Targeted vitest: main-branches, coverage-final, framework-commands-branches, intake-coverage-boost (flaky cases)
- [x] `task check` green

Closes #2166

Made with [Cursor](https://cursor.com)