### PR TITLE
chore(scope): sweep #2209-#2213 migration cohort to completed/ (WIP 5->0)

### DIFF
--- a/xbrief/completed/2026-07-02-2209-flakyci-verify-envbranchestestts-toolchain-check-times-out-a.xbrief.json
+++ b/xbrief/completed/2026-07-02-2209-flakyci-verify-envbranchestestts-toolchain-check-times-out-a.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "flaky(ci): verify-env/branches.test.ts toolchain-check times out at 5s in CI (real subprocess spawn)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "flaky(ci): verify-env/branches.test.ts toolchain-check times out at 5s in CI (real subprocess spawn)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2209",
@@ -27,6 +27,10 @@
         "title": "Issue #975"
       }
     ],
-    "updated": "2026-07-02T23:03:56Z"
+    "updated": "2026-07-02T23:40:01Z",
+    "metadata": {
+      "completedAt": "2026-07-02T23:40:01Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-02-2210-bugtriage-scope-driftadd-ignorets-writes-triagescopeignores.xbrief.json
+++ b/xbrief/completed/2026-07-02-2210-bugtriage-scope-driftadd-ignorets-writes-triagescopeignores.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage): scope-drift/add-ignore.ts writes triageScopeIgnores to vbrief/ path on migrated trees",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage): scope-drift/add-ignore.ts writes triageScopeIgnores to vbrief/ path on migrated trees",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2210",
@@ -37,6 +37,10 @@
         "title": "Issue #2112"
       }
     ],
-    "updated": "2026-07-02T23:04:09Z"
+    "updated": "2026-07-02T23:40:02Z",
+    "metadata": {
+      "completedAt": "2026-07-02T23:40:02Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-02-2211-bugtriage-scoperesolvets-loads-triagescope-from-hardcoded-vb.xbrief.json
+++ b/xbrief/completed/2026-07-02-2211-bugtriage-scoperesolvets-loads-triagescope-from-hardcoded-vb.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage): scope/resolve.ts loads triageScope from hardcoded vbrief/ path on migrated trees",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage): scope/resolve.ts loads triageScope from hardcoded vbrief/ path on migrated trees",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2211",
@@ -36,6 +36,10 @@
         "title": "Issue #2109"
       }
     ],
-    "updated": "2026-07-02T23:04:40Z"
+    "updated": "2026-07-02T23:40:02Z",
+    "metadata": {
+      "completedAt": "2026-07-02T23:40:02Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-02-2212-bugscope-capacity-stampts-reads-capacityallocation-from-hard.xbrief.json
+++ b/xbrief/completed/2026-07-02-2212-bugscope-capacity-stampts-reads-capacityallocation-from-hard.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(scope): capacity-stamp.ts reads capacityAllocation from hardcoded vbrief/ path on migrated trees",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(scope): capacity-stamp.ts reads capacityAllocation from hardcoded vbrief/ path on migrated trees",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2212",
@@ -31,6 +31,10 @@
         "title": "Issue #2207"
       }
     ],
-    "updated": "2026-07-02T23:04:49Z"
+    "updated": "2026-07-02T23:40:02Z",
+    "metadata": {
+      "completedAt": "2026-07-02T23:40:02Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-02-2213-bugscope-project-definition-syncts-skips-project-definition.xbrief.json
+++ b/xbrief/completed/2026-07-02-2213-bugscope-project-definition-syncts-skips-project-definition.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(scope): project-definition-sync.ts skips PROJECT-DEFINITION sync (hardcoded vbrief/ path) on migrated trees",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(scope): project-definition-sync.ts skips PROJECT-DEFINITION sync (hardcoded vbrief/ path) on migrated trees",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2213",
@@ -31,6 +31,10 @@
         "title": "Issue #2207"
       }
     ],
-    "updated": "2026-07-02T23:05:05Z"
+    "updated": "2026-07-02T23:40:02Z",
+    "metadata": {
+      "completedAt": "2026-07-02T23:40:02Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Sweeps the five xbrief-migration fix stories (#2209–#2213) from `xbrief/active/` to `xbrief/completed/` now that their implementation PRs (#2214–#2218) are all merged and the issues are closed.
- Lifecycle-only change (pure `swarm:complete-cohort` sweep, `status: completed`), no code. Drops `task triage:summary` WIP back from **5/10 to 0**.
- These briefs stayed in `active/` because the swarm workers ran `stop-at: pr-open`; the orchestrator owns cohort completion.

## Test plan
- [x] `task swarm:complete-cohort -- --cohort '...' --dry-run` reported SWEEP CLEAN (5 stories, 0 epic parents)
- [x] Real sweep completed all 5; pre-commit encoding + vBRIEF conformance + xbrief-drift gates green
- [ ] CI validate lane green

Refs #2209 #2210 #2211 #2212 #2213

Made with [Cursor](https://cursor.com)