### PR TITLE
fix(release-e2e): quote spaced win32 npm paths for shell spawn (#2555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Windows release:e2e npm dry-run spawns npm under spaced Program Files paths.** `spawnCommandText` now quotes win32 `.cmd` executables that contain spaces before `shell: true` spawn, so `'C:\Program' is not recognized` no longer fails Phase 3 after a green pnpm install. Closes #2555.
 - **Release build-dist excludes Vitest `coverage/` from archive walk (#2556).** `DEFAULT_EXCLUDES` now skips the Vitest `coverage/` tree alongside pytest `.coverage`, so concurrent or leftover `coverage/.tmp` files no longer race the Windows archiver with ENOENT during release Step 8.
 
 ### Removed

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -308,6 +308,26 @@ describe("rehearseNpmPublish", () => {
     expect(types.version).toBe("0.0.1");
   });
 
+  it("passes Program Files npm paths to spawnCommandText for publish dry-run (#2555)", () => {
+    const clone = mkdtempSync(join(tmpdir(), "deft-npm-pub-spaced-"));
+    scaffoldPackages(clone);
+    const npmPath = "C:\\Program Files\\nodejs\\npm.cmd";
+    const spawnSpy = vi.spyOn(commandSpawn, "spawnCommandText").mockReturnValue(ok());
+    const seams: E2ESeams = {
+      which: (n) => {
+        if (n === "npm") return npmPath;
+        if (n === "pnpm") return "C:\\bin\\pnpm.CMD";
+        return null;
+      },
+    };
+    const [okFlag, reason] = rehearseNpmPublish(clone, "0.0.1", seams);
+    expect(okFlag).toBe(true);
+    expect(reason).toContain("npm publish --dry-run clean");
+    const publishCall = spawnSpy.mock.calls.find((call) => call[1]?.includes("publish"));
+    expect(publishCall?.[0]).toBe(npmPath);
+    spawnSpy.mockRestore();
+  });
+
   it("short-circuits before publish when the build fails", () => {
     const clone = mkdtempSync(join(tmpdir(), "deft-npm-build-fail-"));
     scaffoldPackages(clone);

--- a/packages/core/src/verify-env/command-spawn.test.ts
+++ b/packages/core/src/verify-env/command-spawn.test.ts
@@ -1,9 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawnSync: vi.fn(actual.spawnSync) };
+});
+
+import { spawnSync } from "node:child_process";
 import {
+  quoteWin32CommandForShell,
   resolveCommandOnPath,
   shouldUseShellForCommand,
   spawnCommandText,
 } from "./command-spawn.js";
+
+const mockSpawnSync = vi.mocked(spawnSync);
+
+beforeEach(() => {
+  mockSpawnSync.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("shouldUseShellForCommand (#2548)", () => {
   it("uses a shell for Windows command shims", () => {
@@ -50,10 +68,73 @@ describe("resolveCommandOnPath (#2548)", () => {
   });
 });
 
-describe("spawnCommandText (#2548)", () => {
+describe("quoteWin32CommandForShell (#2555)", () => {
+  it("quotes spaced paths on win32", () => {
+    expect(quoteWin32CommandForShell("C:\\Program Files\\nodejs\\npm.cmd", "win32")).toBe(
+      '"C:\\Program Files\\nodejs\\npm.cmd"',
+    );
+  });
+
+  it("leaves unspaced paths and non-win32 platforms unchanged", () => {
+    expect(quoteWin32CommandForShell("C:\\bin\\pnpm.CMD", "win32")).toBe("C:\\bin\\pnpm.CMD");
+    expect(quoteWin32CommandForShell("/usr/bin/npm", "linux")).toBe("/usr/bin/npm");
+  });
+
+  it("does not double-quote already quoted paths", () => {
+    expect(quoteWin32CommandForShell('"C:\\Program Files\\npm.cmd"', "win32")).toBe(
+      '"C:\\Program Files\\npm.cmd"',
+    );
+  });
+});
+
+describe("spawnCommandText (#2548 / #2555)", () => {
   it("surfaces a non-empty stderr when the spawn itself errors", () => {
     const result = spawnCommandText("deft-nonexistent-binary-xyz-2548", ["api"]);
     expect(result.status).not.toBe(0);
     expect(result.stderr.trim().length).toBeGreaterThan(0);
+  });
+
+  it("quotes Program Files-style .cmd paths when shell is required (#2555)", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockSpawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "",
+      stderr: "",
+      pid: 1,
+      output: [null, "", ""] as [null, string, string],
+      signal: null,
+      error: undefined,
+    });
+
+    const npmCmd = "C:\\Program Files\\nodejs\\npm.cmd";
+    spawnCommandText(npmCmd, ["publish", "--dry-run"]);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      `"${npmCmd}"`,
+      ["publish", "--dry-run"],
+      expect.objectContaining({ shell: true }),
+    );
+  });
+
+  it("does not quote unspaced pnpm.cmd paths (#2548 / #2555)", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockSpawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "",
+      stderr: "",
+      pid: 1,
+      output: [null, "", ""] as [null, string, string],
+      signal: null,
+      error: undefined,
+    });
+
+    const pnpmCmd = "C:\\bin\\pnpm.CMD";
+    spawnCommandText(pnpmCmd, ["install"]);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      pnpmCmd,
+      ["install"],
+      expect.objectContaining({ shell: true }),
+    );
   });
 });

--- a/packages/core/src/verify-env/command-spawn.ts
+++ b/packages/core/src/verify-env/command-spawn.ts
@@ -19,6 +19,26 @@ export function shouldUseShellForCommand(
 }
 
 /**
+ * Quote a win32 executable path for `shell: true` spawns when it contains spaces.
+ * Without quoting, cmd.exe treats `C:\Program` as the command (#2555).
+ */
+export function quoteWin32CommandForShell(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32" || !command.includes(" ")) {
+    return command;
+  }
+  if (
+    (command.startsWith('"') && command.endsWith('"')) ||
+    (command.startsWith("'") && command.endsWith("'"))
+  ) {
+    return command;
+  }
+  return `"${command}"`;
+}
+
+/**
  * Resolve an executable on PATH with PATHEXT / Path awareness (#2467 / #2548).
  * Mirrors ts-check-lane `resolvePnpm` and verify-tools `defaultProbe`.
  */
@@ -65,8 +85,10 @@ export function spawnCommandText(
   args: readonly string[],
   options: SpawnCommandTextOptions = {},
 ): SpawnResult {
-  const trySpawn = (shell: boolean) =>
-    spawnSync(cmd, [...args], {
+  const trySpawn = (shell: boolean) => {
+    const spawnCmd =
+      shell && process.platform === "win32" ? quoteWin32CommandForShell(cmd) : cmd;
+    return spawnSync(spawnCmd, [...args], {
       cwd: options.cwd,
       env: options.env ?? process.env,
       encoding: "utf8",
@@ -75,6 +97,7 @@ export function spawnCommandText(
       stdio: ["ignore", "pipe", "pipe"],
       shell,
     });
+  };
 
   let result = trySpawn(shouldUseShellForCommand(cmd));
   const spawnErr = result.error as NodeJS.ErrnoException | undefined;

--- a/packages/core/src/verify-env/command-spawn.ts
+++ b/packages/core/src/verify-env/command-spawn.ts
@@ -86,8 +86,7 @@ export function spawnCommandText(
   options: SpawnCommandTextOptions = {},
 ): SpawnResult {
   const trySpawn = (shell: boolean) => {
-    const spawnCmd =
-      shell && process.platform === "win32" ? quoteWin32CommandForShell(cmd) : cmd;
+    const spawnCmd = shell && process.platform === "win32" ? quoteWin32CommandForShell(cmd) : cmd;
     return spawnSync(spawnCmd, [...args], {
       cwd: options.cwd,
       env: options.env ?? process.env,

--- a/xbrief/active/2026-07-14-2555-fixrelease-e2e-windows-npm-dry-run-breaks-on-spaced-path.xbrief.json
+++ b/xbrief/active/2026-07-14-2555-fixrelease-e2e-windows-npm-dry-run-breaks-on-spaced-path.xbrief.json
@@ -1,0 +1,91 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF from GitHub issue #2555 (manual ingest; issue:ingest scm wrapper failed)",
+    "updated": "2026-07-15T03:00:00Z"
+  },
+  "plan": {
+    "title": "fix(release-e2e): Windows npm dry-run breaks on spaced path (C:\\Program Files)",
+    "status": "running",
+    "narratives": {
+      "Description": "After #2548, release:e2e npm dry-run still fails on Windows when npm lives under a spaced path because spawnCommandText/shell:true splits C:\\Program Files. Quote or argv-spawn npm/pnpm safely and add a Program Files regression test.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2555",
+      "Overview": "## Problem\n\n`task release:e2e` on native Windows gets past pnpm install (#2548) but fails npm publish dry-run with `'C:\\Program' is not recognized`.\n\n## Root cause (likely)\n\n`spawnCommandText` / shell:true on win32 splits paths containing spaces without adequate quoting.\n\n## Expected\n\n- Quote executable paths with spaces on win32, or spawn via argv without shell\n- Regression test covering Program Files-style paths\n- No regression of #2548 pnpm.cmd PATHEXT resolution\n",
+      "Labels": "bug, runtime-portability, urgent, area:release",
+      "UserStory": "As a Windows maintainer, I want release:e2e npm dry-run to spawn npm when it lives under Program Files, so that Phase 3 does not fail after a green GitHub rehearsal.",
+      "ImplementationPlan": "1. Update the packages/core/src/verify-env/command-spawn.ts module so spawnCommandText quotes win32 executable file paths that contain spaces (or argv-spawns without shell) before packages/core/src/release-e2e/npm-ops.ts runs npm publish dry-run.\n2. Add a focused unit test in packages/core/src/verify-env/command-spawn.test.ts (and npm-ops test module if needed) that asserts a Program Files-style npm.cmd path is quoted/spawned correctly and that #2548 pnpm.cmd PATHEXT resolution still verifies.",
+      "Acceptance": "1. npm dry-run succeeds with spaced npm path\n2. Unit coverage for quoted win32 spawn\n3. No #2548 regression"
+    },
+    "items": [
+      {
+        "title": "Quote or argv-spawn spaced win32 paths",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given npm under C:\\Program Files\\nodejs\\npm.cmd, when release-e2e runs npm publish dry-run on win32, then spawn succeeds without treating C:\\Program as the command."
+        }
+      },
+      {
+        "title": "Unit coverage for Program Files paths",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a unit test with a Program Files-style executable path, when spawnCommandText (or the npm-ops wrapper) runs, then the command line is correctly quoted or argv-based."
+        }
+      },
+      {
+        "title": "No #2548 PATHEXT regression",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given pnpm.cmd on PATH, when the win32 resolver runs, then #2548 PATHEXT resolution still prefers pnpm.cmd and does not ENOENT on a bare path."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "runtime-portability",
+      "urgent",
+      "area:release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2555",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2555: fix(release-e2e): Windows npm dry-run breaks on spaced path (C:\\Program Files)"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2548",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2548"
+      }
+    ],
+    "updated": "2026-07-15T03:03:27Z",
+    "id": "release-e2e-npm-spaced-path",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/verify-env/command-spawn.ts",
+          "packages/core/src/verify-env/command-spawn.test.ts",
+          "packages/core/src/release-e2e/npm-ops.ts",
+          "packages/core/src/release-e2e/npm-ops.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- command-spawn",
+          "pnpm --filter @deftai/directive-core test -- npm-ops"
+        ],
+        "expected_outputs": [
+          "Spaced-path npm spawn succeeds on win32",
+          "Regression test for Program Files paths",
+          "#2548 PATHEXT behavior preserved"
+        ],
+        "depends_on": [],
+        "conflict_group": "release-e2e-npm-spawn",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": "Issue #2555; follows #2548 PATHEXT fix into quoting layer."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Quote win32 executable paths that contain spaces when `spawnCommandText` uses `shell: true` (fixes `C:\Program` split).
- Regression tests for Program Files-style `npm.cmd` and unspaced `pnpm.cmd` (#2548 preserved).

Closes #2555

## Test plan
- [x] `pnpm exec vitest run packages/core/src/verify-env/command-spawn.test.ts packages/core/src/release-e2e/npm-ops.test.ts` (32 passed)
