### PR TITLE
fix: refuse symlink escapes in triage cache and init deposit writers (#2446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release Step 5 no longer poisons the TypeScript check lane with branch-bypass and release-preflight environment variables, so production cuts can run a full `task check` on master without false vitest failures or `--skip-ci`. Closes #2434. Closes #2469.
 - **The documented `xbrief:preflight` gate works again.** `task xbrief:preflight` and `deft xbrief:preflight` now resolve to the same #810 implementation-intent check as the legacy `vbrief:preflight` verb, accept `xbrief/active/` paths, and print clearer usage hints on failure. Closes #2449.
 - **New scope xBRIEFs now stamp the current v0.8 schema version.** Emit paths (`scope:decompose`, issue ingest, speckit, and project render) were still writing `vBRIEFInfo.version = "0.6"`; they now follow `@deftai/directive-types` `VBRIEF_VERSION` so freshly generated artifacts match the declared current schema. Closes #2318.
+- **Triage cache and init/update writers refuse symlink escapes.** Routine commands such as doctor, triage summary, and directive init/update no longer follow repo-controlled symlinks on `xbrief`, `.triage-cache`, or installer-managed projection paths — they fail closed instead of writing outside the checkout. Closes #2446.
 
 ### Removed
 

--- a/packages/core/src/init-deposit/scaffold-containment.test.ts
+++ b/packages/core/src/init-deposit/scaffold-containment.test.ts
@@ -131,9 +131,7 @@ describe("init-deposit projection containment (#2446)", () => {
       writeFileSync(join(deftDir, ".githooks", "pre-commit"), "#!/bin/sh\n", "utf8");
       chmodSync(join(deftDir, ".githooks", "pre-commit"), 0o755);
 
-      await expect(writeAgentsSkills(project, captureIo().io)).rejects.toThrow(
-        ProjectionContainmentError,
-      );
+      expect(() => writeAgentsSkills(project, captureIo().io)).toThrow(ProjectionContainmentError);
       expect(existsSync(join(escapeDir, "skills"))).toBe(false);
     },
   );

--- a/packages/core/src/init-deposit/scaffold-containment.test.ts
+++ b/packages/core/src/init-deposit/scaffold-containment.test.ts
@@ -118,21 +118,18 @@ describe("init-deposit projection containment (#2446)", () => {
     },
   );
 
-  itSymlink(
-    "depositNeutralization fails closed when .agents is a symlink outside the project",
-    async () => {
-      const project = freshRoot("scaffold-agentsdir-symlink-");
-      const escapeDir = freshEscape("scaffold-agentsdir-escape-");
-      mkdirSync(escapeDir, { recursive: true });
-      symlinkSync(escapeDir, join(project, ".agents"), "dir");
+  itSymlink("writeAgentsSkills refuses when .agents is a symlink outside the project", () => {
+    const project = freshRoot("scaffold-agentsdir-symlink-");
+    const escapeDir = freshEscape("scaffold-agentsdir-escape-");
+    mkdirSync(escapeDir, { recursive: true });
+    symlinkSync(escapeDir, join(project, ".agents"), "dir");
 
-      const deftDir = join(project, ".deft", "core");
-      mkdirSync(join(deftDir, ".githooks"), { recursive: true });
-      writeFileSync(join(deftDir, ".githooks", "pre-commit"), "#!/bin/sh\n", "utf8");
-      chmodSync(join(deftDir, ".githooks", "pre-commit"), 0o755);
+    const deftDir = join(project, ".deft", "core");
+    mkdirSync(join(deftDir, ".githooks"), { recursive: true });
+    writeFileSync(join(deftDir, ".githooks", "pre-commit"), "#!/bin/sh\n", "utf8");
+    chmodSync(join(deftDir, ".githooks", "pre-commit"), 0o755);
 
-      expect(() => writeAgentsSkills(project, captureIo().io)).toThrow(ProjectionContainmentError);
-      expect(existsSync(join(escapeDir, "skills"))).toBe(false);
-    },
-  );
+    expect(() => writeAgentsSkills(project, captureIo().io)).toThrow(ProjectionContainmentError);
+    expect(existsSync(join(escapeDir, "skills"))).toBe(false);
+  });
 });

--- a/packages/core/src/init-deposit/scaffold-containment.test.ts
+++ b/packages/core/src/init-deposit/scaffold-containment.test.ts
@@ -1,0 +1,140 @@
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
+import {
+  depositNeutralization,
+  ensureGitattributes,
+  ensureTaskfile,
+  writeAgentsMd,
+  writeAgentsSkills,
+} from "./scaffold.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("init-deposit projection containment (#2446)", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshRoot(prefix: string): string {
+    const root = mkdtempSync(join(tmpdir(), prefix));
+    created.push(root);
+    return root;
+  }
+
+  function freshEscape(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    created.push(dir);
+    return dir;
+  }
+
+  function captureIo(): { io: { printf: (text: string) => void } } {
+    return { io: { printf: () => {} } };
+  }
+
+  function seedFramework(deftDir: string): void {
+    mkdirSync(join(deftDir, "templates"), { recursive: true });
+    copyFileSync(
+      join(process.cwd(), "content/templates/agents-entry.md"),
+      join(deftDir, "templates/agents-entry.md"),
+    );
+    copyFileSync(
+      join(process.cwd(), "content/templates/agents-consumer-header.md"),
+      join(deftDir, "templates/agents-consumer-header.md"),
+    );
+  }
+
+  itSymlink("writeAgentsMd refuses when AGENTS.md is a symlink outside the project", () => {
+    const project = freshRoot("scaffold-agents-symlink-");
+    const deftDir = join(project, ".deft", "core");
+    const escapeDir = freshEscape("scaffold-agents-escape-");
+    const escapeFile = join(escapeDir, "stolen-agents.md");
+    seedFramework(deftDir);
+    writeFileSync(escapeFile, "victim\n", "utf8");
+    symlinkSync(escapeFile, join(project, "AGENTS.md"));
+
+    expect(() => writeAgentsMd(project, deftDir, captureIo().io)).toThrow(
+      ProjectionContainmentError,
+    );
+    expect(readFileSync(escapeFile, "utf8")).toBe("victim\n");
+  });
+
+  itSymlink("ensureTaskfile refuses when Taskfile.yml is a symlink outside the project", () => {
+    const project = freshRoot("scaffold-taskfile-symlink-");
+    const escapeDir = freshEscape("scaffold-taskfile-escape-");
+    const escapeFile = join(escapeDir, "stolen-taskfile.yml");
+    writeFileSync(escapeFile, "victim\n", "utf8");
+    symlinkSync(escapeFile, join(project, "Taskfile.yml"));
+
+    expect(() => ensureTaskfile(project, captureIo().io)).toThrow(ProjectionContainmentError);
+    expect(readFileSync(escapeFile, "utf8")).toBe("victim\n");
+  });
+
+  itSymlink(
+    "ensureGitattributes refuses when .gitattributes is a symlink outside the project",
+    () => {
+      const project = freshRoot("scaffold-ga-symlink-");
+      const escapeDir = freshEscape("scaffold-ga-escape-");
+      const escapeFile = join(escapeDir, "stolen.gitattributes");
+      writeFileSync(escapeFile, "victim\n", "utf8");
+      symlinkSync(escapeFile, join(project, ".gitattributes"));
+
+      expect(() => ensureGitattributes(project, captureIo().io)).toThrow(
+        ProjectionContainmentError,
+      );
+      expect(readFileSync(escapeFile, "utf8")).toBe("victim\n");
+    },
+  );
+
+  itSymlink(
+    "depositNeutralization fails closed when greptile.json is a symlink outside the project",
+    async () => {
+      const project = freshRoot("scaffold-greptile-symlink-");
+      const escapeDir = freshEscape("scaffold-greptile-escape-");
+      const escapeFile = join(escapeDir, "stolen-greptile.json");
+      writeFileSync(escapeFile, '{"victim":true}\n', "utf8");
+      symlinkSync(escapeFile, join(project, "greptile.json"));
+
+      await expect(depositNeutralization(project, captureIo().io)).rejects.toThrow(
+        ProjectionContainmentError,
+      );
+      expect(readFileSync(escapeFile, "utf8")).toBe('{"victim":true}\n');
+    },
+  );
+
+  itSymlink(
+    "depositNeutralization fails closed when .agents is a symlink outside the project",
+    async () => {
+      const project = freshRoot("scaffold-agentsdir-symlink-");
+      const escapeDir = freshEscape("scaffold-agentsdir-escape-");
+      mkdirSync(escapeDir, { recursive: true });
+      symlinkSync(escapeDir, join(project, ".agents"), "dir");
+
+      const deftDir = join(project, ".deft", "core");
+      mkdirSync(join(deftDir, ".githooks"), { recursive: true });
+      writeFileSync(join(deftDir, ".githooks", "pre-commit"), "#!/bin/sh\n", "utf8");
+      chmodSync(join(deftDir, ".githooks", "pre-commit"), 0o755);
+
+      await expect(writeAgentsSkills(project, captureIo().io)).rejects.toThrow(
+        ProjectionContainmentError,
+      );
+      expect(existsSync(join(escapeDir, "skills"))).toBe(false);
+    },
+  );
+});

--- a/packages/core/src/init-deposit/scaffold-containment.test.ts
+++ b/packages/core/src/init-deposit/scaffold-containment.test.ts
@@ -118,6 +118,33 @@ describe("init-deposit projection containment (#2446)", () => {
     },
   );
 
+  itSymlink(
+    "writeAgentsSkills refuses symlinked .agents even when all skills already exist outside the project",
+    () => {
+      const project = freshRoot("scaffold-agentsdir-prepop-");
+      const escapeDir = freshEscape("scaffold-agentsdir-prepop-escape-");
+      const skillDirs = [
+        "deft",
+        "deft-directive-setup",
+        "deft-directive-build",
+        "deft-directive-review-cycle",
+        "deft-directive-refinement",
+        "deft-directive-swarm",
+        "deft-directive-interview",
+        "deft-directive-pre-pr",
+        "deft-directive-sync",
+      ];
+      for (const dir of skillDirs) {
+        const skillDir = join(escapeDir, "skills", dir);
+        mkdirSync(skillDir, { recursive: true });
+        writeFileSync(join(skillDir, "SKILL.md"), `# ${dir}\n`, "utf8");
+      }
+      symlinkSync(escapeDir, join(project, ".agents"), "dir");
+
+      expect(() => writeAgentsSkills(project, captureIo().io)).toThrow(ProjectionContainmentError);
+    },
+  );
+
   itSymlink("writeAgentsSkills refuses when .agents is a symlink outside the project", () => {
     const project = freshRoot("scaffold-agentsdir-symlink-");
     const escapeDir = freshEscape("scaffold-agentsdir-escape-");

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -442,6 +442,8 @@ export async function writeConsumerVbrief(
 }
 
 export function writeAgentsSkills(projectDir: string, io: InitDepositIo): boolean {
+  projectionTarget(projectDir, ".agents");
+
   const allExist = AGENTS_SKILLS.every((skill) =>
     existsSync(join(projectDir, ".agents", "skills", skill.dir, "SKILL.md")),
   );

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -19,6 +19,10 @@ import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { platform } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { copyTree } from "../deposit/copy-tree.js";
+import {
+  assertProjectionContained,
+  ProjectionContainmentError,
+} from "../fs/projection-containment.js";
 import { agentsRefreshPlan } from "../platform/agents-md.js";
 import { MIGRATED_ARTIFACT_DIR } from "../xbrief-migrate/constants.js";
 import { CANONICAL_INSTALL_ROOT, type InitDepositIo } from "./constants.js";
@@ -27,6 +31,13 @@ import { installerManagedGuardEre } from "./hygiene.js";
 export type { InitDepositIo };
 export { CANONICAL_INSTALL_ROOT };
 export const CORE_GLOB = ".deft/core/**";
+
+/** Refuse init/update projection writes that escape via repo-controlled symlinks (#2446). */
+function projectionTarget(projectDir: string, ...relSegments: string[]): string {
+  const target = join(projectDir, ...relSegments);
+  assertProjectionContained(projectDir, target);
+  return target;
+}
 
 const CODEQL_CONFIG_REL = ".github/codeql/codeql-config.yml";
 const CORE_GUARD_WORKFLOW_REL = ".github/workflows/deft-core-guard.yml";
@@ -293,7 +304,7 @@ export function ensurePackageJsonPin(
   io: InitDepositIo,
 ): EnsurePackageJsonPinResult {
   const pinVersion = version.trim().replace(/^v/i, "");
-  const path = join(projectDir, "package.json");
+  const path = projectionTarget(projectDir, "package.json");
   const existed = existsSync(path);
 
   let pkg: Record<string, unknown> = {};
@@ -351,7 +362,7 @@ export function writeAgentsMd(projectDir: string, deftDir: string, io: InitDepos
   if (typeof newContent !== "string") {
     throw new Error("AGENTS.md render produced no content");
   }
-  const path = join(projectDir, "AGENTS.md");
+  const path = projectionTarget(projectDir, "AGENTS.md");
   writeFileSync(path, newContent, "utf8");
   if (state === "absent") {
     io.printf("AGENTS.md created.\n");
@@ -361,9 +372,9 @@ export function writeAgentsMd(projectDir: string, deftDir: string, io: InitDepos
   return true;
 }
 
-async function ensureVbriefLifecycleDirs(consumerVbrief: string): Promise<void> {
+async function ensureVbriefLifecycleDirs(projectDir: string): Promise<void> {
   for (const sub of VBRIEF_LIFECYCLE_DIRS) {
-    const dir = join(consumerVbrief, sub);
+    const dir = projectionTarget(projectDir, MIGRATED_ARTIFACT_DIR, sub);
     await mkdir(dir, { recursive: true, mode: 0o755 });
     const gitkeep = join(dir, ".gitkeep");
     try {
@@ -393,9 +404,9 @@ export async function writeConsumerVbrief(
   deftDir: string,
   io: InitDepositIo,
 ): Promise<boolean> {
-  const consumerVbrief = join(projectDir, MIGRATED_ARTIFACT_DIR);
-  const schemasDst = join(consumerVbrief, "schemas");
-  const vbriefMdDst = join(consumerVbrief, "vbrief.md");
+  const consumerVbrief = projectionTarget(projectDir, MIGRATED_ARTIFACT_DIR);
+  const schemasDst = projectionTarget(projectDir, MIGRATED_ARTIFACT_DIR, "schemas");
+  const vbriefMdDst = projectionTarget(projectDir, MIGRATED_ARTIFACT_DIR, "vbrief.md");
 
   const schemasPresent = existsSync(schemasDst) && statSync(schemasDst).isDirectory();
   const vbriefMdPresent = existsSync(vbriefMdDst) && statSync(vbriefMdDst).isFile();
@@ -425,7 +436,7 @@ export async function writeConsumerVbrief(
     }
   }
 
-  await ensureVbriefLifecycleDirs(consumerVbrief);
+  await ensureVbriefLifecycleDirs(projectDir);
   io.printf("vbrief/ deposited at project root (schemas + vbrief.md + lifecycle dirs).\n");
   return true;
 }
@@ -440,9 +451,9 @@ export function writeAgentsSkills(projectDir: string, io: InitDepositIo): boolea
   }
 
   for (const skill of AGENTS_SKILLS) {
-    const dir = join(projectDir, ".agents", "skills", skill.dir);
+    const dir = projectionTarget(projectDir, ".agents", "skills", skill.dir);
     mkdirSync(dir, { recursive: true });
-    const path = join(dir, "SKILL.md");
+    const path = projectionTarget(projectDir, ".agents", "skills", skill.dir, "SKILL.md");
     if (existsSync(path)) continue;
     writeFileSync(path, skill.content, "utf8");
   }
@@ -489,7 +500,7 @@ function insertDeftIncludeAfterIncludesLine(content: string): { content: string;
 }
 
 export function ensureTaskfile(projectDir: string, io: InitDepositIo): boolean {
-  const path = join(projectDir, "Taskfile.yml");
+  const path = projectionTarget(projectDir, "Taskfile.yml");
   let existing = "";
   if (existsSync(path)) {
     existing = readFileSync(path, "utf8");
@@ -560,7 +571,7 @@ export function writeConsumerGitHooks(
     return false;
   }
 
-  const dstDir = join(projectDir, ".githooks");
+  const dstDir = projectionTarget(projectDir, ".githooks");
   mkdirSync(dstDir, { recursive: true });
 
   let filesDeposited = false;
@@ -568,7 +579,7 @@ export function writeConsumerGitHooks(
     const src = join(srcDir, name);
     if (!existsSync(src)) continue;
     const data = readFileSync(src);
-    const dst = join(dstDir, name);
+    const dst = projectionTarget(projectDir, ".githooks", name);
     const existing = existsSync(dst) ? readFileSync(dst) : null;
     const isHookScript = HOOK_FILENAMES.includes(name as (typeof HOOK_FILENAMES)[number]);
     if (!existing?.equals(data)) {
@@ -763,7 +774,7 @@ function coreGuardWorkflowContent(): string {
 }
 
 export function ensureGitattributes(projectDir: string, io: InitDepositIo): boolean {
-  const path = join(projectDir, ".gitattributes");
+  const path = projectionTarget(projectDir, ".gitattributes");
   const existing = existsSync(path) ? readFileSync(path, "utf8") : "";
   const present = new Set(existing.split("\n").map((line) => line.trim()));
   const additions = CORE_GITATTRIBUTES_LINES.filter((line) => !present.has(line));
@@ -799,7 +810,7 @@ function appendGreptilePattern(patterns: string, glob: string): string {
 }
 
 export function ensureGreptileIgnore(projectDir: string, io: InitDepositIo): boolean {
-  const path = join(projectDir, "greptile.json");
+  const path = projectionTarget(projectDir, "greptile.json");
   const fileExisted = existsSync(path);
   let raw = fileExisted ? readFileSync(path, "utf8") : "";
   if (!raw.trim()) raw = "{}";
@@ -878,7 +889,7 @@ function insertCodeqlPathsIgnore(content: string, glob: string): { content: stri
 }
 
 export function ensureCodeqlPathsIgnore(projectDir: string, io: InitDepositIo): boolean {
-  const path = join(projectDir, CODEQL_CONFIG_REL);
+  const path = projectionTarget(projectDir, CODEQL_CONFIG_REL);
   if (!existsSync(path)) {
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, codeqlConfigDefault(), "utf8");
@@ -900,7 +911,7 @@ export function ensureCodeqlPathsIgnore(projectDir: string, io: InitDepositIo): 
 }
 
 export function ensureCoreGuardWorkflow(projectDir: string, io: InitDepositIo): boolean {
-  const path = join(projectDir, CORE_GUARD_WORKFLOW_REL);
+  const path = projectionTarget(projectDir, CORE_GUARD_WORKFLOW_REL);
   const desired = coreGuardWorkflowContent();
   if (existsSync(path)) {
     const existing = readFileSync(path, "utf8");
@@ -1000,6 +1011,9 @@ export async function depositNeutralization(
     try {
       await step();
     } catch (cause) {
+      if (cause instanceof ProjectionContainmentError) {
+        throw cause;
+      }
       io.printf(`Warning: neutralization step failed: ${String(cause)}\n`);
     }
   }

--- a/packages/core/src/triage/bootstrap/gitignore.ts
+++ b/packages/core/src/triage/bootstrap/gitignore.ts
@@ -519,14 +519,17 @@ function ensureEvalReadme(options: EnsureEvalReadmeOptions): StepOutcome {
 
 /** Ensure the #1144 hybrid policy is encoded in the repo (idempotent). */
 export function stepEnsureGitignoreEvalEntries(projectRoot: string): StepOutcome {
-  // Layout-aware (#2109): resolve the README under the active lifecycle `.eval`
-  // dir (xbrief/ when migrated, else vbrief/) instead of a hardcoded vbrief/ path.
-  const readmePath = resolveTriageCachePath(projectRoot, "README.md");
+  const stepName = "ensure_gitignore_eval_entries";
+  let readmePath: string;
+  try {
+    readmePath = resolveTriageCachePath(projectRoot, "README.md");
+  } catch (err) {
+    return containmentFailure(stepName, err);
+  }
   const readmeRel = evalRelDisplay(projectRoot, readmePath);
   const entries = gitignoreTriageCacheEntries(projectRoot);
   const glob = gitattributesTriageCacheGlob(projectRoot);
   const ruleLine = `${glob}  merge=union`;
-  const stepName = "ensure_gitignore_eval_entries";
   const details: Record<string, unknown> = {};
 
   const giResult = ensureGitignoreSelectiveEntries(projectRoot, stepName, entries);

--- a/packages/core/src/triage/cache-path.test.ts
+++ b/packages/core/src/triage/cache-path.test.ts
@@ -1,11 +1,21 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { writeState } from "../doctor/doctor-state.js";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import { append } from "../intake/candidates-log.js";
 import { resolveEvalDir } from "../layout/resolve.js";
 import {
+  ensureTriageCacheDir,
   migrateLegacyTriageCacheFromEval,
   resolveCandidatesLogPath,
   resolveTriageCacheDir,
@@ -13,6 +23,8 @@ import {
   TRIAGE_CACHE_DIR_NAME,
   triageCacheRelPath,
 } from "./cache-path.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
 
 describe("triage cache-path (#1703)", () => {
   let root: string;
@@ -222,5 +234,76 @@ describe("triage cache-path (#1703)", () => {
     const canonical = join(root, "xbrief", TRIAGE_CACHE_DIR_NAME, "candidates.jsonl");
     expect(existsSync(canonical)).toBe(true);
     expect(existsSync(join(legacyDir, "candidates.jsonl"))).toBe(false);
+  });
+});
+
+describe("triage cache-path symlink containment (#2446)", () => {
+  let root: string;
+  const temps: string[] = [];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "triage-cache-contain-"));
+    temps.push(root);
+  });
+
+  afterEach(() => {
+    for (const t of temps.splice(0)) {
+      if (t !== root) rmSync(t, { recursive: true, force: true });
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function seedXbrief(): void {
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "s.xbrief.json"),
+      JSON.stringify({ plan: { id: "s", status: "running", items: [] } }),
+      "utf8",
+    );
+  }
+
+  function freshEscape(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    temps.push(dir);
+    return dir;
+  }
+
+  itSymlink("refuses when xbrief is a symlink escaping the project tree", () => {
+    seedXbrief();
+    const escapeDir = freshEscape("triage-xbrief-escape-");
+    rmSync(join(root, "xbrief"), { recursive: true, force: true });
+    symlinkSync(escapeDir, join(root, "xbrief"), "dir");
+
+    expect(() => resolveTriageCacheDir(root)).toThrow(ProjectionContainmentError);
+    expect(() => ensureTriageCacheDir(root)).toThrow(/symlink escaping/);
+    expect(existsSync(join(escapeDir, TRIAGE_CACHE_DIR_NAME))).toBe(false);
+  });
+
+  itSymlink("refuses when .triage-cache is a symlink escaping the project tree", () => {
+    seedXbrief();
+    const escapeDir = freshEscape("triage-cache-escape-");
+    const escapeFile = join(escapeDir, "stolen.jsonl");
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(escapeFile, "victim\n", "utf8");
+    symlinkSync(escapeFile, join(root, "xbrief", TRIAGE_CACHE_DIR_NAME));
+
+    expect(() => resolveTriageCachePath(root, "candidates.jsonl")).toThrow(
+      ProjectionContainmentError,
+    );
+    expect(readFileSync(escapeFile, "utf8")).toBe("victim\n");
+  });
+
+  itSymlink("migrateLegacyTriageCacheFromEval refuses without out-of-tree mkdir", () => {
+    seedXbrief();
+    const escapeDir = freshEscape("triage-migrate-escape-");
+    const legacyDir = resolveEvalDir(root);
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, "candidates.jsonl"), "legacy\n", "utf8");
+    rmSync(join(root, "xbrief"), { recursive: true, force: true });
+    symlinkSync(escapeDir, join(root, "xbrief"), "dir");
+
+    expect(() => migrateLegacyTriageCacheFromEval(root)).toThrow(/symlink escaping/);
+    expect(existsSync(join(escapeDir, TRIAGE_CACHE_DIR_NAME))).toBe(false);
+    expect(readFileSync(join(legacyDir, "candidates.jsonl"), "utf8")).toBe("legacy\n");
   });
 });

--- a/packages/core/src/triage/cache-path.test.ts
+++ b/packages/core/src/triage/cache-path.test.ts
@@ -296,7 +296,7 @@ describe("triage cache-path symlink containment (#2446)", () => {
   itSymlink("migrateLegacyTriageCacheFromEval refuses without out-of-tree mkdir", () => {
     seedXbrief();
     const escapeDir = freshEscape("triage-migrate-escape-");
-    const legacyDir = resolveEvalDir(root);
+    const legacyDir = join(escapeDir, ".eval");
     mkdirSync(legacyDir, { recursive: true });
     writeFileSync(join(legacyDir, "candidates.jsonl"), "legacy\n", "utf8");
     rmSync(join(root, "xbrief"), { recursive: true, force: true });

--- a/packages/core/src/triage/cache-path.ts
+++ b/packages/core/src/triage/cache-path.ts
@@ -7,6 +7,7 @@
 
 import { existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
+import { assertProjectionContained } from "../fs/projection-containment.js";
 import {
   MIGRATED_ARTIFACT_DIR,
   resolveEvalDir,
@@ -43,8 +44,8 @@ export interface TriageCacheMigrationResult {
   readonly removedLegacyFiles: readonly string[];
 }
 
-/** Absolute path to the layout-aware `.triage-cache/` directory. */
-export function resolveTriageCacheDir(projectRoot: string): string {
+/** Compute the layout-aware `.triage-cache/` directory without containment checks. */
+function triageCacheDirPath(projectRoot: string): string {
   let layoutRoot: string;
   try {
     layoutRoot = resolveLifecycleRoot(projectRoot);
@@ -52,6 +53,19 @@ export function resolveTriageCacheDir(projectRoot: string): string {
     layoutRoot = join(projectRoot, MIGRATED_ARTIFACT_DIR); // No xbrief/ layout; use canonical path.
   }
   return join(layoutRoot, TRIAGE_CACHE_DIR_NAME);
+}
+
+/** Refuse symlink-escaping xbrief/.triage-cache before mkdir/read/write (#2446). */
+function assertWritableTriageCachePath(projectRoot: string, ...segments: string[]): void {
+  const base = triageCacheDirPath(projectRoot);
+  const target = segments.length > 0 ? join(base, ...segments) : base;
+  assertProjectionContained(projectRoot, target);
+}
+
+/** Absolute path to the layout-aware `.triage-cache/` directory. */
+export function resolveTriageCacheDir(projectRoot: string): string {
+  assertWritableTriageCachePath(projectRoot);
+  return triageCacheDirPath(projectRoot);
 }
 
 /** POSIX-style path relative to project root (e.g. `xbrief/.triage-cache/foo`). */
@@ -83,7 +97,8 @@ export function migrateLegacyTriageCacheFromEval(projectRoot: string): TriageCac
       removedLegacyFiles: [],
     };
   }
-  const targetDir = resolveTriageCacheDir(projectRoot);
+  assertWritableTriageCachePath(projectRoot);
+  const targetDir = triageCacheDirPath(projectRoot);
   const migratedFiles: string[] = [];
   const skippedFiles: string[] = [];
   const migratedDirs: string[] = [];
@@ -141,8 +156,9 @@ export function migrateLegacyTriageCacheFromEval(projectRoot: string): TriageCac
 
 /** Resolve a path under `.triage-cache/`, migrating legacy `.eval/` files first. */
 export function resolveTriageCachePath(projectRoot: string, ...segments: string[]): string {
+  assertWritableTriageCachePath(projectRoot, ...segments);
   migrateLegacyTriageCacheFromEval(projectRoot);
-  return join(resolveTriageCacheDir(projectRoot), ...segments);
+  return join(triageCacheDirPath(projectRoot), ...segments);
 }
 
 /** Display helper: project-root-relative POSIX path for logs and gitignore copy. */
@@ -160,8 +176,9 @@ export function resolveCandidatesLogPath(projectRoot: string): string {
 
 /** Ensure the triage cache directory exists (post-migration). */
 export function ensureTriageCacheDir(projectRoot: string): string {
+  assertWritableTriageCachePath(projectRoot);
   migrateLegacyTriageCacheFromEval(projectRoot);
-  const dir = resolveTriageCacheDir(projectRoot);
+  const dir = triageCacheDirPath(projectRoot);
   mkdirSync(dir, { recursive: true });
   return dir;
 }

--- a/packages/core/src/triage/cache-path.ts
+++ b/packages/core/src/triage/cache-path.ts
@@ -97,8 +97,7 @@ export function migrateLegacyTriageCacheFromEval(projectRoot: string): TriageCac
       removedLegacyFiles: [],
     };
   }
-  assertWritableTriageCachePath(projectRoot);
-  const targetDir = triageCacheDirPath(projectRoot);
+  const targetDir = resolveTriageCacheDir(projectRoot);
   const migratedFiles: string[] = [];
   const skippedFiles: string[] = [];
   const migratedDirs: string[] = [];
@@ -176,9 +175,8 @@ export function resolveCandidatesLogPath(projectRoot: string): string {
 
 /** Ensure the triage cache directory exists (post-migration). */
 export function ensureTriageCacheDir(projectRoot: string): string {
-  assertWritableTriageCachePath(projectRoot);
   migrateLegacyTriageCacheFromEval(projectRoot);
-  const dir = triageCacheDirPath(projectRoot);
+  const dir = resolveTriageCacheDir(projectRoot);
   mkdirSync(dir, { recursive: true });
   return dir;
 }

--- a/packages/core/src/triage/scope/mutations-core.ts
+++ b/packages/core/src/triage/scope/mutations-core.ts
@@ -93,23 +93,23 @@ export function recordSubscriptionChange(
     extra?: Record<string, unknown>;
   },
 ): void {
-  const historyPath = resolveTriageCachePath(projectRoot, "subscription-history.jsonl");
-  const record: Record<string, unknown> = {
-    schema: SUBSCRIPTION_HISTORY_SCHEMA,
-    change_id: randomUUID(),
-    timestamp: utcIso(),
-    actor: resolveActor(options.actor),
-    op: options.op,
-    label: options.label ?? null,
-    milestone: options.milestone ?? null,
-    issue: options.issue ?? null,
-    author: options.author ?? null,
-    before: options.before ?? [],
-    after: options.after ?? [],
-  };
-  if (options.extra) record.extra = options.extra;
-  const line = JSON.stringify(record, Object.keys(record).sort());
   try {
+    const historyPath = resolveTriageCachePath(projectRoot, "subscription-history.jsonl");
+    const record: Record<string, unknown> = {
+      schema: SUBSCRIPTION_HISTORY_SCHEMA,
+      change_id: randomUUID(),
+      timestamp: utcIso(),
+      actor: resolveActor(options.actor),
+      op: options.op,
+      label: options.label ?? null,
+      milestone: options.milestone ?? null,
+      issue: options.issue ?? null,
+      author: options.author ?? null,
+      before: options.before ?? [],
+      after: options.after ?? [],
+    };
+    if (options.extra) record.extra = options.extra;
+    const line = JSON.stringify(record, Object.keys(record).sort());
     mkdirSync(dirname(historyPath), { recursive: true });
     appendFileSync(historyPath, `${line}\n`, "utf8");
   } catch {

--- a/packages/core/src/triage/scope/mutations-core.ts
+++ b/packages/core/src/triage/scope/mutations-core.ts
@@ -93,23 +93,23 @@ export function recordSubscriptionChange(
     extra?: Record<string, unknown>;
   },
 ): void {
+  const historyPath = resolveTriageCachePath(projectRoot, "subscription-history.jsonl");
+  const record: Record<string, unknown> = {
+    schema: SUBSCRIPTION_HISTORY_SCHEMA,
+    change_id: randomUUID(),
+    timestamp: utcIso(),
+    actor: resolveActor(options.actor),
+    op: options.op,
+    label: options.label ?? null,
+    milestone: options.milestone ?? null,
+    issue: options.issue ?? null,
+    author: options.author ?? null,
+    before: options.before ?? [],
+    after: options.after ?? [],
+  };
+  if (options.extra) record.extra = options.extra;
+  const line = JSON.stringify(record, Object.keys(record).sort());
   try {
-    const historyPath = resolveTriageCachePath(projectRoot, "subscription-history.jsonl");
-    const record: Record<string, unknown> = {
-      schema: SUBSCRIPTION_HISTORY_SCHEMA,
-      change_id: randomUUID(),
-      timestamp: utcIso(),
-      actor: resolveActor(options.actor),
-      op: options.op,
-      label: options.label ?? null,
-      milestone: options.milestone ?? null,
-      issue: options.issue ?? null,
-      author: options.author ?? null,
-      before: options.before ?? [],
-      after: options.after ?? [],
-    };
-    if (options.extra) record.extra = options.extra;
-    const line = JSON.stringify(record, Object.keys(record).sort());
     mkdirSync(dirname(historyPath), { recursive: true });
     appendFileSync(historyPath, `${line}\n`, "utf8");
   } catch {

--- a/packages/core/src/triage/scope/scope-coverage-boost.test.ts
+++ b/packages/core/src/triage/scope/scope-coverage-boost.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectionContainmentError } from "../../fs/projection-containment.js";
 import { parseCliArgs, runCliCapture } from "./cli.js";
 import {
   addLabelToScope,
@@ -111,7 +112,9 @@ describe("mutations-core branch coverage", () => {
     process.env.DEFT_TRIAGE_ACTOR = "ci:bot";
     recordSubscriptionChange(root, { op: "test", label: "x" });
     delete process.env.DEFT_TRIAGE_ACTOR;
-    recordSubscriptionChange("/\0invalid", { op: "test" });
+    expect(() => recordSubscriptionChange("/\0invalid", { op: "test" })).toThrow(
+      ProjectionContainmentError,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Apply \ssertProjectionContained\ to triage/lifecycle cache path resolution so symlinked \xbrief\ or \.triage-cache\ cannot steer doctor, triage summary, or scope lifecycle writes outside the checkout.
- Guard init/update projection writers (AGENTS.md, Taskfile.yml, .agents/, .githooks/, greptile.json, .gitattributes, CodeQL config, core-guard workflow) before mkdir/write/chmod.
- Add symlink-at-target and parent-path regression tests for both surfaces.

Closes #2446

## Test plan

- [x] \pnpm exec vitest run packages/core/src/fs/projection-containment.test.ts packages/core/src/triage/cache-path.test.ts packages/core/src/init-deposit\`n- [x] \	ask verify:branch\ / \	ask verify:forward-coverage\ / \	ask verify:encoding\`n- [ ] CI green on Linux (symlink regression tests execute there)

Made with [Cursor](https://cursor.com)