### PR TITLE
feat: advisory absolute AGENTS.md managed-section budget (#2450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Layered AGENTS.md budget instrument now reports an advisory absolute north-star.** `verify:agents-md-budget` keeps the #645 relative line ratchet fail-closed and adds a Wave-1 advisory meter for the always-on managed section (≤8 KB / ~2k tok) that reports over-budget gaps without failing `task check`. Absolute fail-closed promotion and DD-3 harness frontmatter are deferred to post-Wave-2 (#2452). Closes #2450.
+
 ### Changed
 
 ### Fixed

--- a/packages/cli/src/verify-agents-md-budget.test.ts
+++ b/packages/cli/src/verify-agents-md-budget.test.ts
@@ -106,7 +106,28 @@ describe("run", () => {
     try {
       expect(run(["--project-root", root, "--quiet"])).toBe(0);
       expect(out.mock.calls.length).toBe(0);
-      expect(err.mock.calls.length).toBe(0);
+      // Absolute advisory may still write to stderr on this repo's large managed section.
+    } finally {
+      out.mockRestore();
+      err.mockRestore();
+    }
+  });
+
+  it("writes absolute advisory to stderr when the managed section is over budget", () => {
+    const markerOpen = "<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->";
+    const markerClose = "<!-- /deft:managed-section -->";
+    const fill = "x".repeat(9000);
+    const agents = ["unmanaged", markerOpen, fill, markerClose].join("\n");
+    const root = buildRepo({
+      plan: { policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } } },
+      agents,
+    });
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(run(["--project-root", root])).toBe(0);
+      const stderrText = err.mock.calls.map((c) => String(c[0])).join("");
+      expect(stderrText).toContain("absolute budget advisory");
     } finally {
       out.mockRestore();
       err.mockRestore();

--- a/packages/cli/src/verify-agents-md-budget.ts
+++ b/packages/cli/src/verify-agents-md-budget.ts
@@ -54,6 +54,14 @@ export function run(argv: string[]): number {
     }
   }
 
+  if (result.advisoryMessage !== undefined && result.advisoryMessage.length > 0) {
+    if (result.advisoryStream === "stdout") {
+      process.stdout.write(`${result.advisoryMessage}\n`);
+    } else if (result.advisoryStream === "stderr") {
+      process.stderr.write(`${result.advisoryMessage}\n`);
+    }
+  }
+
   return result.code;
 }
 

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { countRegions, evaluate } from "./evaluate.js";
+import { countRegions, evaluate, extractManagedSection, measureManagedSection } from "./evaluate.js";
 
 const temps: string[] = [];
 afterAll(() => {
@@ -116,6 +116,85 @@ describe("countRegions", () => {
     ].join("\n");
     const result = countRegions(text);
     expect("error" in result).toBe(true);
+  });
+});
+
+describe("extractManagedSection", () => {
+  it("returns the managed span including markers", () => {
+    const text = agentsWith(2, 4);
+    const result = extractManagedSection(text);
+    expect("section" in result).toBe(true);
+    if ("section" in result) {
+      expect(result.section).toContain("<!-- deft:managed-section");
+      expect(result.section).toContain("<!-- /deft:managed-section -->");
+    }
+  });
+
+  it("returns an empty section when no markers exist", () => {
+    expect(extractManagedSection("a\nb\nc")).toEqual({ section: "" });
+  });
+});
+
+describe("measureManagedSection", () => {
+  it("reports bytes and estimated tokens for the managed span", () => {
+    const text = agentsWith(0, 5);
+    const result = measureManagedSection(text);
+    expect("bytes" in result).toBe(true);
+    if ("bytes" in result) {
+      expect(result.bytes).toBeGreaterThan(0);
+      expect(result.estimatedTokens).toBe(Math.ceil(result.bytes / 4));
+    }
+  });
+});
+
+describe("absolute managed-section advisory", () => {
+  const budgetPlan = { policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } } };
+
+  /** Build a managed block whose UTF-8 body exceeds the 8192-byte north-star. */
+  function agentsOverAbsolute(unmanaged: number, payloadBytes: number): string {
+    const markerOpen = "<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->";
+    const markerClose = "<!-- /deft:managed-section -->";
+    const overhead = Buffer.byteLength(`${markerOpen}\n${markerClose}`, "utf8");
+    const fillLen = Math.max(0, payloadBytes - overhead);
+    const fill = "x".repeat(fillLen);
+    const lines: string[] = [];
+    for (let i = 0; i < unmanaged; i += 1) {
+      lines.push(`unmanaged ${i}`);
+    }
+    lines.push(markerOpen, fill, markerClose);
+    return lines.join("\n");
+  }
+
+  it("emits advisory (exit 0) when the managed section exceeds the absolute ceiling", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsOverAbsolute(5, 9000) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.advisoryMessage).toContain("absolute budget advisory");
+    expect(result.advisoryMessage).toContain("Advisory only");
+    expect(result.advisoryStream).toBe("stderr");
+  });
+
+  it("stays quiet on absolute advisory when the managed section is under budget", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsWith(5, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.advisoryMessage).toBeUndefined();
+  });
+
+  it("still fail-closes the relative ratchet when a region grows", () => {
+    const tightPlan = { policy: { agentsMdBudget: { managedMaxLines: 5, unmanagedMaxLines: 10 } } };
+    const root = makeRepo({ plan: tightPlan, agents: agentsWith(20, 5) });
+    const result = evaluate(root);
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("grew past its ratchet");
+  });
+
+  it("emits absolute advisory even when --quiet suppresses the success banner", () => {
+    const root = makeRepo({ plan: budgetPlan, agents: agentsOverAbsolute(5, 9000) });
+    const result = evaluate(root, { quiet: true });
+    expect(result.code).toBe(0);
+    expect(result.message).toBe("");
+    expect(result.advisoryMessage).toContain("absolute budget advisory");
   });
 });
 

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { countRegions, evaluate, extractManagedSection, measureManagedSection } from "./evaluate.js";
+import {
+  countRegions,
+  evaluate,
+  extractManagedSection,
+  measureManagedSection,
+} from "./evaluate.js";
 
 const temps: string[] = [];
 afterAll(() => {
@@ -148,7 +153,9 @@ describe("measureManagedSection", () => {
 });
 
 describe("absolute managed-section advisory", () => {
-  const budgetPlan = { policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } } };
+  const budgetPlan = {
+    policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } },
+  };
 
   /** Build a managed block whose UTF-8 body exceeds the 8192-byte north-star. */
   function agentsOverAbsolute(unmanaged: number, payloadBytes: number): string {

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -5,11 +5,35 @@ import { resolveAgentsMdBudget } from "../policy/agents-md-budget.js";
 
 export type OutputStream = "stdout" | "stderr" | "none";
 
+/**
+ * Layered absolute north-star for the always-on managed surface (#2372 / #2450).
+ *
+ * Advisory-only in Wave 1: the relative line ratchet remains fail-closed; this
+ * ceiling reports relocation progress without affecting exit codes. Promotion to
+ * fail-closed is deferred to post-Wave-2 (#2369 current-shape).
+ *
+ * DD-3 (harness-injected skill frontmatter in the meter) is deferred to #2452 /
+ * Child A — this Wave-1 measure covers the rendered managed section only.
+ */
+export const ABSOLUTE_MANAGED_MAX_BYTES = 8192;
+export const ABSOLUTE_MANAGED_MAX_TOKENS = 2000;
+/** Rough UTF-8 bytes-per-token estimate for advisory reporting (~8192 B ≈ ~2048 tok). */
+export const ABSOLUTE_BYTES_PER_TOKEN_ESTIMATE = 4;
+
+/** Byte + estimated-token measure of the managed section body. */
+export interface ManagedSectionMeasure {
+  readonly bytes: number;
+  readonly estimatedTokens: number;
+}
+
 /** Result of verify:agents-md-budget evaluation; three-state exit contract. */
 export interface EvaluateResult {
   readonly code: 0 | 1 | 2;
   readonly message: string;
   readonly stream: OutputStream;
+  /** Advisory absolute-budget note (#2450); never affects `code`. */
+  readonly advisoryMessage?: string;
+  readonly advisoryStream?: OutputStream;
 }
 
 export interface EvaluateOptions {
@@ -69,6 +93,100 @@ export function countRegions(text: string): { counts: RegionCounts } | { error: 
 
   const managed = closeLine - openLine + 1;
   return { counts: { total, managed, unmanaged: total - managed } };
+}
+
+/**
+ * Extract the managed-section span (open marker through close marker, inclusive).
+ *
+ * Returns an empty section when no markers are present — consistent with
+ * `countRegions` treating markerless files as entirely unmanaged.
+ */
+export function extractManagedSection(text: string): { section: string } | { error: string } {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  const openLine = lines.findIndex((l) => l.startsWith(OPEN_MARKER_PREFIX));
+  const closeLine = lines.findIndex((l) => l.trim().startsWith(AGENTS_MANAGED_CLOSE));
+  const openCount = lines.filter((l) => l.startsWith(OPEN_MARKER_PREFIX)).length;
+  const closeCount = lines.filter((l) => l.trim().startsWith(AGENTS_MANAGED_CLOSE)).length;
+
+  if (openLine === -1 && closeLine === -1) {
+    return { section: "" };
+  }
+  if (
+    openLine === -1 ||
+    closeLine === -1 ||
+    closeLine < openLine ||
+    openCount > 1 ||
+    closeCount > 1
+  ) {
+    return {
+      error:
+        "AGENTS.md managed-section markers are malformed " +
+        `(open@${openLine === -1 ? "none" : openLine + 1}×${openCount}, ` +
+        `close@${closeLine === -1 ? "none" : closeLine + 1}×${closeCount}); ` +
+        "expected a single <!-- deft:managed-section ... --> ... " +
+        "<!-- /deft:managed-section --> pair.",
+    };
+  }
+
+  return { section: lines.slice(openLine, closeLine + 1).join("\n") };
+}
+
+/** Measure UTF-8 byte length and a rough token estimate for the managed section. */
+export function measureManagedSection(text: string): ManagedSectionMeasure | { error: string } {
+  const extracted = extractManagedSection(text);
+  if ("error" in extracted) {
+    return extracted;
+  }
+  const bytes = Buffer.byteLength(extracted.section, "utf8");
+  return {
+    bytes,
+    estimatedTokens: Math.ceil(bytes / ABSOLUTE_BYTES_PER_TOKEN_ESTIMATE),
+  };
+}
+
+function formatAbsoluteAdvisory(measure: ManagedSectionMeasure): string {
+  const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
+  const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
+  return (
+    `⚠ verify:agents-md-budget: managed section absolute budget advisory — ` +
+    `${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the Wave-1 north-star ` +
+    `of ${ABSOLUTE_MANAGED_MAX_BYTES} bytes / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
+    `(OVER by ${overBytes} bytes / ~${overTokens} tok). Advisory only — task check is NOT affected.\n` +
+    "  The relative line ratchet (#645) remains fail-closed; this absolute ceiling is the\n" +
+    "  relocation goal for epic #2369. Fail-closed promotion is deferred until after Wave 2.\n" +
+    "  DD-3 harness skill frontmatter is not yet included in this meter (#2452)."
+  );
+}
+
+function absoluteAdvisoryForText(
+  text: string,
+): { advisoryMessage: string; advisoryStream: OutputStream } | null {
+  const measureResult = measureManagedSection(text);
+  if ("error" in measureResult) {
+    return null;
+  }
+  const overBytes = measureResult.bytes > ABSOLUTE_MANAGED_MAX_BYTES;
+  const overTokens = measureResult.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  if (!overBytes && !overTokens) {
+    return null;
+  }
+  return {
+    advisoryMessage: formatAbsoluteAdvisory(measureResult),
+    advisoryStream: "stderr",
+  };
+}
+
+function attachAbsoluteAdvisory<T extends EvaluateResult>(result: T, text: string): T {
+  const advisory = absoluteAdvisoryForText(text);
+  if (advisory === null) {
+    return result;
+  }
+  return { ...result, ...advisory };
 }
 
 function formatRefusal(
@@ -153,18 +271,21 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
 
   if (budgetResult.source === "unset") {
     if (quiet) {
-      return { code: 0, message: "", stream: "none" };
+      return attachAbsoluteAdvisory({ code: 0, message: "", stream: "none" }, text);
     }
-    return {
-      code: 0,
-      message:
-        "⚠ verify:agents-md-budget: no plan.policy.agentsMdBudget configured " +
-        `(managed=${counts.managed}, unmanaged=${counts.unmanaged} lines).\n` +
-        "  Seed a ratchet at current size to freeze growth (#645): set\n" +
-        "  plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines} in " +
-        "PROJECT-DEFINITION.",
-      stream: "stderr",
-    };
+    return attachAbsoluteAdvisory(
+      {
+        code: 0,
+        message:
+          "⚠ verify:agents-md-budget: no plan.policy.agentsMdBudget configured " +
+          `(managed=${counts.managed}, unmanaged=${counts.unmanaged} lines).\n` +
+          "  Seed a ratchet at current size to freeze growth (#645): set\n" +
+          "  plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines} in " +
+          "PROJECT-DEFINITION.",
+        stream: "stderr",
+      },
+      text,
+    );
   }
 
   /* v8 ignore start -- defensive: source "typed" always carries a non-null budget. */
@@ -182,20 +303,26 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
 
   if (!overManaged && !overUnmanaged) {
     if (quiet) {
-      return { code: 0, message: "", stream: "none" };
+      return attachAbsoluteAdvisory({ code: 0, message: "", stream: "none" }, text);
     }
-    return {
-      code: 0,
-      message:
-        `✓ verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
-        `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet).`,
-      stream: "stdout",
-    };
+    return attachAbsoluteAdvisory(
+      {
+        code: 0,
+        message:
+          `✓ verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
+          `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet).`,
+        stream: "stdout",
+      },
+      text,
+    );
   }
 
-  return {
-    code: 1,
-    message: formatRefusal(counts, budget.managedMaxLines, budget.unmanagedMaxLines, root),
-    stream: "stderr",
-  };
+  return attachAbsoluteAdvisory(
+    {
+      code: 1,
+      message: formatRefusal(counts, budget.managedMaxLines, budget.unmanagedMaxLines, root),
+      stream: "stderr",
+    },
+    text,
+  );
 }

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -384,7 +384,7 @@ tasks:
           ENGINE_CMD: 'verify:wip-cap --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
   agents-md-budget:
-    desc: "Ratchet gate for AGENTS.md per-region line budgets (#645). Counts the managed section and the unmanaged region separately (the #1309 propagation duplicates content across the marker) and fails when either region grows past plan.policy.agentsMdBudget. Seeded at current size, so it ships green; growth past the ratchet fails. Lowering a budget (a reduction PR) is always allowed; raising it is a reviewed diff to the typed field. Three-state exit (0 within / 1 over / 2 config error)."
+    desc: "Layered AGENTS.md budget instrument (#645 + #2450). Fail-closed relative ratchet: counts the managed section and the unmanaged region separately (the #1309 propagation duplicates content across the marker) and fails when either region grows past plan.policy.agentsMdBudget. Seeded at current size, so it ships green; growth past the ratchet fails. ADVISORY absolute north-star: also reports managed-section size vs ≤8 KB / ~2k tok (#2372 layered instrument) without affecting exit codes in Wave 1. Three-state exit (0 within / 1 over ratchet / 2 config error)."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
       - task: :engine:_ts-build


### PR DESCRIPTION
## Summary

- Extends `verify:agents-md-budget` with a Wave-1 **advisory** absolute north-star for the always-on managed section (≤8 KB / ~2k tok) per the #2372 layered instrument decision.
- The #645 relative line-count ratchet remains **fail-closed** and unchanged in exit-code posture; absolute over-budget reports on stderr without affecting `task check`.
- DD-3 harness skill frontmatter inclusion is explicitly deferred to #2452; promotion to fail-closed absolute is deferred to post-Wave-2.

## Test plan

- [x] `npx vitest run packages/core/src/agents-md-budget/evaluate.test.ts packages/cli/src/verify-agents-md-budget.test.ts`
- [x] Manual `verify:agents-md-budget` on this repo shows advisory gap (~29 KB managed) with exit 0
- [ ] CI `task check`

Closes #2450