### PR TITLE
fix(triage): consumer-safe triage-cache README deposit (#2374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deposited triage-cache README is now consumer-facing.** Bootstrap and migration no longer write directive-internal decision IDs or dead `scripts/candidates_log.py` pointers into `<lifecycle-root>/.triage-cache/README.md`; the file explains tracked vs gitignored cache files in plain project terms. Closes #2374.
+
 - **Merge-readiness no longer clears stale Greptile P0/P1 blockers when GitHub reports clean.** Stale verdicts that carried real P0/P1, errored, or low-confidence findings now stay hard blocks instead of being softened by the GitHub mergeability override, and Dependabot PRs with Greptile excluded-author skip comments are treated as pass rather than parse failures. Closes #2382. Closes #2375.
 - **Go installer consumer projections now refuse repo-controlled symlinks.** `deft-install` checks AGENTS.md, vbrief/, `.agents/`, `.githooks/`, and related projection targets with Lstat/containment before writing, so a malicious checkout cannot trick install or upgrade into overwriting files outside the project tree. Closes #2383.
 

--- a/packages/core/src/triage/bootstrap/gitignore.test.ts
+++ b/packages/core/src/triage/bootstrap/gitignore.test.ts
@@ -167,6 +167,25 @@ describe("stepSeedCandidatesLog", () => {
   });
 });
 
+/** Directive-internal markers that must not ship in consumer README deposits (#2374). */
+const FORBIDDEN_CONSUMER_README_MARKERS = [
+  "candidates_log.py",
+  "scripts/",
+  "#1144",
+  "#1132",
+  "#845",
+  "#1121",
+  "#1180",
+  "#1308",
+  "#1464",
+  "#1119",
+  "#1183",
+  "D13",
+  "D1 /",
+  "Current Shape",
+  "decision_id",
+] as const;
+
 describe("generateTriageCacheReadmeBody", () => {
   it("substitutes xbrief/.triage-cache for the active migrated layout", () => {
     const root = makeRoot();
@@ -179,5 +198,32 @@ describe("generateTriageCacheReadmeBody", () => {
     const body = generateTriageCacheReadmeBody(root);
     expect(body).toContain("xbrief/.triage-cache/");
     expect(body).not.toContain("vbrief/.triage-cache/");
+  });
+
+  it("is consumer-safe: no directive-internal IDs or dead script pointers (#2374)", () => {
+    const root = makeRoot();
+    const body = generateTriageCacheReadmeBody(root);
+    for (const marker of FORBIDDEN_CONSUMER_README_MARKERS) {
+      expect(body).not.toContain(marker);
+    }
+    expect(body).toContain("slices.jsonl");
+    expect(body).toContain("deft triage:bootstrap");
+    expect(body).toContain("merge=union");
+  });
+});
+
+describe("stepEnsureGitignoreEvalEntries README deposit", () => {
+  it("writes a consumer-safe README on bootstrap (#2374)", () => {
+    const root = makeRoot();
+    stepEnsureGitignoreEntry(root);
+    const outcome = stepEnsureGitignoreEvalEntries(root);
+    expect(outcome.ok).toBe(true);
+    expect(outcome.details.readme_created).toBe(true);
+    const readme = readFileSync(join(root, "xbrief", ".triage-cache", "README.md"), "utf8");
+    for (const marker of FORBIDDEN_CONSUMER_README_MARKERS) {
+      expect(readme).not.toContain(marker);
+    }
+    expect(readme).toContain("slices.jsonl");
+    expect(readme).toContain("candidates.jsonl");
   });
 });

--- a/packages/core/src/triage/bootstrap/gitignore.ts
+++ b/packages/core/src/triage/bootstrap/gitignore.ts
@@ -111,78 +111,58 @@ const GITATTRIBUTES_EVAL_RATIONALE =
 const EVAL_ENTRIES_RATIONALE_SENTINEL =
   "# vbrief/.triage-cache/ tracking governance (#1144, N4 of #1119).";
 
-export const EVAL_README_BODY = `# \`vbrief/.triage-cache/\` -- triage working-set artefacts
+export const EVAL_README_BODY = `# \`vbrief/.triage-cache/\` — triage working-set files
 
-This directory holds the append-only JSON-lines logs that the triage and
-slicing skills emit. The framework governs which files in here are tracked
-by git versus gitignored using a **hybrid policy** (#1144, child of #1119).
+This directory holds JSON-lines logs and scratch files that Deft triage and
+slicing workflows emit. Deft configures your repo's \`.gitignore\` and
+\`.gitattributes\` so some files stay local while team-shared records can be
+committed.
 
-## Tracking policy
+## What lives here
 
-| File | Tracked? | Why |
+| File | Committed? | Notes |
 | --- | --- | --- |
-| \`slices.jsonl\` | Yes -- **committed** | Team-shared cohort records produced by slicing skills (D13 / #1132). New operators joining the team need to see prior cohort outputs to detect orphans and avoid re-slicing the same scope. |
-| \`candidates.jsonl\` | No -- **gitignored** | Operator-private triage decisions (#845 Story 2). Each operator's local accept / defer / reject stream is per-machine state; sharing it would conflate operators' timing + identity across the team. Re-derive on a fresh clone via \`task triage:bootstrap\`. |
-| \`summary-history.jsonl\` | No -- **gitignored** | Operator-private observability for \`task triage:summary\` output time-series. Not load-bearing for any decision. |
-| \`scope-lifecycle.jsonl\` | No -- **gitignored** | Operator-private scope-lifecycle audit decisions (D1 / #1121). Each demote (\`task scope:demote\`) appends one entry including a \`demote_meta\` block (\`was_promoted\`, \`original_promotion_decision_id\`, \`days_in_pending\`, \`demote_reason\`, \`demoted_from\`). Per-operator stream; sharing would conflate operators' demote timing across the team. Lightweight metrics over this log are tracked separately at #1180. |
-| \`decompositions/\` | No -- **gitignored** | Temporary story-decomposition proposal drafts. These JSON drafts are local scratch artifacts, not vBRIEFs; generated child story vBRIEFs are created by \`task scope:decompose\` in lifecycle folders, defaulting to \`vbrief/pending/\`. |
-| \`doctor-state.json\` | No -- **gitignored** | Per-machine \`task doctor\` throttle state (last exit code + timestamps) persisted to gate the 24h/4h re-probe window (#1308 / #1464). Local to each clone; never committed. |
+| \`slices.jsonl\` | Yes | Team-shared cohort records from slicing skills. New teammates use prior cohort outputs to spot orphans and avoid re-slicing the same scope. |
+| \`candidates.jsonl\` | No | Your local triage accept / defer / reject stream. Re-create on a fresh clone with \`deft triage:bootstrap\`. |
+| \`summary-history.jsonl\` | No | Local history of \`deft triage:summary\` output; not required for day-to-day work. |
+| \`scope-lifecycle.jsonl\` | No | Local audit trail for scope demotions (\`deft scope:demote\`). Each operator's stream stays on their machine. |
+| \`decompositions/\` | No | Draft story-decomposition scratch. Produced child story xBRIEFs live in lifecycle folders via \`deft scope:decompose\`. |
+| \`doctor-state.json\` | No | Per-clone throttle state for \`deft doctor\` re-probe timing. |
 
-The gitignore lines live in the repo-root \`.gitignore\` (\`vbrief/.triage-cache/candidates.jsonl\`,
+Paths listed as "No" above are added to \`.gitignore\` during bootstrap; anything
+not listed remains committable by default. The selective ignore entries live in
+the repo-root \`.gitignore\` (\`vbrief/.triage-cache/candidates.jsonl\`,
 \`vbrief/.triage-cache/summary-history.jsonl\`, \`vbrief/.triage-cache/scope-lifecycle.jsonl\`,
-\`vbrief/.triage-cache/decompositions/\`, and \`vbrief/.triage-cache/doctor-state.json\`). All paths
-not listed above remain committed by default.
+\`vbrief/.triage-cache/decompositions/\`, and \`vbrief/.triage-cache/doctor-state.json\`).
 
-## Fresh-clone regeneration
+## Fresh clone
 
-On a fresh clone (or any machine that has never run triage), \`candidates.jsonl\`
-is absent. Regenerate it with:
+If \`candidates.jsonl\` is missing, run:
 
 \`\`\`
-task triage:bootstrap
+deft triage:bootstrap
 \`\`\`
 
-The bootstrap path detects the missing file, runs the auto-classifier, and
-writes a fresh \`vbrief/.triage-cache/candidates.jsonl\`. It does NOT touch the tracked
-\`slices.jsonl\`; cohort records remain a team-shared resource.
+Bootstrap rebuilds the local candidates log without altering committed
+\`slices.jsonl\`.
 
-## \`merge=union\` policy for \`*.jsonl\`
+## Merge behavior for \`*.jsonl\`
 
-The repo-root \`.gitattributes\` declares:
+The repo-root \`.gitattributes\` may declare:
 
 \`\`\`
 vbrief/.triage-cache/*.jsonl  merge=union
 \`\`\`
 
-The \`union\` merge driver concatenates both sides' appended lines on
-auto-merge, so two branches that each appended a different record to the
-same JSON-lines file rebase cleanly without operator surgery. Two things
-operators should know:
-
-- **Concatenation, not set-union.** When two branches append DIFFERENT
-  records to the file, the merge driver concatenates both sides' lines
-  -- there is no smart deduplication of "semantically similar" records.
-  (Identical line-for-line appends collapse because git's three-way
-  merge sees them as the same change, but distinct records always
-  survive verbatim, even if a downstream reader would consider them
-  redundant.) The append-only writers in \`scripts/candidates_log.py\`
-  mint a fresh \`decision_id\` per call, so genuinely duplicate records
-  are not the expected case, but downstream readers MUST tolerate
-  multiple records describing the same logical decision.
-- **Single-operator scope only.** This is the foundational rebase
-  ergonomic for the single-operator case (operator A rebases their
-  feature branch onto a master that grew while they were AFK).
-  Multi-operator merge-conflict resolution is explicitly out of scope per
-  #1119 R4 (tracked separately as M1-M4 in #1183).
+The \`union\` merge driver concatenates both sides' appended lines on auto-merge,
+so parallel append-only edits to the same JSON-lines file rebase without manual
+conflict surgery. It does not dedupe semantically similar records — downstream
+readers should tolerate duplicate-looking entries.
 
 ## See also
 
-- Current Shape comment on #1144 for the canonical decisions (the source
-  of truth this README documents).
-- \`.gitignore\` -- selective gitignore entries for the operator-private
-  files.
-- \`.gitattributes\` -- the \`merge=union\` rule.
-- \`scripts/candidates_log.py\` -- the writer for \`candidates.jsonl\`.
+- \`.gitignore\` — selective ignore rules for operator-private files
+- \`.gitattributes\` — merge driver for committed JSON-lines logs
 `;
 
 /** Layout-aware triage-cache README body for the active lifecycle tree (#2344 / #2349). */


### PR DESCRIPTION
## Summary

- Rewrites the bootstrap/migration `generateTriageCacheReadmeBody` template so deposited `<lifecycle-root>/.triage-cache/README.md` files are consumer-facing
- Removes directive-internal decision IDs (#1144, D13, etc.) and the dead `scripts/candidates_log.py` pointer
- Adds vitest guards asserting bootstrap-deposited README content stays consumer-safe

## Test plan

- [x] `pnpm exec vitest run packages/core/src/triage` — 640 tests pass
- [x] New tests cover forbidden internal markers and bootstrap deposit path

Closes #2374

Made with [Cursor](https://cursor.com)