### PR TITLE
fix(doctor): report actionable signal when VERSION tag/ref is empty (#2294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `deft doctor` now surfaces an actionable advisory when a project's `VERSION` manifest carries no semver tag/ref and only a short commit sha — the unpinned state legacy `deft-install` produces without a release pin. Previously the framework version was silently unreportable; the doctor now names the sha-only manifest and points at `directive update` to obtain a pinned npm-managed manifest, without changing the doctor exit code. Closes #2294.
+
 ### Removed
 
 ## [0.69.0] - 2026-07-05

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -6,6 +6,7 @@ import {
   checkInstallPathConsistency,
   checkLegacyLayout,
   checkManifestAgreement,
+  checkManifestVersionReportable,
   checkQuickStartResolves,
   checkSkillPathsResolve,
   deriveExitCode,
@@ -209,5 +210,61 @@ describe("checks", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("checkManifestVersionReportable (#2294)", () => {
+  const seamsFor = (text: string | null) => ({
+    isFile: (p: string) => p.endsWith("VERSION") && text !== null,
+    readText: (p: string) => (p.endsWith("VERSION") ? text : null),
+  });
+
+  it("passes when a semver tag resolves", () => {
+    const result = checkManifestVersionReportable(
+      "/proj",
+      ".deft/core",
+      seamsFor("ref: 'v0.68.1'\nsha: 'abcdef1'\ntag: 'v0.68.1'\n"),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.data?.version).toBe("0.68.1");
+    expect(result.data?.source).toBe("tag");
+  });
+
+  it("advisory-fails (sha only) when tag/ref are empty but a sha is present", () => {
+    const result = checkManifestVersionReportable(
+      "/proj",
+      ".deft/core",
+      seamsFor("ref: ''\nsha: '06329f3'\ntag: ''\ninstall_root: '.deft/core'\n"),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.data?.version).toBeNull();
+    expect(result.data?.sha).toBe("06329f3");
+    expect(result.detail).toContain("directive update");
+    expect(result.detail).toContain("#2294");
+  });
+
+  it("does NOT change the doctor exit code (advisory only)", () => {
+    const shaOnly = checkManifestVersionReportable(
+      "/proj",
+      ".deft/core",
+      seamsFor("ref: ''\nsha: '06329f3'\ntag: ''\n"),
+    );
+    expect(deriveExitCode([shaOnly], [])).toBe(0);
+  });
+
+  it("skips when no manifest is present", () => {
+    const result = checkManifestVersionReportable("/proj", ".deft/core", seamsFor(null));
+    expect(result.status).toBe("skip");
+    expect(result.data?.manifest_path).toBeNull();
+  });
+
+  it("skips when the manifest carries neither semver nor sha", () => {
+    const result = checkManifestVersionReportable(
+      "/proj",
+      ".deft/core",
+      seamsFor("ref: ''\nsha: ''\ntag: ''\ninstall_root: '.deft/core'\n"),
+    );
+    expect(result.status).toBe("skip");
+    expect(result.detail).toContain("no provenance");
   });
 });

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -21,6 +21,7 @@ import {
   isDeprecationRedirectStub,
   locateManifest,
   manifestCandidatePaths,
+  manifestReportableVersion,
   manifestTagToVersion,
   parseInstallManifest,
   parseInstallRootFromAgentsMd,
@@ -426,11 +427,88 @@ export function checkCanonicalVendoredNpmSignpost(
   };
 }
 
+/**
+ * #2294: report whether the located install manifest can surface a version.
+ * A legacy `deft-install` deposit made without a release pin writes empty
+ * `tag`/`ref` and only a short `sha`, leaving the framework version silently
+ * unreportable. Since the Go installer is a frozen legacy bridge (#1912) and
+ * the Python/Go rails are retired (#1933/#2022/#2068), the fix is doctor-side:
+ * turn the silent blank into a visible, actionable finding. Advisory only --
+ * exit-code-exempt like `canonical-vendored-npm-signpost` -- because a sha-only
+ * deposit is still a working install, just an unpinned one.
+ */
+export function checkManifestVersionReportable(
+  projectRoot: string,
+  installRoot: string | null,
+  seams: CheckSeams = {},
+): CheckResult {
+  const isFile = seams.isFile ?? ((p) => readText(p, seams) !== null);
+  const manifestPath = locateManifest(projectRoot, installRoot, isFile);
+  if (manifestPath === null) {
+    return {
+      name: "manifest-version-reportable",
+      status: "skip",
+      detail: "No install manifest found; no framework version to report.",
+      data: { manifest_path: null },
+    };
+  }
+  const text = readText(manifestPath, seams);
+  if (text === null) {
+    return {
+      name: "manifest-version-reportable",
+      status: "skip",
+      detail: `Install manifest at ${manifestPath} is unreadable.`,
+      data: { manifest_path: manifestPath },
+    };
+  }
+  const manifest = parseInstallManifest(text);
+  const reportable = manifestReportableVersion(manifest);
+  if (reportable.version !== null) {
+    return {
+      name: "manifest-version-reportable",
+      status: "pass",
+      detail: `Framework version resolves to ${reportable.version} (from manifest ${reportable.source}) at ${manifestPath}.`,
+      data: {
+        manifest_path: manifestPath,
+        version: reportable.version,
+        source: reportable.source,
+      },
+    };
+  }
+  if (reportable.sha !== null) {
+    const shortSha = reportable.sha.slice(0, 8);
+    return {
+      name: "manifest-version-reportable",
+      status: "fail",
+      detail:
+        `Install manifest at ${manifestPath} carries no semver tag/ref (sha ${shortSha} only), ` +
+        "so the framework version is unreportable. This happens on legacy `deft-install` deposits " +
+        `made without a release pin (#2294). Run \`${CANONICAL_UPGRADE_COMMAND}\` then \`directive update\` ` +
+        `to obtain a pinned npm-managed manifest. See ${UPGRADING_DOC_URL}.`,
+      data: {
+        manifest_path: manifestPath,
+        version: null,
+        source: reportable.source,
+        sha: reportable.sha,
+        upgrade_command: CANONICAL_UPGRADE_COMMAND,
+        upgrading_doc_url: UPGRADING_DOC_URL,
+      },
+    };
+  }
+  return {
+    name: "manifest-version-reportable",
+    status: "skip",
+    detail: `Install manifest at ${manifestPath} has neither a semver tag/ref nor a sha; no provenance to report.`,
+    data: { manifest_path: manifestPath, version: null, sha: null, source: reportable.source },
+  };
+}
+
 export function deriveExitCode(checks: readonly CheckResult[], errors: readonly string[]): number {
+  const exitExempt = new Set(["canonical-vendored-npm-signpost", "manifest-version-reportable"]);
   if (errors.length > 0 || checks.some((c) => c.status === "error")) {
     return 2;
   }
-  if (checks.some((c) => c.status === "fail" && c.name !== "canonical-vendored-npm-signpost")) {
+  if (checks.some((c) => c.status === "fail" && !exitExempt.has(c.name))) {
     return 1;
   }
   return 0;
@@ -467,6 +545,7 @@ export function runChecksImpl(
       data: { agents_md_path: agentsMdPath },
     });
     checks.push(checkManifestAgreement(projectRoot, null, seams));
+    checks.push(checkManifestVersionReportable(projectRoot, null, seams));
     checks.push(checkLegacyLayout(projectRoot, seams));
     checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));
     return {
@@ -480,6 +559,7 @@ export function runChecksImpl(
   checks.push(checkQuickStartResolves(projectRoot, installRoot, seams));
   checks.push(checkSkillPathsResolve(projectRoot, agentsMdText, seams));
   checks.push(checkManifestAgreement(projectRoot, installRoot, seams));
+  checks.push(checkManifestVersionReportable(projectRoot, installRoot, seams));
   checks.push(checkInstallPathConsistency(projectRoot, installRoot, seams));
   checks.push(checkLegacyLayout(projectRoot, seams));
   checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));

--- a/packages/core/src/doctor/coverage-final.test.ts
+++ b/packages/core/src/doctor/coverage-final.test.ts
@@ -7,7 +7,7 @@ import * as checks from "./checks.js";
 import { checkInstallPathConsistency, runChecksImpl } from "./checks.js";
 import { decideThrottle, readState, statePath } from "./doctor-state.js";
 import { cmdDoctor } from "./main.js";
-import { manifestTagToVersion, parseManifest } from "./manifest.js";
+import { manifestReportableVersion, manifestTagToVersion, parseManifest } from "./manifest.js";
 import { createPlainSink } from "./output.js";
 import { resolveDefaultFrameworkRoot, resolvePath, runningInsideDeftRepo } from "./paths.js";
 import { runPayloadStalenessCheck } from "./payload-staleness.js";
@@ -153,6 +153,29 @@ describe("doctor coverage final", () => {
   it("manifest parse skips bad lines", () => {
     expect(parseManifest("# comment\nbadline\nkey: val\n").key).toBe("val");
     expect(manifestTagToVersion({ ref: "  v1.2.3  " })).toBe("1.2.3");
+  });
+
+  it("manifestReportableVersion classifies tag / ref / sha / none (#2294)", () => {
+    expect(manifestReportableVersion({ tag: "v0.68.1", ref: "v0.68.1", sha: "abc" })).toEqual({
+      version: "0.68.1",
+      sha: "abc",
+      source: "tag",
+    });
+    expect(manifestReportableVersion({ tag: "", ref: "v0.2.0", sha: "abc" })).toEqual({
+      version: "0.2.0",
+      sha: "abc",
+      source: "ref",
+    });
+    expect(manifestReportableVersion({ tag: "", ref: "", sha: "06329f3" })).toEqual({
+      version: null,
+      sha: "06329f3",
+      source: "sha",
+    });
+    expect(manifestReportableVersion({ tag: "", ref: "", sha: "" })).toEqual({
+      version: null,
+      sha: null,
+      source: "none",
+    });
   });
 
   it("install path manifest fallback note", () => {

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -437,7 +437,9 @@ function runInstallIntegrityChecks(
         continue;
       }
       if (
-        (name === "legacy-layout" || name === "canonical-vendored-npm-signpost") &&
+        (name === "legacy-layout" ||
+          name === "canonical-vendored-npm-signpost" ||
+          name === "manifest-version-reportable") &&
         status === "fail"
       ) {
         sink.warn(`${name}: ${detail}`);

--- a/packages/core/src/doctor/manifest.ts
+++ b/packages/core/src/doctor/manifest.ts
@@ -47,6 +47,42 @@ export function manifestTagToVersion(manifest: Record<string, string>): string |
   return null;
 }
 
+/** Reportability classes for an install manifest's version provenance (#2294). */
+export type ManifestVersionSource = "tag" | "ref" | "sha" | "none";
+
+export interface ReportableVersion {
+  /** Semver derived from `tag`/`ref` (leading `v` stripped), else null. */
+  readonly version: string | null;
+  /** Recorded commit `sha`, trimmed, else null. */
+  readonly sha: string | null;
+  /** Where a reportable identity was found. */
+  readonly source: ManifestVersionSource;
+}
+
+/**
+ * Classify what a manifest can report as its version (#2294). A legacy
+ * `deft-install` deposit made without a release pin writes empty `tag`/`ref`
+ * and only a short `sha`; `manifestTagToVersion` then returns null and the
+ * version is silently unreportable. This helper distinguishes a pinned
+ * semver (`tag`/`ref`) from a sha-only deposit from a manifest with no
+ * provenance at all, so callers can surface an actionable signal instead of a
+ * blank.
+ */
+export function manifestReportableVersion(manifest: Record<string, string>): ReportableVersion {
+  const version = manifestTagToVersion(manifest);
+  if (version !== null) {
+    const tag = typeof manifest.tag === "string" ? manifest.tag.trim() : "";
+    return { version, sha: readSha(manifest), source: tag ? "tag" : "ref" };
+  }
+  const sha = readSha(manifest);
+  return { version: null, sha, source: sha !== null ? "sha" : "none" };
+}
+
+function readSha(manifest: Record<string, string>): string | null {
+  const raw = typeof manifest.sha === "string" ? manifest.sha.trim() : "";
+  return raw || null;
+}
+
 export function manifestCandidatePaths(projectRoot: string, installRoot: string | null): string[] {
   const raw: string[] = [];
   if (installRoot) {

--- a/xbrief/completed/2026-07-05-2294-doctor-version-reportable.xbrief.json
+++ b/xbrief/completed/2026-07-05-2294-doctor-version-reportable.xbrief.json
@@ -1,0 +1,84 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2294: make the doctor report an actionable signal when the install manifest carries an empty tag/ref (sha only), instead of leaving the framework version silently unreportable.",
+    "created": "2026-07-05T12:00:00Z",
+    "updated": "2026-07-05T12:00:00Z"
+  },
+  "plan": {
+    "id": "2294-doctor-version-reportable",
+    "title": "Doctor-harden version reporting when VERSION manifest tag/ref is empty",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2294",
+    "narratives": {
+      "Description": "Legacy `deft-install` without an explicit release pin writes `.deft/core/VERSION` with empty `ref`/`tag` and only a short sha, so version-reporting tooling shows nothing. Because the Go installer is a frozen legacy bridge (#1912) and the Python/Go rails are retired (#1933/#2022/#2068), the fix lives on the doctor side: surface an actionable finding when the located manifest resolves no semver tag/ref but does carry a sha, pointing the operator at `directive update` to obtain a pinned npm-managed manifest. This converts a silent unreportable state into a visible, remediable one without fabricating a semver or extending the frozen installer.",
+      "ImplementationPlan": "1. Add a pure `manifestReportableVersion(manifest)` helper in packages/core/src/doctor/manifest.ts that returns the semver from tag/ref (reusing manifestTagToVersion) plus the recorded sha, so callers can distinguish 'pinned', 'sha-only', and 'no-provenance'. 2. Add a `checkManifestVersionReportable` check in packages/core/src/doctor/checks.ts: pass when a semver tag/ref resolves; advisory-fail (exit-code-exempt, mirroring canonical-vendored-npm-signpost) when only a sha is present, with a `directive update` remediation; skip when no manifest or no provenance at all. 3. Register the check in runChecksImpl (both AGENTS.md-present and -absent branches) and exempt its name in deriveExitCode so it never fails `deft check`. 4. Add unit tests in checks.test.ts and manifest coverage tests for the new helper covering pinned / sha-only / no-provenance / no-manifest cases.",
+      "UserStory": "As a consumer whose project was installed via the frozen Go installer without a release pin, I want `deft doctor` to tell me my framework version is unpinned and how to fix it, so that an empty VERSION tag is a visible, actionable signal instead of a silent blank.",
+      "Traces": "#2294, #1912, #2068"
+    },
+    "items": [
+      {
+        "id": "2294-a1",
+        "title": "Given a manifest with empty tag/ref but a sha, when doctor runs, then it emits an advisory finding recommending `directive update`",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given `.deft/core/VERSION` with empty `ref`/`tag` and a non-empty `sha`, when the doctor runs, then a `manifest-version-reportable` finding reports the sha-only state and recommends `directive update`, and the finding does NOT change the doctor exit code."
+        }
+      },
+      {
+        "id": "2294-a2",
+        "title": "Given a manifest with a semver tag, when doctor runs, then the reportable-version check passes",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a manifest whose tag/ref resolves to a semver, when the doctor runs, then `manifest-version-reportable` passes and reports the resolved version."
+        }
+      },
+      {
+        "id": "2294-a3",
+        "title": "Given no manifest or no provenance, when doctor runs, then the check skips cleanly",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given no install manifest (or a manifest with neither semver nor sha), when the doctor runs, then `manifest-version-reportable` returns skip and never fails."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "child_issue": "#2294"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/doctor/manifest.ts",
+          "packages/core/src/doctor/checks.ts",
+          "packages/core/src/doctor/checks.test.ts",
+          "packages/core/src/doctor/coverage-final.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm -C packages/core vitest run src/doctor/",
+          "task check"
+        ],
+        "expected_outputs": [
+          "doctor emits an actionable advisory when VERSION tag/ref is empty but a sha is present; exit code unchanged"
+        ],
+        "depends_on": [],
+        "conflict_group": "doctor-version",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completedAt": "2026-07-05T12:25:02Z",
+      "capacityBucket": "new-capability"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2294",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2294: deft-install writes empty tag/ref in VERSION when no release is pinned"
+      }
+    ],
+    "updated": "2026-07-05T12:25:02Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Legacy `deft-install` deposits made without a release pin write an empty `tag`/`ref` (only a short sha) into `.deft/core/VERSION`, leaving the framework version silently unreportable in doctor/audit tooling (blank / `—`).
- The Go installer is a frozen legacy bridge (#1912) and the Python/Go install rails are retired (#1933/#2022/#2068), so the fix lives on the doctor side rather than the installer.
- `deft doctor` now emits an **advisory** finding when the located manifest resolves no semver tag/ref but does carry a sha, pointing at `directive update` to obtain a pinned npm-managed manifest. It never fabricates a semver and never changes the doctor exit code.

## Changes

- `manifestReportableVersion(manifest)` helper (`doctor/manifest.ts`) classifying provenance as `tag` / `ref` / `sha` / `none`.
- `checkManifestVersionReportable` check (`doctor/checks.ts`): `pass` on a resolvable semver, advisory `fail` (exit-code-exempt, mirroring `canonical-vendored-npm-signpost`) on a sha-only manifest, `skip` when no manifest or no provenance.
- Registered in `runChecksImpl` (both AGENTS.md branches); kept advisory (warning, not error) in the doctor main flow.
- Unit tests for the helper (tag/ref/sha/none) and every check state.

## Why doctor-hardening (not an installer fix)

Rationale recorded on the issue: patching the frozen `deft-install` source cuts against the retirement direction and only helps consumers who rebuild-and-reinstall from that rail. The npm/`directive update` path already resolves the tag correctly. Doctor-hardening makes version reporting resilient regardless of which rail produced `VERSION`.

## Test plan

- [x] `pnpm -C packages/core vitest run src/doctor` — 207 pass (incl. new cases)
- [x] `task check` — All checks passed
- [x] Advisory finding does not change doctor exit code (unit-asserted)

Closes #2294

Made with [Cursor](https://cursor.com)