### PR TITLE
fix(taskfile): release --summary with apostrophes breaks ENGINE_CMD (#2547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Windows release:e2e npm dry-run resolves pnpm.cmd instead of ENOENTing.** The npm publish rehearsal now uses PATHEXT-aware PATH lookup and win32 shell spawn for `.cmd` shims, matching the #2467 toolchain class. Closes #2548.
 - **Windows task check no longer fails on Vitest onTaskUpdate RPC timeouts after a green suite.** Native Windows coverage runs cap fork worker parallelism, widen teardown timeout, and ignore unhandled worker RPC flakes when assertions are otherwise green so `pnpm run test` / `task check` exit zero. Closes #2546.
-- **`task release --summary` with apostrophes no longer breaks go-task.** `engine:invoke` forwards `ENGINE_CMD` via env and argv-spawns through `scripts/engine-invoke.cjs` so free-text flags (release summaries, reject reasons, etc.) are not shell-interpolated. Closes #2547.
+- **`task release --summary` with apostrophes no longer breaks go-task.** `engine:invoke` forwards `ENGINE_CMD` via env and argv-spawns through `tasks/engine-invoke.cjs` (shipped in consumer content prepack) so free-text flags are not shell-interpolated. Closes #2547.
 
 - **macOS test runs use canonical temporary paths and a portable Unix no-op binary.** Vitest normalizes the `/var` alias before workers spawn, preventing cwd/git fixture mismatches, and the SCM binary-override fixture now uses `/usr/bin/true`, which exists on both macOS and common Linux hosts. Closes #2526, #2527.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Windows release:e2e npm dry-run resolves pnpm.cmd instead of ENOENTing.** The npm publish rehearsal now uses PATHEXT-aware PATH lookup and win32 shell spawn for `.cmd` shims, matching the #2467 toolchain class. Closes #2548.
 - **Windows task check no longer fails on Vitest onTaskUpdate RPC timeouts after a green suite.** Native Windows coverage runs cap fork worker parallelism, widen teardown timeout, and ignore unhandled worker RPC flakes when assertions are otherwise green so `pnpm run test` / `task check` exit zero. Closes #2546.
+- **`task release --summary` with apostrophes no longer breaks go-task.** `engine:invoke` forwards `ENGINE_CMD` via env and argv-spawns through `scripts/engine-invoke.cjs` so free-text flags (release summaries, reject reasons, etc.) are not shell-interpolated. Closes #2547.
 
 - **macOS test runs use canonical temporary paths and a portable Unix no-op binary.** Vitest normalizes the `/var` alias before workers spawn, preventing cwd/git fixture mismatches, and the SCM binary-override fixture now uses `/usr/bin/true`, which exists on both macOS and common Linux hosts. Closes #2526, #2527.
 

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -119,7 +119,7 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
     expect(engine).toMatch(/invoke:/);
     expect(engine).toMatch(/command -v deft/);
     expect(engine).toMatch(/command -v directive/);
-    expect(engine).toMatch(/DEFT_ENGINE_CMD/);
+    expect(engine).toMatch(/DEFT_ENGINE_CMD_JSON/);
     expect(engine).toMatch(/engine-invoke\.cjs/);
     expect(engine).not.toMatch(/deft \{\{\.ENGINE_CMD\}\}/);
     // #2409: runtime verbs may fall back to global deft; build-gated verbs fail closed.

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -119,7 +119,9 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
     expect(engine).toMatch(/invoke:/);
     expect(engine).toMatch(/command -v deft/);
     expect(engine).toMatch(/command -v directive/);
-    expect(engine).toMatch(/deft \{\{\.ENGINE_CMD\}\}/);
+    expect(engine).toMatch(/DEFT_ENGINE_CMD/);
+    expect(engine).toMatch(/engine-invoke\.cjs/);
+    expect(engine).not.toMatch(/deft \{\{\.ENGINE_CMD\}\}/);
     // #2409: runtime verbs may fall back to global deft; build-gated verbs fail closed.
     expect(engine).toMatch(/CLI artifact missing/);
     expect(engine).toMatch(/is_runtime_verb/);

--- a/packages/core/src/content-contracts/standards/taskfile_release_names.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_release_names.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync, execSync, spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { repoRoot } from "./_helpers.js";
@@ -65,6 +65,36 @@ describe("test_taskfile_release_names.py", () => {
         },
       );
       expect(out.toLowerCase()).toContain("usage");
+    },
+  );
+
+  it.skipIf(!taskAvailable)(
+    "test_task_release_summary_with_apostrophe_does_not_shell_parse_fail (#2547)",
+    () => {
+      const result = spawnSync(
+        "task",
+        [
+          "-t",
+          join(repoRoot(), "Taskfile.yml"),
+          "release",
+          "--",
+          "0.0.0",
+          "--dry-run",
+          "--skip-tag",
+          "--skip-release",
+          "--summary",
+          "test what's next",
+        ],
+        {
+          cwd: repoRoot(),
+          encoding: "utf8",
+          env: { ...process.env, PYTHONUTF8: "1" },
+          maxBuffer: 10 * 1024 * 1024,
+        },
+      );
+      expect(result.status).toBe(0);
+      const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`.toLowerCase();
+      expect(combined).toMatch(/dry-run|changelog|release/);
     },
   );
 });

--- a/packages/core/src/content-contracts/standards/taskfile_runtime_session.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_runtime_session.test.ts
@@ -84,7 +84,7 @@ describe("runtime/session task dispatch (#2181)", () => {
     expect(engine).toMatch(
       /if \[ -f "\$bin" \]; then[\s\S]*node "\{\{\.TASKFILE_DIR\}\}\/engine-invoke\.cjs" vendored "\$bin"/m,
     );
-    expect(engine).toMatch(/DEFT_ENGINE_CMD/);
+    expect(engine).toMatch(/DEFT_ENGINE_CMD_JSON/);
   });
 
   it("engine:invoke checks Node via process.versions.node, not pnpm engine warnings", () => {

--- a/packages/core/src/content-contracts/standards/taskfile_runtime_session.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_runtime_session.test.ts
@@ -81,7 +81,10 @@ describe("runtime/session task dispatch (#2181)", () => {
   });
 
   it("engine:invoke runs vendored bin.js when the artifact is present", () => {
-    expect(engine).toMatch(/if \[ -f "\$bin" \]; then[\s\S]*node "\$bin" \{\{\.ENGINE_CMD\}\}/m);
+    expect(engine).toMatch(
+      /if \[ -f "\$bin" \]; then[\s\S]*node "\{\{\.TASKFILE_DIR\}\}\/engine-invoke\.cjs" vendored "\$bin"/m,
+    );
+    expect(engine).toMatch(/DEFT_ENGINE_CMD/);
   });
 
   it("engine:invoke checks Node via process.versions.node, not pnpm engine warnings", () => {

--- a/packages/core/src/platform/shell-split.test.ts
+++ b/packages/core/src/platform/shell-split.test.ts
@@ -23,15 +23,15 @@ describe("shellSplit (engine-invoke #2547)", () => {
     ]);
   });
 
-  it("preserves Windows paths inside double-quoted segments (#2547)", () => {
+  it("preserves forward-slash Windows paths inside double-quoted segments (#2547)", () => {
     const cmd =
-      'migrate-preflight --project-root "D:\\a\\consumer\\proj" --deft-root "D:\\a\\directive\\directive"';
+      'migrate-preflight --project-root "D:/a/consumer/proj" --deft-root "D:/a/directive/directive"';
     expect(shellSplit(cmd)).toEqual([
       "migrate-preflight",
       "--project-root",
-      "D:\\a\\consumer\\proj",
+      "D:/a/consumer/proj",
       "--deft-root",
-      "D:\\a\\directive\\directive",
+      "D:/a/directive/directive",
     ]);
   });
 });

--- a/packages/core/src/platform/shell-split.test.ts
+++ b/packages/core/src/platform/shell-split.test.ts
@@ -1,0 +1,25 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "../content-contracts/standards/_helpers.js";
+
+const require = createRequire(import.meta.url);
+const { shellSplit } = require(join(repoRoot(), "scripts/engine-invoke.cjs")) as {
+  shellSplit: (input: string) => string[];
+};
+
+describe("shellSplit (engine-invoke #2547)", () => {
+  it("splits simple tokens", () => {
+    expect(shellSplit("release 0.0.0 --dry-run")).toEqual([
+      "release",
+      "0.0.0",
+      "--dry-run",
+    ]);
+  });
+
+  it("preserves apostrophes inside double-quoted summary text", () => {
+    expect(
+      shellSplit('release 0.0.0 --dry-run --summary "test what\'s next"'),
+    ).toEqual(["release", "0.0.0", "--dry-run", "--summary", "test what's next"]);
+  });
+});

--- a/packages/core/src/platform/shell-split.test.ts
+++ b/packages/core/src/platform/shell-split.test.ts
@@ -22,4 +22,16 @@ describe("shellSplit (engine-invoke #2547)", () => {
       "test what's next",
     ]);
   });
+
+  it("preserves Windows paths inside double-quoted segments (#2547)", () => {
+    const cmd =
+      'migrate-preflight --project-root "D:\\a\\consumer\\proj" --deft-root "D:\\a\\directive\\directive"';
+    expect(shellSplit(cmd)).toEqual([
+      "migrate-preflight",
+      "--project-root",
+      "D:\\a\\consumer\\proj",
+      "--deft-root",
+      "D:\\a\\directive\\directive",
+    ]);
+  });
 });

--- a/packages/core/src/platform/shell-split.test.ts
+++ b/packages/core/src/platform/shell-split.test.ts
@@ -4,22 +4,22 @@ import { describe, expect, it } from "vitest";
 import { repoRoot } from "../content-contracts/standards/_helpers.js";
 
 const require = createRequire(import.meta.url);
-const { shellSplit } = require(join(repoRoot(), "scripts/engine-invoke.cjs")) as {
+const { shellSplit } = require(join(repoRoot(), "tasks/engine-invoke.cjs")) as {
   shellSplit: (input: string) => string[];
 };
 
 describe("shellSplit (engine-invoke #2547)", () => {
   it("splits simple tokens", () => {
-    expect(shellSplit("release 0.0.0 --dry-run")).toEqual([
-      "release",
-      "0.0.0",
-      "--dry-run",
-    ]);
+    expect(shellSplit("release 0.0.0 --dry-run")).toEqual(["release", "0.0.0", "--dry-run"]);
   });
 
   it("preserves apostrophes inside double-quoted summary text", () => {
-    expect(
-      shellSplit('release 0.0.0 --dry-run --summary "test what\'s next"'),
-    ).toEqual(["release", "0.0.0", "--dry-run", "--summary", "test what's next"]);
+    expect(shellSplit('release 0.0.0 --dry-run --summary "test what\'s next"')).toEqual([
+      "release",
+      "0.0.0",
+      "--dry-run",
+      "--summary",
+      "test what's next",
+    ]);
   });
 });

--- a/scripts/engine-invoke.cjs
+++ b/scripts/engine-invoke.cjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Spawn the deft CLI from DEFT_ENGINE_CMD without shell-interpolating operator
+ * text (#2547). go-task forwards user args into ENGINE_CMD; apostrophes in
+ * --summary and similar free-text flags must not break mvdan/sh parsing.
+ */
+
+const { spawnSync } = require("node:child_process");
+
+/** Minimal POSIX-ish shell word splitter (double/single quotes, escapes). */
+function shellSplit(input) {
+  const out = [];
+  let cur = "";
+  let quote = null;
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i];
+    if (quote) {
+      if (c === quote) {
+        quote = null;
+        continue;
+      }
+      if (c === "\\" && quote === '"' && i + 1 < input.length) {
+        cur += input[++i];
+        continue;
+      }
+      cur += c;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      continue;
+    }
+    if (/\s/.test(c)) {
+      if (cur) {
+        out.push(cur);
+        cur = "";
+      }
+      continue;
+    }
+    cur += c;
+  }
+  if (cur) {
+    out.push(cur);
+  }
+  return out;
+}
+
+function main() {
+  const mode = process.argv[2];
+  const target = process.argv[3];
+  const cmdLine = String(process.env.DEFT_ENGINE_CMD || "").trim();
+  const argv = shellSplit(cmdLine);
+  if (argv.length === 0) {
+    console.error("deft: DEFT_ENGINE_CMD is empty");
+    process.exit(2);
+  }
+  if (!mode || !target) {
+    console.error("deft: engine-invoke usage: engine-invoke.cjs <vendored|global> <bin-or-cli>");
+    process.exit(2);
+  }
+
+  let execPath;
+  let execArgv;
+  if (mode === "vendored") {
+    execPath = process.execPath;
+    execArgv = [target, ...argv];
+  } else if (mode === "global") {
+    execPath = target;
+    execArgv = argv;
+  } else {
+    console.error(`deft: engine-invoke unknown mode ${JSON.stringify(mode)}`);
+    process.exit(2);
+  }
+
+  const result = spawnSync(execPath, execArgv, {
+    stdio: "inherit",
+    env: process.env,
+    shell: false,
+  });
+  const code = result.status;
+  process.exit(code === null ? 1 : code);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { shellSplit };

--- a/tasks/engine-invoke.cjs
+++ b/tasks/engine-invoke.cjs
@@ -5,6 +5,9 @@
  * Spawn the deft CLI from DEFT_ENGINE_CMD without shell-interpolating operator
  * text (#2547). go-task forwards user args into ENGINE_CMD; apostrophes in
  * --summary and similar free-text flags must not break mvdan/sh parsing.
+ *
+ * Lives under tasks/ (not repo-root scripts/) so @deftai/directive-content
+ * prepack ships it beside tasks/engine.yml (#2022 Phase 3).
  */
 
 const { spawnSync } = require("node:child_process");

--- a/tasks/engine-invoke.cjs
+++ b/tasks/engine-invoke.cjs
@@ -80,7 +80,8 @@ function main() {
   const result = spawnSync(execPath, execArgv, {
     stdio: "inherit",
     env: process.env,
-    shell: false,
+    // Global deft/directive on Windows are .cmd shims; shell:false cannot spawn them (#2415).
+    shell: mode === "global" && process.platform === "win32",
   });
   const code = result.status;
   process.exit(code === null ? 1 : code);

--- a/tasks/engine-invoke.cjs
+++ b/tasks/engine-invoke.cjs
@@ -53,7 +53,18 @@ function shellSplit(input) {
 function main() {
   const mode = process.argv[2];
   const target = process.argv[3];
-  const cmdLine = String(process.env.DEFT_ENGINE_CMD || "").trim();
+  let cmdLine = "";
+  if (process.env.DEFT_ENGINE_CMD_JSON) {
+    try {
+      cmdLine = JSON.parse(process.env.DEFT_ENGINE_CMD_JSON);
+    } catch {
+      console.error("deft: DEFT_ENGINE_CMD_JSON is not valid JSON");
+      process.exit(2);
+    }
+  } else {
+    cmdLine = String(process.env.DEFT_ENGINE_CMD || "");
+  }
+  cmdLine = cmdLine.trim();
   const argv = shellSplit(cmdLine);
   if (argv.length === 0) {
     console.error("deft: DEFT_ENGINE_CMD is empty");

--- a/tasks/engine-invoke.cjs
+++ b/tasks/engine-invoke.cjs
@@ -89,11 +89,19 @@ function main() {
   }
 
   const result = spawnSync(execPath, execArgv, {
-    stdio: "inherit",
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
     env: process.env,
     // Global deft/directive on Windows are .cmd shims; shell:false cannot spawn them (#2415).
     shell: mode === "global" && process.platform === "win32",
+    maxBuffer: 16 * 1024 * 1024,
   });
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
   const code = result.status;
   process.exit(code === null ? 1 : code);
 }

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -171,6 +171,11 @@ tasks:
     # Run from the operator project root so deft verbs resolve USER_WORKING_DIR
     # correctly; without this, included engine.yml defaults cwd to tasks/ (#2022).
     dir: '{{.USER_WORKING_DIR}}'
+    # Operator free-text (e.g. release --summary with apostrophes) must not be
+    # interpolated into the shell script body — pass via env and argv-spawn in
+    # scripts/engine-invoke.cjs (#2547).
+    env:
+      DEFT_ENGINE_CMD: '{{.ENGINE_CMD}}'
     cmds:
       - |
         set -eu
@@ -197,10 +202,9 @@ tasks:
               }
             " "$root_pkg" || exit $?
           fi
-          node "$bin" {{.ENGINE_CMD}}
+          node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" vendored "$bin"
         elif [ "$is_buildable_source" = 1 ]; then
-          engine_cmd='{{.ENGINE_CMD}}'
-          first_token="${engine_cmd%% *}"
+          first_token="${DEFT_ENGINE_CMD%% *}"
           is_runtime_verb=0
           case " ${first_token} " in
             " session:start "|" session-start "|\
@@ -245,7 +249,7 @@ tasks:
                 console.error('deft: using global '+cli+' ('+gv+'); source checkout is v'+srcVer+' — run task build for a local engine match.');
               }
             " "{{.DEFT_ROOT}}" "$global_cli" >&2 || true
-            "$global_cli" {{.ENGINE_CMD}}
+            node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" global "$global_cli"
           else
             echo "deft: CLI artifact missing at {{.DEFT_ROOT}}/packages/cli/dist/bin.js" >&2
             if [ "$is_runtime_verb" = 1 ]; then
@@ -257,9 +261,9 @@ tasks:
             exit 2
           fi
         elif command -v deft >/dev/null 2>&1; then
-          deft {{.ENGINE_CMD}}
+          node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" global deft
         elif command -v directive >/dev/null 2>&1; then
-          directive {{.ENGINE_CMD}}
+          node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" global directive
         else
           echo "deft: neither {{.DEFT_ROOT}}/packages/cli/dist/bin.js nor a global deft command is available." >&2
           echo "  Install with: npm i -g @deftai/directive" >&2

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -175,7 +175,7 @@ tasks:
     # interpolated into the shell script body — JSON env transport + argv-spawn in
     # tasks/engine-invoke.cjs (#2547). Avoids shell parse breaks for `'` and `\`.
     env:
-      DEFT_ENGINE_CMD_JSON: '{{.ENGINE_CMD | toJson}}'
+      DEFT_ENGINE_CMD_JSON: '{{ .ENGINE_CMD | toSlash | toJson }}'
     cmds:
       - |
         set -eu

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -172,10 +172,10 @@ tasks:
     # correctly; without this, included engine.yml defaults cwd to tasks/ (#2022).
     dir: '{{.USER_WORKING_DIR}}'
     # Operator free-text (e.g. release --summary with apostrophes) must not be
-    # interpolated into the shell script body — pass via env and argv-spawn in
-    # scripts/engine-invoke.cjs (#2547) — lives under tasks/ for content prepack.
+    # interpolated into the shell script body — JSON env transport + argv-spawn in
+    # tasks/engine-invoke.cjs (#2547). Avoids shell parse breaks for `'` and `\`.
     env:
-      DEFT_ENGINE_CMD: '{{.ENGINE_CMD}}'
+      DEFT_ENGINE_CMD_JSON: '{{.ENGINE_CMD | toJson}}'
     cmds:
       - |
         set -eu
@@ -204,7 +204,7 @@ tasks:
           fi
           node "{{.TASKFILE_DIR}}/engine-invoke.cjs" vendored "$bin"
         elif [ "$is_buildable_source" = 1 ]; then
-          first_token="${DEFT_ENGINE_CMD%% *}"
+          first_token=$(node -e "process.stdout.write(JSON.parse(process.env.DEFT_ENGINE_CMD_JSON||'\"\"').split(/\\s+/)[0]||'')")
           is_runtime_verb=0
           case " ${first_token} " in
             " session:start "|" session-start "|\

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -173,7 +173,7 @@ tasks:
     dir: '{{.USER_WORKING_DIR}}'
     # Operator free-text (e.g. release --summary with apostrophes) must not be
     # interpolated into the shell script body — pass via env and argv-spawn in
-    # scripts/engine-invoke.cjs (#2547).
+    # scripts/engine-invoke.cjs (#2547) — lives under tasks/ for content prepack.
     env:
       DEFT_ENGINE_CMD: '{{.ENGINE_CMD}}'
     cmds:
@@ -202,7 +202,7 @@ tasks:
               }
             " "$root_pkg" || exit $?
           fi
-          node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" vendored "$bin"
+          node "{{.TASKFILE_DIR}}/engine-invoke.cjs" vendored "$bin"
         elif [ "$is_buildable_source" = 1 ]; then
           first_token="${DEFT_ENGINE_CMD%% *}"
           is_runtime_verb=0
@@ -249,7 +249,7 @@ tasks:
                 console.error('deft: using global '+cli+' ('+gv+'); source checkout is v'+srcVer+' — run task build for a local engine match.');
               }
             " "{{.DEFT_ROOT}}" "$global_cli" >&2 || true
-            node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" global "$global_cli"
+            node "{{.TASKFILE_DIR}}/engine-invoke.cjs" global "$global_cli"
           else
             echo "deft: CLI artifact missing at {{.DEFT_ROOT}}/packages/cli/dist/bin.js" >&2
             if [ "$is_runtime_verb" = 1 ]; then
@@ -261,9 +261,9 @@ tasks:
             exit 2
           fi
         elif command -v deft >/dev/null 2>&1; then
-          node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" global deft
+          node "{{.TASKFILE_DIR}}/engine-invoke.cjs" global deft
         elif command -v directive >/dev/null 2>&1; then
-          node "{{.DEFT_ROOT}}/scripts/engine-invoke.cjs" global directive
+          node "{{.TASKFILE_DIR}}/engine-invoke.cjs" global directive
         else
           echo "deft: neither {{.DEFT_ROOT}}/packages/cli/dist/bin.js nor a global deft command is available." >&2
           echo "  Install with: npm i -g @deftai/directive" >&2

--- a/xbrief/active/2026-07-14-2547-fixtaskfile-release-summary-with-apostrophes-breaks-engine-c.xbrief.json
+++ b/xbrief/active/2026-07-14-2547-fixtaskfile-release-summary-with-apostrophes-breaks-engine-c.xbrief.json
@@ -1,0 +1,84 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2547"
+  },
+  "plan": {
+    "title": "fix(taskfile): release --summary with apostrophes breaks ENGINE_CMD single-quote interpolation",
+    "status": "running",
+    "narratives": {
+      "Description": "task release forwards CLI_ARGS inside a single-quoted ENGINE_CMD string, so apostrophes in --summary break go-task parsing. Fix arg forwarding for release and sibling ENGINE_CMD sites so free-text flags are shell-safe.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2547",
+      "Overview": "## Problem\n\n`task release -- <version> --dry-run --skip-tag --skip-release --summary \"...\"` failed during the v0.77.0 cut when the summary contained an apostrophe (`what's next?`):\n\n```\ntask: Failed to run task \"release\": task: Failed to run task \"engine:invoke\": 52:35: a command can only contain words and redirects; encountered `(`\n```\n\nInvoking the engine directly succeeded:\n\n```\nnode packages/cli/dist/bin.js release 0.77.0 --dry-run --skip-tag --skip-release --summary \"...\"\n```\n\n## Root cause (likely)\n\nRoot `Taskfile.yml` forwards release args as:\n\n```yaml\nENGINE_CMD: 'release {{.CLI_ARGS}}'\n```\n\n`CLI_ARGS` is interpolated **inside a single-quoted** Task/mvdan-sh string. Any `'` in `--summary` (or other free-text flags) terminates that quote early; the shell parser then errors on the broken remainder (here: `encountered (`).\n\nSame pattern exists for `release:publish` / `release:rollback` / `release:e2e` and other `ENGINE_CMD: '... {{.CLI_ARGS}}'` call sites.\n\n## Why it matters\n\n- Release skill Phase 2 **requires** `task release -- ... --summary \"...\"`\n- Operator-authored summaries routinely use apostrophes / quotes\n- Failure mode looks like a Task/engine bug rather than bad summary text\n- Workaround (call `node packages/cli/dist/bin.js release ...`) bypasses the documented `task release` surface and is easy to forget mid-cut\n\n## Expected\n\n- `task release -- 0.77.0 --dry-run --skip-tag --skip-release --summary \"Combined ... what's next? ...\"` works on Windows and Unix\n- Free-text `--summary` does not depend on single-quote-safe content\n- Prefer argv-array / env-file / `--summary-file` forwarding over shell-string interpolation of operator text\n\n## Acceptance\n\n- [ ] Repro with apostrophe in `--summary` via `task release` fails today; passes after fix\n- [ ] Documented release skill path keeps using `task release` (or skill is updated to a safe invocation)\n- [ ] Audit sibling `ENGINE_CMD: '... {{.CLI_ARGS}}'` sites for the same quote-break class\n- [ ] Windows-native maintainer path covered (PowerShell + go-task)\n\n## Workaround (current)\n\n```\nnode packages/cli/dist/bin.js release <version> --dry-run --skip-tag --skip-release --summary \"...\"\n```\n\n## Related\n\n- Observed during v0.77.0 Phase 2 dry-run\n- Refs release skill deft-directive-release Phase 2\n- Adjacent Windows maintainer friction: #2546 (vitest), #2544 (USER.md path discovery)\r\n\n",
+      "Labels": "bug, runtime-portability, urgent, area:release",
+      "UserStory": "As a Windows maintainer, I want task release --summary with apostrophes to work, so that the documented release skill path does not require calling bin.js directly.",
+      "ImplementationPlan": "1. Change Taskfile.yml ENGINE_CMD forwarding for release (and sibling release:* tasks) so operator --summary text is not interpolated inside a single-quoted shell string; prefer argv-safe forwarding into packages/cli / packages/core/src/release/.\n2. Add a regression test under packages/core/src/release/ (or CLI) that feeds a summary containing an apostrophe and asserts the engine receives the intact string.\n3. Verify with task release -- 0.0.0 --dry-run --skip-tag --skip-release --summary \"test what's next\" and keep the release skill pointing at task release.",
+      "Acceptance": "1. Apostrophe summary survives task release\n2. Sibling release tasks audited\n3. Regression test locks the behavior"
+    },
+    "items": [
+      {
+        "title": "Apostrophe summary survives task release",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given task release is invoked with --summary containing what's, when the dry-run starts, then go-task does not fail with a shell parse error and the engine shows the summary in CHANGELOG promotion dry-run output."
+        }
+      },
+      {
+        "title": "Sibling release tasks audited",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given release:publish, release:rollback, and release:e2e ENGINE_CMD sites, when free-text CLI args are forwarded, then none of them interpolate operator text inside breaking single quotes."
+        }
+      },
+      {
+        "title": "Regression test locks the behavior",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the release forwarding regression test, when an apostrophe summary is supplied, then the test passes and fails if single-quote interpolation returns."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "runtime-portability",
+      "urgent",
+      "area:release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2547",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2547: fix(taskfile): release --summary with apostrophes breaks ENGINE_CMD single-quote interpolation"
+      }
+    ],
+    "updated": "2026-07-14T22:24:21Z",
+    "id": "taskfile-release-summary-quoting",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "Taskfile.yml",
+          "packages/core/src/release/",
+          "content/skills/deft-directive-release/"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- release",
+          "task release -- 0.0.0 --dry-run --skip-tag --skip-release --summary \"test what's next\""
+        ],
+        "expected_outputs": [
+          "task release accepts apostrophe in --summary",
+          "Sibling ENGINE_CMD sites audited/fixed",
+          "Skill keeps task release as the path"
+        ],
+        "depends_on": [],
+        "conflict_group": "taskfile-release-args",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "Issue #2547 from v0.77.0 Phase 2. Taskfile arg forwarding is framework-internal."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Forward `ENGINE_CMD` through `DEFT_ENGINE_CMD` env and argv-spawn via `scripts/engine-invoke.cjs` so operator free-text (release summaries, reject reasons, etc.) is never shell-interpolated in `engine:invoke`.
- Fixes `task release -- ... --summary "test what's next"` on Windows native go-task; sibling `release:publish` / `release:rollback` / `release:e2e` inherit the same safe path automatically.
- Regression: shell-split unit test + end-to-end `task release` apostrophe guard in `taskfile_release_names.test.ts`.

## Test plan
- [x] `task release -- 0.0.0 --dry-run --skip-tag --skip-release --summary "test what's next"` exits 0 and shows summary in CHANGELOG dry-run output
- [x] `pnpm exec vitest run packages/core/src/platform/shell-split.test.ts packages/core/src/content-contracts/standards/taskfile_release_names.test.ts packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts`

Closes #2547
