### PR TITLE
fix(reconcile): stamp lifecycle updated into existing info envelope (#2346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `deft reconcile:issues --apply-lifecycle-fixes` no longer corrupts canonical v0.8 scope briefs. When moving a brief to `completed/`/`cancelled/`, it now stamps the `updated` timestamp onto the brief's existing info envelope (`xBRIEFInfo` for v0.8) instead of unconditionally appending a stray, version-less `vBRIEFInfo` block that made the file fail `vbrief:validate`. Fixes a v0.71.0 release-cut blocker. (#2346)
 - The subagent monitor now rejects a non-numeric `--threshold-minutes` value (e.g. a typo) with a clear error and non-zero exit, instead of silently accepting `NaN` and running with an invalid staleness threshold. (#2357)
 - `deft triage:accept` no longer fails with `ModuleNotFoundError: No module named 'issue_ingest'`. It now authors the scope brief through the native TypeScript intake path instead of shelling out to a legacy Python script that was removed during the Python-surface deprecation, so accepting an issue (and the `verify:cache-fresh` dispatch gate that depends on it) works again. (#2350)
 

--- a/packages/core/src/intake/reconcile-issues.test.ts
+++ b/packages/core/src/intake/reconcile-issues.test.ts
@@ -172,4 +172,51 @@ describe("applyLifecycleFixes planRef rewrite (#1667)", () => {
     ]);
     expect(validateEpicStoryLinks(all, vbrief, display)).toEqual([]);
   });
+
+  it("stamps updated into xBRIEFInfo (v0.8) without appending a stray vBRIEFInfo (#2346)", () => {
+    root = mkdtempSync(join(tmpdir(), "reconcile-2346-"));
+    const xbrief = join(root, "xbrief");
+    mkdirSync(join(xbrief, "active"), { recursive: true });
+
+    const name = "2026-07-05-2337-task-aliases.xbrief.json";
+    writeFileSync(
+      join(xbrief, "active", name),
+      `${JSON.stringify(
+        {
+          xBRIEFInfo: { version: "0.8", description: "Scope xBRIEF for #99" },
+          plan: {
+            title: "Story",
+            status: "running",
+            items: [{ title: "slice", status: "running" }],
+            references: [
+              { type: "x-xbrief/github-issue", uri: "https://github.com/o/r/issues/99" },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const anchors = scanLifecycleAnchors(xbrief);
+    const report = buildLifecycleReport(
+      anchors,
+      new Map([[99, new IssueState("CLOSED", "COMPLETED")]]),
+      false,
+    );
+    const [moved, , failures] = applyLifecycleFixes(xbrief, report, root);
+    expect(moved).toBe(1);
+    expect(failures).toEqual([]);
+
+    const movedPath = join(xbrief, "completed", name);
+    const data = JSON.parse(readFileSync(movedPath, "utf8")) as Record<string, unknown>;
+    // The `updated` stamp lands on the existing xBRIEFInfo envelope...
+    const xInfo = data.xBRIEFInfo as Record<string, unknown>;
+    expect(xInfo.version).toBe("0.8");
+    expect(typeof xInfo.updated).toBe("string");
+    // ...and no stray, version-less vBRIEFInfo block is appended (the #2346 bug
+    // that failed vbrief:validate with "'vBRIEFInfo.version' ... got 'undefined'").
+    expect("vBRIEFInfo" in data).toBe(false);
+  });
 });

--- a/packages/core/src/intake/reconcile-issues.ts
+++ b/packages/core/src/intake/reconcile-issues.ts
@@ -6,6 +6,7 @@ import { type CallOptions, type CompletedProcess, call } from "../scm/call.js";
 import { updateDecomposedChildBackReferences } from "../scope/decomposed-refs.js";
 import { resolveProjectRoot } from "../scope/project-context.js";
 import { resolveProjectRepo } from "../slice/project-context.js";
+import { LEGACY_INFO_ROOT_KEY, MIGRATED_INFO_ROOT_KEY } from "../xbrief-migrate/constants.js";
 
 export const LIFECYCLE_FOLDERS = [
   "proposed",
@@ -763,8 +764,14 @@ export function applyLifecycleFixes(
     const terminalStatus = destFolder === "cancelled" ? "cancelled" : "completed";
     plan.status = terminalStatus;
     const stamp = utcNowIso();
-    const info = (data.vBRIEFInfo ?? {}) as Record<string, unknown>;
-    data.vBRIEFInfo = info;
+    // Stamp `updated` into whichever info envelope the file already uses (#2346).
+    // Canonical v0.8 briefs use `xBRIEFInfo`; stamping `vBRIEFInfo` unconditionally
+    // appended a stray, version-less `vBRIEFInfo` block that then failed
+    // `vbrief:validate` ('vBRIEFInfo.version' must be one of ..., got 'undefined').
+    // Legacy briefs (or files without either envelope) keep the `vBRIEFInfo` key.
+    const infoKey = MIGRATED_INFO_ROOT_KEY in data ? MIGRATED_INFO_ROOT_KEY : LEGACY_INFO_ROOT_KEY;
+    const info = (data[infoKey] ?? {}) as Record<string, unknown>;
+    data[infoKey] = info;
     info.updated = stamp;
     plan.updated = stamp;
     propagateItemStatus(plan.items, terminalStatus, stamp);


### PR DESCRIPTION
> Stacked on #2358 (base branch `fix/2357-subagent-monitor-nan-guard`). Rebase onto `master` once #2358 merges.

## Summary

- `applyLifecycleFixes` (`deft reconcile:issues --apply-lifecycle-fixes`) now stamps the `updated` timestamp onto the brief's **existing** info envelope — `xBRIEFInfo` for canonical v0.8 briefs — instead of unconditionally writing `data.vBRIEFInfo`.
- Previously it appended a stray, version-less `vBRIEFInfo: { updated }` block alongside the existing `xBRIEFInfo`, producing a dual-header file that failed `vbrief:validate` (`'vBRIEFInfo.version' must be one of '0.6', '0.8', got 'undefined'`).
- This was a **v0.71.0 release-cut blocker** (Phase 1 lifecycle-move corrupted #2337's brief).

## Test plan

- [x] `npx vitest run packages/core/src/intake/reconcile-issues.test.ts` — 8/8 (incl. new v0.8/xBRIEFInfo regression)
- [x] pre-commit gate green

Closes #2346

Made with [Cursor](https://cursor.com)