### PR TITLE
chore(swarm): finalize #2260 -- sweep active -> completed

### DIFF
--- a/xbrief/completed/2026-07-03-2260-pr-wait-mergeable-reconcile-verdict-gate-with-github-mergeability.xbrief.json
+++ b/xbrief/completed/2026-07-03-2260-pr-wait-mergeable-reconcile-verdict-gate-with-github-mergeability.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(cascade): pr:wait-mergeable-and-merge polls without merging a GitHub-mergeable PR (verdict gate diverges from mergeStateStatus; no heartbeat)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "task pr:wait-mergeable-and-merge (TS pr-wait-mergeable cascade -> pr-monitor poller) can poll for many minutes without concluding merge-ready and without merging, even though GitHub reports mergeStateStatus: CLEAN, mergeable: MERGEABLE, and all required checks green. The operator is left with a live-but-idle process; a manual gh pr merge --admin merges instantly.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2260",
@@ -54,7 +54,10 @@
         "title": "Issue #701 (protected-issue precondition)"
       }
     ],
-    "updated": "2026-07-03T16:04:46Z",
-    "metadata": {}
+    "updated": "2026-07-03T16:33:33Z",
+    "metadata": {
+      "completedAt": "2026-07-03T16:33:33Z",
+      "capacityBucket": "technical-debt"
+    }
   }
 }


### PR DESCRIPTION
Sweeps the #2260 scope xBRIEF from `xbrief/active/` -> `xbrief/completed/` now that PR #2262 merged.

- #2260 -> PR #2262 (reconcile pr-monitor verdict gate with GitHub mergeability + per-poll heartbeat + #2240 noise cleanup)

Generated via `task swarm:finalize-cohort` (commit needed no CLI shim — #2248 fix holding).

Made with [Cursor](https://cursor.com)