### PR TITLE
chore(swarm): finalize cohort 2246,2247,2064,1260,1056

### DIFF
--- a/xbrief/completed/2026-07-03-1056-task-pr-watch-deterministic-pr-verdict-polling-surface.xbrief.json
+++ b/xbrief/completed/2026-07-03-1056-task-pr-watch-deterministic-pr-verdict-polling-surface.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "feat(tasks): task pr:watch -- deterministic PR-verdict polling surface",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Add a deterministic, blocking-by-default `task pr:watch -- <N>` that polls a PR to a terminal verdict (CLEAN / new P0-P1 findings / errored-stall-timeout) using the canonical Greptile/SLizard detector, so an orchestrator that pushes and needs a verdict cannot silently stall by forgetting to poll.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1056",
@@ -54,6 +54,10 @@
         "title": "Issue #1366"
       }
     ],
-    "updated": "2026-07-03T13:27:19Z"
+    "updated": "2026-07-03T14:27:06Z",
+    "metadata": {
+      "completedAt": "2026-07-03T14:27:06Z",
+      "capacityBucket": "technical-debt"
+    }
   }
 }

--- a/xbrief/completed/2026-07-03-1260-adopt-project-definition-mutation-lock-across-all-rmw-mutators.xbrief.json
+++ b/xbrief/completed/2026-07-03-1260-adopt-project-definition-mutation-lock-across-all-rmw-mutators.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(triage,policy): adopt PROJECT-DEFINITION mutation lock across all RMW mutators",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Multiple PROJECT-DEFINITION mutators perform unlocked read-modify-write, so two concurrent mutators (interactive ritual + scripted policy set, or two policy sets) can lose each other's updates and drift the typed override from the audit log. Route every mutator through the existing mutation lock + atomic write.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1260",
@@ -54,6 +54,10 @@
         "title": "Issue #1329"
       }
     ],
-    "updated": "2026-07-03T13:27:17Z"
+    "updated": "2026-07-03T14:27:06Z",
+    "metadata": {
+      "completedAt": "2026-07-03T14:27:06Z",
+      "capacityBucket": "technical-debt"
+    }
   }
 }

--- a/xbrief/completed/2026-07-03-2064-consolidate-install-upgrade-redirect-to-directive-update.xbrief.json
+++ b/xbrief/completed/2026-07-03-2064-consolidate-install-upgrade-redirect-to-directive-update.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "consolidate: redirect deft install-upgrade to directive update (Option A)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Operators have two overlapping upgrade-adjacent verbs (deft install-upgrade and directive update). Consolidate to a single mental model by making install-upgrade a thin redirect that delegates to the update path with a one-line notice and no behavioral drift.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2064",
@@ -54,6 +54,10 @@
         "title": "Issue #2058"
       }
     ],
-    "updated": "2026-07-03T13:27:18Z"
+    "updated": "2026-07-03T14:27:06Z",
+    "metadata": {
+      "completedAt": "2026-07-03T14:27:06Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-07-03-2246-capacity-label-stamp-live-fallback-on-cache-miss.xbrief.json
+++ b/xbrief/completed/2026-07-03-2246-capacity-label-stamp-live-fallback-on-cache-miss.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(capacity): label-aware completion stamping misses freshly-filed issues absent from the on-disk label cache",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "The #2237 label-aware capacityBucket resolution reads labels only from the on-disk label cache (network-free), so a freshly-filed issue not yet in the cache misses and falls back to defaultBucket. Add a fail-open live-label fallback on cache miss.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2246",
@@ -54,6 +54,10 @@
         "title": "Issue #2245"
       }
     ],
-    "updated": "2026-07-03T13:27:16Z"
+    "updated": "2026-07-03T14:27:05Z",
+    "metadata": {
+      "completedAt": "2026-07-03T14:27:05Z",
+      "capacityBucket": "technical-debt"
+    }
   }
 }

--- a/xbrief/completed/2026-07-03-2247-finalize-cohort-skip-closing-ref-with-no-active-brief.xbrief.json
+++ b/xbrief/completed/2026-07-03-2247-finalize-cohort-skip-closing-ref-with-no-active-brief.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(swarm): finalize-cohort aborts the whole sweep on a closing ref to an already-completed/absent issue (no active brief)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "finalize-cohort hard-errors and aborts the entire sweep when a merged PR's structured closing reference points to an issue with no active brief -- even when that issue is already closed/completed and is only an incidental reference. It should skip such refs with a warning.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2247",
@@ -54,6 +54,10 @@
         "title": "Issue #2245"
       }
     ],
-    "updated": "2026-07-03T13:27:16Z"
+    "updated": "2026-07-03T14:27:06Z",
+    "metadata": {
+      "completedAt": "2026-07-03T14:27:06Z",
+      "capacityBucket": "technical-debt"
+    }
   }
 }


### PR DESCRIPTION
Sweeps the completed cohort's scope xBRIEFs from `xbrief/active/` -> `xbrief/completed/` after all five implementation PRs merged.

Cohort:
- #2246 -> PR #2249 (capacity live-label fallback)
- #2247 -> PR #2250 (finalize-cohort skip benign closing refs)
- #2064 -> PR #2251 (install-upgrade redirect)
- #1260 -> PR #2252 (PROJECT-DEFINITION mutation lock)
- #1056 -> PR #2254 (task pr:watch)

Generated via `task swarm:finalize-cohort`. capacityBucket values are label-derived (the #2246 live-label fallback correctly stamped #2246/#2247 as technical-debt).

Made with [Cursor](https://cursor.com)