### PR TITLE
feat: improve directive help discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Top-level `directive` help now opens with a versioned, categorized command guide instead of dumping every registered alias, while `directive commands` / `--commands` keep the exhaustive list available for power users. Colon-style task commands shown in help, including scope and verify workflows, now route through the CLI as single-token commands so copied examples work. Closes #2172.
+
 ### Fixed
 
 - **Merge-readiness no longer clears stale Greptile P0/P1 blockers when GitHub reports clean.** Stale verdicts that carried real P0/P1, errored, or low-confidence findings now stay hard blocks instead of being softened by the GitHub mergeability override, and Dependabot PRs with Greptile excluded-author skip comments are treated as pass rather than parse failures. Closes #2382. Closes #2375.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Directive is driven by **three commands** — `init`, `update`, and `doctor`. Yo
 | Not sure, or something looks broken | `directive doctor` | Read-only diagnosis that prints exactly one recommended next step. |
 | Legacy / pre-v0.20 layout | `directive init` (or `directive doctor`) | Classifies the layout and routes you to the specific migration path (see [UPGRADING.md](./content/UPGRADING.md)). |
 
-`directive init` is the **universal entrypoint**: run it from a project directory and it classifies *that directory* and dispatches to exactly one of the paths above, always printing a state summary plus one recommended next action. `directive doctor` is the safe "where am I?" probe, and `directive update` is the refresh path — the same three-command model the CLI's own `directive` help screen leads with.
+`directive init` is the **universal entrypoint**: run it from a project directory and it classifies *that directory* and dispatches to exactly one of the paths above, always printing a state summary plus one recommended next action. `directive doctor` is the safe "where am I?" probe, and `directive update` is the refresh path — the same three-command model the CLI's own `directive` help screen includes in its setup category.
 
 ### 1. Install and initialize
 

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -227,6 +227,12 @@ function routeThreeToken(
   return null;
 }
 
+function routeColonToken(first: string, rest: string[]): RoutedArgv | null {
+  const colon = first.indexOf(":");
+  if (colon <= 0 || colon === first.length - 1) return null;
+  return routeNamespaceVerb(first.slice(0, colon), first.slice(colon + 1), rest);
+}
+
 /**
  * Transform user-facing argv (`directive <ns> <verb>` or top-level UX) into
  * flat dispatcher argv consumed by `dispatch()`.
@@ -244,6 +250,9 @@ export function routeArgv(argv: readonly string[]): RoutedArgv {
   if (isMetaVerb(first) || first === "help") {
     return { kind: "dispatch", argv: [...argv] };
   }
+
+  const colonToken = routeColonToken(first, argv.slice(1));
+  if (colonToken !== null) return colonToken;
 
   const topLevel = routeTopLevel(first, argv.slice(1));
   if (topLevel !== null) return topLevel;

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -101,7 +101,13 @@ export interface RoutedArgv {
 }
 
 function isMetaVerb(token: string): boolean {
-  return token === "--help" || token === "-h" || token === "--version" || token === "-V";
+  return (
+    token === "--help" ||
+    token === "-h" ||
+    token === "--version" ||
+    token === "-V" ||
+    token === "--commands"
+  );
 }
 
 function routeTopLevel(first: string, rest: string[]): RoutedArgv | null {

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -56,6 +56,15 @@ describe("routeArgv", () => {
     ]);
   });
 
+  it("passes malformed colon tokens through to legacy unknown-verb handling", () => {
+    expect(routeArgv(["scope:", "path.xbrief.json"]).argv).toEqual(["scope:", "path.xbrief.json"]);
+    expect(routeArgv([":scope", "path.xbrief.json"]).argv).toEqual([":scope", "path.xbrief.json"]);
+    expect(routeArgv(["scope::promote", "path.xbrief.json"]).argv).toEqual([
+      "scope::promote",
+      "path.xbrief.json",
+    ]);
+  });
+
   it("maps triage queue to triage:queue", () => {
     expect(routeArgv(["triage", "queue", "--limit", "5"]).argv).toEqual([
       "triage:queue",

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -118,6 +118,7 @@ describe("routeArgv", () => {
   it("passes meta flags through unchanged", () => {
     expect(routeArgv(["--help"]).argv).toEqual(["--help"]);
     expect(routeArgv(["-h"]).argv).toEqual(["-h"]);
+    expect(routeArgv(["--commands"]).argv).toEqual(["--commands"]);
   });
 
   it("routes init and update to dispatch handlers", () => {

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -43,6 +43,19 @@ describe("routeArgv", () => {
     ]);
   });
 
+  it("maps single-token colon task verbs to the same dispatcher routes", () => {
+    expect(routeArgv(["scope:promote", "path.xbrief.json"]).argv).toEqual([
+      "scope-lifecycle",
+      "promote",
+      "path.xbrief.json",
+    ]);
+    expect(routeArgv(["verify:cache-fresh", "--project-root", "."]).argv).toEqual([
+      "preflight-cache",
+      "--project-root",
+      ".",
+    ]);
+  });
+
   it("maps triage queue to triage:queue", () => {
     expect(routeArgv(["triage", "queue", "--limit", "5"]).argv).toEqual([
       "triage:queue",

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -24,6 +24,7 @@ import {
   POLICY_ACTION_ALIAS_SUBCOMMANDS,
   parseDirectiveBootstrapArgs,
   printHelp,
+  printRegisteredCommands,
   registeredVerbs,
   resetHandlerCacheForTests,
   resolveCanonicalVerb,
@@ -37,6 +38,14 @@ import {
 
 const engineVersion = engineInfo().version;
 const VERSION_BANNER = `@deftai/directive (engine: @deftai/directive-core@${engineVersion})\n`;
+
+function normalizeHelpSnapshot(text: string): string {
+  return text.replace(/^Directive v\d+\.\d+/m, "Directive vX.Y");
+}
+
+function normalizeVersionSnapshot(text: string): string {
+  return text.replace(/@deftai\/directive-core@[^)\n]+/, "@deftai/directive-core@X.Y.Z");
+}
 
 afterEach(() => {
   resetHandlerCacheForTests();
@@ -62,9 +71,11 @@ describe("registeredVerbs", () => {
 });
 
 describe("printHelp", () => {
-  function renderHelp(): string {
+  function render(
+    write: (io: { writeOut: (text: string) => void; writeErr: (text: string) => void }) => void,
+  ): string {
     const lines: string[] = [];
-    printHelp({
+    write({
       writeOut: (text) => {
         lines.push(text);
       },
@@ -73,58 +84,76 @@ describe("printHelp", () => {
     return lines.join("");
   }
 
-  it("lists all registered verbs", () => {
-    const body = renderHelp();
-    expect(body).toContain("Usage: directive <verb> [args...]");
-    expect(body).toContain("Registered verbs:");
+  it("snapshots concise categorized top-level help (#2172)", () => {
+    const body = render((io) => printHelp(io));
+    expect(normalizeHelpSnapshot(body)).toMatchInlineSnapshot(`
+"Directive vX.Y
+Deft Directive project automation: setup, health checks, triage, scope, and generated docs.
+
+Usage:
+  directive <command> [options]
+  directive help
+  directive commands
+
+Common options:
+  -h, --help       Show this help.
+  -V, --version    Print version information.
+
+Setup and maintenance:
+  init             Set up Directive in the current project.
+  update           Refresh an existing install and self-heal the engine.
+  doctor           Diagnose the install and print the next step.
+  First project: run \`directive init\`, then \`directive doctor\` from the project root.
+  Cold start: if \`directive\` will not run, read the bootstrap block at the top of README.md.
+
+Daily checks:
+  session:start    Record the session-start ritual state.
+  check            Run the source checkout quality gate.
+  verify:cache-fresh
+                   Verify the deposited cache/bootstrap state.
+
+Triage and scope:
+  triage:welcome   Resume guided onboarding.
+  triage:queue     Show the ranked work queue.
+  scope:promote    Move a proposed scope into pending.
+  scope:activate   Start a pending scope.
+
+Project docs:
+  project:render   Regenerate PROJECT-DEFINITION-derived output.
+  spec:render      Regenerate SPECIFICATION.md.
+
+Help uses colon-style task verbs; dash-style aliases remain supported for compatibility.
+Run \`directive commands\` (or \`directive --commands\`) for the exhaustive registered command and alias list.
+"
+`);
+    expect(body).not.toContain("Registered commands and aliases:");
+    expect(body).not.toContain("verify-encoding");
+    expect(body).not.toContain("framework-commands");
+  });
+
+  it("prints the exhaustive registered list only on the explicit command surface (#2172)", () => {
+    const body = render((io) => printRegisteredCommands(io));
+    expect(body).toContain("Registered commands and aliases:");
     for (const verb of registeredVerbs()) {
       expect(body).toContain(`  ${verb}\n`);
     }
   });
 
-  // #2273: no-arg `directive` leads with the three-command model + first-run
-  // guidance, printed BEFORE the exhaustive verb list.
-  it("prints the three-command model and first-run guidance before the verb list (#2273)", () => {
-    const body = renderHelp();
-    for (const line of [
-      "directive init",
-      "directive update",
-      "directive doctor",
-      "First run?",
-      "npm i -g @deftai/directive",
-    ]) {
-      expect(body).toContain(line);
-    }
-    // Cold-start recovery pointer is payload-independent (points at README.md).
-    expect(body).toContain("README.md");
-
-    const firstVerb = registeredVerbs()[0] ?? "";
-    const modelIdx = body.indexOf("directive init");
-    const listIdx = body.indexOf("Registered verbs:");
-    expect(modelIdx).toBeGreaterThanOrEqual(0);
-    expect(modelIdx).toBeLessThan(listIdx);
-    expect(listIdx).toBeLessThan(body.indexOf(`\n  ${firstVerb}\n`));
-  });
-
-  // #2274: the top-level help snapshot is the source the README / BROWNFIELD /
-  // UPGRADING docs mirror. Lock the "Start here" grouping, the init->update->
-  // doctor ordering, and each command's by-situation one-liner so the docs and
-  // the CLI can never drift out of agreement on the three-command model.
+  // #2274: keep the init->update->doctor ordering in the curated setup group so
+  // README / BROWNFIELD / UPGRADING stay aligned on the three-command model.
   it("routes users by situation: init sets up, update refreshes, doctor diagnoses (#2274)", () => {
-    const body = renderHelp();
-    expect(body).toContain("Start here (most projects only need these three):");
-
-    const initIdx = body.indexOf("directive init");
-    const updateIdx = body.indexOf("directive update");
-    const doctorIdx = body.indexOf("directive doctor");
+    const body = render((io) => printHelp(io));
+    const initIdx = body.indexOf("  init");
+    const updateIdx = body.indexOf("  update");
+    const doctorIdx = body.indexOf("  doctor");
     expect(initIdx).toBeGreaterThanOrEqual(0);
     expect(updateIdx).toBeGreaterThan(initIdx);
     expect(doctorIdx).toBeGreaterThan(updateIdx);
 
     for (const line of [
-      "directive init      Set up Directive in the current project (first-time setup)",
-      "directive update    Refresh an existing install and self-heal the engine",
-      "directive doctor    Diagnose the install and print the one next step",
+      "  init             Set up Directive in the current project.",
+      "  update           Refresh an existing install and self-heal the engine.",
+      "  doctor           Diagnose the install and print the next step.",
     ]) {
       expect(body).toContain(line);
     }
@@ -142,6 +171,9 @@ describe("dispatch", () => {
     });
     expect(code).toBe(0);
     expect(out.join("")).toBe(VERSION_BANNER);
+    expect(normalizeVersionSnapshot(out.join(""))).toMatchInlineSnapshot(
+      `"@deftai/directive (engine: @deftai/directive-core@X.Y.Z)\n"`,
+    );
   });
 
   it("returns 0 for -V and prints the engine banner", async () => {
@@ -165,7 +197,8 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toContain("Usage: directive");
+    expect(out.join("")).toContain("Usage:");
+    expect(out.join("")).toContain("directive <command> [options]");
   });
 
   it("returns 0 for -h and prints help", async () => {
@@ -177,7 +210,8 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toContain("verify-encoding");
+    expect(out.join("")).toContain("Common options:");
+    expect(out.join("")).not.toContain("verify-encoding");
   });
 
   it("returns 0 for help and prints help", async () => {
@@ -189,7 +223,35 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
+    expect(out.join("")).toContain("directive commands");
+    expect(out.join("")).not.toContain("framework-commands");
+  });
+
+  it("returns 0 for commands and prints the full registered list", async () => {
+    const out: string[] = [];
+    const code = await dispatch(["commands"], {
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: () => {},
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("Registered commands and aliases:");
+    expect(out.join("")).toContain("framework-commands");
     expect(out.join("")).toContain("verify-encoding");
+  });
+
+  it("returns 0 for --commands and prints the full registered list", async () => {
+    const out: string[] = [];
+    const code = await dispatch(["--commands"], {
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: () => {},
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("Registered commands and aliases:");
+    expect(out.join("")).toContain("framework-commands");
   });
 
   it("coerces non-number handler return to exit code 0", async () => {
@@ -269,7 +331,7 @@ describe("dispatch", () => {
     expect(err.join("")).toBe("directive: plain\n");
   });
 
-  it("returns 0 for --help and prints the verb list", async () => {
+  it("returns 0 for --help and prints concise help", async () => {
     const out: string[] = [];
     const code = await dispatch(["--help"], {
       writeOut: (text) => {
@@ -278,7 +340,8 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toContain("verify-encoding");
+    expect(out.join("")).toContain("Common options:");
+    expect(out.join("")).not.toContain("verify-encoding");
   });
 
   it("prints an error naming an unknown verb and exits non-zero", async () => {

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -131,6 +131,24 @@ Run \`directive commands\` (or \`directive --commands\`) for the exhaustive regi
     expect(body).not.toContain("framework-commands");
   });
 
+  it("keeps curated task-style help commands routed to registered handlers (#2172)", () => {
+    const registered = new Set(registeredVerbs());
+    for (const command of [
+      "session:start",
+      "verify:cache-fresh",
+      "triage:welcome",
+      "triage:queue",
+      "scope:promote",
+      "scope:activate",
+      "project:render",
+      "spec:render",
+    ]) {
+      const routed = routeArgv([command]);
+      expect(routed.kind, command).toBe("dispatch");
+      expect(registered.has(routed.argv[0] ?? ""), command).toBe(true);
+    }
+  });
+
   it("prints the exhaustive registered list only on the explicit command surface (#2172)", () => {
     const body = render((io) => printRegisteredCommands(io));
     expect(body).toContain("Registered commands and aliases:");
@@ -515,7 +533,7 @@ describe("dispatch", () => {
     const routed = routeArgv(["policy:show", "--field", "valueFeedback"]);
     expect(routed).toEqual({
       kind: "dispatch",
-      argv: ["policy:show", "--field", "valueFeedback"],
+      argv: ["policy", "show", "--field", "valueFeedback"],
     });
   });
 });
@@ -979,6 +997,37 @@ describe("native pack-migrate handlers (#2022)", () => {
     const parsed = readSkillsPack(readFileSync(out, "utf8"));
     const delta = parsed.skills.find((skill) => skill.id === "delta");
     expect(delta?.triggers).toEqual(["what's next, please", "plain"]);
+  });
+
+  it("recognizes CRLF skill frontmatter from Windows checkouts", async () => {
+    const base = join(root, "crlf");
+    writeFixture(
+      "crlf/content/skills/epsilon/SKILL.md",
+      "---\r\nname: epsilon\r\ndescription: Epsilon with CRLF frontmatter.\r\ntriggers:\r\n  - epsilon\r\n---\r\n\r\n# Epsilon\r\n\r\nBody.\r\n",
+    );
+    writeFixture(
+      "crlf/REFERENCES.md",
+      "# Refs\r\n\r\n## Skills Index\r\n\r\n| Skill | Description | Triggers |\r\n|---|---|---|\r\n\r\n## Next\r\n\r\nDone.\r\n",
+    );
+    const out = join(base, "out.json");
+    const result = await runVerb([
+      "pack-migrate-skills",
+      "--skills-dir",
+      join(base, "content/skills"),
+      "--references-md",
+      join(base, "REFERENCES.md"),
+      "--out",
+      out,
+    ]);
+    expect(result.code).toBe(0);
+    const parsed = readSkillsPack(readFileSync(out, "utf8"));
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.skills[0]).toMatchObject({
+      id: "epsilon",
+      description: "Epsilon with CRLF frontmatter.",
+      triggers: ["epsilon"],
+      body: "# Epsilon\n\nBody.\n",
+    });
   });
 
   // #2152 regression guard: building the skills pack from the *real* shipped

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -686,8 +686,9 @@ function stripLeadingBanner(body: string): string {
 const FRONTMATTER_RE = /^---\n([\s\S]*?\n)---\n?([\s\S]*)$/;
 
 function splitFrontmatter(text: string): [string | null, string] {
-  if (!text.startsWith("---\n")) return [null, text];
-  const match = FRONTMATTER_RE.exec(text);
+  const normalized = text.replace(/\r\n?/g, "\n");
+  if (!normalized.startsWith("---\n")) return [null, text];
+  const match = FRONTMATTER_RE.exec(normalized);
   if (!match) return [null, text];
   return [match[1] ?? "", match[2] ?? ""];
 }

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -2726,31 +2726,58 @@ export function registeredVerbs(): readonly string[] {
   return [...names].sort();
 }
 
-/**
- * Print dispatcher help. Leads with the three-command model (init / update /
- * doctor) + first-run guidance so a no-arg `directive` orients a newcomer before
- * the exhaustive verb list, which stays available below for power users (#2273).
- */
+function helpVersion(): string {
+  const version = engineInfo().version;
+  const match = /^v?(\d+)\.(\d+)/.exec(version);
+  return match === null ? `v${version}` : `v${match[1]}.${match[2]}`;
+}
+
+/** Print curated dispatcher help for the human-facing top-level CLI (#2172). */
 export function printHelp(io: DispatchIo = defaultIo()): void {
   io.writeOut(
-    "directive -- the Deft Directive CLI\n" +
+    `Directive ${helpVersion()}\n` +
+      "Deft Directive project automation: setup, health checks, triage, scope, and generated docs.\n" +
       "\n" +
-      "Start here (most projects only need these three):\n" +
-      "  directive init      Set up Directive in the current project (first-time setup)\n" +
-      "  directive update    Refresh an existing install and self-heal the engine\n" +
-      "  directive doctor    Diagnose the install and print the one next step\n" +
+      "Usage:\n" +
+      "  directive <command> [options]\n" +
+      "  directive help\n" +
+      "  directive commands\n" +
       "\n" +
-      "First run? From the project root:\n" +
-      "  1. npm i -g @deftai/directive   (Node >= 20)\n" +
-      "     (pnpm: pnpm add -g @deftai/directive -- ensure PNPM_HOME is on PATH, run `pnpm setup` if needed)\n" +
-      "  2. directive init\n" +
-      "  3. directive doctor\n" +
-      "New clone where `directive` will not run? Read the Cold-start bootstrap block at the top of README.md.\n" +
+      "Common options:\n" +
+      "  -h, --help       Show this help.\n" +
+      "  -V, --version    Print version information.\n" +
       "\n" +
-      "Usage: directive <verb> [args...]\n" +
+      "Setup and maintenance:\n" +
+      "  init             Set up Directive in the current project.\n" +
+      "  update           Refresh an existing install and self-heal the engine.\n" +
+      "  doctor           Diagnose the install and print the next step.\n" +
+      "  First project: run `directive init`, then `directive doctor` from the project root.\n" +
+      "  Cold start: if `directive` will not run, read the bootstrap block at the top of README.md.\n" +
       "\n" +
-      "Registered verbs:\n",
+      "Daily checks:\n" +
+      "  session:start    Record the session-start ritual state.\n" +
+      "  check            Run the source checkout quality gate.\n" +
+      "  verify:cache-fresh\n" +
+      "                   Verify the deposited cache/bootstrap state.\n" +
+      "\n" +
+      "Triage and scope:\n" +
+      "  triage:welcome   Resume guided onboarding.\n" +
+      "  triage:queue     Show the ranked work queue.\n" +
+      "  scope:promote    Move a proposed scope into pending.\n" +
+      "  scope:activate   Start a pending scope.\n" +
+      "\n" +
+      "Project docs:\n" +
+      "  project:render   Regenerate PROJECT-DEFINITION-derived output.\n" +
+      "  spec:render      Regenerate SPECIFICATION.md.\n" +
+      "\n" +
+      "Help uses colon-style task verbs; dash-style aliases remain supported for compatibility.\n" +
+      "Run `directive commands` (or `directive --commands`) for the exhaustive registered command and alias list.\n",
   );
+}
+
+/** Print the exhaustive registered verb list for power users and compatibility checks. */
+export function printRegisteredCommands(io: DispatchIo = defaultIo()): void {
+  io.writeOut("Registered commands and aliases:\n");
   for (const name of registeredVerbs()) {
     io.writeOut(`  ${name}\n`);
   }
@@ -2777,6 +2804,11 @@ export async function dispatch(argv: string[], io: DispatchIo = defaultIo()): Pr
 
   if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h" || argv[0] === "help") {
     printHelp(io);
+    return 0;
+  }
+
+  if (argv[0] === "commands" || argv[0] === "--commands") {
+    printRegisteredCommands(io);
     return 0;
   }
 

--- a/packages/cli/src/gates-cli/session-ritual-cli.test.ts
+++ b/packages/cli/src/gates-cli/session-ritual-cli.test.ts
@@ -118,7 +118,7 @@ describe("verify session ritual TS module (maps tests/cli/test_verify_session_ri
 
 describe("deft-ts resume sentinel (maps tests/cli/test_resume.py — core unit coverage)", () => {
   it("framework resume commands are registered", () => {
-    const { exitCode, stdout } = runDeftTs("", ["--help"]);
+    const { exitCode, stdout } = runDeftTs("", ["commands"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("framework-commands");
   });

--- a/packages/cli/src/render-cli/deft-ts-runner.test.ts
+++ b/packages/cli/src/render-cli/deft-ts-runner.test.ts
@@ -14,7 +14,16 @@ describe("deft-ts runner", () => {
   it("runs --help with exit 0", () => {
     const result = runDeftTsArgv(["--help"]);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Usage: directive");
+    expect(result.stdout).toContain("Usage:");
+    expect(result.stdout).toContain("directive <command> [options]");
+    expect(result.stdout).toContain("directive commands");
+    expect(result.stdout).not.toContain("pack-render");
+  });
+
+  it("runs commands with the exhaustive registry", () => {
+    const result = runDeftTsArgv(["commands"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Registered commands and aliases:");
     expect(result.stdout).toContain("pack-render");
   });
 

--- a/xbrief/completed/2026-07-08-2172-improve-top-level-directive-help-output-and-command-discover.xbrief.json
+++ b/xbrief/completed/2026-07-08-2172-improve-top-level-directive-help-output-and-command-discover.xbrief.json
@@ -1,0 +1,61 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2172"
+  },
+  "plan": {
+    "title": "Improve top-level directive help output and command discovery",
+    "status": "completed",
+    "narratives": {
+      "Description": "Improve top-level directive help output and command discovery",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2172",
+      "Overview": "## Summary\n\nThe top-level `directive` / `directive --help` output is currently an undifferentiated dump of registered verbs. It should be structured like a normal CLI help surface: title/version, usage, common options, common commands, and a clear path to the full command list.\n\n## Current behavior\n\nRunning `directive` or `directive --help` prints:\n\n- `Usage: directive <verb> [args...]`\n- a long `Registered verbs:` list\n- both canonical and alias forms such as `verify-branch` and `verify:branch`\n- no introductory description\n- no command categories\n- no explanation of common options such as `--help`, `-h`, `--version`, or `-V`\n- no version in the help title, even though `--version` exists\n\nThis is difficult for humans and first-time users to scan.\n\n## Proposed behavior\n\nReplace the top-level help spew with a curated help page:\n\n- Title including tool name and major/minor version, for example `Directive v0.x`.\n- One-line description of what Directive does.\n- Usage forms:\n  - `directive <command> [options]`\n  - `directive help`\n  - `directive commands` or equivalent for the full list.\n- Common options:\n  - `-h, --help`\n  - `-V, --version`\n- Common verbs grouped by workflow, such as:\n  - `doctor`\n  - `session:start`\n  - `check`\n  - `triage:welcome`\n  - `triage:queue`\n  - `scope:promote`\n  - `project:render`\n  - `spec:render`\n- A clear note that colon-style task verbs are preferred in help, while dash-style aliases may remain supported for compatibility.\n- A separate full-list command or flag for exhaustive output.\n\n## Acceptance criteria\n\n- `directive` and `directive --help` print concise, categorized help rather than every registered verb.\n- `directive --version` prints only version information.\n- Help output documents common options.\n- The exhaustive registered-verb list remains available through an explicit command or flag.\n- Help avoids listing both dash and colon aliases unless explicitly showing aliases.\n- Tests snapshot the top-level help output and version output.\n\n## Related\n\nRelated but not duplicate: #1150 covers categorized help for `task triage` / `task scope`; #49 covered version display on command startup; #1669 tracks broader distributable CLI work.\n\n",
+      "Labels": "enhancement, interfaces, adoption-blocker, agent-experience, area:cli"
+    },
+    "items": [
+      {
+        "title": "`directive` and `directive --help` print concise, categorized help rather than every registered verb.",
+        "status": "proposed"
+      },
+      {
+        "title": "`directive --version` prints only version information.",
+        "status": "proposed"
+      },
+      {
+        "title": "Help output documents common options.",
+        "status": "proposed"
+      },
+      {
+        "title": "The exhaustive registered-verb list remains available through an explicit command or flag.",
+        "status": "proposed"
+      },
+      {
+        "title": "Help avoids listing both dash and colon aliases unless explicitly showing aliases.",
+        "status": "proposed"
+      },
+      {
+        "title": "Tests snapshot the top-level help output and version output.",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "interfaces",
+      "adoption-blocker",
+      "agent-experience",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2172",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2172: Improve top-level directive help output and command discovery"
+      }
+    ],
+    "updated": "2026-07-08T07:35:13Z",
+    "metadata": {
+      "completedAt": "2026-07-08T07:35:13Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces top-level `directive` / `directive --help` registry spew with versioned, categorized help for setup, checks, triage, scope, and docs.
- Adds `directive commands` / `directive --commands` for the exhaustive registered command and alias list.
- Routes single-token colon task verbs such as `scope:promote` and `verify:cache-fresh` through the same dispatcher paths as namespace-token equivalents.
- Hardens pack-migrate skill frontmatter parsing for CRLF Windows checkouts so shipped skills remain discoverable.

## Related Issues

Closes #2172.
Prior PR: #2391.

## Validation

- `pnpm exec vitest run packages/cli/src/dispatch.test.ts packages/cli/src/cli-router/router.test.ts packages/cli/src/gates-cli/session-ritual-cli.test.ts packages/cli/src/render-cli/deft-ts-runner.test.ts` passed: 138 tests.
- `node packages/cli/dist/bin.js pack-migrate-skills --skills-dir content/skills --references-md REFERENCES.md --out <temp>` passed: 20 skills, zero empty trigger maps.
- `pnpm run build` passed.
- `task vbrief:validate` passed with the existing PRD-stale warning.
- `git diff --check origin/master...HEAD` passed.