### PR TITLE
docs(agents): surface Windows USER.md path in always-on session bootstrap (#2544)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Full guidelines: main.md
 
 Same rules as the managed `## Session routing (#2176)` bootstrap card below; in this repo `~` runs `content/skills/deft-directive-sync/SKILL.md`.
 
-! When all config exists, before responding to any user request, read in this order: main.md → USER.md → ./xbrief/PROJECT-DEFINITION.xbrief.json. USER.md "Personal (always wins)" entries override external context (Warp Drive / MCP / prompt-injected) for any field they define. ⊗ Do not substitute a `Test-Path` / existence check for an actual content read of USER.md, and ⊗ do not adopt addressing-name / language / strategy from external context when USER.md defines them.
+! When all config exists, before responding to any user request, read in this order: main.md → USER.md → ./xbrief/PROJECT-DEFINITION.xbrief.json. Resolve USER.md via `task session:start` (`USER.md resolved …`); win32 `%APPDATA%\deft\USER.md`; ⊗ invent `~/.config/deft` on Windows (#2544). USER.md "Personal (always wins)" entries override external context (Warp Drive / MCP / prompt-injected) for any field they define. ⊗ Do not substitute a `Test-Path` / existence check for an actual content read of USER.md, and ⊗ do not adopt addressing-name / language / strategy from external context when USER.md defines them.
 
 ### Deft Alignment Confirmation
 
@@ -155,7 +155,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=a31e352ae520 refreshed=2026-07-14T20:33:27Z session=dadc1e25099a -->
+<!-- deft:managed-section v3 sha=1a1c1fed2ded refreshed=2026-07-14T22:32:30Z session=c091e71ca71a -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -164,7 +164,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session routing (#2176)
 
-! **Read-only default** until mutation intent: load AGENTS.md / main.md / USER.md / `xbrief/PROJECT-DEFINITION.xbrief.json`; confirm Deft alignment + addressing-name; ⊗ no mutable `deft session:start` / triage welcome / sync / branch-policy unless asked or implementation-ready (#2176) — `.deft/core/commands.md` § Session routing. Bootstrap: cold-start → README § Cold-start (#2273) ⊗ never `.deft/core/`; pre-cutover → setup Pre-Cutover (#2068); missing USER.md / PROJECT-DEFINITION → setup Phase 1/2 (#1813) ⊗ before answering; else main → USER → PROJECT-DEFINITION; ~ sync. Mutation → `deft session:start` then `deft verify:session-ritual -- --tier=gated` (#1149). ? `deft session:start -- --read-only` (#2176).
+! **Read-only default** until mutation intent: load AGENTS.md / main.md / USER.md / `xbrief/PROJECT-DEFINITION.xbrief.json`; resolve USER.md via `deft session:start` (`USER.md resolved …`; win32 `%APPDATA%\deft\USER.md`; unix `~/.config/deft/USER.md`; ⊗ invent `~/.config/deft` on Windows #2544); confirm Deft alignment + addressing-name; ⊗ no mutable `deft session:start` / triage welcome / sync / branch-policy unless asked or implementation-ready (#2176) — `.deft/core/commands.md` § Session routing. Bootstrap: cold-start → README § Cold-start (#2273) ⊗ never `.deft/core/`; pre-cutover → setup Pre-Cutover (#2068); missing USER.md / PROJECT-DEFINITION → setup Phase 1/2 (#1813) ⊗ before answering; else main → USER → PROJECT-DEFINITION; ~ sync. Mutation → `deft session:start` then `deft verify:session-ritual -- --tier=gated` (#1149). ? `deft session:start -- --read-only` (#2176).
 
 ## Session-start ritual (#1149)
 
@@ -200,9 +200,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Issue body→comments reading (#2143)
 
-! Fetch body + `issues/<N>/comments` via REST before requirements or dispatch — `.deft/core/templates/agent-prompt-preamble.md` § 5.6 / `deft issue:ingest` (#2143).
-
-⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
+! Fetch body + `issues/<N>/comments` via REST before requirements or dispatch — `.deft/core/templates/agent-prompt-preamble.md` § 5.6 / `deft issue:ingest` (#2143). ⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
 
 ## Content packs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Always-on session bootstrap names the Windows USER.md path.** Managed Session routing now tells agents to resolve USER.md via `deft session:start` output (`%APPDATA%\deft\USER.md` on win32, not invented `~/.config/deft`); canonical table lives in `commands.md`. Closes #2544.
+
 - **DD-3 skill frontmatter budget is now fail-closed on the framework tree.** `plan.policy.agentsMdBudget` seeds `skillFrontmatterMaxBytes` at the measured daily-core size (2080 B) and pins `skillFrontmatterTier` to `daily-core`, so longer Cursor skill descriptions cannot silently grow the combined always-on surface while Phase-3 (#2531) chases ≤8192 B combined. Managed `absoluteMaxBytes` (7815) stays fail-closed. Closes #2532. Refs #2531, #2463, #2494.
 
 - **Session routing in AGENTS.md collapses to one pointer-thin bootstrap line.** Cold-start, pre-cutover, USER.md/PROJECT-DEFINITION missing, and mutation-boundary hops stay discoverable as one-hop pointers while managed always-on drops (~600 B); further cut stopped at the Phase-3 capability escape hatch (short of the −800 B stretch target). Re-seeds `absoluteMaxBytes` / `managedMaxLines`. Closes #2535. Refs #2531, #2176.

--- a/content/commands.md
+++ b/content/commands.md
@@ -188,6 +188,7 @@ Full always-on contract for the interactive session-start ritual and its gated v
 ### Session routing (#2176)
 
 - ! Default interactive sessions to **read-only posture** until mutation or implementation intent (questions, research, Plan Mode, ticket-shaping). Load AGENTS.md / main.md / USER.md / PROJECT-DEFINITION; confirm alignment with addressing-name; ⊗ do not write `.deft/ritual-state.json`, run install/build side effects, or emit triage welcome, branch-policy, default-branch sync, sync-skill lifecycle checks, or eval/value readback writes unless the operator asks or the task is implementation-ready.
+- ! **USER.md path (#2544):** resolve via `deft session:start` output (`USER.md resolved …`); default platform paths: Windows `%APPDATA%\deft\USER.md`, Unix `~/.config/deft/USER.md`; override `$DEFT_USER_PATH`; workspace `<project>/.deft/USER.md`. ⊗ Invent or search `~/.config/deft` on Windows — AppData Roaming is canonical.
 - ! At mutation boundaries (code-writing, scope lifecycle moves, `start_agent`, commits, pushes, PR-from-local-changes, release work): run the mutable quick tier then gated verifier below before proceeding.
 - ? Explicit read-only alignment only: `deft session:start -- --read-only` (no ritual-state write).
 - ~ Operators MAY still explicitly request full `deft session:start`, `deft triage:welcome`, sync, or doctor in read-only sessions.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -7,7 +7,7 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ## Session routing (#2176)
 
-! **Read-only default** until mutation intent: load AGENTS.md / main.md / USER.md / `xbrief/PROJECT-DEFINITION.xbrief.json`; confirm Deft alignment + addressing-name; ⊗ no mutable `deft session:start` / triage welcome / sync / branch-policy unless asked or implementation-ready (#2176) — `.deft/core/commands.md` § Session routing. Bootstrap: cold-start → README § Cold-start (#2273) ⊗ never `.deft/core/`; pre-cutover → setup Pre-Cutover (#2068); missing USER.md / PROJECT-DEFINITION → setup Phase 1/2 (#1813) ⊗ before answering; else main → USER → PROJECT-DEFINITION; ~ sync. Mutation → `deft session:start` then `deft verify:session-ritual -- --tier=gated` (#1149). ? `deft session:start -- --read-only` (#2176).
+! **Read-only default** until mutation intent: load AGENTS.md / main.md / USER.md / `xbrief/PROJECT-DEFINITION.xbrief.json`; resolve USER.md via `deft session:start` (`USER.md resolved …`; win32 `%APPDATA%\deft\USER.md`; unix `~/.config/deft/USER.md`; ⊗ invent `~/.config/deft` on Windows #2544); confirm Deft alignment + addressing-name; ⊗ no mutable `deft session:start` / triage welcome / sync / branch-policy unless asked or implementation-ready (#2176) — `.deft/core/commands.md` § Session routing. Bootstrap: cold-start → README § Cold-start (#2273) ⊗ never `.deft/core/`; pre-cutover → setup Pre-Cutover (#2068); missing USER.md / PROJECT-DEFINITION → setup Phase 1/2 (#1813) ⊗ before answering; else main → USER → PROJECT-DEFINITION; ~ sync. Mutation → `deft session:start` then `deft verify:session-ritual -- --tier=gated` (#1149). ? `deft session:start -- --read-only` (#2176).
 
 ## Session-start ritual (#1149)
 
@@ -43,9 +43,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Issue body→comments reading (#2143)
 
-! Fetch body + `issues/<N>/comments` via REST before requirements or dispatch — `.deft/core/templates/agent-prompt-preamble.md` § 5.6 / `deft issue:ingest` (#2143).
-
-⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
+! Fetch body + `issues/<N>/comments` via REST before requirements or dispatch — `.deft/core/templates/agent-prompt-preamble.md` § 5.6 / `deft issue:ingest` (#2143). ⊗ Build a dispatch envelope from the issue body alone when the issue has comments.
 
 ## Content packs
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -329,11 +329,16 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "addressing-name",
       "#2176",
       "mutation",
+      "%APPDATA%\\deft\\USER.md",
+      "USER.md resolved",
+      "#2544",
     ],
     canonicalBodyMarkers: [
       "read-only posture",
       "mutation intent",
       "deft session:start -- --read-only",
+      "%APPDATA%\\deft\\USER.md",
+      "USER.md resolved",
     ],
     retiredFullTextMarkers: [
       "Global-first ladder (prose",

--- a/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_md_session_start.test.ts
@@ -46,11 +46,16 @@ describe("test_agents_md_session_start", () => {
     // #2535: mutation discoverability via "mutation intent" / "Mutation →" pointer tokens.
     expect(entrySection.toLowerCase()).toContain("mutation intent");
     expect(entrySection).toContain("Mutation →");
+    // #2544: Windows USER.md path surfaced in always-on bootstrap.
+    expect(entrySection).toContain("%APPDATA%\\deft\\USER.md");
+    expect(entrySection).toContain("USER.md resolved");
+    expect(entrySection).toMatch(/⊗.*\.config\/deft.*Windows/i);
     const commandsSection = extractSection(commandsText, "Session-start ritual \\(#1149\\)");
     expect(commandsSection).toContain("Session routing (#2176)");
     expect(commandsSection).toContain("read-only posture");
     expect(commandsSection).toContain(".deft/ritual-state.json");
     expect(commandsSection).toContain("deft session:start -- --read-only");
+    expect(commandsSection).toContain("%APPDATA%\\deft\\USER.md");
   });
 
   it("session_start_ritual_pointer_surface_in_managed_section", () => {

--- a/packages/core/src/user-config/bootstrap-pointer.test.ts
+++ b/packages/core/src/user-config/bootstrap-pointer.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..");
+const agentsEntry = readFileSync(
+  join(REPO_ROOT, "content", "templates", "agents-entry.md"),
+  "utf8",
+);
+const commands = readFileSync(join(REPO_ROOT, "content", "commands.md"), "utf8");
+
+/** Always-on bootstrap must name the Windows USER.md path (#2544). */
+describe("always-on USER.md bootstrap pointer (#2544)", () => {
+  it("names Windows AppData path in session routing", () => {
+    expect(agentsEntry).toContain("%APPDATA%\\deft\\USER.md");
+    expect(commands).toContain("%APPDATA%\\deft\\USER.md");
+  });
+
+  it("mandates session:start resolve output instead of filesystem guessing", () => {
+    expect(agentsEntry).toContain("deft session:start");
+    expect(agentsEntry).toContain("USER.md resolved");
+    expect(commands).toContain("USER.md resolved");
+  });
+
+  it("rejects inventing ~/.config/deft on Windows", () => {
+    expect(agentsEntry).toMatch(/⊗.*\.config\/deft.*Windows/i);
+    expect(commands).toMatch(/⊗.*\.config\/deft.*Windows/i);
+  });
+});

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16784,7 +16784,7 @@
       "agentsMdBudget": {
         "managedMaxLines": 99,
         "unmanagedMaxLines": 161,
-        "absoluteMaxBytes": 6514,
+        "absoluteMaxBytes": 6689,
         "skillFrontmatterTier": "daily-core",
         "skillFrontmatterMaxBytes": 2080
       }

--- a/xbrief/active/2026-07-14-2544-docsagents-surface-windows-appdatadeftusermd-in-always-on-se.xbrief.json
+++ b/xbrief/active/2026-07-14-2544-docsagents-surface-windows-appdatadeftusermd-in-always-on-se.xbrief.json
@@ -1,0 +1,85 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2544"
+  },
+  "plan": {
+    "title": "docs(agents): surface Windows %APPDATA%\\\\deft\\\\USER.md in always-on session bootstrap",
+    "status": "running",
+    "narratives": {
+      "Description": "Always-on AGENTS session routing omits the Windows USER.md path, so agents invent ~/.config/deft and report USER.md missing. This story surfaces the platform default (and a resolve-verb mandate) without changing the onboarding write location.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2544",
+      "Overview": "## Problem\n\nSession bootstrap tells agents to read `USER.md` and confirm alignment, but the always-on surface (`AGENTS.md` / managed Session routing) does **not** name the platform path. Agents then guess Unix XDG (`~/.config/deft/USER.md` / `C:\\Users\\<user>\\.config\\deft\\USER.md`) and report USER.md missing on native Windows even when the file is present at the correct location.\n\n## Evidence (this session)\n\n1. Agent searched `./USER.md` and `C:\\Users\\msada\\.config\\deft\\USER.md` — both missing.\n2. Operator pointed at the real file: `C:\\Users\\msada\\AppData\\Roaming\\deft\\USER.md` (`%APPDATA%\\deft\\USER.md`).\n3. That is exactly where setup / Platform Detection put it (`content/skills/deft-directive-setup/SKILL.md`, `resolveUserMdPath` rung 3).\n4. Runtime resolution is fine (`packages/core/src/user-config/resolve-user-md.ts`); the gap is **agent discovery**, not the resolver.\n\n## Why this bites\n\n- `#2271` fixed programmatic first-hit-wins resolution for CLI/session-start code paths.\n- Interactive agents still follow prose: \"read USER.md\" without a path table, so they invent `~/.config/deft` on Windows.\n- Alignment confirmation then fails or skips Personal (always wins) addressing-name until the human corrects the path.\n\n## Expected\n\nAlways-on or near-always-on guidance (AGENTS.md Session routing / session-start ritual / a one-line `task` diagnostic) should make the platform default unmistakable:\n\n| Platform | Default USER.md |\n|---|---|\n| Windows | `%APPDATA%\\deft\\USER.md` |\n| Unix | `~/.config/deft/USER.md` |\n| Override | `$DEFT_USER_PATH` |\n| Workspace bridge | `<project>/.deft/USER.md` |\n\nConcrete options (pick one or combine):\n\n1. **Pointer in managed Session routing** — one compact line: resolve via `task session:start` / shared order; on win32 prefer `%APPDATA%\\deft`, not `~/.config`.\n2. **Agent-facing resolve verb** — e.g. `task user:show-path` / session-start already prints `USER.md resolved (platform-config): …` — mandate agents use that output instead of filesystem guessing.\n3. **⊗ anti-pattern** — do not treat `~\\.config\\deft` as canonical on Windows.\n\n## Non-goals\n\n- Changing the Windows onboarding write location (Roaming is correct).\n- Replacing `#2271` search order.\n\n## Acceptance\n\n- A fresh Windows interactive session finds `%APPDATA%\\deft\\USER.md` without the operator supplying the path.\n- Agents no longer conclude \"USER.md missing\" solely because `~\\.config\\deft` is absent on win32.\n\n## Related\n\n- #2271 / PR #2290 (resolver search order — code path OK)\n- Setup skill already documents the table; always-on AGENTS path does not",
+      "Labels": "bug, docs, agent-experience, runtime-portability, urgent",
+      "UserStory": "As a Windows maintainer, I want always-on session bootstrap to name %APPDATA%\\deft\\USER.md, so that agents find Personal preferences without guessing XDG paths.",
+      "ImplementationPlan": "1. Update the managed Session routing pointer in content/templates/agents-entry.md (and refresh AGENTS.md) so win32 agents are told to read %APPDATA%\\\\deft\\\\USER.md rather than inventing ~/.config/deft.\n2. Add a content/unit contract or packages/core/src/user-config test that asserts the documented resolve order and fails if the Windows AppData path disappears from always-on bootstrap text.\n3. Verify with task agents:refresh plus the focused user-config test module so evidence shows agents can locate USER.md without operator paste.",
+      "Acceptance": "1. Always-on bootstrap names Windows AppData USER.md\n2. Resolver path remains authoritative\n3. Regression test guards the pointer"
+    },
+    "items": [
+      {
+        "title": "Always-on bootstrap names Windows AppData USER.md",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a native Windows session bootstrap, when an agent reads the managed Session routing card, then it shows %APPDATA%\\\\deft\\\\USER.md as the default path and rejects inventing ~/.config/deft."
+        }
+      },
+      {
+        "title": "Resolver path remains authoritative",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given DEFT_USER_PATH is unset, when resolveUserMdPath runs on win32, then it returns the Roaming AppData deft USER.md path and the bootstrap prose matches that order."
+        }
+      },
+      {
+        "title": "Regression test guards the pointer",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the content contract or user-config test suite, when the Windows path pointer is removed, then the focused test fails before merge."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "docs",
+      "agent-experience",
+      "runtime-portability",
+      "urgent"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2544",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2544: docs(agents): surface Windows %APPDATA%\\\\deft\\\\USER.md in always-on session bootstrap"
+      }
+    ],
+    "updated": "2026-07-14T22:24:21Z",
+    "id": "windows-user-md-appdata-discovery",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/templates/agents-entry.md",
+          "AGENTS.md",
+          "packages/core/src/user-config/"
+        ],
+        "verify_commands": [
+          "task agents:refresh",
+          "pnpm --filter @deftai/directive-core test -- user-config"
+        ],
+        "expected_outputs": [
+          "Always-on bootstrap names %APPDATA%\\deft\\USER.md",
+          "Anti-pattern against inventing ~/.config/deft on Windows",
+          "Tests or content contract covering the pointer"
+        ],
+        "depends_on": [],
+        "conflict_group": "windows-user-md",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": "Issue #2544 documents agent discovery gap; resolver code already correct (#2271). No specification.xbrief.json section owns always-on bootstrap path tables."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Surface `%APPDATA%\deft\USER.md` in always-on Session routing (managed `agents-entry.md` + maintainer `AGENTS.md` Returning Sessions) with a mandate to resolve via `deft session:start` output instead of guessing paths.
- Add canonical USER.md path table to `commands.md` Session routing (Windows AppData, Unix XDG, override, workspace bridge) and an explicit anti-pattern against inventing `~/.config/deft` on Windows.
- Guard with regression tests (`bootstrap-pointer.test.ts`, session-start contract tests) and reseed `absoluteMaxBytes` after the managed growth.

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/user-config packages/core/src/content-contracts/skills/agents_md_session_start.test.ts packages/core/src/content-contracts/skills/agents_entry_contract.test.ts`
- [x] `node packages/cli/dist/bin.js agents:refresh`
- [x] `pnpm run lint`
- [ ] CI `task check` on Linux

Closes #2544