### PR TITLE
feat(cli): structured top-level directive --help (#2172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Structured top-level `directive --help` for faster command discovery.** Running `directive` or `directive --help` now shows a curated page with version, usage, common options, and grouped everyday commands instead of dumping every registered verb; run `directive commands` for the full list. Closes #2172.
+
 ### Fixed
 
 - **Merge-readiness no longer clears stale Greptile P0/P1 blockers when GitHub reports clean.** Stale verdicts that carried real P0/P1, errored, or low-confidence findings now stay hard blocks instead of being softened by the GitHub mergeability override, and Dependabot PRs with Greptile excluded-author skip comments are treated as pass rather than parse failures. Closes #2382. Closes #2375.

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -119,6 +119,8 @@ describe("printHelp", () => {
     expect(body).not.toContain("  verify-encoding\n");
     expect(body).toContain("  triage:welcome\n");
     expect(body).not.toContain("  triage-welcome\n");
+    expect(body).toContain("  build\n");
+    expect(body).not.toContain("  framework-commands\n");
   });
 
   // #2273: no-arg `directive` leads with the three-command model + first-run

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -18,12 +18,12 @@ import {
   GHX_INSTALL_SH_SHA256,
   GHX_VERSION,
   type GhxInstallerAsset,
+  helpVersionLabel,
   INSTALL_PS1_URL,
   INSTALL_SH_URL,
   installVerifiedGhxAsset,
   POLICY_ACTION_ALIAS_SUBCOMMANDS,
   parseDirectiveBootstrapArgs,
-  helpVersionLabel,
   preferredCommandNames,
   printCommandsList,
   printHelp,
@@ -125,13 +125,7 @@ describe("printHelp", () => {
   // guidance, printed BEFORE the exhaustive verb list.
   it("prints the three-command model and first-run guidance before the verb list (#2273)", () => {
     const body = renderHelp();
-    for (const line of [
-      "init",
-      "update",
-      "doctor",
-      "First run?",
-      "npm i -g @deftai/directive",
-    ]) {
+    for (const line of ["init", "update", "doctor", "First run?", "npm i -g @deftai/directive"]) {
       expect(body).toContain(line);
     }
     // Cold-start recovery pointer is payload-independent (points at README.md).

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -23,6 +23,9 @@ import {
   installVerifiedGhxAsset,
   POLICY_ACTION_ALIAS_SUBCOMMANDS,
   parseDirectiveBootstrapArgs,
+  helpVersionLabel,
+  preferredCommandNames,
+  printCommandsList,
   printHelp,
   registeredVerbs,
   resetHandlerCacheForTests,
@@ -73,13 +76,49 @@ describe("printHelp", () => {
     return lines.join("");
   }
 
-  it("lists all registered verbs", () => {
+  function renderCommands(): string {
+    const lines: string[] = [];
+    printCommandsList({
+      writeOut: (text) => {
+        lines.push(text);
+      },
+      writeErr: () => {},
+    });
+    return lines.join("");
+  }
+
+  it("prints structured curated help instead of dumping every registered verb (#2172)", () => {
     const body = renderHelp();
-    expect(body).toContain("Usage: directive <verb> [args...]");
-    expect(body).toContain("Registered verbs:");
+    expect(body).toContain(`Directive ${helpVersionLabel()}`);
+    expect(body).toContain("Usage:");
+    expect(body).toContain("directive <command> [options]");
+    expect(body).toContain("directive commands");
+    expect(body).toContain("Options:");
+    expect(body).toContain("-h, --help");
+    expect(body).toContain("-V, --version");
+    expect(body).toContain("Getting started:");
+    expect(body).toContain("Session & ritual:");
+    expect(body).toContain("Quality & gates:");
+    expect(body).toContain("Work queue & triage:");
+    expect(body).toContain("Scope lifecycle:");
+    expect(body).toContain("Project artifacts:");
+    expect(body).toContain("Run `directive commands` for the full registered-command list.");
+    expect(body).not.toContain("Registered verbs:");
     for (const verb of registeredVerbs()) {
-      expect(body).toContain(`  ${verb}\n`);
+      expect(body).not.toContain(`  ${verb}\n`);
     }
+  });
+
+  it("lists deduplicated preferred names via directive commands (#2172)", () => {
+    const body = renderCommands();
+    expect(body).toContain("Registered commands:");
+    for (const name of preferredCommandNames()) {
+      expect(body).toContain(`  ${name}\n`);
+    }
+    expect(body).toContain("  verify:encoding\n");
+    expect(body).not.toContain("  verify-encoding\n");
+    expect(body).toContain("  triage:welcome\n");
+    expect(body).not.toContain("  triage-welcome\n");
   });
 
   // #2273: no-arg `directive` leads with the three-command model + first-run
@@ -87,9 +126,9 @@ describe("printHelp", () => {
   it("prints the three-command model and first-run guidance before the verb list (#2273)", () => {
     const body = renderHelp();
     for (const line of [
-      "directive init",
-      "directive update",
-      "directive doctor",
+      "init",
+      "update",
+      "doctor",
       "First run?",
       "npm i -g @deftai/directive",
     ]) {
@@ -98,33 +137,31 @@ describe("printHelp", () => {
     // Cold-start recovery pointer is payload-independent (points at README.md).
     expect(body).toContain("README.md");
 
-    const firstVerb = registeredVerbs()[0] ?? "";
-    const modelIdx = body.indexOf("directive init");
-    const listIdx = body.indexOf("Registered verbs:");
+    const modelIdx = body.indexOf("Getting started:");
+    const commandsPointerIdx = body.indexOf("Run `directive commands`");
     expect(modelIdx).toBeGreaterThanOrEqual(0);
-    expect(modelIdx).toBeLessThan(listIdx);
-    expect(listIdx).toBeLessThan(body.indexOf(`\n  ${firstVerb}\n`));
+    expect(modelIdx).toBeLessThan(commandsPointerIdx);
   });
 
   // #2274: the top-level help snapshot is the source the README / BROWNFIELD /
-  // UPGRADING docs mirror. Lock the "Start here" grouping, the init->update->
+  // UPGRADING docs mirror. Lock the "Getting started" grouping, the init->update->
   // doctor ordering, and each command's by-situation one-liner so the docs and
   // the CLI can never drift out of agreement on the three-command model.
   it("routes users by situation: init sets up, update refreshes, doctor diagnoses (#2274)", () => {
     const body = renderHelp();
-    expect(body).toContain("Start here (most projects only need these three):");
+    expect(body).toContain("Getting started:");
 
-    const initIdx = body.indexOf("directive init");
-    const updateIdx = body.indexOf("directive update");
-    const doctorIdx = body.indexOf("directive doctor");
+    const initIdx = body.indexOf("init");
+    const updateIdx = body.indexOf("update");
+    const doctorIdx = body.indexOf("doctor");
     expect(initIdx).toBeGreaterThanOrEqual(0);
     expect(updateIdx).toBeGreaterThan(initIdx);
     expect(doctorIdx).toBeGreaterThan(updateIdx);
 
     for (const line of [
-      "directive init      Set up Directive in the current project (first-time setup)",
-      "directive update    Refresh an existing install and self-heal the engine",
-      "directive doctor    Diagnose the install and print the one next step",
+      "  init                  Set up Directive in the current project (first-time setup)",
+      "  update                Refresh an existing install and self-heal the engine",
+      "  doctor                Diagnose the install and print the one next step",
     ]) {
       expect(body).toContain(line);
     }
@@ -165,10 +202,10 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toContain("Usage: directive");
+    expect(out.join("")).toContain("directive <command> [options]");
   });
 
-  it("returns 0 for -h and prints help", async () => {
+  it("returns 0 for -h and prints curated help", async () => {
     const out: string[] = [];
     const code = await dispatch(["-h"], {
       writeOut: (text) => {
@@ -177,10 +214,11 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toContain("verify-encoding");
+    expect(out.join("")).toContain("directive commands");
+    expect(out.join("")).not.toContain("Registered verbs:");
   });
 
-  it("returns 0 for help and prints help", async () => {
+  it("returns 0 for help and prints curated help", async () => {
     const out: string[] = [];
     const code = await dispatch(["help"], {
       writeOut: (text) => {
@@ -189,7 +227,8 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toContain("verify-encoding");
+    expect(out.join("")).toContain("Getting started:");
+    expect(out.join("")).not.toContain("Registered verbs:");
   });
 
   it("coerces non-number handler return to exit code 0", async () => {
@@ -269,7 +308,7 @@ describe("dispatch", () => {
     expect(err.join("")).toBe("directive: plain\n");
   });
 
-  it("returns 0 for --help and prints the verb list", async () => {
+  it("returns 0 for --help and prints curated help", async () => {
     const out: string[] = [];
     const code = await dispatch(["--help"], {
       writeOut: (text) => {
@@ -278,7 +317,21 @@ describe("dispatch", () => {
       writeErr: () => {},
     });
     expect(code).toBe(0);
-    expect(out.join("")).toContain("verify-encoding");
+    expect(out.join("")).toContain("Options:");
+    expect(out.join("")).not.toContain("Registered verbs:");
+  });
+
+  it("returns 0 for commands and prints the full registered-command list", async () => {
+    const out: string[] = [];
+    const code = await dispatch(["commands"], {
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: () => {},
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).toContain("Registered commands:");
+    expect(out.join("")).toContain("  verify:encoding\n");
   });
 
   it("prints an error naming an unknown verb and exits non-zero", async () => {

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -2750,16 +2750,19 @@ const SCOPE_COMMAND_NAMES = [
  * task verbs over dash-style canonical stems when both exist (#2172).
  */
 export function preferredCommandNames(): readonly string[] {
-  const colonPreferred = new Set<string>([
-    ...TOP_LEVEL_COMMAND_NAMES,
-    ...SCOPE_COMMAND_NAMES,
-    ...Object.keys(VERB_ALIASES).filter((key) => key.includes(":")),
-  ]);
+  const aliasKeys = Object.keys(VERB_ALIASES);
   const aliasedCanonicals = new Set(Object.values(VERB_ALIASES));
   const unaliasedCanonicals = [...CLI_MODULE_VERBS, ...CORE_MODULE_VERBS].filter(
     (verb) => !aliasedCanonicals.has(verb),
   );
-  return [...new Set([...colonPreferred, ...unaliasedCanonicals])].sort();
+  return [
+    ...new Set([
+      ...TOP_LEVEL_COMMAND_NAMES,
+      ...SCOPE_COMMAND_NAMES,
+      ...aliasKeys,
+      ...unaliasedCanonicals,
+    ]),
+  ].sort();
 }
 
 /** Major.minor label for the curated help title (#2172). */

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -2726,34 +2726,148 @@ export function registeredVerbs(): readonly string[] {
   return [...names].sort();
 }
 
+/** Top-level UX commands routed before the flat dispatcher (#1670). */
+const TOP_LEVEL_COMMAND_NAMES = [
+  "init",
+  "update",
+  "migrate",
+  "bootstrap",
+  "doctor",
+  "check",
+] as const;
+
+/** Scope lifecycle verbs exposed as scope:<verb> in help (#2172). */
+const SCOPE_COMMAND_NAMES = [
+  "scope:promote",
+  "scope:activate",
+  "scope:complete",
+  "scope:demote",
+  "scope:undo",
+] as const;
+
 /**
- * Print dispatcher help. Leads with the three-command model (init / update /
- * doctor) + first-run guidance so a no-arg `directive` orients a newcomer before
- * the exhaustive verb list, which stays available below for power users (#2273).
+ * Deduplicated command names for `directive commands`, preferring colon-style
+ * task verbs over dash-style canonical stems when both exist (#2172).
+ */
+export function preferredCommandNames(): readonly string[] {
+  const colonPreferred = new Set<string>([
+    ...TOP_LEVEL_COMMAND_NAMES,
+    ...SCOPE_COMMAND_NAMES,
+    ...Object.keys(VERB_ALIASES).filter((key) => key.includes(":")),
+  ]);
+  const aliasedCanonicals = new Set(Object.values(VERB_ALIASES));
+  const unaliasedCanonicals = [...CLI_MODULE_VERBS, ...CORE_MODULE_VERBS].filter(
+    (verb) => !aliasedCanonicals.has(verb),
+  );
+  return [...new Set([...colonPreferred, ...unaliasedCanonicals])].sort();
+}
+
+/** Major.minor label for the curated help title (#2172). */
+export function helpVersionLabel(): string {
+  const version = engineInfo().version;
+  const match = /^(\d+\.\d+)/.exec(version);
+  return match ? `v${match[1]}` : `v${version}`;
+}
+
+interface HelpCommand {
+  name: string;
+  summary: string;
+}
+
+interface HelpGroup {
+  title: string;
+  commands: readonly HelpCommand[];
+}
+
+const CURATED_HELP_GROUPS: readonly HelpGroup[] = [
+  {
+    title: "Getting started",
+    commands: [
+      { name: "init", summary: "Set up Directive in the current project (first-time setup)" },
+      { name: "update", summary: "Refresh an existing install and self-heal the engine" },
+      { name: "doctor", summary: "Diagnose the install and print the one next step" },
+    ],
+  },
+  {
+    title: "Session & ritual",
+    commands: [{ name: "session:start", summary: "Record session-start ritual state" }],
+  },
+  {
+    title: "Quality & gates",
+    commands: [{ name: "check", summary: "Run install and lifecycle quality gates" }],
+  },
+  {
+    title: "Work queue & triage",
+    commands: [
+      { name: "triage:welcome", summary: "Session orientation and triage one-liner" },
+      { name: "triage:queue", summary: "Ranked work queue for what to do next" },
+    ],
+  },
+  {
+    title: "Scope lifecycle",
+    commands: [{ name: "scope:promote", summary: "Promote a scope xBRIEF to pending" }],
+  },
+  {
+    title: "Project artifacts",
+    commands: [
+      { name: "project:render", summary: "Render PROJECT-DEFINITION projection" },
+      { name: "spec:render", summary: "Render specification projection" },
+    ],
+  },
+];
+
+function formatHelpCommand(command: HelpCommand): string {
+  const padding = " ".repeat(Math.max(1, 22 - command.name.length));
+  return `  ${command.name}${padding}${command.summary}\n`;
+}
+
+/**
+ * Print the exhaustive registered-command list for `directive commands` (#2172).
+ * Lists deduplicated preferred names (colon-style when available).
+ */
+export function printCommandsList(io: DispatchIo = defaultIo()): void {
+  io.writeOut("Registered commands:\n");
+  for (const name of preferredCommandNames()) {
+    io.writeOut(`  ${name}\n`);
+  }
+}
+
+/**
+ * Print curated top-level help: title/version, usage, common options, grouped
+ * common commands, and a pointer to `directive commands` for the full list
+ * (#2172). Preserves the init/update/doctor first-run guidance from #2273.
  */
 export function printHelp(io: DispatchIo = defaultIo()): void {
+  io.writeOut(`Directive ${helpVersionLabel()}\n`);
+  io.writeOut("AI development framework CLI for project lifecycle, scope, and quality gates.\n\n");
+
+  io.writeOut("Usage:\n");
+  io.writeOut("  directive <command> [options]\n");
+  io.writeOut("  directive help\n");
+  io.writeOut("  directive commands          List every registered command\n\n");
+
+  io.writeOut("Options:\n");
+  io.writeOut("  -h, --help                  Show this help\n");
+  io.writeOut("  -V, --version               Print version information\n\n");
+
+  for (const group of CURATED_HELP_GROUPS) {
+    io.writeOut(`${group.title}:\n`);
+    for (const command of group.commands) {
+      io.writeOut(formatHelpCommand(command));
+    }
+    io.writeOut("\n");
+  }
+
   io.writeOut(
-    "directive -- the Deft Directive CLI\n" +
-      "\n" +
-      "Start here (most projects only need these three):\n" +
-      "  directive init      Set up Directive in the current project (first-time setup)\n" +
-      "  directive update    Refresh an existing install and self-heal the engine\n" +
-      "  directive doctor    Diagnose the install and print the one next step\n" +
-      "\n" +
+    "Commands use colon style (e.g. triage:queue); dash-style aliases remain supported.\n" +
+      "Run `directive commands` for the full registered-command list.\n\n" +
       "First run? From the project root:\n" +
       "  1. npm i -g @deftai/directive   (Node >= 20)\n" +
       "     (pnpm: pnpm add -g @deftai/directive -- ensure PNPM_HOME is on PATH, run `pnpm setup` if needed)\n" +
       "  2. directive init\n" +
       "  3. directive doctor\n" +
-      "New clone where `directive` will not run? Read the Cold-start bootstrap block at the top of README.md.\n" +
-      "\n" +
-      "Usage: directive <verb> [args...]\n" +
-      "\n" +
-      "Registered verbs:\n",
+      "New clone where `directive` will not run? Read the Cold-start bootstrap block at the top of README.md.\n",
   );
-  for (const name of registeredVerbs()) {
-    io.writeOut(`  ${name}\n`);
-  }
 }
 
 async function invokeHandler(handler: CommandHandler, argv: string[]): Promise<number> {
@@ -2781,6 +2895,11 @@ export async function dispatch(argv: string[], io: DispatchIo = defaultIo()): Pr
   }
 
   const [verb, ...rest] = argv;
+
+  if (verb === "commands") {
+    printCommandsList(io);
+    return 0;
+  }
   const canonical = resolveCanonicalVerb(verb ?? "");
   if (canonical === null) {
     io.writeErr(`directive: unknown verb '${verb}'\n`);

--- a/packages/cli/src/gates-cli/session-ritual-cli.test.ts
+++ b/packages/cli/src/gates-cli/session-ritual-cli.test.ts
@@ -118,8 +118,8 @@ describe("verify session ritual TS module (maps tests/cli/test_verify_session_ri
 
 describe("deft-ts resume sentinel (maps tests/cli/test_resume.py — core unit coverage)", () => {
   it("framework resume commands are registered", () => {
-    const { exitCode, stdout } = runDeftTs("", ["--help"]);
+    const { exitCode, stdout } = runDeftTs("", ["commands"]);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("framework-commands");
+    expect(stdout).toContain("build");
   });
 });

--- a/packages/cli/src/render-cli/deft-ts-runner.test.ts
+++ b/packages/cli/src/render-cli/deft-ts-runner.test.ts
@@ -14,7 +14,15 @@ describe("deft-ts runner", () => {
   it("runs --help with exit 0", () => {
     const result = runDeftTsArgv(["--help"]);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Usage: directive");
+    expect(result.stdout).toContain("directive <command> [options]");
+    expect(result.stdout).toContain("directive commands");
+    expect(result.stdout).not.toContain("Registered verbs:");
+  });
+
+  it("lists exhaustive commands via directive commands", () => {
+    const result = runDeftTsArgv(["commands"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Registered commands:");
     expect(result.stdout).toContain("pack-render");
   });
 

--- a/xbrief/active/2026-07-10-2172-improve-top-level-directive-help-output-and-command-discover.xbrief.json
+++ b/xbrief/active/2026-07-10-2172-improve-top-level-directive-help-output-and-command-discover.xbrief.json
@@ -1,0 +1,83 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2172"
+  },
+  "plan": {
+    "title": "Improve top-level directive help output and command discovery",
+    "status": "running",
+    "narratives": {
+      "Description": "Improve top-level directive help output and command discovery. This story closes the linked GitHub issue with a scoped fix, tests, and a CHANGELOG entry. File scope and verify commands are recorded under plan.metadata.swarm for concurrent allocation.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2172",
+      "Overview": "## Summary\n\nThe top-level `directive` / `directive --help` output is currently an undifferentiated dump of registered verbs. It should be structured like a normal CLI help surface: title/version, usage, common options, common commands, and a clear path to the full command list.\n\n## Current behavior\n\nRunning `directive` or `directive --help` prints:\n\n- `Usage: directive <verb> [args...]`\n- a long `Registered verbs:` list\n- both canonical and alias forms such as `verify-branch` and `verify:branch`\n- no introductory description\n- no command categories\n- no explanation of common options such as `--help`, `-h`, `--version`, or `-V`\n- no version in the help title, even though `--version` exists\n\nThis is difficult for humans and first-time users to scan.\n\n## Proposed behavior\n\nReplace the top-level help spew with a curated help page:\n\n- Title including tool name and major/minor version, for example `Directive v0.x`.\n- One-line description of what Directive does.\n- Usage forms:\n  - `directive <command> [options]`\n  - `directive help`\n  - `directive commands` or equivalent for the full list.\n- Common options:\n  - `-h, --help`\n  - `-V, --version`\n- Common verbs grouped by workflow, such as:\n  - `doctor`\n  - `session:start`\n  - `check`\n  - `triage:welcome`\n  - `triage:queue`\n  - `scope:promote`\n  - `project:render`\n  - `spec:render`\n- A clear note that colon-style task verbs are preferred in help, while dash-style aliases may remain supported for compatibility.\n- A separate full-list command or flag for exhaustive output.\n\n## Acceptance criteria\n\n- `directive` and `directive --help` print concise, categorized help rather than every registered verb.\n- `directive --version` prints only version information.\n- Help output documents common options.\n- The exhaustive registered-verb list remains available through an explicit command or flag.\n- Help avoids listing both dash and colon aliases unless explicitly showing aliases.\n- Tests snapshot the top-level help output and version output.\n\n## Related\n\nRelated but not duplicate: #1150 covers categorized help for `task triage` / `task scope`; #49 covered version display on command startup; #1669 tracks broader distributable CLI work.\n\n",
+      "Labels": "enhancement, interfaces, adoption-blocker, agent-experience, area:cli",
+      "UserStory": "As a CLI user, I want structured top-level directive --help, so that I can discover common commands without an undifferentiated verb dump.",
+      "ImplementationPlan": "1. Restructure packages/cli help output: title/version, usage, common options, common commands, path to full list. 2. Add CLI help tests. Verify with pnpm -C packages/cli exec vitest; CHANGELOG Closes #2172."
+    },
+    "items": [
+      {
+        "title": "When a user runs directive --help, the output shows usage, common commands, and a path to ",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "When a user runs directive --help, the output shows usage, common commands, and a path to the full command list."
+        }
+      },
+      {
+        "title": "When help is rendered, it no longer dumps every registered verb as the primary surface.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "When help is rendered, it no longer dumps every registered verb as the primary surface."
+        }
+      },
+      {
+        "title": "Given CLI help fixtures, vitest validates the structured sections are present.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given CLI help fixtures, vitest validates the structured sections are present."
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "interfaces",
+      "adoption-blocker",
+      "agent-experience",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2172",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2172: Improve top-level directive help output and command discovery"
+      }
+    ],
+    "updated": "2026-07-10T01:02:28Z",
+    "id": "2172-directive-help-discovery",
+    "metadata": {
+      "kind": "story",
+      "id": "2172-directive-help-discovery",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/dispatch.ts",
+          "packages/cli/src/dispatch.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm -C packages/cli exec vitest run",
+          "node packages/cli/dist/bin.js --help"
+        ],
+        "expected_outputs": [
+          "Closes #2172 with tests green"
+        ],
+        "depends_on": [],
+        "conflict_group": "cli-help",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium",
+        "missing_traces_justification": "Issue-ingested story; acceptance traces deferred to implementation commits that Closes the GitHub issue."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Restructure `directive` / `directive --help` to show version, usage, common options, and grouped everyday commands instead of dumping every registered verb.
- Add `directive commands` for the exhaustive deduplicated command list (colon-style preferred over dash aliases).
- Add vitest coverage for curated help sections and the commands list.

## Test plan
- [x] `pnpm exec vitest run packages/cli/src/dispatch.test.ts`
- [x] `node packages/cli/dist/bin.js --help`
- [x] `node packages/cli/dist/bin.js commands | head`

Closes #2172

Made with [Cursor](https://cursor.com)