### PR TITLE
fix(init-deposit): make Windows update no-op clean (Closes #2118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,3 +340,65 @@ jobs:
             throw "framework:doctor output contains the Microsoft Store app-execution-alias stub marker -- the #1059 wrapper regression has re-fired"
           }
           Write-Host "framework:doctor smoke OK (#1059) -- exit=$exit, no Store-stub marker in output"
+
+      - name: deft update stays clean with core.autocrlf=true (#2118)
+        shell: pwsh
+        run: |
+          pnpm --dir $env:GITHUB_WORKSPACE run build
+          $contentPackage = Join-Path $env:GITHUB_WORKSPACE 'packages\content'
+          pnpm --dir $contentPackage run prepack
+          $cli = Join-Path $env:GITHUB_WORKSPACE 'packages\cli\dist\bin.js'
+          if (-not (Test-Path $cli)) {
+            throw "missing built CLI at $cli"
+          }
+          $smokeRoot = Join-Path $env:RUNNER_TEMP ("deft-update-autocrlf-" + [System.Guid]::NewGuid().ToString('N'))
+          $shimDir = Join-Path $smokeRoot 'shim'
+          New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
+          [System.IO.File]::WriteAllText(
+            (Join-Path $shimDir 'deft.cmd'),
+            "@echo off`r`nnode `"$cli`" %*`r`n",
+            (New-Object System.Text.UTF8Encoding $false)
+          )
+          [System.IO.File]::WriteAllText(
+            (Join-Path $shimDir 'deft'),
+            "#!/bin/sh`nnode `"$cli`" " + '"$@"' + "`n",
+            (New-Object System.Text.UTF8Encoding $false)
+          )
+          $env:PATH = "$shimDir;$env:PATH"
+          $consumer = Join-Path $smokeRoot 'consumer'
+          New-Item -ItemType Directory -Path $consumer -Force | Out-Null
+          Push-Location $consumer
+          try {
+            git init -q
+            git config core.autocrlf true
+            git config user.name ci
+            git config user.email ci@example.com
+
+            node $cli init --yes --repo-root $consumer
+            if ($LASTEXITCODE -ne 0) { throw "directive init exited $LASTEXITCODE" }
+
+            git add -A
+            git commit --no-verify -q -m baseline
+            if ($LASTEXITCODE -ne 0) { throw "baseline commit exited $LASTEXITCODE" }
+
+            node $cli update --yes --repo-root $consumer
+            if ($LASTEXITCODE -ne 0) { throw "first directive update exited $LASTEXITCODE" }
+            node $cli update --yes --repo-root $consumer
+            if ($LASTEXITCODE -ne 0) { throw "second directive update exited $LASTEXITCODE" }
+
+            task deft:verify:cache-fresh
+            if ($LASTEXITCODE -ne 0) { throw "task deft:verify:cache-fresh exited $LASTEXITCODE" }
+
+            node $cli preflight-cache --project-root $consumer --allow-missing-bootstrap
+            if ($LASTEXITCODE -ne 0) { throw "preflight-cache exited $LASTEXITCODE" }
+
+            $status = git status --porcelain
+            if ($status) {
+              Write-Host "--- dirty status after idempotent update ---"
+              Write-Host $status
+              throw "directive update left a dirty tree under core.autocrlf=true"
+            }
+          } finally {
+            Pop-Location
+            pnpm --dir $contentPackage run postpack
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`directive update` is idempotent on current Windows npm deposits.** Current installs now keep the vendored framework payload LF-pinned, skip payload copy and timestamp rewrites when the deposited content version is already current, and collapse CRLF-only `.deft/core` churn into a short line-ending hint instead of a long dirty-file list. The Windows CI smoke now covers `core.autocrlf=true` init/update/update plus `task deft:verify:cache-fresh` and `preflight-cache`. Closes #2118.
+
 ### Removed
 
 ## [0.73.0] - 2026-07-07

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -18,10 +18,12 @@ import (
 // it as such.
 const coreGlob = ".deft/core/**"
 
-// coreGitattributesLines mark the vendored payload as generated AND vendored so
-// GitHub's linguist excludes it from language statistics and collapses it in
-// diffs. Mirrors the line-based, idempotent contract of EnsureGitignoreLines.
+// coreGitattributesLines pin the vendored payload to LF and mark it generated
+// AND vendored so Git does not rewrite it and GitHub's linguist excludes it
+// from language statistics. Mirrors the line-based, idempotent contract of
+// EnsureGitignoreLines.
 var coreGitattributesLines = []string{
+	coreGlob + " text eol=lf",
 	coreGlob + " linguist-generated=true",
 	coreGlob + " linguist-vendored=true",
 }
@@ -383,10 +385,10 @@ func pruneVendoredTSTests(w *Wizard, projectDir string) (int, error) {
 	return removed, nil
 }
 
-// EnsureGitattributes appends the linguist generated/vendored markers for
-// .deft/core/** to the consumer's .gitattributes if any line is missing. The
-// file is created when absent; pre-existing lines are preserved byte-for-byte.
-// Mirrors EnsureGitignoreLines (#1430). Returns true if the file was modified.
+// EnsureGitattributes appends the LF/generated/vendored markers for .deft/core/**
+// to the consumer's .gitattributes if any line is missing. The file is created
+// when absent; pre-existing lines are preserved byte-for-byte. Mirrors
+// EnsureGitignoreLines (#1430, #2118). Returns true if the file was modified.
 func EnsureGitattributes(w *Wizard, projectDir string) (bool, error) {
 	path := filepath.Join(projectDir, ".gitattributes")
 	data, err := os.ReadFile(path)
@@ -412,7 +414,7 @@ func EnsureGitattributes(w *Wizard, projectDir string) (bool, error) {
 		}
 	}
 	if len(additions) == 0 {
-		w.printf(".gitattributes already marks %s as generated/vendored — skipping.\n", coreGlob)
+		w.printf(".gitattributes already marks %s as LF-pinned/generated/vendored — skipping.\n", coreGlob)
 		return false, nil
 	}
 
@@ -425,8 +427,8 @@ func EnsureGitattributes(w *Wizard, projectDir string) (bool, error) {
 		body.WriteString("\n")
 	}
 	body.WriteString("# Deft framework: the vendored payload is packaged framework code, not\n")
-	body.WriteString("# consumer source. Mark it generated + vendored so language stats and\n")
-	body.WriteString("# diffs treat .deft/core/** as machine-managed (#1430).\n")
+	body.WriteString("# consumer source. Pin LF endings and mark it generated + vendored so\n")
+	body.WriteString("# Git does not rewrite it and diffs treat .deft/core/** as machine-managed (#1430, #2118).\n")
 	for _, add := range additions {
 		body.WriteString(add)
 		body.WriteString("\n")
@@ -435,7 +437,7 @@ func EnsureGitattributes(w *Wizard, projectDir string) (bool, error) {
 	if err := os.WriteFile(path, []byte(body.String()), 0o644); err != nil {
 		return false, fmt.Errorf("could not write .gitattributes: %w", err)
 	}
-	w.printf(".gitattributes updated with linguist markers: %s\n", strings.Join(additions, ", "))
+	w.printf(".gitattributes updated with Deft core markers: %s\n", strings.Join(additions, ", "))
 	return true, nil
 }
 

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -83,6 +83,35 @@ func TestEnsureGitattributes_Idempotent(t *testing.T) {
 	if got := strings.Count(string(data), "linguist-vendored=true"); got != 1 {
 		t.Errorf("expected exactly one linguist-vendored line, got %d", got)
 	}
+	if got := strings.Count(string(data), "text eol=lf"); got != 1 {
+		t.Errorf("expected exactly one LF pin line, got %d", got)
+	}
+}
+
+func TestEnsureGitattributes_RepairsMissingLfPin(t *testing.T) {
+	tmp := t.TempDir()
+	pre := coreGlob + " linguist-generated=true\n" + coreGlob + " linguist-vendored=true\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".gitattributes"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := EnsureGitattributes(newDepositWizard(), tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true when LF pin is missing")
+	}
+	data, _ := os.ReadFile(filepath.Join(tmp, ".gitattributes"))
+	content := string(data)
+	if !strings.Contains(content, coreGlob+" text eol=lf") {
+		t.Fatalf(".gitattributes missing LF pin after repair:\n%s", content)
+	}
+	if got := strings.Count(content, "linguist-generated=true"); got != 1 {
+		t.Errorf("expected exactly one linguist-generated line, got %d", got)
+	}
+	if got := strings.Count(content, "linguist-vendored=true"); got != 1 {
+		t.Errorf("expected exactly one linguist-vendored line, got %d", got)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -172,6 +172,31 @@ describe("scoped staging", () => {
     expect(stagedPaths).not.toContain(".deft/core");
   });
 
+  it("honors includeCore=false while staging repaired projections (#2118)", () => {
+    const project = freshRoot("hygiene-no-core-stage-");
+
+    mkdirSync(join(project, ".deft", "core"), { recursive: true });
+    writeFileSync(join(project, ".deft", "core", "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n", "utf8");
+    initGitRepo(project);
+
+    writeFileSync(join(project, ".deft", "core", "main.md"), "# Deft\r\n", "utf8");
+    writeFileSync(join(project, "AGENTS.md"), "# Agent\n\nupdated\n", "utf8");
+
+    const { stagePaths, stagedPaths } = depositStagePaths(project, { includeCore: false });
+
+    expect(stagePaths).not.toContain(".deft/core");
+    expect(stagedPaths).toContain("AGENTS.md");
+    expect(stagedPaths).not.toContain(".deft/core");
+
+    const cached = execFileSync("git", ["diff", "--cached", "--name-only"], {
+      cwd: project,
+      encoding: "utf8",
+    });
+    expect(cached).toContain("AGENTS.md");
+    expect(cached).not.toContain(".deft/core/main.md");
+  });
+
   it("does not stage Taskfile.yml when the include was not wired this run (#1576)", async () => {
     const project = freshRoot("hygiene-unwired-taskfile-");
 

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -86,6 +86,12 @@ export function isInstallerManagedPath(path: string): boolean {
 
 export interface FrameworkStagePathsOptions {
   /**
+   * Include the vendored `.deft/core` payload in the stage set. Defaults to
+   * `true` for init and real payload swaps. No-op updates set this to `false`
+   * so CRLF-only core noise cannot be staged while safe projections are repaired.
+   */
+  readonly includeCore?: boolean;
+  /**
    * Include the project-root ``Taskfile.yml`` in the stage set. Defaults to
    * ``false``: unlike the other allowlisted paths, ``Taskfile.yml`` is a
    * consumer-owned file that merely *contains* an installer-managed include
@@ -112,7 +118,12 @@ export function frameworkStagePaths(
   };
 
   const relDeft = relative(projectDir, deftDir);
-  if (relDeft && !relDeft.startsWith("..") && !relDeft.startsWith("/")) {
+  if (
+    options.includeCore !== false &&
+    relDeft &&
+    !relDeft.startsWith("..") &&
+    !relDeft.startsWith("/")
+  ) {
     add(relDeft);
   }
 

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -307,6 +307,7 @@ export function depositStagePaths(
 } {
   const deftDir = join(projectDir, CANONICAL_INSTALL_ROOT);
   const stagePaths = frameworkStagePaths(projectDir, deftDir, {
+    includeCore: options.includeCore,
     includeTaskfile: options.includeTaskfile ?? false,
   });
   const { staged } = stageFrameworkPaths(projectDir, stagePaths, options);

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -81,27 +81,68 @@ describe("buildVersionSkewNotice", () => {
 describe("frameworkRefreshSideEffects", () => {
   it("classifies core and installer-managed paths", () => {
     const porcelain = [" M .deft/core/VERSION", " M AGENTS.md", " M src/app.ts"].join("\n");
-    expect(frameworkRefreshSideEffects("/proj", () => porcelain).sort()).toEqual(
-      [".deft/core/VERSION", "AGENTS.md"].sort(),
-    );
+    expect(
+      frameworkRefreshSideEffects(
+        "/proj",
+        () => porcelain,
+        () => null,
+      ).files.sort(),
+    ).toEqual([".deft/core/VERSION", "AGENTS.md"].sort());
   });
 
   it("strips git-quoted porcelain paths", () => {
     const porcelain = ' M ".deft/core/VERSION"';
-    expect(frameworkRefreshSideEffects("/proj", () => porcelain)).toEqual([".deft/core/VERSION"]);
+    expect(
+      frameworkRefreshSideEffects(
+        "/proj",
+        () => porcelain,
+        () => null,
+      ).files,
+    ).toEqual([".deft/core/VERSION"]);
   });
 
   it("returns empty outside git", () => {
-    expect(frameworkRefreshSideEffects("/proj", () => null)).toEqual([]);
+    expect(frameworkRefreshSideEffects("/proj", () => null)).toEqual({
+      files: [],
+      crlfOnlyCoreFiles: [],
+    });
+  });
+
+  it("suppresses core paths when only CRLF/LF noise remains", () => {
+    const porcelain = [" M .deft/core/VERSION", " M AGENTS.md"].join("\n");
+    expect(
+      frameworkRefreshSideEffects(
+        "/proj",
+        () => porcelain,
+        () => [],
+      ),
+    ).toEqual({
+      files: ["AGENTS.md"],
+      crlfOnlyCoreFiles: [".deft/core/VERSION"],
+    });
   });
 });
 
 describe("printRefreshSideEffects", () => {
   it("emits the #1671 disclosure block", () => {
     const lines: string[] = [];
-    printRefreshSideEffects({ printf: (text) => lines.push(text) }, [".deft/core/VERSION"]);
+    printRefreshSideEffects(
+      { printf: (text) => lines.push(text) },
+      { files: [".deft/core/VERSION"], crlfOnlyCoreFiles: [] },
+    );
     expect(lines.join("")).toContain("AGENTS.md refresh side effects (#1671)");
     expect(lines.join("")).toContain(".deft/core/VERSION");
+  });
+
+  it("prints only the Windows hint for CRLF-only core noise", () => {
+    const lines: string[] = [];
+    printRefreshSideEffects(
+      { printf: (text) => lines.push(text) },
+      { files: [], crlfOnlyCoreFiles: [".deft/core/VERSION"] },
+    );
+    const out = lines.join("");
+    expect(out).toContain("Windows line-ending note (#2118)");
+    expect(out).not.toContain("framework deposit commit");
   });
 });
 
@@ -195,14 +236,36 @@ describe("runRefreshDeposit", () => {
     };
     await runRefreshDeposit(args, io, seams);
     const firstAgents = readFileSync(join(project, "AGENTS.md"), "utf8");
+    const firstVersion = readFileSync(join(project, ".deft", "core", "VERSION"), "utf8");
 
     io.printf.mockClear();
-    const second = await runRefreshDeposit(args, io, seams);
+    const copyContent = vi.fn(async () => {
+      throw new Error("copyContent must not run for an already-current refresh");
+    });
+    const nowIso = vi.fn(() => "2026-06-25T12:00:00Z");
+    const second = await runRefreshDeposit(args, io, {
+      ...seams,
+      copyContent,
+      nowIso,
+      gitPorcelain: () => " M .deft/core/VERSION\n",
+      gitSemanticDiffNames: () => [],
+    });
     const secondAgents = readFileSync(join(project, "AGENTS.md"), "utf8");
+    const secondVersion = readFileSync(join(project, ".deft", "core", "VERSION"), "utf8");
 
     expect(secondAgents).toBe(firstAgents);
+    expect(secondVersion).toBe(firstVersion);
     expect(second.agentsMdUpdated).toBe(false);
-    expect(io.printf.mock.calls.flat().join("")).toContain("already advertises install root");
+    expect(second.alreadyCurrent).toBe(true);
+    expect(second.strategy).toBe("no-op");
+    expect(second.stagedPaths).toEqual([]);
+    expect(copyContent).not.toHaveBeenCalled();
+    expect(nowIso).not.toHaveBeenCalled();
+    const out = io.printf.mock.calls.flat().join("");
+    expect(out).toContain("Framework payload already current");
+    expect(out).toContain("Windows line-ending note (#2118)");
+    expect(out).not.toContain("Commit hygiene");
+    expect(out).not.toContain("framework deposit commit");
   });
 
   it("discloses core side-effects when AGENTS.md is already current", async () => {
@@ -388,6 +451,8 @@ describe("runRefreshDeposit", () => {
         contentVersion: "0.61.0",
         engineVersion: "0.61.0",
         previousDepositVersion: "0.60.0",
+        alreadyCurrent: false,
+        strategy: "file-swap",
         agentsMdUpdated: true,
         versionSkewNotice: null,
         legacyLayout: false,
@@ -416,6 +481,8 @@ describe("runRefreshDeposit", () => {
         contentVersion: "0.61.0",
         engineVersion: "0.61.0",
         previousDepositVersion: "0.60.0",
+        alreadyCurrent: false,
+        strategy: "file-swap",
         agentsMdUpdated: true,
         versionSkewNotice: null,
         legacyLayout: false,
@@ -683,11 +750,16 @@ describe("directive update refresh-only + self-heal (#2266)", () => {
     opts: { contentVersion: string; pinVersion: string; sha?: string },
   ): void {
     const deftDir = join(project, ".deft", "core");
-    mkdirSync(deftDir, { recursive: true });
+    mkdirSync(join(deftDir, "templates"), { recursive: true });
     writeFileSync(
       join(deftDir, "VERSION"),
       `tag: 'v${opts.contentVersion}'\nsha: abc\ninstall_root: '.deft/core'\n`,
       "utf8",
+    );
+    writeFileSync(join(deftDir, "main.md"), "# Deft\n", "utf8");
+    copyFileSync(
+      join(process.cwd(), "content/templates/agents-entry.md"),
+      join(deftDir, "templates/agents-entry.md"),
     );
     writeFileSync(
       join(project, "AGENTS.md"),
@@ -805,8 +877,12 @@ describe("directive update refresh-only + self-heal (#2266)", () => {
     const project = freshRoot("update-current-");
     const contentRoot = installFakeContentPackage(project, "0.53.0");
     writeInitializedProject(project, { contentVersion: "0.53.0", pinVersion: "0.53.0" });
+    const copyContent = vi.fn(async () => {
+      throw new Error("copyContent must not run for a current update");
+    });
     const seams = {
       resolveContentRoot: async () => contentRoot,
+      copyContent,
       readEngineVersion: () => "0.53.0",
       nowIso: () => "2026-07-03T12:00:00Z",
       gitPorcelain: () => null,
@@ -831,8 +907,13 @@ describe("directive update refresh-only + self-heal (#2266)", () => {
 
     const first = await run();
     expect(first.update_state).toBe("current");
+    expect(first.already_current).toBe(true);
+    expect(first.strategy).toBe("no-op");
     const second = await run();
     expect(second.update_state).toBe("current");
+    expect(second.already_current).toBe(true);
+    expect(second.strategy).toBe("no-op");
+    expect(copyContent).not.toHaveBeenCalled();
   });
 
   it("reports updated and re-stamps VERSION when content is behind the pin (a2)", async () => {

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -82,27 +82,25 @@ describe("frameworkRefreshSideEffects", () => {
   it("classifies core and installer-managed paths", () => {
     const porcelain = [" M .deft/core/VERSION", " M AGENTS.md", " M src/app.ts"].join("\n");
     expect(
-      frameworkRefreshSideEffects(
-        "/proj",
-        () => porcelain,
-        () => null,
-      ).files.sort(),
+      frameworkRefreshSideEffects("/proj", {
+        readPorcelain: () => porcelain,
+        readSemanticDiffNames: () => null,
+      }).files.sort(),
     ).toEqual([".deft/core/VERSION", "AGENTS.md"].sort());
   });
 
   it("strips git-quoted porcelain paths", () => {
     const porcelain = ' M ".deft/core/VERSION"';
     expect(
-      frameworkRefreshSideEffects(
-        "/proj",
-        () => porcelain,
-        () => null,
-      ).files,
+      frameworkRefreshSideEffects("/proj", {
+        readPorcelain: () => porcelain,
+        readSemanticDiffNames: () => null,
+      }).files,
     ).toEqual([".deft/core/VERSION"]);
   });
 
   it("returns empty outside git", () => {
-    expect(frameworkRefreshSideEffects("/proj", () => null)).toEqual({
+    expect(frameworkRefreshSideEffects("/proj", { readPorcelain: () => null })).toEqual({
       files: [],
       crlfOnlyCoreFiles: [],
     });
@@ -111,11 +109,10 @@ describe("frameworkRefreshSideEffects", () => {
   it("suppresses core paths when only CRLF/LF noise remains", () => {
     const porcelain = [" M .deft/core/VERSION", " M AGENTS.md"].join("\n");
     expect(
-      frameworkRefreshSideEffects(
-        "/proj",
-        () => porcelain,
-        () => [],
-      ),
+      frameworkRefreshSideEffects("/proj", {
+        readPorcelain: () => porcelain,
+        readSemanticDiffNames: () => [],
+      }),
     ).toEqual({
       files: ["AGENTS.md"],
       crlfOnlyCoreFiles: [".deft/core/VERSION"],

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -8,6 +8,7 @@
  * Refs #1942, #1430, #1671.
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { platform as osPlatform } from "node:os";
 import { join, resolve } from "node:path";
@@ -71,12 +72,16 @@ export interface RefreshDepositResult {
   readonly contentVersion: string;
   readonly engineVersion: string;
   readonly previousDepositVersion: string | null;
+  readonly alreadyCurrent: boolean;
+  readonly strategy: RefreshDepositStrategy;
   readonly agentsMdUpdated: boolean;
   readonly versionSkewNotice: string | null;
   readonly legacyLayout: boolean;
   readonly taskfileWired: boolean;
   readonly stagedPaths: string[];
 }
+
+export type RefreshDepositStrategy = "file-swap" | "no-op";
 
 export interface RefreshDepositSeams {
   resolveContentRoot?: () => Promise<string>;
@@ -85,6 +90,7 @@ export interface RefreshDepositSeams {
   readEngineVersion?: () => string;
   nowIso?: () => string;
   gitPorcelain?: (projectRoot: string) => string | null;
+  gitSemanticDiffNames?: GitSemanticDiffNames;
   detectLegacy?: (projectDir: string) => LegacyLayoutDetection;
   /**
    * #2266: `git ls-files` probe threaded into the non-destructive `.gitignore`
@@ -325,57 +331,151 @@ function unquoteGitPath(path: string): string {
   return path;
 }
 
-function porcelainStatusPaths(porcelain: string): string[] {
-  const paths: string[] = [];
+interface PorcelainStatusEntry {
+  readonly status: string;
+  readonly path: string;
+}
+
+function porcelainStatusEntries(porcelain: string): PorcelainStatusEntry[] {
+  const entries: PorcelainStatusEntry[] = [];
   for (const line of porcelain.split("\n")) {
     if (line.length < 4) continue;
+    const status = line.slice(0, 2);
     let rest = line.slice(3);
     const arrow = rest.indexOf(" -> ");
     if (arrow >= 0) rest = rest.slice(arrow + 4);
     const trimmed = unquoteGitPath(rest.trim());
     if (!trimmed) continue;
-    paths.push(trimmed.replace(/\\/g, "/"));
+    entries.push({ status, path: trimmed.replace(/\\/g, "/") });
   }
-  return paths;
+  return entries;
 }
 
-function classifyChangedPaths(changed: readonly string[]): {
-  core: string[];
-  installerManaged: string[];
+function classifyChangedEntries(changed: readonly PorcelainStatusEntry[]): {
+  core: PorcelainStatusEntry[];
+  installerManaged: PorcelainStatusEntry[];
 } {
-  const core: string[] = [];
-  const installerManaged: string[] = [];
-  for (const path of changed) {
+  const core: PorcelainStatusEntry[] = [];
+  const installerManaged: PorcelainStatusEntry[] = [];
+  for (const entry of changed) {
+    const { path } = entry;
     if (!path) continue;
     if (path.startsWith(".deft/core/") || path === ".deft/core") {
-      core.push(path);
+      core.push(entry);
     } else if (isInstallerManagedPath(path)) {
-      installerManaged.push(path);
+      installerManaged.push(entry);
     }
   }
   return { core, installerManaged };
+}
+
+function isCrlfNoiseCandidate(status: string): boolean {
+  return status.includes("M") && /^[ M]+$/.test(status);
+}
+
+function normalizeGitNameList(output: string): string[] {
+  return output
+    .split("\n")
+    .map((line) => line.trim().replace(/\\/g, "/"))
+    .filter(Boolean);
+}
+
+export type GitSemanticDiffNames = (
+  projectRoot: string,
+  paths: readonly string[],
+) => readonly string[] | null;
+
+function gitSemanticDiffNames(projectRoot: string, paths: readonly string[]): string[] | null {
+  if (paths.length === 0) return [];
+  try {
+    const args = ["diff", "--ignore-cr-at-eol", "--name-only", "--", ...paths];
+    const worktree = execFileSync("git", args, {
+      cwd: projectRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const cached = execFileSync(
+      "git",
+      ["diff", "--cached", "--ignore-cr-at-eol", "--name-only", "--", ...paths],
+      {
+        cwd: projectRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    return [...new Set([...normalizeGitNameList(worktree), ...normalizeGitNameList(cached)])];
+  } catch {
+    return null;
+  }
+}
+
+export interface RefreshSideEffects {
+  readonly files: string[];
+  readonly crlfOnlyCoreFiles: string[];
 }
 
 /** Framework-managed uncommitted paths after refresh (#1671). */
 export function frameworkRefreshSideEffects(
   projectDir: string,
   readPorcelain: (root: string) => string | null = gitPorcelain,
-): string[] {
+  readSemanticDiffNames: GitSemanticDiffNames = gitSemanticDiffNames,
+): RefreshSideEffects {
   const porcelain = readPorcelain(projectDir);
-  if (porcelain === null) return [];
-  const changed = porcelainStatusPaths(porcelain);
-  const { core, installerManaged } = classifyChangedPaths(changed);
-  const files = [...core, ...installerManaged].sort();
-  return files.length > 0 ? files : [];
+  if (porcelain === null) return { files: [], crlfOnlyCoreFiles: [] };
+  const changed = porcelainStatusEntries(porcelain);
+  const { core, installerManaged } = classifyChangedEntries(changed);
+  const semanticCoreNames =
+    core.length > 0
+      ? readSemanticDiffNames(
+          projectDir,
+          core.map((entry) => entry.path),
+        )
+      : [];
+  const semanticCoreSet =
+    semanticCoreNames === null ? null : new Set(semanticCoreNames.map((name) => name));
+
+  const coreFiles: string[] = [];
+  const crlfOnlyCoreFiles: string[] = [];
+  for (const entry of core) {
+    if (
+      semanticCoreSet !== null &&
+      isCrlfNoiseCandidate(entry.status) &&
+      !semanticCoreSet.has(entry.path)
+    ) {
+      crlfOnlyCoreFiles.push(entry.path);
+      continue;
+    }
+    coreFiles.push(entry.path);
+  }
+
+  const files = [...coreFiles, ...installerManaged.map((entry) => entry.path)].sort();
+  return { files, crlfOnlyCoreFiles: crlfOnlyCoreFiles.sort() };
 }
 
-export function printRefreshSideEffects(io: InitDepositIo, files: readonly string[]): void {
-  if (files.length === 0) return;
+export function printRefreshSideEffects(
+  io: InitDepositIo,
+  effects: RefreshSideEffects,
+  options: { readonly payloadSwapped?: boolean } = {},
+): void {
+  if (effects.crlfOnlyCoreFiles.length > 0) {
+    io.printf(
+      "\nWindows line-ending note (#2118): suppressed .deft/core CRLF/LF-only noise; " +
+        "ensure .gitattributes contains `.deft/core/** text eol=lf`.\n",
+    );
+  }
+  if (effects.files.length === 0) return;
+  if (options.payloadSwapped === false) {
+    io.printf("\nFramework-managed files still have semantic uncommitted changes:\n");
+    for (const file of effects.files) {
+      io.printf(`  ${file}\n`);
+    }
+    return;
+  }
   io.printf("\nAGENTS.md refresh side effects (#1671): the refresh and framework payload swap\n");
   io.printf("left these framework files with uncommitted changes -- they belong in the\n");
   io.printf("framework deposit commit (the installer stages them before printing the\n");
   io.printf("`git add` list below, so there are no post-stage stragglers):\n");
-  for (const file of files) {
+  for (const file of effects.files) {
     io.printf(`  ${file}\n`);
   }
 }
@@ -430,7 +530,8 @@ export function buildUpdateSummaryJson(
     user_config_dir: "",
     skills_created: false,
     payload_layout: "vendored",
-    strategy: "file-swap",
+    strategy: result.strategy,
+    already_current: result.alreadyCurrent,
     dirty_tree: false,
     dirty_files: [],
     staged_paths: result.stagedPaths,
@@ -447,9 +548,14 @@ export function printUpdateComplete(
   io: InitDepositIo,
   updateState?: UpdateState,
 ): void {
-  io.printf("\n✓ Deft framework payload refreshed.\n\n");
+  io.printf(
+    result.alreadyCurrent
+      ? "\nOK Deft framework payload already current.\n\n"
+      : "\nOK Deft framework payload refreshed.\n\n",
+  );
   io.printf(`  Location     : ${result.deftDir}\n`);
   io.printf(`  Content      : v${normalizeVersion(result.contentVersion)}\n`);
+  io.printf(`  Strategy     : ${result.strategy}\n`);
   if (updateState) {
     io.printf(`  State        : ${updateState}\n`);
   }
@@ -497,35 +603,45 @@ export async function runRefreshDeposit(
     contentVersion,
     previousDepositVersion,
   );
+  const alreadyCurrent =
+    previousDepositVersion !== null &&
+    normalizeVersion(previousDepositVersion) === normalizeVersion(contentVersion);
+  const strategy: RefreshDepositStrategy = alreadyCurrent ? "no-op" : "file-swap";
 
-  await copyContent(contentRoot, deftDir);
-  await prunePythonArtifactsFromDeposit(deftDir, projectDir, io);
-  // #2347: prune framework-source paths that the content package does not ship.
-  // The additive file-swap never removes them, causing the deposit-hygiene
-  // advisory to persist across every upgrade until manually cleaned.
-  await pruneStrayDepositPaths(deftDir, contentRoot, io);
+  if (alreadyCurrent) {
+    io.printf("[deft update] Framework payload already current; skipping payload copy.\n");
+    migrateLegacyInstallManifest(projectDir, join(deftDir, "VERSION"));
+  } else {
+    await copyContent(contentRoot, deftDir);
+    await prunePythonArtifactsFromDeposit(deftDir, projectDir, io);
+    // #2347: prune framework-source paths that the content package does not ship.
+    // The additive file-swap never removes them, causing the deposit-hygiene
+    // advisory to persist across every upgrade until manually cleaned.
+    await pruneStrayDepositPaths(deftDir, contentRoot, io);
 
-  const nowIso = seams.nowIso ?? (() => new Date().toISOString().replace(/\.\d{3}Z$/, "Z"));
-  const manifestFields: InstallManifestFields = {
-    ref: contentVersion.startsWith("v") ? contentVersion : `v${contentVersion}`,
-    sha: "content-package",
-    tag: contentVersion.startsWith("v") ? contentVersion : `v${contentVersion}`,
-    installRoot: CANONICAL_INSTALL_ROOT,
-    fetchedAt: nowIso(),
-    fetchedBy: "directive-update",
-    ...(previousManagedBy ? { managedBy: previousManagedBy } : {}),
-  };
-  const writtenManifestPath = writeInstallManifest(projectDir, deftDir, manifestFields);
+    const nowIso = seams.nowIso ?? (() => new Date().toISOString().replace(/\.\d{3}Z$/, "Z"));
+    const manifestFields: InstallManifestFields = {
+      ref: contentVersion.startsWith("v") ? contentVersion : `v${contentVersion}`,
+      sha: "content-package",
+      tag: contentVersion.startsWith("v") ? contentVersion : `v${contentVersion}`,
+      installRoot: CANONICAL_INSTALL_ROOT,
+      fetchedAt: nowIso(),
+      fetchedBy: "directive-update",
+      ...(previousManagedBy ? { managedBy: previousManagedBy } : {}),
+    };
+    const writtenManifestPath = writeInstallManifest(projectDir, deftDir, manifestFields);
 
-  // #2064: retire a stale legacy .deft/VERSION now that the canonical
-  // .deft/core/VERSION has been rewritten (folded in from install-upgrade so no
-  // manifest behavior is lost by the redirect). Best-effort; never fatal.
-  migrateLegacyInstallManifest(projectDir, writtenManifestPath);
+    // #2064: retire a stale legacy .deft/VERSION now that the canonical
+    // .deft/core/VERSION has been rewritten (folded in from install-upgrade so no
+    // manifest behavior is lost by the redirect). Best-effort; never fatal.
+    migrateLegacyInstallManifest(projectDir, writtenManifestPath);
 
-  // #2055: regenerate the bare .deft-version derivative so it agrees with the
-  // freshly written manifest tag (otherwise doctor's manifest-agreement check
-  // fails and the operator must hand-edit the marker).
-  syncBareVersionMarker(projectDir, contentVersion);
+    // #2055: regenerate the bare .deft-version derivative so it agrees with the
+    // freshly written manifest tag (otherwise doctor's manifest-agreement check
+    // fails and the operator must hand-edit the marker). No-op refreshes skip
+    // this projection because the manifest tag was not rewritten (#2118).
+    syncBareVersionMarker(projectDir, contentVersion);
+  }
 
   const agentsMdUpdated = writeAgentsMd(projectDir, deftDir, io);
 
@@ -550,13 +666,29 @@ export async function runRefreshDeposit(
     taskfileWired = ensureTaskfile(projectDir, io);
   }
 
-  const { stagePaths, staged, stagedPaths } = depositStagePaths(projectDir, {
-    includeTaskfile: taskfileWired,
-  });
-  printCommitGuidance(io, stagePaths, staged);
-
   const readPorcelain = seams.gitPorcelain ?? gitPorcelain;
-  printRefreshSideEffects(io, frameworkRefreshSideEffects(projectDir, readPorcelain));
+  const effects = frameworkRefreshSideEffects(
+    projectDir,
+    readPorcelain,
+    seams.gitSemanticDiffNames ?? gitSemanticDiffNames,
+  );
+
+  let stagedPaths: string[] = [];
+  if (!alreadyCurrent || effects.files.length > 0) {
+    const stagedResult = depositStagePaths(projectDir, {
+      includeTaskfile: taskfileWired,
+      includeCore: !alreadyCurrent,
+    });
+    stagedPaths = stagedResult.stagedPaths;
+    if (!alreadyCurrent) {
+      printCommitGuidance(io, stagedResult.stagePaths, stagedResult.staged);
+    } else if (stagedResult.stagedPaths.length > 0) {
+      io.printf("\nUpdated installer-managed projections for the current framework deposit:\n");
+      io.printf(`  git add ${stagedResult.stagedPaths.join(" ")}\n`);
+    }
+  }
+
+  printRefreshSideEffects(io, effects, { payloadSwapped: !alreadyCurrent });
 
   if (versionSkewNotice) {
     io.printf(`${versionSkewNotice}\n`);
@@ -568,6 +700,8 @@ export async function runRefreshDeposit(
     contentVersion,
     engineVersion,
     previousDepositVersion,
+    alreadyCurrent,
+    strategy,
     agentsMdUpdated,
     versionSkewNotice,
     legacyLayout: false,
@@ -733,7 +867,9 @@ export async function runRefreshDepositCli(options: RunRefreshDepositCliOptions)
 
   try {
     const result = await runRefreshDeposit(options, io, options.seams);
-    const state = classification?.state;
+    const state: UpdateState | undefined = result.alreadyCurrent
+      ? "current"
+      : classification?.state;
     if (options.jsonOut) {
       options.writeOut(
         `${JSON.stringify(buildUpdateSummaryJson(result, options, state), null, 2)}\n`,

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -385,6 +385,11 @@ export type GitSemanticDiffNames = (
   paths: readonly string[],
 ) => readonly string[] | null;
 
+export interface FrameworkRefreshSideEffectsOptions {
+  readonly readPorcelain?: (root: string) => string | null;
+  readonly readSemanticDiffNames?: GitSemanticDiffNames;
+}
+
 function gitSemanticDiffNames(projectRoot: string, paths: readonly string[]): string[] | null {
   if (paths.length === 0) return [];
   try {
@@ -412,14 +417,16 @@ function gitSemanticDiffNames(projectRoot: string, paths: readonly string[]): st
 export interface RefreshSideEffects {
   readonly files: string[];
   readonly crlfOnlyCoreFiles: string[];
+  readonly payloadSwapped?: boolean;
 }
 
 /** Framework-managed uncommitted paths after refresh (#1671). */
 export function frameworkRefreshSideEffects(
   projectDir: string,
-  readPorcelain: (root: string) => string | null = gitPorcelain,
-  readSemanticDiffNames: GitSemanticDiffNames = gitSemanticDiffNames,
+  options?: FrameworkRefreshSideEffectsOptions,
 ): RefreshSideEffects {
+  const readPorcelain = options?.readPorcelain ?? gitPorcelain;
+  const readSemanticDiffNames = options?.readSemanticDiffNames ?? gitSemanticDiffNames;
   const porcelain = readPorcelain(projectDir);
   if (porcelain === null) return { files: [], crlfOnlyCoreFiles: [] };
   const changed = porcelainStatusEntries(porcelain);
@@ -431,8 +438,7 @@ export function frameworkRefreshSideEffects(
           core.map((entry) => entry.path),
         )
       : [];
-  const semanticCoreSet =
-    semanticCoreNames === null ? null : new Set(semanticCoreNames.map((name) => name));
+  const semanticCoreSet = semanticCoreNames === null ? null : new Set(semanticCoreNames);
 
   const coreFiles: string[] = [];
   const crlfOnlyCoreFiles: string[] = [];
@@ -452,11 +458,7 @@ export function frameworkRefreshSideEffects(
   return { files, crlfOnlyCoreFiles: crlfOnlyCoreFiles.sort() };
 }
 
-export function printRefreshSideEffects(
-  io: InitDepositIo,
-  effects: RefreshSideEffects,
-  options: { readonly payloadSwapped?: boolean } = {},
-): void {
+export function printRefreshSideEffects(io: InitDepositIo, effects: RefreshSideEffects): void {
   if (effects.crlfOnlyCoreFiles.length > 0) {
     io.printf(
       "\nWindows line-ending note (#2118): suppressed .deft/core CRLF/LF-only noise; " +
@@ -464,7 +466,7 @@ export function printRefreshSideEffects(
     );
   }
   if (effects.files.length === 0) return;
-  if (options.payloadSwapped === false) {
+  if (effects.payloadSwapped === false) {
     io.printf("\nFramework-managed files still have semantic uncommitted changes:\n");
     for (const file of effects.files) {
       io.printf(`  ${file}\n`);
@@ -667,11 +669,10 @@ export async function runRefreshDeposit(
   }
 
   const readPorcelain = seams.gitPorcelain ?? gitPorcelain;
-  const effects = frameworkRefreshSideEffects(
-    projectDir,
+  const effects = frameworkRefreshSideEffects(projectDir, {
     readPorcelain,
-    seams.gitSemanticDiffNames ?? gitSemanticDiffNames,
-  );
+    readSemanticDiffNames: seams.gitSemanticDiffNames ?? gitSemanticDiffNames,
+  });
 
   let stagedPaths: string[] = [];
   if (!alreadyCurrent || effects.files.length > 0) {
@@ -688,7 +689,7 @@ export async function runRefreshDeposit(
     }
   }
 
-  printRefreshSideEffects(io, effects, { payloadSwapped: !alreadyCurrent });
+  printRefreshSideEffects(io, { ...effects, payloadSwapped: !alreadyCurrent });
 
   if (versionSkewNotice) {
     io.printf(`${versionSkewNotice}\n`);

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -160,7 +160,9 @@ describe("init-deposit scaffold", () => {
 
     await depositNeutralization(project, io);
 
-    expect(readFileSync(join(project, ".gitattributes"), "utf8")).toContain(".deft/core/**");
+    expect(readFileSync(join(project, ".gitattributes"), "utf8")).toContain(
+      ".deft/core/** text eol=lf",
+    );
     expect(readFileSync(join(project, "greptile.json"), "utf8")).toContain(".deft/core/**");
     expect(readFileSync(join(project, ".github/codeql/codeql-config.yml"), "utf8")).toContain(
       "paths-ignore",
@@ -228,6 +230,22 @@ describe("init-deposit scaffold", () => {
         fetchedBy: "test",
       }),
     ).toContain("tag: 'v0.53.0'");
+  });
+
+  it("repairs old .gitattributes entries with the LF pin", () => {
+    const project = freshRoot("scaffold-gitattributes-lf-");
+    const { io } = captureIo();
+    writeFileSync(
+      join(project, ".gitattributes"),
+      ".deft/core/** linguist-generated=true\n.deft/core/** linguist-vendored=true\n",
+      "utf8",
+    );
+
+    expect(ensureGitattributes(project, io)).toBe(true);
+    const attrs = readFileSync(join(project, ".gitattributes"), "utf8");
+    expect(attrs).toContain(".deft/core/** text eol=lf");
+    expect(attrs.match(/linguist-generated=true/g) ?? []).toHaveLength(1);
+    expect(attrs.match(/linguist-vendored=true/g) ?? []).toHaveLength(1);
   });
 
   it("prunes framework self-tests and vendored TS test files", async () => {

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -36,6 +36,7 @@ const VENDORED_TS_PACKAGES_REL = ".deft/core/packages";
 const VENDORED_TS_TEST_RE = /\.(test|spec)\.(c|m)?[jt]sx?$/i;
 
 const CORE_GITATTRIBUTES_LINES = [
+  `${CORE_GLOB} text eol=lf`,
   `${CORE_GLOB} linguist-generated=true`,
   `${CORE_GLOB} linguist-vendored=true`,
 ];
@@ -685,7 +686,9 @@ export function ensureGitattributes(projectDir: string, io: InitDepositIo): bool
   const present = new Set(existing.split("\n").map((line) => line.trim()));
   const additions = CORE_GITATTRIBUTES_LINES.filter((line) => !present.has(line));
   if (additions.length === 0) {
-    io.printf(`.gitattributes already marks ${CORE_GLOB} as generated/vendored — skipping.\n`);
+    io.printf(
+      `.gitattributes already marks ${CORE_GLOB} as LF-pinned/generated/vendored — skipping.\n`,
+    );
     return false;
   }
   let body = existing;
@@ -693,13 +696,13 @@ export function ensureGitattributes(projectDir: string, io: InitDepositIo): bool
   if (body && !body.endsWith("\n\n")) body += "\n";
   body +=
     "# Deft framework: the vendored payload is packaged framework code, not\n" +
-    "# consumer source. Mark it generated + vendored so language stats and\n" +
-    "# diffs treat .deft/core/** as machine-managed (#1430).\n";
+    "# consumer source. Pin LF endings and mark it generated + vendored so\n" +
+    "# Git does not rewrite it and diffs treat .deft/core/** as machine-managed (#1430, #2118).\n";
   for (const add of additions) {
     body += `${add}\n`;
   }
   writeFileSync(path, body, "utf8");
-  io.printf(`.gitattributes updated with linguist markers: ${additions.join(", ")}\n`);
+  io.printf(`.gitattributes updated with Deft core markers: ${additions.join(", ")}\n`);
   return true;
 }
 

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -159,17 +159,36 @@ describe("deposit journey e2e legs (#1942 S5)", () => {
       ...seams,
       gitHooks: { getHooksPath: () => "", setHooksPath: () => true },
     });
+    const initVersion = readFileSync(join(project, ".deft/core", "VERSION"), "utf8");
+    const copyContent = vi.fn(async () => {
+      throw new Error("copyContent must not run for an already-current update");
+    });
+    const updateSeams = {
+      ...seams,
+      copyContent,
+      nowIso: () => "2026-06-25T12:00:00Z",
+      gitSemanticDiffNames: () => [],
+    };
 
     io.printf.mockClear();
-    await runRefreshDeposit(args, io, seams);
+    const first = await runRefreshDeposit(args, io, updateSeams);
     const firstAgents = readFileSync(join(project, "AGENTS.md"), "utf8");
+    const firstVersion = readFileSync(join(project, ".deft/core", "VERSION"), "utf8");
 
     io.printf.mockClear();
-    const second = await runRefreshDeposit(args, io, seams);
+    const second = await runRefreshDeposit(args, io, updateSeams);
     const secondAgents = readFileSync(join(project, "AGENTS.md"), "utf8");
+    const secondVersion = readFileSync(join(project, ".deft/core", "VERSION"), "utf8");
 
     expect(secondAgents).toBe(firstAgents);
+    expect(firstVersion).toBe(initVersion);
+    expect(secondVersion).toBe(initVersion);
+    expect(first.alreadyCurrent).toBe(true);
+    expect(first.strategy).toBe("no-op");
     expect(second.agentsMdUpdated).toBe(false);
+    expect(second.alreadyCurrent).toBe(true);
+    expect(second.strategy).toBe("no-op");
+    expect(copyContent).not.toHaveBeenCalled();
     expect(existsSync(join(project, ".deft/core", "main.md"))).toBe(true);
   });
 });

--- a/packages/core/src/value/readback.test.ts
+++ b/packages/core/src/value/readback.test.ts
@@ -286,7 +286,13 @@ describe("value:show trend readout", () => {
   it("supports json output", () => {
     const root = makeRepo({
       valueFeedback: { enabled: true },
-      events: [{ event: "value:gate-catch", payload: { source: "s", detail: "d" } }],
+      events: [
+        {
+          event: "value:gate-catch",
+          payload: { source: "s", detail: "d" },
+          detected_at: new Date().toISOString(),
+        },
+      ],
     });
     const result = runValueShow({ projectRoot: root, format: "json" });
     expect(result.text.trim().startsWith("{")).toBe(true);

--- a/xbrief/completed/2026-07-08-2118-bug-deft-update-on-current-npm-deposit-creates-phantom-dirty.xbrief.json
+++ b/xbrief/completed/2026-07-08-2118-bug-deft-update-on-current-npm-deposit-creates-phantom-dirty.xbrief.json
@@ -1,0 +1,56 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2118"
+  },
+  "plan": {
+    "title": "bug: deft update on current npm deposit creates phantom dirty tree on Windows and over-reports changes",
+    "status": "completed",
+    "narratives": {
+      "Description": "bug: deft update on current npm deposit creates phantom dirty tree on Windows and over-reports changes",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2118",
+      "Overview": "## Summary\r\n\r\nRunning `deft update` on a consumer project that is **already on the latest npm release** (`@deftai/directive@0.65.0`) produces a misleading operator/agent experience on Windows:\r\n\r\n1. ~280 files under `.deft/core/` appear modified in `git status` even though content is unchanged.\r\n2. The installer prints a long list of paths as \"uncommitted changes\" and implies a framework deposit commit is needed.\r\n3. The only real diff (ignoring line endings) is a `fetched_at` timestamp bump in `.deft/core/VERSION`.\r\n\r\nThis caused a maintainer to investigate whether a commit was required after syncing master and running the canonical npm upgrade path — it was not.\r\n\r\n## Environment\r\n\r\n- **Consumer repo:** `deftai/statusreport` (master at `6173aad`, already on directive v0.65.0 via PR #83)\r\n- **OS:** Windows 10, PowerShell\r\n- **Git:** `core.autocrlf=true`\r\n- **Node:** v22.14.0\r\n- **Global CLI:** `@deftai/directive@0.65.0` (installed via `npm i -g @deftai/directive@latest`)\r\n- **Deposit:** `.deft/core/VERSION` shows `managed_by: npm`, `ref: v0.65.0`\r\n\r\n## Repro\r\n\r\n```powershell\r\ngit checkout master\r\ngit pull origin master   # already at v0.65.0\r\nnpm i -g @deftai/directive@latest\r\ndeft update\r\ngit status --short       # ~280 modified files under .deft/core/\r\ngit diff --ignore-cr-at-eol --stat   # only .deft/core/VERSION (fetched_at line)\r\n```\r\n\r\n## Expected\r\n\r\nWhen `previous_version === content_version` and payload content is unchanged:\r\n\r\n- Clear message: **already current — no repository commit required**\r\n- Do **not** list every touched path as uncommitted framework deposit changes\r\n- Working tree should remain clean (or guidance should explain line-ending-only phantom diffs immediately)\r\n\r\n## Actual\r\n\r\n`deft update` output (abridged):\r\n\r\n```\r\n✓ Deft framework payload refreshed.\r\n  Content      : v0.65.0\r\n  previous_version: 0.65.0\r\n```\r\n\r\nPlus a long \"AGENTS.md refresh side effects\" / uncommitted-changes list (~280 paths).\r\n\r\n`git diff --ignore-cr-at-eol` shows **one** real change:\r\n\r\n```diff\r\n--- a/.deft/core/VERSION\r\n+++ b/.deft/core/VERSION\r\n-fetched_at: '2026-06-30T14:53:46Z'\r\n+fetched_at: '2026-06-30T15:57:01Z'\r\n```\r\n\r\nAll other \"modified\" files are CRLF/LF phantom diffs from `core.autocrlf=true` interacting with LF npm deposit writes.\r\n\r\n## Root causes (proposed)\r\n\r\n1. **Missing `eol=lf` projection for `.deft/core/**`**\r\n   - Consumer `.gitattributes` has `linguist-generated` / `linguist-vendored` but not `text eol=lf`.\r\n   - `deft update` reports \".gitattributes already marks .deft/core/** … — skipping\" and does not add the LF pin.\r\n   - Same pattern already exists in statusreport for `frontend/src/generated/*.ts text eol=lf` to stabilize CI diffs across autocrlf settings.\r\n\r\n2. **No no-op refresh detection**\r\n   - File-swap runs even when tarball content matches on-disk deposit.\r\n   - `fetched_at` is rewritten anyway, creating a tempting-but-meaningless commit.\r\n\r\n3. **Over-aggressive post-update reporting**\r\n   - Installer lists all touched paths as deposit-side uncommitted changes without distinguishing semantic diffs from line-ending noise.\r\n\r\n## Proposed fixes\r\n\r\n### P1 — `.gitattributes` projection\r\n\r\nExtend consumer `.gitattributes` projection to add (when missing):\r\n\r\n```gitattributes\r\n.deft/core/** text eol=lf\r\n```\r\n\r\nIdempotent; mirrors frontend codegen stability pattern.\r\n\r\n### P1 — No-op update path\r\n\r\nWhen content hash / version unchanged:\r\n\r\n- Skip file-swap (or skip reporting touched paths)\r\n- Print explicit \"already current\" exit summary\r\n- Do not rewrite `VERSION.fetched_at` unless content actually changed\r\n\r\n### P2 — Windows post-update hint\r\n\r\nIf deposit version unchanged and git working tree dirty, suggest:\r\n\r\n```powershell\r\ngit diff --ignore-cr-at-eol --stat\r\ngit checkout -- .deft/core/   # when only CRLF phantom diffs\r\n```\r\n\r\n### P2 — Sync / UPGRADING guidance\r\n\r\nDocument that re-running `deft update` on current master often produces **no commit-worthy changes**; version bump commits happen only when `ref`/`tag` in `VERSION` changes.\r\n\r\n## Acceptance criteria\r\n\r\n- [ ] Repro above on Windows + `core.autocrlf=true` leaves clean `git status` after `deft update` when already on latest release\r\n- [ ] `deft update` on unchanged deposit prints \"already current\" (no false deposit-commit nudge)\r\n- [ ] Fresh `deft update` on a project without eol pin adds `.deft/core/** text eol=lf` to `.gitattributes`\r\n- [ ] `VERSION.fetched_at` not bumped on idempotent refresh\r\n- [ ] Test or fixture covering no-op update path (consumer install smoke)\r\n\r\n## Related\r\n\r\n- #2120 — Windows native `engine:_ts-build` doubles `DEFT_ROOT`; `task deft:verify:cache-fresh` fails (separate bug, same session, first native-Windows run vs WSL)\r\n\r\n## Labels rationale\r\n\r\nBug: incorrect/misleading behavior after canonical upgrade path. Also affects agent-experience and adoption (operators/agents infer a commit is needed when it is not).\r\n\n",
+      "Labels": "bug, adoption-blocker, installer, agent-experience"
+    },
+    "items": [
+      {
+        "title": "Repro above on Windows + `core.autocrlf=true` leaves clean `git status` after `deft update` when already on latest release",
+        "status": "proposed"
+      },
+      {
+        "title": "`deft update` on unchanged deposit prints \"already current\" (no false deposit-commit nudge)",
+        "status": "proposed"
+      },
+      {
+        "title": "Fresh `deft update` on a project without eol pin adds `.deft/core/** text eol=lf` to `.gitattributes`",
+        "status": "proposed"
+      },
+      {
+        "title": "`VERSION.fetched_at` not bumped on idempotent refresh",
+        "status": "proposed"
+      },
+      {
+        "title": "Test or fixture covering no-op update path (consumer install smoke)",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "installer",
+      "agent-experience"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2118",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2118: bug: deft update on current npm deposit creates phantom dirty tree on Windows and over-reports changes"
+      }
+    ],
+    "updated": "2026-07-08T06:22:18Z",
+    "metadata": {
+      "completedAt": "2026-07-08T06:22:18Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make `directive update` idempotent when the deposited content version is already current, while still repairing safe projections such as `.gitattributes`
- pin `.deft/core/**` to LF in deposited `.gitattributes` rules across TS and Go parity paths so `core.autocrlf=true` does not dirty the framework payload
- collapse CRLF-only `.deft/core` side effects into a short Windows line-ending hint instead of a long dirty-file list
- add Windows CI smoke coverage for `core.autocrlf=true` init/update/update plus `task deft:verify:cache-fresh` and direct `preflight-cache`
- stabilize the date-sensitive `value:show` JSON fixture so July 8 CI no longer ages its default event outside the 7-day window

## Related Issues
Closes #2118
Refs #2389

## Verification
- `pnpm exec vitest run packages/core/src/init-deposit/refresh.test.ts packages/core/src/init-deposit/scaffold.test.ts packages/core/src/init-deposit/hygiene.test.ts packages/core/src/release-e2e/npm-ops.test.ts` (97 tests passed)
- `pnpm exec vitest run packages/core/src/value/readback.test.ts -t "supports json output"`
- `go test ./cmd/deft-install/`
- `task vbrief:validate` (passes; existing PRD staleness warning remains)
- `git diff --check`
- `task pr:check-closing-keywords -- --body-file <body>`
- current PR CI is green

## CI Note
- The final commit is test-only and keeps the shared TypeScript lane green while this PR is open. It does not change #2118 runtime behavior.

## Checklist
- [x] `/deft:change <name>` -- N/A: accepted #2118 scope xBRIEF is the scoped change artifact for this issue-driven bugfix.
- [x] `CHANGELOG.md` -- added entry under `[Unreleased]`.
- [x] `ROADMAP.md` -- N/A: release-time ROADMAP promotion per repo convention.
- [x] Tests pass locally -- focused #2118 checks, focused value readback check, and CI pass.

## Post-Merge
- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issue actually closed -- `gh issue view 2118 --json state --jq .state`. If still open, close manually with a comment referencing this PR.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)