### PR TITLE
fix(policy): loud shadow diagnostic + triage:scope --set-preset writer (#2301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`triage:scope --set-preset small|mid|mega` sets your whole triage subscription in one command (#2301).** Instead of adding labels and milestones one at a time, you can now apply a named subscription preset — the same `small` / `mid` / `mega` presets the onboarding flow offers — directly from `triage:scope`. It writes through the shared preset writer (so the namespaced `x-directive/policy` key, audit trail, and lock all behave identically to onboarding) and is mutually exclusive with the other mutation flags. Closes #2301. Refs #2295.
+
 ### Changed
 
 ### Fixed
+
+- **A stray bare `plan.policy` block no longer silently swallows your edits (#2301).** When a hand-added bare `plan.policy` (e.g. `triageScope` / `wipCap`) coexists with the namespaced `x-directive/policy`, the bare block is ignored on read — previously with no warning, so edits appeared to do nothing. `policy show` and `doctor` now emit a loud, specific diagnostic naming the shadowed fields and telling you to fold them into `x-directive/policy`. Closes #2301. Refs #2295.
 
 ### Removed
 

--- a/packages/cli/src/policy.test.ts
+++ b/packages/cli/src/policy.test.ts
@@ -158,6 +158,50 @@ describe("run show + set integration", () => {
     expect(out).toContain('"generated_at"');
   });
 
+  it("warns to stderr when a bare plan.policy shadows the namespaced form (#2301)", () => {
+    const r = mkdtempSync(join(tmpdir(), "deft-policy-shadow-"));
+    roots.push(r);
+    mkdirSync(join(r, "vbrief"), { recursive: true });
+    writeFileSync(
+      join(r, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: {
+          title: "T",
+          status: "running",
+          items: [],
+          "x-directive/policy": { wipCap: 8 },
+          policy: { triageScope: [{ rule: "all-open" }] },
+        },
+      }),
+      { encoding: "utf8" },
+    );
+    const { code, out, err } = captureRun(["show", "--project-root", r]);
+    expect(code).toBe(0);
+    expect(err).toContain("[policy:show] WARNING:");
+    expect(err).toContain("bare `plan.policy`");
+    expect(err).toContain("plan.policy.triageScope");
+    // stdout stays clean (JSON/text render is not polluted by the warning).
+    expect(out).toContain("plan.policy.wipCap");
+  });
+
+  it("does not warn when only the namespaced policy exists", () => {
+    const r = mkdtempSync(join(tmpdir(), "deft-policy-noshadow-"));
+    roots.push(r);
+    mkdirSync(join(r, "vbrief"), { recursive: true });
+    writeFileSync(
+      join(r, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6" },
+        plan: { title: "T", status: "running", items: [], "x-directive/policy": { wipCap: 8 } },
+      }),
+      { encoding: "utf8" },
+    );
+    const { code, err } = captureRun(["show", "--project-root", r]);
+    expect(code).toBe(0);
+    expect(err).not.toContain("WARNING:");
+  });
+
   it("runs resolve subcommand", () => {
     const r = project();
     const { code, out } = captureRun(["resolve", "--project-root", r]);

--- a/packages/cli/src/policy.ts
+++ b/packages/cli/src/policy.ts
@@ -7,9 +7,12 @@ import { existsSync } from "node:fs";
 import { join, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  describeShadowedPlanExtension,
+  detectShadowedPlanExtensions,
   disclosureLine,
   inspectAllPolicies,
   inspectOnePolicy,
+  loadProjectDefinition,
   PROJECT_DEFINITION_REL_PATH,
   pythonListRepr,
   pythonStringRepr,
@@ -227,6 +230,20 @@ export function parseArgs(argv: string[]): SetArgs {
   return makeSetError(`unknown subcommand: ${cmd}`);
 }
 
+/**
+ * Emit a loud warning to stderr for every plan-extension key whose bare block
+ * silently shadows the namespaced form (#2301). Never fails / throws: a missing
+ * or malformed PROJECT-DEFINITION simply yields no warnings.
+ */
+function emitPlanExtensionShadowWarnings(projectRoot: string): void {
+  const [data] = loadProjectDefinition(projectRoot);
+  if (data === null) return;
+  const shadows = detectShadowedPlanExtensions(data.plan);
+  for (const shadow of shadows) {
+    process.stderr.write(`[policy:show] WARNING: ${describeShadowedPlanExtension(shadow)}\n`);
+  }
+}
+
 function runShow(args: ShowArgs): number {
   const projectRoot = pathResolve(args.projectRoot);
   const pdPath = join(projectRoot, PROJECT_DEFINITION_REL_PATH);
@@ -236,6 +253,7 @@ function runShow(args: ShowArgs): number {
         "rendering framework defaults.\n",
     );
   }
+  emitPlanExtensionShadowWarnings(projectRoot);
 
   if (args.field !== null) {
     const field = inspectOnePolicy(args.field, projectRoot);

--- a/packages/cli/src/triage-scope.test.ts
+++ b/packages/cli/src/triage-scope.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -31,6 +31,55 @@ describe("triage-scope CLI", () => {
     expect(changed).toBe(true);
     const result = runCliCapture(["--project-root", root, "--list"]);
     expect(result.stdout).toContain("priority:p0");
+  });
+
+  it("set-preset small persists the preset via the shared writer", () => {
+    const root = mkdtempSync(join(tmpdir(), "cli-scope-"));
+    writePd(root);
+    const result = runCliCapture(["--project-root", root, "--set-preset", "small"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("set-preset");
+    const listed = runCliCapture(["--project-root", root, "--list"]);
+    expect(listed.stdout).toContain("all-open");
+  });
+
+  it("set-preset=mega form persists the mega scaffold to the namespaced key", () => {
+    const root = mkdtempSync(join(tmpdir(), "cli-scope-"));
+    writePd(root);
+    // mega ships an explicit-watch scaffold with empty issues; the preset write
+    // is trusted and must report success (not fail the hand-edit validator).
+    const result = runCliCapture(["--project-root", root, "--set-preset=mega"]);
+    expect(result.code).toBe(0);
+    const written = JSON.parse(
+      readFileSync(join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"), "utf8"),
+    );
+    const scope = written.plan["x-directive/policy"].triageScope as Array<Record<string, unknown>>;
+    expect(scope.map((r) => r.rule)).toContain("explicit-watch");
+    expect(scope.map((r) => r.rule)).toContain("referenced-by-vbrief");
+  });
+
+  it("set-preset rejects an unknown preset key with the valid list", () => {
+    const root = mkdtempSync(join(tmpdir(), "cli-scope-"));
+    writePd(root);
+    const result = runCliCapture(["--project-root", root, "--set-preset", "huge"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("unknown preset");
+    expect(result.stderr).toContain("small");
+  });
+
+  it("set-preset is mutually exclusive with --add-label", () => {
+    const root = mkdtempSync(join(tmpdir(), "cli-scope-"));
+    writePd(root);
+    const result = runCliCapture([
+      "--project-root",
+      root,
+      "--set-preset",
+      "small",
+      "--add-label",
+      "x",
+    ]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("mutually exclusive");
   });
 });
 

--- a/packages/cli/src/triage-scope.test.ts
+++ b/packages/cli/src/triage-scope.test.ts
@@ -50,10 +50,14 @@ describe("triage-scope CLI", () => {
     // is trusted and must report success (not fail the hand-edit validator).
     const result = runCliCapture(["--project-root", root, "--set-preset=mega"]);
     expect(result.code).toBe(0);
-    const written = JSON.parse(
+    const written: unknown = JSON.parse(
       readFileSync(join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"), "utf8"),
     );
-    const scope = written.plan["x-directive/policy"].triageScope as Array<Record<string, unknown>>;
+    if (written === null || typeof written !== "object") {
+      throw new Error("expected PROJECT-DEFINITION to parse to an object");
+    }
+    const plan = (written as { plan: Record<string, Record<string, unknown>> }).plan;
+    const scope = (plan["x-directive/policy"].triageScope as Array<Record<string, unknown>>) ?? [];
     expect(scope.map((r) => r.rule)).toContain("explicit-watch");
     expect(scope.map((r) => r.rule)).toContain("referenced-by-vbrief");
   });

--- a/packages/core/src/doctor/main.test.ts
+++ b/packages/core/src/doctor/main.test.ts
@@ -101,7 +101,12 @@ describe("cmdDoctor", () => {
         detectPlanExtensionShadows: () => [],
       });
       expect(exit).toBe(0);
-      expect(stdout.join("")).not.toContain('"status": "shadowed"');
+      const payload = stdout.join("");
+      expect(payload).not.toContain('"status": "shadowed"');
+      // Clean case still emits a per-check skip finding so JSON consumers see an
+      // entry for every check (parity with runUserMdResolutionCheck).
+      expect(payload).toContain('"check": "plan-extension-shadow"');
+      expect(payload).toContain('"status": "clean"');
     } finally {
       process.stdout.write = origWrite;
     }

--- a/packages/core/src/doctor/main.test.ts
+++ b/packages/core/src/doctor/main.test.ts
@@ -66,6 +66,46 @@ describe("cmdDoctor", () => {
       }),
     ).toBe(0);
   });
+
+  it("emits a warning finding when a bare plan.policy shadows the namespaced form (#2301)", () => {
+    const stdout: string[] = [];
+    const write = (t: string) => stdout.push(t);
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = write as typeof process.stdout.write;
+    try {
+      const exit = cmdDoctor(["--full", "--json"], {
+        whichFn: () => "/usr/bin/x",
+        detectPlanExtensionShadows: () => [
+          { namespacedKey: "x-directive/policy", legacyKey: "policy", shadowedSubKeys: ["wipCap"] },
+        ],
+      });
+      // Shadow is a warning, not an error -- doctor stays green.
+      expect(exit).toBe(0);
+      const payload = stdout.join("");
+      expect(payload).toContain('"check": "plan-extension-shadow"');
+      expect(payload).toContain('"status": "shadowed"');
+      expect(payload).toContain("plan.policy.wipCap");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  it("reports a clean plan-extension-shadow check when no shadow is present (#2301)", () => {
+    const stdout: string[] = [];
+    const write = (t: string) => stdout.push(t);
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = write as typeof process.stdout.write;
+    try {
+      const exit = cmdDoctor(["--full", "--json"], {
+        whichFn: () => "/usr/bin/x",
+        detectPlanExtensionShadows: () => [],
+      });
+      expect(exit).toBe(0);
+      expect(stdout.join("")).not.toContain('"status": "shadowed"');
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
 });
 
 describe("parseDoctorFlags", () => {

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -761,7 +761,9 @@ function runPlanExtensionShadowCheck(
   try {
     const shadows = detect(projectRoot);
     if (shadows.length === 0) {
-      sink.success(`${checkName}: no shadowed bare plan keys`);
+      const cleanMessage = `${checkName}: no shadowed bare plan keys`;
+      sink.success(cleanMessage);
+      addFinding({ severity: "skip", message: cleanMessage, check: checkName, status: "clean" });
       return;
     }
     for (const shadow of shadows) {

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -3,6 +3,11 @@ import { join, resolve } from "node:path";
 import { evaluate as evaluateAgentsMdAdvisory } from "../agents-md-advisory/evaluate.js";
 import { contentRoot } from "../content-root.js";
 import {
+  describeShadowedPlanExtension,
+  detectShadowedPlanExtensions,
+} from "../policy/plan-extensions.js";
+import { loadProjectDefinition } from "../policy/resolve.js";
+import {
   checkLocalEngineIntegrity,
   classify,
   detectPackageManager,
@@ -311,6 +316,12 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
   }
   sink.info("Checking USER.md resolution...");
   const userMd = runUserMdResolutionCheck(projectRoot, sink, addFinding, seams);
+
+  if (!jsonMode) {
+    sink.blank();
+  }
+  sink.info("Checking plan.policy namespacing (shadowed bare keys)...");
+  runPlanExtensionShadowCheck(projectRoot, sink, addFinding, seams);
 
   if (!jsonMode) {
     sink.blank();
@@ -724,6 +735,57 @@ function runUserMdResolutionCheck(
     found: result.found,
   });
   return result;
+}
+
+/**
+ * Loud shadow diagnostic (#2301): flag every plan-extension key whose bare form
+ * (e.g. `plan.policy`) coexists with the namespaced form (`plan.x-directive/policy`).
+ * Because the reader is namespace-first, the bare block is silently ignored --
+ * the exact "edit takes no effect, no warning" trap behind #2295. Emits a
+ * `warning` finding per shadowed key; never an `error`, so `deft doctor` stays
+ * green on a merely-legibility issue. A clean project reports a `skip` finding.
+ */
+function runPlanExtensionShadowCheck(
+  projectRoot: string,
+  sink: ReturnType<typeof createPlainSink>,
+  addFinding: (f: Finding) => void,
+  seams: DoctorSeams,
+): void {
+  const checkName = "plan-extension-shadow";
+  const detect =
+    seams.detectPlanExtensionShadows ??
+    ((root: string) => {
+      const [data] = loadProjectDefinition(root);
+      return data === null ? [] : detectShadowedPlanExtensions(data.plan);
+    });
+  try {
+    const shadows = detect(projectRoot);
+    if (shadows.length === 0) {
+      sink.success(`${checkName}: no shadowed bare plan keys`);
+      return;
+    }
+    for (const shadow of shadows) {
+      const message = `plan.policy shadow -- ${describeShadowedPlanExtension(shadow)}`.replace(
+        /\r?\n/g,
+        " ",
+      );
+      sink.warn(message);
+      addFinding({
+        severity: "warning",
+        message,
+        check: checkName,
+        status: "shadowed",
+        namespaced_key: shadow.namespacedKey,
+        legacy_key: shadow.legacyKey,
+        shadowed_sub_keys: [...shadow.shadowedSubKeys],
+      });
+    }
+  } catch (exc) {
+    const detail = `${exc instanceof Error ? exc.name : "Error"}: ${exc}`.replace(/\r?\n/g, " ");
+    const message = `${checkName}: probe failed -- ${detail}`;
+    sink.warn(message);
+    addFinding({ severity: "warning", message, check: checkName });
+  }
 }
 
 /**

--- a/packages/core/src/doctor/types.ts
+++ b/packages/core/src/doctor/types.ts
@@ -1,4 +1,5 @@
 import type { AdvisoryEvaluateResult } from "../agents-md-advisory/evaluate.js";
+import type { ShadowedPlanExtension } from "../policy/plan-extensions.js";
 import type { EngineProbeResult } from "../resolution/classify.js";
 import type { ResolutionMode } from "../resolution/index.js";
 import type { ResolveUserMdResult } from "../user-config/resolve-user-md.js";
@@ -134,4 +135,11 @@ export interface DoctorSeams {
    * first-hit-wins resolver scoped to the project root.
    */
   readonly resolveUserMd?: (projectRoot: string) => ResolveUserMdResult;
+  /**
+   * Plan-extension shadow detector seam (#2301). Injected so the doctor
+   * shadow-diagnostic surface stays deterministic + offline in tests. Defaults
+   * to loading PROJECT-DEFINITION and running `detectShadowedPlanExtensions` on
+   * its `plan` object; returns [] when no project definition is present.
+   */
+  readonly detectPlanExtensionShadows?: (projectRoot: string) => readonly ShadowedPlanExtension[];
 }

--- a/packages/core/src/policy/plan-extensions.test.ts
+++ b/packages/core/src/policy/plan-extensions.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  describeShadowedPlanExtension,
+  detectShadowedPlanExtensions,
   LEGACY_PLAN_COMPLETED_NOTE_KEY,
   LEGACY_PLAN_POLICY_KEY,
   migrateLegacyPolicyKey,
@@ -7,6 +9,7 @@ import {
   PLAN_POLICY_KEY,
   readPlanCompletedNote,
   readPlanPolicy,
+  SHADOWABLE_PLAN_EXTENSIONS,
 } from "./plan-extensions.js";
 
 describe("plan-extensions namespaced accessors (#1650)", () => {
@@ -70,5 +73,78 @@ describe("plan-extensions namespaced accessors (#1650)", () => {
     migrateLegacyPolicyKey(plan);
     expect(PLAN_POLICY_KEY in plan).toBe(false);
     expect(LEGACY_PLAN_POLICY_KEY in plan).toBe(false);
+  });
+});
+
+describe("plan-extension shadow detection (#2301)", () => {
+  it("covers both the policy and completedNote key pairs", () => {
+    const pairs = SHADOWABLE_PLAN_EXTENSIONS.map((p) => [p.namespacedKey, p.legacyKey]);
+    expect(pairs).toContainEqual([PLAN_POLICY_KEY, LEGACY_PLAN_POLICY_KEY]);
+    expect(pairs).toContainEqual([PLAN_COMPLETED_NOTE_KEY, LEGACY_PLAN_COMPLETED_NOTE_KEY]);
+  });
+
+  it("returns [] when only the namespaced key exists", () => {
+    expect(detectShadowedPlanExtensions({ [PLAN_POLICY_KEY]: { wipCap: 8 } })).toEqual([]);
+  });
+
+  it("returns [] when only the legacy bare key exists (un-migrated is fine)", () => {
+    expect(detectShadowedPlanExtensions({ policy: { wipCap: 3 } })).toEqual([]);
+  });
+
+  it("detects a bare plan.policy shadowed by the namespaced form and lists sub-keys", () => {
+    const shadows = detectShadowedPlanExtensions({
+      [PLAN_POLICY_KEY]: { wipCap: 9 },
+      policy: { triageScope: [], wipCap: 1 },
+    });
+    expect(shadows).toHaveLength(1);
+    expect(shadows[0]?.namespacedKey).toBe(PLAN_POLICY_KEY);
+    expect(shadows[0]?.legacyKey).toBe(LEGACY_PLAN_POLICY_KEY);
+    expect(shadows[0]?.shadowedSubKeys).toEqual(["triageScope", "wipCap"]);
+  });
+
+  it("detects multiple shadowed keys at once", () => {
+    const shadows = detectShadowedPlanExtensions({
+      [PLAN_POLICY_KEY]: {},
+      policy: {},
+      [PLAN_COMPLETED_NOTE_KEY]: "n",
+      completedNote: "legacy",
+    });
+    expect(shadows.map((s) => s.legacyKey).sort()).toEqual(
+      [LEGACY_PLAN_COMPLETED_NOTE_KEY, LEGACY_PLAN_POLICY_KEY].sort(),
+    );
+  });
+
+  it("reports no sub-keys when the shadowed bare value is not an object", () => {
+    const shadows = detectShadowedPlanExtensions({
+      [PLAN_COMPLETED_NOTE_KEY]: "current",
+      completedNote: "legacy string",
+    });
+    expect(shadows).toHaveLength(1);
+    expect(shadows[0]?.shadowedSubKeys).toEqual([]);
+  });
+
+  it("returns [] for non-object plans", () => {
+    expect(detectShadowedPlanExtensions(null)).toEqual([]);
+    expect(detectShadowedPlanExtensions([1, 2])).toEqual([]);
+    expect(detectShadowedPlanExtensions("nope")).toEqual([]);
+  });
+
+  it("describes the shadow with a fold/delete remediation and sub-key list", () => {
+    const [shadow] = detectShadowedPlanExtensions({
+      [PLAN_POLICY_KEY]: {},
+      policy: { triageScope: [] },
+    });
+    const message = describeShadowedPlanExtension(
+      shadow ?? {
+        namespacedKey: PLAN_POLICY_KEY,
+        legacyKey: LEGACY_PLAN_POLICY_KEY,
+        shadowedSubKeys: [],
+      },
+    );
+    expect(message).toContain("bare `plan.policy`");
+    expect(message).toContain("x-directive/policy");
+    expect(message).toContain("IGNORED");
+    expect(message).toContain("plan.policy.triageScope");
+    expect(message).toContain("Fold");
   });
 });

--- a/packages/core/src/policy/plan-extensions.ts
+++ b/packages/core/src/policy/plan-extensions.ts
@@ -63,3 +63,71 @@ export function migrateLegacyPolicyKey(plan: Record<string, unknown>): void {
     delete plan[LEGACY_PLAN_POLICY_KEY];
   }
 }
+
+/** The namespaced/legacy key pairs a bare block can silently shadow (#2301). */
+export const SHADOWABLE_PLAN_EXTENSIONS: ReadonlyArray<{
+  readonly namespacedKey: string;
+  readonly legacyKey: string;
+}> = [
+  { namespacedKey: PLAN_POLICY_KEY, legacyKey: LEGACY_PLAN_POLICY_KEY },
+  { namespacedKey: PLAN_COMPLETED_NOTE_KEY, legacyKey: LEGACY_PLAN_COMPLETED_NOTE_KEY },
+];
+
+/** A plan-extension key whose bare form is silently shadowed by the namespaced form. */
+export interface ShadowedPlanExtension {
+  /** The namespaced key that wins the read (e.g. `x-directive/policy`). */
+  readonly namespacedKey: string;
+  /** The bare legacy key that is silently ignored (e.g. `policy`). */
+  readonly legacyKey: string;
+  /**
+   * Best-effort list of sub-keys present in the shadowed bare object (e.g.
+   * `["triageScope", "wipCap"]`). Empty when the bare value is not an object.
+   */
+  readonly shadowedSubKeys: readonly string[];
+}
+
+/**
+ * Detect every plan-extension key where a bare (legacy) block coexists with the
+ * namespaced form (#2301). Because `readPlanExtension` is namespace-first, the
+ * bare block is never read once the namespaced key exists -- edits to it take no
+ * effect. Detecting the coexistence lets callers emit a loud diagnostic instead
+ * of the silent no-op that the #2295 onboarding trap exhibited.
+ */
+export function detectShadowedPlanExtensions(plan: unknown): ShadowedPlanExtension[] {
+  const planObj = asPlanObject(plan);
+  if (planObj === null) {
+    return [];
+  }
+  const shadows: ShadowedPlanExtension[] = [];
+  for (const { namespacedKey, legacyKey } of SHADOWABLE_PLAN_EXTENSIONS) {
+    if (planObj[namespacedKey] === undefined || planObj[legacyKey] === undefined) {
+      continue;
+    }
+    const legacyValue = planObj[legacyKey];
+    const shadowedSubKeys =
+      typeof legacyValue === "object" && legacyValue !== null && !Array.isArray(legacyValue)
+        ? Object.keys(legacyValue as Record<string, unknown>)
+        : [];
+    shadows.push({ namespacedKey, legacyKey, shadowedSubKeys });
+  }
+  return shadows;
+}
+
+/**
+ * Render a human-readable, loud diagnostic for a single shadowed plan-extension
+ * key. The message is surface-agnostic (no leading tag) so each caller can
+ * prefix it (`[policy:show]`, a doctor finding, ...).
+ */
+export function describeShadowedPlanExtension(shadow: ShadowedPlanExtension): string {
+  const subKeys =
+    shadow.shadowedSubKeys.length > 0
+      ? ` Shadowed field(s): ${shadow.shadowedSubKeys
+          .map((k) => `plan.${shadow.legacyKey}.${k}`)
+          .join(", ")}.`
+      : "";
+  return (
+    `bare \`plan.${shadow.legacyKey}\` coexists with namespaced \`plan.${shadow.namespacedKey}\`; ` +
+    `the bare block is IGNORED (namespaced-first read) so edits to it silently take no effect.${subKeys} ` +
+    `Fold its values into \`plan.${shadow.namespacedKey}\` and delete \`plan.${shadow.legacyKey}\`.`
+  );
+}

--- a/packages/core/src/triage/scope/cli.ts
+++ b/packages/core/src/triage/scope/cli.ts
@@ -9,6 +9,7 @@ import {
   computeDiffFromUpstream,
   fetchUpstreamLabelsAndMilestones,
   renderDiffReport,
+  setScopePreset,
 } from "./mutations.js";
 import { subscriptionHash } from "./normalize.js";
 import { pyListRepr } from "./python-repr.js";
@@ -30,6 +31,7 @@ export interface ParsedCliArgs {
   addLabel: string | undefined;
   addMilestone: string | undefined;
   ignoreLabel: string | undefined;
+  setPreset: string | undefined;
   diffFromUpstream: boolean;
   source: string;
   cacheRoot: string | undefined;
@@ -45,6 +47,7 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
     addLabel: undefined,
     addMilestone: undefined,
     ignoreLabel: undefined,
+    setPreset: undefined,
     diffFromUpstream: false,
     source: "github-issue",
     cacheRoot: undefined,
@@ -79,6 +82,11 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
       i += 1;
     } else if (arg?.startsWith("--ignore-label="))
       parsed.ignoreLabel = arg.slice("--ignore-label=".length);
+    else if (arg === "--set-preset") {
+      parsed.setPreset = argv[i + 1];
+      i += 1;
+    } else if (arg?.startsWith("--set-preset="))
+      parsed.setPreset = arg.slice("--set-preset=".length);
     else if (arg === "--source") {
       parsed.source = argv[i + 1] ?? "github-issue";
       i += 1;
@@ -102,16 +110,19 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
 export const CLI_HELP = `usage: triage_scope.py [-h] [--project-root PROJECT_ROOT] [--list]
                        [--refresh-denominator] [--repo REPO]
                        [--add-label ADD_LABEL] [--add-milestone ADD_MILESTONE]
-                       [--ignore-label IGNORE_LABEL] [--diff-from-upstream]
+                       [--ignore-label IGNORE_LABEL] [--set-preset PRESET]
+                       [--diff-from-upstream]
                        [--source SOURCE] [--cache-root CACHE_ROOT]
                        [--count COUNT]
 
 Inspect, mutate, and diff the typed plan.policy.triageScope[] subscription +
 plan.policy.triageScopeIgnores[] (#1131 / D12, #1133 / D14, #1182 / D14c).
 Read paths never trigger a recompute; use --refresh-denominator to update the
-coverage cache. Mutation flags --add-label / --add-milestone / --ignore-label
-are idempotent and atomic; every mutation appends a subscription-change audit
-entry to vbrief/.eval/subscription-history.jsonl.
+coverage cache. Mutation flags --add-label / --add-milestone / --ignore-label /
+--set-preset are idempotent and atomic; every mutation appends a
+subscription-change audit entry to vbrief/.eval/subscription-history.jsonl.
+--set-preset small|mid|mega overwrites plan.policy.triageScope[] with a named
+subscription preset via the same writer that backs triage:welcome --onboard (#2301).
 `;
 
 interface CliOutput {
@@ -137,6 +148,9 @@ function handleMutation(
     } else if (args.ignoreLabel !== undefined) {
       [changed, message] = addLabelToIgnores(projectRoot, args.ignoreLabel);
       verb = "ignore-label";
+    } else if (args.setPreset !== undefined) {
+      [changed, message] = setScopePreset(projectRoot, args.setPreset);
+      verb = "set-preset";
     } else {
       throw new Error("internal: mutation flag set but no handler matched");
     }
@@ -170,6 +184,7 @@ export function runCliCapture(argv: string[]): { code: number; stdout: string; s
     args.addLabel !== undefined ? "--add-label" : null,
     args.addMilestone !== undefined ? "--add-milestone" : null,
     args.ignoreLabel !== undefined ? "--ignore-label" : null,
+    args.setPreset !== undefined ? "--set-preset" : null,
   ].filter((f): f is string => f !== null);
 
   if (mutationFlags.length > 1) {
@@ -177,7 +192,7 @@ export function runCliCapture(argv: string[]): { code: number; stdout: string; s
       code: 2,
       stdout: "",
       stderr:
-        "triage:scope: --add-label / --add-milestone / --ignore-label " +
+        "triage:scope: --add-label / --add-milestone / --ignore-label / --set-preset " +
         `are mutually exclusive (got ${pyListRepr(mutationFlags)}).\n`,
     };
   }
@@ -198,6 +213,15 @@ export function runCliCapture(argv: string[]): { code: number; stdout: string; s
     stdout.push(...mutation.out.stdout);
     if (mutation.code !== 0) {
       return { code: mutation.code, stdout: stdout.join(""), stderr: stderr.join("") };
+    }
+    // A preset write comes from the trusted SUBSCRIPTION_PRESETS constant (the
+    // same source the onboard path writes). The `mega` preset intentionally
+    // ships an `explicit-watch` scaffold with an empty `issues` list for the
+    // operator to fill in, which the strict hand-edit validator below flags.
+    // Bypass that re-validation for a preset write so `--set-preset` reports the
+    // successful, persisted mutation instead of a spurious exit 1 (#2301).
+    if (args.setPreset !== undefined) {
+      return { code: 0, stdout: stdout.join(""), stderr: stderr.join("") };
     }
   }
 

--- a/packages/core/src/triage/scope/mutations.ts
+++ b/packages/core/src/triage/scope/mutations.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { SUBPROCESS_MAX_BUFFER } from "../../subprocess/max-buffer.js";
+import { SUBSCRIPTION_PRESETS } from "../welcome/constants.js";
+import { subscriptionPreset, writeTriageScope } from "../welcome/writers.js";
 import { collectMilestoneSubscribedNames, rulesRequestIsOpen } from "./milestone.js";
 import { addIgnore, subscribe } from "./mutations-core.js";
 import { resolveScopeIgnores, resolveScopeRules } from "./resolve.js";
@@ -248,4 +250,28 @@ export function addLabelToIgnores(projectRoot: string, label: string): [boolean,
   if (!label.trim())
     throw new Error(`label must be a non-empty string; got ${JSON.stringify(label)}`);
   return addIgnore(projectRoot, label);
+}
+
+/** Valid subscription preset keys for `triage:scope --set-preset` (#2301). */
+export function scopePresetKeys(): string[] {
+  return Object.keys(SUBSCRIPTION_PRESETS);
+}
+
+/**
+ * Overwrite plan.policy.triageScope with a named subscription preset (#2301).
+ * Reuses the shared `subscriptionPreset` + `writeTriageScope` helper that backs
+ * `triage:welcome --onboard`, so the write path (namespaced key, legacy-key
+ * migration, audit trail, mutation lock) stays identical across surfaces rather
+ * than being duplicated here.
+ */
+export function setScopePreset(projectRoot: string, presetKey: string): [boolean, string] {
+  const key = presetKey.trim();
+  const validKeys = scopePresetKeys();
+  if (!validKeys.includes(key)) {
+    throw new Error(
+      `unknown preset ${JSON.stringify(presetKey)}; valid presets: ${validKeys.join(", ")}`,
+    );
+  }
+  const rules = subscriptionPreset(key);
+  return writeTriageScope(projectRoot, rules, { presetLabel: key });
 }

--- a/xbrief/completed/2026-07-05-2301-policy-shadow-diagnostic-and-set-preset.xbrief.json
+++ b/xbrief/completed/2026-07-05-2301-policy-shadow-diagnostic-and-set-preset.xbrief.json
@@ -1,0 +1,63 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #2301",
+    "updated": "2026-07-05T14:04:57Z"
+  },
+  "plan": {
+    "title": "stray bare plan.policy silently ignored when x-directive/policy exists (triageScope not applied, no warning)",
+    "status": "completed",
+    "narratives": {
+      "Description": "readPlanExtension is namespace-first: once an x-directive/policy object exists, a hand-added bare plan.policy.triageScope / wipCap is never read and there is no warning -- the exact silent-ignore trap behind #2295. Two parts: (1) add a triage:scope --set-preset small|mid|mega writer that reuses the existing subscriptionPreset + writeTriageScope helper shared with triage:welcome --onboard; (2) emit a loud diagnostic when a bare plan.policy coexists with x-directive/policy so the silent no-op becomes visible.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2301",
+      "Overview": "## Problem\n\n`readPlanExtension` in packages/core/src/policy/plan-extensions.ts reads the namespaced `x-directive/policy` key first and only falls back to bare `plan.policy` when the namespaced key is absent. Once `x-directive/policy` exists (after migrate or any policy CLI write), a hand-added bare `plan.policy.triageScope` / `wipCap` is silently ignored with no diagnostic.\n\n## Two parts\n\n1. **triage:scope --set-preset small|mid|mega writer.** triage:scope currently wires only --add-label / --add-milestone / --ignore-label. The preset primitive already exists (subscriptionPreset + writeTriageScope, also used by triage:welcome --onboard); wrap it as a shared writer path rather than duplicating.\n2. **Loud shadow diagnostic.** When a bare plan.policy coexists with x-directive/policy, emit a visible warning (never a silent no-op). Surfaces: doctor and policy show.\n\n## Acceptance\n\n- A hand-added bare plan.policy alongside x-directive/policy produces a visible warning (never a silent no-op).\n- triage:scope --set-preset <key> persists the preset via the shared writer.\n\nRefs #2295.",
+      "Labels": "bug"
+    },
+    "items": [
+      {
+        "title": "Add `triage:scope --set-preset small|mid|mega` flag (CLI parse + mutation) that persists the preset via the shared subscriptionPreset + writeTriageScope helper (no duplication of the onboard path).",
+        "status": "proposed"
+      },
+      {
+        "title": "--set-preset is mutually exclusive with --add-label / --add-milestone / --ignore-label; unknown preset keys produce a helpful error listing valid keys.",
+        "status": "proposed"
+      },
+      {
+        "title": "Add a shadow-detection primitive in plan-extensions.ts that flags every plan-extension key (policy, completedNote) where the bare and namespaced forms coexist, plus a message formatter.",
+        "status": "proposed"
+      },
+      {
+        "title": "Surface the shadow diagnostic as a visible warning in `policy show` (stderr) and as a `deft doctor` warning finding.",
+        "status": "proposed"
+      },
+      {
+        "title": "Unit tests cover the --set-preset writer path, the shadow detector, and both surfacing sites (forward-coverage).",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "policy",
+      "triage"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2301",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2301: stray bare plan.policy silently ignored when x-directive/policy exists"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2295",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2295: parent -- onboarding shows incomplete with no hint why"
+      }
+    ],
+    "updated": "2026-07-05T14:12:28Z",
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "technical-debt",
+      "capacityBucketSource": "match",
+      "completedAt": "2026-07-05T14:12:28Z"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Split from #2295 (P2). Fixes the silent-ignore trap where a hand-added bare `plan.policy` is never read once the namespaced `x-directive/policy` exists, and adds the missing `triage:scope --set-preset` writer.

- **Loud shadow diagnostic.** `detectShadowedPlanExtensions` / `describeShadowedPlanExtension` (in `plan-extensions.ts`) flag any plan-extension key (`policy`, `completedNote`) whose bare form coexists with the namespaced form. Surfaced as a stderr warning in `policy show` and a `deft doctor` warning finding (never an error) that names the shadowed fields and tells you to fold them into `x-directive/policy`.
- **`triage:scope --set-preset small|mid|mega`.** Wires the preset primitive into `triage:scope`, reusing the shared `subscriptionPreset` + `writeTriageScope` helper that backs `triage:welcome --onboard` (no duplication). Mutually exclusive with `--add-label` / `--add-milestone` / `--ignore-label`; unknown keys produce a helpful error listing valid presets. A preset write is trusted (skips the strict hand-edit re-validation so the `mega` scaffold's placeholder `explicit-watch` issues do not spuriously fail the command).

## Acceptance

- A bare `plan.policy` alongside `x-directive/policy` now produces a visible warning (`policy show`, `doctor`), never a silent no-op.
- `triage:scope --set-preset <key>` persists the preset via the shared writer.

## Test plan

- [x] `TMPDIR=$(mktemp -d) task check` — green (584 test files, 8645 tests; all verify:* gates pass)
- [x] New unit tests: shadow detector + formatter, `policy show` warning (and no-warning) paths, `doctor` shadow check via seam, and the `--set-preset` writer (small/mid/mega persist, unknown-key error, mutual exclusion)

Closes #2301. Refs #2295.
