### PR TITLE
fix(xbrief): correct cohort capacityBucket to technical-debt (#2237)

### DIFF
--- a/xbrief/completed/2026-07-03-1576-installer-taskfileyml-include-is-modified-but-not-staged-or.xbrief.json
+++ b/xbrief/completed/2026-07-03-1576-installer-taskfileyml-include-is-modified-but-not-staged-or.xbrief.json
@@ -47,7 +47,7 @@
     "updated": "2026-07-03T03:05:06Z",
     "metadata": {
       "completedAt": "2026-07-03T03:05:06Z",
-      "capacityBucket": "new-capability"
+      "capacityBucket": "technical-debt"
     }
   }
 }

--- a/xbrief/completed/2026-07-03-1926-path-based-planref-dangles-when-reconcileissues-moves-a-clos.xbrief.json
+++ b/xbrief/completed/2026-07-03-1926-path-based-planref-dangles-when-reconcileissues-moves-a-clos.xbrief.json
@@ -35,7 +35,7 @@
     "updated": "2026-07-03T03:05:06Z",
     "metadata": {
       "completedAt": "2026-07-03T03:05:06Z",
-      "capacityBucket": "new-capability"
+      "capacityBucket": "technical-debt"
     }
   }
 }

--- a/xbrief/completed/2026-07-03-2205-deft-doctor-pre-cutover-detector-false-positives-on-xbrief-m.xbrief.json
+++ b/xbrief/completed/2026-07-03-2205-deft-doctor-pre-cutover-detector-false-positives-on-xbrief-m.xbrief.json
@@ -30,7 +30,7 @@
     "updated": "2026-07-03T03:05:06Z",
     "metadata": {
       "completedAt": "2026-07-03T03:05:06Z",
-      "capacityBucket": "new-capability"
+      "capacityBucket": "technical-debt"
     }
   }
 }

--- a/xbrief/completed/2026-07-03-2230-bugswarm-finalize-cohort-scrapes-pr-body-regex-for-closing-i.xbrief.json
+++ b/xbrief/completed/2026-07-03-2230-bugswarm-finalize-cohort-scrapes-pr-body-regex-for-closing-i.xbrief.json
@@ -57,7 +57,7 @@
     "updated": "2026-07-03T03:05:06Z",
     "metadata": {
       "completedAt": "2026-07-03T03:05:06Z",
-      "capacityBucket": "new-capability"
+      "capacityBucket": "technical-debt"
     }
   }
 }


### PR DESCRIPTION
## Summary

Data-only correction. The #2225 `swarm:finalize-cohort` dogfood stamped `capacityBucket: "new-capability"` (the `defaultBucket`) on four `bug`-labeled briefs when it swept them to `completed/` (PR #2235), because completion stamping ignores the `capacityAllocation` label→bucket mapping. Under the shipped config, `bug` maps to `technical-debt`.

This PR sets the correct bucket on the four affected completed briefs:
- `#2230` finalize-cohort closing-refs
- `#2205` doctor pre-cutover detector
- `#1926` planRef lifecycle-agnostic
- `#1576` installer Taskfile staging

The underlying stamping defect (`stampCompletionMetadata` should match labels, not blindly use `defaultBucket`) is tracked in #2237.

## Test plan
- [x] `verify:xbrief` / conformance gates green (encoding, bare-keys, drift)
- [x] Each diff is a single `capacityBucket` line change; no other brief content touched

Refs #2237, #2235, #2225.

Made with [Cursor](https://cursor.com)