### PR TITLE
fix: preserve deft-core-guard checkout pin on framework refresh (#1672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Deposited triage-cache README is now consumer-facing.** Bootstrap and migration no longer write directive-internal decision IDs or dead `scripts/candidates_log.py` pointers into `<lifecycle-root>/.triage-cache/README.md`; the file explains tracked vs gitignored cache files in plain project terms. Closes #2374.
+- **Framework update no longer reverts Dependabot checkout bumps on deposited deft-core-guard.yml.** New deposits SHA-pin `actions/checkout` (matching directive's own workflow hardening), and refresh preserves an existing consumer pin while updating the managed guard script body — ending the upgrade↔Dependabot ping-pong loop. Closes #1672.
 
 - **Merge-readiness no longer clears stale Greptile P0/P1 blockers when GitHub reports clean.** Stale verdicts that carried real P0/P1, errored, or low-confidence findings now stay hard blocks instead of being softened by the GitHub mergeability override, and Dependabot PRs with Greptile excluded-author skip comments are treated as pass rather than parse failures. Closes #2382. Closes #2375.
 - **Go installer consumer projections now refuse repo-controlled symlinks.** `deft-install` checks AGENTS.md, vbrief/, `.agents/`, `.githooks/`, and related projection targets with Lstat/containment before writing, so a malicious checkout cannot trick install or upgrade into overwriting files outside the project tree. Closes #2383.

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -30,6 +30,7 @@ import {
   PIN_DEPENDENCY_NAME,
   pruneFrameworkSelfTests,
   pruneVendoredTsTests,
+  shouldPreserveCoreGuardCheckoutPin,
   writeAgentsMd,
   writeAgentsSkills,
   writeConsumerGitHooks,
@@ -395,6 +396,24 @@ describe("init-deposit scaffold", () => {
       expect(guard).not.toContain("echo stale-body");
     });
 
+    it("migrates a legacy framework @v4 pin to the SHA template on refresh", () => {
+      const project = freshRoot("scaffold-guard-migrate-v4-");
+      mkdirSync(join(project, ".github/workflows"), { recursive: true });
+      const legacy =
+        "name: deft-core-guard\n\non:\n  pull_request:\n\njobs:\n" +
+        "  no-mixed-core-and-app:\n    runs-on: ubuntu-latest\n    steps:\n" +
+        "      - uses: actions/checkout@v4\n" +
+        "        with:\n          fetch-depth: 0\n" +
+        "      - name: Refuse PRs that mix .deft/core/** with non-framework paths\n" +
+        "        run: echo stale-body\n";
+      writeFileSync(join(project, ".github/workflows/deft-core-guard.yml"), legacy, "utf8");
+      const { io } = captureIo();
+      expect(ensureCoreGuardWorkflow(project, io)).toBe(true);
+      const guard = readFileSync(join(project, ".github/workflows/deft-core-guard.yml"), "utf8");
+      expect(extractCoreGuardCheckoutUsesLine(guard)).toBe(coreGuardCheckoutUsesLine());
+      expect(guard).not.toContain("actions/checkout@v4");
+    });
+
     it("mergeCoreGuardWorkflowRefresh keeps the existing pin when only checkout differs", () => {
       const existing =
         "steps:\n" +
@@ -409,6 +428,22 @@ describe("init-deposit scaffold", () => {
       const merged = mergeCoreGuardWorkflowRefresh(existing, desired);
       expect(extractCoreGuardCheckoutUsesLine(merged)).toBe("      - uses: actions/checkout@v6");
       expect(merged).toContain("run: new");
+    });
+
+    it("shouldPreserveCoreGuardCheckoutPin rejects legacy @v4 but accepts consumer bumps", () => {
+      const desired = coreGuardCheckoutUsesLine();
+      expect(
+        shouldPreserveCoreGuardCheckoutPin("      - uses: actions/checkout@v4", desired),
+      ).toBe(false);
+      expect(
+        shouldPreserveCoreGuardCheckoutPin(
+          "      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
+          desired,
+        ),
+      ).toBe(true);
+      expect(
+        shouldPreserveCoreGuardCheckoutPin("      - uses: actions/checkout@v6", desired),
+      ).toBe(true);
     });
   });
 

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -15,8 +15,6 @@ import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import {
   buildInstallManifestText,
   CANONICAL_TASKFILE_INCLUDE,
-  CORE_GUARD_CHECKOUT_SHA,
-  CORE_GUARD_CHECKOUT_TAG,
   coreGuardCheckoutUsesLine,
   depositNeutralization,
   ensureCodeqlPathsIgnore,
@@ -174,9 +172,7 @@ describe("init-deposit scaffold", () => {
       "paths-ignore",
     );
     const guard = readFileSync(join(project, ".github/workflows/deft-core-guard.yml"), "utf8");
-    expect(guard).toContain(`actions/checkout@${CORE_GUARD_CHECKOUT_SHA}`);
-    expect(guard).toContain(`# ${CORE_GUARD_CHECKOUT_TAG}`);
-    expect(guard).not.toContain("actions/checkout@v4");
+    expect(extractCoreGuardCheckoutUsesLine(guard)).toBe(coreGuardCheckoutUsesLine());
   });
 
   it("skips AGENTS.md rewrite when the managed section is already current", () => {

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -15,6 +15,9 @@ import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import {
   buildInstallManifestText,
   CANONICAL_TASKFILE_INCLUDE,
+  CORE_GUARD_CHECKOUT_SHA,
+  CORE_GUARD_CHECKOUT_TAG,
+  coreGuardCheckoutUsesLine,
   depositNeutralization,
   ensureCodeqlPathsIgnore,
   ensureCoreGuardWorkflow,
@@ -22,6 +25,8 @@ import {
   ensureGreptileIgnore,
   ensurePackageJsonPin,
   ensureTaskfile,
+  extractCoreGuardCheckoutUsesLine,
+  mergeCoreGuardWorkflowRefresh,
   PIN_DEPENDENCY_NAME,
   pruneFrameworkSelfTests,
   pruneVendoredTsTests,
@@ -167,7 +172,10 @@ describe("init-deposit scaffold", () => {
     expect(readFileSync(join(project, ".github/codeql/codeql-config.yml"), "utf8")).toContain(
       "paths-ignore",
     );
-    expect(existsSync(join(project, ".github/workflows/deft-core-guard.yml"))).toBe(true);
+    const guard = readFileSync(join(project, ".github/workflows/deft-core-guard.yml"), "utf8");
+    expect(guard).toContain(`actions/checkout@${CORE_GUARD_CHECKOUT_SHA}`);
+    expect(guard).toContain(`# ${CORE_GUARD_CHECKOUT_TAG}`);
+    expect(guard).not.toContain("actions/checkout@v4");
   });
 
   it("skips AGENTS.md rewrite when the managed section is already current", () => {
@@ -354,6 +362,54 @@ describe("init-deposit scaffold", () => {
     expect(readFileSync(join(project, ".github/workflows/deft-core-guard.yml"), "utf8")).toContain(
       "custom-guard",
     );
+  });
+
+  describe("deft-core-guard checkout pin (#1672)", () => {
+    it("deposits a commit-SHA checkout pin on greenfield guard creation", () => {
+      const project = freshRoot("scaffold-guard-sha-");
+      const { io } = captureIo();
+      expect(ensureCoreGuardWorkflow(project, io)).toBe(true);
+      const guard = readFileSync(join(project, ".github/workflows/deft-core-guard.yml"), "utf8");
+      expect(guard).toContain(coreGuardCheckoutUsesLine());
+      expect(extractCoreGuardCheckoutUsesLine(guard)).toBe(coreGuardCheckoutUsesLine());
+    });
+
+    it("preserves a Dependabot-bumped checkout pin on refresh", () => {
+      const project = freshRoot("scaffold-guard-preserve-");
+      mkdirSync(join(project, ".github/workflows"), { recursive: true });
+      const bumped =
+        "name: deft-core-guard\n\non:\n  pull_request:\n\njobs:\n" +
+        "  no-mixed-core-and-app:\n    runs-on: ubuntu-latest\n    steps:\n" +
+        "      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3\n" +
+        "        with:\n          fetch-depth: 0\n" +
+        "      - name: Refuse PRs that mix .deft/core/** with non-framework paths\n" +
+        "        run: echo stale-body\n";
+      writeFileSync(join(project, ".github/workflows/deft-core-guard.yml"), bumped, "utf8");
+      const { io } = captureIo();
+      expect(ensureCoreGuardWorkflow(project, io)).toBe(true);
+      const guard = readFileSync(join(project, ".github/workflows/deft-core-guard.yml"), "utf8");
+      expect(extractCoreGuardCheckoutUsesLine(guard)).toBe(
+        "      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
+      );
+      expect(guard).toContain("deft-core guard (#1430)");
+      expect(guard).not.toContain("echo stale-body");
+    });
+
+    it("mergeCoreGuardWorkflowRefresh keeps the existing pin when only checkout differs", () => {
+      const existing =
+        "steps:\n" +
+        "      - uses: actions/checkout@v6\n" +
+        "        with:\n          fetch-depth: 0\n" +
+        "      - name: step\n        run: old\n";
+      const desired =
+        "steps:\n" +
+        `${coreGuardCheckoutUsesLine()}\n` +
+        "        with:\n          fetch-depth: 0\n" +
+        "      - name: step\n        run: new\n";
+      const merged = mergeCoreGuardWorkflowRefresh(existing, desired);
+      expect(extractCoreGuardCheckoutUsesLine(merged)).toBe("      - uses: actions/checkout@v6");
+      expect(merged).toContain("run: new");
+    });
   });
 
   it("updates an existing CodeQL config paths-ignore block", () => {

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -432,18 +432,18 @@ describe("init-deposit scaffold", () => {
 
     it("shouldPreserveCoreGuardCheckoutPin rejects legacy @v4 but accepts consumer bumps", () => {
       const desired = coreGuardCheckoutUsesLine();
-      expect(
-        shouldPreserveCoreGuardCheckoutPin("      - uses: actions/checkout@v4", desired),
-      ).toBe(false);
+      expect(shouldPreserveCoreGuardCheckoutPin("      - uses: actions/checkout@v4", desired)).toBe(
+        false,
+      );
       expect(
         shouldPreserveCoreGuardCheckoutPin(
           "      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
           desired,
         ),
       ).toBe(true);
-      expect(
-        shouldPreserveCoreGuardCheckoutPin("      - uses: actions/checkout@v6", desired),
-      ).toBe(true);
+      expect(shouldPreserveCoreGuardCheckoutPin("      - uses: actions/checkout@v6", desired)).toBe(
+        true,
+      );
     });
   });
 

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -641,17 +641,38 @@ export const CORE_GUARD_CHECKOUT_SHA = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 /** Tag comment paired with {@link CORE_GUARD_CHECKOUT_SHA}. */
 export const CORE_GUARD_CHECKOUT_TAG = "v7.0.0";
 
-const CHECKOUT_USES_LINE_RE = /^\s+-\s+uses:\s+actions\/checkout@\S+(?:\s+#\s*.+)?\s*$/m;
+const CHECKOUT_USES_PREFIX = "- uses: actions/checkout@";
 
-/** Extract the `uses: actions/checkout@…` step line from a guard workflow, if present. */
+/**
+ * Extract the `uses: actions/checkout@…` step line from a guard workflow, if present.
+ * Uses linear string scanning (no regex) to avoid CodeQL js/polynomial-redos (#1672).
+ */
 export function extractCoreGuardCheckoutUsesLine(content: string): string | null {
-  const match = content.match(CHECKOUT_USES_LINE_RE);
-  return match ? match[0] : null;
+  for (const line of content.split("\n")) {
+    const trimmed = line.trimStart();
+    if (!trimmed.startsWith(CHECKOUT_USES_PREFIX)) continue;
+    // YAML step lines are indented; a bare top-level match is not a step.
+    if (trimmed.length === line.length) continue;
+    return line;
+  }
+  return null;
 }
 
+/** Ref after `actions/checkout@` (tag, SHA, or major), stopping at whitespace. */
 function checkoutActionRef(usesLine: string): string | null {
-  const match = usesLine.match(/actions\/checkout@(\S+)/);
-  return match?.[1]?.replace(/\s+#.*$/, "") ?? null;
+  const idx = usesLine.indexOf(CHECKOUT_USES_PREFIX);
+  if (idx < 0) return null;
+  const after = usesLine.slice(idx + CHECKOUT_USES_PREFIX.length);
+  let end = after.length;
+  for (let i = 0; i < after.length; i += 1) {
+    const c = after[i];
+    if (c === " " || c === "\t" || c === "\r") {
+      end = i;
+      break;
+    }
+  }
+  const ref = after.slice(0, end);
+  return ref.length > 0 ? ref : null;
 }
 
 /**
@@ -688,7 +709,9 @@ export function mergeCoreGuardWorkflowRefresh(existing: string, desired: string)
   if (!desiredCheckout || !shouldPreserveCoreGuardCheckoutPin(existingCheckout, desiredCheckout)) {
     return desired;
   }
-  return desired.replace(CHECKOUT_USES_LINE_RE, () => existingCheckout);
+  const idx = desired.indexOf(desiredCheckout);
+  if (idx < 0) return desired;
+  return desired.slice(0, idx) + existingCheckout + desired.slice(idx + desiredCheckout.length);
 }
 
 function coreGuardWorkflowContent(): string {

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -664,9 +664,7 @@ export function shouldPreserveCoreGuardCheckoutPin(
 ): boolean {
   if (existingUsesLine === desiredUsesLine) return false;
   const existingRef = checkoutActionRef(existingUsesLine);
-  if (!existingRef || !extractCoreGuardCheckoutUsesLine(`steps:\n${desiredUsesLine}\n`)) {
-    return false;
-  }
+  if (!existingRef) return false;
   // Stale framework-deposited floating major tag — migrate to SHA template (#1672).
   return existingRef !== "v4";
 }
@@ -690,7 +688,7 @@ export function mergeCoreGuardWorkflowRefresh(existing: string, desired: string)
   if (!desiredCheckout || !shouldPreserveCoreGuardCheckoutPin(existingCheckout, desiredCheckout)) {
     return desired;
   }
-  return desired.replace(CHECKOUT_USES_LINE_RE, existingCheckout);
+  return desired.replace(CHECKOUT_USES_LINE_RE, () => existingCheckout);
 }
 
 function coreGuardWorkflowContent(): string {

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -649,6 +649,28 @@ export function extractCoreGuardCheckoutUsesLine(content: string): string | null
   return match ? match[0] : null;
 }
 
+function checkoutActionRef(usesLine: string): string | null {
+  const match = usesLine.match(/actions\/checkout@(\S+)/);
+  return match?.[1]?.replace(/\s+#.*$/, "") ?? null;
+}
+
+/**
+ * Whether refresh should keep the existing checkout pin instead of the template pin.
+ * Legacy framework-deposited `@v4` tags migrate forward; consumer/Dependabot bumps do not.
+ */
+export function shouldPreserveCoreGuardCheckoutPin(
+  existingUsesLine: string,
+  desiredUsesLine: string,
+): boolean {
+  if (existingUsesLine === desiredUsesLine) return false;
+  const existingRef = checkoutActionRef(existingUsesLine);
+  if (!existingRef || !extractCoreGuardCheckoutUsesLine(`steps:\n${desiredUsesLine}\n`)) {
+    return false;
+  }
+  // Stale framework-deposited floating major tag — migrate to SHA template (#1672).
+  return existingRef !== "v4";
+}
+
 /** Canonical SHA-pinned checkout step for the deposited deft-core-guard workflow. */
 export function coreGuardCheckoutUsesLine(
   sha: string = CORE_GUARD_CHECKOUT_SHA,
@@ -665,7 +687,12 @@ export function mergeCoreGuardWorkflowRefresh(existing: string, desired: string)
   const existingCheckout = extractCoreGuardCheckoutUsesLine(existing);
   if (!existingCheckout) return desired;
   const desiredCheckout = extractCoreGuardCheckoutUsesLine(desired);
-  if (!desiredCheckout || existingCheckout === desiredCheckout) return desired;
+  if (
+    !desiredCheckout ||
+    !shouldPreserveCoreGuardCheckoutPin(existingCheckout, desiredCheckout)
+  ) {
+    return desired;
+  }
   return desired.replace(CHECKOUT_USES_LINE_RE, existingCheckout);
 }
 

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -687,10 +687,7 @@ export function mergeCoreGuardWorkflowRefresh(existing: string, desired: string)
   const existingCheckout = extractCoreGuardCheckoutUsesLine(existing);
   if (!existingCheckout) return desired;
   const desiredCheckout = extractCoreGuardCheckoutUsesLine(desired);
-  if (
-    !desiredCheckout ||
-    !shouldPreserveCoreGuardCheckoutPin(existingCheckout, desiredCheckout)
-  ) {
+  if (!desiredCheckout || !shouldPreserveCoreGuardCheckoutPin(existingCheckout, desiredCheckout)) {
     return desired;
   }
   return desired.replace(CHECKOUT_USES_LINE_RE, existingCheckout);

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -636,6 +636,39 @@ function githubActionsExpr(expression: string): string {
   return ["$", "{{ ", expression, " }}"].join("");
 }
 
+/** Commit SHA for `actions/checkout` deposited in deft-core-guard.yml (#1672 / #1072). */
+export const CORE_GUARD_CHECKOUT_SHA = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0";
+/** Tag comment paired with {@link CORE_GUARD_CHECKOUT_SHA}. */
+export const CORE_GUARD_CHECKOUT_TAG = "v7.0.0";
+
+const CHECKOUT_USES_LINE_RE = /^\s+-\s+uses:\s+actions\/checkout@\S+(?:\s+#\s*.+)?\s*$/m;
+
+/** Extract the `uses: actions/checkout@…` step line from a guard workflow, if present. */
+export function extractCoreGuardCheckoutUsesLine(content: string): string | null {
+  const match = content.match(CHECKOUT_USES_LINE_RE);
+  return match ? match[0] : null;
+}
+
+/** Canonical SHA-pinned checkout step for the deposited deft-core-guard workflow. */
+export function coreGuardCheckoutUsesLine(
+  sha: string = CORE_GUARD_CHECKOUT_SHA,
+  tag: string = CORE_GUARD_CHECKOUT_TAG,
+): string {
+  return `      - uses: actions/checkout@${sha} # ${tag}`;
+}
+
+/**
+ * On refresh, preserve an existing consumer `actions/checkout@…` pin while updating
+ * the managed guard script / allowlist body (#1672 option 1).
+ */
+export function mergeCoreGuardWorkflowRefresh(existing: string, desired: string): string {
+  const existingCheckout = extractCoreGuardCheckoutUsesLine(existing);
+  if (!existingCheckout) return desired;
+  const desiredCheckout = extractCoreGuardCheckoutUsesLine(desired);
+  if (!desiredCheckout || existingCheckout === desiredCheckout) return desired;
+  return desired.replace(CHECKOUT_USES_LINE_RE, existingCheckout);
+}
+
 function coreGuardWorkflowContent(): string {
   const baseSha = githubActionsExpr("github.event.pull_request.base.sha");
   const headSha = githubActionsExpr("github.event.pull_request.head.sha");
@@ -654,7 +687,7 @@ function coreGuardWorkflowContent(): string {
     "  no-mixed-core-and-app:\n" +
     "    runs-on: ubuntu-latest\n" +
     "    steps:\n" +
-    "      - uses: actions/checkout@v4\n" +
+    `${coreGuardCheckoutUsesLine()}\n` +
     "        with:\n" +
     "          fetch-depth: 0\n" +
     "      - name: Refuse PRs that mix .deft/core/** with non-framework paths\n" +
@@ -822,15 +855,16 @@ export function ensureCoreGuardWorkflow(projectDir: string, io: InitDepositIo): 
   const desired = coreGuardWorkflowContent();
   if (existsSync(path)) {
     const existing = readFileSync(path, "utf8");
-    if (existing === desired) {
-      io.printf(`${CORE_GUARD_WORKFLOW_REL} already current — skipping.\n`);
-      return false;
-    }
     if (!existing.includes("name: deft-core-guard")) {
       io.printf(`${CORE_GUARD_WORKFLOW_REL} present but not deft-managed — leaving unchanged.\n`);
       return false;
     }
-    writeFileSync(path, desired, "utf8");
+    const refreshed = mergeCoreGuardWorkflowRefresh(existing, desired);
+    if (existing === refreshed) {
+      io.printf(`${CORE_GUARD_WORKFLOW_REL} already current — skipping.\n`);
+      return false;
+    }
+    writeFileSync(path, refreshed, "utf8");
     io.printf(`${CORE_GUARD_WORKFLOW_REL} refreshed: deft-core-guard allowlist updated (#1478).\n`);
     return true;
   }


### PR DESCRIPTION
## Summary
- SHA-pin `actions/checkout` in new `deft-core-guard.yml` deposits (v7.0.0 commit, matching directive CI #1072 hardening).
- On refresh, preserve an existing consumer `actions/checkout@…` pin while updating the managed guard script/allowlist body — stopping the Dependabot ↔ `directive update` ping-pong loop.
- Tests under `packages/core/src/init-deposit/` cover greenfield SHA template and preserve-on-refresh.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/init-deposit/scaffold.test.ts` (29 passed)
- [x] New deposit asserts SHA + tag comment, not floating `@v4`
- [x] Refresh fixture with Dependabot-bumped v6.0.3 pin preserves checkout while updating guard body

Closes #1672

Made with [Cursor](https://cursor.com)