### PR TITLE
chore(xbrief): complete 2026-07-03-2115-bugdoctor-payload-staleness-recommendation-omits-required-de, 2026-07-03-2181-stop-session-startruntime-commands-from-invoking-pnpm-builds, 2026-07-03-2225-enhswarm-auto-sweep-cohort-briefs-active-completed-after-prs post-merge

### DIFF
--- a/xbrief/completed/2026-07-03-2115-bugdoctor-payload-staleness-recommendation-omits-required-de.xbrief.json
+++ b/xbrief/completed/2026-07-03-2115-bugdoctor-payload-staleness-recommendation-omits-required-de.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(doctor): payload-staleness recommendation omits required `deft update` for vendored consumers (incomplete follow-on to #1997)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(doctor): payload-staleness recommendation omits required `deft update` for vendored consumers (incomplete follow-on to #1997)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2115",
@@ -28,6 +28,10 @@
         "title": "Issue #2115: bug(doctor): payload-staleness recommendation omits required `deft update` for vendored consumers (incomplete follow-on to #1997)"
       }
     ],
-    "updated": "2026-07-03T00:34:25Z"
+    "updated": "2026-07-03T01:17:20Z",
+    "metadata": {
+      "completedAt": "2026-07-03T01:17:20Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-03-2181-stop-session-startruntime-commands-from-invoking-pnpm-builds.xbrief.json
+++ b/xbrief/completed/2026-07-03-2181-stop-session-startruntime-commands-from-invoking-pnpm-builds.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Stop session-start/runtime commands from invoking pnpm builds or package-manager retry loops",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Stop session-start/runtime commands from invoking pnpm builds or package-manager retry loops",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2181",
@@ -60,6 +60,10 @@
         "title": "Issue #2181: Stop session-start/runtime commands from invoking pnpm builds or package-manager retry loops"
       }
     ],
-    "updated": "2026-07-03T00:35:30Z"
+    "updated": "2026-07-03T01:17:20Z",
+    "metadata": {
+      "completedAt": "2026-07-03T01:17:20Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-03-2225-enhswarm-auto-sweep-cohort-briefs-active-completed-after-prs.xbrief.json
+++ b/xbrief/completed/2026-07-03-2225-enhswarm-auto-sweep-cohort-briefs-active-completed-after-prs.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "enh(swarm): auto-sweep cohort briefs active/ -> completed/ after PRs merge (eliminate stop-at:pr-open lifecycle-sweep tax)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "enh(swarm): auto-sweep cohort briefs active/ -> completed/ after PRs merge (eliminate stop-at:pr-open lifecycle-sweep tax)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2225",
@@ -44,6 +44,10 @@
         "title": "Issue #1880"
       }
     ],
-    "updated": "2026-07-03T00:34:10Z"
+    "updated": "2026-07-03T01:17:20Z",
+    "metadata": {
+      "completedAt": "2026-07-03T01:17:20Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Automated cohort lifecycle sweep after merge cascade (#2226, #2227, #2228).

## Test plan
- [x] `task xbrief:validate` green
- [x] WIP reset via active/ -> completed/ moves
