### PR TITLE
flaky(ci): make verify-env/branches.test.ts toolchain-check deterministic (inject fake runner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI no longer flakes on the verify-env toolchain-check unit test (#2209).** The `branches.test.ts` toolchain-check case was intermittently hitting vitest's 5s default timeout on cold CI runners because it spawned a real subprocess via `defaultCommandRunner`. The test now injects a stub command runner so `runToolchainCheck` coverage stays deterministic and sub-second, per the #975 test-performance discipline. Closes #2209. Refs #975.
+
 - **`task triage:queue` again shows your triaged work and ranking labels after the `xbrief/` migration (#2207).** Following the `vbrief/`→`xbrief/` rename (#2109), the queue read your triage decisions and `plan.policy.triageRankingLabels` from the wrong location, so every issue showed as `[untriaged]` and the ranking-label header was empty even when your audit log and policy were populated. The queue now resolves the audit log, slices log, and PROJECT-DEFINITION through the layout-aware resolver against your project root — matching the sibling `triage:summary`/`triage:reconcile` verbs — so accepted issues surface correctly and labels rank the list again. Closes #2207. Refs #2109, #1128.
 
 ### Removed

--- a/packages/core/src/verify-env/branches.test.ts
+++ b/packages/core/src/verify-env/branches.test.ts
@@ -259,17 +259,29 @@ describe("toolchain-check branches", () => {
     expect(result.lines.some((line) => line.includes("FAILED (exit 2)"))).toBe(true);
   });
 
-  it("exercises runToolchainCheck with defaultCommandRunner and a single tool", () => {
-    const result = runToolchainCheck(defaultCommandRunner, [
-      { name: "node", command: [process.execPath, "--version"] },
-    ]);
+  it("exercises runToolchainCheck with a custom tools list and injected runner", () => {
+    const result = runToolchainCheck(
+      (command) => ({
+        returncode: 0,
+        stdout: `${command[0]} version test\n`,
+        stderr: "",
+      }),
+      {},
+      [{ name: "node", command: ["node", "--version"] }],
+    );
+    expect(result.exitCode).toBe(0);
     expect(result.lines.length).toBeGreaterThan(1);
+    expect(result.lines.some((line) => line.includes("node:"))).toBe(true);
   });
 
-  it("covers defaultCommandRunner failure branch", () => {
-    const result = defaultCommandRunner([process.execPath, "-e", "process.exit(1)"], 1000);
-    expect("returncode" in result && result.returncode).toBe(1);
-  });
+  it(
+    "covers defaultCommandRunner failure branch",
+    () => {
+      const result = defaultCommandRunner([process.execPath, "-e", "process.exit(1)"], 1000);
+      expect("returncode" in result && result.returncode).toBe(1);
+    },
+    20_000,
+  );
 
   it("covers defaultCommandRunner ENOENT branch", () => {
     const result = defaultCommandRunner(["definitely-missing-binary-xyz"], 1000);

--- a/packages/core/src/verify-env/branches.test.ts
+++ b/packages/core/src/verify-env/branches.test.ts
@@ -274,14 +274,10 @@ describe("toolchain-check branches", () => {
     expect(result.lines.some((line) => line.includes("node:"))).toBe(true);
   });
 
-  it(
-    "covers defaultCommandRunner failure branch",
-    () => {
-      const result = defaultCommandRunner([process.execPath, "-e", "process.exit(1)"], 1000);
-      expect("returncode" in result && result.returncode).toBe(1);
-    },
-    20_000,
-  );
+  it("covers defaultCommandRunner failure branch", () => {
+    const result = defaultCommandRunner([process.execPath, "-e", "process.exit(1)"], 1000);
+    expect("returncode" in result && result.returncode).toBe(1);
+  }, 20_000);
 
   it("covers defaultCommandRunner ENOENT branch", () => {
     const result = defaultCommandRunner(["definitely-missing-binary-xyz"], 1000);

--- a/xbrief/active/2026-07-02-2209-flakyci-verify-envbranchestestts-toolchain-check-times-out-a.xbrief.json
+++ b/xbrief/active/2026-07-02-2209-flakyci-verify-envbranchestestts-toolchain-check-times-out-a.xbrief.json
@@ -1,0 +1,32 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2209"
+  },
+  "plan": {
+    "title": "flaky(ci): verify-env/branches.test.ts toolchain-check times out at 5s in CI (real subprocess spawn)",
+    "status": "running",
+    "narratives": {
+      "Description": "flaky(ci): verify-env/branches.test.ts toolchain-check times out at 5s in CI (real subprocess spawn)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2209",
+      "UserStory": "As a directive contributor, I want the toolchain-check test to be deterministic so my unrelated PRs don't get false-red CI when a cold runner's real subprocess spawn exceeds vitest's 5s default timeout.",
+      "ImplementationPlan": "1. In packages/core/src/verify-env/branches.test.ts, replace the `defaultCommandRunner` in the 'single tool' branch (line ~262) with an injected fake/stub command runner that returns a canned success without spawning a real process — removing the wall-clock dependency (preferred, per #975).\n2. Keep at most one test that genuinely exercises `defaultCommandRunner` end-to-end (if coverage requires it) and give THAT test an explicit generous `testTimeout` (e.g. 20000ms) so cold-runner spawn latency cannot trip the default.\n3. Run the file locally to confirm sub-second determinism; run `task check`.",
+      "Traces": "#2209, #975",
+      "Overview": "## Summary\n\n`packages/core/src/verify-env/branches.test.ts:262` — *\"exercises runToolchainCheck with defaultCommandRunner and a single tool\"* — intermittently fails in the **TypeScript (build + lint + test)** CI job with:\n\n```\nError: Test timed out in 5000ms.\n ❯ packages/core/src/verify-env/branches.test.ts:262:3\n```\n\nObserved on PR #2208 (run 28624441344). The test passes locally in ~457ms.\n\n## Root cause\n\nThe test exercises `runToolchainCheck` with the real `defaultCommandRunner`, which spawns actual subprocesses (e.g. `node --version`). On a cold / loaded CI runner, subprocess spawn + process startup can exceed vitest's default 5000ms `testTimeout`, producing a non-deterministic failure that has nothing to do with the code under test in a given PR.\n\n## Impact\n\n- False-red CI on unrelated PRs; blocks merge until a re-run happens to land under 5s.\n- Wastes a CI round-trip and operator attention per occurrence.\n\n## Proposed fix (pick one)\n\n1. Inject a fake/stubbed command runner for this branch instead of `defaultCommandRunner`, so no real subprocess is spawned (preferred — removes the wall-clock dependency entirely, per the #975 test-performance discipline).\n2. If a real subprocess is intentional for this branch, raise the per-test `testTimeout` (e.g. 20000ms) so cold-runner spawn latency doesn't trip the default.\n\n## Repro\n\nRe-run the TS CI lane on a cold runner, or run under artificial load:\n\n```\nnpx vitest run packages/core/src/verify-env/branches.test.ts\n```\n\nRefs #975 (test performance discipline). Discovered while landing #2207 (PR #2208)."
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2209",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2209: flaky(ci): verify-env/branches.test.ts toolchain-check times out at 5s in CI (real subprocess spawn)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/975",
+        "type": "x-xbrief/refs",
+        "title": "Issue #975"
+      }
+    ],
+    "updated": "2026-07-02T23:03:56Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the flaky `runToolchainCheck` branch test that spawned a real subprocess via `defaultCommandRunner` with an injected stub command runner — deterministic and sub-second per #975.
- Give the remaining `defaultCommandRunner` failure-branch test an explicit 20s timeout so cold-runner spawn latency cannot trip vitest's 5s default.

## Root cause

`packages/core/src/verify-env/branches.test.ts` line ~262 exercised `runToolchainCheck` with the real `defaultCommandRunner`, which spawns actual subprocesses (e.g. `node --version`). On cold/loaded CI runners, spawn latency can exceed vitest's default 5000ms `testTimeout`, producing false-red CI unrelated to the PR under test (observed on PR #2208, run 28624441344).

## Fix

Inject a canned-success stub `CommandRunner` for the custom-tools-list branch of `runToolchainCheck`, mirroring the pattern in `toolchain-check.test.ts`. Real subprocess coverage for `defaultCommandRunner` failure/ENOENT paths is retained in dedicated tests.

## Test plan

- [x] `npx vitest run packages/core/src/verify-env/branches.test.ts` — 27 tests pass in ~426ms
- [x] `task check` — build + lint + test green

Closes #2209

Made with [Cursor](https://cursor.com)