### PR TITLE
feat: invert agents-entry propagation to pointer-sufficient (#2371)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,34 +64,19 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Deterministic questions runtime obligation (#1470)
 
-Same `!` / `⊗` rules as the managed `## Deterministic questions runtime obligation (#1470)` below; in this repo the contract path is `content/contracts/deterministic-questions.md` (#767). ANY agent-initiated structured or numbered question — inside or outside a skill — MUST carry `Discuss` and `Back` as the final two options and obey the Discuss-pause semantic. Self-check before every `ask_user_question` / numbered menu; host `Other` is NOT a substitute for `Discuss`.
+Pointer-sufficient managed section below; canonical contract at `content/contracts/deterministic-questions.md` (#767). One-line: structured questions MUST carry `Discuss` and `Back` as the final two options.
 
 ## Review-surface precedence (#2308)
 
-! When the active host harness exposes its own review-labeled surfaces -- Cursor's `bugbot` / `security-review` Task **subagent types**, the `review-bugbot` / `review-security` **skills**, or any future host equivalent -- the orchestrator MUST route review work through the canonical `deft-directive-review-cycle` skill. A generic "review this" / "get this reviewed" / "use sub-agents for reviews" request maps to `deft-directive-review-cycle` by intent, not literal keyword (extends #1862 / #2261).
-
-~ Host review tools MAY be folded in as *advisory* finding sources inside the review cycle (the #2019 harness-aware-reviewer path) -- their findings are batched alongside Greptile / bot findings, never treated as the review of record.
-
-⊗ Substitute a host-native review subagent type or `review-*` skill for `deft-directive-review-cycle` as the review surface -- the host review tools are advisory inputs, not a replacement. This is the 3rd recurrence of the #1862 / #2261 intent-routing / wrong-review-surface class (see also #2019, #2018).
+! Route review work through `deft-directive-review-cycle` — full workflow in `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host review tools (`bugbot`, `security-review`, `review-*` skills) are advisory-only inputs, not the review of record (#2308 / #1862 / #2261 / #2019).
 
 ## Value feedback and attribution (#1709)
 
-- ! `plan.policy.valueFeedback.enabled` defaults OFF for non-org repos -- while off, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in for any repo via `task policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `task policy:show --field=valueFeedback`.
-- ! Trusted-org local auto-enable (#2376) -- for a repo whose GitHub origin belongs to a company-owned org (built-in default `deftai`; extend via the `DEFT_VALUE_AUTOENABLE_ORGS` env override), LOCAL emit + session readback resolve ON with `source=org-auto` and network/upstream OFF, with NO per-repo or per-machine confirmation: org membership IS the consent for local, no-egress collection on company-owned resources. An explicit typed `valueFeedback` block always wins (including `enabled: false`); a non-matching org or no origin remote stays OFF (fail-safe).
-- ! Attribution records are enriched at emit time (#2376) with `repo`, `directive_version`, `install_id` (a stable per-checkout uuid under gitignored `.deft-cache/`), and `schema_version`, so a later collector can aggregate cross-repo without re-deriving provenance.
-- ! Value claims MUST be attributed-only -- point to concrete logged events ("encoding gate caught 2 corruptions"), never vague quality claims. Silence when the ledger has nothing attributable for the session slot.
-- ! Budgeted awareness -- at most one session readback line when `sessionLine` is allowed; repeat suppression uses a 4-hour window per attribution event id (parity with #1279 triage welcome debounce). Pull-based detail is `task value:show`, not pushed.
-- ! Gap escalation to `deftai/directive` is confirmation-gated -- route conversational filing through `deft-directive-feedback`; the agent drafts + dedups; the operator approves before `task feedback:file -- --confirm`. Use `Refs #1709` in upstream bodies, not `Closes`.
-- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`. Trusted-org auto-enable still turns LOCAL emit ON inside the maintainer repo, but session readback stays gated behind `DEFT_VALUE_SELF_DOGFOOD=1`.
-- ⊗ Enable any NETWORK or upstream value-feedback surface (upstream gap escalation / `task feedback:file`) without operator confirmation -- trusted-org auto-enable authorizes LOCAL, no-egress collection ONLY.
-- ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
-- ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
+! `plan.policy.valueFeedback.enabled` defaults OFF — opt-in via `task policy:show --field=valueFeedback` / `task policy:enable-value-feedback -- --confirm`; pull-based detail via `task value:show`; full rules in `content/skills/deft-directive-feedback/SKILL.md` (#1709). Gap escalation via `task feedback:file` is confirmation-gated (#2376).
 
 ## Eval and framework health (#1703)
 
-- ! Three tiers: **Tier 0** `task eval:health` (static gate score + contradictory-gate detector; ledger: `.eval/results/health-history.jsonl`). **Tier 1** CRUD telemetry on scope transitions (`.eval/results/crud-metrics.jsonl`, automatic). **Tier 2** `task eval:run` / `task eval:report` (golden corpus champion–challenger + holdout tripwire).
-- ! Run `task eval:health` when orienting, after gate/policy/doc changes, or when session start emits a budgeted `[eval]` nudge (score drop or contradictory gate; 4-hour debounce, parity #1279/#1709). Tier 2 is for maintainer release eval (`eval:run -- --model M`; `eval:report -- --champion V --challenger V --model M`).
-- ⊗ Discover eval only via CHANGELOG/`task --list` — AGENTS.md and `task triage:help` are canonical. ⊗ Treat Tier 1 telemetry as operator-invoked.
+! Run `task eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Maintainer release eval: `task eval:run` / `task eval:report` (#1703).
 
 ## Cache-as-authoritative work selection (#1149)
 
@@ -371,12 +356,7 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Deterministic questions runtime obligation (#1470)
 
-Rationale + cross-references: `.deft/core/contracts/deterministic-questions.md` (#767); closes the agent-runtime enforcement gap on issue #1470.
-
-- ! ANY agent-initiated structured question — whether via host `ask_user_question` / `AskQuestion` tooling or a numbered menu rendered in chat — inside OR outside any skill flow MUST include `Discuss` and `Back` as the final two options, in that order, and MUST obey the Discuss-pause semantic documented verbatim in `.deft/core/contracts/deterministic-questions.md`.
-- ! Before emitting any structured or numbered question, self-check: confirm `Discuss` and `Back` are present as the final two options; if not, add them before calling the tool or rendering the menu. Host-native `Other` / free-text affordances are NOT substitutes for `Discuss` (#767 / #431).
-- ⊗ Emit a structured or numbered question without `Discuss` and `Back` as the final two options — including ad-hoc orchestration approvals, dispatch confirmations, and decision walkthroughs outside interview/setup/refinement skills.
-- ⊗ Treat the host UI's automatic `Other` option as the stop-and-discuss escape hatch — `Other` widens the answer space; `Discuss` exits the deterministic flow entirely (see contract).
+! Any agent-initiated structured question MUST include `Discuss` and `Back` as the final two options — full Discuss-pause semantic in `.deft/core/contracts/deterministic-questions.md` (#1470 / #767).
 
 ## Issue body→comments reading (#2143)
 
@@ -411,30 +391,15 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ## Review-surface precedence (#2308)
 
-! When the active host harness exposes its own review-labeled surfaces -- Cursor's `bugbot` / `security-review` Task **subagent types**, the `review-bugbot` / `review-security` **skills**, or any future host equivalent -- the orchestrator MUST route review work through the canonical `deft-directive-review-cycle` skill. A generic "review this" / "get this reviewed" / "use sub-agents for reviews" request maps to `deft-directive-review-cycle` by intent, not literal keyword (extends #1862 / #2261).
-
-~ Host review tools MAY be folded in as *advisory* finding sources inside the review cycle (the #2019 harness-aware-reviewer path) -- their findings are batched alongside Greptile / bot findings, never treated as the review of record.
-
-⊗ Substitute a host-native review subagent type or `review-*` skill for `deft-directive-review-cycle` as the review surface -- the host review tools are advisory inputs, not a replacement. This is the 3rd recurrence of the #1862 / #2261 intent-routing / wrong-review-surface class (see also #2019, #2018).
+! Route review work through `deft-directive-review-cycle` — full workflow in `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host review tools (`bugbot`, `security-review`, `review-*` skills) are advisory-only inputs, not the review of record (#2308 / #1862 / #2261 / #2019).
 
 ## Value feedback and attribution (#1709)
 
-- ! `plan.policy.valueFeedback.enabled` defaults OFF for non-org repos -- while off, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in for any repo via `deft policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `deft policy:show --field=valueFeedback`.
-- ! Trusted-org local auto-enable (#2376) -- for a repo whose GitHub origin belongs to a company-owned org (built-in default `deftai`; extend via the `DEFT_VALUE_AUTOENABLE_ORGS` env override), LOCAL emit + session readback resolve ON with `source=org-auto` and network/upstream OFF, with NO per-repo or per-machine confirmation: org membership IS the consent for local, no-egress collection on company-owned resources. An explicit typed `valueFeedback` block always wins (including `enabled: false`); a non-matching org or no origin remote stays OFF (fail-safe).
-- ! Attribution records are enriched at emit time (#2376) with `repo`, `directive_version`, `install_id` (a stable per-checkout uuid under gitignored `.deft-cache/`), and `schema_version`, so a later collector can aggregate cross-repo without re-deriving provenance.
-- ! Value claims MUST be attributed-only -- point to concrete logged events ("encoding gate caught 2 corruptions"), never vague quality claims. Silence when the ledger has nothing attributable for the session slot.
-- ! Budgeted awareness -- at most one session readback line when `sessionLine` is allowed; repeat suppression uses a 4-hour window per attribution event id (parity with #1279 triage welcome debounce). Pull-based detail is `deft value:show`, not pushed.
-- ! Gap escalation to `deftai/directive` is confirmation-gated -- route conversational filing through `deft-directive-feedback`; the agent drafts + dedups; the operator approves before `deft feedback:file -- --confirm`. Use `Refs #1709` in upstream bodies, not `Closes`.
-- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`. Trusted-org auto-enable still turns LOCAL emit ON inside the maintainer repo, but session readback stays gated behind `DEFT_VALUE_SELF_DOGFOOD=1`.
-- ⊗ Enable any NETWORK or upstream value-feedback surface (upstream gap escalation / `deft feedback:file`) without operator confirmation -- trusted-org auto-enable authorizes LOCAL, no-egress collection ONLY.
-- ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
-- ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
+! `plan.policy.valueFeedback.enabled` defaults OFF — opt-in via `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; pull-based detail via `deft value:show`; full rules in `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709). Trusted-org auto-enable uses `source=org-auto` (#2376); gap escalation via `deft feedback:file` is confirmation-gated.
 
 ## Eval and framework health (#1703)
 
-- ! Three tiers: **Tier 0** `deft eval:health` (static gate score + contradictory-gate detector; ledger: `.eval/results/health-history.jsonl`). **Tier 1** CRUD telemetry on scope transitions (`.eval/results/crud-metrics.jsonl`, automatic). **Tier 2** `deft eval:run` / `deft eval:report` (golden corpus champion–challenger + holdout tripwire).
-- ! Run `deft eval:health` when orienting, after gate/policy/doc changes, or when session start emits a budgeted `[eval]` nudge (score drop or contradictory gate; 4-hour debounce, parity #1279/#1709). Tier 2 is for maintainer release eval (`eval:run -- --model M`; `eval:report -- --champion V --challenger V --model M`).
-- ⊗ Discover eval only via CHANGELOG/`deft --list` — AGENTS.md and `deft triage:help` are canonical. ⊗ Treat Tier 1 telemetry as operator-invoked.
+! Run `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Maintainer release eval: `deft eval:run` / `deft eval:report` (#1703).
 
 ## Branch policy & branch verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Agents-entry propagation is pointer-sufficient.** The `agents_entry_contract` gate now validates skill/gate/doc pointer shapes and canonical homes instead of requiring full-text rule mirrors in the always-on AGENTS.md managed section — unblocking epic #2369 Wave 2 relocation. Closes #2371.
+
 ### Fixed
 
 - **TS-native init now deposits the shared git-hook helper.** npm-installed projects receive `.githooks/_deft-run.sh` alongside `pre-commit` and `pre-push`, `verify:hooks-installed` catches missing helpers, and the Windows update smoke now baseline-commits through the hooks instead of bypassing them. Refs #2067, #2248.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -101,12 +101,7 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Deterministic questions runtime obligation (#1470)
 
-Rationale + cross-references: `.deft/core/contracts/deterministic-questions.md` (#767); closes the agent-runtime enforcement gap on issue #1470.
-
-- ! ANY agent-initiated structured question — whether via host `ask_user_question` / `AskQuestion` tooling or a numbered menu rendered in chat — inside OR outside any skill flow MUST include `Discuss` and `Back` as the final two options, in that order, and MUST obey the Discuss-pause semantic documented verbatim in `.deft/core/contracts/deterministic-questions.md`.
-- ! Before emitting any structured or numbered question, self-check: confirm `Discuss` and `Back` are present as the final two options; if not, add them before calling the tool or rendering the menu. Host-native `Other` / free-text affordances are NOT substitutes for `Discuss` (#767 / #431).
-- ⊗ Emit a structured or numbered question without `Discuss` and `Back` as the final two options — including ad-hoc orchestration approvals, dispatch confirmations, and decision walkthroughs outside interview/setup/refinement skills.
-- ⊗ Treat the host UI's automatic `Other` option as the stop-and-discuss escape hatch — `Other` widens the answer space; `Discuss` exits the deterministic flow entirely (see contract).
+! Any agent-initiated structured question MUST include `Discuss` and `Back` as the final two options — full Discuss-pause semantic in `.deft/core/contracts/deterministic-questions.md` (#1470 / #767).
 
 ## Issue body→comments reading (#2143)
 
@@ -141,30 +136,15 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ## Review-surface precedence (#2308)
 
-! When the active host harness exposes its own review-labeled surfaces -- Cursor's `bugbot` / `security-review` Task **subagent types**, the `review-bugbot` / `review-security` **skills**, or any future host equivalent -- the orchestrator MUST route review work through the canonical `deft-directive-review-cycle` skill. A generic "review this" / "get this reviewed" / "use sub-agents for reviews" request maps to `deft-directive-review-cycle` by intent, not literal keyword (extends #1862 / #2261).
-
-~ Host review tools MAY be folded in as *advisory* finding sources inside the review cycle (the #2019 harness-aware-reviewer path) -- their findings are batched alongside Greptile / bot findings, never treated as the review of record.
-
-⊗ Substitute a host-native review subagent type or `review-*` skill for `deft-directive-review-cycle` as the review surface -- the host review tools are advisory inputs, not a replacement. This is the 3rd recurrence of the #1862 / #2261 intent-routing / wrong-review-surface class (see also #2019, #2018).
+! Route review work through `deft-directive-review-cycle` — full workflow in `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host review tools (`bugbot`, `security-review`, `review-*` skills) are advisory-only inputs, not the review of record (#2308 / #1862 / #2261 / #2019).
 
 ## Value feedback and attribution (#1709)
 
-- ! `plan.policy.valueFeedback.enabled` defaults OFF for non-org repos -- while off, every downstream path (emit-only ledger, budgeted session readback, upstream gap escalation) short-circuits with zero token spend. Opt-in for any repo via `deft policy:enable-value-feedback -- --confirm` after the capability-cost disclosure prints. Inspect with `deft policy:show --field=valueFeedback`.
-- ! Trusted-org local auto-enable (#2376) -- for a repo whose GitHub origin belongs to a company-owned org (built-in default `deftai`; extend via the `DEFT_VALUE_AUTOENABLE_ORGS` env override), LOCAL emit + session readback resolve ON with `source=org-auto` and network/upstream OFF, with NO per-repo or per-machine confirmation: org membership IS the consent for local, no-egress collection on company-owned resources. An explicit typed `valueFeedback` block always wins (including `enabled: false`); a non-matching org or no origin remote stays OFF (fail-safe).
-- ! Attribution records are enriched at emit time (#2376) with `repo`, `directive_version`, `install_id` (a stable per-checkout uuid under gitignored `.deft-cache/`), and `schema_version`, so a later collector can aggregate cross-repo without re-deriving provenance.
-- ! Value claims MUST be attributed-only -- point to concrete logged events ("encoding gate caught 2 corruptions"), never vague quality claims. Silence when the ledger has nothing attributable for the session slot.
-- ! Budgeted awareness -- at most one session readback line when `sessionLine` is allowed; repeat suppression uses a 4-hour window per attribution event id (parity with #1279 triage welcome debounce). Pull-based detail is `deft value:show`, not pushed.
-- ! Gap escalation to `deftai/directive` is confirmation-gated -- route conversational filing through `deft-directive-feedback`; the agent drafts + dedups; the operator approves before `deft feedback:file -- --confirm`. Use `Refs #1709` in upstream bodies, not `Closes`.
-- ! Gap escalation is consumer-only -- no-op inside the directive maintainer repo unless `DEFT_VALUE_SELF_DOGFOOD=1`. Trusted-org auto-enable still turns LOCAL emit ON inside the maintainer repo, but session readback stays gated behind `DEFT_VALUE_SELF_DOGFOOD=1`.
-- ⊗ Enable any NETWORK or upstream value-feedback surface (upstream gap escalation / `deft feedback:file`) without operator confirmation -- trusted-org auto-enable authorizes LOCAL, no-egress collection ONLY.
-- ⊗ File upstream framework-gap issues without operator confirmation or past duplicate detection.
-- ⊗ Treat unattributed self-promotion as value feedback -- if there is no ledger event, emit nothing.
+! `plan.policy.valueFeedback.enabled` defaults OFF — opt-in via `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; pull-based detail via `deft value:show`; full rules in `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709). Trusted-org auto-enable uses `source=org-auto` (#2376); gap escalation via `deft feedback:file` is confirmation-gated.
 
 ## Eval and framework health (#1703)
 
-- ! Three tiers: **Tier 0** `deft eval:health` (static gate score + contradictory-gate detector; ledger: `.eval/results/health-history.jsonl`). **Tier 1** CRUD telemetry on scope transitions (`.eval/results/crud-metrics.jsonl`, automatic). **Tier 2** `deft eval:run` / `deft eval:report` (golden corpus champion–challenger + holdout tripwire).
-- ! Run `deft eval:health` when orienting, after gate/policy/doc changes, or when session start emits a budgeted `[eval]` nudge (score drop or contradictory gate; 4-hour debounce, parity #1279/#1709). Tier 2 is for maintainer release eval (`eval:run -- --model M`; `eval:report -- --champion V --challenger V --model M`).
-- ⊗ Discover eval only via CHANGELOG/`deft --list` — AGENTS.md and `deft triage:help` are canonical. ⊗ Treat Tier 1 telemetry as operator-invoked.
+! Run `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Maintainer release eval: `deft eval:run` / `deft eval:report` (#1703).
 
 ## Branch policy & branch verification
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -9,7 +9,17 @@ import { readRepoFile, repoFileExists, resolveRepoPath } from "./helpers.js";
 
 const OPEN_MARKER = "<!-- deft:managed-section v3 -->";
 const CLOSE_MARKER = "<!-- /deft:managed-section -->";
-const FIXTURES_DIR = join(import.meta.dirname, "..", "..", "..", "..", "..", "tests", "fixtures", "agents-md");
+const FIXTURES_DIR = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "tests",
+  "fixtures",
+  "agents-md",
+);
 
 const PROPAGATION_COMMAND_MARKERS: ReadonlyArray<readonly [string, string]> = [
   ["deft session:start", "task session:start"],
@@ -137,6 +147,13 @@ const UNMANAGED_HEADER_MARKERS = [
   "Session orientation",
 ] as const;
 
+/** Not yet relocated to pointer form — retain full-text markers until Wave 2 (#2454). */
+const PROPAGATION_UMBRELLA_STATUS_MARKERS = [
+  "claim-cites-state-surface",
+  "issues/<N>/comments",
+  "Conclude umbrella or epic status from the issue body alone",
+] as const;
+
 type PointerShape = "skill" | "gate" | "doc";
 
 interface PointerRuleSpec {
@@ -157,17 +174,8 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     shape: "skill",
     header: "Review-surface precedence (#2308)",
     canonicalHome: "skills/deft-directive-review-cycle/SKILL.md",
-    pointerHints: [
-      "deft-directive-review-cycle",
-      "SKILL.md",
-      "advisory",
-      "#2308",
-    ],
-    canonicalBodyMarkers: [
-      "deft-directive-review-cycle",
-      "Greptile",
-      "review cycle",
-    ],
+    pointerHints: ["deft-directive-review-cycle", "SKILL.md", "advisory", "#2308"],
+    canonicalBodyMarkers: ["deft-directive-review-cycle", "Greptile", "review cycle"],
     retiredFullTextMarkers: [
       "wrong-review-surface class",
       "harness-aware-reviewer path",
@@ -179,17 +187,8 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     shape: "skill",
     header: "Value feedback and attribution (#1709)",
     canonicalHome: "skills/deft-directive-feedback/SKILL.md",
-    pointerHints: [
-      "deft-directive-feedback",
-      "SKILL.md",
-      "plan.policy.valueFeedback",
-      "#1709",
-    ],
-    canonicalBodyMarkers: [
-      "plan.policy.valueFeedback",
-      "deft-directive-feedback",
-      "attributed",
-    ],
+    pointerHints: ["deft-directive-feedback", "SKILL.md", "plan.policy.valueFeedback", "#1709"],
+    canonicalBodyMarkers: ["plan.policy.valueFeedback", "deft-directive-feedback", "attributed"],
     retiredFullTextMarkers: [
       "DEFT_VALUE_SELF_DOGFOOD",
       "without operator confirmation",
@@ -210,12 +209,7 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     shape: "doc",
     header: "Deterministic questions runtime obligation (#1470)",
     canonicalHome: "contracts/deterministic-questions.md",
-    pointerHints: [
-      "contracts/deterministic-questions.md",
-      "Discuss",
-      "Back",
-      "#1470",
-    ],
+    pointerHints: ["contracts/deterministic-questions.md", "Discuss", "Back", "#1470"],
     canonicalBodyMarkers: ["Discuss` and `Back`", "final two numbered options"],
     retiredFullTextMarkers: [
       "NOT substitutes for `Discuss`",
@@ -246,7 +240,10 @@ function managedSection(text: string): string {
 }
 
 function extractSection(text: string, heading: string): string {
-  const headingRe = new RegExp(`^##\\s+${heading.replace(/[()]/g, "\\$&")}\\s*$`, "m");
+  const headingRe = new RegExp(
+    `^##\\s+${heading.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&")}\\s*$`,
+    "m",
+  );
   const match = headingRe.exec(text);
   if (!match || match.index === undefined) {
     return "";
@@ -294,7 +291,10 @@ function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
   }
 
   if (spec.retiredFullTextMarkers) {
-    const leaked = spec.retiredFullTextMarkers.filter((m) => section.includes(m));
+    const normalizedSection = normalizeWhitespace(section);
+    const leaked = spec.retiredFullTextMarkers.filter((m) =>
+      normalizedSection.includes(normalizeWhitespace(m)),
+    );
     if (leaked.length > 0) {
       errors.push(
         `${spec.id}: retired full-text markers still in managed section: ${leaked.join(", ")}`,
@@ -379,21 +379,24 @@ describe("test_agents_entry_contract", () => {
     expect(missingMarkers(agents, UNMANAGED_HEADER_MARKERS)).toEqual([]);
   });
 
-  it.each(POINTER_RELOCATED_RULES)(
-    "pointer_sufficient_rule_in_consumer_managed_section $id",
-    (spec) => {
-      const section = extractSection(templateManaged, spec.header);
-      expect(validatePointerRule(section, spec)).toEqual([]);
-    },
-  );
+  it("propagation_umbrella_status_markers_present_in_both_files", () => {
+    expect(missingMarkers(template, PROPAGATION_UMBRELLA_STATUS_MARKERS)).toEqual([]);
+    expect(missingMarkers(agents, PROPAGATION_UMBRELLA_STATUS_MARKERS)).toEqual([]);
+  });
 
-  it.each(POINTER_RELOCATED_RULES)(
-    "pointer_sufficient_rule_in_maintainer_managed_section $id",
-    (spec) => {
-      const section = extractSection(agentsManaged, spec.header);
-      expect(validatePointerRule(section, spec)).toEqual([]);
-    },
-  );
+  it.each(
+    POINTER_RELOCATED_RULES,
+  )("pointer_sufficient_rule_in_consumer_managed_section $id", (spec) => {
+    const section = extractSection(templateManaged, spec.header);
+    expect(validatePointerRule(section, spec)).toEqual([]);
+  });
+
+  it.each(
+    POINTER_RELOCATED_RULES,
+  )("pointer_sufficient_rule_in_maintainer_managed_section $id", (spec) => {
+    const section = extractSection(agentsManaged, spec.header);
+    expect(validatePointerRule(section, spec)).toEqual([]);
+  });
 
   it("value_readback_suppression_window_is_four_hours", () => {
     expect(VALUE_READBACK_SUPPRESSION_HOURS).toBe(4);
@@ -413,27 +416,36 @@ describe("test_agents_entry_pointer_fixtures", () => {
   it("fixture_pointer_to_skill_passes_without_full_rule_body", () => {
     const fixture = readFixture("pointer-sufficient-skill.md");
     const spec = POINTER_RELOCATED_RULES.find((r) => r.id === "review-surface-2308");
-    expect(spec).toBeTruthy();
-    const section = extractSection(fixture, spec!.header);
-    expect(validatePointerRule(section, spec!)).toEqual([]);
+    expect(spec).toBeDefined();
+    if (!spec) {
+      return;
+    }
+    const section = extractSection(fixture, spec.header);
+    expect(validatePointerRule(section, spec)).toEqual([]);
     expect(section).not.toContain("wrong-review-surface class");
   });
 
   it("fixture_pointer_to_gate_passes_without_full_rule_body", () => {
     const fixture = readFixture("pointer-sufficient-gate.md");
     const spec = POINTER_RELOCATED_RULES.find((r) => r.id === "eval-framework-1703");
-    expect(spec).toBeTruthy();
-    const section = extractSection(fixture, spec!.header);
-    expect(validatePointerRule(section, spec!)).toEqual([]);
+    expect(spec).toBeDefined();
+    if (!spec) {
+      return;
+    }
+    const section = extractSection(fixture, spec.header);
+    expect(validatePointerRule(section, spec)).toEqual([]);
     expect(section).not.toContain("crud-metrics.jsonl");
   });
 
   it("fixture_pointer_to_doc_passes_without_full_rule_body", () => {
     const fixture = readFixture("pointer-sufficient-doc.md");
     const spec = POINTER_RELOCATED_RULES.find((r) => r.id === "deterministic-questions-1470");
-    expect(spec).toBeTruthy();
-    const section = extractSection(fixture, spec!.header);
-    expect(validatePointerRule(section, spec!)).toEqual([]);
+    expect(spec).toBeDefined();
+    if (!spec) {
+      return;
+    }
+    const section = extractSection(fixture, spec.header);
+    expect(validatePointerRule(section, spec)).toEqual([]);
     expect(section).not.toContain("Discuss-pause semantic");
   });
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -1,12 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { EVAL_READBACK_SUPPRESSION_HOURS } from "../../eval/readback.js";
 import { VALUE_READBACK_SUPPRESSION_HOURS } from "../../value/readback.js";
-import { readRepoFile } from "./helpers.js";
+import { readRepoFile, repoFileExists, resolveRepoPath } from "./helpers.js";
 
-/** Port of tests/content/test_agents_entry_contract.py (#768, #1309, #2111). */
+/** Port of tests/content/test_agents_entry_contract.py (#768, #1309, #2111, #2371). */
 
 const OPEN_MARKER = "<!-- deft:managed-section v3 -->";
 const CLOSE_MARKER = "<!-- /deft:managed-section -->";
+const FIXTURES_DIR = join(import.meta.dirname, "..", "..", "..", "..", "..", "tests", "fixtures", "agents-md");
 
 const PROPAGATION_COMMAND_MARKERS: ReadonlyArray<readonly [string, string]> = [
   ["deft session:start", "task session:start"],
@@ -103,12 +106,8 @@ const PROPAGATION_ACTION_VERBS = [
   "start agent",
 ] as const;
 
-// #838: skill routing moved from the AGENTS.md `## Skill Routing` table to the
-// REFERENCES.md Skills Index. AGENTS.md keeps only a `## Skills` pointer.
 const SKILLS_POINTER_MARKERS = ["## Skills", "Skills Index", "REFERENCES.md"] as const;
 
-// Every non-deprecated skill catalogued under content/skills/ that the
-// REFERENCES.md Skills Index MUST list (name + description + triggers).
 const INDEXED_SKILL_IDS = [
   "deft-directive-setup",
   "deft-directive-cost",
@@ -132,77 +131,98 @@ const INDEXED_SKILL_IDS = [
   "deft-directive-feedback",
 ] as const;
 
-const PROPAGATION_UMBRELLA_STATUS_MARKERS = [
-  "claim-cites-state-surface",
-  "issues/<N>/comments",
-  "Conclude umbrella or epic status from the issue body alone",
-] as const;
-
 const UNMANAGED_HEADER_MARKERS = [
   "Do NOT treat the unmanaged AGENTS.md header as the work queue",
   "Do NOT add `Status`, `Next:`, or `Known Issues` blocks",
   "Session orientation",
 ] as const;
 
-// #2308: the review-surface precedence rule (deft-directive-review-cycle wins
-// over host-provided review tooling; host reviewers are advisory-only inputs)
-// MUST be mirrored across the maintainer AGENTS.md and the consumer template.
-const REVIEW_SURFACE_PRECEDENCE_MARKERS = [
-  "## Review-surface precedence (#2308)",
-  "deft-directive-review-cycle",
-  "bugbot",
-  "security-review",
-  "review-bugbot",
-  "review-security",
-  "or any future host equivalent",
-  "advisory",
-  "harness-aware-reviewer path",
-  "wrong-review-surface class",
-] as const;
+type PointerShape = "skill" | "gate" | "doc";
 
-// #1709: value-feedback opt-in, attributed readbacks, and confirmation-gated gap
-// escalation MUST be mirrored across maintainer AGENTS.md and the consumer template.
-const VALUE_FEEDBACK_MARKERS = [
-  "## Value feedback and attribution (#1709)",
-  "plan.policy.valueFeedback.enabled",
-  "attributed-only",
-  "4-hour window",
-  "deft-directive-feedback",
-  "Refs #1709",
-  "DEFT_VALUE_SELF_DOGFOOD",
-  "without operator confirmation",
-  "Trusted-org local auto-enable (#2376)",
-  "DEFT_VALUE_AUTOENABLE_ORGS",
-  "source=org-auto",
-] as const;
+interface PointerRuleSpec {
+  id: string;
+  shape: PointerShape;
+  header: string;
+  canonicalHome: string;
+  pointerHints: readonly string[];
+  canonicalBodyMarkers: readonly string[];
+  /** Full-text markers that must NOT appear in the managed section once relocated (#2371). */
+  retiredFullTextMarkers?: readonly string[];
+}
 
-// #1703: tiered eval framework discoverability MUST mirror across maintainer
-// AGENTS.md and the consumer template (#2336 / #1309).
-const EVAL_FRAMEWORK_MARKERS = [
-  "## Eval and framework health (#1703)",
-  "eval:health",
-  "eval:run",
-  "eval:report",
-  "crud-metrics.jsonl",
-  "health-history.jsonl",
-  "contradictory gate",
-  "4-hour debounce",
-  "Tier 1",
-  "Tier 2",
-] as const;
-
-// #1470: Discuss/Back runtime obligation MUST mirror across maintainer AGENTS.md,
-// consumer template, contract scope text, and orchestrator preamble self-check.
-const DETERMINISTIC_QUESTIONS_RUNTIME_MARKERS = [
-  "## Deterministic questions runtime obligation (#1470)",
-  "agent-initiated",
-  "ask_user_question",
-  "Discuss",
-  "Back",
-  "final two options",
-  "Discuss-pause semantic",
-  "contracts/deterministic-questions.md",
-  "NOT substitutes for `Discuss`",
+/** Relocated rules: pointer-sufficient always-on surface (#2371 / #2369 DD-1). */
+const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
+  {
+    id: "review-surface-2308",
+    shape: "skill",
+    header: "Review-surface precedence (#2308)",
+    canonicalHome: "skills/deft-directive-review-cycle/SKILL.md",
+    pointerHints: [
+      "deft-directive-review-cycle",
+      "SKILL.md",
+      "advisory",
+      "#2308",
+    ],
+    canonicalBodyMarkers: [
+      "deft-directive-review-cycle",
+      "Greptile",
+      "review cycle",
+    ],
+    retiredFullTextMarkers: [
+      "wrong-review-surface class",
+      "harness-aware-reviewer path",
+      "or any future host equivalent",
+    ],
+  },
+  {
+    id: "value-feedback-1709",
+    shape: "skill",
+    header: "Value feedback and attribution (#1709)",
+    canonicalHome: "skills/deft-directive-feedback/SKILL.md",
+    pointerHints: [
+      "deft-directive-feedback",
+      "SKILL.md",
+      "plan.policy.valueFeedback",
+      "#1709",
+    ],
+    canonicalBodyMarkers: [
+      "plan.policy.valueFeedback",
+      "deft-directive-feedback",
+      "attributed",
+    ],
+    retiredFullTextMarkers: [
+      "DEFT_VALUE_SELF_DOGFOOD",
+      "without operator confirmation",
+      "DEFT_VALUE_AUTOENABLE_ORGS",
+    ],
+  },
+  {
+    id: "eval-framework-1703",
+    shape: "gate",
+    header: "Eval and framework health (#1703)",
+    canonicalHome: "packages/core/src/eval/health.ts",
+    pointerHints: ["eval:health", "Tier 0", "#1703"],
+    canonicalBodyMarkers: ["health-history", "contradictory"],
+    retiredFullTextMarkers: ["crud-metrics.jsonl", "health-history.jsonl", "Tier 2"],
+  },
+  {
+    id: "deterministic-questions-1470",
+    shape: "doc",
+    header: "Deterministic questions runtime obligation (#1470)",
+    canonicalHome: "contracts/deterministic-questions.md",
+    pointerHints: [
+      "contracts/deterministic-questions.md",
+      "Discuss",
+      "Back",
+      "#1470",
+    ],
+    canonicalBodyMarkers: ["Discuss` and `Back`", "final two numbered options"],
+    retiredFullTextMarkers: [
+      "NOT substitutes for `Discuss`",
+      "ask_user_question",
+      "Emit a structured or numbered question without",
+    ],
+  },
 ] as const;
 
 function normalizeWhitespace(text: string): string {
@@ -218,16 +238,82 @@ function missingMarkers(haystack: string, markers: readonly string[]): string[] 
 }
 
 function managedSection(text: string): string {
-  const start = text.indexOf(OPEN_MARKER);
+  const start = text.search(/<!-- deft:managed-section v3\b/);
   const end = text.indexOf(CLOSE_MARKER);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
   return text.slice(start, end + CLOSE_MARKER.length);
 }
 
+function extractSection(text: string, heading: string): string {
+  const headingRe = new RegExp(`^##\\s+${heading.replace(/[()]/g, "\\$&")}\\s*$`, "m");
+  const match = headingRe.exec(text);
+  if (!match || match.index === undefined) {
+    return "";
+  }
+  const start = match.index;
+  const afterHeading = text.slice(start + match[0].length);
+  const nextHeading = afterHeading.search(/^##\s/m);
+  return nextHeading === -1
+    ? text.slice(start)
+    : text.slice(start, start + match[0].length + nextHeading);
+}
+
+function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
+  const errors: string[] = [];
+  if (!section) {
+    errors.push(`${spec.id}: missing section header "## ${spec.header}"`);
+    return errors;
+  }
+
+  const missingHints = missingMarkers(section, spec.pointerHints);
+  if (missingHints.length > 0) {
+    errors.push(`${spec.id}: missing pointer hints: ${missingHints.join(", ")}`);
+  }
+
+  if (!repoFileExists(spec.canonicalHome)) {
+    errors.push(`${spec.id}: canonical home missing at ${spec.canonicalHome}`);
+  } else {
+    const homeText = readRepoFile(spec.canonicalHome);
+    const missingBody = missingMarkers(homeText, spec.canonicalBodyMarkers);
+    if (missingBody.length > 0) {
+      errors.push(
+        `${spec.id}: canonical home ${spec.canonicalHome} missing: ${missingBody.join(", ")}`,
+      );
+    }
+  }
+
+  if (spec.shape === "skill" && !/SKILL\.md|deft-directive-[\w-]+/.test(section)) {
+    errors.push(`${spec.id}: skill pointer shape not detected`);
+  }
+  if (spec.shape === "gate" && !/eval:health|verify:[\w-]+/.test(section)) {
+    errors.push(`${spec.id}: gate pointer shape not detected`);
+  }
+  if (spec.shape === "doc" && !/contracts\/[\w.-]+\.md|\.deft\/core\/contracts\//.test(section)) {
+    errors.push(`${spec.id}: doc pointer shape not detected`);
+  }
+
+  if (spec.retiredFullTextMarkers) {
+    const leaked = spec.retiredFullTextMarkers.filter((m) => section.includes(m));
+    if (leaked.length > 0) {
+      errors.push(
+        `${spec.id}: retired full-text markers still in managed section: ${leaked.join(", ")}`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+function readFixture(name: string): string {
+  return readFileSync(join(FIXTURES_DIR, name), "utf8");
+}
+
 describe("test_agents_entry_contract", () => {
   const template = readRepoFile("templates/agents-entry.md");
   const agents = readRepoFile("AGENTS.md");
+  const templateManaged = managedSection(template);
+  const agentsManaged = managedSection(agents);
 
   it("template_carries_managed_section_markers", () => {
     expect(template).toContain(OPEN_MARKER);
@@ -236,7 +322,7 @@ describe("test_agents_entry_contract", () => {
   });
 
   it("managed_section_contains_implementation_intent_gate", () => {
-    expect(managedSection(template)).toContain("Implementation Intent Gate");
+    expect(templateManaged).toContain("Implementation Intent Gate");
   });
 
   it("propagation_command_markers_present_in_both_files", () => {
@@ -273,7 +359,6 @@ describe("test_agents_entry_contract", () => {
   });
 
   it("skill_routing_table_removed_from_policy_files", () => {
-    // #838: the keyword->path routing table moved to the REFERENCES.md Skills Index.
     expect(agents).not.toContain("## Skill Routing");
     expect(template).not.toContain("## Skill Routing");
   });
@@ -289,35 +374,26 @@ describe("test_agents_entry_contract", () => {
     expect(missingMarkers(references, INDEXED_SKILL_IDS)).toEqual([]);
   });
 
-  it("propagation_umbrella_status_markers_present_in_both_files", () => {
-    expect(missingMarkers(template, PROPAGATION_UMBRELLA_STATUS_MARKERS)).toEqual([]);
-    expect(missingMarkers(agents, PROPAGATION_UMBRELLA_STATUS_MARKERS)).toEqual([]);
-  });
-
   it("unmanaged_header_contract_markers_present_in_both_files", () => {
     expect(missingMarkers(template, UNMANAGED_HEADER_MARKERS)).toEqual([]);
     expect(missingMarkers(agents, UNMANAGED_HEADER_MARKERS)).toEqual([]);
   });
 
-  it("propagation_review_surface_precedence_markers_present_in_both_files", () => {
-    expect(missingMarkers(template, REVIEW_SURFACE_PRECEDENCE_MARKERS)).toEqual([]);
-    expect(missingMarkers(agents, REVIEW_SURFACE_PRECEDENCE_MARKERS)).toEqual([]);
-  });
+  it.each(POINTER_RELOCATED_RULES)(
+    "pointer_sufficient_rule_in_consumer_managed_section $id",
+    (spec) => {
+      const section = extractSection(templateManaged, spec.header);
+      expect(validatePointerRule(section, spec)).toEqual([]);
+    },
+  );
 
-  it("propagation_value_feedback_markers_present_in_both_files", () => {
-    expect(missingMarkers(template, VALUE_FEEDBACK_MARKERS)).toEqual([]);
-    expect(missingMarkers(agents, VALUE_FEEDBACK_MARKERS)).toEqual([]);
-  });
-
-  it("propagation_eval_framework_markers_present_in_both_files", () => {
-    expect(missingMarkers(template, EVAL_FRAMEWORK_MARKERS)).toEqual([]);
-    expect(missingMarkers(agents, EVAL_FRAMEWORK_MARKERS)).toEqual([]);
-  });
-
-  it("propagation_deterministic_questions_runtime_markers_present_in_both_files", () => {
-    expect(missingMarkers(template, DETERMINISTIC_QUESTIONS_RUNTIME_MARKERS)).toEqual([]);
-    expect(missingMarkers(agents, DETERMINISTIC_QUESTIONS_RUNTIME_MARKERS)).toEqual([]);
-  });
+  it.each(POINTER_RELOCATED_RULES)(
+    "pointer_sufficient_rule_in_maintainer_managed_section $id",
+    (spec) => {
+      const section = extractSection(agentsManaged, spec.header);
+      expect(validatePointerRule(section, spec)).toEqual([]);
+    },
+  );
 
   it("value_readback_suppression_window_is_four_hours", () => {
     expect(VALUE_READBACK_SUPPRESSION_HOURS).toBe(4);
@@ -328,8 +404,43 @@ describe("test_agents_entry_contract", () => {
   });
 
   it("content_packs_note_references_discovery_commands", () => {
-    const section = managedSection(template);
-    expect(section).toContain("--list-packs");
-    expect(section).toContain("<pack> --list");
+    expect(templateManaged).toContain("--list-packs");
+    expect(templateManaged).toContain("<pack> --list");
+  });
+});
+
+describe("test_agents_entry_pointer_fixtures", () => {
+  it("fixture_pointer_to_skill_passes_without_full_rule_body", () => {
+    const fixture = readFixture("pointer-sufficient-skill.md");
+    const spec = POINTER_RELOCATED_RULES.find((r) => r.id === "review-surface-2308");
+    expect(spec).toBeTruthy();
+    const section = extractSection(fixture, spec!.header);
+    expect(validatePointerRule(section, spec!)).toEqual([]);
+    expect(section).not.toContain("wrong-review-surface class");
+  });
+
+  it("fixture_pointer_to_gate_passes_without_full_rule_body", () => {
+    const fixture = readFixture("pointer-sufficient-gate.md");
+    const spec = POINTER_RELOCATED_RULES.find((r) => r.id === "eval-framework-1703");
+    expect(spec).toBeTruthy();
+    const section = extractSection(fixture, spec!.header);
+    expect(validatePointerRule(section, spec!)).toEqual([]);
+    expect(section).not.toContain("crud-metrics.jsonl");
+  });
+
+  it("fixture_pointer_to_doc_passes_without_full_rule_body", () => {
+    const fixture = readFixture("pointer-sufficient-doc.md");
+    const spec = POINTER_RELOCATED_RULES.find((r) => r.id === "deterministic-questions-1470");
+    expect(spec).toBeTruthy();
+    const section = extractSection(fixture, spec!.header);
+    expect(validatePointerRule(section, spec!)).toEqual([]);
+    expect(section).not.toContain("Discuss-pause semantic");
+  });
+
+  it("canonical_homes_resolve_on_disk", () => {
+    for (const spec of POINTER_RELOCATED_RULES) {
+      expect(resolveRepoPath(spec.canonicalHome)).toBeTruthy();
+      expect(repoFileExists(spec.canonicalHome)).toBe(true);
+    }
   });
 });

--- a/tests/fixtures/agents-md/pointer-sufficient-doc.md
+++ b/tests/fixtures/agents-md/pointer-sufficient-doc.md
@@ -1,0 +1,7 @@
+<!-- deft:managed-section v3 -->
+# Fixture: pointer-to-doc (#2371)
+
+## Deterministic questions runtime obligation (#1470)
+
+! Any agent-initiated structured question MUST include `Discuss` and `Back` as the final two options — see `.deft/core/contracts/deterministic-questions.md` (#1470).
+<!-- /deft:managed-section -->

--- a/tests/fixtures/agents-md/pointer-sufficient-gate.md
+++ b/tests/fixtures/agents-md/pointer-sufficient-gate.md
@@ -1,0 +1,7 @@
+<!-- deft:managed-section v3 -->
+# Fixture: pointer-to-gate (#2371)
+
+## Eval and framework health (#1703)
+
+! Run `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce) (#1703).
+<!-- /deft:managed-section -->

--- a/tests/fixtures/agents-md/pointer-sufficient-skill.md
+++ b/tests/fixtures/agents-md/pointer-sufficient-skill.md
@@ -1,0 +1,7 @@
+<!-- deft:managed-section v3 -->
+# Fixture: pointer-to-skill (#2371)
+
+## Review-surface precedence (#2308)
+
+! Route review work through `deft-directive-review-cycle` — full workflow in `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host review tools are advisory-only inputs, not the review of record (#2308).
+<!-- /deft:managed-section -->


### PR DESCRIPTION
## Summary
- Inverts `agents_entry_contract` from full-text mirror markers to pointer-sufficient validation for skill, gate, and doc relocation shapes (#2371 / epic #2369 Wave 1).
- Compresses review-surface, value-feedback, eval, and deterministic-questions managed sections to one-line pointers with canonical-home resolution checks.
- Adds `tests/fixtures/agents-md/pointer-sufficient-{skill,gate,doc}.md` regression fixtures proving full rule bodies are not required when pointers resolve.

## Test plan
- [x] `npx vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts` (26 tests green)
- [x] `npx vitest run packages/core/src/content-contracts/skills/deterministic_questions.test.ts` (17 tests green)
- [ ] CI `task check` on merge

Closes #2371