### PR TITLE
fix(triage): stop legacy .eval triage-cache writes post-migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The subagent monitor now rejects a non-numeric `--threshold-minutes` value (e.g. a typo) with a clear error and non-zero exit, instead of silently accepting `NaN` and running with an invalid staleness threshold. (#2357)
+- Triage working-set writers no longer recreate legacy cache files under `.eval/` after the #1703 relocation: migration now removes orphaned legacy copies, regenerates the relocated README with layout-aware `.triage-cache/` paths (instead of renaming stale `.eval/` content), and the intake candidates-log default resolves through `.triage-cache/`. Refs #2344.
 - `deft triage:accept` no longer fails with `ModuleNotFoundError: No module named 'issue_ingest'`. It now authors the scope brief through the native TypeScript intake path instead of shelling out to a legacy Python script that was removed during the Python-surface deprecation, so accepting an issue (and the `verify:cache-fresh` dispatch gate that depends on it) works again. (#2350)
 
 ### Removed

--- a/packages/core/src/intake/candidates-log.ts
+++ b/packages/core/src/intake/candidates-log.ts
@@ -11,17 +11,11 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { pyRepr } from "../scm/py-format.js";
+import { resolveCandidatesLogPath } from "../triage/cache-path.js";
 
-export const DEFAULT_LOG_PATH = resolve(
-  import.meta.dirname,
-  "..",
-  "..",
-  "..",
-  "..",
-  "vbrief",
-  ".eval",
-  "candidates.jsonl",
-);
+function defaultLogPath(): string {
+  return resolveCandidatesLogPath(process.cwd());
+}
 
 const VALID_DECISIONS = new Set<string>([
   "accept",
@@ -163,7 +157,7 @@ function validateEntry(entry: unknown): void {
 }
 
 function resolvePath(path: string | null | undefined): string {
-  return path !== undefined && path !== null ? resolve(path) : DEFAULT_LOG_PATH;
+  return path !== undefined && path !== null ? resolve(path) : defaultLogPath();
 }
 
 function acquireAppendLock(logPath: string): () => void {

--- a/packages/core/src/triage/bootstrap/gitignore.test.ts
+++ b/packages/core/src/triage/bootstrap/gitignore.test.ts
@@ -5,6 +5,7 @@ import { afterAll, describe, expect, it } from "vitest";
 import {
   GITIGNORE_EVAL_ENTRIES,
   GITIGNORE_LINE,
+  generateTriageCacheReadmeBody,
   stepEnsureGitignoreEntry,
   stepEnsureGitignoreEvalEntries,
   stepSeedCandidatesLog,
@@ -163,5 +164,20 @@ describe("stepSeedCandidatesLog", () => {
     expect(outcome.ok).toBe(true);
     expect(outcome.details.already_present).toBe(true);
     expect(readFileSync(audit, "utf8")).toBe(before);
+  });
+});
+
+describe("generateTriageCacheReadmeBody", () => {
+  it("substitutes xbrief/.triage-cache for the active migrated layout", () => {
+    const root = makeRoot();
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "s.xbrief.json"),
+      JSON.stringify({ plan: { id: "s", status: "running", items: [] } }),
+      "utf8",
+    );
+    const body = generateTriageCacheReadmeBody(root);
+    expect(body).toContain("xbrief/.triage-cache/");
+    expect(body).not.toContain("vbrief/.triage-cache/");
   });
 });

--- a/packages/core/src/triage/bootstrap/gitignore.ts
+++ b/packages/core/src/triage/bootstrap/gitignore.ts
@@ -176,6 +176,13 @@ operators should know:
 - \`scripts/candidates_log.py\` -- the writer for \`candidates.jsonl\`.
 `;
 
+/** Layout-aware triage-cache README body for the active lifecycle tree (#2344 / #2349). */
+export function generateTriageCacheReadmeBody(projectRoot: string): string {
+  const layout = resolveLifecycleLayout(projectRoot);
+  const triagePrefix = `${layout.artifactDir}/${TRIAGE_CACHE_DIR_NAME}`;
+  return EVAL_README_BODY.replaceAll("vbrief/.triage-cache", triagePrefix);
+}
+
 function stepOutcome(
   name: string,
   ok: boolean,
@@ -444,7 +451,12 @@ function ensureGitattributesMergeUnion(
   });
 }
 
-function ensureEvalReadme(readmePath: string, readmeRel: string, stepName: string): StepOutcome {
+function ensureEvalReadme(
+  projectRoot: string,
+  readmePath: string,
+  readmeRel: string,
+  stepName: string,
+): StepOutcome {
   try {
     readFileSync(readmePath, { encoding: "utf8" });
     return stepOutcome(stepName, true, `${readmeRel} already present (no-op)`, {
@@ -457,7 +469,7 @@ function ensureEvalReadme(readmePath: string, readmeRel: string, stepName: strin
 
   try {
     mkdirSync(dirname(readmePath), { recursive: true });
-    writeFileSync(readmePath, EVAL_README_BODY, { encoding: "utf8" });
+    writeFileSync(readmePath, generateTriageCacheReadmeBody(projectRoot), { encoding: "utf8" });
   } catch (exc) {
     return stepOutcome(
       stepName,
@@ -500,7 +512,7 @@ export function stepEnsureGitignoreEvalEntries(projectRoot: string): StepOutcome
   }
   Object.assign(details, gaResult.details);
 
-  const rdResult = ensureEvalReadme(readmePath, readmeRel, stepName);
+  const rdResult = ensureEvalReadme(projectRoot, readmePath, readmeRel, stepName);
   if (!rdResult.ok) {
     Object.assign(details, rdResult.details);
     return stepOutcome(stepName, false, rdResult.message, details, rdResult.error ?? null);

--- a/packages/core/src/triage/bootstrap/gitignore.ts
+++ b/packages/core/src/triage/bootstrap/gitignore.ts
@@ -451,12 +451,15 @@ function ensureGitattributesMergeUnion(
   });
 }
 
-function ensureEvalReadme(
-  projectRoot: string,
-  readmePath: string,
-  readmeRel: string,
-  stepName: string,
-): StepOutcome {
+interface EnsureEvalReadmeOptions {
+  readonly projectRoot: string;
+  readonly readmePath: string;
+  readonly readmeRel: string;
+  readonly stepName: string;
+}
+
+function ensureEvalReadme(options: EnsureEvalReadmeOptions): StepOutcome {
+  const { projectRoot, readmePath, readmeRel, stepName } = options;
   try {
     readFileSync(readmePath, { encoding: "utf8" });
     return stepOutcome(stepName, true, `${readmeRel} already present (no-op)`, {
@@ -512,7 +515,7 @@ export function stepEnsureGitignoreEvalEntries(projectRoot: string): StepOutcome
   }
   Object.assign(details, gaResult.details);
 
-  const rdResult = ensureEvalReadme(projectRoot, readmePath, readmeRel, stepName);
+  const rdResult = ensureEvalReadme({ projectRoot, readmePath, readmeRel, stepName });
   if (!rdResult.ok) {
     Object.assign(details, rdResult.details);
     return stepOutcome(stepName, false, rdResult.message, details, rdResult.error ?? null);

--- a/packages/core/src/triage/cache-path.test.ts
+++ b/packages/core/src/triage/cache-path.test.ts
@@ -146,6 +146,22 @@ describe("triage cache-path (#1703)", () => {
     expect(readme).not.toContain("legacy `.eval/` readme");
   });
 
+  it("preserves an existing canonical README and only removes the legacy copy", () => {
+    seedXbrief();
+    const legacyDir = resolveEvalDir(root);
+    const targetDir = resolveTriageCacheDir(root);
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(legacyDir, "README.md"), "# stale legacy\n", "utf8");
+    writeFileSync(join(targetDir, "README.md"), "# canonical custom\n", "utf8");
+
+    const result = migrateLegacyTriageCacheFromEval(root);
+    expect(result.removedLegacyFiles).toContain("README.md");
+    expect(result.regeneratedFiles).not.toContain("README.md");
+    expect(readFileSync(join(targetDir, "README.md"), "utf8")).toBe("# canonical custom\n");
+    expect(existsSync(join(legacyDir, "README.md"))).toBe(false);
+  });
+
   it("removes orphaned legacy triage-cache files when the canonical .triage-cache copy already exists", () => {
     seedXbrief();
     const legacyDir = resolveEvalDir(root);

--- a/packages/core/src/triage/cache-path.test.ts
+++ b/packages/core/src/triage/cache-path.test.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeState } from "../doctor/doctor-state.js";
+import { append } from "../intake/candidates-log.js";
 import { resolveEvalDir } from "../layout/resolve.js";
 import {
   migrateLegacyTriageCacheFromEval,
@@ -74,7 +76,7 @@ describe("triage cache-path (#1703)", () => {
     expect(existsSync(join(legacyDir, "candidates.jsonl"))).toBe(false);
   });
 
-  it("migrateLegacyTriageCacheFromEval is idempotent and skips when target already exists", () => {
+  it("migrateLegacyTriageCacheFromEval is idempotent and removes orphaned legacy copies when target already exists", () => {
     seedVbrief();
     const legacyDir = resolveEvalDir(root);
     const targetDir = resolveTriageCacheDir(root);
@@ -84,8 +86,9 @@ describe("triage cache-path (#1703)", () => {
     writeFileSync(join(targetDir, "candidates.jsonl"), "canonical\n", "utf8");
 
     const first = migrateLegacyTriageCacheFromEval(root);
-    expect(first.skippedFiles).toContain("candidates.jsonl");
+    expect(first.removedLegacyFiles).toContain("candidates.jsonl");
     expect(readFileSync(join(targetDir, "candidates.jsonl"), "utf8")).toBe("canonical\n");
+    expect(existsSync(join(legacyDir, "candidates.jsonl"))).toBe(false);
 
     writeFileSync(join(legacyDir, "summary-history.jsonl"), "history\n", "utf8");
     const second = migrateLegacyTriageCacheFromEval(root);
@@ -121,5 +124,87 @@ describe("triage cache-path (#1703)", () => {
     expect(existsSync(join(legacyDir, "candidates.jsonl"))).toBe(false);
     expect(existsSync(join(legacyDir, "results", "v0.1.json"))).toBe(true);
     expect(existsSync(join(resolveTriageCacheDir(root), "candidates.jsonl"))).toBe(true);
+  });
+
+  it("regenerates README.md with layout-aware .triage-cache paths instead of renaming stale .eval content", () => {
+    seedXbrief();
+    const legacyDir = resolveEvalDir(root);
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(legacyDir, "README.md"),
+      "# legacy `.eval/` readme -- do not keep\n",
+      "utf8",
+    );
+
+    const result = migrateLegacyTriageCacheFromEval(root);
+    expect(result.regeneratedFiles).toContain("README.md");
+    expect(existsSync(join(legacyDir, "README.md"))).toBe(false);
+
+    const readme = readFileSync(join(resolveTriageCacheDir(root), "README.md"), "utf8");
+    expect(readme).toContain("xbrief/.triage-cache/");
+    expect(readme).not.toContain("`.eval/`");
+    expect(readme).not.toContain("legacy `.eval/` readme");
+  });
+
+  it("removes orphaned legacy triage-cache files when the canonical .triage-cache copy already exists", () => {
+    seedXbrief();
+    const legacyDir = resolveEvalDir(root);
+    const targetDir = resolveTriageCacheDir(root);
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(legacyDir, "doctor-state.json"), '{"stale":true}\n', "utf8");
+    writeFileSync(join(targetDir, "doctor-state.json"), '{"canonical":true}\n', "utf8");
+
+    const result = migrateLegacyTriageCacheFromEval(root);
+    expect(result.removedLegacyFiles).toContain("doctor-state.json");
+    expect(existsSync(join(legacyDir, "doctor-state.json"))).toBe(false);
+    expect(readFileSync(join(targetDir, "doctor-state.json"), "utf8")).toContain("canonical");
+  });
+
+  it("writeState persists under .triage-cache on migrated xbrief trees, not legacy .eval", () => {
+    seedXbrief();
+    const legacyDir = resolveEvalDir(root);
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, "doctor-state.json"), '{"legacy":true}\n', "utf8");
+
+    const path = writeState(root, {
+      exitCode: 0,
+      findingCount: 0,
+      errorCount: 0,
+      now: new Date("2026-07-06T00:00:00Z"),
+    });
+
+    expect(path).not.toBeNull();
+    if (path === null) {
+      throw new Error("expected writeState to return a path");
+    }
+    expect(path).toBe(join(root, "xbrief", TRIAGE_CACHE_DIR_NAME, "doctor-state.json"));
+    expect(existsSync(path)).toBe(true);
+    expect(existsSync(join(legacyDir, "doctor-state.json"))).toBe(false);
+  });
+
+  it("intake candidates-log append defaults to .triage-cache, not legacy .eval", () => {
+    seedXbrief();
+    const legacyDir = resolveEvalDir(root);
+    mkdirSync(legacyDir, { recursive: true });
+
+    const prev = process.cwd();
+    try {
+      process.chdir(root);
+      append({
+        decision_id: "00000000-0000-4000-8000-000000000001",
+        timestamp: "2026-07-06T00:00:00Z",
+        repo: "deftai/directive",
+        issue_number: 2344,
+        decision: "accept",
+        actor: "agent:test",
+      });
+    } finally {
+      process.chdir(prev);
+    }
+
+    const canonical = join(root, "xbrief", TRIAGE_CACHE_DIR_NAME, "candidates.jsonl");
+    expect(existsSync(canonical)).toBe(true);
+    expect(existsSync(join(legacyDir, "candidates.jsonl"))).toBe(false);
   });
 });

--- a/packages/core/src/triage/cache-path.ts
+++ b/packages/core/src/triage/cache-path.ts
@@ -75,9 +75,14 @@ export function migrateLegacyTriageCacheFromEval(projectRoot: string): TriageCac
       continue;
     }
     if (name === "README.md") {
-      writeFileSync(targetPath, generateTriageCacheReadmeBody(projectRoot), "utf8");
-      unlinkSync(legacyPath);
-      regeneratedFiles.push(name);
+      if (existsSync(targetPath)) {
+        unlinkSync(legacyPath);
+        removedLegacyFiles.push(name);
+      } else {
+        writeFileSync(targetPath, generateTriageCacheReadmeBody(projectRoot), "utf8");
+        unlinkSync(legacyPath);
+        regeneratedFiles.push(name);
+      }
       continue;
     }
     if (existsSync(targetPath)) {

--- a/packages/core/src/triage/cache-path.ts
+++ b/packages/core/src/triage/cache-path.ts
@@ -5,9 +5,10 @@
  * `.eval/` namespace can be reclaimed for version-eval results (#1703 Tier 2).
  */
 
-import { existsSync, mkdirSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { resolveEvalDir, resolveLifecycleLayout, resolveLifecycleRoot } from "../layout/resolve.js";
+import { generateTriageCacheReadmeBody } from "./bootstrap/gitignore.js";
 
 /** Directory name for the triage working-set cache (not version-eval results). */
 export const TRIAGE_CACHE_DIR_NAME = ".triage-cache";
@@ -33,6 +34,8 @@ export interface TriageCacheMigrationResult {
   readonly migratedFiles: readonly string[];
   readonly skippedFiles: readonly string[];
   readonly migratedDirs: readonly string[];
+  readonly regeneratedFiles: readonly string[];
+  readonly removedLegacyFiles: readonly string[];
 }
 
 /** Absolute path to the layout-aware `.triage-cache/` directory. */
@@ -56,9 +59,11 @@ export function migrateLegacyTriageCacheFromEval(projectRoot: string): TriageCac
   const migratedFiles: string[] = [];
   const skippedFiles: string[] = [];
   const migratedDirs: string[] = [];
+  const regeneratedFiles: string[] = [];
+  const removedLegacyFiles: string[] = [];
 
   if (!existsSync(legacyDir)) {
-    return { migratedFiles, skippedFiles, migratedDirs };
+    return { migratedFiles, skippedFiles, migratedDirs, regeneratedFiles, removedLegacyFiles };
   }
 
   mkdirSync(targetDir, { recursive: true });
@@ -69,8 +74,15 @@ export function migrateLegacyTriageCacheFromEval(projectRoot: string): TriageCac
     if (!existsSync(legacyPath)) {
       continue;
     }
+    if (name === "README.md") {
+      writeFileSync(targetPath, generateTriageCacheReadmeBody(projectRoot), "utf8");
+      unlinkSync(legacyPath);
+      regeneratedFiles.push(name);
+      continue;
+    }
     if (existsSync(targetPath)) {
-      skippedFiles.push(name);
+      unlinkSync(legacyPath);
+      removedLegacyFiles.push(name);
       continue;
     }
     renameSync(legacyPath, targetPath);
@@ -91,7 +103,7 @@ export function migrateLegacyTriageCacheFromEval(projectRoot: string): TriageCac
     migratedDirs.push(name);
   }
 
-  return { migratedFiles, skippedFiles, migratedDirs };
+  return { migratedFiles, skippedFiles, migratedDirs, regeneratedFiles, removedLegacyFiles };
 }
 
 /** Resolve a path under `.triage-cache/`, migrating legacy `.eval/` files first. */
@@ -115,6 +127,7 @@ export function resolveCandidatesLogPath(projectRoot: string): string {
 
 /** Ensure the triage cache directory exists (post-migration). */
 export function ensureTriageCacheDir(projectRoot: string): string {
+  migrateLegacyTriageCacheFromEval(projectRoot);
   const dir = resolveTriageCacheDir(projectRoot);
   mkdirSync(dir, { recursive: true });
   return dir;

--- a/xbrief/active/2026-07-06-2344-stray-operator-private-artifacts-gitignore-gap-in-reclaimed.xbrief.json
+++ b/xbrief/active/2026-07-06-2344-stray-operator-private-artifacts-gitignore-gap-in-reclaimed.xbrief.json
@@ -1,0 +1,29 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2344"
+  },
+  "plan": {
+    "title": "Stray operator-private artifacts + gitignore gap in reclaimed .eval/ namespace (#1703)",
+    "status": "running",
+    "narratives": {
+      "Description": "Stray operator-private artifacts + gitignore gap in reclaimed .eval/ namespace (#1703)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2344",
+      "Overview": "## Summary\n\nThe reclaimed `.eval/` namespace (#1703 Tier 2) accumulates operator-private cache stragglers and accidentally-committed scratch files that were never added to `.gitignore`.\n\nObserved in a maintainer working tree on `master`:\n\n- **15 tracked junk files** committed under `xbrief/.eval/` — scratch issue-body dumps from earlier issue-editing operations (`_tmp_976_body_*.md`, `_tmp_985_*`, `_tmp_988_*`, `_tmp_issue_*.json`). These are runtime artefacts that should never have been versioned.\n- **3 loose untracked legacy triage-cache files** in `xbrief/.eval/`: `candidates.jsonl`, `summary-history.jsonl`, `doctor-state.json`. These are the exact operator-private basenames that `.triage-cache/` already gitignores (`.gitignore` lines 99–104), but the `.eval/` namespace has no equivalent rule.\n\n```quarantined\n## Why this matters\n\n`.eval/` was the legacy triage-cache directory. `packages/core/src/triage/cache-path.ts` migrates those basenames into `.triage-cache/` on resolve (`LEGACY_TRIAGE_EVAL_DIR_NAME = \".eval\"`), and #1703 reclaimed `.eval/` for team-shared **tracked** version-eval results under `.eval/results/` (`health-history.jsonl`, `golden-runs.jsonl`).\n\nTwo gaps:\n\n1. **Gitignore gap.** The loose operator-private basenames and `_tmp_*` scratch under `.eval/` are not ignored, so `git status` is perpetually dirty and it is easy to re-commit operator-private cache (as already happened with the 15 `_tmp_*` files). We must NOT blanket-ignore `.eval/` — that would drop the tracked `results/` ledger (see the #1464 \"forbidden blanket `vbrief/.eval/` line\" heal path in `init-deposit/gitignore.ts`).\n\n2. **Root-cause question (needs investigation).** `xbrief/.eval/doctor-state.json` was rewritten *today*, after the migration code exists — so a code path is still creating legacy triage-cache files in the legacy `.eval/` location instead of `.triage-cache/`, or the migration only runs lazily on a triage resolve that this tree never hit. Worth confirming which component writes `doctor-state.json` / `candidates.jsonl` to `.eval/` and whether the migration should run proactively.\n\n```\n## Proposed fix\n\n- Remove the 15 tracked `_tmp_*` junk files.\n- Add `.gitignore` rules (mirroring the `.triage-cache` block) for the loose legacy basenames and `_tmp_*` under `xbrief/.eval/` and `vbrief/.eval/`, without touching tracked `.eval/results/`.\n- Investigate and fix the root cause of legacy triage-cache files being written into `.eval/` post-migration (item 2).\n\nThe first two are addressed by the accompanying PR; item 2 remains open for a follow-up if the immediate gitignore + cleanup is deemed sufficient for now.\n\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @MScottAdams (2026-07-06T00:41:18Z)\n\nImmediate cleanup landed in #2345 (merged): the 15 stray `_tmp_*` files are removed, and `.gitignore` now covers the loose legacy triage-cache basenames + `_tmp_*` under `xbrief/.eval/` and `vbrief/.eval/` (without blanket-ignoring the tracked `.eval/results/` ledger). The stale `standards.test.ts` cases for the removed files were dropped.\n\n**Remaining (leaving this issue open):** item 2 — root-cause investigation into why `doctor-state.json` (and the other legacy triage-cache basenames) are still being written to the legacy `.eval/` location post-migration instead of `.triage-cache/`. Either a writer still targets the legacy dir, or the `triage/cache-path.ts` migration only runs lazily on a resolve path that some trees never hit and should run proactively.",
+      "Labels": "triage, tooling"
+    },
+    "items": [],
+    "tags": [
+      "triage",
+      "tooling"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2344",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2344: Stray operator-private artifacts + gitignore gap in reclaimed .eval/ namespace (#1703)"
+      }
+    ],
+    "updated": "2026-07-06T13:36:19Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Fix root cause of legacy triage-cache files (`doctor-state.json`, `candidates.jsonl`, etc.) still landing in `.eval/` after the #1703 relocation.
- `migrateLegacyTriageCacheFromEval()` now removes orphaned legacy copies when the canonical `.triage-cache/` file already exists, regenerates `README.md` with layout-aware paths (instead of renaming stale `.eval/` content — item reassigned from #2349 due to `cache-path.ts` ownership), and runs proactively from `ensureTriageCacheDir()`.
- `intake/candidates-log.ts` default path now resolves through `resolveCandidatesLogPath()` instead of a hardcoded `vbrief/.eval/candidates.jsonl`.

## Test plan

- [x] `TMPDIR=$(mktemp -d) task check`
- [x] New regression tests in `cache-path.test.ts` assert writes land under `.triage-cache/` (not `.eval/`) and README regeneration uses layout-aware paths
- [x] `generateTriageCacheReadmeBody` test in `gitignore.test.ts`

## Issue linkage

Refs #2344 (item 2 — root-cause fix; item 1 landed in #2345)

## PR checklist

- [x] Scope xBRIEF active/running for #2344
- [x] CHANGELOG `[Unreleased]` entry added
- [x] `task check` passes
- [x] Feature branch (not master)
- [ ] `/deft:change` proposal: N/A — single-surface triage cache-path fix scoped to #2344 xBRIEF
