### PR TITLE
fix(test): harden win32 Vitest coverage/.tmp against ENOENT (Closes #2580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` mid-suite (#2580).** Native Windows `task check` coverage runs now pre-create and keep `coverage/.tmp` via globalSetup, serialize v8 `processingConcurrency`, and cap fork workers when `--coverage` is active so green suites are not blocked by temp-directory races; coverage thresholds still fail closed. Closes #2580.
+
 ### Removed
 
 ## [0.78.0] - 2026-07-15

--- a/packages/core/src/vitest-runner/vitest-config-contract.test.ts
+++ b/packages/core/src/vitest-runner/vitest-config-contract.test.ts
@@ -14,8 +14,8 @@ describe("vitest.config.ts Windows runner contract (#2546)", () => {
   });
 
   it("caps fork parallelism on win32 for coordinator headroom", () => {
-    expect(source).toMatch(/maxWorkers:\s*winMaxWorkers/);
-    expect(source).toMatch(/maxForks:\s*winMaxWorkers/);
+    expect(source).toMatch(/maxWorkers:\s*winActiveMaxWorkers/);
+    expect(source).toMatch(/maxForks:\s*winActiveMaxWorkers/);
     expect(source).toMatch(/cpus\(\)\.length\s*\*\s*0\.25/);
     expect(source).toMatch(/Math\.min\(12/);
   });
@@ -28,5 +28,29 @@ describe("vitest.config.ts Windows runner contract (#2546)", () => {
 
   it("widens teardownTimeout on win32 for heavy coverage runs", () => {
     expect(source).toMatch(/teardownTimeout:\s*60_000/);
+  });
+});
+
+describe("vitest.config.ts Windows coverage tmp contract (#2580)", () => {
+  const source = readFileSync(configPath, "utf8");
+
+  it("documents coverage/.tmp ENOENT mitigation for native Windows", () => {
+    expect(source).toContain("#2580");
+    expect(source).toMatch(/coverage\/\.tmp/);
+  });
+
+  it("serializes coverage processing and tightens workers when --coverage is on", () => {
+    expect(source).toMatch(/processingConcurrency:\s*1/);
+    expect(source).toMatch(/coverageEnabled/);
+    expect(source).toMatch(/fileParallelism:\s*false/);
+    expect(source).toMatch(/win32CoverageTmpSetup/);
+  });
+
+  it("globalSetup module keeps coverage/.tmp present on win32", () => {
+    const setupPath = join(repoRoot, "packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts");
+    const setupSource = readFileSync(setupPath, "utf8");
+    expect(setupSource).toContain("#2580");
+    expect(setupSource).toMatch(/coverage.*\.tmp/);
+    expect(setupSource).toMatch(/ensureCoverageTmpDir/);
   });
 });

--- a/packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts
+++ b/packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts
@@ -1,0 +1,27 @@
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const COVERAGE_TMP = resolve(process.cwd(), "coverage", ".tmp");
+
+function ensureCoverageTmpDir(): void {
+  mkdirSync(COVERAGE_TMP, { recursive: true });
+}
+
+/**
+ * Win32 globalSetup for coverage runs (#2580).
+ *
+ * Vitest's v8 provider writes per-suite JSON under coverage/.tmp without always
+ * re-mkdir'ing before writeFile. Under parallel fork load the directory can
+ * disappear mid-suite, surfacing as ENOENT after an otherwise green run.
+ * Keep the directory present for the coordinator process; late ENOENT flakes
+ * are tolerated via vitest dangerouslyIgnoreUnhandledErrors (#2546) without
+ * soft-failing real coverage threshold failures.
+ */
+export default function setup(): void {
+  if (process.platform !== "win32") return;
+
+  ensureCoverageTmpDir();
+
+  const keepalive = setInterval(ensureCoverageTmpDir, 100);
+  keepalive.unref?.();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,20 @@ const testEnvironment =
 const isWin32 = process.platform === "win32";
 const winMaxWorkers = Math.max(1, Math.min(12, Math.floor(cpus().length * 0.25)));
 
+// Coverage chunk writes land in coverage/.tmp; on win32 parallel forks can race the
+// directory away mid-suite (ENOENT after a green run). Serialize coverage processing,
+// tighten fork caps when --coverage is on, and globalSetup keeps .tmp present.
+// Refs #2580.
+const coverageEnabled = process.argv.some(
+  (arg) => arg === "--coverage" || arg.startsWith("--coverage."),
+);
+const winActiveMaxWorkers =
+  isWin32 && coverageEnabled ? Math.max(1, Math.min(4, winMaxWorkers)) : winMaxWorkers;
+const win32CoverageTmpSetup = resolve(
+  import.meta.dirname,
+  "packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts",
+);
+
 // Alias the workspace packages to their TypeScript source so the suite runs
 // against src/ without a prior `tsc -b` build (keeps `vitest --changed` fast
 // and decoupled from build order). `tsc -b` remains the type-check + emit
@@ -129,12 +143,18 @@ export default defineConfig({
     testTimeout: isWin32 ? 20_000 : 5_000,
     ...(isWin32
       ? {
-          maxWorkers: winMaxWorkers,
+          maxWorkers: winActiveMaxWorkers,
           teardownTimeout: 60_000,
           dangerouslyIgnoreUnhandledErrors: true,
+          ...(coverageEnabled
+            ? {
+                globalSetup: [win32CoverageTmpSetup],
+                fileParallelism: false,
+              }
+            : {}),
           poolOptions: {
             forks: {
-              maxForks: winMaxWorkers,
+              maxForks: winActiveMaxWorkers,
             },
           },
         }
@@ -149,6 +169,7 @@ export default defineConfig({
         "packages/cli/src/*-fixtures.ts",
       ],
       reporter: ["text", "text-summary"],
+      ...(isWin32 && coverageEnabled ? { processingConcurrency: 1 } : {}),
       thresholds: {
         lines: 85,
         functions: 85,

--- a/xbrief/active/2026-07-15-2580-vitest-coverage-tmp-enoent-win32.xbrief.json
+++ b/xbrief/active/2026-07-15-2580-vitest-coverage-tmp-enoent-win32.xbrief.json
@@ -1,0 +1,88 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2580"
+  },
+  "plan": {
+    "title": "bug(test,windows): Vitest coverage ENOENT on coverage/.tmp mid-suite fails task check after green tests",
+    "status": "running",
+    "narratives": {
+      "Description": "On native Windows, Vitest coverage runs can fail with ENOENT on coverage/.tmp/coverage-N.json after a green suite. Ensure the tmp dir exists, serialize coverage processing on win32, and tolerate late ENOENT without soft-failing real coverage gate failures.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2580",
+      "Overview": "## Problem\n\nDuring release `task check` on Windows, Vitest can report tests green then exit non-zero:\n\n```\nUnhandled Rejection\nError: ENOENT: no such file or directory, open '...\\\\coverage\\\\.tmp\\\\coverage-0.json'\n```\n\nAdjacent to #2546 (onTaskUpdate RPC) and #2556 (build-dist archiver race) but distinct: the coverage reporter/worker loses `coverage/.tmp` mid-suite under parallel load.\n\n## Operator-locked decision (c)\n\nBOTH ensure `coverage/.tmp` exists + tolerate late ENOENT AND reduce/serialize coverage workers on win32. Do NOT soft-fail the coverage gate when the suite is green.\n\n## Expected\n\n- `coverage/.tmp` is created before workers write chunks\n- win32 coverage runs serialize processing workers\n- Green suite + valid coverage thresholds exit zero\n- Coverage threshold failures still fail closed\n",
+      "Labels": "bug, test-debt, runtime-portability, blocks-release-tag, ci-cd, area:release",
+      "UserStory": "As a Windows maintainer, I want task check coverage runs to finish when tests are green, so that release Step 5 is not blocked by coverage/.tmp ENOENT races.",
+      "ImplementationPlan": "1. Extend vitest.config.ts: win32 coverage processingConcurrency=1, tighter worker caps when --coverage, globalSetup to mkdir coverage/.tmp.\n2. Add win32-coverage-tmp-setup globalSetup module that keeps .tmp present and swallows late ENOENT on coverage chunk paths only.\n3. Extend vitest-config-contract.test.ts with #2580 regression guards.\n4. CHANGELOG [Unreleased] entry.",
+      "Acceptance": "1. coverage/.tmp exists before coverage workers write\n2. win32 serializes/reduces coverage workers\n3. No coverage soft-fail when suite is green\n4. Contract tests guard the mitigation\n5. CHANGELOG updated"
+    },
+    "items": [
+      {
+        "title": "coverage/.tmp exists before workers write",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a win32 coverage run, when workers start, then coverage/.tmp already exists via globalSetup."
+        }
+      },
+      {
+        "title": "win32 serializes coverage workers",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given vitest.config.ts on win32 with --coverage, when loaded, then coverage.processingConcurrency is 1 and worker caps are reduced."
+        }
+      },
+      {
+        "title": "No coverage soft-fail on green suite",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a green suite with passing thresholds, when coverage completes, then exit code is zero; threshold failures still exit non-zero."
+        }
+      },
+      {
+        "title": "Contract tests guard mitigation",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given vitest-config-contract.test.ts, when #2580 settings are removed, then focused tests fail."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "test-debt",
+      "runtime-portability",
+      "blocks-release-tag"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2580",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2580: Vitest coverage ENOENT on coverage/.tmp mid-suite"
+      }
+    ],
+    "updated": "2026-07-15T20:01:09Z",
+    "id": "vitest-coverage-tmp-enoent-win32",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "vitest.config.ts",
+          "packages/core/src/vitest-runner/"
+        ],
+        "verify_commands": [
+          "pnpm run test",
+          "pnpm exec vitest run packages/core/src/vitest-runner/vitest-config-contract.test.ts"
+        ],
+        "expected_outputs": [
+          "Windows coverage runs do not ENOENT on coverage/.tmp after green suite",
+          "Contract tests document win32 coverage tmp mitigation"
+        ],
+        "depends_on": [],
+        "conflict_group": "vitest-runner",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    }
+  }
+}

--- a/xbrief/completed/2026-07-15-2580-vitest-coverage-tmp-enoent-win32.xbrief.json
+++ b/xbrief/completed/2026-07-15-2580-vitest-coverage-tmp-enoent-win32.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "bug(test,windows): Vitest coverage ENOENT on coverage/.tmp mid-suite fails task check after green tests",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "On native Windows, Vitest coverage runs can fail with ENOENT on coverage/.tmp/coverage-N.json after a green suite. Ensure the tmp dir exists, serialize coverage processing on win32, and tolerate late ENOENT without soft-failing real coverage gate failures.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2580",
@@ -58,7 +58,7 @@
         "title": "Issue #2580: Vitest coverage ENOENT on coverage/.tmp mid-suite"
       }
     ],
-    "updated": "2026-07-15T20:01:09Z",
+    "updated": "2026-07-15T20:09:20Z",
     "id": "vitest-coverage-tmp-enoent-win32",
     "metadata": {
       "kind": "story",
@@ -82,7 +82,9 @@
         "size": "S",
         "file_scope_confidence": "high",
         "model_tier": "medium"
-      }
+      },
+      "completedAt": "2026-07-15T20:09:20Z",
+      "capacityBucket": "technical-debt"
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Windows `task check` coverage runs could pass every test yet exit non-zero when Vitest lost `coverage/.tmp` mid-suite under parallel fork load (#2580). This PR hardens the win32 coverage path without soft-failing real threshold failures.

**Changes:**
- `vitest.config.ts`: when `--coverage` is active on win32, cap fork workers tighter, disable file parallelism, set `coverage.processingConcurrency: 1`, and register a globalSetup keepalive for `coverage/.tmp`
- `win32-coverage-tmp-setup.ts`: pre-create and periodically ensure `coverage/.tmp` exists during the coordinator run
- Contract tests in `vitest-config-contract.test.ts` guard #2580 settings
- Late ENOENT flakes remain tolerated via existing `dangerouslyIgnoreUnhandledErrors` (#2546); coverage thresholds stay fail-closed

## Related Issues

Closes #2580

## Checklist

- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] Tests pass locally (vitest-config-contract.test.ts)
- [ ] ROADMAP.md — N/A (issue not in ROADMAP table yet)

## Post-Merge

- [ ] Verify issue auto-close for #2580
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38ab6af1-e322-480f-a45f-decd7f423201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38ab6af1-e322-480f-a45f-decd7f423201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

