### PR TITLE
fix: stop doctor migrate:xbrief dead-end on stale schema (#2368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Doctor and migrate:xbrief no longer dead-end on already-migrated xbrief projects with a stale deposited schema.** When `xbrief/` is canonical but `xbrief/schemas/vbrief-core.schema.json` still carries v0.6 markers, doctor advises `directive update` instead of `migrate:xbrief`, and migrate:xbrief exits cleanly with the same guidance rather than exit 2. Closes #2368.
+
 - **Merge-readiness no longer clears stale Greptile P0/P1 blockers when GitHub reports clean.** Stale verdicts that carried real P0/P1, errored, or low-confidence findings now stay hard blocks instead of being softened by the GitHub mergeability override, and Dependabot PRs with Greptile excluded-author skip comments are treated as pass rather than parse failures. Closes #2382. Closes #2375.
 - **Go installer consumer projections now refuse repo-controlled symlinks.** `deft-install` checks AGENTS.md, vbrief/, `.agents/`, `.githooks/`, and related projection targets with Lstat/containment before writing, so a malicious checkout cannot trick install or upgrade into overwriting files outside the project tree. Closes #2383.
 

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -10,10 +10,12 @@ import {
   checkManifestVersionReportable,
   checkQuickStartResolves,
   checkSkillPathsResolve,
+  checkStaleXbriefSchemaDeposit,
   deriveExitCode,
   runChecks,
   runChecksImpl,
 } from "./checks.js";
+import { renderXbriefMigrationLine } from "../xbrief-migrate/signpost.js";
 
 describe("checks", () => {
   it("derives exit codes", () => {
@@ -344,5 +346,88 @@ describe("checkGitignoreCoverage (#2206)", () => {
     const fail = checkGitignoreCoverage("/proj", seamsFor("node_modules/\n"));
     expect(fail.status).toBe("fail");
     expect(deriveExitCode([fail], [])).toBe(0);
+  });
+});
+
+describe("checkStaleXbriefSchemaDeposit (#2368)", () => {
+  const LIFECYCLE = ["proposed", "pending", "active", "completed", "cancelled"] as const;
+
+  function scaffoldMigratedXbrief(root: string): void {
+    for (const folder of LIFECYCLE) {
+      mkdirSync(join(root, "xbrief", folder), { recursive: true });
+    }
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8", description: "fixture" },
+        plan: { title: "Migrated", status: "running", items: [] },
+      }),
+      "utf8",
+    );
+  }
+
+  it("skips when the project is not on a migrated xbrief layout", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-doc-schema-"));
+    try {
+      const result = checkStaleXbriefSchemaDeposit(root, { isFile: () => false });
+      expect(result.status).toBe("skip");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when the deposited schema is already on xBRIEFInfo", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-doc-schema-"));
+    try {
+      scaffoldMigratedXbrief(root);
+      mkdirSync(join(root, "xbrief", "schemas"), { recursive: true });
+      writeFileSync(
+        join(root, "xbrief", "schemas", "vbrief-core.schema.json"),
+        JSON.stringify({ xBRIEFInfo: { version: "0.8" } }),
+        "utf8",
+      );
+      const result = checkStaleXbriefSchemaDeposit(root);
+      expect(result.status).toBe("pass");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("advises directive update (not migrate:xbrief) for a stale deposited schema", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-doc-schema-"));
+    try {
+      scaffoldMigratedXbrief(root);
+      mkdirSync(join(root, "xbrief", "schemas"), { recursive: true });
+      writeFileSync(
+        join(root, "xbrief", "schemas", "vbrief-core.schema.json"),
+        JSON.stringify({ vBRIEFInfo: { version: "0.6", description: "stale deposit" } }),
+        "utf8",
+      );
+      const result = checkStaleXbriefSchemaDeposit(root);
+      expect(result.status).toBe("fail");
+      expect(result.detail).toContain("directive update");
+      expect(result.detail).toContain("not `deft migrate:xbrief`");
+      expect(deriveExitCode([result], [])).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not recommend migrate:xbrief on the doctor signpost line for stale schema only", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-doc-schema-"));
+    try {
+      scaffoldMigratedXbrief(root);
+      mkdirSync(join(root, "xbrief", "schemas"), { recursive: true });
+      writeFileSync(
+        join(root, "xbrief", "schemas", "vbrief-core.schema.json"),
+        JSON.stringify({ vBRIEFInfo: { version: "0.6" } }),
+        "utf8",
+      );
+      const line = renderXbriefMigrationLine(root);
+      expect(line).toContain("xBrief migration: none");
+      expect(line).not.toContain("migrate:xbrief");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { renderXbriefMigrationLine } from "../xbrief-migrate/signpost.js";
 import {
   checkGitignoreCoverage,
   checkInstallPathConsistency,
@@ -15,7 +16,6 @@ import {
   runChecks,
   runChecksImpl,
 } from "./checks.js";
-import { renderXbriefMigrationLine } from "../xbrief-migrate/signpost.js";
 
 describe("checks", () => {
   it("derives exit codes", () => {

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -1,4 +1,12 @@
 import { join } from "node:path";
+import {
+  LEGACY_INFO_ROOT_KEY,
+  MIGRATED_ARTIFACT_DIR,
+} from "../xbrief-migrate/constants.js";
+import {
+  detectXbriefConvergence,
+  type XbriefConvergenceState,
+} from "../xbrief-migrate/detect.js";
 import { CANONICAL_GITIGNORE_BASELINE } from "../init-deposit/gitignore.js";
 import {
   detectLegacyLayout,
@@ -534,6 +542,83 @@ function gitignoreLineIsCovered(present: ReadonlySet<string>, line: string): boo
  * Skips when `.gitignore` is absent (greenfield project that has not yet run
  * `directive init` or `directive update`).
  */
+/** Relative path to the deposited v0.6 schema file superseded by xbrief-core-0.8.schema.json. */
+export const STALE_VBRIEF_CORE_SCHEMA_REL = join(
+  MIGRATED_ARTIFACT_DIR,
+  "schemas",
+  "vbrief-core.schema.json",
+);
+
+const MIGRATED_XBRIEF_LAYOUT_STATES = new Set<XbriefConvergenceState>([
+  "xbrief-only",
+  "xbrief-marker",
+]);
+
+/**
+ * #2368: on an already-migrated xbrief/ layout, a stale deposited
+ * `xbrief/schemas/vbrief-core.schema.json` (vBRIEFInfo v0.6) must NOT route
+ * operators to `migrate:xbrief` — that verb requires a vbrief/ tree. Point at
+ * `directive update` instead. Advisory only (exit-exempt).
+ */
+export function checkStaleXbriefSchemaDeposit(
+  projectRoot: string,
+  seams: CheckSeams = {},
+): CheckResult {
+  const checkName = "stale-xbrief-schema-deposit";
+  const convergence = detectXbriefConvergence(projectRoot);
+  if (!MIGRATED_XBRIEF_LAYOUT_STATES.has(convergence.state)) {
+    return {
+      name: checkName,
+      status: "skip",
+      detail: "Project is not on a fully migrated xbrief/ layout; stale schema deposit check does not apply.",
+      data: { convergence_state: convergence.state },
+    };
+  }
+
+  const schemaPath = join(projectRoot, STALE_VBRIEF_CORE_SCHEMA_REL);
+  const isFile = seams.isFile ?? ((p) => readText(p, seams) !== null);
+  if (!isFile(schemaPath)) {
+    return {
+      name: checkName,
+      status: "skip",
+      detail: `No deposited schema at ${STALE_VBRIEF_CORE_SCHEMA_REL}.`,
+      data: { schema_path: schemaPath },
+    };
+  }
+
+  const text = readText(schemaPath, seams);
+  if (text === null) {
+    return {
+      name: checkName,
+      status: "skip",
+      detail: `Deposited schema at ${STALE_VBRIEF_CORE_SCHEMA_REL} is unreadable.`,
+      data: { schema_path: schemaPath },
+    };
+  }
+
+  if (!text.includes(`"${LEGACY_INFO_ROOT_KEY}"`)) {
+    return {
+      name: checkName,
+      status: "pass",
+      detail: `Deposited schema at ${STALE_VBRIEF_CORE_SCHEMA_REL} is current (no ${LEGACY_INFO_ROOT_KEY} root key).`,
+      data: { schema_path: schemaPath },
+    };
+  }
+
+  return {
+    name: checkName,
+    status: "fail",
+    detail:
+      `Stale deposited schema at ${STALE_VBRIEF_CORE_SCHEMA_REL} still carries the legacy ${LEGACY_INFO_ROOT_KEY} root key on an already-migrated xbrief/ layout. ` +
+      "Run `directive update` to refresh deposited schema files — not `deft migrate:xbrief` (no vbrief/ tree remains to convert).",
+    data: {
+      schema_path: schemaPath,
+      convergence_state: convergence.state,
+      suggested_fix: "directive update",
+    },
+  };
+}
+
 export function checkGitignoreCoverage(projectRoot: string, seams: CheckSeams = {}): CheckResult {
   const gitignorePath = join(projectRoot, ".gitignore");
   const text = readText(gitignorePath, seams);
@@ -588,6 +673,7 @@ export function deriveExitCode(checks: readonly CheckResult[], errors: readonly 
     "canonical-vendored-npm-signpost",
     "manifest-version-reportable",
     "gitignore-coverage",
+    "stale-xbrief-schema-deposit",
   ]);
   if (errors.length > 0 || checks.some((c) => c.status === "error")) {
     return 2;
@@ -632,6 +718,7 @@ export function runChecksImpl(
     checks.push(checkManifestVersionReportable(projectRoot, null, seams));
     checks.push(checkLegacyLayout(projectRoot, seams));
     checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));
+    checks.push(checkStaleXbriefSchemaDeposit(projectRoot, seams));
     checks.push(checkGitignoreCoverage(projectRoot, seams));
     return {
       projectRoot,
@@ -648,6 +735,7 @@ export function runChecksImpl(
   checks.push(checkInstallPathConsistency(projectRoot, installRoot, seams));
   checks.push(checkLegacyLayout(projectRoot, seams));
   checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));
+  checks.push(checkStaleXbriefSchemaDeposit(projectRoot, seams));
   checks.push(checkGitignoreCoverage(projectRoot, seams));
   return {
     projectRoot,

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -528,14 +528,6 @@ function gitignoreLineIsCovered(present: ReadonlySet<string>, line: string): boo
   return present.has(line);
 }
 
-/**
- * #2206: check that the consumer `.gitignore` carries the canonical Deft baseline
- * entries. Advisory (exit-exempt) because missing entries are an adoption risk, not
- * a broken install.
- *
- * Skips when `.gitignore` is absent (greenfield project that has not yet run
- * `directive init` or `directive update`).
- */
 /** Relative path to the deposited v0.6 schema file superseded by xbrief-core-0.8.schema.json. */
 export const STALE_VBRIEF_CORE_SCHEMA_REL = join(
   MIGRATED_ARTIFACT_DIR,
@@ -614,6 +606,14 @@ export function checkStaleXbriefSchemaDeposit(
   };
 }
 
+/**
+ * #2206: check that the consumer `.gitignore` carries the canonical Deft baseline
+ * entries. Advisory (exit-exempt) because missing entries are an adoption risk, not
+ * a broken install.
+ *
+ * Skips when `.gitignore` is absent (greenfield project that has not yet run
+ * `directive init` or `directive update`).
+ */
 export function checkGitignoreCoverage(projectRoot: string, seams: CheckSeams = {}): CheckResult {
   const gitignorePath = join(projectRoot, ".gitignore");
   const text = readText(gitignorePath, seams);

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -1,12 +1,4 @@
 import { join } from "node:path";
-import {
-  LEGACY_INFO_ROOT_KEY,
-  MIGRATED_ARTIFACT_DIR,
-} from "../xbrief-migrate/constants.js";
-import {
-  detectXbriefConvergence,
-  type XbriefConvergenceState,
-} from "../xbrief-migrate/detect.js";
 import { CANONICAL_GITIGNORE_BASELINE } from "../init-deposit/gitignore.js";
 import {
   detectLegacyLayout,
@@ -22,6 +14,8 @@ import {
 import { resolveLifecycleRoot } from "../layout/resolve.js";
 import { findSkillPathsInText } from "../text/redos-safe.js";
 import { stripGitignoreInlineComment } from "../triage/bootstrap/gitignore.js";
+import { LEGACY_INFO_ROOT_KEY, MIGRATED_ARTIFACT_DIR } from "../xbrief-migrate/constants.js";
+import { detectXbriefConvergence, type XbriefConvergenceState } from "../xbrief-migrate/detect.js";
 import {
   CANONICAL_UPGRADE_COMMAND,
   GO_BRIDGE_RELEASES_URL,
@@ -570,7 +564,8 @@ export function checkStaleXbriefSchemaDeposit(
     return {
       name: checkName,
       status: "skip",
-      detail: "Project is not on a fully migrated xbrief/ layout; stale schema deposit check does not apply.",
+      detail:
+        "Project is not on a fully migrated xbrief/ layout; stale schema deposit check does not apply.",
       data: { convergence_state: convergence.state },
     };
   }

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -451,7 +451,8 @@ function runInstallIntegrityChecks(
         (name === "legacy-layout" ||
           name === "canonical-vendored-npm-signpost" ||
           name === "manifest-version-reportable" ||
-          name === "gitignore-coverage") &&
+          name === "gitignore-coverage" ||
+          name === "stale-xbrief-schema-deposit") &&
         status === "fail"
       ) {
         sink.warn(`${name}: ${detail}`);

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -506,6 +506,25 @@ describe("runXbriefMigration convergence (#2270)", () => {
     const rerun = runXbriefMigration({ projectRoot: project, force: true }, SILENT_IO);
     expect(rerun.kind).toBe("converged");
   });
+
+  it("returns a noop (not exit 2) when only a stale deposited schema remains (#2368)", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-stale-schema-"));
+    temps.push(base);
+    const project = scaffoldCanonicalXbrief(base);
+    mkdirSync(join(project, MIGRATED_ARTIFACT_DIR, "schemas"), { recursive: true });
+    writeFileSync(
+      join(project, MIGRATED_ARTIFACT_DIR, "schemas", "vbrief-core.schema.json"),
+      JSON.stringify({ vBRIEFInfo: { version: "0.6", description: "stale deposit" } }),
+      "utf8",
+    );
+
+    const outcome = runXbriefMigration({ projectRoot: project }, SILENT_IO);
+    expect(outcome.kind).toBe("noop");
+    if (outcome.kind === "noop") {
+      expect(outcome.message).toContain("directive update");
+      expect(outcome.message).not.toContain("Legacy markers detected");
+    }
+  });
 });
 
 describe("convergeLegacyVbriefRoot (#2270)", () => {

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -289,6 +289,16 @@ export function runXbriefMigration(
   }
 
   if (!isDirectory(legacyDir)) {
+    // Already on canonical xbrief/ with no vbrief/ tree — residual markers (e.g. a
+    // stale deposited v0.6 schema under xbrief/schemas/) are refreshed by update,
+    // not migrate:xbrief (#2368).
+    if (convergence.xbriefHasContent && !convergence.vbriefPresent) {
+      return {
+        kind: "noop",
+        message:
+          "Project is already on the xbrief layout — residual legacy markers (e.g. a stale deposited schema) cannot be cleared by migrate:xbrief when no vbrief/ tree remains. Run `directive update` to refresh deposited schema files.",
+      };
+    }
     return {
       kind: "config",
       message: `Legacy markers detected but '${LEGACY_ARTIFACT_DIR}/' directory is missing.`,

--- a/packages/core/src/xbrief-migrate/signpost.test.ts
+++ b/packages/core/src/xbrief-migrate/signpost.test.ts
@@ -145,4 +145,29 @@ describe("renderXbriefMigrationLine", () => {
     expect(line).toContain("both vbrief/ and xbrief/ found");
     expect(line).toContain("migrate:xbrief");
   });
+
+  it("reports none (not migrate:xbrief) when only a stale deposited schema remains (#2368)", () => {
+    const root = mkdtempSync(join(tmpdir(), "xbrief-signpost-stale-schema-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8", description: "fixture" },
+        plan: { title: "Migrated", status: "running", items: [] },
+      }),
+      "utf8",
+    );
+    mkdirSync(join(root, "xbrief", "schemas"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "schemas", "vbrief-core.schema.json"),
+      JSON.stringify({ vBRIEFInfo: { version: "0.6", description: "stale deposit" } }),
+      "utf8",
+    );
+
+    const line = renderXbriefMigrationLine(root);
+    expect(line).toContain("xBrief migration: none");
+    expect(line).not.toContain("migrate:xbrief");
+    expect(line).not.toContain("legacy vbrief layout detected");
+  });
 });


### PR DESCRIPTION
## Summary
- Add an advisory `stale-xbrief-schema-deposit` doctor check that points operators at `directive update` when `xbrief/schemas/vbrief-core.schema.json` still carries v0.6 markers on an already-migrated layout — not `migrate:xbrief`.
- Teach `migrate:xbrief` to exit cleanly (noop + update guidance) when the project is xbrief-canonical but only residual deposited-schema markers remain (no `vbrief/` tree).

## Test plan
- [x] `pnpm exec vitest run packages/core/src/doctor/checks.test.ts`
- [x] `pnpm exec vitest run packages/core/src/xbrief-migrate/signpost.test.ts`
- [x] `pnpm exec vitest run packages/core/src/xbrief-migrate/migrate-project.test.ts`
- [x] `pnpm -C packages/core run build`

Closes #2368

Made with [Cursor](https://cursor.com)