### PR TITLE
fix: fail maintainer installer on missing tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Maintainer installer mode now fails loud when required developer tools are missing.** `deft-install --maintainer --yes --json` no longer reports success with missing Go or Node; it exits non-zero with structured remediation while keeping optional `ghx` non-blocking. The core-tool probe also treats an obvious Ubuntu Taskwarrior `task` binary as missing so Linux bootstrap installs the Taskfile runner instead. Closes #1616.
+
 ### Removed
 
 ## [0.73.0] - 2026-07-07

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,10 +91,15 @@ deft-install --yes --upgrade --maintainer --repo-root /path/to/directive --json
 ```
 
 Maintainer mode validates that `--repo-root` is a `deftai/directive` checkout,
-reports core setup status, and skips consumer projections such as `AGENTS.md`,
-`.gitignore`, `.gitattributes`, guard workflows, consumer `vbrief/` scaffolding,
-and root Taskfile wiring. That keeps the maintainer-owned repository files from
-being rewritten by the consumer installer path.
+reports core setup status, and fails if required maintainer tools (`go`, `node`)
+are missing. It also skips consumer projections such as `AGENTS.md`, `.gitignore`,
+`.gitattributes`, guard workflows, consumer `vbrief/` scaffolding, and root
+Taskfile wiring. That keeps the maintainer-owned repository files from being
+rewritten by the consumer installer path.
+
+On Linux, `task` must be the Taskfile runner from taskfile.dev. Do not install
+Ubuntu's `taskwarrior` package when the shell suggests it for a missing `task`
+command.
 
 `ghx` is maintainer and swarm tooling: it speeds up repeated read-only GitHub API
 calls and helps protect shared rate limits. Consumer projects require `gh` for

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ deft-install --yes --upgrade --maintainer --repo-root /path/to/directive --json
 
 This mode checks maintainer tooling without projecting consumer-managed files
 such as `AGENTS.md`, `.gitignore`, `.gitattributes`, guard workflows, or
-consumer `vbrief/` scaffolding into the framework repository. See
+consumer `vbrief/` scaffolding into the framework repository. Required
+maintainer tools are Go and Node; `task` must be the Taskfile runner from
+taskfile.dev, not Ubuntu's Taskwarrior package. See
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) for maintainer setup details.
 
 ### 2. Set Up Your Preferences

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -625,10 +625,30 @@ func installMaintainerMode(w *Wizard, result *WizardResult, nonInteractive, upgr
 	if nonInteractive {
 		missingTools, toolsErr = EnsureCoreTools(msgWriter, nonInteractive)
 		if toolsErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: tool probe: %v\n", toolsErr)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", toolsErr)
+			if jsonOut {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				if encErr := enc.Encode(coreToolsBootstrapBlockResult(missingTools, toolsErr)); encErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: JSON encode failed: %v\n", encErr)
+				}
+			}
+			return 1
 		}
 	}
 	maintainerTools := EnsureMaintainerTools(msgWriter)
+	requiredMaintainerToolsMissing := missingRequiredMaintainerTools(maintainerTools)
+	if len(requiredMaintainerToolsMissing) > 0 {
+		fmt.Fprintf(os.Stderr, "Error: %s: %s\n", maintainerToolsBlockMessage, strings.Join(requiredMaintainerToolsMissing, ", "))
+		if jsonOut {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if encErr := enc.Encode(maintainerToolsBlockResult(result.ProjectDir, requiredMaintainerToolsMissing, maintainerTools)); encErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: JSON encode failed: %v\n", encErr)
+			}
+		}
+		return 1
+	}
 
 	configDir, err := CreateUserConfigDir(msgWriter)
 	if err != nil {

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -1697,10 +1697,103 @@ func TestInstallSummary_JSONObjectIncludesMaintainerMode(t *testing.T) {
 	}
 }
 
-func TestInstallMaintainerMode_JSONStdoutIsSingleObject(t *testing.T) {
+func TestInstallMaintainerMode_JSONBlocksWhenRequiredToolsMissing(t *testing.T) {
 	origLookPath := lookPathFunc
-	defer func() { lookPathFunc = origLookPath }()
-	lookPathFunc = func(name string) (string, error) { return "", exec.ErrNotFound }
+	origTaskHelp := taskHelpProbeFunc
+	defer func() {
+		lookPathFunc = origLookPath
+		taskHelpProbeFunc = origTaskHelp
+	}()
+	lookPathFunc = func(name string) (string, error) {
+		switch name {
+		case "task", "uv", "python", "python3", "gh":
+			return "/usr/bin/" + name, nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+	taskHelpProbeFunc = func(string) (string, error) {
+		return "Usage: task [flags...] [task...]\nChoose which Taskfile to run. Defaults to Taskfile.yml.\n", nil
+	}
+
+	proj := t.TempDir()
+	for _, rel := range []string{
+		"main.md",
+		"cmd/deft-install/main.go",
+		"templates/agent-prompt-preamble.md",
+		"scripts/setup_ghx.py",
+	} {
+		path := filepath.Join(proj, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("fixture\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEFT_USER_PATH", filepath.Join(t.TempDir(), "cfg"))
+
+	oldStdout := os.Stdout
+	r, wPipe, perr := os.Pipe()
+	if perr != nil {
+		t.Fatalf("os.Pipe: %v", perr)
+	}
+	os.Stdout = wPipe
+	code := installMaintainerMode(
+		NewWizardWithLayout(strings.NewReader(""), os.Stdout, false, false),
+		&WizardResult{ProjectDir: proj, DeftDir: filepath.Join(proj, ".deft", "core"), Update: true},
+		true,
+		true,
+		true,
+		false,
+	)
+	_ = wPipe.Close()
+	os.Stdout = oldStdout
+	stdout, _ := io.ReadAll(r)
+
+	if code != 1 {
+		t.Fatalf("installMaintainerMode returned %d, want 1", code)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(stdout, &obj); err != nil {
+		t.Fatalf("maintainer --json stdout must be a single JSON object: %v\nstdout=%q", err, stdout)
+	}
+	if obj["success"] != false {
+		t.Errorf("success = %v, want false", obj["success"])
+	}
+	if obj["error_code"] != maintainerToolsBlockCode {
+		t.Errorf("error_code = %v, want %q", obj["error_code"], maintainerToolsBlockCode)
+	}
+	if obj["maintainer_mode"] != true {
+		t.Errorf("maintainer_mode = %v, want true", obj["maintainer_mode"])
+	}
+	if _, ok := obj["maintainer_tools"].([]any); !ok {
+		t.Errorf("maintainer_tools must marshal as an array, got %#v", obj["maintainer_tools"])
+	}
+	missing, ok := obj["missing_tools"].([]any)
+	if !ok || len(missing) != 2 || missing[0] != "go" || missing[1] != "node" {
+		t.Errorf("missing_tools = %#v, want [go node]", obj["missing_tools"])
+	}
+}
+
+func TestInstallMaintainerMode_JSONAllowsOptionalGhxMissing(t *testing.T) {
+	origLookPath := lookPathFunc
+	origTaskHelp := taskHelpProbeFunc
+	defer func() {
+		lookPathFunc = origLookPath
+		taskHelpProbeFunc = origTaskHelp
+	}()
+	lookPathFunc = func(name string) (string, error) {
+		switch name {
+		case "go", "node", "task", "uv", "python", "gh":
+			return "/usr/bin/" + name, nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+	taskHelpProbeFunc = func(string) (string, error) {
+		return "Usage: task [flags...] [task...]\nChoose which Taskfile to run. Defaults to Taskfile.yml.\n", nil
+	}
 
 	proj := t.TempDir()
 	for _, rel := range []string{
@@ -1744,11 +1837,11 @@ func TestInstallMaintainerMode_JSONStdoutIsSingleObject(t *testing.T) {
 	if err := json.Unmarshal(stdout, &obj); err != nil {
 		t.Fatalf("maintainer --json stdout must be a single JSON object: %v\nstdout=%q", err, stdout)
 	}
+	if obj["success"] != true {
+		t.Errorf("success = %v, want true", obj["success"])
+	}
 	if obj["maintainer_mode"] != true {
 		t.Errorf("maintainer_mode = %v, want true", obj["maintainer_mode"])
-	}
-	if _, ok := obj["maintainer_tools"].([]any); !ok {
-		t.Errorf("maintainer_tools must marshal as an array, got %#v", obj["maintainer_tools"])
 	}
 }
 

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -1043,6 +1043,13 @@ var goosForCoreTools = func() string { return runtime.GOOS }
 // missing required tools. Tests replace it to avoid real network/package work.
 var bootstrapLinuxCoreToolsFunc = bootstrapLinuxCoreTools
 
+// taskHelpProbeFunc fingerprints the resolved `task` binary. Tests replace it
+// so PATH-only probes can stay deterministic without executing fake paths.
+var taskHelpProbeFunc = func(path string) (string, error) {
+	out, err := exec.Command(path, "--help").CombinedOutput()
+	return string(out), err
+}
+
 // ErrCoreToolsBootstrap is returned when Linux --yes bootstrap cannot satisfy
 // doctor-required tools (uv, task, gh) without claiming install success.
 type ErrCoreToolsBootstrap struct {
@@ -1097,12 +1104,19 @@ func probeCoreToolsMissing() []string {
 	for name, alts := range coreToolCandidates {
 		found := false
 		for _, a := range alts {
-			if _, err := lookPathFunc(a); err == nil {
-				found = true
-				break
-			} else if !errors.Is(err, exec.ErrNotFound) {
-				log.Printf("warning: LookPath %q: %v", a, err)
+			path, err := lookPathFunc(a)
+			if err != nil {
+				if !errors.Is(err, exec.ErrNotFound) {
+					log.Printf("warning: LookPath %q: %v", a, err)
+				}
+				continue
 			}
+			if name == "task" && !isGoTaskBinary(path) {
+				log.Printf("warning: task binary %q does not look like the Taskfile runner; install go-task from taskfile.dev instead of Ubuntu taskwarrior", path)
+				continue
+			}
+			found = true
+			break
 		}
 		if !found {
 			missing = append(missing, name)
@@ -1110,6 +1124,17 @@ func probeCoreToolsMissing() []string {
 	}
 	sort.Strings(missing)
 	return missing
+}
+
+func isGoTaskBinary(path string) bool {
+	help, err := taskHelpProbeFunc(path)
+	if err != nil && strings.TrimSpace(help) == "" {
+		log.Printf("warning: could not fingerprint task binary %q: %v", path, err)
+		// If fingerprinting itself fails, avoid blocking an otherwise valid go-task install.
+		return true
+	}
+	lowerHelp := strings.ToLower(help)
+	return strings.Contains(lowerHelp, "taskfile") || strings.Contains(lowerHelp, "--taskfile")
 }
 
 // missingLinuxBootstrapRequired filters missing to the doctor-required subset
@@ -1133,7 +1158,7 @@ func printCoreToolsFallbacks(w *Wizard, missing []string) {
 	w.printf("  Fallbacks (run manually or via platform package manager):\n")
 	w.printf("    Windows: winget install --id <ID> or scripts/setup_windows.ps1\n")
 	w.printf("    macOS:   brew install go-task uv python gh\n")
-	w.printf("    Linux:   apt/brew equivalent for task uv python3 gh\n")
+	w.printf("    Linux:   install go-task from https://taskfile.dev/installation/ (not Ubuntu taskwarrior), plus uv python3 gh\n")
 	w.printf("  See docs/getting-started.md and QUICK-START.md for details.\n")
 }
 
@@ -1350,6 +1375,11 @@ type maintainerToolStatus struct {
 	Purpose  string `json:"purpose"`
 }
 
+const (
+	maintainerToolsBlockCode    = "maintainer_required_tools_missing"
+	maintainerToolsBlockMessage = "required maintainer tools are missing"
+)
+
 var maintainerToolDefinitions = []maintainerToolStatus{
 	{Name: "go", Binary: "go", Required: true, Purpose: "build and test cmd/deft-install"},
 	{Name: "node", Binary: "node", Required: true, Purpose: "maintainer-side documentation and release tooling"},
@@ -1377,8 +1407,63 @@ func EnsureMaintainerTools(w *Wizard) []maintainerToolStatus {
 	}
 	w.printf("Maintainer tools missing or optional: %s\n", strings.Join(missing, ", "))
 	w.printf("  Required for framework development: go, node.\n")
+	requiredMissing := missingRequiredMaintainerTools(statuses)
+	if len(requiredMissing) > 0 {
+		w.printf("  Install required maintainer tools before running task setup or task check:\n")
+		for _, name := range requiredMissing {
+			w.printf("    %s: %s\n", name, maintainerToolInstallInstruction(name))
+		}
+	}
 	w.printf("  Optional acceleration: ghx (install with `task setup:ghx`; consumers only need gh).\n")
 	return statuses
+}
+
+func missingRequiredMaintainerTools(statuses []maintainerToolStatus) []string {
+	missing := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		if status.Required && !status.Present {
+			missing = append(missing, status.Name)
+		}
+	}
+	return missing
+}
+
+func maintainerToolInstallInstruction(name string) string {
+	switch name {
+	case "go":
+		return "install Go 1.22+ from https://go.dev/doc/install or your OS package manager"
+	case "node":
+		return "install Node.js 22+ from https://nodejs.org/ or your OS package manager"
+	default:
+		return "install this required tool on PATH"
+	}
+}
+
+func maintainerToolsBlockResult(projectDir string, missing []string, statuses []maintainerToolStatus) map[string]any {
+	missingOut := missing
+	if missingOut == nil {
+		missingOut = []string{}
+	}
+	statusesOut := statuses
+	if statusesOut == nil {
+		statusesOut = []maintainerToolStatus{}
+	}
+	remediation := make([]string, 0, len(missingOut))
+	for _, name := range missingOut {
+		remediation = append(remediation, fmt.Sprintf("%s: %s", name, maintainerToolInstallInstruction(name)))
+	}
+	return map[string]any{
+		"success":          false,
+		"error":            maintainerToolsBlockMessage,
+		"error_code":       maintainerToolsBlockCode,
+		"project_dir":      projectDir,
+		"missing_tools":    missingOut,
+		"maintainer_mode":  true,
+		"maintainer_tools": statusesOut,
+		"why":              fmt.Sprintf("%s: %s", maintainerToolsBlockMessage, strings.Join(missingOut, ", ")),
+		"remediation":      remediation,
+		"warnings":         []string{},
+	}
 }
 
 func skippedConsumerProjectionNames() []string {

--- a/cmd/deft-install/setup_test.go
+++ b/cmd/deft-install/setup_test.go
@@ -1233,6 +1233,29 @@ func TestEnsureMaintainerTools_ReportsSeparateMaintainerOnlyStatuses(t *testing.
 	}
 }
 
+func TestEnsureMaintainerTools_PrintsRequiredInstallInstructions(t *testing.T) {
+	origLookPath := lookPathFunc
+	defer func() { lookPathFunc = origLookPath }()
+
+	lookPathFunc = func(name string) (string, error) {
+		if name == "ghx" {
+			return "/usr/bin/ghx", nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	var out bytes.Buffer
+	statuses := EnsureMaintainerTools(NewWizardWithLayout(strings.NewReader(""), &out, false, false))
+	if got := missingRequiredMaintainerTools(statuses); strings.Join(got, ",") != "go,node" {
+		t.Fatalf("missing required tools = %v, want [go node]", got)
+	}
+	for _, want := range []string{"go: install Go 1.22+", "node: install Node.js 22+", "task setup or task check"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("required maintainer guidance missing %q; got:\n%s", want, out.String())
+		}
+	}
+}
+
 func TestMaintainerCheckoutDetection(t *testing.T) {
 	tmp := t.TempDir()
 	for _, rel := range []string{
@@ -1269,14 +1292,28 @@ func withLinuxCoreToolSeams(t *testing.T, lookPath func(string) (string, error),
 	origGOOS := goosForCoreTools
 	origLook := lookPathFunc
 	origBootstrap := bootstrapLinuxCoreToolsFunc
+	origTaskHelp := taskHelpProbeFunc
+	origPath := os.Getenv("PATH")
 	goosForCoreTools = func() string { return "linux" }
 	lookPathFunc = lookPath
 	bootstrapLinuxCoreToolsFunc = bootstrap
-	return func() {
+	taskHelpProbeFunc = func(string) (string, error) {
+		return "Usage: task [flags...] [task...]\nChoose which Taskfile to run. Defaults to Taskfile.yml.\n", nil
+	}
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		restored = true
 		goosForCoreTools = origGOOS
 		lookPathFunc = origLook
 		bootstrapLinuxCoreToolsFunc = origBootstrap
+		taskHelpProbeFunc = origTaskHelp
+		_ = os.Setenv("PATH", origPath)
 	}
+	t.Cleanup(restore)
+	return restore
 }
 
 // TestEnsureCoreTools_LinuxBootstrapSuccess verifies Linux --yes bootstrap
@@ -1391,6 +1428,7 @@ func TestEnsureCoreTools_LinuxBootstrapStillMissingAfterInstall(t *testing.T) {
 func TestEnsureCoreTools_NonLinuxNonInteractiveKeepsFallback(t *testing.T) {
 	origGOOS := goosForCoreTools
 	origLook := lookPathFunc
+	origTaskHelp := taskHelpProbeFunc
 	goosForCoreTools = func() string { return "windows" }
 	lookPathFunc = func(file string) (string, error) {
 		if file == "uv" {
@@ -1398,9 +1436,13 @@ func TestEnsureCoreTools_NonLinuxNonInteractiveKeepsFallback(t *testing.T) {
 		}
 		return "/bin/" + file, nil
 	}
+	taskHelpProbeFunc = func(string) (string, error) {
+		return "Usage: task [flags...] [task...]\nChoose which Taskfile to run. Defaults to Taskfile.yml.\n", nil
+	}
 	defer func() {
 		goosForCoreTools = origGOOS
 		lookPathFunc = origLook
+		taskHelpProbeFunc = origTaskHelp
 	}()
 
 	var out bytes.Buffer
@@ -1413,6 +1455,35 @@ func TestEnsureCoreTools_NonLinuxNonInteractiveKeepsFallback(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Fallbacks") {
 		t.Errorf("expected fallback guidance on non-Linux host; got:\n%s", out.String())
+	}
+}
+
+func TestProbeCoreToolsMissing_TreatsTaskwarriorAsMissing(t *testing.T) {
+	origLook := lookPathFunc
+	origTaskHelp := taskHelpProbeFunc
+	defer func() {
+		lookPathFunc = origLook
+		taskHelpProbeFunc = origTaskHelp
+	}()
+
+	lookPathFunc = func(file string) (string, error) {
+		return "/usr/bin/" + file, nil
+	}
+	taskHelpProbeFunc = func(string) (string, error) {
+		return "Usage: task [options] [<filter>]\nTaskwarrior command line task list manager\n", nil
+	}
+
+	missing := probeCoreToolsMissing()
+	if len(missing) != 1 || missing[0] != "task" {
+		t.Fatalf("missing core tools = %v, want [task]", missing)
+	}
+}
+
+func TestPrintCoreToolsFallbacks_WarnsAgainstTaskwarrior(t *testing.T) {
+	var out bytes.Buffer
+	printCoreToolsFallbacks(NewWizardWithLayout(strings.NewReader(""), &out, false, false), []string{"task"})
+	if !strings.Contains(out.String(), "not Ubuntu taskwarrior") {
+		t.Fatalf("fallback guidance should warn against Taskwarrior; got:\n%s", out.String())
 	}
 }
 
@@ -1441,6 +1512,35 @@ func TestCoreToolsBootstrapBlockResult_JSONShape(t *testing.T) {
 	rem, ok := obj["remediation"].([]string)
 	if !ok || len(rem) == 0 {
 		t.Fatalf("remediation must be a non-empty []string, got %T %v", obj["remediation"], obj["remediation"])
+	}
+	if _, err := json.Marshal(obj); err != nil {
+		t.Fatalf("block result is not JSON-marshalable: %v", err)
+	}
+}
+
+func TestMaintainerToolsBlockResult_JSONShape(t *testing.T) {
+	statuses := []maintainerToolStatus{
+		{Name: "go", Binary: "go", Present: false, Required: true, Purpose: "build"},
+		{Name: "node", Binary: "node", Present: false, Required: true, Purpose: "release"},
+		{Name: "ghx", Binary: "ghx", Present: false, Required: false, Purpose: "cache"},
+	}
+	obj := maintainerToolsBlockResult("/repo/directive", []string{"go", "node"}, statuses)
+	if obj["success"] != false {
+		t.Errorf("success = %v, want false", obj["success"])
+	}
+	if obj["error_code"] != maintainerToolsBlockCode {
+		t.Errorf("error_code = %v, want %q", obj["error_code"], maintainerToolsBlockCode)
+	}
+	if obj["maintainer_mode"] != true {
+		t.Errorf("maintainer_mode = %v, want true", obj["maintainer_mode"])
+	}
+	gotMissing, ok := obj["missing_tools"].([]string)
+	if !ok || strings.Join(gotMissing, ",") != "go,node" {
+		t.Fatalf("missing_tools = %#v, want [go node]", obj["missing_tools"])
+	}
+	rem, ok := obj["remediation"].([]string)
+	if !ok || len(rem) != 2 || !strings.Contains(rem[0], "go.dev") || !strings.Contains(rem[1], "nodejs.org") {
+		t.Fatalf("remediation = %#v, want Go and Node install instructions", obj["remediation"])
 	}
 	if _, err := json.Marshal(obj); err != nil {
 		t.Fatalf("block result is not JSON-marshalable: %v", err)

--- a/xbrief/completed/2026-07-08-1616-maintainer-mode-deft-install-reports-required-tools-go-node.xbrief.json
+++ b/xbrief/completed/2026-07-08-1616-maintainer-mode-deft-install-reports-required-tools-go-node.xbrief.json
@@ -1,0 +1,33 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #1616"
+  },
+  "plan": {
+    "title": "maintainer-mode deft-install reports required tools (go, node) missing but never installs them",
+    "status": "completed",
+    "narratives": {
+      "Description": "maintainer-mode deft-install reports required tools (go, node) missing but never installs them",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1616",
+      "Overview": "## Summary\r\n\r\nIn maintainer mode, `deft-install` **bootstraps and installs missing core tools** (e.g. `uv`) but for **maintainer tools it only reports them as missing** and never installs them — even with `--yes`. As a result `go` and `node` (both `required: true`) are left uninstalled, so subsequent maintainer steps (`task setup`, `task check`, building/testing `cmd/deft-install`) cannot run. Despite this, the command still reports `success: true`.\r\n\r\n## Environment\r\n\r\n- `deft-install`: v0.46.0 (reported \"Running latest\")\r\n- OS: Linux (WSL2) — `msadams@DESKTOP-NLCQ5NK`\r\n- repo-root: `/home/msadams/repos/deft/directive`\r\n\r\n## Command\r\n\r\n```\r\ndeft-install --yes --upgrade --maintainer --repo-root /home/msadams/repos/deft/directive --json\r\n```\r\n\r\n## Actual behavior\r\n\r\nCore tools **were** auto-installed during bootstrap:\r\n\r\n```\r\nBootstrapping required core tools for Linux --yes: uv\r\n  Installing uv via Astral install script...\r\n  ...\r\neverything's installed!\r\nCore tools present after Linux bootstrap: task, uv, python, gh.\r\n```\r\n\r\nBut required maintainer tools were only **reported**, not installed:\r\n\r\n```\r\nMaintainer tools missing or optional: go, node, ghx\r\n  Required for framework development: go, node.\r\n  Optional acceleration: ghx (install with `task setup:ghx`; consumers only need gh).\r\n```\r\n\r\nThe JSON confirms `go` and `node` are `present: false, required: true`, yet `missing_tools: []` and `success: true`:\r\n\r\n```json\r\n\"maintainer_tools\": [\r\n  { \"name\": \"go\",   \"binary\": \"go\",   \"present\": false, \"required\": true,  \"purpose\": \"build and test cmd/deft-install\" },\r\n  { \"name\": \"node\", \"binary\": \"node\", \"present\": false, \"required\": true,  \"purpose\": \"maintainer-side documentation and release tooling\" },\r\n  { \"name\": \"ghx\",  \"binary\": \"ghx\",  \"present\": false, \"required\": false, \"purpose\": \"optional cached GitHub CLI proxy ...\" }\r\n],\r\n\"missing_tools\": [],\r\n\"success\": true\r\n```\r\n\r\nConfirmed missing immediately afterward:\r\n\r\n```\r\n$ go\r\nCommand 'go' not found, but can be installed with:\r\nsudo apt install golang-go\r\n```\r\n\r\n## Expected behavior\r\n\r\nWith `--maintainer --yes`, required maintainer tools (`go`, `node`) should be installed automatically the same way core tools are during bootstrap. If auto-install is intentionally out of scope, the command should at minimum:\r\n\r\n- exit non-zero (not report `success: true`) when required maintainer tools are missing, and\r\n- print explicit install instructions for each required tool (as it already does for the optional `ghx` via `task setup:ghx`).\r\n\r\n## Impact\r\n\r\n- `success: true` is misleading when required maintainer tooling is absent.\r\n- The printed \"Next steps\" (`task setup`, `task check`) will fail without `go`/`node`.\r\n- Inconsistent UX: core tools auto-install, required maintainer tools do not.\r\n\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @MScottAdams (2026-06-14T16:37:39Z)\n\n### Related gap: Ubuntu/`apt` suggests the wrong `task` (Taskwarrior), not the runner directive needs\r\n\r\nSame root cause as the `go`/`node` gap above — leaving required tools for the user to install by hand leads them to the **wrong package** on Debian/Ubuntu.\r\n\r\nWhen the go-task runner (`task`, from taskfile.dev) is missing, the shell \"command not found\" handler and `apt` suggest:\r\n\r\n```\r\n$ task\r\nCommand 'task' not found, but can be installed with:\r\nsudo apt install taskwarrior\r\n```\r\n\r\nInstalling that gives **Taskwarrior** — a CLI to-do/time tracker that also ships a `task` binary — **not** the Taskfile runner directive depends on. A user who follows the suggestion ends up with the wrong `task` on `PATH`, and `task --list` / `task setup` / `task check` will fail or behave nonsensically.\r\n\r\n### Expected\r\n\r\nThe installer should install the **correct** task runner (go-task) directly rather than deferring to `apt`. For example, the official install script:\r\n\r\n```\r\nsh -c \"$(curl --location https://taskfile.dev/install.sh)\" -- -d -b ~/.local/bin\r\n```\r\n\r\n(or the appropriate per-distro method), the same way `uv` is already bootstrapped via the Astral script.\r\n\r\n### Nice to have\r\n\r\nDetect when the resolved `task` is actually Taskwarrior (e.g. `task --version` does not match go-task's output) and warn/replace it, so an already-misinstalled environment is surfaced instead of silently using the wrong binary.",
+      "Labels": "bug, installer"
+    },
+    "items": [],
+    "tags": [
+      "bug",
+      "installer"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1616",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1616: maintainer-mode deft-install reports required tools (go, node) missing but never installs them"
+      }
+    ],
+    "updated": "2026-07-08T10:03:10Z",
+    "metadata": {
+      "completedAt": "2026-07-08T10:03:10Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Make `deft-install --maintainer` fail loud when required maintainer tools (`go`, `node`) are missing, including structured `success:false` JSON and remediation.
- Keep optional `ghx` non-blocking while preserving maintainer tool status in JSON.
- Treat an obvious Ubuntu Taskwarrior `task` binary as a missing Taskfile runner so Linux bootstrap installs the correct go-task binary, and document the maintainer guidance.

## Validation
- `go test ./cmd/deft-install`
- `git diff --check`
- `task vbrief:validate` (passes with existing PRD-stale warning)
- `task verify:branch`
- `task check` (fails on existing `verify:pack-drift` projection drift: 45 out-of-sync content-pack projections, tracked separately in #336)
- `task verify:pack-drift` (same existing #336 blocker)

Closes #1616.