### PR TITLE
Agents can discover and be nudged about eval:health (#2336)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,12 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 - ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
 - ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
 
+## Eval and framework health (#1703)
+
+- ! Three tiers: **Tier 0** `task eval:health` (static gate score + contradictory-gate detector; ledger: `.eval/results/health-history.jsonl`). **Tier 1** CRUD telemetry on scope transitions (`.eval/results/crud-metrics.jsonl`, automatic). **Tier 2** `task eval:run` / `task eval:report` (golden corpus champion–challenger + holdout tripwire).
+- ! Run `task eval:health` when orienting, after gate/policy/doc changes, or when session start emits a budgeted `[eval]` nudge (score drop or contradictory gate; 4-hour debounce, parity #1279/#1709). Tier 2 is for maintainer release eval (`eval:run -- --model M`; `eval:report -- --champion V --challenger V --model M`).
+- ⊗ Discover eval only via CHANGELOG/`task --list` — AGENTS.md and `task triage:help` are canonical. ⊗ Treat Tier 1 telemetry as operator-invoked.
+
 ## Cache-as-authoritative work selection (#1149)
 
 Same `!` / `⊗` rules as the managed section below; in this repo substitute `task` for `deft` (`task triage:queue --limit=10`, D11 / #1128).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Eval framework discoverability (#1703).** Agents now learn the tiered eval surface from AGENTS.md: Tier 0 `task eval:health`, automatic Tier 1 CRUD telemetry, and Tier 2 `eval:run` / `eval:report`. Session start emits a budgeted `[eval]` advisory when health degrades or a contradictory gate fires, and `task triage:help` documents all three eval verbs. Closes #2336.
+
 ### Fixed
 
 - Maintainer `task` aliases for value feedback: `task policy:enable-value-feedback`, `task value:show`, and `task triage:metrics` now resolve through the Taskfile instead of failing with "task not found", matching the documented AGENTS.md surface. Refs #2337.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -149,6 +149,12 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 - ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
 - ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
 
+## Eval and framework health (#1703)
+
+- ! Three tiers: **Tier 0** `deft eval:health` (static gate score + contradictory-gate detector; ledger: `.eval/results/health-history.jsonl`). **Tier 1** CRUD telemetry on scope transitions (`.eval/results/crud-metrics.jsonl`, automatic). **Tier 2** `deft eval:run` / `deft eval:report` (golden corpus champion–challenger + holdout tripwire).
+- ! Run `deft eval:health` when orienting, after gate/policy/doc changes, or when session start emits a budgeted `[eval]` nudge (score drop or contradictory gate; 4-hour debounce, parity #1279/#1709). Tier 2 is for maintainer release eval (`eval:run -- --model M`; `eval:report -- --champion V --challenger V --model M`).
+- ⊗ Discover eval only via CHANGELOG/`deft --list` — AGENTS.md and `deft triage:help` are canonical. ⊗ Treat Tier 1 telemetry as operator-invoked.
+
 ## Branch policy & branch verification
 
 Three consumer-facing surfaces enforce the branch-policy contract (#746 / #747):

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -182,7 +182,7 @@ const EVAL_FRAMEWORK_MARKERS = [
   "crud-metrics.jsonl",
   "health-history.jsonl",
   "contradictory gate",
-  "4-hour window",
+  "4-hour debounce",
   "Tier 1",
   "Tier 2",
 ] as const;

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { EVAL_READBACK_SUPPRESSION_HOURS } from "../../eval/readback.js";
 import { VALUE_READBACK_SUPPRESSION_HOURS } from "../../value/readback.js";
 import { readRepoFile } from "./helpers.js";
 
@@ -32,6 +33,9 @@ const PROPAGATION_COMMAND_MARKERS: ReadonlyArray<readonly [string, string]> = [
   ["deft policy:enable-value-feedback", "task policy:enable-value-feedback"],
   ["deft policy:show --field=valueFeedback", "task policy:show --field=valueFeedback"],
   ["deft value:show", "task value:show"],
+  ["deft eval:health", "task eval:health"],
+  ["deft eval:run", "task eval:run"],
+  ["deft eval:report", "task eval:report"],
   ["deft feedback:file", "task feedback:file"],
   ["deft migrate:xbrief", "deft migrate:xbrief"],
   ["xbrief/PROJECT-DEFINITION.xbrief.json", "xbrief/PROJECT-DEFINITION.xbrief.json"],
@@ -168,6 +172,21 @@ const VALUE_FEEDBACK_MARKERS = [
   "without operator confirmation",
 ] as const;
 
+// #1703: tiered eval framework discoverability MUST mirror across maintainer
+// AGENTS.md and the consumer template (#2336 / #1309).
+const EVAL_FRAMEWORK_MARKERS = [
+  "## Eval and framework health (#1703)",
+  "eval:health",
+  "eval:run",
+  "eval:report",
+  "crud-metrics.jsonl",
+  "health-history.jsonl",
+  "contradictory gate",
+  "4-hour window",
+  "Tier 1",
+  "Tier 2",
+] as const;
+
 function normalizeWhitespace(text: string): string {
   return text
     .replace(/\u00a0/g, " ")
@@ -272,8 +291,17 @@ describe("test_agents_entry_contract", () => {
     expect(missingMarkers(agents, VALUE_FEEDBACK_MARKERS)).toEqual([]);
   });
 
+  it("propagation_eval_framework_markers_present_in_both_files", () => {
+    expect(missingMarkers(template, EVAL_FRAMEWORK_MARKERS)).toEqual([]);
+    expect(missingMarkers(agents, EVAL_FRAMEWORK_MARKERS)).toEqual([]);
+  });
+
   it("value_readback_suppression_window_is_four_hours", () => {
     expect(VALUE_READBACK_SUPPRESSION_HOURS).toBe(4);
+  });
+
+  it("eval_readback_suppression_window_is_four_hours", () => {
+    expect(EVAL_READBACK_SUPPRESSION_HOURS).toBe(4);
   });
 
   it("content_packs_note_references_discovery_commands", () => {

--- a/packages/core/src/eval/readback.test.ts
+++ b/packages/core/src/eval/readback.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { HealthReport } from "./health.js";
+import {
+  EVAL_READBACK_SUPPRESSION_HOURS,
+  emitSessionEvalReadback,
+  evalReadbackNudgeKey,
+  formatEvalHealthSessionLine,
+  renderSessionEvalReadback,
+  shouldNudgeEvalHealth,
+  shouldSuppressEvalReadback,
+} from "./readback.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "eval-readback-"));
+  temps.push(root);
+  return root;
+}
+
+function sampleReport(overrides: Partial<HealthReport> = {}): HealthReport {
+  return {
+    schemaVersion: 1,
+    version: "0.99.0",
+    recordedAt: "2026-07-05T12:00:00Z",
+    score: 80,
+    gates: [
+      { id: "encoding", title: "verify:encoding", pass: true, exitCode: 0 },
+      { id: "links", title: "verify:links", pass: false, exitCode: 1, detail: "broken" },
+    ],
+    contradictions: [],
+    ...overrides,
+  };
+}
+
+describe("shouldNudgeEvalHealth", () => {
+  it("nudges on contradictory gates", () => {
+    const report = sampleReport({
+      contradictions: [
+        {
+          id: "wipCap-unsatisfiable-nudge",
+          kind: "unsatisfiable-nudge",
+          summary: "unsatisfiable",
+          signals: [],
+        },
+      ],
+    });
+    expect(shouldNudgeEvalHealth(report, null)).toBe(true);
+  });
+
+  it("nudges when score drops", () => {
+    const previous = sampleReport({ score: 100 });
+    const current = sampleReport({ score: 85 });
+    expect(shouldNudgeEvalHealth(current, previous)).toBe(true);
+  });
+
+  it("nudges on first degraded run with failing gates", () => {
+    expect(shouldNudgeEvalHealth(sampleReport({ score: 80 }), null)).toBe(true);
+  });
+
+  it("stays silent when healthy with no prior history", () => {
+    const healthy = sampleReport({
+      score: 100,
+      gates: [{ id: "encoding", title: "verify:encoding", pass: true, exitCode: 0 }],
+    });
+    expect(shouldNudgeEvalHealth(healthy, null)).toBe(false);
+  });
+});
+
+describe("formatEvalHealthSessionLine", () => {
+  it("mentions contradictory gate id", () => {
+    const line = formatEvalHealthSessionLine(
+      sampleReport({
+        contradictions: [
+          {
+            id: "wipCap-unsatisfiable-nudge",
+            kind: "unsatisfiable-nudge",
+            summary: "Onboarding vs omit-by-design",
+            signals: [],
+          },
+        ],
+      }),
+      null,
+    );
+    expect(line).toContain("wipCap-unsatisfiable-nudge");
+    expect(line).toContain("task eval:health");
+  });
+
+  it("mentions score drop", () => {
+    const line = formatEvalHealthSessionLine(
+      sampleReport({ score: 70 }),
+      sampleReport({ score: 90 }),
+    );
+    expect(line).toContain("90->70");
+  });
+});
+
+describe("shouldSuppressEvalReadback", () => {
+  it("suppresses repeated nudge within four hours", () => {
+    const root = tempRoot();
+    const hist = join(root, ".deft-cache", "eval-readback-history.jsonl");
+    const key = evalReadbackNudgeKey(sampleReport());
+    const now = new Date("2026-07-05T12:00:00Z");
+    renderSessionEvalReadback(root, {
+      writeHistory: true,
+      now,
+      evaluate: () => ({ report: sampleReport() }),
+    });
+    expect(existsSync(hist)).toBe(true);
+    expect(shouldSuppressEvalReadback(key, hist, { now: new Date("2026-07-05T13:00:00Z") })).toBe(
+      true,
+    );
+    expect(shouldSuppressEvalReadback(key, hist, { now: new Date("2026-07-05T17:00:00Z") })).toBe(
+      false,
+    );
+  });
+});
+
+describe("emitSessionEvalReadback", () => {
+  it("writes nothing when report is healthy", () => {
+    const root = tempRoot();
+    const lines: string[] = [];
+    expect(
+      emitSessionEvalReadback(root, {
+        output: (l) => lines.push(l),
+        writeHistory: false,
+        evaluate: () => ({
+          report: sampleReport({
+            score: 100,
+            gates: [{ id: "encoding", title: "verify:encoding", pass: true, exitCode: 0 }],
+          }),
+        }),
+      }),
+    ).toBeNull();
+    expect(lines).toEqual([]);
+  });
+
+  it("emits advisory line when score drops", () => {
+    const root = tempRoot();
+    const lines: string[] = [];
+    const line = emitSessionEvalReadback(root, {
+      output: (l) => lines.push(l),
+      writeHistory: false,
+      evaluate: () => ({ report: sampleReport({ score: 60 }) }),
+    });
+    expect(line).toContain("[eval]");
+    expect(lines).toHaveLength(1);
+  });
+});
+
+describe("EVAL_READBACK_SUPPRESSION_HOURS", () => {
+  it("matches value-readback debounce parity", () => {
+    expect(EVAL_READBACK_SUPPRESSION_HOURS).toBe(4);
+  });
+});

--- a/packages/core/src/eval/readback.ts
+++ b/packages/core/src/eval/readback.ts
@@ -1,0 +1,267 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { MAX_LINE_CHARS } from "../triage/welcome/constants.js";
+import { evaluateHealth, type HealthReport, healthHistoryPath } from "./health.js";
+
+/** Repeat-suppression window for the budgeted eval session nudge (#1703 / #1279 parity). */
+export const EVAL_READBACK_SUPPRESSION_HOURS = 4;
+
+export const EVAL_READBACK_HISTORY_REL = join(".deft-cache", "eval-readback-history.jsonl");
+export const EVAL_READBACK_HISTORY_SCHEMA = "deft.eval.readback.v1";
+
+export interface SessionEvalReadbackResult {
+  readonly line: string | null;
+  readonly suppressed: boolean;
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  if (maxChars <= 3) {
+    return text.slice(0, maxChars);
+  }
+  return `${text.slice(0, maxChars - 3)}...`;
+}
+
+function parseJsonObjectOrNull(text: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // malformed history line
+  }
+  return null;
+}
+
+function readHealthHistoryRows(projectRoot: string): HealthReport[] {
+  const path = healthHistoryPath(projectRoot);
+  if (!existsSync(path)) {
+    return [];
+  }
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const rows: HealthReport[] = [];
+  for (const line of text.split("\n")) {
+    const stripped = line.trim();
+    if (stripped.length === 0) {
+      continue;
+    }
+    try {
+      rows.push(JSON.parse(stripped) as HealthReport);
+    } catch {
+      // skip malformed ledger rows
+    }
+  }
+  return rows;
+}
+
+function readbackHistoryPath(projectRoot: string): string {
+  return resolve(projectRoot, EVAL_READBACK_HISTORY_REL);
+}
+
+function readLastReadbackRecord(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  const lines = text.split("\n").filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    return null;
+  }
+  const last = lines[lines.length - 1];
+  if (last === undefined) {
+    return null;
+  }
+  return parseJsonObjectOrNull(last);
+}
+
+function parseHistoryEmittedAt(record: Record<string, unknown>): Date | null {
+  const raw = record.emitted_at;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+  let candidate = raw.trim();
+  if (candidate.endsWith("Z")) {
+    candidate = `${candidate.slice(0, -1)}+00:00`;
+  }
+  const parsed = new Date(candidate);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** Stable nudge key for debounce — score + contradiction ids. */
+export function evalReadbackNudgeKey(report: HealthReport): string {
+  const contradictionIds = report.contradictions
+    .map((c) => c.id)
+    .sort()
+    .join(",");
+  return `eval-health:${report.score}:${contradictionIds}`;
+}
+
+/** True when the same eval nudge was read back within the suppression window. */
+export function shouldSuppressEvalReadback(
+  nudgeKey: string,
+  historyFile: string,
+  options: { now?: Date } = {},
+): boolean {
+  const prior = readLastReadbackRecord(historyFile);
+  if (prior === null) {
+    return false;
+  }
+  const emittedAt = parseHistoryEmittedAt(prior);
+  if (emittedAt === null) {
+    return false;
+  }
+  const now = options.now ?? new Date();
+  const ageMs = now.getTime() - emittedAt.getTime();
+  if (ageMs < 0 || ageMs >= EVAL_READBACK_SUPPRESSION_HOURS * 3_600_000) {
+    return false;
+  }
+  return prior.nudge_key === nudgeKey;
+}
+
+function appendEvalReadbackHistory(
+  projectRoot: string,
+  nudgeKey: string,
+  line: string,
+  options: { now?: Date } = {},
+): void {
+  const path = readbackHistoryPath(projectRoot);
+  const record = {
+    schema: EVAL_READBACK_HISTORY_SCHEMA,
+    emitted_at: (options.now ?? new Date()).toISOString().replace(/\.\d{3}Z$/, "Z"),
+    nudge_key: nudgeKey,
+    line,
+  };
+  try {
+    mkdirSync(join(path, ".."), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(record)}\n`, "utf8");
+  } catch {
+    // observability only
+  }
+}
+
+function failedGateCount(report: HealthReport): number {
+  return report.gates.filter((g) => !g.skipped && !g.pass).length;
+}
+
+/** Whether the current health report warrants a session-start advisory nudge (#2336). */
+export function shouldNudgeEvalHealth(
+  report: HealthReport,
+  previous: HealthReport | null,
+): boolean {
+  if (report.contradictions.length > 0) {
+    return true;
+  }
+  if (previous !== null && report.score < previous.score) {
+    return true;
+  }
+  if (previous === null && report.score < 100 && failedGateCount(report) > 0) {
+    return true;
+  }
+  return false;
+}
+
+export function formatEvalHealthSessionLine(
+  report: HealthReport,
+  previous: HealthReport | null,
+): string {
+  if (report.contradictions.length > 0) {
+    const first = report.contradictions[0];
+    const summary = first?.summary ?? "contradictory gate detected";
+    return (
+      `[eval] Framework health ${report.score}/100 — contradictory gate ${first?.id ?? "unknown"}: ` +
+      `${summary.replace(/\r?\n/g, " ")} — run \`task eval:health\` for detail.`
+    );
+  }
+  if (previous !== null && report.score < previous.score) {
+    return (
+      `[eval] Framework health dropped ${previous.score}->${report.score}/100 — ` +
+      "run `task eval:health` for gate detail."
+    );
+  }
+  const failed = failedGateCount(report);
+  return (
+    `[eval] Framework health ${report.score}/100 (${failed} gate${failed === 1 ? "" : "s"} failing) — ` +
+    "run `task eval:health` for detail."
+  );
+}
+
+export interface RenderSessionEvalReadbackOptions {
+  readonly now?: Date;
+  readonly maxChars?: number;
+  readonly writeHistory?: boolean;
+  readonly evaluate?: (projectRoot: string) => { report: HealthReport | null };
+}
+
+/** Budgeted session eval one-liner — silent when healthy or debounced (#1703 / #2336). */
+export function renderSessionEvalReadback(
+  projectRoot: string,
+  options: RenderSessionEvalReadbackOptions = {},
+): SessionEvalReadbackResult {
+  try {
+    const root = resolve(projectRoot);
+    const priorRows = readHealthHistoryRows(root);
+    const previous = priorRows.length > 0 ? (priorRows[priorRows.length - 1] ?? null) : null;
+
+    const evaluateFn =
+      options.evaluate ??
+      ((cwd: string) => {
+        const result = evaluateHealth({ projectRoot: cwd, persist: true });
+        return { report: result.report };
+      });
+    const { report } = evaluateFn(root);
+    if (report === null) {
+      return { line: null, suppressed: false };
+    }
+
+    if (!shouldNudgeEvalHealth(report, previous)) {
+      return { line: null, suppressed: false };
+    }
+
+    const nudgeKey = evalReadbackNudgeKey(report);
+    const hist = readbackHistoryPath(root);
+    if (shouldSuppressEvalReadback(nudgeKey, hist, { now: options.now })) {
+      return { line: null, suppressed: true };
+    }
+
+    const maxChars = options.maxChars ?? MAX_LINE_CHARS;
+    const line = truncate(formatEvalHealthSessionLine(report, previous), maxChars);
+    if (options.writeHistory !== false) {
+      appendEvalReadbackHistory(root, nudgeKey, line, { now: options.now });
+    }
+    return { line, suppressed: false };
+  } catch {
+    return { line: null, suppressed: false };
+  }
+}
+
+/** Emit the eval session readback line when present. Returns the line or null. */
+export function emitSessionEvalReadback(
+  projectRoot: string,
+  options: {
+    output?: (line: string) => void;
+    now?: Date;
+    writeHistory?: boolean;
+    evaluate?: (projectRoot: string) => { report: HealthReport | null };
+  } = {},
+): string | null {
+  const result = renderSessionEvalReadback(projectRoot, options);
+  if (result.line === null) {
+    return null;
+  }
+  const out = options.output ?? ((line: string) => process.stdout.write(`${line}\n`));
+  out(result.line);
+  return result.line;
+}

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { runningInsideDeftRepo } from "../doctor/paths.js";
+import { emitSessionEvalReadback } from "../eval/readback.js";
 import { MIGRATE_COMPLETION_NUDGE, shouldEmitMigrateNudge } from "../init-deposit/migrate.js";
 import { disclosureLine } from "../policy/disclosure.js";
 import { resolvePolicy } from "../policy/resolve.js";
@@ -372,6 +373,15 @@ export function runSessionStart(
     });
   } catch {
     // observability only — session start must not abort on transient readback I/O
+  }
+
+  try {
+    emitSessionEvalReadback(projectRoot, {
+      output: (line) => lines.push(line),
+      writeHistory: options.writeHistory !== false,
+    });
+  } catch {
+    // observability only — session start must not abort on transient eval readback I/O
   }
 
   const payload = newRitualStatePayload({

--- a/packages/core/src/triage/help/index.test.ts
+++ b/packages/core/src/triage/help/index.test.ts
@@ -50,6 +50,21 @@ describe("renderVerbHelp", () => {
     expect(out).toContain("valueFeedback");
     expect(out).toContain("--window");
   });
+
+  it("documents eval:health tier-0 behavior (#2336)", () => {
+    const out = renderVerbHelp("task eval:health");
+    expect(out).not.toContain("not yet implemented");
+    expect(out).toContain("health-history.jsonl");
+    expect(out).toContain("--json");
+  });
+
+  it("lists eval verbs in triage category catalog (#2336)", () => {
+    const out = renderCategoryList("triage");
+    expect(out).toContain("Framework eval (#1703)");
+    expect(out).toContain("task eval:health");
+    expect(out).toContain("task eval:run");
+    expect(out).toContain("task eval:report");
+  });
 });
 
 describe("interceptHelp", () => {

--- a/packages/core/src/triage/help/registry-data.ts
+++ b/packages/core/src/triage/help/registry-data.ts
@@ -570,6 +570,77 @@ export const registryData = {
       ],
       placeholder: false,
     },
+    "task eval:health": {
+      name: "task eval:health",
+      summary: "Tier 0 static framework health score",
+      refs: "(#1703)",
+      description:
+        "Aggregate static self-consistency gates (encoding, links, vBRIEF conformance, AGENTS.md freshness; content-manifest on framework-source trees) into a versioned 0–100 score. Detects contradictory / unsatisfiable gate pairs (#1694). Appends each run to .eval/results/health-history.jsonl. Session start may emit a budgeted [eval] advisory when health degrades.",
+      usage: "task eval:health [-- --json] [--no-persist] [--project-root PATH]",
+      flags: [
+        ["--json", "(off)", "Emit the structured HealthReport instead of the human summary."],
+        ["--no-persist", "(off)", "Run probes without appending to the health history ledger."],
+        [
+          "--project-root PATH",
+          "(cwd)",
+          "Project root override (Taskfile threads USER_WORKING_DIR).",
+        ],
+      ],
+      examples: ["task eval:health", "task eval:health -- --json"],
+      see_also: ["task eval:run", "task eval:report", "#1703"],
+      placeholder: false,
+    },
+    "task eval:run": {
+      name: "task eval:run",
+      summary: "Tier 2 golden corpus eval for a model",
+      refs: "(#1703)",
+      description:
+        "Execute the fixed golden corpus with objective graders (CRUD schema/invention, surgical update, health fixture, rotating holdout tasks). Persists results to .eval/results/golden-runs.jsonl for champion–challenger diffs.",
+      usage:
+        "task eval:run -- --model MODEL [--seed N] [--directive-version V] [--harness NAME] [--json] [--no-persist]",
+      flags: [
+        ["--model MODEL", "(required)", "Model identifier for the run record."],
+        ["--seed N", "(1,2,3)", "Repeatable seed(s); pass multiple --seed flags."],
+        ["--directive-version V", "(engine version)", "Pin the directive version label."],
+        ["--harness NAME", "deterministic-fixture", "Harness label stored on the run record."],
+        ["--json", "(off)", "Emit the GoldenRunRecord JSON."],
+        ["--no-persist", "(off)", "Run without appending to golden-runs.jsonl."],
+        [
+          "--project-root PATH",
+          "(cwd)",
+          "Project root override (Taskfile threads USER_WORKING_DIR).",
+        ],
+      ],
+      examples: [
+        "task eval:run -- --model gpt-5",
+        "task eval:run -- --model claude-sonnet --seed 1 --seed 2 --json",
+      ],
+      see_also: ["task eval:report", "task eval:health", "#1703"],
+      placeholder: false,
+    },
+    "task eval:report": {
+      name: "task eval:report",
+      summary: "Tier 2 champion–challenger diff with significance",
+      refs: "(#1703)",
+      description:
+        "Diff two directive versions' latest golden runs for a model: primary/holdout/overall pass-rate deltas with two-proportion significance and a holdout tripwire when primary gains do not generalize (#1703 Goodhart guard).",
+      usage:
+        "task eval:report -- --champion V --challenger V --model MODEL [--json] [--project-root PATH]",
+      flags: [
+        ["--champion V", "(required)", "Baseline directive version."],
+        ["--challenger V", "(required)", "Candidate directive version."],
+        ["--model MODEL", "(required)", "Model identifier shared by both runs."],
+        ["--json", "(off)", "Emit the GoldenEvalReport JSON."],
+        [
+          "--project-root PATH",
+          "(cwd)",
+          "Project root override (Taskfile threads USER_WORKING_DIR).",
+        ],
+      ],
+      examples: ["task eval:report -- --champion 0.58.0 --challenger 0.59.0 --model gpt-5"],
+      see_also: ["task eval:run", "task eval:health", "#1703"],
+      placeholder: false,
+    },
     "task scope:promote": {
       name: "task scope:promote",
       summary: "proposed/ -> pending/ (set status pending)",
@@ -817,6 +888,7 @@ export const registryData = {
         "task triage:metrics",
       ],
     ],
+    ["Framework eval (#1703)", ["task eval:health", "task eval:run", "task eval:report"]],
   ],
   categoriesScope: [
     ["Promote / demote", ["task scope:promote", "task scope:demote"]],

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16783,7 +16783,7 @@
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
         "managedMaxLines": 225,
-        "unmanagedMaxLines": 256
+        "unmanagedMaxLines": 264
       }
     },
     "updated": "2026-07-02T14:32:31Z"


### PR DESCRIPTION
## Summary

- Adds an **Eval and framework health (#1703)** section to maintainer `AGENTS.md` and the consumer `agents-entry.md` template, with contract-locked markers mirroring the #1709 value-feedback institutionalization pattern.
- Wires a budgeted **`[eval]` session-start advisory** when framework health degrades (score drop, first-run failing gates, or contradictory gate detected), with 4-hour debounce parity to value readback.
- Documents **`task eval:health` / `task eval:run` / `task eval:report`** in the `triage:help` verb registry under a new Framework eval category.

Closes #2336

## Test plan

- [x] `task check` green (agents-entry contract, forward coverage, agents-md-budget ratchet)
- [x] `packages/core/src/eval/readback.test.ts` — nudge logic, debounce, emit path
- [x] `packages/core/src/triage/help/index.test.ts` — eval verbs listed and documented
- [x] `packages/core/src/content-contracts/skills/agents_entry_contract.test.ts` — eval markers mirrored


Made with [Cursor](https://cursor.com)