### PR TITLE
fix(release-e2e): resolve pnpm.cmd on Windows for npm dry-run (#2548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Windows release:e2e npm dry-run resolves pnpm.cmd instead of ENOENTing.** The npm publish rehearsal now uses PATHEXT-aware PATH lookup and win32 shell spawn for `.cmd` shims, matching the #2467 toolchain class. Closes #2548.
+
 - **macOS test runs use canonical temporary paths and a portable Unix no-op binary.** Vitest normalizes the `/var` alias before workers spawn, preventing cwd/git fixture mismatches, and the SCM binary-override fixture now uses `/usr/bin/true`, which exists on both macOS and common Linux hosts. Closes #2526, #2527.
 
 ### Removed

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -22,6 +22,7 @@ import {
   rehearseNpmPublish,
   resolvePnpm,
 } from "./npm-ops.js";
+import * as commandSpawn from "../verify-env/command-spawn.js";
 import type { E2ESeams } from "./types.js";
 
 function installFakeContentPackage(projectRoot: string, version = "0.53.0"): string {
@@ -212,6 +213,15 @@ describe("resolvePnpm", () => {
 
   it("returns null when neither is available", () => {
     expect(resolvePnpm({ which: () => null })).toBeNull();
+  });
+
+  it("uses PATHEXT-aware PATH resolution when no which seam is injected (#2548)", () => {
+    const spy = vi.spyOn(commandSpawn, "resolveCommandOnPath").mockImplementation((name) => {
+      if (name === "pnpm") return "C:\\bin\\pnpm.CMD";
+      return null;
+    });
+    expect(resolvePnpm()).toEqual(["C:\\bin\\pnpm.CMD"]);
+    spy.mockRestore();
   });
 });
 

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -16,13 +16,13 @@ import { CONTENT_PACKAGE_NAME } from "../deposit/resolve-content.js";
 import { runInitDeposit } from "../init-deposit/init-deposit.js";
 import { runRefreshDeposit } from "../init-deposit/refresh.js";
 import type { SpawnResult } from "../release/types.js";
+import * as commandSpawn from "../verify-env/command-spawn.js";
 import {
   alignNpmPackageVersions,
   rehearseNpmInstallAndRun,
   rehearseNpmPublish,
   resolvePnpm,
 } from "./npm-ops.js";
-import * as commandSpawn from "../verify-env/command-spawn.js";
 import type { E2ESeams } from "./types.js";
 
 function installFakeContentPackage(projectRoot: string, version = "0.53.0"): string {

--- a/packages/core/src/release-e2e/npm-ops.ts
+++ b/packages/core/src/release-e2e/npm-ops.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { defaultWhich, spawnText } from "../release/spawn.js";
+import { defaultWhich } from "../release/spawn.js";
+import { resolveCommandOnPath, spawnCommandText } from "../verify-env/command-spawn.js";
 import {
   MODULE_NOT_FOUND_MARKERS,
   NPM_BUILD_TIMEOUT_SECONDS,
@@ -31,12 +32,25 @@ function resolveWhich(seams: E2ESeams): (name: string) => string | null {
  * available.
  */
 export function resolvePnpm(seams: E2ESeams = {}): string[] | null {
-  const which = resolveWhich(seams);
-  const pnpm = which("pnpm");
+  // Injected which seam wins for unit tests; production uses PATHEXT-aware PATH scan
+  // so `where pnpm` extensionless shims do not ENOENT under spawnSync (#2548 / #2467).
+  if (seams.which ?? seams.whichGh) {
+    const which = resolveWhich(seams);
+    const pnpm = which("pnpm");
+    if (pnpm) {
+      return [pnpm];
+    }
+    const corepack = which("corepack");
+    if (corepack) {
+      return [corepack, "pnpm"];
+    }
+    return null;
+  }
+  const pnpm = resolveCommandOnPath("pnpm");
   if (pnpm) {
     return [pnpm];
   }
-  const corepack = which("corepack");
+  const corepack = resolveCommandOnPath("corepack");
   if (corepack) {
     return [corepack, "pnpm"];
   }
@@ -51,7 +65,7 @@ function runNpmStep(
   timeoutSeconds: number,
   seams: E2ESeams,
 ): [boolean, string] {
-  const spawn = seams.spawnText ?? spawnText;
+  const spawn = seams.spawnText ?? spawnCommandText;
   const head = cmd[0] ?? "";
   const result = spawn(head, cmd.slice(1), {
     cwd,
@@ -310,7 +324,7 @@ export function rehearseNpmInstallAndRun(
   );
   if (!ok) return [false, reason];
 
-  const spawn = seams.spawnText ?? spawnText;
+  const spawn = seams.spawnText ?? spawnCommandText;
   const cliBin = join(consumerDir, "node_modules", "@deftai", "directive", "dist", "bin.js");
 
   // Liveness probe (#2010): `--version` loads the cli + core engine via

--- a/packages/core/src/verify-env/command-spawn.test.ts
+++ b/packages/core/src/verify-env/command-spawn.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveCommandOnPath,
+  shouldUseShellForCommand,
+  spawnCommandText,
+} from "./command-spawn.js";
+
+describe("shouldUseShellForCommand (#2548)", () => {
+  it("uses a shell for Windows command shims", () => {
+    expect(shouldUseShellForCommand("C:\\bin\\pnpm.CMD", "win32")).toBe(true);
+    expect(shouldUseShellForCommand("C:\\bin\\pnpm.bat", "win32")).toBe(true);
+  });
+
+  it("does not use a shell for native executables or non-Windows platforms", () => {
+    expect(shouldUseShellForCommand("C:\\bin\\pnpm.EXE", "win32")).toBe(false);
+    expect(shouldUseShellForCommand("/usr/bin/pnpm", "linux")).toBe(false);
+  });
+});
+
+describe("resolveCommandOnPath (#2548)", () => {
+  it("returns null when PATH is empty", () => {
+    expect(resolveCommandOnPath("pnpm", { env: { PATH: "" }, platform: "linux" })).toBeNull();
+  });
+
+  it("finds pnpm on a posix PATH", () => {
+    const found = resolveCommandOnPath("pnpm", {
+      env: { PATH: "/empty:/usr/local/bin" },
+      platform: "linux",
+      exists: (p) => p === "/usr/local/bin/pnpm",
+    });
+    expect(found).toBe("/usr/local/bin/pnpm");
+  });
+
+  it("prefers pnpm.cmd over a bare extensionless shim on win32", () => {
+    const found = resolveCommandOnPath("pnpm", {
+      env: { Path: "C:\\Users\\msada\\AppData\\Roaming\\npm", PATHEXT: ".EXE;.CMD" },
+      platform: "win32",
+      exists: (p) => p.endsWith("pnpm.CMD") || p.endsWith("\\pnpm"),
+    });
+    expect(found?.endsWith("pnpm.CMD")).toBe(true);
+  });
+
+  it("falls back to a default PATHEXT on win32 when unset", () => {
+    const found = resolveCommandOnPath("pnpm", {
+      env: { Path: "C:\\bin" },
+      platform: "win32",
+      exists: (p) => p.endsWith(".EXE"),
+    });
+    expect(found?.endsWith("pnpm.EXE")).toBe(true);
+  });
+});
+
+describe("spawnCommandText (#2548)", () => {
+  it("surfaces a non-empty stderr when the spawn itself errors", () => {
+    const result = spawnCommandText("deft-nonexistent-binary-xyz-2548", ["api"]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/verify-env/command-spawn.ts
+++ b/packages/core/src/verify-env/command-spawn.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { posix, win32 } from "node:path";
-import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import type { SpawnResult } from "../release/types.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 
 export interface ResolveCommandOnPathOptions {
   readonly env?: NodeJS.ProcessEnv;

--- a/packages/core/src/verify-env/command-spawn.ts
+++ b/packages/core/src/verify-env/command-spawn.ts
@@ -1,0 +1,104 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { posix, win32 } from "node:path";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import type { SpawnResult } from "../release/types.js";
+
+export interface ResolveCommandOnPathOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+  readonly exists?: (path: string) => boolean;
+}
+
+/** Windows command shims (.cmd/.bat) need a shell; native executables do not. */
+export function shouldUseShellForCommand(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "win32" && /\.(?:cmd|bat)$/i.test(command);
+}
+
+/**
+ * Resolve an executable on PATH with PATHEXT / Path awareness (#2467 / #2548).
+ * Mirrors ts-check-lane `resolvePnpm` and verify-tools `defaultProbe`.
+ */
+export function resolveCommandOnPath(
+  command: string,
+  options: ResolveCommandOnPathOptions = {},
+): string | null {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const exists = options.exists ?? existsSync;
+
+  const pathValue = env.PATH ?? env.Path ?? "";
+  if (pathValue === "") {
+    return null;
+  }
+  const isWindows = platform === "win32";
+  const exts = isWindows ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";") : [""];
+  const sep = isWindows ? ";" : ":";
+  const joinPath = isWindows ? win32.join : posix.join;
+  for (const dir of pathValue.split(sep)) {
+    if (dir === "") continue;
+    for (const ext of exts) {
+      const candidate = joinPath(dir, `${command}${ext}`);
+      if (exists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+export interface SpawnCommandTextOptions {
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * spawnSync wrapper that applies win32 PATHEXT / shell rules (#2467 / #2548).
+ * Retries with `shell: true` on win32 ENOENT (npm global `.cmd` shims).
+ */
+export function spawnCommandText(
+  cmd: string,
+  args: readonly string[],
+  options: SpawnCommandTextOptions = {},
+): SpawnResult {
+  const trySpawn = (shell: boolean) =>
+    spawnSync(cmd, [...args], {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      encoding: "utf8",
+      timeout: options.timeoutMs,
+      maxBuffer: SUBPROCESS_MAX_BUFFER,
+      stdio: ["ignore", "pipe", "pipe"],
+      shell,
+    });
+
+  let result = trySpawn(shouldUseShellForCommand(cmd));
+  const spawnErr = result.error as NodeJS.ErrnoException | undefined;
+  if (spawnErr?.code === "ENOENT" && process.platform === "win32") {
+    result = trySpawn(true);
+  }
+
+  let status = result.status;
+  let stderr = typeof result.stderr === "string" ? result.stderr : "";
+  if (status === null) {
+    if (result.signal !== null && result.signal !== undefined) {
+      status = 128;
+    } else if (result.error) {
+      status = 2;
+      if (stderr.trim().length === 0) {
+        stderr = result.error.message;
+      }
+    } else {
+      status = 0;
+    }
+  }
+  return {
+    status,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr,
+  };
+}

--- a/packages/core/src/verify-env/index.ts
+++ b/packages/core/src/verify-env/index.ts
@@ -1,3 +1,4 @@
+export * from "./command-spawn.js";
 export * from "./node-runtime.js";
 export * from "./toolchain-check.js";
 export * from "./verify-hooks-installed.js";

--- a/xbrief/active/2026-07-14-2548-fixrelease-e2e-windows-npm-dry-run-fails-spawnsync-pnpm-enoe.xbrief.json
+++ b/xbrief/active/2026-07-14-2548-fixrelease-e2e-windows-npm-dry-run-fails-spawnsync-pnpm-enoe.xbrief.json
@@ -1,0 +1,88 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2548"
+  },
+  "plan": {
+    "title": "fix(release-e2e): Windows npm dry-run fails spawnSync pnpm ENOENT (PATHEXT / .cmd)",
+    "status": "running",
+    "narratives": {
+      "Description": "release:e2e npm publish dry-run uses spawnSync on a bare pnpm path and ENOENTs on Windows despite pnpm.cmd on PATH. Use the shared win32 PATHEXT-aware spawn helper (same class as #2467) or soft-skip with a clear diagnostic.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2548",
+      "Overview": "## Problem\n\n`task release:e2e` on native Windows completed the GitHub release rehearsal cleanly, then failed the npm publish dry-run leg:\n\n```\n[e2e]   rehearsal step: npm publish dry-run... FAIL (pnpm install failed (exit 2): spawnSync C:\\Users\\msada\\AppData\\Roaming\\npm\\pnpm ENOENT)\n```\n\n`pnpm` is installed and resolvable from PowerShell (`pnpm.ps1` / `pnpm.cmd` under `%APPDATA%\\Roaming\\npm`). `where.exe pnpm` finds both the extensionless shim and `pnpm.cmd`. `spawnSync` without `shell: true` does not apply PATHEXT, so the bare `pnpm` path ENOENTs.\n\n## Evidence (v0.77.0 Phase 3)\n\n- clone / set-origin / push-mirror / task release / verify draft / verify tag: **OK**\n- npm publish dry-run: **FAIL** (pnpm ENOENT)\n- Temp repo destroy: WARN (token lacks `delete_repo`) — leftover `deftai/deftai-release-test-20260714221141-bc7550`\n\n## Expected\n\n- release-e2e npm leg resolves `pnpm` on win32 the same way #2467 / toolchain probes do (prefer `.cmd` / `shell: true` / Corepack)\n- Or soft-skip with a clear Windows diagnostic instead of hard-failing a green GitHub rehearsal\n\n## Acceptance\n\n- [ ] `task release:e2e` npm dry-run succeeds on Windows when pnpm.cmd is on PATH\n- [ ] Regression test or shared spawn helper covers win32 PATHEXT for pnpm\n- [ ] Document `--skip-npm` as GitHub-shape-only escape when npm leg is env-blocked\n\n## Related\n\n- Observed during v0.77.0 Phase 3\n- Same class as #2467 (Windows pnpm.cmd / PATHEXT)\n- Refs #2547 (Taskfile quoting), #2546 (vitest flake)\r\n\n",
+      "Labels": "bug, runtime-portability, urgent, area:release",
+      "UserStory": "As a Windows maintainer, I want release:e2e npm dry-run to find pnpm.cmd, so that Phase 3 does not hard-fail after a green GitHub rehearsal.",
+      "ImplementationPlan": "1. Update the release-e2e npm dry-run spawn in packages/core/src/release-e2e/ to resolve pnpm via win32 PATHEXT/.cmd/shell:true using the shared verify-env toolchain helper.\n2. Add a vitest unit test that asserts Windows pnpm resolution prefers pnpm.cmd and does not spawn a bare extensionless path that returns ENOENT.\n3. Verify with the focused release-e2e test module and a release:e2e --skip-npm smoke when full npm leg remains blocked.",
+      "Acceptance": "1. Windows pnpm spawn succeeds\n2. Shared resolution helper used\n3. Unit test covers PATHEXT"
+    },
+    "items": [
+      {
+        "title": "Windows pnpm spawn succeeds",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given pnpm.cmd on PATH, when release-e2e runs the npm dry-run install step on win32, then spawn returns without ENOENT and the step proceeds or soft-skips with an explicit diagnostic."
+        }
+      },
+      {
+        "title": "Shared resolution helper used",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the release-e2e npm leg, when it locates pnpm, then it uses the shared win32-aware resolver rather than spawnSync on a bare pnpm path."
+        }
+      },
+      {
+        "title": "Unit test covers PATHEXT",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the new release-e2e unit test, when executed on the win32 branch of the resolver, then it passes for pnpm.cmd resolution and fails if the bare-path ENOENT regresses."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "runtime-portability",
+      "urgent",
+      "area:release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2548",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2548: fix(release-e2e): Windows npm dry-run fails spawnSync pnpm ENOENT (PATHEXT / .cmd)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2547",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2547"
+      }
+    ],
+    "updated": "2026-07-14T22:24:21Z",
+    "id": "release-e2e-pnpm-pathext",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release-e2e/",
+          "packages/core/src/verify-env/"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- release-e2e",
+          "pnpm --filter @deftai/directive-core test -- verify-env"
+        ],
+        "expected_outputs": [
+          "Windows pnpm resolution succeeds for release-e2e npm leg",
+          "Regression test for win32 spawn",
+          "Clear diagnostic if soft-skip remains"
+        ],
+        "depends_on": [],
+        "conflict_group": "release-e2e-npm",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": "Issue #2548; same PATHEXT class as #2467. Release e2e harness is framework-internal."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add shared verify-env command-spawn helper with PATHEXT-aware PATH lookup and win32 shell spawn (same class as #2467)
- Wire release-e2e npm dry-run to resolve pnpm.cmd instead of extensionless npm global shims that ENOENT under spawnSync
- Add unit tests for PATHEXT resolution and npm-ops integration

Closes #2548

## Test plan
- [x] pnpm exec vitest run packages/core/src/verify-env/command-spawn.test.ts packages/core/src/release-e2e/npm-ops.test.ts
- [x] pnpm run build
- [ ] CI green

Made with [Cursor](https://cursor.com)