### PR TITLE
feat(gate): DD-3 harness skill frontmatter in verify:agents-md-budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **OpenPackage tiered skill package for cross-harness install.** Ships a tiered OpenPackage skill manifest (daily-core / standard / advanced) for Cursor, Codex CLI, and OpenCode via `opkg install`, documented alongside the npm engine — distribution-layer only, no runtime skill router. Closes #2462. Refs #2369.
 
+- **Agents-md budget gate now counts harness skill frontmatter (DD-3).** `verify:agents-md-budget` itemizes managed AGENTS.md bytes, Cursor-injected skill frontmatter, and bootstrap hooks (0 until #2438), supports daily-core vs all skill tiers, and documents remediation when the combined always-on surface exceeds the 8192 B north-star. Managed `absoluteMaxBytes` ratchet stays fail-closed; DD-3 caps are advisory unless `skillFrontmatterMaxBytes` is seeded. Closes #2463. Refs #2370, #2369.
+
 - **Cross-harness packaging spike recommends OpenPackage distribution.** Wave 3 research (#2370) measured always-on bootstrap across Cursor (native skills) and Codex/OpenCode-style harnesses, chose distribution-layer (A) over runtime-router (B), and recorded go for an OpenPackage-based tiered skill package as the Wave 3 packaging action. Closes #2370. Refs #2369.
 
 - **Rule-relocation PRs now require eval:health no-regression.** `verify:eval-health-relocation` classifies diffs touching AGENTS.md, agents-entry, skills, or packs and fail-closed blocks when framework health drops against the committed baseline — the acceptance gate epic #2369 Wave 2 relocation slices need before merge. Closes #2373.

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -89,6 +89,23 @@ The npm engine (`npm i -g @deftai/directive`) remains the canonical runtime hand
 
 Consumer AGENTS.md stays pointer-thin — scan `.deft/core/REFERENCES.md` Skills Index; do not enumerate skills in the managed section.
 
+### Always-on bootstrap budget (DD-3, #2463)
+
+`verify:agents-md-budget` now itemizes the always-on bootstrap surface:
+
+- **Managed AGENTS.md** bytes (fail-closed ratchet via `plan.policy.agentsMdBudget.absoluteMaxBytes`)
+- **Harness skill frontmatter** bytes (Cursor `<agent_skill>` shape; advisory unless `skillFrontmatterMaxBytes` is set)
+- **Bootstrap hooks** bytes (0 until #2438 ships)
+
+The north-star target is **≤8192 B / ~2k tok combined**. On Cursor with all skills injected, managed AGENTS.md (~16.8 KB) plus skill frontmatter (~7.7 KB) still exceeds that target — remediation paths:
+
+1. **Tier skills** — install only the daily-core six (`setup`, `sync`, `build`, `pre-pr`, `review-cycle`, `triage`) via OpenPackage; set `plan.policy.agentsMdBudget.skillFrontmatterTier` to `daily-core` or export `DEFT_AGENTS_MD_BUDGET_SKILL_TIER=daily-core`.
+2. **Thin managed AGENTS.md** — continue epic #2369 relocation; push bulk to `commands.md`, `scm/github.md`, and skills.
+3. **Shorten SKILL.md descriptions** — advanced-tier skills (`release`, `swarm`, `debug`, `article-review`, …) are the largest frontmatter offenders.
+4. **Optional ratchet** — seed `plan.policy.agentsMdBudget.skillFrontmatterMaxBytes` at the measured tier size when you want fail-closed DD-3 growth control.
+
+Non-native-skill harnesses (Codex CLI, OpenCode) report 0 B frontmatter; set `harnessProfile: none` in policy when appropriate.
+
 ## xBRIEF layout migration (#2034 / #2110)
 
 After upgrading to a release that ships the xbrief rename, convert legacy on-disk layout if `deft doctor` reports a `vbrief/` tree or `x-vbrief/` reference tokens:

--- a/packages/cli/src/verify-agents-md-budget.test.ts
+++ b/packages/cli/src/verify-agents-md-budget.test.ts
@@ -127,7 +127,7 @@ describe("run", () => {
     try {
       expect(run(["--project-root", root])).toBe(0);
       const stderrText = err.mock.calls.map((c) => String(c[0])).join("");
-      expect(stderrText).toContain("absolute budget advisory");
+      expect(stderrText).toContain("always-on bootstrap advisory");
     } finally {
       out.mockRestore();
       err.mockRestore();

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -401,11 +401,10 @@ description: ${description}
     const prev = process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER;
     process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER = "daily-core";
     try {
-      const bootstrap = measureBootstrapSurface(
-        root,
-        agentsWith(5, 5),
-        { managedMaxLines: 500, unmanagedMaxLines: 500 },
-      );
+      const bootstrap = measureBootstrapSurface(root, agentsWith(5, 5), {
+        managedMaxLines: 500,
+        unmanagedMaxLines: 500,
+      });
       expect("error" in bootstrap).toBe(false);
       if ("error" in bootstrap) return;
       expect(bootstrap.skillFrontmatter.skillCount).toBe(1);

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -5,9 +5,11 @@ import { afterAll, describe, expect, it } from "vitest";
 import {
   ABSOLUTE_MANAGED_MAX_BYTES,
   ABSOLUTE_MANAGED_MAX_TOKENS,
+  BOOTSTRAP_HOOK_BYTES,
   countRegions,
   evaluate,
   extractManagedSection,
+  measureBootstrapSurface,
   measureManagedSection,
 } from "./evaluate.js";
 
@@ -188,8 +190,9 @@ describe("absolute managed-section budget", () => {
     const root = makeRepo({ plan: budgetPlan, agents: agentsOverAbsolute(5, 9000) });
     const result = evaluate(root);
     expect(result.code).toBe(0);
-    expect(result.northStarMessage).toContain("absolute budget advisory");
+    expect(result.northStarMessage).toContain("always-on bootstrap advisory");
     expect(result.northStarMessage).toContain("Advisory only");
+    expect(result.northStarMessage).toContain("DD-3");
     expect(result.northStarStream).toBe("stderr");
   });
 
@@ -227,7 +230,9 @@ describe("absolute managed-section budget", () => {
     });
     const result = evaluate(root);
     expect(result.code).toBe(0);
-    expect(result.message).toContain(`absolute ${measure.bytes}/${measure.bytes} bytes`);
+    expect(result.message).toContain(`absolute managed ${measure.bytes}/${measure.bytes} bytes`);
+    expect(result.message).toContain("skill-frontmatter");
+    expect(result.message).toContain(`hooks ${BOOTSTRAP_HOOK_BYTES} B`);
     expect(result.northStarMessage).toContain("north-star");
     expect(result.northStarMessage).toContain("tok over");
   });
@@ -272,6 +277,7 @@ describe("absolute managed-section budget", () => {
       const result = evaluate(root);
       expect(result.code).toBe(1);
       expect(result.message).toContain("north-star ceiling");
+      expect(result.message).toContain("combined always-on");
     } finally {
       if (prev === undefined) delete process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR;
       else process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR = prev;
@@ -317,6 +323,97 @@ describe("absolute managed-section budget", () => {
     expect(result.code).toBe(0);
     expect(result.message).toBe("");
     expect(result.northStarMessage).toContain("north-star");
+  });
+});
+
+describe("DD-3 skill frontmatter itemization", () => {
+  const skillBody = (name: string, description: string) => `---
+name: ${name}
+description: ${description}
+---
+# Skill`;
+
+  function makeRepoWithSkills(options: {
+    plan: Record<string, unknown>;
+    agents: string;
+    skills?: Record<string, string>;
+  }): string {
+    const root = makeRepo({ plan: options.plan, agents: options.agents });
+    if (options.skills !== undefined) {
+      for (const [skillName, body] of Object.entries(options.skills)) {
+        const dir = join(root, "content", "skills", skillName);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "SKILL.md"), body, "utf8");
+      }
+    }
+    return root;
+  }
+
+  it("itemizes managed + skill-frontmatter + hooks in gate output", () => {
+    const root = makeRepoWithSkills({
+      plan: { policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } } },
+      agents: agentsWith(5, 5),
+      skills: {
+        "deft-directive-setup": skillBody("deft-directive-setup", "Setup blurb."),
+        "deft-directive-release": skillBody("deft-directive-release", "Release blurb."),
+      },
+    });
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("skill-frontmatter");
+    expect(result.message).toContain("hooks 0 B");
+    expect(result.message).toContain("combined");
+  });
+
+  it("fail-closes when skillFrontmatterMaxBytes ratchet is exceeded", () => {
+    const root = makeRepoWithSkills({
+      plan: {
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 500,
+            unmanagedMaxLines: 500,
+            skillFrontmatterMaxBytes: 10,
+          },
+        },
+      },
+      agents: agentsWith(5, 5),
+      skills: {
+        "deft-directive-setup": skillBody(
+          "deft-directive-setup",
+          "A sufficiently long setup description for ratchet failure.",
+        ),
+      },
+    });
+    const result = evaluate(root);
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("skill frontmatter grew past its DD-3 byte ratchet");
+  });
+
+  it("uses daily-core tier from env without counting advanced skills", () => {
+    const root = makeRepoWithSkills({
+      plan: { policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } } },
+      agents: agentsWith(5, 5),
+      skills: {
+        "deft-directive-setup": skillBody("deft-directive-setup", "Setup."),
+        "deft-directive-release": skillBody("deft-directive-release", "Release."),
+      },
+    });
+    const prev = process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER;
+    process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER = "daily-core";
+    try {
+      const bootstrap = measureBootstrapSurface(
+        root,
+        agentsWith(5, 5),
+        { managedMaxLines: 500, unmanagedMaxLines: 500 },
+      );
+      expect("error" in bootstrap).toBe(false);
+      if ("error" in bootstrap) return;
+      expect(bootstrap.skillFrontmatter.skillCount).toBe(1);
+      expect(bootstrap.skillFrontmatter.tier).toBe("daily-core");
+    } finally {
+      if (prev === undefined) delete process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER;
+      else process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER = prev;
+    }
   });
 });
 

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -1,7 +1,16 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
-import { resolveAgentsMdBudget } from "../policy/agents-md-budget.js";
+import {
+  type AgentsMdBudget,
+  type HarnessProfile,
+  type SkillFrontmatterTier,
+  resolveAgentsMdBudget,
+} from "../policy/agents-md-budget.js";
+import {
+  measureSkillFrontmatter,
+  type SkillFrontmatterMeasure,
+} from "./skill-frontmatter.js";
 
 export type OutputStream = "stdout" | "stderr" | "none";
 
@@ -14,11 +23,15 @@ export type OutputStream = "stdout" | "stderr" | "none";
  * north-star enforcement: DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR=1 (waiver:
  * DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1).
  *
- * DD-3 (harness-injected skill frontmatter in the meter) is deferred — this measure
- * covers the rendered managed section only.
+ * DD-3 (harness-injected skill frontmatter) is measured and itemized (#2463).
+ * Managed `absoluteMaxBytes` remains the fail-closed ratchet for the rendered
+ * managed section; skill-frontmatter caps are advisory unless
+ * `skillFrontmatterMaxBytes` is set (or enforced via env).
  */
 export const ABSOLUTE_MANAGED_MAX_BYTES = 8192;
 export const ABSOLUTE_MANAGED_MAX_TOKENS = 2000;
+/** Bootstrap host hooks are 0 B until #2438 ships. */
+export const BOOTSTRAP_HOOK_BYTES = 0;
 /** Rough UTF-8 bytes-per-token estimate for advisory reporting (~8192 B ≈ ~2048 tok). */
 export const ABSOLUTE_BYTES_PER_TOKEN_ESTIMATE = 4;
 
@@ -26,6 +39,15 @@ export const ABSOLUTE_BYTES_PER_TOKEN_ESTIMATE = 4;
 export interface ManagedSectionMeasure {
   readonly bytes: number;
   readonly estimatedTokens: number;
+}
+
+/** Itemized always-on bootstrap surface (managed + DD-3 + hooks). */
+export interface BootstrapMeasure {
+  readonly managed: ManagedSectionMeasure;
+  readonly skillFrontmatter: SkillFrontmatterMeasure;
+  readonly bootstrapHookBytes: number;
+  readonly totalBytes: number;
+  readonly totalEstimatedTokens: number;
 }
 
 /** Result of verify:agents-md-budget evaluation; three-state exit contract. */
@@ -155,10 +177,61 @@ export function measureManagedSection(text: string): ManagedSectionMeasure | { e
   };
 }
 
-function formatNorthStarOverage(measure: ManagedSectionMeasure): string {
+function resolveHarnessProfile(
+  budget: AgentsMdBudget | null,
+  projectRoot: string,
+): HarnessProfile {
+  const env = process.env.DEFT_AGENTS_MD_BUDGET_HARNESS_PROFILE?.trim();
+  if (env === "cursor" || env === "none") {
+    return env;
+  }
+  if (budget?.harnessProfile !== undefined) {
+    return budget.harnessProfile;
+  }
+  const skillsRoot = join(projectRoot, "content", "skills");
+  if (existsSync(skillsRoot)) {
+    return "cursor";
+  }
+  return "none";
+}
+
+function resolveSkillFrontmatterTier(budget: AgentsMdBudget | null): SkillFrontmatterTier {
+  const env = process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER?.trim();
+  if (env === "daily-core" || env === "all" || env === "none") {
+    return env;
+  }
+  return budget?.skillFrontmatterTier ?? "all";
+}
+
+/** Measure managed + DD-3 skill frontmatter + bootstrap hooks. */
+export function measureBootstrapSurface(
+  projectRoot: string,
+  managedText: string,
+  budget: AgentsMdBudget | null,
+): BootstrapMeasure | { error: string } {
+  const managedResult = measureManagedSection(managedText);
+  if ("error" in managedResult) {
+    return managedResult;
+  }
+  const harnessProfile = resolveHarnessProfile(budget, projectRoot);
+  const tier = resolveSkillFrontmatterTier(budget);
+  const skillFrontmatter = measureSkillFrontmatter(projectRoot, {
+    harnessProfile,
+    tier,
+    bytesPerToken: ABSOLUTE_BYTES_PER_TOKEN_ESTIMATE,
+  });
+  const totalBytes = managedResult.bytes + skillFrontmatter.bytes + BOOTSTRAP_HOOK_BYTES;
+  return {
+    managed: managedResult,
+    skillFrontmatter,
+    bootstrapHookBytes: BOOTSTRAP_HOOK_BYTES,
+    totalBytes,
+    totalEstimatedTokens: Math.ceil(totalBytes / ABSOLUTE_BYTES_PER_TOKEN_ESTIMATE),
+  };
+}
+
+function formatNorthStarOverageBytes(overBytes: number, overTokens: number): string {
   const parts: string[] = [];
-  const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
-  const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
   if (overBytes > 0) {
     parts.push(`${overBytes} bytes over`);
   }
@@ -168,45 +241,101 @@ function formatNorthStarOverage(measure: ManagedSectionMeasure): string {
   return parts.join(", ");
 }
 
+function formatNorthStarOverage(measure: ManagedSectionMeasure): string {
+  return formatNorthStarOverageBytes(
+    measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES,
+    measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS,
+  );
+}
+
+function formatCombinedNorthStarOverage(bootstrap: BootstrapMeasure): string {
+  return formatNorthStarOverageBytes(
+    bootstrap.totalBytes - ABSOLUTE_MANAGED_MAX_BYTES,
+    bootstrap.totalEstimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS,
+  );
+}
+
 function formatNorthStarDistance(measure: ManagedSectionMeasure): string {
   const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
   const overTokens = measure.estimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
   if (overBytes <= 0 && overTokens <= 0) {
     return (
-      `north-star: ${measure.bytes} bytes (~${measure.estimatedTokens} tok) within ` +
+      `north-star: managed ${measure.bytes} bytes (~${measure.estimatedTokens} tok) within ` +
       `≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok target.`
     );
   }
   return (
-    `north-star: ≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
+    `north-star: managed ≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
     `(current ${measure.bytes} bytes / ~${measure.estimatedTokens} tok — ` +
     `${formatNorthStarOverage(measure)}).`
   );
 }
 
-function formatAbsoluteAdvisory(measure: ManagedSectionMeasure): string {
+function formatCombinedNorthStarDistance(bootstrap: BootstrapMeasure): string {
+  const overBytes = bootstrap.totalBytes - ABSOLUTE_MANAGED_MAX_BYTES;
+  const overTokens = bootstrap.totalEstimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
+  if (overBytes <= 0 && overTokens <= 0) {
+    return (
+      `north-star: combined always-on ${bootstrap.totalBytes} bytes ` +
+      `(~${bootstrap.totalEstimatedTokens} tok) within ` +
+      `≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok target.`
+    );
+  }
   return (
-    `⚠ verify:agents-md-budget: managed section absolute budget advisory — ` +
-    `${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the north-star ` +
+    `north-star: combined always-on ≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
+    `(current ${bootstrap.totalBytes} bytes / ~${bootstrap.totalEstimatedTokens} tok — ` +
+    `${formatCombinedNorthStarOverage(bootstrap)}).`
+  );
+}
+
+function formatBootstrapItemization(bootstrap: BootstrapMeasure): string {
+  const { managed, skillFrontmatter, bootstrapHookBytes } = bootstrap;
+  const tierLabel =
+    skillFrontmatter.harnessProfile === "none"
+      ? "none"
+      : `${skillFrontmatter.harnessProfile}/${skillFrontmatter.tier}`;
+  const skillPart =
+    skillFrontmatter.bytes > 0
+      ? `skill-frontmatter ${skillFrontmatter.bytes} B (${tierLabel}, ${skillFrontmatter.skillCount} skills)`
+      : `skill-frontmatter 0 B (${tierLabel})`;
+  return (
+    `bootstrap: managed ${managed.bytes} B, ${skillPart}, hooks ${bootstrapHookBytes} B; ` +
+    `combined ${bootstrap.totalBytes} B (~${bootstrap.totalEstimatedTokens} tok)`
+  );
+}
+
+function formatAbsoluteAdvisory(bootstrap: BootstrapMeasure): string {
+  const measure = bootstrap.managed;
+  return (
+    `⚠ verify:agents-md-budget: always-on bootstrap advisory — ` +
+    `${formatBootstrapItemization(bootstrap)}.\n` +
+    `  Managed section alone: ${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the north-star ` +
     `of ${ABSOLUTE_MANAGED_MAX_BYTES} bytes / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
-    `(OVER: ${formatNorthStarOverage(measure)}). Advisory only — set ` +
-    "plan.policy.agentsMdBudget.absoluteMaxBytes to enable fail-closed growth ratchet (#2452).\n" +
-    "  The relative line ratchet (#645) remains fail-closed.\n" +
-    "  DD-3 harness skill frontmatter is not yet included in this meter."
+    `(OVER: ${formatNorthStarOverage(measure)}).\n` +
+    `  ${formatCombinedNorthStarDistance(bootstrap)}\n` +
+    "  Advisory only — set plan.policy.agentsMdBudget.absoluteMaxBytes to enable " +
+    "fail-closed managed growth ratchet (#2452).\n" +
+    "  Optional DD-3 ratchet: plan.policy.agentsMdBudget.skillFrontmatterMaxBytes (#2463).\n" +
+    "  Tier daily-core skills via OpenPackage or plan.policy.agentsMdBudget.skillFrontmatterTier.\n" +
+    "  Remediation: UPGRADING.md § Always-on bootstrap budget (DD-3).\n" +
+    "  The relative line ratchet (#645) remains fail-closed."
   );
 }
 
 function formatAbsoluteRefusal(
-  measure: ManagedSectionMeasure,
+  bootstrap: BootstrapMeasure,
   absoluteMaxBytes: number,
   projectRoot: string,
 ): string {
+  const measure = bootstrap.managed;
   const overBytes = measure.bytes - absoluteMaxBytes;
   return (
     `❌ verify:agents-md-budget: managed section grew past its absolute byte ratchet ` +
     `(project_root=${projectRoot}).\n` +
     `   managed section: ${measure.bytes}/${absoluteMaxBytes} bytes (OVER by ${overBytes})\n` +
+    `   ${formatBootstrapItemization(bootstrap)}\n` +
     `   ${formatNorthStarDistance(measure)}\n` +
+    `   ${formatCombinedNorthStarDistance(bootstrap)}\n` +
     "   AGENTS.md is a map, not a manual (#1882): push detail into a\n" +
     "   reference doc (main.md / a pack / docs/) and leave a pointer,\n" +
     "   rather than expanding AGENTS.md. See REFERENCES.md.\n" +
@@ -215,15 +344,38 @@ function formatAbsoluteRefusal(
   );
 }
 
-function formatNorthStarRefusal(measure: ManagedSectionMeasure, projectRoot: string): string {
-  const overBytes = measure.bytes - ABSOLUTE_MANAGED_MAX_BYTES;
+function formatSkillFrontmatterRefusal(
+  bootstrap: BootstrapMeasure,
+  skillFrontmatterMaxBytes: number,
+  projectRoot: string,
+): string {
+  const { skillFrontmatter } = bootstrap;
+  const overBytes = skillFrontmatter.bytes - skillFrontmatterMaxBytes;
   return (
-    `❌ verify:agents-md-budget: managed section exceeds the north-star ceiling ` +
+    `❌ verify:agents-md-budget: skill frontmatter grew past its DD-3 byte ratchet ` +
+    `(project_root=${projectRoot}).\n` +
+    `   skill-frontmatter: ${skillFrontmatter.bytes}/${skillFrontmatterMaxBytes} bytes ` +
+    `(OVER by ${overBytes}; tier ${skillFrontmatter.tier}, ${skillFrontmatter.skillCount} skills)\n` +
+    `   ${formatBootstrapItemization(bootstrap)}\n` +
+    `   ${formatCombinedNorthStarDistance(bootstrap)}\n` +
+    "   Tier deferred skills via OpenPackage (daily-core vs advanced) or shorten\n" +
+    "   SKILL.md descriptions. See UPGRADING.md § Always-on bootstrap budget (DD-3).\n" +
+    "   If the growth is deliberate, raise skillFrontmatterMaxBytes in\n" +
+    "   plan.policy.agentsMdBudget in PROJECT-DEFINITION (a reviewed diff). (#2463)"
+  );
+}
+
+function formatNorthStarRefusal(bootstrap: BootstrapMeasure, projectRoot: string): string {
+  const measure = bootstrap.managed;
+  const overBytes = bootstrap.totalBytes - ABSOLUTE_MANAGED_MAX_BYTES;
+  return (
+    `❌ verify:agents-md-budget: combined always-on surface exceeds the north-star ceiling ` +
     `(project_root=${projectRoot}, release-gate mode).\n` +
-    `   managed section: ${measure.bytes}/${ABSOLUTE_MANAGED_MAX_BYTES} bytes ` +
-    `(OVER by ${overBytes})\n` +
-    "   Thin the managed section toward the <=8192 B / ~2k tok north-star, or set\n" +
-    "   DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1 for a time-boxed operator waiver (#2452)."
+    `   ${formatBootstrapItemization(bootstrap)}\n` +
+    `   managed section: ${measure.bytes}/${ABSOLUTE_MANAGED_MAX_BYTES} bytes\n` +
+    `   combined OVER by ${overBytes} bytes vs north-star\n` +
+    "   Thin the managed section and/or tier DD-3 skills toward the <=8192 B target,\n" +
+    "   or set DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1 for a time-boxed operator waiver (#2452)."
   );
 }
 
@@ -237,24 +389,27 @@ function northStarWaiverActive(): boolean {
 
 function attachNorthStarNote<T extends EvaluateResult>(
   result: T,
-  measure: ManagedSectionMeasure,
+  bootstrap: BootstrapMeasure,
   options: { advisoryOnly: boolean },
 ): T {
-  const overBytes = measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES;
-  const overTokens = measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  const measure = bootstrap.managed;
+  const overManagedBytes = measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES;
+  const overManagedTokens = measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  const overCombinedBytes = bootstrap.totalBytes > ABSOLUTE_MANAGED_MAX_BYTES;
+  const overCombinedTokens = bootstrap.totalEstimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
   if (options.advisoryOnly) {
-    if (!overBytes && !overTokens) {
+    if (!overManagedBytes && !overManagedTokens && !overCombinedBytes && !overCombinedTokens) {
       return result;
     }
     return {
       ...result,
-      northStarMessage: formatAbsoluteAdvisory(measure),
+      northStarMessage: formatAbsoluteAdvisory(bootstrap),
       northStarStream: "stderr",
-      advisoryMessage: formatAbsoluteAdvisory(measure),
+      advisoryMessage: formatAbsoluteAdvisory(bootstrap),
       advisoryStream: "stderr",
     };
   }
-  const distance = formatNorthStarDistance(measure);
+  const distance = `${formatNorthStarDistance(measure)}\n   ${formatCombinedNorthStarDistance(bootstrap)}`;
   return {
     ...result,
     northStarMessage: distance,
@@ -264,8 +419,12 @@ function attachNorthStarNote<T extends EvaluateResult>(
   };
 }
 
-function formatAbsoluteSummary(measure: ManagedSectionMeasure, absoluteMaxBytes: number): string {
-  return `absolute ${measure.bytes}/${absoluteMaxBytes} bytes (~${measure.estimatedTokens} tok)`;
+function formatAbsoluteSummary(bootstrap: BootstrapMeasure, absoluteMaxBytes: number): string {
+  const measure = bootstrap.managed;
+  return (
+    `absolute managed ${measure.bytes}/${absoluteMaxBytes} bytes (~${measure.estimatedTokens} tok); ` +
+    `${formatBootstrapItemization(bootstrap)}`
+  );
 }
 
 function formatRefusal(
@@ -347,21 +506,23 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     };
   }
   const counts = regionResult.counts;
-  const measureResult = measureManagedSection(text);
-  if ("error" in measureResult) {
+  const bootstrapResult = measureBootstrapSurface(root, text, budgetResult.budget);
+  if ("error" in bootstrapResult) {
     return {
       code: 2,
-      message: `❌ verify:agents-md-budget: ${measureResult.error}`,
+      message: `❌ verify:agents-md-budget: ${bootstrapResult.error}`,
       stream: "stderr",
     };
   }
-  const measure = measureResult;
+  const bootstrap = bootstrapResult;
+  const measure = bootstrap.managed;
   const absoluteMaxBytes = budgetResult.budget?.absoluteMaxBytes;
   const advisoryOnly = absoluteMaxBytes === undefined;
+  const skillFrontmatterMaxBytes = budgetResult.budget?.skillFrontmatterMaxBytes;
 
   if (budgetResult.source === "unset") {
     if (quiet) {
-      return attachNorthStarNote({ code: 0, message: "", stream: "none" }, measure, {
+      return attachNorthStarNote({ code: 0, message: "", stream: "none" }, bootstrap, {
         advisoryOnly,
       });
     }
@@ -371,12 +532,13 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
         message:
           "⚠ verify:agents-md-budget: no plan.policy.agentsMdBudget configured " +
           `(managed=${counts.managed}, unmanaged=${counts.unmanaged} lines).\n` +
+          `  ${formatBootstrapItemization(bootstrap)}.\n` +
           "  Seed a ratchet at current size to freeze growth (#645): set\n" +
           "  plan.policy.agentsMdBudget.{managedMaxLines,unmanagedMaxLines} in " +
           "PROJECT-DEFINITION.",
         stream: "stderr",
       },
-      measure,
+      bootstrap,
       { advisoryOnly },
     );
   }
@@ -401,7 +563,7 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
         message: formatRefusal(counts, budget.managedMaxLines, budget.unmanagedMaxLines, root),
         stream: "stderr",
       },
-      measure,
+      bootstrap,
       { advisoryOnly },
     );
   }
@@ -410,34 +572,60 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     return attachNorthStarNote(
       {
         code: 1,
-        message: formatAbsoluteRefusal(measure, absoluteMaxBytes, root),
+        message: formatAbsoluteRefusal(bootstrap, absoluteMaxBytes, root),
         stream: "stderr",
       },
-      measure,
+      bootstrap,
       { advisoryOnly: false },
     );
   }
 
-  const overNorthStar =
-    measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES ||
-    measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
-  if (enforceNorthStarEnabled() && overNorthStar && !northStarWaiverActive()) {
+  if (
+    skillFrontmatterMaxBytes !== undefined &&
+    bootstrap.skillFrontmatter.bytes > skillFrontmatterMaxBytes
+  ) {
     return attachNorthStarNote(
       {
         code: 1,
-        message: formatNorthStarRefusal(measure, root),
+        message: formatSkillFrontmatterRefusal(bootstrap, skillFrontmatterMaxBytes, root),
         stream: "stderr",
       },
-      measure,
+      bootstrap,
+      { advisoryOnly: false },
+    );
+  }
+
+  const overNorthStarManaged =
+    measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES ||
+    measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  const overNorthStarCombined =
+    bootstrap.totalBytes > ABSOLUTE_MANAGED_MAX_BYTES ||
+    bootstrap.totalEstimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  if (
+    enforceNorthStarEnabled() &&
+    (overNorthStarManaged || overNorthStarCombined) &&
+    !northStarWaiverActive()
+  ) {
+    return attachNorthStarNote(
+      {
+        code: 1,
+        message: formatNorthStarRefusal(bootstrap, root),
+        stream: "stderr",
+      },
+      bootstrap,
       { advisoryOnly: false },
     );
   }
 
   const absoluteSummary =
-    absoluteMaxBytes !== undefined ? `; ${formatAbsoluteSummary(measure, absoluteMaxBytes)}` : "";
+    absoluteMaxBytes !== undefined ? `; ${formatAbsoluteSummary(bootstrap, absoluteMaxBytes)}` : "";
+  const bootstrapSummary =
+    absoluteMaxBytes === undefined ? `; ${formatBootstrapItemization(bootstrap)}` : "";
 
   if (quiet) {
-    return attachNorthStarNote({ code: 0, message: "", stream: "none" }, measure, { advisoryOnly });
+    return attachNorthStarNote({ code: 0, message: "", stream: "none" }, bootstrap, {
+      advisoryOnly,
+    });
   }
   return attachNorthStarNote(
     {
@@ -445,10 +633,10 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
       message:
         `✓ verify:agents-md-budget: managed ${counts.managed}/${budget.managedMaxLines}, ` +
         `unmanaged ${counts.unmanaged}/${budget.unmanagedMaxLines} lines (within ratchet)` +
-        `${absoluteSummary}.`,
+        `${absoluteSummary}${bootstrapSummary}.`,
       stream: "stdout",
     },
-    measure,
+    bootstrap,
     { advisoryOnly },
   );
 }

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -4,13 +4,10 @@ import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import {
   type AgentsMdBudget,
   type HarnessProfile,
-  type SkillFrontmatterTier,
   resolveAgentsMdBudget,
+  type SkillFrontmatterTier,
 } from "../policy/agents-md-budget.js";
-import {
-  measureSkillFrontmatter,
-  type SkillFrontmatterMeasure,
-} from "./skill-frontmatter.js";
+import { measureSkillFrontmatter, type SkillFrontmatterMeasure } from "./skill-frontmatter.js";
 
 export type OutputStream = "stdout" | "stderr" | "none";
 
@@ -177,10 +174,7 @@ export function measureManagedSection(text: string): ManagedSectionMeasure | { e
   };
 }
 
-function resolveHarnessProfile(
-  budget: AgentsMdBudget | null,
-  projectRoot: string,
-): HarnessProfile {
+function resolveHarnessProfile(budget: AgentsMdBudget | null, projectRoot: string): HarnessProfile {
   const env = process.env.DEFT_AGENTS_MD_BUDGET_HARNESS_PROFILE?.trim();
   if (env === "cursor" || env === "none") {
     return env;

--- a/packages/core/src/agents-md-budget/index.ts
+++ b/packages/core/src/agents-md-budget/index.ts
@@ -1,1 +1,2 @@
 export * from "./evaluate.js";
+export * from "./skill-frontmatter.js";

--- a/packages/core/src/agents-md-budget/skill-frontmatter.test.ts
+++ b/packages/core/src/agents-md-budget/skill-frontmatter.test.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  DAILY_CORE_SKILL_NAMES,
+  extractSkillDescription,
+  formatCursorAgentSkill,
+  measureSkillFrontmatter,
+} from "./skill-frontmatter.js";
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const t of temps) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function makeSkillsRepo(skills: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-skill-frontmatter-"));
+  temps.push(root);
+  for (const [name, body] of Object.entries(skills)) {
+    const dir = join(root, "content", "skills", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), body, "utf8");
+  }
+  return root;
+}
+
+describe("extractSkillDescription", () => {
+  it("parses folded YAML descriptions", () => {
+    const text = `---
+name: demo
+description: >-
+  Line one
+  line two.
+---
+# body`;
+    expect(extractSkillDescription(text)).toBe("Line one\nline two.");
+  });
+
+  it("parses single-line descriptions", () => {
+    const text = `---
+name: demo
+description: Short skill blurb.
+---
+# body`;
+    expect(extractSkillDescription(text)).toBe("Short skill blurb.");
+  });
+});
+
+describe("formatCursorAgentSkill", () => {
+  it("uses repo-relative POSIX paths", () => {
+    expect(formatCursorAgentSkill("content/skills/foo/SKILL.md", "Do foo.")).toBe(
+      '<agent_skill fullPath="content/skills/foo/SKILL.md">Do foo.</agent_skill>',
+    );
+  });
+});
+
+describe("measureSkillFrontmatter", () => {
+  const setupSkill = `---
+name: deft-directive-setup
+description: Setup project.
+---
+# Setup`;
+
+  const syncSkill = `---
+name: deft-directive-sync
+description: Sync framework.
+---
+# Sync`;
+
+  const releaseSkill = `---
+name: deft-directive-release
+description: Release workflows.
+---
+# Release`;
+
+  it("returns zero bytes when harness profile is none", () => {
+    const root = makeSkillsRepo({
+      "deft-directive-setup": setupSkill,
+    });
+    const result = measureSkillFrontmatter(root, { harnessProfile: "none" });
+    expect(result.bytes).toBe(0);
+    expect(result.skillCount).toBe(0);
+  });
+
+  it("measures all skills for cursor/all tier", () => {
+    const root = makeSkillsRepo({
+      "deft-directive-setup": setupSkill,
+      "deft-directive-release": releaseSkill,
+    });
+    const result = measureSkillFrontmatter(root, { harnessProfile: "cursor", tier: "all" });
+    expect(result.skillCount).toBe(2);
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it("filters to daily-core tier only", () => {
+    const root = makeSkillsRepo({
+      "deft-directive-setup": setupSkill,
+      "deft-directive-sync": syncSkill,
+      "deft-directive-release": releaseSkill,
+    });
+    const all = measureSkillFrontmatter(root, { harnessProfile: "cursor", tier: "all" });
+    const daily = measureSkillFrontmatter(root, { harnessProfile: "cursor", tier: "daily-core" });
+    expect(daily.skillCount).toBe(2);
+    expect(daily.bytes).toBeLessThan(all.bytes);
+    expect(daily.entries.every((e) => DAILY_CORE_SKILL_NAMES.includes(e.skillName as never))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/core/src/agents-md-budget/skill-frontmatter.ts
+++ b/packages/core/src/agents-md-budget/skill-frontmatter.ts
@@ -28,11 +28,11 @@ export function extractSkillDescription(text: string): string {
   const frontmatter = text.slice(3, closing).replace(/^\r?\n/, "");
   const lines = frontmatter.split(/\r?\n/);
   for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i];
+    const line = lines[i] ?? "";
     if (/^description:\s*>(-)?\s*$/.test(line)) {
       const descLines: string[] = [];
       for (let j = i + 1; j < lines.length; j += 1) {
-        const next = lines[j];
+        const next = lines[j] ?? "";
         if (!/^[ \t]/.test(next)) {
           break;
         }

--- a/packages/core/src/agents-md-budget/skill-frontmatter.ts
+++ b/packages/core/src/agents-md-budget/skill-frontmatter.ts
@@ -21,17 +21,31 @@ export function extractSkillDescription(text: string): string {
   if (!text.startsWith("---")) {
     return "";
   }
-  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (match === null || match[1] === undefined) {
+  const closing = text.indexOf("\n---", 3);
+  if (closing === -1) {
     return "";
   }
-  const frontmatter = match[1];
-  const folded = frontmatter.match(/^description:\s*>-?\s*\r?\n((?:[ \t].*\r?\n?)+)/m);
-  if (folded !== null && folded[1] !== undefined) {
-    return folded[1].replace(/^[ \t]+/gm, "").trim();
+  const frontmatter = text.slice(3, closing).replace(/^\r?\n/, "");
+  const lines = frontmatter.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^description:\s*>(-)?\s*$/.test(line)) {
+      const descLines: string[] = [];
+      for (let j = i + 1; j < lines.length; j += 1) {
+        const next = lines[j];
+        if (!/^[ \t]/.test(next)) {
+          break;
+        }
+        descLines.push(next.replace(/^[ \t]+/, ""));
+      }
+      return descLines.join("\n").trim();
+    }
+    const single = line.match(/^description:\s*(.+)$/);
+    if (single !== null && single[1] !== undefined) {
+      return single[1].trim();
+    }
   }
-  const single = frontmatter.match(/^description:\s*(.+)$/m);
-  return single !== null && single[1] !== undefined ? single[1].trim() : "";
+  return "";
 }
 
 /**

--- a/packages/core/src/agents-md-budget/skill-frontmatter.ts
+++ b/packages/core/src/agents-md-budget/skill-frontmatter.ts
@@ -1,0 +1,139 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, posix } from "node:path";
+
+/** Daily-core tier from spike #2370 / OpenPackage manifest (#2462). */
+export const DAILY_CORE_SKILL_NAMES = [
+  "deft-directive-setup",
+  "deft-directive-sync",
+  "deft-directive-build",
+  "deft-directive-pre-pr",
+  "deft-directive-review-cycle",
+  "deft-directive-triage",
+] as const;
+
+export type SkillFrontmatterTier = "daily-core" | "all" | "none";
+export type HarnessProfile = "cursor" | "none";
+
+const DAILY_CORE_SET = new Set<string>(DAILY_CORE_SKILL_NAMES);
+
+/** Extract the YAML `description` field from a SKILL.md frontmatter block. */
+export function extractSkillDescription(text: string): string {
+  if (!text.startsWith("---")) {
+    return "";
+  }
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (match === null || match[1] === undefined) {
+    return "";
+  }
+  const frontmatter = match[1];
+  const folded = frontmatter.match(/^description:\s*>-?\s*\r?\n((?:[ \t].*\r?\n?)+)/m);
+  if (folded !== null && folded[1] !== undefined) {
+    return folded[1].replace(/^[ \t]+/gm, "").trim();
+  }
+  const single = frontmatter.match(/^description:\s*(.+)$/m);
+  return single !== null && single[1] !== undefined ? single[1].trim() : "";
+}
+
+/**
+ * Cursor `<agent_skill>` injection shape (DD-3 minimum).
+ * Uses repo-relative POSIX paths for stable cross-platform byte counts.
+ */
+export function formatCursorAgentSkill(relPath: string, description: string): string {
+  const normalized = relPath.replace(/\\/g, "/");
+  return `<agent_skill fullPath="${normalized}">${description}</agent_skill>`;
+}
+
+export interface SkillFrontmatterEntry {
+  readonly skillName: string;
+  readonly relPath: string;
+  readonly bytes: number;
+}
+
+export interface SkillFrontmatterMeasure {
+  readonly bytes: number;
+  readonly estimatedTokens: number;
+  readonly skillCount: number;
+  readonly tier: SkillFrontmatterTier;
+  readonly harnessProfile: HarnessProfile;
+  readonly entries: readonly SkillFrontmatterEntry[];
+}
+
+export interface MeasureSkillFrontmatterOptions {
+  readonly skillsRoot?: string;
+  readonly tier?: SkillFrontmatterTier;
+  readonly harnessProfile?: HarnessProfile;
+  readonly bytesPerToken?: number;
+}
+
+function defaultSkillsRoot(projectRoot: string): string {
+  return join(projectRoot, "content", "skills");
+}
+
+function listSkillDirs(skillsRoot: string): string[] {
+  if (!existsSync(skillsRoot)) {
+    return [];
+  }
+  return readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function skillMatchesTier(skillName: string, tier: SkillFrontmatterTier): boolean {
+  if (tier === "none") {
+    return false;
+  }
+  if (tier === "all") {
+    return true;
+  }
+  return DAILY_CORE_SET.has(skillName);
+}
+
+/** Measure harness-injected skill frontmatter bytes for the configured profile/tier. */
+export function measureSkillFrontmatter(
+  projectRoot: string,
+  options: MeasureSkillFrontmatterOptions = {},
+): SkillFrontmatterMeasure {
+  const harnessProfile = options.harnessProfile ?? "cursor";
+  const tier = options.tier ?? "all";
+  const bytesPerToken = options.bytesPerToken ?? 4;
+  const skillsRoot = options.skillsRoot ?? defaultSkillsRoot(projectRoot);
+
+  if (harnessProfile === "none" || tier === "none") {
+    return {
+      bytes: 0,
+      estimatedTokens: 0,
+      skillCount: 0,
+      tier,
+      harnessProfile,
+      entries: [],
+    };
+  }
+
+  const entries: SkillFrontmatterEntry[] = [];
+  for (const skillName of listSkillDirs(skillsRoot)) {
+    if (!skillMatchesTier(skillName, tier)) {
+      continue;
+    }
+    const skillPath = join(skillsRoot, skillName, "SKILL.md");
+    if (!existsSync(skillPath)) {
+      continue;
+    }
+    const text = readFileSync(skillPath, "utf8");
+    const description = extractSkillDescription(text);
+    const relPath = posix.join("content", "skills", skillName, "SKILL.md");
+    const block = formatCursorAgentSkill(relPath, description);
+    const bytes = Buffer.byteLength(block, "utf8");
+    entries.push({ skillName, relPath, bytes });
+  }
+
+  const bytes = entries.reduce((sum, entry) => sum + entry.bytes, 0);
+  return {
+    bytes,
+    estimatedTokens: Math.ceil(bytes / bytesPerToken),
+    skillCount: entries.length,
+    tier,
+    harnessProfile,
+    entries,
+  };
+}

--- a/packages/core/src/policy/agents-md-budget.test.ts
+++ b/packages/core/src/policy/agents-md-budget.test.ts
@@ -180,6 +180,62 @@ describe("resolveAgentsMdBudget", () => {
     expect(result.error).toContain("absoluteMaxBytes");
   });
 
+  it("resolves optional DD-3 harness and tier fields", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepoWithPlan({
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 1,
+            unmanagedMaxLines: 2,
+            harnessProfile: "cursor",
+            skillFrontmatterTier: "daily-core",
+            skillFrontmatterMaxBytes: 2080,
+          },
+        },
+      }),
+    );
+    expect(result.source).toBe("typed");
+    expect(result.budget).toEqual({
+      managedMaxLines: 1,
+      unmanagedMaxLines: 2,
+      harnessProfile: "cursor",
+      skillFrontmatterTier: "daily-core",
+      skillFrontmatterMaxBytes: 2080,
+    });
+  });
+
+  it("returns default-on-error when harnessProfile is invalid", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepoWithPlan({
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 1,
+            unmanagedMaxLines: 2,
+            harnessProfile: "warp",
+          },
+        },
+      }),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("harnessProfile");
+  });
+
+  it("returns default-on-error when skillFrontmatterTier is invalid", () => {
+    const result = resolveAgentsMdBudget(
+      makeRepoWithPlan({
+        policy: {
+          agentsMdBudget: {
+            managedMaxLines: 1,
+            unmanagedMaxLines: 2,
+            skillFrontmatterTier: "premium",
+          },
+        },
+      }),
+    );
+    expect(result.source).toBe("default-on-error");
+    expect(result.error).toContain("skillFrontmatterTier");
+  });
+
   it("reads the namespaced x-directive/policy block", () => {
     const result = resolveAgentsMdBudget(
       makeRepoWithPlan({

--- a/packages/core/src/policy/agents-md-budget.ts
+++ b/packages/core/src/policy/agents-md-budget.ts
@@ -12,6 +12,9 @@ import { loadProjectDefinition } from "./resolve.js";
  * it is an explicit, reviewed diff to this typed field -- that diff IS the
  * "was this growth deliberate?" checkpoint.
  */
+export type HarnessProfile = "cursor" | "none";
+export type SkillFrontmatterTier = "daily-core" | "all" | "none";
+
 export interface AgentsMdBudget {
   readonly managedMaxLines: number;
   readonly unmanagedMaxLines: number;
@@ -21,6 +24,21 @@ export interface AgentsMdBudget {
    * this ceiling fails. The <=8192 B north-star is reported separately.
    */
   readonly absoluteMaxBytes?: number;
+  /**
+   * Harness profile for DD-3 skill-frontmatter measurement (#2463).
+   * When unset, the gate auto-detects `cursor` when `content/skills/` exists.
+   */
+  readonly harnessProfile?: HarnessProfile;
+  /**
+   * Skill tier for DD-3 frontmatter caps (`daily-core` vs `all` vs `none`).
+   * Defaults to `all` for reporting when unset.
+   */
+  readonly skillFrontmatterTier?: SkillFrontmatterTier;
+  /**
+   * Optional fail-closed ratchet for DD-3 skill-frontmatter bytes (#2463).
+   * Advisory when unset; growth past this ceiling fails when set.
+   */
+  readonly skillFrontmatterMaxBytes?: number;
 }
 
 export type AgentsMdBudgetSource = "typed" | "unset" | "default-on-error";
@@ -133,21 +151,81 @@ export function resolveAgentsMdBudget(projectRoot: string): AgentsMdBudgetResult
     return { budget: null, source: "default-on-error", error: absolute.error };
   }
 
+  const skillFrontmatterMax = readOptionalRegion(block, "skillFrontmatterMaxBytes");
+  if (skillFrontmatterMax.error !== null) {
+    return { budget: null, source: "default-on-error", error: skillFrontmatterMax.error };
+  }
+
+  const harnessProfile = readOptionalHarnessProfile(block, "harnessProfile");
+  if (harnessProfile.error !== null) {
+    return { budget: null, source: "default-on-error", error: harnessProfile.error };
+  }
+
+  const skillFrontmatterTier = readOptionalSkillTier(block, "skillFrontmatterTier");
+  if (skillFrontmatterTier.error !== null) {
+    return { budget: null, source: "default-on-error", error: skillFrontmatterTier.error };
+  }
+
   const budget: AgentsMdBudget = {
     managedMaxLines: managed.value as number,
     unmanagedMaxLines: unmanaged.value as number,
   };
-  if (absolute.value !== undefined) {
-    return {
-      budget: { ...budget, absoluteMaxBytes: absolute.value },
-      source: "typed",
-      error: null,
-    };
-  }
+  const withOptional: AgentsMdBudget = {
+    ...budget,
+    ...(absolute.value !== undefined ? { absoluteMaxBytes: absolute.value } : {}),
+    ...(skillFrontmatterMax.value !== undefined
+      ? { skillFrontmatterMaxBytes: skillFrontmatterMax.value }
+      : {}),
+    ...(harnessProfile.value !== undefined ? { harnessProfile: harnessProfile.value } : {}),
+    ...(skillFrontmatterTier.value !== undefined
+      ? { skillFrontmatterTier: skillFrontmatterTier.value }
+      : {}),
+  };
 
   return {
-    budget,
+    budget: withOptional,
     source: "typed",
     error: null,
   };
+}
+
+const HARNESS_PROFILES = new Set<HarnessProfile>(["cursor", "none"]);
+const SKILL_FRONTMATTER_TIERS = new Set<SkillFrontmatterTier>(["daily-core", "all", "none"]);
+
+function readOptionalHarnessProfile(
+  block: Record<string, unknown>,
+  key: string,
+): { value: HarnessProfile | undefined; error: string | null } {
+  if (!(key in block)) {
+    return { value: undefined, error: null };
+  }
+  const raw = block[key];
+  if (typeof raw !== "string" || !HARNESS_PROFILES.has(raw as HarnessProfile)) {
+    return {
+      value: undefined,
+      error:
+        `plan.policy.agentsMdBudget.${key} must be one of ${[...HARNESS_PROFILES].join(", ")}; ` +
+        `got ${pythonTypeName(raw)} (${pythonRepr(raw)})`,
+    };
+  }
+  return { value: raw as HarnessProfile, error: null };
+}
+
+function readOptionalSkillTier(
+  block: Record<string, unknown>,
+  key: string,
+): { value: SkillFrontmatterTier | undefined; error: string | null } {
+  if (!(key in block)) {
+    return { value: undefined, error: null };
+  }
+  const raw = block[key];
+  if (typeof raw !== "string" || !SKILL_FRONTMATTER_TIERS.has(raw as SkillFrontmatterTier)) {
+    return {
+      value: undefined,
+      error:
+        `plan.policy.agentsMdBudget.${key} must be one of ${[...SKILL_FRONTMATTER_TIERS].join(", ")}; ` +
+        `got ${pythonTypeName(raw)} (${pythonRepr(raw)})`,
+    };
+  }
+  return { value: raw as SkillFrontmatterTier, error: null };
 }

--- a/xbrief/active/2026-07-13-2463-featgate-dd-3-harness-skill-frontmatter-in-verifyagents-md-b.xbrief.json
+++ b/xbrief/active/2026-07-13-2463-featgate-dd-3-harness-skill-frontmatter-in-verifyagents-md-b.xbrief.json
@@ -1,0 +1,108 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "feat(gate): DD-3 harness skill frontmatter in verify:agents-md-budget",
+    "created": "2026-07-13T01:07:42.365Z",
+    "updated": "2026-07-13T01:07:42.365Z"
+  },
+  "plan": {
+    "id": "2463-dd3-budget-meter",
+    "title": "feat(gate): DD-3 harness skill frontmatter in verify:agents-md-budget",
+    "status": "running",
+    "narratives": {
+      "Description": "Extend verify:agents-md-budget so gate output itemizes managed AGENTS.md bytes plus harness-injected skill frontmatter (Cursor agent_skill shape) and bootstrap-hook bytes (0 until #2438). Support tier-aware caps for daily-core versus all skills, keep task check green at the seeded absoluteMaxBytes ratchet, and document remediation when the combined always-on surface exceeds the 8192 B north-star.",
+      "UserStory": "As a framework maintainer, I want verify:agents-md-budget to count DD-3 skill frontmatter bytes, so that always-on bootstrap cost is visible and ratchetable against the north-star.",
+      "ImplementationPlan": "1) Extend packages/core/src/agents-md-budget/evaluate.ts (and index.ts) to measure skill frontmatter for configured harness profiles; Cursor <agent_skill> shape minimum; remove/update the DD-3 deferred comment. 2) Itemize gate output: managed bytes + skill-frontmatter bytes + bootstrap-hook bytes (0 until #2438). Support tier-aware caps (daily-core vs all) via plan.policy.agentsMdBudget and/or env; align daily-core skill list with #2462 / spike docs/analysis/2026-07-13-2370-packaging-cross-harness-spike.md. 3) Update packages/core/src/policy/agents-md-budget.ts (+ tests) for any new typed policy fields. 4) Tests in packages/core/src/agents-md-budget/evaluate.test.ts covering itemization, tier caps, and master green at current seeded budgets. 5) Document remediation when DD-3 + managed exceeds north-star (gate message and/or UPGRADING/docs pointer). CHANGELOG [Unreleased] Closes #2463. Verify: pnpm exec vitest run packages/core/src/agents-md-budget packages/core/src/policy/agents-md-budget.test.ts; task check --allow-over-cap; task verify:agents-md-budget.",
+      "Origin": "Enriched for swarm from #2463 under epic #2369 Wave 3 action"
+    },
+    "items": [
+      {
+        "id": "2463-a1",
+        "title": "Itemize managed + frontmatter + hooks in evaluate",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given Cursor skill frontmatter fixtures, when verify:agents-md-budget runs, then output itemizes managed + skill-frontmatter + bootstrap-hook bytes.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2463-a2",
+        "title": "Tier-aware caps daily-core vs all",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a daily-core tier config, when the gate evaluates, then frontmatter cap can use the daily-core skill set without requiring all skills.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2463-a3",
+        "title": "Tests + task check green on seeded budgets",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given current absoluteMaxBytes seed, when task check runs on master-equivalent tree, then the gate stays green and new tests pass.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2463-a4",
+        "title": "CHANGELOG + PR Closes #2463",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the meter lands, when PR merges, then CHANGELOG cites Closes #2463 and remediation guidance exists.",
+          "Traces": "FR-1"
+        }
+      }
+    ],
+    "tags": [
+      "context-engineering",
+      "harness"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2463",
+        "type": "x-xbrief/github-issue",
+        "title": "#2463"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2370",
+        "type": "x-xbrief/refs",
+        "title": "#2370"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2452",
+        "type": "x-xbrief/refs",
+        "title": "#2452"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/agents-md-budget/",
+          "packages/core/src/policy/agents-md-budget.ts",
+          "packages/core/src/policy/agents-md-budget.test.ts",
+          "CHANGELOG.md",
+          "UPGRADING.md"
+        ],
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "size": "medium",
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/agents-md-budget",
+          "task verify:agents-md-budget",
+          "task check --allow-over-cap"
+        ],
+        "expected_outputs": [
+          "DD-3 itemized gate output",
+          "tests green",
+          "PR merged Closes #2463"
+        ],
+        "depends_on": [],
+        "conflict_group": "agents-md-budget-2463"
+      }
+    },
+    "updated": "2026-07-13T01:07:42.365Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Extend `verify:agents-md-budget` to itemize managed AGENTS.md bytes, Cursor `<agent_skill>` frontmatter (DD-3), and bootstrap hooks (0 until #2438)
- Add tier-aware measurement (daily-core vs all) via policy fields and env overrides; managed `absoluteMaxBytes` ratchet stays fail-closed, DD-3 caps advisory unless `skillFrontmatterMaxBytes` is seeded
- Document remediation in UPGRADING when combined always-on exceeds the 8192 B north-star

## Test plan
- [x] `npx vitest run packages/core/src/agents-md-budget packages/core/src/policy/agents-md-budget.test.ts`
- [x] `npx vitest run packages/cli/src/verify-agents-md-budget.test.ts`
- [x] `task verify:agents-md-budget` (itemizes 16843 + 7727 + 0 B on maintainer HEAD)
- [ ] CI `task check`

Closes #2463
