### PR TITLE
refactor(agents-md): Phase 2 catalog eviction — command list out of managed section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ Install-generated AGENTS.md uses deft/-prefixed paths.
 
 When the template is updated, run `task agents:refresh` to regenerate consumer-installed AGENTS.md from `content/templates/agents-entry.md` (see `## Template propagation discipline (#1309)` above).
 
-<!-- deft:managed-section v3 sha=dced3f4cf6d0 refreshed=2026-07-13T21:27:10Z session=68814a30e020 -->
+<!-- deft:managed-section v3 sha=2a80393a31f3 refreshed=2026-07-13T22:18:18Z session=ed5f556ad7e6 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -399,23 +399,5 @@ Contextual / platform-specific rules lazy-load from `.deft/core/scm/github.md` �
 
 ## Commands
 
-Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `.deft/core/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
-
-**Directive product (`/deft:directive:*`):**
-
-- /deft:directive:change <name>        — Propose a scoped change (alias: `/deft:change`, deprecated)
-- /deft:directive:run:interview        — Structured spec interview (alias: `/deft:run:interview`, deprecated)
-- /deft:directive:run:speckit          — Five-phase spec workflow (alias: `/deft:run:speckit`, deprecated)
-- /deft:directive:run:discuss <topic>  — Feynman-style alignment (alias: `/deft:run:discuss`, deprecated)
-- /deft:directive:run:research <topic> — Research before planning (alias: `/deft:run:research`, deprecated)
-- /deft:directive:run:map              — Map an existing codebase (alias: `/deft:run:map`, deprecated)
-
-**Cross-product (umbrella `/deft:*`):**
-
-- /deft:continue — Resume from continue checkpoint
-- /deft:checkpoint — Save session state to `./xbrief/continue.xbrief.json`
-
-**CLI compatibility:**
-
-The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup and project/spec generation; if `deft` or `directive` will not run, follow the payload-independent recovery ladder in the `## Cold-start bootstrap (#2273)` section above (top of the project's `README.md`), not a path inside `.deft/core/`.
+! Directive product commands use the `/deft:directive:*` namespace (#418 / #1670); the full command and alias table lives in `.deft/core/commands.md` — load on demand, not rendered here.
 <!-- /deft:managed-section -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Always-on AGENTS.md no longer ships a full slash-command catalog.** The managed section now points to `commands.md` for `/deft:directive:*` and cross-product aliases, trimming always-loaded bootstrap text toward the 8 KB north-star. Closes #2492. Refs #2491.
+
 - **Session posture is ephemeral — ceremony runs only at mutation boundaries.** Cleared or fresh agent contexts default to read-only; `verify:session-ritual` no longer treats `.deft/ritual-state.json` as proof of mutation intent, and gated checks still run fresh when you actually start mutating work. Closes #2180. Refs #2491 #2176.
 
 - **Security docs clarify LLM trust-tier framing for informational AppSec findings.** Guidance in REFERENCES, security taxonomy, context engineering, llm-app patterns, and coding rules now states that provider/SDK mentions are framework guidance for consumer projects, not runtime surfaces in the directive repo. Closes #2414.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -180,23 +180,5 @@ Contextual / platform-specific rules lazy-load from `.deft/core/scm/github.md` �
 
 ## Commands
 
-Directive product commands use the `/deft:directive:*` namespace (#418 / #1670). Prior `/deft:*` product forms remain as deprecation-warning aliases — see `.deft/core/commands.md` for the full alias table. Cross-product session commands stay at the umbrella `/deft:*` level.
-
-**Directive product (`/deft:directive:*`):**
-
-- /deft:directive:change <name>        — Propose a scoped change (alias: `/deft:change`, deprecated)
-- /deft:directive:run:interview        — Structured spec interview (alias: `/deft:run:interview`, deprecated)
-- /deft:directive:run:speckit          — Five-phase spec workflow (alias: `/deft:run:speckit`, deprecated)
-- /deft:directive:run:discuss <topic>  — Feynman-style alignment (alias: `/deft:run:discuss`, deprecated)
-- /deft:directive:run:research <topic> — Research before planning (alias: `/deft:run:research`, deprecated)
-- /deft:directive:run:map              — Map an existing codebase (alias: `/deft:run:map`, deprecated)
-
-**Cross-product (umbrella `/deft:*`):**
-
-- /deft:continue — Resume from continue checkpoint
-- /deft:checkpoint — Save session state to `./xbrief/continue.xbrief.json`
-
-**CLI compatibility:**
-
-The legacy Python `.deft/core/run` CLI is deprecated and is no longer a load-bearing operator path (#1933 Option 1, deprecate-by-disuse). Use the agent-driven setup skill for first-time setup and project/spec generation; if `deft` or `directive` will not run, follow the payload-independent recovery ladder in the `## Cold-start bootstrap (#2273)` section above (top of the project's `README.md`), not a path inside `.deft/core/`.
+! Directive product commands use the `/deft:directive:*` namespace (#418 / #1670); the full command and alias table lives in `.deft/core/commands.md` — load on demand, not rendered here.
 <!-- /deft:managed-section -->

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -299,6 +299,21 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     ],
   },
   {
+    id: "commands-catalog-2492",
+    shape: "doc",
+    header: "Commands",
+    canonicalHome: "commands.md",
+    pointerHints: ["/deft:directive:*", "commands.md", "#418", "#1670"],
+    canonicalBodyMarkers: ["/deft:directive:change", "/deft:continue", "Slash Command"],
+    retiredFullTextMarkers: [
+      "/deft:directive:change <name>",
+      "/deft:directive:run:interview",
+      "/deft:continue — Resume",
+      "/deft:checkpoint — Save",
+      "legacy Python `.deft/core/run` CLI is deprecated",
+    ],
+  },
+  {
     id: "contextual-guardrails-2454",
     shape: "doc",
     header: "Contextual guardrails (runtime-detect lazy-load)",

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16782,9 +16782,9 @@
       },
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
-        "managedMaxLines": 244,
+        "managedMaxLines": 184,
         "unmanagedMaxLines": 270,
-        "absoluteMaxBytes": 18523
+        "absoluteMaxBytes": 17113
       }
     },
     "updated": "2026-07-02T14:32:31Z"


### PR DESCRIPTION
## Summary
- Remove the full /deft:directive:* command bullet catalog from the always-on managed section in agents-entry.md; replace with a one-line pointer to commands.md.
- Refresh AGENTS.md managed section via agents-refresh (#1309).
- Add pointer-sufficient contract rule (commands-catalog-2492) with retired full-text markers.
- Re-seed budget ratchet: managedMaxLines 244->184, absoluteMaxBytes 18523->17113 (~1.4 KB drop).

## Test plan
- [x] pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
- [x] task verify:agents-md-budget
- [x] task verify:encoding

Closes #2492
Refs #2491

Made with [Cursor](https://cursor.com)