### PR TITLE
feat(gate): promote absolute agents-md budget to fail-closed (#2452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Layered AGENTS.md budget instrument now reports an advisory absolute north-star.** `verify:agents-md-budget` keeps the #645 relative line ratchet fail-closed and adds a Wave-1 advisory meter for the always-on managed section (≤8 KB / ~2k tok) that reports over-budget gaps without failing `task check`. Absolute fail-closed promotion and DD-3 harness frontmatter are deferred to post-Wave-2 (#2452). Closes #2450.
 
+- **Absolute always-on budget now fail-closes on growth.** `verify:agents-md-budget` promotes the managed-section byte ratchet from advisory to fail-closed via `plan.policy.agentsMdBudget.absoluteMaxBytes` (seeded at the current size so master stays green), keeps the ≤8192 B / ~2k tok north-star visible as distance-to-target, and supports optional release-gate north-star enforcement with `DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1`. Closes #2452. Refs #2369.
+
 ### Changed
 
 - **Universal always-on guardrails are pointer-thin.** Session ritual, WIP cap, branch policy, implementation-intent, and story-start rules in AGENTS.md / agents-entry compress to one-line imperatives plus gate/skill/doc pointers; bulk lives in `commands.md`, `scm/github.md`, and swarm skill. Closes #2453. Refs #2369.

--- a/packages/cli/src/verify-agents-md-budget.test.ts
+++ b/packages/cli/src/verify-agents-md-budget.test.ts
@@ -113,7 +113,7 @@ describe("run", () => {
     }
   });
 
-  it("writes absolute advisory to stderr when the managed section is over budget", () => {
+  it("writes north-star note to stderr when absoluteMaxBytes is unset and over north-star", () => {
     const markerOpen = "<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->";
     const markerClose = "<!-- /deft:managed-section -->";
     const fill = "x".repeat(9000);
@@ -132,5 +132,25 @@ describe("run", () => {
       out.mockRestore();
       err.mockRestore();
     }
+  });
+
+  it("returns 1 when absoluteMaxBytes is set and the managed section grows", () => {
+    const markerOpen = "<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->";
+    const markerClose = "<!-- /deft:managed-section -->";
+    const fill = "x".repeat(9000);
+    const agents = ["unmanaged", markerOpen, fill, markerClose].join("\n");
+    const root = buildRepo({
+      plan: {
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 500,
+            unmanagedMaxLines: 500,
+            absoluteMaxBytes: 8000,
+          },
+        },
+      },
+      agents,
+    });
+    expect(silentRun(["--project-root", root])).toBe(1);
   });
 });

--- a/packages/cli/src/verify-agents-md-budget.ts
+++ b/packages/cli/src/verify-agents-md-budget.ts
@@ -54,11 +54,11 @@ export function run(argv: string[]): number {
     }
   }
 
-  if (result.advisoryMessage !== undefined && result.advisoryMessage.length > 0) {
-    if (result.advisoryStream === "stdout") {
-      process.stdout.write(`${result.advisoryMessage}\n`);
-    } else if (result.advisoryStream === "stderr") {
-      process.stderr.write(`${result.advisoryMessage}\n`);
+  if (result.northStarMessage !== undefined && result.northStarMessage.length > 0) {
+    if (result.northStarStream === "stdout") {
+      process.stdout.write(`${result.northStarMessage}\n`);
+    } else if (result.northStarStream === "stderr") {
+      process.stderr.write(`${result.northStarMessage}\n`);
     }
   }
 

--- a/packages/cli/src/verify-agents-md-budget.ts
+++ b/packages/cli/src/verify-agents-md-budget.ts
@@ -60,6 +60,12 @@ export function run(argv: string[]): number {
     } else if (result.northStarStream === "stderr") {
       process.stderr.write(`${result.northStarMessage}\n`);
     }
+  } else if (result.advisoryMessage !== undefined && result.advisoryMessage.length > 0) {
+    if (result.advisoryStream === "stdout") {
+      process.stdout.write(`${result.advisoryMessage}\n`);
+    } else if (result.advisoryStream === "stderr") {
+      process.stderr.write(`${result.advisoryMessage}\n`);
+    }
   }
 
   return result.code;

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
+  ABSOLUTE_MANAGED_MAX_BYTES,
+  ABSOLUTE_MANAGED_MAX_TOKENS,
   countRegions,
   evaluate,
   extractManagedSection,
@@ -227,7 +229,7 @@ describe("absolute managed-section budget", () => {
     expect(result.code).toBe(0);
     expect(result.message).toContain(`absolute ${measure.bytes}/${measure.bytes} bytes`);
     expect(result.northStarMessage).toContain("north-star");
-    expect(result.northStarMessage).toContain("over target");
+    expect(result.northStarMessage).toContain("tok over");
   });
 
   it("stays quiet on north-star note when the managed section is under budget", () => {
@@ -276,6 +278,37 @@ describe("absolute managed-section budget", () => {
       if (prevWaiver === undefined) delete process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER;
       else process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER = prevWaiver;
     }
+  });
+
+  it("reports token-only north-star overage without negative byte deltas", () => {
+    const markerOpen = "<!-- deft:managed-section v3 sha=abc refreshed=x session=y -->";
+    const markerClose = "<!-- /deft:managed-section -->";
+    const overhead = Buffer.byteLength(`${markerOpen}\n${markerClose}`, "utf8");
+    const targetBytes = 8001;
+    const fillLen = targetBytes - overhead;
+    const agents = ["", markerOpen, "x".repeat(fillLen), markerClose].join("\n");
+    const measure = measureManagedSection(agents);
+    expect("bytes" in measure).toBe(true);
+    if (!("bytes" in measure)) return;
+    expect(measure.bytes).toBeLessThanOrEqual(ABSOLUTE_MANAGED_MAX_BYTES);
+    expect(measure.estimatedTokens).toBeGreaterThan(ABSOLUTE_MANAGED_MAX_TOKENS);
+
+    const root = makeRepo({
+      plan: {
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 500,
+            unmanagedMaxLines: 500,
+            absoluteMaxBytes: measure.bytes,
+          },
+        },
+      },
+      agents,
+    });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.northStarMessage).toMatch(/~\d+ tok over/);
+    expect(result.northStarMessage).not.toContain("bytes over");
   });
 
   it("emits north-star note even when --quiet suppresses the success banner", () => {

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -152,9 +152,19 @@ describe("measureManagedSection", () => {
   });
 });
 
-describe("absolute managed-section advisory", () => {
+describe("absolute managed-section budget", () => {
   const budgetPlan = {
     policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } },
+  };
+
+  const budgetWithAbsolute = {
+    policy: {
+      agentsMdBudget: {
+        managedMaxLines: 500,
+        unmanagedMaxLines: 500,
+        absoluteMaxBytes: 10_000,
+      },
+    },
   };
 
   /** Build a managed block whose UTF-8 body exceeds the 8192-byte north-star. */
@@ -172,20 +182,55 @@ describe("absolute managed-section advisory", () => {
     return lines.join("\n");
   }
 
-  it("emits advisory (exit 0) when the managed section exceeds the absolute ceiling", () => {
+  it("emits advisory (exit 0) when absoluteMaxBytes is unset and section exceeds north-star", () => {
     const root = makeRepo({ plan: budgetPlan, agents: agentsOverAbsolute(5, 9000) });
     const result = evaluate(root);
     expect(result.code).toBe(0);
-    expect(result.advisoryMessage).toContain("absolute budget advisory");
-    expect(result.advisoryMessage).toContain("Advisory only");
-    expect(result.advisoryStream).toBe("stderr");
+    expect(result.northStarMessage).toContain("absolute budget advisory");
+    expect(result.northStarMessage).toContain("Advisory only");
+    expect(result.northStarStream).toBe("stderr");
   });
 
-  it("stays quiet on absolute advisory when the managed section is under budget", () => {
+  it("fail-closes when absoluteMaxBytes is set and the managed section grows past it", () => {
+    const root = makeRepo({
+      plan: { policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500, absoluteMaxBytes: 8000 } } },
+      agents: agentsOverAbsolute(5, 9000),
+    });
+    const result = evaluate(root);
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("absolute byte ratchet");
+    expect(result.northStarMessage).toContain("north-star");
+  });
+
+  it("passes at the seeded absolute ratchet and reports north-star distance", () => {
+    const agents = agentsOverAbsolute(5, 9000);
+    const measure = measureManagedSection(agents);
+    expect("bytes" in measure).toBe(true);
+    if (!("bytes" in measure)) return;
+    const root = makeRepo({
+      plan: {
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 500,
+            unmanagedMaxLines: 500,
+            absoluteMaxBytes: measure.bytes,
+          },
+        },
+      },
+      agents,
+    });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.message).toContain(`absolute ${measure.bytes}/${measure.bytes} bytes`);
+    expect(result.northStarMessage).toContain("north-star");
+    expect(result.northStarMessage).toContain("over target");
+  });
+
+  it("stays quiet on north-star note when the managed section is under budget", () => {
     const root = makeRepo({ plan: budgetPlan, agents: agentsWith(5, 5) });
     const result = evaluate(root);
     expect(result.code).toBe(0);
-    expect(result.advisoryMessage).toBeUndefined();
+    expect(result.northStarMessage).toBeUndefined();
   });
 
   it("still fail-closes the relative ratchet when a region grows", () => {
@@ -196,12 +241,45 @@ describe("absolute managed-section advisory", () => {
     expect(result.message).toContain("grew past its ratchet");
   });
 
-  it("emits absolute advisory even when --quiet suppresses the success banner", () => {
-    const root = makeRepo({ plan: budgetPlan, agents: agentsOverAbsolute(5, 9000) });
+  it("fail-closes in release-gate north-star mode without a waiver", () => {
+    const agents = agentsOverAbsolute(5, 9000);
+    const measure = measureManagedSection(agents);
+    expect("bytes" in measure).toBe(true);
+    if (!("bytes" in measure)) return;
+    const root = makeRepo({
+      plan: {
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 500,
+            unmanagedMaxLines: 500,
+            absoluteMaxBytes: measure.bytes,
+          },
+        },
+      },
+      agents,
+    });
+    const prev = process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR;
+    const prevWaiver = process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER;
+    process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR = "1";
+    delete process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER;
+    try {
+      const result = evaluate(root);
+      expect(result.code).toBe(1);
+      expect(result.message).toContain("north-star ceiling");
+    } finally {
+      if (prev === undefined) delete process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR;
+      else process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR = prev;
+      if (prevWaiver === undefined) delete process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER;
+      else process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER = prevWaiver;
+    }
+  });
+
+  it("emits north-star note even when --quiet suppresses the success banner", () => {
+    const root = makeRepo({ plan: budgetWithAbsolute, agents: agentsOverAbsolute(5, 9000) });
     const result = evaluate(root, { quiet: true });
     expect(result.code).toBe(0);
     expect(result.message).toBe("");
-    expect(result.advisoryMessage).toContain("absolute budget advisory");
+    expect(result.northStarMessage).toContain("north-star");
   });
 });
 

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -193,7 +193,11 @@ describe("absolute managed-section budget", () => {
 
   it("fail-closes when absoluteMaxBytes is set and the managed section grows past it", () => {
     const root = makeRepo({
-      plan: { policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500, absoluteMaxBytes: 8000 } } },
+      plan: {
+        policy: {
+          agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500, absoluteMaxBytes: 8000 },
+        },
+      },
       agents: agentsOverAbsolute(5, 9000),
     });
     const result = evaluate(root);

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -430,9 +430,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
   }
 
   const absoluteSummary =
-    absoluteMaxBytes !== undefined
-      ? `; ${formatAbsoluteSummary(measure, absoluteMaxBytes)}`
-      : "";
+    absoluteMaxBytes !== undefined ? `; ${formatAbsoluteSummary(measure, absoluteMaxBytes)}` : "";
 
   if (quiet) {
     return attachNorthStarNote({ code: 0, message: "", stream: "none" }, text, { advisoryOnly });

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -36,6 +36,10 @@ export interface EvaluateResult {
   /** North-star distance note (#2452); may accompany success or failure paths. */
   readonly northStarMessage?: string;
   readonly northStarStream?: OutputStream;
+  /** @deprecated Use northStarMessage — retained for one release of CLI compat. */
+  readonly advisoryMessage?: string;
+  /** @deprecated Use northStarStream — retained for one release of CLI compat. */
+  readonly advisoryStream?: OutputStream;
 }
 
 export interface EvaluateOptions {
@@ -246,12 +250,17 @@ function attachNorthStarNote<T extends EvaluateResult>(
       ...result,
       northStarMessage: formatAbsoluteAdvisory(measure),
       northStarStream: "stderr",
+      advisoryMessage: formatAbsoluteAdvisory(measure),
+      advisoryStream: "stderr",
     };
   }
+  const distance = formatNorthStarDistance(measure);
   return {
     ...result,
-    northStarMessage: formatNorthStarDistance(measure),
+    northStarMessage: distance,
     northStarStream: "stderr",
+    advisoryMessage: distance,
+    advisoryStream: "stderr",
   };
 }
 

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -151,6 +151,19 @@ export function measureManagedSection(text: string): ManagedSectionMeasure | { e
   };
 }
 
+function formatNorthStarOverage(measure: ManagedSectionMeasure): string {
+  const parts: string[] = [];
+  const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
+  const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
+  if (overBytes > 0) {
+    parts.push(`${overBytes} bytes over`);
+  }
+  if (overTokens > 0) {
+    parts.push(`~${overTokens} tok over`);
+  }
+  return parts.join(", ");
+}
+
 function formatNorthStarDistance(measure: ManagedSectionMeasure): string {
   const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
   const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
@@ -163,18 +176,16 @@ function formatNorthStarDistance(measure: ManagedSectionMeasure): string {
   return (
     `north-star: ≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
     `(current ${measure.bytes} bytes / ~${measure.estimatedTokens} tok — ` +
-    `${overBytes} bytes / ~${overTokens} tok over target).`
+    `${formatNorthStarOverage(measure)}).`
   );
 }
 
 function formatAbsoluteAdvisory(measure: ManagedSectionMeasure): string {
-  const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
-  const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
   return (
     `⚠ verify:agents-md-budget: managed section absolute budget advisory — ` +
     `${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the north-star ` +
     `of ${ABSOLUTE_MANAGED_MAX_BYTES} bytes / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
-    `(OVER by ${overBytes} bytes / ~${overTokens} tok). Advisory only — set ` +
+    `(OVER: ${formatNorthStarOverage(measure)}). Advisory only — set ` +
     "plan.policy.agentsMdBudget.absoluteMaxBytes to enable fail-closed growth ratchet (#2452).\n" +
     "  The relative line ratchet (#645) remains fail-closed.\n" +
     "  DD-3 harness skill frontmatter is not yet included in this meter."
@@ -220,44 +231,26 @@ function northStarWaiverActive(): boolean {
   return process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER === "1";
 }
 
-function absoluteAdvisoryForText(
-  text: string,
-): { northStarMessage: string; northStarStream: OutputStream } | null {
-  const measureResult = measureManagedSection(text);
-  if ("error" in measureResult) {
-    return null;
-  }
-  const overBytes = measureResult.bytes > ABSOLUTE_MANAGED_MAX_BYTES;
-  const overTokens = measureResult.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
-  if (!overBytes && !overTokens) {
-    return null;
-  }
-  return {
-    northStarMessage: formatAbsoluteAdvisory(measureResult),
-    northStarStream: "stderr",
-  };
-}
-
 function attachNorthStarNote<T extends EvaluateResult>(
   result: T,
-  text: string,
+  measure: ManagedSectionMeasure,
   options: { advisoryOnly: boolean },
 ): T {
+  const overBytes = measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES;
+  const overTokens = measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
   if (options.advisoryOnly) {
-    const advisory = absoluteAdvisoryForText(text);
-    if (advisory === null) {
+    if (!overBytes && !overTokens) {
       return result;
     }
-    return { ...result, ...advisory };
-  }
-
-  const measureResult = measureManagedSection(text);
-  if ("error" in measureResult) {
-    return result;
+    return {
+      ...result,
+      northStarMessage: formatAbsoluteAdvisory(measure),
+      northStarStream: "stderr",
+    };
   }
   return {
     ...result,
-    northStarMessage: formatNorthStarDistance(measureResult),
+    northStarMessage: formatNorthStarDistance(measure),
     northStarStream: "stderr",
   };
 }
@@ -359,7 +352,9 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
 
   if (budgetResult.source === "unset") {
     if (quiet) {
-      return attachNorthStarNote({ code: 0, message: "", stream: "none" }, text, { advisoryOnly });
+      return attachNorthStarNote({ code: 0, message: "", stream: "none" }, measure, {
+        advisoryOnly,
+      });
     }
     return attachNorthStarNote(
       {
@@ -372,7 +367,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
           "PROJECT-DEFINITION.",
         stream: "stderr",
       },
-      text,
+      measure,
       { advisoryOnly },
     );
   }
@@ -397,7 +392,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
         message: formatRefusal(counts, budget.managedMaxLines, budget.unmanagedMaxLines, root),
         stream: "stderr",
       },
-      text,
+      measure,
       { advisoryOnly },
     );
   }
@@ -409,7 +404,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
         message: formatAbsoluteRefusal(measure, absoluteMaxBytes, root),
         stream: "stderr",
       },
-      text,
+      measure,
       { advisoryOnly: false },
     );
   }
@@ -424,7 +419,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
         message: formatNorthStarRefusal(measure, root),
         stream: "stderr",
       },
-      text,
+      measure,
       { advisoryOnly: false },
     );
   }
@@ -433,7 +428,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     absoluteMaxBytes !== undefined ? `; ${formatAbsoluteSummary(measure, absoluteMaxBytes)}` : "";
 
   if (quiet) {
-    return attachNorthStarNote({ code: 0, message: "", stream: "none" }, text, { advisoryOnly });
+    return attachNorthStarNote({ code: 0, message: "", stream: "none" }, measure, { advisoryOnly });
   }
   return attachNorthStarNote(
     {
@@ -444,7 +439,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
         `${absoluteSummary}.`,
       stream: "stdout",
     },
-    text,
+    measure,
     { advisoryOnly },
   );
 }

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -6,14 +6,16 @@ import { resolveAgentsMdBudget } from "../policy/agents-md-budget.js";
 export type OutputStream = "stdout" | "stderr" | "none";
 
 /**
- * Layered absolute north-star for the always-on managed surface (#2372 / #2450).
+ * Layered absolute north-star for the always-on managed surface (#2372 / #2450 / #2452).
  *
- * Advisory-only in Wave 1: the relative line ratchet remains fail-closed; this
- * ceiling reports relocation progress without affecting exit codes. Promotion to
- * fail-closed is deferred to post-Wave-2 (#2369 current-shape).
+ * `ABSOLUTE_MANAGED_MAX_BYTES` is the relocation north-star (<=8192 B / ~2k tok).
+ * When `plan.policy.agentsMdBudget.absoluteMaxBytes` is set, growth past that seeded
+ * ratchet fails closed; distance-to-north-star is always reported. Optional release-gate
+ * north-star enforcement: DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR=1 (waiver:
+ * DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1).
  *
- * DD-3 (harness-injected skill frontmatter in the meter) is deferred to #2452 /
- * Child A — this Wave-1 measure covers the rendered managed section only.
+ * DD-3 (harness-injected skill frontmatter in the meter) is deferred — this measure
+ * covers the rendered managed section only.
  */
 export const ABSOLUTE_MANAGED_MAX_BYTES = 8192;
 export const ABSOLUTE_MANAGED_MAX_TOKENS = 2000;
@@ -31,9 +33,9 @@ export interface EvaluateResult {
   readonly code: 0 | 1 | 2;
   readonly message: string;
   readonly stream: OutputStream;
-  /** Advisory absolute-budget note (#2450); never affects `code`. */
-  readonly advisoryMessage?: string;
-  readonly advisoryStream?: OutputStream;
+  /** North-star distance note (#2452); may accompany success or failure paths. */
+  readonly northStarMessage?: string;
+  readonly northStarStream?: OutputStream;
 }
 
 export interface EvaluateOptions {
@@ -149,23 +151,78 @@ export function measureManagedSection(text: string): ManagedSectionMeasure | { e
   };
 }
 
+function formatNorthStarDistance(measure: ManagedSectionMeasure): string {
+  const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
+  const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
+  if (overBytes <= 0 && overTokens <= 0) {
+    return (
+      `north-star: ${measure.bytes} bytes (~${measure.estimatedTokens} tok) within ` +
+      `≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok target.`
+    );
+  }
+  return (
+    `north-star: ≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
+    `(current ${measure.bytes} bytes / ~${measure.estimatedTokens} tok — ` +
+    `${overBytes} bytes / ~${overTokens} tok over target).`
+  );
+}
+
 function formatAbsoluteAdvisory(measure: ManagedSectionMeasure): string {
   const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
   const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
   return (
     `⚠ verify:agents-md-budget: managed section absolute budget advisory — ` +
-    `${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the Wave-1 north-star ` +
+    `${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the north-star ` +
     `of ${ABSOLUTE_MANAGED_MAX_BYTES} bytes / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
-    `(OVER by ${overBytes} bytes / ~${overTokens} tok). Advisory only — task check is NOT affected.\n` +
-    "  The relative line ratchet (#645) remains fail-closed; this absolute ceiling is the\n" +
-    "  relocation goal for epic #2369. Fail-closed promotion is deferred until after Wave 2.\n" +
-    "  DD-3 harness skill frontmatter is not yet included in this meter (#2452)."
+    `(OVER by ${overBytes} bytes / ~${overTokens} tok). Advisory only — set ` +
+    "plan.policy.agentsMdBudget.absoluteMaxBytes to enable fail-closed growth ratchet (#2452).\n" +
+    "  The relative line ratchet (#645) remains fail-closed.\n" +
+    "  DD-3 harness skill frontmatter is not yet included in this meter."
   );
+}
+
+function formatAbsoluteRefusal(
+  measure: ManagedSectionMeasure,
+  absoluteMaxBytes: number,
+  projectRoot: string,
+): string {
+  const overBytes = measure.bytes - absoluteMaxBytes;
+  return (
+    `❌ verify:agents-md-budget: managed section grew past its absolute byte ratchet ` +
+    `(project_root=${projectRoot}).\n` +
+    `   managed section: ${measure.bytes}/${absoluteMaxBytes} bytes (OVER by ${overBytes})\n` +
+    `   ${formatNorthStarDistance(measure)}\n` +
+    "   AGENTS.md is a map, not a manual (#1882): push detail into a\n" +
+    "   reference doc (main.md / a pack / docs/) and leave a pointer,\n" +
+    "   rather than expanding AGENTS.md. See REFERENCES.md.\n" +
+    "   If the growth is deliberate, raise absoluteMaxBytes in\n" +
+    "   plan.policy.agentsMdBudget in PROJECT-DEFINITION (a reviewed diff). (#2452)"
+  );
+}
+
+function formatNorthStarRefusal(measure: ManagedSectionMeasure, projectRoot: string): string {
+  const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
+  return (
+    `❌ verify:agents-md-budget: managed section exceeds the north-star ceiling ` +
+    `(project_root=${projectRoot}, release-gate mode).\n` +
+    `   managed section: ${measure.bytes}/${ABSOLUTE_MANAGED_MAX_BYTES} bytes ` +
+    `(OVER by ${overBytes})\n` +
+    "   Thin the managed section toward the <=8192 B / ~2k tok north-star, or set\n" +
+    "   DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1 for a time-boxed operator waiver (#2452)."
+  );
+}
+
+function enforceNorthStarEnabled(): boolean {
+  return process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR === "1";
+}
+
+function northStarWaiverActive(): boolean {
+  return process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER === "1";
 }
 
 function absoluteAdvisoryForText(
   text: string,
-): { advisoryMessage: string; advisoryStream: OutputStream } | null {
+): { northStarMessage: string; northStarStream: OutputStream } | null {
   const measureResult = measureManagedSection(text);
   if ("error" in measureResult) {
     return null;
@@ -176,17 +233,37 @@ function absoluteAdvisoryForText(
     return null;
   }
   return {
-    advisoryMessage: formatAbsoluteAdvisory(measureResult),
-    advisoryStream: "stderr",
+    northStarMessage: formatAbsoluteAdvisory(measureResult),
+    northStarStream: "stderr",
   };
 }
 
-function attachAbsoluteAdvisory<T extends EvaluateResult>(result: T, text: string): T {
-  const advisory = absoluteAdvisoryForText(text);
-  if (advisory === null) {
+function attachNorthStarNote<T extends EvaluateResult>(
+  result: T,
+  text: string,
+  options: { advisoryOnly: boolean },
+): T {
+  if (options.advisoryOnly) {
+    const advisory = absoluteAdvisoryForText(text);
+    if (advisory === null) {
+      return result;
+    }
+    return { ...result, ...advisory };
+  }
+
+  const measureResult = measureManagedSection(text);
+  if ("error" in measureResult) {
     return result;
   }
-  return { ...result, ...advisory };
+  return {
+    ...result,
+    northStarMessage: formatNorthStarDistance(measureResult),
+    northStarStream: "stderr",
+  };
+}
+
+function formatAbsoluteSummary(measure: ManagedSectionMeasure, absoluteMaxBytes: number): string {
+  return `absolute ${measure.bytes}/${absoluteMaxBytes} bytes (~${measure.estimatedTokens} tok)`;
 }
 
 function formatRefusal(
@@ -268,12 +345,23 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     };
   }
   const counts = regionResult.counts;
+  const measureResult = measureManagedSection(text);
+  if ("error" in measureResult) {
+    return {
+      code: 2,
+      message: `❌ verify:agents-md-budget: ${measureResult.error}`,
+      stream: "stderr",
+    };
+  }
+  const measure = measureResult;
+  const absoluteMaxBytes = budgetResult.budget?.absoluteMaxBytes;
+  const advisoryOnly = absoluteMaxBytes === undefined;
 
   if (budgetResult.source === "unset") {
     if (quiet) {
-      return attachAbsoluteAdvisory({ code: 0, message: "", stream: "none" }, text);
+      return attachNorthStarNote({ code: 0, message: "", stream: "none" }, text, { advisoryOnly });
     }
-    return attachAbsoluteAdvisory(
+    return attachNorthStarNote(
       {
         code: 0,
         message:
@@ -285,6 +373,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
         stream: "stderr",
       },
       text,
+      { advisoryOnly },
     );
   }
 
@@ -301,28 +390,63 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
   const overManaged = counts.managed > budget.managedMaxLines;
   const overUnmanaged = counts.unmanaged > budget.unmanagedMaxLines;
 
-  if (!overManaged && !overUnmanaged) {
-    if (quiet) {
-      return attachAbsoluteAdvisory({ code: 0, message: "", stream: "none" }, text);
-    }
-    return attachAbsoluteAdvisory(
+  if (overManaged || overUnmanaged) {
+    return attachNorthStarNote(
       {
-        code: 0,
-        message:
-          `✓ verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
-          `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet).`,
-        stream: "stdout",
+        code: 1,
+        message: formatRefusal(counts, budget.managedMaxLines, budget.unmanagedMaxLines, root),
+        stream: "stderr",
       },
       text,
+      { advisoryOnly },
     );
   }
 
-  return attachAbsoluteAdvisory(
+  if (absoluteMaxBytes !== undefined && measure.bytes > absoluteMaxBytes) {
+    return attachNorthStarNote(
+      {
+        code: 1,
+        message: formatAbsoluteRefusal(measure, absoluteMaxBytes, root),
+        stream: "stderr",
+      },
+      text,
+      { advisoryOnly: false },
+    );
+  }
+
+  const overNorthStar =
+    measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES ||
+    measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  if (enforceNorthStarEnabled() && overNorthStar && !northStarWaiverActive()) {
+    return attachNorthStarNote(
+      {
+        code: 1,
+        message: formatNorthStarRefusal(measure, root),
+        stream: "stderr",
+      },
+      text,
+      { advisoryOnly: false },
+    );
+  }
+
+  const absoluteSummary =
+    absoluteMaxBytes !== undefined
+      ? `; ${formatAbsoluteSummary(measure, absoluteMaxBytes)}`
+      : "";
+
+  if (quiet) {
+    return attachNorthStarNote({ code: 0, message: "", stream: "none" }, text, { advisoryOnly });
+  }
+  return attachNorthStarNote(
     {
-      code: 1,
-      message: formatRefusal(counts, budget.managedMaxLines, budget.unmanagedMaxLines, root),
-      stream: "stderr",
+      code: 0,
+      message:
+        `✓ verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
+        `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet)` +
+        `${absoluteSummary}.`,
+      stream: "stdout",
     },
     text,
+    { advisoryOnly },
   );
 }

--- a/packages/core/src/policy/agents-md-budget.test.ts
+++ b/packages/core/src/policy/agents-md-budget.test.ts
@@ -140,19 +140,16 @@ describe("resolveAgentsMdBudget", () => {
   });
 
   it("resolves optional absoluteMaxBytes when present", () => {
-    const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({
-          policy: {
-            agentsMdBudget: {
-              managedMaxLines: 1,
-              unmanagedMaxLines: 2,
-              absoluteMaxBytes: 16843,
-            },
-          },
-        }),
-      ),
-    );
+    const raw = withPlan({
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 1,
+          unmanagedMaxLines: 2,
+          absoluteMaxBytes: 16843,
+        },
+      },
+    });
+    const result = resolveAgentsMdBudget(makeRepo(raw));
     expect(result.source).toBe("typed");
     expect(result.budget).toEqual({
       managedMaxLines: 1,

--- a/packages/core/src/policy/agents-md-budget.test.ts
+++ b/packages/core/src/policy/agents-md-budget.test.ts
@@ -139,6 +139,46 @@ describe("resolveAgentsMdBudget", () => {
     expect(result.budget).toEqual({ managedMaxLines: 223, unmanagedMaxLines: 347 });
   });
 
+  it("resolves optional absoluteMaxBytes when present", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({
+          policy: {
+            agentsMdBudget: {
+              managedMaxLines: 1,
+              unmanagedMaxLines: 2,
+              absoluteMaxBytes: 16843,
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.source).toBe("typed");
+    expect(result.budget).toEqual({
+      managedMaxLines: 1,
+      unmanagedMaxLines: 2,
+      absoluteMaxBytes: 16843,
+    });
+  });
+
+  it("returns default-on-error when absoluteMaxBytes is invalid", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepo(
+        withPlan({
+          policy: {
+            agentsMdBudget: {
+              managedMaxLines: 1,
+              unmanagedMaxLines: 2,
+              absoluteMaxBytes: -1,
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("absoluteMaxBytes");
+  });
+
   it("reads the namespaced x-directive/policy block", () => {
     const result = resolveAgentsMdBudget(
       makeRepo(

--- a/packages/core/src/policy/agents-md-budget.test.ts
+++ b/packages/core/src/policy/agents-md-budget.test.ts
@@ -27,6 +27,11 @@ function withPlan(plan: unknown): string {
   return JSON.stringify({ xBRIEFInfo: { version: "0.8" }, plan });
 }
 
+/** Create a temp project root with a typed PROJECT-DEFINITION plan object. */
+function makeRepoWithPlan(plan: unknown): string {
+  return makeRepo(withPlan(plan));
+}
+
 describe("resolveAgentsMdBudget", () => {
   it("returns default-on-error when PROJECT-DEFINITION is absent", () => {
     const result = resolveAgentsMdBudget(makeRepo());
@@ -99,9 +104,9 @@ describe("resolveAgentsMdBudget", () => {
 
   it("returns default-on-error when a region value is a non-integer float", () => {
     const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({ policy: { agentsMdBudget: { managedMaxLines: 5.5, unmanagedMaxLines: 10 } } }),
-      ),
+      makeRepoWithPlan({
+        policy: { agentsMdBudget: { managedMaxLines: 5.5, unmanagedMaxLines: 10 } },
+      }),
     );
     expect(result.source).toBe("default-on-error");
     expect(result.error).toContain("must be a non-negative integer");
@@ -110,9 +115,9 @@ describe("resolveAgentsMdBudget", () => {
 
   it("returns default-on-error when a region value is a string (reports str type)", () => {
     const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({ policy: { agentsMdBudget: { managedMaxLines: "5", unmanagedMaxLines: 10 } } }),
-      ),
+      makeRepoWithPlan({
+        policy: { agentsMdBudget: { managedMaxLines: "5", unmanagedMaxLines: 10 } },
+      }),
     );
     expect(result.source).toBe("default-on-error");
     expect(result.error).toContain("got str ('5')");
@@ -120,9 +125,9 @@ describe("resolveAgentsMdBudget", () => {
 
   it("returns default-on-error when a region value is negative", () => {
     const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({ policy: { agentsMdBudget: { managedMaxLines: 5, unmanagedMaxLines: -1 } } }),
-      ),
+      makeRepoWithPlan({
+        policy: { agentsMdBudget: { managedMaxLines: 5, unmanagedMaxLines: -1 } },
+      }),
     );
     expect(result.source).toBe("default-on-error");
     expect(result.error).toContain("must be a non-negative integer");
@@ -130,9 +135,9 @@ describe("resolveAgentsMdBudget", () => {
 
   it("resolves a typed budget when both regions are valid non-negative integers", () => {
     const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({ policy: { agentsMdBudget: { managedMaxLines: 223, unmanagedMaxLines: 347 } } }),
-      ),
+      makeRepoWithPlan({
+        policy: { agentsMdBudget: { managedMaxLines: 223, unmanagedMaxLines: 347 } },
+      }),
     );
     expect(result.source).toBe("typed");
     expect(result.error).toBeNull();
@@ -140,16 +145,17 @@ describe("resolveAgentsMdBudget", () => {
   });
 
   it("resolves optional absoluteMaxBytes when present", () => {
-    const raw = withPlan({
-      policy: {
-        agentsMdBudget: {
-          managedMaxLines: 1,
-          unmanagedMaxLines: 2,
-          absoluteMaxBytes: 16843,
+    const result = resolveAgentsMdBudget(
+      makeRepoWithPlan({
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 1,
+            unmanagedMaxLines: 2,
+            absoluteMaxBytes: 16843,
+          },
         },
-      },
-    });
-    const result = resolveAgentsMdBudget(makeRepo(raw));
+      }),
+    );
     expect(result.source).toBe("typed");
     expect(result.budget).toEqual({
       managedMaxLines: 1,
@@ -160,17 +166,15 @@ describe("resolveAgentsMdBudget", () => {
 
   it("returns default-on-error when absoluteMaxBytes is invalid", () => {
     const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({
-          policy: {
-            agentsMdBudget: {
-              managedMaxLines: 1,
-              unmanagedMaxLines: 2,
-              absoluteMaxBytes: -1,
-            },
+      makeRepoWithPlan({
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 1,
+            unmanagedMaxLines: 2,
+            absoluteMaxBytes: -1,
           },
-        }),
-      ),
+        },
+      }),
     );
     expect(result.source).toBe("default-on-error");
     expect(result.error).toContain("absoluteMaxBytes");
@@ -178,11 +182,9 @@ describe("resolveAgentsMdBudget", () => {
 
   it("reads the namespaced x-directive/policy block", () => {
     const result = resolveAgentsMdBudget(
-      makeRepo(
-        withPlan({
-          "x-directive/policy": { agentsMdBudget: { managedMaxLines: 1, unmanagedMaxLines: 2 } },
-        }),
-      ),
+      makeRepoWithPlan({
+        "x-directive/policy": { agentsMdBudget: { managedMaxLines: 1, unmanagedMaxLines: 2 } },
+      }),
     );
     expect(result.source).toBe("typed");
     expect(result.budget).toEqual({ managedMaxLines: 1, unmanagedMaxLines: 2 });

--- a/packages/core/src/policy/agents-md-budget.ts
+++ b/packages/core/src/policy/agents-md-budget.ts
@@ -15,6 +15,12 @@ import { loadProjectDefinition } from "./resolve.js";
 export interface AgentsMdBudget {
   readonly managedMaxLines: number;
   readonly unmanagedMaxLines: number;
+  /**
+   * Fail-closed UTF-8 byte ratchet for the managed section (#2452).
+   * Seeded at the current measured size so the gate ships green; growth past
+   * this ceiling fails. The <=8192 B north-star is reported separately.
+   */
+  readonly absoluteMaxBytes?: number;
 }
 
 export type AgentsMdBudgetSource = "typed" | "unset" | "default-on-error";
@@ -54,6 +60,23 @@ function readRegion(
   if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) {
     return {
       value: null,
+      error: `plan.policy.agentsMdBudget.${key} must be a non-negative integer; got ${pythonTypeName(raw)} (${pythonRepr(raw)})`,
+    };
+  }
+  return { value: raw, error: null };
+}
+
+function readOptionalRegion(
+  block: Record<string, unknown>,
+  key: string,
+): { value: number | undefined; error: string | null } {
+  if (!(key in block)) {
+    return { value: undefined, error: null };
+  }
+  const raw = block[key];
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) {
+    return {
+      value: undefined,
       error: `plan.policy.agentsMdBudget.${key} must be a non-negative integer; got ${pythonTypeName(raw)} (${pythonRepr(raw)})`,
     };
   }
@@ -105,11 +128,25 @@ export function resolveAgentsMdBudget(projectRoot: string): AgentsMdBudgetResult
     return { budget: null, source: "default-on-error", error: unmanaged.error };
   }
 
+  const absolute = readOptionalRegion(block, "absoluteMaxBytes");
+  if (absolute.error !== null) {
+    return { budget: null, source: "default-on-error", error: absolute.error };
+  }
+
+  const budget: AgentsMdBudget = {
+    managedMaxLines: managed.value as number,
+    unmanagedMaxLines: unmanaged.value as number,
+  };
+  if (absolute.value !== undefined) {
+    return {
+      budget: { ...budget, absoluteMaxBytes: absolute.value },
+      source: "typed",
+      error: null,
+    };
+  }
+
   return {
-    budget: {
-      managedMaxLines: managed.value as number,
-      unmanagedMaxLines: unmanaged.value as number,
-    },
+    budget,
     source: "typed",
     error: null,
   };

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16783,7 +16783,8 @@
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
         "managedMaxLines": 244,
-        "unmanagedMaxLines": 270
+        "unmanagedMaxLines": 270,
+        "absoluteMaxBytes": 16843
       }
     },
     "updated": "2026-07-02T14:32:31Z"

--- a/xbrief/active/2026-07-12-2452-gateagents-md-promote-absolute-always-on-budget-from-advisor.xbrief.json
+++ b/xbrief/active/2026-07-12-2452-gateagents-md-promote-absolute-always-on-budget-from-advisor.xbrief.json
@@ -1,0 +1,85 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Promote absolute always-on budget from advisory to fail-closed",
+    "created": "2026-07-12T23:51:52.401Z",
+    "updated": "2026-07-12T23:51:52.401Z"
+  },
+  "plan": {
+    "id": "2452-promote-absolute-budget",
+    "title": "gate(agents-md): promote absolute always-on budget from advisory to fail-closed",
+    "status": "running",
+    "narratives": {
+      "Description": "Wave 2 relocation landed but the managed section is still ~16.6 KB vs the <=8 KB / ~2k tok north-star. This story promotes the absolute meter from advisory (#2450) to fail-closed without breaking master: seed an absolute byte ratchet at the current measured size (anti-growth), keep the <=8192 north-star documented, and provide a clear remediation path for further thinning. Relative #645 line ratchet stays fail-closed.",
+      "ImplementationPlan": "1) Extend packages/core agents-md-budget evaluate path / packages/cli/src/verify-agents-md-budget.ts so absolute over-budget can fail-closed. 2) Add plan.policy field (or reuse agentsMdBudget) for absoluteMaxBytes seeded at current managed UTF-8 size (~17029) so task check stays green, while documenting northStarBytes=8192. 3) Growth above seeded absolute max fails closed; report distance-to-north-star in output. 4) Optional release-gate mode that fails on north-star unless DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1 (time-boxed waiver documented in CHANGELOG/UPGRADING). 5) Tests in packages/core agents-md-budget evaluate tests. 6) Verify: pnpm exec vitest run packages/core/**/agents-md-budget* and task verify:agents-md-budget exits 0 on master. 7) CHANGELOG. DD-3 frontmatter: stub note that meter still excludes harness skill frontmatter.",
+      "UserStory": "As a framework maintainer, I want the absolute always-on budget to fail closed against growth while tracking the 8 KB north-star, so that Wave 2 gains cannot be given back and further thinning stays measurable.",
+      "Origin": "Enriched for swarm from #2452 under epic #2369 after Wave 2 relocation"
+    },
+    "items": [
+      {
+        "id": "2452-a1",
+        "title": "Fail-closed absolute growth ratchet",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given managed bytes above seeded absoluteMaxBytes, when verify:agents-md-budget runs, then it exits non-zero; master at seed size exits 0.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2452-a2",
+        "title": "North-star remaining visible",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given output/docs, when read, then <=8192 / ~2k tok north-star and distance-to-target are explicit.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2452-a3",
+        "title": "Relative ratchet unchanged",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given line-count growth past agentsMdBudget, when the gate runs, then it still fails closed as before.",
+          "Traces": "FR-1"
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/agents-md-budget",
+          "packages/cli/src/verify-agents-md-budget.ts",
+          "xbrief/PROJECT-DEFINITION.xbrief.json"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/agents-md-budget",
+          "task verify:agents-md-budget"
+        ],
+        "expected_outputs": [
+          "absolute fail-closed growth ratchet shipped",
+          "PR merged for #2452"
+        ],
+        "depends_on": [],
+        "conflict_group": "agents-md-budget-absolute",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "x-tracking": {
+        "parent_epic": "#2369",
+        "origin_issue": "#2452"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2452",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2452"
+      }
+    ],
+    "updated": "2026-07-12T23:51:52.401Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Promote the Wave-1 advisory absolute managed-section meter to a fail-closed growth ratchet via `plan.policy.agentsMdBudget.absoluteMaxBytes`, seeded at the current 16843-byte managed section so `task check` stays green on master.
- Always report distance to the <=8192 B / ~2k tok north-star in gate output; relative #645 line ratchet unchanged.
- Optional release-gate north-star enforcement: `DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR=1` with waiver `DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1`.

## Test plan
- [x] `npx vitest run packages/core/src/agents-md-budget packages/core/src/policy/agents-md-budget.test.ts packages/cli/src/verify-agents-md-budget.test.ts`
- [x] `node packages/cli/dist/bin.js verify:agents-md-budget` exits 0 on this branch with north-star distance visible
- [ ] CI `task check` green

Closes #2452
Refs #2369