### PR TITLE
Wire task aliases for value-feedback and triage metrics commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Maintainer `task` aliases for value feedback: `task policy:enable-value-feedback`, `task value:show`, and `task triage:metrics` now resolve through the Taskfile instead of failing with "task not found", matching the documented AGENTS.md surface. Refs #2337.
+
 ### Added
 
 - Budgeted value-awareness readbacks: when value feedback is enabled, session start can show one attributed line from the local ledger (silent when empty), and `task value:show` reports attribution trends on demand — also available as `task triage:metrics`. Refs #1709.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -248,6 +248,12 @@ includes:
   triage-smoketest:
     taskfile: ./tasks/triage-smoketest.yml
     optional: true
+  # D17 (#1709): `task triage:metrics` trend readout from summary-history.jsonl.
+  # Inner task `metrics` is exposed as the user-facing alias `task triage:metrics`
+  # in the alias block below.
+  triage-metrics:
+    taskfile: ./tasks/triage-metrics.yml
+    optional: true
   # Windows maintainer onboarding fragment (#902). Exposes the inner task
   # `toolchain` as `task setup:toolchain`. Note: the root-level `setup` task
   # below (git-hooks bootstrap) coexists with `setup:toolchain` because
@@ -304,6 +310,11 @@ includes:
   # confirmation-gated, deduped framework-gap issues for consumer projects.
   feedback:
     taskfile: ./tasks/feedback.yml
+    optional: true
+  # Pull-based value-awareness readbacks (#1709). Inner task `show` is exposed as
+  # `task value:show` via the include namespace key.
+  value:
+    taskfile: ./tasks/value.yml
     optional: true
   # Pack-slicing surface (#1283 design, #1294 pilot, ADR-001 Layer B). Exposes
   # `task packs:slice` (named-slice API), `task packs:render` (regenerate the
@@ -861,6 +872,13 @@ tasks:
     desc: "Emit the one-line triage state for the session-start ritual (D2 / #1122). Always exits 0; appends a JSONL record to vbrief/.eval/summary-history.jsonl. -- task triage:summary -- [--json] [--no-history]"
     cmds:
       - task: triage-summary:summary
+        vars:
+          CLI_ARGS: "{{.CLI_ARGS}}"
+
+  triage:metrics:
+    desc: "Trend lines from summary-history.jsonl (#1709 / D17). -- task triage:metrics -- [--window=7d|30d] [--format=text|json]"
+    cmds:
+      - task: triage-metrics:metrics
         vars:
           CLI_ARGS: "{{.CLI_ARGS}}"
 

--- a/packages/core/src/content-contracts/standards/taskfile_value_feedback_aliases.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_value_feedback_aliases.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./_helpers.js";
+import { iterTaskBlocks, readRoot } from "./_taskfile-helpers.js";
+
+/** Documented value-feedback / metrics `task` forms that must resolve (#2337). */
+const REQUIRED_VALUE_TASK_ALIASES = [
+  "policy:enable-value-feedback",
+  "value:show",
+  "triage:metrics",
+  "feedback:file",
+  "policy:show",
+] as const;
+
+const INCLUDE_LINE = /^\s{2}([A-Za-z][\w-]*):\s*$/;
+const TASKFILE_LINE = /^\s{4}taskfile:\s+\.\/tasks\/([\w-]+\.ya?ml)\s*$/;
+
+function parseIncludes(text: string): Map<string, string> {
+  const includes = new Map<string, string>();
+  const lines = text.split("\n");
+  let inIncludes = false;
+  let currentKey: string | null = null;
+  for (const line of lines) {
+    if (line.startsWith("includes:")) {
+      inIncludes = true;
+      continue;
+    }
+    if (inIncludes && line && !line.startsWith(" ") && !line.startsWith("\t")) {
+      inIncludes = false;
+      currentKey = null;
+      continue;
+    }
+    if (!inIncludes) continue;
+    const keyMatch = line.match(INCLUDE_LINE);
+    if (keyMatch?.[1]) {
+      currentKey = keyMatch[1];
+      continue;
+    }
+    const fileMatch = line.match(TASKFILE_LINE);
+    if (fileMatch?.[1] && currentKey) {
+      includes.set(currentKey, fileMatch[1]);
+      currentKey = null;
+    }
+  }
+  return includes;
+}
+
+function collectTaskSurface(): Set<string> {
+  const names = new Set<string>();
+  const rootText = readRoot("Taskfile.yml");
+  for (const { name } of iterTaskBlocks(rootText)) {
+    names.add(name);
+  }
+  const includes = parseIncludes(rootText);
+  for (const [namespace, fileName] of includes) {
+    const fragmentPath = join(repoRoot(), "tasks", fileName);
+    const fragmentText = readFileSync(fragmentPath, { encoding: "utf8" });
+    for (const { name, start, end } of iterTaskBlocks(fragmentText)) {
+      const body = fragmentText.split("\n").slice(start, end).join("\n");
+      if (/^\s+internal:\s*true\s*$/m.test(body)) {
+        continue;
+      }
+      names.add(`${namespace}:${name}`);
+    }
+  }
+  return names;
+}
+
+/** Extract bare `task namespace:verb` tokens from maintainer docs. */
+function extractDocumentedTaskRefs(text: string): string[] {
+  const refs: string[] = [];
+  const re = /`task ([a-z][\w:-]*)`/g;
+  for (const match of text.matchAll(re)) {
+    const name = match[1];
+    if (name && !name.includes("<") && !name.includes(">")) {
+      refs.push(name);
+    }
+  }
+  return refs;
+}
+
+const VALUE_DOC_MARKERS = ["policy:enable-value-feedback", "value:show", "triage:metrics"] as const;
+
+describe("taskfile value-feedback aliases (#2337)", () => {
+  it("registers required value-feedback / metrics task names on the Taskfile surface", () => {
+    const surface = collectTaskSurface();
+    for (const name of REQUIRED_VALUE_TASK_ALIASES) {
+      expect(surface.has(name), `missing task ${name}`).toBe(true);
+    }
+  });
+
+  it("policy.yml forwards enable-value-feedback via engine:invoke", () => {
+    const text = readFileSync(join(repoRoot(), "tasks", "policy.yml"), { encoding: "utf8" });
+    const block = iterTaskBlocks(text).find((b) => b.name === "enable-value-feedback");
+    expect(block).toBeDefined();
+    const body = text.split("\n").slice(block?.start, block?.end).join("\n");
+    expect(body).toContain("policy enable-value-feedback");
+    expect(body).toContain("{{.CLI_ARGS}}");
+  });
+
+  it("value.yml and triage-metrics.yml forward CLI_ARGS without caching keys", () => {
+    for (const file of ["value.yml", "triage-metrics.yml"]) {
+      const text = readFileSync(join(repoRoot(), "tasks", file), { encoding: "utf8" });
+      expect(text).toContain("{{.CLI_ARGS}}");
+      expect(text).not.toMatch(/^\s{4}(sources|generates)\s*:/m);
+    }
+  });
+
+  it("AGENTS.md value-feedback task references resolve on the Taskfile surface", () => {
+    const agents = readFileSync(join(repoRoot(), "AGENTS.md"), { encoding: "utf8" });
+    const documented = extractDocumentedTaskRefs(agents).filter((name) =>
+      VALUE_DOC_MARKERS.some((marker) => name === marker),
+    );
+    expect(documented.length).toBeGreaterThan(0);
+    const surface = collectTaskSurface();
+    for (const name of documented) {
+      expect(surface.has(name), `AGENTS.md references missing task ${name}`).toBe(true);
+    }
+  });
+});

--- a/tasks/policy.yml
+++ b/tasks/policy.yml
@@ -52,6 +52,16 @@ tasks:
         vars:
           ENGINE_CMD: 'policy allow-direct-commits --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
+  enable-value-feedback:
+    desc: "Opt in to value-feedback surfaces (#1709). Requires --confirm after the capability-cost disclosure prints. -- task policy:enable-value-feedback -- [--confirm] [--json]"
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'policy enable-value-feedback --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
+
   wip-cap:
     desc: "Set plan.policy.wipCap=N (#1124 / D4 of #1119). Requires --set N --confirm. Default cap is 20 (#2319; raised from the original 10 per umbrella #1119 Current Shape v3)."
     dir: '{{.USER_WORKING_DIR}}'

--- a/tasks/triage-metrics.yml
+++ b/tasks/triage-metrics.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+# tasks/triage-metrics.yml -- D17 triage metrics alias for value-readback (#1709).
+#
+# Inner task `metrics` is exposed as the user-facing alias `task triage:metrics`
+# in the root Taskfile.yml alias block (same pattern as triage:summary).
+#
+# Per `conventions/task-caching.md`, tasks forwarding user-facing flags via
+# {{.CLI_ARGS}} MUST NOT declare `sources:` / `generates:`.
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+  metrics:
+    desc: "Trend lines from summary-history.jsonl (#1709 / D17). -- task triage:metrics -- [--window=7d|30d] [--format=text|json]"
+    internal: true
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'triage:metrics --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/value.yml
+++ b/tasks/value.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+# tasks/value.yml -- pull-based value-awareness readbacks (#1709).
+#
+# Per `conventions/task-caching.md`, tasks forwarding user-facing flags via
+# {{.CLI_ARGS}} MUST NOT declare `sources:` / `generates:`.
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+  show:
+    desc: "Pull-based attributed-value trend readout (#1709). -- task value:show -- [--window=7d|30d] [--format=text|json]"
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'value:show --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/xbrief/active/2026-07-05-2337-task-aliases-value-feedback-metrics.xbrief.json
+++ b/xbrief/active/2026-07-05-2337-task-aliases-value-feedback-metrics.xbrief.json
@@ -1,0 +1,48 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for GitHub issue #2337 — missing Taskfile aliases for value-feedback / metrics commands."
+  },
+  "plan": {
+    "id": "2337-task-aliases",
+    "title": "Add Taskfile aliases for policy:enable-value-feedback, value:show, triage:metrics",
+    "status": "running",
+    "narratives": {
+      "Description": "Several documented value-feedback commands exist on the deft CLI but lack tasks/*.yml wrappers, so `task policy:enable-value-feedback`, `task value:show`, and `task triage:metrics` fail with task not found. Add the missing Taskfile entries forwarding {{.CLI_ARGS}} to the engine and a contract test guarding the value/metrics surface.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2337",
+      "UserStory": "As a directive maintainer following AGENTS.md, I want documented `task` forms for value-feedback commands to resolve, so printed instructions work without switching to the deft binary.",
+      "ImplementationPlan": "1. Add `enable-value-feedback` to tasks/policy.yml. 2. Add tasks/value.yml with `show`. 3. Add tasks/triage-metrics.yml plus root `triage:metrics` alias in Taskfile.yml. 4. Add deterministic contract test for documented value/metrics task names. 5. CHANGELOG [Unreleased] entry; run task check.",
+      "Traces": "#2337, #1709"
+    },
+    "items": [
+      {
+        "id": "2337-a1-aliases",
+        "title": "Taskfile aliases resolve for all three commands",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "`task policy:enable-value-feedback`, `task value:show`, and `task triage:metrics` are listed by go-task and forward CLI_ARGS to the engine."
+        }
+      },
+      {
+        "id": "2337-a2-contract",
+        "title": "Contract test guards value/metrics task surface",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "A deterministic test fails when any documented value-feedback `task` name from AGENTS.md / templates is missing from the Taskfile surface."
+        }
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2337",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2337: Missing Taskfile aliases for policy:enable-value-feedback / value:show / triage:metrics"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "agentic-debt"
+    },
+    "updated": "2026-07-05T23:13:28Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Add missing Taskfile wrappers for `task policy:enable-value-feedback`, `task value:show`, and `task triage:metrics`, forwarding `{{.CLI_ARGS}}` to the engine like existing policy/feedback verbs.
- Add a deterministic contract test that documented value-feedback `task` names in AGENTS.md resolve on the Taskfile surface.

Closes #2337

## Test plan
- [x] `task --list` shows `policy:enable-value-feedback`, `value:show`, and `triage:metrics`
- [x] `pnpm --filter @deftai/directive-core test taskfile_value_feedback_aliases`
- [x] `task check`

Made with [Cursor](https://cursor.com)