### PR TITLE
fix: warn on completed scopes referenced by umbrellas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Release Step 5 pre-flight now inherits the pipeline's self-auth bypass on master.** `task release` Step 5 runs `task check` with the same branch-bypass flags as git-mutation steps plus a Step-5-only `DEFT_RELEASE_PREFLIGHT` env for stale-cache tolerance, so `verify:branch` and aged triage cache no longer block an authorized release on the default branch while normal operator commits stay gated. Closes #2386.
 - **Windows-native `engine:_ts-build` now detects Corepack without Unix `sh`.** Package-manager probes use a cross-platform `shell:true` `--version` check so `corepack.cmd` is visible when bare `pnpm` and `sh` are absent from PATH, while preserving the #2411 Corepack step order and #2181 no-auto-build session path. Closes #2415. Refs #2410, #2411.
+- **Completed scopes now warn when open umbrellas still reference them.** `task scope:complete` points maintainers at `task vbrief:reconcile:umbrellas` when a shipped scope remains linked from an open tracker, while suppressing cached closed trackers so current-shape comments do not silently drift. Closes #2322. Refs #1119, #1152.
 
 ### Removed
 

--- a/packages/core/src/scope/index.ts
+++ b/packages/core/src/scope/index.ts
@@ -3,6 +3,7 @@ export * from "./constants.js";
 export * from "./decomposed-refs.js";
 export * from "./demote.js";
 export * from "./main.js";
+export * from "./open-umbrella-warning.js";
 export * from "./project-context.js";
 export * from "./transition.js";
 export * from "./undo.js";

--- a/packages/core/src/scope/main.ts
+++ b/packages/core/src/scope/main.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { canonicalLogPath, readAll } from "./audit-log.js";
 import { TRANSITIONS } from "./constants.js";
 import {
@@ -10,6 +10,11 @@ import {
   resolveFilePath,
   resolveProjectRootStrict,
 } from "./demote.js";
+import {
+  completedPathForScopeMove,
+  findOpenUmbrellaReferences,
+  renderOpenUmbrellaWarning,
+} from "./open-umbrella-warning.js";
 import { resolveProjectRoot } from "./project-context.js";
 import { recordWipCapOverride, runTransition } from "./transition.js";
 import {
@@ -136,6 +141,21 @@ export function lifecycleMain(argv: string[]): number {
       );
     }
     process.stdout.write(`${result.message}\n`);
+    if (action === "complete") {
+      try {
+        const completedPath = completedPathForScopeMove(filePath);
+        const rootForWarning =
+          resolveProjectRoot(projectRoot) ?? dirname(dirname(dirname(completedPath)));
+        const warning = renderOpenUmbrellaWarning(
+          findOpenUmbrellaReferences(rootForWarning, completedPath),
+        );
+        if (warning.length > 0) {
+          process.stderr.write(`${warning}\n`);
+        }
+      } catch {
+        /* best-effort drift warning; lifecycle success remains authoritative */
+      }
+    }
     return 0;
   }
   process.stderr.write(`Error: ${result.message}\n`);

--- a/packages/core/src/scope/open-umbrella-warning.test.ts
+++ b/packages/core/src/scope/open-umbrella-warning.test.ts
@@ -124,6 +124,32 @@ describe("scope complete open umbrella warning", () => {
     expect(warning).toContain("task vbrief:reconcile:umbrellas");
   });
 
+  it("detects direct stale active-scope links after the child moves to completed", () => {
+    root = makeRepo();
+    writeScope(root, "active", "umbrella.xbrief.json", {
+      title: "Umbrella tracker",
+      status: "running",
+      planRef: "active/child.xbrief.json",
+      references: [
+        { type: "x-xbrief/plan", uri: "active/child.xbrief.json" },
+        { type: "x-xbrief/github-issue", uri: `https://github.com/${REPO}/issues/1119` },
+      ],
+    });
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
+    });
+    writeCachedIssue(root, 1119, { title: "Umbrella tracker", labels: ["epic"] });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.sources).toEqual(expect.arrayContaining(["plan.references", "planRef"]));
+  });
+
   it("suppresses a local parent reference when the cached issue is closed", () => {
     root = makeRepo();
     writeScope(root, "active", "umbrella.xbrief.json", {
@@ -170,12 +196,14 @@ describe("scope complete open umbrella warning", () => {
     expect(refs[0]?.sources).toContain("cached issue body");
   });
 
-  it("scans cached markdown and URL mentions when the completed issue ref has no repo", () => {
+  it("scans cross-repo cached markdown URL mentions for qualified completed issue refs", () => {
     root = makeRepo();
     const child = writeScope(root, "completed", "child.xbrief.json", {
       title: "Completed child",
       status: "completed",
-      references: [{ type: "x-vbrief/github-issue", uri: "2322" }],
+      references: [
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
     });
     writeCachedIssue(root, 1119, {
       repo: "deftai/other",
@@ -375,6 +403,19 @@ describe("scope complete open umbrella warning", () => {
       ],
     });
     expect(findOpenUmbrellaReferences(root, childWithoutCache)).toEqual([]);
+
+    const childBare = writeScope(root, "completed", "bare.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [{ type: "x-vbrief/github-issue", uri: "2322" }],
+    });
+    writeCachedIssue(root, 1200, {
+      repo: "deftai/other",
+      title: "Bare ref near miss",
+      labels: ["meta"],
+      body: "Current shape still lists #2322.",
+    });
+    expect(findOpenUmbrellaReferences(root, childBare)).toEqual([]);
 
     const childZero = writeScope(root, "completed", "zero.xbrief.json", {
       title: "Completed child",

--- a/packages/core/src/scope/open-umbrella-warning.test.ts
+++ b/packages/core/src/scope/open-umbrella-warning.test.ts
@@ -38,14 +38,18 @@ function writeCachedIssue(
   root: string,
   number: number,
   payload: {
+    readonly repo?: string;
     readonly title: string;
     readonly state?: string;
     readonly body?: string;
     readonly labels?: readonly string[];
+    readonly rawLabels?: unknown;
     readonly subIssuesTotal?: number;
+    readonly contentMarkdown?: string;
   },
 ): void {
-  const issueDir = join(root, ".deft-cache", "github-issue", "deftai", "directive", String(number));
+  const [owner, repoName] = (payload.repo ?? REPO).split("/", 2);
+  const issueDir = join(root, ".deft-cache", "github-issue", owner, repoName, String(number));
   mkdirSync(issueDir, { recursive: true });
   writeFileSync(
     join(issueDir, "raw.json"),
@@ -55,7 +59,7 @@ function writeCachedIssue(
         title: payload.title,
         state: payload.state ?? "open",
         body: payload.body ?? "",
-        labels: (payload.labels ?? []).map((name) => ({ name })),
+        labels: payload.rawLabels ?? (payload.labels ?? []).map((name) => ({ name })),
         sub_issues_summary: { total: payload.subIssuesTotal ?? 0 },
       },
       null,
@@ -63,6 +67,9 @@ function writeCachedIssue(
     )}\n`,
     "utf8",
   );
+  if (payload.contentMarkdown !== undefined) {
+    writeFileSync(join(issueDir, "content.md"), payload.contentMarkdown, "utf8");
+  }
 }
 
 describe("scope complete open umbrella warning", () => {
@@ -157,6 +164,88 @@ describe("scope complete open umbrella warning", () => {
 
     expect(refs.map((ref) => ref.issueNumber)).toEqual([1119]);
     expect(refs[0]?.sources).toContain("cached issue body");
+  });
+
+  it("scans cached markdown and URL mentions when the completed issue ref has no repo", () => {
+    root = makeRepo();
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [{ type: "x-vbrief/github-issue", uri: "2322" }],
+    });
+    writeCachedIssue(root, 1119, {
+      repo: "deftai/other",
+      title: "Other repo umbrella",
+      labels: ["bug"],
+      contentMarkdown: "Current shape links https://github.com/deftai/directive/issues/2322.",
+    });
+    writeCachedIssue(root, 1200, {
+      repo: "deftai/other",
+      title: "Other repo tracker",
+      labels: ["meta"],
+      body: "This near miss references #23220 only.",
+    });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      repo: "deftai/other",
+      issueNumber: 1119,
+      title: "Other repo umbrella",
+    });
+  });
+
+  it("uses string labels and sub-issue totals to classify cached trackers", () => {
+    root = makeRepo();
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
+    });
+    writeCachedIssue(root, 1119, {
+      title: "Label tracker",
+      rawLabels: ["umbrella"],
+      body: "Current shape still lists #2322.",
+    });
+    writeCachedIssue(root, 1120, {
+      title: "Sub-issue parent",
+      subIssuesTotal: 2,
+      body: "Current shape still lists #2322.",
+    });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs.map((ref) => ref.issueNumber)).toEqual([1119, 1120]);
+  });
+
+  it("keeps unknown local parent references while ignoring malformed scopes", () => {
+    root = makeRepo();
+    writeFileSync(join(root, "xbrief", "active", "broken.xbrief.json"), "{", "utf8");
+    writeScope(root, "active", "loose-parent.xbrief.json", {
+      title: "Loose parent",
+      status: "running",
+      references: [{ type: "x-xbrief/plan", uri: "completed/child.xbrief.json" }],
+    });
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+    });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      issueNumber: null,
+      path: "xbrief/active/loose-parent.xbrief.json",
+      title: "Loose parent",
+    });
+  });
+
+  it("returns an empty warning for no open references", () => {
+    expect(renderOpenUmbrellaWarning([])).toBe("");
   });
 
   it("prints a non-blocking warning after scope:complete succeeds", () => {

--- a/packages/core/src/scope/open-umbrella-warning.test.ts
+++ b/packages/core/src/scope/open-umbrella-warning.test.ts
@@ -1,0 +1,193 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { lifecycleMain } from "./main.js";
+import { findOpenUmbrellaReferences, renderOpenUmbrellaWarning } from "./open-umbrella-warning.js";
+import { formatVbriefJson } from "./vbrief-json.js";
+
+const REPO = "deftai/directive";
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "scope-umbrella-"));
+  for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+    mkdirSync(join(root, "xbrief", folder), { recursive: true });
+  }
+  return root;
+}
+
+function writeScope(
+  root: string,
+  folder: string,
+  name: string,
+  plan: Record<string, unknown>,
+): string {
+  const path = join(root, "xbrief", folder, name);
+  writeFileSync(
+    path,
+    formatVbriefJson({
+      xBRIEFInfo: { version: "0.8" },
+      plan,
+    }),
+    "utf8",
+  );
+  return path;
+}
+
+function writeCachedIssue(
+  root: string,
+  number: number,
+  payload: {
+    readonly title: string;
+    readonly state?: string;
+    readonly body?: string;
+    readonly labels?: readonly string[];
+    readonly subIssuesTotal?: number;
+  },
+): void {
+  const issueDir = join(root, ".deft-cache", "github-issue", "deftai", "directive", String(number));
+  mkdirSync(issueDir, { recursive: true });
+  writeFileSync(
+    join(issueDir, "raw.json"),
+    `${JSON.stringify(
+      {
+        number,
+        title: payload.title,
+        state: payload.state ?? "open",
+        body: payload.body ?? "",
+        labels: (payload.labels ?? []).map((name) => ({ name })),
+        sub_issues_summary: { total: payload.subIssuesTotal ?? 0 },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
+describe("scope complete open umbrella warning", () => {
+  let root = "";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (root.length > 0) {
+      rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("finds open xBRIEF parent references and renders a reconcile hint", () => {
+    root = makeRepo();
+    writeScope(root, "active", "umbrella.xbrief.json", {
+      title: "Umbrella tracker",
+      status: "running",
+      metadata: { kind: "epic" },
+      references: [
+        { type: "x-xbrief/plan", uri: "completed/child.xbrief.json" },
+        { type: "x-xbrief/github-issue", uri: `https://github.com/${REPO}/issues/1119` },
+      ],
+    });
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      planRef: "active/umbrella.xbrief.json",
+      references: [
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
+    });
+    writeCachedIssue(root, 1119, { title: "Umbrella tracker", labels: ["epic"] });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      repo: REPO,
+      issueNumber: 1119,
+      title: "Umbrella tracker",
+    });
+    expect(refs[0]?.sources).toEqual(
+      expect.arrayContaining(["plan.references", "completed planRef"]),
+    );
+    const warning = renderOpenUmbrellaWarning(refs);
+    expect(warning).toContain("#1119");
+    expect(warning).toContain("task vbrief:reconcile:umbrellas");
+  });
+
+  it("suppresses a local parent reference when the cached issue is closed", () => {
+    root = makeRepo();
+    writeScope(root, "active", "umbrella.xbrief.json", {
+      title: "Closed umbrella",
+      status: "running",
+      metadata: { kind: "epic" },
+      references: [
+        { type: "x-xbrief/plan", uri: "completed/child.xbrief.json" },
+        { type: "x-xbrief/github-issue", uri: `https://github.com/${REPO}/issues/1119` },
+      ],
+    });
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+    });
+    writeCachedIssue(root, 1119, { title: "Closed umbrella", state: "closed", labels: ["epic"] });
+
+    expect(findOpenUmbrellaReferences(root, child)).toEqual([]);
+  });
+
+  it("detects cached open tracker bodies that mention the completed scope issue", () => {
+    root = makeRepo();
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
+    });
+    writeCachedIssue(root, 1119, {
+      title: "Umbrella tracker",
+      labels: ["meta"],
+      body: "Current shape still lists #2322 as in flight.",
+    });
+    writeCachedIssue(root, 1200, {
+      title: "Ordinary bug",
+      labels: ["bug"],
+      body: "Mentions #2322 but is not an umbrella/tracker.",
+    });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs.map((ref) => ref.issueNumber)).toEqual([1119]);
+    expect(refs[0]?.sources).toContain("cached issue body");
+  });
+
+  it("prints a non-blocking warning after scope:complete succeeds", () => {
+    root = makeRepo();
+    writeScope(root, "active", "umbrella.xbrief.json", {
+      title: "Umbrella tracker",
+      status: "running",
+      metadata: { kind: "epic" },
+      references: [
+        { type: "x-xbrief/plan", uri: "active/child.xbrief.json" },
+        { type: "x-xbrief/github-issue", uri: `https://github.com/${REPO}/issues/1119` },
+      ],
+    });
+    const child = writeScope(root, "active", "child.xbrief.json", {
+      title: "Completed child",
+      status: "running",
+      planRef: "active/umbrella.xbrief.json",
+      references: [
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
+    });
+    writeCachedIssue(root, 1119, { title: "Umbrella tracker", labels: ["epic"] });
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    expect(lifecycleMain(["complete", child, "--project-root", root])).toBe(0);
+
+    const out = stdout.mock.calls.map(([chunk]) => String(chunk)).join("");
+    const err = stderr.mock.calls.map(([chunk]) => String(chunk)).join("");
+    expect(out).toContain("Completed child.xbrief.json");
+    expect(err).toContain("Warning: scope:complete found open umbrella/tracker reference");
+    expect(err).toContain("#1119");
+  });
+});

--- a/packages/core/src/scope/open-umbrella-warning.test.ts
+++ b/packages/core/src/scope/open-umbrella-warning.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { lifecycleMain } from "./main.js";
-import { findOpenUmbrellaReferences, renderOpenUmbrellaWarning } from "./open-umbrella-warning.js";
+import {
+  completedPathForScopeMove,
+  findOpenUmbrellaReferences,
+  renderOpenUmbrellaWarning,
+} from "./open-umbrella-warning.js";
 import { formatVbriefJson } from "./vbrief-json.js";
 
 const REPO = "deftai/directive";
@@ -242,6 +246,150 @@ describe("scope complete open umbrella warning", () => {
       path: "xbrief/active/loose-parent.xbrief.json",
       title: "Loose parent",
     });
+  });
+
+  it("deduplicates local issue refs and preserves unknown local parents", () => {
+    root = makeRepo();
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+    });
+    writeScope(root, "active", "a-parent.xbrief.json", {
+      status: "running",
+      references: [
+        { type: "x-xbrief/plan", uri: "completed/child.xbrief.json" },
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/1119` },
+      ],
+    });
+    writeScope(root, "active", "b-parent.xbrief.json", {
+      title: "Named umbrella",
+      status: "running",
+      references: [
+        { type: "x-xbrief/plan", uri: "completed/child.xbrief.json" },
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/1119` },
+      ],
+    });
+    writeScope(root, "active", "c-parent.xbrief.json", {
+      status: "running",
+      planRef: "completed/child.xbrief.json",
+    });
+    writeScope(root, "active", "d-parent.xbrief.json", {
+      title: "Number-only parent",
+      status: "running",
+      references: [
+        { type: "x-xbrief/plan", uri: "completed/child.xbrief.json" },
+        { type: "x-vbrief/github-issue", uri: "1118" },
+        { type: "x-vbrief/github-issue", uri: "1119" },
+      ],
+    });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs).toHaveLength(3);
+    expect(refs.find((ref) => ref.issueNumber === 1119 && ref.repo === REPO)).toMatchObject({
+      title: "Named umbrella",
+      path: "xbrief/active/a-parent.xbrief.json",
+    });
+    expect(refs.find((ref) => ref.issueNumber === 1118 && ref.repo === null)).toMatchObject({
+      title: "Number-only parent",
+    });
+    expect(refs.find((ref) => ref.path === "xbrief/active/c-parent.xbrief.json")).toMatchObject({
+      title: "open scope",
+    });
+
+    const warning = renderOpenUmbrellaWarning([
+      { repo: null, issueNumber: null, title: "Manual tracker", path: null, sources: [] },
+      ...refs,
+    ]);
+    expect(warning).toContain("Manual tracker: Manual tracker");
+    expect(warning).toContain("#1118");
+  });
+
+  it("handles malformed references and cache-directory edge cases", () => {
+    root = makeRepo();
+    rmSync(join(root, "xbrief", "proposed"), { recursive: true, force: true });
+    const child = writeScope(root, "completed", "child.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [
+        null,
+        [],
+        { type: "note", uri: "https://github.com/deftai/directive/issues/2322" },
+        { type: "x-vbrief/github-issue", uri: "not-an-issue" },
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
+    });
+    writeScope(root, "active", "noise.xbrief.json", {
+      title: "Noise",
+      status: "running",
+      references: [
+        null,
+        [],
+        { type: "note", uri: "completed/child.xbrief.json" },
+        { type: "x-xbrief/plan", uri: "https://github.com/deftai/directive/issues/2322" },
+      ],
+    });
+    const cacheRoot = join(root, ".deft-cache", "github-issue");
+    mkdirSync(join(cacheRoot, "deftai", "directive", "not-a-number"), { recursive: true });
+    writeFileSync(join(cacheRoot, "not-owner"), "not a directory", "utf8");
+    writeFileSync(join(cacheRoot, "deftai", "not-repo"), "not a directory", "utf8");
+    writeFileSync(join(cacheRoot, "deftai", "directive", "readme.txt"), "not a directory", "utf8");
+    mkdirSync(join(cacheRoot, "deftai", "directive", "1200"), { recursive: true });
+    writeCachedIssue(root, 1119, {
+      title: "Omnibus tracker",
+      labels: ["bug"],
+      body: "Current shape still lists #2322.",
+      rawLabels: [{ name: 42 }, []],
+    });
+    writeCachedIssue(root, 1120, {
+      title: "Closed tracker",
+      state: "closed",
+      labels: ["meta"],
+      body: "Current shape still lists #2322.",
+    });
+    writeCachedIssue(root, 1300, {
+      repo: "deftai/other",
+      title: "Other repo tracker",
+      labels: ["meta"],
+      body: "Current shape still lists #2322.",
+    });
+
+    const refs = findOpenUmbrellaReferences(root, child);
+
+    expect(refs.map((ref) => ref.issueNumber)).toEqual([1119]);
+    expect(refs[0]?.title).toBe("Omnibus tracker");
+  });
+
+  it("returns empty results for invalid completed payloads, missing cache, and issue zero", () => {
+    root = makeRepo();
+    const invalid = join(root, "xbrief", "completed", "invalid.xbrief.json");
+    writeFileSync(invalid, "[]\n", "utf8");
+    expect(findOpenUmbrellaReferences(root, invalid)).toEqual([]);
+
+    const childWithoutCache = writeScope(root, "completed", "without-cache.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [
+        { type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/2322` },
+      ],
+    });
+    expect(findOpenUmbrellaReferences(root, childWithoutCache)).toEqual([]);
+
+    const childZero = writeScope(root, "completed", "zero.xbrief.json", {
+      title: "Completed child",
+      status: "completed",
+      references: [{ type: "x-vbrief/github-issue", uri: `https://github.com/${REPO}/issues/0` }],
+    });
+    writeCachedIssue(root, 1119, {
+      title: "Zero tracker",
+      labels: ["meta"],
+      body: "Current shape still lists #0.",
+    });
+    expect(findOpenUmbrellaReferences(root, childZero)).toEqual([]);
+    expect(completedPathForScopeMove(join(root, "xbrief", "active", "story.xbrief.json"))).toBe(
+      join(root, "xbrief", "completed", "story.xbrief.json"),
+    );
   });
 
   it("returns an empty warning for no open references", () => {

--- a/packages/core/src/scope/open-umbrella-warning.ts
+++ b/packages/core/src/scope/open-umbrella-warning.ts
@@ -1,0 +1,483 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { referenceTypeMatches } from "@deftai/directive-types";
+import { hasArtifactSuffix } from "../layout/resolve.js";
+import { CACHE_DIR_NAME, CACHE_SOURCE_GITHUB_ISSUE } from "../triage/queue/constants.js";
+import { parseGithubIssueUri } from "../triage/reconcile/parse-uri.js";
+import { collectPlanRefs, resolveVbriefRef } from "./vbrief-ref.js";
+
+const OPEN_FOLDERS = ["proposed", "pending", "active"] as const;
+const TRACKER_LABELS = new Set(["epic", "meta", "tracker", "type:tracker", "status:tracker"]);
+
+export interface OpenUmbrellaReference {
+  readonly repo: string | null;
+  readonly issueNumber: number | null;
+  readonly title: string;
+  readonly path: string | null;
+  readonly sources: readonly string[];
+}
+
+interface IssueRef {
+  readonly repo: string | null;
+  readonly number: number;
+}
+
+interface CachedIssue {
+  readonly repo: string;
+  readonly number: number;
+  readonly title: string;
+  readonly state: string;
+  readonly body: string;
+  readonly labels: readonly string[];
+  readonly subIssuesTotal: number;
+}
+
+interface MutableReference {
+  repo: string | null;
+  issueNumber: number | null;
+  title: string;
+  path: string | null;
+  sources: Set<string>;
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function planOf(data: Record<string, unknown> | null): Record<string, unknown> | null {
+  const plan = data?.plan;
+  return typeof plan === "object" && plan !== null && !Array.isArray(plan)
+    ? (plan as Record<string, unknown>)
+    : null;
+}
+
+function issueRefsFromPlan(plan: Record<string, unknown> | null): IssueRef[] {
+  const refs = plan?.references;
+  if (!Array.isArray(refs)) {
+    return [];
+  }
+  const out: IssueRef[] = [];
+  const seen = new Set<string>();
+  for (const ref of refs) {
+    if (typeof ref !== "object" || ref === null || Array.isArray(ref)) {
+      continue;
+    }
+    const typed = ref as Record<string, unknown>;
+    if (!referenceTypeMatches(String(typed.type ?? ""), "github-issue")) {
+      continue;
+    }
+    const [repo, number] = parseGithubIssueUri(typed.uri);
+    if (number === null) {
+      continue;
+    }
+    const key = `${repo ?? ""}:${number}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push({ repo, number });
+  }
+  return out;
+}
+
+function labelsFromRaw(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const out: string[] = [];
+  for (const label of raw) {
+    if (typeof label === "string") {
+      out.push(label);
+    } else if (typeof label === "object" && label !== null && !Array.isArray(label)) {
+      const name = (label as Record<string, unknown>).name;
+      if (typeof name === "string") {
+        out.push(name);
+      }
+    }
+  }
+  return out;
+}
+
+function subIssueTotal(raw: unknown): number {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return 0;
+  }
+  const total = (raw as Record<string, unknown>).total;
+  return typeof total === "number" && Number.isFinite(total) ? total : 0;
+}
+
+function readTextIfPresent(path: string): string {
+  if (!existsSync(path)) {
+    return "";
+  }
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function readCachedIssue(projectRoot: string, repo: string, number: number): CachedIssue | null {
+  const [owner, name] = repo.split("/", 2);
+  if (!owner || !name) {
+    return null;
+  }
+  const issueDir = join(
+    projectRoot,
+    CACHE_DIR_NAME,
+    CACHE_SOURCE_GITHUB_ISSUE,
+    owner,
+    name,
+    String(number),
+  );
+  const rawPath = join(issueDir, "raw.json");
+  const raw = readJson(rawPath);
+  if (raw === null) {
+    return null;
+  }
+  const body = typeof raw.body === "string" ? raw.body : "";
+  const content = readTextIfPresent(join(issueDir, "content.md"));
+  return {
+    repo,
+    number: typeof raw.number === "number" && Number.isFinite(raw.number) ? raw.number : number,
+    title: typeof raw.title === "string" ? raw.title : `#${number}`,
+    state: typeof raw.state === "string" ? raw.state.toLowerCase() : "open",
+    body: content.length > 0 ? `${body}\n${content}` : body,
+    labels: labelsFromRaw(raw.labels).map((label) => label.toLowerCase()),
+    subIssuesTotal: subIssueTotal(raw.sub_issues_summary),
+  };
+}
+
+function cachedState(projectRoot: string, ref: IssueRef): "open" | "closed" | null {
+  if (ref.repo === null) {
+    return null;
+  }
+  const cached = readCachedIssue(projectRoot, ref.repo, ref.number);
+  if (cached === null) {
+    return null;
+  }
+  return cached.state === "closed" ? "closed" : "open";
+}
+
+function chooseOpenIssueRef(projectRoot: string, refs: readonly IssueRef[]): IssueRef | null {
+  if (refs.length === 0) {
+    return null;
+  }
+  let firstUnknown: IssueRef | null = null;
+  for (const ref of refs) {
+    const state = cachedState(projectRoot, ref);
+    if (state === "open") {
+      return ref;
+    }
+    if (state === null && firstUnknown === null) {
+      firstUnknown = ref;
+    }
+  }
+  return firstUnknown;
+}
+
+function refUriMatchesPath(uri: unknown, targetPath: string, vbriefRoot: string): boolean {
+  if (typeof uri !== "string" || uri.length === 0) {
+    return false;
+  }
+  const resolved = resolveVbriefRef(uri, vbriefRoot);
+  if (resolved === null) {
+    return false;
+  }
+  return resolve(resolved) === resolve(targetPath);
+}
+
+function planReferenceMatchesTarget(ref: unknown, targetPath: string, vbriefRoot: string): boolean {
+  if (typeof ref !== "object" || ref === null || Array.isArray(ref)) {
+    return false;
+  }
+  const typed = ref as Record<string, unknown>;
+  if (!referenceTypeMatches(String(typed.type ?? ""), "plan")) {
+    return false;
+  }
+  return refUriMatchesPath(typed.uri, targetPath, vbriefRoot);
+}
+
+function planReferencesTarget(
+  plan: Record<string, unknown>,
+  targetPath: string,
+  vbriefRoot: string,
+): boolean {
+  const refs = plan.references;
+  if (!Array.isArray(refs)) {
+    return false;
+  }
+  return refs.some((ref) => planReferenceMatchesTarget(ref, targetPath, vbriefRoot));
+}
+
+function planRefsTarget(
+  plan: Record<string, unknown>,
+  targetPath: string,
+  vbriefRoot: string,
+): boolean {
+  return collectPlanRefs(plan).some((uri) => refUriMatchesPath(uri, targetPath, vbriefRoot));
+}
+
+function relToRoot(path: string, root: string): string {
+  return relative(resolve(root), resolve(path)).replace(/\\/g, "/");
+}
+
+function addReference(
+  out: Map<string, MutableReference>,
+  ref: {
+    readonly repo: string | null;
+    readonly issueNumber: number | null;
+    readonly title: string;
+    readonly path: string | null;
+    readonly source: string;
+  },
+): void {
+  const key =
+    ref.repo !== null && ref.issueNumber !== null
+      ? `${ref.repo}#${ref.issueNumber}`
+      : (ref.path ?? ref.title);
+  const existing = out.get(key);
+  if (existing !== undefined) {
+    existing.sources.add(ref.source);
+    if (existing.title.startsWith("#") && !ref.title.startsWith("#")) {
+      existing.title = ref.title;
+    }
+    return;
+  }
+  out.set(key, {
+    repo: ref.repo,
+    issueNumber: ref.issueNumber,
+    title: ref.title,
+    path: ref.path,
+    sources: new Set([ref.source]),
+  });
+}
+
+function titleForLocalCandidate(
+  plan: Record<string, unknown>,
+  issueRef: IssueRef | null,
+  projectRoot: string,
+): string {
+  if (issueRef?.repo !== null && issueRef?.repo !== undefined) {
+    const cached = readCachedIssue(projectRoot, issueRef.repo, issueRef.number);
+    if (cached !== null) {
+      return cached.title;
+    }
+  }
+  return typeof plan.title === "string" && plan.title.length > 0
+    ? plan.title
+    : issueRef !== null
+      ? `#${issueRef.number}`
+      : "open scope";
+}
+
+function findLocalReferences(
+  projectRoot: string,
+  completedScopePath: string,
+  completedPlan: Record<string, unknown>,
+  out: Map<string, MutableReference>,
+): void {
+  const vbriefRoot = dirname(dirname(resolve(completedScopePath)));
+  const targetParentPaths = collectPlanRefs(completedPlan)
+    .map((uri) => resolveVbriefRef(uri, vbriefRoot))
+    .filter((path): path is string => path !== null)
+    .map((path) => resolve(path));
+
+  for (const folder of OPEN_FOLDERS) {
+    const folderPath = join(vbriefRoot, folder);
+    if (!existsSync(folderPath)) {
+      continue;
+    }
+    for (const name of readdirSync(folderPath)
+      .filter((entry) => hasArtifactSuffix(entry))
+      .sort()) {
+      const path = join(folderPath, name);
+      const plan = planOf(readJson(path));
+      if (plan === null) {
+        continue;
+      }
+      const sources: string[] = [];
+      if (planReferencesTarget(plan, completedScopePath, vbriefRoot)) {
+        sources.push("plan.references");
+      }
+      if (planRefsTarget(plan, completedScopePath, vbriefRoot)) {
+        sources.push("planRef");
+      }
+      if (targetParentPaths.includes(resolve(path))) {
+        sources.push("completed planRef");
+      }
+      if (sources.length === 0) {
+        continue;
+      }
+      const issueRefs = issueRefsFromPlan(plan);
+      const issueRef = chooseOpenIssueRef(projectRoot, issueRefs);
+      if (issueRefs.length > 0 && issueRef === null) {
+        continue;
+      }
+      const relPath = relToRoot(path, projectRoot);
+      for (const source of sources) {
+        addReference(out, {
+          repo: issueRef?.repo ?? null,
+          issueNumber: issueRef?.number ?? null,
+          title: titleForLocalCandidate(plan, issueRef, projectRoot),
+          path: relPath,
+          source,
+        });
+      }
+    }
+  }
+}
+
+function cachedRepoDirs(projectRoot: string, targetRepos: ReadonlySet<string>): string[] {
+  const base = join(projectRoot, CACHE_DIR_NAME, CACHE_SOURCE_GITHUB_ISSUE);
+  if (!existsSync(base)) {
+    return [];
+  }
+  const repos: string[] = [];
+  for (const ownerEntry of readdirSync(base, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
+    if (!ownerEntry.isDirectory()) {
+      continue;
+    }
+    const owner = ownerEntry.name;
+    const ownerPath = join(base, owner);
+    for (const repoEntry of readdirSync(ownerPath, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      if (!repoEntry.isDirectory()) {
+        continue;
+      }
+      const name = repoEntry.name;
+      const repo = `${owner}/${name}`;
+      if (targetRepos.size === 0 || targetRepos.has(repo)) {
+        repos.push(repo);
+      }
+    }
+  }
+  return repos;
+}
+
+function textMentionsIssue(text: string, issueNumber: number): boolean {
+  const hash = new RegExp(`(^|[^A-Za-z0-9_#])#${issueNumber}(?!\\d)`);
+  const url = new RegExp(`/issues/${issueNumber}(?:\\D|$)`);
+  return hash.test(text) || url.test(text);
+}
+
+function looksLikeTracker(issue: CachedIssue): boolean {
+  if (issue.subIssuesTotal > 0) {
+    return true;
+  }
+  if (issue.labels.some((label) => TRACKER_LABELS.has(label) || label.includes("umbrella"))) {
+    return true;
+  }
+  return /\b(epic|omnibus|tracker|umbrella)\b/i.test(issue.title);
+}
+
+function findCachedIssueBodyReferences(
+  projectRoot: string,
+  targetIssueRefs: readonly IssueRef[],
+  out: Map<string, MutableReference>,
+): void {
+  const targetNumbers = new Set(targetIssueRefs.map((ref) => ref.number));
+  if (targetNumbers.size === 0) {
+    return;
+  }
+  const targetRepos = new Set(
+    targetIssueRefs.flatMap((ref) => (ref.repo === null ? [] : [ref.repo])),
+  );
+  for (const repo of cachedRepoDirs(projectRoot, targetRepos)) {
+    const [owner, name] = repo.split("/", 2);
+    if (!owner || !name) {
+      continue;
+    }
+    const repoDir = join(projectRoot, CACHE_DIR_NAME, CACHE_SOURCE_GITHUB_ISSUE, owner, name);
+    for (const entry of readdirSync(repoDir, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) {
+        continue;
+      }
+      const issueNumber = Number(entry.name);
+      if (targetNumbers.has(issueNumber)) {
+        continue;
+      }
+      const issue = readCachedIssue(projectRoot, repo, issueNumber);
+      if (issue === null || issue.state !== "open" || !looksLikeTracker(issue)) {
+        continue;
+      }
+      const haystack = `${issue.title}\n${issue.body}`;
+      if (![...targetNumbers].some((number) => textMentionsIssue(haystack, number))) {
+        continue;
+      }
+      addReference(out, {
+        repo,
+        issueNumber: issue.number,
+        title: issue.title,
+        path: null,
+        source: "cached issue body",
+      });
+    }
+  }
+}
+
+/** Find open umbrella/tracker surfaces that still mention a just-completed scope. */
+export function findOpenUmbrellaReferences(
+  projectRoot: string,
+  completedScopePath: string,
+): OpenUmbrellaReference[] {
+  const data = readJson(completedScopePath);
+  const completedPlan = planOf(data);
+  if (completedPlan === null) {
+    return [];
+  }
+
+  const out = new Map<string, MutableReference>();
+  findLocalReferences(projectRoot, completedScopePath, completedPlan, out);
+  findCachedIssueBodyReferences(projectRoot, issueRefsFromPlan(completedPlan), out);
+
+  return [...out.values()]
+    .map((ref) => ({
+      repo: ref.repo,
+      issueNumber: ref.issueNumber,
+      title: ref.title,
+      path: ref.path,
+      sources: [...ref.sources].sort(),
+    }))
+    .sort((a, b) => {
+      const aKey = a.issueNumber !== null ? `${a.repo ?? ""}#${a.issueNumber}` : (a.path ?? "");
+      const bKey = b.issueNumber !== null ? `${b.repo ?? ""}#${b.issueNumber}` : (b.path ?? "");
+      return aKey.localeCompare(bKey);
+    });
+}
+
+function displayReference(ref: OpenUmbrellaReference): string {
+  const issue =
+    ref.issueNumber !== null ? `#${ref.issueNumber}${ref.repo ? ` (${ref.repo})` : ""}` : null;
+  const path = ref.path !== null ? ref.path : null;
+  const name = issue ?? path ?? ref.title;
+  return `${name}: ${ref.title}`;
+}
+
+export function renderOpenUmbrellaWarning(refs: readonly OpenUmbrellaReference[]): string {
+  if (refs.length === 0) {
+    return "";
+  }
+  const names = refs.map(displayReference).join("; ");
+  return (
+    `Warning: scope:complete found open umbrella/tracker reference(s) to the completed scope: ${names}. ` +
+    "Run `task vbrief:reconcile:umbrellas` to refresh current-shape comments."
+  );
+}
+
+export function completedPathForScopeMove(filePath: string): string {
+  const resolved = resolve(filePath);
+  return join(dirname(dirname(resolved)), "completed", basename(resolved));
+}

--- a/packages/core/src/scope/open-umbrella-warning.ts
+++ b/packages/core/src/scope/open-umbrella-warning.ts
@@ -365,9 +365,17 @@ function cachedRepoDirs(projectRoot: string, targetRepos: ReadonlySet<string>): 
   return repos;
 }
 
+function issueNumberToken(issueNumber: number): string | null {
+  return Number.isSafeInteger(issueNumber) && issueNumber > 0 ? String(issueNumber) : null;
+}
+
 function textMentionsIssue(text: string, issueNumber: number): boolean {
-  const hash = new RegExp(`(^|[^A-Za-z0-9_#])#${issueNumber}(?!\\d)`);
-  const url = new RegExp(`/issues/${issueNumber}(?:\\D|$)`);
+  const token = issueNumberToken(issueNumber);
+  if (token === null) {
+    return false;
+  }
+  const hash = new RegExp(`(^|[^A-Za-z0-9_#])#${token}(?!\\d)`);
+  const url = new RegExp(`/issues/${token}(?:\\D|$)`);
   return hash.test(text) || url.test(text);
 }
 

--- a/packages/core/src/scope/open-umbrella-warning.ts
+++ b/packages/core/src/scope/open-umbrella-warning.ts
@@ -183,7 +183,11 @@ function chooseOpenIssueRef(projectRoot: string, refs: readonly IssueRef[]): Iss
   return firstUnknown;
 }
 
-function refUriMatchesPath(uri: unknown, targetPath: string, vbriefRoot: string): boolean {
+function refUriMatchesPath(
+  uri: unknown,
+  targetPaths: ReadonlySet<string>,
+  vbriefRoot: string,
+): boolean {
   if (typeof uri !== "string" || uri.length === 0) {
     return false;
   }
@@ -191,10 +195,14 @@ function refUriMatchesPath(uri: unknown, targetPath: string, vbriefRoot: string)
   if (resolved === null) {
     return false;
   }
-  return resolve(resolved) === resolve(targetPath);
+  return targetPaths.has(resolve(resolved));
 }
 
-function planReferenceMatchesTarget(ref: unknown, targetPath: string, vbriefRoot: string): boolean {
+function planReferenceMatchesTarget(
+  ref: unknown,
+  targetPaths: ReadonlySet<string>,
+  vbriefRoot: string,
+): boolean {
   if (typeof ref !== "object" || ref === null || Array.isArray(ref)) {
     return false;
   }
@@ -202,27 +210,27 @@ function planReferenceMatchesTarget(ref: unknown, targetPath: string, vbriefRoot
   if (!referenceTypeMatches(String(typed.type ?? ""), "plan")) {
     return false;
   }
-  return refUriMatchesPath(typed.uri, targetPath, vbriefRoot);
+  return refUriMatchesPath(typed.uri, targetPaths, vbriefRoot);
 }
 
 function planReferencesTarget(
   plan: Record<string, unknown>,
-  targetPath: string,
+  targetPaths: ReadonlySet<string>,
   vbriefRoot: string,
 ): boolean {
   const refs = plan.references;
   if (!Array.isArray(refs)) {
     return false;
   }
-  return refs.some((ref) => planReferenceMatchesTarget(ref, targetPath, vbriefRoot));
+  return refs.some((ref) => planReferenceMatchesTarget(ref, targetPaths, vbriefRoot));
 }
 
 function planRefsTarget(
   plan: Record<string, unknown>,
-  targetPath: string,
+  targetPaths: ReadonlySet<string>,
   vbriefRoot: string,
 ): boolean {
-  return collectPlanRefs(plan).some((uri) => refUriMatchesPath(uri, targetPath, vbriefRoot));
+  return collectPlanRefs(plan).some((uri) => refUriMatchesPath(uri, targetPaths, vbriefRoot));
 }
 
 function relToRoot(path: string, root: string): string {
@@ -285,6 +293,12 @@ function findLocalReferences(
   out: Map<string, MutableReference>,
 ): void {
   const vbriefRoot = dirname(dirname(resolve(completedScopePath)));
+  const targetScopePaths = new Set(
+    [
+      completedScopePath,
+      ...OPEN_FOLDERS.map((folder) => join(vbriefRoot, folder, basename(completedScopePath))),
+    ].map((path) => resolve(path)),
+  );
   const targetParentPaths = collectPlanRefs(completedPlan)
     .map((uri) => resolveVbriefRef(uri, vbriefRoot))
     .filter((path): path is string => path !== null)
@@ -304,10 +318,10 @@ function findLocalReferences(
         continue;
       }
       const sources: string[] = [];
-      if (planReferencesTarget(plan, completedScopePath, vbriefRoot)) {
+      if (planReferencesTarget(plan, targetScopePaths, vbriefRoot)) {
         sources.push("plan.references");
       }
-      if (planRefsTarget(plan, completedScopePath, vbriefRoot)) {
+      if (planRefsTarget(plan, targetScopePaths, vbriefRoot)) {
         sources.push("planRef");
       }
       if (targetParentPaths.includes(resolve(path))) {
@@ -335,7 +349,7 @@ function findLocalReferences(
   }
 }
 
-function cachedRepoDirs(projectRoot: string, targetRepos: ReadonlySet<string>): string[] {
+function cachedRepoDirs(projectRoot: string): string[] {
   const base = join(projectRoot, CACHE_DIR_NAME, CACHE_SOURCE_GITHUB_ISSUE);
   if (!existsSync(base)) {
     return [];
@@ -356,10 +370,7 @@ function cachedRepoDirs(projectRoot: string, targetRepos: ReadonlySet<string>): 
         continue;
       }
       const name = repoEntry.name;
-      const repo = `${owner}/${name}`;
-      if (targetRepos.size === 0 || targetRepos.has(repo)) {
-        repos.push(repo);
-      }
+      repos.push(`${owner}/${name}`);
     }
   }
   return repos;
@@ -369,14 +380,27 @@ function issueNumberToken(issueNumber: number): string | null {
   return Number.isSafeInteger(issueNumber) && issueNumber > 0 ? String(issueNumber) : null;
 }
 
-function textMentionsIssue(text: string, issueNumber: number): boolean {
-  const token = issueNumberToken(issueNumber);
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function textMentionsIssue(text: string, ref: IssueRef, cachedRepo: string): boolean {
+  const token = issueNumberToken(ref.number);
   if (token === null) {
     return false;
   }
   const hash = new RegExp(`(^|[^A-Za-z0-9_#])#${token}(?!\\d)`);
-  const url = new RegExp(`/issues/${token}(?:\\D|$)`);
-  return hash.test(text) || url.test(text);
+  if (ref.repo === cachedRepo && hash.test(text)) {
+    return true;
+  }
+  if (ref.repo === null) {
+    return false;
+  }
+  const repo = escapeRegExp(ref.repo);
+  const qualifiedUrl = new RegExp(
+    `(?:github\\.com|api\\.github\\.com/repos)/${repo}/issues/${token}(?:\\D|$)`,
+  );
+  return qualifiedUrl.test(text);
 }
 
 function looksLikeTracker(issue: CachedIssue): boolean {
@@ -398,10 +422,10 @@ function findCachedIssueBodyReferences(
   if (targetNumbers.size === 0) {
     return;
   }
-  const targetRepos = new Set(
-    targetIssueRefs.flatMap((ref) => (ref.repo === null ? [] : [ref.repo])),
-  );
-  for (const repo of cachedRepoDirs(projectRoot, targetRepos)) {
+  if (!targetIssueRefs.some((ref) => ref.repo !== null)) {
+    return;
+  }
+  for (const repo of cachedRepoDirs(projectRoot)) {
     const [owner, name] = repo.split("/", 2);
     if (!owner || !name) {
       continue;
@@ -422,7 +446,7 @@ function findCachedIssueBodyReferences(
         continue;
       }
       const haystack = `${issue.title}\n${issue.body}`;
-      if (![...targetNumbers].some((number) => textMentionsIssue(haystack, number))) {
+      if (!targetIssueRefs.some((ref) => textMentionsIssue(haystack, ref, repo))) {
         continue;
       }
       addReference(out, {

--- a/packages/core/src/scope/open-umbrella-warning.ts
+++ b/packages/core/src/scope/open-umbrella-warning.ts
@@ -77,7 +77,7 @@ function issueRefsFromPlan(plan: Record<string, unknown> | null): IssueRef[] {
     if (number === null) {
       continue;
     }
-    const key = `${repo ?? ""}:${number}`;
+    const key = repo === null ? `bare:${number}` : `${repo}:${number}`;
     if (seen.has(key)) {
       continue;
     }

--- a/xbrief/completed/2026-07-08-2322-scope-complete-open-umbrella-reconcile.xbrief.json
+++ b/xbrief/completed/2026-07-08-2322-scope-complete-open-umbrella-reconcile.xbrief.json
@@ -1,0 +1,68 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2322"
+  },
+  "plan": {
+    "title": "scope:complete should warn and reconcile when completed scope is referenced by an open umbrella",
+    "status": "completed",
+    "narratives": {
+      "Description": "When task scope:complete moves a scope xBRIEF from active/ to completed/, it does not warn when an open umbrella or tracker issue still references that completed scope. The umbrella current-shape comment and body checklist can keep showing the scope as in-flight, and nothing points the operator at vbrief:reconcile:umbrellas.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2322",
+      "UserStory": "As a maintainer completing scope work under umbrella trackers, I want scope:complete to detect open umbrellas that still reference the completed scope and print a non-blocking reconcile hint, so umbrella current-shape/checklist state does not silently drift after the scope ships.",
+      "ImplementationPlan": "1. Find the TS scope-complete path and the existing umbrella reconciliation helpers. 2. After the lifecycle move succeeds, detect open umbrella/tracker references to the completed scope using available xBRIEF references, planRef links, and GitHub issue-reference compatibility. 3. Emit a non-blocking warning naming each open umbrella and pointing at task vbrief:reconcile:umbrellas. 4. Keep auto-reconcile behind an explicit flag or leave it as a clear follow-up if no existing consent surface is present. 5. Add consumer-style tests proving completion succeeds, the warning appears for open umbrella references, closed/non-referencing umbrellas do not warn, and existing completion behavior is preserved.",
+      "Traces": "#2322, #1649, #370, #1152, #1119",
+      "Overview": "Issue #2322 reports a recurrence from PR #2320: a completed scope moved to xbrief/completed while umbrella #1119 correctly stayed open, but no warning or reconcile handoff told the operator that the open umbrella still referenced the shipped scope. This complements #1649 and #370 by covering loose umbrella/tracker relationships rather than decomposed epic-child completion."
+    },
+    "items": [
+      {
+        "title": "scope:complete detects open umbrella or tracker issues that reference the completed scope.",
+        "status": "proposed"
+      },
+      {
+        "title": "scope:complete prints a non-blocking warning naming the open umbrella and the vbrief:reconcile:umbrellas next step.",
+        "status": "proposed"
+      },
+      {
+        "title": "Detection handles xBRIEF plan links and legacy GitHub issue-reference styles without regressing existing scope completion.",
+        "status": "proposed"
+      },
+      {
+        "title": "Tests cover open umbrella warning, closed or unrelated umbrella suppression, and successful completion lifecycle behavior.",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2322",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2322: scope:complete should warn + reconcile when the completed scope is referenced by an OPEN umbrella"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1649",
+        "type": "x-xbrief/refs",
+        "title": "Issue #1649"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/370",
+        "type": "x-xbrief/refs",
+        "title": "Issue #370"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1152",
+        "type": "x-xbrief/refs",
+        "title": "Issue #1152"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1119",
+        "type": "x-xbrief/refs",
+        "title": "Issue #1119"
+      }
+    ],
+    "updated": "2026-07-08T08:11:29Z",
+    "metadata": {
+      "completedAt": "2026-07-08T08:11:29Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a best-effort `scope:complete` warning when the completed scope is still referenced by an open umbrella or tracker.
- Detects local xBRIEF parent references, child `planRef` links, and cached open tracker bodies while suppressing cached closed trackers.
- Completes the #2322 scope xBRIEF and adds the release note.

## Related Issues

Closes #2322.
Refs #1119, #1152.
Prior PR: #2392.

## Validation

- `pnpm exec vitest run packages/core/src/scope/open-umbrella-warning.test.ts` passed: 12 tests.
- `pnpm run build` passed.
- `task vbrief:validate` passed with the existing PRD-stale warning.
- `git diff --check origin/master...HEAD` passed.
- Broader `pnpm exec vitest run packages/core/src/scope` was attempted on Windows native and fails in unrelated existing path-assumption suites; the focused #2322 suite passes.

## Post-Merge

- Verify issue auto-close for #2322 after squash merge.
- Confirm protected references #1119 and #1152 remain open.