### PR TITLE
fix(agents-md): drop spurious content/ prefix + dead docs/analysis links in managed template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,23 +366,21 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Umbrella status reading (#1152 / #2066)
 
-Rationale + cross-references: `.deft/core/docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Umbrella current-shape convention (#1152).
-
 - ! Fetch issue comments via REST (`gh api repos/<owner>/<repo>/issues/<N>/comments`), read the `## Current shape (as of pass-N)` comment, and any linked context or `LockedDecisions` xBRIEF referenced there — following the reading order body -> current-shape comment -> amendment comments (claim-cites-state-surface, #2066). Prefer the deterministic read path: `deft umbrella:current-shape <N>` (or `task umbrella:current-shape <N>`) — it locates the canonical comment, validates #1152 sections, and never falls back to the issue body.
 - ⊗ Conclude umbrella or epic status from the issue body alone. Any "X is done" / "X is the blocker" assertion about an umbrella MUST cite the current-shape comment or another state artifact, not the body.
 
 ## Deterministic questions runtime obligation (#1470)
 
-Rationale + cross-references: `.deft/core/content/contracts/deterministic-questions.md` (#767); closes the agent-runtime enforcement gap on issue #1470.
+Rationale + cross-references: `.deft/core/contracts/deterministic-questions.md` (#767); closes the agent-runtime enforcement gap on issue #1470.
 
-- ! ANY agent-initiated structured question — whether via host `ask_user_question` / `AskQuestion` tooling or a numbered menu rendered in chat — inside OR outside any skill flow MUST include `Discuss` and `Back` as the final two options, in that order, and MUST obey the Discuss-pause semantic documented verbatim in `.deft/core/content/contracts/deterministic-questions.md`.
+- ! ANY agent-initiated structured question — whether via host `ask_user_question` / `AskQuestion` tooling or a numbered menu rendered in chat — inside OR outside any skill flow MUST include `Discuss` and `Back` as the final two options, in that order, and MUST obey the Discuss-pause semantic documented verbatim in `.deft/core/contracts/deterministic-questions.md`.
 - ! Before emitting any structured or numbered question, self-check: confirm `Discuss` and `Back` are present as the final two options; if not, add them before calling the tool or rendering the menu. Host-native `Other` / free-text affordances are NOT substitutes for `Discuss` (#767 / #431).
 - ⊗ Emit a structured or numbered question without `Discuss` and `Back` as the final two options — including ad-hoc orchestration approvals, dispatch confirmations, and decision walkthroughs outside interview/setup/refinement skills.
 - ⊗ Treat the host UI's automatic `Other` option as the stop-and-discuss escape hatch — `Other` widens the answer space; `Discuss` exits the deterministic flow entirely (see contract).
 
 ## Issue body→comments reading (#2143)
 
-Rationale + cross-references: `.deft/core/docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Issue body→comments reading (#2143); preamble § 5.6 in `.deft/core/content/templates/agent-prompt-preamble.md`.
+Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-prompt-preamble.md` (#2143).
 
 - ! Fetch both the issue body and `repos/<owner>/<repo>/issues/<N>/comments` via REST before concluding what the issue asks for or building a worker dispatch envelope. Read body first, then the comment thread in chronological order.
 - ! `deft issue:ingest` / `task issue:ingest` fetches `/comments` by default and folds the thread into the ingested overview (#2143).
@@ -462,7 +460,7 @@ Override paths (`deft policy:show` / `deft policy:enforce-branches` / `deft poli
 
 ## Platform-conditional rules (PowerShell / Windows)
 
-Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they don't crowd context for sessions that can't trigger them (#2157 / #1882). If your session matches a trigger below, load `.deft/core/content/scm/github.md` § "PowerShell platform-conditional rules for agents" **before** the risky operation:
+Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they don't crowd context for sessions that can't trigger them (#2157 / #1882). If your session matches a trigger below, load `.deft/core/scm/github.md` § "PowerShell platform-conditional rules for agents" **before** the risky operation:
 
 - ! Editing files with non-ASCII glyphs from PowerShell (especially PS 5.1) -- enforced at commit by `deft verify:encoding` (#798).
 - ! Running shell commands under the Grok Build Windows + pwsh 7+ runtime -- piped/redirected commands leak wrapper text (#1353); PTY-based Warp + Claude are exempt.
@@ -492,7 +490,7 @@ Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they
 
 ## Commands
 
-Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `content/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
+Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `.deft/core/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
 
 **Directive product (`/deft:directive:*`):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Consumer `AGENTS.md` cross-references now resolve correctly after install.** The managed template rendered a spurious `content/` path segment and two dead maintainer-only rationale links into every consumer's `AGENTS.md`, so the affected links 404'd for anyone outside the framework repo. Both are fixed and this repo's own `AGENTS.md` is regenerated to match. PR #2408.
-
 ### Fixed
 
 - **`directive update` is idempotent on current Windows npm deposits.** Current installs now keep the vendored framework payload LF-pinned, skip payload copy and timestamp rewrites when the deposited content version is already current, and collapse CRLF-only `.deft/core` churn into a short line-ending hint instead of a long dirty-file list. The Windows CI smoke now covers `core.autocrlf=true` init/update/update plus `task deft:verify:cache-fresh` and `preflight-cache`. Closes #2118.
 - **Windows-native cache-fresh now has consumer-smoke coverage (#2120).** CI now stages a temp consumer repo with a deposited `.deft/core`, shims the built `deft` CLI, and verifies both direct `deft preflight-cache --allow-missing-bootstrap` and included `task deft:verify:cache-fresh` succeed without reaching a build path. Closes #2120.
 - **`task check` now reaches the Biome lane on native Windows CRLF checkouts.** The repo Biome formatter uses platform-native line endings, and the TypeScript lane now starts Windows `pnpm.cmd` shims through the shell instead of misreporting them as signal-killed. Closes #2389.
+- **Consumer `AGENTS.md` cross-references now resolve correctly after install.** The managed template rendered a spurious `content/` path segment and two dead maintainer-only rationale links into every consumer's `AGENTS.md`, so the affected links 404'd for anyone outside the framework repo. Both are fixed and this repo's own `AGENTS.md` is regenerated to match. PR #2408.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Consumer `AGENTS.md` cross-references now resolve correctly after install.** The managed template rendered a spurious `content/` path segment and two dead maintainer-only rationale links into every consumer's `AGENTS.md`, so the affected links 404'd for anyone outside the framework repo. Both are fixed and this repo's own `AGENTS.md` is regenerated to match. PR #2408.
+
 ### Fixed
 
 - **`directive update` is idempotent on current Windows npm deposits.** Current installs now keep the vendored framework payload LF-pinned, skip payload copy and timestamp rewrites when the deposited content version is already current, and collapse CRLF-only `.deft/core` churn into a short line-ending hint instead of a long dirty-file list. The Windows CI smoke now covers `core.autocrlf=true` init/update/update plus `task deft:verify:cache-fresh` and `preflight-cache`. Closes #2118.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -96,23 +96,21 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Umbrella status reading (#1152 / #2066)
 
-Rationale + cross-references: `.deft/core/docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Umbrella current-shape convention (#1152).
-
 - ! Fetch issue comments via REST (`gh api repos/<owner>/<repo>/issues/<N>/comments`), read the `## Current shape (as of pass-N)` comment, and any linked context or `LockedDecisions` xBRIEF referenced there — following the reading order body -> current-shape comment -> amendment comments (claim-cites-state-surface, #2066). Prefer the deterministic read path: `deft umbrella:current-shape <N>` (or `task umbrella:current-shape <N>`) — it locates the canonical comment, validates #1152 sections, and never falls back to the issue body.
 - ⊗ Conclude umbrella or epic status from the issue body alone. Any "X is done" / "X is the blocker" assertion about an umbrella MUST cite the current-shape comment or another state artifact, not the body.
 
 ## Deterministic questions runtime obligation (#1470)
 
-Rationale + cross-references: `.deft/core/content/contracts/deterministic-questions.md` (#767); closes the agent-runtime enforcement gap on issue #1470.
+Rationale + cross-references: `.deft/core/contracts/deterministic-questions.md` (#767); closes the agent-runtime enforcement gap on issue #1470.
 
-- ! ANY agent-initiated structured question — whether via host `ask_user_question` / `AskQuestion` tooling or a numbered menu rendered in chat — inside OR outside any skill flow MUST include `Discuss` and `Back` as the final two options, in that order, and MUST obey the Discuss-pause semantic documented verbatim in `.deft/core/content/contracts/deterministic-questions.md`.
+- ! ANY agent-initiated structured question — whether via host `ask_user_question` / `AskQuestion` tooling or a numbered menu rendered in chat — inside OR outside any skill flow MUST include `Discuss` and `Back` as the final two options, in that order, and MUST obey the Discuss-pause semantic documented verbatim in `.deft/core/contracts/deterministic-questions.md`.
 - ! Before emitting any structured or numbered question, self-check: confirm `Discuss` and `Back` are present as the final two options; if not, add them before calling the tool or rendering the menu. Host-native `Other` / free-text affordances are NOT substitutes for `Discuss` (#767 / #431).
 - ⊗ Emit a structured or numbered question without `Discuss` and `Back` as the final two options — including ad-hoc orchestration approvals, dispatch confirmations, and decision walkthroughs outside interview/setup/refinement skills.
 - ⊗ Treat the host UI's automatic `Other` option as the stop-and-discuss escape hatch — `Other` widens the answer space; `Discuss` exits the deterministic flow entirely (see contract).
 
 ## Issue body→comments reading (#2143)
 
-Rationale + cross-references: `.deft/core/docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Issue body→comments reading (#2143); preamble § 5.6 in `.deft/core/content/templates/agent-prompt-preamble.md`.
+Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-prompt-preamble.md` (#2143).
 
 - ! Fetch both the issue body and `repos/<owner>/<repo>/issues/<N>/comments` via REST before concluding what the issue asks for or building a worker dispatch envelope. Read body first, then the comment thread in chronological order.
 - ! `deft issue:ingest` / `task issue:ingest` fetches `/comments` by default and folds the thread into the ingested overview (#2143).
@@ -192,7 +190,7 @@ Override paths (`deft policy:show` / `deft policy:enforce-branches` / `deft poli
 
 ## Platform-conditional rules (PowerShell / Windows)
 
-Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they don't crowd context for sessions that can't trigger them (#2157 / #1882). If your session matches a trigger below, load `.deft/core/content/scm/github.md` § "PowerShell platform-conditional rules for agents" **before** the risky operation:
+Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they don't crowd context for sessions that can't trigger them (#2157 / #1882). If your session matches a trigger below, load `.deft/core/scm/github.md` § "PowerShell platform-conditional rules for agents" **before** the risky operation:
 
 - ! Editing files with non-ASCII glyphs from PowerShell (especially PS 5.1) -- enforced at commit by `deft verify:encoding` (#798).
 - ! Running shell commands under the Grok Build Windows + pwsh 7+ runtime -- piped/redirected commands leak wrapper text (#1353); PTY-based Warp + Claude are exempt.
@@ -222,7 +220,7 @@ Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they
 
 ## Commands
 
-Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `content/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
+Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `.deft/core/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
 
 **Directive product (`/deft:directive:*`):**
 


### PR DESCRIPTION
## Problem

The managed-section template (`content/templates/agents-entry.md`) emits several **consumer-relative** cross-references that don't resolve on a consumer deposit:

1. **Spurious `content/` segment.** The prepack flattens `content/` into the package root, so on a consumer these files live at `.deft/core/<...>`. The template instead rendered `.deft/core/content/<...>`, making the links dead:
   - `.deft/core/content/contracts/deterministic-questions.md` → `.deft/core/contracts/deterministic-questions.md`
   - `.deft/core/content/scm/github.md` → `.deft/core/scm/github.md`
   - `.deft/core/content/templates/agent-prompt-preamble.md` → `.deft/core/templates/agent-prompt-preamble.md`
   - `content/commands.md` → `.deft/core/commands.md`
2. **Dead `docs/analysis/` links.** Two references to `.deft/core/docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` — `docs/analysis/` is maintainer-only and is **not shipped in the npm payload**, so the path never resolves for consumers.

These render verbatim into every consumer's `AGENTS.md` managed section, so a downstream framework-update PR flagged them (Greptile, 2×P1).

## Fix

- Strip the `content/` segment from the four consumer paths in the managed template.
- Drop the two dead `docs/analysis/...rationale.md` cross-reference lines from the managed body (the `## Umbrella status reading` rationale line is removed entirely; the `## Issue body→comments reading` line keeps its still-valid preamble reference).
- Regenerate this repo's own `AGENTS.md` managed section from the fixed template so the managed-section drift gate stays green.

The **unmanaged maintainer sections** keep their source-relative `docs/analysis/` and `content/` paths — those are correct in-repo and are intentionally unchanged.

## Validation

- `renderManagedSection(template) === managed body of AGENTS.md` (body-equality drift check) holds; the version-stamp `sha=` is unaffected (it's framework-version-derived, and the freshness check strips marker attributes before comparing).
- `vitest run` on the affected suites is green:
  - `content-contracts/skills/agents_entry_contract.test.ts` ✅
  - `content-contracts/skills/agents_md_current_shape.test.ts` ✅ (targets the unmanaged "Umbrella current-shape convention" section, unaffected)
  - full `content-contracts` + `platform` + `doctor` + `init-deposit` sweep: 3740 passed; the only failures are environment-local (`pnpm` not on PATH for `task`-invoking release/render tests, and a git-tag version seam in a throwaway repo) — unrelated to this change.

Docs-only change to a template + its regenerated render; no code paths touched.

Made with [Cursor](https://cursor.com)