### PR TITLE
feat(value-feedback): trusted-org auto-enable of local collection + event enrichment (Refs #1709)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,12 +74,14 @@ Same `!` / `⊗` rules as the managed `## Deterministic questions runtime obliga
 
 ## Value feedback and attribution (#1709)
 
-- ! `plan.policy.valueFeedback.enabled` defaults OFF -- while false, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in ONLY via `task policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `task policy:show --field=valueFeedback`.
+- ! `plan.policy.valueFeedback.enabled` defaults OFF for non-org repos -- while off, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in for any repo via `task policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `task policy:show --field=valueFeedback`.
+- ! Trusted-org local auto-enable (#2376) -- for a repo whose GitHub origin belongs to a company-owned org (built-in default `deftai`; extend via the `DEFT_VALUE_AUTOENABLE_ORGS` env override), LOCAL emit + session readback resolve ON with `source=org-auto` and network/upstream OFF, with NO per-repo or per-machine confirmation: org membership IS the consent for local, no-egress collection on company-owned resources. An explicit typed `valueFeedback` block always wins (including `enabled: false`); a non-matching org or no origin remote stays OFF (fail-safe).
+- ! Attribution records are enriched at emit time (#2376) with `repo`, `directive_version`, `install_id` (a stable per-checkout uuid under gitignored `.deft-cache/`), and `schema_version`, so a later collector can aggregate cross-repo without re-deriving provenance.
 - ! Value claims MUST be attributed-only -- point to concrete logged events ("encoding gate caught 2 corruptions"), never vague quality claims. Silence when the ledger has nothing attributable for the session slot.
 - ! Budgeted awareness -- at most one session readback line when `sessionLine` is allowed; repeat suppression uses a 4-hour window per attribution event id (parity with #1279 triage welcome debounce). Pull-based detail is `task value:show`, not pushed.
 - ! Gap escalation to `deftai/directive` is confirmation-gated -- route conversational filing through `deft-directive-feedback`; the agent drafts + dedups; the operator approves before `task feedback:file -- --confirm`. Use `Refs #1709` in upstream bodies, not `Closes`.
-- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`.
-- ⊗ Enable value-feedback surfaces without explicit operator confirmation on the typed policy flag.
+- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`. Trusted-org auto-enable still turns LOCAL emit ON inside the maintainer repo, but session readback stays gated behind `DEFT_VALUE_SELF_DOGFOOD=1`.
+- ⊗ Enable any NETWORK or upstream value-feedback surface (upstream gap escalation / `task feedback:file`) without operator confirmation -- trusted-org auto-enable authorizes LOCAL, no-egress collection ONLY.
 - ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
 - ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
 
@@ -415,12 +417,14 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ## Value feedback and attribution (#1709)
 
-- ! `plan.policy.valueFeedback.enabled` defaults OFF -- while false, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in ONLY via `deft policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `deft policy:show --field=valueFeedback`.
+- ! `plan.policy.valueFeedback.enabled` defaults OFF for non-org repos -- while off, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in for any repo via `deft policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `deft policy:show --field=valueFeedback`.
+- ! Trusted-org local auto-enable (#2376) -- for a repo whose GitHub origin belongs to a company-owned org (built-in default `deftai`; extend via the `DEFT_VALUE_AUTOENABLE_ORGS` env override), LOCAL emit + session readback resolve ON with `source=org-auto` and network/upstream OFF, with NO per-repo or per-machine confirmation: org membership IS the consent for local, no-egress collection on company-owned resources. An explicit typed `valueFeedback` block always wins (including `enabled: false`); a non-matching org or no origin remote stays OFF (fail-safe).
+- ! Attribution records are enriched at emit time (#2376) with `repo`, `directive_version`, `install_id` (a stable per-checkout uuid under gitignored `.deft-cache/`), and `schema_version`, so a later collector can aggregate cross-repo without re-deriving provenance.
 - ! Value claims MUST be attributed-only -- point to concrete logged events ("encoding gate caught 2 corruptions"), never vague quality claims. Silence when the ledger has nothing attributable for the session slot.
 - ! Budgeted awareness -- at most one session readback line when `sessionLine` is allowed; repeat suppression uses a 4-hour window per attribution event id (parity with #1279 triage welcome debounce). Pull-based detail is `deft value:show`, not pushed.
 - ! Gap escalation to `deftai/directive` is confirmation-gated -- route conversational filing through `deft-directive-feedback`; the agent drafts + dedups; the operator approves before `deft feedback:file -- --confirm`. Use `Refs #1709` in upstream bodies, not `Closes`.
-- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`.
-- ⊗ Enable value-feedback surfaces without explicit operator confirmation on the typed policy flag.
+- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`. Trusted-org auto-enable still turns LOCAL emit ON inside the maintainer repo, but session readback stays gated behind `DEFT_VALUE_SELF_DOGFOOD=1`.
+- ⊗ Enable any NETWORK or upstream value-feedback surface (upstream gap escalation / `deft feedback:file`) without operator confirmation -- trusted-org auto-enable authorizes LOCAL, no-egress collection ONLY.
 - ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
 - ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Company-owned repos auto-enable local value feedback.** Repositories whose GitHub origin belongs to a trusted org (built-in `deftai`, extendable via `DEFT_VALUE_AUTOENABLE_ORGS`) now switch on local, no-egress value-feedback collection automatically -- org membership is the consent, while network/upstream escalation stays opt-in. Every attribution event is now stamped with its repo, the directive version, a stable per-checkout install id, and a schema version so the local ledgers can be aggregated later without re-deriving provenance. Refs #1709, #2376.
+
 ### Changed
 
 ### Fixed

--- a/content/templates/agent-prompt-preamble.md
+++ b/content/templates/agent-prompt-preamble.md
@@ -262,7 +262,8 @@ Reference: AGENTS.md `## Issue body→comments reading (#2143)`, `## Umbrella cu
 
 Value attribution, budgeted session readbacks, and upstream gap escalation are gated on `plan.policy.valueFeedback` (default OFF). Workers MUST NOT emit value claims, session readback lines, or file upstream framework-gap issues unless the relevant sub-flag is ON and the operator has confirmed enablement where required.
 
-- ! While `valueFeedback.enabled` is false, treat every value-feedback path as a no-op -- no ledger writes, no session lines, no upstream prompts, no token spend.
+- ! Trusted-org local auto-enable (#2376): a repo whose GitHub origin belongs to a company-owned org (default `deftai`; extend via `DEFT_VALUE_AUTOENABLE_ORGS`) auto-resolves LOCAL emit + session readback ON with `source=org-auto` and network/upstream OFF -- no per-repo confirmation. An explicit typed `valueFeedback` block (including `enabled: false`) always wins; any other repo or no origin remote stays OFF.
+- ! While `valueFeedback.enabled` is false AND no trusted-org auto-enable applies, treat every value-feedback path as a no-op -- no ledger writes, no session lines, no upstream prompts, no token spend.
 - ! Value claims MUST cite concrete attributed ledger events; silence when nothing is attributable.
 - ! Session readback repeats suppress for 4 hours per attribution event id (same debounce class as #1279 triage welcome). Pull-based detail uses `task value:show` / `deft value:show`, not ambient pushes.
 - ! Upstream gap filing is confirmation-gated -- route through `deft-directive-feedback`; draft + dedup with `task feedback:file` / `deft feedback:file`, then re-run with `--confirm` only after explicit operator approval. Consumer projects only; maintainer repo no-ops unless `DEFT_VALUE_SELF_DOGFOOD=1`.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -149,12 +149,14 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ## Value feedback and attribution (#1709)
 
-- ! `plan.policy.valueFeedback.enabled` defaults OFF -- while false, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in ONLY via `deft policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `deft policy:show --field=valueFeedback`.
+- ! `plan.policy.valueFeedback.enabled` defaults OFF for non-org repos -- while off, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in for any repo via `deft policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `deft policy:show --field=valueFeedback`.
+- ! Trusted-org local auto-enable (#2376) -- for a repo whose GitHub origin belongs to a company-owned org (built-in default `deftai`; extend via the `DEFT_VALUE_AUTOENABLE_ORGS` env override), LOCAL emit + session readback resolve ON with `source=org-auto` and network/upstream OFF, with NO per-repo or per-machine confirmation: org membership IS the consent for local, no-egress collection on company-owned resources. An explicit typed `valueFeedback` block always wins (including `enabled: false`); a non-matching org or no origin remote stays OFF (fail-safe).
+- ! Attribution records are enriched at emit time (#2376) with `repo`, `directive_version`, `install_id` (a stable per-checkout uuid under gitignored `.deft-cache/`), and `schema_version`, so a later collector can aggregate cross-repo without re-deriving provenance.
 - ! Value claims MUST be attributed-only -- point to concrete logged events ("encoding gate caught 2 corruptions"), never vague quality claims. Silence when the ledger has nothing attributable for the session slot.
 - ! Budgeted awareness -- at most one session readback line when `sessionLine` is allowed; repeat suppression uses a 4-hour window per attribution event id (parity with #1279 triage welcome debounce). Pull-based detail is `deft value:show`, not pushed.
 - ! Gap escalation to `deftai/directive` is confirmation-gated -- route conversational filing through `deft-directive-feedback`; the agent drafts + dedups; the operator approves before `deft feedback:file -- --confirm`. Use `Refs #1709` in upstream bodies, not `Closes`.
-- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`.
-- ⊗ Enable value-feedback surfaces without explicit operator confirmation on the typed policy flag.
+- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`. Trusted-org auto-enable still turns LOCAL emit ON inside the maintainer repo, but session readback stays gated behind `DEFT_VALUE_SELF_DOGFOOD=1`.
+- ⊗ Enable any NETWORK or upstream value-feedback surface (upstream gap escalation / `deft feedback:file`) without operator confirmation -- trusted-org auto-enable authorizes LOCAL, no-egress collection ONLY.
 - ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
 - ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -171,6 +171,9 @@ const VALUE_FEEDBACK_MARKERS = [
   "Refs #1709",
   "DEFT_VALUE_SELF_DOGFOOD",
   "without operator confirmation",
+  "Trusted-org local auto-enable (#2376)",
+  "DEFT_VALUE_AUTOENABLE_ORGS",
+  "source=org-auto",
 ] as const;
 
 // #1703: tiered eval framework discoverability MUST mirror across maintainer

--- a/packages/core/src/events/attribution-enrichment.test.ts
+++ b/packages/core/src/events/attribution-enrichment.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  ATTRIBUTION_SCHEMA_VERSION,
+  buildAttributionEnrichment,
+  INSTALL_ID_REL,
+  resolveInstallId,
+} from "./attribution-enrichment.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function makeTemp(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-attrib-enrich-"));
+  temps.push(root);
+  return root;
+}
+
+describe("resolveInstallId", () => {
+  it("creates a stable id persisted in .deft-cache/install-id", () => {
+    const root = makeTemp();
+    const first = resolveInstallId(root);
+    expect(first).not.toBeNull();
+    expect(existsSync(join(root, INSTALL_ID_REL))).toBe(true);
+    const second = resolveInstallId(root);
+    expect(second).toBe(first);
+  });
+
+  it("returns null without throwing when the cache dir is unwritable", () => {
+    const root = makeTemp();
+    writeFileSync(join(root, ".deft-cache"), "not-a-directory", "utf8");
+    expect(() => resolveInstallId(root)).not.toThrow();
+    expect(resolveInstallId(root)).toBeNull();
+  });
+});
+
+describe("buildAttributionEnrichment", () => {
+  it("stamps repo, directive_version, install_id, and schema_version", () => {
+    const root = makeTemp();
+    const enrichment = buildAttributionEnrichment(root, {
+      repoResolver: () => "deftai/directive",
+    });
+    expect(enrichment.repo).toBe("deftai/directive");
+    expect(typeof enrichment.directive_version).toBe("string");
+    expect(enrichment.directive_version.length).toBeGreaterThan(0);
+    expect(enrichment.install_id).not.toBeNull();
+    expect(enrichment.schema_version).toBe(ATTRIBUTION_SCHEMA_VERSION);
+  });
+
+  it("degrades repo to null when the resolver throws", () => {
+    const root = makeTemp();
+    const enrichment = buildAttributionEnrichment(root, {
+      repoResolver: () => {
+        throw new Error("git unavailable");
+      },
+    });
+    expect(enrichment.repo).toBeNull();
+    expect(enrichment.schema_version).toBe(ATTRIBUTION_SCHEMA_VERSION);
+  });
+
+  it("carries a null repo when no origin remote resolves", () => {
+    const root = makeTemp();
+    const enrichment = buildAttributionEnrichment(root, { repoResolver: () => null });
+    expect(enrichment.repo).toBeNull();
+  });
+});

--- a/packages/core/src/events/attribution-enrichment.test.ts
+++ b/packages/core/src/events/attribution-enrichment.test.ts
@@ -69,4 +69,19 @@ describe("buildAttributionEnrichment", () => {
     const enrichment = buildAttributionEnrichment(root, { repoResolver: () => null });
     expect(enrichment.repo).toBeNull();
   });
+
+  it("memoizes per projectRoot with the default resolver to stay off the hot path (#2377)", () => {
+    const root = makeTemp();
+    const first = buildAttributionEnrichment(root);
+    const second = buildAttributionEnrichment(root);
+    expect(second).toBe(first);
+  });
+
+  it("a custom resolver bypasses the cache for deterministic tests (#2377)", () => {
+    const root = makeTemp();
+    const a = buildAttributionEnrichment(root, { repoResolver: () => "deftai/a" });
+    const b = buildAttributionEnrichment(root, { repoResolver: () => "deftai/b" });
+    expect(a.repo).toBe("deftai/a");
+    expect(b.repo).toBe("deftai/b");
+  });
 });

--- a/packages/core/src/events/attribution-enrichment.ts
+++ b/packages/core/src/events/attribution-enrichment.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { readCorePackageVersion } from "../engine-version.js";
+import { inferRepoFromGit } from "../triage/queue/repo.js";
+
+/** Record-shape version for attribution ledger entries (#2376). Bump on shape changes. */
+export const ATTRIBUTION_SCHEMA_VERSION = 1 as const;
+
+/** Project-local, gitignored install-identity file. */
+export const INSTALL_ID_REL = join(".deft-cache", "install-id");
+
+/** Identity + provenance fields stamped onto every attribution record (#2376). */
+export interface AttributionEnrichment {
+  /** Normalized `owner/name` of the origin remote, or null when unavailable. */
+  readonly repo: string | null;
+  /** directive engine version at emit time. */
+  readonly directive_version: string;
+  /** Stable per-checkout uuid, or null when it cannot be read/created. */
+  readonly install_id: string | null;
+  /** Attribution record-shape version. */
+  readonly schema_version: number;
+}
+
+/**
+ * Read-or-create a stable per-checkout install id in `.deft-cache/install-id`.
+ * Best-effort: returns null (never throws) if the file cannot be read or written.
+ */
+export function resolveInstallId(projectRoot: string): string | null {
+  const path = resolve(projectRoot, INSTALL_ID_REL);
+  try {
+    if (existsSync(path)) {
+      const existing = readFileSync(path, "utf8").trim();
+      if (existing.length > 0) {
+        return existing;
+      }
+    }
+  } catch {
+    // fall through and try to (re)create
+  }
+  try {
+    const id = randomUUID();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${id}\n`, "utf8");
+    return id;
+  } catch {
+    return null;
+  }
+}
+
+export interface BuildAttributionEnrichmentOptions {
+  /** Test seam for origin-repo resolution; defaults to `inferRepoFromGit`. */
+  readonly repoResolver?: (projectRoot: string) => string | null;
+}
+
+/**
+ * Build the identity/provenance enrichment stamped on attribution records (#2376).
+ * Every field degrades gracefully; this function never throws.
+ */
+export function buildAttributionEnrichment(
+  projectRoot: string,
+  options: BuildAttributionEnrichmentOptions = {},
+): AttributionEnrichment {
+  const resolver = options.repoResolver ?? inferRepoFromGit;
+  let repo: string | null = null;
+  try {
+    repo = resolver(projectRoot);
+  } catch {
+    repo = null;
+  }
+  return {
+    repo,
+    directive_version: readCorePackageVersion(),
+    install_id: resolveInstallId(projectRoot),
+    schema_version: ATTRIBUTION_SCHEMA_VERSION,
+  };
+}

--- a/packages/core/src/events/attribution-enrichment.ts
+++ b/packages/core/src/events/attribution-enrichment.ts
@@ -53,14 +53,28 @@ export interface BuildAttributionEnrichmentOptions {
   readonly repoResolver?: (projectRoot: string) => string | null;
 }
 
+const enrichmentCache = new Map<string, AttributionEnrichment>();
+
 /**
  * Build the identity/provenance enrichment stamped on attribution records (#2376).
- * Every field degrades gracefully; this function never throws.
+ *
+ * Memoized per `projectRoot` (identity/version/repo are stable within a session)
+ * so a caller that emits many signals in one run does not spawn a git process and
+ * open the install-id file per event -- mirrors `detectOriginOrg`'s cache to keep
+ * this off the hot emit path (#2377 review). A custom `repoResolver` bypasses the
+ * cache so tests stay deterministic. Every field degrades gracefully; never throws.
  */
 export function buildAttributionEnrichment(
   projectRoot: string,
   options: BuildAttributionEnrichmentOptions = {},
 ): AttributionEnrichment {
+  const useCache = options.repoResolver === undefined;
+  if (useCache) {
+    const cached = enrichmentCache.get(projectRoot);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
   const resolver = options.repoResolver ?? inferRepoFromGit;
   let repo: string | null = null;
   try {
@@ -68,10 +82,14 @@ export function buildAttributionEnrichment(
   } catch {
     repo = null;
   }
-  return {
+  const enrichment: AttributionEnrichment = {
     repo,
     directive_version: readCorePackageVersion(),
     install_id: resolveInstallId(projectRoot),
     schema_version: ATTRIBUTION_SCHEMA_VERSION,
   };
+  if (useCache) {
+    enrichmentCache.set(projectRoot, enrichment);
+  }
+  return enrichment;
 }

--- a/packages/core/src/events/attribution-ledger.test.ts
+++ b/packages/core/src/events/attribution-ledger.test.ts
@@ -132,6 +132,29 @@ describe("four signal classes", () => {
     expect("install_id" in (record?.payload ?? {})).toBe(true);
   });
 
+  it("enrichment + signal_class are authoritative over caller payload (#2377)", () => {
+    const root = makeRepo(enabled);
+    const record = emitAttributionSignal(
+      ATTRIBUTION_EVENT_NAMES.frictionDirectiveGap,
+      {
+        source: "test",
+        detail: "gap",
+        // Hostile payload attempting to shadow authoritative fields.
+        signal_class: "value",
+        schema_version: 999,
+        directive_version: "SPOOFED",
+        repo: "attacker/spoof",
+      },
+      { projectRoot: root, logPath: logPath(root) },
+    );
+    expect(record?.payload.signal_class).toBe("friction");
+    expect(record?.payload.schema_version).toBe(1);
+    expect(record?.payload.directive_version).not.toBe("SPOOFED");
+    // Non-authoritative payload keys still pass through.
+    expect(record?.payload.source).toBe("test");
+    expect(record?.payload.detail).toBe("gap");
+  });
+
   it("emitAttributionSignal rejects unknown names at compile time only", () => {
     const root = makeRepo(enabled);
     const record = emitAttributionSignal(

--- a/packages/core/src/events/attribution-ledger.test.ts
+++ b/packages/core/src/events/attribution-ledger.test.ts
@@ -122,6 +122,16 @@ describe("four signal classes", () => {
     }
   });
 
+  it("stamps enrichment (directive_version, install_id, schema_version) on records (#2376)", () => {
+    const root = makeRepo(enabled);
+    const record = recordGateCatch(root, "verify:branch", "gate", { logPath: logPath(root) });
+    expect(record).not.toBeNull();
+    expect(typeof record?.payload.directive_version).toBe("string");
+    expect(record?.payload.schema_version).toBe(1);
+    expect("repo" in (record?.payload ?? {})).toBe(true);
+    expect("install_id" in (record?.payload ?? {})).toBe(true);
+  });
+
   it("emitAttributionSignal rejects unknown names at compile time only", () => {
     const root = makeRepo(enabled);
     const record = emitAttributionSignal(

--- a/packages/core/src/events/attribution-ledger.ts
+++ b/packages/core/src/events/attribution-ledger.ts
@@ -57,12 +57,14 @@ export function emitAttributionSignal(
     const signalClass = signalClassForEvent(name);
     const logPath = resolveLedgerLogPath(options.projectRoot, options.logPath);
     const enrichment = buildAttributionEnrichment(options.projectRoot);
+    // Authoritative fields (signal_class + provenance enrichment) are spread LAST
+    // so a caller payload can never silently shadow them (#2377 review).
     return emit(
       name,
       {
+        ...payload,
         signal_class: signalClass,
         ...enrichment,
-        ...payload,
       },
       { logPath },
     );

--- a/packages/core/src/events/attribution-ledger.ts
+++ b/packages/core/src/events/attribution-ledger.ts
@@ -6,6 +6,7 @@ import {
   type ValueFeedbackResolved,
 } from "../policy/value-feedback.js";
 import { ATTRIBUTION_EVENT_NAMES, type AttributionEventName } from "./attribution-constants.js";
+import { buildAttributionEnrichment } from "./attribution-enrichment.js";
 
 export {
   ALL_ATTRIBUTION_EVENT_NAMES,
@@ -55,10 +56,12 @@ export function emitAttributionSignal(
     }
     const signalClass = signalClassForEvent(name);
     const logPath = resolveLedgerLogPath(options.projectRoot, options.logPath);
+    const enrichment = buildAttributionEnrichment(options.projectRoot);
     return emit(
       name,
       {
         signal_class: signalClass,
+        ...enrichment,
         ...payload,
       },
       { logPath },

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -246,10 +246,13 @@ function inspectSwarmSubagentBackend(data: Record<string, unknown> | null): Poli
   };
 }
 
-type Inspector = (data: Record<string, unknown> | null) => PolicyField;
+type Inspector = (data: Record<string, unknown> | null, projectRoot?: string) => PolicyField;
 
-function inspectValueFeedbackField(data: Record<string, unknown> | null): PolicyField {
-  const field = inspectValueFeedback(data);
+function inspectValueFeedbackField(
+  data: Record<string, unknown> | null,
+  projectRoot?: string,
+): PolicyField {
+  const field = inspectValueFeedback(data, projectRoot);
   return {
     name: field.name,
     current: field.current,
@@ -295,7 +298,7 @@ const REGISTERED_POLICIES: readonly Inspector[] = [
 /** Walk registered inspectors and return one row per field (#1148). */
 export function inspectAllPolicies(projectRoot: string): PolicyField[] {
   const [data] = loadProjectDefinition(projectRoot);
-  return REGISTERED_POLICIES.map((inspect) => inspect(data));
+  return REGISTERED_POLICIES.map((inspect) => inspect(data, projectRoot));
 }
 
 /** Look up a single registered field by canonical dotted-path name (or CLI alias). */

--- a/packages/core/src/policy/value-feedback-autoenable.test.ts
+++ b/packages/core/src/policy/value-feedback-autoenable.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AUTOENABLE_ORGS_ENV,
+  clearOriginOrgCache,
+  DEFAULT_AUTOENABLE_ORGS,
+  detectOriginOrg,
+  isTrustedOrgAutoEnable,
+  resolveTrustedOrgs,
+} from "./value-feedback-autoenable.js";
+
+afterEach(() => {
+  clearOriginOrgCache();
+});
+
+describe("resolveTrustedOrgs", () => {
+  it("includes the built-in deftai org by default", () => {
+    const orgs = resolveTrustedOrgs({});
+    expect(orgs.has("deftai")).toBe(true);
+    for (const org of DEFAULT_AUTOENABLE_ORGS) {
+      expect(orgs.has(org.toLowerCase())).toBe(true);
+    }
+  });
+
+  it("extends (never replaces) the set from the env override, normalized", () => {
+    const orgs = resolveTrustedOrgs({ [AUTOENABLE_ORGS_ENV]: " Acme , Globex ,, " });
+    expect(orgs.has("deftai")).toBe(true);
+    expect(orgs.has("acme")).toBe(true);
+    expect(orgs.has("globex")).toBe(true);
+  });
+});
+
+describe("detectOriginOrg", () => {
+  it("lowercases the owner segment of the resolved slug", () => {
+    const org = detectOriginOrg("/tmp/x", { repoResolver: () => "DeftAI/statusreport" });
+    expect(org).toBe("deftai");
+  });
+
+  it("returns null when there is no origin remote", () => {
+    expect(detectOriginOrg("/tmp/x", { repoResolver: () => null })).toBeNull();
+  });
+
+  it("returns null (never throws) when the resolver throws", () => {
+    expect(
+      detectOriginOrg("/tmp/x", {
+        repoResolver: () => {
+          throw new Error("git absent");
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("isTrustedOrgAutoEnable", () => {
+  it("is true for a deftai-owned origin", () => {
+    expect(isTrustedOrgAutoEnable("/tmp/x", { repoResolver: () => "deftai/cartograph" })).toBe(
+      true,
+    );
+  });
+
+  it("is false for a non-trusted org", () => {
+    expect(isTrustedOrgAutoEnable("/tmp/x", { repoResolver: () => "someone-else/proj" })).toBe(
+      false,
+    );
+  });
+
+  it("is false when no origin remote resolves (fail-safe)", () => {
+    expect(isTrustedOrgAutoEnable("/tmp/x", { repoResolver: () => null })).toBe(false);
+  });
+
+  it("honours an env-extended org", () => {
+    expect(
+      isTrustedOrgAutoEnable("/tmp/x", {
+        repoResolver: () => "acme/widget",
+        env: { [AUTOENABLE_ORGS_ENV]: "acme" },
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/policy/value-feedback-autoenable.ts
+++ b/packages/core/src/policy/value-feedback-autoenable.ts
@@ -1,0 +1,89 @@
+import { inferRepoFromGit } from "../triage/queue/repo.js";
+
+/**
+ * Company-owned GitHub orgs whose repos auto-enable LOCAL value-feedback
+ * collection (#2376). Org membership is the consent for local, no-egress
+ * collection; network/upstream surfaces stay opt-in regardless.
+ */
+export const DEFAULT_AUTOENABLE_ORGS: readonly string[] = ["deftai"];
+
+/** Optional comma-separated env override that EXTENDS the built-in trusted-org set. */
+export const AUTOENABLE_ORGS_ENV = "DEFT_VALUE_AUTOENABLE_ORGS";
+
+/** Built-in trusted orgs plus any from the env override, normalized to lowercase. */
+export function resolveTrustedOrgs(env: NodeJS.ProcessEnv = process.env): Set<string> {
+  const orgs = new Set<string>(DEFAULT_AUTOENABLE_ORGS.map((o) => o.toLowerCase()));
+  const raw = env[AUTOENABLE_ORGS_ENV];
+  if (typeof raw === "string") {
+    for (const part of raw.split(",")) {
+      const trimmed = part.trim().toLowerCase();
+      if (trimmed.length > 0) {
+        orgs.add(trimmed);
+      }
+    }
+  }
+  return orgs;
+}
+
+const originOrgCache = new Map<string, string | null>();
+
+/** Test/hygiene hook: drop the memoized origin-org lookups. */
+export function clearOriginOrgCache(): void {
+  originOrgCache.clear();
+}
+
+export interface OriginOrgOptions {
+  /** Test seam for origin-repo resolution; defaults to `inferRepoFromGit`. */
+  readonly repoResolver?: (projectRoot: string) => string | null;
+  /** Override caching; defaults to caching only when no custom resolver is supplied. */
+  readonly useCache?: boolean;
+}
+
+/**
+ * Lowercased owner of the origin remote for `projectRoot`, or null when there is
+ * no remote / not a git checkout. Memoized per projectRoot (the org does not
+ * change within a session) to keep the resolver off the hot emit path.
+ */
+export function detectOriginOrg(
+  projectRoot: string,
+  options: OriginOrgOptions = {},
+): string | null {
+  const useCache = options.useCache ?? options.repoResolver === undefined;
+  if (useCache && originOrgCache.has(projectRoot)) {
+    return originOrgCache.get(projectRoot) ?? null;
+  }
+  const resolver = options.repoResolver ?? inferRepoFromGit;
+  let org: string | null = null;
+  try {
+    const repo = resolver(projectRoot);
+    if (typeof repo === "string") {
+      const owner = repo.split("/")[0]?.trim().toLowerCase() ?? "";
+      org = owner.length > 0 ? owner : null;
+    }
+  } catch {
+    org = null;
+  }
+  if (useCache) {
+    originOrgCache.set(projectRoot, org);
+  }
+  return org;
+}
+
+export interface OrgAutoEnableOptions extends OriginOrgOptions {
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * True when `projectRoot`'s origin org is in the trusted-org set (#2376).
+ * Fail-safe: any resolution failure (no remote, non-GitHub, git absent) is false.
+ */
+export function isTrustedOrgAutoEnable(
+  projectRoot: string,
+  options: OrgAutoEnableOptions = {},
+): boolean {
+  const org = detectOriginOrg(projectRoot, options);
+  if (org === null) {
+    return false;
+  }
+  return resolveTrustedOrgs(options.env).has(org);
+}

--- a/packages/core/src/policy/value-feedback.test.ts
+++ b/packages/core/src/policy/value-feedback.test.ts
@@ -114,6 +114,51 @@ describe("resolveValueFeedback defaults", () => {
   });
 });
 
+describe("resolveValueFeedback trusted-org auto-enable (#2376)", () => {
+  it("auto-enables local emit + sessionLine for a deftai origin when the flag is absent", () => {
+    const root = makeRepo({ policy: { wipCap: 10 } });
+    const resolved = resolveValueFeedback(root, {
+      autoEnable: { repoResolver: () => "deftai/statusreport" },
+    });
+    expect(resolved.source).toBe("org-auto");
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.emitEvents).toBe(true);
+    expect(resolved.sessionLine).toBe(true);
+    expect(resolved.upstreamPrompt).toBe(false);
+  });
+
+  it("stays OFF for a non-trusted org", () => {
+    const root = makeRepo({ policy: { wipCap: 10 } });
+    const resolved = resolveValueFeedback(root, {
+      autoEnable: { repoResolver: () => "someone-else/proj" },
+    });
+    expect(resolved.source).toBe("default");
+    expect(resolved.enabled).toBe(false);
+    expect(resolved.emitEvents).toBe(false);
+  });
+
+  it("stays OFF (fail-safe) when no origin remote resolves", () => {
+    const root = makeRepo({ policy: { wipCap: 10 } });
+    const resolved = resolveValueFeedback(root, {
+      autoEnable: { repoResolver: () => null },
+    });
+    expect(resolved.source).toBe("default");
+    expect(resolved.enabled).toBe(false);
+  });
+
+  it("an explicit typed enabled:false wins over trusted-org auto-enable", () => {
+    const root = makeRepo({
+      policy: { valueFeedback: { enabled: false, emitEvents: true } },
+    });
+    const resolved = resolveValueFeedback(root, {
+      autoEnable: { repoResolver: () => "deftai/directive" },
+    });
+    expect(resolved.source).toBe("typed");
+    expect(resolved.enabled).toBe(false);
+    expect(resolved.emitEvents).toBe(false);
+  });
+});
+
 describe("isValueFeedbackPathAllowed master gate", () => {
   it("rejects every path when enabled is false", () => {
     const policy = resolveValueFeedback(makeRepo());

--- a/packages/core/src/policy/value-feedback.test.ts
+++ b/packages/core/src/policy/value-feedback.test.ts
@@ -288,4 +288,43 @@ describe("policy:show --field=valueFeedback reader", () => {
     });
     expect(field.source).toBe("default");
   });
+
+  it("inspectValueFeedback mirrors org-auto so policy:show never lies for deftai repos (#2377)", () => {
+    const data = { plan: { title: "T", status: "running", items: [], policy: { wipCap: 10 } } };
+    const field = inspectValueFeedback(data, "/some/root", {
+      autoEnable: { repoResolver: () => "deftai/statusreport" },
+    });
+    expect(field.source).toBe("org-auto");
+    expect(field.current).toEqual({
+      enabled: true,
+      emitEvents: true,
+      sessionLine: true,
+      upstreamPrompt: false,
+    });
+  });
+
+  it("inspectValueFeedback stays default for a non-trusted org with no explicit block (#2377)", () => {
+    const data = { plan: { title: "T", status: "running", items: [], policy: { wipCap: 10 } } };
+    const field = inspectValueFeedback(data, "/some/root", {
+      autoEnable: { repoResolver: () => "someone-else/proj" },
+    });
+    expect(field.source).toBe("default");
+    expect(field.current.enabled).toBe(false);
+  });
+
+  it("inspectValueFeedback: explicit typed enabled:false wins over org-auto (#2377)", () => {
+    const data = {
+      plan: {
+        title: "T",
+        status: "running",
+        items: [],
+        policy: { valueFeedback: { enabled: false } },
+      },
+    };
+    const field = inspectValueFeedback(data, "/some/root", {
+      autoEnable: { repoResolver: () => "deftai/directive" },
+    });
+    expect(field.source).toBe("typed");
+    expect(field.current.enabled).toBe(false);
+  });
 });

--- a/packages/core/src/policy/value-feedback.ts
+++ b/packages/core/src/policy/value-feedback.ts
@@ -5,6 +5,7 @@ import {
 } from "../vbrief-build/project-definition-io.js";
 import { migrateLegacyPolicyKey, PLAN_POLICY_KEY, readPlanPolicy } from "./plan-extensions.js";
 import { appendAuditLog, loadProjectDefinition, projectDefinitionPath } from "./resolve.js";
+import { isTrustedOrgAutoEnable, type OrgAutoEnableOptions } from "./value-feedback-autoenable.js";
 
 /** Canonical registered policy field name (matches other FIELD_* dotted paths). */
 export const FIELD_VALUE_FEEDBACK = "plan.policy.valueFeedback";
@@ -30,7 +31,7 @@ export interface ValueFeedbackConfig {
   readonly upstreamPrompt: boolean;
 }
 
-export type ValueFeedbackSource = "typed" | "default" | "default-on-error";
+export type ValueFeedbackSource = "typed" | "org-auto" | "default" | "default-on-error";
 
 export interface ValueFeedbackResolved extends ValueFeedbackConfig {
   readonly source: ValueFeedbackSource;
@@ -60,6 +61,21 @@ function defaultResolved(
     upstreamPrompt: false,
     source,
     error,
+  };
+}
+
+/**
+ * Trusted-org auto-enable resolution (#2376): LOCAL emit + session readback ON,
+ * network/upstream OFF. Applies only when the typed flag is absent.
+ */
+function orgAutoResolved(): ValueFeedbackResolved {
+  return {
+    enabled: true,
+    emitEvents: VALUE_FEEDBACK_SUBFLAG_DEFAULTS_WHEN_ENABLED.emitEvents,
+    sessionLine: VALUE_FEEDBACK_SUBFLAG_DEFAULTS_WHEN_ENABLED.sessionLine,
+    upstreamPrompt: false,
+    source: "org-auto",
+    error: null,
   };
 }
 
@@ -126,8 +142,24 @@ function resolveFromPolicyBlock(raw: unknown): ValueFeedbackResolved {
   };
 }
 
-/** Resolve `plan.policy.valueFeedback` from PROJECT-DEFINITION (#1709). */
-export function resolveValueFeedback(projectRoot: string): ValueFeedbackResolved {
+export interface ResolveValueFeedbackOptions {
+  /** Test seam for origin-org auto-enable resolution (#2376). */
+  readonly autoEnable?: OrgAutoEnableOptions;
+}
+
+/**
+ * Resolve `plan.policy.valueFeedback` from PROJECT-DEFINITION (#1709).
+ *
+ * Precedence (#2376): an explicit typed `valueFeedback` block always wins
+ * (including `enabled: false`). Only when the typed flag is ABSENT does the
+ * trusted-org auto-enable layer apply -- for company-owned (deftai) repos it
+ * turns LOCAL emit + session readback ON while leaving network/upstream OFF.
+ * Any other repo (or no origin remote) stays OFF.
+ */
+export function resolveValueFeedback(
+  projectRoot: string,
+  options: ResolveValueFeedbackOptions = {},
+): ValueFeedbackResolved {
   const [data, err] = loadProjectDefinition(projectRoot);
   if (data === null) {
     return defaultResolved("default-on-error", err);
@@ -139,6 +171,9 @@ export function resolveValueFeedback(projectRoot: string): ValueFeedbackResolved
     Array.isArray(policyBlock) ||
     !("valueFeedback" in (policyBlock as Record<string, unknown>))
   ) {
+    if (isTrustedOrgAutoEnable(projectRoot, options.autoEnable)) {
+      return orgAutoResolved();
+    }
     return defaultResolved("default");
   }
   return resolveFromPolicyBlock((policyBlock as Record<string, unknown>).valueFeedback);

--- a/packages/core/src/policy/value-feedback.ts
+++ b/packages/core/src/policy/value-feedback.ts
@@ -219,49 +219,7 @@ export interface ValueFeedbackPolicyField {
   readonly source: string;
 }
 
-function defaultInspectorConfig(): ValueFeedbackConfig {
-  const defaults = defaultResolved("default");
-  return {
-    enabled: defaults.enabled,
-    emitEvents: defaults.emitEvents,
-    sessionLine: defaults.sessionLine,
-    upstreamPrompt: defaults.upstreamPrompt,
-  };
-}
-
-function buildDefaultInspectorField(): ValueFeedbackPolicyField {
-  return {
-    name: FIELD_VALUE_FEEDBACK,
-    current: defaultInspectorConfig(),
-    default: {
-      enabled: DEFAULT_VALUE_FEEDBACK_ENABLED,
-      emitEvents: false,
-      sessionLine: false,
-      upstreamPrompt: false,
-    },
-    source: "default",
-  };
-}
-
-/** Inspector row for `policy:show --field=valueFeedback`. */
-export function inspectValueFeedback(
-  data: Record<string, unknown> | null,
-): ValueFeedbackPolicyField {
-  if (data === null) {
-    return buildDefaultInspectorField();
-  }
-
-  const policyBlock = readPlanPolicy(data.plan);
-  if (
-    typeof policyBlock !== "object" ||
-    policyBlock === null ||
-    Array.isArray(policyBlock) ||
-    !("valueFeedback" in (policyBlock as Record<string, unknown>))
-  ) {
-    return buildDefaultInspectorField();
-  }
-
-  const resolved = resolveFromPolicyBlock((policyBlock as Record<string, unknown>).valueFeedback);
+function fieldFromResolved(resolved: ValueFeedbackResolved): ValueFeedbackPolicyField {
   return {
     name: FIELD_VALUE_FEEDBACK,
     current: {
@@ -278,6 +236,46 @@ export function inspectValueFeedback(
     },
     source: resolved.source,
   };
+}
+
+export interface InspectValueFeedbackOptions {
+  /** Test seam for origin-org auto-enable resolution (#2376). */
+  readonly autoEnable?: OrgAutoEnableOptions;
+}
+
+/**
+ * Inspector row for `policy:show --field=valueFeedback`.
+ *
+ * When `projectRoot` is supplied this MUST mirror {@link resolveValueFeedback}'s
+ * precedence exactly (#2377 review): with no explicit typed block, a trusted-org
+ * checkout resolves to `org-auto`/ON so `policy:show` never reports OFF while the
+ * ledger is actively collecting. Omitting `projectRoot` keeps the legacy
+ * data-only behavior for callers that only need the field name/shape.
+ */
+export function inspectValueFeedback(
+  data: Record<string, unknown> | null,
+  projectRoot?: string,
+  options: InspectValueFeedbackOptions = {},
+): ValueFeedbackPolicyField {
+  if (data === null) {
+    return fieldFromResolved(defaultResolved("default"));
+  }
+
+  const policyBlock = readPlanPolicy(data.plan);
+  if (
+    typeof policyBlock !== "object" ||
+    policyBlock === null ||
+    Array.isArray(policyBlock) ||
+    !("valueFeedback" in (policyBlock as Record<string, unknown>))
+  ) {
+    if (projectRoot !== undefined && isTrustedOrgAutoEnable(projectRoot, options.autoEnable)) {
+      return fieldFromResolved(orgAutoResolved());
+    }
+    return fieldFromResolved(defaultResolved("default"));
+  }
+
+  const resolved = resolveFromPolicyBlock((policyBlock as Record<string, unknown>).valueFeedback);
+  return fieldFromResolved(resolved);
 }
 
 export interface EnableValueFeedbackOptions {

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16782,8 +16782,8 @@
       },
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
-        "managedMaxLines": 240,
-        "unmanagedMaxLines": 266
+        "managedMaxLines": 242,
+        "unmanagedMaxLines": 268
       }
     },
     "updated": "2026-07-02T14:32:31Z"

--- a/xbrief/completed/2026-07-06-2376-value-feedback-org-autoenable.xbrief.json
+++ b/xbrief/completed/2026-07-06-2376-value-feedback-org-autoenable.xbrief.json
@@ -1,0 +1,74 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for GitHub issue #2376",
+    "updated": "2026-07-06T21:15:00Z"
+  },
+  "plan": {
+    "title": "feat(value-feedback): enrich attribution events + trusted-org auto-enable of local collection (Refs #1709)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Make the per-machine value-feedback ledger (#1709) good enough to aggregate later, and auto-enable LOCAL collection for company-owned (deftai) repos with zero per-repo or per-machine setup. Strictly local + no network; the collector/push/aggregation is a deferred follow-up.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2376",
+      "ImplementationPlan": "Part A -- Event enrichment: stamp each attribution record at emit time with `repo` (normalized owner/name via inferRepoFromGit/parseGitHubRemoteRepo), `directive_version` (readCorePackageVersion at emit), `install_id` (stable per-checkout uuid persisted in .deft-cache/), and `schema_version` for future migration. Part B -- Trusted-org auto-enable: add a resolution layer above the typed policy that reads the origin org and, when it matches a built-in DEFAULT_AUTOENABLE_ORGS constant (['deftai']) or the optional DEFT_VALUE_AUTOENABLE_ORGS env override AND no explicit typed valueFeedback flag is set, resolves emitEvents+sessionLine ON with source=org-auto and network/upstream OFF; explicit typed enabled:false always wins; no remote / no match stays OFF. Contract-locked docs: reword the #1709 value-feedback block in AGENTS.md + content/templates/agents-entry.md + agent-prompt-preamble.md in lockstep, scope the operator-confirmation prohibition to network/upstream surfaces, add a VALUE_FEEDBACK_MARKERS marker for the new rule, and run agents:refresh.",
+      "Overview": "See https://github.com/deftai/directive/issues/2376. Company policy decision (resolved): for deftai-owned repos, org membership IS the consent for local, no-egress collection; network/upstream still requires explicit opt-in. Open sub-decision resolved during dispatch: keep the maintainer-repo split (in-org emit auto-enables, session readback stays behind DEFT_VALUE_SELF_DOGFOOD=1).",
+      "Traces": "Refs #1709. Consumer-facing follow-up on the value-feedback framework shipped in v0.71.0."
+    },
+    "items": [
+      {
+        "id": "2376-a1",
+        "title": "Attribution records enriched with repo, directive_version, install_id, schema_version",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Every attribution ledger record carries repo (normalized owner/name), directive_version (from readCorePackageVersion at emit), a stable install_id persisted once in .deft-cache/, and a schema_version. Enrichment is best-effort and never interrupts the emit path."
+        }
+      },
+      {
+        "id": "2376-a2",
+        "title": "Trusted-org auto-enable resolution layer (local-only)",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "A github.com/deftai/* clone with no explicit typed valueFeedback flag resolves emitEvents+sessionLine ON with source=org-auto and network OFF. Explicit typed enabled:false overrides. Non-matching org or no origin remote stays OFF. DEFT_VALUE_AUTOENABLE_ORGS extends the matched-org set."
+        }
+      },
+      {
+        "id": "2376-a3",
+        "title": "Contract-locked doc rules reworded in lockstep",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "The #1709 value-feedback block in AGENTS.md, content/templates/agents-entry.md, and content/templates/agent-prompt-preamble.md carries the trusted-org local auto-enable rule and scopes the operator-confirmation prohibition to network/upstream surfaces; VALUE_FEEDBACK_MARKERS is updated; agents:refresh has been run; the agents-entry contract test is green."
+        }
+      },
+      {
+        "id": "2376-a4",
+        "title": "Tests and quality gates",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "New/changed source files ship with tests (verify:forward-coverage); task check is green; a CHANGELOG [Unreleased] entry is added."
+        }
+      }
+    ],
+    "tags": [
+      "value-feedback",
+      "telemetry",
+      "policy"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2376",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2376: feat(value-feedback): enrich attribution events + trusted-org auto-enable of local collection (Refs #1709)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1709",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1709: Epic: Directive value attribution & adoption loop (RFC)"
+      }
+    ],
+    "updated": "2026-07-06T21:41:05Z",
+    "metadata": {
+      "completedAt": "2026-07-06T21:41:05Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements #2376 — makes the per-machine value-feedback ledger (#1709) good enough to aggregate later, and auto-enables **local** collection for company-owned (`deftai`) repos with zero per-repo/per-machine setup. Strictly local + no network; the central collector/push/aggregation stays a deferred follow-up.

**Part A — event enrichment.** Every attribution record is stamped at emit time with `repo` (normalized `owner/name` from the git origin), `directive_version` (`readCorePackageVersion`), a stable per-checkout `install_id` (persisted once in gitignored `.deft-cache/install-id`), and `schema_version`. Enrichment is best-effort and never interrupts the emit path.

**Part B — trusted-org auto-enable.** A new resolution layer above the typed policy: when the typed `valueFeedback` block is **absent** and the origin org is in the trusted set (built-in `deftai`, extendable via `DEFT_VALUE_AUTOENABLE_ORGS`), LOCAL `emitEvents` + `sessionLine` resolve ON with `source=org-auto` and network/upstream OFF. Precedence: an explicit typed block (including `enabled: false`) always wins; a non-matching org or no origin remote stays OFF (fail-safe). Org detection is memoized to stay off the hot emit path.

**Company policy (resolved).** For `deftai`-owned repos, org membership *is* the consent for local, no-egress collection on company-owned resources — network/upstream escalation still requires explicit operator confirmation. The maintainer-repo split is preserved: in-org emit auto-enables, but session readback stays gated behind `DEFT_VALUE_SELF_DOGFOOD=1`.

**Docs (contract-locked).** The #1709 rules are reworded in lockstep across `AGENTS.md`, `content/templates/agents-entry.md`, and `content/templates/agent-prompt-preamble.md`; the operator-confirmation prohibition is scoped to network/upstream surfaces; new `#2376` markers were added to `agents_entry_contract.test.ts`; the AGENTS.md region budget was raised for the added rules.

## Out of scope (deferred)

Central collector service, network push, high-water-mark cursor, and cross-repo aggregation.

## Test plan

- [x] `task check` green (validate + lint + full test + coverage 88.79% stmts / 85.05% branches)
- [x] New source files ship with tests (`verify:forward-coverage`)
- [x] `agents_entry_contract` markers present in AGENTS.md + template
- [x] Temp-dir tests (no git remote) confirm org-auto stays OFF — existing #1709 expectations preserved
- [x] Explicit `enabled:false` overrides org-auto; non-trusted org / no remote → OFF

Refs #1709

Made with [Cursor](https://cursor.com)