### PR TITLE
fix(taskfile): scrub engine transport from child env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nested Task commands no longer inherit stale engine transport.** `engine-invoke` now scrubs both current and legacy command variables before spawning the CLI, preventing recursive `check` dispatch in consumer smoke runs. Closes #2554.
+
 ### Removed
 
 ## [0.77.0] - 2026-07-15

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -1,4 +1,6 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { repoRoot } from "./_helpers.js";
@@ -126,6 +128,78 @@ describe("task surface routes through the guarded :engine:* pattern (#2126)", ()
     expect(engine).toMatch(/CLI artifact missing/);
     expect(engine).toMatch(/is_runtime_verb/);
     expect(engine).toMatch(/process\.versions\.node/);
+  });
+
+  it("treats command transport as one-hop so nested Task commands win (#2554)", () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), "deft-engine-invoke-"));
+    const helper = join(repoRoot(), "tasks", "engine-invoke.cjs");
+    const recorder = join(fixtureDir, "record-child.cjs");
+    const nestedTask = join(fixtureDir, "nested-task.cjs");
+
+    try {
+      writeFileSync(
+        recorder,
+        `process.stdout.write(JSON.stringify({
+  argv: process.argv.slice(2),
+  jsonTransport: process.env.DEFT_ENGINE_CMD_JSON ?? null,
+  legacyTransport: process.env.DEFT_ENGINE_CMD ?? null,
+}));\n`,
+        "utf8",
+      );
+      writeFileSync(
+        nestedTask,
+        `const { spawnSync } = require("node:child_process");
+const env = { ...process.env };
+// Mirrors go-task's inherited-environment precedence: set the nested command
+// only when no stale parent transport value is present.
+env.DEFT_ENGINE_CMD_JSON ??= JSON.stringify("verify:tools --nested");
+const nested = spawnSync(process.execPath, [process.env.TEST_ENGINE_HELPER, "vendored", process.env.TEST_ENGINE_RECORDER], {
+  encoding: "utf8",
+  env,
+});
+if (nested.stderr) process.stderr.write(nested.stderr);
+if (nested.status !== 0) process.exit(nested.status ?? 1);
+process.stdout.write(JSON.stringify({
+  argv: process.argv.slice(2),
+  jsonTransport: process.env.DEFT_ENGINE_CMD_JSON ?? null,
+  legacyTransport: process.env.DEFT_ENGINE_CMD ?? null,
+  nested: JSON.parse(nested.stdout),
+}));\n`,
+        "utf8",
+      );
+
+      const result = spawnSync(process.execPath, [helper, "vendored", nestedTask], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DEFT_ENGINE_CMD_JSON: JSON.stringify('check:consumer --flag "value with spaces"'),
+          DEFT_ENGINE_CMD: "legacy-stale-command",
+          TEST_ENGINE_HELPER: helper,
+          TEST_ENGINE_RECORDER: recorder,
+        },
+      });
+
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(result.stdout) as {
+        argv: string[];
+        jsonTransport: string | null;
+        legacyTransport: string | null;
+        nested: {
+          argv: string[];
+          jsonTransport: string | null;
+          legacyTransport: string | null;
+        };
+      };
+      expect(payload.argv).toEqual(["check:consumer", "--flag", "value with spaces"]);
+      expect(payload.jsonTransport).toBeNull();
+      expect(payload.legacyTransport).toBeNull();
+      expect(payload.nested.argv).toEqual(["verify:tools", "--nested"]);
+      expect(payload.nested.jsonTransport).toBeNull();
+      expect(payload.nested.legacyTransport).toBeNull();
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
   });
 
   it("pm-run / _ts-build hasCmd is cross-platform (no Unix sh/command -v) (#2415)", () => {

--- a/tasks/engine-invoke.cjs
+++ b/tasks/engine-invoke.cjs
@@ -88,10 +88,16 @@ function main() {
     process.exit(2);
   }
 
+  // Command transport is one-hop: a spawned CLI may invoke Task again with a
+  // different ENGINE_CMD, which must not be shadowed by this inherited value.
+  const childEnv = { ...process.env };
+  delete childEnv.DEFT_ENGINE_CMD_JSON;
+  delete childEnv.DEFT_ENGINE_CMD;
+
   const result = spawnSync(execPath, execArgv, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
-    env: process.env,
+    env: childEnv,
     // Global deft/directive on Windows are .cmd shims; shell:false cannot spawn them (#2415).
     shell: mode === "global" && process.platform === "win32",
     maxBuffer: 16 * 1024 * 1024,

--- a/xbrief/active/2026-07-15-2554-cismoke-greenfield-python-free-smoke-exits-143-sigterm-with.xbrief.json
+++ b/xbrief/active/2026-07-15-2554-cismoke-greenfield-python-free-smoke-exits-143-sigterm-with.xbrief.json
@@ -1,0 +1,53 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2554"
+  },
+  "plan": {
+    "title": "ci(smoke): greenfield-python-free-smoke exits 143 (SIGTERM) with no stdout after engine-invoke",
+    "status": "running",
+    "narratives": {
+      "Description": "ci(smoke): greenfield-python-free-smoke exits 143 (SIGTERM) with no stdout after engine-invoke",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2554",
+      "Overview": "## Problem\n\n`greenfield-python-free-smoke` (`node packages/core/dist/release-e2e/greenfield-python-free-smoke-cli.js`) fails on PRs that touch `engine:invoke` / Taskfile dispatch with **exit code 143** (SIGTERM) and **no stdout**.\n\nObserved on PR #2551 (`fix(taskfile): argv-safe ENGINE_CMD forwarding` / #2547) both before and after rebase onto master:\n\n- Job runs ~48–80s then dies: `Process completed with exit code 143`\n- No smoke CLI output in the failed-log snippet\n- Re-run of the failed job reproduced the same 143\n\nOther CI on that PR was green (TypeScript, Windows task dispatch, Greptile, Go).\n\n## Why it matters\n\n- Soft-blocks merge confidence for Taskfile / engine-invoke changes even when smoke is not in `master` required status checks\n- May indicate a hang (then runner SIGTERM) in the consumer deposit `task` path after `tasks/engine-invoke.cjs` landed\n- Windows release cohort (#2544–#2548) merged despite this; the gate is still unreliable for future cuts\n\n## Suspected area\n\n- `tasks/engine.yml` + `tasks/engine-invoke.cjs` (#2547 / PR #2551)\n- Greenfield smoke path that invokes `task` / `deft` in a consumer deposit after content prepack\n- Possible hang waiting on shell/spawn rather than an assertion failure\n\n## Expected\n\n- Smoke either passes with clear logs or fails with a diagnostic (timeout message, last step, stderr)\n- No silent 143 when the suite is otherwise healthy\n- If the job is over budget, fail closed with an explicit timeout rather than SIGTERM with empty output\n\n## Acceptance\n\n- [ ] Reproduce greenfield-python-free-smoke 143 on a minimal engine-invoke / Taskfile change (or document as flake with rate)\n- [ ] Root cause: hang vs OOM vs runner timeout vs spawn deadlock\n- [ ] Fix or harden: progress logs, bounded timeout, and/or repair engine-invoke consumer path\n- [ ] Smoke green on a PR that exercises `task release` / `engine:invoke` on Linux CI\n\n## Related\n\n- Refs #2547 / PR #2551 (engine-invoke JSON env + argv spawn)\n- Adjacent Windows maintainer friction: #2546 (vitest), #2548 (pnpm PATHEXT)\n- Observed during v0.77.0 Windows release cohort merge\r\n\n",
+      "Labels": "bug, ci-cd, urgent, area:release"
+    },
+    "items": [
+      {
+        "title": "Reproduce greenfield-python-free-smoke 143 on a minimal engine-invoke / Taskfile change (or document as flake with rate)",
+        "status": "proposed"
+      },
+      {
+        "title": "Root cause: hang vs OOM vs runner timeout vs spawn deadlock",
+        "status": "proposed"
+      },
+      {
+        "title": "Fix or harden: progress logs, bounded timeout, and/or repair engine-invoke consumer path",
+        "status": "proposed"
+      },
+      {
+        "title": "Smoke green on a PR that exercises `task release` / `engine:invoke` on Linux CI",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "ci-cd",
+      "urgent",
+      "area:release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2554",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2554: ci(smoke): greenfield-python-free-smoke exits 143 (SIGTERM) with no stdout after engine-invoke"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2547",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2547"
+      }
+    ],
+    "updated": "2026-07-15T12:15:08Z"
+  }
+}


### PR DESCRIPTION
## Closed as superseded

Maintainers closed this PR in favor of the keep-#2558 plan. The environment scrub now lands through #2558, while the inherited-stdio smoke repair landed through #2564. This PR must remain closed and must not be merged directly.

## Why the changes remain relevant

The two repairs are complementary:

- #2564 prevents the pipe-buffer deadlock by inheriting child stdio and adds smoke progress/timeout diagnostics
- the scrub prevents a consumed `DEFT_ENGINE_CMD_JSON` or legacy `DEFT_ENGINE_CMD` value from reaching the spawned CLI and shadowing a nested Task command

The scrub is preserved on the rebased #2558 branch together with #2564's inherited-stdio behavior.

## Historical verification

- Node 24 targeted Vitest: 277 tests passed with one worker and file parallelism disabled
- Node 24 TypeScript build: passed
- changed-file Biome and `node --check tasks/engine-invoke.cjs`: passed
- `task verify:tools`: passed and ran the tool verification result
- branch, forward-coverage, xBRIEF-drift, changelog, and diff-whitespace gates: passed

## Related

Superseded by #2558. Related context: #2554, #2563, and #2564.
