### PR TITLE
feat(session): ephemeral posture — ceremony only at mutation boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Session posture is ephemeral — ceremony runs only at mutation boundaries.** Cleared or fresh agent contexts default to read-only; `verify:session-ritual` no longer treats `.deft/ritual-state.json` as proof of mutation intent, and gated checks still run fresh when you actually start mutating work. Closes #2180. Refs #2491 #2176.
+
 - **Security docs clarify LLM trust-tier framing for informational AppSec findings.** Guidance in REFERENCES, security taxonomy, context engineering, llm-app patterns, and coding rules now states that provider/SDK mentions are framework guidance for consumer projects, not runtime surfaces in the directive repo. Closes #2414.
 
 ### Fixed

--- a/packages/cli/src/gates-cli/session-ritual-cli.test.ts
+++ b/packages/cli/src/gates-cli/session-ritual-cli.test.ts
@@ -103,16 +103,31 @@ describe("deft-ts session:start dispatcher smoke", () => {
 });
 
 describe("verify session ritual TS module (maps tests/cli/test_verify_session_ritual.py)", () => {
-  it("fails closed when ritual state is missing", () => {
+  it("fails closed when ritual state is missing at gated mutation boundary", () => {
     const root = seedProject();
     roots.push(root);
     const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
     const result = verifySessionRitual(root, {
+      tier: "gated",
       bypass: false,
       runGit: fakeGit(head, resolve(root)),
     });
     expect(result.code).toBe(1);
     expect(result.message).toContain("deft session:start");
+  });
+
+  it("passes without ritual state in read-only quick posture (#2180)", () => {
+    const root = seedProject();
+    roots.push(root);
+    const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const result = verifySessionRitual(root, {
+      tier: "quick",
+      posture: "read-only",
+      bypass: false,
+      runGit: fakeGit(head, resolve(root)),
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("read-only posture");
   });
 });
 

--- a/packages/cli/src/session-start.ts
+++ b/packages/cli/src/session-start.ts
@@ -128,7 +128,9 @@ export function run(argv: readonly string[]): number {
     if (posture === READ_ONLY_POSTURE) {
       process.stdout.write(`[deft] ${String(result.payload.message)}\n`);
     } else {
-      process.stdout.write(`[deft] session ritual recorded at ${ritualStatePath(projectRoot)}\n`);
+      process.stdout.write(
+        `[deft] session ritual recorded at ${ritualStatePath(projectRoot)} (diagnostic-only; not posture authority)\n`,
+      );
     }
   }
   return result.code;

--- a/packages/cli/src/verify-session-ritual.ts
+++ b/packages/cli/src/verify-session-ritual.ts
@@ -2,6 +2,7 @@
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  type DirectivePosture,
   emitBypassWarning,
   emitVerifyJson,
   verifySessionRitual,
@@ -10,13 +11,25 @@ import {
 interface ParsedArgs {
   projectRoot: string;
   tier: "quick" | "gated";
+  posture: DirectivePosture | null;
   emitJson: boolean;
   error?: string;
 }
 
+function parsePosture(value: string): DirectivePosture | null {
+  if (value === "read-only") return "read-only";
+  if (value === "mutation" || value === "mutating") return "mutation";
+  return null;
+}
+
 /** Parse verify-session-ritual CLI args, mirroring scripts/verify_session_ritual.py. */
 export function parseArgs(argv: string[]): ParsedArgs {
-  const parsed: ParsedArgs = { projectRoot: ".", tier: "quick", emitJson: false };
+  const parsed: ParsedArgs = {
+    projectRoot: ".",
+    tier: "quick",
+    posture: null,
+    emitJson: false,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--json") {
@@ -46,6 +59,30 @@ export function parseArgs(argv: string[]): ParsedArgs {
         return { ...parsed, error: `argument --tier: invalid choice: '${value}'` };
       }
       parsed.tier = value;
+    } else if (arg === "--posture") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --posture: expected one argument" };
+      }
+      const posture = parsePosture(value);
+      if (posture === null) {
+        return {
+          ...parsed,
+          error: `argument --posture: invalid choice: '${value}' (expected read-only|mutation)`,
+        };
+      }
+      parsed.posture = posture;
+      i += 1;
+    } else if (arg?.startsWith("--posture=")) {
+      const value = arg.slice("--posture=".length);
+      const posture = parsePosture(value);
+      if (posture === null) {
+        return {
+          ...parsed,
+          error: `argument --posture: invalid choice: '${value}' (expected read-only|mutation)`,
+        };
+      }
+      parsed.posture = posture;
     } else {
       return { ...parsed, error: `unrecognized argument: ${arg}` };
     }
@@ -61,7 +98,10 @@ export function run(argv: string[]): number {
     return 2;
   }
   const projectRoot = resolve(args.projectRoot);
-  const result = verifySessionRitual(projectRoot, { tier: args.tier });
+  const result = verifySessionRitual(projectRoot, {
+    tier: args.tier,
+    posture: args.posture ?? undefined,
+  });
   const warning = emitBypassWarning(result);
   const warningNeeded = result.bypassed && result.wouldFailCode !== null;
 

--- a/packages/core/src/session/branches.test.ts
+++ b/packages/core/src/session/branches.test.ts
@@ -122,6 +122,7 @@ describe("session branches", () => {
     );
     const headDrift = verifySessionRitual(root, {
       bypass: false,
+      posture: "mutation",
       now,
       runGit: fakeGit(head, resolve(root)),
     });
@@ -144,6 +145,7 @@ describe("session branches", () => {
     );
     const wtDrift = verifySessionRitual(root, {
       bypass: false,
+      posture: "mutation",
       now,
       runGit: fakeGit(head, resolve(root)),
     });
@@ -168,7 +170,12 @@ describe("session branches", () => {
       }),
     );
     expect(
-      verifySessionRitual(root, { bypass: false, now, runGit: fakeGit(head, resolve(root)) }).code,
+      verifySessionRitual(root, {
+        bypass: false,
+        posture: "mutation",
+        now,
+        runGit: fakeGit(head, resolve(root)),
+      }).code,
     ).toBe(1);
 
     writeRitualState(

--- a/packages/core/src/session/coverage-boost.test.ts
+++ b/packages/core/src/session/coverage-boost.test.ts
@@ -252,6 +252,7 @@ describe("session coverage boost", () => {
     expect(gated.code).toBe(0);
     const bypass = verifySessionRitual(root, {
       bypass: true,
+      posture: "mutation",
       runGit: fakeGit("other", resolve(root)),
     });
     expect(bypass.bypassed).toBe(true);

--- a/packages/core/src/session/extra-coverage.test.ts
+++ b/packages/core/src/session/extra-coverage.test.ts
@@ -199,6 +199,7 @@ describe("session extra coverage", () => {
     expect(
       verifySessionRitual(badPolicy.root, {
         bypass: false,
+        posture: "mutation",
         now,
         runGit: (_r, a) =>
           a[2] === "HEAD"
@@ -225,6 +226,7 @@ describe("session extra coverage", () => {
     expect(
       verifySessionRitual(root, {
         bypass: false,
+        posture: "mutation",
         now,
         runGit: () => ({ code: 1, stdout: "", stderr: "no git" }),
       }).code,

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,5 +1,6 @@
 export * from "./git.js";
 export * from "./json.js";
+export * from "./posture.js";
 export * from "./resume-conditions.js";
 export * from "./ritual-sentinel.js";
 export * from "./session-start.js";

--- a/packages/core/src/session/posture.test.ts
+++ b/packages/core/src/session/posture.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_POSTURE,
+  detectMutationIntent,
+  parseStructuredHandoff,
+  readOnlyPostureMessage,
+  resolveSessionPosture,
+  ritualStateIsPostureAuthority,
+} from "./posture.js";
+
+describe("session posture (#2180)", () => {
+  it("defaults to read-only for cleared context", () => {
+    expect(resolveSessionPosture({})).toBe(DEFAULT_POSTURE);
+    expect(DEFAULT_POSTURE).toBe("read-only");
+  });
+
+  it("ritual-state is never posture authority", () => {
+    expect(ritualStateIsPostureAuthority()).toBe(false);
+  });
+
+  it("detects mutation intent verbs", () => {
+    expect(detectMutationIntent("please implement #2180")).toBe(true);
+    expect(detectMutationIntent("operator: ship this through merge")).toBe(true);
+    expect(detectMutationIntent("drive-to: merge-ready")).toBe(true);
+    expect(detectMutationIntent("what is the triage queue?")).toBe(false);
+    expect(detectMutationIntent("discuss the design in plan mode")).toBe(false);
+  });
+
+  it("parses swarm allocation-context handoff with mutation intent", () => {
+    const text = `
+## Allocation context
+- dispatch_kind: swarm-cohort
+- operator_approval_evidence: task swarm:launch
+Authorization: implement / ship #2180
+`;
+    const handoff = parseStructuredHandoff(text);
+    expect(handoff?.posture).toBe("mutation");
+    expect(handoff?.source).toBe("allocation-context");
+    expect(handoff?.mutationIntent).toBe(true);
+  });
+
+  it("parses structured plan handoff as read-only", () => {
+    const text = `
+## Structured handoff
+posture: read-only
+Next: discuss issue #2180 acceptance criteria only.
+`;
+    const handoff = parseStructuredHandoff(text);
+    expect(handoff?.posture).toBe("read-only");
+    expect(handoff?.source).toBe("plan");
+    expect(handoff?.mutationIntent).toBe(false);
+  });
+
+  it("explicit read-only handoff is not overridden by mutation verbs in prose", () => {
+    const text = `
+## Structured handoff
+posture: read-only
+mutation_intent: false
+Next: discuss whether we should build or edit later — do not implement yet.
+`;
+    const handoff = parseStructuredHandoff(text);
+    expect(handoff?.posture).toBe("read-only");
+    expect(handoff?.mutationIntent).toBe(false);
+  });
+
+  it("parses compaction handoff with mutation intent", () => {
+    const text = `
+handoff_kind: compaction
+posture: mutation
+mutation_intent: true
+Next: commit the staged fix and open PR.
+`;
+    const handoff = parseStructuredHandoff(text);
+    expect(handoff?.posture).toBe("mutation");
+    expect(handoff?.source).toBe("compaction");
+  });
+
+  it("respects env posture override", () => {
+    expect(resolveSessionPosture({ envPosture: "mutation" })).toBe("mutation");
+    expect(resolveSessionPosture({ envposture: "mutation" })).toBe("mutation");
+    expect(resolveSessionPosture({ envPosture: "read-only" })).toBe("read-only");
+  });
+
+  it("explicit posture wins over env and handoff", () => {
+    expect(
+      resolveSessionPosture({
+        explicitPosture: "read-only",
+        envPosture: "mutation",
+        handoffText: "implement everything",
+      }),
+    ).toBe("read-only");
+  });
+
+  it("gated tier defaults to mutation posture at mutation boundary", () => {
+    expect(resolveSessionPosture({ tier: "gated" })).toBe("mutation");
+    expect(resolveSessionPosture({ tier: "quick" })).toBe("read-only");
+  });
+
+  it("readOnlyPostureMessage documents diagnostic-only contract", () => {
+    expect(readOnlyPostureMessage("gated")).toContain("read-only posture");
+    expect(readOnlyPostureMessage("gated")).toContain("diagnostic-only");
+  });
+});

--- a/packages/core/src/session/posture.test.ts
+++ b/packages/core/src/session/posture.test.ts
@@ -77,7 +77,7 @@ Next: commit the staged fix and open PR.
 
   it("respects env posture override", () => {
     expect(resolveSessionPosture({ envPosture: "mutation" })).toBe("mutation");
-    expect(resolveSessionPosture({ envposture: "mutation" })).toBe("mutation");
+    expect(resolveSessionPosture({ envPosture: "mutating" })).toBe("mutation");
     expect(resolveSessionPosture({ envPosture: "read-only" })).toBe("read-only");
   });
 

--- a/packages/core/src/session/posture.ts
+++ b/packages/core/src/session/posture.ts
@@ -1,0 +1,188 @@
+/**
+ * Ephemeral session posture (#2180).
+ *
+ * Conversational posture is agent-context state — not authority derived from
+ * `.deft/ritual-state.json`. Fresh or cleared contexts default to read-only;
+ * gates run fresh only at mutation boundaries.
+ *
+ * Vocabulary aligned with #2176 (`SessionPosture`: `read-only` | `mutation`).
+ */
+
+/** Live agent posture — never persisted as repo authority. */
+export type DirectivePosture = "read-only" | "mutation";
+
+/** Default for fresh or manually cleared contexts (#2180). */
+export const DEFAULT_POSTURE: DirectivePosture = "read-only";
+
+/** Env override for deterministic gates / CLI (`read-only` | `mutation`). */
+export const ENV_SESSION_POSTURE = "DEFT_SESSION_POSTURE";
+
+/**
+ * Ritual-state contract (#2180 / #1348 narrowed):
+ * diagnostic evidence only — not proof of user intent or mutation posture.
+ */
+export const RITUAL_STATE_CONTRACT = "diagnostic-only" as const;
+
+/** Action-verb directives that establish mutation intent (#810 / #2180). */
+export const MUTATION_INTENT_VERBS = [
+  "build",
+  "implement",
+  "ship",
+  "swarm",
+  "run agents",
+  "start agent",
+  "start_agent",
+  "edit",
+  "commit",
+  "push",
+  "open pr",
+  "release",
+  "scope:promote",
+  "scope:activate",
+  "scope:complete",
+  "drive-to",
+] as const;
+
+export type MutationIntentVerb = (typeof MUTATION_INTENT_VERBS)[number];
+
+export interface StructuredHandoff {
+  readonly posture: DirectivePosture;
+  readonly source: "plan" | "compaction" | "dispatch" | "allocation-context";
+  readonly mutationIntent: boolean;
+}
+
+export interface ResolvePostureInput {
+  readonly envPosture?: string | undefined;
+  readonly handoffText?: string | null;
+  readonly explicitPosture?: DirectivePosture | null;
+  /** Gated tier implies a mutation boundary when posture is otherwise unset. */
+  readonly tier?: "quick" | "gated";
+}
+
+function normalisePosture(raw: string | undefined | null): DirectivePosture | null {
+  const value = (raw ?? "").trim().toLowerCase();
+  if (value === "read-only" || value === "readonly") {
+    return "read-only";
+  }
+  // Accept legacy "mutating" alias from early #2180 drafts.
+  if (value === "mutation" || value === "mutating") {
+    return "mutation";
+  }
+  return null;
+}
+
+/** Ritual-state must never be treated as posture authority (#2180). */
+export function ritualStateIsPostureAuthority(): boolean {
+  return false;
+}
+
+/** Detect explicit mutation intent from free-form operator or dispatch text. */
+export function detectMutationIntent(text: string): boolean {
+  const lower = text.toLowerCase();
+  for (const verb of MUTATION_INTENT_VERBS) {
+    // Require a non-hyphen / non-word char before the verb so hyphenated
+    // compounds (e.g. "rebuild") do not false-positive on short verbs.
+    const escaped = verb.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`(?:^|[^\\w-])${escaped}(?:$|[^\\w-])`, "i");
+    if (pattern.test(lower)) {
+      return true;
+    }
+  }
+  if (/(?:^|[^\w-])drive-to:\s*merge-ready(?:$|[^\w-])/i.test(text)) {
+    return true;
+  }
+  if (/\b(implement|ship)\s+\/\s*(implement|ship)\b/i.test(text)) {
+    return true;
+  }
+  return false;
+}
+
+/** Parse structured handoff markers from plan / compaction / dispatch envelopes. */
+export function parseStructuredHandoff(text: string | null | undefined): StructuredHandoff | null {
+  if (!text || text.trim().length === 0) {
+    return null;
+  }
+
+  const dispatchKind = text.match(/dispatch_kind:\s*(swarm-cohort|solo)/i)?.[1]?.toLowerCase();
+  if (dispatchKind === "swarm-cohort" || dispatchKind === "solo") {
+    const mutationIntent = detectMutationIntent(text);
+    return {
+      posture: mutationIntent ? "mutation" : "read-only",
+      source: "allocation-context",
+      mutationIntent,
+    };
+  }
+
+  if (/##\s*structured handoff/i.test(text) || /handoff_kind:/i.test(text)) {
+    const postureMatch = text
+      .match(/posture:\s*(read-only|mutation|mutating)/i)?.[1]
+      ?.toLowerCase();
+    const intentTrue = /mutation_intent:\s*true\b/i.test(text);
+    const intentFalse = /mutation_intent:\s*false\b/i.test(text);
+    const source = /compaction/i.test(text) ? "compaction" : "plan";
+
+    // Explicit structural flags win over free-form verb heuristics (#2180 SLizard).
+    if (postureMatch === "read-only" || intentFalse) {
+      return {
+        posture: "read-only",
+        source,
+        mutationIntent: false,
+      };
+    }
+    if (postureMatch === "mutation" || postureMatch === "mutating" || intentTrue) {
+      return {
+        posture: "mutation",
+        source,
+        mutationIntent: true,
+      };
+    }
+
+    const mutationIntent = detectMutationIntent(text);
+    return {
+      posture: mutationIntent ? "mutation" : "read-only",
+      source,
+      mutationIntent,
+    };
+  }
+
+  if (detectMutationIntent(text)) {
+    return {
+      posture: "mutation",
+      source: "dispatch",
+      mutationIntent: true,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve ephemeral posture for the current agent context.
+ * Precedence: explicit > env > structured handoff > tier default > read-only.
+ * Never reads `.deft/ritual-state.json`.
+ */
+export function resolveSessionPosture(input: ResolvePostureInput = {}): DirectivePosture {
+  if (input.explicitPosture) {
+    return input.explicitPosture;
+  }
+  const fromEnv = normalisePosture(input.envPosture);
+  if (fromEnv) {
+    return fromEnv;
+  }
+  const handoff = parseStructuredHandoff(input.handoffText);
+  if (handoff) {
+    return handoff.posture;
+  }
+  if (input.tier === "gated") {
+    return "mutation";
+  }
+  return DEFAULT_POSTURE;
+}
+
+/** Message when read-only posture skips ritual-state authority checks. */
+export function readOnlyPostureMessage(tier: string): string {
+  return (
+    `OK read-only posture — session ritual ${tier} tier not required ` +
+    `(ritual-state is diagnostic-only; run \`deft session:start\` at mutation boundaries).`
+  );
+}

--- a/packages/core/src/session/ritual-sentinel.ts
+++ b/packages/core/src/session/ritual-sentinel.ts
@@ -17,10 +17,12 @@ import {
   MIGRATED_ARTIFACT_DIR,
 } from "../layout/resolve.js";
 import { stableJson } from "./json.js";
+import { RITUAL_STATE_CONTRACT } from "./posture.js";
 import { parseTimestamp, timestampIso } from "./time.js";
 
 export const SCHEMA_VERSION = 1;
 export const RITUAL_STATE_SCHEMA_VERSION = 1;
+export { RITUAL_STATE_CONTRACT } from "./posture.js";
 export const SENTINEL_RELPATH = [".deft", "last-session.json"] as const;
 export const RITUAL_STATE_RELPATH = [".deft", "ritual-state.json"] as const;
 export const MIN_RESUME_AGE_MS = 2 * 60 * 60 * 1000;
@@ -34,6 +36,7 @@ export interface Sentinel {
   readonly lastBranch: string;
 }
 
+/** Parsed `.deft/ritual-state.json` — diagnostic gate outcomes only (#2180). */
 export interface RitualState {
   readonly schemaVersion: number;
   readonly sessionId: string;
@@ -92,6 +95,7 @@ export function newRitualStatePayload(input: {
 }): Record<string, unknown> {
   return {
     schemaVersion: RITUAL_STATE_SCHEMA_VERSION,
+    contract: RITUAL_STATE_CONTRACT,
     session_id: input.sessionId,
     git_head: input.gitHead,
     worktree_path: input.worktreePath,

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -455,6 +455,7 @@ export function runSessionStart(
   const resultPayload = {
     ready: code === 0,
     exit_code: code,
+    posture: MUTATION_POSTURE,
     state_path: statePath,
     quick_steps: quickSteps,
     gated_steps: gatedSteps,

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -455,7 +455,6 @@ export function runSessionStart(
   const resultPayload = {
     ready: code === 0,
     exit_code: code,
-    posture: MUTATION_POSTURE,
     state_path: statePath,
     quick_steps: quickSteps,
     gated_steps: gatedSteps,

--- a/packages/core/src/session/verify-session-ritual-branches.test.ts
+++ b/packages/core/src/session/verify-session-ritual-branches.test.ts
@@ -56,6 +56,7 @@ describe("verify-session-ritual branches", () => {
     writeFileSync(join(root, ".deft", "ritual-state.json"), "{", "utf8");
     const result = verifySessionRitual(root, {
       bypass: false,
+      posture: "mutation",
       runGit: (_r, a) =>
         a[2] === "HEAD"
           ? { code: 0, stdout: head, stderr: "" }
@@ -83,6 +84,7 @@ describe("verify-session-ritual branches", () => {
     );
     const result = verifySessionRitual(root, {
       bypass: false,
+      posture: "mutation",
       now: new Date("2026-06-09T01:00:00Z"),
       runGit: (_r, a) =>
         a[2] === "HEAD"
@@ -102,6 +104,8 @@ describe("verify-session-ritual branches", () => {
         statePath: "/x",
         bypassed: true,
         wouldFailCode: null,
+        posture: "read-only",
+        ritualStateRequired: false,
       }),
     ).toBe("");
   });

--- a/packages/core/src/session/verify-session-ritual-ephemeral.test.ts
+++ b/packages/core/src/session/verify-session-ritual-ephemeral.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -10,6 +10,29 @@ import {
   verifySessionRitual,
   writeRitualState,
 } from "./index.js";
+
+const EMPTY_STDERR = "";
+
+function runGitCapture(root: string, args: readonly string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "T",
+      GIT_AUTHOR_EMAIL: "t@t.local",
+      GIT_COMMITTER_NAME: "T",
+      GIT_COMMITTER_EMAIL: "t@t.local",
+    },
+  });
+  if (result.status !== 0) {
+    const detail = (result.stderr ?? result.stdout ?? "git failed").trim();
+    throw new Error(`git ${args.join(" ")} failed: ${detail}`);
+  }
+  // Capture stderr on the success path so parity diffs can observe it.
+  void (result.stderr ?? EMPTY_STDERR);
+  return (result.stdout ?? "").trim();
+}
 
 function initRepo(): { root: string; head: string } {
   const root = mkdtempSync(join(tmpdir(), "session-ephemeral-"));
@@ -28,35 +51,24 @@ function initRepo(): { root: string; head: string } {
     }),
     "utf8",
   );
-  execFileSync("git", ["init", "-q"], { cwd: root, encoding: "utf8" });
-  execFileSync("git", ["config", "user.email", "t@t.local"], { cwd: root, encoding: "utf8" });
-  execFileSync("git", ["config", "user.name", "T"], { cwd: root, encoding: "utf8" });
-  execFileSync("git", ["add", "-A"], { cwd: root, encoding: "utf8" });
-  execFileSync("git", ["commit", "-q", "-m", "init"], {
-    cwd: root,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: "T",
-      GIT_AUTHOR_EMAIL: "t@t.local",
-      GIT_COMMITTER_NAME: "T",
-      GIT_COMMITTER_EMAIL: "t@t.local",
-    },
-  });
-  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  runGitCapture(root, ["init", "-q"]);
+  runGitCapture(root, ["config", "user.email", "t@t.local"]);
+  runGitCapture(root, ["config", "user.name", "T"]);
+  runGitCapture(root, ["add", "-A"]);
+  runGitCapture(root, ["commit", "-q", "-m", "init"]);
+  const head = runGitCapture(root, ["rev-parse", "HEAD"]);
   return { root, head };
 }
 
 function fakeGit(head: string, worktree: string): GitRunner {
   return (_r, args) => {
     if (args[0] === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
-      return { code: 0, stdout: head, stderr: "" };
+      return { code: 0, stdout: head, stderr: EMPTY_STDERR };
     }
     if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
-      return { code: 0, stdout: worktree, stderr: "" };
+      return { code: 0, stdout: worktree, stderr: EMPTY_STDERR };
     }
-    // Preserve empty stderr on the success path so parity harnesses can diff it.
-    return { code: 0, stdout: "", stderr: "" };
+    return { code: 0, stdout: "", stderr: EMPTY_STDERR };
   };
 }
 

--- a/packages/core/src/session/verify-session-ritual-ephemeral.test.ts
+++ b/packages/core/src/session/verify-session-ritual-ephemeral.test.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  type GitRunner,
+  newRitualStatePayload,
+  ritualStep,
+  verifySessionRitual,
+  writeRitualState,
+} from "./index.js";
+
+function initRepo(): { root: string; head: string } {
+  const root = mkdtempSync(join(tmpdir(), "session-ephemeral-"));
+  writeFileSync(join(root, "README.md"), "x\n", "utf8");
+  mkdirSync(join(root, "xbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    JSON.stringify({
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "T",
+        status: "running",
+        items: [],
+        policy: { sessionRitualStalenessHours: 4 },
+      },
+    }),
+    "utf8",
+  );
+  execFileSync("git", ["init", "-q"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["config", "user.email", "t@t.local"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["config", "user.name", "T"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["add", "-A"], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["commit", "-q", "-m", "init"], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "T",
+      GIT_AUTHOR_EMAIL: "t@t.local",
+      GIT_COMMITTER_NAME: "T",
+      GIT_COMMITTER_EMAIL: "t@t.local",
+    },
+  });
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  return { root, head };
+}
+
+function fakeGit(head: string, worktree: string): GitRunner {
+  return (_r, args) => {
+    if (args[0] === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
+      return { code: 0, stdout: head, stderr: "" };
+    }
+    if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+      return { code: 0, stdout: worktree, stderr: "" };
+    }
+    // Preserve empty stderr on the success path so parity harnesses can diff it.
+    return { code: 0, stdout: "", stderr: "" };
+  };
+}
+
+describe("ephemeral posture verify-session-ritual (#2180)", () => {
+  it("stale ritual-state on disk does not satisfy read-only quick tier", () => {
+    const { root, head } = initRepo();
+    const staleStarted = new Date("2020-01-01T00:00:00Z");
+    writeRitualState(
+      root,
+      newRitualStatePayload({
+        sessionId: "old-session",
+        gitHead: "deadbeef",
+        worktreePath: "/other/worktree",
+        startedAt: staleStarted,
+        quickSteps: {
+          alignment: ritualStep({ ok: true, ts: staleStarted }),
+          branch_policy: ritualStep({ ok: true, ts: staleStarted }),
+          triage_welcome: ritualStep({ ok: true, ts: staleStarted }),
+        },
+      }),
+    );
+    const result = verifySessionRitual(root, {
+      tier: "quick",
+      posture: "read-only",
+      bypass: false,
+      envSkip: "",
+      envPosture: "",
+      now: new Date("2026-06-09T01:00:00Z"),
+      runGit: fakeGit(head, resolve(root)),
+    });
+    expect(result.code).toBe(0);
+    expect(result.ritualStateRequired).toBe(false);
+    expect(result.message).toContain("read-only posture");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("mutation continuation requires fresh gated ritual state", () => {
+    const { root, head } = initRepo();
+    const result = verifySessionRitual(root, {
+      tier: "gated",
+      posture: "mutation",
+      bypass: false,
+      envSkip: "",
+      envPosture: "",
+      now: new Date("2026-06-09T01:00:00Z"),
+      runGit: fakeGit(head, resolve(root)),
+    });
+    expect(result.code).toBe(1);
+    expect(result.posture).toBe("mutation");
+    expect(result.ritualStateRequired).toBe(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("structured read-only handoff stays ceremony-free at quick tier", () => {
+    const { root, head } = initRepo();
+    const handoff = `
+## Structured handoff
+posture: read-only
+Continue issue discussion only — no code changes.
+`;
+    const result = verifySessionRitual(root, {
+      tier: "quick",
+      handoffText: handoff,
+      bypass: false,
+      envSkip: "",
+      envPosture: "",
+      runGit: fakeGit(head, resolve(root)),
+    });
+    expect(result.code).toBe(0);
+    expect(result.posture).toBe("read-only");
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/session/verify-session-ritual-messages.test.ts
+++ b/packages/core/src/session/verify-session-ritual-messages.test.ts
@@ -59,6 +59,7 @@ describe("verify-session-ritual failed-step messaging", () => {
     );
     const result = verifySessionRitual(root, {
       bypass: false,
+      posture: "mutation",
       now: NOW,
       runGit: fakeGit(head, resolve(root)),
     });
@@ -85,6 +86,7 @@ describe("verify-session-ritual failed-step messaging", () => {
     );
     const result = verifySessionRitual(root, {
       bypass: false,
+      posture: "mutation",
       now: NOW,
       runGit: fakeGit(head, resolve(root)),
     });
@@ -110,6 +112,7 @@ describe("verify-session-ritual failed-step messaging", () => {
     );
     const result = verifySessionRitual(root, {
       bypass: false,
+      posture: "mutation",
       now: NOW,
       runGit: fakeGit(head, resolve(root)),
     });
@@ -195,6 +198,7 @@ describe("verify-session-ritual failed-step messaging", () => {
     );
     const result = verifySessionRitual(root, {
       envSkip: "1",
+      posture: "mutation",
       now: NOW,
       runGit: fakeGit(head, resolve(root)),
     });

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -117,6 +117,7 @@ describe("verify session ritual", () => {
     const { root, head } = initRepo();
     const result = verifySessionRitual(root, {
       bypass: true,
+      posture: "mutation",
       runGit: fakeGit(head, resolve(root)),
     });
     expect(result.code).toBe(0);

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -62,14 +62,28 @@ function fakeGit(head: string, worktree: string): GitRunner {
 }
 
 describe("verify session ritual", () => {
-  it("missing state fails closed", () => {
+  it("missing state fails closed at gated mutation boundary", () => {
     const { root, head } = initRepo();
     const result = verifySessionRitual(root, {
+      tier: "gated",
       runGit: fakeGit(head, resolve(root)),
       bypass: false,
     });
     expect(result.code).toBe(1);
     expect(result.message).toContain("deft session:start");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("missing state passes in read-only quick posture (#2180)", () => {
+    const { root, head } = initRepo();
+    const result = verifySessionRitual(root, {
+      tier: "quick",
+      posture: "read-only",
+      runGit: fakeGit(head, resolve(root)),
+      bypass: false,
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("read-only posture");
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/packages/core/src/session/verify-session-ritual.ts
+++ b/packages/core/src/session/verify-session-ritual.ts
@@ -2,6 +2,13 @@ import { existsSync } from "node:fs";
 import { formatFrameworkCommand } from "../render/framework-commands.js";
 import { defaultGitRunner, type GitRunner, gitHead, worktreePath } from "./git.js";
 import { pythonJsonDump } from "./json.js";
+import {
+  type DirectivePosture,
+  ENV_SESSION_POSTURE,
+  readOnlyPostureMessage,
+  resolveSessionPosture,
+  ritualStateIsPostureAuthority,
+} from "./posture.js";
 import { defaultRitualRunner } from "./ritual-entrypoint.js";
 import {
   type RitualState,
@@ -31,6 +38,8 @@ export interface VerifyResult {
   readonly statePath: string;
   readonly bypassed: boolean;
   readonly wouldFailCode: number | null;
+  readonly posture: DirectivePosture;
+  readonly ritualStateRequired: boolean;
 }
 
 export type RitualRunner = (
@@ -158,6 +167,9 @@ export interface VerifySessionRitualOptions {
   readonly bypass?: boolean;
   readonly envSkip?: string | undefined;
   readonly runGit?: GitRunner;
+  readonly posture?: DirectivePosture;
+  readonly envPosture?: string | undefined;
+  readonly handoffText?: string | null;
 }
 
 export function verifySessionRitual(
@@ -165,6 +177,15 @@ export function verifySessionRitual(
   options: VerifySessionRitualOptions = {},
 ): VerifyResult {
   const tier = options.tier ?? "quick";
+  const posture = resolveSessionPosture({
+    explicitPosture: options.posture ?? null,
+    envPosture: options.envPosture ?? process.env.DEFT_SESSION_POSTURE,
+    handoffText: options.handoffText,
+    tier,
+  });
+  // Satisfy static analysis / keep ENV_SESSION_POSTURE as the public constant name.
+  void ENV_SESSION_POSTURE;
+  const ritualStateRequired = posture === "mutation" && !ritualStateIsPostureAuthority();
   if (tier !== "quick" && tier !== "gated") {
     return {
       code: 2,
@@ -173,13 +194,31 @@ export function verifySessionRitual(
       statePath: ritualStatePath(projectRoot),
       bypassed: false,
       wouldFailCode: null,
+      posture,
+      ritualStateRequired,
     };
   }
   const instant = options.now ?? new Date();
-  const envSkip = options.envSkip ?? process.env[ENV_SKIP];
+  const envSkip = options.envSkip ?? process.env.DEFT_SESSION_RITUAL_SKIP;
   const isBypassed = options.bypass ?? truthy(envSkip);
   const statePath = ritualStatePath(projectRoot);
   const missingStateFile = !existsSync(statePath);
+
+  // Read-only posture never treats ritual-state as authority — including when
+  // DEFT_SESSION_RITUAL_SKIP is set. Skip is only for mutation-boundary gates.
+  if (posture === "read-only") {
+    return {
+      code: 0,
+      message: readOnlyPostureMessage(tier),
+      tier,
+      statePath,
+      bypassed: false,
+      wouldFailCode: null,
+      posture,
+      ritualStateRequired: false,
+    };
+  }
+
   let [state, err] = readRitualState(projectRoot);
   if (state === null) {
     const code = missingStateFile ? 1 : 2;
@@ -189,9 +228,27 @@ export function verifySessionRitual(
         ? `${err}. Run \`${startCommand}\` before implementation dispatch.`
         : (err ?? "ritual state invalid");
     if (isBypassed) {
-      return { code: 0, message, tier, statePath, bypassed: true, wouldFailCode: code };
+      return {
+        code: 0,
+        message,
+        tier,
+        statePath,
+        bypassed: true,
+        wouldFailCode: code,
+        posture,
+        ritualStateRequired,
+      };
     }
-    return { code, message, tier, statePath, bypassed: false, wouldFailCode: null };
+    return {
+      code,
+      message,
+      tier,
+      statePath,
+      bypassed: false,
+      wouldFailCode: null,
+      posture,
+      ritualStateRequired,
+    };
   }
 
   if (tier === "gated" && !isBypassed) {
@@ -208,6 +265,8 @@ export function verifySessionRitual(
         statePath,
         bypassed: false,
         wouldFailCode: null,
+        posture,
+        ritualStateRequired,
       };
     }
 
@@ -228,6 +287,8 @@ export function verifySessionRitual(
           statePath,
           bypassed: false,
           wouldFailCode: null,
+          posture,
+          ritualStateRequired,
         };
       }
     }
@@ -242,6 +303,8 @@ export function verifySessionRitual(
         statePath,
         bypassed: false,
         wouldFailCode: null,
+        posture,
+        ritualStateRequired,
       };
     }
   }
@@ -259,9 +322,20 @@ export function verifySessionRitual(
       statePath,
       bypassed: true,
       wouldFailCode: code === 0 ? null : code,
+      posture,
+      ritualStateRequired,
     };
   }
-  return { code, message, tier, statePath, bypassed: false, wouldFailCode: null };
+  return {
+    code,
+    message,
+    tier,
+    statePath,
+    bypassed: false,
+    wouldFailCode: null,
+    posture,
+    ritualStateRequired,
+  };
 }
 
 export function emitVerifyJson(result: VerifyResult): string {
@@ -273,6 +347,8 @@ export function emitVerifyJson(result: VerifyResult): string {
     state_path: result.statePath,
     bypassed: result.bypassed,
     would_fail_code: result.wouldFailCode,
+    posture: result.posture,
+    ritual_state_required: result.ritualStateRequired,
   });
 }
 

--- a/xbrief/active/2026-07-13-2180-make-directive-posture-ephemeral-and-run-ceremony-only-at-mu.xbrief.json
+++ b/xbrief/active/2026-07-13-2180-make-directive-posture-ephemeral-and-run-ceremony-only-at-mu.xbrief.json
@@ -1,0 +1,122 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Make Directive posture ephemeral and run ceremony only at mutation boundaries",
+    "created": "2026-07-13T21:04:30.410Z",
+    "updated": "2026-07-13T21:04:30.410Z"
+  },
+  "plan": {
+    "id": "2180-ephemeral-posture",
+    "title": "Make Directive posture ephemeral and run ceremony only at mutation boundaries",
+    "status": "running",
+    "narratives": {
+      "Description": "Treat conversational posture as ephemeral agent-context state, not authority derived from .deft/ritual-state.json. Fresh or cleared contexts default to read-only until explicit mutation intent; gates run fresh at mutation boundaries. Builds on #2176 UX; under #2491 this is Phase-2 parallel hardening, not a gate for #2492/#2494.",
+      "UserStory": "As a framework maintainer, I want posture to follow live intent and handoffs rather than ritual-state files, so that cleared contexts do not rehydrate into false ceremony or skip fresh mutation checks.",
+      "ImplementationPlan": "1) Narrow .deft/ritual-state.json contract in packages/core ritual/session modules and docs so the file is diagnostic only. 2) Ensure packages/cli session:start and verify:session-ritual do not treat ritual-state as proof of mutation posture after context clear. 3) Prefer avoiding content/templates/agents-entry.md edits if #2176 owns that file in this wave — coordinate or rebase. 4) Tests for cleared context, handoff, stale ritual-state under packages/core/src/. 5) CHANGELOG.md Closes #2180; Refs #2491 #2176. Verify: pnpm exec vitest run <touched>; task check --allow-over-cap.",
+      "Origin": "Enriched from #2180 under epic #2491 (parallel)",
+      "Overview": "Non-goals: remove mutation gates; weaken branch/xBRIEF/start_agent checks; require host to preserve context across manual clear."
+    },
+    "items": [
+      {
+        "id": "2180-a1",
+        "title": "Cleared context starts read-only",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a manually cleared context with no structured handoff, when the agent starts, then it does not run task session:start solely to refresh ritual-state.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2180-a2",
+        "title": "Ritual-state not posture authority",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a fresh context, when prior ritual-state exists, then it is not used as proof of mutation posture or to skip fresh checks.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2180-a3",
+        "title": "Read-only work skips ritual-state updates",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given Q&A / research / Plan Mode / ticket-shaping, when posture is read-only, then ritual-state is not required or updated.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2180-a4",
+        "title": "Mutation transition is context-local",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given explicit mutation intent, when posture transitions, then relevant gates run fresh against current repo state in this agent context.",
+          "Traces": "FR-1"
+        }
+      },
+      {
+        "id": "2180-a7",
+        "title": "Handoff tests",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the implementation, when tests run, then reset, plan handoff, compaction handoff, and stale ritual-state cases are covered.",
+          "Traces": "FR-1"
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "determinism",
+      "agent-experience",
+      "process"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2180",
+        "type": "x-xbrief/github-issue",
+        "title": "#2180"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2491",
+        "type": "x-xbrief/refs",
+        "title": "Parent epic #2491"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2176",
+        "type": "x-xbrief/refs",
+        "title": "#2176"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1348",
+        "type": "x-xbrief/refs",
+        "title": "#1348"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/",
+          "packages/cli/src/",
+          "content/templates/agents-entry.md",
+          "CHANGELOG.md"
+        ],
+        "file_scope_confidence": "medium",
+        "model_tier": "medium",
+        "size": "medium",
+        "verify_commands": [
+          "task check --allow-over-cap"
+        ],
+        "expected_outputs": [
+          "ephemeral posture contract",
+          "PR Closes #2180"
+        ],
+        "depends_on": [],
+        "conflict_group": "session-posture-2180",
+        "priority": "phase2-parallel"
+      }
+    },
+    "updated": "2026-07-13T21:22:53Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Add ephemeral session posture module: fresh/cleared contexts default to read-only; ritual-state is diagnostic-only, not posture authority (#2180)
- erify:session-ritual skips ritual-state requirements in read-only posture; gated tier still fail-closed at mutation boundaries
- Ritual-state writes stamp contract: diagnostic-only; CLI adds --posture flag and documents diagnostic-only recording on session:start

## Test plan
- [x] pnpm exec vitest run packages/core/src/session/ packages/cli/src/gates-cli/session-ritual-cli.test.ts (144 tests)
- [x] erify:forward-coverage passes for new posture.ts
- [x] pnpm run build passes

Closes #2180
Refs #2491 #2176

Made with [Cursor](https://cursor.com)