### PR TITLE
fix(release): strip Step-5 poison env from ts check lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release Step 5 no longer poisons the TypeScript check lane with branch-bypass and release-preflight environment variables, so production cuts can run a full `task check` on master without false vitest failures or `--skip-ci`. Closes #2434. Closes #2469.
+
 ### Removed
 
 ## [0.75.0] - 2026-07-13

--- a/packages/core/src/ts-check-lane/index.ts
+++ b/packages/core/src/ts-check-lane/index.ts
@@ -1,2 +1,8 @@
 export type { LaneRunner, ResolvePnpmOptions, RunnerResult, RunTsLaneOptions } from "./run-lane.js";
-export { LANE_COMMANDS, resolvePnpm, runTsLane, SKIP_NOTICE } from "./run-lane.js";
+export {
+  LANE_COMMANDS,
+  resolvePnpm,
+  runTsLane,
+  SKIP_NOTICE,
+  sanitizeTsLaneEnv,
+} from "./run-lane.js";

--- a/packages/core/src/ts-check-lane/run-lane.test.ts
+++ b/packages/core/src/ts-check-lane/run-lane.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV } from "../release/constants.js";
 import {
   LANE_COMMANDS,
   resolvePnpm,
   runTsLane,
   SKIP_NOTICE,
+  sanitizeTsLaneEnv,
   shouldUseShellForCommand,
 } from "./run-lane.js";
 
@@ -22,6 +24,36 @@ class Runner {
     return { status: code };
   };
 }
+
+describe("sanitizeTsLaneEnv", () => {
+  it("removes release Step-5 bypass vars while preserving other env", () => {
+    const base = {
+      PATH: "/usr/bin",
+      HOME: "/home/user",
+      [BRANCH_GATE_BYPASS_ENV]: "1",
+      [RELEASE_PREFLIGHT_ENV]: "1",
+    };
+
+    const sanitized = sanitizeTsLaneEnv(base);
+
+    expect(sanitized.PATH).toBe("/usr/bin");
+    expect(sanitized.HOME).toBe("/home/user");
+    expect(sanitized[BRANCH_GATE_BYPASS_ENV]).toBeUndefined();
+    expect(sanitized[RELEASE_PREFLIGHT_ENV]).toBeUndefined();
+  });
+
+  it("does not mutate the input env object", () => {
+    const base = {
+      [BRANCH_GATE_BYPASS_ENV]: "1",
+      [RELEASE_PREFLIGHT_ENV]: "1",
+    };
+
+    sanitizeTsLaneEnv(base);
+
+    expect(base[BRANCH_GATE_BYPASS_ENV]).toBe("1");
+    expect(base[RELEASE_PREFLIGHT_ENV]).toBe("1");
+  });
+});
 
 describe("runTsLane", () => {
   it("skips with a notice when pnpm is absent", () => {

--- a/packages/core/src/ts-check-lane/run-lane.ts
+++ b/packages/core/src/ts-check-lane/run-lane.ts
@@ -20,6 +20,10 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { posix, win32 } from "node:path";
+import { BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV } from "../release/constants.js";
+
+/** Release Step-5 vars that must not leak into vitest via inherited pnpm env (#2434). */
+const TS_LANE_POISON_ENV_KEYS = [BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV] as const;
 
 /**
  * Run order is deliberate: lint (cheapest, catches the biome class first),
@@ -45,6 +49,18 @@ export interface RunnerResult {
 
 export type LaneRunner = (argv: readonly string[], cwd: string) => RunnerResult;
 
+/**
+ * Strip release preflight bypass vars before spawning pnpm/vitest so nested unit
+ * tests observe fail-closed branch and cache gates (#2434 / #1553 recurrence).
+ */
+export function sanitizeTsLaneEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...base };
+  for (const key of TS_LANE_POISON_ENV_KEYS) {
+    delete env[key];
+  }
+  return env;
+}
+
 export interface RunTsLaneOptions {
   /** Resolved pnpm executable path, or null when not installed. */
   readonly pnpm: string | null;
@@ -68,6 +84,7 @@ function defaultRunner(argv: readonly string[], cwd: string): RunnerResult {
   const commandPath = command ?? "";
   const result = spawnSync(commandPath, rest, {
     cwd,
+    env: sanitizeTsLaneEnv(process.env),
     stdio: "inherit",
     shell: shouldUseShellForCommand(commandPath),
   });


### PR DESCRIPTION
## Summary

Release Step 5 `releaseCheckEnv` intentionally sets branch-bypass and release-preflight flags for live `verify:branch` / `verify:cache-fresh`, but those vars were inherited by the whole `pnpm run test` / vitest tree and caused false failures on production cuts. This change strips those vars in `sanitizeTsLaneEnv` before the TS check lane spawns pnpm/vitest while leaving `releaseCheckEnv` unchanged for gate siblings.

## Related Issues

Closes #2434
Closes #2469

## Checklist

- [x] `/deft:change <name>` — N/A (<3 file source changes; scoped bugfix)
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A (release-time batch)
- [x] Tests pass locally (`pnpm run test`, targeted `run-lane` vitest)

## Test plan

- [x] `pnpm exec vitest run packages/core/src/ts-check-lane/run-lane.test.ts`
- [x] `pnpm run test` (full vitest suite)
- [x] `pnpm run build`
