### PR TITLE
Fix stale triage:metrics help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`task triage:metrics` help now matches the shipped command.** The help registry no longer describes the old summary-history.jsonl placeholder; it documents the value-feedback attribution-ledger trend (per-class and per-event counts over a window, gated on the opt-in policy). Refs #2338.
 - **chore(triage): move triage working-set cache off `.eval` to `.triage-cache/` (#1703)** — Triage append-only logs and decomposition scratch now resolve under a dedicated `.triage-cache/` namespace with an idempotent migration from legacy `.eval/` paths, reclaiming `.eval/` for the version-eval results store. Refs #1703.
 
 ### Fixed

--- a/packages/core/src/triage/help/index.test.ts
+++ b/packages/core/src/triage/help/index.test.ts
@@ -43,9 +43,12 @@ describe("renderVerbHelp", () => {
     expect(out).toContain("See also:");
   });
 
-  it("marks placeholder verbs", () => {
+  it("documents triage:metrics attribution-ledger behavior (#2338)", () => {
     const out = renderVerbHelp("task triage:metrics");
-    expect(out).toContain("not yet implemented");
+    expect(out).not.toContain("not yet implemented");
+    expect(out).toContain("events.jsonl");
+    expect(out).toContain("valueFeedback");
+    expect(out).toContain("--window");
   });
 });
 

--- a/packages/core/src/triage/help/registry-data.ts
+++ b/packages/core/src/triage/help/registry-data.ts
@@ -553,18 +553,25 @@ export const registryData = {
     },
     "task triage:metrics": {
       name: "task triage:metrics",
-      summary: "Trend lines from summary-history.jsonl",
-      refs: "(D17, coming)",
+      summary: "Attributed-value trend from the events ledger",
+      refs: "(#1709)",
       description:
-        "Print trend lines computed from vbrief/.triage-cache/summary-history.jsonl: decisions-per-day, defer/accept ratio, stale-defer drift, etc.",
+        "Report value-feedback attribution trends from .deft-cache/events.jsonl: total signal count plus per-class (value, bypass, adoption, friction) and per-event breakdowns over a time window. Alias of the value:show handler. Requires plan.policy.valueFeedback.enabled (default OFF) — exits blocked when disabled; an empty ledger prints a no-signals message. In the maintainer repo, skipped unless DEFT_VALUE_SELF_DOGFOOD=1.",
       usage: "task triage:metrics [-- --window=7d] [--format=text|json]",
       flags: [
-        ["--window WINDOW", "7d", "Time window over which to aggregate."],
-        ["--format text|json", "text", "Output shape."],
+        ["--window WINDOW", "7d", "Time window (e.g. 7d, 30d, 24h)."],
+        ["--format text|json", "text", "Output shape (json emits the full trend object)."],
       ],
-      examples: ["task triage:metrics -- --window 30d"],
-      see_also: ["task triage:summary", "#1119 / D17"],
-      placeholder: true,
+      examples: [
+        "task triage:metrics",
+        "task triage:metrics -- --window=30d --format=json",
+      ],
+      see_also: [
+        "task policy:show --field=valueFeedback",
+        "task policy:enable-value-feedback -- --confirm",
+        "#1709",
+      ],
+      placeholder: false,
     },
     "task scope:promote": {
       name: "task scope:promote",

--- a/packages/core/src/triage/help/registry-data.ts
+++ b/packages/core/src/triage/help/registry-data.ts
@@ -562,10 +562,7 @@ export const registryData = {
         ["--window WINDOW", "7d", "Time window (e.g. 7d, 30d, 24h)."],
         ["--format text|json", "text", "Output shape (json emits the full trend object)."],
       ],
-      examples: [
-        "task triage:metrics",
-        "task triage:metrics -- --window=30d --format=json",
-      ],
+      examples: ["task triage:metrics", "task triage:metrics -- --window=30d --format=json"],
       see_also: [
         "task policy:show --field=valueFeedback",
         "task policy:enable-value-feedback -- --confirm",

--- a/xbrief/active/2026-07-05-2338-stale-triage-metrics-help-text.xbrief.json
+++ b/xbrief/active/2026-07-05-2338-stale-triage-metrics-help-text.xbrief.json
@@ -1,0 +1,44 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF for #2338: update stale triage:metrics help registry entry"
+  },
+  "plan": {
+    "title": "#2338: Fix stale triage:metrics help text",
+    "status": "running",
+    "narratives": {
+      "Overview": "The triage:metrics help registry entry still describes the old summary-history.jsonl placeholder. Update packages/core/src/triage/help/registry-data.ts so help accurately documents the shipped value-feedback attribution-ledger behavior (alias of value:show / #1709 readback handler).",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2338"
+    },
+    "items": [
+      {
+        "title": "Rewrite triage:metrics help entry to describe attribution-ledger trend reporting",
+        "status": "proposed"
+      },
+      {
+        "title": "Update help registry test expectations for triage:metrics",
+        "status": "proposed"
+      },
+      {
+        "title": "Add CHANGELOG [Unreleased] entry and open PR closing #2338",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2338",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2338: Stale triage:metrics help text"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1709",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1709: Value feedback attribution"
+      }
+    ],
+    "metadata": {
+      "capacityBucket": "maintenance"
+    },
+    "updated": "2026-07-05T23:13:39Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Update the `task triage:metrics` help registry entry to describe the shipped value-feedback attribution-ledger behavior (reads `.deft-cache/events.jsonl`, reports per-class and per-event counts over a window)
- Remove the stale `summary-history.jsonl` placeholder and mark the verb as implemented
- Document the opt-in `plan.policy.valueFeedback` gate and maintainer-repo dogfood bypass

Closes #2338

## Test plan

- [x] `task check` passes
- [x] Updated `packages/core/src/triage/help/index.test.ts` asserts triage:metrics help mentions events.jsonl, valueFeedback, and --window
- [ ] Greptile / CI clean on PR


Made with [Cursor](https://cursor.com)