### PR TITLE
ci: add Windows cache-fresh consumer smoke (Closes #2120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,9 @@ jobs:
           $workspaceSh = $env:GITHUB_WORKSPACE.Replace('\', '/')
           $shBody = "#!/usr/bin/env sh`nnode `"$workspaceSh/packages/cli/dist/bin.js`" `"`$@`"`n"
           [System.IO.File]::WriteAllText($shShim, $shBody, (New-Object System.Text.UTF8Encoding $false))
+          if (Get-Command bash -ErrorAction SilentlyContinue) {
+            bash -lc "chmod +x '$($shShim.Replace('\', '/'))'"
+          }
 
           $env:PATH = "$shimDir;$env:PATH"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,78 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: task deft:verify:cache-fresh consumer smoke (#2120)
+        shell: pwsh
+        run: |
+          pnpm run build
+          if ($LASTEXITCODE -ne 0) {
+            throw "pnpm run build exited $LASTEXITCODE"
+          }
+
+          $consumer = Join-Path $env:RUNNER_TEMP 'cache-fresh-consumer'
+          $core = Join-Path $consumer '.deft\core'
+          $shimDir = Join-Path $env:RUNNER_TEMP 'deft-cli-shim'
+          New-Item -ItemType Directory -Path $core -Force | Out-Null
+          New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
+
+          Copy-Item (Join-Path $env:GITHUB_WORKSPACE 'Taskfile.yml') (Join-Path $core 'Taskfile.yml')
+          Copy-Item (Join-Path $env:GITHUB_WORKSPACE 'tasks') (Join-Path $core 'tasks') -Recurse
+
+          $consumerTaskfile = @(
+            "version: '3'",
+            "",
+            "includes:",
+            "  deft:",
+            "    taskfile: ./.deft/core/Taskfile.yml",
+            "    optional: true"
+          ) -join [Environment]::NewLine
+          [System.IO.File]::WriteAllText((Join-Path $consumer 'Taskfile.yml'), $consumerTaskfile, (New-Object System.Text.UTF8Encoding $false))
+
+          $cmdShim = Join-Path $shimDir 'deft.cmd'
+          $cmdBody = "@echo off`r`nnode `"$env:GITHUB_WORKSPACE\packages\cli\dist\bin.js`" %*`r`n"
+          [System.IO.File]::WriteAllText($cmdShim, $cmdBody, (New-Object System.Text.UTF8Encoding $false))
+
+          $shShim = Join-Path $shimDir 'deft'
+          $workspaceSh = $env:GITHUB_WORKSPACE.Replace('\', '/')
+          $shBody = "#!/usr/bin/env sh`nnode `"$workspaceSh/packages/cli/dist/bin.js`" `"`$@`"`n"
+          [System.IO.File]::WriteAllText($shShim, $shBody, (New-Object System.Text.UTF8Encoding $false))
+
+          $env:PATH = "$shimDir;$env:PATH"
+
+          Push-Location $consumer
+          try {
+            git init -q
+            git config core.autocrlf true
+            git -c user.name=ci -c user.email=ci@example.com add -A
+            git -c user.name=ci -c user.email=ci@example.com commit -q -m seed
+
+            $directOutput = deft preflight-cache --project-root . --allow-missing-bootstrap 2>&1 | Out-String
+            Write-Host "--- direct deft preflight-cache ---"
+            Write-Host $directOutput
+            if ($LASTEXITCODE -ne 0) {
+              throw "deft preflight-cache exited $LASTEXITCODE"
+            }
+
+            $taskOutput = task deft:verify:cache-fresh -- --allow-missing-bootstrap 2>&1 | Out-String
+            Write-Host "--- task deft:verify:cache-fresh ---"
+            Write-Host $taskOutput
+            if ($LASTEXITCODE -ne 0) {
+              throw "task deft:verify:cache-fresh exited $LASTEXITCODE"
+            }
+            if ($taskOutput -match 'engine:_ts-build|pnpm\s+.*run build') {
+              throw "task deft:verify:cache-fresh reached a build path on a consumer deposit (#2120)"
+            }
+
+            $dirtyStatus = git status --short
+            if ($dirtyStatus) {
+              Write-Host "--- dirty status after cache-fresh smoke ---"
+              Write-Host ($dirtyStatus | Out-String)
+              throw "cache-fresh smoke left the consumer fixture dirty (#2120)"
+            }
+          } finally {
+            Pop-Location
+          }
+
       - name: Stage pre-cutover fixture as consumer project
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-<<<<<<< HEAD
 - **`directive update` is idempotent on current Windows npm deposits.** Current installs now keep the vendored framework payload LF-pinned, skip payload copy and timestamp rewrites when the deposited content version is already current, and collapse CRLF-only `.deft/core` churn into a short line-ending hint instead of a long dirty-file list. The Windows CI smoke now covers `core.autocrlf=true` init/update/update plus `task deft:verify:cache-fresh` and `preflight-cache`. Closes #2118.
-=======
 - **Windows-native cache-fresh now has consumer-smoke coverage (#2120).** CI now stages a temp consumer repo with a deposited `.deft/core`, shims the built `deft` CLI, and verifies both direct `deft preflight-cache --allow-missing-bootstrap` and included `task deft:verify:cache-fresh` succeed without reaching a build path. Closes #2120.
->>>>>>> 993f68e5 (ci: add Windows cache-fresh consumer smoke)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+<<<<<<< HEAD
 - **`directive update` is idempotent on current Windows npm deposits.** Current installs now keep the vendored framework payload LF-pinned, skip payload copy and timestamp rewrites when the deposited content version is already current, and collapse CRLF-only `.deft/core` churn into a short line-ending hint instead of a long dirty-file list. The Windows CI smoke now covers `core.autocrlf=true` init/update/update plus `task deft:verify:cache-fresh` and `preflight-cache`. Closes #2118.
+=======
+- **Windows-native cache-fresh now has consumer-smoke coverage (#2120).** CI now stages a temp consumer repo with a deposited `.deft/core`, shims the built `deft` CLI, and verifies both direct `deft preflight-cache --allow-missing-bootstrap` and included `task deft:verify:cache-fresh` succeed without reaching a build path. Closes #2120.
+>>>>>>> 993f68e5 (ci: add Windows cache-fresh consumer smoke)
 
 ### Removed
 

--- a/xbrief/completed/2026-07-08-2120-bug-engine-ts-build-doubles-deft-root-on-windows-native-task.xbrief.json
+++ b/xbrief/completed/2026-07-08-2120-bug-engine-ts-build-doubles-deft-root-on-windows-native-task.xbrief.json
@@ -1,0 +1,52 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2120"
+  },
+  "plan": {
+    "title": "bug: engine:_ts-build doubles DEFT_ROOT on Windows native — task deft:verify:cache-fresh fails",
+    "status": "completed",
+    "narratives": {
+      "Description": "bug: engine:_ts-build doubles DEFT_ROOT on Windows native — task deft:verify:cache-fresh fails",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2120",
+      "Overview": "## Summary\r\n\r\nOn **Windows native** (PowerShell / go-task, not WSL), `task deft:verify:cache-fresh` fails before the gate runs because the `engine:_ts-build` dependency doubles `DEFT_ROOT` into an invalid path. The same consumer project works under WSL and the underlying gate works via the global npm CLI (`deft preflight-cache`).\r\n\r\nThis breaks the AGENTS.md session-start ritual step 5 (`task verify:cache-fresh` / `task deft:verify:cache-fresh`) for Windows-native operators who have not previously exercised directive on that host.\r\n\r\nRelated but distinct from #2118 (CRLF phantom dirty tree after `deft update` on an already-current deposit).\r\n\r\n## Environment\r\n\r\n- **Consumer repo:** `deftai/statusreport` (master, directive v0.65.0 npm deposit)\r\n- **OS:** Windows 10/11 native — PowerShell, **not WSL**\r\n- **task:** go-task (Taskfile v3 include: `task deft:verify:cache-fresh`)\r\n- **Global CLI:** `@deftai/directive@0.65.0` installed via `npm i -g @deftai/directive@latest`\r\n- **First exercise on this host:** operator previously used directive only under WSL; first native-Windows run surfaced this\r\n\r\n## Repro\r\n\r\n```powershell\r\ncd C:\\Repos\\Deft\\statusreport   # clean master, v0.65.0 deposit\r\nnpm i -g @deftai/directive@latest\r\ntask deft:verify:cache-fresh\r\n```\r\n\r\n## Expected\r\n\r\nGate runs (or exits with a cache-freshness result). On a project with no triage bootstrap yet, `--allow-missing-bootstrap` should treat missing cache as fresh — same as direct CLI:\r\n\r\n```powershell\r\ndeft preflight-cache --project-root . --allow-missing-bootstrap\r\n# ✓ deft cache-fresh: no cache found (bootstrap state) -- treating as fresh.\r\n```\r\n\r\n## Actual\r\n\r\n```\r\ntask: [deft:engine:_ts-build] set -eu\r\nif [ -f packages/cli/dist/bin.js ]; then\r\n  pnpm run build\r\nfi\r\n\r\ntask: Failed to run task \"deft:verify:cache-fresh\":\r\n  task: Failed to run task \"deft:engine:_ts-build\":\r\n  could not stat: CreateFile C:\\Repos\\Deft\\statusreport\\.deft\\core\\C:\\Repos\\Deft\\statusreport\\.deft\\core:\r\n  The filename, directory name, or volume label syntax is incorrect.\r\n```\r\n\r\n`DEFT_ROOT` is concatenated twice when go-task resolves `dir: '{{.DEFT_ROOT}}'` for the included `engine:_ts-build` task on Windows native.\r\n\r\n## Scope\r\n\r\n`verify:cache-fresh` declares:\r\n\r\n```yaml\r\ndeps:\r\n  - task: :engine:_ts-build\r\n```\r\n\r\n`tasks/engine.yml`:\r\n\r\n```yaml\r\n_ts-build:\r\n  dir: '{{.DEFT_ROOT}}'\r\n```\r\n\r\nOther `engine:invoke` gates that **omit** the `_ts-build` dep work on the same host — e.g. `task deft:doctor` succeeds and falls through to global `deft doctor`.\r\n\r\nAny task depending on `:engine:_ts-build` via the cross-include `:engine:` prefix is likely affected on Windows native; `verify:cache-fresh` is the session-start / pre-`start_agent` gate called out in AGENTS.md.\r\n\r\n## Workarounds\r\n\r\n1. Use the global CLI directly: `deft preflight-cache --project-root . --allow-missing-bootstrap`\r\n2. Run directive workflows under WSL (where this path doubling was not observed)\r\n3. Session-start step 5 can be skipped only when operator accepts bypassing the gate (not ideal for agent dispatch)\r\n\r\n## Proposed fix directions\r\n\r\n1. Fix `engine:_ts-build` `dir` resolution on Windows when invoked as `:engine:_ts-build` from an included namespace (go-task path join / `DEFT_ROOT` expansion).\r\n2. Or remove `_ts-build` as a hard dep for npm consumer deposits where `packages/cli/dist/bin.js` is intentionally absent — `_ts-build` is already a no-op when bin.js missing; the dep should not block `engine:invoke` fallback to global `deft`.\r\n3. Add a Windows-native CI or smoke step that runs `task deft:verify:cache-fresh` on a consumer fixture (parity with WSL/Linux coverage).\r\n\r\n## Acceptance criteria\r\n\r\n- [ ] `task deft:verify:cache-fresh` exits 0 on Windows native PowerShell for a v0.65.0 npm consumer deposit with global `deft` installed\r\n- [ ] No doubled `DEFT_ROOT` path in go-task `dir` resolution\r\n- [ ] `deft preflight-cache` and `task deft:verify:cache-fresh` remain behaviorally equivalent on Windows native\r\n- [ ] Regression test or documented smoke for Windows-native consumer Taskfile includes\r\n\r\n## Related\r\n\r\n- #2118 — Windows CRLF phantom dirty tree after no-op `deft update` (separate issue)\r\n- #2022 Phase 3 — Python-free npm deposit; `engine:invoke` + global `deft` fallback\r\n- AGENTS.md session-start ritual step 5 (`task verify:cache-fresh`)\r\n\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @MScottAdams (2026-06-30T16:21:02Z)\n\nCross-linked from #2118 (CRLF / no-op deft update noise on Windows native). Same statusreport session; separate root cause and fix.",
+      "Labels": "bug, adoption-blocker, installer, agent-experience"
+    },
+    "items": [
+      {
+        "title": "`task deft:verify:cache-fresh` exits 0 on Windows native PowerShell for a v0.65.0 npm consumer deposit with global `deft` installed",
+        "status": "proposed"
+      },
+      {
+        "title": "No doubled `DEFT_ROOT` path in go-task `dir` resolution",
+        "status": "proposed"
+      },
+      {
+        "title": "`deft preflight-cache` and `task deft:verify:cache-fresh` remain behaviorally equivalent on Windows native",
+        "status": "proposed"
+      },
+      {
+        "title": "Regression test or documented smoke for Windows-native consumer Taskfile includes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "installer",
+      "agent-experience"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2120",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2120: bug: engine:_ts-build doubles DEFT_ROOT on Windows native — task deft:verify:cache-fresh fails"
+      }
+    ],
+    "updated": "2026-07-08T08:04:46Z",
+    "metadata": {
+      "completedAt": "2026-07-08T08:04:46Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-08-2120-bug-engine-ts-build-doubles-deft-root-on-windows-native-task.xbrief.json
+++ b/xbrief/completed/2026-07-08-2120-bug-engine-ts-build-doubles-deft-root-on-windows-native-task.xbrief.json
@@ -15,19 +15,19 @@
     "items": [
       {
         "title": "`task deft:verify:cache-fresh` exits 0 on Windows native PowerShell for a v0.65.0 npm consumer deposit with global `deft` installed",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "No doubled `DEFT_ROOT` path in go-task `dir` resolution",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "`deft preflight-cache` and `task deft:verify:cache-fresh` remain behaviorally equivalent on Windows native",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Regression test or documented smoke for Windows-native consumer Taskfile includes",
-        "status": "proposed"
+        "status": "completed"
       }
     ],
     "tags": [


### PR DESCRIPTION
## Summary
- add a Windows-native consumer smoke that deposits `Taskfile.yml` and `tasks/` under `.deft/core` and runs the included `task deft:verify:cache-fresh` path
- assert the prebuilt CLI shim handles both direct `deft preflight-cache --allow-missing-bootstrap` and the Taskfile include without reaching `engine:_ts-build` / `pnpm run build`
- assert the consumer fixture remains clean after the cache-fresh smoke

## Related Issues
Closes #2120

## Verification
- local Windows consumer smoke: `directExit=0 taskExit=0 matchedBuildPath=False dirtyCount=0`
- `pnpm exec vitest run packages/core/src/content-contracts/standards/taskfile_runtime_session.test.ts packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts`
- `task vbrief:validate` (passes; existing PRD staleness warning remains)
- `git diff --check`
- `task pr:check-closing-keywords -- --body-file <body>`
- `task pr:check-closing-keywords -- --commits-file <commits>`

## Local caveat
- `task check` on this Windows checkout fails in `pnpm run lint` because global Git `core.autocrlf=true` makes Biome report CRLF formatting across 1,279 existing files. The focused #2120 smoke and contract tests pass locally; CI should run from a fresh checkout.

## Checklist
- [x] `/deft:change <name>` -- N/A: this PR is one accepted #2120 scope, limited to CI smoke coverage plus its changelog/lifecycle artifact.
- [x] `CHANGELOG.md` -- added entry under `[Unreleased]`.
- [x] `ROADMAP.md` -- N/A: release-time ROADMAP promotion per repo convention.
- [x] Tests pass locally -- focused #2120 checks pass; full `task check` caveat documented above.

## Post-Merge
- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed -- `gh issue view 2120 --json state --jq .state`. If still open, close manually with a comment referencing this PR.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)