### PR TITLE
refactor(agents-md): Wave 2 — compress universal guardrails to pointer-thin always-on surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,7 @@ Same rules as the managed `### Deft Alignment Confirmation` below: at session st
 
 ## Session-start ritual (#1149)
 
-Same rules as the managed `## Session-start ritual` below; in this repo substitute `task` for `deft`:
-
-- ! On every interactive session start, run `task session:start` after loading AGENTS.md — it records the quick-tier ritual in `.deft/ritual-state.json` (alignment, branch-policy disclosure, `task verify:tools` guidance, default-branch sync, the `task triage:welcome` one-liner); the state is worktree/HEAD-bound and stale after `plan.policy.sessionRitualStalenessHours` (default 4).
-- ! Before any code-writing tool call or `start_agent` dispatch, run `task verify:session-ritual -- --tier=gated` (fails closed unless the quick-tier state is fresh; also records the `task doctor` + `task verify:cache-fresh` entrypoints). Any non-zero exit aborts dispatch.
-- ? Postpone a step with `task session:start -- --defer step=reason`; headless/CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`. ⊗ Do not self-report the ritual complete without fresh state, and ⊗ do not reorder / skip / merge the ritual tiers without an explicit operator override.
-
-`task doctor` points at `task agents:refresh` when the managed section is stale and emits `npm i -g @deftai/directive@latest` when the payload is behind (bootstrap/upgrade path: UPGRADING.md). `task triage:welcome`'s D2 4-hour suppression window and comparison-key set are owned by the implementation (#1279); `task triage:summary` stays as a composable non-session-start primitive.
+Same rules as the managed `## Session-start ritual` below; in this repo substitute `task` for `deft` (`task session:start`, `task verify:session-ritual -- --tier=gated`, `task verify:tools`, `task doctor`, `task verify:cache-fresh`).
 
 ## Template propagation discipline (#1309)
 
@@ -98,17 +92,11 @@ See managed `## Skills` below and the **Skills Index** in `REFERENCES.md`; maint
 
 ### Implementation Intent Gate (#810)
 
-Same rules as the managed `### Implementation Intent Gate` below; in this repo use `task xbrief:preflight -- <path>` (passes only when the xBRIEF is in `xbrief/active/` with `plan.status == "running"`; `task xbrief:activate <path>` is the idempotent activation companion). Require an explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) before preflight / `start_agent`; ⊗ never infer implementation intent from lifecycle / branching / workflow-shape vocabulary, and ⊗ never treat a bare "yes / go / proceed / do it" as authorization unless the prior turn explicitly proposed implementation.
+Same rules as the managed `### Implementation Intent Gate` below; in this repo use `task xbrief:preflight -- <path>` — full #810 rules in `content/commands.md` § Scope xBRIEF Lifecycle.
 
 ### Story Start Gate
 
-Same rules as the managed `### Story Start Gate` below; in this repo substitute `task` for `deft`:
-
-- ! Before starting or switching stories, run `git status --short --branch`. If the tree is dirty, stop and summarize the current branch, modified/untracked files, and whether they relate to the next story, then ask the operator to choose: commit existing work, stash existing work, include existing work in the current story, or stop. ⊗ Do not begin a new story while unrelated dirty work is present without explicit operator approval.
-- ! Resolve exactly one target story xBRIEF by default; batching requires explicit operator approval + a short rationale. When invoked as part of a swarm cohort dispatch, the approved Phase 5 allocation plan IS the consent token (#954, all-or-nothing dispatch envelope) — do not re-prompt mid-cohort. Within a swarm cohort, between stories the tree MUST be checkpoint-clean; if `git status --short` shows uncommitted state, checkpoint-commit it and proceed (the "ask the operator" branch applies only at the FIRST story-start of a fresh branch).
-- ! Promote/activate scope with `task scope:promote -- <path>` then `task scope:activate -- <path>`, run `task xbrief:preflight -- <active-story-path>` before code-writing, keep one story per branch/PR with a checkpoint commit between stories, and finish with `task scope:complete -- <active-story-path>`. Gate 0 `task verify:story-ready` machine-checks these preconditions (see the pre-`start_agent` gate stack below).
-
-**Pre-`start_agent` gate stack (#1149/#1348):** Before dispatching an implementation sub-agent via `start_agent`, run the gates in the canonical order: (0) session ritual gate (#1348, `task verify:session-ritual -- --tier=gated`) → (1) story-start Gate 0 (#1378, `task verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]`) → (2) xBRIEF implementation-intent gate (#810, `task xbrief:preflight -- <path>`) → (3) `task verify:cache-fresh` (D5 / #1127) → (4) branch-policy gate (`task verify:branch` and the `.githooks/pre-commit` / `pre-push` hooks; see `**Branching:**` below) → (5) `start_agent`. Any non-zero exit aborts dispatch; do NOT spawn the sub-agent past a failed gate. The canonical order makes the gates composable so each one assumes the previous one has already cleared.
+Same rules as the managed `### Story Start Gate` below; in this repo substitute `task` for `deft` (`task verify:story-ready`, `task scope:promote -- <path>`, `task scope:activate -- <path>`, `task scope:complete -- <active-story-path>`).
 
 **Before code changes:**
 - ! Check `./xbrief/` lifecycle folders for existing scope xBRIEF coverage of the issue being fixed
@@ -319,21 +307,11 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session-start ritual (#1149)
 
-! On every interactive session start, run `deft session:start` after loading AGENTS.md. This records the quick-tier ritual in `.deft/ritual-state.json`: Deft alignment confirmation, branch-policy disclosure, required-tool guidance from `deft verify:tools`, default-branch sync warnings, and `deft triage:welcome` one-line state/nudge. The state is worktree- and HEAD-bound, and becomes stale after `plan.policy.sessionRitualStalenessHours` hours (default: 4).
-
-! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. The gated tier fails closed unless the quick-tier state is fresh, then lazily records the doctor and cache-fresh Python entrypoints (the checks exposed to operators as `deft doctor` and `deft verify:cache-fresh`) in the same ritual state. The verifier is now step 0 of the pre-`start_agent` gate stack; any non-zero exit aborts dispatch.
-
-? If a quick or gated step must be intentionally postponed, record the decision with `deft session:start -- --defer step=reason` using one of `alignment`, `branch_policy`, `triage_welcome`, `doctor`, or `cache_fresh`. Deferred steps satisfy the verifier but remain auditable in `.deft/ritual-state.json`.
-
-⊗ Self-report the session-start ritual as complete without a fresh `deft session:start` state, or bypass `deft verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
-
-⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
-
-`deft doctor` is the install-integrity + toolchain + managed-section freshness probe (#1308); when the managed section is stale it points at `deft agents:refresh`, and when the payload is behind it emits the upgrade command `npm i -g @deftai/directive@latest`. Install/upgrade via npm (`npm i -g @deftai/directive`; Node ≥ 20) — see `.deft/core/UPGRADING.md` for the bootstrap/upgrade path (the legacy Go installer is a legacy/offline bridge only). `deft triage:welcome` emits the triage one-liner and nudges `deft triage:welcome --onboard` when state is incomplete; its D2 4-hour suppression window and comparison-key set are owned by the `triage:welcome` implementation (#1143 / #1279).
+! On every interactive session start run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, and headless bypass in `.deft/core/commands.md` § Session-start ritual.
 
 ## WIP cap
 
-The `plan.policy.wipCap` field caps the number of in-flight scope xBRIEFs (`xbrief/pending/` + `xbrief/active/`). The framework default is 20 (#2319; raised from the original 10 per umbrella #1119 Current Shape v3). When the cap is reached, `deft scope:promote` refuses with a relief hint pointing at `deft scope:demote --batch --older-than-days 30` (D1 / #1121). Operators can override the cap from the consumer side via `deft triage:welcome --onboard` (the Phase 4 wipCap prompt) or by inspecting / editing the typed field via `deft policy:show --field=wipCap`.
+! Respect `plan.policy.wipCap` (default 20) — at cap `deft scope:promote` refuses; relief via `deft scope:demote --batch --older-than-days 30` (#2319 / #1121). Full WIP workflow: `.deft/core/.agents/skills/deft-directive-swarm/SKILL.md`.
 
 ## xBRIEF layout (#2034 / #2110)
 
@@ -403,25 +381,11 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ## Branch policy & branch verification
 
-Three consumer-facing surfaces enforce the branch-policy contract (#746 / #747):
-
-- `deft check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `deft check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
-- `deft verify:branch` -- branch gate wired into the `deft check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
-- `.githooks/pre-commit` / `pre-push` -- local hooks installed via `deft setup`; verify via `deft verify:hooks-installed`. After a framework upgrade, run `deft update` to refresh hook templates to the current TS-native `deft verify:*` / `deft preflight-gh` wiring (#2049).
-- `deft policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `deft policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
-- `deft verify:forward-coverage` -- forward-coverage gate (#1310): a NEW source file (`scripts/`, `src/`, `cmd/`, `packages/*/src`, or `*.py`/`*.go`/`*.ts`/`*.tsx`, excluding tests + `*.d.ts`) added without a corresponding test in the SAME diff fails the gate. Wired into `deft check` + the pre-commit hook (`--staged`); document genuine exceptions (shims, generated code) via `--allow-list <path>`. Mirrors the `deft verify:encoding` (#798) prose->deterministic migration.
+! Work on feature branches — `deft verify:branch`, `deft verify:forward-coverage`, hooks, and `deft check` enforce default-branch protection (#746 / #747); full surfaces in `.deft/core/scm/github.md` § Branch policy.
 
 ## Branch Policy Disclosure (#746)
 
-When the active project's `xbrief/PROJECT-DEFINITION.xbrief.json` has `plan.policy.allowDirectCommitsToMaster = true`, the agent MUST surface the policy state at the start of any interactive session (immediately after the Deft Directive alignment confirmation):
-
-> "[deft policy] Direct commits to the default branch are ENABLED (source: typed). Branch-protection policy is OFF."
-
-This phrasing is produced by `deft policy:show --field=allowDirectCommitsToMaster` and stays in lockstep with the typed surface (#746). When the policy is OFF (default; `allowDirectCommitsToMaster=false`), no session-start disclosure is required -- the absence of the disclosure line itself signals the default-enforcing state.
-
-Override paths (`deft policy:show` / `deft policy:enforce-branches` / `deft policy:allow-direct-commits -- --confirm` / `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1`) are detailed in the Branch policy & branch verification section above.
-
-⊗ Begin a session that will commit/push without surfacing the policy state when allowDirectCommitsToMaster=true.
+! When `plan.policy.allowDirectCommitsToMaster = true`, surface policy at session start via `deft policy:show --field=allowDirectCommitsToMaster` (#746) — full phrasing and override paths in `.deft/core/scm/github.md` § Branch policy.
 
 ## Platform-conditional rules (PowerShell / Windows)
 
@@ -434,24 +398,11 @@ Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they
 
 ### Implementation Intent Gate (#810)
 
-- ! Run `deft xbrief:preflight -- <path>` before any code-writing tool call or `start_agent` dispatch -- the gate exits 0 only when the candidate xBRIEF lives in `xbrief/active/` AND `plan.status == "running"`. Use the pre-`start_agent` gate stack step 2 for ordering and the Story Start Gate below for the `deft scope:promote` / `deft scope:activate` workflow bridge. If the gate is misconfigured, run `deft framework:doctor` and follow UPGRADING.md recovery guidance (#1046 / #1047).
-- ! Require an explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) from the user before invoking the preflight gate or `start_agent` for implementation. When intent is ambiguous, ask one targeted question instead of inferring.
-- ⊗ Infer implementation intent from lifecycle vocabulary ("do the full PR process", "start the work", "poller agents"), branching language, or workflow shape. Workflow-shape vocabulary is NOT authorization to spawn an implementation agent.
-- ⊗ Treat affirmative continuation phrases (`yes`, `go`, `proceed`, `do it`) as implementation authorization unless the prior turn explicitly proposed implementation. Broad approval is not a substitute for an explicit action-verb directive.
-
-**Pre-`start_agent` gate stack (#1149/#1348):** Before dispatching an implementation sub-agent via `start_agent`, run the gates in the canonical order: (0) session ritual gate (#1348, `deft verify:session-ritual -- --tier=gated`) -> (1) story-start Gate 0 (#1378, `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]`) -> (2) xBRIEF implementation-intent gate (#810, `deft xbrief:preflight -- <path>`) -> (3) `deft verify:cache-fresh` (D5 / #1127) -> (4) branch-policy gate (`deft verify:branch` and the `.githooks/pre-commit` / `pre-push` hooks) -> (5) `start_agent`. Any non-zero exit aborts dispatch.
+! Run `deft xbrief:preflight -- <path>` before code-writing (`xbrief/active/` + `plan.status == "running"`); require explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) (#810) — full rules in `.deft/core/commands.md` § Scope xBRIEF Lifecycle; `deft verify:cache-fresh` is gate-stack step 3 in `.deft/core/commands.md` § Session-start ritual.
 
 ### Story Start Gate
 
-- ! Before starting any new implementation story or switching from one story to another, run `git status --short --branch`.
-- ! If the working tree is dirty, stop and summarize the current branch, modified/untracked files, and whether the changes appear related to the next story. Ask the operator to choose one path: commit existing work, stash existing work, include existing work in the current story, or stop.
-- ⊗ Begin a new story while unrelated dirty work is present without explicit operator approval.
-- ! Default to one story per branch/PR: resolve exactly one target story xBRIEF path by default, require explicit operator approval plus a short rationale for batching multiple stories, and create a checkpoint commit after each completed story before beginning another story.
-- ! When invoked as part of a swarm cohort dispatch, the approved Phase 5 allocation plan satisfies the "explicit operator approval and a short rationale" requirement above -- the dispatched paths and allocation rationale ARE the consent token. Do NOT re-prompt the parent for batching approval mid-cohort; the all-or-nothing dispatch envelope rule (#954) forbids mid-scope user-approval gates.
-- ! Within a swarm cohort, between stories, the working tree MUST be clean (a checkpoint commit + `deft scope:complete` just landed). If `git status --short` shows uncommitted state between stories, checkpoint-commit it and proceed -- do NOT pause to ask the operator. The dirty-tree "ask the operator" branch above applies only at the FIRST story-start of a fresh branch.
-- ! If the target story is in `xbrief/proposed/`, run `deft scope:promote -- <path>` first; if it is in `xbrief/pending/`, run `deft scope:activate -- <path>`. After activation, run `deft xbrief:preflight -- <active-story-path>` before code-writing.
-- ! After checks pass for the story, complete the lifecycle with `deft scope:complete -- <active-story-path>` before final PR handoff.
-- ! Before dispatching an implementation sub-agent, run the deterministic Gate 0 `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]` ahead of `deft xbrief:preflight`. It machine-checks a clean working tree (or `--allow-dirty`), the target xBRIEF in `xbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token; three-state exit (0 ready / 1 not ready / 2 config error). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null; an absent section is the solo path. Any non-zero exit aborts dispatch.
+! Before starting stories run `git status --short --branch` and Gate 0 `deft verify:story-ready`; lifecycle via `deft scope:promote -- <path>` / `deft scope:activate -- <path>` / `deft scope:complete -- <active-story-path>` (#1378) — full workflow in `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Universal always-on guardrails are pointer-thin.** Session ritual, WIP cap, branch policy, implementation-intent, and story-start rules in AGENTS.md / agents-entry compress to one-line imperatives plus gate/skill/doc pointers; bulk lives in `commands.md`, `scm/github.md`, and swarm skill. Closes #2453. Refs #2369.
+
 - **Agents-entry propagation is pointer-sufficient.** The `agents_entry_contract` gate now validates skill/gate/doc pointer shapes and canonical homes instead of requiring full-text rule mirrors in the always-on AGENTS.md managed section — unblocking epic #2369 Wave 2 relocation. Closes #2371.
 
 ### Fixed

--- a/content/commands.md
+++ b/content/commands.md
@@ -99,11 +99,14 @@ Common commands:
 Before implementation work, use:
 
 ```bash
+git status --short --branch
 task verify:story-ready -- --vbrief-path xbrief/active/<file>.xbrief.json
 deft xbrief:preflight -- xbrief/active/<file>.xbrief.json
 ```
 
-The implementation gate succeeds only for active scope xBRIEFs with `plan.status == "running"`.
+Gate 0 `task verify:story-ready` machine-checks working-tree cleanliness (or `--allow-dirty`), the target xBRIEF in `xbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token (#1378). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null. Complete stories with `task scope:complete -- <active-story-path>`.
+
+The implementation gate succeeds only for active scope xBRIEFs with `plan.status == "running"`. Do not infer implementation intent from lifecycle vocabulary — require explicit action-verb directives (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) per #810.
 
 ```mermaid
 flowchart TD
@@ -175,6 +178,18 @@ Current status: the validation, extractor, provider, registry, generated MAP, an
 - `task verify:capacity`, `task verify:wip-cap`, and `task verify:judgment-gates` -- policy/capacity gates.
 
 Use `task --list` for the exact current verify namespace.
+
+## Session-start ritual (#1149)
+
+Full always-on contract for the interactive session-start ritual and its gated verifier (#1149 / #1348).
+
+- ! On every interactive session start, run `deft session:start` (or `task session:start` in framework source) after loading AGENTS.md. Records quick-tier ritual in `.deft/ritual-state.json`: alignment confirmation, branch-policy disclosure, `deft verify:tools` guidance, default-branch sync warnings, and `deft triage:welcome` one-liner. State is worktree- and HEAD-bound; stale after `plan.policy.sessionRitualStalenessHours` hours (default 4).
+- ! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. Gated tier fails closed unless quick-tier state is fresh; lazily records `deft doctor` and `deft verify:cache-fresh` entrypoints. Step 0 of the pre-`start_agent` gate stack.
+- ? Postpone with `deft session:start -- --defer step=reason` (`alignment`, `branch_policy`, `triage_welcome`, `doctor`, `cache_fresh`).
+- Headless workers / CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; verifier exits 0 but warns when bypass hides failure.
+- ⊗ Self-report ritual complete without fresh `deft session:start` state; ⊗ bypass `deft verify:session-ritual` before implementation dispatch; ⊗ reorder/skip/merge ritual tiers without operator override.
+
+**Pre-`start_agent` gate stack (#1149/#1348):** (0) `deft verify:session-ritual -- --tier=gated` → (1) `deft verify:story-ready` → (2) `deft xbrief:preflight` → (3) `deft verify:cache-fresh` → (4) `deft verify:branch` + hooks → (5) `start_agent`.
 
 ```mermaid
 flowchart TD

--- a/content/commands.md
+++ b/content/commands.md
@@ -106,6 +106,8 @@ deft xbrief:preflight -- xbrief/active/<file>.xbrief.json
 
 Gate 0 `task verify:story-ready` machine-checks working-tree cleanliness (or `--allow-dirty`), the target xBRIEF in `xbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token (#1378). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null. Complete stories with `task scope:complete -- <active-story-path>`.
 
+**Story Start Gate (#1378):** Before starting any new implementation story or switching stories, run `git status --short --branch`. If the working tree is dirty, stop and summarize the current branch, modified/untracked files, and whether the changes appear related to the next story — ask the operator to choose: commit existing work, stash existing work, include existing work in the current story, or stop. ⊗ Do not begin a new story while unrelated dirty work is present without explicit operator approval. When invoked as part of a swarm cohort dispatch, the approved Phase 5 allocation plan satisfies batching consent (#954); between stories checkpoint-commit it and proceed — do not pause to ask the operator mid-cohort. Promote/activate via `task scope:promote -- <path>` / `task scope:activate -- <path>`; preflight with `deft xbrief:preflight -- <active-story-path>`.
+
 The implementation gate succeeds only for active scope xBRIEFs with `plan.status == "running"`. Do not infer implementation intent from lifecycle vocabulary — require explicit action-verb directives (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) per #810.
 
 ```mermaid

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -257,6 +257,24 @@ task setup:ghx -- --yes      # non-interactive CI / scripted approval
 - ! Use live `gh` for mutations (POST/PATCH/PUT/DELETE) and for immediate read-back after a mutation — ghx is a cached GET proxy only
 - ⊗ Use `ghx api` for multi-arg write invocations — ghx accepts a single positional path arg; writes fall through to `gh`
 
+## Branch policy (#746 / #747)
+
+Three consumer-facing surfaces enforce the branch-policy contract:
+
+- `deft check` — consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `deft check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
+- `deft verify:branch` — refuses default-branch commit unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1`.
+- `.githooks/pre-commit` / `pre-push` — installed via `deft setup`; verify via `deft verify:hooks-installed`. After a framework upgrade, run `deft update` to refresh hook templates (#2049).
+- `deft policy:show --field=allowDirectCommitsToMaster` — inspect policy; `deft policy:allow-direct-commits -- --confirm` writes typed override with audit row.
+- `deft verify:forward-coverage` — forward-coverage gate (#1310), wired into `deft check` + pre-commit (`--staged`); document exceptions via `--allow-list <path>`.
+
+When `plan.policy.allowDirectCommitsToMaster = true`, the agent MUST surface at session start (after alignment confirmation):
+
+> "[deft policy] Direct commits to the default branch are ENABLED (source: typed). Branch-protection policy is OFF."
+
+Phrasing from `deft policy:show --field=allowDirectCommitsToMaster`. When OFF (default), absence of the disclosure signals enforcing state. Override paths: `deft policy:show` / `deft policy:enforce-branches` / `deft policy:allow-direct-commits -- --confirm` / `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1`.
+
+⊗ Begin a session that will commit/push without surfacing policy when `allowDirectCommitsToMaster=true`.
+
 ## Local git hooks (#747 / #2049)
 
 Project-root `.githooks/` enforce branch policy and encoding gates through the **`deft` CLI only** — no Python `scripts/*.py` dispatch (#2049). Hooks are installed idempotently via `deft setup` (`git config core.hooksPath .githooks`).

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -64,21 +64,11 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session-start ritual (#1149)
 
-! On every interactive session start, run `deft session:start` after loading AGENTS.md. This records the quick-tier ritual in `.deft/ritual-state.json`: Deft alignment confirmation, branch-policy disclosure, required-tool guidance from `deft verify:tools`, default-branch sync warnings, and `deft triage:welcome` one-line state/nudge. The state is worktree- and HEAD-bound, and becomes stale after `plan.policy.sessionRitualStalenessHours` hours (default: 4).
-
-! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. The gated tier fails closed unless the quick-tier state is fresh, then lazily records the doctor and cache-fresh Python entrypoints (the checks exposed to operators as `deft doctor` and `deft verify:cache-fresh`) in the same ritual state. The verifier is now step 0 of the pre-`start_agent` gate stack; any non-zero exit aborts dispatch.
-
-? If a quick or gated step must be intentionally postponed, record the decision with `deft session:start -- --defer step=reason` using one of `alignment`, `branch_policy`, `triage_welcome`, `doctor`, or `cache_fresh`. Deferred steps satisfy the verifier but remain auditable in `.deft/ritual-state.json`.
-
-⊗ Self-report the session-start ritual as complete without a fresh `deft session:start` state, or bypass `deft verify:session-ritual` before implementation dispatch. Headless workers and CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; the verifier exits 0 but warns when the bypass hides a failure.
-
-⊗ Reorder, skip, or merge the ritual tiers above without an explicit operator override -- the canonical order is what makes the downstream gate stack composable.
-
-`deft doctor` is the install-integrity + toolchain + managed-section freshness probe (#1308); when the managed section is stale it points at `deft agents:refresh`, and when the payload is behind it emits the upgrade command `npm i -g @deftai/directive@latest`. Install/upgrade via npm (`npm i -g @deftai/directive`; Node ≥ 20) — see `.deft/core/UPGRADING.md` for the bootstrap/upgrade path (the legacy Go installer is a legacy/offline bridge only). `deft triage:welcome` emits the triage one-liner and nudges `deft triage:welcome --onboard` when state is incomplete; its D2 4-hour suppression window and comparison-key set are owned by the `triage:welcome` implementation (#1143 / #1279).
+! On every interactive session start run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, and headless bypass in `.deft/core/commands.md` § Session-start ritual.
 
 ## WIP cap
 
-The `plan.policy.wipCap` field caps the number of in-flight scope xBRIEFs (`xbrief/pending/` + `xbrief/active/`). The framework default is 20 (#2319; raised from the original 10 per umbrella #1119 Current Shape v3). When the cap is reached, `deft scope:promote` refuses with a relief hint pointing at `deft scope:demote --batch --older-than-days 30` (D1 / #1121). Operators can override the cap from the consumer side via `deft triage:welcome --onboard` (the Phase 4 wipCap prompt) or by inspecting / editing the typed field via `deft policy:show --field=wipCap`.
+! Respect `plan.policy.wipCap` (default 20) — at cap `deft scope:promote` refuses; relief via `deft scope:demote --batch --older-than-days 30` (#2319 / #1121). Full WIP workflow: `.deft/core/.agents/skills/deft-directive-swarm/SKILL.md`.
 
 ## xBRIEF layout (#2034 / #2110)
 
@@ -148,25 +138,11 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ## Branch policy & branch verification
 
-Three consumer-facing surfaces enforce the branch-policy contract (#746 / #747):
-
-- `deft check` -- authoritative consumer pre-commit quality gate. In vendored `.deft/core` installs it runs consumer-safe Deft install/lifecycle gates and does NOT run framework source-repo self-tests. Run `deft check:framework-source` only when explicitly validating the vendored framework payload itself (#1519).
-- `deft verify:branch` -- branch gate wired into the `deft check` aggregate; refuses a commit on the default branch unless `plan.policy.allowDirectCommitsToMaster = true` (typed) or `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1` is set.
-- `.githooks/pre-commit` / `pre-push` -- local hooks installed via `deft setup`; verify via `deft verify:hooks-installed`. After a framework upgrade, run `deft update` to refresh hook templates to the current TS-native `deft verify:*` / `deft preflight-gh` wiring (#2049).
-- `deft policy:show --field=allowDirectCommitsToMaster` -- inspect the resolved policy; `deft policy:allow-direct-commits -- --confirm` writes the typed override with an audit row.
-- `deft verify:forward-coverage` -- forward-coverage gate (#1310): a NEW source file (`scripts/`, `src/`, `cmd/`, `packages/*/src`, or `*.py`/`*.go`/`*.ts`/`*.tsx`, excluding tests + `*.d.ts`) added without a corresponding test in the SAME diff fails the gate. Wired into `deft check` + the pre-commit hook (`--staged`); document genuine exceptions (shims, generated code) via `--allow-list <path>`. Mirrors the `deft verify:encoding` (#798) prose->deterministic migration.
+! Work on feature branches — `deft verify:branch`, `deft verify:forward-coverage`, hooks, and `deft check` enforce default-branch protection (#746 / #747); full surfaces in `.deft/core/scm/github.md` § Branch policy.
 
 ## Branch Policy Disclosure (#746)
 
-When the active project's `xbrief/PROJECT-DEFINITION.xbrief.json` has `plan.policy.allowDirectCommitsToMaster = true`, the agent MUST surface the policy state at the start of any interactive session (immediately after the Deft Directive alignment confirmation):
-
-> "[deft policy] Direct commits to the default branch are ENABLED (source: typed). Branch-protection policy is OFF."
-
-This phrasing is produced by `deft policy:show --field=allowDirectCommitsToMaster` and stays in lockstep with the typed surface (#746). When the policy is OFF (default; `allowDirectCommitsToMaster=false`), no session-start disclosure is required -- the absence of the disclosure line itself signals the default-enforcing state.
-
-Override paths (`deft policy:show` / `deft policy:enforce-branches` / `deft policy:allow-direct-commits -- --confirm` / `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1`) are detailed in the Branch policy & branch verification section above.
-
-⊗ Begin a session that will commit/push without surfacing the policy state when allowDirectCommitsToMaster=true.
+! When `plan.policy.allowDirectCommitsToMaster = true`, surface policy at session start via `deft policy:show --field=allowDirectCommitsToMaster` (#746) — full phrasing and override paths in `.deft/core/scm/github.md` § Branch policy.
 
 ## Platform-conditional rules (PowerShell / Windows)
 
@@ -179,24 +155,11 @@ Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they
 
 ### Implementation Intent Gate (#810)
 
-- ! Run `deft xbrief:preflight -- <path>` before any code-writing tool call or `start_agent` dispatch -- the gate exits 0 only when the candidate xBRIEF lives in `xbrief/active/` AND `plan.status == "running"`. Use the pre-`start_agent` gate stack step 2 for ordering and the Story Start Gate below for the `deft scope:promote` / `deft scope:activate` workflow bridge. If the gate is misconfigured, run `deft framework:doctor` and follow UPGRADING.md recovery guidance (#1046 / #1047).
-- ! Require an explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) from the user before invoking the preflight gate or `start_agent` for implementation. When intent is ambiguous, ask one targeted question instead of inferring.
-- ⊗ Infer implementation intent from lifecycle vocabulary ("do the full PR process", "start the work", "poller agents"), branching language, or workflow shape. Workflow-shape vocabulary is NOT authorization to spawn an implementation agent.
-- ⊗ Treat affirmative continuation phrases (`yes`, `go`, `proceed`, `do it`) as implementation authorization unless the prior turn explicitly proposed implementation. Broad approval is not a substitute for an explicit action-verb directive.
-
-**Pre-`start_agent` gate stack (#1149/#1348):** Before dispatching an implementation sub-agent via `start_agent`, run the gates in the canonical order: (0) session ritual gate (#1348, `deft verify:session-ritual -- --tier=gated`) -> (1) story-start Gate 0 (#1378, `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]`) -> (2) xBRIEF implementation-intent gate (#810, `deft xbrief:preflight -- <path>`) -> (3) `deft verify:cache-fresh` (D5 / #1127) -> (4) branch-policy gate (`deft verify:branch` and the `.githooks/pre-commit` / `pre-push` hooks) -> (5) `start_agent`. Any non-zero exit aborts dispatch.
+! Run `deft xbrief:preflight -- <path>` before code-writing (`xbrief/active/` + `plan.status == "running"`); require explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) (#810) — full rules in `.deft/core/commands.md` § Scope xBRIEF Lifecycle; `deft verify:cache-fresh` is gate-stack step 3 in `.deft/core/commands.md` § Session-start ritual.
 
 ### Story Start Gate
 
-- ! Before starting any new implementation story or switching from one story to another, run `git status --short --branch`.
-- ! If the working tree is dirty, stop and summarize the current branch, modified/untracked files, and whether the changes appear related to the next story. Ask the operator to choose one path: commit existing work, stash existing work, include existing work in the current story, or stop.
-- ⊗ Begin a new story while unrelated dirty work is present without explicit operator approval.
-- ! Default to one story per branch/PR: resolve exactly one target story xBRIEF path by default, require explicit operator approval plus a short rationale for batching multiple stories, and create a checkpoint commit after each completed story before beginning another story.
-- ! When invoked as part of a swarm cohort dispatch, the approved Phase 5 allocation plan satisfies the "explicit operator approval and a short rationale" requirement above -- the dispatched paths and allocation rationale ARE the consent token. Do NOT re-prompt the parent for batching approval mid-cohort; the all-or-nothing dispatch envelope rule (#954) forbids mid-scope user-approval gates.
-- ! Within a swarm cohort, between stories, the working tree MUST be clean (a checkpoint commit + `deft scope:complete` just landed). If `git status --short` shows uncommitted state between stories, checkpoint-commit it and proceed -- do NOT pause to ask the operator. The dirty-tree "ask the operator" branch above applies only at the FIRST story-start of a fresh branch.
-- ! If the target story is in `xbrief/proposed/`, run `deft scope:promote -- <path>` first; if it is in `xbrief/pending/`, run `deft scope:activate -- <path>`. After activation, run `deft xbrief:preflight -- <active-story-path>` before code-writing.
-- ! After checks pass for the story, complete the lifecycle with `deft scope:complete -- <active-story-path>` before final PR handoff.
-- ! Before dispatching an implementation sub-agent, run the deterministic Gate 0 `deft verify:story-ready -- --vbrief-path <active-story-path> [--allocation-context <dispatch-envelope-file>]` ahead of `deft xbrief:preflight`. It machine-checks a clean working tree (or `--allow-dirty`), the target xBRIEF in `xbrief/active/` with `plan.status == "running"`, and the dispatch envelope's `## Allocation context` consent token; three-state exit (0 ready / 1 not ready / 2 config error). A `swarm-cohort` section is ready only when `allocation_plan_id` AND `batching_rationale` are non-null; an absent section is the solo path. Any non-zero exit aborts dispatch.
+! Before starting stories run `git status --short --branch` and Gate 0 `deft verify:story-ready`; lifecycle via `deft scope:promote -- <path>` / `deft scope:activate -- <path>` / `deft scope:complete -- <active-story-path>` (#1378) — full workflow in `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
 
 ## Commands
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -217,6 +217,85 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "Emit a structured or numbered question without",
     ],
   },
+  {
+    id: "session-ritual-1149",
+    shape: "doc",
+    header: "Session-start ritual (#1149)",
+    canonicalHome: "commands.md",
+    pointerHints: ["deft session:start", "deft verify:session-ritual", "#1149"],
+    canonicalBodyMarkers: ["sessionRitualStalenessHours", "DEFT_SESSION_RITUAL_SKIP", "ritual-state.json"],
+    retiredFullTextMarkers: [
+      "lazily records the doctor and cache-fresh Python entrypoints",
+      "D2 4-hour suppression window",
+      "triage:welcome` implementation (#1143 / #1279)",
+    ],
+  },
+  {
+    id: "wip-cap-2319",
+    shape: "skill",
+    header: "WIP cap",
+    canonicalHome: "skills/deft-directive-swarm/SKILL.md",
+    pointerHints: ["plan.policy.wipCap", "deft scope:demote", "#1121"],
+    canonicalBodyMarkers: ["plan.policy.wipCap", "scope:demote --batch", "wip_cap_override"],
+    retiredFullTextMarkers: [
+      "raised from the original 10 per umbrella",
+      "Phase 4 wipCap prompt",
+    ],
+  },
+  {
+    id: "branch-policy-746",
+    shape: "doc",
+    header: "Branch policy & branch verification",
+    canonicalHome: "scm/github.md",
+    pointerHints: ["deft verify:branch", "#746", "#747"],
+    canonicalBodyMarkers: ["allowDirectCommitsToMaster", "verify:branch", "pre-commit"],
+    retiredFullTextMarkers: [
+      "deft check:framework-source",
+      "forward-coverage gate (#1310)",
+      "Mirrors the `deft verify:encoding`",
+    ],
+  },
+  {
+    id: "branch-disclosure-746",
+    shape: "doc",
+    header: "Branch Policy Disclosure (#746)",
+    canonicalHome: "scm/github.md",
+    pointerHints: ["deft policy:show --field=allowDirectCommitsToMaster", "#746"],
+    canonicalBodyMarkers: [
+      "Direct commits to the default branch are ENABLED",
+      "allowDirectCommitsToMaster",
+    ],
+    retiredFullTextMarkers: [
+      "Override paths (`deft policy:show`",
+      "absence of the disclosure line itself signals",
+    ],
+  },
+  {
+    id: "implementation-intent-810",
+    shape: "doc",
+    header: "Implementation Intent Gate (#810)",
+    canonicalHome: "commands.md",
+    pointerHints: ["deft xbrief:preflight", "action-verb", "#810"],
+    canonicalBodyMarkers: ["xbrief:preflight", 'plan.status == "running"', "implementation intent"],
+    retiredFullTextMarkers: [
+      "Workflow-shape vocabulary is NOT authorization",
+      "Broad approval is not a substitute",
+      "pre-`start_agent` gate stack (#1149/#1348)",
+    ],
+  },
+  {
+    id: "story-start-1378",
+    shape: "doc",
+    header: "Story Start Gate",
+    canonicalHome: "commands.md",
+    pointerHints: ["deft verify:story-ready", "git status --short --branch", "#1378"],
+    canonicalBodyMarkers: ["verify:story-ready", "git status --short --branch", "scope:complete"],
+    retiredFullTextMarkers: [
+      "A `swarm-cohort` section is ready only when",
+      "checkpoint-commit it and proceed",
+      "Ask the operator to choose one path",
+    ],
+  },
 ] as const;
 
 function normalizeWhitespace(text: string): string {
@@ -240,20 +319,24 @@ function managedSection(text: string): string {
 }
 
 function extractSection(text: string, heading: string): string {
-  const headingRe = new RegExp(
-    `^##\\s+${heading.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&")}\\s*$`,
-    "m",
-  );
-  const match = headingRe.exec(text);
-  if (!match || match.index === undefined) {
-    return "";
+  for (const level of [2, 3] as const) {
+    const hashes = "#".repeat(level);
+    const headingRe = new RegExp(
+      `^${hashes}\\s+${heading.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&")}\\s*$`,
+      "m",
+    );
+    const match = headingRe.exec(text);
+    if (!match || match.index === undefined) {
+      continue;
+    }
+    const start = match.index;
+    const afterHeading = text.slice(start + match[0].length);
+    const nextHeading = afterHeading.search(/^#{2,3}\s/m);
+    return nextHeading === -1
+      ? text.slice(start)
+      : text.slice(start, start + match[0].length + nextHeading);
   }
-  const start = match.index;
-  const afterHeading = text.slice(start + match[0].length);
-  const nextHeading = afterHeading.search(/^##\s/m);
-  return nextHeading === -1
-    ? text.slice(start)
-    : text.slice(start, start + match[0].length + nextHeading);
+  return "";
 }
 
 function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
@@ -286,7 +369,7 @@ function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
   if (spec.shape === "gate" && !/eval:health|verify:[\w-]+/.test(section)) {
     errors.push(`${spec.id}: gate pointer shape not detected`);
   }
-  if (spec.shape === "doc" && !/contracts\/[\w.-]+\.md|\.deft\/core\/contracts\//.test(section)) {
+  if (spec.shape === "doc" && !/commands\.md|scm\/|contracts\/[\w.-]+\.md|\.deft\/core\/contracts\//.test(section)) {
     errors.push(`${spec.id}: doc pointer shape not detected`);
   }
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -223,7 +223,11 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     header: "Session-start ritual (#1149)",
     canonicalHome: "commands.md",
     pointerHints: ["deft session:start", "deft verify:session-ritual", "#1149"],
-    canonicalBodyMarkers: ["sessionRitualStalenessHours", "DEFT_SESSION_RITUAL_SKIP", "ritual-state.json"],
+    canonicalBodyMarkers: [
+      "sessionRitualStalenessHours",
+      "DEFT_SESSION_RITUAL_SKIP",
+      "ritual-state.json",
+    ],
     retiredFullTextMarkers: [
       "lazily records the doctor and cache-fresh Python entrypoints",
       "D2 4-hour suppression window",
@@ -237,10 +241,7 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     canonicalHome: "skills/deft-directive-swarm/SKILL.md",
     pointerHints: ["plan.policy.wipCap", "deft scope:demote", "#1121"],
     canonicalBodyMarkers: ["plan.policy.wipCap", "scope:demote --batch", "wip_cap_override"],
-    retiredFullTextMarkers: [
-      "raised from the original 10 per umbrella",
-      "Phase 4 wipCap prompt",
-    ],
+    retiredFullTextMarkers: ["raised from the original 10 per umbrella", "Phase 4 wipCap prompt"],
   },
   {
     id: "branch-policy-746",
@@ -369,7 +370,10 @@ function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
   if (spec.shape === "gate" && !/eval:health|verify:[\w-]+/.test(section)) {
     errors.push(`${spec.id}: gate pointer shape not detected`);
   }
-  if (spec.shape === "doc" && !/commands\.md|scm\/|contracts\/[\w.-]+\.md|\.deft\/core\/contracts\//.test(section)) {
+  if (
+    spec.shape === "doc" &&
+    !/commands\.md|scm\/|contracts\/[\w.-]+\.md|\.deft\/core\/contracts\//.test(section)
+  ) {
     errors.push(`${spec.id}: doc pointer shape not detected`);
   }
 

--- a/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { readRepoFile } from "./helpers.js";
 
-/** Port of tests/content/test_agents_md_session_start.py (#1838 #1530) */
+/** Port of tests/content/test_agents_md_session_start.py (#1838 #1530); #2453 pointer relocation. */
 
 const agentsMdText = readRepoFile("AGENTS.md");
+const agentsEntryText = readRepoFile("templates/agents-entry.md");
+const commandsText = readRepoFile("commands.md");
 
 function extractSection(text: string, headingPattern: string): string {
   const headingRe = new RegExp(`^##\\s+${headingPattern}`, "m");
@@ -19,45 +21,48 @@ function extractSection(text: string, headingPattern: string): string {
     : text.slice(start, start + match[0].length + nextHeading);
 }
 
-function extractGateStackParagraph(agentsMd: string): string {
-  const intentGate = extractSection(agentsMd, "Development Process \\(always follow\\)");
-  const stackMatch = intentGate.match(
-    /\*\*Pre-`start_agent` gate stack \(#1149\/#1348\):\*\*[\s\S]*?(?=\r?\n\r?\n|^#{2,3}\s)/m,
-  );
-  return stackMatch?.[0] ?? "";
+function extractManagedSection(text: string): string {
+  const start = text.search(/<!-- deft:managed-section v3\b/);
+  const end = text.indexOf("<!-- /deft:managed-section -->");
+  if (start < 0 || end < start) {
+    return "";
+  }
+  return text.slice(start, end);
 }
 
 describe("test_agents_md_session_start", () => {
   it("session_start_ritual_header_present", () => {
     expect(/^##\s+Session-start ritual\s+\(#1149\)\s*$/m.test(agentsMdText)).toBe(true);
+    expect(/^##\s+Session-start ritual\s+\(#1149\)\s*$/m.test(agentsEntryText)).toBe(true);
   });
 
-  it("session_start_ritual_documents_two_tier_verifier_order", () => {
-    const section = extractSection(agentsMdText, "Session-start ritual \\(#1149\\)");
+  it("session_start_ritual_pointer_surface_in_managed_section", () => {
+    for (const text of [agentsMdText, agentsEntryText]) {
+      const managed = extractManagedSection(text);
+      const section = extractSection(managed, "Session-start ritual \\(#1149\\)");
+      expect(section).toBeTruthy();
+      expect(section).toContain("deft session:start");
+      expect(section).toContain("deft verify:session-ritual");
+      expect(section).toContain("plan.policy.sessionRitualStalenessHours");
+      expect(section).toContain("commands.md");
+    }
+  });
+
+  it("session_start_ritual_bulk_in_commands_canonical_home", () => {
+    const section = extractSection(commandsText, "Session-start ritual \\(#1149\\)");
     expect(section).toBeTruthy();
-    const pStart = section.indexOf("`task session:start`");
-    const pState = section.indexOf(".deft/ritual-state.json");
-    const pVerify = section.indexOf("`task verify:session-ritual -- --tier=gated`");
-    const pDoctor = section.indexOf("`task doctor`");
-    const pTriage = section.indexOf("`task triage:welcome`");
-    expect(pStart).toBeGreaterThanOrEqual(0);
-    expect(pStart).toBeLessThan(pState);
-    expect(pState).toBeLessThan(pTriage);
-    expect(pTriage).toBeLessThan(pVerify);
-    expect(pVerify).toBeLessThan(pDoctor);
     expect(section).toContain("plan.policy.sessionRitualStalenessHours");
     expect(section).toContain("DEFT_SESSION_RITUAL_SKIP=1");
     expect(section).toContain("--defer step=reason");
-  });
-
-  it("session_start_ritual_documents_d2_suppression_window", () => {
-    const section = extractSection(agentsMdText, "Session-start ritual \\(#1149\\)");
-    expect(/4[ -]hour/.test(section)).toBe(true);
-  });
-
-  it("session_start_ritual_marks_cache_fresh_as_stale_only", () => {
-    const section = extractSection(agentsMdText, "Session-start ritual \\(#1149\\)");
     expect(section.toLowerCase()).toContain("stale");
+    expect(section).toContain("Pre-`start_agent` gate stack (#1149/#1348)");
+  });
+
+  it("session_start_ritual_maintainer_substitution_line_present", () => {
+    const section = extractSection(agentsMdText, "Session-start ritual \\(#1149\\)");
+    expect(section).toContain("`task session:start`");
+    expect(section).toContain("`task verify:session-ritual -- --tier=gated`");
+    expect(section).toContain("`task verify:cache-fresh`");
   });
 
   it("cache_as_authoritative_section_present", () => {
@@ -103,33 +108,24 @@ describe("test_agents_md_session_start", () => {
     expect(skills).toContain("task triage:welcome --onboard");
   });
 
-  it("pre_start_agent_gate_stack_paragraph_present", () => {
-    const intentGate = extractSection(agentsMdText, "Development Process \\(always follow\\)");
-    expect(intentGate).toBeTruthy();
-    expect(intentGate).toContain("Pre-`start_agent` gate stack (#1149/#1348)");
-  });
-
-  it("pre_start_agent_gate_stack_canonical_order", () => {
-    const stack = extractGateStackParagraph(agentsMdText);
-    expect(stack).toBeTruthy();
-    const pSession = stack.indexOf("session ritual gate");
-    const pStory = stack.indexOf("story-start Gate 0");
-    const pVbrief = stack.indexOf("xBRIEF implementation-intent gate");
-    const pCache = stack.indexOf("task verify:cache-fresh");
-    const pBranch = stack.indexOf("branch-policy gate");
-    const pStart = stack.lastIndexOf("start_agent");
+  it("pre_start_agent_gate_stack_in_commands_canonical_home", () => {
+    const section = extractSection(commandsText, "Session-start ritual \\(#1149\\)");
+    const stackLine =
+      section.match(/\*\*Pre-`start_agent` gate stack[^\n]*/)?.[0] ?? "";
+    expect(stackLine).toContain("Pre-`start_agent` gate stack (#1149/#1348)");
+    const pSession = stackLine.indexOf("verify:session-ritual");
+    const pStory = stackLine.indexOf("verify:story-ready");
+    const pVbrief = stackLine.indexOf("xbrief:preflight");
+    const pCache = stackLine.indexOf("verify:cache-fresh");
+    const pBranch = stackLine.indexOf("verify:branch");
+    const pStart = stackLine.lastIndexOf("start_agent");
     expect(pSession).toBeGreaterThanOrEqual(0);
     expect(pSession).toBeLessThan(pStory);
     expect(pStory).toBeLessThan(pVbrief);
     expect(pVbrief).toBeLessThan(pCache);
     expect(pCache).toBeLessThan(pBranch);
     expect(pBranch).toBeLessThan(pStart);
-  });
-
-  it("pre_start_agent_gate_stack_cites_downstream_owners", () => {
-    const stack = extractGateStackParagraph(agentsMdText);
-    expect(stack).toContain("#1348");
-    expect(stack).toContain("#810");
-    expect(stack).toContain("#1127");
+    expect(section).toContain("#1348");
+    expect(section).toContain("verify:cache-fresh");
   });
 });

--- a/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
@@ -110,8 +110,7 @@ describe("test_agents_md_session_start", () => {
 
   it("pre_start_agent_gate_stack_in_commands_canonical_home", () => {
     const section = extractSection(commandsText, "Session-start ritual \\(#1149\\)");
-    const stackLine =
-      section.match(/\*\*Pre-`start_agent` gate stack[^\n]*/)?.[0] ?? "";
+    const stackLine = section.match(/\*\*Pre-`start_agent` gate stack[^\n]*/)?.[0] ?? "";
     expect(stackLine).toContain("Pre-`start_agent` gate stack (#1149/#1348)");
     const pSession = stackLine.indexOf("verify:session-ritual");
     const pStory = stackLine.indexOf("verify:story-ready");

--- a/packages/core/src/content-contracts/skills/story_start_gate.test.ts
+++ b/packages/core/src/content-contracts/skills/story_start_gate.test.ts
@@ -8,24 +8,28 @@ function _read(rel_path: string) {
 }
 
 describe("test_story_start_gate", () => {
-  it("agents_template_contains_story_start_dirty_tree_guard", () => {
+  it("agents_template_contains_story_start_pointer_surface", () => {
     const text = readRepoFile("templates/agents-entry.md");
     expect(text).toContain("### Story Start Gate");
     expect(text).toContain("git status --short --branch");
+    expect(text).toContain("deft verify:story-ready");
     expect(text).toContain("deft scope:promote -- <path>");
-    expect(text).toContain("current branch");
-    expect(text).toContain("modified/untracked files");
-    expect(text).toContain("commit existing work");
-    expect(text).toContain("stash existing work");
-    expect(text).toContain("include existing work in the current story");
-    expect(text).toContain("unrelated dirty work");
     expect(text).toContain("deft scope:activate -- <path>");
-    expect(text).toContain("deft xbrief:preflight -- <active-story-path>");
     expect(text).toContain("deft scope:complete -- <active-story-path>");
+    expect(text).toContain("commands.md");
   });
-  it("agents_md_contains_story_start_lifecycle_guard", () => {
+  it("agents_md_contains_story_start_pointer_surface", () => {
     const text = readRepoFile("AGENTS.md");
     expect(text).toContain("### Story Start Gate");
+    expect(text).toContain("git status --short --branch");
+    expect(text).toContain("task verify:story-ready");
+    expect(text).toContain("task scope:promote -- <path>");
+    expect(text).toContain("task scope:activate -- <path>");
+    expect(text).toContain("task scope:complete -- <active-story-path>");
+    expect(text).toContain("commands.md");
+  });
+  it("commands_carries_story_start_bulk", () => {
+    const text = readRepoFile("commands.md");
     expect(text).toContain("git status --short --branch");
     expect(text).toContain("current branch");
     expect(text).toContain("modified/untracked files");
@@ -33,9 +37,11 @@ describe("test_story_start_gate", () => {
     expect(text).toContain("stash existing work");
     expect(text).toContain("include existing work in the current story");
     expect(text).toContain("unrelated dirty work");
-    expect(text).toContain("task scope:promote -- <path>");
-    expect(text).toContain("task scope:activate -- <path>");
-    expect(text).toContain("task xbrief:preflight -- <active-story-path>");
+    expect(text).toContain("swarm-cohort");
+    expect(text).toContain("approved Phase 5 allocation plan");
+    expect(text).toContain("(#954)");
+    expect(text).toContain("checkpoint-commit it and proceed");
+    expect(text).toContain("deft xbrief:preflight -- <active-story-path>");
     expect(text).toContain("task scope:complete -- <active-story-path>");
   });
   it("build_skill_requires_dirty_work_prompt_before_implementation", () => {
@@ -81,13 +87,14 @@ describe("test_story_start_gate", () => {
     expect(text).toContain("checkpoint-commit it and proceed");
     expect(text).toContain("FIRST story-start of a fresh branch");
   });
-  it("agents_md_and_template_carry_swarm_carve_out", () => {
-    for (const rel_path of ["AGENTS.md", "templates/agents-entry.md"]) {
-      const text = readRepoFile(rel_path);
-      expect(text).toContain("swarm cohort dispatch");
+  it("build_skill_and_commands_carry_swarm_carve_out", () => {
+    const build = readRepoFile("skills/deft-directive-build/SKILL.md");
+    const commands = readRepoFile("commands.md");
+    for (const text of [build, commands]) {
+      expect(text).toContain("swarm-cohort");
       expect(text).toContain("approved Phase 5 allocation plan");
       expect(text).toContain("(#954)");
-      expect(text).toContain("checkpoint-commit it and proceed");
     }
+    expect(build).toContain("checkpoint-commit it and proceed");
   });
 });

--- a/xbrief/active/2026-07-12-2453-refactoragents-md-wave-2-relocation-compress-universal-guard.xbrief.json
+++ b/xbrief/active/2026-07-12-2453-refactoragents-md-wave-2-relocation-compress-universal-guard.xbrief.json
@@ -1,0 +1,86 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "refactor(agents-md): Wave 2 relocation — compress universal guardrails to one-line + gate pointers",
+    "created": "2026-07-12T23:03:51.565Z",
+    "updated": "2026-07-12T23:03:51.565Z"
+  },
+  "plan": {
+    "id": "2453-relocate-universal-guardrails",
+    "title": "refactor(agents-md): Wave 2 relocation — compress universal guardrails to one-line + gate pointers",
+    "status": "running",
+    "narratives": {
+      "Description": "Universal always-on guardrails still carry paragraph bulk in AGENTS.md and agents-entry despite #2371 pointer-sufficient contract. This story compresses branch policy, implementation-intent, deterministic-questions, session ritual, WIP, story-start stack, review-surface, value-feedback, and eval/framework-health to one-line imperatives plus gate/skill/doc pointers per DD-1/DD-2.",
+      "ImplementationPlan": "1) Inventory universal guardrail sections in AGENTS.md and content/templates/agents-entry.md. 2) Compress each to one-line imperative + pointer-to-gate/skill/doc; move bulk into canonical homes under content/skills, content/docs, or gate help text. 3) Keep agents_entry_contract pointer-sufficient tests green; add fixtures if needed. 4) Run task verify:eval-health-relocation / task check paths that fire the #2373 gate. 5) Verify: pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts and task eval:health. 6) CHANGELOG entry. Stay out of contextual PowerShell/SCM bulk owned by #2454.",
+      "UserStory": "As a framework maintainer, I want universal guardrails reduced to one-line always-on pointers, so that the managed section moves toward the <=8 KB absolute north-star without losing enforceable gates.",
+      "Origin": "Enriched for swarm from #2453 under epic #2369 Wave 2"
+    },
+    "items": [
+      {
+        "id": "2453-relocate-universal-guardrails-a1",
+        "title": "Relocate targeted rule bulk",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the targeted always-on sections, when the PR lands, then paragraph bulk is gone and pointers remain.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2453-relocate-universal-guardrails-a2",
+        "title": "Pointer contract + eval-health gate green",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given agents_entry_contract and verify:eval-health-relocation, when run on the PR diff, then both pass.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2453-relocate-universal-guardrails-a3",
+        "title": "CHANGELOG documents relocation",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given CHANGELOG [Unreleased], when read, then the user-visible always-on thinning is described.",
+          "Traces": "FR-1"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "AGENTS.md",
+          "content/templates/agents-entry.md",
+          "content/skills",
+          "content/docs",
+          "packages/core/src/content-contracts/skills"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts",
+          "task eval:health"
+        ],
+        "expected_outputs": [
+          "relocation PR merged for #2453"
+        ],
+        "depends_on": [],
+        "conflict_group": "relocate-universal",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      },
+      "x-tracking": {
+        "parent_epic": "#2369",
+        "origin_issue": "#2453"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2453",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2453"
+      }
+    ],
+    "updated": "2026-07-12T23:03:51.565Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Compress universal always-on guardrails (session ritual, WIP cap, branch policy, implementation-intent, story-start) in AGENTS.md and agents-entry to one-line imperatives plus gate/skill/doc pointers per #2371 DD-1/DD-2.
- Relocate paragraph bulk into canonical homes: `content/commands.md`, `content/scm/github.md`, and swarm skill references; extend `agents_entry_contract` pointer specs for six additional relocated rules.
- Leaves contextual PowerShell/SCM/cascade bulk untouched for #2454.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts`
- [x] `task verify:eval-health-relocation -- --base-ref origin/master`
- [x] `task eval:health` (via relocation gate — score 85/100, no regression)
- [ ] CI branch-gate + framework-source check

Closes #2453