### PR TITLE
fix: refuse symlink escapes in Go installer consumer projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Go installer consumer projections now refuse repo-controlled symlinks.** `deft-install` checks AGENTS.md, vbrief/, `.agents/`, `.githooks/`, and related projection targets with Lstat/containment before writing, so a malicious checkout cannot trick install or upgrade into overwriting files outside the project tree. Closes #2383.
+
 - **Windows-native `engine:_ts-build` now detects Corepack without Unix `sh`.** Package-manager probes use a cross-platform `shell:true` `--version` check so `corepack.cmd` is visible when bare `pnpm` and `sh` are absent from PATH, while preserving the #2411 Corepack step order and #2181 no-auto-build session path. Closes #2415. Refs #2410, #2411.
 
 ### Removed

--- a/cmd/deft-install/githooks.go
+++ b/cmd/deft-install/githooks.go
@@ -117,6 +117,9 @@ var gitIndexChmodExecFunc = func(dir string, relPaths ...string) error {
 // tree, permission denied) is returned so the installer can surface it; callers
 // treat hook wiring as non-fatal, mirroring depositNeutralization.
 func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) {
+	if err := assertConsumerProjectionContained(projectDir, consumerHooksDirName); err != nil {
+		return false, err
+	}
 	srcDir := filepath.Join(deftDir, consumerHooksDirName)
 	info, err := os.Stat(srcDir)
 	if err != nil || !info.IsDir() {
@@ -143,6 +146,10 @@ func WriteConsumerGitHooks(w *Wizard, projectDir, deftDir string) (bool, error) 
 			return false, fmt.Errorf("could not read hook %s: %w", name, err)
 		}
 		dst := filepath.Join(dstDir, name)
+		hookRel := filepath.ToSlash(filepath.Join(consumerHooksDirName, name))
+		if err := assertConsumerProjectionContained(projectDir, hookRel); err != nil {
+			return false, err
+		}
 		// Idempotency probe: skip the WRITE ONLY when the hook is already present
 		// byte-for-byte. A read error (os.ErrNotExist on first deposit, or an
 		// unreadable existing hook) is intentionally folded into upToDate=false so

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -17,6 +17,133 @@ import (
 	"github.com/deftai/directive/content/templates"
 )
 
+// ---------------------------------------------------------------------------
+// Consumer projection containment (#2383)
+// ---------------------------------------------------------------------------
+//
+// Consumer projection helpers write repo-relative targets (AGENTS.md, vbrief/,
+// .agents/, .githooks/, etc.) via MkdirAll / WriteFile / copyDir / Chmod. A
+// malicious repo that commits one of those names as a symlink pointing outside
+// the checkout would otherwise let install/upgrade follow the link and write
+// out-of-tree. assertConsumerProjectionContained mirrors the deposit-boundary
+// guard in packages/core/src/deposit/contain.ts (#2305): Lstat each existing
+// path component, refuse escaping symlinks, and assert segment containment
+// (filepath.Rel, not string HasPrefix).
+
+// pathSegmentContained reports whether child is equal to parent or nested under
+// it using path-segment containment (so /foo does not contain /foobar).
+func pathSegmentContained(parent, child string) bool {
+	if parent == child {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel) && rel != ""
+}
+
+// assertDestinationNotSymlink refuses when target already exists as a symlink.
+// Missing paths are allowed — only pre-existing symlinks matter.
+func assertDestinationNotSymlink(target string) error {
+	info, err := os.Lstat(target)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("consumer projection: lstat %s: %w", target, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("consumer projection refused: refusing to write through destination symlink %s", target)
+	}
+	return nil
+}
+
+// assertConsumerProjectionContained refuses when targetRel (POSIX-style, relative
+// to projectDir) or any existing component on the way to it is a symlink that
+// escapes the resolved project tree. Call before MkdirAll / WriteFile / Chmod
+// on consumer projection targets (#2383).
+func assertConsumerProjectionContained(projectDir, targetRel string) error {
+	projectAbs, err := filepath.Abs(projectDir)
+	if err != nil {
+		return fmt.Errorf("consumer projection: %w", err)
+	}
+	projectReal, err := filepath.EvalSymlinks(projectAbs)
+	if err != nil {
+		return fmt.Errorf("consumer projection: resolve project root: %w", err)
+	}
+
+	targetRel = filepath.ToSlash(strings.TrimPrefix(targetRel, "./"))
+	targetAbs := filepath.Join(projectAbs, filepath.FromSlash(targetRel))
+	relToProject, err := filepath.Rel(projectAbs, targetAbs)
+	if err != nil || relToProject == ".." || strings.HasPrefix(relToProject, ".."+string(filepath.Separator)) || filepath.IsAbs(relToProject) {
+		return fmt.Errorf("consumer projection refused: %s is not under the project root", targetRel)
+	}
+
+	segments := strings.Split(targetRel, "/")
+	current := projectAbs
+	deepestExistingReal := projectReal
+
+	for _, seg := range segments {
+		if seg == "" || seg == "." {
+			continue
+		}
+		current = filepath.Join(current, seg)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				break
+			}
+			return fmt.Errorf("consumer projection: lstat %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkReal, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return fmt.Errorf("consumer projection refused: %s is a broken symlink: %w", current, err)
+			}
+			if !pathSegmentContained(projectReal, linkReal) {
+				return fmt.Errorf(
+					"consumer projection refused: %s is a symlink escaping the project tree (resolves to %s, outside %s)",
+					current, linkReal, projectReal,
+				)
+			}
+			deepestExistingReal = linkReal
+		} else {
+			linkReal, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return fmt.Errorf("consumer projection: resolve %s: %w", current, err)
+			}
+			deepestExistingReal = linkReal
+		}
+	}
+
+	if !pathSegmentContained(projectReal, deepestExistingReal) {
+		return fmt.Errorf(
+			"consumer projection refused: path escapes the project tree (%s is outside %s)",
+			deepestExistingReal, projectReal,
+		)
+	}
+	return nil
+}
+
+// assertConsumerProjectionPath is assertConsumerProjectionContained for an
+// absolute target path under projectDir.
+func assertConsumerProjectionPath(projectDir, targetAbs string) error {
+	projectAbs, err := filepath.Abs(projectDir)
+	if err != nil {
+		return fmt.Errorf("consumer projection: %w", err)
+	}
+	targetAbs, err = filepath.Abs(targetAbs)
+	if err != nil {
+		return fmt.Errorf("consumer projection: %w", err)
+	}
+	rel, err := filepath.Rel(projectAbs, targetAbs)
+	if err != nil {
+		return fmt.Errorf("consumer projection: %w", err)
+	}
+	return assertConsumerProjectionContained(projectDir, filepath.ToSlash(rel))
+}
+
 // bareSemverPattern matches a bare `X.Y.Z[-pre][+build]` semver triple (no
 // leading `v`). Used by BuildInstallManifestText to gate the v-prefix
 // normalisation: only bare semver strings get the `v` prepended; branch refs
@@ -585,6 +712,9 @@ func rewriteAgentsMDBlock(body, replacement string) (string, bool) {
 // (the same value the deposit path uses) and normalised to POSIX form so the
 // AGENTS.md body never carries Windows backslashes regardless of host OS.
 func WriteAgentsMD(w *Wizard, projectDir string) error {
+	if err := assertConsumerProjectionContained(projectDir, "AGENTS.md"); err != nil {
+		return err
+	}
 	installRoot := filepath.ToSlash(w.frameworkSubdir())
 	path := filepath.Join(projectDir, "AGENTS.md")
 	body := renderAgentsEntry(installRoot)
@@ -703,6 +833,9 @@ func WriteAgentsMD(w *Wizard, projectDir string) error {
 // canonical default). Returns true if the file was modified -- a heal with no
 // additions still counts as a modification.
 func EnsureGitignoreLines(w *Wizard, projectDir string) (bool, error) {
+	if err := assertConsumerProjectionContained(projectDir, ".gitignore"); err != nil {
+		return false, err
+	}
 	path := filepath.Join(projectDir, ".gitignore")
 	existing := ""
 	if data, err := os.ReadFile(path); err == nil {
@@ -936,6 +1069,9 @@ func insertDeftIncludeAfterIncludesLine(content string) (string, bool) {
 // that is correct regardless of what other top-level keys come after
 // `includes:`.
 func EnsureTaskfile(w *Wizard, projectDir string) (bool, error) {
+	if err := assertConsumerProjectionContained(projectDir, "Taskfile.yml"); err != nil {
+		return false, err
+	}
 	path := filepath.Join(projectDir, "Taskfile.yml")
 	existing := ""
 	if data, err := os.ReadFile(path); err == nil {
@@ -1486,11 +1622,19 @@ const vbriefLifecycleGitkeepBody = `# This file keeps the lifecycle directory pr
 // later) are preserved. When a lifecycle directory already contains files
 // (e.g. the operator has filed scope vBRIEFs there) the `.gitkeep` is skipped
 // because the directory is no longer empty.
-func ensureVbriefLifecycleDirs(consumerVbrief string) error {
+func ensureVbriefLifecycleDirs(projectDir, consumerVbrief string) error {
 	for _, sub := range vbriefLifecycleDirs {
+		dirRel := filepath.ToSlash(filepath.Join("vbrief", sub))
+		if err := assertConsumerProjectionContained(projectDir, dirRel); err != nil {
+			return err
+		}
 		dir := filepath.Join(consumerVbrief, sub)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("could not create vbrief/%s/: %w", sub, err)
+		}
+		gitkeepRel := filepath.ToSlash(filepath.Join("vbrief", sub, ".gitkeep"))
+		if err := assertConsumerProjectionContained(projectDir, gitkeepRel); err != nil {
+			return err
 		}
 		gitkeep := filepath.Join(dir, ".gitkeep")
 		if _, err := os.Stat(gitkeep); err == nil {
@@ -1552,6 +1696,9 @@ func vbriefLifecycleDirsPresent(consumerVbrief string) bool {
 // lifecycle dirs at install time keeps the guard quiet and the install
 // greenfield-ready.
 func WriteConsumerVbrief(w *Wizard, projectDir, deftDir string) (bool, error) {
+	if err := assertConsumerProjectionContained(projectDir, "vbrief"); err != nil {
+		return false, err
+	}
 	consumerVbrief := filepath.Join(projectDir, "vbrief")
 	schemasDst := filepath.Join(consumerVbrief, "schemas")
 	vbriefMDDst := filepath.Join(consumerVbrief, "vbrief.md")
@@ -1578,7 +1725,7 @@ func WriteConsumerVbrief(w *Wizard, projectDir, deftDir string) (bool, error) {
 	if !schemasPresent {
 		fwSchemas := filepath.Join(deftDir, "vbrief", "schemas")
 		if info, err := os.Stat(fwSchemas); err == nil && info.IsDir() {
-			if err := copyDir(fwSchemas, schemasDst); err != nil {
+			if err := copyDir(fwSchemas, schemasDst, projectDir); err != nil {
 				return false, fmt.Errorf("could not seed vbrief/schemas/: %w", err)
 			}
 		} else {
@@ -1606,7 +1753,7 @@ func WriteConsumerVbrief(w *Wizard, projectDir, deftDir string) (bool, error) {
 	// Materialise the canonical lifecycle directories (#1179). Done
 	// unconditionally on every call so a half-state install left behind by
 	// an older installer rail is repaired on the next re-run.
-	if err := ensureVbriefLifecycleDirs(consumerVbrief); err != nil {
+	if err := ensureVbriefLifecycleDirs(projectDir, consumerVbrief); err != nil {
 		return false, err
 	}
 
@@ -1617,13 +1764,22 @@ func WriteConsumerVbrief(w *Wizard, projectDir, deftDir string) (bool, error) {
 // copyDir recursively copies src into dst. Intermediate directories are
 // created with mode 0o755; files keep their source bytes. Used by
 // WriteConsumerVbrief to seed schemas from the framework deposit.
-func copyDir(src, dst string) error {
+func copyDir(src, dst, projectDir string) error {
+	if err := assertConsumerProjectionPath(projectDir, dst); err != nil {
+		return err
+	}
 	return filepathWalk(src, func(srcPath string, isDir bool) error {
 		rel, err := filepath.Rel(src, srcPath)
 		if err != nil {
 			return err
 		}
 		dstPath := filepath.Join(dst, rel)
+		if err := assertConsumerProjectionPath(projectDir, dstPath); err != nil {
+			return err
+		}
+		if err := assertDestinationNotSymlink(dstPath); err != nil {
+			return err
+		}
 		if isDir {
 			return os.MkdirAll(dstPath, 0o755)
 		}
@@ -1711,6 +1867,9 @@ func copyStream(in io.Reader, out io.WriteCloser) (err error) {
 // Idempotent — skips only when all skill files are present.
 // Returns true if files were created, false if skipped.
 func WriteAgentsSkills(w *Wizard, projectDir string) (bool, error) {
+	if err := assertConsumerProjectionContained(projectDir, ".agents"); err != nil {
+		return false, err
+	}
 	// All skills that the installer creates thin pointers for.
 	allSkillNames := []string{
 		"deft", "deft-directive-setup", "deft-directive-build",
@@ -1751,6 +1910,10 @@ func WriteAgentsSkills(w *Wizard, projectDir string) (bool, error) {
 	}
 
 	for _, skill := range skills {
+		skillRel := filepath.ToSlash(filepath.Join(".agents", "skills", skill.dir, "SKILL.md"))
+		if err := assertConsumerProjectionContained(projectDir, skillRel); err != nil {
+			return false, err
+		}
 		dir := filepath.Join(projectDir, ".agents", "skills", skill.dir)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return false, fmt.Errorf("could not create %s: %w", dir, err)

--- a/cmd/deft-install/setup_test.go
+++ b/cmd/deft-install/setup_test.go
@@ -1098,20 +1098,21 @@ func TestWriteConsumerVbrief_LifecycleDirs_Idempotent(t *testing.T) {
 // WriteConsumerVbrief) still get covered.
 func TestEnsureVbriefLifecycleDirs_DirectCall(t *testing.T) {
 	tmp := t.TempDir()
-	if err := ensureVbriefLifecycleDirs(tmp); err != nil {
+	consumerVbrief := filepath.Join(tmp, "vbrief")
+	if err := ensureVbriefLifecycleDirs(tmp, consumerVbrief); err != nil {
 		t.Fatal(err)
 	}
 	for _, sub := range vbriefLifecycleDirsExpected {
-		if info, err := os.Stat(filepath.Join(tmp, sub)); err != nil || !info.IsDir() {
+		if info, err := os.Stat(filepath.Join(consumerVbrief, sub)); err != nil || !info.IsDir() {
 			t.Errorf("ensureVbriefLifecycleDirs did not create %s: %v", sub, err)
 		}
-		if _, err := os.Stat(filepath.Join(tmp, sub, ".gitkeep")); err != nil {
+		if _, err := os.Stat(filepath.Join(consumerVbrief, sub, ".gitkeep")); err != nil {
 			t.Errorf("ensureVbriefLifecycleDirs did not drop .gitkeep in %s: %v", sub, err)
 		}
 	}
 
 	// Calling again must be a no-op on the filesystem.
-	if err := ensureVbriefLifecycleDirs(tmp); err != nil {
+	if err := ensureVbriefLifecycleDirs(tmp, consumerVbrief); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -2330,5 +2331,112 @@ func TestUpgradeRefreshBeforeStage_NoStragglers_RealGit(t *testing.T) {
 		if x := ln[0]; x == '?' || x == ' ' {
 			t.Errorf("post-stage straggler: framework file %q is unstaged (status %q) -- refresh-before-stage invariant violated (#1671)", paths[0], ln[:2])
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Consumer projection containment (#2383)
+// ---------------------------------------------------------------------------
+
+func seedOutsideSymlinkTarget(t *testing.T) string {
+	t.Helper()
+	outside := filepath.Join(t.TempDir(), "outside-target")
+	if err := os.WriteFile(outside, []byte("untouched-sensitive-content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return outside
+}
+
+func symlinkOrSkip(t *testing.T, oldname, newname string) {
+	t.Helper()
+	if err := os.Symlink(oldname, newname); err != nil {
+		t.Skipf("symlink not supported on this host: %v", err)
+	}
+}
+
+// TestWriteAgentsMD_SymlinkOutside_RejectsProjection pins #2383: when AGENTS.md
+// is a repo-controlled symlink pointing outside the checkout, WriteAgentsMD
+// refuses before writing through the link.
+func TestWriteAgentsMD_SymlinkOutside_RejectsProjection(t *testing.T) {
+	proj := t.TempDir()
+	outside := seedOutsideSymlinkTarget(t)
+	symlinkOrSkip(t, outside, filepath.Join(proj, "AGENTS.md"))
+
+	w := NewWizard(strings.NewReader(""), io.Discard, false)
+	err := WriteAgentsMD(w, proj)
+	if err == nil {
+		t.Fatal("expected WriteAgentsMD to refuse symlink AGENTS.md, got nil")
+	}
+	if !strings.Contains(err.Error(), "consumer projection refused") {
+		t.Fatalf("expected containment refusal, got: %v", err)
+	}
+	got, readErr := os.ReadFile(outside)
+	if readErr != nil {
+		t.Fatalf("read outside target: %v", readErr)
+	}
+	if string(got) != "untouched-sensitive-content\n" {
+		t.Fatalf("outside target was modified through symlink; got %q", got)
+	}
+}
+
+// TestWriteConsumerGitHooks_SymlinkHooksDir_RejectsProjection pins #2383:
+// when .githooks is a symlink escaping the project tree, hook deposit refuses.
+func TestWriteConsumerGitHooks_SymlinkHooksDir_RejectsProjection(t *testing.T) {
+	origStatus := gitPorcelainStatusFunc
+	origGet := gitConfigGetHooksPathFunc
+	origSet := setGitHooksPathFunc
+	origIdx := gitIndexChmodExecFunc
+	defer func() {
+		gitPorcelainStatusFunc = origStatus
+		gitConfigGetHooksPathFunc = origGet
+		setGitHooksPathFunc = origSet
+		gitIndexChmodExecFunc = origIdx
+	}()
+
+	proj := t.TempDir()
+	deftDir := filepath.Join(proj, ".deft", "core")
+	seedPayloadHooks(t, deftDir)
+
+	outsideDir := filepath.Join(t.TempDir(), "outside-hooks")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkOrSkip(t, outsideDir, filepath.Join(proj, ".githooks"))
+
+	gitPorcelainStatusFunc = func(string) ([]string, bool, error) { return nil, true, nil }
+	gitConfigGetHooksPathFunc = func(string) (string, error) { return "", nil }
+	setGitHooksPathFunc = func(string, string) error { return nil }
+	gitIndexChmodExecFunc = func(string, ...string) error { return nil }
+
+	_, err := WriteConsumerGitHooks(newGithooksWizard(), proj, deftDir)
+	if err == nil {
+		t.Fatal("expected WriteConsumerGitHooks to refuse symlink .githooks, got nil")
+	}
+	if !strings.Contains(err.Error(), "consumer projection refused") {
+		t.Fatalf("expected containment refusal, got: %v", err)
+	}
+	entries, err := os.ReadDir(outsideDir)
+	if err != nil {
+		t.Fatalf("read outside hooks dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no hooks written through symlink, found %d entries", len(entries))
+	}
+}
+
+// TestWriteAgentsMD_RegularFile_Succeeds pins #2383 happy path: a normal
+// AGENTS.md deposit still succeeds when the target is not a symlink.
+func TestWriteAgentsMD_RegularFile_Succeeds(t *testing.T) {
+	proj := t.TempDir()
+	w := NewWizard(strings.NewReader(""), io.Discard, false)
+	if err := WriteAgentsMD(w, proj); err != nil {
+		t.Fatalf("WriteAgentsMD on greenfield project: %v", err)
+	}
+	info, err := os.Lstat(filepath.Join(proj, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("stat AGENTS.md: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("AGENTS.md should be a regular file, not a symlink")
 	}
 }


### PR DESCRIPTION
## Summary
- Add Lstat/containment guards to Go installer consumer projection helpers (`setup.go`, `githooks.go`) so repo-controlled symlinks at `AGENTS.md`, `vbrief/`, `.agents/`, or `.githooks/` cannot redirect install/upgrade writes outside the checkout.
- Add regression tests for symlink `AGENTS.md`, symlink `.githooks`, and the greenfield happy path.
- CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] `go test ./cmd/deft-install/...`
- [ ] CI green

Closes #2383

Made with [Cursor](https://cursor.com)