### PR TITLE
fix(smoke): greenfield SIGTERM hang — inherit stdio + progress timeout (#2554)

### DIFF
--- a/.github/workflows/greenfield-python-free-smoke.yml
+++ b/.github/workflows/greenfield-python-free-smoke.yml
@@ -32,6 +32,8 @@ jobs:
         run: pnpm run build
 
       - name: Greenfield Python-free smoke (#2022 Phase 3)
+        timeout-minutes: 15
         env:
           DEFT_GREENFIELD_SKIP_PREP: "1"
+          DEFT_GREENFIELD_OVERALL_TIMEOUT_MS: "840000"
         run: node packages/core/dist/release-e2e/greenfield-python-free-smoke-cli.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Greenfield Python-free smoke no longer hangs with silent SIGTERM on engine-invoke PRs.** `tasks/engine-invoke.cjs` forwards child stdio with `inherit` instead of piped buffers (pipe deadlock on verbose `task deft:check`), and the smoke CLI emits step progress plus an overall budget timeout so CI failures are diagnostic. Closes #2554.
 - Release Step 3 vBRIEF lifecycle sync no longer hard-fails when a referenced number is a pull request mistaken for an issue; issue-state fetch now uses REST instead of GraphQL (#2557).
 - **Windows release:e2e npm dry-run spawns npm under spaced Program Files paths.** `spawnCommandText` now quotes win32 `.cmd` executables that contain spaces before `shell: true` spawn, so `'C:\Program' is not recognized` no longer fails Phase 3 after a green pnpm install. Closes #2555.
 - **Release build-dist excludes Vitest `coverage/` from archive walk (#2556).** `DEFAULT_EXCLUDES` now skips the Vitest `coverage/` tree alongside pytest `.coverage`, so concurrent or leftover `coverage/.tmp` files no longer race the Windows archiver with ENOENT during release Step 8.

--- a/packages/core/src/platform/shell-split.test.ts
+++ b/packages/core/src/platform/shell-split.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -33,5 +34,11 @@ describe("shellSplit (engine-invoke #2547)", () => {
       "--deft-root",
       "D:/a/directive/directive",
     ]);
+  });
+
+  it("uses stdio inherit to avoid pipe-buffer deadlock on verbose consumer deft:check (#2554)", () => {
+    const src = readFileSync(join(repoRoot(), "tasks/engine-invoke.cjs"), "utf8");
+    expect(src).toMatch(/stdio:\s*["']inherit["']/);
+    expect(src).not.toMatch(/stdio:\s*\["ignore",\s*"pipe",\s*"pipe"\]/);
   });
 });

--- a/packages/core/src/release-e2e/greenfield-python-free-smoke-cli.ts
+++ b/packages/core/src/release-e2e/greenfield-python-free-smoke-cli.ts
@@ -3,8 +3,70 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { rehearseGreenfieldPythonFreeSmoke } from "./greenfield-python-free-smoke.js";
 
+const DEFAULT_OVERALL_TIMEOUT_MS = 900_000;
+
+function parseOverallTimeoutMs(): number {
+  const raw = process.env.DEFT_GREENFIELD_OVERALL_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_OVERALL_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_OVERALL_TIMEOUT_MS;
+}
+
+function logProgress(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const skipWorkspacePrep = process.env.DEFT_GREENFIELD_SKIP_PREP === "1";
-const [ok, reason] = rehearseGreenfieldPythonFreeSmoke(repoRoot, {}, { skipWorkspacePrep });
+const overallTimeoutMs = parseOverallTimeoutMs();
+
+let lastProgress = "starting";
+let finished = false;
+
+const onProgress = (message: string): void => {
+  lastProgress = message;
+  logProgress(message);
+};
+
+const failClosed = (reason: string, exitCode = 1): void => {
+  if (finished) {
+    return;
+  }
+  finished = true;
+  process.stdout.write(`${reason}\n`);
+  process.exit(exitCode);
+};
+
+const overallTimer = setTimeout(() => {
+  failClosed(
+    `greenfield-python-free-smoke FAIL: overall budget exceeded (${overallTimeoutMs}ms); last step: ${lastProgress}`,
+    1,
+  );
+}, overallTimeoutMs);
+
+process.on("SIGTERM", () => {
+  failClosed(
+    `greenfield-python-free-smoke FAIL: received SIGTERM during "${lastProgress}" — likely runner kill after hang (root cause: spawn pipe deadlock fixed in engine-invoke #2554)`,
+    143,
+  );
+});
+
+process.on("SIGINT", () => {
+  failClosed(`greenfield-python-free-smoke FAIL: interrupted during "${lastProgress}"`, 130);
+});
+
+logProgress(
+  `greenfield-python-free-smoke: starting (overall budget ${overallTimeoutMs}ms, skipPrep=${skipWorkspacePrep})`,
+);
+
+const [ok, reason] = rehearseGreenfieldPythonFreeSmoke(
+  repoRoot,
+  {},
+  { skipWorkspacePrep, onProgress },
+);
+clearTimeout(overallTimer);
+finished = true;
 process.stdout.write(`${reason}\n`);
 process.exit(ok ? 0 : 1);

--- a/packages/core/src/release-e2e/greenfield-python-free-smoke.test.ts
+++ b/packages/core/src/release-e2e/greenfield-python-free-smoke.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { repoRoot } from "../content-contracts/standards/_helpers.js";
 import { rehearseGreenfieldPythonFreeSmoke } from "./greenfield-python-free-smoke.js";
 
 describe("rehearseGreenfieldPythonFreeSmoke (#2022 Phase 3)", () => {
@@ -37,5 +38,39 @@ describe("rehearseGreenfieldPythonFreeSmoke (#2022 Phase 3)", () => {
     );
     expect(ok).toBe(false);
     expect(reason).toContain("version-align FAIL");
+  });
+
+  it("emits progress callbacks before failing early (#2554)", () => {
+    const progress: string[] = [];
+    rehearseGreenfieldPythonFreeSmoke(
+      "/tmp/deft-greenfield-missing-packages",
+      {
+        which: (name) => {
+          if (name === "npm" || name === "task" || name === "pnpm") return `/usr/bin/${name}`;
+          return null;
+        },
+      },
+      {
+        skipWorkspacePrep: true,
+        onProgress: (message) => progress.push(message),
+      },
+    );
+    expect(progress.some((line) => line.includes("aligning npm package versions"))).toBe(true);
+  });
+
+  it("reports spawn timeout diagnostics when a step is killed (#2554)", () => {
+    const [ok, reason] = rehearseGreenfieldPythonFreeSmoke(
+      repoRoot(),
+      {
+        which: (name) => {
+          if (name === "npm" || name === "task" || name === "pnpm") return `/usr/bin/${name}`;
+          return null;
+        },
+        spawnText: () => ({ status: 128, stdout: "", stderr: "" }),
+      },
+      { skipWorkspacePrep: true },
+    );
+    expect(ok).toBe(false);
+    expect(reason).toContain("spawn budget");
   });
 });

--- a/packages/core/src/release-e2e/greenfield-python-free-smoke.ts
+++ b/packages/core/src/release-e2e/greenfield-python-free-smoke.ts
@@ -69,12 +69,27 @@ function runStep(
   cmd: string,
   args: string[],
   options: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
+  onProgress?: (message: string) => void,
 ): [boolean, string] {
+  onProgress?.(`greenfield smoke: ${label} — starting`);
+  const startedMs = Date.now();
   const result = spawn(cmd, args, options);
+  const elapsedMs = Date.now() - startedMs;
   if (result.status !== 0) {
     const detail = (result.stderr || result.stdout || "").trim();
-    return [false, `${label} failed (exit ${result.status}): ${detail.slice(-800)}`];
+    const timeoutHint =
+      options.timeoutMs !== undefined && result.status === 128
+        ? `; subprocess killed after ${elapsedMs}ms (spawn budget ${options.timeoutMs}ms — likely hang or timeout)`
+        : "";
+    onProgress?.(
+      `greenfield smoke: ${label} — failed (exit ${result.status}) after ${elapsedMs}ms`,
+    );
+    return [
+      false,
+      `${label} failed (exit ${result.status})${timeoutHint}: ${detail.slice(-800) || "(no captured output)"}`,
+    ];
   }
+  onProgress?.(`greenfield smoke: ${label} — OK (${elapsedMs}ms)`);
   return [true, `${label} OK`];
 }
 
@@ -82,6 +97,8 @@ export interface GreenfieldSmokeSeams extends E2ESeams {}
 
 export interface GreenfieldSmokeOptions {
   skipWorkspacePrep?: boolean;
+  /** Emits step progress immediately (stderr in CLI) so CI logs are never empty on hang (#2554). */
+  onProgress?: (message: string) => void;
 }
 
 /**
@@ -112,6 +129,8 @@ export function rehearseGreenfieldPythonFreeSmoke(
   }
 
   const spawn = seams.spawnText ?? spawnText;
+  const onProgress = options.onProgress;
+  onProgress?.("greenfield smoke: workspace prep starting");
 
   const work = mkdtempSync(join(tmpdir(), "deft-greenfield-smoke-"));
   const packDir = join(work, "packs");
@@ -142,17 +161,28 @@ export function rehearseGreenfieldPythonFreeSmoke(
           env: envBase,
           timeoutMs: 120_000,
         },
+        onProgress,
       );
       if (!ok) return [false, `greenfield smoke: ${reason}`];
 
-      [ok, reason] = runStep(spawn, "pnpm build", pnpmCmd, [...pnpmArgs, "run", "build"], {
-        cwd: repoRoot,
-        env: envBase,
-        timeoutMs: 120_000,
-      });
+      [ok, reason] = runStep(
+        spawn,
+        "pnpm build",
+        pnpmCmd,
+        [...pnpmArgs, "run", "build"],
+        {
+          cwd: repoRoot,
+          env: envBase,
+          timeoutMs: 120_000,
+        },
+        onProgress,
+      );
       if (!ok) return [false, `greenfield smoke: ${reason}`];
+    } else {
+      onProgress?.("greenfield smoke: skipping workspace prep (DEFT_GREENFIELD_SKIP_PREP=1)");
     }
 
+    onProgress?.("greenfield smoke: aligning npm package versions");
     [ok, reason] = alignNpmPackageVersions(repoRoot, SMOKE_VERSION);
     if (!ok) return [false, `greenfield smoke: ${reason}`];
 
@@ -165,6 +195,7 @@ export function rehearseGreenfieldPythonFreeSmoke(
         npm,
         ["pack", "--pack-destination", packDir],
         { cwd: pkgDir, env: envBase, timeoutMs: 120_000 },
+        onProgress,
       );
       if (!ok) return [false, `greenfield smoke: ${reason}`];
       const tgz = packTarballPath(packDir, pkgDir);
@@ -174,10 +205,17 @@ export function rehearseGreenfieldPythonFreeSmoke(
       packed.push(tgz);
     }
 
-    [ok, reason] = runStep(spawn, "npm install -g", npm, ["install", "-g", ...packed], {
-      env: envBase,
-      timeoutMs: 120_000,
-    });
+    [ok, reason] = runStep(
+      spawn,
+      "npm install -g",
+      npm,
+      ["install", "-g", ...packed],
+      {
+        env: envBase,
+        timeoutMs: 120_000,
+      },
+      onProgress,
+    );
     if (!ok) return [false, `greenfield smoke: ${reason}`];
 
     const deft = join(npmPrefix, "bin", "deft");
@@ -196,9 +234,11 @@ export function rehearseGreenfieldPythonFreeSmoke(
         env: pyFree,
         timeoutMs: 120_000,
       },
+      onProgress,
     );
     if (!ok) return [false, `greenfield smoke: ${reason}`];
 
+    onProgress?.("greenfield smoke: seeding fixture PROJECT-DEFINITION");
     seedMinimalProjectDefinition(projectDir);
 
     const depositDir = join(projectDir, ".deft", "core");
@@ -219,13 +259,22 @@ export function rehearseGreenfieldPythonFreeSmoke(
       DEFT_SESSION_RITUAL_SKIP: "1",
     };
 
-    [ok, reason] = runStep(spawn, "task deft:check", task, ["deft:check"], {
-      cwd: projectDir,
-      env: checkEnv,
-      timeoutMs: 180_000,
-    });
+    onProgress?.("greenfield smoke: running consumer task deft:check (engine-invoke path)");
+    [ok, reason] = runStep(
+      spawn,
+      "task deft:check",
+      task,
+      ["deft:check"],
+      {
+        cwd: projectDir,
+        env: checkEnv,
+        timeoutMs: 180_000,
+      },
+      onProgress,
+    );
     if (!ok) return [false, `greenfield smoke: ${reason}`];
 
+    onProgress?.("greenfield smoke: all steps passed");
     return [
       true,
       "greenfield-python-free-smoke: directive init + task deft:check passed with Python absent from PATH",

--- a/tasks/engine-invoke.cjs
+++ b/tasks/engine-invoke.cjs
@@ -88,20 +88,15 @@ function main() {
     process.exit(2);
   }
 
+  // stdio inherit (not pipe): piped stdout/stderr deadlocks when the child emits
+  // more than the OS pipe buffer before exit — observed as greenfield smoke
+  // hanging then CI SIGTERM exit 143 with no output (#2554 / #2547).
   const result = spawnSync(execPath, execArgv, {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: "inherit",
     env: process.env,
     // Global deft/directive on Windows are .cmd shims; shell:false cannot spawn them (#2415).
     shell: mode === "global" && process.platform === "win32",
-    maxBuffer: 16 * 1024 * 1024,
   });
-  if (result.stdout) {
-    process.stdout.write(result.stdout);
-  }
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
-  }
   const code = result.status;
   process.exit(code === null ? 1 : code);
 }

--- a/xbrief/active/2026-07-14-2554-cismoke-greenfield-python-free-smoke-exits-143-sigterm.xbrief.json
+++ b/xbrief/active/2026-07-14-2554-cismoke-greenfield-python-free-smoke-exits-143-sigterm.xbrief.json
@@ -1,0 +1,92 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF from GitHub issue #2554 (manual ingest; issue:ingest scm wrapper failed)",
+    "updated": "2026-07-15T03:00:00Z"
+  },
+  "plan": {
+    "title": "ci(smoke): greenfield-python-free-smoke exits 143 (SIGTERM) with no stdout after engine-invoke",
+    "status": "running",
+    "narratives": {
+      "Description": "greenfield-python-free-smoke dies with exit 143 and empty stdout on PRs that touch engine-invoke / Taskfile dispatch. Reproduce, root-cause hang vs timeout, then harden with progress logs and bounded timeout so the smoke fails closed with diagnostics.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2554",
+      "Overview": "## Problem\n\n`greenfield-python-free-smoke` fails on PRs that touch `engine:invoke` / Taskfile dispatch with exit code 143 (SIGTERM) and no stdout. Observed on PR #2551 both before and after rebase onto master (~48-80s then SIGTERM).\n\n## Expected\n\n- Smoke passes with clear logs or fails with a diagnostic (timeout message, last step, stderr)\n- No silent 143 when the suite is otherwise healthy\n- If over budget, fail closed with an explicit timeout rather than empty SIGTERM\n\n## Acceptance\n\n- Reproduce or document flake rate\n- Root cause hang vs OOM vs runner timeout vs spawn deadlock\n- Fix/harden: progress logs, bounded timeout, and/or repair engine-invoke consumer path\n- Smoke green on a PR that exercises `task release` / `engine:invoke` on Linux CI\n",
+      "Labels": "bug, ci-cd, urgent, area:release",
+      "UserStory": "As a maintainer merging Taskfile/engine-invoke changes, I want greenfield-python-free-smoke to pass or fail with clear diagnostics, so that silent 143 SIGTERM does not soft-block merge confidence.",
+      "ImplementationPlan": "1. Reproduce greenfield-python-free-smoke 143 against a minimal engine-invoke change and capture whether hang, OOM, or runner timeout.\n2. Harden the smoke CLI / consumer task path with progress logs and a bounded explicit timeout that fails closed with stderr.\n3. Verify smoke green on Linux CI for a PR that exercises engine:invoke.",
+      "Acceptance": "1. Root cause identified\n2. Silent 143 eliminated or converted to diagnostic timeout\n3. Smoke green on engine-invoke PR in Linux CI"
+    },
+    "items": [
+      {
+        "title": "Reproduce and identify root cause",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a PR that touches engine-invoke/Taskfile, when greenfield-python-free-smoke runs, then the failure mode is classified as hang, OOM, runner timeout, or spawn deadlock (or documented flake rate)."
+        }
+      },
+      {
+        "title": "Harden smoke with logs and bounded timeout",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the smoke path, when it exceeds budget or hangs, then it fails closed with progress logs and an explicit timeout diagnostic instead of empty exit 143."
+        }
+      },
+      {
+        "title": "Smoke green on engine-invoke PR",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a PR that exercises task release / engine:invoke on Linux CI, when greenfield-python-free-smoke runs, then it exits 0 with visible stdout or a clear soft-skip."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "ci-cd",
+      "urgent",
+      "area:release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2554",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2554: ci(smoke): greenfield-python-free-smoke exits 143 (SIGTERM) with no stdout after engine-invoke"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2547",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2547"
+      }
+    ],
+    "updated": "2026-07-15T03:03:08Z",
+    "id": "smoke-greenfield-143",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release-e2e/greenfield-python-free-smoke.ts",
+          "packages/core/src/release-e2e/greenfield-python-free-smoke-cli.ts",
+          "packages/core/src/release-e2e/greenfield-python-free-smoke.test.ts",
+          "tasks/engine-invoke.cjs",
+          "tasks/engine.yml",
+          ".github/workflows/"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- greenfield-python-free-smoke"
+        ],
+        "expected_outputs": [
+          "Root cause for exit 143 documented or fixed",
+          "Bounded timeout + progress logs",
+          "Smoke green or clear diagnostic on engine-invoke PRs"
+        ],
+        "depends_on": [],
+        "conflict_group": "greenfield-smoke",
+        "size": "M",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium",
+        "missing_traces_justification": "Issue #2554; CI hang diagnosis may touch workflow timeout knobs and engine-invoke consumer path."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `tasks/engine-invoke.cjs` uses `stdio: inherit` instead of piped stdout/stderr to avoid pipe-buffer deadlock that hung greenfield smoke until CI SIGTERM (exit 143, empty logs).
- Smoke CLI emits step progress on stderr, enforces an overall budget (`DEFT_GREENFIELD_OVERALL_TIMEOUT_MS`), and fail-closes on SIGTERM with last-step diagnostics.
- Workflow adds `timeout-minutes: 15` and the overall timeout env.

Closes #2554

## Test plan
- [x] `pnpm exec vitest run` greenfield-python-free-smoke + shell-split (10 passed)
- [ ] CI greenfield-python-free-smoke job (should no longer silent-143)
