### PR TITLE
feat: budgeted value-awareness readbacks (session line + value:show)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Budgeted value-awareness readbacks: when value feedback is enabled, session start can show one attributed line from the local ledger (silent when empty), and `task value:show` reports attribution trends on demand — also available as `task triage:metrics`. Refs #1709.
 - Capability adoption registry: directive can now detect when relevant capabilities (planning, cost, decompose, swarm, pre-PR, and others) were applicable but unused, using conservative heuristics that suppress nudges for small or non-parallelizable work. Signals are gated on the value-feedback opt-in policy. Refs #1709.
 - Value feedback opt-in gate: operators can enable value-attribution surfaces via a new typed policy block (default OFF), with per-feature sub-flags and a capability-cost disclosure printed before any change is persisted. Refs #1709.
 - **Attribution ledger for value feedback (#1709).** When value feedback is enabled, directive records value, bypass, adoption, and friction signals to the local events ledger, with branch and WIP-cap gates wired as the first high-signal sources. Refs #1709.

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -195,6 +195,7 @@ export const CORE_MODULE_VERBS = [
   "changelog-resolve-unreleased",
   "architecture-preflight-sor",
   "feedback-file",
+  "value-readback",
 ] as const;
 
 /** Colon aliases for triage-actions (mirrors cli-router SUBCOMMAND_ROUTES). */
@@ -274,6 +275,8 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   doctor: "doctor",
   "eval:health": "eval-health",
   "feedback:file": "feedback-file",
+  "value:show": "value-readback",
+  "triage:metrics": "value-readback",
   "eval:run": "eval-run",
   "eval:report": "eval-report",
   build: "framework-commands",
@@ -2650,6 +2653,10 @@ async function loadCoreModuleHandler(verb: string, io: DispatchIo): Promise<Comm
     }
     case "feedback-file": {
       const { mainEntry } = await import("@deftai/directive-core/dist/value/feedback-file.js");
+      return mainEntry;
+    }
+    case "value-readback": {
+      const { mainEntry } = await import("@deftai/directive-core/dist/value/readback.js");
       return mainEntry;
     }
     default:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/value/feedback-file.d.ts",
       "default": "./dist/value/feedback-file.js"
     },
+    "./value/readback": {
+      "types": "./dist/value/readback.d.ts",
+      "default": "./dist/value/readback.js"
+    },
     "./events": {
       "types": "./dist/events/attribution-ledger.d.ts",
       "default": "./dist/events/attribution-ledger.js"

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -365,10 +365,14 @@ export function runSessionStart(
     lines.push(MIGRATE_COMPLETION_NUDGE);
   }
 
-  emitSessionValueReadback(projectRoot, {
-    output: (line) => lines.push(line),
-    writeHistory: true,
-  });
+  try {
+    emitSessionValueReadback(projectRoot, {
+      output: (line) => lines.push(line),
+      writeHistory: options.writeHistory !== false,
+    });
+  } catch {
+    // observability only — session start must not abort on transient readback I/O
+  }
 
   const payload = newRitualStatePayload({
     sessionId: (options.newSessionId ?? randomUUID)(),

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -5,6 +5,7 @@ import { disclosureLine } from "../policy/disclosure.js";
 import { resolvePolicy } from "../policy/resolve.js";
 import { runDefaultMode } from "../triage/welcome/default-mode.js";
 import { type ResolveUserMdResult, resolveUserMdPath } from "../user-config/resolve-user-md.js";
+import { emitSessionValueReadback } from "../value/readback.js";
 import { verifyRequiredTools } from "../verify-env/verify-tools.js";
 import type { GitRunner } from "./git.js";
 import { defaultGitRunner, gitHead, worktreePath } from "./git.js";
@@ -363,6 +364,11 @@ export function runSessionStart(
   if (!runningInsideDeftRepo(projectRoot) && shouldEmitMigrateNudge(projectRoot)) {
     lines.push(MIGRATE_COMPLETION_NUDGE);
   }
+
+  emitSessionValueReadback(projectRoot, {
+    output: (line) => lines.push(line),
+    writeHistory: true,
+  });
 
   const payload = newRitualStatePayload({
     sessionId: (options.newSessionId ?? randomUUID)(),

--- a/packages/core/src/value/readback.test.ts
+++ b/packages/core/src/value/readback.test.ts
@@ -7,6 +7,7 @@ import {
   computeValueShowTrend,
   emitSessionValueReadback,
   formatAttributedSessionLine,
+  parseValueShowArgs,
   parseWindowMs,
   readAttributionEvents,
   renderSessionReadback,
@@ -252,6 +253,12 @@ describe("parseWindowMs", () => {
   });
 });
 
+describe("parseValueShowArgs", () => {
+  it("errors when --window is missing its value", () => {
+    expect(parseValueShowArgs(["--window"]).error).toContain("--window requires");
+  });
+});
+
 describe("shouldSuppressSessionReadback", () => {
   it("returns false when history is missing", () => {
     const root = makeRepo({});
@@ -272,10 +279,11 @@ describe("debounce history persistence", () => {
     renderSessionReadback(root, { now: new Date("2026-07-05T10:00:00Z") });
     const hist = join(root, VALUE_READBACK_HISTORY_REL);
     expect(existsSync(hist)).toBe(true);
-    const parsed = JSON.parse(readFileSync(hist, "utf8").trim()) as {
-      event_id: string;
-      line: string;
-    };
+    const raw = JSON.parse(readFileSync(hist, "utf8").trim()) as unknown;
+    expect(typeof raw).toBe("object");
+    expect(raw).not.toBeNull();
+    expect(Array.isArray(raw)).toBe(false);
+    const parsed = raw as { event_id: string; line: string };
     expect(parsed.event_id).toBe("evt-0");
     expect(parsed.line.length).toBeGreaterThan(0);
   });

--- a/packages/core/src/value/readback.test.ts
+++ b/packages/core/src/value/readback.test.ts
@@ -1,0 +1,282 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { clearRegistryCache } from "../lifecycle/events.js";
+import {
+  computeValueShowTrend,
+  emitSessionValueReadback,
+  formatAttributedSessionLine,
+  parseWindowMs,
+  readAttributionEvents,
+  renderSessionReadback,
+  runValueShow,
+  selectSessionAttribution,
+  shouldSuppressSessionReadback,
+  VALUE_READBACK_HISTORY_REL,
+} from "./readback.js";
+
+const temps: string[] = [];
+
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+afterEach(() => {
+  clearRegistryCache();
+});
+
+function makeRepo(options: {
+  valueFeedback?: Record<string, unknown>;
+  events?: Array<{ event: string; payload: Record<string, unknown>; detected_at?: string }>;
+}): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-readback-"));
+  temps.push(root);
+  mkdirSync(join(root, "vbrief"), { recursive: true });
+  const policy =
+    options.valueFeedback !== undefined ? { valueFeedback: options.valueFeedback } : {};
+  writeFileSync(
+    join(root, "vbrief", "PROJECT-DEFINITION.vbrief.json"),
+    JSON.stringify({
+      vBRIEFInfo: { version: "0.6" },
+      plan: { title: "T", status: "running", items: [], policy },
+    }),
+    "utf8",
+  );
+  if (options.events !== undefined && options.events.length > 0) {
+    mkdirSync(join(root, ".deft-cache"), { recursive: true });
+    const lines = options.events.map((entry, index) =>
+      JSON.stringify({
+        event: entry.event,
+        id: `evt-${index}`,
+        detected_at: entry.detected_at ?? "2026-07-01T12:00:00Z",
+        payload: { signal_class: entry.event.split(":")[0], ...entry.payload },
+      }),
+    );
+    writeFileSync(join(root, ".deft-cache", "events.jsonl"), `${lines.join("\n")}\n`, "utf8");
+  }
+  return root;
+}
+
+describe("readAttributionEvents", () => {
+  it("returns empty when the ledger file is absent", () => {
+    const root = makeRepo({});
+    expect(readAttributionEvents({ projectRoot: root })).toEqual([]);
+  });
+
+  it("filters to attribution event names only", () => {
+    const root = makeRepo({
+      events: [
+        { event: "value:gate-catch", payload: { source: "verify:branch", detail: "blocked" } },
+        { event: "session:interrupted", payload: { session_id: "s", reason: "r" } } as never,
+      ],
+    });
+    expect(readAttributionEvents({ projectRoot: root })).toHaveLength(1);
+  });
+});
+
+describe("session readback silence and budget", () => {
+  it("emits no session line when the ledger is empty", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true, sessionLine: true, emitEvents: true },
+    });
+    const result = renderSessionReadback(root);
+    expect(result.line).toBeNull();
+    expect(result.gated).toBe(false);
+  });
+
+  it("stays gated when sessionLine path is OFF", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true, sessionLine: false, emitEvents: true },
+      events: [{ event: "value:gate-catch", payload: { source: "verify:branch", detail: "x" } }],
+    });
+    expect(renderSessionReadback(root).line).toBeNull();
+    expect(renderSessionReadback(root).gated).toBe(true);
+  });
+
+  it("renders at most one attributed line within the char budget", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true, sessionLine: true, emitEvents: true },
+      events: [
+        {
+          event: "adoption:unused-capability",
+          payload: { source: "a", capability: "swarm", detail: "hint" },
+        },
+        {
+          event: "value:gate-catch",
+          payload: { source: "verify:branch", detail: "blocked default branch" },
+        },
+      ],
+    });
+    const result = renderSessionReadback(root, { writeHistory: false });
+    expect(result.line).toMatch(/^\[value\]/);
+    expect(result.line?.length ?? 0).toBeLessThanOrEqual(120);
+  });
+
+  it("prefers value signals over adoption for the single session slot", () => {
+    const events = [
+      {
+        event: "adoption:unused-capability",
+        payload: { source: "a", capability: "cost", detail: "run capacity" },
+      },
+      { event: "bypass:off-flow", payload: { source: "hook", detail: "skipped pre-commit" } },
+      { event: "value:wip-cap-protect", payload: { source: "verify:wip-cap", count: 3, cap: 2 } },
+    ];
+    const selected = selectSessionAttribution(
+      readAttributionEvents({
+        projectRoot: makeRepo({ events }),
+      }),
+    );
+    expect(selected?.event).toBe("value:wip-cap-protect");
+  });
+
+  it("suppresses repeat emission within the 4h debounce window", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true, sessionLine: true, emitEvents: true },
+      events: [
+        { event: "value:gate-catch", payload: { source: "verify:branch", detail: "blocked" } },
+      ],
+    });
+    const first = renderSessionReadback(root, { now: new Date("2026-07-05T10:00:00Z") });
+    expect(first.line).not.toBeNull();
+
+    const hist = join(root, VALUE_READBACK_HISTORY_REL);
+    expect(existsSync(hist)).toBe(true);
+
+    const second = renderSessionReadback(root, { now: new Date("2026-07-05T11:00:00Z") });
+    expect(second.line).toBeNull();
+    expect(second.suppressed).toBe(true);
+  });
+
+  it("emitSessionValueReadback writes nothing when empty", () => {
+    const root = makeRepo({ valueFeedback: { enabled: true, sessionLine: true } });
+    const lines: string[] = [];
+    expect(
+      emitSessionValueReadback(root, { output: (l) => lines.push(l), writeHistory: false }),
+    ).toBeNull();
+    expect(lines).toEqual([]);
+  });
+});
+
+describe("formatAttributedSessionLine", () => {
+  it("formats concrete gate-catch attribution", () => {
+    const line = formatAttributedSessionLine({
+      event: "value:gate-catch",
+      id: "1",
+      detected_at: "2026-07-01T00:00:00Z",
+      payload: { signal_class: "value", source: "verify:branch", detail: "default branch block" },
+    });
+    expect(line).toContain("verify:branch");
+    expect(line).toContain("default branch block");
+  });
+});
+
+describe("value:show trend readout", () => {
+  it("reports empty ledger for the window", () => {
+    const root = makeRepo({ valueFeedback: { enabled: true } });
+    const result = runValueShow({ projectRoot: root, window: "7d" });
+    expect(result.exitCode).toBe(0);
+    expect(result.empty).toBe(true);
+    expect(result.text).toContain("ledger empty");
+  });
+
+  it("returns class and event counts for recent attribution", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true, emitEvents: true },
+      events: [
+        {
+          event: "value:gate-catch",
+          payload: { source: "verify:branch", detail: "a" },
+          detected_at: "2026-07-04T10:00:00Z",
+        },
+        {
+          event: "value:gate-catch",
+          payload: { source: "verify:branch", detail: "b" },
+          detected_at: "2026-07-04T11:00:00Z",
+        },
+        {
+          event: "bypass:off-flow",
+          payload: { source: "hook", detail: "skip" },
+          detected_at: "2026-07-04T12:00:00Z",
+        },
+      ],
+    });
+    const trend = computeValueShowTrend(root, {
+      windowMs: 7 * 86_400_000,
+      now: new Date("2026-07-05T12:00:00Z"),
+    });
+    expect(trend.total).toBe(3);
+    expect(trend.byClass.value).toBe(2);
+    expect(trend.byClass.bypass).toBe(1);
+
+    const result = runValueShow({
+      projectRoot: root,
+      window: "7d",
+      policyOverride: {
+        enabled: true,
+        emitEvents: true,
+        sessionLine: true,
+        upstreamPrompt: false,
+        source: "typed",
+        error: null,
+      },
+    });
+    expect(result.text).toContain("value=2");
+    expect(result.text).toContain("bypass=1");
+  });
+
+  it("supports json output", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true },
+      events: [{ event: "value:gate-catch", payload: { source: "s", detail: "d" } }],
+    });
+    const result = runValueShow({ projectRoot: root, format: "json" });
+    expect(result.text.trim().startsWith("{")).toBe(true);
+    expect(JSON.parse(result.text)).toHaveProperty("total", 1);
+  });
+
+  it("blocks when valueFeedback master flag is OFF", () => {
+    const root = makeRepo({ valueFeedback: { enabled: false } });
+    const result = runValueShow({ projectRoot: root });
+    expect(result.exitCode).toBe(1);
+    expect(result.gated).toBe(true);
+  });
+});
+
+describe("parseWindowMs", () => {
+  it("parses day and hour windows", () => {
+    expect(parseWindowMs("7d")).toBe(7 * 86_400_000);
+    expect(parseWindowMs("24h")).toBe(24 * 3_600_000);
+  });
+});
+
+describe("shouldSuppressSessionReadback", () => {
+  it("returns false when history is missing", () => {
+    const root = makeRepo({});
+    expect(
+      shouldSuppressSessionReadback("evt-0", join(root, VALUE_READBACK_HISTORY_REL), {
+        now: new Date("2026-07-05T12:00:00Z"),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("debounce history persistence", () => {
+  it("records emitted session lines for suppression checks", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true, sessionLine: true },
+      events: [{ event: "value:gate-catch", payload: { source: "verify:branch", detail: "x" } }],
+    });
+    renderSessionReadback(root, { now: new Date("2026-07-05T10:00:00Z") });
+    const hist = join(root, VALUE_READBACK_HISTORY_REL);
+    expect(existsSync(hist)).toBe(true);
+    const parsed = JSON.parse(readFileSync(hist, "utf8").trim()) as {
+      event_id: string;
+      line: string;
+    };
+    expect(parsed.event_id).toBe("evt-0");
+    expect(parsed.line.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/value/readback.test.ts
+++ b/packages/core/src/value/readback.test.ts
@@ -19,6 +19,18 @@ import {
 
 const temps: string[] = [];
 
+// `JSON.parse` returns top-level `null` (not a throw) for the literal `null`,
+// so a guarded parse keeps property reads from blowing up with a TypeError.
+function parseJsonObject(text: string): Record<string, unknown> {
+  const value: unknown = JSON.parse(text);
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `expected a JSON object payload, received ${value === null ? "null" : typeof value}`,
+    );
+  }
+  return value as Record<string, unknown>;
+}
+
 afterAll(() => {
   for (const t of temps) {
     rmSync(t, { recursive: true, force: true });
@@ -279,12 +291,8 @@ describe("debounce history persistence", () => {
     renderSessionReadback(root, { now: new Date("2026-07-05T10:00:00Z") });
     const hist = join(root, VALUE_READBACK_HISTORY_REL);
     expect(existsSync(hist)).toBe(true);
-    const raw = JSON.parse(readFileSync(hist, "utf8").trim()) as unknown;
-    expect(typeof raw).toBe("object");
-    expect(raw).not.toBeNull();
-    expect(Array.isArray(raw)).toBe(false);
-    const parsed = raw as { event_id: string; line: string };
+    const parsed = parseJsonObject(readFileSync(hist, "utf8").trim());
     expect(parsed.event_id).toBe("evt-0");
-    expect(parsed.line.length).toBeGreaterThan(0);
+    expect(String(parsed.line).length).toBeGreaterThan(0);
   });
 });

--- a/packages/core/src/value/readback.ts
+++ b/packages/core/src/value/readback.ts
@@ -87,6 +87,9 @@ export function readAttributionEvents(options: ReadAttributionOptions): Behavior
       if (typeof record?.event !== "string" || !ATTRIBUTION_NAME_SET.has(record.event)) {
         return false;
       }
+      if (!isRecordPayload(record.payload)) {
+        return false;
+      }
       if (since === null) {
         return true;
       }
@@ -99,9 +102,12 @@ export function readAttributionEvents(options: ReadAttributionOptions): Behavior
 }
 
 function signalClassOf(record: BehavioralEventRecord): SignalClass | null {
-  const raw = record.payload.signal_class;
-  if (raw === "value" || raw === "bypass" || raw === "adoption" || raw === "friction") {
-    return raw;
+  const payload = record.payload;
+  if (isRecordPayload(payload)) {
+    const raw = payload.signal_class;
+    if (raw === "value" || raw === "bypass" || raw === "adoption" || raw === "friction") {
+      return raw;
+    }
   }
   const prefix = record.event.split(":")[0];
   if (prefix === "value" || prefix === "bypass" || prefix === "adoption" || prefix === "friction") {
@@ -142,7 +148,7 @@ function payloadString(payload: Record<string, unknown>, key: string): string {
 /** Format one attributed session line from a concrete ledger event (#1709 attributed-only). */
 export function formatAttributedSessionLine(record: BehavioralEventRecord): string {
   const cls = signalClassOf(record) ?? "value";
-  const payload = record.payload;
+  const payload = isRecordPayload(record.payload) ? record.payload : {};
   const source = payloadString(payload, "source");
   const detail = payloadString(payload, "detail");
   const capability = payloadString(payload, "capability");
@@ -194,6 +200,22 @@ export function selectSessionAttribution(
   return sorted[0] ?? null;
 }
 
+function parseJsonObjectOrNull(text: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // malformed history line
+  }
+  return null;
+}
+
+function isRecordPayload(payload: unknown): payload is Record<string, unknown> {
+  return payload !== null && typeof payload === "object" && !Array.isArray(payload);
+}
+
 function historyPath(projectRoot: string): string {
   return resolve(projectRoot, VALUE_READBACK_HISTORY_REL);
 }
@@ -216,15 +238,7 @@ function readLastHistoryRecord(path: string): Record<string, unknown> | null {
   if (last === undefined) {
     return null;
   }
-  try {
-    const parsed = JSON.parse(last) as unknown;
-    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {
-    return null;
-  }
-  return null;
+  return parseJsonObjectOrNull(last);
 }
 
 function parseHistoryEmittedAt(record: Record<string, unknown>): Date | null {

--- a/packages/core/src/value/readback.ts
+++ b/packages/core/src/value/readback.ts
@@ -1,0 +1,578 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { runningInsideDeftRepo } from "../doctor/paths.js";
+import { ALL_ATTRIBUTION_EVENT_NAMES } from "../events/attribution-constants.js";
+import { type BehavioralEventRecord, DEFAULT_EVENT_LOG, readEvents } from "../lifecycle/events.js";
+import {
+  isValueFeedbackPathAllowed,
+  resolveValueFeedback,
+  type ValueFeedbackResolved,
+} from "../policy/value-feedback.js";
+import { resolveProjectRoot } from "../scope/project-context.js";
+import { MAX_LINE_CHARS } from "../triage/welcome/constants.js";
+
+/** Repeat-suppression window for the budgeted session readback (#1709 / #1279 parity). */
+export const VALUE_READBACK_SUPPRESSION_HOURS = 4;
+
+export const VALUE_READBACK_HISTORY_REL = join(".deft-cache", "value-readback-history.jsonl");
+export const VALUE_READBACK_HISTORY_SCHEMA = "deft.value.readback.v1";
+
+const ATTRIBUTION_NAME_SET = new Set<string>(ALL_ATTRIBUTION_EVENT_NAMES);
+
+/** Signal-class priority: value/bypass beat adoption (#1709 RFC nudge ordering). */
+const SIGNAL_CLASS_PRIORITY: Record<string, number> = {
+  value: 0,
+  bypass: 1,
+  adoption: 2,
+  friction: 3,
+};
+
+export type SignalClass = "value" | "bypass" | "adoption" | "friction";
+
+export interface ReadAttributionOptions {
+  readonly projectRoot: string;
+  readonly logPath?: string | null;
+  readonly since?: Date | null;
+}
+
+export interface ValueShowTrend {
+  readonly windowLabel: string;
+  readonly windowMs: number;
+  readonly total: number;
+  readonly byClass: Readonly<Record<SignalClass, number>>;
+  readonly byEvent: Readonly<Record<string, number>>;
+  readonly recent: readonly BehavioralEventRecord[];
+}
+
+export interface ValueShowResult {
+  readonly exitCode: 0 | 1 | 2;
+  readonly gated: boolean;
+  readonly empty: boolean;
+  readonly text: string;
+  readonly trend: ValueShowTrend | null;
+}
+
+export interface SessionReadbackResult {
+  readonly line: string | null;
+  readonly suppressed: boolean;
+  readonly gated: boolean;
+}
+
+function resolveLedgerPath(projectRoot: string, logPath?: string | null): string {
+  if (logPath !== undefined && logPath !== null) {
+    return resolve(logPath);
+  }
+  return resolve(projectRoot, DEFAULT_EVENT_LOG);
+}
+
+function parseDetectedAt(record: BehavioralEventRecord): Date | null {
+  const raw = record.detected_at;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+  let text = raw.trim();
+  if (text.endsWith("Z")) {
+    text = `${text.slice(0, -1)}+00:00`;
+  }
+  const parsed = new Date(text);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** Read attribution ledger entries in emission order (#1709). */
+export function readAttributionEvents(options: ReadAttributionOptions): BehavioralEventRecord[] {
+  const logPath = resolveLedgerPath(options.projectRoot, options.logPath);
+  const since = options.since ?? null;
+  return readEvents(logPath).filter((record) => {
+    if (!ATTRIBUTION_NAME_SET.has(record.event)) {
+      return false;
+    }
+    if (since === null) {
+      return true;
+    }
+    const at = parseDetectedAt(record);
+    return at !== null && at.getTime() >= since.getTime();
+  });
+}
+
+function signalClassOf(record: BehavioralEventRecord): SignalClass | null {
+  const raw = record.payload.signal_class;
+  if (raw === "value" || raw === "bypass" || raw === "adoption" || raw === "friction") {
+    return raw;
+  }
+  const prefix = record.event.split(":")[0];
+  if (prefix === "value" || prefix === "bypass" || prefix === "adoption" || prefix === "friction") {
+    return prefix;
+  }
+  return null;
+}
+
+function priorityOf(record: BehavioralEventRecord): number {
+  const cls = signalClassOf(record);
+  if (cls === null) {
+    return 99;
+  }
+  return SIGNAL_CLASS_PRIORITY[cls] ?? 99;
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  if (maxChars <= 3) {
+    return text.slice(0, maxChars);
+  }
+  return `${text.slice(0, maxChars - 3)}...`;
+}
+
+function payloadString(payload: Record<string, unknown>, key: string): string {
+  const raw = payload[key];
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    return raw.trim();
+  }
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return String(raw);
+  }
+  return "";
+}
+
+/** Format one attributed session line from a concrete ledger event (#1709 attributed-only). */
+export function formatAttributedSessionLine(record: BehavioralEventRecord): string {
+  const cls = signalClassOf(record) ?? "value";
+  const payload = record.payload;
+  const source = payloadString(payload, "source");
+  const detail = payloadString(payload, "detail");
+  const capability = payloadString(payload, "capability");
+
+  switch (record.event) {
+    case "value:gate-catch": {
+      const tail = detail.length > 0 ? `: ${detail}` : "";
+      return `[value] Gate catch (${source || "gate"})${tail}`;
+    }
+    case "value:wip-cap-protect": {
+      const count = payloadString(payload, "count");
+      const cap = payloadString(payload, "cap");
+      const pair = count && cap ? ` ${count}/${cap}` : "";
+      return `[value] WIP cap protected in-flight scope${pair}.`;
+    }
+    case "bypass:off-flow": {
+      const tail = detail.length > 0 ? `: ${detail}` : "";
+      return `[boundary] Off-flow signal (${source || "bypass"})${tail}`;
+    }
+    case "adoption:unused-capability": {
+      const tail = detail.length > 0 ? `: ${detail}` : capability;
+      return `[adoption] Unused capability${tail ? ` (${tail})` : ""}.`;
+    }
+    case "friction:directive-gap": {
+      const tail = detail.length > 0 ? `: ${detail}` : "";
+      return `[friction] Directive gap (${source || "friction"})${tail}`;
+    }
+    default:
+      return `[${cls}] ${record.event}`;
+  }
+}
+
+/** Pick the single highest-priority recent attribution for the session one-liner. */
+export function selectSessionAttribution(
+  events: readonly BehavioralEventRecord[],
+): BehavioralEventRecord | null {
+  if (events.length === 0) {
+    return null;
+  }
+  const sorted = [...events].sort((a, b) => {
+    const pri = priorityOf(a) - priorityOf(b);
+    if (pri !== 0) {
+      return pri;
+    }
+    const aAt = parseDetectedAt(a)?.getTime() ?? 0;
+    const bAt = parseDetectedAt(b)?.getTime() ?? 0;
+    return bAt - aAt;
+  });
+  return sorted[0] ?? null;
+}
+
+function historyPath(projectRoot: string): string {
+  return resolve(projectRoot, VALUE_READBACK_HISTORY_REL);
+}
+
+function readLastHistoryRecord(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  const lines = text.split("\n").filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    return null;
+  }
+  const last = lines[lines.length - 1];
+  if (last === undefined) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(last) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function parseHistoryEmittedAt(record: Record<string, unknown>): Date | null {
+  const raw = record.emitted_at;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+  let candidate = raw.trim();
+  if (candidate.endsWith("Z")) {
+    candidate = `${candidate.slice(0, -1)}+00:00`;
+  }
+  const parsed = new Date(candidate);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** True when the same attribution event id was read back within the suppression window. */
+export function shouldSuppressSessionReadback(
+  eventId: string,
+  historyFile: string,
+  options: { now?: Date } = {},
+): boolean {
+  const prior = readLastHistoryRecord(historyFile);
+  if (prior === null) {
+    return false;
+  }
+  const emittedAt = parseHistoryEmittedAt(prior);
+  if (emittedAt === null) {
+    return false;
+  }
+  const now = options.now ?? new Date();
+  const ageMs = now.getTime() - emittedAt.getTime();
+  if (ageMs < 0 || ageMs >= VALUE_READBACK_SUPPRESSION_HOURS * 3_600_000) {
+    return false;
+  }
+  return prior.event_id === eventId;
+}
+
+function appendReadbackHistory(
+  projectRoot: string,
+  eventId: string,
+  line: string,
+  options: { now?: Date } = {},
+): void {
+  const path = historyPath(projectRoot);
+  const record = {
+    schema: VALUE_READBACK_HISTORY_SCHEMA,
+    emitted_at: (options.now ?? new Date()).toISOString().replace(/\.\d{3}Z$/, "Z"),
+    event_id: eventId,
+    line,
+  };
+  try {
+    mkdirSync(join(path, ".."), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(record)}\n`, "utf8");
+  } catch {
+    // observability only
+  }
+}
+
+function maintainerReadbackDisabled(projectRoot: string): boolean {
+  if (!runningInsideDeftRepo(projectRoot)) {
+    return false;
+  }
+  return process.env.DEFT_VALUE_SELF_DOGFOOD !== "1";
+}
+
+/** Budgeted session one-liner — silent when gated, empty, or debounced (#1709). */
+export function renderSessionReadback(
+  projectRoot: string,
+  options: {
+    policyOverride?: ValueFeedbackResolved;
+    logPath?: string | null;
+    now?: Date;
+    maxChars?: number;
+    writeHistory?: boolean;
+  } = {},
+): SessionReadbackResult {
+  const root = resolve(projectRoot);
+  if (maintainerReadbackDisabled(root)) {
+    return { line: null, suppressed: false, gated: true };
+  }
+
+  const policy = options.policyOverride ?? resolveValueFeedback(root);
+  if (!isValueFeedbackPathAllowed("sessionLine", policy)) {
+    return { line: null, suppressed: false, gated: true };
+  }
+
+  const events = readAttributionEvents({ projectRoot: root, logPath: options.logPath });
+  if (events.length === 0) {
+    return { line: null, suppressed: false, gated: false };
+  }
+
+  const selected = selectSessionAttribution(events);
+  if (selected === null) {
+    return { line: null, suppressed: false, gated: false };
+  }
+
+  const hist = historyPath(root);
+  if (shouldSuppressSessionReadback(selected.id, hist, { now: options.now })) {
+    return { line: null, suppressed: true, gated: false };
+  }
+
+  const maxChars = options.maxChars ?? MAX_LINE_CHARS;
+  const line = truncate(formatAttributedSessionLine(selected), maxChars);
+  if (options.writeHistory !== false) {
+    appendReadbackHistory(root, selected.id, line, { now: options.now });
+  }
+  return { line, suppressed: false, gated: false };
+}
+
+/** Emit the session readback line to stdout when present. Returns the line or null. */
+export function emitSessionValueReadback(
+  projectRoot: string,
+  options: {
+    output?: (line: string) => void;
+    policyOverride?: ValueFeedbackResolved;
+    logPath?: string | null;
+    now?: Date;
+    writeHistory?: boolean;
+  } = {},
+): string | null {
+  const result = renderSessionReadback(projectRoot, options);
+  if (result.line === null) {
+    return null;
+  }
+  const out = options.output ?? ((line: string) => process.stdout.write(`${line}\n`));
+  out(result.line);
+  return result.line;
+}
+
+export function parseWindowMs(raw: string | undefined, defaultDays = 7): number {
+  if (raw === undefined || raw.trim().length === 0) {
+    return defaultDays * 86_400_000;
+  }
+  const match = /^(\d+)([dhm])$/i.exec(raw.trim());
+  if (match === null) {
+    return defaultDays * 86_400_000;
+  }
+  const amount = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return defaultDays * 86_400_000;
+  }
+  const unit = (match[2] ?? "d").toLowerCase();
+  if (unit === "h") {
+    return amount * 3_600_000;
+  }
+  if (unit === "m") {
+    return amount * 60_000;
+  }
+  return amount * 86_400_000;
+}
+
+function formatWindowLabel(windowMs: number): string {
+  const days = Math.round(windowMs / 86_400_000);
+  if (days >= 1 && days * 86_400_000 === windowMs) {
+    return `${days}d`;
+  }
+  const hours = Math.round(windowMs / 3_600_000);
+  if (hours >= 1 && hours * 3_600_000 === windowMs) {
+    return `${hours}h`;
+  }
+  return `${windowMs}ms`;
+}
+
+/** Build attributed-value trend counts for pull-based value:show (#1709). */
+export function computeValueShowTrend(
+  projectRoot: string,
+  options: { windowMs?: number; logPath?: string | null; now?: Date } = {},
+): ValueShowTrend {
+  const windowMs = options.windowMs ?? 7 * 86_400_000;
+  const now = options.now ?? new Date();
+  const since = new Date(now.getTime() - windowMs);
+  const events = readAttributionEvents({
+    projectRoot,
+    logPath: options.logPath,
+    since,
+  });
+
+  const byClass: Record<SignalClass, number> = {
+    value: 0,
+    bypass: 0,
+    adoption: 0,
+    friction: 0,
+  };
+  const byEvent: Record<string, number> = {};
+
+  for (const record of events) {
+    const cls = signalClassOf(record);
+    if (cls !== null) {
+      byClass[cls] += 1;
+    }
+    byEvent[record.event] = (byEvent[record.event] ?? 0) + 1;
+  }
+
+  return {
+    windowLabel: formatWindowLabel(windowMs),
+    windowMs,
+    total: events.length,
+    byClass,
+    byEvent,
+    recent: events.slice(-5),
+  };
+}
+
+export function formatValueShowReport(trend: ValueShowTrend): string {
+  if (trend.total === 0) {
+    return (
+      `[value] No attributed signals in the last ${trend.windowLabel} ` +
+      "(ledger empty for this window).\n" +
+      "Inspect policy: `task policy:show --field=valueFeedback`.\n"
+    );
+  }
+
+  const classParts = (["value", "bypass", "adoption", "friction"] as const)
+    .filter((key) => trend.byClass[key] > 0)
+    .map((key) => `${key}=${trend.byClass[key]}`);
+
+  const eventParts = Object.entries(trend.byEvent)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, count]) => `${name}: ${count}`);
+
+  const lines = [
+    `[value] Attributed signals (${trend.windowLabel}): ${trend.total} total`,
+    `  classes: ${classParts.join(", ")}`,
+    `  events: ${eventParts.join("; ")}`,
+    "Pull detail any time with `task value:show -- --window=30d --format=json`.",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+/** Pull-based value:show CLI core (#1709). */
+export function runValueShow(options: {
+  projectRoot?: string | null;
+  window?: string;
+  format?: "text" | "json";
+  logPath?: string | null;
+  policyOverride?: ValueFeedbackResolved;
+}): ValueShowResult {
+  const rootRaw = resolveProjectRoot(options.projectRoot ?? undefined);
+  if (rootRaw === null) {
+    return {
+      exitCode: 2,
+      gated: false,
+      empty: true,
+      text: "Error: could not resolve project root.\n",
+      trend: null,
+    };
+  }
+  const root = resolve(rootRaw);
+
+  if (maintainerReadbackDisabled(root)) {
+    return {
+      exitCode: 0,
+      gated: true,
+      empty: true,
+      text: "[value] Skipped: maintainer framework repo (set DEFT_VALUE_SELF_DOGFOOD=1 to dogfood).\n",
+      trend: null,
+    };
+  }
+
+  const policy = options.policyOverride ?? resolveValueFeedback(root);
+  if (!policy.enabled) {
+    return {
+      exitCode: 1,
+      gated: true,
+      empty: true,
+      text:
+        "[value] Blocked: plan.policy.valueFeedback is OFF. " +
+        "Enable with `task policy:enable-value-feedback -- --confirm`.\n",
+      trend: null,
+    };
+  }
+
+  const windowMs = parseWindowMs(options.window);
+  const trend = computeValueShowTrend(root, { windowMs, logPath: options.logPath });
+  const empty = trend.total === 0;
+
+  if (options.format === "json") {
+    return {
+      exitCode: 0,
+      gated: false,
+      empty,
+      text: `${JSON.stringify(trend, null, 2)}\n`,
+      trend,
+    };
+  }
+
+  return {
+    exitCode: 0,
+    gated: false,
+    empty,
+    text: formatValueShowReport(trend),
+    trend,
+  };
+}
+
+export interface ValueShowCliArgs {
+  window?: string;
+  format?: "text" | "json";
+  projectRoot?: string;
+  error?: string;
+}
+
+export function parseValueShowArgs(argv: readonly string[]): ValueShowCliArgs {
+  const out: ValueShowCliArgs = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i] as string;
+    if (arg === "--format") {
+      const raw = argv[++i];
+      if (raw === "json" || raw === "text") {
+        out.format = raw;
+      } else {
+        return { ...out, error: `--format expects text|json, got ${JSON.stringify(raw)}` };
+      }
+    } else if (arg?.startsWith("--format=")) {
+      const raw = arg.slice("--format=".length);
+      if (raw === "json" || raw === "text") {
+        out.format = raw;
+      } else {
+        return { ...out, error: `--format expects text|json, got ${JSON.stringify(raw)}` };
+      }
+    } else if (arg === "--window") {
+      out.window = argv[++i];
+    } else if (arg?.startsWith("--window=")) {
+      out.window = arg.slice("--window=".length);
+    } else if (arg === "--project-root") {
+      out.projectRoot = argv[++i];
+    } else if (arg?.startsWith("--project-root=")) {
+      out.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg.startsWith("-")) {
+      return { ...out, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return out;
+}
+
+/** CLI entry for value:show (#1709). */
+export function valueShowMain(argv: readonly string[] = process.argv.slice(2)): number {
+  const args = parseValueShowArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`value:show: ${args.error}\n`);
+    return 2;
+  }
+  const result = runValueShow({
+    projectRoot: args.projectRoot,
+    window: args.window,
+    format: args.format ?? "text",
+  });
+  process.stdout.write(result.text);
+  return result.exitCode;
+}
+
+/** CLI module entrypoint for dispatch (#1709). */
+export function mainEntry(argv: string[] = process.argv.slice(2)): number {
+  return valueShowMain(argv);
+}

--- a/packages/core/src/value/readback.ts
+++ b/packages/core/src/value/readback.ts
@@ -80,18 +80,22 @@ function parseDetectedAt(record: BehavioralEventRecord): Date | null {
 
 /** Read attribution ledger entries in emission order (#1709). */
 export function readAttributionEvents(options: ReadAttributionOptions): BehavioralEventRecord[] {
-  const logPath = resolveLedgerPath(options.projectRoot, options.logPath);
-  const since = options.since ?? null;
-  return readEvents(logPath).filter((record) => {
-    if (!ATTRIBUTION_NAME_SET.has(record.event)) {
-      return false;
-    }
-    if (since === null) {
-      return true;
-    }
-    const at = parseDetectedAt(record);
-    return at !== null && at.getTime() >= since.getTime();
-  });
+  try {
+    const logPath = resolveLedgerPath(options.projectRoot, options.logPath);
+    const since = options.since ?? null;
+    return readEvents(logPath).filter((record) => {
+      if (typeof record?.event !== "string" || !ATTRIBUTION_NAME_SET.has(record.event)) {
+        return false;
+      }
+      if (since === null) {
+        return true;
+      }
+      const at = parseDetectedAt(record);
+      return at !== null && at.getTime() >= since.getTime();
+    });
+  } catch {
+    return [];
+  }
 }
 
 function signalClassOf(record: BehavioralEventRecord): SignalClass | null {
@@ -297,37 +301,41 @@ export function renderSessionReadback(
     writeHistory?: boolean;
   } = {},
 ): SessionReadbackResult {
-  const root = resolve(projectRoot);
-  if (maintainerReadbackDisabled(root)) {
-    return { line: null, suppressed: false, gated: true };
-  }
+  try {
+    const root = resolve(projectRoot);
+    if (maintainerReadbackDisabled(root)) {
+      return { line: null, suppressed: false, gated: true };
+    }
 
-  const policy = options.policyOverride ?? resolveValueFeedback(root);
-  if (!isValueFeedbackPathAllowed("sessionLine", policy)) {
-    return { line: null, suppressed: false, gated: true };
-  }
+    const policy = options.policyOverride ?? resolveValueFeedback(root);
+    if (!isValueFeedbackPathAllowed("sessionLine", policy)) {
+      return { line: null, suppressed: false, gated: true };
+    }
 
-  const events = readAttributionEvents({ projectRoot: root, logPath: options.logPath });
-  if (events.length === 0) {
+    const events = readAttributionEvents({ projectRoot: root, logPath: options.logPath });
+    if (events.length === 0) {
+      return { line: null, suppressed: false, gated: false };
+    }
+
+    const selected = selectSessionAttribution(events);
+    if (selected === null) {
+      return { line: null, suppressed: false, gated: false };
+    }
+
+    const hist = historyPath(root);
+    if (shouldSuppressSessionReadback(selected.id, hist, { now: options.now })) {
+      return { line: null, suppressed: true, gated: false };
+    }
+
+    const maxChars = options.maxChars ?? MAX_LINE_CHARS;
+    const line = truncate(formatAttributedSessionLine(selected), maxChars);
+    if (options.writeHistory !== false) {
+      appendReadbackHistory(root, selected.id, line, { now: options.now });
+    }
+    return { line, suppressed: false, gated: false };
+  } catch {
     return { line: null, suppressed: false, gated: false };
   }
-
-  const selected = selectSessionAttribution(events);
-  if (selected === null) {
-    return { line: null, suppressed: false, gated: false };
-  }
-
-  const hist = historyPath(root);
-  if (shouldSuppressSessionReadback(selected.id, hist, { now: options.now })) {
-    return { line: null, suppressed: true, gated: false };
-  }
-
-  const maxChars = options.maxChars ?? MAX_LINE_CHARS;
-  const line = truncate(formatAttributedSessionLine(selected), maxChars);
-  if (options.writeHistory !== false) {
-    appendReadbackHistory(root, selected.id, line, { now: options.now });
-  }
-  return { line, suppressed: false, gated: false };
 }
 
 /** Emit the session readback line to stdout when present. Returns the line or null. */
@@ -542,11 +550,19 @@ export function parseValueShowArgs(argv: readonly string[]): ValueShowCliArgs {
         return { ...out, error: `--format expects text|json, got ${JSON.stringify(raw)}` };
       }
     } else if (arg === "--window") {
-      out.window = argv[++i];
+      const raw = argv[++i];
+      if (raw === undefined) {
+        return { ...out, error: "--window requires a value (e.g. --window=7d)" };
+      }
+      out.window = raw;
     } else if (arg?.startsWith("--window=")) {
       out.window = arg.slice("--window=".length);
     } else if (arg === "--project-root") {
-      out.projectRoot = argv[++i];
+      const raw = argv[++i];
+      if (raw === undefined) {
+        return { ...out, error: "--project-root requires a path" };
+      }
+      out.projectRoot = raw;
     } else if (arg?.startsWith("--project-root=")) {
       out.projectRoot = arg.slice("--project-root=".length);
     } else if (arg.startsWith("-")) {

--- a/xbrief/completed/2026-07-05-1709-awareness-readbacks.xbrief.json
+++ b/xbrief/completed/2026-07-05-1709-awareness-readbacks.xbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "1709-awareness-readbacks",
     "title": "Budgeted awareness readbacks (session line + value:show)",
-    "status": "pending",
+    "status": "completed",
     "narratives": {
       "Description": "Add a budgeted one-line session readback that surfaces in-flow value, boundary, and adoption signals, staying silent when nothing is attributed. Add a pull-based value:show trend readout that fills the currently-stubbed metrics slot.",
       "ImplementationPlan": "- Add a readback module that queries the ledger and registry and renders at most one session line within the existing nudge budget.\n- Implement the value:show command with a trend report and add tests asserting silence when the ledger is empty.",
@@ -63,7 +63,9 @@
         "size": "M",
         "file_scope_confidence": "medium",
         "model_tier": "standard"
-      }
+      },
+      "completedAt": "2026-07-05T21:52:41Z",
+      "capacityBucket": "agentic-debt"
     },
     "references": [
       {
@@ -78,6 +80,7 @@
         "title": "Issue #1709 child 4: awareness readbacks",
         "TrustLevel": "external"
       }
-    ]
+    ],
+    "updated": "2026-07-05T21:52:41Z"
   }
 }


### PR DESCRIPTION
## Summary
- Add a budgeted session readback that surfaces one attributed line from the local attribution ledger at session start (silent when empty or gated OFF).
- Add pull-based `task value:show` (alias `task triage:metrics`) trend readout over recent ledger signals, respecting `plan.policy.valueFeedback`.

## Test plan
- [x] `pnpm exec vitest run readback`
- [x] `TMPDIR=$(mktemp -d) task check`

Refs #1709

Made with [Cursor](https://cursor.com)