### PR TITLE
fix(orchestration): reject NaN --threshold-minutes in subagent-monitor (#2357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The subagent monitor now rejects a non-numeric `--threshold-minutes` value (e.g. a typo) with a clear error and non-zero exit, instead of silently accepting `NaN` and running with an invalid staleness threshold. (#2357)
 - `deft triage:accept` no longer fails with `ModuleNotFoundError: No module named 'issue_ingest'`. It now authors the scope brief through the native TypeScript intake path instead of shelling out to a legacy Python script that was removed during the Python-surface deprecation, so accepting an issue (and the `verify:cache-fresh` dispatch gate that depends on it) works again. (#2350)
 
 ### Removed

--- a/packages/core/src/orchestration/subagent-monitor.ts
+++ b/packages/core/src/orchestration/subagent-monitor.ts
@@ -449,9 +449,9 @@ export function cmdSubagentMonitor(argv: string[], cwd: string = process.cwd()):
     return EXIT_EXTERNAL_ERROR;
   }
 
-  if (args.thresholdMinutes <= 0) {
+  if (Number.isNaN(args.thresholdMinutes) || args.thresholdMinutes <= 0) {
     process.stderr.write(
-      `Error: --threshold-minutes must be positive, got ${args.thresholdMinutes}\n`,
+      `Error: --threshold-minutes must be a positive number, got ${args.thresholdMinutes}\n`,
     );
     return EXIT_EXTERNAL_ERROR;
   }


### PR DESCRIPTION
## Summary

- `cmdSubagentMonitor` now rejects a non-numeric `--threshold-minutes` value with `EXIT_EXTERNAL_ERROR` and a clear message, instead of letting `NaN` slip past the `<= 0` guard (`NaN <= 0` is `false`).
- Fixes the pre-existing red `cmd rejects NaN threshold` test on `master`, so the framework-source self-test lane in `task check` passes again.

## Root cause

`parseSubagentMonitorArgs` uses `Number(value)`, so `--threshold-minutes abc` yields `NaN`. The positive-value guard `args.thresholdMinutes <= 0` does not catch `NaN`. Introduced in #1817 (source + test landed together with the `<= 0`-only guard). Sibling date parsers already use `Number.isNaN`.

## Test plan

- [x] `npx vitest run packages/core/src/orchestration/branch-coverage.test.ts` — 28/28 pass (was 1 failing)
- [x] `task check` — green (framework-source lane no longer red)

Closes #2357

Made with [Cursor](https://cursor.com)