### PR TITLE
feat: capability adoption registry with applicability heuristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Capability adoption registry: directive can now detect when relevant capabilities (planning, cost, decompose, swarm, pre-PR, and others) were applicable but unused, using conservative heuristics that suppress nudges for small or non-parallelizable work. Signals are gated on the value-feedback opt-in policy. Refs #1709.
 - Value feedback opt-in gate: operators can enable value-attribution surfaces via a new typed policy block (default OFF), with per-feature sub-flags and a capability-cost disclosure printed before any change is persisted. Refs #1709.
 - **`task eval:health` aggregates static self-consistency into a versioned framework health score (#1703 Tier 0).** Maintainers can run one cheap, model-free command to probe encoding, link integrity, vBRIEF conformance, AGENTS.md freshness, and (on the framework source tree) content-manifest drift, plus a contradictory-gate detector that surfaces unsatisfiable nudges such as the #1694 wipCap case. Each run appends to a versioned ledger under `.eval/results/` so health can be trended across releases. Refs #1703.
 - **Version-eval operation telemetry (#1703).** vBRIEF file operations now emit per-operation metrics tagged with the directive version, covering schema validity, detection of non-spec keys added by agents, and whether an update rewrote the whole file or made a targeted change. Refs #1703.

--- a/packages/core/src/value/adoption-registry.test.ts
+++ b/packages/core/src/value/adoption-registry.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADOPTION_SIGNAL_CLASS,
+  ADOPTION_THRESHOLDS,
+  type CapabilityId,
+  detectApplicableButUnused,
+  detectApplicableButUnusedGated,
+  evaluateApplicability,
+  formatAdoptionEventName,
+  getCapability,
+  isCapabilityUsed,
+  isWorkTooSmallForAdoptionNudges,
+  listCapabilities,
+  type WorkContext,
+} from "./adoption-registry.js";
+
+function ctx(partial: Partial<WorkContext> & Pick<WorkContext, "filesTouched">): WorkContext {
+  return {
+    distinctModuleGlobs: partial.distinctModuleGlobs ?? 1,
+    usedCapabilities: partial.usedCapabilities ?? [],
+    isBuildIntent: partial.isBuildIntent,
+    isPrOpening: partial.isPrOpening,
+    ...partial,
+  };
+}
+
+describe("capability catalog (#1709-adoption-registry-a1)", () => {
+  it("records each capability with heuristic metadata and usage signal", () => {
+    const catalog = listCapabilities();
+    const ids = catalog.map((entry) => entry.id);
+    const expected: CapabilityId[] = [
+      "planning",
+      "cost",
+      "decompose",
+      "swarm",
+      "pre-pr",
+      "debug",
+      "glossary",
+      "lessons",
+    ];
+    expect(ids).toEqual(expected);
+    for (const entry of catalog) {
+      expect(entry.label.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+      expect(entry.usageSignal.length).toBeGreaterThan(0);
+      expect(entry.nudgeHint.length).toBeGreaterThan(0);
+      expect(getCapability(entry.id)).toEqual(entry);
+    }
+  });
+
+  it("formats adoption event names for the ledger", () => {
+    expect(formatAdoptionEventName("decompose")).toBe(`${ADOPTION_SIGNAL_CLASS}:decompose`);
+  });
+});
+
+describe("applicable-but-unused detection (#1709-adoption-registry-a2)", () => {
+  it("emits decompose adoption signal for large multi-file work without decompose", () => {
+    const signals = detectApplicableButUnused(
+      ctx({
+        filesTouched: ADOPTION_THRESHOLDS.largeMultiFileMinFiles,
+        distinctModuleGlobs: ADOPTION_THRESHOLDS.largeMultiFileMinModules,
+      }),
+    );
+    const decompose = signals.find((signal) => signal.capabilityId === "decompose");
+    expect(decompose).toBeDefined();
+    expect(decompose?.event).toBe("adoption:decompose");
+    expect(decompose?.signalClass).toBe("adoption");
+    expect(decompose?.evidence.filesTouched).toBe(ADOPTION_THRESHOLDS.largeMultiFileMinFiles);
+  });
+
+  it("suppresses signals for capabilities already used", () => {
+    const signals = detectApplicableButUnused(
+      ctx({
+        filesTouched: 6,
+        distinctModuleGlobs: 2,
+        usedCapabilities: ["decompose"],
+      }),
+    );
+    expect(signals.some((signal) => signal.capabilityId === "decompose")).toBe(false);
+  });
+
+  it("emits pre-pr signal at PR-open boundary when pre-pr was skipped", () => {
+    const signals = detectApplicableButUnused(
+      ctx({
+        filesTouched: 3,
+        isPrOpening: true,
+      }),
+    );
+    expect(signals.some((signal) => signal.capabilityId === "pre-pr")).toBe(true);
+  });
+
+  it("emits cost signal for build intent without cost phase", () => {
+    const signals = detectApplicableButUnused(
+      ctx({
+        filesTouched: ADOPTION_THRESHOLDS.costMinFiles,
+        isBuildIntent: true,
+      }),
+    );
+    expect(signals.some((signal) => signal.capabilityId === "cost")).toBe(true);
+  });
+});
+
+describe("conservative false-positive guard (#1709-adoption-registry-a3)", () => {
+  it("rejects adoption nudges for small work", () => {
+    const small = ctx({ filesTouched: ADOPTION_THRESHOLDS.smallWorkMaxFiles });
+    expect(isWorkTooSmallForAdoptionNudges(small)).toBe(true);
+    expect(detectApplicableButUnused(small)).toEqual([]);
+    expect(evaluateApplicability("decompose", small).applicable).toBe(false);
+  });
+
+  it("rejects decompose for non-parallelizable single-module work", () => {
+    const verdict = evaluateApplicability(
+      "decompose",
+      ctx({
+        filesTouched: 10,
+        distinctModuleGlobs: 1,
+      }),
+    );
+    expect(verdict.applicable).toBe(false);
+    expect(verdict.reason).toContain("parallelizable");
+    expect(
+      detectApplicableButUnused(
+        ctx({
+          filesTouched: 10,
+          distinctModuleGlobs: 1,
+        }),
+      ).some((signal) => signal.capabilityId === "decompose"),
+    ).toBe(false);
+  });
+
+  it("rejects swarm below module breadth threshold", () => {
+    const verdict = evaluateApplicability(
+      "swarm",
+      ctx({
+        filesTouched: ADOPTION_THRESHOLDS.swarmMinFiles,
+        distinctModuleGlobs: ADOPTION_THRESHOLDS.swarmMinModules - 1,
+      }),
+    );
+    expect(verdict.applicable).toBe(false);
+  });
+
+  it("never auto-nudges debug without an explicit failure signal", () => {
+    expect(
+      evaluateApplicability(
+        "debug",
+        ctx({
+          filesTouched: 20,
+          distinctModuleGlobs: 5,
+        }),
+      ).applicable,
+    ).toBe(false);
+  });
+});
+
+describe("isCapabilityUsed", () => {
+  it("reflects the usedCapabilities list", () => {
+    const work = ctx({ filesTouched: 1, usedCapabilities: ["planning", "lessons"] });
+    expect(isCapabilityUsed("planning", work)).toBe(true);
+    expect(isCapabilityUsed("decompose", work)).toBe(false);
+  });
+});
+
+describe("value-feedback policy gate", () => {
+  it("returns no signals when value feedback is disabled", () => {
+    const signals = detectApplicableButUnusedGated(
+      ctx({
+        filesTouched: 8,
+        distinctModuleGlobs: 3,
+      }),
+      {
+        enabled: false,
+        emitEvents: false,
+        sessionLine: false,
+        upstreamPrompt: false,
+        source: "default",
+        error: null,
+      },
+    );
+    expect(signals).toEqual([]);
+  });
+
+  it("returns signals when enabled and emitEvents path is allowed", () => {
+    const signals = detectApplicableButUnusedGated(
+      ctx({
+        filesTouched: 8,
+        distinctModuleGlobs: 3,
+      }),
+      {
+        enabled: true,
+        emitEvents: true,
+        sessionLine: true,
+        upstreamPrompt: false,
+        source: "typed",
+        error: null,
+      },
+    );
+    expect(signals.length).toBeGreaterThan(0);
+  });
+
+  it("returns no signals when enabled but emitEvents sub-flag is off", () => {
+    const signals = detectApplicableButUnusedGated(
+      ctx({
+        filesTouched: 8,
+        distinctModuleGlobs: 3,
+      }),
+      {
+        enabled: true,
+        emitEvents: false,
+        sessionLine: true,
+        upstreamPrompt: false,
+        source: "typed",
+        error: null,
+      },
+    );
+    expect(signals).toEqual([]);
+  });
+});

--- a/packages/core/src/value/adoption-registry.test.ts
+++ b/packages/core/src/value/adoption-registry.test.ts
@@ -7,7 +7,6 @@ import {
   detectApplicableButUnusedGated,
   evaluateApplicability,
   formatAdoptionEventName,
-  isCapabilityUsed,
   isWorkTooSmallForAdoptionNudges,
   type WorkContext,
 } from "./adoption-registry.js";
@@ -24,36 +23,46 @@ const ALL_CAPABILITY_IDS: CapabilityId[] = [
 ];
 
 function applicableContext(id: CapabilityId): WorkContext {
+  const base = { usedCapabilities: [] as const };
   switch (id) {
     case "planning":
-      return { filesTouched: ADOPTION_THRESHOLDS.planningMinFiles, distinctModuleGlobs: 1 };
+      return {
+        ...base,
+        filesTouched: ADOPTION_THRESHOLDS.planningMinFiles,
+        distinctModuleGlobs: 1,
+      };
     case "cost":
       return {
+        ...base,
         filesTouched: ADOPTION_THRESHOLDS.costMinFiles,
         distinctModuleGlobs: 1,
         isBuildIntent: true,
       };
     case "decompose":
       return {
+        ...base,
         filesTouched: ADOPTION_THRESHOLDS.largeMultiFileMinFiles,
         distinctModuleGlobs: ADOPTION_THRESHOLDS.largeMultiFileMinModules,
       };
     case "swarm":
       return {
+        ...base,
         filesTouched: ADOPTION_THRESHOLDS.swarmMinFiles,
         distinctModuleGlobs: ADOPTION_THRESHOLDS.swarmMinModules,
       };
     case "pre-pr":
-      return { filesTouched: 3, distinctModuleGlobs: 1, isPrOpening: true };
+      return { ...base, filesTouched: 3, distinctModuleGlobs: 1, isPrOpening: true };
     case "debug":
-      return { filesTouched: 10, distinctModuleGlobs: 3 };
+      return { ...base, filesTouched: 10, distinctModuleGlobs: 3 };
     case "glossary":
       return {
+        ...base,
         filesTouched: ADOPTION_THRESHOLDS.glossaryMinFiles,
         distinctModuleGlobs: 2,
       };
     case "lessons":
       return {
+        ...base,
         filesTouched: ADOPTION_THRESHOLDS.lessonsMinFiles,
         distinctModuleGlobs: 2,
       };
@@ -202,13 +211,34 @@ describe("conservative false-positive guard (#1709-adoption-registry-a3)", () =>
       ).applicable,
     ).toBe(false);
   });
+  it("suppresses planning nudges at the PR-open boundary", () => {
+    expect(
+      detectApplicableButUnused(
+        ctx({
+          filesTouched: 8,
+          distinctModuleGlobs: 2,
+          isPrOpening: true,
+        }),
+      ).some((signal) => signal.capabilityId === "planning"),
+    ).toBe(false);
+    expect(
+      detectApplicableButUnused(
+        ctx({
+          filesTouched: 8,
+          distinctModuleGlobs: 2,
+          isPrOpening: true,
+        }),
+      ).some((signal) => signal.capabilityId === "pre-pr"),
+    ).toBe(true);
+  });
 });
 
-describe("isCapabilityUsed", () => {
-  it("reflects the usedCapabilities list", () => {
-    const work = ctx({ filesTouched: 1, usedCapabilities: ["planning", "lessons"] });
-    expect(isCapabilityUsed("planning", work)).toBe(true);
-    expect(isCapabilityUsed("decompose", work)).toBe(false);
+describe("used capability suppression", () => {
+  it("reflects the usedCapabilities list via detection output", () => {
+    const work = ctx({ filesTouched: 6, distinctModuleGlobs: 2, usedCapabilities: ["decompose"] });
+    expect(
+      detectApplicableButUnused(work).some((signal) => signal.capabilityId === "decompose"),
+    ).toBe(false);
   });
 });
 

--- a/packages/core/src/value/adoption-registry.test.ts
+++ b/packages/core/src/value/adoption-registry.test.ts
@@ -7,12 +7,58 @@ import {
   detectApplicableButUnusedGated,
   evaluateApplicability,
   formatAdoptionEventName,
-  getCapability,
   isCapabilityUsed,
   isWorkTooSmallForAdoptionNudges,
-  listCapabilities,
   type WorkContext,
 } from "./adoption-registry.js";
+
+const ALL_CAPABILITY_IDS: CapabilityId[] = [
+  "planning",
+  "cost",
+  "decompose",
+  "swarm",
+  "pre-pr",
+  "debug",
+  "glossary",
+  "lessons",
+];
+
+function applicableContext(id: CapabilityId): WorkContext {
+  switch (id) {
+    case "planning":
+      return { filesTouched: ADOPTION_THRESHOLDS.planningMinFiles, distinctModuleGlobs: 1 };
+    case "cost":
+      return {
+        filesTouched: ADOPTION_THRESHOLDS.costMinFiles,
+        distinctModuleGlobs: 1,
+        isBuildIntent: true,
+      };
+    case "decompose":
+      return {
+        filesTouched: ADOPTION_THRESHOLDS.largeMultiFileMinFiles,
+        distinctModuleGlobs: ADOPTION_THRESHOLDS.largeMultiFileMinModules,
+      };
+    case "swarm":
+      return {
+        filesTouched: ADOPTION_THRESHOLDS.swarmMinFiles,
+        distinctModuleGlobs: ADOPTION_THRESHOLDS.swarmMinModules,
+      };
+    case "pre-pr":
+      return { filesTouched: 3, distinctModuleGlobs: 1, isPrOpening: true };
+    case "debug":
+      return { filesTouched: 10, distinctModuleGlobs: 3 };
+    case "glossary":
+      return {
+        filesTouched: ADOPTION_THRESHOLDS.glossaryMinFiles,
+        distinctModuleGlobs: 2,
+      };
+    case "lessons":
+      return {
+        filesTouched: ADOPTION_THRESHOLDS.lessonsMinFiles,
+        distinctModuleGlobs: 2,
+      };
+  }
+}
 
 function ctx(partial: Partial<WorkContext> & Pick<WorkContext, "filesTouched">): WorkContext {
   return {
@@ -25,27 +71,33 @@ function ctx(partial: Partial<WorkContext> & Pick<WorkContext, "filesTouched">):
 }
 
 describe("capability catalog (#1709-adoption-registry-a1)", () => {
-  it("records each capability with heuristic metadata and usage signal", () => {
-    const catalog = listCapabilities();
-    const ids = catalog.map((entry) => entry.id);
-    const expected: CapabilityId[] = [
-      "planning",
-      "cost",
-      "decompose",
-      "swarm",
-      "pre-pr",
-      "debug",
-      "glossary",
-      "lessons",
-    ];
-    expect(ids).toEqual(expected);
-    for (const entry of catalog) {
-      expect(entry.label.length).toBeGreaterThan(0);
-      expect(entry.description.length).toBeGreaterThan(0);
-      expect(entry.usageSignals.length).toBeGreaterThan(0);
-      expect(entry.nudgeHint.length).toBeGreaterThan(0);
-      expect(getCapability(entry.id)).toEqual(entry);
+  it("records each capability with heuristic metadata and usage signals", () => {
+    expect(ALL_CAPABILITY_IDS).toHaveLength(8);
+    for (const id of ALL_CAPABILITY_IDS) {
+      const verdict = evaluateApplicability(id, applicableContext(id));
+      if (id === "debug") {
+        expect(verdict.applicable).toBe(false);
+        continue;
+      }
+      expect(verdict.applicable).toBe(true);
+      const signal = detectApplicableButUnused(applicableContext(id)).find(
+        (entry) => entry.capabilityId === id,
+      );
+      expect(signal).toBeDefined();
+      expect(signal?.message.length).toBeGreaterThan(0);
+      expect(signal?.evidence.usageSignals).toBeDefined();
+      expect((signal?.evidence.usageSignals as unknown[]).length).toBeGreaterThan(0);
     }
+  });
+
+  it("includes interview and speckit usage signals for planning", () => {
+    const signal = detectApplicableButUnused(applicableContext("planning")).find(
+      (entry) => entry.capabilityId === "planning",
+    );
+    expect(signal?.evidence.usageSignals).toEqual([
+      "command:/deft:directive:run:interview",
+      "command:/deft:directive:run:speckit",
+    ]);
   });
 
   it("formats adoption event names for the ledger", () => {

--- a/packages/core/src/value/adoption-registry.test.ts
+++ b/packages/core/src/value/adoption-registry.test.ts
@@ -42,7 +42,7 @@ describe("capability catalog (#1709-adoption-registry-a1)", () => {
     for (const entry of catalog) {
       expect(entry.label.length).toBeGreaterThan(0);
       expect(entry.description.length).toBeGreaterThan(0);
-      expect(entry.usageSignal.length).toBeGreaterThan(0);
+      expect(entry.usageSignals.length).toBeGreaterThan(0);
       expect(entry.nudgeHint.length).toBeGreaterThan(0);
       expect(getCapability(entry.id)).toEqual(entry);
     }

--- a/packages/core/src/value/adoption-registry.ts
+++ b/packages/core/src/value/adoption-registry.ts
@@ -144,6 +144,9 @@ function verdict(applicable: boolean, reason: string): ApplicabilityVerdict {
 
 const APPLICABILITY_RULES: Record<CapabilityId, ApplicabilityRule> = {
   planning(ctx) {
+    if (ctx.isPrOpening) {
+      return verdict(false, "at PR-open boundary — planning phase is past");
+    }
     if (ctx.filesTouched < ADOPTION_THRESHOLDS.planningMinFiles) {
       return verdict(false, "scope below planning threshold");
     }
@@ -225,15 +228,6 @@ export function evaluateApplicability(id: CapabilityId, ctx: WorkContext): Appli
     return verdict(false, "small work — adoption nudges suppressed");
   }
   return APPLICABILITY_RULES[id](ctx);
-}
-
-/** Whether the caller reported the capability as already used. */
-export function isCapabilityUsed(
-  id: CapabilityId,
-  ctx: WorkContext,
-  used?: ReadonlySet<CapabilityId>,
-): boolean {
-  return (used ?? usedSet(ctx)).has(id);
 }
 
 function buildAdoptionSignal(

--- a/packages/core/src/value/adoption-registry.ts
+++ b/packages/core/src/value/adoption-registry.ts
@@ -1,0 +1,288 @@
+import {
+  isValueFeedbackPathAllowed,
+  type ValueFeedbackResolved,
+} from "../policy/value-feedback.js";
+
+/** Canonical directive capabilities tracked for underutilization nudges (#1709). */
+export type CapabilityId =
+  | "planning"
+  | "cost"
+  | "decompose"
+  | "swarm"
+  | "pre-pr"
+  | "debug"
+  | "glossary"
+  | "lessons";
+
+/** How downstream instrumentation knows a capability was exercised. */
+export type UsageSignalSource =
+  | "command:/deft:directive:run:interview"
+  | "command:/deft:directive:run:speckit"
+  | "command:task capacity:show"
+  | "command:split-to-prs"
+  | "command:task swarm:launch"
+  | "skill:deft-directive-pre-pr"
+  | "skill:debug-mode"
+  | "command:/deft:glossary"
+  | "command:deft packs:slice";
+
+export interface CapabilityRecord {
+  readonly id: CapabilityId;
+  readonly label: string;
+  readonly description: string;
+  readonly usageSignal: UsageSignalSource;
+  readonly nudgeHint: string;
+}
+
+/** Work snapshot supplied by callers when evaluating adoption heuristics. */
+export interface WorkContext {
+  readonly filesTouched: number;
+  /** Distinct module globs from the codebase map (parallelizability proxy). */
+  readonly distinctModuleGlobs: number;
+  readonly usedCapabilities: readonly CapabilityId[];
+  readonly isBuildIntent?: boolean;
+  readonly isPrOpening?: boolean;
+}
+
+export interface ApplicabilityVerdict {
+  readonly applicable: boolean;
+  readonly reason: string;
+}
+
+export interface AdoptionSignal {
+  readonly signalClass: "adoption";
+  readonly event: string;
+  readonly capabilityId: CapabilityId;
+  readonly message: string;
+  readonly evidence: Readonly<Record<string, unknown>>;
+}
+
+/** Conservative thresholds — adoption nudges fire only above these bars (#1709). */
+export const ADOPTION_THRESHOLDS = {
+  smallWorkMaxFiles: 2,
+  planningMinFiles: 4,
+  costMinFiles: 3,
+  largeMultiFileMinFiles: 5,
+  largeMultiFileMinModules: 2,
+  swarmMinFiles: 8,
+  swarmMinModules: 3,
+  glossaryMinFiles: 6,
+  lessonsMinFiles: 5,
+} as const;
+
+export const ADOPTION_SIGNAL_CLASS = "adoption" as const;
+
+const CAPABILITY_CATALOG: readonly CapabilityRecord[] = [
+  {
+    id: "planning",
+    label: "Planning",
+    description: "Structured spec interview or speckit planning before implementation.",
+    usageSignal: "command:/deft:directive:run:speckit",
+    nudgeHint: "Consider `/deft:directive:run:speckit` before a multi-file build.",
+  },
+  {
+    id: "cost",
+    label: "Cost awareness",
+    description: "Capacity/cost phase before committing to a build.",
+    usageSignal: "command:task capacity:show",
+    nudgeHint: "Run `task capacity:show` before a build to surface allocation targets.",
+  },
+  {
+    id: "decompose",
+    label: "Decompose",
+    description: "Split large multi-file work into reviewable PRs.",
+    usageSignal: "command:split-to-prs",
+    nudgeHint: "Large multi-file work may benefit from split-to-prs decomposition.",
+  },
+  {
+    id: "swarm",
+    label: "Swarm",
+    description: "Parallel agent dispatch for disjoint multi-story cohorts.",
+    usageSignal: "command:task swarm:launch",
+    nudgeHint: "Disjoint multi-story work may benefit from `task swarm:launch`.",
+  },
+  {
+    id: "pre-pr",
+    label: "Pre-PR loop",
+    description: "Iterative pre-PR quality loop before opening a pull request.",
+    usageSignal: "skill:deft-directive-pre-pr",
+    nudgeHint: "Run the deft-directive-pre-pr skill before opening a PR.",
+  },
+  {
+    id: "debug",
+    label: "Debug mode",
+    description: "Systematic debug workflow for failures and regressions.",
+    usageSignal: "skill:debug-mode",
+    nudgeHint: "Switch to debug mode when chasing a failure systematically.",
+  },
+  {
+    id: "glossary",
+    label: "Glossary",
+    description: "Project glossary for unfamiliar domain terms.",
+    usageSignal: "command:/deft:glossary",
+    nudgeHint: "Consult `/deft:glossary` when domain terms are ambiguous.",
+  },
+  {
+    id: "lessons",
+    label: "Lessons packs",
+    description: "Prior-art slices from directive content packs.",
+    usageSignal: "command:deft packs:slice",
+    nudgeHint: "Load a lessons pack slice before improvising on a novel problem.",
+  },
+] as const;
+
+type ApplicabilityRule = (ctx: WorkContext) => ApplicabilityVerdict;
+
+function usedSet(ctx: WorkContext): Set<CapabilityId> {
+  return new Set(ctx.usedCapabilities);
+}
+
+function verdict(applicable: boolean, reason: string): ApplicabilityVerdict {
+  return { applicable, reason };
+}
+
+const APPLICABILITY_RULES: Record<CapabilityId, ApplicabilityRule> = {
+  planning(ctx) {
+    if (ctx.filesTouched < ADOPTION_THRESHOLDS.planningMinFiles) {
+      return verdict(false, "scope below planning threshold");
+    }
+    return verdict(true, "multi-file scope without a planning pass");
+  },
+  cost(ctx) {
+    if (!ctx.isBuildIntent) {
+      return verdict(false, "not a build-intent session");
+    }
+    if (ctx.filesTouched < ADOPTION_THRESHOLDS.costMinFiles) {
+      return verdict(false, "build scope below cost threshold");
+    }
+    return verdict(true, "build intent without a cost phase");
+  },
+  decompose(ctx) {
+    if (ctx.filesTouched < ADOPTION_THRESHOLDS.largeMultiFileMinFiles) {
+      return verdict(false, "file count below large multi-file threshold");
+    }
+    if (ctx.distinctModuleGlobs < ADOPTION_THRESHOLDS.largeMultiFileMinModules) {
+      return verdict(false, "work is not parallelizable across modules");
+    }
+    return verdict(true, "large multi-file parallelizable work");
+  },
+  swarm(ctx) {
+    if (ctx.filesTouched < ADOPTION_THRESHOLDS.swarmMinFiles) {
+      return verdict(false, "file count below swarm threshold");
+    }
+    if (ctx.distinctModuleGlobs < ADOPTION_THRESHOLDS.swarmMinModules) {
+      return verdict(false, "insufficient module breadth for swarm cohort");
+    }
+    return verdict(true, "broad parallelizable cohort scope");
+  },
+  "pre-pr"(ctx) {
+    if (!ctx.isPrOpening) {
+      return verdict(false, "not at PR-open boundary");
+    }
+    return verdict(true, "PR opening without pre-PR loop");
+  },
+  debug(_ctx) {
+    return verdict(false, "debug nudges require an explicit failure signal");
+  },
+  glossary(ctx) {
+    if (ctx.filesTouched < ADOPTION_THRESHOLDS.glossaryMinFiles) {
+      return verdict(false, "scope below glossary threshold");
+    }
+    return verdict(true, "broad unfamiliar scope");
+  },
+  lessons(ctx) {
+    if (ctx.filesTouched < ADOPTION_THRESHOLDS.lessonsMinFiles) {
+      return verdict(false, "scope below lessons threshold");
+    }
+    return verdict(true, "novel multi-file scope");
+  },
+};
+
+/** Return the full capability catalog (#1709-adoption-registry-a1). */
+export function listCapabilities(): readonly CapabilityRecord[] {
+  return CAPABILITY_CATALOG;
+}
+
+/** Lookup a single catalog entry by id. */
+export function getCapability(id: CapabilityId): CapabilityRecord | undefined {
+  return CAPABILITY_CATALOG.find((entry) => entry.id === id);
+}
+
+/** Event name for the attribution ledger (`adoption:<capability>`). */
+export function formatAdoptionEventName(id: CapabilityId): string {
+  return `${ADOPTION_SIGNAL_CLASS}:${id}`;
+}
+
+/** True when work is too small for any adoption nudge (#1709-adoption-registry-a3). */
+export function isWorkTooSmallForAdoptionNudges(ctx: WorkContext): boolean {
+  return ctx.filesTouched <= ADOPTION_THRESHOLDS.smallWorkMaxFiles;
+}
+
+/** Evaluate whether a capability's conservative heuristic applies to the work snapshot. */
+export function evaluateApplicability(id: CapabilityId, ctx: WorkContext): ApplicabilityVerdict {
+  if (isWorkTooSmallForAdoptionNudges(ctx)) {
+    return verdict(false, "small work — adoption nudges suppressed");
+  }
+  return APPLICABILITY_RULES[id](ctx);
+}
+
+/** Whether the caller reported the capability as already used. */
+export function isCapabilityUsed(id: CapabilityId, ctx: WorkContext): boolean {
+  return usedSet(ctx).has(id);
+}
+
+function buildAdoptionSignal(
+  record: CapabilityRecord,
+  ctx: WorkContext,
+  applicability: ApplicabilityVerdict,
+): AdoptionSignal {
+  return {
+    signalClass: ADOPTION_SIGNAL_CLASS,
+    event: formatAdoptionEventName(record.id),
+    capabilityId: record.id,
+    message: record.nudgeHint,
+    evidence: {
+      filesTouched: ctx.filesTouched,
+      distinctModuleGlobs: ctx.distinctModuleGlobs,
+      usageSignal: record.usageSignal,
+      applicabilityReason: applicability.reason,
+    },
+  };
+}
+
+/**
+ * Detect applicable-but-unused capabilities (#1709-adoption-registry-a2).
+ * Does not consult the value-feedback policy — use `detectApplicableButUnusedGated`.
+ */
+export function detectApplicableButUnused(ctx: WorkContext): AdoptionSignal[] {
+  if (isWorkTooSmallForAdoptionNudges(ctx)) {
+    return [];
+  }
+
+  const signals: AdoptionSignal[] = [];
+  for (const record of CAPABILITY_CATALOG) {
+    if (isCapabilityUsed(record.id, ctx)) {
+      continue;
+    }
+    const applicability = evaluateApplicability(record.id, ctx);
+    if (!applicability.applicable) {
+      continue;
+    }
+    signals.push(buildAdoptionSignal(record, ctx, applicability));
+  }
+  return signals;
+}
+
+/**
+ * Policy-gated adoption detection — returns signals only when value feedback
+ * is enabled and the emitEvents path is allowed (#1709 opt-in gate).
+ */
+export function detectApplicableButUnusedGated(
+  ctx: WorkContext,
+  policy: ValueFeedbackResolved,
+): AdoptionSignal[] {
+  if (!isValueFeedbackPathAllowed("emitEvents", policy)) {
+    return [];
+  }
+  return detectApplicableButUnused(ctx);
+}

--- a/packages/core/src/value/adoption-registry.ts
+++ b/packages/core/src/value/adoption-registry.ts
@@ -200,12 +200,12 @@ const APPLICABILITY_RULES: Record<CapabilityId, ApplicabilityRule> = {
 };
 
 /** Return the full capability catalog (#1709-adoption-registry-a1). */
-export function listCapabilities(): readonly CapabilityRecord[] {
+function listCapabilities(): readonly CapabilityRecord[] {
   return CAPABILITY_CATALOG;
 }
 
 /** Lookup a single catalog entry by id. */
-export function getCapability(id: CapabilityId): CapabilityRecord | undefined {
+function getCapability(id: CapabilityId): CapabilityRecord | undefined {
   return CAPABILITY_CATALOG.find((entry) => entry.id === id);
 }
 

--- a/packages/core/src/value/adoption-registry.ts
+++ b/packages/core/src/value/adoption-registry.ts
@@ -30,7 +30,7 @@ export interface CapabilityRecord {
   readonly id: CapabilityId;
   readonly label: string;
   readonly description: string;
-  readonly usageSignal: UsageSignalSource;
+  readonly usageSignals: readonly UsageSignalSource[];
   readonly nudgeHint: string;
 }
 
@@ -77,56 +77,57 @@ const CAPABILITY_CATALOG: readonly CapabilityRecord[] = [
     id: "planning",
     label: "Planning",
     description: "Structured spec interview or speckit planning before implementation.",
-    usageSignal: "command:/deft:directive:run:speckit",
-    nudgeHint: "Consider `/deft:directive:run:speckit` before a multi-file build.",
+    usageSignals: ["command:/deft:directive:run:interview", "command:/deft:directive:run:speckit"],
+    nudgeHint:
+      "Consider `/deft:directive:run:interview` or `/deft:directive:run:speckit` before a multi-file build.",
   },
   {
     id: "cost",
     label: "Cost awareness",
     description: "Capacity/cost phase before committing to a build.",
-    usageSignal: "command:task capacity:show",
+    usageSignals: ["command:task capacity:show"],
     nudgeHint: "Run `task capacity:show` before a build to surface allocation targets.",
   },
   {
     id: "decompose",
     label: "Decompose",
     description: "Split large multi-file work into reviewable PRs.",
-    usageSignal: "command:split-to-prs",
+    usageSignals: ["command:split-to-prs"],
     nudgeHint: "Large multi-file work may benefit from split-to-prs decomposition.",
   },
   {
     id: "swarm",
     label: "Swarm",
     description: "Parallel agent dispatch for disjoint multi-story cohorts.",
-    usageSignal: "command:task swarm:launch",
+    usageSignals: ["command:task swarm:launch"],
     nudgeHint: "Disjoint multi-story work may benefit from `task swarm:launch`.",
   },
   {
     id: "pre-pr",
     label: "Pre-PR loop",
     description: "Iterative pre-PR quality loop before opening a pull request.",
-    usageSignal: "skill:deft-directive-pre-pr",
+    usageSignals: ["skill:deft-directive-pre-pr"],
     nudgeHint: "Run the deft-directive-pre-pr skill before opening a PR.",
   },
   {
     id: "debug",
     label: "Debug mode",
     description: "Systematic debug workflow for failures and regressions.",
-    usageSignal: "skill:debug-mode",
+    usageSignals: ["skill:debug-mode"],
     nudgeHint: "Switch to debug mode when chasing a failure systematically.",
   },
   {
     id: "glossary",
     label: "Glossary",
     description: "Project glossary for unfamiliar domain terms.",
-    usageSignal: "command:/deft:glossary",
+    usageSignals: ["command:/deft:glossary"],
     nudgeHint: "Consult `/deft:glossary` when domain terms are ambiguous.",
   },
   {
     id: "lessons",
     label: "Lessons packs",
     description: "Prior-art slices from directive content packs.",
-    usageSignal: "command:deft packs:slice",
+    usageSignals: ["command:deft packs:slice"],
     nudgeHint: "Load a lessons pack slice before improvising on a novel problem.",
   },
 ] as const;
@@ -227,15 +228,23 @@ export function evaluateApplicability(id: CapabilityId, ctx: WorkContext): Appli
 }
 
 /** Whether the caller reported the capability as already used. */
-export function isCapabilityUsed(id: CapabilityId, ctx: WorkContext): boolean {
-  return usedSet(ctx).has(id);
+export function isCapabilityUsed(
+  id: CapabilityId,
+  ctx: WorkContext,
+  used?: ReadonlySet<CapabilityId>,
+): boolean {
+  return (used ?? usedSet(ctx)).has(id);
 }
 
 function buildAdoptionSignal(
-  record: CapabilityRecord,
+  id: CapabilityId,
   ctx: WorkContext,
   applicability: ApplicabilityVerdict,
-): AdoptionSignal {
+): AdoptionSignal | null {
+  const record = getCapability(id);
+  if (record === undefined) {
+    return null;
+  }
   return {
     signalClass: ADOPTION_SIGNAL_CLASS,
     event: formatAdoptionEventName(record.id),
@@ -244,7 +253,7 @@ function buildAdoptionSignal(
     evidence: {
       filesTouched: ctx.filesTouched,
       distinctModuleGlobs: ctx.distinctModuleGlobs,
-      usageSignal: record.usageSignal,
+      usageSignals: record.usageSignals,
       applicabilityReason: applicability.reason,
     },
   };
@@ -259,16 +268,20 @@ export function detectApplicableButUnused(ctx: WorkContext): AdoptionSignal[] {
     return [];
   }
 
+  const used = usedSet(ctx);
   const signals: AdoptionSignal[] = [];
-  for (const record of CAPABILITY_CATALOG) {
-    if (isCapabilityUsed(record.id, ctx)) {
+  for (const record of listCapabilities()) {
+    if (used.has(record.id)) {
       continue;
     }
     const applicability = evaluateApplicability(record.id, ctx);
     if (!applicability.applicable) {
       continue;
     }
-    signals.push(buildAdoptionSignal(record, ctx, applicability));
+    const signal = buildAdoptionSignal(record.id, ctx, applicability);
+    if (signal !== null) {
+      signals.push(signal);
+    }
   }
   return signals;
 }

--- a/xbrief/completed/2026-07-05-1709-adoption-registry.xbrief.json
+++ b/xbrief/completed/2026-07-05-1709-adoption-registry.xbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1709-adoption-registry",
     "title": "Capability adoption registry with applicability heuristics",
-    "status": "pending",
+    "status": "completed",
     "narratives": {
       "Description": "Catalog directive capabilities such as planning, cost, decompose, swarm, pre-PR, debug, glossary, and lessons, each with a conservative applicability heuristic and a usage signal. This registry powers underutilization nudges that only fire on genuinely relevant work.",
       "ImplementationPlan": "- Add a registry module describing each capability, its applicability heuristic, and its usage-signal source.\n- Emit adoption events when applicable-but-unused work is detected and add tests with fixtures covering conservative false-positive avoidance.",
@@ -62,7 +62,9 @@
         "size": "L",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-07-05T20:54:45Z",
+      "capacityBucket": "agentic-debt"
     },
     "references": [
       {
@@ -77,6 +79,7 @@
         "title": "Issue #1709 child 3: capability adoption registry",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-07-05T20:54:45Z"
   }
 }


### PR DESCRIPTION
## Summary

Adds the capability adoption registry module (#1709 child 3) that catalogs directive capabilities with conservative applicability heuristics and usage-signal metadata. The registry detects applicable-but-unused capabilities (e.g. decompose on large multi-file parallelizable work) and emits adoption signals gated on the value-feedback opt-in policy.

## Related Issues

Refs #1709

## Checklist

- [x] `/deft:change <name>` — N/A (<3 unrelated surfaces; scoped story xBRIEF covers the work)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (release-time batch move)
- [x] Tests pass locally (`TMPDIR=$(mktemp -d) task check`)

## Test plan

- [x] `pnpm -w exec vitest run packages/core/src/value/adoption-registry.test.ts`
- [x] `TMPDIR=$(mktemp -d) task check`
