### PR TITLE
fix(security): contain four path-escape write sinks (#2470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The documented `xbrief:preflight` gate works again.** `task xbrief:preflight` and `deft xbrief:preflight` now resolve to the same #810 implementation-intent check as the legacy `vbrief:preflight` verb, accept `xbrief/active/` paths, and print clearer usage hints on failure. Closes #2449.
 - **New scope xBRIEFs now stamp the current v0.8 schema version.** Emit paths (`scope:decompose`, issue ingest, speckit, and project render) were still writing `vBRIEFInfo.version = "0.6"`; they now follow `@deftai/directive-types` `VBRIEF_VERSION` so freshly generated artifacts match the declared current schema. Closes #2318.
 - **Triage cache and init/update writers refuse symlink escapes.** Routine commands such as doctor, triage summary, and directive init/update no longer follow repo-controlled symlinks on `xbrief`, `.triage-cache`, or installer-managed projection paths — they fail closed instead of writing outside the checkout. Closes #2446.
+- **Scope, cache, welcome, and release writers refuse path escapes.** Lifecycle planRef resolution, issue cache, policy audit, and release markdown writes now use the shared projection-containment guard so crafted refs and repo-controlled symlinks cannot steer routine commands into out-of-tree writes. Closes #2470.
 
 ### Removed
 

--- a/packages/core/src/cache/operations.test.ts
+++ b/packages/core/src/cache/operations.test.ts
@@ -1,9 +1,12 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import { cacheGet, cacheInvalidate, cachePrune, cachePut, isFresh } from "./operations.js";
 import { FixedClock } from "./test-helpers.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
 
 function goodRaw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -120,6 +123,27 @@ describe("audit log", () => {
       expect(audit).toContain('"event":"cache:put"');
     } finally {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("cache containment (#2470)", () => {
+  itSymlink("refuses cache put when .deft-cache is a symlink outside the project", () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "cache-contain-proj-"));
+    const escapeTarget = mkdtempSync(join(tmpdir(), "cache-contain-escape-"));
+    const escapeFile = join(escapeTarget, "stolen-cache");
+    try {
+      writeFileSync(escapeFile, "", { encoding: "utf8" });
+      symlinkSync(escapeFile, join(projectDir, ".deft-cache"));
+      expect(() =>
+        cachePut("github-issue", "deftai/directive/900", goodRaw({ number: 900 }), {
+          cacheRoot: join(projectDir, ".deft-cache"),
+        }),
+      ).toThrow(ProjectionContainmentError);
+      expect(readFileSync(escapeFile, { encoding: "utf8" })).toBe("");
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(escapeTarget, { recursive: true, force: true });
     }
   });
 });

--- a/packages/core/src/cache/operations.ts
+++ b/packages/core/src/cache/operations.ts
@@ -1,5 +1,9 @@
 import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import {
+  assertProjectionContained,
+  ProjectionContainmentError,
+} from "../fs/projection-containment.js";
 import { pyRepr } from "../scm/py-format.js";
 import { ALLOWED_SOURCES, REPO_RE, SOURCE_TTL_SECONDS } from "./constants.js";
 import {
@@ -22,6 +26,17 @@ import { flagsForMeta, SCANNER_VERSION, scan } from "./scanner.js";
 import { addSeconds, type Clock, parseIso, systemClock, utcIso } from "./time.js";
 import type { CacheGetOptions, CachePutOptions, GetResult, PutResult } from "./types.js";
 import { validateMeta } from "./validate.js";
+
+export { ProjectionContainmentError as CacheContainmentError };
+
+/** Refuse symlink-escaping `.deft-cache` before mkdir/read/write (#2470). */
+function assertWritableCachePath(cacheRoot: string, ...segments: string[]): string {
+  const cacheAbs = resolve(cacheRoot);
+  const projectDir = dirname(cacheAbs);
+  const target = segments.length > 0 ? join(cacheAbs, ...segments) : cacheAbs;
+  assertProjectionContained(projectDir, target);
+  return target;
+}
 
 function renderContent(source: string, raw: Record<string, unknown>): string {
   if (source === "github-issue") {
@@ -119,6 +134,7 @@ export function cachePut(
   }
   const expires = addSeconds(fetched, ttl);
   const cacheRoot = options.cacheRoot ?? ".deft-cache";
+  assertWritableCachePath(cacheRoot);
   const edir = entryDir(source, key, cacheRoot);
 
   const rawText = pythonJsonDump(raw);
@@ -235,6 +251,7 @@ export function cachePut(
 export function cacheGet(source: string, key: string, options: CacheGetOptions = {}): GetResult {
   const clock = options.clock ?? systemClock;
   const cacheRoot = options.cacheRoot ?? ".deft-cache";
+  assertWritableCachePath(cacheRoot);
   const allowStale = options.allowStale ?? true;
   const edir = entryDir(source, key, cacheRoot);
   const metaRelPath = `${source}/${key}/meta.json`;
@@ -283,6 +300,7 @@ export function cacheInvalidate(
   const clock = options.clock ?? systemClock;
   validateKey(source, key);
   const cacheRoot = options.cacheRoot ?? ".deft-cache";
+  assertWritableCachePath(cacheRoot);
   const edir = entryDir(source, key, cacheRoot);
   const existed = existsSync(edir);
   if (existed) removeEntryDir(edir);
@@ -327,6 +345,7 @@ export function cachePrune(
     throw new CacheError(`--older-than-days must be >= 0 (got ${JSON.stringify(olderThanDays)})`);
   }
   const cacheRoot = options.cacheRoot ?? ".deft-cache";
+  assertWritableCachePath(cacheRoot);
   if (!existsSync(cacheRoot)) return [];
 
   const cutoff = addSeconds(clock.now(), -olderThanDays * 24 * 60 * 60);
@@ -391,6 +410,7 @@ export function cachePruneToCap(
 ): EntryUsage[] {
   const clock = options.clock ?? systemClock;
   const cacheRoot = options.cacheRoot ?? ".deft-cache";
+  assertWritableCachePath(cacheRoot);
   const resolved = options.caps ?? resolveCaps();
   if (!resolved.maxBytes && !resolved.maxEntries) return [];
   if (options.dryRun) {

--- a/packages/core/src/release/coverage-extra.test.ts
+++ b/packages/core/src/release/coverage-extra.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { parseReleaseFlags } from "./flags.js";
 import { checkGitClean, commitReleaseArtifacts } from "./git.js";
-import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { defaultWhich, spawnText } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 import { isPublishable } from "./version.js";

--- a/packages/core/src/release/coverage-extra.test.ts
+++ b/packages/core/src/release/coverage-extra.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { parseReleaseFlags } from "./flags.js";
 import { checkGitClean, commitReleaseArtifacts } from "./git.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
 import { defaultWhich, spawnText } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
@@ -81,7 +82,7 @@ describe("pipeline branches extra", () => {
       version: "0.21.0",
       repo: "deftai/directive",
       baseBranch: "master",
-      projectRoot: "/proj",
+      projectRoot: seedReleaseProjectDir(CHANGELOG),
       dryRun: false,
       skipTag: true,
       skipRelease: true,

--- a/packages/core/src/release/coverage-final.test.ts
+++ b/packages/core/src/release/coverage-final.test.ts
@@ -2,8 +2,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { promoteChangelog } from "./changelog.js";
 import { cmdRelease } from "./main.js";
-import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { defaultWhich } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 

--- a/packages/core/src/release/coverage-final.test.ts
+++ b/packages/core/src/release/coverage-final.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { promoteChangelog } from "./changelog.js";
 import { cmdRelease } from "./main.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
 import { defaultWhich } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
@@ -16,11 +17,12 @@ describe("spawn helpers", () => {
 });
 
 describe("pipeline write path", () => {
+  const projectRoot = seedReleaseProjectDir(CHANGELOG);
   const config: ReleaseConfig = {
     version: "0.21.0",
     repo: "deftai/directive",
     baseBranch: "master",
-    projectRoot: "/proj",
+    projectRoot,
     dryRun: false,
     skipTag: true,
     skipRelease: true,
@@ -50,7 +52,7 @@ describe("pipeline write path", () => {
       todayIso: () => "2026-04-28",
     };
     expect(runPipeline(config, seams)).toBe(0);
-    expect(writes[join("/proj", "CHANGELOG.md")]).toContain("## [0.21.0]");
+    expect(writes[join(projectRoot, "CHANGELOG.md")]).toContain("## [0.21.0]");
   });
 });
 

--- a/packages/core/src/release/main.test.ts
+++ b/packages/core/src/release/main.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { cmdRelease } from "./main.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
 import type { ReleaseSeams } from "./types.js";
 
@@ -50,7 +51,7 @@ describe("pipeline verify flip failure", () => {
       version: "0.21.0",
       repo: "deftai/directive",
       baseBranch: "master",
-      projectRoot: "/proj",
+      projectRoot: seedReleaseProjectDir(CHANGELOG),
       dryRun: false,
       skipTag: true,
       skipRelease: false,

--- a/packages/core/src/release/main.test.ts
+++ b/packages/core/src/release/main.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { cmdRelease } from "./main.js";
-import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import type { ReleaseSeams } from "./types.js";
 
 const CHANGELOG = `## [Unreleased]\n\n### Added\n- x\n`;

--- a/packages/core/src/release/pipeline-branches.test.ts
+++ b/packages/core/src/release/pipeline-branches.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createGithubRelease, verifyReleaseDraft } from "./gh.js";
 import { checkGitClean, commitReleaseArtifacts, createTag, pushRelease } from "./git.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
 import { spawnText } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
@@ -31,7 +32,7 @@ const baseConfig: ReleaseConfig = {
   version: "0.21.0",
   repo: "deftai/directive",
   baseBranch: "master",
-  projectRoot: "/proj",
+  projectRoot: seedReleaseProjectDir(),
   dryRun: false,
   skipTag: false,
   skipRelease: false,

--- a/packages/core/src/release/pipeline-branches.test.ts
+++ b/packages/core/src/release/pipeline-branches.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createGithubRelease, verifyReleaseDraft } from "./gh.js";
 import { checkGitClean, commitReleaseArtifacts, createTag, pushRelease } from "./git.js";
-import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { runPipeline } from "./pipeline.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { spawnText } from "./spawn.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 

--- a/packages/core/src/release/pipeline-fixture.test.ts
+++ b/packages/core/src/release/pipeline-fixture.test.ts
@@ -1,0 +1,16 @@
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
+
+describe("seedReleaseProjectDir", () => {
+  it("creates changelog and roadmap on disk", () => {
+    const dir = seedReleaseProjectDir();
+    try {
+      expect(existsSync(join(dir, "CHANGELOG.md"))).toBe(true);
+      expect(existsSync(join(dir, "ROADMAP.md"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/release/pipeline-fixture.ts
+++ b/packages/core/src/release/pipeline-fixture.ts
@@ -1,0 +1,11 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Seed a real on-disk project root for pipeline write-path tests (#2470). */
+export function seedReleaseProjectDir(changelog = `## [Unreleased]\n\n### Added\n- x\n`): string {
+  const dir = mkdtempSync(join(tmpdir(), "release-proj-"));
+  writeFileSync(join(dir, "CHANGELOG.md"), changelog, "utf8");
+  writeFileSync(join(dir, "ROADMAP.md"), "# Roadmap\n", "utf8");
+  return dir;
+}

--- a/packages/core/src/release/pipeline.test.ts
+++ b/packages/core/src/release/pipeline.test.ts
@@ -1,8 +1,13 @@
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import { prependUpgradeBanner } from "./changelog.js";
 import { formatReleaseHelp } from "./flags.js";
 import { checkTagAvailable } from "./gh.js";
 import { cmdRelease } from "./main.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { emit, runPipeline } from "./pipeline.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 
@@ -90,11 +95,13 @@ describe("runPipeline dry-run", () => {
   });
 
   it("Step-5 invokes the native TypeScript task check seam (not ci_local.py)", () => {
+    const projectDir = seedReleaseProjectDir();
     const orig = process.stderr.write.bind(process.stderr);
     process.stderr.write = (() => true) as typeof process.stderr.write;
     let runCiInvoked = false;
     const config: ReleaseConfig = {
       ...baseConfig,
+      projectRoot: projectDir,
       dryRun: false,
       skipCi: false,
       skipBuild: true,
@@ -112,7 +119,7 @@ describe("runPipeline dry-run", () => {
         runCiInvoked = true;
         return [true, "ran native TypeScript task check"];
       },
-      fileExists: (p) => p.endsWith("CHANGELOG.md"),
+      fileExists: (p) => p.endsWith("CHANGELOG.md") || p.endsWith("ROADMAP.md"),
       readFile: () => `## [Unreleased]\n\n### Added\n`,
       writeFile: () => undefined,
       refreshRoadmap: () => [true, "ok"],
@@ -122,6 +129,7 @@ describe("runPipeline dry-run", () => {
       expect(runCiInvoked).toBe(true);
     } finally {
       process.stderr.write = orig;
+      rmSync(projectDir, { recursive: true, force: true });
     }
   });
 
@@ -130,6 +138,53 @@ describe("runPipeline dry-run", () => {
       fileExists: () => false,
     };
     expect(runPipeline(baseConfig, seams)).toBe(2);
+  });
+});
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("release markdown containment (#2470)", () => {
+  itSymlink("refuses CHANGELOG promotion when CHANGELOG.md is a symlink outside the project", () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "release-cl-proj-"));
+    const escapeTarget = mkdtempSync(join(tmpdir(), "release-cl-escape-"));
+    const escapeFile = join(escapeTarget, "stolen-changelog.md");
+    try {
+      writeFileSync(escapeFile, "victim\n", { encoding: "utf8" });
+      symlinkSync(escapeFile, join(projectDir, "CHANGELOG.md"));
+
+      const config: ReleaseConfig = {
+        version: "0.21.0",
+        repo: "deftai/directive",
+        baseBranch: "master",
+        projectRoot: projectDir,
+        dryRun: false,
+        skipTag: true,
+        skipRelease: true,
+        allowDirty: true,
+        draft: true,
+        skipCi: true,
+        skipBuild: true,
+        summary: null,
+        allowVbriefDrift: true,
+      };
+      const seams: ReleaseSeams = {
+        todayIso: () => "2026-04-28",
+        spawnText: (_c, a) => {
+          if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+          if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+          return { status: 0, stdout: "", stderr: "" };
+        },
+        checkTagAvailable: () => [true, "ok"],
+        fileExists: (p) => p.endsWith("CHANGELOG.md") || p.endsWith("ROADMAP.md"),
+        readFile: () => "## [Unreleased]\n\n### Added\n",
+      };
+
+      expect(() => runPipeline(config, seams)).toThrow(ProjectionContainmentError);
+      expect(readFileSync(escapeFile, { encoding: "utf8" })).toBe("victim\n");
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(escapeTarget, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/release/pipeline.test.ts
+++ b/packages/core/src/release/pipeline.test.ts
@@ -7,8 +7,8 @@ import { prependUpgradeBanner } from "./changelog.js";
 import { formatReleaseHelp } from "./flags.js";
 import { checkTagAvailable } from "./gh.js";
 import { cmdRelease } from "./main.js";
-import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import { emit, runPipeline } from "./pipeline.js";
+import { seedReleaseProjectDir } from "./pipeline-fixture.js";
 import type { ReleaseConfig, ReleaseSeams } from "./types.js";
 
 describe("cmdRelease", () => {
@@ -144,48 +144,51 @@ describe("runPipeline dry-run", () => {
 const itSymlink = it.skipIf(process.platform === "win32");
 
 describe("release markdown containment (#2470)", () => {
-  itSymlink("refuses CHANGELOG promotion when CHANGELOG.md is a symlink outside the project", () => {
-    const projectDir = mkdtempSync(join(tmpdir(), "release-cl-proj-"));
-    const escapeTarget = mkdtempSync(join(tmpdir(), "release-cl-escape-"));
-    const escapeFile = join(escapeTarget, "stolen-changelog.md");
-    try {
-      writeFileSync(escapeFile, "victim\n", { encoding: "utf8" });
-      symlinkSync(escapeFile, join(projectDir, "CHANGELOG.md"));
+  itSymlink(
+    "refuses CHANGELOG promotion when CHANGELOG.md is a symlink outside the project",
+    () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "release-cl-proj-"));
+      const escapeTarget = mkdtempSync(join(tmpdir(), "release-cl-escape-"));
+      const escapeFile = join(escapeTarget, "stolen-changelog.md");
+      try {
+        writeFileSync(escapeFile, "victim\n", { encoding: "utf8" });
+        symlinkSync(escapeFile, join(projectDir, "CHANGELOG.md"));
 
-      const config: ReleaseConfig = {
-        version: "0.21.0",
-        repo: "deftai/directive",
-        baseBranch: "master",
-        projectRoot: projectDir,
-        dryRun: false,
-        skipTag: true,
-        skipRelease: true,
-        allowDirty: true,
-        draft: true,
-        skipCi: true,
-        skipBuild: true,
-        summary: null,
-        allowVbriefDrift: true,
-      };
-      const seams: ReleaseSeams = {
-        todayIso: () => "2026-04-28",
-        spawnText: (_c, a) => {
-          if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
-          if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
-          return { status: 0, stdout: "", stderr: "" };
-        },
-        checkTagAvailable: () => [true, "ok"],
-        fileExists: (p) => p.endsWith("CHANGELOG.md") || p.endsWith("ROADMAP.md"),
-        readFile: () => "## [Unreleased]\n\n### Added\n",
-      };
+        const config: ReleaseConfig = {
+          version: "0.21.0",
+          repo: "deftai/directive",
+          baseBranch: "master",
+          projectRoot: projectDir,
+          dryRun: false,
+          skipTag: true,
+          skipRelease: true,
+          allowDirty: true,
+          draft: true,
+          skipCi: true,
+          skipBuild: true,
+          summary: null,
+          allowVbriefDrift: true,
+        };
+        const seams: ReleaseSeams = {
+          todayIso: () => "2026-04-28",
+          spawnText: (_c, a) => {
+            if (a.includes("status")) return { status: 0, stdout: "", stderr: "" };
+            if (a.includes("branch")) return { status: 0, stdout: "master\n", stderr: "" };
+            return { status: 0, stdout: "", stderr: "" };
+          },
+          checkTagAvailable: () => [true, "ok"],
+          fileExists: (p) => p.endsWith("CHANGELOG.md") || p.endsWith("ROADMAP.md"),
+          readFile: () => "## [Unreleased]\n\n### Added\n",
+        };
 
-      expect(() => runPipeline(config, seams)).toThrow(ProjectionContainmentError);
-      expect(readFileSync(escapeFile, { encoding: "utf8" })).toBe("victim\n");
-    } finally {
-      rmSync(projectDir, { recursive: true, force: true });
-      rmSync(escapeTarget, { recursive: true, force: true });
-    }
-  });
+        expect(() => runPipeline(config, seams)).toThrow(ProjectionContainmentError);
+        expect(readFileSync(escapeFile, { encoding: "utf8" })).toBe("victim\n");
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+        rmSync(escapeTarget, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("emit", () => {

--- a/packages/core/src/release/pipeline.ts
+++ b/packages/core/src/release/pipeline.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { assertProjectionContained } from "../fs/projection-containment.js";
 import { prependUpgradeBanner, promoteChangelog, sectionForVersion } from "./changelog.js";
 import {
   EXIT_CONFIG_ERROR,
@@ -38,6 +39,7 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
   const version = config.version;
   const today = (seams.todayIso ?? todayIso)();
   const changelogPath = join(projectRoot, "CHANGELOG.md");
+  const roadmapPath = join(projectRoot, "ROADMAP.md");
   const readFile = seams.readFile ?? ((p: string) => readFileSync(p, "utf8"));
   const writeFile = seams.writeFile ?? ((p: string, c: string) => writeFileSync(p, c, "utf8"));
   const fileExists = seams.fileExists ?? ((p: string) => existsSync(p));
@@ -184,6 +186,7 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
       `DRYRUN (would rewrite CHANGELOG.md: ## [Unreleased] -> ## [${version}] - ${today}; new compare link added;${summaryNote})`,
     );
   } else {
+    assertProjectionContained(projectRoot, changelogPath);
     writeFile(changelogPath, promotedChangelog);
     emit(6, label, `OK (## [${version}] - ${today};${summaryNote})`);
   }
@@ -193,6 +196,7 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
   if (config.dryRun) {
     emit(7, label, "DRYRUN (would run task roadmap:render)");
   } else {
+    assertProjectionContained(projectRoot, roadmapPath);
     const [ok, reason] = refreshRoadmapFn(projectRoot);
     if (ok) {
       emit(7, label, `OK (${reason})`);

--- a/packages/core/src/scope/vbrief-ref.test.ts
+++ b/packages/core/src/scope/vbrief-ref.test.ts
@@ -1,22 +1,52 @@
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import {
   canonicalRelpath,
   collectChildUris,
   collectPlanRefs,
   relativeToVbrief,
+  rejectEscapingLifecycleRel,
   resolveVbriefRef,
   scopeIdsForFilename,
 } from "./vbrief-ref.js";
 
 describe("vbrief-ref branches", () => {
   it("resolves and rejects uri forms", () => {
-    const vbrief = "/proj/vbrief";
-    expect(resolveVbriefRef("file://active/x.xbrief.json", vbrief)).toContain("active");
-    expect(resolveVbriefRef("https://example.com/x", vbrief)).toBeNull();
-    expect(resolveVbriefRef("#anchor", vbrief)).toBeNull();
-    expect(collectPlanRefs({ planRef: "", items: [{ planRef: "a" }, null] })).toEqual(["a"]);
-    expect(collectChildUris({ references: [{ type: "x-vbrief/plan", uri: "" }] })).toEqual([]);
+    const vbrief = mkdtempSync(join(tmpdir(), "vbrief-uri-"));
+    mkdirSync(join(vbrief, "active"), { recursive: true });
+    try {
+      expect(resolveVbriefRef("file://active/x.xbrief.json", vbrief)).toContain("active");
+      expect(resolveVbriefRef("https://example.com/x", vbrief)).toBeNull();
+      expect(resolveVbriefRef("#anchor", vbrief)).toBeNull();
+      expect(collectPlanRefs({ planRef: "", items: [{ planRef: "a" }, null] })).toEqual(["a"]);
+      expect(collectChildUris({ references: [{ type: "x-vbrief/plan", uri: "" }] })).toEqual([]);
+    } finally {
+      rmSync(vbrief, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects escaping and absolute lifecycle refs (#2470)", () => {
+    const vbrief = mkdtempSync(join(tmpdir(), "vbrief-ref-root-"));
+    mkdirSync(join(vbrief, "active"), { recursive: true });
+    try {
+      expect(() => rejectEscapingLifecycleRel("../outside.xbrief.json")).toThrow(
+        ProjectionContainmentError,
+      );
+      expect(() => rejectEscapingLifecycleRel(resolve("/outside/story.xbrief.json"))).toThrow(
+        /absolute path/,
+      );
+      expect(() => resolveVbriefRef("../outside.xbrief.json", vbrief)).toThrow(
+        /lifecycle ref refused/,
+      );
+      expect(() => resolveVbriefRef("active/../../outside.xbrief.json", vbrief)).toThrow(
+        /parent traversal/,
+      );
+    } finally {
+      rmSync(vbrief, { recursive: true, force: true });
+    }
   });
 
   it("scopeIdsForFilename handles non-vbrief extensions", () => {

--- a/packages/core/src/scope/vbrief-ref.test.ts
+++ b/packages/core/src/scope/vbrief-ref.test.ts
@@ -7,8 +7,8 @@ import {
   canonicalRelpath,
   collectChildUris,
   collectPlanRefs,
-  relativeToVbrief,
   rejectEscapingLifecycleRel,
+  relativeToVbrief,
   resolveVbriefRef,
   scopeIdsForFilename,
 } from "./vbrief-ref.js";

--- a/packages/core/src/scope/vbrief-ref.ts
+++ b/packages/core/src/scope/vbrief-ref.ts
@@ -1,10 +1,41 @@
-import { resolve, sep } from "node:path";
+import { isAbsolute, resolve, sep } from "node:path";
 import { referenceTypeMatches } from "@deftai/directive-types";
+import {
+  assertProjectionContained,
+  ProjectionContainmentError,
+} from "../fs/projection-containment.js";
 import {
   type ResolveLifecycleArtifactRefOptions,
   resolveLifecycleArtifactRef,
 } from "../layout/lifecycle-ref.js";
 import { hasArtifactSuffix, stripArtifactSuffix } from "../layout/resolve.js";
+
+export { ProjectionContainmentError as LifecycleRefContainmentError };
+
+/** Reject absolute or `..`-escaping lifecycle refs before path resolution (#2470). */
+export function rejectEscapingLifecycleRel(rel: string): void {
+  if (isAbsolute(rel)) {
+    throw new ProjectionContainmentError(
+      `lifecycle ref refused: absolute path ${rel} is not allowed under the lifecycle root`,
+      { projectDir: "", targetPath: rel, offendingPath: rel },
+    );
+  }
+  const segments = rel.split(/[/\\]+/).filter((segment) => segment.length > 0);
+  if (segments.includes("..")) {
+    throw new ProjectionContainmentError(
+      `lifecycle ref refused: path ${rel} contains parent traversal (..)`,
+      { projectDir: "", targetPath: rel, offendingPath: rel },
+    );
+  }
+}
+
+/** Assert a resolved lifecycle artifact path stays under the lifecycle root (#2470). */
+export function assertLifecycleArtifactContained(
+  lifecycleRoot: string,
+  resolvedPath: string,
+): void {
+  assertProjectionContained(lifecycleRoot, resolvedPath);
+}
 
 /** Resolve a vBRIEF reference URI to an absolute path, or null. */
 export function resolveVbriefRef(
@@ -23,7 +54,10 @@ export function resolveVbriefRef(
   } else {
     rel = uri;
   }
-  return resolveLifecycleArtifactRef(rel, vbriefDir, options);
+  rejectEscapingLifecycleRel(rel);
+  const resolved = resolveLifecycleArtifactRef(rel, vbriefDir, options);
+  assertLifecycleArtifactContained(vbriefDir, resolved);
+  return resolved;
 }
 
 /** Collect planRef values from the plan root and top-level items. */

--- a/packages/core/src/triage/welcome/writers.test.ts
+++ b/packages/core/src/triage/welcome/writers.test.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../../fs/projection-containment.js";
 import { DEFAULT_WIP_CAP } from "./constants.js";
 import {
   appendAuditEntry,
@@ -90,5 +91,25 @@ describe("welcome writers", () => {
 
   it("subscriptionPreset throws on unknown key", () => {
     expect(() => subscriptionPreset("nope")).toThrow();
+  });
+});
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("welcome audit containment (#2470)", () => {
+  itSymlink("refuses audit append when policy-changes.log is a symlink outside the project", () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "writers-contain-proj-"));
+    const escapeTarget = mkdtempSync(join(tmpdir(), "writers-contain-escape-"));
+    const escapeFile = join(escapeTarget, "stolen-audit.log");
+    try {
+      mkdirSync(join(projectDir, "meta"), { recursive: true });
+      writeFileSync(escapeFile, "victim\n", { encoding: "utf8" });
+      symlinkSync(escapeFile, join(projectDir, "meta", "policy-changes.log"));
+      expect(() => appendAuditEntry(projectDir, "injected")).toThrow(ProjectionContainmentError);
+      expect(readFileSync(escapeFile, { encoding: "utf8" })).toBe("victim\n");
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(escapeTarget, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/src/triage/welcome/writers.ts
+++ b/packages/core/src/triage/welcome/writers.ts
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { assertProjectionContained } from "../../fs/projection-containment.js";
 import {
   hasArtifactSuffix,
   resolveLifecycleFolder,
@@ -34,6 +35,7 @@ function utcIso(): string {
 
 export function appendAuditEntry(projectRoot: string, entry: string): string {
   const logPath = join(resolve(projectRoot), AUDIT_LOG_REL_PATH);
+  assertProjectionContained(projectRoot, logPath);
   mkdirSync(dirname(logPath), { recursive: true });
   const line = `${utcIso()} ${entry}\n`;
   if (!existsSync(logPath)) {


### PR DESCRIPTION
## Summary
- Apply shared `assertProjectionContained` to four remaining medium path-escape sinks from the AppSec pass
- Reject absolute / `..`-escaping lifecycle `planRef` resolution before scope lifecycle rewrites
- Fail closed on symlink-escaping `.deft-cache`, `meta/policy-changes.log`, and release `CHANGELOG.md` / `ROADMAP.md` writes

## Test plan
- [x] `pnpm exec vitest run` on scope/cache/release/welcome regression suites
- [x] Symlink escape cases covered on non-Windows CI (skipped locally on win32)

Closes #2470
