### PR TITLE
fix(task-surface): tolerate CRLF in changelog-check (#2329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The subagent monitor now rejects a non-numeric `--threshold-minutes` value (e.g. a typo) with a clear error and non-zero exit, instead of silently accepting `NaN` and running with an invalid staleness threshold. (#2357)
+- `deft changelog-check` no longer false-fails with "No [Unreleased] section found" on Windows checkouts that use CRLF line endings (`core.autocrlf=true`). The parser now normalizes line endings before matching, so the changelog gate — and any `deft check` wiring that depends on it — passes on CRLF working trees. (#2329)
 - `deft triage:accept` no longer fails with `ModuleNotFoundError: No module named 'issue_ingest'`. It now authors the scope brief through the native TypeScript intake path instead of shelling out to a legacy Python script that was removed during the Python-surface deprecation, so accepting an issue (and the `verify:cache-fresh` dispatch gate that depends on it) works again. (#2350)
 
 ### Removed

--- a/packages/core/src/task-surface/index.test.ts
+++ b/packages/core/src/task-surface/index.test.ts
@@ -62,6 +62,21 @@ describe("task-surface", () => {
     expect(lines.join("")).toContain("1 entries");
   });
 
+  it("changelog-check passes on a CRLF working tree (#2329)", () => {
+    // Windows checkouts with core.autocrlf=true yield a CRLF working tree.
+    // Before #2329 the `[ \t]*\n` header pattern did not consume the `\r`,
+    // so a valid section false-failed as "No [Unreleased] section found".
+    const project = makeProject();
+    writeFileSync(
+      join(project, "CHANGELOG.md"),
+      "## [Unreleased]\r\n\r\n- Added thing\r\n\r\n## [0.1.0]\r\n",
+      "utf8",
+    );
+    const { lines, io } = captureIo();
+    expect(runChangelogCheck(project, io)).toBe(0);
+    expect(lines.join("")).toContain("1 entries");
+  });
+
   it("changelog-check fails when changelog is missing", () => {
     const project = makeProject();
     const { lines, io } = captureIo();

--- a/packages/core/src/task-surface/index.ts
+++ b/packages/core/src/task-surface/index.ts
@@ -46,7 +46,10 @@ export function runChangelogCheck(projectRoot: string, io: TaskSurfaceIo): numbe
     io.writeOut("FAIL: CHANGELOG.md not found\n");
     return 1;
   }
-  const text = readFileSync(path, "utf8");
+  // Normalize CRLF -> LF before matching (#2329). On Windows checkouts with
+  // core.autocrlf=true the working tree uses CRLF, and the `[ \t]*\n` header
+  // pattern does not consume the `\r`, so the section falsely reads as absent.
+  const text = readFileSync(path, "utf8").replace(/\r\n/g, "\n");
   const match = UNRELEASED_RE.exec(text);
   if (match === null) {
     io.writeOut("FAIL: No [Unreleased] section found in CHANGELOG.md\n");


### PR DESCRIPTION
> Stacked on #2358 (base branch `fix/2357-subagent-monitor-nan-guard`). Rebase onto `master` once #2358 merges.

## Summary

- `runChangelogCheck` now normalizes CRLF -> LF before matching the `## [Unreleased]` section. On Windows checkouts with `core.autocrlf=true` the working tree uses CRLF, and the `[ \t]*\n` header pattern did not consume the `\r`, so a valid changelog false-failed as "No [Unreleased] section found".
- Added a CRLF regression test.

## Test plan

- [x] `npx vitest run packages/core/src/task-surface/index.test.ts` — 12/12 pass (incl. new CRLF case)
- [x] pre-commit `task check` — green

Closes #2329

Made with [Cursor](https://cursor.com)