### PR TITLE
feat(session): read-only posture defers ceremony until mutation (#2176)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ Same rules as the managed `### Deft Alignment Confirmation` below: at session st
 
 Same rules as the managed `## Session-start ritual` below; in this repo substitute `task` for `deft` (`task session:start`, `task verify:session-ritual -- --tier=gated`, `task verify:tools`, `task doctor`, `task verify:cache-fresh`).
 
+## Session routing (#2176)
+
+Same rules as the managed `## Session routing (#2176)` below: default to read-only posture for Q&A, Plan Mode, and ticket-shaping; defer mutable `task session:start` until mutation intent. Explicit read-only CLI: `task session:start -- --read-only`.
+
 ## Template propagation discipline (#1309)
 
 ! When a maintainer-side rule lands in this `AGENTS.md` that is consumer-relevant (welcome / WIP cap / triage / install integrity / branch policy / encoding gates / canonical commands / skill routing), the same PR MUST update `content/templates/agents-entry.md` to mirror it, then run `task agents:refresh` so consumer-side AGENTS.md inherits the change. The deterministic gate `tests/content/test_agents_entry_contract.py` enforces this with a whitespace-normalized substring containment check over a curated marker list (commands, policy keys, distinctive headers, action-verb directive list); adding a new consumer-relevant rule means extending that marker list in the same PR.
@@ -213,7 +217,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `content/templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=977563e97ddc refreshed=2026-07-07T14:02:20Z session=8d3ecca17184 -->
+<!-- deft:managed-section v3 sha=dced3f4cf6d0 refreshed=2026-07-13T21:27:10Z session=68814a30e020 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -277,9 +281,24 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ⊗ Confirm Deft alignment without first reading USER.md content -- a presence / `Test-Path` existence check is insufficient; the confirmation MUST echo the addressing-name read from inside USER.md.
 
+## Session routing (#2176)
+
+! Default interactive sessions to **read-only posture** until mutation or implementation intent: questions, research, Plan Mode, ticket-shaping, and issue filing that does not depend on fresh local repo state. Read required context (AGENTS.md, main.md, USER.md, PROJECT-DEFINITION when present); confirm Deft alignment with addressing-name; ⊗ do not run mutable ceremony or emit branch/triage/sync/lifecycle noise unless the operator asks or the task is implementation-ready.
+
+**Read-only posture (default for Q&A / Plan Mode):**
+- ! Load accurate project/user context; confirm alignment with USER.md addressing-name.
+- ⊗ Run `deft session:start` when it would write `.deft/ritual-state.json`, install/build dependencies, or emit triage welcome, branch-policy, default-branch sync, sync-skill lifecycle checks, or eval/value readback writes.
+- ~ Operators MAY explicitly request `deft session:start`, `deft triage:welcome`, sync, or doctor output in read-only sessions.
+
+**Mutation boundaries** (lazy full ritual before proceeding):
+- ! At the first code-writing tool call, scope lifecycle mutation, `start_agent` / implementation dispatch, commits, pushes, PR-from-local-changes, or release work: run the mutable quick tier (`deft session:start`) then gated tier (`deft verify:session-ritual -- --tier=gated`) per `.deft/core/commands.md` § Session-start ritual before continuing.
+- ⊗ Proceed to mutation without running the gated ritual stack first.
+
+**Explicit read-only CLI:** `deft session:start -- --read-only` records alignment only and writes no ritual-state (#2176).
+
 ## Session-start ritual (#1149)
 
-! On every interactive session start run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, and headless bypass in `.deft/core/commands.md` § Session-start ritual.
+! On **mutation** session start (implementation intent or explicit operator request), run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, headless bypass, and read-only default in `.deft/core/commands.md` § Session-start ritual.
 
 ## WIP cap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Read-only Directive session posture defers ceremony until you start changing things.** Questions, Plan Mode, and ticket-shaping now default to alignment-only context loads without writing `.deft/ritual-state.json`, triage welcome, branch-policy dumps, or install side effects; the full mutable ritual still runs at mutation boundaries. Use `deft session:start -- --read-only` for explicit alignment-only mode. Closes #2176. Refs #2491.
+
 ### Changed
 
 - **Security docs clarify LLM trust-tier framing for informational AppSec findings.** Guidance in REFERENCES, security taxonomy, context engineering, llm-app patterns, and coding rules now states that provider/SDK mentions are framework guidance for consumer projects, not runtime surfaces in the directive repo. Closes #2414.

--- a/content/commands.md
+++ b/content/commands.md
@@ -183,9 +183,18 @@ Use `task --list` for the exact current verify namespace.
 
 ## Session-start ritual (#1149)
 
-Full always-on contract for the interactive session-start ritual and its gated verifier (#1149 / #1348).
+Full always-on contract for the interactive session-start ritual and its gated verifier (#1149 / #1348). Read-only posture (#2176) defers this ceremony until mutation intent — see `.deft/core/commands.md` § Session routing.
 
-- ! On every interactive session start, run `deft session:start` (or `task session:start` in framework source) after loading AGENTS.md. Records quick-tier ritual in `.deft/ritual-state.json`: alignment confirmation, branch-policy disclosure, `deft verify:tools` guidance, default-branch sync warnings, and `deft triage:welcome` one-liner. State is worktree- and HEAD-bound; stale after `plan.policy.sessionRitualStalenessHours` hours (default 4).
+### Session routing (#2176)
+
+- ! Default interactive sessions to **read-only posture** until mutation or implementation intent (questions, research, Plan Mode, ticket-shaping). Load AGENTS.md / main.md / USER.md / PROJECT-DEFINITION; confirm alignment with addressing-name; ⊗ do not write `.deft/ritual-state.json`, run install/build side effects, or emit triage welcome, branch-policy, default-branch sync, sync-skill lifecycle checks, or eval/value readback writes unless the operator asks or the task is implementation-ready.
+- ! At mutation boundaries (code-writing, scope lifecycle moves, `start_agent`, commits, pushes, PR-from-local-changes, release work): run the mutable quick tier then gated verifier below before proceeding.
+- ? Explicit read-only alignment only: `deft session:start -- --read-only` (no ritual-state write).
+- ~ Operators MAY still explicitly request full `deft session:start`, `deft triage:welcome`, sync, or doctor in read-only sessions.
+
+### Mutable ritual (mutation posture)
+
+- ! On **mutation** session start, run `deft session:start` (or `task session:start` in framework source) after loading AGENTS.md. Records quick-tier ritual in `.deft/ritual-state.json`: alignment confirmation, branch-policy disclosure, `deft verify:tools` guidance, default-branch sync warnings, and `deft triage:welcome` one-liner. State is worktree- and HEAD-bound; stale after `plan.policy.sessionRitualStalenessHours` hours (default 4).
 - ! Before any code-writing tool call or `start_agent` implementation dispatch, run `deft verify:session-ritual -- --tier=gated`. Gated tier fails closed unless quick-tier state is fresh; lazily records `deft doctor` and `deft verify:cache-fresh` entrypoints. Step 0 of the pre-`start_agent` gate stack.
 - ? Postpone with `deft session:start -- --defer step=reason` (`alignment`, `branch_policy`, `triage_welcome`, `doctor`, `cache_fresh`).
 - Headless workers / CI MAY set `DEFT_SESSION_RITUAL_SKIP=1`; verifier exits 0 but warns when bypass hides failure.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -62,9 +62,24 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ⊗ Confirm Deft alignment without first reading USER.md content -- a presence / `Test-Path` existence check is insufficient; the confirmation MUST echo the addressing-name read from inside USER.md.
 
+## Session routing (#2176)
+
+! Default interactive sessions to **read-only posture** until mutation or implementation intent: questions, research, Plan Mode, ticket-shaping, and issue filing that does not depend on fresh local repo state. Read required context (AGENTS.md, main.md, USER.md, PROJECT-DEFINITION when present); confirm Deft alignment with addressing-name; ⊗ do not run mutable ceremony or emit branch/triage/sync/lifecycle noise unless the operator asks or the task is implementation-ready.
+
+**Read-only posture (default for Q&A / Plan Mode):**
+- ! Load accurate project/user context; confirm alignment with USER.md addressing-name.
+- ⊗ Run `deft session:start` when it would write `.deft/ritual-state.json`, install/build dependencies, or emit triage welcome, branch-policy, default-branch sync, sync-skill lifecycle checks, or eval/value readback writes.
+- ~ Operators MAY explicitly request `deft session:start`, `deft triage:welcome`, sync, or doctor output in read-only sessions.
+
+**Mutation boundaries** (lazy full ritual before proceeding):
+- ! At the first code-writing tool call, scope lifecycle mutation, `start_agent` / implementation dispatch, commits, pushes, PR-from-local-changes, or release work: run the mutable quick tier (`deft session:start`) then gated tier (`deft verify:session-ritual -- --tier=gated`) per `.deft/core/commands.md` § Session-start ritual before continuing.
+- ⊗ Proceed to mutation without running the gated ritual stack first.
+
+**Explicit read-only CLI:** `deft session:start -- --read-only` records alignment only and writes no ritual-state (#2176).
+
 ## Session-start ritual (#1149)
 
-! On every interactive session start run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, and headless bypass in `.deft/core/commands.md` § Session-start ritual.
+! On **mutation** session start (implementation intent or explicit operator request), run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, headless bypass, and read-only default in `.deft/core/commands.md` § Session-start ritual.
 
 ## WIP cap
 

--- a/packages/cli/src/session-start.test.ts
+++ b/packages/cli/src/session-start.test.ts
@@ -16,6 +16,7 @@ describe("session-start parseArgs", () => {
       deferValues: [],
       emitJson: false,
       noHistory: false,
+      readOnly: false,
     });
   });
 
@@ -34,6 +35,7 @@ describe("session-start parseArgs", () => {
       deferValues: ["doctor=postponed"],
       emitJson: true,
       noHistory: true,
+      readOnly: false,
     });
   });
 
@@ -43,6 +45,17 @@ describe("session-start parseArgs", () => {
       deferValues: ["cache_fresh=later"],
       emitJson: false,
       noHistory: false,
+      readOnly: false,
+    });
+  });
+
+  it("parses --read-only", () => {
+    expect(parseArgs(["--read-only", "--project-root", "/x"])).toEqual({
+      projectRoot: "/x",
+      deferValues: [],
+      emitJson: false,
+      noHistory: false,
+      readOnly: true,
     });
   });
 
@@ -81,6 +94,34 @@ describe("session-start run", () => {
       expect(run(["--defer", "not-a-valid-step"])).toBe(2);
       expect(err.length).toBeGreaterThan(0);
     } finally {
+      process.stderr.write = prevStderr;
+    }
+  });
+
+  it("writes read-only footer without ritual-state on --read-only", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-session-start-ro-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      `${JSON.stringify({ xBRIEFInfo: { version: "0.8" }, plan: { title: "T", status: "running", items: [] } })}\n`,
+      "utf8",
+    );
+    const prevStdout = process.stdout.write.bind(process.stdout);
+    const prevStderr = process.stderr.write.bind(process.stderr);
+    let out = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      out += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      const code = run(["--project-root", root, "--read-only", "--no-history"]);
+      expect(code).toBe(0);
+      expect(out).toContain("read-only session posture");
+      expect(out).not.toContain("session ritual recorded");
+    } finally {
+      process.stdout.write = prevStdout;
       process.stderr.write = prevStderr;
     }
   });

--- a/packages/cli/src/session-start.ts
+++ b/packages/cli/src/session-start.ts
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseDeferrals, ritualStatePath, runSessionStart } from "@deftai/directive-core/session";
+import {
+  parseDeferrals,
+  READ_ONLY_POSTURE,
+  ritualStatePath,
+  runSessionStart,
+} from "@deftai/directive-core/session";
 
 export interface ParsedSessionStartArgs {
   projectRoot: string;
   deferValues: string[];
   emitJson: boolean;
   noHistory: boolean;
+  readOnly: boolean;
   error?: string;
 }
 
@@ -18,6 +24,7 @@ export function parseArgs(argv: readonly string[]): ParsedSessionStartArgs {
     deferValues: [],
     emitJson: false,
     noHistory: false,
+    readOnly: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -25,6 +32,8 @@ export function parseArgs(argv: readonly string[]): ParsedSessionStartArgs {
       parsed.emitJson = true;
     } else if (arg === "--no-history") {
       parsed.noHistory = true;
+    } else if (arg === "--read-only") {
+      parsed.readOnly = true;
     } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -87,6 +96,7 @@ export function run(argv: readonly string[]): number {
     result = runSessionStart(projectRoot, {
       deferrals,
       writeHistory: !args.noHistory,
+      posture: args.readOnly ? READ_ONLY_POSTURE : undefined,
     });
   } finally {
     process.stdout.write = prevWrite;
@@ -114,7 +124,12 @@ export function run(argv: readonly string[]): number {
     sink.write(`${line}\n`);
   }
   if (result.code === 0) {
-    process.stdout.write(`[deft] session ritual recorded at ${ritualStatePath(projectRoot)}\n`);
+    const posture = result.payload.posture;
+    if (posture === READ_ONLY_POSTURE) {
+      process.stdout.write(`[deft] ${String(result.payload.message)}\n`);
+    } else {
+      process.stdout.write(`[deft] session ritual recorded at ${ritualStatePath(projectRoot)}\n`);
+    }
   }
   return result.code;
 }

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -95,6 +95,7 @@ const PROPAGATION_POLICY_KEY_MARKERS = [
 ] as const;
 
 const PROPAGATION_HEADER_MARKERS = [
+  "## Session routing (#2176)",
   "## Session-start ritual (#1149)",
   "## Unmanaged project header (#2065)",
   "## Cache-as-authoritative work selection (#1149)",

--- a/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
@@ -34,6 +34,19 @@ describe("test_agents_md_session_start", () => {
   it("session_start_ritual_header_present", () => {
     expect(/^##\s+Session-start ritual\s+\(#1149\)\s*$/m.test(agentsMdText)).toBe(true);
     expect(/^##\s+Session-start ritual\s+\(#1149\)\s*$/m.test(agentsEntryText)).toBe(true);
+    expect(/^##\s+Session routing\s+\(#2176\)\s*$/m.test(agentsEntryText)).toBe(true);
+  });
+
+  it("session_routing_read_only_posture_present", () => {
+    const entrySection = extractSection(agentsEntryText, "Session routing \\(#2176\\)");
+    expect(entrySection).toBeTruthy();
+    expect(entrySection).toContain("read-only posture");
+    expect(entrySection).toContain("deft session:start -- --read-only");
+    expect(entrySection).toContain(".deft/ritual-state.json");
+    expect(entrySection).toContain("Mutation boundaries");
+    const commandsSection = extractSection(commandsText, "Session-start ritual \\(#1149\\)");
+    expect(commandsSection).toContain("Session routing (#2176)");
+    expect(commandsSection).toContain("deft session:start -- --read-only");
   });
 
   it("session_start_ritual_pointer_surface_in_managed_section", () => {

--- a/packages/core/src/session/package-manager-network.test.ts
+++ b/packages/core/src/session/package-manager-network.test.ts
@@ -98,6 +98,16 @@ describe("package-manager network scope (#2182)", () => {
     temps.length = 0;
   });
 
+  it("session:start (read-only) invokes no npm/pnpm even with a private-scope registry present", () => {
+    const { root } = initPrivateScopeRepo();
+    temps.push(root);
+
+    const result = runSessionStart(root, { writeHistory: false, posture: "read-only" });
+
+    expect(result.code).toBe(0);
+    expect(packageManagerCalls(spawnSyncMock)).toEqual([]);
+  });
+
   it("session:start (quick tier) invokes no npm/pnpm even with a private-scope registry present", () => {
     const { root } = initPrivateScopeRepo();
     temps.push(root);

--- a/packages/core/src/session/session-start-read-only.test.ts
+++ b/packages/core/src/session/session-start-read-only.test.ts
@@ -1,0 +1,71 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ResolveUserMdResult } from "../user-config/resolve-user-md.js";
+import { ritualStatePath } from "./ritual-sentinel.js";
+import { READ_ONLY_POSTURE, READ_ONLY_RESULT_MESSAGE, runSessionStart } from "./session-start.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const t of temps) rmSync(t, { recursive: true, force: true });
+  temps.length = 0;
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "session-read-only-"));
+  temps.push(root);
+  return root;
+}
+
+function userMdResult(overrides: Partial<ResolveUserMdResult> = {}): ResolveUserMdResult {
+  return {
+    path: "/home/x/.config/deft/USER.md",
+    rung: "platform-config",
+    found: true,
+    diagnostic: "USER.md resolved from platform config dir",
+    searched: [],
+    ...overrides,
+  };
+}
+
+describe("runSessionStart read-only posture (#2176)", () => {
+  it("records alignment only and writes no ritual-state", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      posture: READ_ONLY_POSTURE,
+      resolveUserMd: () => userMdResult({ path: "/opt/USER.md", rung: "env-override" }),
+    });
+    expect(result.code).toBe(0);
+    expect(result.payload.posture).toBe(READ_ONLY_POSTURE);
+    expect(result.payload.state_path).toBeNull();
+    expect(result.payload.message).toBe(READ_ONLY_RESULT_MESSAGE);
+    expect(existsSync(ritualStatePath(root))).toBe(false);
+    expect(result.lines.join("\n")).toContain("Deft Directive active");
+    expect(result.lines.join("\n")).toContain("USER.md resolved (env-override)");
+    expect(result.lines.join("\n")).not.toContain("[deft policy]");
+    expect(result.lines.join("\n")).not.toContain("[welcome]");
+  });
+
+  it("mutation posture still writes ritual-state by default", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      writeHistory: false,
+      resolveUserMd: () => userMdResult(),
+      verifyTools: () => ({ exitCode: 0 }),
+      runTriageWelcome: () => ({ exitCode: 0 }),
+      runGit: (_r, args) => {
+        if (args[0] === "rev-parse" && args.includes("HEAD")) {
+          return { code: 0, stdout: "abc123", stderr: "" };
+        }
+        if (args[0] === "rev-parse" && args.includes("--show-toplevel")) {
+          return { code: 0, stdout: root, stderr: "" };
+        }
+        return { code: 1, stdout: "", stderr: "" };
+      },
+    });
+    expect(result.code).toBe(0);
+    expect(result.payload.posture).toBeUndefined();
+    expect(existsSync(ritualStatePath(root))).toBe(true);
+  });
+});

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -17,6 +17,14 @@ import {
   writeRitualState,
 } from "./ritual-sentinel.js";
 
+export const SESSION_POSTURES = ["read-only", "mutation"] as const;
+export type SessionPosture = (typeof SESSION_POSTURES)[number];
+export const READ_ONLY_POSTURE: SessionPosture = "read-only";
+export const MUTATION_POSTURE: SessionPosture = "mutation";
+export const READ_ONLY_ALIGNMENT_MESSAGE = "Deft Directive active -- AGENTS.md loaded.";
+export const READ_ONLY_RESULT_MESSAGE =
+  "read-only session posture (alignment only; no ritual-state write)";
+
 export const QUICK_STEPS = ["alignment", "branch_policy", "triage_welcome"] as const;
 export const GATED_STEPS = ["doctor", "cache_fresh"] as const;
 
@@ -44,6 +52,8 @@ export interface SessionStartResult {
 }
 
 export interface SessionStartOptions {
+  /** #2176: read-only records alignment only; mutation runs the full quick tier. */
+  readonly posture?: SessionPosture;
   readonly deferrals?: Readonly<Record<string, string>>;
   readonly now?: Date;
   readonly writeHistory?: boolean;
@@ -236,13 +246,58 @@ export function defaultBranchSync(
   return { branch, upstream, ahead, behind, warning };
 }
 
+function runReadOnlySessionStart(
+  projectRoot: string,
+  options: SessionStartOptions,
+  instant: Date,
+): SessionStartResult {
+  const lines: string[] = [];
+  const resolveUserMd =
+    options.resolveUserMd ?? ((root) => resolveUserMdPath({ projectRoot: root }));
+  const userMd = resolveUserMd(projectRoot);
+  const safePath = userMd.path.replace(/\r?\n/g, " ");
+  const safeDiagnostic = userMd.diagnostic.replace(/\r?\n/g, " ");
+  const userMdLine = userMd.found
+    ? `USER.md resolved (${userMd.rung}): ${safePath}`
+    : safeDiagnostic;
+  lines.push(READ_ONLY_ALIGNMENT_MESSAGE);
+  lines.push(userMdLine);
+  const resultPayload = {
+    ready: true,
+    exit_code: 0,
+    posture: READ_ONLY_POSTURE,
+    state_path: null,
+    quick_steps: {
+      alignment: ritualStep({
+        ok: true,
+        ts: instant,
+        message: `${READ_ONLY_ALIGNMENT_MESSAGE} ${userMdLine}`,
+      }),
+    },
+    gated_steps: {},
+    user_md: {
+      path: userMd.path,
+      rung: userMd.rung,
+      found: userMd.found,
+      diagnostic: userMd.diagnostic,
+    },
+    message: READ_ONLY_RESULT_MESSAGE,
+  };
+  return { code: 0, payload: resultPayload, lines };
+}
+
 export function runSessionStart(
   projectRoot: string,
   options: SessionStartOptions = {},
 ): SessionStartResult {
+  const posture = options.posture ?? MUTATION_POSTURE;
   const instant = options.now ?? new Date();
   const deferrals = options.deferrals ?? {};
   const runGit = options.runGit ?? defaultGitRunner;
+
+  if (posture === READ_ONLY_POSTURE) {
+    return runReadOnlySessionStart(projectRoot, options, instant);
+  }
   const { head: gitHeadValue, error: gitError } = gitHead(projectRoot, runGit);
   if (gitHeadValue === null) {
     const payload = {

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16784,7 +16784,7 @@
       "agentsMdBudget": {
         "managedMaxLines": 244,
         "unmanagedMaxLines": 270,
-        "absoluteMaxBytes": 16843
+        "absoluteMaxBytes": 18523
       }
     },
     "updated": "2026-07-02T14:32:31Z"

--- a/xbrief/active/2026-07-13-2176-add-a-read-only-directive-session-posture-that-defers-mutabl.xbrief.json
+++ b/xbrief/active/2026-07-13-2176-add-a-read-only-directive-session-posture-that-defers-mutabl.xbrief.json
@@ -1,0 +1,128 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Add a read-only Directive session posture that defers mutable ceremony until implementation intent",
+    "created": "2026-07-13T21:04:30.410Z",
+    "updated": "2026-07-13T21:04:30.410Z"
+  },
+  "plan": {
+    "id": "2176-read-only-session-posture",
+    "title": "Add a read-only Directive session posture that defers mutable ceremony until implementation intent",
+    "status": "running",
+    "narratives": {
+      "Description": "Add a true read-only Directive posture for questions, research, Plan Mode, and ticket-shaping so agents do not run mutable session:start ceremony, triage welcome, sync validation, or branch-policy dumps until mutation or implementation intent. Alignment confirmation and accurate context reads remain. This is Wave 0 under epic #2491 and the hard gate for #2493 session-routing compression. Tier-1 host hooks (#2437/#2438) may enforce later; this story targets Tier-0 prose/policy/CLI behavior.",
+      "UserStory": "As an operator, I want to open a Directive repo and ask questions without session ceremony or local mutations, so that Directive feels light to adopt while remaining strict when I start changing the tree.",
+      "ImplementationPlan": "1) Encode read-only posture in content/templates/agents-entry.md session-routing sections and content/commands.md ritual pointers. 2) Implement no-mutate / deferred path in packages/cli session:start (and packages/core ritual-state writers) so read-only sessions need not write .deft/ritual-state.json or trigger pnpm install side effects. 3) Gate triage welcome / branch-policy / sync dumps behind mutation posture in the CLI surfaces that emit them. 4) Add tests under packages/core/src/ and/or packages/cli for read-only vs mutation transition. 5) CHANGELOG.md Closes #2176; Refs #2491. Verify: pnpm exec vitest run <new-or-touched-tests>; task check --allow-over-cap.",
+      "Origin": "Enriched from #2176 under epic #2491 Wave 0",
+      "Overview": "Non-goals: remove ritual for implementation; weaken branch/xBRIEF gates; block explicit session:start requests."
+    },
+    "items": [
+      {
+        "id": "2176-a1",
+        "title": "No ritual-state write in read-only / Plan Mode",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a read-only or Plan Mode session, when the agent answers questions, then .deft/ritual-state.json is not written.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2176-a2",
+        "title": "No install/build side effects in read-only",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given read-only posture, when ceremony is deferred, then no dependency install/build leaves artifacts such as .pnpm-store/.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2176-a3",
+        "title": "Concise alignment without ceremony dumps",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given Q&A or ticket-shaping, when the session starts, then alignment confirms without triage/branch/sync/lifecycle ceremony.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2176-a7",
+        "title": "Full gated ritual at mutation",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given mutation or implementation intent, when the agent proceeds, then the mutable/gated ritual still runs before code changes, dispatch, scope mutation, commits, pushes, and release work.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2176-a8",
+        "title": "Tests for posture transition",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the implementation, when tests run, then read-only, Plan Mode, and lazy read-only→mutable transition are covered.",
+          "Traces": "FR-1"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "triage",
+      "agent-experience",
+      "process"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2176",
+        "type": "x-xbrief/github-issue",
+        "title": "#2176"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2491",
+        "type": "x-xbrief/refs",
+        "title": "Parent epic #2491"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2493",
+        "type": "x-xbrief/refs",
+        "title": "Gates #2493"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2180",
+        "type": "x-xbrief/refs",
+        "title": "Parallel #2180"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2437",
+        "type": "x-xbrief/refs",
+        "title": "Hooks epic #2437"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/templates/agents-entry.md",
+          "content/commands.md",
+          "packages/cli/src/",
+          "packages/core/src/",
+          "CHANGELOG.md"
+        ],
+        "file_scope_confidence": "medium",
+        "model_tier": "medium",
+        "size": "medium",
+        "verify_commands": [
+          "task check --allow-over-cap"
+        ],
+        "expected_outputs": [
+          "read-only posture documented + enforced for ceremony deferral",
+          "PR Closes #2176"
+        ],
+        "depends_on": [],
+        "conflict_group": "session-posture-2176",
+        "priority": "wave-0"
+      }
+    },
+    "updated": "2026-07-13T21:22:46Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Add read-only Directive session posture for Q&A, Plan Mode, and ticket-shaping: alignment + context reads only, no `.deft/ritual-state.json` write, no triage welcome / branch-policy / install side effects.
- Encode posture contract in `content/templates/agents-entry.md` (`## Session routing (#2176)`) and `content/commands.md`; mutation boundaries still run the full gated ritual stack.
- CLI: `deft session:start -- --read-only` for explicit alignment-only mode; core `runSessionStart({ posture: "read-only" })` skips mutable quick-tier steps.

## Test plan
- [x] `pnpm exec vitest run` session-start read-only + contract tests
- [x] `verify:agents-md-budget` ratchet re-seeded to 18523 B
- [ ] CI `task check` on Linux

Closes #2176
Refs #2491