### PR TITLE
fix: gate merge-readiness on the SLizard review verdict (#2189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Merge-readiness now fails closed on a blocking SLizard review, not just Greptile (#2189).** `task pr:merge-ready` and `task swarm:verify-review-clean` now parse the SLizard check-run's structured verdict (`Decision`, `Merge impact`, severity counts) and block merge when SLizard is requesting changes or marks the change blocking — even when Greptile's own verdict and CI are clean. Previously a PR could merge through the `task pr:wait-mergeable-and-merge` cascade with an unresolved SLizard blocking finding. An absent SLizard check is treated as "skipped" (it's an optional second reviewer), and `--skip-slizard` is the explicit override. Closes #2189. Refs #2169, #1369.
 - **Mocked unit tests no longer depend on real network or subprocess latency (#2166).** Doctor payload-staleness branch tests, framework-command validation, and GitHub auth-mode CLI coverage now stub git-ls-remote, npm-view, filesystem-walk, and gh-auth seams so CI cannot spuriously hit 5s vitest timeouts under load. Closes #2166. Refs #1882, #644.
 
 ### Added

--- a/packages/core/src/doctor/network-gate.test.ts
+++ b/packages/core/src/doctor/network-gate.test.ts
@@ -94,10 +94,11 @@ describe("payload-staleness offline-by-default gating (#2182)", () => {
     // the #2182 acceptance criteria calls out: "assert not-called-with-network".
     expect(spawnSyncMock).not.toHaveBeenCalled();
 
-    const payload = JSON.parse(stdout.join(""));
-    const finding = (payload.findings as Array<Record<string, unknown>>).find(
-      (f) => f.check === "payload-staleness",
-    );
+    const payload: unknown = JSON.parse(stdout.join(""));
+    expect(payload).not.toBeNull();
+    expect(typeof payload).toBe("object");
+    const findings = (payload as { findings: Array<Record<string, unknown>> }).findings;
+    const finding = findings.find((f) => f.check === "payload-staleness");
     expect(finding?.status).toBe("skip");
     expect(finding?.reason).toBe("offline-tier");
     expect(String(finding?.message)).toContain("--network");

--- a/packages/core/src/pr-merge-readiness/compute.ts
+++ b/packages/core/src/pr-merge-readiness/compute.ts
@@ -9,6 +9,7 @@ import {
 } from "./constants.js";
 import { evaluateGates, isMergeReady } from "./evaluate.js";
 import {
+  type CheckRunRecord,
   fetchCheckRunsRest,
   fetchGreptileBodyRest,
   fetchGreptileCommentBody,
@@ -17,6 +18,8 @@ import {
   resolveRepo,
 } from "./gh.js";
 import { emptyVerdict, parseGreptileBody } from "./parse.js";
+import type { SlizardGateOptions } from "./slizard-gate.js";
+import { evaluateSlizardGate, isSlizardCheck } from "./slizard-gate.js";
 import type { GateResult, RunGhFn } from "./types.js";
 
 function buildGateResult(
@@ -42,14 +45,41 @@ function buildGateResult(
   };
 }
 
-export interface ComputeGateOptions extends CiGateOptions {}
+export interface ComputeGateOptions extends CiGateOptions, SlizardGateOptions {}
+
+interface ReviewGateOutcome {
+  failures: string[];
+  ci: Record<string, unknown>;
+  slizard: Record<string, unknown>;
+}
+
+/** Run the CI + SLizard gates off a single check-runs fetch (#2169 / #2189). */
+function evaluateCiAndSlizard(
+  checkRuns: readonly CheckRunRecord[],
+  options: ComputeGateOptions,
+): { failures: string[]; ci: Record<string, unknown>; slizard: Record<string, unknown> } {
+  const slizardResult = evaluateSlizardGate(checkRuns, options);
+  // The SLizard check is scored by the structured gate, so exclude it from the
+  // generic CI required set to avoid double-counting the same run.
+  const slizardNames = checkRuns.filter((r) => isSlizardCheck(r.name)).map((r) => r.name);
+  const ciOptions: CiGateOptions = {
+    skipCi: options.skipCi,
+    ignoreCheckNames: [...(options.ignoreCheckNames ?? []), ...slizardNames],
+  };
+  const ciResult = evaluateCiGate(checkRuns, ciOptions);
+  return {
+    failures: [...ciResult.failures, ...slizardResult.failures],
+    ci: { ...ciResult.summary, summary_line: buildCiSummaryLine(ciResult.summary) },
+    slizard: { ...slizardResult.summary },
+  };
+}
 
 function applyCiGateForHead(
   repo: string | null,
   headSha: string,
   runGh: RunGhFn,
   options: ComputeGateOptions,
-): { failures: string[]; ci: Record<string, unknown> } {
+): ReviewGateOutcome {
   if (repo === null) {
     return {
       failures: [
@@ -60,18 +90,20 @@ function applyCiGateForHead(
         ready_state: "blocked",
         error: "repo unresolved for check-runs lookup",
       },
+      slizard: {
+        ready_state: "skipped",
+        present: false,
+        summary_line: "SLizard review: skipped (repo unresolved for check-runs lookup)",
+      },
     };
   }
 
+  // When CI is skipped we do not fetch check-runs, so the SLizard gate cannot
+  // evaluate either; run both gates against an empty set to honor the overrides.
   if (options.skipCi === true) {
-    const ciResult = evaluateCiGate([], { skipCi: true });
-    return {
-      failures: [],
-      ci: {
-        ...ciResult.summary,
-        summary_line: "CI check-runs: skipped (--skip-ci)",
-      },
-    };
+    const outcome = evaluateCiAndSlizard([], options);
+    outcome.ci.summary_line = "CI check-runs: skipped (--skip-ci)";
+    return { failures: outcome.failures, ci: outcome.ci, slizard: outcome.slizard };
   }
 
   const check = fetchCheckRunsRest(headSha, repo, runGh);
@@ -90,17 +122,16 @@ function applyCiGateForHead(
         pending_required: [],
         conclusions: [],
       },
+      slizard: {
+        ready_state: "skipped",
+        present: false,
+        summary_line: `SLizard review: skipped (check-runs unavailable: ${check.error})`,
+      },
     };
   }
 
-  const ciResult = evaluateCiGate(check.checkRuns, options);
-  return {
-    failures: [...ciResult.failures],
-    ci: {
-      ...ciResult.summary,
-      summary_line: buildCiSummaryLine(ciResult.summary),
-    },
-  };
+  const outcome = evaluateCiAndSlizard(check.checkRuns, options);
+  return { failures: outcome.failures, ci: outcome.ci, slizard: outcome.slizard };
 }
 
 function computePrimary(
@@ -132,6 +163,7 @@ function computePrimary(
     const ci = applyCiGateForHead(resolved.repo, headSha, runGh, options);
     failures.push(...ci.failures);
     partialData.ci = ci.ci;
+    partialData.slizard = ci.slizard;
   }
   return {
     result: {
@@ -192,6 +224,7 @@ function computeFallback1(
     const ci = applyCiGateForHead(resolved.repo, headSha, runGh, options);
     failures.push(...ci.failures);
     partialData.ci = ci.ci;
+    partialData.slizard = ci.slizard;
   }
 
   return {

--- a/packages/core/src/pr-merge-readiness/gh.ts
+++ b/packages/core/src/pr-merge-readiness/gh.ts
@@ -8,6 +8,8 @@ export interface CheckRunRecord {
   readonly name: string;
   readonly status: string;
   readonly conclusion: string;
+  /** check-run `output.summary` text, when present (used by the SLizard verdict gate, #2189). */
+  readonly summary?: string;
 }
 
 /** UTF-8-safe gh capture via execFile (no shell) — mirrors _safe_subprocess.run_text (#1366). */
@@ -272,6 +274,16 @@ export function fetchPrHeadShaRest(
   return { sha: null, error: "PR JSON missing head.sha" };
 }
 
+/** Pull the `output.summary` string off a raw check-run payload, if present (#2189). */
+function extractCheckRunSummary(run: Record<string, unknown>): string | null {
+  const output = run.output;
+  if (output === null || typeof output !== "object" || Array.isArray(output)) {
+    return null;
+  }
+  const summary = (output as Record<string, unknown>).summary;
+  return typeof summary === "string" && summary.length > 0 ? summary : null;
+}
+
 export function fetchCheckRunsRest(
   sha: string,
   repo: string,
@@ -312,6 +324,7 @@ export function fetchCheckRunsRest(
     by_status: {} as Record<string, number>,
     by_conclusion: {} as Record<string, number>,
     greptile_review: null,
+    slizard_review: null,
   };
   const byStatus = summary.by_status as Record<string, number>;
   const byConclusion = summary.by_conclusion as Record<string, number>;
@@ -323,11 +336,19 @@ export function fetchCheckRunsRest(
     const status = typeof r.status === "string" ? r.status : "unknown";
     const conclusion = typeof r.conclusion === "string" ? r.conclusion : "none";
     const name = typeof r.name === "string" && r.name.length > 0 ? r.name : "<unnamed>";
-    checkRuns.push({ name, status, conclusion });
+    const runSummary = extractCheckRunSummary(r);
+    const record: CheckRunRecord =
+      runSummary === null
+        ? { name, status, conclusion }
+        : { name, status, conclusion, summary: runSummary };
+    checkRuns.push(record);
     byStatus[status] = (byStatus[status] ?? 0) + 1;
     byConclusion[conclusion] = (byConclusion[conclusion] ?? 0) + 1;
     if (r.name === "Greptile Review") {
       summary.greptile_review = { status, conclusion };
+    }
+    if (name.toLowerCase().includes("slizard")) {
+      summary.slizard_review = { status, conclusion };
     }
   }
   return { summary, checkRuns, error: "" };

--- a/packages/core/src/pr-merge-readiness/index.ts
+++ b/packages/core/src/pr-merge-readiness/index.ts
@@ -6,4 +6,16 @@ export { defaultRunGh } from "./gh.js";
 export { cmdPrMergeReadiness, parseArgs, run } from "./main.js";
 export { emitJson, exitCodeFor, gateResultToDict, printHuman } from "./output.js";
 export { emptyVerdict, isInformalCleanMissingCanonicalFields, parseGreptileBody } from "./parse.js";
+export type {
+  SlizardGateOptions,
+  SlizardGateResult,
+  SlizardGateSummary,
+  SlizardVerdict,
+} from "./slizard-gate.js";
+export {
+  evaluateSlizardGate,
+  isSlizardCheck,
+  parseSlizardVerdict,
+  SLIZARD_CHECK_NAME,
+} from "./slizard-gate.js";
 export type { GateResult, GreptileVerdict, RunGhFn, RunGhResult } from "./types.js";

--- a/packages/core/src/pr-merge-readiness/main.test.ts
+++ b/packages/core/src/pr-merge-readiness/main.test.ts
@@ -45,7 +45,15 @@ describe("parseArgs", () => {
       repo: "deftai/directive",
       emitJson: true,
       skipCi: false,
+      skipSlizard: false,
       ciIgnoreChecks: [],
+    });
+  });
+
+  it("parses --skip-slizard", () => {
+    expect(parseArgs(["4", "--skip-slizard"])).toMatchObject({
+      prNumber: 4,
+      skipSlizard: true,
     });
   });
 

--- a/packages/core/src/pr-merge-readiness/main.ts
+++ b/packages/core/src/pr-merge-readiness/main.ts
@@ -8,6 +8,7 @@ export interface ParsedArgs {
   readonly repo: string | null;
   readonly emitJson: boolean;
   readonly skipCi: boolean;
+  readonly skipSlizard: boolean;
   readonly ciIgnoreChecks: readonly string[];
   readonly error?: string;
 }
@@ -17,6 +18,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   let repo: string | null = null;
   let json = false;
   let skipCi = false;
+  let skipSlizard = false;
   const ciIgnoreChecks: string[] = [];
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -25,6 +27,8 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       json = true;
     } else if (arg === "--skip-ci") {
       skipCi = true;
+    } else if (arg === "--skip-slizard") {
+      skipSlizard = true;
     } else if (arg === "--ci-ignore-check") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -33,6 +37,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
           repo,
           emitJson: json,
           skipCi,
+          skipSlizard,
           ciIgnoreChecks,
           error: "argument --ci-ignore-check: expected one argument",
         };
@@ -49,6 +54,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
           repo,
           emitJson: json,
           skipCi,
+          skipSlizard,
           ciIgnoreChecks,
           error: "argument --repo: expected one argument",
         };
@@ -63,6 +69,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
         repo,
         emitJson: json,
         skipCi,
+        skipSlizard,
         ciIgnoreChecks,
         error: `unrecognized arguments: ${arg}`,
       };
@@ -74,6 +81,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
           repo,
           emitJson: json,
           skipCi,
+          skipSlizard,
           ciIgnoreChecks,
           error: `invalid PR number: ${arg}`,
         };
@@ -85,6 +93,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
         repo,
         emitJson: json,
         skipCi,
+        skipSlizard,
         ciIgnoreChecks,
         error: `unrecognized arguments: ${arg}`,
       };
@@ -97,11 +106,12 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       repo,
       emitJson: json,
       skipCi,
+      skipSlizard,
       ciIgnoreChecks,
       error: "the following arguments are required: pr_number",
     };
   }
-  return { prNumber, repo, emitJson: json, skipCi, ciIgnoreChecks };
+  return { prNumber, repo, emitJson: json, skipCi, skipSlizard, ciIgnoreChecks };
 }
 
 export interface RunOptions {
@@ -118,6 +128,7 @@ export function run(argv: readonly string[], options: RunOptions = {}): number {
   const runGh = options.runGh ?? defaultRunGh;
   const result = computeGateResult(args.prNumber as number, args.repo, runGh, {
     skipCi: args.skipCi,
+    skipSlizard: args.skipSlizard,
     ignoreCheckNames: args.ciIgnoreChecks,
   });
 

--- a/packages/core/src/pr-merge-readiness/output.ts
+++ b/packages/core/src/pr-merge-readiness/output.ts
@@ -77,6 +77,15 @@ export function printHuman(result: GateResult): string {
       lines.push(`  CI check-runs: ${ci.ready_state}`);
     }
   }
+  const slizardBlock = result.partialData.slizard;
+  if (slizardBlock !== null && typeof slizardBlock === "object" && !Array.isArray(slizardBlock)) {
+    const slizard = slizardBlock as Record<string, unknown>;
+    if (typeof slizard.summary_line === "string") {
+      lines.push(`  ${slizard.summary_line}`);
+    } else if (typeof slizard.ready_state === "string") {
+      lines.push(`  SLizard review: ${slizard.ready_state}`);
+    }
+  }
   if (result.via === VIA_FALLBACK2 && Object.keys(result.partialData).length > 0) {
     lines.push("  Fallback2 signal:");
     for (const key of ["pr_state", "merged", "mergeable", "mergeable_state"] as const) {

--- a/packages/core/src/pr-merge-readiness/slizard-gate.test.ts
+++ b/packages/core/src/pr-merge-readiness/slizard-gate.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { computeGateResult } from "./compute.js";
+import type { CheckRunRecord } from "./gh.js";
+import {
+  evaluateSlizardGate,
+  isSlizardCheck,
+  parseSlizardVerdict,
+  SLIZARD_CHECK_NAME,
+} from "./slizard-gate.js";
+import type { RunGhFn } from "./types.js";
+
+const BLOCKING_SUMMARY = [
+  "Decision: request_changes",
+  "Merge impact: blocking",
+  "Findings: 2 (P0: 0, P1: 1, P2: 0, P3: 0)",
+  "Important files: packages/core/src/doctor/network-gate.test.ts (P1, 2 finding(s))",
+].join("\n");
+
+const CLEAN_SUMMARY = ["Decision: approve", "Merge impact: non-blocking", "Findings: 0"].join("\n");
+
+function slizardRun(overrides: Partial<CheckRunRecord> = {}): CheckRunRecord {
+  return {
+    name: SLIZARD_CHECK_NAME,
+    status: "completed",
+    conclusion: "success",
+    summary: CLEAN_SUMMARY,
+    ...overrides,
+  };
+}
+
+describe("isSlizardCheck", () => {
+  it("matches the canonical name and case-insensitive variants", () => {
+    expect(isSlizardCheck("SLizard")).toBe(true);
+    expect(isSlizardCheck("slizard review")).toBe(true);
+    expect(isSlizardCheck("TypeScript (build + lint + test)")).toBe(false);
+  });
+});
+
+describe("parseSlizardVerdict", () => {
+  it("extracts decision, merge impact, and severity counts", () => {
+    const v = parseSlizardVerdict(BLOCKING_SUMMARY);
+    expect(v.decision).toBe("request_changes");
+    expect(v.mergeImpact).toBe("blocking");
+    expect(v.p0Count).toBe(0);
+    expect(v.p1Count).toBe(1);
+    expect(v.p2Count).toBe(0);
+  });
+
+  it("returns nulls for a missing/empty summary", () => {
+    const v = parseSlizardVerdict(undefined);
+    expect(v.decision).toBeNull();
+    expect(v.mergeImpact).toBeNull();
+    expect(v.p0Count).toBeNull();
+  });
+});
+
+describe("evaluateSlizardGate", () => {
+  it("blocks on a request_changes decision", () => {
+    const result = evaluateSlizardGate([slizardRun({ summary: BLOCKING_SUMMARY })]);
+    expect(result.summary.ready_state).toBe("blocked");
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toContain("SLizard review is blocking");
+    expect(result.failures[0]).toContain("decision=request_changes");
+    expect(result.failures[0]).toContain("P1=1");
+  });
+
+  it("blocks on a blocking merge impact even with a non-failure conclusion", () => {
+    const summary = ["Decision: comment", "Merge impact: blocking"].join("\n");
+    const result = evaluateSlizardGate([slizardRun({ conclusion: "neutral", summary })]);
+    expect(result.summary.ready_state).toBe("blocked");
+    expect(result.failures[0]).toContain("merge impact=blocking");
+  });
+
+  it("blocks on a failed conclusion", () => {
+    const result = evaluateSlizardGate([slizardRun({ conclusion: "failure", summary: undefined })]);
+    expect(result.summary.ready_state).toBe("blocked");
+    expect(result.failures[0]).toContain("conclusion=failure");
+  });
+
+  it("passes a clean approve verdict", () => {
+    const result = evaluateSlizardGate([slizardRun()]);
+    expect(result.summary.ready_state).toBe("ready");
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("treats an in-progress SLizard run as not-ready-yet", () => {
+    const result = evaluateSlizardGate([
+      slizardRun({ status: "in_progress", conclusion: "none", summary: undefined }),
+    ]);
+    expect(result.summary.ready_state).toBe("not_ready_yet");
+    expect(result.failures[0]).toContain("still in progress");
+  });
+
+  it("skips (no block) when no SLizard check-run is present", () => {
+    const other: CheckRunRecord = {
+      name: "TypeScript (build + lint + test)",
+      status: "completed",
+      conclusion: "success",
+    };
+    const result = evaluateSlizardGate([other]);
+    expect(result.summary.ready_state).toBe("skipped");
+    expect(result.summary.present).toBe(false);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("skips when --skip-slizard is set even if the verdict is blocking", () => {
+    const result = evaluateSlizardGate([slizardRun({ summary: BLOCKING_SUMMARY })], {
+      skipSlizard: true,
+    });
+    expect(result.summary.ready_state).toBe("skipped");
+    expect(result.failures).toHaveLength(0);
+  });
+});
+
+const HEAD = "abc1234567890def1234567890abcdef12345678";
+
+function fakeRunGh(slizardSummary: string, slizardConclusion = "failure"): RunGhFn {
+  return (cmd) => {
+    const joined = cmd.join(" ");
+    if (joined.includes("headRefOid")) {
+      return { returncode: 0, stdout: `${HEAD}\n`, stderr: "" };
+    }
+    if (joined.includes("/comments")) {
+      return {
+        returncode: 0,
+        stdout:
+          "## Greptile Summary\n\n**Confidence Score: 5/5**\n\n" +
+          `Last reviewed commit: [x](https://github.com/deftai/directive/commit/${HEAD})\n`,
+        stderr: "",
+      };
+    }
+    if (joined.includes("/check-runs")) {
+      return {
+        returncode: 0,
+        stdout: JSON.stringify({
+          check_runs: [
+            {
+              name: "TypeScript (build + lint + test)",
+              status: "completed",
+              conclusion: "success",
+            },
+            {
+              name: "SLizard",
+              status: "completed",
+              conclusion: slizardConclusion,
+              output: { summary: slizardSummary },
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    return { returncode: 1, stdout: "", stderr: "unexpected" };
+  };
+}
+
+describe("computeGateResult SLizard integration", () => {
+  it("blocks merge when SLizard requests changes even though Greptile + CI are clean", () => {
+    const result = computeGateResult(1, "deftai/directive", fakeRunGh(BLOCKING_SUMMARY));
+    expect(result.failures.some((f) => f.includes("SLizard review is blocking"))).toBe(true);
+    const slizard = result.partialData.slizard as Record<string, unknown>;
+    expect(slizard.ready_state).toBe("blocked");
+    // SLizard must be excluded from the generic CI required set (no double-count).
+    const ci = result.partialData.ci as Record<string, unknown>;
+    expect(ci.ignored_checks).toContain("SLizard");
+    expect(ci.ready_state).toBe("ready");
+  });
+
+  it("is merge-ready when SLizard approves", () => {
+    const result = computeGateResult(1, "deftai/directive", fakeRunGh(CLEAN_SUMMARY, "success"));
+    expect(result.failures).toHaveLength(0);
+    const slizard = result.partialData.slizard as Record<string, unknown>;
+    expect(slizard.ready_state).toBe("ready");
+  });
+
+  it("--skip-slizard overrides a blocking SLizard verdict", () => {
+    const result = computeGateResult(1, "deftai/directive", fakeRunGh(BLOCKING_SUMMARY), {
+      skipSlizard: true,
+    });
+    expect(result.failures.some((f) => f.includes("SLizard"))).toBe(false);
+  });
+});

--- a/packages/core/src/pr-merge-readiness/slizard-gate.ts
+++ b/packages/core/src/pr-merge-readiness/slizard-gate.ts
@@ -1,0 +1,169 @@
+import type { CheckRunRecord } from "./gh.js";
+
+/**
+ * Dedicated gate for the SLizard second-reviewer verdict (#2189).
+ *
+ * SLizard posts a check-run whose `output.summary` carries a structured verdict:
+ *
+ *   Decision: request_changes
+ *   Merge impact: blocking
+ *   Findings: 2 (P0: 0, P1: 1, P2: 0, P3: 0)
+ *
+ * The generic CI check-run gate (#2169) only fails closed on a check-run
+ * `conclusion` in the failed set, so a blocking *decision* carried on a
+ * non-`failure` conclusion (e.g. `neutral`) would slip through and the review
+ * is surfaced indistinctly among build/test checks. This gate parses the
+ * structured verdict and fails merge-readiness on a blocking decision.
+ */
+
+/** Canonical SLizard check-run name; matching is case-insensitive substring for resilience. */
+export const SLIZARD_CHECK_NAME = "SLizard";
+
+const FAILED_CONCLUSIONS = new Set(["failure", "cancelled", "timed_out"]);
+const PENDING_STATUSES = new Set(["queued", "in_progress"]);
+const BLOCKING_DECISIONS = new Set(["request_changes", "changes_requested", "reject"]);
+
+export type SlizardReadyState = "ready" | "blocked" | "not_ready_yet" | "skipped";
+
+export interface SlizardGateOptions {
+  readonly skipSlizard?: boolean;
+}
+
+export interface SlizardVerdict {
+  readonly decision: string | null;
+  readonly mergeImpact: string | null;
+  readonly p0Count: number | null;
+  readonly p1Count: number | null;
+  readonly p2Count: number | null;
+}
+
+export interface SlizardGateSummary {
+  readonly ready_state: SlizardReadyState;
+  readonly present: boolean;
+  readonly check_name: string | null;
+  readonly status: string | null;
+  readonly conclusion: string | null;
+  readonly verdict: SlizardVerdict | null;
+  readonly summary_line: string;
+}
+
+export interface SlizardGateResult {
+  readonly failures: readonly string[];
+  readonly summary: SlizardGateSummary;
+}
+
+export function isSlizardCheck(name: string): boolean {
+  return name.toLowerCase().includes("slizard");
+}
+
+function firstMatch(text: string, re: RegExp): string | null {
+  const m = re.exec(text);
+  return m?.[1] !== undefined ? m[1].trim() : null;
+}
+
+function countFor(text: string, sev: "P0" | "P1" | "P2"): number | null {
+  const m = new RegExp(`${sev}\\s*:\\s*(\\d+)`, "i").exec(text);
+  return m?.[1] !== undefined ? Number.parseInt(m[1], 10) : null;
+}
+
+/** Parse a SLizard check-run `output.summary` into a structured verdict. */
+export function parseSlizardVerdict(summary: string | undefined | null): SlizardVerdict {
+  const text = summary ?? "";
+  const decision = firstMatch(text, /Decision\s*:\s*([A-Za-z_]+)/i);
+  const mergeImpact = firstMatch(text, /Merge impact\s*:\s*([A-Za-z_-]+)/i);
+  return {
+    decision: decision ? decision.toLowerCase() : null,
+    mergeImpact: mergeImpact ? mergeImpact.toLowerCase() : null,
+    p0Count: countFor(text, "P0"),
+    p1Count: countFor(text, "P1"),
+    p2Count: countFor(text, "P2"),
+  };
+}
+
+function skippedSummary(reason: string): SlizardGateSummary {
+  return {
+    ready_state: "skipped",
+    present: false,
+    check_name: null,
+    status: null,
+    conclusion: null,
+    verdict: null,
+    summary_line: `SLizard review: skipped (${reason})`,
+  };
+}
+
+function isPending(status: string, conclusion: string): boolean {
+  if (PENDING_STATUSES.has(status)) {
+    return true;
+  }
+  return status !== "completed" || conclusion === "none";
+}
+
+export function evaluateSlizardGate(
+  checkRuns: readonly CheckRunRecord[],
+  options: SlizardGateOptions = {},
+): SlizardGateResult {
+  if (options.skipSlizard === true) {
+    return { failures: [], summary: skippedSummary("--skip-slizard") };
+  }
+
+  const run = checkRuns.find((r) => isSlizardCheck(r.name));
+  if (run === undefined) {
+    // SLizard is an optional second reviewer; its absence does not block merge.
+    return { failures: [], summary: skippedSummary("no SLizard check-run on this commit") };
+  }
+
+  const verdict = parseSlizardVerdict(run.summary);
+  const blockingDecision = verdict.decision !== null && BLOCKING_DECISIONS.has(verdict.decision);
+  const blockingImpact = verdict.mergeImpact === "blocking";
+  const failedConclusion = FAILED_CONCLUSIONS.has(run.conclusion);
+
+  const failures: string[] = [];
+  let readyState: SlizardReadyState;
+
+  if (blockingDecision || blockingImpact || failedConclusion) {
+    readyState = "blocked";
+    const reasons: string[] = [];
+    if (verdict.decision !== null) {
+      reasons.push(`decision=${verdict.decision}`);
+    }
+    if (verdict.mergeImpact !== null) {
+      reasons.push(`merge impact=${verdict.mergeImpact}`);
+    }
+    if (failedConclusion) {
+      reasons.push(`conclusion=${run.conclusion}`);
+    }
+    const findings =
+      verdict.p0Count !== null || verdict.p1Count !== null || verdict.p2Count !== null
+        ? ` (P0=${verdict.p0Count ?? 0} P1=${verdict.p1Count ?? 0} P2=${verdict.p2Count ?? 0})`
+        : "";
+    failures.push(
+      `SLizard review is blocking: ${reasons.join(", ")}${findings}. ` +
+        "Resolve the SLizard findings or pass --skip-slizard to override (#2189).",
+    );
+  } else if (isPending(run.status, run.conclusion)) {
+    readyState = "not_ready_yet";
+    failures.push(
+      `SLizard review still in progress (${run.status}); wait for the verdict before merge (#2189).`,
+    );
+  } else {
+    readyState = "ready";
+  }
+
+  const parts: string[] = [
+    `decision=${verdict.decision ?? "?"}`,
+    `impact=${verdict.mergeImpact ?? "?"}`,
+  ];
+  return {
+    failures,
+    summary: {
+      ready_state: readyState,
+      present: true,
+      check_name: run.name,
+      status: run.status,
+      conclusion: run.conclusion,
+      verdict,
+      summary_line: `SLizard review: ${readyState} (${parts.join(", ")})`,
+    },
+  };
+}

--- a/packages/core/src/swarm/verify-review-clean-cli.ts
+++ b/packages/core/src/swarm/verify-review-clean-cli.ts
@@ -9,6 +9,7 @@ export function verifyReviewCleanMain(argv: string[] = process.argv.slice(2)): n
   let repo: string | null = null;
   let emitJson = false;
   let skipCi = false;
+  let skipSlizard = false;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--cohort" && argv[i + 1] !== undefined) {
@@ -21,6 +22,8 @@ export function verifyReviewCleanMain(argv: string[] = process.argv.slice(2)): n
       emitJson = true;
     } else if (arg === "--skip-ci") {
       skipCi = true;
+    } else if (arg === "--skip-slizard") {
+      skipSlizard = true;
     } else if (arg === "--ci-ignore-check" && argv[i + 1] !== undefined) {
       ciIgnoreChecks.push(argv[i + 1] ?? "");
       i += 1;
@@ -36,6 +39,7 @@ export function verifyReviewCleanMain(argv: string[] = process.argv.slice(2)): n
     repo,
     emitJson,
     skipCi,
+    skipSlizard,
     ciIgnoreChecks,
   });
   if (result.stdout.length > 0) {

--- a/packages/core/src/swarm/verify-review-clean.ts
+++ b/packages/core/src/swarm/verify-review-clean.ts
@@ -10,7 +10,12 @@ import {
   fetchPrHeadSha,
 } from "../pr-merge-readiness/gh.js";
 import { evaluateGates, parseGreptileBody } from "../pr-merge-readiness/index.js";
+import type { SlizardGateOptions } from "../pr-merge-readiness/slizard-gate.js";
+import { evaluateSlizardGate, isSlizardCheck } from "../pr-merge-readiness/slizard-gate.js";
 import type { RunGhFn } from "../pr-merge-readiness/types.js";
+
+type ReviewGateOptions = CiGateOptions & SlizardGateOptions;
+
 import { EXIT_EXTERNAL_ERROR, EXIT_OK, EXIT_UNCLEAN } from "./constants.js";
 
 export interface CohortResolutionError {
@@ -25,6 +30,7 @@ export interface CohortPRResult {
   failures: string[];
   clean: boolean;
   ci_summary: Record<string, unknown> | null;
+  slizard_summary: Record<string, unknown> | null;
 }
 
 export interface CohortResult {
@@ -143,7 +149,7 @@ export function evaluatePr(
   prNumber: number,
   repo: string | null,
   runGh: RunGhFn = defaultRunGh,
-  options: CiGateOptions = {},
+  options: ReviewGateOptions = {},
 ): CohortPRResult | null {
   const headSha = fetchPrHeadSha(prNumber, repo, runGh);
   if (headSha === null) {
@@ -156,6 +162,7 @@ export function evaluatePr(
   const verdict = parseGreptileBody(body);
   const failures = evaluateGates(prNumber, headSha, verdict);
   let ciSummary: Record<string, unknown> | null = null;
+  let slizardSummary: Record<string, unknown> | null = null;
   if (failures.length === 0) {
     if (repo === null) {
       failures.push(
@@ -166,12 +173,16 @@ export function evaluatePr(
         ready_state: "blocked",
         error: "repo unresolved for check-runs lookup",
       };
+      slizardSummary = { ready_state: "skipped", present: false };
     } else if (options.skipCi === true) {
       const ci = evaluateCiGate([], { skipCi: true });
       ciSummary = {
         ...ci.summary,
         summary_line: "CI check-runs: skipped (--skip-ci)",
       };
+      const slizard = evaluateSlizardGate([], options);
+      failures.push(...slizard.failures);
+      slizardSummary = { ...slizard.summary };
     } else {
       const checks = fetchCheckRunsRest(headSha, repo, runGh);
       if (checks.summary === null) {
@@ -188,13 +199,23 @@ export function evaluatePr(
           pending_required: [],
           conclusions: [],
         };
+        slizardSummary = { ready_state: "skipped", present: false };
       } else {
-        const ci = evaluateCiGate(checks.checkRuns, options);
-        failures.push(...ci.failures);
+        const slizard = evaluateSlizardGate(checks.checkRuns, options);
+        // SLizard is scored by the structured gate; exclude it from the generic CI set.
+        const slizardNames = checks.checkRuns
+          .filter((r) => isSlizardCheck(r.name))
+          .map((r) => r.name);
+        const ci = evaluateCiGate(checks.checkRuns, {
+          skipCi: options.skipCi,
+          ignoreCheckNames: [...(options.ignoreCheckNames ?? []), ...slizardNames],
+        });
+        failures.push(...ci.failures, ...slizard.failures);
         ciSummary = {
           ...ci.summary,
           summary_line: buildCiSummaryLine(ci.summary),
         };
+        slizardSummary = { ...slizard.summary };
       }
     }
   }
@@ -205,6 +226,7 @@ export function evaluatePr(
     failures: [...failures],
     clean: failures.length === 0,
     ci_summary: ciSummary,
+    slizard_summary: slizardSummary,
   };
 }
 
@@ -220,6 +242,7 @@ export function cohortResultToDict(cohort: CohortResult): Record<string, unknown
       verdict: r.verdict,
       failures: r.failures,
       ci_summary: r.ci_summary,
+      slizard_summary: r.slizard_summary,
     })),
     resolution_errors: cohort.resolution_errors,
   };
@@ -256,6 +279,9 @@ export function renderReviewCleanText(cohort: CohortResult): string {
     if (r.ci_summary && typeof r.ci_summary.summary_line === "string") {
       lines.push(`    ${r.ci_summary.summary_line}`);
     }
+    if (r.slizard_summary && typeof r.slizard_summary.summary_line === "string") {
+      lines.push(`    ${r.slizard_summary.summary_line}`);
+    }
     r.failures.forEach((fail, index) => {
       lines.push(`      [${index + 1}] ${fail}`);
     });
@@ -280,6 +306,7 @@ export interface VerifyReviewCleanArgs {
   repo?: string | null;
   emitJson?: boolean;
   skipCi?: boolean;
+  skipSlizard?: boolean;
   ciIgnoreChecks?: readonly string[];
   runGh?: RunGhFn;
 }
@@ -330,6 +357,7 @@ export function verifyReviewClean(args: VerifyReviewCleanArgs): {
   for (const prNum of prNumbers) {
     const perPr = evaluatePr(prNum, args.repo ?? null, runGh, {
       skipCi: args.skipCi,
+      skipSlizard: args.skipSlizard,
       ignoreCheckNames: args.ciIgnoreChecks,
     });
     if (perPr === null) {

--- a/xbrief/completed/2026-07-02-2189-slizard-merge-gate.xbrief.json
+++ b/xbrief/completed/2026-07-02-2189-slizard-merge-gate.xbrief.json
@@ -1,0 +1,102 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2189: gate pr:merge-ready / swarm:verify-review-clean on the SLizard check-run's structured verdict (Decision / Merge impact / severity counts), not just the Greptile rolling-summary. Fixes the gap where a PR merged through the cascade with an unresolved SLizard blocking finding.",
+    "created": "2026-07-02T00:00:00Z",
+    "updated": "2026-07-02T00:00:00Z"
+  },
+  "plan": {
+    "id": "2189-slizard-merge-gate",
+    "title": "Gate merge-readiness on the SLizard structured review verdict (mirror the Greptile + CI gates)",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2189",
+    "narratives": {
+      "Description": "PR #2187 merged through `task pr:wait-mergeable-and-merge` while a SLizard review was still requesting changes (Decision: request_changes, Merge impact: blocking, P1: 1). The merge-readiness gate only parses the Greptile rolling-summary comment for its verdict; it has no equivalent check for SLizard, which posts its verdict in a check-run named `SLizard` (output.summary carries `Decision:` / `Merge impact:` / severity counts). Because the cascade uses `gh pr merge --admin`, branch-protection required-status enforcement is also bypassed, so nothing caught the blocking finding. The generic CI check-run gate (#2169) fails closed on a check-run `conclusion=failure`, which partially covers a failing SLizard run, but it (a) does not parse the structured verdict, so a `request_changes`/`blocking` decision carried on a non-`failure` conclusion is missed, and (b) surfaces SLizard indistinctly among build/test checks. This story adds a dedicated SLizard verdict gate that parses the check-run summary and fails merge-readiness on a blocking decision, mirroring the existing Greptile + CI gates, and wires it into both `pr:merge-ready` and `swarm:verify-review-clean` in lockstep.",
+      "ImplementationPlan": "1. gh.ts: add optional `summary` (from check-run `output.summary`) to CheckRunRecord and populate it in fetchCheckRunsRest; capture a `slizard_review` block in the summary dict (mirroring greptile_review) for fallback2 surfacing. 2. New slizard-gate.ts: SLIZARD_CHECK_NAME + isSlizardCheck(name); parseSlizardVerdict(summary) extracting Decision, Merge impact, P0/P1/P2 counts; evaluateSlizardGate(checkRuns, {skipSlizard}) returning {failures, summary} -> blocked on Decision=request_changes OR Merge impact=blocking OR conclusion in FAILED set; not_ready_yet when the SLizard run is pending; skipped when no SLizard check-run present (optional second reviewer) or --skip-slizard. 3. compute.ts: run evaluateSlizardGate off the same fetched checkRuns, auto-add the SLizard check name to the CI gate's ignore list so it is not double-counted, and attach a `slizard` partialData block + its failures (primary + fallback1). 4. main.ts: add `--skip-slizard` flag threaded into ComputeGateOptions. 5. output.ts: add a SLizard verdict line to the human output; JSON carries partial_data.slizard automatically. 6. verify-review-clean.ts + verify-review-clean-cli.ts: run the SLizard gate in evaluatePr lockstep with the CI gate; add `--skip-slizard`. 7. Fold in the test-only null-guard nit from #2189 in packages/core/src/doctor/network-gate.test.ts (JSON.parse result may be non-object). 8. Tests: slizard-gate.test.ts (blocking decision, blocking impact, clean approve, absent->skipped, pending->not-ready-yet, conclusion=failure, --skip-slizard) + a compute-level integration test with a fake runGh. 9. CHANGELOG [Unreleased] user-visible entry. 10. task check GREEN.",
+      "UserStory": "As an operator driving a PR to merge via the cascade (or the merge-at-will path), I want merge-readiness to fail closed while SLizard is still requesting changes, so that a second reviewer's blocking finding cannot be bypassed just because Greptile's own verdict is clean.",
+      "Traces": "#2189, #2169, #1369, #1368"
+    },
+    "items": [
+      {
+        "id": "a1",
+        "title": "SLizard check-run verdict is fetched and parsed",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a commit whose check-runs include a `SLizard` run with output.summary containing `Decision:` / `Merge impact:` / severity counts, when fetchCheckRunsRest runs, then the SLizard run's summary is captured and parseSlizardVerdict extracts decision, merge impact, and P0/P1/P2 counts."
+        }
+      },
+      {
+        "id": "a2",
+        "title": "Blocking SLizard verdict fails merge-readiness",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a SLizard verdict with Decision=request_changes or Merge impact=blocking (or a failing conclusion), when evaluateSlizardGate runs, then it returns a failure and pr:merge-ready exits non-zero; a clean approve verdict passes; an absent SLizard check-run or --skip-slizard yields ready_state=skipped without failing."
+        }
+      },
+      {
+        "id": "a3",
+        "title": "Gate wired into pr:merge-ready and swarm:verify-review-clean in lockstep",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given compute.ts (primary + fallback1) and verify-review-clean.ts evaluatePr, when a blocking SLizard verdict is present, then both surfaces report the SLizard failure and the SLizard check is excluded from the generic CI required set (no double-count); the human/JSON output surfaces the SLizard verdict distinctly."
+        }
+      },
+      {
+        "id": "a4",
+        "title": "task check green; nit folded; CHANGELOG entry",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given task check, when it runs, then the new slizard-gate tests + full suite + verify:encoding + agents-md-budget pass; the network-gate.test.ts JSON.parse null-guard nit is folded in; CHANGELOG [Unreleased] has a user-visible entry."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#1369",
+        "child_issue": "#2189"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/pr-merge-readiness/gh.ts",
+          "packages/core/src/pr-merge-readiness/slizard-gate.ts",
+          "packages/core/src/pr-merge-readiness/slizard-gate.test.ts",
+          "packages/core/src/pr-merge-readiness/compute.ts",
+          "packages/core/src/pr-merge-readiness/main.ts",
+          "packages/core/src/pr-merge-readiness/output.ts",
+          "packages/core/src/swarm/verify-review-clean.ts",
+          "packages/core/src/swarm/verify-review-clean-cli.ts",
+          "packages/core/src/doctor/network-gate.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task check"
+        ],
+        "expected_outputs": [
+          "SLizard structured verdict gate added; pr:merge-ready + swarm:verify-review-clean fail closed on a blocking SLizard decision; --skip-slizard escape hatch; task check green"
+        ],
+        "depends_on": [],
+        "conflict_group": "pr-merge-readiness",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completedAt": "2026-07-02T18:29:17Z"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2189",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2189: pr:wait-mergeable-and-merge merges through SLizard blocking findings"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2169",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2169: harden pr:merge-ready to gate on CI check-run conclusions"
+      }
+    ],
+    "updated": "2026-07-02T18:29:17Z"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2189: `task pr:merge-ready` / `task pr:wait-mergeable-and-merge` / `task swarm:verify-review-clean` only parsed the **Greptile** rolling-summary for their merge verdict, so a PR could merge through the cascade (which uses `gh pr merge --admin`) with an unresolved **SLizard** blocking finding as long as Greptile + CI were clean. Observed on PR #2187.

This adds a dedicated **SLizard verdict gate** that parses the SLizard check-run's structured `output.summary` (`Decision`, `Merge impact`, severity counts) and fails closed on a blocking verdict.

## What changed

- **`slizard-gate.ts` (new):** `evaluateSlizardGate` / `parseSlizardVerdict` — blocks on `Decision: request_changes` **or** `Merge impact: blocking` **or** a failed check-run conclusion; `not_ready_yet` while the SLizard run is in progress; `skipped` when no SLizard check-run is present (optional second reviewer) or `--skip-slizard` is passed.
- **`gh.ts`:** `fetchCheckRunsRest` now captures each check-run's `output.summary` (added to `CheckRunRecord`) and records a `slizard_review` block.
- **`compute.ts` + `verify-review-clean.ts`:** both surfaces run the SLizard gate off the same single check-runs fetch, in lockstep with the #2169 CI gate, and **exclude the SLizard check from the generic CI required set** so it isn't double-counted. Human + JSON output surface the SLizard verdict distinctly.
- **`--skip-slizard`** escape hatch added to `pr:merge-ready` and `swarm:verify-review-clean`.
- Folds in the trivial test-only `JSON.parse` null-guard nit from #2189 (`doctor/network-gate.test.ts`).

Relationship to #2169: the generic CI gate already fails closed on a check-run `conclusion=failure`, which partially covered a failing SLizard run. This gate is strictly more precise — it catches a blocking *decision* carried on a non-`failure` conclusion and reports the verdict as a first-class signal.

## Test plan

- [x] New `slizard-gate.test.ts`: blocking decision, blocking merge-impact (non-failure conclusion), failed conclusion, clean approve, pending → not-ready-yet, absent → skipped, `--skip-slizard`, plus compute-level integration (blocks despite clean Greptile+CI; SLizard excluded from CI set; skip override).
- [x] `task check` green (full suite + coverage + verify:encoding + agents-md-budget + cache-fresh).

Closes #2189. Refs #2169, #1369.

Made with [Cursor](https://cursor.com)