### PR TITLE
fix: warn on completed scopes in open umbrellas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `task scope:complete` now warns when a completed scope is still referenced by an open umbrella or tracker issue in the local xBRIEF/cache state, pointing maintainers at `task vbrief:reconcile:umbrellas` instead of silently leaving stale current-shape/checklist state behind. Closes #2322.
+
 ### Removed
 
 ## [0.73.0] - 2026-07-07

--- a/packages/core/src/scope/transition.ts
+++ b/packages/core/src/scope/transition.ts
@@ -18,6 +18,7 @@ import {
   updateDecomposedParentBackReferences,
 } from "./decomposed-refs.js";
 import { syncProjectDefinitionAfterScopeMove } from "./project-definition-sync.js";
+import { scopeCompleteUmbrellaWarnings } from "./umbrella-warning.js";
 import { formatVbriefJson, utcNowIso } from "./vbrief-json.js";
 import type { WipCapCheck } from "./wip-cap-check.js";
 
@@ -139,9 +140,20 @@ export function runTransition(
     updateDecomposedChildBackReferences(data, resolvedPath, destPath, vbriefRoot);
     syncProjectDefinitionAfterScopeMove(data, resolvedPath, destPath, vbriefRoot, targetStatus);
     const actionLabel = MOVE_LABELS[act] ?? act.charAt(0).toUpperCase() + act.slice(1);
+    const warnings =
+      act === "complete"
+        ? scopeCompleteUmbrellaWarnings({
+            projectRoot,
+            vbriefRoot,
+            oldPath: resolvedPath,
+            newPath: destPath,
+            scopeData: data,
+          })
+        : [];
+    const warningText = warnings.length > 0 ? `\n${warnings.join("\n")}` : "";
     return {
       ok: true,
-      message: `${actionLabel} ${basename}: ${currentFolder}/ -> ${targetFolder}/ (status: ${targetStatus})`,
+      message: `${actionLabel} ${basename}: ${currentFolder}/ -> ${targetFolder}/ (status: ${targetStatus})${warningText}`,
     };
   }
 

--- a/packages/core/src/scope/umbrella-warning.test.ts
+++ b/packages/core/src/scope/umbrella-warning.test.ts
@@ -1,0 +1,235 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runTransition } from "./transition.js";
+import { scopeCompleteUmbrellaWarnings } from "./umbrella-warning.js";
+import { formatVbriefJson } from "./vbrief-json.js";
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "scope-umbrella-"));
+  for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+    mkdirSync(join(root, "xbrief", folder), { recursive: true });
+  }
+  return root;
+}
+
+function writeScope(
+  root: string,
+  folder: string,
+  name: string,
+  plan: Record<string, unknown>,
+): string {
+  const path = join(root, "xbrief", folder, name);
+  writeFileSync(path, formatVbriefJson({ plan }), "utf8");
+  return path;
+}
+
+function writeCachedIssue(
+  root: string,
+  number: number,
+  issue: {
+    readonly title?: string;
+    readonly state?: string;
+    readonly labels?: readonly string[];
+    readonly body?: string;
+  } = {},
+): void {
+  const dir = join(root, ".deft-cache", "github-issue", "deftai", "directive", String(number));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "raw.json"),
+    JSON.stringify(
+      {
+        number,
+        title: issue.title ?? `Issue ${number}`,
+        state: issue.state ?? "open",
+        labels: (issue.labels ?? []).map((name) => ({ name })),
+        body: issue.body ?? "",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+function writeRawCachedIssue(root: string, number: number, raw: unknown): void {
+  const dir = join(root, ".deft-cache", "github-issue", "deftai", "directive", String(number));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "raw.json"), JSON.stringify(raw, null, 2), "utf8");
+}
+
+describe("scope complete umbrella warnings", () => {
+  let root = "";
+
+  afterEach(() => {
+    if (root.length > 0) {
+      rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("warns when an open umbrella xBRIEF references the completed scope", () => {
+    root = makeRepo();
+    writeCachedIssue(root, 1119, {
+      title: "tracker: umbrella",
+      labels: ["meta"],
+      body: "open working-set tracker",
+    });
+    writeCachedIssue(root, 2320, { title: "child scope", state: "closed" });
+    const child = writeScope(root, "active", "child.xbrief.json", {
+      title: "Child",
+      status: "running",
+      items: [],
+      references: [
+        { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/2320" },
+      ],
+    });
+    writeScope(root, "active", "umbrella.xbrief.json", {
+      title: "Umbrella",
+      status: "running",
+      items: [],
+      references: [
+        { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/1119" },
+        { type: "x-vbrief/plan", uri: "active/child.xbrief.json" },
+      ],
+    });
+
+    const result = runTransition("complete", child);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("referenced by OPEN umbrella #1119");
+    expect(result.message).toContain("task vbrief:reconcile:umbrellas");
+  });
+
+  it("warns when a cached open umbrella body lists the completed scope issue", () => {
+    root = makeRepo();
+    writeCachedIssue(root, 1119, {
+      title: "working-set tracker",
+      body: "Current shape still includes #2320 as in-flight.",
+    });
+    writeCachedIssue(root, 2320, { title: "child scope", state: "closed" });
+    const child = writeScope(root, "active", "child.xbrief.json", {
+      title: "Child",
+      status: "running",
+      items: [],
+      references: [
+        { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/2320" },
+      ],
+    });
+
+    const result = runTransition("complete", child);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("referenced by OPEN umbrella #1119");
+  });
+
+  it("warns when an open umbrella xBRIEF references the completed issue directly", () => {
+    root = makeRepo();
+    writeRawCachedIssue(root, 1119, {
+      number: 1119,
+      title: 1119,
+      state: "OPEN",
+      labels: ["tracker"],
+      body: null,
+    });
+    writeCachedIssue(root, 2320, { title: "child scope", state: "closed" });
+    writeFileSync(join(root, "xbrief", "pending", "broken.xbrief.json"), "{", "utf8");
+    writeFileSync(
+      join(root, "xbrief", "pending", "missing-plan.xbrief.json"),
+      JSON.stringify({ nope: true }),
+      "utf8",
+    );
+    const child = writeScope(root, "active", "child.xbrief.json", {
+      title: "Child",
+      status: "running",
+      items: [],
+      references: [
+        { type: "x-xbrief/github-issue", uri: "https://github.com/deftai/directive/issues/2320" },
+      ],
+    });
+    writeScope(root, "pending", "umbrella.xbrief.json", {
+      title: "Umbrella",
+      status: "pending",
+      items: [],
+      references: [
+        { type: "x-xbrief/github-issue", uri: "https://github.com/deftai/directive/issues/1119" },
+        { type: "x-xbrief/github-issue", uri: "https://github.com/deftai/directive/issues/2320" },
+      ],
+    });
+
+    const result = runTransition("complete", child);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("referenced by OPEN umbrella #1119");
+  });
+
+  it("warns for cached umbrella issue URLs and skips malformed cache entries", () => {
+    root = makeRepo();
+    writeCachedIssue(root, 1119, {
+      title: "release umbrella",
+      body: "Current shape points at https://github.com/deftai/directive/issues/2320/.",
+    });
+    const malformedDir = join(root, ".deft-cache", "github-issue", "deftai", "directive", "2222");
+    mkdirSync(malformedDir, { recursive: true });
+    writeFileSync(join(malformedDir, "raw.json"), "{", "utf8");
+    writeRawCachedIssue(root, 3333, null);
+    mkdirSync(join(root, ".deft-cache", "github-issue", "deftai", "directive", "not-a-number"), {
+      recursive: true,
+    });
+    const child = writeScope(root, "active", "child.xbrief.json", {
+      title: "Child",
+      status: "running",
+      items: [],
+      references: [
+        { type: "x-xbrief/github-issue", uri: "https://github.com/deftai/directive/issues/2320" },
+      ],
+    });
+
+    const result = runTransition("complete", child);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("referenced by OPEN umbrella #1119");
+  });
+
+  it("returns no warnings when completion data has no plan", () => {
+    root = makeRepo();
+
+    expect(
+      scopeCompleteUmbrellaWarnings({
+        projectRoot: root,
+        vbriefRoot: join(root, "xbrief"),
+        oldPath: join(root, "xbrief", "active", "missing.xbrief.json"),
+        newPath: join(root, "xbrief", "completed", "missing.xbrief.json"),
+        scopeData: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not warn for closed umbrella references", () => {
+    root = makeRepo();
+    writeCachedIssue(root, 1119, {
+      title: "tracker: umbrella",
+      state: "closed",
+      body: "Current shape includes #2320.",
+    });
+    writeCachedIssue(root, 2320, { title: "child scope", state: "closed" });
+    const child = writeScope(root, "active", "child.xbrief.json", {
+      title: "Child",
+      status: "running",
+      items: [],
+      references: [
+        { type: "x-vbrief/github-issue", uri: "https://github.com/deftai/directive/issues/2320" },
+      ],
+    });
+
+    const result = runTransition("complete", child);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).not.toContain("OPEN umbrella");
+    expect(readFileSync(join(root, "xbrief", "completed", "child.xbrief.json"), "utf8")).toContain(
+      '"completed"',
+    );
+  });
+});

--- a/packages/core/src/scope/umbrella-warning.ts
+++ b/packages/core/src/scope/umbrella-warning.ts
@@ -1,0 +1,299 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
+import { CACHE_DIR_NAME, CACHE_SOURCE_GITHUB_ISSUE } from "../triage/queue/constants.js";
+import { parseGithubIssueUri } from "../triage/reconcile/parse-uri.js";
+import { collectChildUris, collectPlanRefs, resolveVbriefRef } from "./vbrief-ref.js";
+
+interface IssueRef {
+  readonly repo: string | null;
+  readonly number: number;
+}
+
+interface CachedIssuePayload {
+  readonly number: number;
+  readonly title: string;
+  readonly state: string;
+  readonly labels: readonly string[];
+  readonly body: string;
+}
+
+export interface ScopeCompleteUmbrellaWarningOptions {
+  readonly projectRoot: string;
+  readonly vbriefRoot: string;
+  readonly oldPath: string;
+  readonly newPath: string;
+  readonly scopeData: Record<string, unknown>;
+}
+
+function asPlan(data: Record<string, unknown>): Record<string, unknown> | null {
+  const plan = data.plan;
+  if (typeof plan !== "object" || plan === null || Array.isArray(plan)) {
+    return null;
+  }
+  return plan as Record<string, unknown>;
+}
+
+function issueRefsFromPlan(plan: Record<string, unknown>): IssueRef[] {
+  const refs = plan.references;
+  if (!Array.isArray(refs)) {
+    return [];
+  }
+  const out: IssueRef[] = [];
+  for (const ref of refs) {
+    if (typeof ref !== "object" || ref === null || Array.isArray(ref)) {
+      continue;
+    }
+    const rec = ref as Record<string, unknown>;
+    if (!referenceTypeMatches(String(rec.type ?? ""), "github-issue")) {
+      continue;
+    }
+    const [repo, number] = parseGithubIssueUri(rec.uri);
+    if (number !== null) {
+      out.push({ repo, number });
+    }
+  }
+  return out;
+}
+
+function issueKey(ref: IssueRef): string {
+  return `${ref.repo ?? ""}#${ref.number}`;
+}
+
+function planReferencesMovedScope(
+  plan: Record<string, unknown>,
+  oldPath: string,
+  newPath: string,
+  vbriefRoot: string,
+): boolean {
+  const oldResolved = resolve(oldPath);
+  const newResolved = resolve(newPath);
+  const refs = [...collectPlanRefs(plan), ...collectChildUris(plan)];
+  for (const ref of refs) {
+    const resolved = resolveVbriefRef(ref, vbriefRoot);
+    if (resolved === null) {
+      continue;
+    }
+    const normalized = resolve(resolved);
+    if (normalized === oldResolved || normalized === newResolved) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function planReferencesCompletedIssue(
+  plan: Record<string, unknown>,
+  completedRefs: readonly IssueRef[],
+): boolean {
+  const completedKeys = new Set(completedRefs.map(issueKey));
+  const completedNumbers = new Set(completedRefs.map((ref) => ref.number));
+  for (const ref of issueRefsFromPlan(plan)) {
+    if (completedKeys.has(issueKey(ref))) {
+      return true;
+    }
+    if (ref.repo === null && completedNumbers.has(ref.number)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function cachedIssuePath(projectRoot: string, repo: string, issueNumber: number): string {
+  const [owner, name] = repo.split("/", 2);
+  return join(
+    projectRoot,
+    CACHE_DIR_NAME,
+    CACHE_SOURCE_GITHUB_ISSUE,
+    owner ?? "",
+    name ?? "",
+    String(issueNumber),
+    "raw.json",
+  );
+}
+
+function labelsFromRaw(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const out: string[] = [];
+  for (const label of raw) {
+    if (typeof label === "string") {
+      out.push(label);
+    } else if (typeof label === "object" && label !== null) {
+      const name = (label as Record<string, unknown>).name;
+      if (typeof name === "string") {
+        out.push(name);
+      }
+    }
+  }
+  return out;
+}
+
+function readCachedIssue(
+  projectRoot: string,
+  repo: string | null,
+  issueNumber: number,
+): CachedIssuePayload | null {
+  if (repo === null || !repo.includes("/")) {
+    return null;
+  }
+  const rawPath = cachedIssuePath(projectRoot, repo, issueNumber);
+  if (!existsSync(rawPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(rawPath, "utf8")) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    const issue = parsed as Record<string, unknown>;
+    const number = typeof issue.number === "number" ? issue.number : issueNumber;
+    return {
+      number,
+      title: typeof issue.title === "string" ? issue.title : "",
+      state: typeof issue.state === "string" ? issue.state.toLowerCase() : "open",
+      labels: labelsFromRaw(issue.labels),
+      body: typeof issue.body === "string" ? issue.body : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isOpenUmbrella(issue: CachedIssuePayload | null): issue is CachedIssuePayload {
+  if (issue === null || issue.state !== "open") {
+    return false;
+  }
+  const labels = issue.labels.map((label) => label.toLowerCase());
+  if (labels.some((label) => ["epic", "meta", "tracker", "umbrella"].includes(label))) {
+    return true;
+  }
+  return /\b(umbrella|tracker)\b/i.test(issue.title);
+}
+
+function bodyMentionsIssue(body: string, issueNumber: number): boolean {
+  const escaped = String(issueNumber).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (
+    new RegExp(`(^|[^0-9])#${escaped}\\b`).test(body) ||
+    new RegExp(`/issues/${escaped}(\\b|/)`).test(body)
+  );
+}
+
+function readLifecycleScopeFiles(vbriefRoot: string): string[] {
+  const out: string[] = [];
+  for (const folder of ["proposed", "pending", "active"]) {
+    const dir = join(vbriefRoot, folder);
+    if (!existsSync(dir)) {
+      continue;
+    }
+    for (const name of readdirSync(dir)) {
+      if (name.endsWith(".xbrief.json") || name.endsWith(".vbrief.json")) {
+        out.push(join(dir, name));
+      }
+    }
+  }
+  return out;
+}
+
+function addOpenUmbrella(
+  out: Map<number, CachedIssuePayload>,
+  issue: CachedIssuePayload | null,
+): void {
+  if (isOpenUmbrella(issue)) {
+    out.set(issue.number, issue);
+  }
+}
+
+function scanLocalScopeReferences(
+  options: ScopeCompleteUmbrellaWarningOptions,
+  completedRefs: readonly IssueRef[],
+  umbrellas: Map<number, CachedIssuePayload>,
+): void {
+  const completedKeys = new Set(completedRefs.map(issueKey));
+  for (const file of readLifecycleScopeFiles(options.vbriefRoot)) {
+    if (resolve(file) === resolve(options.newPath)) {
+      continue;
+    }
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const plan = asPlan(data);
+    if (plan === null) {
+      continue;
+    }
+    const referencesScope =
+      planReferencesMovedScope(plan, options.oldPath, options.newPath, options.vbriefRoot) ||
+      planReferencesCompletedIssue(plan, completedRefs);
+    if (!referencesScope) {
+      continue;
+    }
+    const ownRefs = issueRefsFromPlan(plan).filter((ref) => !completedKeys.has(issueKey(ref)));
+    for (const ref of ownRefs) {
+      const repo =
+        ref.repo ?? completedRefs.find((completed) => completed.repo !== null)?.repo ?? null;
+      addOpenUmbrella(umbrellas, readCachedIssue(options.projectRoot, repo, ref.number));
+    }
+  }
+}
+
+function scanCachedUmbrellaBodies(
+  options: ScopeCompleteUmbrellaWarningOptions,
+  completedRefs: readonly IssueRef[],
+  umbrellas: Map<number, CachedIssuePayload>,
+): void {
+  const repos = new Set(
+    completedRefs.map((ref) => ref.repo).filter((repo): repo is string => repo !== null),
+  );
+  for (const repo of repos) {
+    const [owner, name] = repo.split("/", 2);
+    const repoDir = join(
+      options.projectRoot,
+      CACHE_DIR_NAME,
+      CACHE_SOURCE_GITHUB_ISSUE,
+      owner ?? "",
+      name ?? "",
+    );
+    if (!existsSync(repoDir)) {
+      continue;
+    }
+    for (const entry of readdirSync(repoDir)) {
+      if (!/^\d+$/.test(entry)) {
+        continue;
+      }
+      const issue = readCachedIssue(options.projectRoot, repo, Number(entry));
+      if (!isOpenUmbrella(issue)) {
+        continue;
+      }
+      if (completedRefs.some((ref) => bodyMentionsIssue(issue.body, ref.number))) {
+        umbrellas.set(issue.number, issue);
+      }
+    }
+  }
+}
+
+export function scopeCompleteUmbrellaWarnings(
+  options: ScopeCompleteUmbrellaWarningOptions,
+): string[] {
+  try {
+    const plan = asPlan(options.scopeData);
+    if (plan === null) {
+      return [];
+    }
+    const completedRefs = issueRefsFromPlan(plan);
+    const umbrellas = new Map<number, CachedIssuePayload>();
+    scanLocalScopeReferences(options, completedRefs, umbrellas);
+    scanCachedUmbrellaBodies(options, completedRefs, umbrellas);
+    return [...umbrellas.values()]
+      .sort((a, b) => a.number - b.number)
+      .map(
+        (issue) =>
+          `Warning: scope completed but referenced by OPEN umbrella #${issue.number} -- run task vbrief:reconcile:umbrellas`,
+      );
+  } catch {
+    return [];
+  }
+}

--- a/xbrief/completed/2026-07-08-2322-scopecomplete-should-warn-reconcile-when-the-completed-scope.xbrief.json
+++ b/xbrief/completed/2026-07-08-2322-scopecomplete-should-warn-reconcile-when-the-completed-scope.xbrief.json
@@ -1,0 +1,40 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2322"
+  },
+  "plan": {
+    "title": "scope:complete should warn + reconcile when the completed scope is referenced by an OPEN umbrella",
+    "status": "completed",
+    "narratives": {
+      "Description": "scope:complete should warn + reconcile when the completed scope is referenced by an OPEN umbrella",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2322",
+      "Overview": "## Problem\n\nWhen `task scope:complete -- <path>` moves a scope xBRIEF `active/ -> completed/`, it fires no signal even when that scope is referenced by an **open umbrella / tracker issue**. The umbrella's `## Current shape` comment and body checklist keep showing the scope as in-flight, and nothing triggers a reconcile.\n\nThis is the uncovered angle between the two existing open items:\n- #370 (Epic tier RFC) covers the *epic <-> decomposed-child* relationship and auto-completion.\n- #1649 covers *umbrella current-shape / checkbox sync* for epics whose children are decomposed plan-refs.\n\nNeither covers a scope reaching `completed/` while an **open umbrella references it loosely** (working-set / meta tracker, or via legacy github-issue refs rather than `x-xbrief/plan`).\n\n## Concrete recurrence\n\nJust observed on PR #2320: `task scope:complete` on `2026-07-05-security-triage-deposit-ingest-umbrella-omnibus.xbrief.json` moved it to `completed/` while umbrella #1119 stayed OPEN (correctly -- it's a meta working-set tracker). But:\n- nothing warned that a still-open umbrella references the shipped scope, and\n- nothing offered / triggered `task vbrief:reconcile:umbrellas`.\n\nThis is the folder-vs-forge-state \"secondary smell\" from #1649, but at the **scope** (non-epic-child) level, so #1649's fix scope wouldn't catch it.\n\n## Proposed behavior\n\nOn `scope:complete`, after the folder move:\n\n1. **Detect** any open umbrella/tracker issue that references the completed scope -- via `plan.references[]` back-links, `planRef`, or a scan of open umbrellas whose current-shape/body lists the scope's issue number. Resolve BOTH canonical plan refs and legacy github-issue refs (the #1649 Defect 2 blind spot).\n2. **Warn** (non-blocking) naming the umbrella(s), e.g. `scope completed but referenced by OPEN umbrella #1119 -- run task vbrief:reconcile:umbrellas`.\n3. Optionally **auto-trigger** `reconcile:umbrellas` for the affected umbrella(s) (gated behind a flag / consent), closing the loop #1649 Defect \"no automation trigger\" leaves open.\n\n## Scope / relationship\n\n- Depends conceptually on #1649 Defects 2 + 3 (github-issue ref resolution + forge-state-aware open/closed) for the detection to be accurate.\n- Complementary to #370 auto-completion (that proposes completing the *epic*; this warns when a *scope* completes under an open *umbrella*).\n\nRefs #1649, #370, #1152, #1119.",
+      "Labels": "triage, source-of-truth, tooling, urgent"
+    },
+    "items": [],
+    "tags": [
+      "triage",
+      "source-of-truth",
+      "tooling",
+      "urgent"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2322",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2322: scope:complete should warn + reconcile when the completed scope is referenced by an OPEN umbrella"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1649",
+        "type": "x-xbrief/refs",
+        "title": "Issue #1649"
+      }
+    ],
+    "updated": "2026-07-08T10:40:57Z",
+    "metadata": {
+      "completedAt": "2026-07-08T10:40:57Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}


### PR DESCRIPTION
﻿## Summary

- Add a non-blocking `task scope:complete` warning when the completed scope is still referenced by an open umbrella/tracker in local xBRIEF or GitHub-issue cache state.
- Detect references through moved scope plan refs, completed-scope issue refs, and cached open umbrella body mentions.
- Add focused regression coverage and complete the #2322 scope brief.

Closes #2322.
Refs #1649, #370, #1119.

## Verification

- `pnpm exec vitest run packages/core/src/scope/umbrella-warning.test.ts`
- `task verify:xbrief-drift`
- `pnpm exec tsc -b`
- `task vbrief:validate` (passes with existing PRD staleness warning)
- `task verify:branch`
- `task check` (fails on existing pack projection drift for #336; branch-owned xBRIEF drift fixed)
