### PR TITLE
fix(triage): implement triage:welcome --onboard in the TS CLI (#2295 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `deft triage:welcome --onboard` now actually runs onboarding instead of exiting with "not implemented". Every first-time/incomplete welcome nudge points at this command, so it was a guaranteed dead-end loop for new users; it now writes your triage-scope preset (`--preset small|mid|mega`, default `small`) and optional WIP cap (`--wip-cap N`) into the project's canonical policy, previews WIP relief when you're at/over cap, and prints a completion summary with next steps. Closes #2295.
+
 ### Removed
 
 ## [0.69.0] - 2026-07-05

--- a/packages/cli/src/triage-welcome.test.ts
+++ b/packages/cli/src/triage-welcome.test.ts
@@ -29,6 +29,12 @@ describe("triage:welcome CLI arg parsing (#2295)", () => {
     expect(args.error).toContain("--preset");
   });
 
+  it("errors on the empty equals form --preset= (no silent default)", () => {
+    const args = parseArgs(["--onboard", "--preset="]);
+    expect(args.error).toContain("--preset");
+    expect(args.preset).toBeNull();
+  });
+
   it("errors when --wip-cap is not an integer", () => {
     const args = parseArgs(["--wip-cap", "lots"]);
     expect(args.error).toContain("--wip-cap");

--- a/packages/cli/src/triage-welcome.test.ts
+++ b/packages/cli/src/triage-welcome.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "./triage-welcome.js";
+
+describe("triage:welcome CLI arg parsing (#2295)", () => {
+  it("defaults onboard/preset/wipCap to off/null", () => {
+    const args = parseArgs([]);
+    expect(args.error).toBeUndefined();
+    expect(args.onboard).toBe(false);
+    expect(args.preset).toBeNull();
+    expect(args.wipCap).toBeNull();
+  });
+
+  it("parses --onboard with --preset and --wip-cap (spaced form)", () => {
+    const args = parseArgs(["--onboard", "--preset", "mid", "--wip-cap", "8"]);
+    expect(args.error).toBeUndefined();
+    expect(args.onboard).toBe(true);
+    expect(args.preset).toBe("mid");
+    expect(args.wipCap).toBe(8);
+  });
+
+  it("parses the --flag=value form", () => {
+    const args = parseArgs(["--onboard", "--preset=mega", "--wip-cap=12"]);
+    expect(args.preset).toBe("mega");
+    expect(args.wipCap).toBe(12);
+  });
+
+  it("errors when --preset is missing its value", () => {
+    const args = parseArgs(["--preset"]);
+    expect(args.error).toContain("--preset");
+  });
+
+  it("errors when --wip-cap is not an integer", () => {
+    const args = parseArgs(["--wip-cap", "lots"]);
+    expect(args.error).toContain("--wip-cap");
+  });
+});

--- a/packages/cli/src/triage-welcome.ts
+++ b/packages/cli/src/triage-welcome.ts
@@ -35,7 +35,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       parsed.preset = value;
       i += 1;
     } else if (arg?.startsWith("--preset=")) {
-      parsed.preset = arg.slice("--preset=".length);
+      const value = arg.slice("--preset=".length);
+      if (value === "") return { ...parsed, error: "argument --preset: expected one argument" };
+      parsed.preset = value;
     } else if (arg === "--wip-cap") {
       const value = argv[i + 1];
       if (value === undefined)

--- a/packages/cli/src/triage-welcome.ts
+++ b/packages/cli/src/triage-welcome.ts
@@ -3,12 +3,15 @@ import { statSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runDefaultMode } from "@deftai/directive-core/dist/triage/welcome/default-mode.js";
+import { runOnboardMode } from "@deftai/directive-core/dist/triage/welcome/onboard.js";
 
 interface ParsedArgs {
   projectRoot: string;
   onboard: boolean;
   noHistory: boolean;
   taskPrefix: string;
+  preset: string | null;
+  wipCap: number | null;
   error?: string;
 }
 
@@ -18,12 +21,37 @@ export function parseArgs(argv: string[]): ParsedArgs {
     onboard: false,
     noHistory: false,
     taskPrefix: process.env.DEFT_TASK_PREFIX ?? "",
+    preset: null,
+    wipCap: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--onboard") parsed.onboard = true;
     else if (arg === "--no-history") parsed.noHistory = true;
-    else if (arg === "--project-root") {
+    else if (arg === "--preset") {
+      const value = argv[i + 1];
+      if (value === undefined)
+        return { ...parsed, error: "argument --preset: expected one argument" };
+      parsed.preset = value;
+      i += 1;
+    } else if (arg?.startsWith("--preset=")) {
+      parsed.preset = arg.slice("--preset=".length);
+    } else if (arg === "--wip-cap") {
+      const value = argv[i + 1];
+      if (value === undefined)
+        return { ...parsed, error: "argument --wip-cap: expected one argument" };
+      const parsedCap = Number(value);
+      if (!Number.isInteger(parsedCap))
+        return { ...parsed, error: `argument --wip-cap: expected an integer, got ${value}` };
+      parsed.wipCap = parsedCap;
+      i += 1;
+    } else if (arg?.startsWith("--wip-cap=")) {
+      const value = arg.slice("--wip-cap=".length);
+      const parsedCap = Number(value);
+      if (!Number.isInteger(parsedCap))
+        return { ...parsed, error: `argument --wip-cap: expected an integer, got ${value}` };
+      parsed.wipCap = parsedCap;
+    } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined)
         return { ...parsed, error: "argument --project-root: expected one argument" };
@@ -66,10 +94,13 @@ export function run(argv: string[]): number {
   }
 
   if (args.onboard) {
-    process.stderr.write(
-      "triage:welcome: --onboard is not implemented in the TypeScript CLI yet.\n",
-    );
-    return 2;
+    const onboardOutcome = runOnboardMode(projectRoot, {
+      preset: args.preset,
+      wipCap: args.wipCap,
+      writeHistory: !args.noHistory,
+      taskPrefix: args.taskPrefix || null,
+    });
+    return onboardOutcome.exitCode;
   }
 
   const outcome = runDefaultMode(projectRoot, {

--- a/packages/core/src/triage/welcome/index.ts
+++ b/packages/core/src/triage/welcome/index.ts
@@ -7,6 +7,12 @@ export {
   type WelcomeOutcome,
 } from "./default-mode.js";
 export {
+  DEFAULT_ONBOARD_PRESET,
+  type OnboardOptions,
+  type OnboardOutcome,
+  runOnboardMode,
+} from "./onboard.js";
+export {
   candidatesLogPath,
   classifyOnboarding,
   detectPriorState,

--- a/packages/core/src/triage/welcome/onboard.test.ts
+++ b/packages/core/src/triage/welcome/onboard.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runOnboardMode } from "./onboard.js";
+import { subscriptionPreset } from "./writers.js";
+
+const temps: string[] = [];
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function seedProject(): { root: string; out: string[] } {
+  const root = mkdtempSync(join(tmpdir(), "onboard-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+    JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { policy: {} } }),
+    "utf8",
+  );
+  return { root, out: [] };
+}
+
+function readPolicy(root: string): Record<string, unknown> {
+  const data = JSON.parse(
+    readFileSync(join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"), "utf8"),
+  );
+  return data.plan["x-directive/policy"] ?? {};
+}
+
+const noHeal = () => {};
+
+describe("runOnboardMode (#2295)", () => {
+  it("writes the default preset and exits 0 (no more not-implemented stub)", () => {
+    const { root, out } = seedProject();
+    const outcome = runOnboardMode(root, {
+      writeHistory: false,
+      selfHealFn: noHeal,
+      output: (l) => out.push(l),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.presetApplied).toBe("small");
+    expect(readPolicy(root).triageScope).toEqual(subscriptionPreset("small"));
+    expect(out.some((l) => l.includes("Onboarding applied"))).toBe(true);
+    expect(out.some((l) => l.includes("triage:bootstrap"))).toBe(true);
+  });
+
+  it("honors an explicit --preset", () => {
+    const { root, out } = seedProject();
+    const outcome = runOnboardMode(root, {
+      preset: "mid",
+      writeHistory: false,
+      selfHealFn: noHeal,
+      output: (l) => out.push(l),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.presetApplied).toBe("mid");
+    expect(readPolicy(root).triageScope).toEqual(subscriptionPreset("mid"));
+  });
+
+  it("persists a non-default wipCap", () => {
+    const { root, out } = seedProject();
+    const outcome = runOnboardMode(root, {
+      wipCap: 8,
+      writeHistory: false,
+      selfHealFn: noHeal,
+      output: (l) => out.push(l),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.wipCapApplied).toBe(8);
+    expect(readPolicy(root).wipCap).toBe(8);
+  });
+
+  it("rejects an unknown preset without writing", () => {
+    const { root, out } = seedProject();
+    const outcome = runOnboardMode(root, {
+      preset: "enormous",
+      selfHealFn: noHeal,
+      output: (l) => out.push(l),
+    });
+    expect(outcome.exitCode).toBe(2);
+    expect(readPolicy(root).triageScope).toBeUndefined();
+    expect(out.some((l) => l.includes("Unknown --preset"))).toBe(true);
+  });
+
+  it("rejects a non-positive wipCap without writing", () => {
+    const { root, out } = seedProject();
+    const outcome = runOnboardMode(root, {
+      wipCap: 0,
+      selfHealFn: noHeal,
+      output: (l) => out.push(l),
+    });
+    expect(outcome.exitCode).toBe(2);
+    expect(readPolicy(root).triageScope).toBeUndefined();
+    expect(out.some((l) => l.includes("--wip-cap must be a positive integer"))).toBe(true);
+  });
+
+  it("fails cleanly when no project definition exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "onboard-empty-"));
+    temps.push(root);
+    const out: string[] = [];
+    const outcome = runOnboardMode(root, { selfHealFn: noHeal, output: (l) => out.push(l) });
+    expect(outcome.exitCode).toBe(2);
+    expect(out.some((l) => l.includes("No project definition found"))).toBe(true);
+  });
+});

--- a/packages/core/src/triage/welcome/onboard.test.ts
+++ b/packages/core/src/triage/welcome/onboard.test.ts
@@ -13,23 +13,36 @@ afterEach(() => {
   }
 });
 
-function seedProject(): { root: string; out: string[] } {
+function seedProject(policy: Record<string, unknown> = {}): { root: string; out: string[] } {
   const root = mkdtempSync(join(tmpdir(), "onboard-"));
   temps.push(root);
   mkdirSync(join(root, "vbrief"), { recursive: true });
   writeFileSync(
     join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
-    JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { policy: {} } }),
+    JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { policy } }),
     "utf8",
   );
   return { root, out: [] };
 }
 
+/** Seed an old (demote-eligible) pending scope artifact so WIP relief fires. */
+function seedPendingScope(root: string, name: string, updated = "2020-01-01T00:00:00Z"): void {
+  mkdirSync(join(root, "vbrief", "pending"), { recursive: true });
+  writeFileSync(
+    join(root, "vbrief", "pending", name),
+    JSON.stringify({ vBRIEFInfo: { version: "0.6" }, plan: { updated } }),
+    "utf8",
+  );
+}
+
 function readPolicy(root: string): Record<string, unknown> {
-  const data = JSON.parse(
+  const payload: unknown = JSON.parse(
     readFileSync(join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"), "utf8"),
   );
-  return data.plan["x-directive/policy"] ?? {};
+  if (payload === null || typeof payload !== "object") return {};
+  const plan = (payload as { plan?: unknown }).plan;
+  if (plan === null || typeof plan !== "object") return {};
+  return ((plan as Record<string, unknown>)["x-directive/policy"] as Record<string, unknown>) ?? {};
 }
 
 const noHeal = () => {};
@@ -106,5 +119,37 @@ describe("runOnboardMode (#2295)", () => {
     const outcome = runOnboardMode(root, { selfHealFn: noHeal, output: (l) => out.push(l) });
     expect(outcome.exitCode).toBe(2);
     expect(out.some((l) => l.includes("No project definition found"))).toBe(true);
+  });
+
+  it("offers scope:demote relief when WIP is at/over cap (#2295 coverage)", () => {
+    // Pre-populate WIP above a low cap with a demote-eligible (old) pending
+    // scope so the relief branch in runOnboardMode actually fires.
+    const { root, out } = seedProject({ wipCap: 1 });
+    seedPendingScope(root, "2020-01-01-old-scope.vbrief.json");
+    const outcome = runOnboardMode(root, {
+      writeHistory: false,
+      selfHealFn: noHeal,
+      taskPrefix: "task",
+      output: (l) => out.push(l),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.reliefOffered).toBe(true);
+    const reliefLine = out.find((l) => l.includes("demote-eligible"));
+    expect(reliefLine).toBeDefined();
+    expect(reliefLine).toContain("at/over cap");
+    expect(reliefLine).toContain("scope:demote");
+  });
+
+  it("does not offer relief when WIP is under cap", () => {
+    const { root, out } = seedProject({ wipCap: 10 });
+    seedPendingScope(root, "2020-01-01-old-scope.vbrief.json");
+    const outcome = runOnboardMode(root, {
+      writeHistory: false,
+      selfHealFn: noHeal,
+      output: (l) => out.push(l),
+    });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.reliefOffered).toBe(false);
+    expect(out.some((l) => l.includes("demote-eligible"))).toBe(false);
   });
 });

--- a/packages/core/src/triage/welcome/onboard.ts
+++ b/packages/core/src/triage/welcome/onboard.ts
@@ -111,9 +111,10 @@ export function runOnboardMode(projectRoot: string, options: OnboardOptions = {}
       const demote = formatWelcomeCommand(
         ["scope:demote", "--batch", "--older-than-days", String(relief.olderThanDays)],
         options.taskPrefix,
-      );
+      ).replace(/\r?\n/g, " ");
+      const eligibleCount = String(relief.eligibleCount).replace(/\r?\n/g, " ");
       out(
-        `[welcome] WIP ${state.wipCount}/${state.wipCap} at/over cap -- ${relief.eligibleCount} pending scope(s) ` +
+        `[welcome] WIP ${state.wipCount}/${state.wipCap} at/over cap -- ${eligibleCount} pending scope(s) ` +
           `older than ${relief.olderThanDays}d are demote-eligible. Relieve with \`${demote}\`.`,
       );
     }

--- a/packages/core/src/triage/welcome/onboard.ts
+++ b/packages/core/src/triage/welcome/onboard.ts
@@ -1,0 +1,138 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { maybeSelfHealCache } from "../../cache/fetch.js";
+import { resolveProjectDefinitionPath } from "../../layout/resolve.js";
+import { DEFAULT_WIP_CAP, SUBSCRIPTION_PRESETS, TRIAGE_SKILL_PATH } from "./constants.js";
+import { formatWelcomeCommand } from "./default-mode.js";
+import { detectPriorState } from "./prior-state.js";
+import { emitOneliner } from "./summary.js";
+import { previewWipRelief, subscriptionPreset, writeTriageScope, writeWipCap } from "./writers.js";
+
+/** Default triage-scope preset applied when `--onboard` is run without `--preset`. */
+export const DEFAULT_ONBOARD_PRESET = "small";
+
+export interface OnboardOptions {
+  /** Triage-scope preset key; defaults to {@link DEFAULT_ONBOARD_PRESET}. */
+  readonly preset?: string | null;
+  /** Explicit WIP cap to persist; omitted keeps the current/default cap. */
+  readonly wipCap?: number | null;
+  readonly output?: (line: string) => void;
+  readonly writeHistory?: boolean;
+  readonly taskPrefix?: string | null;
+  readonly selfHealFn?: (projectRoot: string) => void;
+  readonly now?: Date;
+}
+
+export interface OnboardOutcome {
+  readonly exitCode: number;
+  readonly presetApplied: string | null;
+  readonly triageScopeChanged: boolean;
+  readonly wipCapApplied: number | null;
+  readonly wipCapChanged: boolean;
+  readonly reliefOffered: boolean;
+}
+
+function failure(exitCode: number): OnboardOutcome {
+  return {
+    exitCode,
+    presetApplied: null,
+    triageScopeChanged: false,
+    wipCapApplied: null,
+    wipCapChanged: false,
+    reliefOffered: false,
+  };
+}
+
+/**
+ * Non-interactive onboarding for `deft triage:welcome --onboard` (#2295).
+ *
+ * The welcome nudges point every fresh consumer at `--onboard`; this wires that
+ * command to the already-tested core writers instead of the old "not
+ * implemented" stub. It writes the chosen triage-scope preset and (optionally)
+ * a WIP cap via {@link writeTriageScope} / {@link writeWipCap} -- which already
+ * target the canonical `x-directive/policy` key and migrate any legacy bare
+ * block -- previews WIP relief when at/over cap, then prints a completion
+ * summary and the next-step guidance. Flag-driven by design: agents/CI pass
+ * `--preset` / `--wip-cap`; sensible defaults apply otherwise.
+ */
+export function runOnboardMode(projectRoot: string, options: OnboardOptions = {}): OnboardOutcome {
+  const out = options.output ?? ((line: string) => process.stdout.write(`${line}\n`));
+
+  const preset = (options.preset ?? DEFAULT_ONBOARD_PRESET).trim() || DEFAULT_ONBOARD_PRESET;
+  if (!Object.hasOwn(SUBSCRIPTION_PRESETS, preset)) {
+    out(
+      `[welcome] Unknown --preset '${preset}'. Choose one of: ${Object.keys(SUBSCRIPTION_PRESETS).join(", ")}.`,
+    );
+    return failure(2);
+  }
+
+  const wipCap = options.wipCap ?? null;
+  if (wipCap !== null && (!Number.isInteger(wipCap) || wipCap < 1)) {
+    out(`[welcome] --wip-cap must be a positive integer, got ${JSON.stringify(options.wipCap)}.`);
+    return failure(2);
+  }
+
+  const pdPath = resolveProjectDefinitionPath(projectRoot);
+  if (!existsSync(pdPath)) {
+    out(
+      `[welcome] No project definition found at ${pdPath}. Run project setup first (deft-directive-setup) before onboarding triage.`,
+    );
+    return failure(2);
+  }
+
+  const heal =
+    options.selfHealFn ??
+    ((root: string) => {
+      maybeSelfHealCache(resolve(root));
+    });
+  heal(projectRoot);
+
+  const rules = subscriptionPreset(preset);
+  const [triageScopeChanged] = writeTriageScope(projectRoot, rules, { presetLabel: preset });
+
+  let wipCapChanged = false;
+  if (wipCap !== null) {
+    [wipCapChanged] = writeWipCap(projectRoot, wipCap);
+  }
+
+  emitOneliner(projectRoot, {
+    writeHistory: options.writeHistory !== false,
+    now: options.now,
+    output: out,
+    applyD2Suppression: false,
+  });
+
+  const state = detectPriorState(projectRoot);
+  let reliefOffered = false;
+  if (state.wipCount >= state.wipCap) {
+    const relief = previewWipRelief(projectRoot);
+    if (relief.eligibleCount > 0) {
+      reliefOffered = true;
+      const demote = formatWelcomeCommand(
+        ["scope:demote", "--batch", "--older-than-days", String(relief.olderThanDays)],
+        options.taskPrefix,
+      );
+      out(
+        `[welcome] WIP ${state.wipCount}/${state.wipCap} at/over cap -- ${relief.eligibleCount} pending scope(s) ` +
+          `older than ${relief.olderThanDays}d are demote-eligible. Relieve with \`${demote}\`.`,
+      );
+    }
+  }
+
+  const capNote = wipCap !== null ? `, wipCap ${wipCap}` : ` (wipCap default ${DEFAULT_WIP_CAP})`;
+  out(`[welcome] Onboarding applied: triage scope preset '${preset}'${capNote}.`);
+  const bootstrap = formatWelcomeCommand(["triage:bootstrap"], options.taskPrefix);
+  const queue = formatWelcomeCommand(["triage:queue", "--limit=10"], options.taskPrefix);
+  out(
+    `[welcome] Next: run \`${bootstrap}\` to populate the triage cache, then \`${queue}\` to pick work. See ${TRIAGE_SKILL_PATH}.`,
+  );
+
+  return {
+    exitCode: 0,
+    presetApplied: preset,
+    triageScopeChanged,
+    wipCapApplied: wipCap,
+    wipCapChanged,
+    reliefOffered,
+  };
+}

--- a/xbrief/completed/2026-07-05-2295-triage-welcome-onboard.xbrief.json
+++ b/xbrief/completed/2026-07-05-2295-triage-welcome-onboard.xbrief.json
@@ -1,0 +1,87 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Story vBRIEF for #2295 (P1 slice): implement `deft triage:welcome --onboard` in the TypeScript CLI so the command every welcome nudge points at actually completes onboarding instead of exiting 2. P2 (set-preset writer + stray-plan.policy warn) and P3 (papercuts) are deferred to separate stories.",
+    "created": "2026-07-05T13:00:00Z",
+    "updated": "2026-07-05T13:00:00Z"
+  },
+  "plan": {
+    "id": "2295-triage-welcome-onboard",
+    "title": "Implement triage:welcome --onboard in the TS CLI (kill the dead-end nudge loop)",
+    "status": "completed",
+    "planRef": "https://github.com/deftai/directive/issues/2295",
+    "narratives": {
+      "Description": "Every welcome nudge (FIRST_TIME_NUDGE / INCOMPLETE_NUDGE_TEMPLATE) tells the user to run `deft triage:welcome --onboard`, but the CLI handler is a hard stub that writes 'not implemented' and returns 2 -- a guaranteed dead-end loop for every fresh consumer. The underlying core writers already exist and are tested (`subscriptionPreset`, `writeTriageScope`, `writeWipCap`, `previewWipRelief`), so the fix is orchestration, not new subsystem logic. Add a non-interactive `runOnboardMode` in core that self-heals the cache, writes the chosen triage-scope preset and wipCap into the project definition (via the existing writers, which already target the canonical `x-directive/policy` key and migrate any legacy bare block), previews WIP relief when over cap, and prints a clear summary plus next-step guidance. Wire the CLI `--onboard` flag (plus `--preset` and `--wip-cap`) to it. Non-interactive by design: agents/CI pass flags; sensible defaults apply otherwise. P2/P3 items from #2295 are out of scope for this story.",
+      "ImplementationPlan": "1. Add packages/core/src/triage/welcome/onboard.ts exporting `runOnboardMode(projectRoot, options)` that: self-heals cache, resolves preset (default 'small', validated against SUBSCRIPTION_PRESETS), writes triageScope via subscriptionPreset+writeTriageScope, writes wipCap via writeWipCap when provided, previews WIP relief when wipCount>=cap, emits the triage one-liner + an 'onboarding complete' summary with next-step guidance, and returns an OnboardOutcome {exitCode, presetApplied, wipCapApplied, ...}. Missing PROJECT-DEFINITION -> friendly error + exit 2. 2. Export it from the welcome barrel index.ts. 3. Wire packages/cli/src/triage-welcome.ts: parse --preset <key> and --wip-cap <n>, replace the `return 2` stub with a call to runOnboardMode. 4. Add onboard.test.ts (core) covering default preset, explicit preset, wipCap write, invalid preset, missing project definition; update the CLI test to assert --onboard now succeeds and writes the preset.",
+      "UserStory": "As a new directive user who is nudged to run `deft triage:welcome --onboard`, I want that command to actually set up my triage scope and WIP cap and confirm completion, so that onboarding finishes instead of dead-ending on a 'not implemented' error.",
+      "Traces": "#2295"
+    },
+    "items": [
+      {
+        "id": "2295-a1",
+        "title": "Given the onboard command, when run in a project, then it writes a triage-scope preset and exits 0",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a project with a PROJECT-DEFINITION, when `deft triage:welcome --onboard` runs (default or explicit --preset), then triageScope is written under the canonical policy key and the command exits 0 with a completion summary -- never the old 'not implemented' exit 2."
+        }
+      },
+      {
+        "id": "2295-a2",
+        "title": "Given --wip-cap N, when onboard runs, then the WIP cap is persisted",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given `--wip-cap N` (non-default positive int), when onboard runs, then wipCap is persisted via the existing writer and reflected in the summary."
+        }
+      },
+      {
+        "id": "2295-a3",
+        "title": "Given a bad preset or missing project definition, when onboard runs, then it fails cleanly with guidance",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an unknown --preset value or a project with no PROJECT-DEFINITION, when onboard runs, then it prints an actionable error and exits 2 without partial writes."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "child_issue": "#2295",
+        "slice": "P1 of #2295 (onboard wiring); P2 set-preset+warn and P3 papercuts deferred"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/welcome/onboard.ts",
+          "packages/core/src/triage/welcome/onboard.test.ts",
+          "packages/core/src/triage/welcome/index.ts",
+          "packages/cli/src/triage-welcome.ts",
+          "packages/cli/src/triage-welcome.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm -C packages/core vitest run src/triage/welcome/",
+          "pnpm -C packages/cli vitest run src/triage-welcome.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "`deft triage:welcome --onboard` completes onboarding (writes preset + wipCap) and exits 0 instead of returning the not-implemented stub"
+        ],
+        "depends_on": [],
+        "conflict_group": "triage-welcome-onboard",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completedAt": "2026-07-05T13:33:26Z",
+      "capacityBucket": "new-capability"
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2295",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2295: triage:welcome --onboard unimplemented in TS CLI"
+      }
+    ],
+    "updated": "2026-07-05T13:33:26Z"
+  }
+}


### PR DESCRIPTION
## Summary

`deft triage:welcome --onboard` — the command **every** first-time / incomplete welcome nudge points at — was a hard stub that printed `--onboard is not implemented in the TypeScript CLI yet.` and returned `2`. That made onboarding a guaranteed dead-end loop for every fresh consumer. This wires it to the already-tested core writers (the fix is orchestration, not new subsystem logic).

## Changes

- **`runOnboardMode` (core, `triage/welcome/onboard.ts`)** — self-heals the cache, writes the chosen triage-scope preset and optional WIP cap via the existing `subscriptionPreset` / `writeTriageScope` / `writeWipCap` writers (which already target the canonical `x-directive/policy` key and migrate any legacy bare block), previews WIP relief when at/over cap, and prints a completion summary + next-step guidance. Non-interactive by design.
- **CLI (`triage-welcome.ts`)** — replaced the `return 2` stub with a `runOnboardMode` call; added `--preset small|mid|mega` (default `small`) and `--wip-cap N` flags.
- Exported `runOnboardMode` from the welcome barrel.
- Tests: core onboard states (default/explicit preset, wipCap persist, invalid preset, bad cap, missing project definition) + CLI arg parsing.

## Scope — P1 of 3

This is the **P1** slice from the #2295 analysis (the dead-end loop). Tracked separately (this PR does **not** close #2295):
- **P2 → #2301** — `triage:scope --set-preset` writer + a loud warn/read-migrate when a stray bare `plan.policy` coexists with `x-directive/policy` (the silent-ignore trap).
- **P3 → #2302** — the `vbrief/`-path warning on xbrief projects, cache task passthrough, and help-text papercuts.

## Test plan

- [x] `pnpm -C packages/core vitest run src/triage/welcome` — 53 pass (incl. 6 new onboard cases)
- [x] `pnpm -C packages/cli vitest run src/triage-welcome.test.ts` — 5 pass
- [x] `task check` — All checks passed

Refs #2295, #2301, #2302