### PR TITLE
fix(scope): capacity-stamp.ts resolves PROJECT-DEFINITION via layout resolver on migrated trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`task triage:queue` again shows your triaged work and ranking labels after the `xbrief/` migration (#2207).** Following the `vbrief/`→`xbrief/` rename (#2109), the queue read your triage decisions and `plan.policy.triageRankingLabels` from the wrong location, so every issue showed as `[untriaged]` and the ranking-label header was empty even when your audit log and policy were populated. The queue now resolves the audit log, slices log, and PROJECT-DEFINITION through the layout-aware resolver against your project root — matching the sibling `triage:summary`/`triage:reconcile` verbs — so accepted issues surface correctly and labels rank the list again. Closes #2207. Refs #2109, #1128.
+- **Scope completion again stamps capacity buckets on migrated `xbrief/` trees (#2212).** After the `vbrief/`→`xbrief/` rename (#2109), completing a scope read `plan.policy.capacityAllocation.defaultBucket` from the legacy path and silently skipped stamping `metadata.capacityBucket`, leaving capacity accounting empty. The completion stamper now resolves PROJECT-DEFINITION through the layout-aware resolver so your configured default bucket is recorded when a scope finishes. Closes #2212. Refs #2207, #2109, #1419.
 
 ### Removed
 

--- a/packages/core/src/scope/capacity-stamp.ts
+++ b/packages/core/src/scope/capacity-stamp.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
+import { resolveProjectDefinitionPath } from "../layout/resolve.js";
 import { readPlanPolicy } from "../policy/plan-extensions.js";
-import { PROJECT_DEFINITION_REL_PATH } from "../policy/resolve.js";
 
 function resolveDefaultCapacityBucket(projectRoot: string): string {
   try {
-    const path = join(resolve(projectRoot), PROJECT_DEFINITION_REL_PATH);
+    const path = resolveProjectDefinitionPath(resolve(projectRoot));
     const raw = readFileSync(path, "utf8");
     const data = JSON.parse(raw) as Record<string, unknown>;
     const plan = data.plan;

--- a/packages/core/src/scope/scope-branch-coverage.test.ts
+++ b/packages/core/src/scope/scope-branch-coverage.test.ts
@@ -130,6 +130,28 @@ describe("scope branch coverage", () => {
     expect(plan3.metadata).toBeTruthy();
   });
 
+  // #2212: after the vbrief->xbrief migration the stamper MUST resolve the
+  // xbrief/ PROJECT-DEFINITION so capacityBucket is not silently empty.
+  it("capacity-stamp reads default bucket from a migrated xbrief tree", () => {
+    root = mkdtempSync(join(tmpdir(), "cap-xbrief-"));
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "seed.xbrief.json"),
+      formatVbriefJson({ plan: { title: "s", status: "running", items: [] } }),
+      "utf8",
+    );
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      formatVbriefJson({
+        plan: { policy: { capacityAllocation: { defaultBucket: "debt" } } },
+      }),
+      "utf8",
+    );
+    const plan: Record<string, unknown> = { status: "running" };
+    stampCompletionMetadata(plan, root, "2026-06-01T00:00:00Z");
+    expect((plan.metadata as Record<string, unknown>).capacityBucket).toBe("debt");
+  });
+
   it("transition covers error paths, no-ops, block/unblock, complete", () => {
     root = mkdtempSync(join(tmpdir(), "trans-"));
     expect(runTransition("bogus", "/x").ok).toBe(false);

--- a/xbrief/active/2026-07-02-2212-bugscope-capacity-stampts-reads-capacityallocation-from-hard.xbrief.json
+++ b/xbrief/active/2026-07-02-2212-bugscope-capacity-stampts-reads-capacityallocation-from-hard.xbrief.json
@@ -1,0 +1,36 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2212"
+  },
+  "plan": {
+    "title": "bug(scope): capacity-stamp.ts reads capacityAllocation from hardcoded vbrief/ path on migrated trees",
+    "status": "running",
+    "narratives": {
+      "Description": "bug(scope): capacity-stamp.ts reads capacityAllocation from hardcoded vbrief/ path on migrated trees",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2212",
+      "UserStory": "As a maintainer completing scopes on a migrated xbrief/ tree, I want metadata.capacityBucket stamped from plan.policy.capacityAllocation.defaultBucket so capacity accounting isn't silently empty.",
+      "ImplementationPlan": "1. In packages/core/src/scope/capacity-stamp.ts, resolve the PROJECT-DEFINITION via `resolveProjectDefinitionPath(projectRoot)` from packages/core/src/layout/resolve.ts instead of `join(resolve(projectRoot), PROJECT_DEFINITION_REL_PATH)`.\n2. Drop the now-unused import from policy/resolve.js.\n3. Add a migrated-tree regression test: stampCompletionMetadata stamps capacityBucket from xbrief/PROJECT-DEFINITION.xbrief.json.\n4. Run `task check`.",
+      "Traces": "#2212, #2207, #2109, #2112, #1419",
+      "Overview": "## Summary\n\nSame class as #2207 / #2210. `packages/core/src/scope/capacity-stamp.ts` reads `plan.policy.capacityAllocation.defaultBucket` from a hardcoded path:\n\n```ts\n// capacity-stamp.ts:4,8\nimport { PROJECT_DEFINITION_REL_PATH } from \"../policy/resolve.js\"; // \"vbrief/PROJECT-DEFINITION.vbrief.json\"\nconst path = join(resolve(projectRoot), PROJECT_DEFINITION_REL_PATH);\n```\n\nThe read is wrapped in `try/catch` returning `\"\"` on failure. On a migrated `xbrief/` tree the file is absent -> catch -> `\"\"`.\n\n## Impact\n\n`stampCompletionMetadata()` (#1419) never stamps `metadata.capacityBucket` on completing briefs on migrated trees, because the default bucket resolves to empty. Silent capacity-accounting gap.\n\n## Fix\n\nResolve via `resolveProjectDefinitionPath(projectRoot)` from `packages/core/src/layout/resolve.ts` instead of `join(projectRoot, PROJECT_DEFINITION_REL_PATH)`. Add a migrated-tree regression test asserting the bucket is stamped.\n\n## Related\n- Refs #2207 (PR #2208), #2210, #2109, #2112, #1419",
+      "Labels": "bug"
+    },
+    "items": [],
+    "tags": [
+      "bug"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2212",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2212: bug(scope): capacity-stamp.ts reads capacityAllocation from hardcoded vbrief/ path on migrated trees"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2207",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2207"
+      }
+    ],
+    "updated": "2026-07-02T23:04:49Z"
+  }
+}


### PR DESCRIPTION
## Summary

- `stampCompletionMetadata()` now resolves PROJECT-DEFINITION via `resolveProjectDefinitionPath()` so `metadata.capacityBucket` is stamped from `plan.policy.capacityAllocation.defaultBucket` on migrated `xbrief/` trees.

## Root cause

`capacity-stamp.ts` read `plan.policy.capacityAllocation.defaultBucket` from a hardcoded `vbrief/PROJECT-DEFINITION.vbrief.json` path. The read was wrapped in try/catch returning `""` on failure, so on migrated trees the default bucket silently resolved to empty and capacity accounting was never stamped.

## Fix

Mirror the #2207 / PR #2208 pattern: use the layout-aware `resolveProjectDefinitionPath(projectRoot)` from `packages/core/src/layout/resolve.ts` instead of `join(projectRoot, PROJECT_DEFINITION_REL_PATH)`.

## Test plan

- [x] Added migrated-tree regression: temp tree with `xbrief/PROJECT-DEFINITION.xbrief.json` containing `plan.policy.capacityAllocation.defaultBucket` → `stampCompletionMetadata()` sets `metadata.capacityBucket`
- [x] Existing vbrief/ capacity-stamp branch tests still pass
- [x] `task check` green locally

Closes #2212
Refs #2207, #2109, #1419

Made with [Cursor](https://cursor.com)