### PR TITLE
feat: Tier 0 eval:health framework health score (#1703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`task eval:health` aggregates static self-consistency into a versioned framework health score (#1703 Tier 0).** Maintainers can run one cheap, model-free command to probe encoding, link integrity, vBRIEF conformance, AGENTS.md freshness, and (on the framework source tree) content-manifest drift, plus a contradictory-gate detector that surfaces unsatisfiable nudges such as the #1694 wipCap case. Each run appends to a versioned ledger under `.eval/results/` so health can be trended across releases. Refs #1703.
+
 ### Changed
 
 ### Fixed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -295,6 +295,11 @@ includes:
   capacity:
     taskfile: ./tasks/capacity.yml
     optional: true
+  # Tier 0 framework-eval surface (#1703). Exposes `task eval:health` --
+  # aggregates static self-consistency gates into a versioned health score.
+  eval:
+    taskfile: ./tasks/eval.yml
+    optional: true
   # Pack-slicing surface (#1283 design, #1294 pilot, ADR-001 Layer B). Exposes
   # `task packs:slice` (named-slice API), `task packs:render` (regenerate the
   # meta/lessons.md projection), and `task packs:verify-drift` (the drift gate,

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -151,6 +151,7 @@ export const CLI_MODULE_VERBS = [
   "verify-wip-cap",
   "verify-agents-md-budget",
   "verify-agents-md-advisory",
+  "eval-health",
 ] as const;
 
 /** Core-only CLI entrypoints without a packages/cli wrapper. */
@@ -268,6 +269,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "project:render": "project-render",
   "project:export-spec": "export-spec",
   doctor: "doctor",
+  "eval:health": "eval-health",
   build: "framework-commands",
   "setup:ghx": "setup-ghx",
 };

--- a/packages/cli/src/eval-health.test.ts
+++ b/packages/cli/src/eval-health.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseArgs, run } from "./eval-health.js";
+
+describe("eval-health CLI", () => {
+  it("parses defaults", () => {
+    expect(parseArgs([])).toMatchObject({
+      projectRoot: ".",
+      json: false,
+      noPersist: false,
+    });
+  });
+
+  it("runs with --no-persist and --json", () => {
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      const code = run(["--no-persist", "--json", "--project-root", "."]);
+      expect([0, 1, 2]).toContain(code);
+    } finally {
+      out.mockRestore();
+      err.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/eval-health.ts
+++ b/packages/cli/src/eval-health.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluateHealth } from "@deftai/directive-core/eval";
+
+interface ParsedArgs {
+  projectRoot: string;
+  json: boolean;
+  noPersist: boolean;
+  error?: string;
+}
+
+/** Parse eval-health CLI args. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    projectRoot: ".",
+    json: false,
+    noPersist: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      parsed.json = true;
+    } else if (arg === "--no-persist") {
+      parsed.noPersist = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run eval:health and return the process exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`eval:health: ${args.error}\n`);
+    return 2;
+  }
+
+  const result = evaluateHealth({
+    projectRoot: resolve(args.projectRoot),
+    persist: !args.noPersist,
+  });
+
+  if (result.report === null) {
+    process.stderr.write(`${result.message}\n`);
+    return result.code;
+  }
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result.report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${result.message}\n`);
+  }
+
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/doctor/index.d.ts",
       "default": "./dist/doctor/index.js"
     },
+    "./eval": {
+      "types": "./dist/eval/health.d.ts",
+      "default": "./dist/eval/health.js"
+    },
     "./triage": {
       "types": "./dist/triage/index.d.ts",
       "default": "./dist/triage/index.js"

--- a/packages/core/src/eval/health.test.ts
+++ b/packages/core/src/eval/health.test.ts
@@ -93,7 +93,11 @@ describe("detectWipCapUnsatisfiableNudge", () => {
   it("returns null when wipCap is materialized", () => {
     const root = seedRepo();
     const pdPath = join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json");
-    const data = JSON.parse(readFileSync(pdPath, "utf8")) as Record<string, unknown>;
+    const raw: unknown = JSON.parse(readFileSync(pdPath, "utf8"));
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error("fixture PROJECT-DEFINITION must be an object");
+    }
+    const data = raw as Record<string, unknown>;
     (data.plan as Record<string, unknown>)["x-directive/policy"] = {
       triageScope: [{ rule: "all-open" }],
       wipCap: 8,
@@ -140,5 +144,24 @@ describe("evaluateHealth", () => {
     expect(result.report?.recordedAt).toBe("2026-07-05T18:00:00Z");
     expect(existsSync(healthHistoryPath(root))).toBe(true);
     expect(result.message).toContain("score=");
+  });
+
+  it("still returns the computed report when persistence fails", () => {
+    const root = seedRepo();
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- deft:managed-section v3 -->\n<!-- /deft:managed-section -->\n",
+      "utf8",
+    );
+    rmSync(join(root, "xbrief", ".eval"), { recursive: true, force: true });
+    writeFileSync(join(root, "xbrief", ".eval"), "not-a-directory", "utf8");
+    const result = evaluateHealth({
+      projectRoot: root,
+      frameworkSource: false,
+      now: () => new Date("2026-07-05T18:00:00Z"),
+    });
+    expect(result.report).not.toBeNull();
+    expect(result.message).toContain("score=");
+    expect(result.message).toContain("failed to persist health history");
   });
 });

--- a/packages/core/src/eval/health.test.ts
+++ b/packages/core/src/eval/health.test.ts
@@ -1,0 +1,144 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  computeHealthScore,
+  detectWipCapUnsatisfiableNudge,
+  evaluateHealth,
+  type GateProbeResult,
+  type HealthReport,
+  healthHistoryPath,
+  persistHealthRun,
+} from "./health.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function seedRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-eval-health-"));
+  temps.push(root);
+  mkdirSync(join(root, "xbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    JSON.stringify({
+      xBRIEFInfo: { version: "0.6" },
+      plan: {
+        title: "T",
+        status: "running",
+        items: [],
+        "x-directive/policy": {
+          triageScope: [{ rule: "all-open" }],
+        },
+      },
+    }),
+    "utf8",
+  );
+  mkdirSync(join(root, "xbrief", ".eval"), { recursive: true });
+  writeFileSync(join(root, "xbrief", ".eval", "candidates.jsonl"), '{"issue":1}\n', "utf8");
+  return root;
+}
+
+describe("computeHealthScore", () => {
+  it("returns 100 when all active gates pass and no contradictions", () => {
+    const gates: GateProbeResult[] = [
+      { id: "a", title: "A", pass: true, exitCode: 0 },
+      { id: "b", title: "B", pass: true, exitCode: 0 },
+    ];
+    expect(computeHealthScore(gates, [])).toBe(100);
+  });
+
+  it("penalizes failing gates and contradictions", () => {
+    const gates: GateProbeResult[] = [
+      { id: "a", title: "A", pass: true, exitCode: 0 },
+      { id: "b", title: "B", pass: false, exitCode: 1 },
+    ];
+    expect(computeHealthScore(gates, [])).toBe(50);
+    expect(
+      computeHealthScore(gates, [
+        { id: "x", kind: "unsatisfiable-nudge", summary: "s", signals: [] },
+      ]),
+    ).toBe(35);
+  });
+
+  it("ignores skipped gates in the denominator", () => {
+    const gates: GateProbeResult[] = [
+      { id: "a", title: "A", pass: true, exitCode: 0 },
+      {
+        id: "b",
+        title: "B",
+        pass: true,
+        exitCode: 0,
+        skipped: true,
+        skipReason: "framework-only",
+      },
+    ];
+    expect(computeHealthScore(gates, [])).toBe(100);
+  });
+});
+
+describe("detectWipCapUnsatisfiableNudge", () => {
+  it("reports the canonical #1694 contradiction when wipCap is omitted but onboarding expects it", () => {
+    const root = seedRepo();
+    const evidence = detectWipCapUnsatisfiableNudge(root);
+    expect(evidence).not.toBeNull();
+    expect(evidence?.id).toBe("wipCap-unsatisfiable-nudge");
+    expect(evidence?.kind).toBe("unsatisfiable-nudge");
+  });
+
+  it("returns null when wipCap is materialized", () => {
+    const root = seedRepo();
+    const pdPath = join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json");
+    const data = JSON.parse(readFileSync(pdPath, "utf8")) as Record<string, unknown>;
+    (data.plan as Record<string, unknown>)["x-directive/policy"] = {
+      triageScope: [{ rule: "all-open" }],
+      wipCap: 8,
+    };
+    writeFileSync(pdPath, JSON.stringify(data), "utf8");
+    expect(detectWipCapUnsatisfiableNudge(root)).toBeNull();
+  });
+});
+
+describe("persistHealthRun", () => {
+  it("appends versioned records to xbrief/.eval/results/health-history.jsonl", () => {
+    const root = seedRepo();
+    const report: HealthReport = {
+      schemaVersion: 1,
+      version: "0.70.0-test",
+      recordedAt: "2026-07-05T18:00:00Z",
+      score: 85,
+      gates: [],
+      contradictions: [],
+    };
+    persistHealthRun(root, report);
+    const path = healthHistoryPath(root);
+    expect(existsSync(path)).toBe(true);
+    const lines = readFileSync(path, "utf8").trim().split("\n");
+    expect(JSON.parse(lines[0] ?? "{}")).toMatchObject({ version: "0.70.0-test", score: 85 });
+  });
+});
+
+describe("evaluateHealth", () => {
+  it("emits a versioned score and persists by default", () => {
+    const root = seedRepo();
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- deft:managed-section v3 -->\n<!-- /deft:managed-section -->\n",
+      "utf8",
+    );
+    const result = evaluateHealth({
+      projectRoot: root,
+      frameworkSource: false,
+      now: () => new Date("2026-07-05T18:00:00Z"),
+    });
+    expect(result.report).not.toBeNull();
+    expect(result.report?.version.length).toBeGreaterThan(0);
+    expect(result.report?.recordedAt).toBe("2026-07-05T18:00:00Z");
+    expect(existsSync(healthHistoryPath(root))).toBe(true);
+    expect(result.message).toContain("score=");
+  });
+});

--- a/packages/core/src/eval/health.ts
+++ b/packages/core/src/eval/health.ts
@@ -1,0 +1,303 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { agentsRefreshPlan } from "../doctor/agents-md.js";
+import { evaluate as evaluateEncoding } from "../encoding/evaluate.js";
+import { readCorePackageVersion } from "../engine-version.js";
+import { resolveEvalPath, resolveProjectDefinitionPath } from "../layout/resolve.js";
+import { readPlanPolicy } from "../policy/plan-extensions.js";
+import { classifyOnboarding, detectPriorState } from "../triage/welcome/prior-state.js";
+import { validateLinks } from "../validate-content/index.js";
+import { evaluateConformance } from "../vbrief-validate/conformance.js";
+import { validateWipCapOnPlan } from "../vbrief-validate/plan-hooks.js";
+import { evaluateContentManifest } from "../verify-source/content-manifest.js";
+
+export const HEALTH_SCHEMA_VERSION = 1 as const;
+export const HEALTH_HISTORY_REL = "results/health-history.jsonl";
+
+/** One static Tier-0 gate probe aggregated into the health score. */
+export interface GateProbeResult {
+  readonly id: string;
+  readonly title: string;
+  readonly pass: boolean;
+  readonly exitCode: number;
+  readonly detail?: string;
+  readonly skipped?: boolean;
+  readonly skipReason?: string;
+}
+
+/** Evidence for a contradictory / unsatisfiable gate pair (#1694 class). */
+export interface ContradictionEvidence {
+  readonly id: string;
+  readonly kind: "unsatisfiable-nudge";
+  readonly summary: string;
+  readonly signals: readonly string[];
+}
+
+/** Versioned Tier-0 health run persisted for trending (#1703). */
+export interface HealthReport {
+  readonly schemaVersion: typeof HEALTH_SCHEMA_VERSION;
+  readonly version: string;
+  readonly recordedAt: string;
+  readonly score: number;
+  readonly gates: readonly GateProbeResult[];
+  readonly contradictions: readonly ContradictionEvidence[];
+}
+
+export interface EvaluateHealthOptions {
+  readonly projectRoot?: string;
+  readonly persist?: boolean;
+  readonly now?: () => Date;
+  readonly frameworkSource?: boolean;
+}
+
+export interface EvaluateHealthResult {
+  readonly code: 0 | 1 | 2;
+  readonly report: HealthReport | null;
+  readonly message: string;
+}
+
+function isFrameworkSourceCheckout(projectRoot: string): boolean {
+  const rootPkg = resolve(projectRoot, "package.json");
+  const cliPkg = resolve(projectRoot, "packages/cli/package.json");
+  if (!existsSync(rootPkg) || !existsSync(cliPkg)) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(rootPkg, "utf8")) as { scripts?: { build?: unknown } };
+    return typeof parsed.scripts?.build === "string";
+  } catch {
+    return false;
+  }
+}
+
+function loadPlan(projectRoot: string): { plan: unknown; filepath: string } | null {
+  const filepath = resolveProjectDefinitionPath(projectRoot);
+  if (!existsSync(filepath)) {
+    return null;
+  }
+  try {
+    const data = JSON.parse(readFileSync(filepath, "utf8")) as { plan?: unknown };
+    return { plan: data.plan, filepath };
+  } catch {
+    return null;
+  }
+}
+
+function probeEncoding(projectRoot: string): GateProbeResult {
+  const result = evaluateEncoding(projectRoot, { mode: "all" });
+  return {
+    id: "encoding",
+    title: "verify:encoding",
+    pass: result.exitCode === 0,
+    exitCode: result.exitCode,
+    detail: result.exitCode === 0 ? undefined : result.message.split("\n")[0],
+  };
+}
+
+function probeLinks(projectRoot: string): GateProbeResult {
+  const result = validateLinks.evaluate({
+    cwd: projectRoot,
+    strict: false,
+    argv: [],
+    linkCheckStrict: process.env.LINK_CHECK_STRICT === "1",
+  });
+  return {
+    id: "links",
+    title: "verify:links",
+    pass: result.code === 0,
+    exitCode: result.code,
+    detail: result.code === 0 ? undefined : result.message.split("\n")[0],
+  };
+}
+
+function probeVbriefConformance(projectRoot: string): GateProbeResult {
+  const result = evaluateConformance(projectRoot, { mode: "all" });
+  return {
+    id: "vbrief-conformance",
+    title: "verify:vbrief-conformance",
+    pass: result.exitCode === 0,
+    exitCode: result.exitCode,
+    detail: result.exitCode === 0 ? undefined : result.message.split("\n")[0],
+  };
+}
+
+function probeAgentsMdFreshness(projectRoot: string): GateProbeResult {
+  const plan = agentsRefreshPlan(projectRoot);
+  const state = String(plan.state ?? "unknown");
+  const pass = state === "current";
+  return {
+    id: "agents-md-freshness",
+    title: "AGENTS.md managed-section freshness",
+    pass,
+    exitCode: pass ? 0 : 1,
+    detail: pass ? undefined : `state=${state}`,
+  };
+}
+
+function probeContentManifest(projectRoot: string): GateProbeResult {
+  const result = evaluateContentManifest(projectRoot, { root: projectRoot });
+  return {
+    id: "content-manifest",
+    title: "verify:content-manifest",
+    pass: result.code === 0,
+    exitCode: result.code,
+    detail: result.code === 0 ? undefined : result.message.split("\n")[0],
+  };
+}
+
+/** Absolute path to the versioned health history ledger. */
+export function healthHistoryPath(projectRoot: string): string {
+  return resolveEvalPath(projectRoot, HEALTH_HISTORY_REL);
+}
+
+/** Detect the canonical wipCap unsatisfiable-nudge contradiction (#1694). */
+export function detectWipCapUnsatisfiableNudge(projectRoot: string): ContradictionEvidence | null {
+  const loaded = loadPlan(projectRoot);
+  if (loaded === null) {
+    return null;
+  }
+  const { plan, filepath } = loaded;
+  const policy = readPlanPolicy(plan);
+  const wipCapPresent =
+    typeof policy === "object" &&
+    policy !== null &&
+    !Array.isArray(policy) &&
+    "wipCap" in (policy as Record<string, unknown>);
+  if (wipCapPresent) {
+    return null;
+  }
+
+  const state = detectPriorState(projectRoot);
+  const [, missing] = classifyOnboarding(state);
+  if (!missing.includes("wipCap")) {
+    return null;
+  }
+
+  const validatorErrors = validateWipCapOnPlan(plan, filepath);
+  if (validatorErrors.length > 0) {
+    return null;
+  }
+
+  return {
+    id: "wipCap-unsatisfiable-nudge",
+    kind: "unsatisfiable-nudge",
+    summary:
+      "Onboarding completeness treats absent plan.policy.wipCap as incomplete, but omit-by-design accepts absence as valid (#1694 / #1186 D1).",
+    signals: [
+      "classifyOnboarding: wipCap listed in missing onboarding signals",
+      "validateWipCapOnPlan: omitted wipCap is valid",
+      "triage:welcome --onboard nudge cannot clear without violating omit-by-design contract",
+    ],
+  };
+}
+
+/** Run all registered contradictory-gate detectors. */
+export function detectContradictoryGates(projectRoot: string): ContradictionEvidence[] {
+  const wipCap = detectWipCapUnsatisfiableNudge(projectRoot);
+  return wipCap === null ? [] : [wipCap];
+}
+
+/** Compute a 0-100 score from gate pass rate minus contradiction penalty. */
+export function computeHealthScore(
+  gates: readonly GateProbeResult[],
+  contradictions: readonly ContradictionEvidence[],
+): number {
+  const active = gates.filter((g) => !g.skipped);
+  if (active.length === 0) {
+    return contradictions.length > 0 ? 0 : 100;
+  }
+  const passed = active.filter((g) => g.pass).length;
+  const base = Math.round((passed / active.length) * 100);
+  const penalty = contradictions.length * 15;
+  return Math.max(0, base - penalty);
+}
+
+/** Append one health run to the versioned ledger (#1703 Tier 0). */
+export function persistHealthRun(projectRoot: string, report: HealthReport): void {
+  const path = healthHistoryPath(projectRoot);
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(report)}\n`, "utf8");
+}
+
+function collectStaticGates(projectRoot: string, frameworkSource: boolean): GateProbeResult[] {
+  const gates: GateProbeResult[] = [
+    probeEncoding(projectRoot),
+    probeLinks(projectRoot),
+    probeVbriefConformance(projectRoot),
+    probeAgentsMdFreshness(projectRoot),
+  ];
+
+  if (frameworkSource) {
+    gates.push(probeContentManifest(projectRoot));
+  } else {
+    gates.push({
+      id: "content-manifest",
+      title: "verify:content-manifest",
+      pass: true,
+      exitCode: 0,
+      skipped: true,
+      skipReason: "framework-source-only gate",
+    });
+  }
+
+  return gates;
+}
+
+function formatHumanReport(report: HealthReport): string {
+  const lines = [
+    `eval:health v${report.version} score=${report.score}/100 (${report.recordedAt})`,
+    ...report.gates.map((g) => {
+      const status = g.skipped ? "SKIP" : g.pass ? "PASS" : "FAIL";
+      const suffix = g.skipped ? ` (${g.skipReason})` : g.detail ? ` -- ${g.detail}` : "";
+      return `  [${status}] ${g.title}${suffix}`;
+    }),
+  ];
+  if (report.contradictions.length > 0) {
+    lines.push("  Contradictory gates:");
+    for (const c of report.contradictions) {
+      lines.push(`    - ${c.id}: ${c.summary}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/** Aggregate Tier-0 static gates into a versioned framework health score (#1703). */
+export function evaluateHealth(options: EvaluateHealthOptions = {}): EvaluateHealthResult {
+  const projectRoot = resolve(options.projectRoot ?? process.cwd());
+  const frameworkSource = options.frameworkSource ?? isFrameworkSourceCheckout(projectRoot);
+  const now = options.now ?? (() => new Date());
+  const persist = options.persist ?? true;
+
+  const gates = collectStaticGates(projectRoot, frameworkSource);
+  const contradictions = detectContradictoryGates(projectRoot);
+  const score = computeHealthScore(gates, contradictions);
+  const report: HealthReport = {
+    schemaVersion: HEALTH_SCHEMA_VERSION,
+    version: readCorePackageVersion(),
+    recordedAt: now()
+      .toISOString()
+      .replace(/\.\d{3}Z$/, "Z"),
+    score,
+    gates,
+    contradictions,
+  };
+
+  if (persist) {
+    try {
+      persistHealthRun(projectRoot, report);
+    } catch (err: unknown) {
+      return {
+        code: 2,
+        report: null,
+        message: `eval:health: failed to persist health history: ${String(err)}`,
+      };
+    }
+  }
+
+  const healthy = score === 100 && contradictions.length === 0;
+  return {
+    code: healthy ? 0 : 1,
+    report,
+    message: formatHumanReport(report),
+  };
+}

--- a/packages/core/src/eval/health.ts
+++ b/packages/core/src/eval/health.ts
@@ -56,18 +56,14 @@ export interface EvaluateHealthResult {
   readonly message: string;
 }
 
+function sanitizeOneLine(value: string): string {
+  return value.replace(/\r?\n/g, " ");
+}
+
 function isFrameworkSourceCheckout(projectRoot: string): boolean {
-  const rootPkg = resolve(projectRoot, "package.json");
+  const manifest = resolve(projectRoot, "conventions/content-manifest.json");
   const cliPkg = resolve(projectRoot, "packages/cli/package.json");
-  if (!existsSync(rootPkg) || !existsSync(cliPkg)) {
-    return false;
-  }
-  try {
-    const parsed = JSON.parse(readFileSync(rootPkg, "utf8")) as { scripts?: { build?: unknown } };
-    return typeof parsed.scripts?.build === "string";
-  } catch {
-    return false;
-  }
+  return existsSync(manifest) && existsSync(cliPkg);
 }
 
 function loadPlan(projectRoot: string): { plan: unknown; filepath: string } | null {
@@ -76,8 +72,11 @@ function loadPlan(projectRoot: string): { plan: unknown; filepath: string } | nu
     return null;
   }
   try {
-    const data = JSON.parse(readFileSync(filepath, "utf8")) as { plan?: unknown };
-    return { plan: data.plan, filepath };
+    const data: unknown = JSON.parse(readFileSync(filepath, "utf8"));
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
+      return null;
+    }
+    return { plan: (data as { plan?: unknown }).plan, filepath };
   } catch {
     return null;
   }
@@ -248,14 +247,18 @@ function formatHumanReport(report: HealthReport): string {
     `eval:health v${report.version} score=${report.score}/100 (${report.recordedAt})`,
     ...report.gates.map((g) => {
       const status = g.skipped ? "SKIP" : g.pass ? "PASS" : "FAIL";
-      const suffix = g.skipped ? ` (${g.skipReason})` : g.detail ? ` -- ${g.detail}` : "";
+      const suffix = g.skipped
+        ? ` (${sanitizeOneLine(g.skipReason ?? "")})`
+        : g.detail
+          ? ` -- ${sanitizeOneLine(g.detail)}`
+          : "";
       return `  [${status}] ${g.title}${suffix}`;
     }),
   ];
   if (report.contradictions.length > 0) {
     lines.push("  Contradictory gates:");
     for (const c of report.contradictions) {
-      lines.push(`    - ${c.id}: ${c.summary}`);
+      lines.push(`    - ${c.id}: ${sanitizeOneLine(c.summary)}`);
     }
   }
   return lines.join("\n");
@@ -286,10 +289,12 @@ export function evaluateHealth(options: EvaluateHealthOptions = {}): EvaluateHea
     try {
       persistHealthRun(projectRoot, report);
     } catch (err: unknown) {
+      const persistError = `eval:health: failed to persist health history: ${String(err)}`;
+      const healthy = score === 100 && contradictions.length === 0;
       return {
-        code: 2,
-        report: null,
-        message: `eval:health: failed to persist health history: ${String(err)}`,
+        code: healthy ? 0 : 1,
+        report,
+        message: `${formatHumanReport(report)}\n${persistError}`,
       };
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,7 @@ export * as capacity from "./capacity/index.js";
 export * as codebase from "./codebase/index.js";
 export * as doctor from "./doctor/index.js";
 export * from "./encoding/index.js";
-export * as eval from "./eval/health.js";
+export * as evalHealth from "./eval/health.js";
 export * from "./forward-coverage/evaluate.js";
 export * as intake from "./intake/index.js";
 export * as layout from "./layout/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * as capacity from "./capacity/index.js";
 export * as codebase from "./codebase/index.js";
 export * as doctor from "./doctor/index.js";
 export * from "./encoding/index.js";
+export * as eval from "./eval/health.js";
 export * from "./forward-coverage/evaluate.js";
 export * as intake from "./intake/index.js";
 export * as layout from "./layout/index.js";

--- a/tasks/eval.yml
+++ b/tasks/eval.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+  health:
+    desc: "Tier 0 static self-consistency aggregation -- versioned framework health score (#1703). -- task eval:health [-- --json] [--no-persist] [--project-root PATH]"
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'eval:health --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,7 @@ const subpathAliases: Record<string, string> = {
   "@deftai/directive-core/slice": sub("core", "slice"),
   "@deftai/directive-core/cache": sub("core", "cache"),
   "@deftai/directive-core/doctor": sub("core", "doctor"),
+  "@deftai/directive-core/eval": resolve(import.meta.dirname, "packages/core/src/eval/health.ts"),
   "@deftai/directive-core/triage": sub("core", "triage"),
   "@deftai/directive-core/release": sub("core", "release"),
   "@deftai/directive-core/release-publish": sub("core", "release-publish"),

--- a/xbrief/completed/2026-07-05-1703-tier0-health.xbrief.json
+++ b/xbrief/completed/2026-07-05-1703-tier0-health.xbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1703-tier0-health",
     "title": "Tier 0 static self-consistency aggregation (eval:health)",
-    "status": "pending",
+    "status": "completed",
     "narratives": {
       "Description": "Aggregate directive's existing static gates such as render-staleness, dead cross-refs, conformance, encoding, and template propagation drift, plus a new contradictory-gate detector, into a single per-version framework health score. This tier is the cheapest, model-free, highest-ROI signal and is trended over time.",
       "ImplementationPlan": "- Add an eval:health module that runs the existing static verifiers and aggregates their results into a versioned score.\n- Add the contradictory-gate detector and tests asserting the wipCap-class unsatisfiable-nudge is reported as evidence.",
@@ -60,7 +60,9 @@
         "size": "M",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-07-05T18:39:07Z",
+      "capacityBucket": "cognitive-debt"
     },
     "references": [
       {
@@ -75,6 +77,7 @@
         "title": "Issue #1703 Tier 0: static self-consistency aggregation",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-07-05T18:39:07Z"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `task eval:health` — Tier 0 static self-consistency aggregation from RFC #1703
- Runs existing static gates (encoding, links, vBRIEF conformance, AGENTS.md freshness, content-manifest on framework source) and computes a versioned 0–100 health score
- Introduces a contradictory-gate detector that surfaces unsatisfiable nudges (canonical case: #1694 wipCap omit-by-design vs onboarding completeness)
- Persists each run to `xbrief/.eval/results/health-history.jsonl` for trending across releases

## Test plan

- [x] `pnpm -w exec vitest run packages/core/src/eval packages/cli/src/eval-health.test.ts`
- [x] `TMPDIR=$(mktemp -d) task check`
- [x] `task eval:health -- --no-persist` smoke on framework tree (detects wipCap contradiction, score < 100)

Refs #1703