### PR TITLE
feat(evals): trigger coverage evals for AGENTS.md skill routing (#1586)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
           git fetch origin "${{ github.base_ref }}" --depth=1
           node packages/cli/dist/bin.js verify:eval-health-relocation --project-root . --base-ref "origin/${{ github.base_ref }}"
 
+      - name: Trigger-routing eval:triggers gate (#1586)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          node packages/cli/dist/bin.js verify:eval-triggers-relocation --project-root . --base-ref "origin/${{ github.base_ref }}"
+
   go:
     name: Go (test + build)
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Pointer-sufficient managed section below; `content/contracts/deterministic-quest
 
 ## Eval and framework health (#1703)
 
-! `task eval:health`; `task eval:run` / `task eval:report` (#1703).
+! `task eval:health`; `task eval:run` / `task eval:report`; skill routing: `task eval:triggers` (#1586 / #1703).
 
 ## Cache-as-authoritative work selection (#1149)
 
@@ -230,7 +230,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Eval and framework health (#1703)
 
-! `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Release: `deft eval:run` / `deft eval:report` (#1703).
+! `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Release: `deft eval:run` / `deft eval:report`; skill routing: `deft eval:triggers` (#1586 / #1703).
 
 ## Branch policy & branch verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Trigger routing evals for AGENTS.md skill discovery (#1586).** `evals/trigger-cases.jsonl` holds skill-pi-trigger-eval compatible should-fire / should-not-fire rows for every Skills Index rule in `REFERENCES.md` (including review-cycle babysit/shepherd and sub-agent paraphrases from #2261). `task eval:triggers` runs deterministic offline routing; `verify:eval-triggers-relocation` and CI run it when AGENTS.md or routing artifacts change. Closes #1586. Refs #1862, #1703.
+
 - **Agent-host hooks enforce Directive's mutation boundary for direct writes.** `directive init` / `deft update` now merge project `SessionStart` and `PreToolUse` registrations for Claude Code, Grok Build, and Cursor into their native hook files. The shared `deft hook:dispatch` bridge denies direct edit/write tools until the existing gated session ritual is fresh and an active/running xBRIEF passes canonical preflight; `deft verify:hooks-installed --scope=agent` and `doctor --full` report registration health. Shell/MCP policy, compact re-arm, and plugin packaging remain in their separate follow-ups. Closes #2438. Refs #2437, #2113, #1394, #2369.
 - **Always-on skill pin policy reduces false negatives on process gates.** AGENTS.md and the consumer template now document three pin tiers (always-pin / on-demand / reference-only), a default always-pin set for build / pre-PR / review-cycle / swarm skills, and an explicit anti-pattern against pinning entire language or deployment packs. Canonical policy: `content/docs/skill-pin-policy.md`; Skills Index and setup skill carry consumer guidance. Closes #2508. Refs #1862, #2484.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -390,6 +390,7 @@ tasks:
       - verify-wip-cap-framework-self-check
       - verify:agents-md-budget
       - verify-eval-health-relocation-framework-check
+      - verify-eval-triggers-relocation-framework-check
       - vbrief:validate
       - codebase:validate-structure
       - verify:codebase-map-fresh
@@ -435,6 +436,15 @@ tasks:
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: verify:eval-health-relocation
+        vars:
+          CLI_ARGS: "--base-ref origin/master"
+
+  verify-eval-triggers-relocation-framework-check:
+    internal: true
+    desc: "Framework self-check shim for verify:eval-triggers-relocation (#1586)."
+    dir: '{{.USER_WORKING_DIR}}'
+    cmds:
+      - task: verify:eval-triggers-relocation
         vars:
           CLI_ARGS: "--base-ref origin/master"
 

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -73,7 +73,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Eval and framework health (#1703)
 
-! `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Release: `deft eval:run` / `deft eval:report` (#1703).
+! `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Release: `deft eval:run` / `deft eval:report`; skill routing: `deft eval:triggers` (#1586 / #1703).
 
 ## Branch policy & branch verification
 

--- a/evals/trigger-cases.jsonl
+++ b/evals/trigger-cases.jsonl
@@ -1,0 +1,62 @@
+{"id":"setup-pos-1","query":"help me setup this new deft project","skill":"deft-directive-setup","should_trigger":true}
+{"id":"setup-pos-2","query":"bootstrap directive for this repository","skill":"deft-directive-setup","should_trigger":true}
+{"id":"setup-neg-1","query":"list open issues in the directive backlog","skill":"deft-directive-setup","should_trigger":false}
+{"id":"cost-pos-1","query":"how much will this cost to implement the feature","skill":"deft-directive-cost","should_trigger":true}
+{"id":"cost-pos-2","query":"run a pre-build cost estimate before we commit","skill":"deft-directive-cost","should_trigger":true}
+{"id":"cost-neg-1","query":"summarize the project architecture overview","skill":"deft-directive-cost","should_trigger":false}
+{"id":"build-pos-1","query":"build the feature from the active xBRIEF","skill":"deft-directive-build","should_trigger":true}
+{"id":"build-pos-2","query":"implement spec phase two with quality gates","skill":"deft-directive-build","should_trigger":true}
+{"id":"build-neg-1","query":"list the open issues in the backlog","skill":"deft-directive-build","should_trigger":false}
+{"id":"pre-pr-pos-1","query":"run the pre-pr quality loop on this branch","skill":"deft-directive-pre-pr","should_trigger":true}
+{"id":"pre-pr-pos-2","query":"rwldl before I push this branch","skill":"deft-directive-pre-pr","should_trigger":true}
+{"id":"pre-pr-neg-1","query":"show the current git branch status","skill":"deft-directive-pre-pr","should_trigger":false}
+{"id":"review-cycle-pos-1","query":"run review cycle on this PR","skill":"deft-directive-review-cycle","should_trigger":true}
+{"id":"review-cycle-pos-2","query":"use sub-agents for reviews on PR 2569","skill":"deft-directive-review-cycle","should_trigger":true}
+{"id":"review-cycle-pos-3","query":"babysit this PR until merge-ready","skill":"deft-directive-review-cycle","should_trigger":true}
+{"id":"review-cycle-pos-4","query":"shepherd the PR through Greptile review","skill":"deft-directive-review-cycle","should_trigger":true}
+{"id":"review-cycle-neg-1","query":"merge this documentation typo fix","skill":"deft-directive-review-cycle","should_trigger":false}
+{"id":"swarm-pos-1","query":"swarm these three stories in parallel","skill":"deft-directive-swarm","should_trigger":true}
+{"id":"swarm-pos-2","query":"run agents on the cohort xBRIEFs","skill":"deft-directive-swarm","should_trigger":true}
+{"id":"swarm-neg-1","query":"what is the current WIP cap policy","skill":"deft-directive-swarm","should_trigger":false}
+{"id":"decompose-pos-1","query":"decompose this epic into story xBRIEFs","skill":"deft-directive-decompose","should_trigger":true}
+{"id":"decompose-pos-2","query":"check swarm readiness for the umbrella cohort","skill":"deft-directive-decompose","should_trigger":true}
+{"id":"decompose-neg-1","query":"validate xbrief conformance in task check","skill":"deft-directive-decompose","should_trigger":false}
+{"id":"refinement-pos-1","query":"refine the proposed backlog priorities","skill":"deft-directive-refinement","should_trigger":true}
+{"id":"refinement-pos-2","query":"triage issue 1586 into xbrief proposed","skill":"deft-directive-refinement","should_trigger":true}
+{"id":"refinement-neg-1","query":"run eval health on this checkout","skill":"deft-directive-refinement","should_trigger":false}
+{"id":"triage-pos-1","query":"what's next in the queue","skill":"deft-directive-triage","should_trigger":true}
+{"id":"triage-pos-2","query":"run triage hygiene on the cache","skill":"deft-directive-triage","should_trigger":true}
+{"id":"triage-neg-1","query":"implement the payment module from spec","skill":"deft-directive-triage","should_trigger":false}
+{"id":"sync-pos-1","query":"good morning, sync deft for this session","skill":"deft-directive-sync","should_trigger":true}
+{"id":"sync-pos-2","query":"update xbrief lifecycle structure now","skill":"deft-directive-sync","should_trigger":true}
+{"id":"sync-neg-1","query":"run task check on this branch","skill":"deft-directive-sync","should_trigger":false}
+{"id":"interview-pos-1","query":"run interview loop for the scope narratives","skill":"deft-directive-interview","should_trigger":true}
+{"id":"interview-pos-2","query":"start a q&a loop to fill requirement gaps","skill":"deft-directive-interview","should_trigger":true}
+{"id":"interview-neg-1","query":"promote the active story to running","skill":"deft-directive-interview","should_trigger":false}
+{"id":"probe-pos-1","query":"run probe on this architecture plan","skill":"deft-directive-probe","should_trigger":true}
+{"id":"probe-pos-2","query":"use /deft:run:probe before we write xBRIEFs","skill":"deft-directive-probe","should_trigger":true}
+{"id":"probe-neg-1","query":"open a pull request for the fix","skill":"deft-directive-probe","should_trigger":false}
+{"id":"debug-pos-1","query":"debug why task check fails on Windows","skill":"deft-directive-debug","should_trigger":true}
+{"id":"debug-pos-2","query":"investigate root cause of the stale cache","skill":"deft-directive-debug","should_trigger":true}
+{"id":"debug-neg-1","query":"show policy for allowDirectCommitsToMaster","skill":"deft-directive-debug","should_trigger":false}
+{"id":"glossary-pos-1","query":"create a ubiquitous language glossary for payments","skill":"deft-directive-glossary","should_trigger":true}
+{"id":"glossary-pos-2","query":"define terms for this domain using DDD","skill":"deft-directive-glossary","should_trigger":true}
+{"id":"glossary-neg-1","query":"render the project specification markdown","skill":"deft-directive-glossary","should_trigger":false}
+{"id":"gh-arch-pos-1","query":"improve architecture with deep modules analysis","skill":"deft-directive-gh-arch","should_trigger":true}
+{"id":"gh-arch-pos-2","query":"file a refactor RFC for the coupling hotspot","skill":"deft-directive-gh-arch","should_trigger":true}
+{"id":"gh-arch-neg-1","query":"run task check on this branch","skill":"deft-directive-gh-arch","should_trigger":false}
+{"id":"gh-slice-pos-1","query":"gh slice this specification into vertical slices","skill":"deft-directive-gh-slice","should_trigger":true}
+{"id":"gh-slice-pos-2","query":"break into issues as tracer-bullet tickets","skill":"deft-directive-gh-slice","should_trigger":true}
+{"id":"gh-slice-neg-1","query":"fetch umbrella current shape for epic 1862","skill":"deft-directive-gh-slice","should_trigger":false}
+{"id":"release-pos-1","query":"cut release v0.78.0 today","skill":"deft-directive-release","should_trigger":true}
+{"id":"release-pos-2","query":"run the publish release workflow","skill":"deft-directive-release","should_trigger":true}
+{"id":"release-neg-1","query":"validate xbrief conformance in task check","skill":"deft-directive-release","should_trigger":false}
+{"id":"write-skill-pos-1","query":"write skill for the new workflow gate","skill":"deft-directive-write-skill","should_trigger":true}
+{"id":"write-skill-pos-2","query":"create skill with RFC2119 triggers and progressive disclosure","skill":"deft-directive-write-skill","should_trigger":true}
+{"id":"write-skill-neg-1","query":"refresh agents md managed section","skill":"deft-directive-write-skill","should_trigger":false}
+{"id":"article-review-pos-1","query":"analyze this article for directive lessons","skill":"deft-directive-article-review","should_trigger":true}
+{"id":"article-review-pos-2","query":"what can we learn from this paper on agent routing","skill":"deft-directive-article-review","should_trigger":true}
+{"id":"article-review-neg-1","query":"show the triage queue limit ten","skill":"deft-directive-article-review","should_trigger":false}
+{"id":"feedback-pos-1","query":"file upstream feedback about framework gaps","skill":"deft-directive-feedback","should_trigger":true}
+{"id":"feedback-pos-2","query":"directive feedback: session ritual too noisy","skill":"deft-directive-feedback","should_trigger":true}
+{"id":"feedback-neg-1","query":"run eval health check on master","skill":"deft-directive-feedback","should_trigger":false}

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -157,9 +157,11 @@ export const CLI_MODULE_VERBS = [
   "verify-agents-md-budget",
   "verify-agents-md-advisory",
   "verify-eval-health-relocation",
+  "verify-eval-triggers-relocation",
   "eval-health",
   "eval-run",
   "eval-report",
+  "eval-triggers",
 ] as const;
 
 /** Core-only CLI entrypoints without a packages/cli wrapper. */
@@ -255,6 +257,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "verify:agents-md-budget": "verify-agents-md-budget",
   "verify:agents-md-advisory": "verify-agents-md-advisory",
   "verify:eval-health-relocation": "verify-eval-health-relocation",
+  "verify:eval-triggers-relocation": "verify-eval-triggers-relocation",
   "verify:hooks-installed": "verify-hooks-installed",
   "verify:no-task-runtime": "verify-no-task-runtime",
   "vbrief:validate": "vbrief-validate",
@@ -314,6 +317,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "value:show": "value-readback",
   "triage:metrics": "value-readback",
   "eval:run": "eval-run",
+  "eval:triggers": "eval-triggers",
   "eval:report": "eval-report",
   build: "framework-commands",
   "setup:ghx": "setup-ghx",

--- a/packages/cli/src/eval-triggers.ts
+++ b/packages/cli/src/eval-triggers.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runTriggerEval } from "@deftai/directive-core/eval/triggers";
+
+interface ParsedArgs {
+  projectRoot: string;
+  json: boolean;
+  error?: string;
+}
+
+/** Parse eval-triggers CLI args. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    projectRoot: ".",
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      parsed.json = true;
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run eval:triggers (offline skill-pi-trigger-eval routing) and return exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`eval:triggers: ${args.error}\n`);
+    return 2;
+  }
+
+  const result = runTriggerEval({ projectRoot: resolve(args.projectRoot) });
+  if (result.report === null) {
+    process.stderr.write(`${result.message}\n`);
+    return result.code;
+  }
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result.report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${result.message}\n`);
+  }
+
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/verify-eval-triggers-relocation.ts
+++ b/packages/cli/src/verify-eval-triggers-relocation.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluate } from "@deftai/directive-core/eval-triggers-relocation";
+
+interface ParsedArgs {
+  projectRoot: string;
+  baseRef?: string;
+  staged: boolean;
+  quiet: boolean;
+  error?: string;
+}
+
+/** Parse verify-eval-triggers-relocation CLI args. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    projectRoot: ".",
+    staged: false,
+    quiet: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--staged") {
+      parsed.staged = true;
+    } else if (arg === "--quiet") {
+      parsed.quiet = true;
+    } else if (arg === "--base-ref") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --base-ref: expected one argument" };
+      }
+      parsed.baseRef = value;
+      i += 1;
+    } else if (arg?.startsWith("--base-ref=")) {
+      parsed.baseRef = arg.slice("--base-ref=".length);
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+    } else {
+      return { ...parsed, error: `unrecognized argument: ${arg}` };
+    }
+  }
+  return parsed;
+}
+
+/** Run verify:eval-triggers-relocation and return exit code. */
+export function run(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`verify:eval-triggers-relocation: ${args.error}\n`);
+    return 2;
+  }
+
+  const result = evaluate({
+    projectRoot: resolve(args.projectRoot),
+    baseRef: args.baseRef,
+    staged: args.staged,
+    quiet: args.quiet,
+  });
+
+  if (result.message.length > 0) {
+    if (result.stream === "stderr") {
+      process.stderr.write(`${result.message}\n`);
+    } else if (result.stream === "stdout") {
+      process.stdout.write(`${result.message}\n`);
+    }
+  }
+
+  return result.code;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/eval-health-relocation/index.d.ts",
       "default": "./dist/eval-health-relocation/index.js"
     },
+    "./eval-triggers-relocation": {
+      "types": "./dist/eval-triggers-relocation/index.d.ts",
+      "default": "./dist/eval-triggers-relocation/index.js"
+    },
     "./xbrief-migrate": {
       "types": "./dist/xbrief-migrate/index.d.ts",
       "default": "./dist/xbrief-migrate/index.js"
@@ -109,6 +113,10 @@
     "./eval/run": {
       "types": "./dist/eval/run.d.ts",
       "default": "./dist/eval/run.js"
+    },
+    "./eval/triggers": {
+      "types": "./dist/eval/triggers.d.ts",
+      "default": "./dist/eval/triggers.js"
     },
     "./eval/report": {
       "types": "./dist/eval/report.d.ts",

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -48,6 +48,7 @@ const PROPAGATION_COMMAND_MARKERS: ReadonlyArray<readonly [string, string]> = [
   ["deft value:show", "task value:show"],
   ["deft eval:health", "task eval:health"],
   ["deft eval:run", "task eval:run"],
+  ["deft eval:triggers", "task eval:triggers"],
   ["deft eval:report", "task eval:report"],
   ["deft feedback:file", "task feedback:file"],
   ["deft migrate:xbrief", "deft migrate:xbrief"],

--- a/packages/core/src/eval-triggers-relocation/evaluate.test.ts
+++ b/packages/core/src/eval-triggers-relocation/evaluate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { classifyTriggerRoutingPaths, evaluate, isTriggerRoutingPath } from "./evaluate.js";
+
+describe("eval-triggers-relocation (#1586)", () => {
+  it("isTriggerRoutingPath matches routing homes", () => {
+    expect(isTriggerRoutingPath("REFERENCES.md")).toBe(true);
+    expect(isTriggerRoutingPath("packages/core/src/eval/triggers.ts")).toBe(true);
+    expect(isTriggerRoutingPath("README.md")).toBe(false);
+  });
+
+  it("classifyTriggerRoutingPaths skips unrelated diffs", () => {
+    const result = evaluate({
+      paths: ["packages/cli/src/dispatch.ts"],
+      quiet: true,
+    });
+    expect(result.code).toBe(0);
+    expect(result.skipped).toBe(true);
+  });
+
+  it("classifyTriggerRoutingPaths runs eval when routing paths change", () => {
+    const { isTriggerRouting, matchedPaths } = classifyTriggerRoutingPaths([
+      "evals/trigger-cases.jsonl",
+      "CHANGELOG.md",
+    ]);
+    expect(isTriggerRouting).toBe(true);
+    expect(matchedPaths).toEqual(["evals/trigger-cases.jsonl"]);
+  });
+});

--- a/packages/core/src/eval-triggers-relocation/evaluate.ts
+++ b/packages/core/src/eval-triggers-relocation/evaluate.ts
@@ -1,0 +1,152 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { runTriggerEval } from "../eval/triggers.js";
+import { matchAny } from "../orchestration/pathspec.js";
+
+export type OutputStream = "stdout" | "stderr" | "none";
+
+/** Glob patterns that classify a change as skill-routing / trigger eval relevant (#1586). */
+export const TRIGGER_ROUTING_PATH_PATTERNS = [
+  "AGENTS.md",
+  "REFERENCES.md",
+  "evals/trigger-cases.jsonl",
+  "content/templates/agents-entry.md",
+] as const;
+
+export interface EvaluateResult {
+  readonly code: 0 | 1 | 2;
+  readonly message: string;
+  readonly stream: OutputStream;
+  readonly skipped?: boolean;
+}
+
+export interface EvaluateOptions {
+  readonly projectRoot?: string;
+  readonly baseRef?: string;
+  readonly staged?: boolean;
+  readonly paths?: readonly string[];
+  readonly quiet?: boolean;
+}
+
+/** True when *path* matches a trigger-routing home. */
+export function isTriggerRoutingPath(path: string): boolean {
+  return matchAny(TRIGGER_ROUTING_PATH_PATTERNS, path);
+}
+
+/** Classify a path list for trigger-routing coverage. */
+export function classifyTriggerRoutingPaths(paths: readonly string[]): {
+  readonly isTriggerRouting: boolean;
+  readonly matchedPaths: readonly string[];
+} {
+  const matchedPaths = paths.filter(isTriggerRoutingPath);
+  return { isTriggerRouting: matchedPaths.length > 0, matchedPaths };
+}
+
+function gitNameOnlyDiff(projectRoot: string, args: string[]): string[] | { error: string } {
+  try {
+    const stdout = execFileSync("git", ["-C", projectRoot, "diff", "--name-only", ...args], {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } catch (err: unknown) {
+    return { error: String(err) };
+  }
+}
+
+/** Collect changed paths from git (base ref or staged index). */
+export function collectChangedPaths(
+  projectRoot: string,
+  options: { baseRef?: string; staged?: boolean },
+): string[] | { error: string } {
+  if (options.staged) {
+    return gitNameOnlyDiff(projectRoot, ["--cached"]);
+  }
+  if (options.baseRef !== undefined && options.baseRef.length > 0) {
+    return gitNameOnlyDiff(projectRoot, [options.baseRef, "HEAD"]);
+  }
+  return [];
+}
+
+function formatSkipMessage(matchedPaths: readonly string[]): string {
+  return (
+    "✓ verify:eval-triggers-relocation: no trigger-routing paths in diff " +
+    `(checked ${TRIGGER_ROUTING_PATH_PATTERNS.length} patterns; ` +
+    `diff had ${matchedPaths.length} routing match${matchedPaths.length === 1 ? "" : "es"}).`
+  );
+}
+
+function formatPassMessage(matchedPaths: readonly string[], summary: string): string {
+  return (
+    `✓ verify:eval-triggers-relocation: eval:triggers OK ` +
+    `(routing paths: ${matchedPaths.join(", ")}; ${summary}).`
+  );
+}
+
+/**
+ * Conditional gate: run eval:triggers when AGENTS.md / REFERENCES.md / trigger
+ * cases change (#1586). Skips (exit 0) when the diff does not touch routing homes.
+ */
+export function evaluate(options: EvaluateOptions = {}): EvaluateResult {
+  const projectRoot = resolve(options.projectRoot ?? process.cwd());
+  const quiet = options.quiet ?? false;
+
+  let paths: string[];
+  if (options.paths !== undefined) {
+    paths = [...options.paths];
+  } else if (options.baseRef !== undefined || options.staged) {
+    const collected = collectChangedPaths(projectRoot, {
+      baseRef: options.baseRef,
+      staged: options.staged,
+    });
+    if ("error" in collected) {
+      return {
+        code: 2,
+        message:
+          "❌ verify:eval-triggers-relocation: could not read git diff " +
+          `(project_root=${projectRoot}): ${collected.error}`,
+        stream: "stderr",
+      };
+    }
+    paths = collected;
+  } else {
+    return { code: 0, message: "", stream: "none", skipped: true };
+  }
+
+  const { isTriggerRouting, matchedPaths } = classifyTriggerRoutingPaths(paths);
+  if (!isTriggerRouting) {
+    if (quiet) {
+      return { code: 0, message: "", stream: "none", skipped: true };
+    }
+    return {
+      code: 0,
+      message: formatSkipMessage(matchedPaths),
+      stream: "stdout",
+      skipped: true,
+    };
+  }
+
+  const evalResult = runTriggerEval({ projectRoot });
+  if (evalResult.code !== 0) {
+    return {
+      code: evalResult.code,
+      message:
+        `❌ verify:eval-triggers-relocation: eval:triggers failed on trigger-routing PR (#1586).\n` +
+        `   Matched routing paths: ${matchedPaths.join(", ")}\n` +
+        `   ${evalResult.message.replace(/\n/g, "\n   ")}`,
+      stream: "stderr",
+    };
+  }
+
+  if (quiet) {
+    return { code: 0, message: "", stream: "none" };
+  }
+  return {
+    code: 0,
+    message: formatPassMessage(matchedPaths, evalResult.message),
+    stream: "stdout",
+  };
+}

--- a/packages/core/src/eval-triggers-relocation/evaluate.ts
+++ b/packages/core/src/eval-triggers-relocation/evaluate.ts
@@ -11,6 +11,7 @@ export const TRIGGER_ROUTING_PATH_PATTERNS = [
   "REFERENCES.md",
   "evals/trigger-cases.jsonl",
   "content/templates/agents-entry.md",
+  "packages/core/src/eval/triggers.ts",
 ] as const;
 
 export interface EvaluateResult {
@@ -71,11 +72,10 @@ export function collectChangedPaths(
   return [];
 }
 
-function formatSkipMessage(matchedPaths: readonly string[]): string {
+function formatSkipMessage(): string {
   return (
     "✓ verify:eval-triggers-relocation: no trigger-routing paths in diff " +
-    `(checked ${TRIGGER_ROUTING_PATH_PATTERNS.length} patterns; ` +
-    `diff had ${matchedPaths.length} routing match${matchedPaths.length === 1 ? "" : "es"}).`
+    `(checked ${TRIGGER_ROUTING_PATH_PATTERNS.length} patterns).`
   );
 }
 
@@ -123,7 +123,7 @@ export function evaluate(options: EvaluateOptions = {}): EvaluateResult {
     }
     return {
       code: 0,
-      message: formatSkipMessage(matchedPaths),
+      message: formatSkipMessage(),
       stream: "stdout",
       skipped: true,
     };

--- a/packages/core/src/eval-triggers-relocation/index.ts
+++ b/packages/core/src/eval-triggers-relocation/index.ts
@@ -1,0 +1,10 @@
+export {
+  classifyTriggerRoutingPaths,
+  collectChangedPaths,
+  type EvaluateOptions,
+  type EvaluateResult,
+  evaluate,
+  isTriggerRoutingPath,
+  type OutputStream,
+  TRIGGER_ROUTING_PATH_PATTERNS,
+} from "./evaluate.js";

--- a/packages/core/src/eval/triggers.test.ts
+++ b/packages/core/src/eval/triggers.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   loadTriggerCases,
@@ -9,6 +9,7 @@ import {
   resolveTriggerWinner,
   runTriggerEval,
   SKILLS_INDEX_REL,
+  sanitizeTriggerLogLine,
   TRIGGER_CASES_REL,
   validateTriggerCoverage,
   wouldRouteToSkill,
@@ -65,5 +66,32 @@ describe("eval triggers (#1586)", () => {
     const result = runTriggerEval({ projectRoot: repoRoot });
     expect(result.code).toBe(0);
     expect(result.report?.failed).toBe(0);
+  });
+
+  it("runTriggerEval fails when trigger cases file is missing", () => {
+    const result = runTriggerEval({
+      projectRoot: repoRoot,
+      casesPath: join(repoRoot, "evals", "missing-trigger-cases.jsonl"),
+    });
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("missing trigger cases");
+  });
+
+  it("runTriggerEval fails when Skills Index parses empty", () => {
+    const loaded = loadTriggerCases(join(repoRoot, TRIGGER_CASES_REL));
+    if ("error" in loaded) {
+      throw new Error(loaded.error);
+    }
+    const result = runTriggerEval({
+      projectRoot: repoRoot,
+      cases: loaded,
+      indexText: "# no skills table\n",
+    });
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("no Skills Index rows");
+  });
+
+  it("sanitizeTriggerLogLine collapses embedded newlines", () => {
+    expect(sanitizeTriggerLogLine("a\nb")).toBe("a b");
   });
 });

--- a/packages/core/src/eval/triggers.test.ts
+++ b/packages/core/src/eval/triggers.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  loadTriggerCases,
+  normalizeTriggerText,
+  parseSkillsIndex,
+  parseTriggerCell,
+  resolveTriggerWinner,
+  runTriggerEval,
+  SKILLS_INDEX_REL,
+  TRIGGER_CASES_REL,
+  validateTriggerCoverage,
+  wouldRouteToSkill,
+} from "./triggers.js";
+
+const repoRoot = resolve(import.meta.dirname, "..", "..", "..", "..");
+
+describe("eval triggers (#1586)", () => {
+  const referencesText = readFileSync(resolve(repoRoot, SKILLS_INDEX_REL), "utf8");
+  const index = parseSkillsIndex(referencesText);
+
+  it("parses all indexed directive skills from REFERENCES.md", () => {
+    expect(index.length).toBeGreaterThanOrEqual(20);
+    expect(index.some((entry) => entry.skillId === "deft-directive-review-cycle")).toBe(true);
+  });
+
+  it("parseTriggerCell extracts backtick phrases", () => {
+    expect(parseTriggerCell("`review cycle`, `babysit`, `shepherd`")).toEqual([
+      "review cycle",
+      "babysit",
+      "shepherd",
+    ]);
+  });
+
+  it("normalizeTriggerText lowercases and collapses whitespace", () => {
+    expect(normalizeTriggerText("  Run   Review   Cycle  ")).toBe("run review cycle");
+  });
+
+  it("review-cycle babysit and sub-agent paraphrases route correctly (#2261)", () => {
+    expect(wouldRouteToSkill("babysit this PR", "deft-directive-review-cycle", index)).toBe(true);
+    expect(
+      wouldRouteToSkill("use sub-agents for reviews", "deft-directive-review-cycle", index),
+    ).toBe(true);
+    expect(
+      wouldRouteToSkill("shepherd the PR through review", "deft-directive-review-cycle", index),
+    ).toBe(true);
+  });
+
+  it("longest trigger wins for triage hygiene vs bare triage", () => {
+    const winner = resolveTriggerWinner("run triage hygiene on the cache", index);
+    expect(winner?.skillId).toBe("deft-directive-triage");
+  });
+
+  it("trigger-cases.jsonl meets per-skill coverage minimums", () => {
+    const loaded = loadTriggerCases(resolve(repoRoot, TRIGGER_CASES_REL));
+    expect("error" in loaded).toBe(false);
+    if ("error" in loaded) {
+      return;
+    }
+    expect(validateTriggerCoverage(loaded, index)).toEqual([]);
+  });
+
+  it("runTriggerEval passes committed trigger-cases against REFERENCES.md", () => {
+    const result = runTriggerEval({ projectRoot: repoRoot });
+    expect(result.code).toBe(0);
+    expect(result.report?.failed).toBe(0);
+  });
+});

--- a/packages/core/src/eval/triggers.ts
+++ b/packages/core/src/eval/triggers.ts
@@ -92,15 +92,21 @@ export function parseSkillsIndex(markdown: string): SkillsIndexEntry[] {
     }
     const linkCell = columns[1] ?? "";
     const triggersCell = columns[3] ?? "";
-    const skillMatch = linkCell.match(/\[([^\]]+)\]/);
-    if (skillMatch === null || skillMatch[1] === undefined) {
+    // Avoid nested character-class regex (CodeQL js/polynomial-redos on \[([^\]]+)\]).
+    const open = linkCell.indexOf("[");
+    const close = open === -1 ? -1 : linkCell.indexOf("]", open + 1);
+    if (open === -1 || close === -1) {
+      continue;
+    }
+    const skillId = linkCell.slice(open + 1, close).trim();
+    if (skillId.length === 0) {
       continue;
     }
     const triggers = parseTriggerCell(triggersCell);
     if (triggers.length === 0) {
       continue;
     }
-    entries.push({ skillId: skillMatch[1], triggers });
+    entries.push({ skillId, triggers });
   }
   return entries;
 }

--- a/packages/core/src/eval/triggers.ts
+++ b/packages/core/src/eval/triggers.ts
@@ -1,0 +1,352 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/** Relative path to skill-pi-trigger-eval compatible case rows (#1586). */
+export const TRIGGER_CASES_REL = "evals/trigger-cases.jsonl";
+
+/** Default Skills Index source for AGENTS.md skill routing (#1586). */
+export const SKILLS_INDEX_REL = "REFERENCES.md";
+
+/** One trigger phrase extracted from the Skills Index table. */
+export interface SkillTriggerRule {
+  readonly skillId: string;
+  readonly trigger: string;
+}
+
+/** Parsed Skills Index row. */
+export interface SkillsIndexEntry {
+  readonly skillId: string;
+  readonly triggers: readonly string[];
+}
+
+/** One row in evals/trigger-cases.jsonl (skill-pi-trigger-eval eval-set + skill id). */
+export interface TriggerCaseRow {
+  readonly id: string;
+  readonly query: string;
+  readonly skill: string;
+  readonly should_trigger: boolean;
+}
+
+/** Outcome for a single trigger case. */
+export interface TriggerCaseResult {
+  readonly id: string;
+  readonly query: string;
+  readonly skill: string;
+  readonly should_trigger: boolean;
+  readonly actual: boolean;
+  readonly pass: boolean;
+  readonly matchedTrigger?: string;
+  readonly winnerSkill?: string;
+}
+
+/** Aggregate eval:triggers report. */
+export interface TriggerEvalReport {
+  readonly total: number;
+  readonly passed: number;
+  readonly failed: number;
+  readonly pass_rate: number | null;
+  readonly results: readonly TriggerCaseResult[];
+  readonly coverageErrors: readonly string[];
+}
+
+export interface RunTriggerEvalOptions {
+  readonly projectRoot?: string;
+  readonly casesPath?: string;
+  readonly indexPath?: string;
+  readonly cases?: readonly TriggerCaseRow[];
+  readonly indexText?: string;
+}
+
+export interface RunTriggerEvalResult {
+  readonly code: 0 | 1 | 2;
+  readonly report: TriggerEvalReport | null;
+  readonly message: string;
+}
+
+/** Normalize user text for deterministic substring trigger matching. */
+export function normalizeTriggerText(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** Extract backtick trigger phrases from a Skills Index triggers cell. */
+export function parseTriggerCell(cell: string): string[] {
+  const triggers: string[] = [];
+  for (const match of cell.matchAll(/`([^`]+)`/g)) {
+    const phrase = normalizeTriggerText(match[1] ?? "");
+    if (phrase.length > 0) {
+      triggers.push(phrase);
+    }
+  }
+  return triggers;
+}
+
+/** Parse the Skills Index markdown table in REFERENCES.md. */
+export function parseSkillsIndex(markdown: string): SkillsIndexEntry[] {
+  const entries: SkillsIndexEntry[] = [];
+  for (const line of markdown.split(/\r?\n/)) {
+    if (!line.startsWith("| [deft-directive-")) {
+      continue;
+    }
+    const columns = line.split("|").map((col) => col.trim());
+    if (columns.length < 5) {
+      continue;
+    }
+    const linkCell = columns[1] ?? "";
+    const triggersCell = columns[3] ?? "";
+    const skillMatch = linkCell.match(/\[([^\]]+)\]/);
+    if (skillMatch === null || skillMatch[1] === undefined) {
+      continue;
+    }
+    const triggers = parseTriggerCell(triggersCell);
+    if (triggers.length === 0) {
+      continue;
+    }
+    entries.push({ skillId: skillMatch[1], triggers });
+  }
+  return entries;
+}
+
+/** Expand index rows into flat trigger rules sorted longest-first per skill. */
+export function flattenTriggerRules(index: readonly SkillsIndexEntry[]): SkillTriggerRule[] {
+  const rules: SkillTriggerRule[] = [];
+  for (const entry of index) {
+    const sorted = [...entry.triggers].sort((a, b) => b.length - a.length);
+    for (const trigger of sorted) {
+      rules.push({ skillId: entry.skillId, trigger });
+    }
+  }
+  return rules;
+}
+
+interface TriggerMatch {
+  readonly skillId: string;
+  readonly trigger: string;
+}
+
+/** Find the winning skill for a query using longest-trigger-wins disambiguation. */
+export function resolveTriggerWinner(
+  query: string,
+  index: readonly SkillsIndexEntry[],
+): TriggerMatch | null {
+  const normalized = normalizeTriggerText(query);
+  let best: TriggerMatch | null = null;
+  for (const entry of index) {
+    for (const trigger of entry.triggers) {
+      if (!normalized.includes(trigger)) {
+        continue;
+      }
+      if (
+        best === null ||
+        trigger.length > best.trigger.length ||
+        (trigger.length === best.trigger.length && entry.skillId.localeCompare(best.skillId) < 0)
+      ) {
+        best = { skillId: entry.skillId, trigger };
+      }
+    }
+  }
+  return best;
+}
+
+/** True when the Skills Index routing would send *query* to *skillId*. */
+export function wouldRouteToSkill(
+  query: string,
+  skillId: string,
+  index: readonly SkillsIndexEntry[],
+): boolean {
+  const winner = resolveTriggerWinner(query, index);
+  return winner !== null && winner.skillId === skillId;
+}
+
+/** Validate one JSONL row against the skill-pi-trigger-eval row contract. */
+export function parseTriggerCaseRow(raw: unknown, lineNumber: number): TriggerCaseRow | string {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return `line ${lineNumber}: expected a JSON object`;
+  }
+  const record = raw as Record<string, unknown>;
+  const id = record.id;
+  const query = record.query;
+  const skill = record.skill;
+  const shouldTrigger = record.should_trigger;
+  if (typeof id !== "string" || id.trim().length === 0) {
+    return `line ${lineNumber}: id must be a non-empty string`;
+  }
+  if (typeof query !== "string" || query.trim().length === 0) {
+    return `line ${lineNumber}: query must be a non-empty string`;
+  }
+  if (typeof skill !== "string" || !skill.startsWith("deft-directive-")) {
+    return `line ${lineNumber}: skill must be a deft-directive-* id`;
+  }
+  if (typeof shouldTrigger !== "boolean") {
+    return `line ${lineNumber}: should_trigger must be true or false`;
+  }
+  return {
+    id: id.trim(),
+    query: query.trim(),
+    skill: skill.trim(),
+    should_trigger: shouldTrigger,
+  };
+}
+
+/** Load evals/trigger-cases.jsonl. */
+export function loadTriggerCases(path: string): TriggerCaseRow[] | { error: string } {
+  if (!existsSync(path)) {
+    return { error: `missing trigger cases at ${path}` };
+  }
+  const text = readFileSync(path, "utf8");
+  const rows: TriggerCaseRow[] = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]?.trim() ?? "";
+    if (line.length === 0 || line.startsWith("#")) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return { error: `line ${i + 1}: invalid JSON` };
+    }
+    const row = parseTriggerCaseRow(parsed, i + 1);
+    if (typeof row === "string") {
+      return { error: row };
+    }
+    rows.push(row);
+  }
+  if (rows.length === 0) {
+    return { error: "trigger-cases.jsonl has no cases" };
+  }
+  return rows;
+}
+
+/** Verify at least two positive and one negative case per indexed skill. */
+export function validateTriggerCoverage(
+  cases: readonly TriggerCaseRow[],
+  index: readonly SkillsIndexEntry[],
+): string[] {
+  const errors: string[] = [];
+  const bySkill = new Map<string, { positive: number; negative: number }>();
+  for (const entry of index) {
+    bySkill.set(entry.skillId, { positive: 0, negative: 0 });
+  }
+  for (const row of cases) {
+    const bucket = bySkill.get(row.skill);
+    if (bucket === undefined) {
+      errors.push(`case '${row.id}' references unknown skill '${row.skill}'`);
+      continue;
+    }
+    if (row.should_trigger) {
+      bucket.positive += 1;
+    } else {
+      bucket.negative += 1;
+    }
+  }
+  for (const [skillId, counts] of bySkill) {
+    if (counts.positive < 2) {
+      errors.push(`${skillId}: need at least 2 positive trigger cases (have ${counts.positive})`);
+    }
+    if (counts.negative < 1) {
+      errors.push(`${skillId}: need at least 1 negative trigger case (have ${counts.negative})`);
+    }
+  }
+  return errors;
+}
+
+/** Run deterministic trigger routing eval (offline skill-pi-trigger-eval counterpart). */
+export function runTriggerEval(options: RunTriggerEvalOptions = {}): RunTriggerEvalResult {
+  const projectRoot = resolve(options.projectRoot ?? process.cwd());
+  const casesPath = options.casesPath ?? resolve(projectRoot, TRIGGER_CASES_REL);
+  const indexPath = options.indexPath ?? resolve(projectRoot, SKILLS_INDEX_REL);
+
+  let cases: TriggerCaseRow[];
+  if (options.cases !== undefined) {
+    cases = [...options.cases];
+  } else {
+    const loaded = loadTriggerCases(casesPath);
+    if ("error" in loaded) {
+      return { code: 2, report: null, message: `eval:triggers: ${loaded.error}` };
+    }
+    cases = loaded;
+  }
+
+  let indexText: string;
+  if (options.indexText !== undefined) {
+    indexText = options.indexText;
+  } else if (!existsSync(indexPath)) {
+    return { code: 2, report: null, message: `eval:triggers: missing ${SKILLS_INDEX_REL}` };
+  } else {
+    indexText = readFileSync(indexPath, "utf8");
+  }
+
+  const index = parseSkillsIndex(indexText);
+  if (index.length === 0) {
+    return {
+      code: 2,
+      report: null,
+      message: `eval:triggers: no Skills Index rows parsed from ${SKILLS_INDEX_REL}`,
+    };
+  }
+
+  const coverageErrors = validateTriggerCoverage(cases, index);
+  const results: TriggerCaseResult[] = [];
+  for (const row of cases) {
+    const winner = resolveTriggerWinner(row.query, index);
+    const actual = winner !== null && winner.skillId === row.skill;
+    results.push({
+      id: row.id,
+      query: row.query,
+      skill: row.skill,
+      should_trigger: row.should_trigger,
+      actual,
+      pass: actual === row.should_trigger,
+      matchedTrigger: winner?.trigger,
+      winnerSkill: winner?.skillId,
+    });
+  }
+
+  const passed = results.filter((result) => result.pass).length;
+  const failed = results.length - passed;
+  const report: TriggerEvalReport = {
+    total: results.length,
+    passed,
+    failed,
+    pass_rate: results.length > 0 ? passed / results.length : null,
+    results,
+    coverageErrors,
+  };
+
+  if (coverageErrors.length > 0) {
+    const detail = coverageErrors.map((err) => `   - ${err}`).join("\n");
+    return {
+      code: 1,
+      report,
+      message: `eval:triggers: trigger coverage incomplete\n${detail}`,
+    };
+  }
+
+  if (failed > 0) {
+    const detail = results
+      .filter((result) => !result.pass)
+      .slice(0, 8)
+      .map(
+        (result) =>
+          `   - ${result.id}: expected ${result.should_trigger ? "trigger" : "no-trigger"} ` +
+          `for ${result.skill}; winner=${result.winnerSkill ?? "none"}`,
+      )
+      .join("\n");
+    return {
+      code: 1,
+      report,
+      message:
+        `eval:triggers: ${failed}/${results.length} trigger cases failed ` +
+        `(offline skill-pi-trigger-eval routing against ${SKILLS_INDEX_REL})\n${detail}`,
+    };
+  }
+
+  return {
+    code: 0,
+    report,
+    message:
+      `eval:triggers: ${passed}/${results.length} trigger cases passed ` +
+      `(offline skill-pi-trigger-eval routing against ${SKILLS_INDEX_REL})`,
+  };
+}

--- a/packages/core/src/eval/triggers.ts
+++ b/packages/core/src/eval/triggers.ts
@@ -7,12 +7,6 @@ export const TRIGGER_CASES_REL = "evals/trigger-cases.jsonl";
 /** Default Skills Index source for AGENTS.md skill routing (#1586). */
 export const SKILLS_INDEX_REL = "REFERENCES.md";
 
-/** One trigger phrase extracted from the Skills Index table. */
-export interface SkillTriggerRule {
-  readonly skillId: string;
-  readonly trigger: string;
-}
-
 /** Parsed Skills Index row. */
 export interface SkillsIndexEntry {
   readonly skillId: string;
@@ -68,6 +62,11 @@ export function normalizeTriggerText(text: string): string {
   return text.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
+/** Collapse embedded newlines before interpolating user/data into log lines. */
+export function sanitizeTriggerLogLine(text: string): string {
+  return text.replace(/\r?\n/g, " ").trim();
+}
+
 /** Extract backtick trigger phrases from a Skills Index triggers cell. */
 export function parseTriggerCell(cell: string): string[] {
   const triggers: string[] = [];
@@ -104,18 +103,6 @@ export function parseSkillsIndex(markdown: string): SkillsIndexEntry[] {
     entries.push({ skillId: skillMatch[1], triggers });
   }
   return entries;
-}
-
-/** Expand index rows into flat trigger rules sorted longest-first per skill. */
-export function flattenTriggerRules(index: readonly SkillsIndexEntry[]): SkillTriggerRule[] {
-  const rules: SkillTriggerRule[] = [];
-  for (const entry of index) {
-    const sorted = [...entry.triggers].sort((a, b) => b.length - a.length);
-    for (const trigger of sorted) {
-      rules.push({ skillId: entry.skillId, trigger });
-    }
-  }
-  return rules;
 }
 
 interface TriggerMatch {
@@ -290,7 +277,7 @@ export function runTriggerEval(options: RunTriggerEvalOptions = {}): RunTriggerE
   const results: TriggerCaseResult[] = [];
   for (const row of cases) {
     const winner = resolveTriggerWinner(row.query, index);
-    const actual = winner !== null && winner.skillId === row.skill;
+    const actual = wouldRouteToSkill(row.query, row.skill, index);
     results.push({
       id: row.id,
       query: row.query,
@@ -315,7 +302,7 @@ export function runTriggerEval(options: RunTriggerEvalOptions = {}): RunTriggerE
   };
 
   if (coverageErrors.length > 0) {
-    const detail = coverageErrors.map((err) => `   - ${err}`).join("\n");
+    const detail = coverageErrors.map((err) => `   - ${sanitizeTriggerLogLine(err)}`).join("\n");
     return {
       code: 1,
       report,
@@ -329,8 +316,8 @@ export function runTriggerEval(options: RunTriggerEvalOptions = {}): RunTriggerE
       .slice(0, 8)
       .map(
         (result) =>
-          `   - ${result.id}: expected ${result.should_trigger ? "trigger" : "no-trigger"} ` +
-          `for ${result.skill}; winner=${result.winnerSkill ?? "none"}`,
+          `   - ${sanitizeTriggerLogLine(result.id)}: expected ${result.should_trigger ? "trigger" : "no-trigger"} ` +
+          `for ${sanitizeTriggerLogLine(result.skill)}; winner=${sanitizeTriggerLogLine(result.winnerSkill ?? "none")}`,
       )
       .join("\n");
     return {

--- a/packages/core/src/triage/help/registry-data.ts
+++ b/packages/core/src/triage/help/registry-data.ts
@@ -590,6 +590,25 @@ export const registryData = {
       see_also: ["task eval:run", "task eval:report", "#1703"],
       placeholder: false,
     },
+    "task eval:triggers": {
+      name: "task eval:triggers",
+      summary: "Trigger routing coverage for Skills Index rules",
+      refs: "(#1586)",
+      description:
+        "Offline skill-pi-trigger-eval compatible routing check: grades evals/trigger-cases.jsonl against REFERENCES.md Skills Index triggers (should-fire / should-not-fire per skill).",
+      usage: "task eval:triggers [-- --json] [--project-root PATH]",
+      flags: [
+        ["--json", "(off)", "Emit the TriggerEvalReport JSON."],
+        [
+          "--project-root PATH",
+          "(cwd)",
+          "Project root override (Taskfile threads USER_WORKING_DIR).",
+        ],
+      ],
+      examples: ["task eval:triggers", "task eval:triggers -- --json"],
+      see_also: ["task eval:health", "task verify:eval-triggers-relocation", "#1862"],
+      placeholder: false,
+    },
     "task eval:run": {
       name: "task eval:run",
       summary: "Tier 2 golden corpus eval for a model",
@@ -888,7 +907,10 @@ export const registryData = {
         "task triage:metrics",
       ],
     ],
-    ["Framework eval (#1703)", ["task eval:health", "task eval:run", "task eval:report"]],
+    [
+      "Framework eval (#1703)",
+      ["task eval:health", "task eval:triggers", "task eval:run", "task eval:report"],
+    ],
   ],
   categoriesScope: [
     ["Promote / demote", ["task scope:promote", "task scope:demote"]],

--- a/tasks/eval.yml
+++ b/tasks/eval.yml
@@ -30,3 +30,12 @@ tasks:
       - task: :engine:invoke
         vars:
           ENGINE_CMD: 'eval:report --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
+
+  triggers:
+    desc: "Trigger routing coverage for AGENTS.md / Skills Index (#1586). Offline skill-pi-trigger-eval compatible eval over evals/trigger-cases.jsonl vs REFERENCES.md. -- task eval:triggers [-- --json] [--project-root PATH]"
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'eval:triggers --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -415,6 +415,16 @@ tasks:
         vars:
           ENGINE_CMD: 'verify:eval-health-relocation --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
 
+  eval-triggers-relocation:
+    desc: "Fail-closed eval:triggers gate when AGENTS.md / REFERENCES.md / trigger cases change (#1586). Skips (exit 0) when the diff does not touch trigger-routing homes. -- task verify:eval-triggers-relocation [-- --base-ref <ref> | --staged] [--quiet]"
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'verify:eval-triggers-relocation --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}'
+
   agents-md-advisory:
     desc: "ADVISORY (never fail-closing) consumer AGENTS.md legibility signal (#2155). Counts the UNMANAGED (project-authored) region only -- the framework-owned managed section is excluded -- and compares it against the SOFT, operator-adjustable budget plan.policy.agentsMdAdvisory.unmanagedSoftMaxLines (generous default when unset). Consumer companion to the maintainer-only #645 ratchet; deliberately NOT a check:consumer dependency (advise->observe->enforce per #1419). Default posture ALWAYS exits 0; the opt-in --enforce flag promotes an over-budget region to a hard cap (exit 1). Raising the field is the documented, no-friction way to accept growth and silence the nudge."
     dir: '{{.USER_WORKING_DIR}}'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,7 @@ const subpathAliases: Record<string, string> = {
   "@deftai/directive-core/agents-md-budget": sub("core", "agents-md-budget"),
   "@deftai/directive-core/agents-md-advisory": sub("core", "agents-md-advisory"),
   "@deftai/directive-core/eval-health-relocation": sub("core", "eval-health-relocation"),
+  "@deftai/directive-core/eval-triggers-relocation": sub("core", "eval-triggers-relocation"),
   "@deftai/directive-core/scm": sub("core", "scm"),
   "@deftai/directive-core/scope": sub("core", "scope"),
   "@deftai/directive-core/session": sub("core", "session"),
@@ -55,6 +56,10 @@ const subpathAliases: Record<string, string> = {
     "packages/core/src/eval/crud-telemetry.ts",
   ),
   "@deftai/directive-core/eval/run": resolve(import.meta.dirname, "packages/core/src/eval/run.ts"),
+  "@deftai/directive-core/eval/triggers": resolve(
+    import.meta.dirname,
+    "packages/core/src/eval/triggers.ts",
+  ),
   "@deftai/directive-core/eval/report": resolve(
     import.meta.dirname,
     "packages/core/src/eval/report.ts",

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16784,7 +16784,7 @@
       "agentsMdBudget": {
         "managedMaxLines": 103,
         "unmanagedMaxLines": 161,
-        "absoluteMaxBytes": 7247,
+        "absoluteMaxBytes": 7292,
         "skillFrontmatterTier": "daily-core",
         "skillFrontmatterMaxBytes": 2189
       }

--- a/xbrief/active/2026-07-15-1586-featevals-trigger-coverage-evals-for-agentsmd-skill-routing.xbrief.json
+++ b/xbrief/active/2026-07-15-1586-featevals-trigger-coverage-evals-for-agentsmd-skill-routing.xbrief.json
@@ -1,0 +1,65 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #1586"
+  },
+  "plan": {
+    "title": "feat(evals): trigger coverage evals for AGENTS.md skill routing — skill-pi-trigger-eval integration",
+    "status": "running",
+    "narratives": {
+      "Description": "feat(evals): trigger coverage evals for AGENTS.md skill routing — skill-pi-trigger-eval integration",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/1586",
+      "Overview": "feat(evals): trigger coverage evals for AGENTS.md skill routing using skill-pi-trigger-eval\n\n## Summary\n\nAGENTS.md defines explicit skill-routing triggers (17 rules mapping keyword phrases to skills: \"review cycle\" -> deft-directive-review-cycle, \"swarm\" -> deft-directive-swarm, \"triage\" -> deft-directive-gh-triage, etc.). These routing rules have no automated test coverage. A false positive (wrong skill fires for an unrelated context) or false negative (correct skill does not fire when it should) is a silent correctness failure. skill-eval-harness includes skill-pi-trigger-eval for exactly this: smoke evals that check trigger keyword routing without forcing the skill flag.\n\n## The gap\n\nCurrently:\n- No test covers \"does the agent correctly route to deft-directive-review-cycle when the user says run review cycle?\"\n- No test covers \"does the agent NOT trigger deft-directive-swarm when the user says something that contains the word swarm in an unrelated context?\"\n- A AGENTS.md change that breaks a routing trigger is undetectable before shipping\n\n## What trigger coverage looks like\n\nA trigger-cases.jsonl file with entries per skill:\n\nFor deft-directive-review-cycle:\n- Positive: \"run review cycle on this PR\" -> should trigger deft-directive-review-cycle\n- Positive: \"check reviews\" -> should trigger\n- Negative: \"I want to review this design document\" -> should NOT trigger (review without cycle context)\n\nFor deft-directive-swarm:\n- Positive: \"run agents in parallel on these three vBRIEFs\" -> should trigger\n- Positive: \"swarm these stories\" -> should trigger\n- Negative: \"there was a swarm of bees outside\" -> should NOT trigger\n\n## Proposed files\n\n- evals/trigger-cases.jsonl -- trigger test cases per skill in the format expected by skill-pi-trigger-eval\n- Taskfile.yml -- new task eval:triggers: runs skill-pi-trigger-eval against AGENTS.md\n\n## Acceptance criteria\n\n- evals/trigger-cases.jsonl has at least 2 positive and 1 negative case per trigger rule in AGENTS.md\n- task eval:triggers runs skill-pi-trigger-eval and passes\n- All positive cases pass (correct skill fires)\n- All negative cases pass (no false positives)\n- task check or CI runs task eval:triggers on AGENTS.md changes\n\n## Related\n\n- Depends on #1584 (base eval infrastructure -- trigger evals are a companion to the benchmark manifest)\n- Related to #635 (skill-system maturity -- trigger correctness is part of skill quality)\n- Related to #1532 (skill validation in task check -- trigger coverage is a runtime validation complement to the static validation)\n\n## Source\n\nhttps://github.com/adewale/skill-eval-harness: \"Trigger checks -- run Pi skill-trigger smoke evals without forcing --skill\" feature; skill-pi-trigger-eval CLI.\n\n## Parent / tracker\n\nParent epic: #1862. Eval companion — intent-paraphrase / trigger coverage for review-cycle routing (incl. \"use sub-agents for reviews\").\n\n",
+      "Labels": "enhancement, skills, determinism, test-debt, agent-experience, review-cycle, evals"
+    },
+    "items": [
+      {
+        "title": "evals/trigger-cases.jsonl has at least 2 positive and 1 negative case per trigger rule in AGENTS.md",
+        "status": "proposed"
+      },
+      {
+        "title": "task eval:triggers runs skill-pi-trigger-eval and passes",
+        "status": "proposed"
+      },
+      {
+        "title": "All positive cases pass (correct skill fires)",
+        "status": "proposed"
+      },
+      {
+        "title": "All negative cases pass (no false positives)",
+        "status": "proposed"
+      },
+      {
+        "title": "task check or CI runs task eval:triggers on AGENTS.md changes",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "skills",
+      "determinism",
+      "test-debt",
+      "agent-experience",
+      "review-cycle",
+      "evals"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/1586",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #1586: feat(evals): trigger coverage evals for AGENTS.md skill routing — skill-pi-trigger-eval integration"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/635",
+        "type": "x-xbrief/refs",
+        "title": "Issue #635"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/1532",
+        "type": "x-xbrief/refs",
+        "title": "Issue #1532"
+      }
+    ],
+    "updated": "2026-07-15T14:32:19Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `evals/trigger-cases.jsonl` with skill-pi-trigger-eval compatible should-fire / should-not-fire rows for all 20 Skills Index rules in `REFERENCES.md` (including review-cycle babysit/shepherd and "use sub-agents for reviews" paraphrases from #2261).
- Add `task eval:triggers` — deterministic offline routing eval mirroring the harness eval-set contract — plus `verify:eval-triggers-relocation` wired into `task check` and CI when AGENTS.md / REFERENCES.md / trigger cases change.
- Document the surface in AGENTS.md, agents-entry template, triage help, and re-seed `absoluteMaxBytes` for the small managed-section growth.

## Test plan
- [x] `task eval:triggers` — 62/62 cases pass
- [x] `pnpm exec vitest run packages/core/src/eval/triggers.test.ts`
- [x] `pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts -t propagation_command`
- [ ] CI TypeScript job (includes trigger-routing gate on PR diff)

Closes #1586