### PR TITLE
feat: confirmation-gated feedback:file gap escalation (#1709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Value feedback opt-in gate: operators can enable value-attribution surfaces via a new typed policy block (default OFF), with per-feature sub-flags and a capability-cost disclosure printed before any change is persisted. Refs #1709.
+- **Gap escalation for directive consumers (#1709).** When value-feedback upstream prompts are enabled, `task feedback:file` drafts a deduped framework-gap issue for deftai/directive and files it only after explicit `--confirm`; the path no-ops inside the maintainer repo. Refs #1709.
 - **`task eval:health` aggregates static self-consistency into a versioned framework health score (#1703 Tier 0).** Maintainers can run one cheap, model-free command to probe encoding, link integrity, vBRIEF conformance, AGENTS.md freshness, and (on the framework source tree) content-manifest drift, plus a contradictory-gate detector that surfaces unsatisfiable nudges such as the #1694 wipCap case. Each run appends to a versioned ledger under `.eval/results/` so health can be trended across releases. Refs #1703.
 - **Version-eval operation telemetry (#1703).** vBRIEF file operations now emit per-operation metrics tagged with the directive version, covering schema validity, detection of non-spec keys added by agents, and whether an update rewrote the whole file or made a targeted change. Refs #1703.
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -92,6 +92,7 @@ Skills live under [`content/skills/`](./content/skills/) (installed as `.deft/co
 | [deft-directive-release](./content/skills/deft-directive-release/SKILL.md) | **Maintainer-only** (not a consumer-facing surface): cut a v0.X.Y release of the deft framework safely through the 8-phase pre-flight / rehearsal / draft / publish workflow. | `release`, `cut release`, `v0.X.Y`, `publish release` |
 | [deft-directive-write-skill](./content/skills/deft-directive-write-skill/SKILL.md) | Create a new deft skill with proper structure, RFC2119 notation, triggers, and progressive disclosure. | `write skill`, `create skill`, `new skill` |
 | [deft-directive-article-review](./content/skills/deft-directive-article-review/SKILL.md) | Evaluate an article, paper, or post for lessons that could improve directive, and optionally file GitHub issues. | `analyze this article`, `evaluate this article`, `what can we learn from this` |
+| [deft-directive-feedback](./content/skills/deft-directive-feedback/SKILL.md) | Batched session-end gap escalation: draft deduped framework-gap issues against deftai/directive and file upstream only after explicit confirmation. | `feedback`, `framework gap`, `file upstream`, `gap escalation`, `directive feedback` |
 
 The `welcome` / `onboard triage` phrase invokes `task triage:welcome --onboard` (N3 / #1143) rather than routing to a skill. The framework doc routing (which framework `.md` file to load for a given task) lives in the Task-Based Loading sections below.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -300,6 +300,11 @@ includes:
   eval:
     taskfile: ./tasks/eval.yml
     optional: true
+  # Gap escalation upstream filing (#1709 child 5). Exposes `task feedback:file` --
+  # confirmation-gated, deduped framework-gap issues for consumer projects.
+  feedback:
+    taskfile: ./tasks/feedback.yml
+    optional: true
   # Pack-slicing surface (#1283 design, #1294 pilot, ADR-001 Layer B). Exposes
   # `task packs:slice` (named-slice API), `task packs:render` (regenerate the
   # meta/lessons.md projection), and `task packs:verify-drift` (the drift gate,

--- a/content/.agents/skills/deft-directive-feedback/SKILL.md
+++ b/content/.agents/skills/deft-directive-feedback/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: deft-directive-feedback
+description: >-
+  Batched session-end gap escalation for directive consumers. Collects
+  friction/gap reports, drafts deduped framework-gap issues against
+  deftai/directive, and files upstream only after explicit operator
+  confirmation.
+---
+
+Read and follow: skills/deft-directive-feedback/SKILL.md

--- a/content/skills/deft-directive-feedback/SKILL.md
+++ b/content/skills/deft-directive-feedback/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: deft-directive-feedback
+description: >-
+  Batched session-end gap escalation for directive consumers. Collects
+  friction/gap reports, drafts deduped framework-gap issues against
+  deftai/directive, and files upstream only after explicit operator
+  confirmation. Gated on plan.policy.valueFeedback upstreamPrompt.
+---
+
+# Deft Directive Feedback -- gap escalation to upstream
+
+Conversational batched flow for filing framework gaps discovered during consumer sessions. Mirrors the confirmation gate from `deft-directive-article-review` -- the agent drafts and dedups; the operator approves before any upstream issue is created.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+## When to Use
+
+- Session end when `friction:*` ledger signals or operator reports a directive shortfall
+- Operator says "file this upstream", "report a framework gap", or "directive feedback"
+- After enabling `plan.policy.valueFeedback.upstreamPrompt` during onboarding
+
+## Preconditions
+
+- ! Run only from a **consumer project** -- the filing path no-ops inside the directive maintainer repo
+- ! `plan.policy.valueFeedback.upstreamPrompt` MUST be ON (`task policy:show --field=valueFeedback`)
+- ⊗ File upstream issues without explicit operator confirmation
+- ⊗ Invoke when `valueFeedback.enabled` is OFF
+
+## Phase 1 -- Collect (batched)
+
+- ! Gather concrete gap reports from the session: what was expected, what happened, and minimal reproduction context
+- ! Batch multiple friction items into one upstream issue when they share a root cause; otherwise prepare separate drafts
+- ~ Prefer attributed phrasing ("encoding gate blocked a valid file") over vague quality claims
+
+## Phase 2 -- Draft + dedup
+
+- ! For each candidate report, run a dry draft:
+
+```bash
+task feedback:file -- --summary "<one-line summary>" --context "<session context>" --expected "<expected>" --actual "<actual>" --notes "<optional>"
+```
+
+- ! Read the printed draft title/body with the operator before proceeding
+- ! If the command reports a duplicate open issue, STOP and link the existing issue instead of filing again
+- ⊗ Proceed past a duplicate-detection block without operator override
+
+## Phase 3 -- Confirm + file
+
+- ! Present the final draft and ask for explicit yes/no confirmation
+- ! Only after approval, re-run with `--confirm`:
+
+```bash
+task feedback:file -- --summary "<one-line summary>" --context "<session context>" --expected "<expected>" --actual "<actual>" --confirm
+```
+
+- ! Print the filed issue URL to the operator
+- ⊗ Use `Closes`/`Fixes`/`Resolves` in the upstream body -- use `Refs #1709` only
+
+## Phase 4 -- Handoff
+
+- ~ Record the upstream issue URL in the session handoff or continue checkpoint if the operator tracks follow-ups locally
+- ~ Return to the prior workflow; gap escalation does not block story completion
+
+## Anti-Patterns
+
+- ⊗ Filing from the maintainer framework repo (consumer-only guard)
+- ⊗ Skipping dedup review when the command reports an existing open issue
+- ⊗ Treating `--confirm` as implicit from broad session approval -- require an explicit filing confirmation step

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -192,6 +192,7 @@ export const CORE_MODULE_VERBS = [
   "scope-decompose",
   "changelog-resolve-unreleased",
   "architecture-preflight-sor",
+  "feedback-file",
 ] as const;
 
 /** Colon aliases for triage-actions (mirrors cli-router SUBCOMMAND_ROUTES). */
@@ -270,6 +271,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "project:export-spec": "export-spec",
   doctor: "doctor",
   "eval:health": "eval-health",
+  "feedback:file": "feedback-file",
   build: "framework-commands",
   "setup:ghx": "setup-ghx",
 };
@@ -2641,6 +2643,10 @@ async function loadCoreModuleHandler(verb: string, io: DispatchIo): Promise<Comm
         "@deftai/directive-core/dist/architecture/sor-preflight.js"
       );
       return architecturePreflightSorMain;
+    }
+    case "feedback-file": {
+      const { mainEntry } = await import("@deftai/directive-core/dist/value/feedback-file.js");
+      return mainEntry;
     }
     default:
       throw new Error(`unknown core verb: ${verb}`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,10 @@
       "types": "./dist/eval/crud-telemetry.d.ts",
       "default": "./dist/eval/crud-telemetry.js"
     },
+    "./value/feedback-file": {
+      "types": "./dist/value/feedback-file.d.ts",
+      "default": "./dist/value/feedback-file.js"
+    },
     "./triage": {
       "types": "./dist/triage/index.d.ts",
       "default": "./dist/triage/index.js"

--- a/packages/core/src/value/feedback-file.test.ts
+++ b/packages/core/src/value/feedback-file.test.ts
@@ -1,0 +1,233 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildFrameworkGapBody,
+  buildFrameworkGapTitle,
+  FRAMEWORK_GAP_TITLE_PREFIX,
+  feedbackFileMain,
+  findDuplicateIssue,
+  isMaintainerFrameworkRepo,
+  normalizeForDedup,
+  parseFeedbackFileArgs,
+  runFeedbackFile,
+} from "./feedback-file.js";
+
+function makeConsumerProject(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-feedback-consumer-"));
+  mkdirSync(join(root, "xbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    JSON.stringify(
+      {
+        plan: {
+          policy: {
+            valueFeedback: {
+              enabled: true,
+              emitEvents: true,
+              sessionLine: true,
+              upstreamPrompt: true,
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  return root;
+}
+
+describe("feedback-file helpers", () => {
+  it("builds a prefixed framework-gap title", () => {
+    expect(buildFrameworkGapTitle("Missing decompose hint")).toBe(
+      `${FRAMEWORK_GAP_TITLE_PREFIX} Missing decompose hint`,
+    );
+    expect(buildFrameworkGapTitle("[framework-gap] Already tagged")).toBe(
+      "[framework-gap] Already tagged",
+    );
+  });
+
+  it("renders structured body sections", () => {
+    const body = buildFrameworkGapBody({
+      summary: "Gate false positive",
+      context: "During pre-PR",
+      expected: "Pass",
+      actual: "Failed on encoding",
+    });
+    expect(body).toContain("## Summary");
+    expect(body).toContain("Gate false positive");
+    expect(body).toContain("During pre-PR");
+    expect(body).toContain("Refs #1709");
+  });
+
+  it("normalizes titles for dedup", () => {
+    expect(normalizeForDedup("[framework-gap] Hello World")).toBe("hello world");
+    expect(normalizeForDedup("  [FRAMEWORK-GAP]  Hello!!!  ")).toBe("hello");
+  });
+});
+
+describe("findDuplicateIssue", () => {
+  it("returns a match when normalized titles align", () => {
+    const seams = {
+      runGhApiFn: vi.fn(() => ({
+        returncode: 0,
+        stdout: JSON.stringify([
+          {
+            title: "[framework-gap] Missing skill coverage",
+            html_url: "https://github.com/deftai/directive/issues/42",
+          },
+        ]),
+        stderr: "",
+      })),
+    };
+    const match = findDuplicateIssue(
+      "deftai/directive",
+      buildFrameworkGapTitle("Missing skill coverage"),
+      seams,
+    );
+    expect(match?.url).toBe("https://github.com/deftai/directive/issues/42");
+  });
+});
+
+describe("runFeedbackFile gates", () => {
+  it("rejects filing without confirmation", () => {
+    const root = makeConsumerProject();
+    const restCreateIssue = vi.fn();
+    try {
+      const result = runFeedbackFile({
+        summary: "Needs clearer onboarding",
+        projectRoot: root,
+        confirm: false,
+        seams: {
+          runGhApiFn: vi.fn(() => ({ returncode: 0, stdout: "[]", stderr: "" })),
+        },
+      });
+      expect(result.outcome).toBe("draft");
+      expect(result.exitCode).toBe(1);
+      expect(result.message).toContain("Re-run with --confirm");
+      expect(restCreateIssue).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips filing inside the maintainer framework repo", () => {
+    const repoRoot = process.cwd();
+    expect(isMaintainerFrameworkRepo(repoRoot)).toBe(true);
+    const result = runFeedbackFile({
+      summary: "Dogfood gap",
+      projectRoot: repoRoot,
+      confirm: true,
+    });
+    expect(result.outcome).toBe("skipped-maintainer");
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toContain("Skipped");
+  });
+
+  it("blocks duplicate upstream issues", () => {
+    const root = makeConsumerProject();
+    try {
+      const result = runFeedbackFile({
+        summary: "Duplicate gap",
+        projectRoot: root,
+        confirm: true,
+        seams: {
+          runGhApiFn: vi.fn(() => ({
+            returncode: 0,
+            stdout: JSON.stringify([
+              {
+                title: "[framework-gap] Duplicate gap",
+                html_url: "https://github.com/deftai/directive/issues/99",
+              },
+            ]),
+            stderr: "",
+          })),
+        },
+      });
+      expect(result.outcome).toBe("blocked-duplicate");
+      expect(result.exitCode).toBe(1);
+      expect(result.duplicateUrl).toContain("/issues/99");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("files upstream only after explicit confirmation", () => {
+    const root = makeConsumerProject();
+    const createPayload = vi.fn(() => ({
+      returncode: 0,
+      stdout: JSON.stringify({
+        html_url: "https://github.com/deftai/directive/issues/1001",
+        number: 1001,
+      }),
+      stderr: "",
+    }));
+    try {
+      const result = runFeedbackFile({
+        summary: "Confirmed gap",
+        projectRoot: root,
+        confirm: true,
+        seams: {
+          runGhApiFn: (args: readonly string[]) => {
+            if (args.includes("POST")) {
+              return createPayload();
+            }
+            return { returncode: 0, stdout: "[]", stderr: "" };
+          },
+        },
+      });
+      expect(result.outcome).toBe("filed");
+      expect(result.exitCode).toBe(0);
+      expect(result.issueUrl).toBe("https://github.com/deftai/directive/issues/1001");
+      expect(createPayload).toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when upstreamPrompt policy path is OFF", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-feedback-off-"));
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({
+        plan: { policy: { valueFeedback: { enabled: true, upstreamPrompt: false } } },
+      }),
+      "utf8",
+    );
+    try {
+      const result = runFeedbackFile({
+        summary: "Policy blocked",
+        projectRoot: root,
+        confirm: true,
+      });
+      expect(result.outcome).toBe("blocked-policy");
+      expect(result.exitCode).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("feedback-file CLI", () => {
+  it("parses positional summary and flags", () => {
+    const parsed = parseFeedbackFileArgs([
+      "--context",
+      "ctx",
+      "--confirm",
+      "My",
+      "summary",
+      "here",
+    ]);
+    expect(parsed.summary).toBe("My summary here");
+    expect(parsed.context).toBe("ctx");
+    expect(parsed.confirm).toBe(true);
+  });
+
+  it("returns config error when summary missing", () => {
+    expect(feedbackFileMain([])).toBe(2);
+  });
+});

--- a/packages/core/src/value/feedback-file.test.ts
+++ b/packages/core/src/value/feedback-file.test.ts
@@ -230,4 +230,70 @@ describe("feedback-file CLI", () => {
   it("returns config error when summary missing", () => {
     expect(feedbackFileMain([])).toBe(2);
   });
+
+  it("returns error-network when duplicate search fails", () => {
+    const root = makeConsumerProject();
+    try {
+      const result = runFeedbackFile({
+        summary: "Network gap",
+        projectRoot: root,
+        confirm: false,
+        seams: {
+          runGhApiFn: () => ({
+            returncode: 1,
+            stdout: "",
+            stderr: "rate limit",
+          }),
+        },
+      });
+      expect(result.outcome).toBe("error-network");
+      expect(result.exitCode).toBe(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error-network when filing fails after confirm", () => {
+    const root = makeConsumerProject();
+    try {
+      const result = runFeedbackFile({
+        summary: "Filing gap",
+        projectRoot: root,
+        confirm: true,
+        seams: {
+          runGhApiFn: (args: readonly string[]) => {
+            if (args.includes("POST")) {
+              return { returncode: 1, stdout: "", stderr: "forbidden" };
+            }
+            return { returncode: 0, stdout: "[]", stderr: "" };
+          },
+        },
+      });
+      expect(result.outcome).toBe("error-network");
+      expect(result.exitCode).toBe(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("runs duplicate detection during dry-run preview", () => {
+    const root = makeConsumerProject();
+    const listCalls = vi.fn(() => ({
+      returncode: 0,
+      stdout: JSON.stringify([]),
+      stderr: "",
+    }));
+    try {
+      runFeedbackFile({
+        summary: "Dry preview",
+        projectRoot: root,
+        dryRun: true,
+        confirm: false,
+        seams: { runGhApiFn: listCalls },
+      });
+      expect(listCalls).toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/src/value/feedback-file.ts
+++ b/packages/core/src/value/feedback-file.ts
@@ -1,0 +1,406 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { isFrameworkRepoRoot } from "../check/orchestrator.js";
+import { isValueFeedbackPathAllowed, resolveValueFeedback } from "../policy/value-feedback.js";
+import { type GhRestSeams, restCreateIssue, restIssueListPaginated } from "../scm/gh-rest.js";
+import { resolveProjectRoot } from "../scope/project-context.js";
+
+export const DEFAULT_UPSTREAM_REPO = "deftai/directive";
+export const FRAMEWORK_GAP_TITLE_PREFIX = "[framework-gap]";
+
+export type FeedbackFileOutcome =
+  | "draft"
+  | "filed"
+  | "skipped-maintainer"
+  | "blocked-policy"
+  | "blocked-duplicate"
+  | "blocked-no-confirm";
+
+export interface FeedbackGapInput {
+  readonly summary: string;
+  readonly context?: string;
+  readonly expected?: string;
+  readonly actual?: string;
+  readonly sessionNotes?: string;
+}
+
+export interface FeedbackFileOptions extends FeedbackGapInput {
+  readonly projectRoot?: string | null;
+  readonly repo?: string;
+  readonly confirm?: boolean;
+  readonly dryRun?: boolean;
+  readonly json?: boolean;
+  readonly seams?: GhRestSeams;
+}
+
+export interface FeedbackFileResult {
+  readonly outcome: FeedbackFileOutcome;
+  readonly exitCode: 0 | 1 | 2;
+  readonly title: string;
+  readonly body: string;
+  readonly repo: string;
+  readonly issueUrl?: string | null;
+  readonly duplicateUrl?: string | null;
+  readonly message: string;
+}
+
+function sanitizeOneLine(value: string): string {
+  return value.replace(/\r?\n/g, " ").trim();
+}
+
+function sectionOrPlaceholder(value: string | undefined, placeholder: string): string {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : placeholder;
+}
+
+/** True when the resolved project root is the directive maintainer source checkout. */
+export function isMaintainerFrameworkRepo(projectRoot: string): boolean {
+  return isFrameworkRepoRoot(resolve(projectRoot));
+}
+
+/** Normalize a title for duplicate comparison (#1709). */
+export function normalizeForDedup(title: string): string {
+  return title
+    .trim()
+    .replace(/^\[framework-gap\]\s*/i, "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+/** Build the upstream issue title for a framework-gap report. */
+export function buildFrameworkGapTitle(summary: string): string {
+  const clean = sanitizeOneLine(summary);
+  if (clean.toLowerCase().startsWith(FRAMEWORK_GAP_TITLE_PREFIX.toLowerCase())) {
+    return clean;
+  }
+  return `${FRAMEWORK_GAP_TITLE_PREFIX} ${clean}`;
+}
+
+/** Build the structured framework-gap issue body. */
+export function buildFrameworkGapBody(input: FeedbackGapInput): string {
+  const summary = sanitizeOneLine(input.summary);
+  const lines = [
+    "## Summary",
+    "",
+    summary,
+    "",
+    "## Context",
+    "",
+    sectionOrPlaceholder(input.context, "_(not provided)_"),
+    "",
+    "## Expected behavior",
+    "",
+    sectionOrPlaceholder(input.expected, "_(not provided)_"),
+    "",
+    "## Actual behavior / gap",
+    "",
+    sectionOrPlaceholder(input.actual, summary),
+    "",
+    "## Session notes",
+    "",
+    sectionOrPlaceholder(input.sessionNotes, "_(not provided)_"),
+    "",
+    "---",
+    "_Filed via `task feedback:file` from a directive consumer project (Refs #1709 value-feedback gap escalation)._",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export interface DuplicateMatch {
+  readonly url: string;
+  readonly title: string;
+}
+
+/** Search open upstream issues for a normalized title match. */
+export function findDuplicateIssue(
+  repo: string,
+  title: string,
+  seams: GhRestSeams = {},
+): DuplicateMatch | null {
+  const needle = normalizeForDedup(title);
+  if (needle.length === 0) {
+    return null;
+  }
+  const issues = restIssueListPaginated(
+    repo,
+    { state: "open", limit: 100, excludePulls: true },
+    seams,
+  );
+  for (const issue of issues) {
+    const issueTitle = typeof issue.title === "string" ? issue.title : "";
+    if (normalizeForDedup(issueTitle) === needle) {
+      const url = typeof issue.html_url === "string" ? issue.html_url : "";
+      if (url.length > 0) {
+        return { url, title: issueTitle };
+      }
+    }
+  }
+  return null;
+}
+
+function resolveRepo(options: FeedbackFileOptions): string {
+  const explicit = options.repo?.trim();
+  return explicit && explicit.length > 0 ? explicit : DEFAULT_UPSTREAM_REPO;
+}
+
+function isNoNetwork(dryRun: boolean): boolean {
+  return dryRun || process.env.DEFT_NO_NETWORK === "1";
+}
+
+function buildConfirmationPrompt(title: string, body: string): string {
+  return (
+    "Draft framework-gap issue (not filed yet):\n\n" +
+    `Title: ${title}\n\n` +
+    `${body}\n` +
+    "Re-run with --confirm to file this issue upstream after reviewing the draft.\n"
+  );
+}
+
+/** Core feedback:file workflow (#1709 gap escalation). */
+export function runFeedbackFile(options: FeedbackFileOptions): FeedbackFileResult {
+  const summary = sanitizeOneLine(options.summary);
+  if (summary.length === 0) {
+    return {
+      outcome: "blocked-no-confirm",
+      exitCode: 2,
+      title: "",
+      body: "",
+      repo: resolveRepo(options),
+      message: "Error: summary is required (pass --summary or a positional argument).\n",
+    };
+  }
+
+  const projectRootRaw = resolveProjectRoot(options.projectRoot ?? undefined);
+  if (projectRootRaw === null) {
+    return {
+      outcome: "blocked-no-confirm",
+      exitCode: 2,
+      title: buildFrameworkGapTitle(summary),
+      body: buildFrameworkGapBody(options),
+      repo: resolveRepo(options),
+      message:
+        "Error: could not resolve project root. Pass --project-root or run from a directive consumer repo.\n",
+    };
+  }
+  const projectRoot = resolve(projectRootRaw);
+
+  const repo = resolveRepo(options);
+  const title = buildFrameworkGapTitle(summary);
+  const body = buildFrameworkGapBody(options);
+
+  if (isMaintainerFrameworkRepo(projectRoot)) {
+    return {
+      outcome: "skipped-maintainer",
+      exitCode: 0,
+      title,
+      body,
+      repo,
+      message:
+        "[deft feedback] Skipped: maintainer framework repo detected; gap escalation targets consumer projects only.\n",
+    };
+  }
+
+  const policy = resolveValueFeedback(projectRoot);
+  if (!isValueFeedbackPathAllowed("upstreamPrompt", policy)) {
+    return {
+      outcome: "blocked-policy",
+      exitCode: 1,
+      title,
+      body,
+      repo,
+      message:
+        "[deft feedback] Blocked: plan.policy.valueFeedback upstreamPrompt is OFF. " +
+        "Enable with `task policy:enable-value-feedback -- --confirm` and set upstreamPrompt, " +
+        "or inspect via `task policy:show --field=valueFeedback`.\n",
+    };
+  }
+
+  const noNetwork = isNoNetwork(options.dryRun ?? false);
+  const seams = options.seams ?? {};
+
+  if (!noNetwork) {
+    const duplicate = findDuplicateIssue(repo, title, seams);
+    if (duplicate !== null) {
+      return {
+        outcome: "blocked-duplicate",
+        exitCode: 1,
+        title,
+        body,
+        repo,
+        duplicateUrl: duplicate.url,
+        message:
+          `[deft feedback] Duplicate detected: open issue ${duplicate.url} ` +
+          `("${duplicate.title}") matches this report.\n`,
+      };
+    }
+  }
+
+  if (!options.confirm) {
+    return {
+      outcome: "draft",
+      exitCode: 1,
+      title,
+      body,
+      repo,
+      message: buildConfirmationPrompt(title, body),
+    };
+  }
+
+  if (noNetwork) {
+    return {
+      outcome: "draft",
+      exitCode: 0,
+      title,
+      body,
+      repo,
+      message: `[deft feedback] Dry run: would file upstream issue in ${repo}.\n${buildConfirmationPrompt(title, body)}`,
+    };
+  }
+
+  const created = restCreateIssue(repo, title, body, [], seams);
+  const issueUrl =
+    typeof created.html_url === "string" && created.html_url.length > 0 ? created.html_url : null;
+  const number = created.number;
+  const urlLine =
+    issueUrl ?? (typeof number === "number" ? `https://github.com/${repo}/issues/${number}` : null);
+
+  return {
+    outcome: "filed",
+    exitCode: 0,
+    title,
+    body,
+    repo,
+    issueUrl: urlLine,
+    message:
+      urlLine !== null
+        ? `[deft feedback] Filed upstream issue: ${urlLine}\n`
+        : "[deft feedback] Issue filed upstream (URL unavailable in API response).\n",
+  };
+}
+
+export interface FeedbackFileCliArgs {
+  summary?: string;
+  context?: string;
+  expected?: string;
+  actual?: string;
+  sessionNotes?: string;
+  confirm?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+  repo?: string;
+  projectRoot?: string;
+  error?: string;
+}
+
+/** Parse argv for feedback:file. */
+export function parseFeedbackFileArgs(argv: readonly string[]): FeedbackFileCliArgs {
+  const out: FeedbackFileCliArgs = {};
+  const positionals: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i] as string;
+    if (arg === "--confirm") out.confirm = true;
+    else if (arg === "--dry-run") out.dryRun = true;
+    else if (arg === "--json") out.json = true;
+    else if (arg === "--summary") {
+      out.summary = argv[++i];
+    } else if (arg?.startsWith("--summary=")) {
+      out.summary = arg.slice("--summary=".length);
+    } else if (arg === "--context") {
+      out.context = argv[++i];
+    } else if (arg?.startsWith("--context=")) {
+      out.context = arg.slice("--context=".length);
+    } else if (arg === "--expected") {
+      out.expected = argv[++i];
+    } else if (arg?.startsWith("--expected=")) {
+      out.expected = arg.slice("--expected=".length);
+    } else if (arg === "--actual") {
+      out.actual = argv[++i];
+    } else if (arg?.startsWith("--actual=")) {
+      out.actual = arg.slice("--actual=".length);
+    } else if (arg === "--notes" || arg === "--session-notes") {
+      out.sessionNotes = argv[++i];
+    } else if (arg?.startsWith("--notes=")) {
+      out.sessionNotes = arg.slice("--notes=".length);
+    } else if (arg?.startsWith("--session-notes=")) {
+      out.sessionNotes = arg.slice("--session-notes=".length);
+    } else if (arg === "--repo") {
+      out.repo = argv[++i];
+    } else if (arg?.startsWith("--repo=")) {
+      out.repo = arg.slice("--repo=".length);
+    } else if (arg === "--project-root") {
+      out.projectRoot = argv[++i];
+    } else if (arg?.startsWith("--project-root=")) {
+      out.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg.startsWith("-")) {
+      return { ...out, error: `unrecognized argument: ${arg}` };
+    } else {
+      positionals.push(arg);
+    }
+  }
+  if ((out.summary === undefined || out.summary.trim().length === 0) && positionals.length > 0) {
+    out.summary = positionals.join(" ");
+  }
+  return out;
+}
+
+/** CLI entry for feedback:file. */
+export function feedbackFileMain(argv: readonly string[]): number {
+  const args = parseFeedbackFileArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`feedback:file: ${args.error}\n`);
+    return 2;
+  }
+
+  const result = runFeedbackFile({
+    summary: args.summary ?? "",
+    context: args.context,
+    expected: args.expected,
+    actual: args.actual,
+    sessionNotes: args.sessionNotes,
+    confirm: args.confirm,
+    dryRun: args.dryRun,
+    json: args.json,
+    repo: args.repo,
+    projectRoot: args.projectRoot,
+  });
+
+  if (args.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          outcome: result.outcome,
+          exit_code: result.exitCode,
+          title: result.title,
+          body: result.body,
+          repo: result.repo,
+          issue_url: result.issueUrl ?? null,
+          duplicate_url: result.duplicateUrl ?? null,
+          message: result.message.trim(),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    process.stdout.write(result.message);
+  }
+
+  return result.exitCode;
+}
+
+/** CLI module entrypoint for dispatch (#1709). */
+export function mainEntry(argv: string[] = process.argv.slice(2)): number {
+  return feedbackFileMain(argv);
+}
+
+/** Convenience probe used in tests for project-root sentinel presence. */
+export function projectRootLooksLikeConsumer(projectRoot: string): boolean {
+  const root = resolve(projectRoot);
+  return (
+    existsSync(resolve(root, "xbrief")) ||
+    existsSync(resolve(root, "vbrief")) ||
+    existsSync(resolve(root, ".deft"))
+  );
+}

--- a/packages/core/src/value/feedback-file.ts
+++ b/packages/core/src/value/feedback-file.ts
@@ -2,7 +2,12 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { isFrameworkRepoRoot } from "../check/orchestrator.js";
 import { isValueFeedbackPathAllowed, resolveValueFeedback } from "../policy/value-feedback.js";
-import { type GhRestSeams, restCreateIssue, restIssueListPaginated } from "../scm/gh-rest.js";
+import {
+  GhRestError,
+  type GhRestSeams,
+  restCreateIssue,
+  restIssueListPaginated,
+} from "../scm/gh-rest.js";
 import { resolveProjectRoot } from "../scope/project-context.js";
 
 export const DEFAULT_UPSTREAM_REPO = "deftai/directive";
@@ -14,7 +19,10 @@ export type FeedbackFileOutcome =
   | "skipped-maintainer"
   | "blocked-policy"
   | "blocked-duplicate"
-  | "blocked-no-confirm";
+  | "blocked-no-confirm"
+  | "error-bad-args"
+  | "error-config"
+  | "error-network";
 
 export interface FeedbackGapInput {
   readonly summary: string;
@@ -145,8 +153,13 @@ function resolveRepo(options: FeedbackFileOptions): string {
   return explicit && explicit.length > 0 ? explicit : DEFAULT_UPSTREAM_REPO;
 }
 
-function isNoNetwork(dryRun: boolean): boolean {
-  return dryRun || process.env.DEFT_NO_NETWORK === "1";
+function isOffline(): boolean {
+  return process.env.DEFT_NO_NETWORK === "1";
+}
+
+function networkErrorMessage(prefix: string, err: unknown): string {
+  const detail = err instanceof GhRestError ? err.message : String(err);
+  return `[deft feedback] ${prefix}: ${detail}\n`;
 }
 
 function buildConfirmationPrompt(title: string, body: string): string {
@@ -163,7 +176,7 @@ export function runFeedbackFile(options: FeedbackFileOptions): FeedbackFileResul
   const summary = sanitizeOneLine(options.summary);
   if (summary.length === 0) {
     return {
-      outcome: "blocked-no-confirm",
+      outcome: "error-bad-args",
       exitCode: 2,
       title: "",
       body: "",
@@ -175,7 +188,7 @@ export function runFeedbackFile(options: FeedbackFileOptions): FeedbackFileResul
   const projectRootRaw = resolveProjectRoot(options.projectRoot ?? undefined);
   if (projectRootRaw === null) {
     return {
-      outcome: "blocked-no-confirm",
+      outcome: "error-config",
       exitCode: 2,
       title: buildFrameworkGapTitle(summary),
       body: buildFrameworkGapBody(options),
@@ -217,24 +230,39 @@ export function runFeedbackFile(options: FeedbackFileOptions): FeedbackFileResul
     };
   }
 
-  const noNetwork = isNoNetwork(options.dryRun ?? false);
+  const offline = isOffline();
+  const dryRun = options.dryRun ?? false;
   const seams = options.seams ?? {};
+  let dedupSkippedNote = "";
 
-  if (!noNetwork) {
-    const duplicate = findDuplicateIssue(repo, title, seams);
-    if (duplicate !== null) {
+  if (!offline) {
+    try {
+      const duplicate = findDuplicateIssue(repo, title, seams);
+      if (duplicate !== null) {
+        return {
+          outcome: "blocked-duplicate",
+          exitCode: 1,
+          title,
+          body,
+          repo,
+          duplicateUrl: duplicate.url,
+          message:
+            `[deft feedback] Duplicate detected: open issue ${duplicate.url} ` +
+            `("${duplicate.title}") matches this report.\n`,
+        };
+      }
+    } catch (err: unknown) {
       return {
-        outcome: "blocked-duplicate",
-        exitCode: 1,
+        outcome: "error-network",
+        exitCode: 2,
         title,
         body,
         repo,
-        duplicateUrl: duplicate.url,
-        message:
-          `[deft feedback] Duplicate detected: open issue ${duplicate.url} ` +
-          `("${duplicate.title}") matches this report.\n`,
+        message: networkErrorMessage("Duplicate search failed", err),
       };
     }
+  } else {
+    dedupSkippedNote = "[deft feedback] Note: duplicate detection skipped (DEFT_NO_NETWORK=1).\n\n";
   }
 
   if (!options.confirm) {
@@ -244,40 +272,54 @@ export function runFeedbackFile(options: FeedbackFileOptions): FeedbackFileResul
       title,
       body,
       repo,
-      message: buildConfirmationPrompt(title, body),
+      message: `${dedupSkippedNote}${buildConfirmationPrompt(title, body)}`,
     };
   }
 
-  if (noNetwork) {
+  if (dryRun || offline) {
     return {
       outcome: "draft",
       exitCode: 0,
       title,
       body,
       repo,
-      message: `[deft feedback] Dry run: would file upstream issue in ${repo}.\n${buildConfirmationPrompt(title, body)}`,
+      message:
+        `${dedupSkippedNote}[deft feedback] Dry run: would file upstream issue in ${repo}.\n` +
+        `${buildConfirmationPrompt(title, body)}`,
     };
   }
 
-  const created = restCreateIssue(repo, title, body, [], seams);
-  const issueUrl =
-    typeof created.html_url === "string" && created.html_url.length > 0 ? created.html_url : null;
-  const number = created.number;
-  const urlLine =
-    issueUrl ?? (typeof number === "number" ? `https://github.com/${repo}/issues/${number}` : null);
+  try {
+    const created = restCreateIssue(repo, title, body, [], seams);
+    const issueUrl =
+      typeof created.html_url === "string" && created.html_url.length > 0 ? created.html_url : null;
+    const number = created.number;
+    const urlLine =
+      issueUrl ??
+      (typeof number === "number" ? `https://github.com/${repo}/issues/${number}` : null);
 
-  return {
-    outcome: "filed",
-    exitCode: 0,
-    title,
-    body,
-    repo,
-    issueUrl: urlLine,
-    message:
-      urlLine !== null
-        ? `[deft feedback] Filed upstream issue: ${urlLine}\n`
-        : "[deft feedback] Issue filed upstream (URL unavailable in API response).\n",
-  };
+    return {
+      outcome: "filed",
+      exitCode: 0,
+      title,
+      body,
+      repo,
+      issueUrl: urlLine,
+      message:
+        urlLine !== null
+          ? `[deft feedback] Filed upstream issue: ${urlLine}\n`
+          : "[deft feedback] Issue filed upstream (URL unavailable in API response).\n",
+    };
+  } catch (err: unknown) {
+    return {
+      outcome: "error-network",
+      exitCode: 2,
+      title,
+      body,
+      repo,
+      message: networkErrorMessage("Upstream filing failed", err),
+    };
+  }
 }
 
 export interface FeedbackFileCliArgs {

--- a/tasks/feedback.yml
+++ b/tasks/feedback.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+  file:
+    desc: "Draft or file a deduped framework-gap issue upstream (#1709). -- task feedback:file -- [--summary TEXT | positional] [--context ...] [--confirm] [--dry-run] [--json]"
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'feedback:file --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/xbrief/completed/2026-07-05-1709-gap-escalation.xbrief.json
+++ b/xbrief/completed/2026-07-05-1709-gap-escalation.xbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1709-gap-escalation",
     "title": "Gap escalation to upstream feedback (feedback:file + skill)",
-    "status": "pending",
+    "status": "completed",
     "narratives": {
       "Description": "Add a feedback:file command that drafts and dedups a framework-gap issue against deftai/directive, gated behind a confirmation prompt and consumer-only guards. Add a deft-directive-feedback skill for the conversational batched session-end flow.",
       "ImplementationPlan": "- Add a feedback module that builds the gap template, dedups against existing upstream issues via the scm shim, and files only after explicit confirmation.\n- Guard against filing inside the maintainer repo and add tests asserting no issue is created without confirmation.",
@@ -63,7 +63,9 @@
         "size": "L",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-07-05T20:56:36Z",
+      "capacityBucket": "agentic-debt"
     },
     "references": [
       {
@@ -78,6 +80,7 @@
         "title": "Issue #1709 child 5: gap escalation to upstream",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-07-05T20:56:36Z"
   }
 }


### PR DESCRIPTION
## Summary

- Add `task feedback:file` for consumer projects to draft deduped framework-gap issues against `deftai/directive`, gated on `plan.policy.valueFeedback.upstreamPrompt` and explicit `--confirm`.
- No-op inside the maintainer framework repo; duplicate detection blocks filing when a matching open upstream issue exists.
- Add `deft-directive-feedback` skill for the batched session-end conversational flow.

Refs #1709

## Test plan

- [x] `pnpm exec vitest run packages/core/src/value/feedback-file.test.ts`
- [x] `TMPDIR=$(mktemp -d) task check`
- [x] Manual: `task feedback:file -- "test gap"` prints draft without filing; maintainer repo skips with consumer-only message

## PR checklist

- [x] Scope xBRIEF covers all changes (`xbrief/completed/2026-07-05-1709-gap-escalation.xbrief.json`)
- [x] CHANGELOG `[Unreleased]` entry added
- [x] `task check` green
- [x] Feature branch (not master)
- [x] Uses `Refs #1709` (umbrella stays open)

Made with [Cursor](https://cursor.com)