### PR TITLE
chore(agents-md): raise combined always-on north-star to 9 KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Medium AGENTS.md cards are pointer-thinner (Phase-3 Wave A2).** Development Process, MAP, Skills, value/eval/branch/guardrail cards compress further while keeping contract markers and one-hop destinations — managed ~7209→6479 B (−730). Combined still ~367 B over ≤8192; remaining gap is escape-hatch / optional Wave B territory. Closes #2536. Refs #2531.
 
+- **Combined always-on north-star raised to 9 KB.** After Wave A thinning, further cuts hit diminishing returns vs capability/discoverability; `verify:agents-md-budget` now treats combined (managed + DD-3 + hooks) ≤**9216 B** as the Phase-3 north-star while managed stays ≤8192. Current combined ~8594 is within bar. Closes #2531. Cancels #2537.
+
 ### Fixed
 
 - **macOS test runs use canonical temporary paths and a portable Unix no-op binary.** Vitest normalizes the `/var` alias before workers spawn, preventing cwd/git fixture mismatches, and the SCM binary-override fixture now uses `/usr/bin/true`, which exists on both macOS and common Linux hosts. Closes #2526, #2527.

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -99,7 +99,7 @@ Consumer AGENTS.md stays pointer-thin — scan `.deft/core/REFERENCES.md` Skills
 - **Harness skill frontmatter** bytes (Cursor `<agent_skill>` shape; advisory unless `skillFrontmatterMaxBytes` is set)
 - **Bootstrap hooks** bytes (0 until #2438 ships)
 
-The north-star target is **≤8192 B / ~2k tok combined**. On Cursor with all skills injected, managed AGENTS.md (~16.8 KB) plus skill frontmatter (~7.7 KB) still exceeds that target — remediation paths:
+The north-star target is **≤8192 B / ~2k tok for the managed section** (Phase-2) and **≤9216 B / ~2.3k tok combined** (managed + DD-3 + hooks; Phase-3 closeout #2531). On Cursor with all skills injected, managed AGENTS.md plus skill frontmatter can still exceed the combined bar — remediation paths:
 
 1. **Tier skills** — install only the daily-core six (`setup`, `sync`, `build`, `pre-pr`, `review-cycle`, `triage`) via OpenPackage; set `plan.policy.agentsMdBudget.skillFrontmatterTier` to `daily-core` or export `DEFT_AGENTS_MD_BUDGET_SKILL_TIER=daily-core`.
 2. **Thin managed AGENTS.md** — continue epic #2369 relocation; push bulk to `commands.md`, `scm/github.md`, and skills.

--- a/packages/core/src/agents-md-budget/evaluate.test.ts
+++ b/packages/core/src/agents-md-budget/evaluate.test.ts
@@ -6,6 +6,7 @@ import {
   ABSOLUTE_MANAGED_MAX_BYTES,
   ABSOLUTE_MANAGED_MAX_TOKENS,
   BOOTSTRAP_HOOK_BYTES,
+  COMBINED_ALWAYS_ON_MAX_BYTES,
   countRegions,
   evaluate,
   extractManagedSection,
@@ -276,8 +277,92 @@ describe("absolute managed-section budget", () => {
     try {
       const result = evaluate(root);
       expect(result.code).toBe(1);
-      expect(result.message).toContain("north-star ceiling");
-      expect(result.message).toContain("combined always-on");
+      expect(result.message).toContain("managed section exceeds the north-star ceiling");
+      expect(result.message).toContain("bytes over");
+      expect(result.message).not.toMatch(/OVER by -\d+/);
+    } finally {
+      if (prev === undefined) delete process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR;
+      else process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR = prev;
+      if (prevWaiver === undefined) delete process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER;
+      else process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER = prevWaiver;
+    }
+  });
+
+  it("emits combined-only advisory when managed is within budget but combined exceeds 9 KB", () => {
+    const skillBody = (name: string, description: string) => `---
+name: ${name}
+description: ${description}
+---
+# Skill`;
+    const root = mkdtempSync(join(tmpdir(), "deft-agents-budget-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(join(root, "xbrief", "seed.xbrief.json"), "{}", { encoding: "utf8" });
+    writeProjectDefinition(root, {
+      policy: { agentsMdBudget: { managedMaxLines: 500, unmanagedMaxLines: 500 } },
+    });
+    writeFileSync(join(root, "AGENTS.md"), agentsWith(5, 5), "utf8");
+    const skillDir = join(root, "content", "skills", "deft-directive-setup");
+    mkdirSync(skillDir, { recursive: true });
+    const padding = "y".repeat(COMBINED_ALWAYS_ON_MAX_BYTES);
+    writeFileSync(join(skillDir, "SKILL.md"), skillBody("deft-directive-setup", padding), "utf8");
+    const bootstrap = measureBootstrapSurface(root, agentsWith(5, 5), {
+      managedMaxLines: 500,
+      unmanagedMaxLines: 500,
+    });
+    expect("error" in bootstrap).toBe(false);
+    if ("error" in bootstrap) return;
+    expect(bootstrap.managed.bytes).toBeLessThanOrEqual(ABSOLUTE_MANAGED_MAX_BYTES);
+    expect(bootstrap.totalBytes).toBeGreaterThan(COMBINED_ALWAYS_ON_MAX_BYTES);
+
+    const result = evaluate(root);
+    expect(result.code).toBe(0);
+    expect(result.northStarMessage).toContain("Combined always-on");
+    expect(result.northStarMessage).toContain("bytes over");
+    expect(result.northStarMessage).not.toContain("Managed section alone");
+  });
+
+  it("fail-closes on combined-only north-star in release-gate mode", () => {
+    const skillBody = (name: string, description: string) => `---
+name: ${name}
+description: ${description}
+---
+# Skill`;
+    const root = mkdtempSync(join(tmpdir(), "deft-agents-budget-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(join(root, "xbrief", "seed.xbrief.json"), "{}", { encoding: "utf8" });
+    const agents = agentsWith(5, 5);
+    const measure = measureManagedSection(agents);
+    expect("bytes" in measure).toBe(true);
+    if (!("bytes" in measure)) return;
+    writeProjectDefinition(root, {
+      policy: {
+        agentsMdBudget: {
+          managedMaxLines: 500,
+          unmanagedMaxLines: 500,
+          absoluteMaxBytes: measure.bytes,
+        },
+      },
+    });
+    writeFileSync(join(root, "AGENTS.md"), agents, "utf8");
+    const skillDir = join(root, "content", "skills", "deft-directive-setup");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      skillBody("deft-directive-setup", "z".repeat(COMBINED_ALWAYS_ON_MAX_BYTES)),
+      "utf8",
+    );
+    const prev = process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR;
+    const prevWaiver = process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER;
+    process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR = "1";
+    delete process.env.DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER;
+    try {
+      const result = evaluate(root);
+      expect(result.code).toBe(1);
+      expect(result.message).toContain("combined always-on surface exceeds the north-star ceiling");
+      expect(result.message).toContain("bytes over");
+      expect(result.message).not.toContain("managed section exceeds");
     } finally {
       if (prev === undefined) delete process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR;
       else process.env.DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR = prev;

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -18,7 +18,11 @@ export type OutputStream = "stdout" | "stderr" | "none";
 /**
  * Layered absolute north-star for the always-on managed surface (#2372 / #2450 / #2452).
  *
- * `ABSOLUTE_MANAGED_MAX_BYTES` is the relocation north-star (<=8192 B / ~2k tok).
+ * `ABSOLUTE_MANAGED_MAX_BYTES` is the managed-section relocation north-star (<=8192 B / ~2k tok)
+ * — Phase-2 success bar. `COMBINED_ALWAYS_ON_MAX_BYTES` is the Phase-3 combined always-on
+ * north-star (managed + DD-3 + hooks), raised to 9 KB after diminishing returns on further
+ * thinning (#2531 closeout).
+ *
  * When `plan.policy.agentsMdBudget.absoluteMaxBytes` is set, growth past that seeded
  * ratchet fails closed; distance-to-north-star is always reported. Optional release-gate
  * north-star enforcement: DEFT_AGENTS_MD_BUDGET_ENFORCE_NORTH_STAR=1 (waiver:
@@ -31,6 +35,9 @@ export type OutputStream = "stdout" | "stderr" | "none";
  */
 export const ABSOLUTE_MANAGED_MAX_BYTES = 8192;
 export const ABSOLUTE_MANAGED_MAX_TOKENS = 2000;
+/** Phase-3 combined always-on north-star (managed + DD-3 + hooks) — 9 KB (#2531). */
+export const COMBINED_ALWAYS_ON_MAX_BYTES = 9216;
+export const COMBINED_ALWAYS_ON_MAX_TOKENS = 2304;
 /** Bootstrap host hooks are 0 B until #2438 ships. */
 export const BOOTSTRAP_HOOK_BYTES = 0;
 /** Rough UTF-8 bytes-per-token estimate for advisory reporting (~8192 B ≈ ~2048 tok). */
@@ -268,8 +275,8 @@ function formatNorthStarOverage(measure: ManagedSectionMeasure): string {
 
 function formatCombinedNorthStarOverage(bootstrap: BootstrapMeasure): string {
   return formatNorthStarOverageBytes(
-    bootstrap.totalBytes - ABSOLUTE_MANAGED_MAX_BYTES,
-    bootstrap.totalEstimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS,
+    bootstrap.totalBytes - COMBINED_ALWAYS_ON_MAX_BYTES,
+    bootstrap.totalEstimatedTokens - COMBINED_ALWAYS_ON_MAX_TOKENS,
   );
 }
 
@@ -290,17 +297,17 @@ function formatNorthStarDistance(measure: ManagedSectionMeasure): string {
 }
 
 function formatCombinedNorthStarDistance(bootstrap: BootstrapMeasure): string {
-  const overBytes = bootstrap.totalBytes - ABSOLUTE_MANAGED_MAX_BYTES;
-  const overTokens = bootstrap.totalEstimatedTokens - ABSOLUTE_MANAGED_MAX_TOKENS;
+  const overBytes = bootstrap.totalBytes - COMBINED_ALWAYS_ON_MAX_BYTES;
+  const overTokens = bootstrap.totalEstimatedTokens - COMBINED_ALWAYS_ON_MAX_TOKENS;
   if (overBytes <= 0 && overTokens <= 0) {
     return (
       `north-star: combined always-on ${bootstrap.totalBytes} bytes ` +
       `(~${bootstrap.totalEstimatedTokens} tok) within ` +
-      `≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok target.`
+      `≤${COMBINED_ALWAYS_ON_MAX_BYTES} B / ~${COMBINED_ALWAYS_ON_MAX_TOKENS} tok target.`
     );
   }
   return (
-    `north-star: combined always-on ≤${ABSOLUTE_MANAGED_MAX_BYTES} B / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
+    `north-star: combined always-on ≤${COMBINED_ALWAYS_ON_MAX_BYTES} B / ~${COMBINED_ALWAYS_ON_MAX_TOKENS} tok ` +
     `(current ${bootstrap.totalBytes} bytes / ~${bootstrap.totalEstimatedTokens} tok — ` +
     `${formatCombinedNorthStarOverage(bootstrap)}).`
   );
@@ -385,14 +392,14 @@ function formatSkillFrontmatterRefusal(
 
 function formatNorthStarRefusal(bootstrap: BootstrapMeasure, projectRoot: string): string {
   const measure = bootstrap.managed;
-  const overBytes = bootstrap.totalBytes - ABSOLUTE_MANAGED_MAX_BYTES;
+  const overBytes = bootstrap.totalBytes - COMBINED_ALWAYS_ON_MAX_BYTES;
   return (
     `❌ verify:agents-md-budget: combined always-on surface exceeds the north-star ceiling ` +
     `(project_root=${projectRoot}, release-gate mode).\n` +
     `   ${formatBootstrapItemization(bootstrap)}\n` +
     `   managed section: ${measure.bytes}/${ABSOLUTE_MANAGED_MAX_BYTES} bytes\n` +
-    `   combined OVER by ${overBytes} bytes vs north-star\n` +
-    "   Thin the managed section and/or tier DD-3 skills toward the <=8192 B target,\n" +
+    `   combined OVER by ${overBytes} bytes vs north-star ≤${COMBINED_ALWAYS_ON_MAX_BYTES} B\n` +
+    "   Thin the managed section and/or tier DD-3 skills toward the combined ≤9 KB target,\n" +
     "   or set DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1 for a time-boxed operator waiver (#2452)."
   );
 }
@@ -413,8 +420,8 @@ function attachNorthStarNote<T extends EvaluateResult>(
   const measure = bootstrap.managed;
   const overManagedBytes = measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES;
   const overManagedTokens = measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
-  const overCombinedBytes = bootstrap.totalBytes > ABSOLUTE_MANAGED_MAX_BYTES;
-  const overCombinedTokens = bootstrap.totalEstimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  const overCombinedBytes = bootstrap.totalBytes > COMBINED_ALWAYS_ON_MAX_BYTES;
+  const overCombinedTokens = bootstrap.totalEstimatedTokens > COMBINED_ALWAYS_ON_MAX_TOKENS;
   if (options.advisoryOnly) {
     if (!overManagedBytes && !overManagedTokens && !overCombinedBytes && !overCombinedTokens) {
       return result;
@@ -617,8 +624,8 @@ export function evaluate(projectRoot: string, options: EvaluateOptions = {}): Ev
     measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES ||
     measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
   const overNorthStarCombined =
-    bootstrap.totalBytes > ABSOLUTE_MANAGED_MAX_BYTES ||
-    bootstrap.totalEstimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+    bootstrap.totalBytes > COMBINED_ALWAYS_ON_MAX_BYTES ||
+    bootstrap.totalEstimatedTokens > COMBINED_ALWAYS_ON_MAX_TOKENS;
   if (
     enforceNorthStarEnabled() &&
     (overNorthStarManaged || overNorthStarCombined) &&

--- a/packages/core/src/agents-md-budget/evaluate.ts
+++ b/packages/core/src/agents-md-budget/evaluate.ts
@@ -331,13 +331,29 @@ function formatBootstrapItemization(bootstrap: BootstrapMeasure): string {
 
 function formatAbsoluteAdvisory(bootstrap: BootstrapMeasure): string {
   const measure = bootstrap.managed;
+  const overManagedBytes = measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES;
+  const overManagedTokens = measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  const overCombinedBytes = bootstrap.totalBytes > COMBINED_ALWAYS_ON_MAX_BYTES;
+  const overCombinedTokens = bootstrap.totalEstimatedTokens > COMBINED_ALWAYS_ON_MAX_TOKENS;
+  const violationLines: string[] = [];
+  if (overManagedBytes || overManagedTokens) {
+    violationLines.push(
+      `  Managed section alone: ${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the north-star ` +
+        `of ${ABSOLUTE_MANAGED_MAX_BYTES} bytes / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
+        `(OVER: ${formatNorthStarOverage(measure)}).`,
+    );
+  }
+  if (overCombinedBytes || overCombinedTokens) {
+    violationLines.push(
+      `  Combined always-on: ${bootstrap.totalBytes} bytes (~${bootstrap.totalEstimatedTokens} tok) exceeds the north-star ` +
+        `of ${COMBINED_ALWAYS_ON_MAX_BYTES} bytes / ~${COMBINED_ALWAYS_ON_MAX_TOKENS} tok ` +
+        `(OVER: ${formatCombinedNorthStarOverage(bootstrap)}).`,
+    );
+  }
   return (
     `⚠ verify:agents-md-budget: always-on bootstrap advisory — ` +
     `${formatBootstrapItemization(bootstrap)}.\n` +
-    `  Managed section alone: ${measure.bytes} bytes (~${measure.estimatedTokens} tok) exceeds the north-star ` +
-    `of ${ABSOLUTE_MANAGED_MAX_BYTES} bytes / ~${ABSOLUTE_MANAGED_MAX_TOKENS} tok ` +
-    `(OVER: ${formatNorthStarOverage(measure)}).\n` +
-    `  ${formatCombinedNorthStarDistance(bootstrap)}\n` +
+    `${violationLines.join("\n")}\n` +
     "  Advisory only — set plan.policy.agentsMdBudget.absoluteMaxBytes to enable " +
     "fail-closed managed growth ratchet (#2452).\n" +
     "  Optional DD-3 ratchet: plan.policy.agentsMdBudget.skillFrontmatterMaxBytes (#2463).\n" +
@@ -392,13 +408,36 @@ function formatSkillFrontmatterRefusal(
 
 function formatNorthStarRefusal(bootstrap: BootstrapMeasure, projectRoot: string): string {
   const measure = bootstrap.managed;
-  const overBytes = bootstrap.totalBytes - COMBINED_ALWAYS_ON_MAX_BYTES;
+  const overNorthStarManaged =
+    measure.bytes > ABSOLUTE_MANAGED_MAX_BYTES ||
+    measure.estimatedTokens > ABSOLUTE_MANAGED_MAX_TOKENS;
+  const overNorthStarCombined =
+    bootstrap.totalBytes > COMBINED_ALWAYS_ON_MAX_BYTES ||
+    bootstrap.totalEstimatedTokens > COMBINED_ALWAYS_ON_MAX_TOKENS;
+  const headline =
+    overNorthStarManaged && overNorthStarCombined
+      ? "managed and combined always-on surfaces exceed the north-star ceiling"
+      : overNorthStarManaged
+        ? "managed section exceeds the north-star ceiling"
+        : "combined always-on surface exceeds the north-star ceiling";
+  const detailLines: string[] = [];
+  if (overNorthStarManaged) {
+    detailLines.push(
+      `   managed section: ${measure.bytes}/${ABSOLUTE_MANAGED_MAX_BYTES} bytes ` +
+        `(OVER: ${formatNorthStarOverage(measure)})`,
+    );
+  }
+  if (overNorthStarCombined) {
+    detailLines.push(
+      `   combined always-on: ${bootstrap.totalBytes}/${COMBINED_ALWAYS_ON_MAX_BYTES} bytes ` +
+        `(OVER: ${formatCombinedNorthStarOverage(bootstrap)})`,
+    );
+  }
   return (
-    `❌ verify:agents-md-budget: combined always-on surface exceeds the north-star ceiling ` +
+    `❌ verify:agents-md-budget: ${headline} ` +
     `(project_root=${projectRoot}, release-gate mode).\n` +
     `   ${formatBootstrapItemization(bootstrap)}\n` +
-    `   managed section: ${measure.bytes}/${ABSOLUTE_MANAGED_MAX_BYTES} bytes\n` +
-    `   combined OVER by ${overBytes} bytes vs north-star ≤${COMBINED_ALWAYS_ON_MAX_BYTES} B\n` +
+    `${detailLines.join("\n")}\n` +
     "   Thin the managed section and/or tier DD-3 skills toward the combined ≤9 KB target,\n" +
     "   or set DEFT_ALLOW_ABSOLUTE_BUDGET_WAIVER=1 for a time-boxed operator waiver (#2452)."
   );


### PR DESCRIPTION
## Summary

- Split combined always-on north-star from managed: managed stays ≤**8192 B**; combined (managed + DD-3 + hooks) is ≤**9216 B (9 KB)**.
- Documents Phase-3 closeout after Wave A diminishing returns (capability escape hatch).
- Cancels Wave B (#2537); closes epic #2531.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/agents-md-budget/evaluate.test.ts`
- [x] `task verify:agents-md-budget` reports combined within ≤9216
- [ ] CI green

Closes #2531