### PR TITLE
fix(triage,docs): surface triage:welcome onboarding flags in help/usage (#2302 item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`triage:welcome`'s onboarding flags are now discoverable in `--help` (#2302).** Running `deft triage:welcome --help` (or `task triage:welcome -- --help`) now lists `--onboard`, `--preset small|mid|mega`, and `--wip-cap N` with descriptions and an onboarding example, so the non-interactive onboarding surface shipped for #2295 is visible from the CLI instead of only in source. Refs #2302, #2295.
 - **`triage:scope --set-preset small|mid|mega` sets your whole triage subscription in one command (#2301).** Instead of adding labels and milestones one at a time, you can now apply a named subscription preset — the same `small` / `mid` / `mega` presets the onboarding flow offers — directly from `triage:scope`. It writes through the shared preset writer (so the namespaced `x-directive/policy` key, audit trail, and lock all behave identically to onboarding) and is mutually exclusive with the other mutation flags. Closes #2301. Refs #2295.
 
 ### Changed

--- a/packages/cli/src/triage-welcome.test.ts
+++ b/packages/cli/src/triage-welcome.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseArgs } from "./triage-welcome.js";
+import { parseArgs, run } from "./triage-welcome.js";
 
 describe("triage:welcome CLI arg parsing (#2295)", () => {
   it("defaults onboard/preset/wipCap to off/null", () => {
@@ -38,5 +38,37 @@ describe("triage:welcome CLI arg parsing (#2295)", () => {
   it("errors when --wip-cap is not an integer", () => {
     const args = parseArgs(["--wip-cap", "lots"]);
     expect(args.error).toContain("--wip-cap");
+  });
+});
+
+describe("triage:welcome CLI --help discoverability (#2302 item 3)", () => {
+  function captureRun(argv: string[]): { rc: number; out: string } {
+    const chunks: string[] = [];
+    const origOut = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      const rc = run(argv);
+      return { rc, out: chunks.join("") };
+    } finally {
+      process.stdout.write = origOut;
+    }
+  }
+
+  it("prints onboarding flags for --help without touching the filesystem", () => {
+    const { rc, out } = captureRun(["--help"]);
+    expect(rc).toBe(0);
+    expect(out).toContain("task triage:welcome");
+    expect(out).toContain("--onboard");
+    expect(out).toContain("--preset");
+    expect(out).toContain("--wip-cap");
+  });
+
+  it("also intercepts the -h short flag", () => {
+    const { rc, out } = captureRun(["-h"]);
+    expect(rc).toBe(0);
+    expect(out).toContain("--onboard");
   });
 });

--- a/packages/cli/src/triage-welcome.ts
+++ b/packages/cli/src/triage-welcome.ts
@@ -2,6 +2,7 @@
 import { statSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { interceptHelp } from "@deftai/directive-core/dist/triage/help/index.js";
 import { runDefaultMode } from "@deftai/directive-core/dist/triage/welcome/default-mode.js";
 import { runOnboardMode } from "@deftai/directive-core/dist/triage/welcome/onboard.js";
 
@@ -79,6 +80,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
 }
 
 export function run(argv: string[]): number {
+  const helpRc = interceptHelp("triage_welcome", argv);
+  if (helpRc !== null) {
+    return helpRc;
+  }
+
   const args = parseArgs(argv);
   if (args.error !== undefined) {
     process.stderr.write(`triage:welcome: ${args.error}\n`);

--- a/packages/core/src/triage/help/index.test.ts
+++ b/packages/core/src/triage/help/index.test.ts
@@ -102,6 +102,19 @@ describe("interceptHelp", () => {
     expect(rc).toBe(0);
     expect(lines.join("")).toContain("triage:smoketest");
   });
+
+  it("surfaces welcome onboarding flags for triage_welcome --help (#2302 item 3)", () => {
+    const lines: string[] = [];
+    const rc = interceptHelp("triage_welcome", ["--help"], {
+      write: (t) => lines.push(t),
+    });
+    expect(rc).toBe(0);
+    const out = lines.join("");
+    expect(out).toContain("task triage:welcome");
+    expect(out).toContain("--onboard");
+    expect(out).toContain("--preset");
+    expect(out).toContain("--wip-cap");
+  });
 });
 
 describe("runHelp CLI", () => {

--- a/packages/core/src/triage/help/registry-data.ts
+++ b/packages/core/src/triage/help/registry-data.ts
@@ -317,12 +317,26 @@ export const registryData = {
     "task triage:welcome": {
       name: "task triage:welcome",
       summary: "Single-entry-point upgrade ritual",
-      refs: "(N3 / #1143)",
+      refs: "(N3 / #1143, #2295)",
       description:
-        "6-phase onboarding ritual: detect prior state, prompt for subscription scope, run triage:bootstrap, prompt for wipCap, offer WIP relief, print triage:summary. Idempotent on re-run; safe entrypoint for fresh consumers.",
-      usage: "task triage:welcome [-- --no-subprocess]",
-      flags: [["--no-subprocess", "(off)", "Dry-mode: don't shell out to sibling tasks."]],
-      examples: ["task triage:welcome"],
+        "6-phase onboarding ritual: detect prior state, prompt for subscription scope, run triage:bootstrap, prompt for wipCap, offer WIP relief, print triage:summary. Idempotent on re-run; safe entrypoint for fresh consumers. Pass --onboard for the non-interactive path that applies a triage-scope preset (and optional --wip-cap) without prompting -- the form agents/CI use.",
+      usage:
+        "task triage:welcome [-- --onboard [--preset small|mid|mega] [--wip-cap N]] [--no-subprocess]",
+      flags: [
+        [
+          "--onboard",
+          "(off)",
+          "Non-interactive onboarding: apply a triage-scope preset (and optional WIP cap) without prompting.",
+        ],
+        ["--preset small|mid|mega", "small", "Subscription-scope preset applied by --onboard."],
+        [
+          "--wip-cap N",
+          "(policy default)",
+          "Persist an explicit in-flight scope cap during --onboard (positive integer).",
+        ],
+        ["--no-subprocess", "(off)", "Dry-mode: don't shell out to sibling tasks."],
+      ],
+      examples: ["task triage:welcome", "task triage:welcome -- --onboard --preset small"],
       see_also: ["task triage:bootstrap", "task triage:summary", "#1119 / N3"],
       placeholder: false,
     },

--- a/xbrief/active/2026-07-05-2302-triage-welcome-help-discoverability.xbrief.json
+++ b/xbrief/active/2026-07-05-2302-triage-welcome-help-discoverability.xbrief.json
@@ -1,0 +1,42 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF for #2302 item 3: make triage:welcome --onboard / --preset / --wip-cap discoverable in --help / usage",
+    "updated": "2026-07-05T15:18:28Z"
+  },
+  "plan": {
+    "title": "#2302 item 3: triage:welcome onboarding flags discoverable in help/usage",
+    "status": "running",
+    "narratives": {
+      "Overview": "The final remaining slice of #2302 (items 1 & 2 shipped in PR #2304). The --onboard / --preset / --wip-cap flags implemented by PR #2300 are not discoverable in --help / usage listings. Surface them in the triage help registry (source scripts/triage_help.py, regenerated into packages/core/src/triage/help/registry-data.ts) and the triage-welcome CLI usage text. Closing #2302 lets the #2295 tracker close (its other child #2301 is already closed).",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2302"
+    },
+    "items": [
+      {
+        "title": "Add --onboard / --preset / --wip-cap flags to the triage:welcome help registry entry (scripts/triage_help.py) and regenerate registry-data.ts",
+        "status": "proposed"
+      },
+      {
+        "title": "Surface the onboarding flags in the triage-welcome CLI --help / usage text",
+        "status": "proposed"
+      },
+      {
+        "title": "After PR merges, close #2302; verify #2295 tracker closes",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2302",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2302: bug(triage,docs): triage:welcome papercuts"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2295",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2295: triage:welcome --onboard tracker (P1 done, P3 remaining)"
+      }
+    ],
+    "updated": "2026-07-05T15:18:26Z"
+  }
+}

--- a/xbrief/completed/2026-07-05-2302-triage-welcome-help-discoverability.xbrief.json
+++ b/xbrief/completed/2026-07-05-2302-triage-welcome-help-discoverability.xbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "#2302 item 3: triage:welcome onboarding flags discoverable in help/usage",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "The final remaining slice of #2302 (items 1 & 2 shipped in PR #2304). The --onboard / --preset / --wip-cap flags implemented by PR #2300 are not discoverable in --help / usage listings. Surface them in the triage help registry (source scripts/triage_help.py, regenerated into packages/core/src/triage/help/registry-data.ts) and the triage-welcome CLI usage text. Closing #2302 lets the #2295 tracker close (its other child #2301 is already closed).",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2302"
@@ -37,6 +37,10 @@
         "title": "Issue #2295: triage:welcome --onboard tracker (P1 done, P3 remaining)"
       }
     ],
-    "updated": "2026-07-05T15:18:26Z"
+    "updated": "2026-07-05T15:29:32Z",
+    "metadata": {
+      "completedAt": "2026-07-05T15:29:32Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Item 3 of #2302 (the last remaining papercut; items 1 & 2 shipped in PR #2304). The `triage:welcome --onboard` non-interactive onboarding surface (`--preset small|mid|mega`, `--wip-cap N`) shipped for #2295 but was not discoverable in `--help` / usage listings. This PR surfaces those flags.

- **Help registry** (`packages/core/src/triage/help/registry-data.ts`): the `task triage:welcome` entry now documents `--onboard`, `--preset small|mid|mega` (default `small`), and `--wip-cap N`, with an updated usage string and an onboarding example (`task triage:welcome -- --onboard --preset small`).
- **CLI** (`packages/cli/src/triage-welcome.ts`): `run()` now routes through the shared `interceptHelp("triage_welcome", argv)` path (same pattern as `triage-subscribe` / `triage-bulk` / `triage-smoketest`), so `deft triage:welcome --help` / `-h` (and `task triage:welcome -- --help`) render the registry entry before arg parsing.
- **Tests**: extended `packages/core/src/triage/help/index.test.ts` and `packages/cli/src/triage-welcome.test.ts` to assert the onboarding flags appear in the rendered help/usage.

### Note on regeneration (anomaly)

The `registry-data.ts` banner reads "Auto-generated from `scripts/triage_help.py`", but that Python source — and the entire `scripts/` directory — no longer exists (the repo has fully migrated to TS-native; `registry-data.ts` was last touched by the #1725/#1755 TS port). There is no generator command and no Python↔TS contract test remaining, so `registry-data.ts` was edited directly. The stale banner is left as-is to keep this PR scoped to #2302 item 3; a follow-up could drop or update the banner.

## Related Issues

Refs #2302
Refs #2295

(Issue closure is handled by the orchestrator, not by this PR body.)

## Checklist

- [x] `/deft:change <name>` — N/A (scoped change tracked by the #2302 xBRIEF)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (issue closure handled downstream)
- [x] Tests pass locally (`TMPDIR=$(mktemp -d) task check` green)

## Post-Merge

- [ ] **Verify issue auto-close**: confirm #2302 state after merge; close manually if needed.
- [ ] Confirm #2295 tracker can close once #2302 is closed.
