### PR TITLE
fix: unblock Windows Biome check lane (Closes #2389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`directive update` is idempotent on current Windows npm deposits.** Current installs now keep the vendored framework payload LF-pinned, skip payload copy and timestamp rewrites when the deposited content version is already current, and collapse CRLF-only `.deft/core` churn into a short line-ending hint instead of a long dirty-file list. The Windows CI smoke now covers `core.autocrlf=true` init/update/update plus `task deft:verify:cache-fresh` and `preflight-cache`. Closes #2118.
 - **Windows-native cache-fresh now has consumer-smoke coverage (#2120).** CI now stages a temp consumer repo with a deposited `.deft/core`, shims the built `deft` CLI, and verifies both direct `deft preflight-cache --allow-missing-bootstrap` and included `task deft:verify:cache-fresh` succeed without reaching a build path. Closes #2120.
+- **`task check` now reaches the Biome lane on native Windows CRLF checkouts.** The repo Biome formatter uses platform-native line endings, and the TypeScript lane now starts Windows `pnpm.cmd` shims through the shell instead of misreporting them as signal-killed. Closes #2389.
 
 ### Removed
 

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2,
+    "lineEnding": "auto",
     "lineWidth": 100
   },
   "linter": {

--- a/packages/core/src/ts-check-lane/run-lane.test.ts
+++ b/packages/core/src/ts-check-lane/run-lane.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { LANE_COMMANDS, resolvePnpm, runTsLane, SKIP_NOTICE } from "./run-lane.js";
+import {
+  LANE_COMMANDS,
+  resolvePnpm,
+  runTsLane,
+  SKIP_NOTICE,
+  shouldUseShellForCommand,
+} from "./run-lane.js";
 
 /** Records invocations and returns a scripted exit code per call. */
 class Runner {
@@ -66,11 +72,34 @@ describe("runTsLane", () => {
     const messages: string[] = [];
     const rc = runTsLane("/repo", {
       pnpm: "pnpm",
-      runner: () => ({ status: null }),
+      runner: () => ({ signal: "SIGTERM", status: null }),
       out: (m) => messages.push(m),
     });
     expect(rc).toBe(1);
-    expect(messages.some((m) => m.includes("killed by a signal"))).toBe(true);
+    expect(messages.some((m) => m.includes("killed by SIGTERM"))).toBe(true);
+  });
+
+  it("reports subprocess start errors separately from signal kills", () => {
+    const messages: string[] = [];
+    const rc = runTsLane("/repo", {
+      pnpm: "pnpm",
+      runner: () => ({ error: new Error("spawn EINVAL"), status: null }),
+      out: (m) => messages.push(m),
+    });
+    expect(rc).toBe(1);
+    expect(messages.some((m) => m.includes("failed to start: spawn EINVAL"))).toBe(true);
+  });
+});
+
+describe("shouldUseShellForCommand", () => {
+  it("uses a shell for Windows command shims", () => {
+    expect(shouldUseShellForCommand("C:\\bin\\pnpm.CMD", "win32")).toBe(true);
+    expect(shouldUseShellForCommand("C:\\bin\\pnpm.bat", "win32")).toBe(true);
+  });
+
+  it("does not use a shell for native executables or non-Windows platforms", () => {
+    expect(shouldUseShellForCommand("C:\\bin\\pnpm.EXE", "win32")).toBe(false);
+    expect(shouldUseShellForCommand("/usr/bin/pnpm", "linux")).toBe(false);
   });
 });
 

--- a/packages/core/src/ts-check-lane/run-lane.ts
+++ b/packages/core/src/ts-check-lane/run-lane.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { posix, win32 } from "node:path";
 
 /**
  * Run order is deliberate: lint (cheapest, catches the biome class first),
@@ -39,6 +39,8 @@ export const SKIP_NOTICE =
 /** Result of a single lane command invocation. Mirrors a subset of SpawnSyncReturns. */
 export interface RunnerResult {
   readonly status: number | null;
+  readonly signal?: NodeJS.Signals | null;
+  readonly error?: Error;
 }
 
 export type LaneRunner = (argv: readonly string[], cwd: string) => RunnerResult;
@@ -52,11 +54,24 @@ export interface RunTsLaneOptions {
   readonly out?: (message: string) => void;
 }
 
-/** Default runner: a non-shell, inherited-stdio pnpm invocation. */
+/** Windows command shims (.cmd/.bat) need a shell; native executables do not. */
+export function shouldUseShellForCommand(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "win32" && /\.(?:cmd|bat)$/i.test(command);
+}
+
+/** Default runner: an inherited-stdio pnpm invocation. */
 function defaultRunner(argv: readonly string[], cwd: string): RunnerResult {
   const [command, ...rest] = argv;
-  const result = spawnSync(command ?? "", rest, { cwd, stdio: "inherit" });
-  return { status: result.status };
+  const commandPath = command ?? "";
+  const result = spawnSync(commandPath, rest, {
+    cwd,
+    stdio: "inherit",
+    shell: shouldUseShellForCommand(commandPath),
+  });
+  return { error: result.error, signal: result.signal, status: result.status };
 }
 
 export interface ResolvePnpmOptions {
@@ -79,10 +94,11 @@ export function resolvePnpm(options: ResolvePnpmOptions = {}): string | null {
   const isWindows = platform === "win32";
   const exts = isWindows ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";") : [""];
   const sep = isWindows ? ";" : ":";
+  const joinPath = isWindows ? win32.join : posix.join;
   for (const dir of pathValue.split(sep)) {
     if (dir === "") continue;
     for (const ext of exts) {
-      const candidate = join(dir, `pnpm${ext}`);
+      const candidate = joinPath(dir, `pnpm${ext}`);
       if (exists(candidate)) {
         return candidate;
       }
@@ -117,8 +133,14 @@ export function runTsLane(projectRoot: string, options: RunTsLaneOptions): numbe
     // failure -- this mirrors the Python oracle, whose returncode is negative
     // (non-zero) for a signal-killed process.
     if (code === null) {
+      if (result.error) {
+        out(
+          `[ts:check-lane] \`pnpm ${command.join(" ")}\` failed to start: ${result.error.message}`,
+        );
+        return 1;
+      }
       out(
-        `[ts:check-lane] \`pnpm ${command.join(" ")}\` was killed by a signal before exit -- treating as failure.`,
+        `[ts:check-lane] \`pnpm ${command.join(" ")}\` was killed by ${result.signal ?? "a signal"} before exit -- treating as failure.`,
       );
       return 1;
     }

--- a/packages/core/src/verify-source/biome-config.test.ts
+++ b/packages/core/src/verify-source/biome-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -122,5 +122,13 @@ describe("evaluateBiomeConfigGuard", () => {
   it("validates the repo's own biome.json declares explicit severities", () => {
     const result = evaluateBiomeConfigGuard(join(import.meta.dirname, "..", "..", "..", ".."));
     expect(result.code).toBe(0);
+  });
+
+  it("keeps the repo biome formatter line ending platform-native for Windows checkouts", () => {
+    const root = join(import.meta.dirname, "..", "..", "..", "..");
+    const config = JSON.parse(readFileSync(join(root, "biome.json"), "utf8")) as {
+      formatter?: { lineEnding?: unknown };
+    };
+    expect(config.formatter?.lineEnding).toBe("auto");
   });
 });

--- a/xbrief/completed/2026-07-08-2389-bug-task-check-biome-lane-fails-on-native-windows-crlf-checkout.xbrief.json
+++ b/xbrief/completed/2026-07-08-2389-bug-task-check-biome-lane-fails-on-native-windows-crlf-checkout.xbrief.json
@@ -1,0 +1,47 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2389"
+  },
+  "plan": {
+    "title": "bug: task check Biome lane fails on native Windows CRLF checkout",
+    "status": "completed",
+    "narratives": {
+      "Description": "bug: task check Biome lane fails on native Windows CRLF checkout",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2389",
+      "Overview": "On a native Windows checkout with core.autocrlf=true, task check fails in ts:check-lane because biome check sees CRLF-normalized working-tree files and reports repo-wide line-ending formatter errors. The wrapper can also misreport Windows pnpm command-shim spawn failures as signal-killed lint runs. Keep the fix limited to Biome line-ending policy and Windows command-shim spawning so the TypeScript lane reaches lint/build without formatting churn.",
+      "Labels": "bug, windows, biome"
+    },
+    "items": [
+      {
+        "title": "Biome line-ending policy accepts platform-native CRLF working trees on Windows",
+        "status": "completed"
+      },
+      {
+        "title": "Native Windows checkout can run the Biome lane without repo-wide CRLF formatter errors",
+        "status": "completed"
+      },
+      {
+        "title": "TypeScript check lane starts Windows pnpm command shims without false signal-kill reports",
+        "status": "completed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "windows",
+      "biome"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2389",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2389: bug: task check Biome lane fails on native Windows CRLF checkout"
+      }
+    ],
+    "updated": "2026-07-08T12:46:30Z",
+    "metadata": {
+      "completedAt": "2026-07-08T12:46:30Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Set Biome formatter line endings to `auto` so native Windows CRLF checkouts do not fail before the source checks run.
- Start Windows `pnpm.cmd`/`.bat` shims through the shell in `ts-check-lane` and report spawn errors separately from signal exits.
- Add focused regression coverage, changelog, and the completed #2389 xBRIEF.
- Stabilize the date-sensitive `value:show` JSON fixture so July 8 CI no longer ages its default event outside the 7-day window.

## Verification
- `pnpm exec vitest run packages/core/src/verify-source/biome-config.test.ts packages/core/src/ts-check-lane/run-lane.test.ts packages/cli/src/ts-check-lane.test.ts`
- `pnpm exec vitest run packages/core/src/value/readback.test.ts -t "supports json output"`
- `pnpm run lint`
- `pnpm run build`
- `task vbrief:validate`
- `git diff --check origin/master...HEAD`
- current PR CI is green

## CI Note
- The final commit is test-only and keeps the shared TypeScript lane green while this PR is open. It does not change #2389 runtime behavior.

Closes #2389