### PR TITLE
chore(scope): sweep #2219-#2220 follow-up cohort to completed/ (WIP 2->0)

### DIFF
--- a/xbrief/completed/2026-07-02-2219-flakyci-verify-env-clitestts-toolchain-check-runs-without-co.xbrief.json
+++ b/xbrief/completed/2026-07-02-2219-flakyci-verify-env-clitestts-toolchain-check-runs-without-co.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "flaky(ci): verify-env-cli.test.ts 'toolchain-check runs without config error' times out at 5s (real subprocess) — #2209 follow-up",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "flaky(ci): verify-env-cli.test.ts 'toolchain-check runs without config error' times out at 5s (real subprocess) — #2209 follow-up",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2219",
@@ -31,6 +31,10 @@
         "title": "Issue #2209"
       }
     ],
-    "updated": "2026-07-02T23:39:20Z"
+    "updated": "2026-07-02T23:51:41Z",
+    "metadata": {
+      "completedAt": "2026-07-02T23:51:41Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-02-2220-bugcheck-task-check-diverges-from-ci-ts-lane-pnpm-run-lint-b.xbrief.json
+++ b/xbrief/completed/2026-07-02-2220-bugcheck-task-check-diverges-from-ci-ts-lane-pnpm-run-lint-b.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(check): `task check` diverges from CI TS lane (`pnpm run lint`) — biome format violations pass locally, fail CI",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(check): `task check` diverges from CI TS lane (`pnpm run lint`) — biome format violations pass locally, fail CI",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2220",
@@ -26,6 +26,10 @@
         "title": "Issue #2220: bug(check): `task check` diverges from CI TS lane (`pnpm run lint`) — biome format violations pass locally, fail CI"
       }
     ],
-    "updated": "2026-07-02T23:39:41Z"
+    "updated": "2026-07-02T23:51:41Z",
+    "metadata": {
+      "completedAt": "2026-07-02T23:51:41Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Sweeps the two follow-up fix stories (#2219 flaky CLI toolchain-check test, #2220 `task check` biome-lane divergence) from `xbrief/active/` to `xbrief/completed/` now that PRs #2222/#2223 are merged and the issues are closed.
- Lifecycle-only `swarm:complete-cohort` sweep, no code. Drops `triage:summary` WIP from 2 to 0.

Refs #2219 #2220

Made with [Cursor](https://cursor.com)