### PR TITLE
fix(init): deposit shared hook helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,15 @@ jobs:
           )
           if (Get-Command bash -ErrorAction SilentlyContinue) {
             $shShim = Join-Path $shimDir 'deft'
-            bash -lc "chmod +x '$($shShim.Replace('\', '/'))'"
+            $env:DEFT_SMOKE_SHIM = $shShim.Replace('\', '/')
+            try {
+              bash -lc 'chmod +x "$DEFT_SMOKE_SHIM"'
+              if ($LASTEXITCODE -ne 0) {
+                throw "failed to chmod deft shell shim"
+              }
+            } finally {
+              Remove-Item Env:DEFT_SMOKE_SHIM -ErrorAction SilentlyContinue
+            }
           }
           $env:PATH = "$shimDir;$env:PATH"
           $consumer = Join-Path $smokeRoot 'consumer'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,10 @@ jobs:
             "#!/bin/sh`nnode `"$cli`" " + '"$@"' + "`n",
             (New-Object System.Text.UTF8Encoding $false)
           )
+          if (Get-Command bash -ErrorAction SilentlyContinue) {
+            $shShim = Join-Path $shimDir 'deft'
+            bash -lc "chmod +x '$($shShim.Replace('\', '/'))'"
+          }
           $env:PATH = "$shimDir;$env:PATH"
           $consumer = Join-Path $smokeRoot 'consumer'
           New-Item -ItemType Directory -Path $consumer -Force | Out-Null
@@ -448,12 +452,14 @@ jobs:
             git config core.autocrlf true
             git config user.name ci
             git config user.email ci@example.com
+            git switch -c smoke-baseline
+            if ($LASTEXITCODE -ne 0) { throw "git switch smoke-baseline exited $LASTEXITCODE" }
 
             node $cli init --yes --repo-root $consumer
             if ($LASTEXITCODE -ne 0) { throw "directive init exited $LASTEXITCODE" }
 
             git add -A
-            git commit --no-verify -q -m baseline
+            git commit -q -m baseline
             if ($LASTEXITCODE -ne 0) { throw "baseline commit exited $LASTEXITCODE" }
 
             node $cli update --yes --repo-root $consumer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TS-native init now deposits the shared git-hook helper.** npm-installed projects receive `.githooks/_deft-run.sh` alongside `pre-commit` and `pre-push`, `verify:hooks-installed` catches missing helpers, and the Windows update smoke now baseline-commits through the hooks instead of bypassing them. Refs #2067, #2248.
+
 ### Removed
 
 ## [0.74.0] - 2026-07-10

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -125,6 +125,11 @@ describe("runInitDeposit", () => {
       "utf8",
     );
     chmodSync(join(pkgDir, ".githooks", "pre-push"), 0o755);
+    writeFileSync(
+      join(pkgDir, ".githooks", "_deft-run.sh"),
+      readFileSync(join(process.cwd(), ".githooks/_deft-run.sh"), "utf8"),
+      "utf8",
+    );
     writeFileSync(join(pkgDir, "Taskfile.yml"), "version: '3'\n", "utf8");
     return pkgDir;
   }
@@ -156,6 +161,9 @@ describe("runInitDeposit", () => {
     expect(existsSync(join(project, ".githooks", "pre-commit"))).toBe(true);
     expect(readFileSync(join(project, ".githooks", "pre-commit"), "utf8")).toContain(
       "deft verify:branch",
+    );
+    expect(readFileSync(join(project, ".githooks", "_deft-run.sh"), "utf8")).toContain(
+      "run_deft()",
     );
     expect(readFileSync(join(project, "Taskfile.yml"), "utf8")).toContain(
       "./.deft/core/Taskfile.yml",

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -89,6 +89,11 @@ describe("init-deposit scaffold", () => {
       "utf8",
     );
     chmodSync(join(deftDir, ".githooks", "pre-push"), 0o755);
+    writeFileSync(
+      join(deftDir, ".githooks", "_deft-run.sh"),
+      readFileSync(join(process.cwd(), ".githooks/_deft-run.sh"), "utf8"),
+      "utf8",
+    );
   }
 
   it("writes AGENTS.md managed section on greenfield", () => {
@@ -155,6 +160,9 @@ describe("init-deposit scaffold", () => {
     ).toBe(true);
     expect(readFileSync(join(project, ".githooks", "pre-commit"), "utf8")).toContain(
       "deft verify:branch",
+    );
+    expect(readFileSync(join(project, ".githooks", "_deft-run.sh"), "utf8")).toContain(
+      "run_deft()",
     );
   });
 

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -539,7 +539,9 @@ export function ensureTaskfile(projectDir: string, io: InitDepositIo): boolean {
 }
 
 const HOOK_FILENAMES = ["pre-commit", "pre-push"] as const;
+const HOOK_SUPPORT_FILENAMES = ["_deft-run.sh"] as const;
 const HOOK_FILE_MODE = 0o755;
+const HOOK_SUPPORT_FILE_MODE = 0o644;
 
 export interface GitHooksSeams {
   getHooksPath?: (projectDir: string) => string | null;
@@ -562,17 +564,19 @@ export function writeConsumerGitHooks(
   mkdirSync(dstDir, { recursive: true });
 
   let filesDeposited = false;
-  for (const name of HOOK_FILENAMES) {
+  for (const name of [...HOOK_FILENAMES, ...HOOK_SUPPORT_FILENAMES]) {
     const src = join(srcDir, name);
     if (!existsSync(src)) continue;
     const data = readFileSync(src);
     const dst = join(dstDir, name);
     const existing = existsSync(dst) ? readFileSync(dst) : null;
+    const isHookScript = HOOK_FILENAMES.includes(name as (typeof HOOK_FILENAMES)[number]);
     if (!existing?.equals(data)) {
-      writeFileSync(dst, data, { mode: HOOK_FILE_MODE });
+      const mode = isHookScript ? HOOK_FILE_MODE : HOOK_SUPPORT_FILE_MODE;
+      writeFileSync(dst, data, { mode });
       filesDeposited = true;
     }
-    if (platform() !== "win32") {
+    if (platform() !== "win32" && isHookScript) {
       try {
         const mode = statSync(dst).mode & 0o777;
         if ((mode & 0o111) === 0) {

--- a/packages/core/src/release-e2e/content-prepack.test.ts
+++ b/packages/core/src/release-e2e/content-prepack.test.ts
@@ -58,6 +58,7 @@ function buildFakeRepo(options: { withScripts?: boolean } = {}): { root: string;
   mkdirSync(join(root, ".githooks"), { recursive: true });
   writeFileSync(join(root, ".githooks", "pre-commit"), "#!/bin/sh\nexit 0\n", "utf8");
   writeFileSync(join(root, ".githooks", "pre-push"), "#!/bin/sh\nexit 0\n", "utf8");
+  writeFileSync(join(root, ".githooks", "_deft-run.sh"), 'run_deft() { deft "$@"; }\n', "utf8");
   writeFileSync(join(root, "Taskfile.yml"), "version: '3'\n", "utf8");
   mkdirSync(join(root, "tasks"), { recursive: true });
   writeFileSync(join(root, "tasks", "swarm.yml"), "version: '3'\n", "utf8");
@@ -121,6 +122,7 @@ describe("@deftai/directive-content prepack (#1967 / #2022 Phase 3)", () => {
     runPrepack(pkgDir);
     expect(existsSync(join(pkgDir, ".githooks", "pre-commit"))).toBe(true);
     expect(existsSync(join(pkgDir, ".githooks", "pre-push"))).toBe(true);
+    expect(existsSync(join(pkgDir, ".githooks", "_deft-run.sh"))).toBe(true);
     expect(existsSync(join(pkgDir, "Taskfile.yml"))).toBe(true);
     expect(existsSync(join(pkgDir, "tasks", "swarm.yml"))).toBe(true);
   });
@@ -139,6 +141,7 @@ describe("@deftai/directive-content prepack (#1967 / #2022 Phase 3)", () => {
     runPrepack(pkgDir);
     expect(existsSync(join(pkgDir, "scripts"))).toBe(false);
     expect(existsSync(join(pkgDir, ".githooks", "pre-commit"))).toBe(true);
+    expect(existsSync(join(pkgDir, ".githooks", "_deft-run.sh"))).toBe(true);
     expect(existsSync(join(pkgDir, "Taskfile.yml"))).toBe(true);
   });
 });

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -49,6 +49,7 @@ function installFakeContentPackage(projectRoot: string, version = "0.53.0"): str
   chmodSync(join(pkgDir, ".githooks", "pre-commit"), 0o755);
   writeFileSync(join(pkgDir, ".githooks", "pre-push"), "#!/bin/sh\nexit 0\n", "utf8");
   chmodSync(join(pkgDir, ".githooks", "pre-push"), 0o755);
+  writeFileSync(join(pkgDir, ".githooks", "_deft-run.sh"), 'run_deft() { deft "$@"; }\n', "utf8");
   writeFileSync(join(pkgDir, "Taskfile.yml"), "version: '3'\n", "utf8");
   writeFileSync(join(pkgDir, "tasks", "swarm.yml"), "version: '3'\n", "utf8");
   return pkgDir;
@@ -127,11 +128,13 @@ describe("deposit journey e2e legs (#1942 S5)", () => {
     // resolvable Taskfile (with its tasks/ fragments + helper scripts), not a
     // graceful "absent — skipping" deposit.
     expect(existsSync(join(result.deftDir, ".githooks", "pre-commit"))).toBe(true);
+    expect(existsSync(join(result.deftDir, ".githooks", "_deft-run.sh"))).toBe(true);
     expect(existsSync(join(result.deftDir, "Taskfile.yml"))).toBe(true);
     expect(existsSync(join(result.deftDir, "tasks", "swarm.yml"))).toBe(true);
     expect(existsSync(join(result.deftDir, "scripts"))).toBe(false);
     // ...and `directive init` wires the hooks to the consumer root + include.
     expect(existsSync(join(project, ".githooks", "pre-commit"))).toBe(true);
+    expect(existsSync(join(project, ".githooks", "_deft-run.sh"))).toBe(true);
     expect(readFileSync(join(project, "Taskfile.yml"), "utf8")).toContain(
       "./.deft/core/Taskfile.yml",
     );

--- a/packages/core/src/verify-env/branches.test.ts
+++ b/packages/core/src/verify-env/branches.test.ts
@@ -159,6 +159,7 @@ deft preflight-gh --pre-push-stdin
       writeFileSync(hook, body, "utf8");
       chmodSync(hook, mode);
     }
+    writeFileSync(join(hooksDir, "_deft-run.sh"), 'run_deft() { deft "$@"; }\n', "utf8");
   }
 
   it("covers missing hooks dir and hook files", () => {
@@ -182,6 +183,7 @@ deft preflight-gh --pre-push-stdin
     writeDeftHooks(hooks, 0o644);
     const result = evaluate(root, {
       platform: "linux",
+      hookExecutable: () => false,
       gitConfigReader: () => ({ hooksPath: ".githooks", error: null }),
     });
     expect(result.code).toBe(1);
@@ -292,7 +294,7 @@ describe("verify-no-task-runtime branches", () => {
     writeFileSync(join(root, "run"), "#", "utf8");
     writeFileSync(join(root, "scripts", "a.py"), "#", "utf8");
     writeFileSync(join(root, "scripts", "verify_no_task_runtime.py"), "#", "utf8");
-    const files = defaultPythonFiles(root);
+    const files = defaultPythonFiles(root).map((file) => file.replace(/\\/g, "/"));
     expect(files.some((f) => f.endsWith("/run"))).toBe(true);
     expect(files.some((f) => f.endsWith("/a.py"))).toBe(true);
     expect(files.some((f) => f.endsWith("/verify_no_task_runtime.py"))).toBe(false);

--- a/packages/core/src/verify-env/verify-hooks-installed.test.ts
+++ b/packages/core/src/verify-env/verify-hooks-installed.test.ts
@@ -49,6 +49,7 @@ function makeDeftHooks(root: string, rel = ".githooks"): string {
   const prePush = join(hooks, "pre-push");
   writeFileSync(preCommit, DEFT_PRE_COMMIT, "utf8");
   writeFileSync(prePush, DEFT_PRE_PUSH, "utf8");
+  writeFileSync(join(hooks, "_deft-run.sh"), 'run_deft() { deft "$@"; }\n', "utf8");
   chmodSync(preCommit, 0o755);
   chmodSync(prePush, 0o755);
   return hooks;
@@ -152,10 +153,12 @@ describe("evaluate", () => {
     mkdirSync(hooks, { recursive: true });
     writeFileSync(join(hooks, "pre-commit"), DEFT_PRE_COMMIT, "utf8");
     writeFileSync(join(hooks, "pre-push"), DEFT_PRE_PUSH, "utf8");
+    writeFileSync(join(hooks, "_deft-run.sh"), 'run_deft() { deft "$@"; }\n', "utf8");
     chmodSync(join(hooks, "pre-commit"), 0o644);
     chmodSync(join(hooks, "pre-push"), 0o644);
     const result = evaluate(root, {
       platform: "linux",
+      hookExecutable: () => false,
       gitConfigReader: () => ({ hooksPath: ".githooks", error: null }),
     });
     expect(result.code).toBe(1);
@@ -257,6 +260,21 @@ describe("evaluate", () => {
     expect(result.message).toContain("pre-push must not invoke verify:branch");
   });
 
+  it("fails when the shared hook helper is missing", () => {
+    const root = makeRepo();
+    const hooks = join(root, ".githooks");
+    mkdirSync(hooks, { recursive: true });
+    writeFileSync(join(hooks, "pre-commit"), DEFT_PRE_COMMIT, "utf8");
+    writeFileSync(join(hooks, "pre-push"), DEFT_PRE_PUSH, "utf8");
+    chmodSync(join(hooks, "pre-commit"), 0o755);
+    chmodSync(join(hooks, "pre-push"), 0o755);
+    const result = evaluate(root, {
+      gitConfigReader: () => ({ hooksPath: ".githooks", error: null }),
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("_deft-run.sh");
+  });
+
   it("greenfield smoke: passes with no scripts/ on PATH (Python-free deposit)", () => {
     const root = makeRepo();
     makeDeftHooks(root);
@@ -285,6 +303,11 @@ describe("evaluate", () => {
     writeFileSync(
       join(hooks, "pre-push"),
       readFileSync(join(REPO_ROOT, ".githooks/pre-push"), "utf8"),
+      "utf8",
+    );
+    writeFileSync(
+      join(hooks, "_deft-run.sh"),
+      readFileSync(join(REPO_ROOT, ".githooks/_deft-run.sh"), "utf8"),
       "utf8",
     );
     chmodSync(join(hooks, "pre-commit"), 0o755);

--- a/packages/core/src/verify-env/verify-hooks-installed.test.ts
+++ b/packages/core/src/verify-env/verify-hooks-installed.test.ts
@@ -270,9 +270,27 @@ describe("evaluate", () => {
     chmodSync(join(hooks, "pre-push"), 0o755);
     const result = evaluate(root, {
       gitConfigReader: () => ({ hooksPath: ".githooks", error: null }),
+      platform: "linux",
+      hookExecutable: () => true,
     });
     expect(result.code).toBe(1);
     expect(result.message).toContain("_deft-run.sh");
+  });
+
+  it("reports a missing shared hook helper before stale hook content", () => {
+    const root = makeRepo();
+    const hooks = join(root, ".githooks");
+    mkdirSync(hooks, { recursive: true });
+    writeFileSync(join(hooks, "pre-commit"), LEGACY_PYTHON_PRE_COMMIT, "utf8");
+    writeFileSync(join(hooks, "pre-push"), DEFT_PRE_PUSH, "utf8");
+    const result = evaluate(root, {
+      gitConfigReader: () => ({ hooksPath: ".githooks", error: null }),
+      platform: "linux",
+      hookExecutable: () => true,
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("_deft-run.sh");
+    expect(result.message).toContain("Python scripts");
   });
 
   it("greenfield smoke: passes with no scripts/ on PATH (Python-free deposit)", () => {

--- a/packages/core/src/verify-env/verify-hooks-installed.ts
+++ b/packages/core/src/verify-env/verify-hooks-installed.ts
@@ -11,6 +11,7 @@ export interface EvaluateResult {
 }
 
 export const REQUIRED_HOOKS = ["pre-commit", "pre-push"] as const;
+export const REQUIRED_HOOK_SUPPORT_FILES = ["_deft-run.sh"] as const;
 
 /** Substrings each hook must contain when it dispatches through the deft CLI (#2049). */
 export const PRE_COMMIT_DEFT_COMMANDS = ["verify:branch", "verify:encoding"] as const;
@@ -33,6 +34,7 @@ export type GitConfigReader = (projectRoot: string) => {
 export interface EvaluateOptions {
   readonly gitConfigReader?: GitConfigReader;
   readonly platform?: NodeJS.Platform;
+  readonly hookExecutable?: (hookPath: string) => boolean;
 }
 
 function defaultGitConfigReader(projectRoot: string): {
@@ -82,7 +84,7 @@ function isPosix(platform: NodeJS.Platform): boolean {
   return platform !== "win32";
 }
 
-function hookExecutable(hookPath: string): boolean {
+function defaultHookExecutable(hookPath: string): boolean {
   try {
     accessSync(hookPath, constants.X_OK);
     return true;
@@ -150,6 +152,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
   const root = resolve(projectRoot);
   const gitReader = options.gitConfigReader ?? defaultGitConfigReader;
   const platform = options.platform ?? process.platform;
+  const hookExecutable = options.hookExecutable ?? defaultHookExecutable;
 
   if (!isDirectory(root)) {
     return {
@@ -259,11 +262,25 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     };
   }
 
+  const missingSupport = REQUIRED_HOOK_SUPPORT_FILES.filter((h) => !isFile(join(hooksDir, h)));
+  if (missingSupport.length > 0) {
+    return {
+      code: 1,
+      message:
+        `❌ deft hooks wired but NON-FUNCTIONAL: ${hooksDir} is missing ` +
+        `${missingSupport.join(", ")} helper(s); pre-commit/pre-push source them at runtime.\n` +
+        "  Recovery: re-run the deft installer / `task setup` to refresh .githooks/.",
+      stream: "stderr",
+    };
+  }
+
   return {
     code: 0,
     message:
       `✓ deft hooks installed and functional: core.hooksPath=${hooksPath}, ` +
-      `hooks ${REQUIRED_HOOKS.join(", ")} present and dispatch via deft CLI (#2049).`,
+      `hooks ${REQUIRED_HOOKS.join(", ")} plus ${REQUIRED_HOOK_SUPPORT_FILES.join(
+        ", ",
+      )} present and dispatch via deft CLI (#2049).`,
     stream: "stdout",
   };
 }

--- a/packages/core/src/verify-env/verify-hooks-installed.ts
+++ b/packages/core/src/verify-env/verify-hooks-installed.ts
@@ -259,7 +259,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
       code: 1,
       message:
         "❌ deft hooks wired but NON-FUNCTIONAL:\n" +
-        contentIssues.map((issue) => `  - ${issue}`).join("\n") +
+        contentIssues.map((issue) => `  - ${issue.replace(/\r?\n/g, " ")}`).join("\n") +
         "\n" +
         "  Recovery: re-run the deft installer / `task setup` to refresh .githooks/.",
       stream: "stderr",

--- a/packages/core/src/verify-env/verify-hooks-installed.ts
+++ b/packages/core/src/verify-env/verify-hooks-installed.ts
@@ -226,49 +226,41 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     }
   }
 
+  const contentIssues: string[] = [];
+  const missingSupport = REQUIRED_HOOK_SUPPORT_FILES.filter((h) => !isFile(join(hooksDir, h)));
+  if (missingSupport.length > 0) {
+    contentIssues.push(
+      `${hooksDir} is missing ${missingSupport.join(
+        ", ",
+      )} helper(s); pre-commit/pre-push source them at runtime`,
+    );
+  }
+
   const preCommitIssue = validateHookContent(
     "pre-commit",
     readHookContent(join(hooksDir, "pre-commit")),
     PRE_COMMIT_DEFT_COMMANDS,
   );
   if (preCommitIssue) {
-    return {
-      code: 1,
-      message:
-        `❌ deft hooks wired but NON-FUNCTIONAL: ${preCommitIssue} (#2049).\n` +
-        "  Recovery: re-run the deft installer / `task setup` to refresh .githooks/.",
-      stream: "stderr",
-    };
+    contentIssues.push(`${preCommitIssue} (#2049)`);
   }
 
   const prePushContent = readHookContent(join(hooksDir, "pre-push"));
   const prePushIssue = validateHookContent("pre-push", prePushContent, PRE_PUSH_DEFT_COMMANDS);
   if (prePushIssue) {
-    return {
-      code: 1,
-      message:
-        `❌ deft hooks wired but NON-FUNCTIONAL: ${prePushIssue} (#2049).\n` +
-        "  Recovery: re-run the deft installer / `task setup` to refresh .githooks/.",
-      stream: "stderr",
-    };
+    contentIssues.push(`${prePushIssue} (#2049)`);
   }
   if (prePushContent && prePushInvokesVerifyBranch(prePushContent)) {
-    return {
-      code: 1,
-      message:
-        "❌ deft hooks wired but NON-FUNCTIONAL: pre-push must not invoke verify:branch (#1814).\n" +
-        "  Recovery: re-run the deft installer / `task setup` to refresh .githooks/.",
-      stream: "stderr",
-    };
+    contentIssues.push("pre-push must not invoke verify:branch (#1814)");
   }
 
-  const missingSupport = REQUIRED_HOOK_SUPPORT_FILES.filter((h) => !isFile(join(hooksDir, h)));
-  if (missingSupport.length > 0) {
+  if (contentIssues.length > 0) {
     return {
       code: 1,
       message:
-        `❌ deft hooks wired but NON-FUNCTIONAL: ${hooksDir} is missing ` +
-        `${missingSupport.join(", ")} helper(s); pre-commit/pre-push source them at runtime.\n` +
+        "❌ deft hooks wired but NON-FUNCTIONAL:\n" +
+        contentIssues.map((issue) => `  - ${issue}`).join("\n") +
+        "\n" +
         "  Recovery: re-run the deft installer / `task setup` to refresh .githooks/.",
       stream: "stderr",
     };


### PR DESCRIPTION
## Summary
- Deposit `.githooks/_deft-run.sh` alongside the TS-native consumer hook scripts.
- Teach hook verification to require the shared helper and keep permission checks deterministic on Windows.
- Strengthen the Windows update smoke so the baseline commit runs through hooks instead of bypassing them.

## Validation
- `pnpm exec vitest run packages/core/src/verify-env/verify-hooks-installed.test.ts packages/core/src/verify-env/branches.test.ts packages/core/src/content-contracts/standards/branch_gate.test.ts packages/core/src/content-contracts/standards/deft_run_resolver.test.ts`
- `pnpm exec vitest run packages/core/src/init-deposit/scaffold.test.ts packages/core/src/release-e2e/content-prepack.test.ts packages/core/src/release-e2e/npm-ops.test.ts`
- `pnpm exec vitest run packages/core/src/init-deposit/init-deposit.test.ts -t "creates a complete greenfield deposit"`
- `pnpm run build`
- `pnpm run lint`
- Windows native consumer smoke: init, normal baseline commit through hooks, update twice, `task deft:verify:cache-fresh`, direct `preflight-cache`, clean git status.

## Notes
`task check` was run on Windows and still reports the existing native-Windows baseline failures unrelated to this hook-helper change: path normalization expectations, pack/content contract drift, and one timeout in an existing Taskfile caching test. The hook-helper surfaces passed inside that aggregate run.