### PR TITLE
feat(migrate:xbrief): converge empty vbrief/xbrief roots (#2270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`migrate:xbrief` now converges to a single, unambiguous lifecycle root instead of stranding an empty `vbrief/` next to `xbrief/` (#2270).** A fully-migrated empty `vbrief/` is removed (or, with the new `--keep-legacy` flag, retained for read-compatibility behind an explicit `DEPRECATED.md` marker so it never looks like an active source of truth), and a stray empty `vbrief/` alongside a canonical `xbrief/` is cleaned up rather than dead-ending on a refusal. `doctor` now reports an unambiguous `xbrief active` state (`vbrief removed` or `vbrief legacy marker`), and re-running the migration is idempotent. Closes #2270. Refs #2203.
+
 ### Removed
 
 ## [0.68.1] - 2026-07-03

--- a/packages/cli/src/migrate-xbrief.test.ts
+++ b/packages/cli/src/migrate-xbrief.test.ts
@@ -25,6 +25,13 @@ describe("migrate-xbrief CLI", () => {
     expect(args.projectRoot).toBe("/tmp/project");
     expect(args.frameworkRoot).toBe("/tmp/deft");
     expect(args.force).toBe(true);
+    expect(args.keepLegacy).toBe(false);
+  });
+
+  it("parses --keep-legacy (#2270)", () => {
+    const args = parseArgs(["--project-root", "/tmp/project", "--keep-legacy"]);
+    expect(args.error).toBeUndefined();
+    expect(args.keepLegacy).toBe(true);
   });
 
   it("returns 2 for unknown flags", () => {

--- a/packages/cli/src/migrate-xbrief.ts
+++ b/packages/cli/src/migrate-xbrief.ts
@@ -7,6 +7,7 @@ export interface ParsedMigrateXbriefArgs {
   projectRoot: string;
   frameworkRoot: string;
   force: boolean;
+  keepLegacy: boolean;
   error?: string;
 }
 
@@ -14,11 +15,14 @@ export function parseArgs(argv: readonly string[]): ParsedMigrateXbriefArgs {
   let projectRoot = ".";
   let explicitFrameworkRoot: string | undefined;
   let force = false;
+  let keepLegacy = false;
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i] ?? "";
     if (arg === "--force") {
       force = true;
+    } else if (arg === "--keep-legacy") {
+      keepLegacy = true;
     } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -26,6 +30,7 @@ export function parseArgs(argv: readonly string[]): ParsedMigrateXbriefArgs {
           projectRoot,
           frameworkRoot: resolveFrameworkRootForProject(projectRoot, explicitFrameworkRoot),
           force,
+          keepLegacy,
           error: "argument --project-root: expected one argument",
         };
       }
@@ -40,6 +45,7 @@ export function parseArgs(argv: readonly string[]): ParsedMigrateXbriefArgs {
           projectRoot,
           frameworkRoot: resolveFrameworkRootForProject(projectRoot, explicitFrameworkRoot),
           force,
+          keepLegacy,
           error: "argument --framework-root: expected one argument",
         };
       }
@@ -52,13 +58,14 @@ export function parseArgs(argv: readonly string[]): ParsedMigrateXbriefArgs {
         projectRoot,
         frameworkRoot: resolveFrameworkRootForProject(projectRoot, explicitFrameworkRoot),
         force,
+        keepLegacy,
         error: `unrecognized argument: ${arg}`,
       };
     }
   }
 
   const frameworkRoot = resolveFrameworkRootForProject(projectRoot, explicitFrameworkRoot);
-  return { projectRoot, frameworkRoot, force };
+  return { projectRoot, frameworkRoot, force, keepLegacy };
 }
 
 export function run(argv: readonly string[]): number {
@@ -73,6 +80,7 @@ export function run(argv: readonly string[]): number {
       projectRoot: args.projectRoot,
       frameworkRoot: args.frameworkRoot,
       force: args.force,
+      keepLegacy: args.keepLegacy,
     },
     {
       writeOut: (text) => {

--- a/packages/core/src/xbrief-migrate/constants.ts
+++ b/packages/core/src/xbrief-migrate/constants.ts
@@ -24,3 +24,25 @@ export const MIGRATED_INFO_ROOT_KEY = "xBRIEFInfo" as const;
 
 /** Item-only status value added in xBRIEF v0.8. */
 export const V08_ITEM_STATUS_AUTO = "auto" as const;
+
+/**
+ * Filename of the explicit deprecation marker written into a legacy `vbrief/`
+ * root that is retained for read-compatibility after convergence (#2270). Its
+ * presence is what tells `doctor` the folder is NOT an active source of truth.
+ */
+export const VBRIEF_DEPRECATION_MARKER_FILENAME = "DEPRECATED.md" as const;
+
+/** Sentinel line identifying a deft-written `vbrief/` deprecation marker (#2270). */
+export const VBRIEF_DEPRECATION_MARKER_SENTINEL = "<!-- deft:vbrief-deprecated -->" as const;
+
+/** Body written into the retained legacy `vbrief/` deprecation marker (#2270). */
+export const VBRIEF_DEPRECATION_MARKER_BODY = `${VBRIEF_DEPRECATION_MARKER_SENTINEL}
+# Deprecated: legacy \`vbrief/\` root
+
+This project has migrated to the \`xbrief/\` lifecycle layout. This \`vbrief/\`
+directory is retained only for read-compatibility and is **not** an active
+source of truth. Do not add new scope work here — use \`xbrief/\` instead.
+
+Once you no longer need read-compatibility with the legacy layout, delete this
+\`vbrief/\` directory. Re-running \`deft migrate:xbrief\` re-checks convergence.
+` as const;

--- a/packages/core/src/xbrief-migrate/detect.test.ts
+++ b/packages/core/src/xbrief-migrate/detect.test.ts
@@ -2,8 +2,26 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { LEGACY_ARTIFACT_DIR, LEGACY_ARTIFACT_SUFFIX } from "./constants.js";
-import { detectLegacyVbriefLayout } from "./detect.js";
+import {
+  LEGACY_ARTIFACT_DIR,
+  LEGACY_ARTIFACT_SUFFIX,
+  MIGRATED_ARTIFACT_DIR,
+  VBRIEF_DEPRECATION_MARKER_BODY,
+  VBRIEF_DEPRECATION_MARKER_FILENAME,
+} from "./constants.js";
+import { detectLegacyVbriefLayout, detectXbriefConvergence } from "./detect.js";
+
+function writeXbriefStory(root: string): void {
+  mkdirSync(join(root, MIGRATED_ARTIFACT_DIR, "active"), { recursive: true });
+  writeFileSync(
+    join(root, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"),
+    JSON.stringify({
+      xBRIEFInfo: { version: "0.8", description: "fixture" },
+      plan: { title: "Migrated", status: "running", items: [] },
+    }),
+    "utf8",
+  );
+}
 
 describe("detectLegacyVbriefLayout branch coverage", () => {
   let root: string;
@@ -84,5 +102,81 @@ describe("detectLegacyVbriefLayout branch coverage", () => {
     const result = detectLegacyVbriefLayout(root);
     expect(result.legacyLayout).toBe(true);
     expect(result.reasons.some((r) => r.includes("x-vbrief/"))).toBe(true);
+  });
+});
+
+describe("detectXbriefConvergence (#2270)", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "xbrief-converge-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("classifies a bare project as none", () => {
+    expect(detectXbriefConvergence(root).state).toBe("none");
+  });
+
+  it("classifies a canonical xbrief-only project", () => {
+    writeXbriefStory(root);
+    const conv = detectXbriefConvergence(root);
+    expect(conv.state).toBe("xbrief-only");
+    expect(conv.vbriefPresent).toBe(false);
+    expect(conv.xbriefHasContent).toBe(true);
+  });
+
+  it("classifies an ambiguous empty vbrief/ alongside a populated xbrief/ as empty-vbrief", () => {
+    writeXbriefStory(root);
+    // Empty legacy lifecycle scaffolding — the dual-empty-root ambiguity (#2270).
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "pending"), { recursive: true });
+    const conv = detectXbriefConvergence(root);
+    expect(conv.state).toBe("empty-vbrief");
+    expect(conv.vbriefEmpty).toBe(true);
+  });
+
+  it("ignores .gitkeep placeholders when judging vbrief emptiness", () => {
+    writeXbriefStory(root);
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(join(root, LEGACY_ARTIFACT_DIR, "active", ".gitkeep"), "", "utf8");
+    expect(detectXbriefConvergence(root).state).toBe("empty-vbrief");
+  });
+
+  it("classifies a marked legacy root as xbrief-marker", () => {
+    writeXbriefStory(root);
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(
+      join(root, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME),
+      VBRIEF_DEPRECATION_MARKER_BODY,
+      "utf8",
+    );
+    const conv = detectXbriefConvergence(root);
+    expect(conv.state).toBe("xbrief-marker");
+    expect(conv.vbriefHasMarker).toBe(true);
+    expect(conv.vbriefEmpty).toBe(false);
+  });
+
+  it("classifies vbrief content with no canonical xbrief as legacy-only", () => {
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(
+      join(root, LEGACY_ARTIFACT_DIR, "active", `story${LEGACY_ARTIFACT_SUFFIX}`),
+      JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { title: "t", items: [] } }),
+      "utf8",
+    );
+    expect(detectXbriefConvergence(root).state).toBe("legacy-only");
+  });
+
+  it("classifies content in both roots (no marker) as dual-populated", () => {
+    writeXbriefStory(root);
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(
+      join(root, LEGACY_ARTIFACT_DIR, "active", `story${LEGACY_ARTIFACT_SUFFIX}`),
+      JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { title: "t", items: [] } }),
+      "utf8",
+    );
+    expect(detectXbriefConvergence(root).state).toBe("dual-populated");
   });
 });

--- a/packages/core/src/xbrief-migrate/detect.test.ts
+++ b/packages/core/src/xbrief-migrate/detect.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -167,6 +167,16 @@ describe("detectXbriefConvergence (#2270)", () => {
       "utf8",
     );
     expect(detectXbriefConvergence(root).state).toBe("legacy-only");
+  });
+
+  it("does not treat a vbrief/ holding only a symlink as empty (never wipes symlinked content)", () => {
+    writeXbriefStory(root);
+    const target = join(root, "target.txt");
+    writeFileSync(target, "real content\n", "utf8");
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR), { recursive: true });
+    symlinkSync(target, join(root, LEGACY_ARTIFACT_DIR, "link.txt"));
+    // A symlink is real content, so the tree is not the empty-vbrief cleanup case.
+    expect(detectXbriefConvergence(root).state).not.toBe("empty-vbrief");
   });
 
   it("classifies content in both roots (no marker) as dual-populated", () => {

--- a/packages/core/src/xbrief-migrate/detect.ts
+++ b/packages/core/src/xbrief-migrate/detect.ts
@@ -8,11 +8,45 @@ import {
   MIGRATED_ARTIFACT_DIR,
   VBRIEF_REFERENCE_PREFIX,
 } from "./constants.js";
+import { hasVbriefDeprecationMarker, isEffectivelyEmptyDir } from "./fs-helpers.js";
 
 /** Structured result of a legacy vbrief layout probe (#2108 / #2034). */
 export interface LegacyVbriefLayoutDetection {
   legacyLayout: boolean;
   reasons: string[];
+}
+
+/**
+ * Discriminated convergence state of the `vbrief/` + `xbrief/` lifecycle roots
+ * (#2270). Distinguishes the ambiguous dual-empty-root case that `migrate:xbrief`
+ * must converge from the states that are already unambiguous.
+ *
+ * - `none` — neither root carries content (nothing to converge).
+ * - `xbrief-only` — canonical `xbrief/` with content and no `vbrief/`.
+ * - `xbrief-marker` — `vbrief/` retained behind an explicit deprecation marker.
+ * - `empty-vbrief` — a stray, fully-migrated empty `vbrief/` (the ambiguous root
+ *   to clean up: remove it, or mark it when read-compat retention is requested).
+ * - `legacy-only` — `vbrief/` holds content and there is no canonical `xbrief/`;
+ *   a full migration is required.
+ * - `dual-populated` — both roots hold content with no marker; converge by
+ *   marking the legacy tree deprecated (never destructively merged).
+ */
+export type XbriefConvergenceState =
+  | "none"
+  | "xbrief-only"
+  | "xbrief-marker"
+  | "empty-vbrief"
+  | "legacy-only"
+  | "dual-populated";
+
+/** Structured convergence probe of the two lifecycle roots (#2270). */
+export interface XbriefConvergenceDetection {
+  state: XbriefConvergenceState;
+  vbriefPresent: boolean;
+  vbriefEmpty: boolean;
+  vbriefHasMarker: boolean;
+  xbriefPresent: boolean;
+  xbriefHasContent: boolean;
 }
 
 function isDirectory(path: string): boolean {
@@ -97,4 +131,37 @@ export function detectLegacyVbriefLayout(projectRoot: string): LegacyVbriefLayou
 
   const reasonList = [...reasons];
   return { legacyLayout: reasonList.length > 0, reasons: reasonList };
+}
+
+/**
+ * Classify the convergence state of the `vbrief/` and `xbrief/` lifecycle roots
+ * so the orchestrator can converge to a single unambiguous root (#2270). Unlike
+ * {@link detectLegacyVbriefLayout} (which only asks "is there anything legacy?"),
+ * this probe distinguishes the ambiguous dual-empty-root case from an already
+ * unambiguous layout, and never falls back to a `run migrate:xbrief` dead end
+ * for a `vbrief/` that is merely an empty leftover.
+ */
+export function detectXbriefConvergence(projectRoot: string): XbriefConvergenceDetection {
+  const legacyDir = join(projectRoot, LEGACY_ARTIFACT_DIR);
+  const migratedDir = join(projectRoot, MIGRATED_ARTIFACT_DIR);
+
+  const vbriefPresent = isDirectory(legacyDir);
+  const vbriefHasMarker = vbriefPresent && hasVbriefDeprecationMarker(legacyDir);
+  const vbriefEmpty = vbriefPresent && !vbriefHasMarker && isEffectivelyEmptyDir(legacyDir);
+  const xbriefPresent = isDirectory(migratedDir);
+  const xbriefHasContent = xbriefPresent && !isEffectivelyEmptyDir(migratedDir);
+
+  let state: XbriefConvergenceState;
+  if (vbriefHasMarker) {
+    state = "xbrief-marker";
+  } else if (!vbriefPresent) {
+    state = xbriefHasContent ? "xbrief-only" : "none";
+  } else if (vbriefEmpty) {
+    state = "empty-vbrief";
+  } else {
+    // vbrief/ holds real content and carries no marker.
+    state = xbriefHasContent ? "dual-populated" : "legacy-only";
+  }
+
+  return { state, vbriefPresent, vbriefEmpty, vbriefHasMarker, xbriefPresent, xbriefHasContent };
 }

--- a/packages/core/src/xbrief-migrate/fs-helpers.ts
+++ b/packages/core/src/xbrief-migrate/fs-helpers.ts
@@ -1,9 +1,56 @@
-import { statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  VBRIEF_DEPRECATION_MARKER_FILENAME,
+  VBRIEF_DEPRECATION_MARKER_SENTINEL,
+} from "./constants.js";
 
 /** True when `path` exists and is a directory; false on any stat error. */
 export function isDirectory(path: string): boolean {
   try {
     return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Placeholder files that do not count as real content when judging emptiness. */
+const PLACEHOLDER_FILES = new Set([".gitkeep", ".keep"]);
+
+/**
+ * True when `dir` holds no meaningful content at any depth — a "fully migrated"
+ * lifecycle root. Empty subdirectories and VCS placeholder files (`.gitkeep`,
+ * `.keep`) are ignored, so a scaffolded-but-empty `vbrief/proposed/` tree still
+ * counts as empty. A missing directory is trivially empty (#2270).
+ */
+export function isEffectivelyEmptyDir(dir: string): boolean {
+  if (!isDirectory(dir)) {
+    return true;
+  }
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile()) {
+      if (PLACEHOLDER_FILES.has(entry.name)) {
+        continue;
+      }
+      return false;
+    }
+    if (entry.isDirectory() && !isEffectivelyEmptyDir(join(dir, entry.name))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * True when `dir` carries a deft-written deprecation marker identifying it as a
+ * retained-for-read-compat legacy root rather than an active source of truth
+ * (#2270). Matched on the sentinel so an unrelated `DEPRECATED.md` is ignored.
+ */
+export function hasVbriefDeprecationMarker(dir: string): boolean {
+  try {
+    return readFileSync(join(dir, VBRIEF_DEPRECATION_MARKER_FILENAME), "utf8").includes(
+      VBRIEF_DEPRECATION_MARKER_SENTINEL,
+    );
   } catch {
     return false;
   }

--- a/packages/core/src/xbrief-migrate/fs-helpers.ts
+++ b/packages/core/src/xbrief-migrate/fs-helpers.ts
@@ -34,6 +34,11 @@ export function isEffectivelyEmptyDir(dir: string): boolean {
       }
       return false;
     }
+    // A symlink (to a file or dir) is real content: `isFile`/`isDirectory` both
+    // report false for symlink dirents, so treat it explicitly as non-empty.
+    if (entry.isSymbolicLink()) {
+      return false;
+    }
     if (entry.isDirectory() && !isEffectivelyEmptyDir(join(dir, entry.name))) {
       return false;
     }

--- a/packages/core/src/xbrief-migrate/index.ts
+++ b/packages/core/src/xbrief-migrate/index.ts
@@ -11,8 +11,16 @@ export {
   type StaleHeaderDetection,
 } from "./agents-header.js";
 export {
+  VBRIEF_DEPRECATION_MARKER_BODY,
+  VBRIEF_DEPRECATION_MARKER_FILENAME,
+  VBRIEF_DEPRECATION_MARKER_SENTINEL,
+} from "./constants.js";
+export {
   detectLegacyVbriefLayout,
+  detectXbriefConvergence,
   type LegacyVbriefLayoutDetection,
+  type XbriefConvergenceDetection,
+  type XbriefConvergenceState,
 } from "./detect.js";
 export {
   BUILTIN_ALLOW_LIST,
@@ -25,9 +33,16 @@ export {
   scanCorpusToken,
 } from "./drift-gate.js";
 export {
+  hasVbriefDeprecationMarker,
+  isDirectory,
+  isEffectivelyEmptyDir,
+} from "./fs-helpers.js";
+export {
+  convergeLegacyVbriefRoot,
   emitXbriefMigration,
   runXbriefMigration,
   runXbriefMigrationCli,
+  type VbriefConvergeAction,
   type XbriefMigrationArgs,
   type XbriefMigrationIo,
   type XbriefMigrationOutcome,

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -1,10 +1,25 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { LEGACY_ARTIFACT_DIR, MIGRATED_ARTIFACT_DIR } from "./constants.js";
 import {
+  LEGACY_ARTIFACT_DIR,
+  MIGRATED_ARTIFACT_DIR,
+  VBRIEF_DEPRECATION_MARKER_FILENAME,
+  VBRIEF_DEPRECATION_MARKER_SENTINEL,
+} from "./constants.js";
+import { detectXbriefConvergence } from "./detect.js";
+import {
+  convergeLegacyVbriefRoot,
   emitXbriefMigration,
   runXbriefMigration,
   runXbriefMigrationCli,
@@ -320,5 +335,188 @@ describe("runXbriefMigrationCli", () => {
     );
     expect(code).toBe(2);
     expect(errs.join("")).toContain("agents:refresh failed");
+  });
+});
+
+const SILENT_IO = { writeOut: () => {}, writeErr: () => {} };
+
+function scaffoldCanonicalXbrief(base: string): string {
+  const project = join(base, "consumer");
+  mkdirSync(join(project, MIGRATED_ARTIFACT_DIR, "active"), { recursive: true });
+  writeFileSync(
+    join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"),
+    JSON.stringify({
+      xBRIEFInfo: { version: "0.8", description: "fixture" },
+      plan: { title: "Migrated", status: "running", items: [] },
+    }),
+    "utf8",
+  );
+  return project;
+}
+
+function countMarkers(dir: string): number {
+  if (!existsSync(dir)) {
+    return 0;
+  }
+  return readdirSync(dir).filter((name) => name === VBRIEF_DEPRECATION_MARKER_FILENAME).length;
+}
+
+describe("runXbriefMigration convergence (#2270)", () => {
+  it("removes a fully-migrated empty vbrief/ alongside a canonical xbrief/ (no dual empty roots) [a1]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-empty-"));
+    temps.push(base);
+    const project = scaffoldCanonicalXbrief(base);
+    // The stuck dual-empty-root state: canonical xbrief/ + a stray empty vbrief/.
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "pending"), { recursive: true });
+
+    const outcome = runXbriefMigration({ projectRoot: project }, SILENT_IO);
+    expect(outcome.kind).toBe("converged");
+    if (outcome.kind === "converged") {
+      expect(outcome.action).toBe("removed");
+      expect(outcome.already).toBe(false);
+    }
+    // Single unambiguous root remains.
+    expect(existsSync(join(project, LEGACY_ARTIFACT_DIR))).toBe(false);
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"))).toBe(
+      true,
+    );
+  });
+
+  it("retains an empty vbrief/ behind a deprecation marker when --keep-legacy is set [a4]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-keep-"));
+    temps.push(base);
+    const project = scaffoldCanonicalXbrief(base);
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+
+    const outcome = runXbriefMigration({ projectRoot: project, keepLegacy: true }, SILENT_IO);
+    expect(outcome.kind).toBe("converged");
+    if (outcome.kind === "converged") {
+      expect(outcome.action).toBe("marker");
+    }
+    const marker = readFileSync(
+      join(project, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME),
+      "utf8",
+    );
+    expect(marker).toContain(VBRIEF_DEPRECATION_MARKER_SENTINEL);
+    // The retained folder no longer looks like an active source of truth.
+    expect(detectXbriefConvergence(project).state).toBe("xbrief-marker");
+  });
+
+  it("marks a populated legacy vbrief/ deprecated when a canonical xbrief/ already has content [a4]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-dual-"));
+    temps.push(base);
+    const project = scaffoldCanonicalXbrief(base);
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(
+      join(project, LEGACY_ARTIFACT_DIR, "active", "old.vbrief.json"),
+      JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { title: "old", items: [] } }),
+      "utf8",
+    );
+
+    const outcome = runXbriefMigration({ projectRoot: project }, SILENT_IO);
+    expect(outcome.kind).toBe("converged");
+    if (outcome.kind === "converged") {
+      expect(outcome.action).toBe("marker");
+    }
+    // Legacy content is never destructively deleted; the marker rides alongside it.
+    expect(existsSync(join(project, LEGACY_ARTIFACT_DIR, "active", "old.vbrief.json"))).toBe(true);
+    expect(existsSync(join(project, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME))).toBe(
+      true,
+    );
+  });
+
+  it("is idempotent: rerun after a removed converge is a clean no-op [a3]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-idem-rm-"));
+    temps.push(base);
+    const project = scaffoldCanonicalXbrief(base);
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+
+    expect(runXbriefMigration({ projectRoot: project }, SILENT_IO).kind).toBe("converged");
+    const second = runXbriefMigration({ projectRoot: project }, SILENT_IO);
+    expect(second.kind).toBe("noop");
+    expect(existsSync(join(project, LEGACY_ARTIFACT_DIR))).toBe(false);
+  });
+
+  it("is idempotent: rerun after a marker converge does not duplicate the marker [a3]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-idem-mark-"));
+    temps.push(base);
+    const project = scaffoldCanonicalXbrief(base);
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+
+    expect(runXbriefMigration({ projectRoot: project, keepLegacy: true }, SILENT_IO).action).toBe(
+      "marker",
+    );
+    const before = readFileSync(
+      join(project, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME),
+      "utf8",
+    );
+
+    const second = runXbriefMigration({ projectRoot: project, keepLegacy: true }, SILENT_IO);
+    expect(second.kind).toBe("converged");
+    if (second.kind === "converged") {
+      expect(second.already).toBe(true);
+    }
+    expect(countMarkers(join(project, LEGACY_ARTIFACT_DIR))).toBe(1);
+    expect(
+      readFileSync(join(project, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME), "utf8"),
+    ).toBe(before);
+  });
+
+  it("retains vbrief/ behind a marker on a full migration when keepLegacy is set", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-keep-"));
+    temps.push(base);
+    const project = scaffoldLegacyProject(base);
+
+    const outcome = runXbriefMigration(
+      { projectRoot: project, force: true, keepLegacy: true },
+      SILENT_IO,
+    );
+    expect(outcome.kind).toBe("migrated");
+    // The migrated content is canonical in xbrief/, and vbrief/ survives with a marker.
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"))).toBe(
+      true,
+    );
+    expect(existsSync(join(project, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME))).toBe(
+      true,
+    );
+    // Rerun converges to the idempotent already-marked no-op.
+    const rerun = runXbriefMigration({ projectRoot: project, force: true }, SILENT_IO);
+    expect(rerun.kind).toBe("converged");
+  });
+});
+
+describe("convergeLegacyVbriefRoot (#2270)", () => {
+  it("returns removed when the legacy dir is already absent", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-absent-"));
+    temps.push(base);
+    expect(convergeLegacyVbriefRoot(base, { retain: false })).toBe("removed");
+  });
+
+  it("marks an empty dir when retain is requested instead of removing it", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-retain-"));
+    temps.push(base);
+    mkdirSync(join(base, LEGACY_ARTIFACT_DIR), { recursive: true });
+    expect(convergeLegacyVbriefRoot(base, { retain: true })).toBe("marker");
+    expect(existsSync(join(base, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME))).toBe(
+      true,
+    );
+  });
+});
+
+describe("emitXbriefMigration converged (#2270)", () => {
+  it("returns exit code 0 and writes the converge message to stdout", () => {
+    const outs: string[] = [];
+    const code = emitXbriefMigration(
+      {
+        kind: "converged",
+        action: "removed",
+        already: false,
+        message: "Converged layout: removed",
+      },
+      { writeOut: (t) => outs.push(t), writeErr: () => {} },
+    );
+    expect(code).toBe(0);
+    expect(outs.join("")).toContain("Converged layout: removed");
   });
 });

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -426,6 +426,28 @@ describe("runXbriefMigration convergence (#2270)", () => {
     );
   });
 
+  it("never marks an empty legacy root when no canonical xbrief/ exists, even with keepLegacy (no dead end)", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-converge-nocanon-"));
+    temps.push(base);
+    const project = join(base, "consumer");
+    // Empty legacy root, and no canonical xbrief/ content to migrate to.
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+
+    const outcome = runXbriefMigration({ projectRoot: project, keepLegacy: true }, SILENT_IO);
+    expect(outcome.kind).toBe("converged");
+    if (outcome.kind === "converged") {
+      // The stray empty root is removed, not marked — a marker without a
+      // canonical replacement would permanently strand the project.
+      expect(outcome.action).toBe("removed");
+      expect(outcome.message).toContain("no canonical");
+    }
+    expect(existsSync(join(project, LEGACY_ARTIFACT_DIR))).toBe(false);
+    // Rerun is a clean no-op, not a stuck "already converged behind a marker".
+    expect(runXbriefMigration({ projectRoot: project, keepLegacy: true }, SILENT_IO).kind).toBe(
+      "noop",
+    );
+  });
+
   it("is idempotent: rerun after a removed converge is a clean no-op [a3]", () => {
     const base = mkdtempSync(join(tmpdir(), "xbrief-converge-idem-rm-"));
     temps.push(base);

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -245,17 +245,22 @@ export function runXbriefMigration(
     // Ambiguous dual-empty root: a fully-migrated empty legacy tree. Converge to
     // a single canonical root by removing it (or marking it when read-compat
     // retention is requested); never leave two indistinguishable empty roots.
+    // Read-compat retention is only honored when a canonical xbrief/ actually
+    // has content — marking an empty legacy root with no canonical replacement
+    // would strand the project behind a marker that claims a migration that
+    // never happened, so that case always removes the stray empty root.
     case "empty-vbrief": {
-      const action = convergeLegacyVbriefRoot(projectRoot, { retain: keepLegacy });
-      return {
-        kind: "converged",
-        action,
-        already: false,
-        message:
-          action === "removed"
-            ? `Converged layout: removed empty legacy '${LEGACY_ARTIFACT_DIR}/' — single '${MIGRATED_ARTIFACT_DIR}/' root.`
-            : `Converged layout: wrote deprecation marker to legacy '${LEGACY_ARTIFACT_DIR}/' (retained for read-compat).`,
-      };
+      const retain = keepLegacy && convergence.xbriefHasContent;
+      const action = convergeLegacyVbriefRoot(projectRoot, { retain });
+      let message: string;
+      if (action === "removed") {
+        message = convergence.xbriefHasContent
+          ? `Converged layout: removed empty legacy '${LEGACY_ARTIFACT_DIR}/' — single '${MIGRATED_ARTIFACT_DIR}/' root.`
+          : `Converged layout: removed empty legacy '${LEGACY_ARTIFACT_DIR}/' — no canonical '${MIGRATED_ARTIFACT_DIR}/' root to migrate to yet.`;
+      } else {
+        message = `Converged layout: wrote deprecation marker to legacy '${LEGACY_ARTIFACT_DIR}/' (retained for read-compat).`;
+      }
+      return { kind: "converged", action, already: false, message };
     }
 
     // Legacy content coexisting with a populated canonical xbrief/. We never

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -16,9 +16,11 @@ import {
   LEGACY_ARTIFACT_SUFFIX,
   MIGRATED_ARTIFACT_DIR,
   MIGRATED_ARTIFACT_SUFFIX,
+  VBRIEF_DEPRECATION_MARKER_BODY,
+  VBRIEF_DEPRECATION_MARKER_FILENAME,
 } from "./constants.js";
-import { detectLegacyVbriefLayout } from "./detect.js";
-import { isDirectory } from "./fs-helpers.js";
+import { detectLegacyVbriefLayout, detectXbriefConvergence } from "./detect.js";
+import { hasVbriefDeprecationMarker, isDirectory, isEffectivelyEmptyDir } from "./fs-helpers.js";
 import { renderXbriefMigrationLine, xbriefMigrationGuidance } from "./signpost.js";
 import type { JsonObject } from "./transforms.js";
 import { rewriteEmbeddedTokens, transformArtifactV06ToV08Transactional } from "./transforms.js";
@@ -27,6 +29,11 @@ export interface XbriefMigrationArgs {
   readonly projectRoot: string;
   readonly frameworkRoot?: string;
   readonly force?: boolean;
+  /**
+   * Retain a fully-migrated `vbrief/` for read-compatibility behind an explicit
+   * deprecation marker instead of removing it (#2270). Default: remove.
+   */
+  readonly keepLegacy?: boolean;
 }
 
 export interface XbriefMigrationIo {
@@ -34,10 +41,19 @@ export interface XbriefMigrationIo {
   writeErr: (text: string) => void;
 }
 
+/** How the legacy `vbrief/` root was converged to an unambiguous state (#2270). */
+export type VbriefConvergeAction = "removed" | "marker";
+
 export type XbriefMigrationOutcome =
   | { readonly kind: "noop"; readonly message: string }
   | { readonly kind: "refused"; readonly message: string }
   | { readonly kind: "migrated"; readonly backupDir: string; readonly files: number }
+  | {
+      readonly kind: "converged";
+      readonly action: VbriefConvergeAction;
+      readonly already: boolean;
+      readonly message: string;
+    }
   | { readonly kind: "config"; readonly message: string };
 
 function collectFiles(root: string, acc: string[] = []): string[] {
@@ -93,6 +109,7 @@ function backupLegacyTree(projectRoot: string, legacyDir: string): string {
 function migrateLegacyTree(
   projectRoot: string,
   legacyDir: string,
+  options: { keepLegacy: boolean },
 ): { backupDir: string; files: number } {
   const migratedDir = join(projectRoot, MIGRATED_ARTIFACT_DIR);
   if (existsSync(migratedDir)) {
@@ -116,12 +133,58 @@ function migrateLegacyTree(
       writeMigratedFile(srcPath, destPath);
     }
     renameOrReplace(stagedDir, migratedDir);
-    rmSync(legacyDir, { recursive: true, force: true });
+    // Converge to a single unambiguous root: the fully-migrated legacy tree is
+    // either removed (default) or retained for read-compat behind an explicit
+    // deprecation marker so it never looks like an active source of truth (#2270).
+    if (options.keepLegacy) {
+      writeVbriefDeprecationMarker(legacyDir);
+    } else {
+      rmSync(legacyDir, { recursive: true, force: true });
+    }
     return { backupDir, files: files.length };
   } catch (err) {
     rmSync(stagedDir, { recursive: true, force: true });
     throw err;
   }
+}
+
+/** Idempotently write the legacy-root deprecation marker (#2270). */
+function writeVbriefDeprecationMarker(legacyDir: string): void {
+  mkdirSync(legacyDir, { recursive: true });
+  if (hasVbriefDeprecationMarker(legacyDir)) {
+    return;
+  }
+  writeFileSync(
+    join(legacyDir, VBRIEF_DEPRECATION_MARKER_FILENAME),
+    VBRIEF_DEPRECATION_MARKER_BODY,
+    "utf8",
+  );
+}
+
+/**
+ * Converge a leftover legacy `vbrief/` root to an unambiguous state (#2270).
+ * An effectively-empty tree is removed by default (single canonical root); a
+ * tree with real content — or an empty tree when `retain` is requested — is
+ * kept for read-compat behind an explicit deprecation marker. Idempotent: a
+ * missing dir or an already-marked dir is a no-op.
+ */
+export function convergeLegacyVbriefRoot(
+  projectRoot: string,
+  options: { retain: boolean },
+): VbriefConvergeAction {
+  const legacyDir = join(projectRoot, LEGACY_ARTIFACT_DIR);
+  if (!isDirectory(legacyDir)) {
+    return "removed";
+  }
+  if (hasVbriefDeprecationMarker(legacyDir)) {
+    return "marker";
+  }
+  if (isEffectivelyEmptyDir(legacyDir) && !options.retain) {
+    rmSync(legacyDir, { recursive: true, force: true });
+    return "removed";
+  }
+  writeVbriefDeprecationMarker(legacyDir);
+  return "marker";
 }
 
 function renameOrReplace(src: string, dest: string): void {
@@ -158,12 +221,60 @@ function runAgentsRefresh(
   return 0;
 }
 
-/** Core orchestrator for the consumer xbrief rename (#2110). */
+/** Core orchestrator for the consumer xbrief rename (#2110) + convergence (#2270). */
 export function runXbriefMigration(
   args: XbriefMigrationArgs,
   _io: XbriefMigrationIo,
 ): XbriefMigrationOutcome {
   const projectRoot = resolve(args.projectRoot);
+  const legacyDir = join(projectRoot, LEGACY_ARTIFACT_DIR);
+  const keepLegacy = args.keepLegacy ?? false;
+  const convergence = detectXbriefConvergence(projectRoot);
+
+  switch (convergence.state) {
+    // Already converged: legacy root is retained behind an explicit marker.
+    // Rerun is a pure no-op (no re-removal, no duplicate marker) — idempotent.
+    case "xbrief-marker":
+      return {
+        kind: "converged",
+        action: "marker",
+        already: true,
+        message: `Legacy '${LEGACY_ARTIFACT_DIR}/' already carries a deprecation marker — layout already converged.`,
+      };
+
+    // Ambiguous dual-empty root: a fully-migrated empty legacy tree. Converge to
+    // a single canonical root by removing it (or marking it when read-compat
+    // retention is requested); never leave two indistinguishable empty roots.
+    case "empty-vbrief": {
+      const action = convergeLegacyVbriefRoot(projectRoot, { retain: keepLegacy });
+      return {
+        kind: "converged",
+        action,
+        already: false,
+        message:
+          action === "removed"
+            ? `Converged layout: removed empty legacy '${LEGACY_ARTIFACT_DIR}/' — single '${MIGRATED_ARTIFACT_DIR}/' root.`
+            : `Converged layout: wrote deprecation marker to legacy '${LEGACY_ARTIFACT_DIR}/' (retained for read-compat).`,
+      };
+    }
+
+    // Legacy content coexisting with a populated canonical xbrief/. We never
+    // destructively merge; converge non-destructively by marking the legacy
+    // tree deprecated so it no longer looks like an active source of truth.
+    case "dual-populated": {
+      convergeLegacyVbriefRoot(projectRoot, { retain: true });
+      return {
+        kind: "converged",
+        action: "marker",
+        already: false,
+        message: `Converged layout: '${MIGRATED_ARTIFACT_DIR}/' is canonical; wrote deprecation marker to legacy '${LEGACY_ARTIFACT_DIR}/' (retained for read-compat).`,
+      };
+    }
+
+    default:
+      break;
+  }
+
   const detection = detectLegacyVbriefLayout(projectRoot);
   if (!detection.legacyLayout) {
     return {
@@ -172,7 +283,6 @@ export function runXbriefMigration(
     };
   }
 
-  const legacyDir = join(projectRoot, LEGACY_ARTIFACT_DIR);
   if (!isDirectory(legacyDir)) {
     return {
       kind: "config",
@@ -191,7 +301,7 @@ export function runXbriefMigration(
   }
 
   try {
-    const { backupDir, files } = migrateLegacyTree(projectRoot, legacyDir);
+    const { backupDir, files } = migrateLegacyTree(projectRoot, legacyDir, { keepLegacy });
     return { kind: "migrated", backupDir, files };
   } catch (err) {
     return {
@@ -228,6 +338,9 @@ export function emitXbriefMigration(
         `Migrated ${outcome.files} file(s) from ${LEGACY_ARTIFACT_DIR}/ to ${MIGRATED_ARTIFACT_DIR}/.\n` +
           `Backup written to ${outcome.backupDir}.\n`,
       );
+      return 0;
+    case "converged":
+      io.writeOut(`${outcome.message}\n`);
       return 0;
     default: {
       const _exhaustive: never = outcome;

--- a/packages/core/src/xbrief-migrate/signpost.test.ts
+++ b/packages/core/src/xbrief-migrate/signpost.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { VBRIEF_DEPRECATION_MARKER_BODY, VBRIEF_DEPRECATION_MARKER_FILENAME } from "./constants.js";
 import { renderXbriefMigrationLine } from "./signpost.js";
 
 const SAMPLE_V06 = {
@@ -53,5 +54,70 @@ describe("renderXbriefMigrationLine", () => {
     expect(line).toContain("legacy vbrief layout detected");
     expect(line).toContain("migrate:xbrief");
     expect(line).toContain("more marker(s)");
+  });
+
+  it("reports an unambiguous xbrief-active + vbrief-removed state after migration [a2]", () => {
+    const root = mkdtempSync(join(tmpdir(), "xbrief-signpost-removed-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8", description: "fixture" },
+        plan: { title: "Migrated", status: "running", items: [] },
+      }),
+      "utf8",
+    );
+
+    const line = renderXbriefMigrationLine(root);
+    expect(line).toContain("xbrief active");
+    expect(line).toContain("vbrief removed");
+    // Backward-compatible substring doctor asserts on.
+    expect(line).toContain("xBrief migration: none");
+  });
+
+  it("reports an unambiguous xbrief-active + vbrief-legacy-marker state when retained [a2]", () => {
+    const root = mkdtempSync(join(tmpdir(), "xbrief-signpost-marker-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8", description: "fixture" },
+        plan: { title: "Migrated", status: "running", items: [] },
+      }),
+      "utf8",
+    );
+    mkdirSync(join(root, "vbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "vbrief", VBRIEF_DEPRECATION_MARKER_FILENAME),
+      VBRIEF_DEPRECATION_MARKER_BODY,
+      "utf8",
+    );
+
+    const line = renderXbriefMigrationLine(root);
+    expect(line).toContain("xbrief active");
+    expect(line).toContain("vbrief legacy marker");
+    expect(line).not.toContain("dual");
+  });
+
+  it("calls out a stray empty vbrief/ as converge-pending, not a generic dead end", () => {
+    const root = mkdtempSync(join(tmpdir(), "xbrief-signpost-empty-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8", description: "fixture" },
+        plan: { title: "Migrated", status: "running", items: [] },
+      }),
+      "utf8",
+    );
+    mkdirSync(join(root, "vbrief", "active"), { recursive: true });
+
+    const line = renderXbriefMigrationLine(root);
+    expect(line).toContain("converge pending");
+    expect(line).toContain("empty legacy vbrief/");
+    expect(line).toContain("migrate:xbrief");
   });
 });

--- a/packages/core/src/xbrief-migrate/signpost.ts
+++ b/packages/core/src/xbrief-migrate/signpost.ts
@@ -1,15 +1,33 @@
-import { detectLegacyVbriefLayout } from "./detect.js";
+import { detectLegacyVbriefLayout, detectXbriefConvergence } from "./detect.js";
 
 /** Operator guidance for the TS-native xbrief rename (#2034 / #2110). */
 export function xbriefMigrationGuidance(): string {
   return "Run `deft migrate:xbrief` (or `task migrate:xbrief`) to convert vbrief/ to xbrief/ safely.";
 }
 
-/** One-line doctor / ritual signpost mirroring `renderPrecutoverLine` (#2110). */
+/**
+ * One-line doctor / ritual signpost mirroring `renderPrecutoverLine` (#2110),
+ * reporting an unambiguous convergence state (#2270). A migrated project reads
+ * as `xbrief active` plus either `vbrief legacy marker` or `vbrief removed`; a
+ * stray empty legacy root is called out as a pending convergence rather than a
+ * generic "run migrate" dead end — never a dual-empty-root ambiguity.
+ */
 export function renderXbriefMigrationLine(projectRoot: string): string {
+  const convergence = detectXbriefConvergence(projectRoot);
+
+  // Converged: legacy vbrief/ retained for read-compat behind an explicit marker.
+  if (convergence.state === "xbrief-marker") {
+    return "xBrief migration: converged -- xbrief active, vbrief legacy marker (read-compat).";
+  }
+
+  // Ambiguous dual-empty root: canonical xbrief/ (or none) plus a stray empty vbrief/.
+  if (convergence.state === "empty-vbrief") {
+    return `xBrief migration: converge pending -- xbrief active, empty legacy vbrief/ present. ${xbriefMigrationGuidance()}`;
+  }
+
   const { legacyLayout, reasons } = detectLegacyVbriefLayout(projectRoot);
   if (!legacyLayout) {
-    return "xBrief migration: none -- project is on the xbrief layout.";
+    return "xBrief migration: none -- xbrief active, vbrief removed.";
   }
   const maxReasons = 3;
   const shown = reasons.slice(0, maxReasons);

--- a/xbrief/completed/2026-07-03-2270-migratexbrief-clean-up-ambiguous-empty-vbriefxbrief-roots.xbrief.json
+++ b/xbrief/completed/2026-07-03-2270-migratexbrief-clean-up-ambiguous-empty-vbriefxbrief-roots.xbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "2270-migrate-xbrief-cleanup",
     "title": "migrate:xbrief: clean up ambiguous empty vbrief/xbrief roots",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Make `migrate:xbrief` converge the project layout cleanly instead of leaving ambiguous empty `vbrief/` and `xbrief/` lifecycle roots after a migration. A successful migration removes a fully-migrated empty `vbrief/` or replaces it with an explicit deprecation marker so it never looks like an active source of truth, the doctor signpost reports an unambiguous single-root state, and the cleanup is idempotent across reruns.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2270",
@@ -126,8 +126,10 @@
           "Colocated vitest across empty/non-empty/already-migrated/rerun states green under task check:framework-source."
         ],
         "notes": "Refined swarm-ready 2026-07-03. Runs CONCURRENTLY with #2265 (init) and #2273 (cold-start docs) in wave 4 -- file_scope is disjoint (this touches xbrief-migrate/* + the thin migrate-xbrief CLI wrapper; doctor state flows through signpost.ts which doctor already consumes, so doctor/main.ts + doctor.ts are intentionally NOT in scope to avoid contention). CHANGELOG.md omitted from file_scope (worker still adds a bullet; 3-way merge handles it). No issue-level deps (migrate:xbrief is already registered); consumes nothing from the wave-4 siblings."
-      }
+      },
+      "completedAt": "2026-07-04T00:55:09Z",
+      "capacityBucket": "new-capability"
     },
-    "updated": "2026-07-04T00:35:13Z"
+    "updated": "2026-07-04T00:55:09Z"
   }
 }


### PR DESCRIPTION
## Summary

Makes `migrate:xbrief` converge to a single, unambiguous lifecycle root instead of leaving an ambiguous empty `vbrief/` next to a canonical `xbrief/` (the state where `doctor` says "run migrate" but `migrate` refuses — a dead end).

- **`detectXbriefConvergence`** classifier (in `detect.ts`) distinguishes the ambiguous dual-empty-root state (`empty-vbrief`) from the already-unambiguous states (`xbrief-only`, `xbrief-marker`, `legacy-only`, `dual-populated`, `none`).
- **Converge step** (`migrate-project.ts`): a fully-migrated empty `vbrief/` is removed by default, or retained for read-compatibility behind an explicit `DEPRECATED.md` marker via the new `--keep-legacy` flag. A populated legacy tree coexisting with a canonical `xbrief/` is non-destructively marked deprecated rather than dead-ending on a refusal. All cleanup is idempotent (rerun is a clean no-op / already-marked).
- **Signpost** (`signpost.ts`, consumed by `doctor`) now reports an unambiguous state: `xbrief active` plus either `vbrief removed` or `vbrief legacy marker` — never a dual-empty ambiguity. Backward-compatible substrings (`xBrief migration: none`, `... legacy vbrief layout detected`) are preserved so out-of-scope doctor tests are unaffected.
- **Marker constants** in `constants.ts`; empty-dir + marker helpers in `fs-helpers.ts`; new symbols exported from `index.ts`; `--keep-legacy` passthrough in the thin `migrate-xbrief` CLI wrapper.

Acceptance criteria (a1 no dual empty roots, a2 unambiguous doctor state, a3 idempotent, a4 retained folder never looks active) are each covered by colocated vitest.

Scope note: strictly within `packages/core/src/xbrief-migrate/*` + the thin `packages/cli/src/migrate-xbrief.ts` wrapper (+ colocated tests) + a distinct CHANGELOG bullet. `doctor/main.ts` / `doctor.ts`, init/dispatch, README, and the agents-entry template were not touched (concurrent wave-4 cohort).

## Test plan

- [x] `task ts:check-lane`
- [x] `pnpm exec vitest run packages/core/src/xbrief-migrate` (24 migrate + 11 detect + 5 signpost + others green)
- [x] `pnpm exec vitest run packages/cli/src/migrate-xbrief.test.ts`
- [x] `task check:framework-source` — All checks passed (out-of-scope `doctor.test.ts` still green; xbrief-migrate coverage: signpost 100%, constants 100%, detect ~96%, migrate-project ~90%)

Closes #2270. Refs #2203.
