### PR TITLE
fix(intake): normalize cache-read Overview to match live fetch (#2314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ingesting the same GitHub issue now produces an identical scope brief whether the source was a warm cache hit or a live fetch. The cache path previously carried a rendered `# #<n>: <title>` header into the brief's `Overview` that the live path omitted, so the two runs committed subtly different content. (#2314)
 - The subagent monitor now rejects a non-numeric `--threshold-minutes` value (e.g. a typo) with a clear error and non-zero exit, instead of silently accepting `NaN` and running with an invalid staleness threshold. (#2357)
 - `deft triage:accept` no longer fails with `ModuleNotFoundError: No module named 'issue_ingest'`. It now authors the scope brief through the native TypeScript intake path instead of shelling out to a legacy Python script that was removed during the Python-surface deprecation, so accepting an issue (and the `verify:cache-fresh` dispatch gate that depends on it) works again. (#2350)
 

--- a/packages/core/src/intake/issue-ingest.test.ts
+++ b/packages/core/src/intake/issue-ingest.test.ts
@@ -16,6 +16,7 @@ import {
   ingestOne,
   provenanceIssueNumber,
   ScannerHardFailError,
+  stripRenderedIssueHeader,
 } from "./issue-ingest.js";
 
 function completed(stdout: string, stderr: string, returncode: number): CompletedProcess {
@@ -302,6 +303,56 @@ describe("issue:ingest quarantine scanning (#2306)", () => {
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true });
     }
+  });
+
+  it("(e) cache-read body drops the rendered `# #<n>: <title>` header for live parity (#2314)", () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), "deft-ingest-parity-"));
+    try {
+      cachePut(
+        "github-issue",
+        "o/r/2314",
+        {
+          number: 2314,
+          title: "Cache vs live drift",
+          html_url: "https://github.com/o/r/issues/2314",
+          body: "The observable body text.",
+        },
+        { cacheRoot },
+      );
+      const issue = fetchFromCache("o/r", 2314, { cacheRoot });
+      const body = issue?.body as string;
+      // The `# #2314: Cache vs live drift` header that renderContent prepends at
+      // cache-put must NOT leak into the cache-read body (the live/raw path has
+      // no such header), so the durable Overview is identical either way.
+      expect(body.startsWith("# #2314:")).toBe(false);
+      expect(body).toBe("The observable body text.");
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("stripRenderedIssueHeader (#2314)", () => {
+  it("strips the matching rendered header and preserves the body", () => {
+    expect(stripRenderedIssueHeader("# #42: Title\n\nBody text", 42)).toBe("Body text");
+  });
+
+  it("handles an empty title", () => {
+    expect(stripRenderedIssueHeader("# #42: \n\nBody", 42)).toBe("Body");
+  });
+
+  it("leaves content without a header intact", () => {
+    expect(stripRenderedIssueHeader("Just a body, no header.", 42)).toBe("Just a body, no header.");
+  });
+
+  it("does not strip a header for a different issue number", () => {
+    expect(stripRenderedIssueHeader("# #99: Other\n\nBody", 42)).toBe("# #99: Other\n\nBody");
+  });
+
+  it("only strips the leading header, not later matching lines", () => {
+    expect(stripRenderedIssueHeader("# #42: T\n\nfirst\n\n# #42: T\n\nsecond", 42)).toBe(
+      "first\n\n# #42: T\n\nsecond",
+    );
   });
 });
 

--- a/packages/core/src/intake/issue-ingest.ts
+++ b/packages/core/src/intake/issue-ingest.ts
@@ -506,6 +506,21 @@ export interface FetchIssueOptions {
   readonly scmCall?: ScmCallFn;
 }
 
+/**
+ * Strip the `# #<number>: <title>` header that `renderContent` prepends when it
+ * materializes an issue's `content.md` at cache-put (#2314). The header is the
+ * only shape difference between the cache-read body and the live/raw-body path;
+ * removing it makes an ingested xBRIEF's `Overview` identical whether the source
+ * was a cache hit or a live fetch. A missing/older-shape header is left intact.
+ */
+export function stripRenderedIssueHeader(content: string, number: number): string {
+  if (!Number.isFinite(number)) {
+    return content;
+  }
+  const header = new RegExp(`^# #${number}:[^\\n]*\\n\\n`);
+  return content.replace(header, "");
+}
+
 export function fetchFromCache(
   repo: string,
   number: number,
@@ -529,7 +544,14 @@ export function fetchFromCache(
     // buildIssueVbrief.
     if (result.contentPath !== null) {
       try {
-        issue.body = readFileSync(result.contentPath, "utf8");
+        // #2314: content.md is `renderContent`-prefixed with a `# #<n>: <title>`
+        // header at cache-put. Strip that header so the cache-read Overview
+        // matches the live/raw-body path (which has no header), keeping the
+        // durable xBRIEF identical for a cache hit vs a live fetch.
+        issue.body = stripRenderedIssueHeader(
+          readFileSync(result.contentPath, "utf8"),
+          Number(issue.number),
+        );
       } catch {
         // fall back to the raw body (re-scanned downstream)
       }


### PR DESCRIPTION
> Stacked on #2358 (base branch `fix/2357-subagent-monitor-nan-guard`). Rebase onto `master` once #2358 merges.

## Summary

- `fetchFromCache` now strips the `# #<n>: <title>` header that `renderContent` prepends to `content.md` at cache-put time.
- Previously a cache hit surfaced that header into the ingested brief's `narratives.Overview`, while a live fetch (raw body) did not — so ingesting the same issue cold vs warm committed subtly different durable content.
- The quarantine/scan transform on `content.md` is preserved (only the leading header line is removed); a missing/older-shape header is left intact.

## Test plan

- [x] `npx vitest run packages/core/src/intake/issue-ingest.test.ts` — 23/23 (new cache-read parity test + `stripRenderedIssueHeader` unit tests)
- [x] `task check` — green

Closes #2314

Made with [Cursor](https://cursor.com)