### PR TITLE
refactor(agents-md): Wave 2 — relocate contextual guardrails to lazy pointers (#2454)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,31 +140,14 @@ Rationale: `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § CH
 
 Product commands use the `/deft:directive:*` namespace (#418 / #1670); the prior `/deft:*` product forms are deprecation-warning aliases, and cross-product session commands (`/deft:continue`, `/deft:checkpoint`) stay at the umbrella `/deft:*` level. The legacy Python `run` CLI is deprecated (#1933) -- use the agent-driven setup skill for first-time setup and spec generation. See `content/commands.md` for the full command + alias table and the managed `## Commands` section below for the rendered surface.
 
-## Platform-conditional rules (PowerShell / Windows)
+## Contextual guardrails (runtime-detect lazy-load)
 
-Platform/tool/runtime-specific rules are lazy-loaded, not shipped in the always-loaded surface, so they don't crowd context for sessions that can't trigger them (#2157). If your session matches a trigger below, load `content/scm/github.md` § "PowerShell platform-conditional rules for agents" **before** the risky operation:
+Contextual / platform-specific rules lazy-load from `content/scm/github.md` — load the matching section **before** the risky operation when your session matches a trigger (#2157 / #2369):
 
-- ! Editing files with non-ASCII glyphs from PowerShell (especially PS 5.1) -- authoritatively enforced at commit by `task verify:encoding` (#798); the gate is the rule.
-- ! Running shell commands under the Grok Build Windows + pwsh 7+ runtime -- piped/redirected commands leak wrapper text (#1353); PTY-based Warp + Claude are exempt.
-
-## Safe subprocess capture (#1366)
-
-Rationale + recurrence record: `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Safe subprocess capture (#1366).
-
-- ! The `scripts/` Python directory was removed in #2022 (TS-native migration). All subprocess capture rules from this section now apply to TS tooling only -- the `scripts/_safe_subprocess.py` helper no longer exists; TS equivalents use the Node.js `child_process` / `execa` patterns and are not subject to Python locale-codepage decode issues.
-- ! TS scripts that shell out for parsable output (gh, git, task) MUST use `execa` or `child_process.spawn` with `encoding: "utf8"` -- never `execSync` with default encoding when the output may carry non-ASCII glyphs (Greptile bodies, gh REST bodies, user-authored commit messages).
-- ⊗ Use `execSync` / `spawnSync` without explicit `encoding: "utf8"` when capturing `gh api` output that may contain non-ASCII glyphs -- the default `Buffer` return is the TS analogue of the Python locale-codepage bug.
-- ⊗ Reference `scripts/_safe_subprocess.py`, `scripts/pr_merge_readiness.py`, or any deleted Python script as a live implementation path -- the entire `scripts/` directory was removed in #2022.
-
-## Cascade automation surface (#1369)
-
-Rationale + recurrence record + cross-references: `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Cascade automation surface (#1369). Canonical surface: `task pr:wait-mergeable-and-merge`.
-
-- ! Cascade automation on the Grok Build hybrid path MUST go through `task pr:wait-mergeable-and-merge -- <N> --repo <owner>/<repo>`. Do NOT hand-roll a `while ...; do task pr:merge-ready ...; done` shell loop or a per-cascade ad-hoc Python monitor. The helper composes the resilient wait-until-ready loop (#1368) with the Layer-3 protected-issue check (#701) and the `gh pr merge --squash --delete-branch --admin` invocation behind a single three-state exit (0 merged / 1 timeout-or-escalation / 2 config error).
-- ! The per-PR atomic gate (`task pr:merge-ready -- <N> && gh pr merge <N> --squash --delete-branch --admin`) documented in `content/skills/deft-directive-swarm/SKILL.md` Phase 5 -> 6 STILL applies for any in-cascade merge an operator runs by hand. The Wave-3 cascade surface is the automated wrapper; the per-PR atomic gate is the manual freshness-window-atomic check. The two co-exist -- one does not retire the other.
-- ! When `--protected <issue-numbers>` is supplied, the helper runs the protected-issue check (#701) BEFORE the wait loop. A persistent `closingIssuesReferences` link short-circuits the cascade with exit 1 (escalation) AHEAD of any `gh pr merge` call. New cascade scripts MUST preserve this ordering -- the protected-issue check is structurally a pre-condition that cannot be resolved by waiting.
-- ⊗ Hand-roll a cascade `while ... task pr:merge-ready` shell loop (or equivalent ad-hoc Python monitor) when `task pr:wait-mergeable-and-merge` is available. The Wave-1+2 hardening is in the helpers the new task composes; hand-rolled loops re-introduce the `head: None` / babysit-each-PR failure mode #1369 closes.
-- ⊗ Run `gh pr merge <N>` from inside a cascade automation script without first chaining the Layer-3 protected-issue check (#701) when the PR is known to reference any umbrella / staying-OPEN issue. The cascade surface (`task pr:wait-mergeable-and-merge` with `--protected`) is the canonical compose-point; hand-rolled merges that skip the chain re-surface the PR #700 / PR #401 persistent-link recurrence.
+- ! **PowerShell / Windows** → § PowerShell platform-conditional rules (#798 / #1353); encoding gate: `task verify:encoding`.
+- ! **TS subprocess capture** → § Safe subprocess capture (#1366).
+- ! **Cascade / batch merge** → § Cascade automation surface (#1369); canonical `task pr:wait-mergeable-and-merge`.
+- ! **GitHub CLI / SCM shim** → § SCM tooling (#884 / #1145); boundary gate: `task verify:scm-boundary`.
 
 ## Headless swarm launch gate-stack (#1387)
 
@@ -174,17 +157,6 @@ Rationale + cross-references: `docs/analysis/2026-07-02-agents-md-incident-rule-
 - ! Phase 2 accepts a **pre-created worktree map** (the **C3** JSON array of `{ story_id, worktree_path, base_branch }`) resolved via `resolveWorktreeMap` (`packages/core/src/swarm/worktrees.ts`) -- which raises on same-path collisions or base-branch mismatches -- instead of always running `git worktree add` per agent.
 - ! Phase 3 consumes the **C2** launch-manifest (the JSON array of `{ story_id, xbrief_path, worktree_path, branch, allocation_context }`, where `allocation_context` is the #1378 token) emitted by `task swarm:launch` as dispatch PREP before spawning; the spawn itself stays agent-driven via the platform adapter (`start_agent` / `spawn_subagent`). `task swarm:launch` does NOT spawn agents -- it emits the manifest and stops.
 - ⊗ Re-prompt the operator for per-phase batching approval when a pre-approved cohort is launched via `task swarm:launch` -- the #1378 allocation-context token is the batched consent (all-or-nothing dispatch envelope, #954).
-
-## SCM tooling -- prefer ghx (#884)
-
-Rationale: `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § SCM tooling — prefer ghx (#884).
-
-- ! When you need to invoke the GitHub CLI (`gh issue view`, `gh pr list`, `gh api`, ...) and `ghx` is on PATH, prefer `ghx` over `gh` -- the surface is identical and the cached responses are 10x faster on repeated calls
-- ! Fall back to `gh` transparently when `ghx` is not on PATH; do NOT fail or warn -- this keeps the rule additive for consumers who have not yet opted in
-- ~ Maintainers SHOULD run `task setup` to install `ghx`; the install is consent-gated and never auto-runs by default. Pass `--yes` for non-interactive (CI / scripted) approval
-- ⊗ Auto-install `ghx` without explicit operator consent -- `task setup` MUST prompt before invoking the upstream installer; the only non-interactive paths are `--yes` (explicit approval) or `DEFT_SETUP_GHX_SKIP=1` (explicit opt-out)
-- ! Raw `gh` calls outside the TS SCM shim layer are forbidden by `task verify:scm-boundary` (#1145 / N5 -- partial down-payment on #445 / #935 Workstream 6). The TS verb layer MUST route `gh` calls through the canonical SCM shim; the deterministic gate scans the canonical scope globs and fails `task check` when any of them route around the shim. Non-`github-issue` sources raise `NotImplementedError` so a consumer on GitLab / Gitea / local sees the deferred abstraction immediately.
-- ? Power users MAY install `ghx` manually via the upstream `install.ps1` (Windows) or `install.sh` (macOS / Linux); the `task setup` prompt is a convenience, not a gate
 
 ## Test performance discipline (#975)
 
@@ -387,12 +359,14 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ! When `plan.policy.allowDirectCommitsToMaster = true`, surface policy at session start via `deft policy:show --field=allowDirectCommitsToMaster` (#746) — full phrasing and override paths in `.deft/core/scm/github.md` § Branch policy.
 
-## Platform-conditional rules (PowerShell / Windows)
+## Contextual guardrails (runtime-detect lazy-load)
 
-Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they don't crowd context for sessions that can't trigger them (#2157 / #1882). If your session matches a trigger below, load `.deft/core/scm/github.md` § "PowerShell platform-conditional rules for agents" **before** the risky operation:
+Contextual / platform-specific rules lazy-load from `.deft/core/scm/github.md` — load the matching section **before** the risky operation when your session matches a trigger (#2157 / #2369):
 
-- ! Editing files with non-ASCII glyphs from PowerShell (especially PS 5.1) -- enforced at commit by `deft verify:encoding` (#798).
-- ! Running shell commands under the Grok Build Windows + pwsh 7+ runtime -- piped/redirected commands leak wrapper text (#1353); PTY-based Warp + Claude are exempt.
+- ! **PowerShell / Windows** → § PowerShell platform-conditional rules (#798 / #1353); encoding gate: `deft verify:encoding`.
+- ! **TS subprocess capture** → § Safe subprocess capture (#1366).
+- ! **Cascade / batch merge** → § Cascade automation surface (#1369); canonical `deft pr:wait-mergeable-and-merge`.
+- ! **GitHub CLI / SCM shim** → § SCM tooling (#884 / #1145); boundary gate: `deft verify:scm-boundary`.
 
 ## Development Process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Universal always-on guardrails are pointer-thin.** Session ritual, WIP cap, branch policy, implementation-intent, and story-start rules in AGENTS.md / agents-entry compress to one-line imperatives plus gate/skill/doc pointers; bulk lives in `commands.md`, `scm/github.md`, and swarm skill. Closes #2453. Refs #2369.
 
+- **Contextual guardrails lazy-load on runtime match.** PowerShell encoding, safe-subprocess capture, cascade automation, and SCM-boundary rules move out of the always-on AGENTS.md / agents-entry surface into `scm/github.md`; runtime-detect trigger pointers remain. Closes #2454. Refs #2369.
+
 - **Agents-entry propagation is pointer-sufficient.** The `agents_entry_contract` gate now validates skill/gate/doc pointer shapes and canonical homes instead of requiring full-text rule mirrors in the always-on AGENTS.md managed section — unblocking epic #2369 Wave 2 relocation. Closes #2371.
 
 ### Fixed

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -172,6 +172,38 @@ When running under the Grok Build runtime on Windows + pwsh 7+, `run_terminal_co
 
 Refs #798, #1353 (root-cause audit), #2157.
 
+## Safe subprocess capture (#1366)
+
+Rationale + recurrence record: `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Safe subprocess capture (#1366).
+
+- ! The `scripts/` Python directory was removed in #2022 (TS-native migration). All subprocess capture rules from this section now apply to TS tooling only -- the `scripts/_safe_subprocess.py` helper no longer exists; TS equivalents use the Node.js `child_process` / `execa` patterns and are not subject to Python locale-codepage decode issues.
+- ! TS scripts that shell out for parsable output (gh, git, task) MUST use `execa` or `child_process.spawn` with `encoding: "utf8"` -- never `execSync` with default encoding when the output may carry non-ASCII glyphs (Greptile bodies, gh REST bodies, user-authored commit messages).
+- ⊗ Use `execSync` / `spawnSync` without explicit `encoding: "utf8"` when capturing `gh api` output that may contain non-ASCII glyphs -- the default `Buffer` return is the TS analogue of the Python locale-codepage bug.
+- ⊗ Reference `scripts/_safe_subprocess.py`, `scripts/pr_merge_readiness.py`, or any deleted Python script as a live implementation path -- the entire `scripts/` directory was removed in #2022.
+
+## Cascade automation surface (#1369)
+
+Rationale + recurrence record + cross-references: `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § Cascade automation surface (#1369). Canonical surface: `task pr:wait-mergeable-and-merge`.
+
+- ! Cascade automation on the Grok Build hybrid path MUST go through `task pr:wait-mergeable-and-merge -- <N> --repo <owner>/<repo>`. Do NOT hand-roll a `while ...; do task pr:merge-ready ...; done` shell loop or a per-cascade ad-hoc Python monitor. The helper composes the resilient wait-until-ready loop (#1368) with the Layer-3 protected-issue check (#701) and the `gh pr merge --squash --delete-branch --admin` invocation behind a single three-state exit (0 merged / 1 timeout-or-escalation / 2 config error).
+- ! The per-PR atomic gate (`task pr:merge-ready -- <N> && gh pr merge <N> --squash --delete-branch --admin`) documented in `content/skills/deft-directive-swarm/SKILL.md` Phase 5 -> 6 STILL applies for any in-cascade merge an operator runs by hand. The Wave-3 cascade surface is the automated wrapper; the per-PR atomic gate is the manual freshness-window-atomic check. The two co-exist -- one does not retire the other.
+- ! When `--protected <issue-numbers>` is supplied, the helper runs the protected-issue check (#701) BEFORE the wait loop. A persistent `closingIssuesReferences` link short-circuits the cascade with exit 1 (escalation) AHEAD of any `gh pr merge` call. New cascade scripts MUST preserve this ordering -- the protected-issue check is structurally a pre-condition that cannot be resolved by waiting.
+- ⊗ Hand-roll a cascade `while ... task pr:merge-ready` shell loop (or equivalent ad-hoc Python monitor) when `task pr:wait-mergeable-and-merge` is available. The Wave-1+2 hardening is in the helpers the new task composes; hand-rolled loops re-introduce the `head: None` / babysit-each-PR failure mode #1369 closes.
+- ⊗ Run `gh pr merge <N>` from inside a cascade automation script without first chaining the Layer-3 protected-issue check (#701) when the PR is known to reference any umbrella / staying-OPEN issue. The cascade surface (`task pr:wait-mergeable-and-merge` with `--protected`) is the canonical compose-point; hand-rolled merges that skip the chain re-surface the PR #700 / PR #401 persistent-link recurrence.
+
+## SCM tooling (#884 / #1145)
+
+Rationale: `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § SCM tooling — prefer ghx (#884).
+
+- ! When you need to invoke the GitHub CLI (`gh issue view`, `gh pr list`, `gh api`, ...) and `ghx` is on PATH, prefer `ghx` over `gh` -- the surface is identical and the cached responses are 10x faster on repeated calls
+- ! Fall back to `gh` transparently when `ghx` is not on PATH; do NOT fail or warn -- this keeps the rule additive for consumers who have not yet opted in
+- ~ Maintainers SHOULD run `task setup` to install `ghx`; the install is consent-gated and never auto-runs by default. Pass `--yes` for non-interactive (CI / scripted) approval
+- ⊗ Auto-install `ghx` without explicit operator consent -- `task setup` MUST prompt before invoking the upstream installer; the only non-interactive paths are `--yes` (explicit approval) or `DEFT_SETUP_GHX_SKIP=1` (explicit opt-out)
+- ! Raw `gh` calls outside the TS SCM shim layer are forbidden by `task verify:scm-boundary` (#1145 / N5 -- partial down-payment on #445 / #935 Workstream 6). The TS verb layer MUST route `gh` calls through the canonical SCM shim; the deterministic gate scans the canonical scope globs and fails `task check` when any of them route around the shim. Non-`github-issue` sources raise `NotImplementedError` so a consumer on GitLab / Gitea / local sees the deferred abstraction immediately.
+- ? Power users MAY install `ghx` manually via the upstream `install.ps1` (Windows) or `install.sh` (macOS / Linux); the `task setup` prompt is a convenience, not a gate
+
+See also § ghx cache proxy (#884) for install surfaces and read-only vs mutation rules.
+
 ## Windows / ASCII Conventions for Machine-Editable Sections
 
 Agent `edit_files` operations can fail when structured file sections contain Unicode characters that do not round-trip cleanly through Windows toolchains (xref warpdotdev/warp#9022). The following rules apply to **machine-editable structured sections**: ROADMAP.md phase bodies, CHANGELOG.md entries, and Open Issues Index rows.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -144,12 +144,14 @@ Skill routing (which skill answers which trigger) is not a table in this policy 
 
 ! When `plan.policy.allowDirectCommitsToMaster = true`, surface policy at session start via `deft policy:show --field=allowDirectCommitsToMaster` (#746) — full phrasing and override paths in `.deft/core/scm/github.md` § Branch policy.
 
-## Platform-conditional rules (PowerShell / Windows)
+## Contextual guardrails (runtime-detect lazy-load)
 
-Platform/tool/runtime-specific rules are lazy-loaded, not rendered here, so they don't crowd context for sessions that can't trigger them (#2157 / #1882). If your session matches a trigger below, load `.deft/core/scm/github.md` § "PowerShell platform-conditional rules for agents" **before** the risky operation:
+Contextual / platform-specific rules lazy-load from `.deft/core/scm/github.md` — load the matching section **before** the risky operation when your session matches a trigger (#2157 / #2369):
 
-- ! Editing files with non-ASCII glyphs from PowerShell (especially PS 5.1) -- enforced at commit by `deft verify:encoding` (#798).
-- ! Running shell commands under the Grok Build Windows + pwsh 7+ runtime -- piped/redirected commands leak wrapper text (#1353); PTY-based Warp + Claude are exempt.
+- ! **PowerShell / Windows** → § PowerShell platform-conditional rules (#798 / #1353); encoding gate: `deft verify:encoding`.
+- ! **TS subprocess capture** → § Safe subprocess capture (#1366).
+- ! **Cascade / batch merge** → § Cascade automation surface (#1369); canonical `deft pr:wait-mergeable-and-merge`.
+- ! **GitHub CLI / SCM shim** → § SCM tooling (#884 / #1145); boundary gate: `deft verify:scm-boundary`.
 
 ## Development Process
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -103,7 +103,7 @@ const PROPAGATION_HEADER_MARKERS = [
   "## WIP cap",
   "## Codebase MAP Projection (#1595 / #1498)",
   "### Story Start Gate",
-  "## Platform-conditional rules (PowerShell / Windows)",
+  "## Contextual guardrails (runtime-detect lazy-load)",
   "## Content packs",
 ] as const;
 
@@ -295,6 +295,33 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "A `swarm-cohort` section is ready only when",
       "checkpoint-commit it and proceed",
       "Ask the operator to choose one path",
+    ],
+  },
+  {
+    id: "contextual-guardrails-2454",
+    shape: "doc",
+    header: "Contextual guardrails (runtime-detect lazy-load)",
+    canonicalHome: "scm/github.md",
+    pointerHints: [
+      "scm/github.md",
+      "runtime-detect",
+      "#2157",
+      "verify:encoding",
+      "verify:scm-boundary",
+    ],
+    canonicalBodyMarkers: [
+      "PowerShell platform-conditional rules for agents",
+      "Safe subprocess capture",
+      "Cascade automation surface",
+      "verify:scm-boundary",
+    ],
+    retiredFullTextMarkers: [
+      "piped/redirected commands leak wrapper text",
+      "execSync",
+      "hand-roll a cascade",
+      "Raw `gh` calls outside the TS SCM shim",
+      "authoritatively enforced at commit",
+      "lazy-loaded, not rendered here",
     ],
   },
 ] as const;

--- a/xbrief/active/2026-07-12-2454-refactoragents-md-wave-2-relocation-move-contextual-guardrai.xbrief.json
+++ b/xbrief/active/2026-07-12-2454-refactoragents-md-wave-2-relocation-move-contextual-guardrai.xbrief.json
@@ -1,0 +1,86 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "refactor(agents-md): Wave 2 relocation — move contextual guardrails behind runtime-detect lazy pointers",
+    "created": "2026-07-12T23:03:51.565Z",
+    "updated": "2026-07-12T23:03:51.565Z"
+  },
+  "plan": {
+    "id": "2454-relocate-contextual-guardrails",
+    "title": "refactor(agents-md): Wave 2 relocation — move contextual guardrails behind runtime-detect lazy pointers",
+    "status": "running",
+    "narratives": {
+      "Description": "Contextual guardrails (PowerShell encoding, SCM-boundary, safe-subprocess, cascade automation, platform-conditional rules) should not occupy always-on paragraph bulk. Per DD-2 and #2157 precedent, move them behind runtime-detect lazy doc pointers.",
+      "ImplementationPlan": "1) Inventory contextual/platform-conditional blocks remaining in AGENTS.md and content/templates/agents-entry.md after #2453 (PowerShell encoding, SCM-boundary, safe-subprocess, cascade automation, other runtime-detect rules). 2) Move rule bodies into content/scm/github.md and sibling lazy docs; leave one-line runtime-detect pointers in always-on surfaces. 3) Keep agents_entry_contract pointer-sufficient tests green; add fixtures if needed. 4) Pass task verify:eval-health-relocation and task eval:health (baseline 85). 5) Verify: pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts. 6) CHANGELOG [Unreleased]. Do not rework universal one-liners already relocated by #2453.",
+      "UserStory": "As a framework maintainer, I want contextual guardrails loaded only when the runtime matches, so that always-on AGENTS.md stops carrying platform-specific rule bulk.",
+      "Origin": "Enriched for swarm from #2454 under epic #2369 Wave 2"
+    },
+    "items": [
+      {
+        "id": "2454-relocate-contextual-guardrails-a1",
+        "title": "Relocate targeted rule bulk",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the targeted always-on sections, when the PR lands, then paragraph bulk is gone and pointers remain.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2454-relocate-contextual-guardrails-a2",
+        "title": "Pointer contract + eval-health gate green",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given agents_entry_contract and verify:eval-health-relocation, when run on the PR diff, then both pass.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2454-relocate-contextual-guardrails-a3",
+        "title": "CHANGELOG documents relocation",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given CHANGELOG [Unreleased], when read, then the user-visible always-on thinning is described.",
+          "Traces": "FR-1"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "AGENTS.md",
+          "content/templates/agents-entry.md",
+          "content/scm",
+          "content/docs",
+          "packages/core/src/content-contracts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts",
+          "task eval:health"
+        ],
+        "expected_outputs": [
+          "relocation PR merged for #2454"
+        ],
+        "depends_on": [],
+        "conflict_group": "relocate-contextual",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      },
+      "x-tracking": {
+        "parent_epic": "#2369",
+        "origin_issue": "#2454"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2454",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2454"
+      }
+    ],
+    "updated": "2026-07-12T23:42:41.315Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Consolidate contextual guardrails (PowerShell encoding, safe-subprocess capture, cascade automation, SCM-boundary) into runtime-detect lazy-load pointers in AGENTS.md and agents-entry.
- Move full rule bodies to `content/scm/github.md` (Safe subprocess #1366, Cascade automation #1369, SCM tooling #884/#1145).
- Extend `agents_entry_contract` with pointer-sufficient spec for the new `Contextual guardrails (runtime-detect lazy-load)` section.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts`
- [x] `task verify:eval-health-relocation --staged` (score 85, no regression)
- [x] `task eval:health` (baseline 85)

Closes #2454