### PR TITLE
fix(hooks): guard xbrief-drift and pass project-root on pre-push

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,6 +21,5 @@ run_deft verify:forward-coverage --staged --project-root "$REPO_ROOT" || exit $?
 
 if [ -d "$REPO_ROOT/xbrief" ] || [ -d "$REPO_ROOT/vbrief" ]; then
     run_deft verify:vbrief-conformance --staged --project-root "$REPO_ROOT" || exit $?
+    run_deft verify:xbrief-drift --staged --project-root "$REPO_ROOT" || exit $?
 fi
-
-run_deft verify:xbrief-drift --staged --project-root "$REPO_ROOT" || exit $?

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,5 +14,5 @@ fi
 
 . "$REPO_ROOT/.githooks/_deft-run.sh"
 
-run_deft preflight-gh --pre-push-stdin
+run_deft preflight-gh --pre-push-stdin --project-root "$REPO_ROOT"
 exit $?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Go installer consumer projections now refuse repo-controlled symlinks.** `deft-install` checks AGENTS.md, vbrief/, `.agents/`, `.githooks/`, and related projection targets with Lstat/containment before writing, so a malicious checkout cannot trick install or upgrade into overwriting files outside the project tree. Closes #2383.
-
+- **Deposited git hooks no longer fail on repos without a lifecycle tree, and pre-push resolves project config from the repo root.** Pre-commit now runs `verify:xbrief-drift` only when `xbrief/` or `vbrief/` exists (matching the conformance guard), and pre-push passes `--project-root` to `preflight-gh` for parity with the other hook gates. Closes #2406.
 - **Windows-native `engine:_ts-build` now detects Corepack without Unix `sh`.** Package-manager probes use a cross-platform `shell:true` `--version` check so `corepack.cmd` is visible when bare `pnpm` and `sh` are absent from PATH, while preserving the #2411 Corepack step order and #2181 no-auto-build session path. Closes #2415. Refs #2410, #2411.
 
 ### Removed

--- a/packages/core/src/content-contracts/standards/branch_gate.test.ts
+++ b/packages/core/src/content-contracts/standards/branch_gate.test.ts
@@ -12,10 +12,21 @@ describe("test_branch_gate.py", () => {
   });
   it("test_pre_push_hook_exists_and_calls_script", () => {
     const text = readText(".githooks/pre-push");
-    expect(text).toContain("run_deft preflight-gh --pre-push-stdin");
+    expect(text).toContain("run_deft preflight-gh --pre-push-stdin --project-root");
     expect(text).toContain("_deft-run.sh");
     expect(text).not.toContain("preflight_branch.py");
     expect(text).not.toContain("deft verify:branch");
+  });
+  it("test_pre_commit_xbrief_drift_guarded_like_conformance (#2406)", () => {
+    const text = readText(".githooks/pre-commit");
+    const guardStart = text.indexOf('[ -d "$REPO_ROOT/xbrief" ]');
+    expect(guardStart).toBeGreaterThanOrEqual(0);
+    const guardEnd = text.indexOf("fi", guardStart);
+    expect(guardEnd).toBeGreaterThan(guardStart);
+    const guardBlock = text.slice(guardStart, guardEnd);
+    expect(guardBlock).toContain("verify:vbrief-conformance");
+    expect(guardBlock).toContain("verify:xbrief-drift");
+    expect(text.slice(guardEnd)).not.toContain("verify:xbrief-drift");
   });
   it("test_deft_run_sh_falls_back_to_local_cli", () => {
     const text = readText(".githooks/_deft-run.sh");


### PR DESCRIPTION
## Summary

- Gate `verify:xbrief-drift` in `.githooks/pre-commit` behind the same `xbrief/` / `vbrief/` directory check used for `verify:vbrief-conformance`, so repos without a lifecycle tree are not blocked at commit time.
- Pass `--project-root "$REPO_ROOT"` to `preflight-gh` in `.githooks/pre-push` for parity with pre-commit gate invocations.
- Add a contract test in `branch_gate.test.ts` that locks both guards in the deposited hook templates.

Closes #2406

## Test plan

- [x] `npx vitest run packages/core/src/content-contracts/standards/branch_gate.test.ts packages/core/src/verify-env/verify-hooks-installed.test.ts`
- [x] Pre-commit hook passed on commit (encoding, forward-coverage, vbrief-conformance, xbrief-drift)
- [x] `rg` verification: drift guard inside xbrief/vbrief block; pre-push includes `--project-root`


Made with [Cursor](https://cursor.com)