### PR TITLE
feat(packaging): default OpenPackage install to daily-core tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OpenPackage consumer installs default to daily-core skills.** The tier manifest and sync script now select the six session-bootstrap skills unless you pass `--tier all`, `--tier standard`, or `--tier advanced`; README and UPGRADING document how to expand tiers. Closes #2494. Refs #2491, #2462, #2463, #2370.
 - **Read-only Directive session posture defers ceremony until you start changing things.** Questions, Plan Mode, and ticket-shaping now default to alignment-only context loads without writing `.deft/ritual-state.json`, triage welcome, branch-policy dumps, or install side effects; the full mutable ritual still runs at mutation boundaries. Use `deft session:start -- --read-only` for explicit alignment-only mode. Closes #2176. Refs #2491.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ node /path/to/directive/packaging/openpackage/sync-skills.mjs
 opkg install /path/to/directive/packaging/openpackage/deft-directive-skills --platforms cursor codex opencode
 ```
 
-Install **daily-core** only on Cursor to keep injected skill frontmatter lean — see [`packaging/openpackage/deft-directive-skills/README.md`](./packaging/openpackage/deft-directive-skills/README.md). This is distribution-layer (A) only; there is no runtime skill router.
+**Default install is daily-core** (six session-bootstrap skills) so Cursor injected frontmatter stays ~2 KB class. Sync copies only daily-core unless you pass `--tier all` or `--tier standard` / `--tier advanced` — see [`packaging/openpackage/deft-directive-skills/README.md`](./packaging/openpackage/deft-directive-skills/README.md). This is distribution-layer (A) only; there is no runtime skill router.
 
 **Where your project lands (honest scope):** the global install above is location-independent, but `directive init` acts on the **current working directory** — it inspects that directory and dispatches, so `cd` into the folder you want the project to live in first (create it if it doesn't exist yet). init does not reach outside the directory you run it in. When an engine is already installed, Directive reconciles it against your committed `package.json` pin: a **matched** engine (same version as the pin) proceeds; a **mismatched** engine (ahead of or behind the pin) prints the exact `npm i -g` / `directive update` step to take rather than silently running against the wrong version.
 

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -73,11 +73,13 @@ Start a **new agent session** after steps 2–3 so the refreshed AGENTS.md and s
 The npm engine (`npm i -g @deftai/directive`) remains the canonical runtime handler for gates, lifecycle, and `.deft/core/` refresh. **OpenPackage** is an optional cross-harness distribution path for placing tiered consumer skills into Cursor, Codex CLI, and OpenCode native directories — without a Directive-owned skill router.
 
 1. Install OpenPackage CLI: `npm i -g opkg`
-2. From a maintainer checkout (or release tree), sync skills into the package:
+2. From a maintainer checkout (or release tree), sync skills into the package (default: **daily-core** only):
 
    ```bash
    node packaging/openpackage/sync-skills.mjs
    ```
+
+   For all tiers on disk (maintainer release prep): `node packaging/openpackage/sync-skills.mjs --tier all`
 
 3. From your **project root** (after `directive init`):
 
@@ -85,7 +87,7 @@ The npm engine (`npm i -g @deftai/directive`) remains the canonical runtime hand
    opkg install /path/to/directive/packaging/openpackage/deft-directive-skills --platforms cursor codex opencode
    ```
 
-**Tiers:** **daily-core** (setup, sync, build, pre-pr, review-cycle, triage) for session bootstrap; **standard** for operational workflows; **advanced** (release, swarm, debug, article-review) for deferred install. Full lists: `packaging/openpackage/deft-tiers.json`. Detail: [`packaging/openpackage/deft-directive-skills/README.md`](../packaging/openpackage/deft-directive-skills/README.md).
+**Default install tier:** **daily-core** (setup, sync, build, pre-pr, review-cycle, triage) — the sync script and `deft-tiers.json` `defaultInstallTier` select this unless you override with `--tier all`, `--tier standard`, or `--tier advanced`. **Standard** covers operational workflows; **advanced** (release, swarm, debug, article-review) stays deferred. Full lists: `packaging/openpackage/deft-tiers.json`. Detail: [`packaging/openpackage/deft-directive-skills/README.md`](../packaging/openpackage/deft-directive-skills/README.md).
 
 Consumer AGENTS.md stays pointer-thin — scan `.deft/core/REFERENCES.md` Skills Index; do not enumerate skills in the managed section.
 

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
@@ -409,6 +409,24 @@ description: ${description}
       if ("error" in bootstrap) return;
       expect(bootstrap.skillFrontmatter.skillCount).toBe(1);
       expect(bootstrap.skillFrontmatter.tier).toBe("daily-core");
+    } finally {
+      if (prev === undefined) delete process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER;
+      else process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER = prev;
+    }
+  });
+
+  it("defaults skill frontmatter tier to daily-core from OpenPackage manifest (#2494)", () => {
+    const repoRoot = join(import.meta.dirname, "..", "..", "..", "..");
+    const agentsPath = join(repoRoot, "AGENTS.md");
+    const text = readFileSync(agentsPath, "utf8");
+    const prev = process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER;
+    delete process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER;
+    try {
+      const bootstrap = measureBootstrapSurface(repoRoot, text, null);
+      expect("error" in bootstrap).toBe(false);
+      if ("error" in bootstrap) return;
+      expect(bootstrap.skillFrontmatter.tier).toBe("daily-core");
+      expect(bootstrap.skillFrontmatter.skillCount).toBe(6);
     } finally {
       if (prev === undefined) delete process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER;
       else process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER = prev;

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -1,6 +1,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { loadOpenPackageTierManifest, resolveTierSkills } from "../packaging/openpackage-tiers.js";
+import {
+  getOpenPackageDefaultInstallTier,
+  resolveOpenPackageTierSkills,
+} from "../packaging/openpackage-tiers.js";
 import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import {
   type AgentsMdBudget,
@@ -202,8 +205,7 @@ function resolveSkillFrontmatterTier(
     return budget.skillFrontmatterTier;
   }
   try {
-    const manifest = loadOpenPackageTierManifest(projectRoot);
-    if (manifest.defaultInstallTier === "daily-core") {
+    if (getOpenPackageDefaultInstallTier(projectRoot) === "daily-core") {
       return "daily-core";
     }
   } catch {
@@ -226,8 +228,7 @@ export function measureBootstrapSurface(
   const tier = resolveSkillFrontmatterTier(budget, projectRoot);
   let dailyCoreSkills: readonly string[] | undefined;
   try {
-    const manifest = loadOpenPackageTierManifest(projectRoot);
-    dailyCoreSkills = resolveTierSkills(manifest, "daily-core");
+    dailyCoreSkills = resolveOpenPackageTierSkills(projectRoot, "daily-core");
   } catch {
     // Maintainer trees without packaging/openpackage fall back to hardcoded daily-core.
   }

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { loadOpenPackageTierManifest } from "../packaging/openpackage-tiers.js";
+import { loadOpenPackageTierManifest, resolveTierSkills } from "../packaging/openpackage-tiers.js";
 import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import {
   type AgentsMdBudget,
@@ -224,10 +224,18 @@ export function measureBootstrapSurface(
   }
   const harnessProfile = resolveHarnessProfile(budget, projectRoot);
   const tier = resolveSkillFrontmatterTier(budget, projectRoot);
+  let dailyCoreSkills: readonly string[] | undefined;
+  try {
+    const manifest = loadOpenPackageTierManifest(projectRoot);
+    dailyCoreSkills = resolveTierSkills(manifest, "daily-core");
+  } catch {
+    // Maintainer trees without packaging/openpackage fall back to hardcoded daily-core.
+  }
   const skillFrontmatter = measureSkillFrontmatter(projectRoot, {
     harnessProfile,
     tier,
     bytesPerToken: ABSOLUTE_BYTES_PER_TOKEN_ESTIMATE,
+    dailyCoreSkills,
   });
   const totalBytes = managedResult.bytes + skillFrontmatter.bytes + BOOTSTRAP_HOOK_BYTES;
   return {

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -193,7 +193,7 @@ function resolveHarnessProfile(budget: AgentsMdBudget | null, projectRoot: strin
   return "none";
 }
 
-function resolveSkillFrontmatterTier(
+function resolveBootstrapSkillTier(
   budget: AgentsMdBudget | null,
   projectRoot: string,
 ): SkillFrontmatterTier {
@@ -225,7 +225,7 @@ export function measureBootstrapSurface(
     return managedResult;
   }
   const harnessProfile = resolveHarnessProfile(budget, projectRoot);
-  const tier = resolveSkillFrontmatterTier(budget, projectRoot);
+  const tier = resolveBootstrapSkillTier(budget, projectRoot);
   let dailyCoreSkills: readonly string[] | undefined;
   try {
     dailyCoreSkills = resolveOpenPackageTierSkills(projectRoot, "daily-core");

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { loadOpenPackageTierManifest } from "../packaging/openpackage-tiers.js";
 import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import {
   type AgentsMdBudget,
@@ -189,12 +190,26 @@ function resolveHarnessProfile(budget: AgentsMdBudget | null, projectRoot: strin
   return "none";
 }
 
-function resolveSkillFrontmatterTier(budget: AgentsMdBudget | null): SkillFrontmatterTier {
+function resolveSkillFrontmatterTier(
+  budget: AgentsMdBudget | null,
+  projectRoot: string,
+): SkillFrontmatterTier {
   const env = process.env.DEFT_AGENTS_MD_BUDGET_SKILL_TIER?.trim();
   if (env === "daily-core" || env === "all" || env === "none") {
     return env;
   }
-  return budget?.skillFrontmatterTier ?? "all";
+  if (budget?.skillFrontmatterTier !== undefined) {
+    return budget.skillFrontmatterTier;
+  }
+  try {
+    const manifest = loadOpenPackageTierManifest(projectRoot);
+    if (manifest.defaultInstallTier === "daily-core") {
+      return "daily-core";
+    }
+  } catch {
+    // No OpenPackage manifest at this project root — fall through.
+  }
+  return "all";
 }
 
 /** Measure managed + DD-3 skill frontmatter + bootstrap hooks. */
@@ -208,7 +223,7 @@ export function measureBootstrapSurface(
     return managedResult;
   }
   const harnessProfile = resolveHarnessProfile(budget, projectRoot);
-  const tier = resolveSkillFrontmatterTier(budget);
+  const tier = resolveSkillFrontmatterTier(budget, projectRoot);
   const skillFrontmatter = measureSkillFrontmatter(projectRoot, {
     harnessProfile,
     tier,

--- a/packages/core/src/agents-md-budget/skill-frontmatter.ts
+++ b/packages/core/src/agents-md-budget/skill-frontmatter.ts
@@ -77,6 +77,8 @@ export interface MeasureSkillFrontmatterOptions {
   readonly tier?: SkillFrontmatterTier;
   readonly harnessProfile?: HarnessProfile;
   readonly bytesPerToken?: number;
+  /** Override daily-core skill names (from OpenPackage resolveTierSkills). */
+  readonly dailyCoreSkills?: readonly string[];
 }
 
 function defaultSkillsRoot(projectRoot: string): string {
@@ -93,14 +95,18 @@ function listSkillDirs(skillsRoot: string): string[] {
     .sort();
 }
 
-function skillMatchesTier(skillName: string, tier: SkillFrontmatterTier): boolean {
+function skillMatchesTier(
+  skillName: string,
+  tier: SkillFrontmatterTier,
+  dailyCore: ReadonlySet<string>,
+): boolean {
   if (tier === "none") {
     return false;
   }
   if (tier === "all") {
     return true;
   }
-  return DAILY_CORE_SET.has(skillName);
+  return dailyCore.has(skillName);
 }
 
 /** Measure harness-injected skill frontmatter bytes for the configured profile/tier. */
@@ -112,6 +118,8 @@ export function measureSkillFrontmatter(
   const tier = options.tier ?? "all";
   const bytesPerToken = options.bytesPerToken ?? 4;
   const skillsRoot = options.skillsRoot ?? defaultSkillsRoot(projectRoot);
+  const dailyCore =
+    options.dailyCoreSkills !== undefined ? new Set(options.dailyCoreSkills) : DAILY_CORE_SET;
 
   if (harnessProfile === "none" || tier === "none") {
     return {
@@ -126,7 +134,7 @@ export function measureSkillFrontmatter(
 
   const entries: SkillFrontmatterEntry[] = [];
   for (const skillName of listSkillDirs(skillsRoot)) {
-    if (!skillMatchesTier(skillName, tier)) {
+    if (!skillMatchesTier(skillName, tier, dailyCore)) {
       continue;
     }
     const skillPath = join(skillsRoot, skillName, "SKILL.md");

--- a/packages/core/src/agents-md-budget/skill-frontmatter.ts
+++ b/packages/core/src/agents-md-budget/skill-frontmatter.ts
@@ -95,7 +95,7 @@ function listSkillDirs(skillsRoot: string): string[] {
     .sort();
 }
 
-function skillMatchesTier(
+function skillInSelectedTier(
   skillName: string,
   tier: SkillFrontmatterTier,
   dailyCore: ReadonlySet<string>,
@@ -134,7 +134,7 @@ export function measureSkillFrontmatter(
 
   const entries: SkillFrontmatterEntry[] = [];
   for (const skillName of listSkillDirs(skillsRoot)) {
-    if (!skillMatchesTier(skillName, tier, dailyCore)) {
+    if (!skillInSelectedTier(skillName, tier, dailyCore)) {
       continue;
     }
     const skillPath = join(skillsRoot, skillName, "SKILL.md");

--- a/packages/core/src/packaging/openpackage-manifest.test.ts
+++ b/packages/core/src/packaging/openpackage-manifest.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   getOpenPackageDefaultInstallTier,
-  readOpenPackageTierManifest,
+  type OpenPackageTierManifest,
   resolveOpenPackageTierSkills,
 } from "./openpackage-tiers.js";
 
@@ -19,9 +19,13 @@ function listContentSkills(): string[] {
     .sort();
 }
 
+function loadTiersJson(): OpenPackageTierManifest {
+  return JSON.parse(readFileSync(TIERS_PATH, "utf8")) as OpenPackageTierManifest;
+}
+
 describe("OpenPackage tier manifest (#2462)", () => {
   it("partitions every content/skills directory across exactly one tier", () => {
-    const manifest = readOpenPackageTierManifest(REPO_ROOT);
+    const manifest = loadTiersJson();
     const onDisk = listContentSkills();
     const seen = new Map<string, string>();
 
@@ -37,7 +41,7 @@ describe("OpenPackage tier manifest (#2462)", () => {
   });
 
   it("declares daily-core, standard, and advanced tiers with expected counts", () => {
-    const manifest = readOpenPackageTierManifest(REPO_ROOT);
+    const manifest = loadTiersJson();
     expect(manifest.tiers["daily-core"].skills).toHaveLength(6);
     expect(manifest.tiers.standard.skills).toHaveLength(10);
     expect(manifest.tiers.advanced.skills).toHaveLength(4);

--- a/packages/core/src/packaging/openpackage-manifest.test.ts
+++ b/packages/core/src/packaging/openpackage-manifest.test.ts
@@ -1,7 +1,11 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { loadOpenPackageTierManifest, resolveTierSkills } from "./openpackage-tiers.js";
+import {
+  getOpenPackageDefaultInstallTier,
+  readOpenPackageTierManifest,
+  resolveOpenPackageTierSkills,
+} from "./openpackage-tiers.js";
 
 const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..");
 const PACKAGING = join(REPO_ROOT, "packaging", "openpackage");
@@ -17,7 +21,7 @@ function listContentSkills(): string[] {
 
 describe("OpenPackage tier manifest (#2462)", () => {
   it("partitions every content/skills directory across exactly one tier", () => {
-    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
+    const manifest = readOpenPackageTierManifest(REPO_ROOT);
     const onDisk = listContentSkills();
     const seen = new Map<string, string>();
 
@@ -33,17 +37,16 @@ describe("OpenPackage tier manifest (#2462)", () => {
   });
 
   it("declares daily-core, standard, and advanced tiers with expected counts", () => {
-    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
+    const manifest = readOpenPackageTierManifest(REPO_ROOT);
     expect(manifest.tiers["daily-core"].skills).toHaveLength(6);
     expect(manifest.tiers.standard.skills).toHaveLength(10);
     expect(manifest.tiers.advanced.skills).toHaveLength(4);
   });
 
   it("defaults consumer install to daily-core (#2494)", () => {
-    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
-    expect(manifest.defaultInstallTier).toBe("daily-core");
-    expect(resolveTierSkills(manifest, manifest.defaultInstallTier)).toHaveLength(6);
-    expect(resolveTierSkills(manifest, "all")).toHaveLength(20);
+    expect(getOpenPackageDefaultInstallTier(REPO_ROOT)).toBe("daily-core");
+    expect(resolveOpenPackageTierSkills(REPO_ROOT, "daily-core")).toHaveLength(6);
+    expect(resolveOpenPackageTierSkills(REPO_ROOT, "all")).toHaveLength(20);
   });
 
   it("openpackage.yml points at deft-tiers.json and declares defaultInstallTier", () => {

--- a/packages/core/src/packaging/openpackage-manifest.test.ts
+++ b/packages/core/src/packaging/openpackage-manifest.test.ts
@@ -1,19 +1,12 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { loadOpenPackageTierManifest, resolveTierSkills } from "./openpackage-tiers.js";
 
 const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..");
 const PACKAGING = join(REPO_ROOT, "packaging", "openpackage");
 const TIERS_PATH = join(PACKAGING, "deft-tiers.json");
 const SKILLS_SOURCE = join(REPO_ROOT, "content", "skills");
-
-type TierManifest = {
-  tiers: Record<string, { skills: string[] }>;
-};
-
-function loadTiers(): TierManifest {
-  return JSON.parse(readFileSync(TIERS_PATH, "utf8")) as TierManifest;
-}
 
 function listContentSkills(): string[] {
   return readdirSync(SKILLS_SOURCE, { withFileTypes: true })
@@ -24,7 +17,7 @@ function listContentSkills(): string[] {
 
 describe("OpenPackage tier manifest (#2462)", () => {
   it("partitions every content/skills directory across exactly one tier", () => {
-    const manifest = loadTiers();
+    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
     const onDisk = listContentSkills();
     const seen = new Map<string, string>();
 
@@ -40,17 +33,30 @@ describe("OpenPackage tier manifest (#2462)", () => {
   });
 
   it("declares daily-core, standard, and advanced tiers with expected counts", () => {
-    const manifest = loadTiers();
+    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
     expect(manifest.tiers["daily-core"].skills).toHaveLength(6);
     expect(manifest.tiers.standard.skills).toHaveLength(10);
     expect(manifest.tiers.advanced.skills).toHaveLength(4);
   });
 
-  it("openpackage.yml points at deft-tiers.json without duplicating tier lists", () => {
+  it("defaults consumer install to daily-core (#2494)", () => {
+    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
+    expect(manifest.defaultInstallTier).toBe("daily-core");
+    expect(resolveTierSkills(manifest, manifest.defaultInstallTier)).toHaveLength(6);
+    expect(resolveTierSkills(manifest, "all")).toHaveLength(20);
+  });
+
+  it("openpackage.yml points at deft-tiers.json and declares defaultInstallTier", () => {
     const yml = join(PACKAGING, "deft-directive-skills", "openpackage.yml");
     const text = readFileSync(yml, "utf8");
     expect(text).toContain('name: "@deftai/deft-directive-skills"');
     expect(text).toContain("tierManifest: ../deft-tiers.json");
+    expect(text).toContain("defaultInstallTier: daily-core");
     expect(text).not.toContain("deft-directive-setup");
+  });
+
+  it("deft-tiers.json declares defaultInstallTier daily-core", () => {
+    const raw = JSON.parse(readFileSync(TIERS_PATH, "utf8")) as { defaultInstallTier?: string };
+    expect(raw.defaultInstallTier).toBe("daily-core");
   });
 });

--- a/packages/core/src/packaging/openpackage-tiers.test.ts
+++ b/packages/core/src/packaging/openpackage-tiers.test.ts
@@ -1,0 +1,30 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  isOpenPackageTierName,
+  loadOpenPackageTierManifest,
+  resolveTierSkills,
+} from "./openpackage-tiers.js";
+
+const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..");
+
+describe("openpackage-tiers (#2494)", () => {
+  it("loads defaultInstallTier and resolves daily-core skill list", () => {
+    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
+    expect(manifest.defaultInstallTier).toBe("daily-core");
+    const dailyCore = resolveTierSkills(manifest, "daily-core");
+    expect(dailyCore).toContain("deft-directive-setup");
+    expect(dailyCore).toHaveLength(6);
+    expect(dailyCore).not.toContain("deft-directive-release");
+  });
+
+  it("resolveTierSkills all returns every mapped skill", () => {
+    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
+    expect(resolveTierSkills(manifest, "all")).toHaveLength(20);
+  });
+
+  it("isOpenPackageTierName rejects unknown tiers", () => {
+    expect(isOpenPackageTierName("daily-core")).toBe(true);
+    expect(isOpenPackageTierName("bogus")).toBe(false);
+  });
+});

--- a/packages/core/src/packaging/openpackage-tiers.test.ts
+++ b/packages/core/src/packaging/openpackage-tiers.test.ts
@@ -2,7 +2,6 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   getOpenPackageDefaultInstallTier,
-  readOpenPackageTierManifest,
   resolveOpenPackageTierSkills,
 } from "./openpackage-tiers.js";
 
@@ -21,11 +20,5 @@ describe("openpackage-tiers (#2494)", () => {
     const all = resolveOpenPackageTierSkills(REPO_ROOT, "all");
     expect(all).toHaveLength(20);
     expect(new Set(all).size).toBe(20);
-  });
-
-  it("readOpenPackageTierManifest exposes tier tables", () => {
-    const manifest = readOpenPackageTierManifest(REPO_ROOT);
-    expect(manifest.tiers["daily-core"].skills).toHaveLength(6);
-    expect(manifest.defaultInstallTier).toBe("daily-core");
   });
 });

--- a/packages/core/src/packaging/openpackage-tiers.test.ts
+++ b/packages/core/src/packaging/openpackage-tiers.test.ts
@@ -1,32 +1,31 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  isOpenPackageTierName,
-  loadOpenPackageTierManifest,
-  resolveTierSkills,
+  getOpenPackageDefaultInstallTier,
+  readOpenPackageTierManifest,
+  resolveOpenPackageTierSkills,
 } from "./openpackage-tiers.js";
 
 const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..");
 
 describe("openpackage-tiers (#2494)", () => {
   it("loads defaultInstallTier and resolves daily-core skill list", () => {
-    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
-    expect(manifest.defaultInstallTier).toBe("daily-core");
-    const dailyCore = resolveTierSkills(manifest, "daily-core");
+    expect(getOpenPackageDefaultInstallTier(REPO_ROOT)).toBe("daily-core");
+    const dailyCore = resolveOpenPackageTierSkills(REPO_ROOT, "daily-core");
     expect(dailyCore).toContain("deft-directive-setup");
     expect(dailyCore).toHaveLength(6);
     expect(dailyCore).not.toContain("deft-directive-release");
   });
 
-  it("resolveTierSkills all returns every mapped skill without duplicates", () => {
-    const manifest = loadOpenPackageTierManifest(REPO_ROOT);
-    const all = resolveTierSkills(manifest, "all");
+  it("resolveOpenPackageTierSkills all returns every mapped skill without duplicates", () => {
+    const all = resolveOpenPackageTierSkills(REPO_ROOT, "all");
     expect(all).toHaveLength(20);
     expect(new Set(all).size).toBe(20);
   });
 
-  it("isOpenPackageTierName rejects unknown tiers", () => {
-    expect(isOpenPackageTierName("daily-core")).toBe(true);
-    expect(isOpenPackageTierName("bogus")).toBe(false);
+  it("readOpenPackageTierManifest exposes tier tables", () => {
+    const manifest = readOpenPackageTierManifest(REPO_ROOT);
+    expect(manifest.tiers["daily-core"].skills).toHaveLength(6);
+    expect(manifest.defaultInstallTier).toBe("daily-core");
   });
 });

--- a/packages/core/src/packaging/openpackage-tiers.test.ts
+++ b/packages/core/src/packaging/openpackage-tiers.test.ts
@@ -18,9 +18,11 @@ describe("openpackage-tiers (#2494)", () => {
     expect(dailyCore).not.toContain("deft-directive-release");
   });
 
-  it("resolveTierSkills all returns every mapped skill", () => {
+  it("resolveTierSkills all returns every mapped skill without duplicates", () => {
     const manifest = loadOpenPackageTierManifest(REPO_ROOT);
-    expect(resolveTierSkills(manifest, "all")).toHaveLength(20);
+    const all = resolveTierSkills(manifest, "all");
+    expect(all).toHaveLength(20);
+    expect(new Set(all).size).toBe(20);
   });
 
   it("isOpenPackageTierName rejects unknown tiers", () => {

--- a/packages/core/src/packaging/openpackage-tiers.ts
+++ b/packages/core/src/packaging/openpackage-tiers.ts
@@ -10,12 +10,11 @@ export interface OpenPackageTierManifest {
 
 const TIER_NAMES: readonly OpenPackageTierName[] = ["daily-core", "standard", "advanced"];
 
-export function isOpenPackageTierName(value: string): value is OpenPackageTierName {
+function isOpenPackageTierName(value: string): value is OpenPackageTierName {
   return (TIER_NAMES as readonly string[]).includes(value);
 }
 
-/** Load packaging/openpackage/deft-tiers.json from a repo root. */
-export function loadOpenPackageTierManifest(repoRoot: string): OpenPackageTierManifest {
+function loadOpenPackageTierManifest(repoRoot: string): OpenPackageTierManifest {
   const path = join(repoRoot, "packaging", "openpackage", "deft-tiers.json");
   const parsed = JSON.parse(readFileSync(path, "utf8")) as {
     defaultInstallTier?: string;
@@ -46,8 +45,7 @@ export function loadOpenPackageTierManifest(repoRoot: string): OpenPackageTierMa
   };
 }
 
-/** Resolve skill names to sync/install for a tier selection (`all` = every tier). */
-export function resolveTierSkills(
+function resolveTierSkills(
   manifest: OpenPackageTierManifest,
   tier: OpenPackageTierName | "all",
 ): string[] {
@@ -55,4 +53,22 @@ export function resolveTierSkills(
     return [...new Set(TIER_NAMES.flatMap((name) => manifest.tiers[name].skills))];
   }
   return [...manifest.tiers[tier].skills];
+}
+
+/** Default OpenPackage install tier from deft-tiers.json (#2494). */
+export function getOpenPackageDefaultInstallTier(repoRoot: string): OpenPackageTierName {
+  return loadOpenPackageTierManifest(repoRoot).defaultInstallTier;
+}
+
+/** Skill names for an OpenPackage tier selection (`all` = every mapped skill). */
+export function resolveOpenPackageTierSkills(
+  repoRoot: string,
+  tier: OpenPackageTierName | "all",
+): string[] {
+  return resolveTierSkills(loadOpenPackageTierManifest(repoRoot), tier);
+}
+
+/** Full typed manifest (tests + callers that need tier tables). */
+export function readOpenPackageTierManifest(repoRoot: string): OpenPackageTierManifest {
+  return loadOpenPackageTierManifest(repoRoot);
 }

--- a/packages/core/src/packaging/openpackage-tiers.ts
+++ b/packages/core/src/packaging/openpackage-tiers.ts
@@ -67,8 +67,3 @@ export function resolveOpenPackageTierSkills(
 ): string[] {
   return resolveTierSkills(loadOpenPackageTierManifest(repoRoot), tier);
 }
-
-/** Full typed manifest (tests + callers that need tier tables). */
-export function readOpenPackageTierManifest(repoRoot: string): OpenPackageTierManifest {
-  return loadOpenPackageTierManifest(repoRoot);
-}

--- a/packages/core/src/packaging/openpackage-tiers.ts
+++ b/packages/core/src/packaging/openpackage-tiers.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type OpenPackageTierName = "daily-core" | "standard" | "advanced";
+
+export interface OpenPackageTierManifest {
+  readonly defaultInstallTier: OpenPackageTierName;
+  readonly tiers: Record<OpenPackageTierName, { skills: string[] }>;
+}
+
+const TIER_NAMES: readonly OpenPackageTierName[] = ["daily-core", "standard", "advanced"];
+
+export function isOpenPackageTierName(value: string): value is OpenPackageTierName {
+  return (TIER_NAMES as readonly string[]).includes(value);
+}
+
+/** Load packaging/openpackage/deft-tiers.json from a repo root. */
+export function loadOpenPackageTierManifest(repoRoot: string): OpenPackageTierManifest {
+  const path = join(repoRoot, "packaging", "openpackage", "deft-tiers.json");
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as {
+    defaultInstallTier?: string;
+    tiers?: Record<string, { skills?: string[] }>;
+  };
+
+  if (parsed === null || typeof parsed !== "object" || !parsed.tiers) {
+    throw new Error("deft-tiers.json must be an object with a tiers field");
+  }
+
+  for (const tier of TIER_NAMES) {
+    const block = parsed.tiers[tier];
+    if (!block || !Array.isArray(block.skills)) {
+      throw new Error(`deft-tiers.json missing tiers.${tier}.skills`);
+    }
+  }
+
+  const defaultInstallTier = parsed.defaultInstallTier ?? "daily-core";
+  if (!isOpenPackageTierName(defaultInstallTier)) {
+    throw new Error(
+      `deft-tiers.json defaultInstallTier must be one of ${TIER_NAMES.join(", ")}; got ${defaultInstallTier}`,
+    );
+  }
+
+  return {
+    defaultInstallTier,
+    tiers: parsed.tiers as OpenPackageTierManifest["tiers"],
+  };
+}
+
+/** Resolve skill names to sync/install for a tier selection (`all` = every tier). */
+export function resolveTierSkills(
+  manifest: OpenPackageTierManifest,
+  tier: OpenPackageTierName | "all",
+): string[] {
+  if (tier === "all") {
+    return TIER_NAMES.flatMap((name) => manifest.tiers[name].skills);
+  }
+  return [...manifest.tiers[tier].skills];
+}

--- a/packages/core/src/packaging/openpackage-tiers.ts
+++ b/packages/core/src/packaging/openpackage-tiers.ts
@@ -52,7 +52,7 @@ export function resolveTierSkills(
   tier: OpenPackageTierName | "all",
 ): string[] {
   if (tier === "all") {
-    return TIER_NAMES.flatMap((name) => manifest.tiers[name].skills);
+    return [...new Set(TIER_NAMES.flatMap((name) => manifest.tiers[name].skills))];
   }
   return [...manifest.tiers[tier].skills];
 }

--- a/packaging/openpackage/README.md
+++ b/packaging/openpackage/README.md
@@ -4,9 +4,9 @@ Cross-harness tiered skill packaging for Deft Directive consumer content ([#2462
 
 | Path | Role |
 | --- | --- |
-| `deft-tiers.json` | Machine-readable tier → skill mapping (source of truth) |
+| `deft-tiers.json` | Machine-readable tier → skill mapping (source of truth; `defaultInstallTier: daily-core`) |
 | `deft-directive-skills/` | OpenPackage package (`openpackage.yml`, `skills/`, thin `AGENTS.md`) |
-| `sync-skills.mjs` | Copy `content/skills/` into the package before `opkg install` |
+| `sync-skills.mjs` | Copy `content/skills/` into the package before `opkg install` (default: daily-core tier) |
 | `measure-daily-core-frontmatter.mjs` | Spike acceptance: daily-core Cursor frontmatter ≤ 2080 B |
 
 Spike background: [`docs/analysis/2026-07-13-2370-packaging-cross-harness-spike.md`](../../docs/analysis/2026-07-13-2370-packaging-cross-harness-spike.md).

--- a/packaging/openpackage/README.md
+++ b/packaging/openpackage/README.md
@@ -5,6 +5,7 @@ Cross-harness tiered skill packaging for Deft Directive consumer content ([#2462
 | Path | Role |
 | --- | --- |
 | `deft-tiers.json` | Machine-readable tier → skill mapping (source of truth; `defaultInstallTier: daily-core`) |
+| `openpackage-tiers.mjs` | Shared load/resolve helpers used by `sync-skills.mjs` |
 | `deft-directive-skills/` | OpenPackage package (`openpackage.yml`, `skills/`, thin `AGENTS.md`) |
 | `sync-skills.mjs` | Copy `content/skills/` into the package before `opkg install` (default: daily-core tier) |
 | `measure-daily-core-frontmatter.mjs` | Spike acceptance: daily-core Cursor frontmatter ≤ 2080 B |

--- a/packaging/openpackage/deft-directive-skills/README.md
+++ b/packaging/openpackage/deft-directive-skills/README.md
@@ -6,7 +6,7 @@ Tiered consumer skills for **Cursor**, **Codex CLI**, and **OpenCode**. This pac
 
 | Tier | Purpose | Install when |
 | --- | --- | --- |
-| **daily-core** | setup, sync, build, pre-pr, review-cycle, triage | Every session bootstrap (Cursor native skill injection) |
+| **daily-core** (default) | setup, sync, build, pre-pr, review-cycle, triage | Every session bootstrap (Cursor native skill injection) |
 | **standard** | decompose, feedback, gh-slice, interview, … | On-demand operational workflows |
 | **advanced** | release, swarm, debug, article-review | Maintainer / heavy workflows (deferred frontmatter) |
 
@@ -21,7 +21,11 @@ Full skill lists: [`../deft-tiers.json`](../deft-tiers.json).
 3. **Sync skills** from `content/skills/` (maintainer checkout or release prep):
 
    ```bash
+   # Default: daily-core only (recommended consumer path)
    node packaging/openpackage/sync-skills.mjs
+
+   # Maintainer / all tiers on disk before release
+   node packaging/openpackage/sync-skills.mjs --tier all
    ```
 
 ## Install (project)
@@ -29,11 +33,12 @@ Full skill lists: [`../deft-tiers.json`](../deft-tiers.json).
 From your **project root** (after `directive init`):
 
 ```bash
-# All tiers, Cursor + Codex CLI + OpenCode
+# Default — daily-core tier only (lean Cursor frontmatter)
+node /path/to/directive/packaging/openpackage/sync-skills.mjs
 opkg install /path/to/directive/packaging/openpackage/deft-directive-skills \
   --platforms cursor codex opencode
 
-# Daily-core only (recommended first pass on Cursor)
+# Explicit daily-core on Cursor only (same skill set as default sync)
 opkg install /path/to/directive/packaging/openpackage/deft-directive-skills \
   --skills deft-directive-setup deft-directive-sync deft-directive-build \
             deft-directive-pre-pr deft-directive-review-cycle deft-directive-triage \
@@ -41,6 +46,24 @@ opkg install /path/to/directive/packaging/openpackage/deft-directive-skills \
 ```
 
 Replace `/path/to/directive` with a clone path, or use a published registry snapshot when available.
+
+### Expanding tiers
+
+After the default daily-core install, add deferred workflows by syncing the broader tier and re-running `opkg install`:
+
+```bash
+# All tiers (standard + advanced on disk)
+node /path/to/directive/packaging/openpackage/sync-skills.mjs --tier all
+opkg install /path/to/directive/packaging/openpackage/deft-directive-skills \
+  --platforms cursor codex opencode
+
+# Standard tier only (operational workflows, no advanced)
+node /path/to/directive/packaging/openpackage/sync-skills.mjs --tier standard
+opkg install /path/to/directive/packaging/openpackage/deft-directive-skills \
+  --platforms cursor
+```
+
+For DD-3 budget reporting aligned with daily-core, set `plan.policy.agentsMdBudget.skillFrontmatterTier` to `daily-core` or export `DEFT_AGENTS_MD_BUDGET_SKILL_TIER=daily-core` (see UPGRADING.md § Always-on bootstrap budget).
 
 ## Uninstall
 

--- a/packaging/openpackage/deft-directive-skills/openpackage.yml
+++ b/packaging/openpackage/deft-directive-skills/openpackage.yml
@@ -15,6 +15,7 @@ keywords:
   - opencode
 x-deft:
   tierManifest: ../deft-tiers.json
+  defaultInstallTier: daily-core
   installPlatforms:
     - cursor
     - codex

--- a/packaging/openpackage/deft-tiers.json
+++ b/packaging/openpackage/deft-tiers.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "platforms": ["cursor", "codex", "opencode"],
+  "defaultInstallTier": "daily-core",
   "dailyCoreFrontmatterBudgetBytes": 2080,
   "tiers": {
     "daily-core": {

--- a/packaging/openpackage/openpackage-tiers.mjs
+++ b/packaging/openpackage/openpackage-tiers.mjs
@@ -3,8 +3,7 @@
  * Mirrors packages/core/src/packaging/openpackage-tiers.ts for node-runnable sync without a prior tsc build.
  */
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 const TIER_NAMES = ["daily-core", "standard", "advanced"];
 
@@ -55,9 +54,4 @@ export function resolveTierSkills(manifest, tier) {
     throw new Error(`unknown tier ${tier}; expected one of ${[...TIER_NAMES, "all"].join(", ")}`);
   }
   return [...manifest.tiers[tier].skills];
-}
-
-/** Resolve the packaging/openpackage directory that contains this module. */
-export function packagingOpenPackageDir() {
-  return dirname(fileURLToPath(import.meta.url));
 }

--- a/packaging/openpackage/openpackage-tiers.mjs
+++ b/packaging/openpackage/openpackage-tiers.mjs
@@ -1,0 +1,63 @@
+/**
+ * OpenPackage tier manifest helpers for packaging scripts (#2494).
+ * Mirrors packages/core/src/packaging/openpackage-tiers.ts for node-runnable sync without a prior tsc build.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TIER_NAMES = ["daily-core", "standard", "advanced"];
+
+export function isOpenPackageTierName(value) {
+  return TIER_NAMES.includes(value);
+}
+
+/** Load packaging/openpackage/deft-tiers.json from a repo root. */
+export function loadOpenPackageTierManifest(repoRoot) {
+  const path = join(repoRoot, "packaging", "openpackage", "deft-tiers.json");
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new Error(`deft-tiers.json unreadable at ${path}: ${err}`);
+  }
+
+  if (parsed === null || typeof parsed !== "object" || !parsed.tiers) {
+    throw new Error("deft-tiers.json must be an object with a tiers field");
+  }
+
+  for (const tier of TIER_NAMES) {
+    const block = parsed.tiers[tier];
+    if (!block || !Array.isArray(block.skills)) {
+      throw new Error(`deft-tiers.json missing tiers.${tier}.skills`);
+    }
+  }
+
+  const defaultInstallTier = parsed.defaultInstallTier ?? "daily-core";
+  if (!isOpenPackageTierName(defaultInstallTier)) {
+    throw new Error(
+      `deft-tiers.json defaultInstallTier must be one of ${TIER_NAMES.join(", ")}; got ${defaultInstallTier}`,
+    );
+  }
+
+  return {
+    defaultInstallTier,
+    tiers: parsed.tiers,
+  };
+}
+
+/** Resolve skill names to sync/install for a tier selection (`all` = every tier). */
+export function resolveTierSkills(manifest, tier) {
+  if (tier === "all") {
+    return [...new Set(TIER_NAMES.flatMap((name) => manifest.tiers[name].skills))];
+  }
+  if (!isOpenPackageTierName(tier)) {
+    throw new Error(`unknown tier ${tier}; expected one of ${[...TIER_NAMES, "all"].join(", ")}`);
+  }
+  return [...manifest.tiers[tier].skills];
+}
+
+/** Resolve the packaging/openpackage directory that contains this module. */
+export function packagingOpenPackageDir() {
+  return dirname(fileURLToPath(import.meta.url));
+}

--- a/packaging/openpackage/sync-skills.mjs
+++ b/packaging/openpackage/sync-skills.mjs
@@ -2,6 +2,9 @@
 /**
  * Copy content/skills/* into the OpenPackage skills/ tree before opkg install.
  * Source of truth remains content/skills/ (pack-rendered); this is distribution prep only.
+ *
+ * Default (--tier omitted): sync defaultInstallTier from deft-tiers.json (daily-core).
+ * Use --tier all for maintainer release prep with every tier on disk.
  */
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -14,6 +17,24 @@ const packageRoot = join(here, "deft-directive-skills");
 const skillsDest = join(packageRoot, "skills");
 const skillsSource = join(repoRoot, "content/skills");
 const gitkeepPath = join(skillsDest, ".gitkeep");
+
+const TIER_NAMES = ["daily-core", "standard", "advanced"];
+
+function parseArgs(argv) {
+  let tier = null;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--tier" && argv[i + 1]) {
+      tier = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--tier=")) {
+      tier = arg.slice("--tier=".length);
+    }
+  }
+  return { tier };
+}
 
 function loadTiers() {
   let parsed;
@@ -30,22 +51,53 @@ function loadTiers() {
   return parsed;
 }
 
+function resolveSyncTier(tiersDoc, cliTier) {
+  const selected = cliTier ?? tiersDoc.defaultInstallTier ?? "daily-core";
+  if (selected === "all") {
+    return "all";
+  }
+  if (!TIER_NAMES.includes(selected)) {
+    console.error(
+      `sync-skills: --tier must be one of ${[...TIER_NAMES, "all"].join(", ")}; got ${selected}`,
+    );
+    process.exit(1);
+  }
+  return selected;
+}
+
+function skillsForTier(tiersDoc, tier) {
+  if (tier === "all") {
+    return new Set(TIER_NAMES.flatMap((name) => tiersDoc.tiers[name].skills));
+  }
+  return new Set(tiersDoc.tiers[tier].skills);
+}
+
+const { tier: cliTier } = parseArgs(process.argv.slice(2));
 const tiers = loadTiers();
-const wanted = new Set(Object.values(tiers.tiers).flatMap((t) => t.skills));
+const syncTier = resolveSyncTier(tiers, cliTier);
+const wanted = skillsForTier(tiers, syncTier);
+
+const allMapped = new Set(Object.values(tiers.tiers).flatMap((t) => t.skills));
 
 const onDisk = readdirSync(skillsSource, { withFileTypes: true })
   .filter((d) => d.isDirectory())
   .map((d) => d.name);
 
-const missing = [...wanted].filter((s) => !onDisk.includes(s));
+const missing = [...allMapped].filter((s) => !onDisk.includes(s));
 if (missing.length > 0) {
   console.error(`sync-skills: missing content/skills entries: ${missing.join(", ")}`);
   process.exit(1);
 }
 
-const extra = onDisk.filter((s) => !wanted.has(s));
+const extra = onDisk.filter((s) => !allMapped.has(s));
 if (extra.length > 0) {
   console.error(`sync-skills: content/skills not mapped in deft-tiers.json: ${extra.join(", ")}`);
+  process.exit(1);
+}
+
+const missingForTier = [...wanted].filter((s) => !onDisk.includes(s));
+if (missingForTier.length > 0) {
+  console.error(`sync-skills: tier ${syncTier} references missing skills: ${missingForTier.join(", ")}`);
   process.exit(1);
 }
 
@@ -67,4 +119,4 @@ if (!existsSync(gitkeepPath)) {
   writeFileSync(gitkeepPath, "\n");
 }
 
-console.log(`sync-skills: copied ${wanted.size} skills to ${skillsDest}`);
+console.log(`sync-skills: tier=${syncTier}; copied ${wanted.size} skills to ${skillsDest}`);

--- a/packaging/openpackage/sync-skills.mjs
+++ b/packaging/openpackage/sync-skills.mjs
@@ -95,12 +95,6 @@ if (extra.length > 0) {
   process.exit(1);
 }
 
-const missingForTier = [...wanted].filter((s) => !onDisk.includes(s));
-if (missingForTier.length > 0) {
-  console.error(`sync-skills: tier ${syncTier} references missing skills: ${missingForTier.join(", ")}`);
-  process.exit(1);
-}
-
 if (existsSync(skillsDest)) {
   for (const entry of readdirSync(skillsDest, { withFileTypes: true })) {
     if (entry.name === ".gitkeep") continue;

--- a/packaging/openpackage/sync-skills.mjs
+++ b/packaging/openpackage/sync-skills.mjs
@@ -6,19 +6,21 @@
  * Default (--tier omitted): sync defaultInstallTier from deft-tiers.json (daily-core).
  * Use --tier all for maintainer release prep with every tier on disk.
  */
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  isOpenPackageTierName,
+  loadOpenPackageTierManifest,
+  resolveTierSkills,
+} from "./openpackage-tiers.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../..");
-const tiersPath = join(here, "deft-tiers.json");
 const packageRoot = join(here, "deft-directive-skills");
 const skillsDest = join(packageRoot, "skills");
 const skillsSource = join(repoRoot, "content/skills");
 const gitkeepPath = join(skillsDest, ".gitkeep");
-
-const TIER_NAMES = ["daily-core", "standard", "advanced"];
 
 function parseArgs(argv) {
   let tier = null;
@@ -36,48 +38,33 @@ function parseArgs(argv) {
   return { tier };
 }
 
-function loadTiers() {
-  let parsed;
-  try {
-    parsed = JSON.parse(readFileSync(tiersPath, "utf8"));
-  } catch (err) {
-    console.error(`sync-skills: invalid JSON in ${tiersPath}: ${err}`);
-    process.exit(1);
-  }
-  if (parsed === null || typeof parsed !== "object" || !parsed.tiers) {
-    console.error(`sync-skills: ${tiersPath} must be an object with a tiers field`);
-    process.exit(1);
-  }
-  return parsed;
-}
-
-function resolveSyncTier(tiersDoc, cliTier) {
-  const selected = cliTier ?? tiersDoc.defaultInstallTier ?? "daily-core";
+function resolveSyncTier(manifest, cliTier) {
+  const selected = cliTier ?? manifest.defaultInstallTier;
   if (selected === "all") {
     return "all";
   }
-  if (!TIER_NAMES.includes(selected)) {
+  if (!isOpenPackageTierName(selected)) {
     console.error(
-      `sync-skills: --tier must be one of ${[...TIER_NAMES, "all"].join(", ")}; got ${selected}`,
+      `sync-skills: --tier must be one of daily-core, standard, advanced, all; got ${selected}`,
     );
     process.exit(1);
   }
   return selected;
 }
 
-function skillsForTier(tiersDoc, tier) {
-  if (tier === "all") {
-    return new Set(TIER_NAMES.flatMap((name) => tiersDoc.tiers[name].skills));
-  }
-  return new Set(tiersDoc.tiers[tier].skills);
+const { tier: cliTier } = parseArgs(process.argv.slice(2));
+
+let manifest;
+try {
+  manifest = loadOpenPackageTierManifest(repoRoot);
+} catch (err) {
+  console.error(`sync-skills: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
 }
 
-const { tier: cliTier } = parseArgs(process.argv.slice(2));
-const tiers = loadTiers();
-const syncTier = resolveSyncTier(tiers, cliTier);
-const wanted = skillsForTier(tiers, syncTier);
-
-const allMapped = new Set(Object.values(tiers.tiers).flatMap((t) => t.skills));
+const syncTier = resolveSyncTier(manifest, cliTier);
+const wanted = new Set(resolveTierSkills(manifest, syncTier));
+const allMapped = new Set(resolveTierSkills(manifest, "all"));
 
 const onDisk = readdirSync(skillsSource, { withFileTypes: true })
   .filter((d) => d.isDirectory())

--- a/xbrief/active/2026-07-13-2494-featpackaging-phase-2-daily-core-install-default-for-consume.xbrief.json
+++ b/xbrief/active/2026-07-13-2494-featpackaging-phase-2-daily-core-install-default-for-consume.xbrief.json
@@ -1,0 +1,120 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "feat(packaging): Phase 2 daily-core install default for consumer always-on (DD-3)",
+    "created": "2026-07-13T21:04:30.410Z",
+    "updated": "2026-07-13T21:04:30.410Z"
+  },
+  "plan": {
+    "id": "2494-daily-core-default",
+    "title": "feat(packaging): Phase 2 daily-core install default for consumer always-on (DD-3)",
+    "status": "running",
+    "narratives": {
+      "Description": "Make daily-core the default skill tier for consumer installs (Cursor + documented OpenPackage path) so DD-3 frontmatter stays ~2 KB class instead of all-skills ~7.7 KB. Phase-2 success with managed ≤8192 B; hard combined ≤8192 remains Phase-3 prep on #2491. Builds on #2462/#2463; does not require #2176.",
+      "UserStory": "As a consumer operator, I want new installs to default to daily-core skills, so that Cursor always-on frontmatter cost stays low unless I opt into broader tiers.",
+      "ImplementationPlan": "1) Edit packaging/openpackage/deft-tiers.json and packaging/openpackage/deft-directive-skills/openpackage.yml so default install selects daily-core. 2) Update packaging/openpackage/sync-skills.mjs and packaging/openpackage/deft-directive-skills/README.md for default-tier behavior. 3) Document in README.md and content/UPGRADING.md beside npm i -g @deftai/directive. 4) Extend packages/core/src/packaging/openpackage-manifest.test.ts (or add packaging/openpackage tests) for default=daily-core; run node packaging/openpackage/measure-daily-core-frontmatter.mjs. 5) CHANGELOG.md [Unreleased] Closes #2494. Verify: node packaging/openpackage/measure-daily-core-frontmatter.mjs; pnpm exec vitest run packages/core/src/packaging; task check --allow-over-cap.",
+      "Origin": "Enriched from #2494 under epic #2491",
+      "Overview": "Out of scope: hard combined ≤8192; runtime router."
+    },
+    "items": [
+      {
+        "id": "2494-a1",
+        "title": "Default install is daily-core",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a consumer install via documented OpenPackage path, when no tier override is set, then daily-core skills are what get installed/synced by default.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2494-a2",
+        "title": "Meter can show daily-core tier",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given verify:agents-md-budget or packaging smoke, when daily-core tier is selected, then frontmatter reporting reflects the daily-core skill set.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2494-a3",
+        "title": "Docs for expanding tiers",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given README/UPGRADING, when an operator wants standard/advanced, then expansion steps are documented.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2494-a4",
+        "title": "CHANGELOG + close",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given merge, when PR lands, then CHANGELOG cites Closes #2494.",
+          "Traces": "FR-1"
+        }
+      }
+    ],
+    "tags": [
+      "context-engineering",
+      "agent-experience",
+      "skills",
+      "urgent"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2494",
+        "type": "x-xbrief/github-issue",
+        "title": "#2494"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2491",
+        "type": "x-xbrief/refs",
+        "title": "Parent epic #2491"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2462",
+        "type": "x-xbrief/refs",
+        "title": "#2462"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2463",
+        "type": "x-xbrief/refs",
+        "title": "#2463"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2370",
+        "type": "x-xbrief/refs",
+        "title": "#2370"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packaging/openpackage/",
+          "README.md",
+          "content/UPGRADING.md",
+          "packages/core/src/packaging/",
+          "CHANGELOG.md"
+        ],
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "size": "medium",
+        "verify_commands": [
+          "node packaging/openpackage/measure-daily-core-frontmatter.mjs",
+          "task check --allow-over-cap"
+        ],
+        "expected_outputs": [
+          "daily-core default install path",
+          "PR Closes #2494"
+        ],
+        "depends_on": [],
+        "conflict_group": "openpackage-daily-core-2494",
+        "priority": "phase2-shrink"
+      }
+    },
+    "updated": "2026-07-13T21:22:59Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `defaultInstallTier: daily-core` to `deft-tiers.json` and `openpackage.yml` so the documented consumer path installs only the six session-bootstrap skills by default.
- Update `sync-skills.mjs` to default to daily-core (with `--tier all|standard|advanced` overrides) and document tier expansion in README, UPGRADING, and OpenPackage package README.
- Add `openpackage-tiers.ts` loader/tests and extend manifest tests; daily-core frontmatter meter stays at 1826 B (budget 2080 B).

## Test plan

- [x] `node packaging/openpackage/sync-skills.mjs` copies 6 daily-core skills
- [x] `node packaging/openpackage/measure-daily-core-frontmatter.mjs` passes (1826 B <= 2080 B)
- [x] `pnpm exec vitest run packages/core/src/packaging` (8 tests)
- [ ] CI `task check`

Closes #2494. Refs #2491, #2462, #2463, #2370.