### PR TITLE
refactor(agents-md): Phase 2 Wave 3b — compress process cards to clear ≤8192

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=680de731aec9 refreshed=2026-07-14T02:08:51Z session=a8e1c54fa8c4 -->
+<!-- deft:managed-section v3 sha=2d37b23afdc7 refreshed=2026-07-14T02:23:46Z session=d8b403d4ba5c -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -181,7 +181,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session-start ritual (#1149)
 
-! On **mutation** session start (implementation intent or explicit operator request), run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, headless bypass, and read-only default in `.deft/core/commands.md` § Session-start ritual.
+! On **mutation** session start, run `deft session:start`; before code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft verify:cache-fresh` / `deft agents:refresh` / `npm i -g @deftai/directive@latest`; #1149 / #1348) — `.deft/core/commands.md` § Session-start ritual.
 
 ## WIP cap
 
@@ -189,7 +189,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## xBRIEF layout (#2034 / #2110)
 
-Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate:xbrief` to convert safely to `xbrief/` with semantic v0.6→v0.8 transforms. Legacy `x-vbrief/` reference tokens remain read-accepted until you migrate.
+Projects on legacy `vbrief/` still read-accepted; run `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8). `x-vbrief/` tokens read-accepted until migrated.
 
 ## Unmanaged project header (#2065)
 
@@ -197,14 +197,15 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Cache-as-authoritative work selection (#1149)
 
-! When the operator asks "what should I work on next?" / "build a cohort" / "what's the queue?", run `deft triage:queue --limit=10` (D11 / #1128) and present the ranked list before suggesting anything else. The agent MUST NOT recommend work from memory or open-GitHub-issue intuition. This is the consumer-side mirror of the maintainer rule of the same name; the triage queue is the source of truth for what to work on next.
+! "what next?" / cohort / queue → `deft triage:queue --limit=10` (D11 / #1128); present ranked list first — `.deft/core/commands.md` § Backlog Triage.
 
-⊗ Recommend a specific issue or xBRIEF without consulting `deft triage:queue` (or showing the operator the result of the consultation).
+⊗ Recommend issue or xBRIEF without `deft triage:queue` (or showing its result).
 
 ## Umbrella status reading (#1152 / #2066)
 
-- ! Fetch issue comments via REST (`gh api repos/<owner>/<repo>/issues/<N>/comments`), read the `## Current shape (as of pass-N)` comment, and any linked context or `LockedDecisions` xBRIEF referenced there — following the reading order body -> current-shape comment -> amendment comments (claim-cites-state-surface, #2066). Prefer the deterministic read path: `deft umbrella:current-shape <N>` (or `task umbrella:current-shape <N>`) — it locates the canonical comment, validates #1152 sections, and never falls back to the issue body.
-- ⊗ Conclude umbrella or epic status from the issue body alone. Any "X is done" / "X is the blocker" assertion about an umbrella MUST cite the current-shape comment or another state artifact, not the body.
+! `issues/<N>/comments` via REST → `## Current shape (as of pass-N)` + linked context (claim-cites-state-surface, #2066); body → shape → amendments. Prefer `deft umbrella:current-shape <N>` — full contract: `.deft/core/templates/agent-prompt-preamble.md` § 5.6.
+
+⊗ Conclude umbrella or epic status from the issue body alone — cite current-shape or another state artifact (#2066).
 
 ## Deterministic questions runtime obligation (#1470)
 
@@ -212,11 +213,9 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Issue body→comments reading (#2143)
 
-Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-prompt-preamble.md` (#2143).
+! Fetch body + `issues/<N>/comments` via REST before requirements or dispatch — `.deft/core/templates/agent-prompt-preamble.md` § 5.6 / `deft issue:ingest` (#2143).
 
-- ! Fetch both the issue body and `repos/<owner>/<repo>/issues/<N>/comments` via REST before concluding what the issue asks for or building a worker dispatch envelope. Read body first, then the comment thread in chronological order.
-- ! `deft issue:ingest` / `task issue:ingest` fetches `/comments` by default and folds the thread into the ingested overview (#2143).
-- ⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
+⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
 
 ## Content packs
 
@@ -232,11 +231,11 @@ Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-pro
 
 ## Review-surface precedence (#2308)
 
-! Route review work through `deft-directive-review-cycle` — full workflow in `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host review tools (`bugbot`, `security-review`, `review-*` skills) are advisory-only inputs, not the review of record (#2308 / #1862 / #2261 / #2019).
+! Route review work through `deft-directive-review-cycle` — `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host tools (`bugbot`, `security-review`, `review-*` skills) advisory-only (#2308).
 
 ## Value feedback and attribution (#1709)
 
-! `plan.policy.valueFeedback.enabled` defaults OFF — opt-in via `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; pull-based detail via `deft value:show`; full rules in `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709). Trusted-org auto-enable uses `source=org-auto` (#2376); gap escalation via `deft feedback:file` is confirmation-gated.
+! `plan.policy.valueFeedback.enabled` defaults OFF — opt-in via `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; detail via `deft value:show`; gaps via `deft feedback:file`; rules in `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709).
 
 ## Eval and framework health (#1703)
 
@@ -252,22 +251,17 @@ Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-pro
 
 ## Contextual guardrails (runtime-detect lazy-load)
 
-Contextual / platform-specific rules lazy-load from `.deft/core/scm/github.md` — load the matching section **before** the risky operation when your session matches a trigger (#2157 / #2369):
-
-- ! **PowerShell / Windows** → § PowerShell platform-conditional rules (#798 / #1353); encoding gate: `deft verify:encoding`.
-- ! **TS subprocess capture** → § Safe subprocess capture (#1366).
-- ! **Cascade / batch merge** → § Cascade automation surface (#1369); canonical `deft pr:wait-mergeable-and-merge`.
-- ! **GitHub CLI / SCM shim** → § SCM tooling (#884 / #1145); boundary gate: `deft verify:scm-boundary`.
+! Lazy-load `.deft/core/scm/github.md` sections before risky ops (#2157 / #2369): PowerShell → `deft verify:encoding` (#798); TS capture (#1366); cascade → `deft pr:wait-mergeable-and-merge` (#1369); SCM → `deft verify:scm-boundary` (#884).
 
 ## Development Process
 
 ### Implementation Intent Gate (#810)
 
-! Run `deft xbrief:preflight -- <path>` before code-writing (`xbrief/active/` + `plan.status == "running"`); require explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) (#810) — full rules in `.deft/core/commands.md` § Scope xBRIEF Lifecycle; `deft verify:cache-fresh` is gate-stack step 3 in `.deft/core/commands.md` § Session-start ritual.
+! `deft xbrief:preflight -- <path>` on `xbrief/active/` before code-writing; action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) (#810) — `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
 
 ### Story Start Gate
 
-! Before starting stories run `git status --short --branch` and Gate 0 `deft verify:story-ready`; lifecycle via `deft scope:promote -- <path>` / `deft scope:activate -- <path>` / `deft scope:complete -- <active-story-path>` (#1378) — full workflow in `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
+! `git status --short --branch` + `deft verify:story-ready`; lifecycle via `deft scope:promote -- <path>` / `deft scope:activate -- <path>` / `deft scope:complete -- <active-story-path>` (#1378) — `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Process and reading cards in AGENTS.md are pointer-thin.** Umbrella status, triage queue, issue body→comments, development-process gates, and contextual guardrails collapse to `!` / `⊗` pointers at `commands.md`, the agent preamble, and SCM docs — clearing the Phase-2 managed ≤8192 B bar. Closes #2502. Refs #2491.
+
 - **Always-on AGENTS.md discovery cards are pointer-thin.** Content packs, Skills, and Codebase MAP collapse to one-line `!` / `⊗` pointers at `packs:slice`, the REFERENCES.md Skills Index, and `codebase:map` / `codeStructure`, so agents load less bootstrap text while still finding discovery surfaces on demand. Closes #2501. Refs #2491.
 
 - **Session routing in AGENTS.md is now a thin bootstrap card.** First-session, returning-session, pre-cutover, and cold-start procedures collapse into one pointer-thin routing section that defaults to read-only posture and defers mutable ceremony until mutation intent, trimming always-loaded bootstrap text. Closes #2493. Refs #2491, #2176.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -20,7 +20,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session-start ritual (#1149)
 
-! On **mutation** session start (implementation intent or explicit operator request), run `deft session:start`; before any code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft agents:refresh` / `npm i -g @deftai/directive@latest` entrypoints; #1149 / #1348) — full quick/gated tiers, defer steps, headless bypass, and read-only default in `.deft/core/commands.md` § Session-start ritual.
+! On **mutation** session start, run `deft session:start`; before code-writing or `start_agent` dispatch run `deft verify:session-ritual -- --tier=gated` (stale after `plan.policy.sessionRitualStalenessHours`; records `deft verify:tools` / `deft doctor` / `deft verify:cache-fresh` / `deft agents:refresh` / `npm i -g @deftai/directive@latest`; #1149 / #1348) — `.deft/core/commands.md` § Session-start ritual.
 
 ## WIP cap
 
@@ -28,7 +28,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## xBRIEF layout (#2034 / #2110)
 
-Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate:xbrief` to convert safely to `xbrief/` with semantic v0.6→v0.8 transforms. Legacy `x-vbrief/` reference tokens remain read-accepted until you migrate.
+Projects on legacy `vbrief/` still read-accepted; run `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8). `x-vbrief/` tokens read-accepted until migrated.
 
 ## Unmanaged project header (#2065)
 
@@ -36,14 +36,15 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Cache-as-authoritative work selection (#1149)
 
-! When the operator asks "what should I work on next?" / "build a cohort" / "what's the queue?", run `deft triage:queue --limit=10` (D11 / #1128) and present the ranked list before suggesting anything else. The agent MUST NOT recommend work from memory or open-GitHub-issue intuition. This is the consumer-side mirror of the maintainer rule of the same name; the triage queue is the source of truth for what to work on next.
+! "what next?" / cohort / queue → `deft triage:queue --limit=10` (D11 / #1128); present ranked list first — `.deft/core/commands.md` § Backlog Triage.
 
-⊗ Recommend a specific issue or xBRIEF without consulting `deft triage:queue` (or showing the operator the result of the consultation).
+⊗ Recommend issue or xBRIEF without `deft triage:queue` (or showing its result).
 
 ## Umbrella status reading (#1152 / #2066)
 
-- ! Fetch issue comments via REST (`gh api repos/<owner>/<repo>/issues/<N>/comments`), read the `## Current shape (as of pass-N)` comment, and any linked context or `LockedDecisions` xBRIEF referenced there — following the reading order body -> current-shape comment -> amendment comments (claim-cites-state-surface, #2066). Prefer the deterministic read path: `deft umbrella:current-shape <N>` (or `task umbrella:current-shape <N>`) — it locates the canonical comment, validates #1152 sections, and never falls back to the issue body.
-- ⊗ Conclude umbrella or epic status from the issue body alone. Any "X is done" / "X is the blocker" assertion about an umbrella MUST cite the current-shape comment or another state artifact, not the body.
+! `issues/<N>/comments` via REST → `## Current shape (as of pass-N)` + linked context (claim-cites-state-surface, #2066); body → shape → amendments. Prefer `deft umbrella:current-shape <N>` — full contract: `.deft/core/templates/agent-prompt-preamble.md` § 5.6.
+
+⊗ Conclude umbrella or epic status from the issue body alone — cite current-shape or another state artifact (#2066).
 
 ## Deterministic questions runtime obligation (#1470)
 
@@ -51,11 +52,9 @@ Projects on the legacy `vbrief/` tree are still read-accepted; run `deft migrate
 
 ## Issue body→comments reading (#2143)
 
-Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-prompt-preamble.md` (#2143).
+! Fetch body + `issues/<N>/comments` via REST before requirements or dispatch — `.deft/core/templates/agent-prompt-preamble.md` § 5.6 / `deft issue:ingest` (#2143).
 
-- ! Fetch both the issue body and `repos/<owner>/<repo>/issues/<N>/comments` via REST before concluding what the issue asks for or building a worker dispatch envelope. Read body first, then the comment thread in chronological order.
-- ! `deft issue:ingest` / `task issue:ingest` fetches `/comments` by default and folds the thread into the ingested overview (#2143).
-- ⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
+⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
 
 ## Content packs
 
@@ -71,11 +70,11 @@ Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-pro
 
 ## Review-surface precedence (#2308)
 
-! Route review work through `deft-directive-review-cycle` — full workflow in `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host review tools (`bugbot`, `security-review`, `review-*` skills) are advisory-only inputs, not the review of record (#2308 / #1862 / #2261 / #2019).
+! Route review work through `deft-directive-review-cycle` — `.deft/core/.agents/skills/deft-directive-review-cycle/SKILL.md`; host tools (`bugbot`, `security-review`, `review-*` skills) advisory-only (#2308).
 
 ## Value feedback and attribution (#1709)
 
-! `plan.policy.valueFeedback.enabled` defaults OFF — opt-in via `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; pull-based detail via `deft value:show`; full rules in `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709). Trusted-org auto-enable uses `source=org-auto` (#2376); gap escalation via `deft feedback:file` is confirmation-gated.
+! `plan.policy.valueFeedback.enabled` defaults OFF — opt-in via `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; detail via `deft value:show`; gaps via `deft feedback:file`; rules in `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709).
 
 ## Eval and framework health (#1703)
 
@@ -91,22 +90,17 @@ Rationale + cross-references: preamble § 5.6 in `.deft/core/templates/agent-pro
 
 ## Contextual guardrails (runtime-detect lazy-load)
 
-Contextual / platform-specific rules lazy-load from `.deft/core/scm/github.md` — load the matching section **before** the risky operation when your session matches a trigger (#2157 / #2369):
-
-- ! **PowerShell / Windows** → § PowerShell platform-conditional rules (#798 / #1353); encoding gate: `deft verify:encoding`.
-- ! **TS subprocess capture** → § Safe subprocess capture (#1366).
-- ! **Cascade / batch merge** → § Cascade automation surface (#1369); canonical `deft pr:wait-mergeable-and-merge`.
-- ! **GitHub CLI / SCM shim** → § SCM tooling (#884 / #1145); boundary gate: `deft verify:scm-boundary`.
+! Lazy-load `.deft/core/scm/github.md` sections before risky ops (#2157 / #2369): PowerShell → `deft verify:encoding` (#798); TS capture (#1366); cascade → `deft pr:wait-mergeable-and-merge` (#1369); SCM → `deft verify:scm-boundary` (#884).
 
 ## Development Process
 
 ### Implementation Intent Gate (#810)
 
-! Run `deft xbrief:preflight -- <path>` before code-writing (`xbrief/active/` + `plan.status == "running"`); require explicit action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) (#810) — full rules in `.deft/core/commands.md` § Scope xBRIEF Lifecycle; `deft verify:cache-fresh` is gate-stack step 3 in `.deft/core/commands.md` § Session-start ritual.
+! `deft xbrief:preflight -- <path>` on `xbrief/active/` before code-writing; action-verb directive (`build`, `implement`, `ship`, `swarm`, `run agents`, `start agent`) (#810) — `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
 
 ### Story Start Gate
 
-! Before starting stories run `git status --short --branch` and Gate 0 `deft verify:story-ready`; lifecycle via `deft scope:promote -- <path>` / `deft scope:activate -- <path>` / `deft scope:complete -- <active-story-path>` (#1378) — full workflow in `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
+! `git status --short --branch` + `deft verify:story-ready`; lifecycle via `deft scope:promote -- <path>` / `deft scope:activate -- <path>` / `deft scope:complete -- <active-story-path>` (#1378) — `.deft/core/commands.md` § Scope xBRIEF Lifecycle.
 
 ## Commands
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -283,7 +283,7 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "Workflow-shape vocabulary is NOT authorization",
       "Broad approval is not a substitute",
       "pre-`start_agent` gate stack (#1149/#1348)",
-      "plan.status == \"running\"",
+      'plan.status == "running"',
       "deft verify:cache-fresh` is gate-stack step 3",
     ],
   },
@@ -476,12 +476,7 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
     shape: "doc",
     header: "Issue body→comments reading (#2143)",
     canonicalHome: "templates/agent-prompt-preamble.md",
-    pointerHints: [
-      "agent-prompt-preamble.md",
-      "deft issue:ingest",
-      "issues/<N>/comments",
-      "#2143",
-    ],
+    pointerHints: ["agent-prompt-preamble.md", "deft issue:ingest", "issues/<N>/comments", "#2143"],
     canonicalBodyMarkers: [
       "body first, then the comment thread",
       "repos/<owner>/<repo>/issues/<N>/comments",

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -283,6 +283,8 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "Workflow-shape vocabulary is NOT authorization",
       "Broad approval is not a substitute",
       "pre-`start_agent` gate stack (#1149/#1348)",
+      "plan.status == \"running\"",
+      "deft verify:cache-fresh` is gate-stack step 3",
     ],
   },
   {
@@ -296,6 +298,8 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "A `swarm-cohort` section is ready only when",
       "checkpoint-commit it and proceed",
       "Ask the operator to choose one path",
+      "Gate 0",
+      "full workflow in",
     ],
   },
   {
@@ -372,6 +376,12 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "Raw `gh` calls outside the TS SCM shim",
       "authoritatively enforced at commit",
       "lazy-loaded, not rendered here",
+      "platform-specific rules lazy-load",
+      "load the matching section **before**",
+      "PowerShell / Windows",
+      "TS subprocess capture",
+      "Cascade / batch merge",
+      "GitHub CLI / SCM shim",
     ],
   },
   {
@@ -421,6 +431,68 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "Skill routing (which skill answers which trigger) is not a table",
       "unified with the framework doc routing so you consult one place",
       "skills are versioned and tested",
+    ],
+  },
+  {
+    id: "cache-triage-1149",
+    shape: "doc",
+    header: "Cache-as-authoritative work selection (#1149)",
+    canonicalHome: "commands.md",
+    pointerHints: ["deft triage:queue", "commands.md", "#1149", "D11"],
+    canonicalBodyMarkers: ["triage:queue --limit=10", "ranked candidate work"],
+    retiredFullTextMarkers: [
+      "consumer-side mirror of the maintainer rule",
+      "open-GitHub-issue intuition",
+      "source of truth for what to work on next",
+      "what should I work on next",
+    ],
+  },
+  {
+    id: "umbrella-status-1152",
+    shape: "doc",
+    header: "Umbrella status reading (#1152 / #2066)",
+    canonicalHome: "templates/agent-prompt-preamble.md",
+    pointerHints: [
+      "deft umbrella:current-shape",
+      "issues/<N>/comments",
+      "agent-prompt-preamble.md",
+      "#1152",
+    ],
+    canonicalBodyMarkers: [
+      "Current shape (as of pass-N)",
+      "umbrella:current-shape",
+      "amendment comments",
+    ],
+    retiredFullTextMarkers: [
+      "LockedDecisions",
+      "never falls back to the issue body",
+      "validates #1152 sections",
+      "gh api repos/<owner>/<repo>/issues",
+      "task umbrella:current-shape",
+    ],
+  },
+  {
+    id: "issue-body-comments-2143",
+    shape: "doc",
+    header: "Issue body→comments reading (#2143)",
+    canonicalHome: "templates/agent-prompt-preamble.md",
+    pointerHints: [
+      "agent-prompt-preamble.md",
+      "deft issue:ingest",
+      "issues/<N>/comments",
+      "#2143",
+    ],
+    canonicalBodyMarkers: [
+      "body first, then the comment thread",
+      "repos/<owner>/<repo>/issues/<N>/comments",
+      "issue-ingest",
+    ],
+    retiredFullTextMarkers: [
+      "Rationale + cross-references: preamble § 5.6",
+      "repos/<owner>/<repo>/issues/<N>/comments",
+      "folds the thread into the ingested overview",
+      "chronological order",
+      "task issue:ingest",
     ],
   },
 ] as const;
@@ -498,7 +570,7 @@ function validatePointerRule(section: string, spec: PointerRuleSpec): string[] {
   }
   if (
     spec.shape === "doc" &&
-    !/commands\.md|scm\/|contracts\/[\w.-]+\.md|\.deft\/core\/contracts\/|REFERENCES\.md/.test(
+    !/commands\.md|scm\/|contracts\/[\w.-]+\.md|\.deft\/core\/contracts\/|REFERENCES\.md|templates\/agent-prompt-preamble\.md/.test(
       section,
     )
   ) {

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16784,7 +16784,7 @@
       "agentsMdBudget": {
         "managedMaxLines": 114,
         "unmanagedMaxLines": 161,
-        "absoluteMaxBytes": 9780
+        "absoluteMaxBytes": 7815
       }
     },
     "updated": "2026-07-02T14:32:31Z"


### PR DESCRIPTION
## Summary
- Compress Umbrella status, Cache-as-authoritative triage queue, Issue body→comments, Development Process gates, and Contextual guardrails in \content/templates/agents-entry.md\ to pointer-thin \!\/\⊗\ cards targeting \commands.md\, agent preamble § 5.6, and SCM docs.
- Extend \gents_entry_contract.test.ts\ with pointer-sufficient rules for the relocated cards; re-seed \bsoluteMaxBytes\ to 7815 B.
- Phase-2 managed north-star met: \erify:agents-md-budget\ reports 7815 B (≤8192 B).

Closes #2502
Refs #2491

## Test plan
- [x] \pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts\
- [x] \	ask verify:agents-md-budget\ — managed 7815/7815 B, north-star ≤8192 met
- [ ] CI \	ask check\

Made with [Cursor](https://cursor.com)