### PR TITLE
docs(migrate): durable, self-documenting frozen pre-v0.20 migration path (#2297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The frozen pre-v0.20 migration path is now durable-by-documentation. `deft doctor` / `task migrate:preflight` guidance and UPGRADING.md now anchor recovery on the permanent `v0.59.0` git tag (GitHub serves a source tarball for any tag, so recovery no longer hinges on an uploaded release asset), spell out the two-hop migration chain (pre-v0.20 flat → vBRIEF v0.6 → xBRIEF), and add a manual `directive init` fresh-start fallback for when the frozen payload is unreachable. Closes #2297.
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The frozen pre-v0.20 migration path is now durable-by-documentation. `deft doctor` / `task migrate:preflight` guidance and UPGRADING.md now anchor recovery on the permanent `v0.59.0` git tag (GitHub serves a source tarball for any tag, so recovery no longer hinges on an uploaded release asset), spell out the two-hop migration chain (pre-v0.20 flat → vBRIEF v0.6 → xBRIEF), and add a manual `directive init` fresh-start fallback for when the frozen payload is unreachable. Closes #2297.
+- The frozen pre-v0.20 migration path is now durable-by-documentation. `deft doctor` / `task migrate:preflight` guidance now anchors recovery on the permanent `v0.59.0` git tag (GitHub serves a source tarball for any tag, so recovery no longer hinges on an uploaded release asset), spells out the two-hop migration chain (pre-v0.20 flat → vBRIEF v0.6 → xBRIEF), and adds a manual `directive init` fresh-start fallback for when the frozen payload is unreachable. Closes #2297.
 
 ### Fixed
 

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -137,16 +137,21 @@ These commands are unrelated — do not confuse them:
 
 Current `@deftai/directive` npm releases no longer ship `task migrate:vbrief` or `scripts/migrate_vbrief.py` on the consumer deposit path (#2022 Phase 3). If your project still uses the pre-v0.20 flat document model (authoritative root `SPECIFICATION.md` / `PROJECT.md` without vBRIEF lifecycle folders), migrate **once** on a pinned release that still bundles the Python migrator, then join the normal npm upgrade path.
 
+> **Durability & support horizon (#2297).** This is a **best-effort** path for a document model that predates v0.20. The permanence anchor is the **`v0.59.0` git tag** — GitHub serves a source tarball for any tag on demand (`https://github.com/deftai/directive/archive/refs/tags/v0.59.0.tar.gz`), so recovery does **not** depend on any uploaded release asset staying attached. As long as the tag exists, the migrator is reachable. If you cannot reach the frozen payload at all, use the **[Fresh-start fallback](#fresh-start-fallback-2297)** below.
+
 **Applies when:** `deft doctor` reports `Pre-cutover: migration needed`, or `task migrate:preflight` exits non-zero with a `document-model` FAIL line.
 
-**Pinned release:** `v0.59.0` (last release before the Python-free npm deposit; includes `scripts/migrate_vbrief.py`).
+**Pinned tag:** `v0.59.0` — the last release before the Python-free npm deposit; the tagged tree includes `scripts/migrate_vbrief.py`.
+
+**This is a two-hop chain.** The pre-v0.20 flat model does not migrate straight to the current layout: hop 1 is `task migrate:vbrief` on **v0.59.0** (flat → vBRIEF v0.6); hop 2 is `deft migrate:xbrief` on **current npm** (vBRIEF v0.6 → xBRIEF v0.8). Steps 5–6 below cover hop 2.
 
 **Steps:**
 
 1. Install **Python 3.11+** and **[uv](https://docs.astral.sh/uv/)** on the migration machine.
-2. Deposit framework **v0.59.0** using one of:
-   - **Frozen Go installer** at [GitHub Releases tag v0.59.0](https://github.com/deftai/directive/releases/tag/v0.59.0) (layout migration + full source tarball under `.deft/core/`), or
-   - **Git submodule / clone:** `git checkout v0.59.0` in your framework checkout.
+2. Deposit framework **v0.59.0** using one of (git-tag methods first — they survive even if release assets are removed):
+   - **Source tarball from the tag:** `curl -fsSL https://github.com/deftai/directive/archive/refs/tags/v0.59.0.tar.gz | tar xz` (full source tree including the migrator), or
+   - **Git clone / submodule:** `git checkout v0.59.0` in your framework checkout, or
+   - **Frozen Go installer** at [GitHub Releases tag v0.59.0](https://github.com/deftai/directive/releases/tag/v0.59.0) (legacy bridge; relies on the uploaded asset, so prefer a git-tag method above for durability).
 3. From the project root, preview then apply:
    ```bash
    task migrate:preflight
@@ -159,6 +164,16 @@ Current `@deftai/directive` npm releases no longer ship `task migrate:vbrief` or
 6. Start a **new agent session** so refreshed AGENTS.md and skills load from a clean context.
 
 ⊗ Run `npm i -g @deftai/directive@latest` / `deft update` on a project that still has authoritative pre-v0.20 root docs — the current deposit cannot run the migrator; follow the frozen path first.
+
+#### Fresh-start fallback (#2297)
+
+The automated migrator is a convenience, not the only route. If the `v0.59.0` payload is genuinely unreachable (tag deleted, no network, Python/uv unavailable, or the migrator errors on an unusual legacy shape), you are **not** stranded — port forward manually:
+
+1. On **current npm**, scaffold a clean project beside the old one: `directive init` (or `npx @deftai/directive init`). This produces the current xBRIEF layout directly, skipping both hops.
+2. Hand-port your content: copy the substance of the old `SPECIFICATION.md` / `PROJECT.md` into the new project definition and scope xBRIEFs the setup flow creates. Your prose is the source of truth; only the container format changed.
+3. Keep the old tree read-only for reference until the new project's `deft doctor` is green, then archive it.
+
+This is lossless for content (you re-author the container, not the substance) and depends on nothing but current npm — so it is the guaranteed floor under the best-effort automated path.
 
 See [docs/BROWNFIELD.md](./docs/BROWNFIELD.md) for what migration produces and how content is preserved.
 

--- a/packages/core/src/vbrief-validate/precutover.test.ts
+++ b/packages/core/src/vbrief-validate/precutover.test.ts
@@ -197,4 +197,11 @@ describe("precutover helpers", () => {
     expect(guidance).toContain("v0.59.0");
     expect(guidance).toContain("#2068");
   });
+
+  it("frozenPreCutoverMigrationGuidance names the fresh-start fallback and two-hop chain (#2297)", () => {
+    const guidance = frozenPreCutoverMigrationGuidance();
+    expect(guidance).toContain("directive init");
+    expect(guidance).toContain("two-hop");
+    expect(guidance).toContain("git tag");
+  });
 });

--- a/packages/core/src/vbrief-validate/precutover.ts
+++ b/packages/core/src/vbrief-validate/precutover.ts
@@ -131,9 +131,13 @@ export const FROZEN_PRECUTOVER_MIGRATION_TAG = "v0.59.0";
 
 export function frozenPreCutoverMigrationGuidance(): string {
   return (
-    `Current npm releases no longer ship in-product \`task migrate:vbrief\`. Pin framework ${FROZEN_PRECUTOVER_MIGRATION_TAG} ` +
-    `(frozen Go installer or git tag), install Python 3.11+ and uv, run \`task migrate:vbrief\` once from that payload, ` +
-    `then upgrade to current npm. See UPGRADING.md § Frozen pre-v0.20 document-model migration (#2068).`
+    `Current npm releases no longer ship in-product \`task migrate:vbrief\`. Best-effort path (anchored on the ` +
+    `${FROZEN_PRECUTOVER_MIGRATION_TAG} git tag, from which GitHub serves a source tarball on demand): pin framework ` +
+    `${FROZEN_PRECUTOVER_MIGRATION_TAG}, install Python 3.11+ and uv, run \`task migrate:vbrief\` once from that payload, ` +
+    `then upgrade to current npm. This is a two-hop chain: pre-v0.20 flat model -> vBRIEF v0.6 (on ${FROZEN_PRECUTOVER_MIGRATION_TAG}) ` +
+    `-> xBRIEF via \`deft migrate:xbrief\` on current npm. If the ${FROZEN_PRECUTOVER_MIGRATION_TAG} payload is unavailable, ` +
+    `fall back to a manual fresh start: \`directive init\` a new project on current npm and hand-port your spec content. ` +
+    `See UPGRADING.md § Frozen pre-v0.20 document-model migration (#2068).`
   );
 }
 

--- a/xbrief/completed/2026-07-05-2297-durable-prev020-migration.xbrief.json
+++ b/xbrief/completed/2026-07-05-2297-durable-prev020-migration.xbrief.json
@@ -1,0 +1,75 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2297: make the frozen pre-v0.20 migration path durable and self-documenting (git-tag anchor, best-effort horizon, two-hop chain, manual fresh-start fallback) without vendoring the migrator bundle.",
+    "created": "2026-07-05T12:30:00Z",
+    "updated": "2026-07-05T12:30:00Z"
+  },
+  "plan": {
+    "id": "2297-durable-prev020-migration",
+    "title": "Durable, self-documenting frozen pre-v0.20 migration path (cheap-durable variant)",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2297",
+    "narratives": {
+      "Description": "The pre-v0.20 document-model migrator (`migrate_vbrief.py`) was removed from current npm deposits; the only way to run it is to pin framework v0.59.0. The real permanence dependency is the v0.59.0 git tag (GitHub generates source tarballs from tags on demand), not any uploaded release asset. Rather than vendor a heavyweight migrator bundle (dropped Option 1), make the path durable-by-documentation: frame support as best-effort, anchor on the git tag, spell out the two-hop chain (pre-v0.20 flat -> vBRIEF v0.6 -> xBRIEF v0.8), and give operators a manual fresh-start fallback (`directive init`) for when the frozen payload is unavailable. The one code change extends the shared frozen-migration guidance string so `task migrate:preflight` and `deft doctor` both surface the fresh-start fallback.",
+      "ImplementationPlan": "1. Extend `frozenPreCutoverMigrationGuidance()` in packages/core/src/vbrief-validate/precutover.ts to frame the path as best-effort, cite the git-tag anchor, mention the two-hop chain, and add the manual fresh-start fallback (`directive init`) as the last resort. Keep the existing v0.59.0 + #2068 citations. 2. Update precutover.test.ts to assert the new guidance content (fresh-start fallback + two-hop). 3. Rewrite content/UPGRADING.md 'Frozen pre-v0.20 document-model migration (#2068)' section: add a durability/support-horizon note anchored on the git tag, prefer the source-tag/clone deposit method, document the two-hop chain, and add a 'Fresh-start fallback' subsection. Tag protection (protecting the v0.59.0 tag) is an operator/repo-admin action called out in the PR, not a code change.",
+      "UserStory": "As a maintainer of a very old (pre-v0.20) directive project, I want the frozen migration path to be durable and to tell me exactly what to do if the frozen payload is ever unavailable, so that I am never stranded with an unmigratable project.",
+      "Traces": "#2297, #2068, #2022, #1912"
+    },
+    "items": [
+      {
+        "id": "2297-a1",
+        "title": "Given a pre-cutover project, when preflight/doctor emit frozen guidance, then it names a manual fresh-start fallback",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the shared frozen-migration guidance, when rendered by `task migrate:preflight` or `deft doctor`, then it frames support as best-effort, cites the v0.59.0 git tag, and points at a manual `directive init` fresh-start fallback when the frozen payload is unavailable."
+        }
+      },
+      {
+        "id": "2297-a2",
+        "title": "Given UPGRADING.md, when a reader reaches the frozen section, then durability, the two-hop chain, and the fresh-start fallback are documented",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given content/UPGRADING.md, when a reader reaches the Frozen pre-v0.20 section, then it explains the git-tag durability anchor + best-effort horizon, the two-hop migration chain, and a fresh-start fallback subsection."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "child_issue": "#2297"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/vbrief-validate/precutover.ts",
+          "packages/core/src/vbrief-validate/precutover.test.ts",
+          "content/UPGRADING.md"
+        ],
+        "verify_commands": [
+          "pnpm -C packages/core vitest run src/vbrief-validate/ src/migrate-preflight/",
+          "task check"
+        ],
+        "expected_outputs": [
+          "frozen-migration guidance surfaces a fresh-start fallback; UPGRADING.md documents durability, two-hop chain, and fresh-start"
+        ],
+        "depends_on": [],
+        "conflict_group": "prev020-migration-docs",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completedAt": "2026-07-05T12:29:40Z",
+      "capacityBucket": "technical-debt"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2297",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2297: durable pre-v0.20 migrator path"
+      }
+    ],
+    "updated": "2026-07-05T12:29:40Z"
+  }
+}


### PR DESCRIPTION
## Summary

Makes the frozen pre-v0.20 document-model migration path durable **by documentation** (the cheap-durable variant; Option 1 vendoring was dropped as too heavy for a pre-v0.20 audience).

- The real permanence dependency is the **`v0.59.0` git tag**, not an uploaded release asset — GitHub serves a source tarball for any tag on demand (`archive/refs/tags/v0.59.0.tar.gz`). Guidance and docs now anchor recovery there.
- Frames support as **best-effort**, spells out the **two-hop chain** (pre-v0.20 flat → vBRIEF v0.6 on v0.59.0 → xBRIEF v0.8 on current npm), and adds a **manual `directive init` fresh-start fallback** as the guaranteed floor when the frozen payload is unreachable.

## Changes

- `frozenPreCutoverMigrationGuidance()` (`vbrief-validate/precutover.ts`) — best-effort framing + git-tag anchor + two-hop chain + fresh-start fallback. This is the shared string surfaced by both `task migrate:preflight` and `deft doctor`.
- `content/UPGRADING.md` § Frozen pre-v0.20 — durability/support-horizon note, git-tag-first deposit methods (Go installer demoted to a legacy option), two-hop callout, and a new **Fresh-start fallback** subsection.
- Tests asserting the new guidance content.

## Operator follow-up (not code)

Tag **permanence** for `v0.59.0` (branch/tag protection so it can't be deleted) is a repo-admin action, not something this PR can enforce in code. Recommend enabling tag protection for `v*` on the repo. Called out here so it isn't lost.

## Test plan

- [x] `pnpm -C packages/core vitest run src/vbrief-validate/precutover src/migrate-preflight` — 36 pass
- [x] `task check` — All checks passed (includes markdown link/anchor check for the new `#fresh-start-fallback-2297` anchor)

Closes #2297

Made with [Cursor](https://cursor.com)