### PR TITLE
fix: wire xbrief:preflight implementation-intent gate (#2449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Release Step 5 no longer poisons the TypeScript check lane with branch-bypass and release-preflight environment variables, so production cuts can run a full `task check` on master without false vitest failures or `--skip-ci`. Closes #2434. Closes #2469.
+- **The documented `xbrief:preflight` gate works again.** `task xbrief:preflight` and `deft xbrief:preflight` now resolve to the same #810 implementation-intent check as the legacy `vbrief:preflight` verb, accept `xbrief/active/` paths, and print clearer usage hints on failure. Closes #2449.
 
 ### Removed
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -125,6 +125,9 @@ includes:
   vbrief:
     taskfile: ./tasks/vbrief.yml
     optional: true
+  xbrief:
+    taskfile: ./tasks/xbrief.yml
+    optional: true
   prd:
     taskfile: ./tasks/prd.yml
     optional: true

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -64,6 +64,13 @@ describe("routeArgv", () => {
     expect(routeArgv(["vbrief", "validate"]).argv).toEqual(["vbrief:validate"]);
   });
 
+  it("maps xbrief preflight to xbrief:preflight", () => {
+    expect(routeArgv(["xbrief", "preflight", "xbrief/active/story.xbrief.json"]).argv).toEqual([
+      "xbrief:preflight",
+      "xbrief/active/story.xbrief.json",
+    ]);
+  });
+
   it("maps pr merge-ready to pr-merge-readiness", () => {
     expect(routeArgv(["pr", "merge-ready", "--repo", "deftai/directive"]).argv).toEqual([
       "pr-merge-readiness",
@@ -135,6 +142,7 @@ describe("taskKeyToDispatchArgv", () => {
       "x.xbrief.json",
     ]);
     expect(taskKeyToDispatchArgv("vbrief:preflight")).toEqual(["vbrief:preflight"]);
+    expect(taskKeyToDispatchArgv("xbrief:preflight")).toEqual(["xbrief:preflight"]);
     expect(taskKeyToDispatchArgv("triage:welcome")).toEqual(["triage:welcome"]);
     expect(taskKeyToDispatchArgv("triage:reset", ["--issue", "1"])).toEqual([
       "triage-actions",

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -243,6 +243,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "verify:no-task-runtime": "verify-no-task-runtime",
   "vbrief:validate": "vbrief-validate",
   "vbrief:preflight": "vbrief-preflight",
+  "xbrief:preflight": "vbrief-preflight",
   "vbrief:activate": "vbrief-activate",
   "verify:story-ready": "verify-story-ready",
   "verify:tools": "verify-tools",

--- a/packages/cli/src/lifecycle-cli/dispatch-vbrief.test.ts
+++ b/packages/cli/src/lifecycle-cli/dispatch-vbrief.test.ts
@@ -30,6 +30,7 @@ function writePendingVbrief(root: string, status = "pending"): string {
 describe("deft-ts vbrief lifecycle verbs (#1838 s3)", () => {
   it("resolves task-style vbrief aliases to canonical verbs", () => {
     expect(resolveCanonicalVerb("vbrief:preflight")).toBe("vbrief-preflight");
+    expect(resolveCanonicalVerb("xbrief:preflight")).toBe("vbrief-preflight");
     expect(resolveCanonicalVerb("vbrief:validate")).toBe("vbrief-validate");
     expect(resolveCanonicalVerb("vbrief:activate")).toBe("vbrief-activate");
   });
@@ -47,6 +48,15 @@ describe("deft-ts vbrief lifecycle verbs (#1838 s3)", () => {
     const alias = await runDispatch(["vbrief:preflight", "--vbrief-path", path]);
     expect(alias.exitCode).toBe(canonical.exitCode);
     expect(canonical.exitCode).toBe(1);
+  });
+
+  it("xbrief:preflight alias resolves and matches vbrief:preflight", async () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-lc-xpf-"));
+    temps.push(root);
+    const path = writePendingVbrief(root);
+    const legacy = await runDispatch(["vbrief:preflight", "--vbrief-path", path]);
+    const canonical = await runDispatch(["xbrief:preflight", "--vbrief-path", path]);
+    expect(canonical.exitCode).toBe(legacy.exitCode);
   });
 
   it("vbrief-activate requires a positional vbrief path", async () => {

--- a/packages/cli/src/vbrief-preflight.test.ts
+++ b/packages/cli/src/vbrief-preflight.test.ts
@@ -33,14 +33,23 @@ function silentRun(argv: string[]): number {
 }
 
 describe("parseArgs", () => {
-  it("requires --vbrief-path", () => {
+  it("requires --vbrief-path or positional path", () => {
     expect(parseArgs([]).error).toContain("--vbrief-path");
+    expect(parseArgs([]).error).toContain("xbrief:preflight");
   });
   it("parses --vbrief-path and --json", () => {
     expect(parseArgs(["--vbrief-path", "/x", "--json"])).toMatchObject({
       vbriefPath: "/x",
       emitJson: true,
     });
+  });
+  it("parses --brief-path alias", () => {
+    expect(parseArgs(["--brief-path", "/x"]).vbriefPath).toBe("/x");
+  });
+  it("parses positional path", () => {
+    expect(parseArgs(["xbrief/active/story.xbrief.json"]).vbriefPath).toBe(
+      "xbrief/active/story.xbrief.json",
+    );
   });
   it("parses --vbrief-path= form", () => {
     expect(parseArgs(["--vbrief-path=/y"]).vbriefPath).toBe("/y");

--- a/packages/cli/src/vbrief-preflight.ts
+++ b/packages/cli/src/vbrief-preflight.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
-import { emitJson, evaluate } from "@deftai/directive-core/preflight";
+import { emitJson, evaluate, PREFLIGHT_USAGE_HINT } from "@deftai/directive-core/preflight";
 
 interface ParsedArgs {
   vbriefPath: string | null;
@@ -8,7 +8,19 @@ interface ParsedArgs {
   error?: string;
 }
 
-/** Parse vbrief-preflight CLI args, mirroring the Python argparse surface (#810). */
+const PATH_FLAG_NAMES = ["--vbrief-path", "--brief-path", "--xbrief-path"] as const;
+
+function assignPathFlag(parsed: ParsedArgs, value: string | undefined): ParsedArgs | null {
+  if (value === undefined || value.length === 0) {
+    return { ...parsed, error: "argument --vbrief-path: expected one argument" };
+  }
+  if (parsed.vbriefPath !== null) {
+    return { ...parsed, error: "multiple path arguments are not allowed" };
+  }
+  return { ...parsed, vbriefPath: value };
+}
+
+/** Parse vbrief-preflight / xbrief:preflight CLI args (#810 / #2449). */
 export function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     vbriefPath: null,
@@ -18,21 +30,41 @@ export function parseArgs(argv: string[]): ParsedArgs {
     const arg = argv[i];
     if (arg === "--json") {
       parsed.emitJson = true;
-    } else if (arg === "--vbrief-path") {
-      const value = argv[i + 1];
-      if (value === undefined) {
-        return { ...parsed, error: "argument --vbrief-path: expected one argument" };
-      }
-      parsed.vbriefPath = value;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      return parsed;
+    }
+    if (PATH_FLAG_NAMES.includes(arg as (typeof PATH_FLAG_NAMES)[number])) {
+      const next = assignPathFlag(parsed, argv[i + 1]);
+      if (next?.error !== undefined) return next;
+      parsed.vbriefPath = next?.vbriefPath ?? null;
       i += 1;
-    } else if (arg?.startsWith("--vbrief-path=")) {
-      parsed.vbriefPath = arg.slice("--vbrief-path=".length);
-    } else {
+      continue;
+    }
+    let matchedEqualsForm = false;
+    for (const flag of PATH_FLAG_NAMES) {
+      if (arg?.startsWith(`${flag}=`)) {
+        const next = assignPathFlag(parsed, arg.slice(flag.length + 1));
+        if (next?.error !== undefined) return next;
+        parsed.vbriefPath = next?.vbriefPath ?? null;
+        matchedEqualsForm = true;
+        break;
+      }
+    }
+    if (matchedEqualsForm) continue;
+    if (arg?.startsWith("-")) {
       return { ...parsed, error: `unrecognized argument: ${arg}` };
     }
+    const next = assignPathFlag(parsed, arg);
+    if (next?.error !== undefined) return next;
+    parsed.vbriefPath = next?.vbriefPath ?? null;
   }
   if (parsed.vbriefPath === null) {
-    return { ...parsed, error: "the following arguments are required: --vbrief-path" };
+    return {
+      ...parsed,
+      error: `the following arguments are required: --vbrief-path (or positional path). ${PREFLIGHT_USAGE_HINT}`,
+    };
   }
   return parsed;
 }

--- a/packages/core/src/content-contracts/standards/taskfile_cli_args.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_cli_args.test.ts
@@ -420,6 +420,15 @@ describe("test_taskfile_cli_args.py", () => {
     }
     expect(matches).toEqual([]);
   });
+  it("test_no_double_quoted_cli_args[xbrief.yml]", () => {
+    const text = readFileSync(join(repoRoot(), "tasks", "xbrief.yml"), { encoding: "utf8" });
+    const matches: string[] = [];
+    for (const line of text.split("\n")) {
+      if (line.trimStart().startsWith("#")) continue;
+      if (DOUBLE_QUOTED_CLI_ARGS.test(line)) matches.push(line.trim());
+    }
+    expect(matches).toEqual([]);
+  });
   it("test_no_double_quoted_cli_args[verify.yml]", () => {
     const text = readFileSync(join(repoRoot(), "tasks", "verify.yml"), { encoding: "utf8" });
     const matches: string[] = [];

--- a/packages/core/src/preflight/evaluate.test.ts
+++ b/packages/core/src/preflight/evaluate.test.ts
@@ -6,7 +6,13 @@ import { afterAll, describe, expect, it } from "vitest";
 // chmodSync does not reliably block file reads on Windows; skip chmod-dependent tests there.
 const itChmod = it.skipIf(process.platform === "win32");
 
-import { ELIGIBLE_STATUS, emitJson, evaluate, formatActivateHint } from "./evaluate.js";
+import {
+  ELIGIBLE_STATUS,
+  emitJson,
+  evaluate,
+  formatActivateHint,
+  PREFLIGHT_USAGE_HINT,
+} from "./evaluate.js";
 import { emitJson as emitJsonFromIndex, evaluate as evaluateFromIndex } from "./index.js";
 
 const temps: string[] = [];
@@ -38,6 +44,17 @@ describe("evaluate", () => {
     expect(result.message).toBe(`OK ${path} -- ready for implementation.`);
   });
 
+  it("returns exit 0 for xbrief/active/ layout path", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-preflight-xbrief-"));
+    temps.push(root);
+    const dir = join(root, "xbrief", "active");
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "story.xbrief.json");
+    writeFileSync(path, JSON.stringify({ plan: { status: "running" } }), "utf8");
+    const result = evaluate(path);
+    expect(result.exitCode).toBe(0);
+  });
+
   it("rejects pending/ folder", () => {
     const path = writeVbrief(
       "pending",
@@ -47,6 +64,8 @@ describe("evaluate", () => {
     const result = evaluate(path);
     expect(result.exitCode).toBe(1);
     expect(result.message).toContain("pending/");
+    expect(result.message).toContain("xbrief/active/");
+    expect(result.message).toContain(PREFLIGHT_USAGE_HINT);
     expect(result.message).toContain(formatActivateHint(path));
   });
 

--- a/packages/core/src/preflight/evaluate.ts
+++ b/packages/core/src/preflight/evaluate.ts
@@ -7,9 +7,15 @@ export const ACTIVE_FOLDER = "active";
 /** Canonical eligibility status — only `running` signals an active handoff. */
 export const ELIGIBLE_STATUS = "running";
 
-/** Actionable redirect appended to every reject path (#810). */
+/** Actionable redirect appended to every reject path (#810 / #2449). */
 export const ACTIVATE_HINT =
-  "Run `task vbrief:activate {path}` before spawning an implementation agent.";
+  "Run `task scope:activate -- {path}` (or legacy `task vbrief:activate -- {path}`) before spawning an implementation agent.";
+
+/** Lifecycle folder names eligible for implementation (#810). */
+export const ELIGIBLE_LIFECYCLE_DIRS = ["xbrief/active", "vbrief/active"] as const;
+
+export const PREFLIGHT_USAGE_HINT =
+  "Expected: `task xbrief:preflight -- xbrief/active/<story>.xbrief.json` (legacy: `task vbrief:preflight -- <path>`).";
 
 /** Result of a vBRIEF preflight evaluation; mirrors the Python `evaluate` tuple. */
 export interface EvaluateResult {
@@ -23,7 +29,7 @@ export function formatActivateHint(path: string): string {
 }
 
 function buildReject(path: string, reason: string): string {
-  return `${reason}\n  ${formatActivateHint(path)}`;
+  return `${reason}\n  ${PREFLIGHT_USAGE_HINT}\n  ${formatActivateHint(path)}`;
 }
 
 /** Map Node `JSON.parse` errors to CPython `json.JSONDecodeError.msg` for parity (#1721). */
@@ -112,12 +118,14 @@ export function evaluate(vbriefPath: string): EvaluateResult {
   }
 
   const folder = basename(dirname(vbriefPath));
+  const parent = basename(dirname(dirname(vbriefPath)));
+  const lifecycleDir = `${parent}/${folder}`;
   if (folder !== ACTIVE_FOLDER) {
     return {
       exitCode: 1,
       message: buildReject(
         path,
-        `vBRIEF is in ${folder}/ -- only vbrief/active/ is eligible for implementation.`,
+        `xBRIEF is in ${lifecycleDir}/ -- only xbrief/active/ (or legacy vbrief/active/) is eligible for implementation.`,
       ),
     };
   }

--- a/packages/core/src/preflight/index.ts
+++ b/packages/core/src/preflight/index.ts
@@ -2,8 +2,10 @@ export type { EvaluateResult } from "./evaluate.js";
 export {
   ACTIVATE_HINT,
   ACTIVE_FOLDER,
+  ELIGIBLE_LIFECYCLE_DIRS,
   ELIGIBLE_STATUS,
   emitJson,
   evaluate,
   formatActivateHint,
+  PREFLIGHT_USAGE_HINT,
 } from "./evaluate.js";

--- a/tasks/vbrief.yml
+++ b/tasks/vbrief.yml
@@ -68,7 +68,7 @@ tasks:
     # NOTE: NO ``sources:`` / ``generates:`` per ``conventions/task-caching.md``
     # because the vBRIEF path is a user-facing argument forwarded via
     # {{.CLI_ARGS}} and a cached cmds skip would silently swallow it.
-    desc: "Preflight an implementation-intent gate (#810): exits 0 only when vBRIEF is in vbrief/active/ AND plan.status == 'running'. Fails closed (#1046 PR-C / #1047) if the wrapped script cannot be resolved."
+    desc: "Preflight an implementation-intent gate (#810): exits 0 only when the scope xBRIEF is in xbrief/active/ (or legacy vbrief/active/) AND plan.status == 'running'. Prefer `task xbrief:preflight -- <path>`; this task remains for backward compatibility."
     dir: '{{.USER_WORKING_DIR}}'
     deps:
       - task: :engine:_ts-build

--- a/tasks/xbrief.yml
+++ b/tasks/xbrief.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+
+  preflight:
+    # Canonical #810 implementation-intent gate for the xBRIEF lifecycle (#2449).
+    # Mirrors tasks/vbrief.yml preflight; callers use:
+    #   task xbrief:preflight -- xbrief/active/<story>.xbrief.json
+    # Legacy `task vbrief:preflight -- <path>` remains accepted for the same gate.
+    desc: "Preflight an implementation-intent gate (#810): exits 0 only when the xBRIEF is in xbrief/active/ AND plan.status == 'running'. Alias of vbrief:preflight with xbrief-first help."
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'xbrief:preflight --vbrief-path {{.CLI_ARGS}}'


### PR DESCRIPTION
## Summary
- Wire `task xbrief:preflight` and `deft xbrief:preflight` as aliases to the existing #810 implementation-intent gate handler.
- Improve preflight rejection messages to cite `xbrief/active/` paths and the canonical invocation form.
- Accept positional paths and `--brief-path` on the CLI; keep `vbrief:preflight` as a legacy alias.

## Test plan
- [x] `task xbrief:preflight -- xbrief/active/<story>.xbrief.json` exits 0 for running active stories
- [x] `deft xbrief:preflight <path>` resolves (no unknown verb)
- [x] Targeted vitest: preflight evaluate, vbrief-preflight CLI, dispatch aliases, router, taskfile_cli_args
- [ ] CI `task check`

Closes #2449
