### PR TITLE
fix: allowlist xbrief/ paths in deft-core-guard installer classifier (#2277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Migrated `xbrief/` projects can now run routine framework upgrades without the deft-core-guard falsely blocking the deposit PR (#2277).** The installer-managed allowlist only listed the legacy `vbrief/` paths, so after the `vbrief/`->`xbrief/` migration the framework-managed `xbrief/.deft-version` marker was treated as an app file and every `deft update` deposit PR tripped the `no-mixed-core-and-app` guard. The allowlist (which drives both the deposited guard workflow and the staging classifier) now mirrors the `xbrief/` version marker, `xbrief.md`, `schemas/`, `migration/`, and lifecycle `.gitkeep` paths, while keeping the `vbrief/` entries for not-yet-migrated consumers. Closes #2277. Refs #2034, #2110, #1576.
+
 ### Removed
 
 ## [0.68.0] - 2026-07-03

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -43,6 +43,42 @@ describe("installer-managed allowlist (#1576)", () => {
   });
 });
 
+describe("xbrief/ allowlist parity (#2277)", () => {
+  const xbriefLifecycleDirs = ["proposed", "pending", "active", "completed", "cancelled"] as const;
+
+  it("treats xbrief/.deft-version as installer-managed", () => {
+    expect(isInstallerManagedPath("xbrief/.deft-version")).toBe(true);
+  });
+
+  it("treats each xbrief/<lifecycle>/.gitkeep marker as installer-managed", () => {
+    for (const sub of xbriefLifecycleDirs) {
+      expect(isInstallerManagedPath(`xbrief/${sub}/.gitkeep`)).toBe(true);
+    }
+  });
+
+  it("treats xbrief/xbrief.md and the xbrief/ schema+migration prefixes as installer-managed", () => {
+    expect(isInstallerManagedPath("xbrief/xbrief.md")).toBe(true);
+    expect(isInstallerManagedPath("xbrief/schemas/scope.schema.json")).toBe(true);
+    expect(isInstallerManagedPath("xbrief/migration/2026-07-03.md")).toBe(true);
+  });
+
+  it("allowlists xbrief/.deft-version in the deposited guard ERE alternation", () => {
+    const ere = installerManagedGuardEre();
+    expect(ere).toContain("xbrief/\\.deft-version");
+    for (const sub of xbriefLifecycleDirs) {
+      expect(ere).toContain(`xbrief/${sub}/\\.gitkeep`);
+    }
+  });
+
+  it("keeps the legacy vbrief/ allowlist entries for not-yet-migrated projects", () => {
+    expect(isInstallerManagedPath("vbrief/.deft-version")).toBe(true);
+    for (const sub of xbriefLifecycleDirs) {
+      expect(isInstallerManagedPath(`vbrief/${sub}/.gitkeep`)).toBe(true);
+    }
+    expect(installerManagedGuardEre()).toContain("vbrief/\\.deft-version");
+  });
+});
+
 describe("scoped staging", () => {
   const created: string[] = [];
 

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -14,6 +14,8 @@ import { CANONICAL_INSTALL_ROOT, type InitDepositIo } from "./constants.js";
 export const CODEQL_CONFIG_REL = ".github/codeql/codeql-config.yml";
 export const CORE_GUARD_WORKFLOW_REL = ".github/workflows/deft-core-guard.yml";
 
+// The lifecycle dir names are identical across the legacy `vbrief/` tree and the
+// post-#2034 / #2110 `xbrief/` tree, so both allowlist families reuse this list.
 const VBRIEF_LIFECYCLE_DIRS = ["proposed", "pending", "active", "completed", "cancelled"] as const;
 
 export interface InstallerManagedMatcher {
@@ -33,11 +35,20 @@ export function installerManagedMatchers(): InstallerManagedMatcher[] {
     { exact: CODEQL_CONFIG_REL },
     { exact: CORE_GUARD_WORKFLOW_REL },
     { exact: "Taskfile.yml" },
+    // Legacy vbrief/ tree -- retained for not-yet-migrated consumers.
     { exact: "vbrief/.deft-version" },
     { exact: "vbrief/vbrief.md" },
     { prefix: "vbrief/schemas/" },
     { prefix: "vbrief/migration/" },
     ...VBRIEF_LIFECYCLE_DIRS.map((sub) => ({ exact: `vbrief/${sub}/.gitkeep` })),
+    // Migrated xbrief/ tree (#2034 / #2110). The framework-managed version marker
+    // now lives at xbrief/.deft-version, so it MUST be allowlisted or every routine
+    // `deft update` framework-deposit PR trips no-mixed-core-and-app (#2277).
+    { exact: "xbrief/.deft-version" },
+    { exact: "xbrief/xbrief.md" },
+    { prefix: "xbrief/schemas/" },
+    { prefix: "xbrief/migration/" },
+    ...VBRIEF_LIFECYCLE_DIRS.map((sub) => ({ exact: `xbrief/${sub}/.gitkeep` })),
   ];
 }
 

--- a/xbrief/active/2026-07-03-2277-deft-core-guard-allowlist-omits-xbrief-paths.xbrief.json
+++ b/xbrief/active/2026-07-03-2277-deft-core-guard-allowlist-omits-xbrief-paths.xbrief.json
@@ -1,0 +1,52 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #2277"
+  },
+  "plan": {
+    "title": "deft-core-guard allowlist omits xbrief/ paths -- blocks framework-deposit PRs on migrated projects",
+    "status": "running",
+    "narratives": {
+      "Description": "The deft-core-guard.yml installer-managed allowlist enumerates only legacy vbrief/ paths and was never given xbrief/ equivalents when the vbrief->xbrief migration (#2034 / #2110) landed. On any migrated (xbrief/) project, a routine `deft update` framework-deposit PR fails the no-mixed-core-and-app guard because the framework-managed xbrief/.deft-version marker is classified as a non-framework file.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2277",
+      "Overview": "## Summary\n\nThe deft-core-guard.yml workflow's allowlist (the `grep -vE` that classifies 'non-framework' changes) only enumerates legacy vbrief/ paths and was never given the xbrief/ equivalents when the vbrief->xbrief migration (#2034 / #2110) landed.\n\nAs a result, on any project that has migrated to xbrief/, a normal `deft update` framework-deposit PR fails the no-mixed-core-and-app guard: the framework-managed xbrief/.deft-version marker (bumped automatically by the upgrade, and intended to travel with the .deft/core deposit) is classified as a non-framework file, so the PR appears to 'mix' framework + app changes.\n\n## Root cause\n\nThe single source of truth is `installerManagedMatchers()` in packages/core/src/init-deposit/hygiene.ts, which feeds both `installerManagedGuardEre()` (the deposited guard workflow's POSIX ERE alternation, embedded via coreGuardWorkflowContent() in scaffold.ts) and the TS classifier. It lists vbrief/.deft-version, vbrief/vbrief.md, vbrief/schemas/, vbrief/migration/, and the vbrief/<lifecycle>/.gitkeep markers -- but has NO xbrief/ counterparts. Because .deft-version now lives at xbrief/.deft-version on migrated projects, it is no longer allowlisted, and the guard trips whenever it co-occurs with .deft/core/** changes -- which is exactly every framework upgrade. The legacy Go path (cmd/deft-install/hygiene.go + deposit.go installerManagedMatchers) is the parity mirror referenced by the TS module header.\n\n## Suggested fix\n\nIn installerManagedMatchers() (hygiene.ts), mirror the vbrief/ allowlist entries for xbrief/: xbrief/.deft-version, xbrief/xbrief.md, xbrief/schemas/, xbrief/migration/, and xbrief/<lifecycle>/.gitkeep for each of proposed/pending/active/completed/cancelled. Keep the vbrief/ entries for back-compat with not-yet-migrated projects. Mirror the same additions into the Go parity source (cmd/deft-install/hygiene.go / deposit.go) so the two classifiers stay in lockstep per the module header contract.\n\n## Impact\n\n- Every migrated (xbrief/) consumer hits a red guard on routine framework upgrades.\n- Workaround forces either a hand-edit of a generated file (churn, reverted next upgrade) or dropping the version marker from the deposit.\n\nObserved on cartograph consumer, framework payload v0.68.0. Related churn/guard issues: #2148, #1672, #1478 (same class -- allowlist omitted .githooks/).",
+      "Labels": "adoption-blocker"
+    },
+    "items": [
+      {
+        "title": "installerManagedMatchers() enumerates xbrief/.deft-version, xbrief/xbrief.md, xbrief/schemas/, xbrief/migration/, and xbrief/<lifecycle>/.gitkeep alongside the existing vbrief/ entries (vbrief/ retained for back-compat).",
+        "status": "proposed"
+      },
+      {
+        "title": "The generated deft-core-guard.yml allowlist (installerManagedGuardEre()) allowlists xbrief/.deft-version so a migrated-project framework-deposit PR carrying xbrief/.deft-version + .deft/core/** passes no-mixed-core-and-app.",
+        "status": "proposed"
+      },
+      {
+        "title": "Go parity source (cmd/deft-install hygiene/deposit installerManagedMatchers) mirrors the xbrief/ additions to keep the two classifiers in lockstep.",
+        "status": "proposed"
+      },
+      {
+        "title": "Regression tests pin xbrief/.deft-version (and the xbrief/ lifecycle .gitkeep markers) as installer-managed / allowlisted, guarding against future re-omission.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "adoption-blocker",
+      "installer",
+      "bug"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2277",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2277: deft-core-guard allowlist omits xbrief/ paths -- blocks framework-deposit PRs on migrated projects"
+      }
+    ],
+    "updated": "2026-07-03T20:02:52Z",
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-03-2277-deft-core-guard-allowlist-omits-xbrief-paths.xbrief.json
+++ b/xbrief/completed/2026-07-03-2277-deft-core-guard-allowlist-omits-xbrief-paths.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "deft-core-guard allowlist omits xbrief/ paths -- blocks framework-deposit PRs on migrated projects",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "The deft-core-guard.yml installer-managed allowlist enumerates only legacy vbrief/ paths and was never given xbrief/ equivalents when the vbrief->xbrief migration (#2034 / #2110) landed. On any migrated (xbrief/) project, a routine `deft update` framework-deposit PR fails the no-mixed-core-and-app guard because the framework-managed xbrief/.deft-version marker is classified as a non-framework file.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2277",
@@ -42,11 +42,12 @@
         "title": "Issue #2277: deft-core-guard allowlist omits xbrief/ paths -- blocks framework-deposit PRs on migrated projects"
       }
     ],
-    "updated": "2026-07-03T20:02:52Z",
+    "updated": "2026-07-03T20:09:08Z",
     "metadata": {
       "kind": "story",
       "capacityBucket": "technical-debt",
-      "capacityBucketSource": "match"
+      "capacityBucketSource": "match",
+      "completedAt": "2026-07-03T20:09:08Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

Migrated (`xbrief/`) projects were tripping the deposited `deft-core-guard`
`no-mixed-core-and-app` check on every routine `deft update` framework-deposit
PR. The installer-managed allowlist enumerated only the legacy `vbrief/` paths
and never got `xbrief/` counterparts when the `vbrief/`->`xbrief/` migration
(#2034 / #2110) landed. Because the framework-managed version marker now lives at
`xbrief/.deft-version` (bumped automatically by the upgrade and intended to
travel with the `.deft/core/**` deposit), the guard classified it as a
non-framework "app" file, so every framework upgrade PR looked like it "mixed"
framework + app changes. Observed live on the cartograph consumer at framework
payload v0.68.0.

### Root cause

`installerManagedMatchers()` in `packages/core/src/init-deposit/hygiene.ts` is
the single source of truth that feeds BOTH `installerManagedGuardEre()` (the
POSIX ERE alternation embedded in the deposited `deft-core-guard.yml` via
`coreGuardWorkflowContent()` in `scaffold.ts`) AND the `isInstallerManagedPath()`
staging classifier. The matcher list enumerated only `vbrief/` paths, with no
`xbrief/` equivalents.

### Fix

- Mirror the `vbrief/` entries for the migrated `xbrief/` tree in
  `installerManagedMatchers()`: `xbrief/.deft-version`, `xbrief/xbrief.md`,
  prefix `xbrief/schemas/`, prefix `xbrief/migration/`, and an
  `xbrief/<lifecycle>/.gitkeep` exact matcher for each of
  proposed/pending/active/completed/cancelled (reusing the existing lifecycle
  list — the dir names are identical across both trees).
- Keep every `vbrief/` entry for back-compat with not-yet-migrated projects.

### Go parity — intentionally deferred

The TS module header notes it mirrors `cmd/deft-install/hygiene.go` +
`deposit.go`. The legacy Go installer is **frozen at v0.58.0** (`legacy-bridge`
SoT `LAST_GO_INSTALLER`, #1912); releases are cut at/below that tag, so the Go
bridge will never re-ship this change to any consumer. The issue was observed on
the TS path (v0.68.0+), which is the shipped/authoritative surface. Modifying the
frozen Go source would expand scope without ever reaching a consumer, so Go
parity is deferred here. `task verify:go-freeze` remains clean (advisory).

## Related Issues

Closes #2277

Acceptance criteria (from the scope xBRIEF):
- [x] `installerManagedMatchers()` enumerates `xbrief/.deft-version`,
  `xbrief/xbrief.md`, `xbrief/schemas/`, `xbrief/migration/`, and
  `xbrief/<lifecycle>/.gitkeep` alongside the existing `vbrief/` entries
  (`vbrief/` retained for back-compat).
- [x] The generated `deft-core-guard.yml` allowlist (`installerManagedGuardEre()`)
  allowlists `xbrief/.deft-version` so a migrated-project framework-deposit PR
  carrying `xbrief/.deft-version` + `.deft/core/**` passes no-mixed-core-and-app.
- [~] Go parity source mirrors the additions — intentionally deferred (frozen
  bridge; see above).
- [x] Regression tests pin `xbrief/.deft-version` and the `xbrief/` lifecycle
  `.gitkeep` markers as installer-managed / allowlisted.

## Checklist

- [x] `/deft:change <name>` — N/A; scoped bug fix tracked by xBRIEF for #2277
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [ ] `ROADMAP.md` — N/A (batched at release-time CHANGELOG promotion)
- [x] Tests pass locally (`task check` — all checks passed)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm #2277 closed.
