### PR TITLE
refactor(agents-md): Phase 2 Wave 3a — pointer-thin Content packs / Skills / MAP (#2501)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=cd248a4b6da7 refreshed=2026-07-13T22:54:13Z session=296a12950982 -->
+<!-- deft:managed-section v3 sha=680de731aec9 refreshed=2026-07-14T02:08:51Z session=a8e1c54fa8c4 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -220,26 +220,15 @@ Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-pro
 
 ## Content packs
 
-Deft ships versioned content packs (e.g. lessons learned from prior work) under `.deft/core/packs/`. Discover and LOAD pack content via the slice surface instead of reading whole pack files into context:
-
-- `deft packs:slice --list-packs` -- discover which packs exist (short-name + version + one-line description). Registry-driven, so new packs appear automatically with no edit here.
-- `deft packs:slice <pack> --list` -- discover the named slices a pack exposes.
-- `deft packs:slice <pack> <slice> [-- <filters>]` -- load just the slice you need; read the slice, not the whole file.
-
-! Before improvising on a problem, discover packs with `deft packs:slice --list-packs`, then load the relevant slice. This wiring references the discovery commands on purpose -- it never enumerates pack or slice names, so new packs/slices need no change here.
+! Before improvising, discover packs with `deft packs:slice --list-packs`, then load via `deft packs:slice <pack> --list` / `deft packs:slice <pack> <slice>` — full pack surface in `.deft/core/commands.md` (§ packs); never enumerate pack or slice names here.
 
 ## Codebase MAP Projection (#1595 / #1498)
 
-`xbrief/PROJECT-DEFINITION.xbrief.json` `plan.architecture.codeStructure` is the durable codebase-structure source. `.planning/codebase/MAP.md` is a generated orientation projection from that metadata plus provider/code-derived facts.
-
-- ~ If `.planning/codebase/MAP.md` exists, read it as orientation before broad codebase scanning.
-- ~ If it is absent or may be stale, run `deft codebase:map` and `deft verify:codebase-map-fresh` when those commands resolve; treat the result as advisory unless the current task edits `plan.architecture.codeStructure`, a configured provider artifact, or the generated MAP itself.
-- ! When the MAP is wrong, update `plan.architecture.codeStructure` or the selected provider artifact, then regenerate the MAP.
-- ⊗ Treat a stale or absent MAP as an unrelated implementation blocker, hand-edit `.planning/codebase/MAP.md`, or make the generated projection more authoritative than the xBRIEF metadata.
+! `plan.architecture.codeStructure` is durable SoT; `.planning/codebase/MAP.md` is generated orientation — use `deft codebase:map` / `deft verify:codebase-map-fresh` (`.deft/core/commands.md` § Project And Architecture). ⊗ Do not hand-edit the MAP, block unrelated work on stale/absent MAP, or treat the projection as more authoritative than the xBRIEF metadata (#1595 / #1498).
 
 ## Skills
 
-Skill routing (which skill answers which trigger) is not a table in this policy section. To pick a skill, scan the **Skills Index** (Level-0) in `.deft/core/REFERENCES.md` — it lists every skill under `.deft/core/.agents/skills/` with a one-sentence description and trigger keywords, unified with the framework doc routing so you consult one place to decide what to load. Read a `SKILL.md` (Level-1) only when the index indicates a match. Before improvising a multi-step workflow, scan the skills catalog first — skills are versioned and tested. The `welcome` / `onboard triage` trigger invokes `deft triage:welcome --onboard` (N3 / #1143); for `lessons` / `prior art`, discover packs with `deft packs:slice --list-packs` then load the relevant slice (see Content packs above).
+! Skill routing lives in the **Skills Index** (Level-0) in `.deft/core/REFERENCES.md` — scan it before improvising; read a `SKILL.md` only on index match. `welcome` / `onboard triage` → `deft triage:welcome --onboard` (N3 / #1143); `lessons` / `prior art` → Content packs `packs:slice` above.
 
 ## Review-surface precedence (#2308)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Always-on AGENTS.md discovery cards are pointer-thin.** Content packs, Skills, and Codebase MAP collapse to one-line `!` / `⊗` pointers at `packs:slice`, the REFERENCES.md Skills Index, and `codebase:map` / `codeStructure`, so agents load less bootstrap text while still finding discovery surfaces on demand. Closes #2501. Refs #2491.
+
 - **Session routing in AGENTS.md is now a thin bootstrap card.** First-session, returning-session, pre-cutover, and cold-start procedures collapse into one pointer-thin routing section that defaults to read-only posture and defers mutable ceremony until mutation intent, trimming always-loaded bootstrap text. Closes #2493. Refs #2491, #2176.
 
 - **Always-on AGENTS.md no longer ships a full slash-command catalog.** The managed section now points to `commands.md` for `/deft:directive:*` and cross-product aliases, trimming always-loaded bootstrap text toward the 8 KB north-star. Closes #2492. Refs #2491.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -59,26 +59,15 @@ Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-pro
 
 ## Content packs
 
-Deft ships versioned content packs (e.g. lessons learned from prior work) under `.deft/core/packs/`. Discover and LOAD pack content via the slice surface instead of reading whole pack files into context:
-
-- `deft packs:slice --list-packs` -- discover which packs exist (short-name + version + one-line description). Registry-driven, so new packs appear automatically with no edit here.
-- `deft packs:slice <pack> --list` -- discover the named slices a pack exposes.
-- `deft packs:slice <pack> <slice> [-- <filters>]` -- load just the slice you need; read the slice, not the whole file.
-
-! Before improvising on a problem, discover packs with `deft packs:slice --list-packs`, then load the relevant slice. This wiring references the discovery commands on purpose -- it never enumerates pack or slice names, so new packs/slices need no change here.
+! Before improvising, discover packs with `deft packs:slice --list-packs`, then load via `deft packs:slice <pack> --list` / `deft packs:slice <pack> <slice>` — full pack surface in `.deft/core/commands.md` (§ packs); never enumerate pack or slice names here.
 
 ## Codebase MAP Projection (#1595 / #1498)
 
-`xbrief/PROJECT-DEFINITION.xbrief.json` `plan.architecture.codeStructure` is the durable codebase-structure source. `.planning/codebase/MAP.md` is a generated orientation projection from that metadata plus provider/code-derived facts.
-
-- ~ If `.planning/codebase/MAP.md` exists, read it as orientation before broad codebase scanning.
-- ~ If it is absent or may be stale, run `deft codebase:map` and `deft verify:codebase-map-fresh` when those commands resolve; treat the result as advisory unless the current task edits `plan.architecture.codeStructure`, a configured provider artifact, or the generated MAP itself.
-- ! When the MAP is wrong, update `plan.architecture.codeStructure` or the selected provider artifact, then regenerate the MAP.
-- ⊗ Treat a stale or absent MAP as an unrelated implementation blocker, hand-edit `.planning/codebase/MAP.md`, or make the generated projection more authoritative than the xBRIEF metadata.
+! `plan.architecture.codeStructure` is durable SoT; `.planning/codebase/MAP.md` is generated orientation — use `deft codebase:map` / `deft verify:codebase-map-fresh` (`.deft/core/commands.md` § Project And Architecture). ⊗ Do not hand-edit the MAP, block unrelated work on stale/absent MAP, or treat the projection as more authoritative than the xBRIEF metadata (#1595 / #1498).
 
 ## Skills
 
-Skill routing (which skill answers which trigger) is not a table in this policy section. To pick a skill, scan the **Skills Index** (Level-0) in `.deft/core/REFERENCES.md` — it lists every skill under `.deft/core/.agents/skills/` with a one-sentence description and trigger keywords, unified with the framework doc routing so you consult one place to decide what to load. Read a `SKILL.md` (Level-1) only when the index indicates a match. Before improvising a multi-step workflow, scan the skills catalog first — skills are versioned and tested. The `welcome` / `onboard triage` trigger invokes `deft triage:welcome --onboard` (N3 / #1143); for `lessons` / `prior art`, discover packs with `deft packs:slice --list-packs` then load the relevant slice (see Content packs above).
+! Skill routing lives in the **Skills Index** (Level-0) in `.deft/core/REFERENCES.md` — scan it before improvising; read a `SKILL.md` only on index match. `welcome` / `onboard triage` → `deft triage:welcome --onboard` (N3 / #1143); `lessons` / `prior art` → Content packs `packs:slice` above.
 
 ## Review-surface precedence (#2308)
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -374,6 +374,55 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "lazy-loaded, not rendered here",
     ],
   },
+  {
+    id: "content-packs-2501",
+    shape: "doc",
+    header: "Content packs",
+    canonicalHome: "commands.md",
+    pointerHints: ["packs:slice --list-packs", "commands.md", "<pack> --list"],
+    canonicalBodyMarkers: ["task packs:*", "content packs"],
+    retiredFullTextMarkers: [
+      "Deft ships versioned content packs",
+      "Registry-driven, so new packs appear automatically",
+      "short-name + version + one-line description",
+    ],
+  },
+  {
+    id: "codebase-map-2501",
+    shape: "doc",
+    header: "Codebase MAP Projection (#1595 / #1498)",
+    canonicalHome: "commands.md",
+    pointerHints: [
+      "plan.architecture.codeStructure",
+      "codebase:map",
+      "verify:codebase-map-fresh",
+      "commands.md",
+      "#1595",
+    ],
+    canonicalBodyMarkers: [
+      "codebase:map",
+      "plan.architecture.codeStructure",
+      ".planning/codebase/MAP.md",
+    ],
+    retiredFullTextMarkers: [
+      "read it as orientation before broad codebase scanning",
+      "provider/code-derived facts",
+      "unless the current task edits `plan.architecture.codeStructure`",
+    ],
+  },
+  {
+    id: "skills-index-2501",
+    shape: "doc",
+    header: "Skills",
+    canonicalHome: "REFERENCES.md",
+    pointerHints: ["Skills Index", "REFERENCES.md", "SKILL.md", "Level-0"],
+    canonicalBodyMarkers: ["Skills Index", "Level 0", "SKILL.md"],
+    retiredFullTextMarkers: [
+      "Skill routing (which skill answers which trigger) is not a table",
+      "unified with the framework doc routing so you consult one place",
+      "skills are versioned and tested",
+    ],
+  },
 ] as const;
 
 function normalizeWhitespace(text: string): string {
@@ -449,7 +498,9 @@ function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
   }
   if (
     spec.shape === "doc" &&
-    !/commands\.md|scm\/|contracts\/[\w.-]+\.md|\.deft\/core\/contracts\//.test(section)
+    !/commands\.md|scm\/|contracts\/[\w.-]+\.md|\.deft\/core\/contracts\/|REFERENCES\.md/.test(
+      section,
+    )
   ) {
     errors.push(`${spec.id}: doc pointer shape not detected`);
   }
@@ -573,6 +624,7 @@ describe("test_agents_entry_contract", () => {
   it("content_packs_note_references_discovery_commands", () => {
     expect(templateManaged).toContain("--list-packs");
     expect(templateManaged).toContain("<pack> --list");
+    expect(templateManaged).not.toContain("Deft ships versioned content packs");
   });
 });
 

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16782,9 +16782,9 @@
       },
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
-        "managedMaxLines": 184,
+        "managedMaxLines": 114,
         "unmanagedMaxLines": 161,
-        "absoluteMaxBytes": 11399
+        "absoluteMaxBytes": 9780
       }
     },
     "updated": "2026-07-02T14:32:31Z"


### PR DESCRIPTION
## Summary
- Pointer-thin **Content packs**, **Skills**, and **Codebase MAP** in `content/templates/agents-entry.md` (keep `!`/`⊗` one-liners; discovery walkthroughs out of always-on).
- Update `agents_entry_contract` pointer-sufficient markers; `agents:refresh` + re-seed `absoluteMaxBytes`/`managedMaxLines` (11399→9780 B, 184→114 lines).
- CHANGELOG `[Unreleased]` Closes #2501 Refs #2491.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts`
- [x] `task verify:agents-md-budget` (or `node packages/cli/dist/bin.js verify:agents-md-budget`)
- [x] `task check -- --allow-over-cap`
- [ ] CI green + review-cycle CLEAN
