### PR TITLE
fix: stale Greptile P0/P1 hard blocks + excluded-author pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Merge-readiness no longer clears stale Greptile P0/P1 blockers when GitHub reports clean.** Stale verdicts that carried real P0/P1, errored, or low-confidence findings now stay hard blocks instead of being softened by the GitHub mergeability override, and Dependabot PRs with Greptile excluded-author skip comments are treated as pass rather than parse failures. Closes #2382. Closes #2375.
 - **Go installer consumer projections now refuse repo-controlled symlinks.** `deft-install` checks AGENTS.md, vbrief/, `.agents/`, `.githooks/`, and related projection targets with Lstat/containment before writing, so a malicious checkout cannot trick install or upgrade into overwriting files outside the project tree. Closes #2383.
 - **Deposited git hooks no longer fail on repos without a lifecycle tree, and pre-push resolves project config from the repo root.** Pre-commit now runs `verify:xbrief-drift` only when `xbrief/` or `vbrief/` exists (matching the conformance guard), and pre-push passes `--project-root` to `preflight-gh` for parity with the other hook gates. Closes #2406.
 - **Windows-native `engine:_ts-build` now detects Corepack without Unix `sh`.** Package-manager probes use a cross-platform `shell:true` `--version` check so `corepack.cmd` is visible when bare `pnpm` and `sh` are absent from PATH, while preserving the #2411 Corepack step order and #2181 no-auto-build session path. Closes #2415. Refs #2410, #2411.

--- a/packages/core/src/pr-merge-readiness/compute.test.ts
+++ b/packages/core/src/pr-merge-readiness/compute.test.ts
@@ -105,6 +105,32 @@ describe("computeGateResult #2260 reconciliation", () => {
     expect(mergeability.mergeable_state).toBe("unstable");
   });
 
+  it("does NOT merge stale P0/P1 even when GitHub is CLEAN (#2382)", () => {
+    const body =
+      "## Greptile Summary\n\n**Confidence Score: 5/5**\n\n" +
+      `Last reviewed commit: [x](https://github.com/deftai/directive/commit/${OLD})\n` +
+      '### P0 findings (1)\n<img alt="P0" />\n';
+    const result = computeGateResult(
+      2258,
+      "deftai/directive",
+      fakeRunGh({ commentBody: body, mergeableState: "clean", mergeable: true }),
+    );
+    expect(result.failures.length).toBeGreaterThan(0);
+    expect((result.partialData as Record<string, unknown>).verdict_override).toBeUndefined();
+  });
+
+  it("merges when Greptile excluded-author skip is present and CI is green (#2375)", () => {
+    const body = "<!-- greptile-status --> PR author is in the excluded authors list.";
+    const result = computeGateResult(
+      2352,
+      "deftai/directive",
+      fakeRunGh({ commentBody: body, mergeableState: "clean", mergeable: true }),
+    );
+    expect(result.failures).toEqual([]);
+    expect(result.verdict.excludedAuthor).toBe(true);
+    expect((result.partialData as Record<string, unknown>).verdict_override).toBeUndefined();
+  });
+
   it("does NOT merge a genuine P0/P1 on the current head even when GitHub is CLEAN", () => {
     const body =
       "## Greptile Summary\n\n**Confidence Score: 5/5**\n\n" +

--- a/packages/core/src/pr-merge-readiness/constants.ts
+++ b/packages/core/src/pr-merge-readiness/constants.ts
@@ -6,6 +6,13 @@ export const GREPTILE_LOGIN = "greptile-apps[bot]";
 
 export const GREPTILE_ERRORED_SENTINEL = "Greptile encountered an error while reviewing this PR";
 
+/** Greptile status marker on excluded-author skip comments (#2375). */
+export const GREPTILE_STATUS_MARKER = "<!-- greptile-status -->";
+
+/** Intentional opt-out when the PR author is on the excluded-authors list (#2375). */
+export const GREPTILE_EXCLUDED_AUTHOR_RE =
+  /(?:<!--\s*greptile-status\s*-->[\s\S]*)?excluded authors list/i;
+
 export const LAST_REVIEWED_RE =
   /Last reviewed commit:\s*\[[^\]]*\]\(https?:\/\/github\.com\/[^/]+\/[^/]+\/commit\/(?<sha>[0-9a-f]{7,40})/g;
 

--- a/packages/core/src/pr-merge-readiness/constants.ts
+++ b/packages/core/src/pr-merge-readiness/constants.ts
@@ -9,9 +9,8 @@ export const GREPTILE_ERRORED_SENTINEL = "Greptile encountered an error while re
 /** Greptile status marker on excluded-author skip comments (#2375). */
 export const GREPTILE_STATUS_MARKER = "<!-- greptile-status -->";
 
-/** Intentional opt-out when the PR author is on the excluded-authors list (#2375). */
-export const GREPTILE_EXCLUDED_AUTHOR_RE =
-  /(?:<!--\s*greptile-status\s*-->[\s\S]*)?excluded authors list/i;
+/** Substring Greptile posts when the PR author is on the excluded-authors list (#2375). */
+export const GREPTILE_EXCLUDED_AUTHOR_PHRASE = "excluded authors list";
 
 export const LAST_REVIEWED_RE =
   /Last reviewed commit:\s*\[[^\]]*\]\(https?:\/\/github\.com\/[^/]+\/[^/]+\/commit\/(?<sha>[0-9a-f]{7,40})/g;

--- a/packages/core/src/pr-merge-readiness/evaluate.ts
+++ b/packages/core/src/pr-merge-readiness/evaluate.ts
@@ -18,6 +18,10 @@ export function evaluateGates(
     return failures;
   }
 
+  if (verdict.excludedAuthor) {
+    return failures;
+  }
+
   if (verdict.errored) {
     failures.push(
       "Greptile review is in the ERRORED state on the current HEAD (#526). " +

--- a/packages/core/src/pr-merge-readiness/mergeability.test.ts
+++ b/packages/core/src/pr-merge-readiness/mergeability.test.ts
@@ -118,10 +118,31 @@ describe("verdictBlockIsSoftOnly", () => {
     expect(verdictBlockIsSoftOnly(emptyVerdict(), HEAD)).toBe(true);
   });
 
-  it("stale head SHA is soft even with prior findings", () => {
+  it("stale head SHA without blocker findings is soft", () => {
+    expect(
+      verdictBlockIsSoftOnly(verdict({ found: true, lastReviewedSha: OLD, confidence: 5 }), HEAD),
+    ).toBe(true);
+  });
+
+  it("stale head SHA with P0/P1 is a HARD block (#2382)", () => {
     expect(
       verdictBlockIsSoftOnly(
         verdict({ found: true, lastReviewedSha: OLD, p0Count: 3, confidence: 1 }),
+        HEAD,
+      ),
+    ).toBe(false);
+  });
+
+  it("stale head SHA with errored is a HARD block (#2382)", () => {
+    expect(
+      verdictBlockIsSoftOnly(verdict({ found: true, lastReviewedSha: OLD, errored: true }), HEAD),
+    ).toBe(false);
+  });
+
+  it("excluded-author skip is soft (#2375)", () => {
+    expect(
+      verdictBlockIsSoftOnly(
+        verdict({ found: true, excludedAuthor: true, lastReviewedSha: null, confidence: null }),
         HEAD,
       ),
     ).toBe(true);

--- a/packages/core/src/pr-merge-readiness/mergeability.ts
+++ b/packages/core/src/pr-merge-readiness/mergeability.ts
@@ -90,13 +90,15 @@ export function verdictShaIsStale(verdict: GreptileVerdict, headSha: string | nu
  * Classify whether the verdict-based merge block is ONLY "soft" (#2260).
  *
  * A soft block means the review verdict is absent or pinned to a prior head
- * SHA (rebased staleness) -- i.e. the review has not spoken about the CURRENT
- * head. It is safe to reconcile a soft block against GitHub mergeability.
+ * SHA without carrying real blocker-class findings (rebased staleness with no
+ * P0/P1/errored/low-confidence) -- i.e. the review has not spoken about the
+ * CURRENT head in a blocking way. It is safe to reconcile a soft block against
+ * GitHub mergeability.
  *
- * A HARD block -- a genuine P0/P1 finding, an ERRORED review, or a low
- * confidence score on the current head -- is NEVER soft; those must keep
- * blocking regardless of GitHub mergeability (guardrail: do not merge a PR
- * with a real P0/P1 review finding).
+ * A HARD block -- a genuine P0/P1 finding (even on a stale SHA), an ERRORED
+ * review, or a low confidence score -- is NEVER soft; those must keep blocking
+ * regardless of GitHub mergeability (guardrail: do not merge a PR with a real
+ * P0/P1 review finding).
  */
 export function verdictBlockIsSoftOnly(verdict: GreptileVerdict, headSha: string | null): boolean {
   // Absent: no Greptile rolling-summary comment at all.
@@ -108,12 +110,11 @@ export function verdictBlockIsSoftOnly(verdict: GreptileVerdict, headSha: string
   if (verdict.informalClean) {
     return false;
   }
-  // Stale: verdict pinned to a prior head SHA -> its findings pertain to old code.
-  if (verdictShaIsStale(verdict, headSha)) {
+  // Excluded-author skip is an intentional N/A reviewer state (#2375).
+  if (verdict.excludedAuthor) {
     return true;
   }
-  // Verdict is current (or its SHA is unparseable). A genuine current-head
-  // finding is a hard block and must not be overridden.
+  // Blocker-class signals apply even when the verdict SHA is stale (#2382).
   if (verdict.errored) {
     return false;
   }
@@ -122,6 +123,10 @@ export function verdictBlockIsSoftOnly(verdict: GreptileVerdict, headSha: string
   }
   if (verdict.p0Count > 0 || verdict.p1Count > 0) {
     return false;
+  }
+  // Stale without blocker findings: review has not spoken about the current head.
+  if (verdictShaIsStale(verdict, headSha)) {
+    return true;
   }
   // No genuine finding: the block is a missing-canonical-field / not-yet-posted
   // wait, which GitHub mergeability may resolve.

--- a/packages/core/src/pr-merge-readiness/output.test.ts
+++ b/packages/core/src/pr-merge-readiness/output.test.ts
@@ -57,6 +57,20 @@ describe("output helpers", () => {
     expect(out).toContain("CI check-runs: 1 passed / 0 failed / 0 pending");
   });
 
+  it("prints excluded-author skip line (#2375)", () => {
+    const out = printHuman({
+      ...baseResult,
+      verdict: {
+        ...baseResult.verdict,
+        excludedAuthor: true,
+        lastReviewedSha: null,
+        confidence: null,
+      },
+    });
+    expect(out).toContain("Greptile review:    skipped (author excluded)");
+    expect(out).not.toContain("Confidence:");
+  });
+
   it("prints human merge-blocked", () => {
     const out = printHuman({ ...baseResult, failures: ["low confidence"] });
     expect(out).toContain("MERGE-BLOCKED");

--- a/packages/core/src/pr-merge-readiness/output.ts
+++ b/packages/core/src/pr-merge-readiness/output.ts
@@ -18,6 +18,7 @@ function verdictToDict(verdict: GreptileVerdict): Record<string, unknown> {
     p1_count: verdict.p1Count,
     p2_count: verdict.p2Count,
     informal_clean: verdict.informalClean,
+    excluded_author: verdict.excludedAuthor,
     raw_body_excerpt: verdict.rawBodyExcerpt,
   };
 }
@@ -59,15 +60,19 @@ export function printHuman(result: GateResult): string {
   const lines: string[] = [];
   lines.push(`PR #${result.prNumber} merge-readiness check  (via=${result.via})`);
   lines.push(`  HEAD SHA:           ${result.headSha ?? "<unknown>"}`);
-  lines.push(`  Greptile reviewed:  ${result.verdict.lastReviewedSha ?? "<not parsed>"}`);
-  const confidenceStr =
-    result.verdict.confidence !== null ? String(result.verdict.confidence) : "<not parsed>";
-  lines.push(`  Confidence:         ${confidenceStr}/5`);
-  lines.push(
-    `  Findings:           P0=${result.verdict.p0Count}  ` +
-      `P1=${result.verdict.p1Count}  P2=${result.verdict.p2Count}`,
-  );
-  lines.push(`  Errored sentinel:   ${result.verdict.errored ? "True" : "False"}`);
+  if (result.verdict.excludedAuthor) {
+    lines.push("  Greptile review:    skipped (author excluded)");
+  } else {
+    lines.push(`  Greptile reviewed:  ${result.verdict.lastReviewedSha ?? "<not parsed>"}`);
+    const confidenceStr =
+      result.verdict.confidence !== null ? String(result.verdict.confidence) : "<not parsed>";
+    lines.push(`  Confidence:         ${confidenceStr}/5`);
+    lines.push(
+      `  Findings:           P0=${result.verdict.p0Count}  ` +
+        `P1=${result.verdict.p1Count}  P2=${result.verdict.p2Count}`,
+    );
+    lines.push(`  Errored sentinel:   ${result.verdict.errored ? "True" : "False"}`);
+  }
   const ciBlock = result.partialData.ci;
   if (ciBlock !== null && typeof ciBlock === "object" && !Array.isArray(ciBlock)) {
     const ci = ciBlock as Record<string, unknown>;

--- a/packages/core/src/pr-merge-readiness/parse.test.ts
+++ b/packages/core/src/pr-merge-readiness/parse.test.ts
@@ -107,6 +107,15 @@ describe("parseGreptileBody", () => {
     expect(v.informalClean).toBe(true);
   });
 
+  it("detects excluded-author skip sentinel (#2375)", () => {
+    const body = "<!-- greptile-status --> PR author is in the excluded authors list.";
+    const v = parseGreptileBody(body);
+    expect(v.found).toBe(true);
+    expect(v.excludedAuthor).toBe(true);
+    expect(v.lastReviewedSha).toBeNull();
+    expect(v.confidence).toBeNull();
+  });
+
   it("isInformalClean helper respects canonical fields", () => {
     const v = parseGreptileBody(cleanBody());
     expect(isInformalCleanMissingCanonicalFields(v, cleanBody())).toBe(false);
@@ -178,6 +187,16 @@ describe("evaluateGates", () => {
     expect(failures).toHaveLength(1);
     expect(failures[0]).toContain(INFORMAL_CLEAN_DIAGNOSTIC.slice(0, 40));
     expect(failures[0]).toContain("@greptileai review");
+  });
+
+  it("passes excluded-author skip without parse failures (#2375)", () => {
+    expect(
+      evaluateGates(
+        1,
+        HEAD,
+        verdict({ excludedAuthor: true, lastReviewedSha: null, confidence: null }),
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/packages/core/src/pr-merge-readiness/parse.ts
+++ b/packages/core/src/pr-merge-readiness/parse.ts
@@ -2,6 +2,7 @@ import { findLastReviewedCommitSha } from "../text/redos-safe.js";
 import {
   CONFIDENCE_RE,
   GREPTILE_ERRORED_SENTINEL,
+  GREPTILE_EXCLUDED_AUTHOR_RE,
   INFORMAL_CLEAN_SIGNAL_RE,
   P0_BADGE,
   P1_BADGE,
@@ -19,8 +20,13 @@ export function emptyVerdict(): GreptileVerdict {
     p1Count: 0,
     p2Count: 0,
     informalClean: false,
+    excludedAuthor: false,
     rawBodyExcerpt: "",
   };
+}
+
+export function isGreptileExcludedAuthor(body: string): boolean {
+  return GREPTILE_EXCLUDED_AUTHOR_RE.test(body);
 }
 
 export function isInformalCleanMissingCanonicalFields(
@@ -58,6 +64,7 @@ export function parseGreptileBody(body: string): GreptileVerdict {
   }
 
   const errored = body.trim().startsWith(GREPTILE_ERRORED_SENTINEL);
+  const excludedAuthor = isGreptileExcludedAuthor(body);
 
   const lastReviewedSha = findLastReviewedCommitSha(body);
 
@@ -92,6 +99,7 @@ export function parseGreptileBody(body: string): GreptileVerdict {
     p1Count,
     p2Count,
     informalClean: false,
+    excludedAuthor,
     rawBodyExcerpt: body.slice(0, 200),
   };
 

--- a/packages/core/src/pr-merge-readiness/parse.ts
+++ b/packages/core/src/pr-merge-readiness/parse.ts
@@ -2,7 +2,8 @@ import { findLastReviewedCommitSha } from "../text/redos-safe.js";
 import {
   CONFIDENCE_RE,
   GREPTILE_ERRORED_SENTINEL,
-  GREPTILE_EXCLUDED_AUTHOR_RE,
+  GREPTILE_EXCLUDED_AUTHOR_PHRASE,
+  GREPTILE_STATUS_MARKER,
   INFORMAL_CLEAN_SIGNAL_RE,
   P0_BADGE,
   P1_BADGE,
@@ -26,7 +27,11 @@ export function emptyVerdict(): GreptileVerdict {
 }
 
 export function isGreptileExcludedAuthor(body: string): boolean {
-  return GREPTILE_EXCLUDED_AUTHOR_RE.test(body);
+  const lower = body.toLowerCase();
+  return (
+    lower.includes(GREPTILE_EXCLUDED_AUTHOR_PHRASE) &&
+    (lower.includes("greptile-status") || body.includes(GREPTILE_STATUS_MARKER))
+  );
 }
 
 export function isInformalCleanMissingCanonicalFields(

--- a/packages/core/src/pr-merge-readiness/types.ts
+++ b/packages/core/src/pr-merge-readiness/types.ts
@@ -7,6 +7,8 @@ export interface GreptileVerdict {
   readonly p1Count: number;
   readonly p2Count: number;
   readonly informalClean: boolean;
+  /** Greptile deliberately skipped review for an excluded PR author (#2375). */
+  readonly excludedAuthor: boolean;
   readonly rawBodyExcerpt: string;
 }
 


### PR DESCRIPTION
## Summary
- Keep stale Greptile verdicts with P0/P1, errored, or low-confidence findings as **hard blocks** so GitHub `mergeable_state=clean` cannot squash-merge known blockers (#2382).
- Treat Greptile excluded-author skip comments (e.g. Dependabot PRs) as **N/A pass** instead of parse-failure MERGE-BLOCKED (#2375).

## Test plan
- [x] `pnpm exec vitest run packages/core/src/pr-merge-readiness` (137 tests)
- [x] `biome check` on touched pr-merge-readiness files
- [x] `verify:branch` on feature branch
- [ ] CI green on PR

Closes #2382
Closes #2375

Made with [Cursor](https://cursor.com)