### PR TITLE
fix(gitignore): ignore xbrief/.triage-cache/* symmetric to vbrief (#2348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `deft update` now ignores operator-private triage-cache files on the `xbrief/` layout. The canonical `.gitignore` entries previously covered only `vbrief/.triage-cache/*`, so on migrated `xbrief/` projects those cache files were trackable and could be committed; the symmetric `xbrief/.triage-cache/*` entries are now emitted too. (#2348)
 - The subagent monitor now rejects a non-numeric `--threshold-minutes` value (e.g. a typo) with a clear error and non-zero exit, instead of silently accepting `NaN` and running with an invalid staleness threshold. (#2357)
 - `deft triage:accept` no longer fails with `ModuleNotFoundError: No module named 'issue_ingest'`. It now authors the scope brief through the native TypeScript intake path instead of shelling out to a legacy Python script that was removed during the Python-surface deprecation, so accepting an issue (and the `verify:cache-fresh` dispatch gate that depends on it) works again. (#2350)
 

--- a/packages/core/src/init-deposit/gitignore.test.ts
+++ b/packages/core/src/init-deposit/gitignore.test.ts
@@ -59,6 +59,22 @@ describe("ensureInitGitignoreLines", () => {
     expect(lines.join("")).toContain(".gitignore updated");
   });
 
+  it("ignores triage-cache files on both vbrief/ and xbrief/ layouts (#2348)", () => {
+    // The engine writes operator-private triage-cache files under the active
+    // layout's `.triage-cache/`. Before #2348 only the `vbrief/` set was in the
+    // baseline, so on an `xbrief/` project those paths were trackable.
+    for (const leaf of [
+      "candidates.jsonl",
+      "summary-history.jsonl",
+      "scope-lifecycle.jsonl",
+      "decompositions/",
+      "doctor-state.json",
+    ]) {
+      expect(CANONICAL_GITIGNORE_BASELINE).toContain(`vbrief/.triage-cache/${leaf}`);
+      expect(CANONICAL_GITIGNORE_BASELINE).toContain(`xbrief/.triage-cache/${leaf}`);
+    }
+  });
+
   it("born-ignores the local engine cache dir (.deft/.cli/) (#2264)", () => {
     const root = freshRoot("gitignore-cli-");
     ensureInitGitignoreLines(root, { printf: () => {} });

--- a/packages/core/src/init-deposit/gitignore.ts
+++ b/packages/core/src/init-deposit/gitignore.ts
@@ -39,6 +39,16 @@ export const CANONICAL_GITIGNORE_BASELINE: readonly string[] = [
   "vbrief/.triage-cache/scope-lifecycle.jsonl",
   "vbrief/.triage-cache/decompositions/",
   "vbrief/.triage-cache/doctor-state.json",
+  // Symmetric `xbrief/` layout entries (#2348). On the migrated `xbrief/` tree
+  // the engine writes operator-private triage-cache files to
+  // `xbrief/.triage-cache/`; without these the paths are trackable, violating
+  // the #1144 hybrid policy. Both layouts are emitted (harmless extra lines on
+  // the layout not in use) to match the both-layout `.eval/` treatment.
+  "xbrief/.triage-cache/candidates.jsonl",
+  "xbrief/.triage-cache/summary-history.jsonl",
+  "xbrief/.triage-cache/scope-lifecycle.jsonl",
+  "xbrief/.triage-cache/decompositions/",
+  "xbrief/.triage-cache/doctor-state.json",
   "vbrief/*.lock",
   ".deft/core.bak-*/",
   ".deft/*.bak-*",


### PR DESCRIPTION
> Stacked on #2358 (base branch `fix/2357-subagent-monitor-nan-guard`). Rebase onto `master` once #2358 merges.

## Summary

- `CANONICAL_GITIGNORE_BASELINE` (used by `deft update` via `ensureInitGitignoreLines`) now includes the `xbrief/.triage-cache/*` entries symmetric to the existing `vbrief/.triage-cache/*` set.
- On migrated `xbrief/` projects the engine writes operator-private triage-cache files to `xbrief/.triage-cache/`, but those paths were not ignored — so they could be committed, violating the #1144 hybrid tracking policy. Both layouts are now emitted (harmless extra lines on the layout not in use).

## Test plan

- [x] `npx vitest run packages/core/src/init-deposit/gitignore.test.ts` — 13/13 (incl. new both-layout assertion)
- [x] `task check` — green

Closes #2348

Made with [Cursor](https://cursor.com)