### PR TITLE
feat: add AGENTS.md absolute budget target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **AGENTS.md budget now has an explicit always-on target (#2372).** The existing per-region line ratchet remains the hard anti-growth gate, and `verify:agents-md-budget` now also measures the configured absolute target for AGENTS.md plus injected skill frontmatter. Maintainers can pass `--enforce-target` when the 8192-byte / roughly 2000-token north-star should fail as a release gate. Closes #2372.
+
 ### Fixed
 
 ### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,9 +133,10 @@ task check    # runs: validate + lint + test
 
 ### AGENTS.md line budget (#645)
 
-`task verify:agents-md-budget` (wired into `task check:framework-source`) is a **ratchet** that keeps AGENTS.md a map, not a manual (#1882). It counts the managed section and the unmanaged region separately and fails when either grows past `plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines}` in `PROJECT-DEFINITION`. The budget is seeded at the current per-region size, so the gate ships green; only *growth* fails.
+`task verify:agents-md-budget` (wired into `task check:framework-source`) is a **layered** budget gate that keeps AGENTS.md a map, not a manual (#1882/#2372). The hard ratchet counts the managed section and the unmanaged region separately and fails when either grows past `plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines}` in `PROJECT-DEFINITION`. The optional absolute target (`plan.policy.agentsMdBudget.absoluteTarget`) measures AGENTS.md bytes plus injected skill frontmatter by default; run `task verify:agents-md-budget -- --enforce-target` when the absolute target should fail as a release gate.
 
 - ! When you need to add content, push the detail into a reference doc (`main.md` section, a content pack, or `docs/`) and leave a pointer from AGENTS.md — do not expand AGENTS.md itself. See `REFERENCES.md` § "AGENTS.md is a map, not a manual".
+- ! The absolute north-star for the always-on surface is 8192 bytes / roughly 2000 tokens. Relocation work should move rule bulk into lazy docs, packs, deterministic gates, or invoked skills until AGENTS.md plus skill frontmatter fits that ceiling.
 - ! When you *reduce* AGENTS.md, lower the matching `managedMaxLines` / `unmanagedMaxLines` in the same PR so the ratchet tightens toward the ~150-line ceiling.
 - ? If growth is genuinely warranted (e.g. a new #1309-propagated consumer rule), raising the budget is an explicit, reviewed diff to the typed field — that diff is the "was this growth deliberate?" checkpoint.
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -22,7 +22,7 @@
 AGENTS.md is the always-loaded front door. Empirical study (`content/docs/good-agents-md.md`) found agent-quality gains from AGENTS.md **reverse** once the file grows past ~100–150 lines: context is scarce, "everything important" becomes non-guidance, and stale rules accumulate.
 
 - **Default when adding content**: push the detail into a reference doc (`main.md` section, a content pack, or `docs/`) and leave a *pointer* from AGENTS.md — do **not** expand AGENTS.md itself.
-- **Enforced by a ratchet (maintainer repo only)**: `task verify:agents-md-budget` (wired into `check:framework-source`) fails when the managed section or the unmanaged region grows past `plan.policy.agentsMdBudget` in `PROJECT-DEFINITION`. The budget is seeded at the current per-region size, so *growth* fails while *reductions* are always allowed.
+- **Enforced by a layered budget (maintainer repo only)**: `task verify:agents-md-budget` (wired into `check:framework-source`) fails when the managed section or the unmanaged region grows past `plan.policy.agentsMdBudget` in `PROJECT-DEFINITION`. The optional `absoluteTarget` measures AGENTS.md plus injected skill frontmatter against the 8192-byte / roughly 2000-token north-star; pass `--enforce-target` when that target should fail as a release gate.
 - **Lowering the budget is free; raising it is a reviewed diff.** Each reduction should tighten the matching `managedMaxLines` / `unmanagedMaxLines` line so the ratchet only ever ratchets down toward the ceiling.
 
 ### Consumer projects: an *advisory* signal, never a failing gate (#2155)

--- a/content/docs/agent-docs.md
+++ b/content/docs/agent-docs.md
@@ -41,4 +41,4 @@ These are the specific blocks the study measured *hurting* agent quality — tre
 
 ## Relationship to directive's own dogfooding
 
-Directive holds its own AGENTS.md to this bar via the `verify:agents-md-budget` ratchet (#645) and the consumer-side advisory signal (`agentsMdAdvisory`, #2155). The doc-sprawl awareness step in the `deft-directive-sync` skill (#647) surfaces reachable-doc-volume drift before it silently degrades agent quality. This doc is the "how to structure it well" companion to those "keep it from bloating" guards.
+Directive holds its own AGENTS.md to this bar via the layered `verify:agents-md-budget` gate (#645/#2372) and the consumer-side advisory signal (`agentsMdAdvisory`, #2155). The doc-sprawl awareness step in the `deft-directive-sync` skill (#647) surfaces reachable-doc-volume drift before it silently degrades agent quality. This doc is the "how to structure it well" companion to those "keep it from bloating" guards.

--- a/packages/cli/src/verify-agents-md-budget.test.ts
+++ b/packages/cli/src/verify-agents-md-budget.test.ts
@@ -57,13 +57,14 @@ function silentRun(argv: string[]): number {
 
 describe("parseArgs", () => {
   it("parses defaults", () => {
-    expect(parseArgs([])).toMatchObject({ projectRoot: ".", quiet: false });
+    expect(parseArgs([])).toMatchObject({ projectRoot: ".", quiet: false, enforceTarget: false });
   });
 
   it("parses flags and = form", () => {
-    expect(parseArgs(["--project-root", "/root", "--quiet"])).toMatchObject({
+    expect(parseArgs(["--project-root", "/root", "--quiet", "--enforce-target"])).toMatchObject({
       projectRoot: "/root",
       quiet: true,
+      enforceTarget: true,
     });
     expect(parseArgs(["--project-root=/tmp/x"]).projectRoot).toBe("/tmp/x");
   });
@@ -85,6 +86,23 @@ describe("run", () => {
   it("returns 1 when a region grows past its ratchet", () => {
     const root = buildRepo({ plan, agents: agentsWith(20, 5) });
     expect(silentRun(["--project-root", root])).toBe(1);
+  });
+
+  it("returns 1 under --enforce-target when only the absolute target is over", () => {
+    const root = buildRepo({
+      plan: {
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 5,
+            unmanagedMaxLines: 10,
+            absoluteTarget: { maxBytes: 1, includeSkillFrontmatter: false },
+          },
+        },
+      },
+      agents: agentsWith(10, 5),
+    });
+    expect(silentRun(["--project-root", root])).toBe(0);
+    expect(silentRun(["--project-root", root, "--enforce-target"])).toBe(1);
   });
 
   it("returns 2 for a malformed budget field", () => {

--- a/packages/cli/src/verify-agents-md-budget.test.ts
+++ b/packages/cli/src/verify-agents-md-budget.test.ts
@@ -105,6 +105,11 @@ describe("run", () => {
     expect(silentRun(["--project-root", root, "--enforce-target"])).toBe(1);
   });
 
+  it("returns 2 under --enforce-target when no absolute target is configured", () => {
+    const root = buildRepo({ plan, agents: agentsWith(10, 5) });
+    expect(silentRun(["--project-root", root, "--enforce-target"])).toBe(2);
+  });
+
   it("returns 2 for a malformed budget field", () => {
     const root = buildRepo({
       plan: { policy: { agentsMdBudget: { managedMaxLines: "bad", unmanagedMaxLines: 10 } } },

--- a/packages/cli/src/verify-agents-md-budget.ts
+++ b/packages/cli/src/verify-agents-md-budget.ts
@@ -6,6 +6,7 @@ import { evaluate } from "@deftai/directive-core/agents-md-budget";
 interface ParsedArgs {
   projectRoot: string;
   quiet: boolean;
+  enforceTarget: boolean;
   error?: string;
 }
 
@@ -14,11 +15,14 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     projectRoot: ".",
     quiet: false,
+    enforceTarget: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--quiet") {
       parsed.quiet = true;
+    } else if (arg === "--enforce-target") {
+      parsed.enforceTarget = true;
     } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -44,7 +48,10 @@ export function run(argv: string[]): number {
   }
 
   const projectRoot = resolve(args.projectRoot);
-  const result = evaluate(projectRoot, { quiet: args.quiet });
+  const result = evaluate(projectRoot, {
+    quiet: args.quiet,
+    enforceTarget: args.enforceTarget,
+  });
 
   if (result.message.length > 0) {
     if (result.stream === "stdout") {

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -128,9 +128,26 @@ describe("countRegions", () => {
 describe("always-on byte counting", () => {
   it("extracts yaml frontmatter even when a preamble precedes it", () => {
     const frontmatter = extractYamlFrontmatter(
-      ["<!-- preamble -->", "---", "name: deft", "description: test", "---", "# Body"].join("\n"),
+      [
+        "<!-- DEFT-PREAMBLE-V1 -->",
+        "<!--",
+        "! Cold-start check.",
+        "-->",
+        "---",
+        "name: deft",
+        "description: test",
+        "---",
+        "# Body",
+      ].join("\n"),
     );
     expect(frontmatter).toBe(["---", "name: deft", "description: test", "---"].join("\n"));
+  });
+
+  it("does not treat body horizontal rules as yaml frontmatter", () => {
+    const frontmatter = extractYamlFrontmatter(
+      ["# Body", "", "---", "not: frontmatter", "---"].join("\n"),
+    );
+    expect(frontmatter).toBeNull();
   });
 
   it("counts root and content skill frontmatter when configured", () => {
@@ -235,6 +252,14 @@ describe("evaluate", () => {
     expect(result.code).toBe(1);
     expect(result.stream).toBe("stderr");
     expect(result.message).toContain("exceeds its absolute target");
+  });
+
+  it("returns config error when --enforce-target is requested without a target", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsWith(10, 5) });
+    const result = evaluate(root, { enforceTarget: true });
+    expect(result.code).toBe(2);
+    expect(result.stream).toBe("stderr");
+    expect(result.message).toContain("absoluteTarget is not configured");
   });
 
   it("returns exit 1 when the managed region grows past its ratchet", () => {

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { countRegions, evaluate } from "./evaluate.js";
+import { countAlwaysOnBytes, countRegions, evaluate, extractYamlFrontmatter } from "./evaluate.js";
 
 const temps: string[] = [];
 afterAll(() => {
@@ -52,6 +52,12 @@ function makeRepo(options: { plan?: Record<string, unknown>; agents?: string }):
     writeFileSync(join(root, "AGENTS.md"), options.agents, "utf8");
   }
   return root;
+}
+
+function writeSkill(root: string, relPath: string, text: string): void {
+  const path = join(root, relPath);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, text, "utf8");
 }
 
 describe("countRegions", () => {
@@ -119,6 +125,54 @@ describe("countRegions", () => {
   });
 });
 
+describe("always-on byte counting", () => {
+  it("extracts yaml frontmatter even when a preamble precedes it", () => {
+    const frontmatter = extractYamlFrontmatter(
+      ["<!-- preamble -->", "---", "name: deft", "description: test", "---", "# Body"].join("\n"),
+    );
+    expect(frontmatter).toBe(["---", "name: deft", "description: test", "---"].join("\n"));
+  });
+
+  it("counts root and content skill frontmatter when configured", () => {
+    const root = makeRepo({ agents: "AGENTS" });
+    writeSkill(
+      root,
+      "SKILL.md",
+      ["<!-- preamble -->", "---", "name: root", "description: root skill", "---", "# Body"].join(
+        "\n",
+      ),
+    );
+    writeSkill(
+      root,
+      join("content", "skills", "deft-test", "SKILL.md"),
+      ["---", "name: child", "description: child skill", "---", "# Body"].join("\n"),
+    );
+
+    const counts = countAlwaysOnBytes(root, "AGENTS", {
+      maxBytes: 9999,
+      approxTokens: null,
+      includeSkillFrontmatter: true,
+    });
+    expect(counts.agentsBytes).toBe(Buffer.byteLength("AGENTS", "utf8"));
+    expect(counts.skillFrontmatterFiles).toBe(2);
+    expect(counts.skillFrontmatterBytes).toBeGreaterThan(0);
+    expect(counts.bytes).toBe(counts.agentsBytes + counts.skillFrontmatterBytes);
+  });
+
+  it("can exclude skill frontmatter for compatibility fixtures", () => {
+    const root = makeRepo({ agents: "AGENTS" });
+    writeSkill(root, "SKILL.md", ["---", "name: root", "description: root", "---"].join("\n"));
+    const counts = countAlwaysOnBytes(root, "AGENTS", {
+      maxBytes: 9999,
+      approxTokens: null,
+      includeSkillFrontmatter: false,
+    });
+    expect(counts.skillFrontmatterFiles).toBe(0);
+    expect(counts.skillFrontmatterBytes).toBe(0);
+    expect(counts.bytes).toBe(Buffer.byteLength("AGENTS", "utf8"));
+  });
+});
+
 describe("evaluate", () => {
   const budgetPlan = { policy: { agentsMdBudget: { managedMaxLines: 5, unmanagedMaxLines: 10 } } };
 
@@ -128,6 +182,59 @@ describe("evaluate", () => {
     expect(result.code).toBe(0);
     expect(result.stream).toBe("stdout");
     expect(result.message).toContain("managed 5/5, unmanaged 10/10");
+  });
+
+  it("reports the absolute target when the always-on surface is within it", () => {
+    const plan = {
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 5,
+          unmanagedMaxLines: 10,
+          absoluteTarget: { maxBytes: 9999, approxTokens: 2000, includeSkillFrontmatter: false },
+        },
+      },
+    };
+    const root = makeRepo({ plan, agents: agentsWith(10, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.stream).toBe("stdout");
+    expect(result.message).toContain("within absolute target");
+    expect(result.message).toContain("skill frontmatter excluded");
+  });
+
+  it("keeps the default mode non-failing when only the absolute target is over", () => {
+    const plan = {
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 5,
+          unmanagedMaxLines: 10,
+          absoluteTarget: { maxBytes: 1, approxTokens: 1, includeSkillFrontmatter: false },
+        },
+      },
+    };
+    const root = makeRepo({ plan, agents: agentsWith(10, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.stream).toBe("stderr");
+    expect(result.message).toContain("absolute target not yet met");
+    expect(result.message).toContain("--enforce-target");
+  });
+
+  it("fails when the absolute target is over and --enforce-target is requested", () => {
+    const plan = {
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 5,
+          unmanagedMaxLines: 10,
+          absoluteTarget: { maxBytes: 1, includeSkillFrontmatter: false },
+        },
+      },
+    };
+    const root = makeRepo({ plan, agents: agentsWith(10, 5) });
+    const result = evaluate(root, { enforceTarget: true });
+    expect(result.code).toBe(1);
+    expect(result.stream).toBe("stderr");
+    expect(result.message).toContain("exceeds its absolute target");
   });
 
   it("returns exit 1 when the managed region grows past its ratchet", () => {

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -154,10 +154,37 @@ function skillFilePaths(projectRoot: string): string[] {
 
 export function extractYamlFrontmatter(text: string): string | null {
   const lines = text.replace(/\r\n/g, "\n").split("\n");
-  const open = lines.findIndex((line) => line.trim() === "---");
+  let open = -1;
+  let inHtmlComment = false;
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trim();
+    if (inHtmlComment) {
+      if (trimmed.endsWith("-->")) {
+        inHtmlComment = false;
+      }
+      continue;
+    }
+    if (trimmed === "---") {
+      open = index;
+      break;
+    }
+    if (trimmed === "") {
+      continue;
+    }
+    if (trimmed.startsWith("<!--")) {
+      if (!trimmed.endsWith("-->")) {
+        inHtmlComment = true;
+      }
+      continue;
+    }
+    if (trimmed !== "") {
+      return null;
+    }
+  }
   if (open === -1) {
     return null;
   }
+
   const close = lines.findIndex((line, index) => index > open && line.trim() === "---");
   if (close === -1) {
     return null;
@@ -291,6 +318,15 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
   const counts = regionResult.counts;
 
   if (budgetResult.source === "unset") {
+    if (enforceTarget) {
+      return {
+        code: 2,
+        message:
+          "❌ verify:agents-md-budget: --enforce-target was requested, but " +
+          "plan.policy.agentsMdBudget.absoluteTarget is not configured.",
+        stream: "stderr",
+      };
+    }
     if (quiet) {
       return { code: 0, message: "", stream: "none" };
     }
@@ -319,6 +355,15 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
   const overManaged = counts.managed > budget.managedMaxLines;
   const overUnmanaged = counts.unmanaged > budget.unmanagedMaxLines;
   const absoluteTarget = budget.absoluteTarget;
+  if (enforceTarget && absoluteTarget === null) {
+    return {
+      code: 2,
+      message:
+        "❌ verify:agents-md-budget: --enforce-target was requested, but " +
+        "plan.policy.agentsMdBudget.absoluteTarget is not configured.",
+      stream: "stderr",
+    };
+  }
   const alwaysOnCounts =
     absoluteTarget === null ? null : countAlwaysOnBytes(root, text, absoluteTarget);
   const overAbsoluteTarget =

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
-import { resolveAgentsMdBudget } from "../policy/agents-md-budget.js";
+import { type AgentsMdAbsoluteTarget, resolveAgentsMdBudget } from "../policy/agents-md-budget.js";
 
 export type OutputStream = "stdout" | "stderr" | "none";
 
@@ -14,6 +14,7 @@ export interface EvaluateResult {
 
 export interface EvaluateOptions {
   readonly quiet?: boolean;
+  readonly enforceTarget?: boolean;
 }
 
 /** Per-region line counts of an AGENTS.md file. */
@@ -21,6 +22,14 @@ export interface RegionCounts {
   readonly total: number;
   readonly managed: number;
   readonly unmanaged: number;
+}
+
+export interface AlwaysOnCounts {
+  readonly bytes: number;
+  readonly approxTokens: number;
+  readonly agentsBytes: number;
+  readonly skillFrontmatterBytes: number;
+  readonly skillFrontmatterFiles: number;
 }
 
 const OPEN_MARKER_PREFIX = "<!-- deft:managed-section";
@@ -100,17 +109,147 @@ function formatRefusal(
   );
 }
 
+function utf8Bytes(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+function approxTokensForBytes(bytes: number): number {
+  return Math.ceil(bytes / 4.096);
+}
+
+function walkSkillFiles(dir: string, out: string[]): void {
+  if (!existsSync(dir)) {
+    return;
+  }
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkSkillFiles(path, out);
+    } else if (entry.isFile() && entry.name === "SKILL.md") {
+      out.push(path);
+    }
+  }
+}
+
+function skillFilePaths(projectRoot: string): string[] {
+  const paths: string[] = [];
+  const rootSkill = join(projectRoot, "SKILL.md");
+  try {
+    if (existsSync(rootSkill) && statSync(rootSkill).isFile()) {
+      paths.push(rootSkill);
+    }
+  } catch {
+    // Optional skill metadata must not make the primary AGENTS.md gate flaky.
+  }
+  walkSkillFiles(join(projectRoot, "content", "skills"), paths);
+  return paths.sort();
+}
+
+export function extractYamlFrontmatter(text: string): string | null {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const open = lines.findIndex((line) => line.trim() === "---");
+  if (open === -1) {
+    return null;
+  }
+  const close = lines.findIndex((line, index) => index > open && line.trim() === "---");
+  if (close === -1) {
+    return null;
+  }
+  return lines.slice(open, close + 1).join("\n");
+}
+
+export function countAlwaysOnBytes(
+  projectRoot: string,
+  agentsText: string,
+  target: AgentsMdAbsoluteTarget,
+): AlwaysOnCounts {
+  const agentsBytes = utf8Bytes(agentsText);
+  let skillFrontmatterBytes = 0;
+  let skillFrontmatterFiles = 0;
+
+  if (target.includeSkillFrontmatter) {
+    for (const path of skillFilePaths(projectRoot)) {
+      let skillText: string;
+      try {
+        skillText = readFileSync(path, { encoding: "utf8" });
+      } catch {
+        continue;
+      }
+      const frontmatter = extractYamlFrontmatter(skillText);
+      if (frontmatter === null) {
+        continue;
+      }
+      skillFrontmatterBytes += utf8Bytes(frontmatter);
+      skillFrontmatterFiles += 1;
+    }
+  }
+
+  const bytes = agentsBytes + skillFrontmatterBytes;
+  return {
+    bytes,
+    approxTokens: approxTokensForBytes(bytes),
+    agentsBytes,
+    skillFrontmatterBytes,
+    skillFrontmatterFiles,
+  };
+}
+
+function formatTarget(counts: AlwaysOnCounts, target: AgentsMdAbsoluteTarget): string {
+  const tokenPart =
+    target.approxTokens === null
+      ? `~${counts.approxTokens} tok`
+      : `~${counts.approxTokens}/${target.approxTokens} tok`;
+  const skillPart = target.includeSkillFrontmatter
+    ? `; skill frontmatter ${counts.skillFrontmatterBytes} bytes from ${counts.skillFrontmatterFiles} file(s)`
+    : "; skill frontmatter excluded";
+  return (
+    `always-on ${counts.bytes}/${target.maxBytes} bytes (${tokenPart}; ` +
+    `AGENTS.md ${counts.agentsBytes} bytes${skillPart})`
+  );
+}
+
+function formatTargetRefusal(
+  counts: AlwaysOnCounts,
+  target: AgentsMdAbsoluteTarget,
+  projectRoot: string,
+): string {
+  return (
+    `ERROR verify:agents-md-budget: always-on surface exceeds its absolute target ` +
+    `(project_root=${projectRoot}).\n` +
+    `   ${formatTarget(counts, target)} (OVER by ${counts.bytes - target.maxBytes} bytes)\n` +
+    "   Keep the line ratchet as the anti-inflation floor, then relocate rule\n" +
+    "   bulk into lazy docs, packs, deterministic gates, or invoked skills so\n" +
+    "   AGENTS.md plus injected skill frontmatter fit the configured target. (#2372)"
+  );
+}
+
+function formatTargetAdvisory(counts: AlwaysOnCounts, target: AgentsMdAbsoluteTarget): string {
+  return (
+    `WARN verify:agents-md-budget: absolute target not yet met: ` +
+    `${formatTarget(counts, target)} (OVER by ${counts.bytes - target.maxBytes} bytes). ` +
+    "Default mode preserves the hard ratchet gate; pass --enforce-target when this " +
+    "target becomes a release gate. (#2372)"
+  );
+}
+
 /**
- * Pure evaluator for the AGENTS.md line-budget ratchet gate (#645).
+ * Pure evaluator for the layered AGENTS.md budget gate (#645 / #2372).
  *
- * Counts the managed section and the unmanaged region separately (the #1309
- * propagation duplicates content across the marker) and fails when either
- * region exceeds its typed per-region budget. Ships green because the budget is
- * seeded at current size; growth past the ratchet fails.
+ * The per-region line ratchet fails on growth. The optional absolute target
+ * reports AGENTS.md plus injected skill frontmatter by default and fails only
+ * when callers request target enforcement.
  */
 export function evaluate(projectRoot: string, options: EvaluateOptions = {}): EvaluateResult {
   const root = resolve(projectRoot);
   const quiet = options.quiet ?? false;
+  const enforceTarget = options.enforceTarget ?? false;
 
   const budgetResult = resolveAgentsMdBudget(root);
   if (budgetResult.source === "default-on-error") {
@@ -179,16 +318,44 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
   const budget = budgetResult.budget;
   const overManaged = counts.managed > budget.managedMaxLines;
   const overUnmanaged = counts.unmanaged > budget.unmanagedMaxLines;
+  const absoluteTarget = budget.absoluteTarget;
+  const alwaysOnCounts =
+    absoluteTarget === null ? null : countAlwaysOnBytes(root, text, absoluteTarget);
+  const overAbsoluteTarget =
+    alwaysOnCounts !== null &&
+    absoluteTarget !== null &&
+    alwaysOnCounts.bytes > absoluteTarget.maxBytes;
 
   if (!overManaged && !overUnmanaged) {
+    if (enforceTarget && overAbsoluteTarget && alwaysOnCounts !== null && absoluteTarget !== null) {
+      return {
+        code: 1,
+        message: formatTargetRefusal(alwaysOnCounts, absoluteTarget, root),
+        stream: "stderr",
+      };
+    }
     if (quiet) {
       return { code: 0, message: "", stream: "none" };
     }
+    if (overAbsoluteTarget && alwaysOnCounts !== null && absoluteTarget !== null) {
+      return {
+        code: 0,
+        message:
+          `OK verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
+          `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet).\n` +
+          formatTargetAdvisory(alwaysOnCounts, absoluteTarget),
+        stream: "stderr",
+      };
+    }
+    const targetText =
+      alwaysOnCounts !== null && absoluteTarget !== null
+        ? `; ${formatTarget(alwaysOnCounts, absoluteTarget)} (within absolute target)`
+        : "";
     return {
       code: 0,
       message:
         `✓ verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
-        `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet).`,
+        `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet)${targetText}.`,
       stream: "stdout",
     };
   }

--- a/packages/core/src/policy/agents-md-budget.test.ts
+++ b/packages/core/src/policy/agents-md-budget.test.ts
@@ -144,19 +144,16 @@ describe("resolveAgentsMdBudget", () => {
   });
 
   it("resolves the optional absolute target and defaults skill frontmatter inclusion on", () => {
-    const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({
-          policy: {
-            agentsMdBudget: {
-              managedMaxLines: 223,
-              unmanagedMaxLines: 347,
-              absoluteTarget: { maxBytes: 8192, approxTokens: 2000 },
-            },
-          },
-        }),
-      ),
-    );
+    const projectDefinition = withPlan({
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 223,
+          unmanagedMaxLines: 347,
+          absoluteTarget: { maxBytes: 8192, approxTokens: 2000 },
+        },
+      },
+    });
+    const result = resolveAgentsMdBudget(makeRepo(projectDefinition));
     expect(result.source).toBe("typed");
     expect(result.budget).toEqual({
       managedMaxLines: 223,
@@ -170,19 +167,16 @@ describe("resolveAgentsMdBudget", () => {
   });
 
   it("allows the absolute target to exclude skill frontmatter explicitly", () => {
-    const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({
-          policy: {
-            agentsMdBudget: {
-              managedMaxLines: 1,
-              unmanagedMaxLines: 2,
-              absoluteTarget: { maxBytes: 3, includeSkillFrontmatter: false },
-            },
-          },
-        }),
-      ),
-    );
+    const projectDefinition = withPlan({
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 1,
+          unmanagedMaxLines: 2,
+          absoluteTarget: { maxBytes: 3, includeSkillFrontmatter: false },
+        },
+      },
+    });
+    const result = resolveAgentsMdBudget(makeRepo(projectDefinition));
     expect(result.source).toBe("typed");
     expect(result.budget?.absoluteTarget).toEqual({
       maxBytes: 3,
@@ -192,19 +186,16 @@ describe("resolveAgentsMdBudget", () => {
   });
 
   it("returns default-on-error when the absolute target is malformed", () => {
-    const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({
-          policy: {
-            agentsMdBudget: {
-              managedMaxLines: 1,
-              unmanagedMaxLines: 2,
-              absoluteTarget: { maxBytes: "8192" },
-            },
-          },
-        }),
-      ),
-    );
+    const projectDefinition = withPlan({
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 1,
+          unmanagedMaxLines: 2,
+          absoluteTarget: { maxBytes: "8192" },
+        },
+      },
+    });
+    const result = resolveAgentsMdBudget(makeRepo(projectDefinition));
     expect(result.source).toBe("default-on-error");
     expect(result.error).toContain("absoluteTarget.maxBytes must be a non-negative integer");
   });
@@ -213,7 +204,12 @@ describe("resolveAgentsMdBudget", () => {
     const result = resolveAgentsMdBudget(
       makeRepo(
         withPlan({
-          "x-directive/policy": { agentsMdBudget: { managedMaxLines: 1, unmanagedMaxLines: 2 } },
+          "x-directive/policy": {
+            agentsMdBudget: {
+              managedMaxLines: 1,
+              unmanagedMaxLines: 2,
+            },
+          },
         }),
       ),
     );

--- a/packages/core/src/policy/agents-md-budget.test.ts
+++ b/packages/core/src/policy/agents-md-budget.test.ts
@@ -136,7 +136,77 @@ describe("resolveAgentsMdBudget", () => {
     );
     expect(result.source).toBe("typed");
     expect(result.error).toBeNull();
-    expect(result.budget).toEqual({ managedMaxLines: 223, unmanagedMaxLines: 347 });
+    expect(result.budget).toEqual({
+      managedMaxLines: 223,
+      unmanagedMaxLines: 347,
+      absoluteTarget: null,
+    });
+  });
+
+  it("resolves the optional absolute target and defaults skill frontmatter inclusion on", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({
+          policy: {
+            agentsMdBudget: {
+              managedMaxLines: 223,
+              unmanagedMaxLines: 347,
+              absoluteTarget: { maxBytes: 8192, approxTokens: 2000 },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.source).toBe("typed");
+    expect(result.budget).toEqual({
+      managedMaxLines: 223,
+      unmanagedMaxLines: 347,
+      absoluteTarget: {
+        maxBytes: 8192,
+        approxTokens: 2000,
+        includeSkillFrontmatter: true,
+      },
+    });
+  });
+
+  it("allows the absolute target to exclude skill frontmatter explicitly", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({
+          policy: {
+            agentsMdBudget: {
+              managedMaxLines: 1,
+              unmanagedMaxLines: 2,
+              absoluteTarget: { maxBytes: 3, includeSkillFrontmatter: false },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.source).toBe("typed");
+    expect(result.budget?.absoluteTarget).toEqual({
+      maxBytes: 3,
+      approxTokens: null,
+      includeSkillFrontmatter: false,
+    });
+  });
+
+  it("returns default-on-error when the absolute target is malformed", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({
+          policy: {
+            agentsMdBudget: {
+              managedMaxLines: 1,
+              unmanagedMaxLines: 2,
+              absoluteTarget: { maxBytes: "8192" },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("absoluteTarget.maxBytes must be a non-negative integer");
   });
 
   it("reads the namespaced x-directive/policy block", () => {
@@ -148,6 +218,10 @@ describe("resolveAgentsMdBudget", () => {
       ),
     );
     expect(result.source).toBe("typed");
-    expect(result.budget).toEqual({ managedMaxLines: 1, unmanagedMaxLines: 2 });
+    expect(result.budget).toEqual({
+      managedMaxLines: 1,
+      unmanagedMaxLines: 2,
+      absoluteTarget: null,
+    });
   });
 });

--- a/packages/core/src/policy/agents-md-budget.ts
+++ b/packages/core/src/policy/agents-md-budget.ts
@@ -2,19 +2,31 @@ import { readPlanPolicy } from "./plan-extensions.js";
 import { loadProjectDefinition } from "./resolve.js";
 
 /**
- * Per-region line-budget ratchet for AGENTS.md (#645).
+ * Layered AGENTS.md budget policy (#645 / #2372).
  *
- * The budget is seeded at the CURRENT per-region line counts and forbids
- * INCREASE, rather than encoding a static absolute ceiling. This decouples the
- * gate from the reduction work (#1882): the file is by definition within its
- * own seeded baseline, so the gate ships green, while any growth past the
- * ratchet fails. Lowering a budget (a reduction PR) is always allowed; raising
- * it is an explicit, reviewed diff to this typed field -- that diff IS the
- * "was this growth deliberate?" checkpoint.
+ * The per-region line counts are the hard ratchet seeded at current size: any
+ * growth past those values fails, reductions are always allowed, and increases
+ * are reviewed diffs. The optional absolute target is a deterministic
+ * north-star for the always-on context surface, enforceable by callers that pass
+ * the release-gate flag.
  */
 export interface AgentsMdBudget {
   readonly managedMaxLines: number;
   readonly unmanagedMaxLines: number;
+  readonly absoluteTarget: AgentsMdAbsoluteTarget | null;
+}
+
+/**
+ * Absolute always-on context target layered below the ratchet (#2372).
+ *
+ * `maxBytes` is the enforceable ceiling when callers pass the `--enforce-target`
+ * flag. `approxTokens` is display-only: bytes are the deterministic unit, while
+ * tokens vary by model/tokenizer.
+ */
+export interface AgentsMdAbsoluteTarget {
+  readonly maxBytes: number;
+  readonly approxTokens: number | null;
+  readonly includeSkillFrontmatter: boolean;
 }
 
 export type AgentsMdBudgetSource = "typed" | "unset" | "default-on-error";
@@ -43,7 +55,7 @@ function pythonRepr(value: unknown): string {
   return String(value);
 }
 
-function readRegion(
+function readNonNegativeInteger(
   block: Record<string, unknown>,
   key: string,
 ): { value: number | null; error: string | null } {
@@ -58,6 +70,94 @@ function readRegion(
     };
   }
   return { value: raw, error: null };
+}
+
+function readOptionalNonNegativeInteger(
+  block: Record<string, unknown>,
+  key: string,
+  path: string,
+): { value: number | null; error: string | null } {
+  if (!(key in block)) {
+    return { value: null, error: null };
+  }
+  const raw = block[key];
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) {
+    return {
+      value: null,
+      error: `${path}.${key} must be a non-negative integer; got ${pythonTypeName(raw)} (${pythonRepr(raw)})`,
+    };
+  }
+  return { value: raw, error: null };
+}
+
+function readOptionalBoolean(
+  block: Record<string, unknown>,
+  key: string,
+  path: string,
+  defaultValue: boolean,
+): { value: boolean; error: string | null } {
+  if (!(key in block)) {
+    return { value: defaultValue, error: null };
+  }
+  const raw = block[key];
+  if (typeof raw !== "boolean") {
+    return {
+      value: defaultValue,
+      error: `${path}.${key} must be a bool; got ${pythonTypeName(raw)} (${pythonRepr(raw)})`,
+    };
+  }
+  return { value: raw, error: null };
+}
+
+function readAbsoluteTarget(block: Record<string, unknown>): {
+  value: AgentsMdAbsoluteTarget | null;
+  error: string | null;
+} {
+  const path = "plan.policy.agentsMdBudget.absoluteTarget";
+  if (!("absoluteTarget" in block)) {
+    return { value: null, error: null };
+  }
+
+  const raw = block.absoluteTarget;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return {
+      value: null,
+      error: `${path} must be an object with maxBytes; got ${pythonTypeName(raw)}`,
+    };
+  }
+
+  const targetBlock = raw as Record<string, unknown>;
+  const maxBytes = readOptionalNonNegativeInteger(targetBlock, "maxBytes", path);
+  if (maxBytes.error !== null) {
+    return { value: null, error: maxBytes.error };
+  }
+  if (maxBytes.value === null) {
+    return { value: null, error: `${path}.maxBytes is required` };
+  }
+
+  const approxTokens = readOptionalNonNegativeInteger(targetBlock, "approxTokens", path);
+  if (approxTokens.error !== null) {
+    return { value: null, error: approxTokens.error };
+  }
+
+  const includeSkillFrontmatter = readOptionalBoolean(
+    targetBlock,
+    "includeSkillFrontmatter",
+    path,
+    true,
+  );
+  if (includeSkillFrontmatter.error !== null) {
+    return { value: null, error: includeSkillFrontmatter.error };
+  }
+
+  return {
+    value: {
+      maxBytes: maxBytes.value,
+      approxTokens: approxTokens.value,
+      includeSkillFrontmatter: includeSkillFrontmatter.value,
+    },
+    error: null,
+  };
 }
 
 /** Resolve plan.policy.agentsMdBudget from PROJECT-DEFINITION (#645). */
@@ -96,19 +196,24 @@ export function resolveAgentsMdBudget(projectRoot: string): AgentsMdBudgetResult
   }
 
   const block = rawBudget as Record<string, unknown>;
-  const managed = readRegion(block, "managedMaxLines");
+  const managed = readNonNegativeInteger(block, "managedMaxLines");
   if (managed.error !== null) {
     return { budget: null, source: "default-on-error", error: managed.error };
   }
-  const unmanaged = readRegion(block, "unmanagedMaxLines");
+  const unmanaged = readNonNegativeInteger(block, "unmanagedMaxLines");
   if (unmanaged.error !== null) {
     return { budget: null, source: "default-on-error", error: unmanaged.error };
+  }
+  const absoluteTarget = readAbsoluteTarget(block);
+  if (absoluteTarget.error !== null) {
+    return { budget: null, source: "default-on-error", error: absoluteTarget.error };
   }
 
   return {
     budget: {
       managedMaxLines: managed.value as number,
       unmanagedMaxLines: unmanaged.value as number,
+      absoluteTarget: absoluteTarget.value,
     },
     source: "typed",
     error: null,

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -384,7 +384,7 @@ tasks:
           ENGINE_CMD: 'verify:wip-cap --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   agents-md-budget:
-    desc: "Ratchet gate for AGENTS.md per-region line budgets (#645). Counts the managed section and the unmanaged region separately (the #1309 propagation duplicates content across the marker) and fails when either region grows past plan.policy.agentsMdBudget. Seeded at current size, so it ships green; growth past the ratchet fails. Lowering a budget (a reduction PR) is always allowed; raising it is a reviewed diff to the typed field. Three-state exit (0 within / 1 over / 2 config error)."
+    desc: "Layered AGENTS.md budget gate (#645/#2372). Fails when managed/unmanaged line counts grow past plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines}; also reports optional plan.policy.agentsMdBudget.absoluteTarget.{maxBytes,approxTokens,includeSkillFrontmatter}. Pass --enforce-target to fail when AGENTS.md plus injected skill frontmatter exceeds the absolute target. Three-state exit (0 within / 1 over enforced budget / 2 config error)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
       - task: :engine:_ts-build

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16783,9 +16783,14 @@
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
         "managedMaxLines": 244,
-        "unmanagedMaxLines": 270
+        "unmanagedMaxLines": 270,
+        "absoluteTarget": {
+          "maxBytes": 8192,
+          "approxTokens": 2000,
+          "includeSkillFrontmatter": true
+        }
       }
     },
-    "updated": "2026-07-02T14:32:31Z"
+    "updated": "2026-07-08T07:19:18Z"
   }
 }

--- a/xbrief/active/2026-07-08-2372-designagents-md-decide-context-budget-instrument-relative-ra.xbrief.json
+++ b/xbrief/active/2026-07-08-2372-designagents-md-decide-context-budget-instrument-relative-ra.xbrief.json
@@ -1,0 +1,30 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2372"
+  },
+  "plan": {
+    "title": "design(agents-md): decide context-budget instrument — relative ratchet vs absolute target (recommend ≤8 KB / ~2k tok)",
+    "status": "running",
+    "narratives": {
+      "Description": "design(agents-md): decide context-budget instrument — relative ratchet vs absolute target (recommend ≤8 KB / ~2k tok)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2372",
+      "Overview": "Parent epic: #2369 · Predecessor context: #1882\n\n## Decision\n\nDecide the context-budget instrument for the always-on surface:\n\n- **Relative ratchet** — the current `verify:agents-md-budget` design (#645): per-region line counts seeded at current size, forbids increase. Deliberately chose *not* to encode an absolute ceiling.\n- **Absolute target** — a fixed north-star ceiling on the always-on surface.\n\n## Recommendation (potential target, not committed)\n\nAdd an absolute north-star of **≤8 KB / ~2k tok** layered *below* the existing ratchet: the ratchet remains the anti-inflation floor, and the absolute target becomes the release-gate goal the relocation work (parent epic #2369) drives toward. Left open for decision — this revisits a settled #645 design choice, so it should be an explicit call, not an assumption.\n\n## Acceptance\n\n- Instrument decided (relative-only, absolute-only, or layered).\n- If an absolute target is adopted, it is wired as a gate with a documented ceiling + remediation, consistent with the existing `verify:agents-md-budget` surface.\n\nWave 1 — unblocks the relocation target.\n\n",
+      "Labels": "design, context-engineering, determinism"
+    },
+    "items": [],
+    "tags": [
+      "design",
+      "context-engineering",
+      "determinism"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2372",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2372: design(agents-md): decide context-budget instrument — relative ratchet vs absolute target (recommend ≤8 KB / ~2k tok)"
+      }
+    ],
+    "updated": "2026-07-08T09:37:32Z"
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Add optional `agentsMdBudget.absoluteTarget` policy with a deterministic byte ceiling and display-only approximate token target.
- Teach `verify:agents-md-budget` to report AGENTS.md plus injected skill frontmatter, defaulting to advisory output while `--enforce-target` makes the absolute target fail-closing.
- Document the layered budget policy and set the maintainer north-star to 8192 bytes / roughly 2000 tokens.

## Related Issues
Closes #2372
Refs #2369
Refs #2389

## Verification
- `pnpm exec vitest run packages/core/src/policy/agents-md-budget.test.ts packages/core/src/agents-md-budget/evaluate.test.ts packages/cli/src/verify-agents-md-budget.test.ts` -- 56 tests passed.
- `pnpm exec biome check packages/core/src/policy/agents-md-budget.ts packages/core/src/policy/agents-md-budget.test.ts packages/core/src/agents-md-budget/evaluate.ts packages/core/src/agents-md-budget/evaluate.test.ts packages/cli/src/verify-agents-md-budget.ts packages/cli/src/verify-agents-md-budget.test.ts` -- clean.
- `pnpm run build` -- clean.
- `task verify:agents-md-budget` -- ratchet passes; absolute target reports advisory drift as expected.
- `task vbrief:validate` -- passes with existing PRD staleness warning.
- `task check` -- exits through #2389 on this native Windows checkout (`ts:check-lane` reports `pnpm run lint` killed by signal). The same run also prints existing pack projection drift output; the scoped budget, encoding, branch, vBRIEF, and focused TypeScript gates passed.

## Checklist
- [x] `/deft:change <name>` -- N/A: this is a single issue-scoped xBRIEF (#2372) accepted through triage, with explicit operator instruction to proceed/resume on this PR stream.
- [x] `CHANGELOG.md` -- added entry under `[Unreleased]`.
- [x] `ROADMAP.md` -- N/A: release-time roadmap promotion per directive policy.
- [x] Tests pass locally -- scoped tests/build pass; full `task check` local blocker is #2389 as noted above.

## Post-Merge
- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed -- `gh issue view <N> --json state --jq .state`. Squash merges can silently fail to process closing keywords (#167). If still open, close manually: `gh issue close <N> --comment "Closed by #<PR> (squash merge -- auto-close did not trigger)"`
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
