### PR TITLE
fix(release): Step 3 rate-limit retry and actionable FAIL (#2577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-<<<<<<< HEAD
 - **pr-wait-mergeable unit tests no longer inherit parent-shell `GH_REPO`.** `main.test.ts` clears `GH_REPO` in `beforeEach` so config-error cases stay deterministic when maintainers or release Step 5 run `task check` with orchestration env set. Closes #2579.
-=======
-<<<<<<< HEAD
->>>>>>> 962e48e2 (fix(release): Step 3 rate-limit retry and actionable FAIL (#2577))
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` mid-suite (#2580).** Native Windows `task check` coverage runs now pre-create and keep `coverage/.tmp` via globalSetup, serialize v8 `processingConcurrency`, and cap fork workers when `--coverage` is active so green suites are not blocked by temp-directory races; coverage thresholds still fail closed. Closes #2580.
-=======
 - **Release Step 3 retries once when GitHub REST core rate limit is exhausted (#2577).** `task release` Step 3 (`Pre-flight vBRIEF lifecycle sync`) now sleeps once (capped at 120s) and retries issue-state fetch on HTTP 403 rate-limit errors instead of failing immediately. Persistent exhaustion emits actionable stderr with `gh api rate_limit` probe output and documents that `--allow-vbrief-drift` is appropriate after local `task vbrief:validate` is green. Closes #2577.
->>>>>>> c21d301f (fix(release): Step 3 rate-limit retry and actionable FAIL (#2577))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+<<<<<<< HEAD
 - **pr-wait-mergeable unit tests no longer inherit parent-shell `GH_REPO`.** `main.test.ts` clears `GH_REPO` in `beforeEach` so config-error cases stay deterministic when maintainers or release Step 5 run `task check` with orchestration env set. Closes #2579.
+=======
+<<<<<<< HEAD
+>>>>>>> 962e48e2 (fix(release): Step 3 rate-limit retry and actionable FAIL (#2577))
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` mid-suite (#2580).** Native Windows `task check` coverage runs now pre-create and keep `coverage/.tmp` via globalSetup, serialize v8 `processingConcurrency`, and cap fork workers when `--coverage` is active so green suites are not blocked by temp-directory races; coverage thresholds still fail closed. Closes #2580.
+=======
+- **Release Step 3 retries once when GitHub REST core rate limit is exhausted (#2577).** `task release` Step 3 (`Pre-flight vBRIEF lifecycle sync`) now sleeps once (capped at 120s) and retries issue-state fetch on HTTP 403 rate-limit errors instead of failing immediately. Persistent exhaustion emits actionable stderr with `gh api rate_limit` probe output and documents that `--allow-vbrief-drift` is appropriate after local `task vbrief:validate` is green. Closes #2577.
+>>>>>>> c21d301f (fix(release): Step 3 rate-limit retry and actionable FAIL (#2577))
 
 ### Removed
 

--- a/content/commands.md
+++ b/content/commands.md
@@ -282,6 +282,8 @@ flowchart TD
 - `task packs:*` -- render and verify content packs.
 - `task pr:*` -- protected issue checks, closing-keyword checks, merge readiness, and merge helpers.
 - `task release:*` -- release, publish, rollback, and e2e release rehearsal.
+  - Step 3 (`Pre-flight vBRIEF lifecycle sync`) fetches GitHub issue states via REST. On HTTP 403 rate-limit exhaustion it sleeps once (capped at 120s) and retries before failing.
+  - When Step 3 still fails with rate-limit exhaustion, stderr includes a `gh api rate_limit` probe (`core.remaining`, reset time) and recovery guidance. After local `task vbrief:validate` (or `task xbrief:validate`) exits 0, operators may pass `--allow-vbrief-drift` to skip Step 3 for that cut — reserved for transient SCM bucket stalls, not unreviewed lifecycle drift.
 - `task swarm:*` -- readiness, launch, review-clean verification, and cohort completion.
 - `task slice:*` -- feature-slice helpers.
 - `task policy:*` and `task capacity:*` -- policy inspection and allocation helpers.

--- a/packages/core/src/release/issue-state-fetch.test.ts
+++ b/packages/core/src/release/issue-state-fetch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CompletedProcess } from "../scm/call.js";
 import { IssueState } from "../intake/reconcile-issues.js";
+import type { CompletedProcess } from "../scm/call.js";
 import {
   computeRateLimitSleepSeconds,
   fetchIssueStatesForRelease,
@@ -69,7 +69,7 @@ describe("issue-state-fetch", () => {
     const sleep = vi.fn();
     const now = vi.fn().mockReturnValue(2_000_000_000);
     let issueCalls = 0;
-    const scmCall = vi.fn((source: string, verb: string, args: readonly string[] | null) => {
+    const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[] | null) => {
       if (args?.[0] === "rate_limit") {
         return completed(
           JSON.stringify({
@@ -104,7 +104,7 @@ describe("issue-state-fetch", () => {
   it("fetchIssueStatesForRelease emits actionable failure after retry still rate-limited", () => {
     const sleep = vi.fn();
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    const scmCall = vi.fn((source: string, verb: string, args: readonly string[] | null) => {
+    const scmCall = vi.fn((_source: string, _verb: string, args: readonly string[] | null) => {
       if (args?.[0] === "rate_limit") {
         return completed(
           JSON.stringify({
@@ -154,7 +154,10 @@ describe("issue-state-fetch", () => {
     const scmCall = vi
       .fn()
       .mockReturnValue(completed(JSON.stringify({ state: "closed", state_reason: "completed" })));
-    const result = fetchIssueStatesForRelease("deftai/directive", new Set([11]), { scmCall, sleep });
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([11]), {
+      scmCall,
+      sleep,
+    });
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.states.get(11)).toEqual(new IssueState("CLOSED", "COMPLETED"));

--- a/packages/core/src/release/issue-state-fetch.test.ts
+++ b/packages/core/src/release/issue-state-fetch.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CompletedProcess } from "../scm/call.js";
+import { IssueState } from "../intake/reconcile-issues.js";
+import {
+  computeRateLimitSleepSeconds,
+  fetchIssueStatesForRelease,
+  formatRateLimitFailureDetails,
+  MAX_RATE_LIMIT_RETRY_SLEEP_S,
+  probeGithubRateLimit,
+} from "./issue-state-fetch.js";
+
+function completed(stdout = "", stderr = "", returncode = 0): CompletedProcess {
+  return { args: [], returncode, stdout, stderr };
+}
+
+const RATE_LIMIT_STDERR =
+  "gh: API rate limit exceeded for user (HTTP 403)\nX-RateLimit-Reset: 2000000300\n";
+
+describe("issue-state-fetch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("probeGithubRateLimit parses core and graphql remaining", () => {
+    const scmCall = vi.fn().mockReturnValue(
+      completed(
+        JSON.stringify({
+          resources: {
+            core: { remaining: 0, reset: 2000000300 },
+            graphql: { remaining: 4933, reset: 2000000300 },
+          },
+        }),
+      ),
+    );
+    const probe = probeGithubRateLimit(scmCall);
+    expect(probe).toEqual({
+      coreRemaining: 0,
+      coreResetUnix: 2000000300,
+      graphqlRemaining: 4933,
+    });
+    expect(scmCall).toHaveBeenCalledWith("github-issue", "api", ["rate_limit"], {
+      timeout: 30,
+      cwd: undefined,
+    });
+  });
+
+  it("computeRateLimitSleepSeconds caps at MAX_RATE_LIMIT_RETRY_SLEEP_S", () => {
+    const nowSec = 2_000_000_000;
+    const probe = { coreRemaining: 0, coreResetUnix: nowSec + 900, graphqlRemaining: 100 };
+    const sleepS = computeRateLimitSleepSeconds(RATE_LIMIT_STDERR, probe, nowSec);
+    expect(sleepS).toBe(MAX_RATE_LIMIT_RETRY_SLEEP_S);
+  });
+
+  it("computeRateLimitSleepSeconds returns 0 when not rate-limited", () => {
+    expect(computeRateLimitSleepSeconds("404 Not Found", null, 1_700_000_000)).toBe(0);
+  });
+
+  it("formatRateLimitFailureDetails includes vbrief:validate and allow-vbrief-drift guidance", () => {
+    const details = formatRateLimitFailureDetails(
+      { coreRemaining: 0, coreResetUnix: 2_000_000_300, graphqlRemaining: 4933 },
+      true,
+    );
+    expect(details).toContain("core.remaining=0");
+    expect(details).toContain("task vbrief:validate");
+    expect(details).toContain("--allow-vbrief-drift");
+  });
+
+  it("fetchIssueStatesForRelease retries once after rate-limit sleep", () => {
+    const sleep = vi.fn();
+    const now = vi.fn().mockReturnValue(2_000_000_000);
+    let issueCalls = 0;
+    const scmCall = vi.fn((source: string, verb: string, args: readonly string[] | null) => {
+      if (args?.[0] === "rate_limit") {
+        return completed(
+          JSON.stringify({
+            resources: {
+              core: { remaining: 0, reset: 2_000_000_060 },
+              graphql: { remaining: 4933, reset: 2_000_000_060 },
+            },
+          }),
+        );
+      }
+      issueCalls += 1;
+      if (issueCalls === 1) {
+        return completed("", RATE_LIMIT_STDERR, 1);
+      }
+      return completed(JSON.stringify({ state: "open", state_reason: null }));
+    });
+
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([206]), {
+      scmCall,
+      sleep,
+      now,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.states.get(206)?.value).toBe("OPEN");
+    }
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(issueCalls).toBe(2);
+  });
+
+  it("fetchIssueStatesForRelease emits actionable failure after retry still rate-limited", () => {
+    const sleep = vi.fn();
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const scmCall = vi.fn((source: string, verb: string, args: readonly string[] | null) => {
+      if (args?.[0] === "rate_limit") {
+        return completed(
+          JSON.stringify({
+            resources: {
+              core: { remaining: 0, reset: 2_000_000_300 },
+              graphql: { remaining: 4933, reset: 2_000_000_300 },
+            },
+          }),
+        );
+      }
+      return completed("", RATE_LIMIT_STDERR, 1);
+    });
+
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([206]), {
+      scmCall,
+      sleep,
+      now: () => 2_000_000_000,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("rate limit exhausted");
+    }
+    expect(sleep).toHaveBeenCalledTimes(1);
+    const stderrText = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(stderrText).toContain("core.remaining=0");
+    expect(stderrText).toContain("--allow-vbrief-drift");
+    stderrSpy.mockRestore();
+  });
+
+  it("fetchIssueStatesForRelease does not retry on non-rate-limit failures", () => {
+    const sleep = vi.fn();
+    const scmCall = vi.fn().mockReturnValue(completed("", "auth failed", 1));
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([1]), {
+      scmCall,
+      sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("failed to fetch issue states from gh");
+    }
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("fetchIssueStatesForRelease succeeds without retry when first fetch works", () => {
+    const sleep = vi.fn();
+    const scmCall = vi
+      .fn()
+      .mockReturnValue(completed(JSON.stringify({ state: "closed", state_reason: "completed" })));
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([11]), { scmCall, sleep });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.states.get(11)).toEqual(new IssueState("CLOSED", "COMPLETED"));
+    }
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/release/issue-state-fetch.test.ts
+++ b/packages/core/src/release/issue-state-fetch.test.ts
@@ -135,6 +135,22 @@ describe("issue-state-fetch", () => {
     stderrSpy.mockRestore();
   });
 
+  it("fetchIssueStatesForRelease does not probe rate_limit on non-rate-limit failures", () => {
+    const sleep = vi.fn();
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const scmCall = vi.fn().mockReturnValue(completed("", "auth failed", 1));
+    const result = fetchIssueStatesForRelease("deftai/directive", new Set([1]), {
+      scmCall,
+      sleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(scmCall).toHaveBeenCalledTimes(1);
+    const stderrText = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(stderrText).not.toContain("rate limit probe");
+    expect(stderrText).not.toContain("--allow-vbrief-drift");
+    stderrSpy.mockRestore();
+  });
+
   it("fetchIssueStatesForRelease does not retry on non-rate-limit failures", () => {
     const sleep = vi.fn();
     const scmCall = vi.fn().mockReturnValue(completed("", "auth failed", 1));

--- a/packages/core/src/release/issue-state-fetch.ts
+++ b/packages/core/src/release/issue-state-fetch.ts
@@ -1,0 +1,209 @@
+/**
+ * Release Step 3 issue-state fetch with capped rate-limit retry (#2577).
+ */
+import { detectRateLimit } from "../cache/fetch.js";
+import {
+  fetchIssueStates,
+  type FetchIssueStatesOptions,
+} from "../intake/reconcile-issues.js";
+import { call, type CallOptions, type CompletedProcess } from "../scm/call.js";
+
+export type ScmCallFn = (
+  source: string,
+  verb: string,
+  args: readonly string[] | null,
+  options?: CallOptions,
+) => CompletedProcess;
+
+/** Max seconds to sleep before the single rate-limit retry (operator-locked cap). */
+export const MAX_RATE_LIMIT_RETRY_SLEEP_S = 120;
+
+const X_RATE_LIMIT_RESET_RE = /X-RateLimit-Reset:\s*(\d+)/i;
+
+export type SleepFn = (seconds: number) => void;
+
+export interface RateLimitProbe {
+  readonly coreRemaining: number | null;
+  readonly coreResetUnix: number | null;
+  readonly graphqlRemaining: number | null;
+}
+
+export interface FetchIssueStatesForReleaseOptions extends FetchIssueStatesOptions {
+  readonly sleep?: SleepFn;
+  readonly now?: () => number;
+}
+
+export type FetchIssueStatesForReleaseResult =
+  | { readonly ok: true; readonly states: Map<number, import("../intake/reconcile-issues.js").IssueState> }
+  | { readonly ok: false; readonly reason: string };
+
+function defaultSleep(seconds: number): void {
+  const ms = Math.max(0, Math.trunc(seconds * 1000));
+  if (ms === 0) {
+    return;
+  }
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, ms);
+}
+
+function parseRateLimitProbe(stdout: string): RateLimitProbe | null {
+  try {
+    const body = JSON.parse(stdout) as unknown;
+    if (typeof body !== "object" || body === null) {
+      return null;
+    }
+    const resources = (body as { resources?: unknown }).resources;
+    if (typeof resources !== "object" || resources === null) {
+      return null;
+    }
+    const core = (resources as { core?: unknown }).core;
+    const graphql = (resources as { graphql?: unknown }).graphql;
+    if (
+      typeof core !== "object" ||
+      core === null ||
+      Array.isArray(core) ||
+      typeof graphql !== "object" ||
+      graphql === null ||
+      Array.isArray(graphql)
+    ) {
+      return null;
+    }
+    const coreRemainingRaw = (core as { remaining?: unknown }).remaining;
+    const coreResetRaw = (core as { reset?: unknown }).reset;
+    const graphqlRemainingRaw = (graphql as { remaining?: unknown }).remaining;
+    const coreRemaining =
+      coreRemainingRaw === undefined ? null : Number.parseInt(String(coreRemainingRaw), 10);
+    const coreResetUnix =
+      coreResetRaw === undefined ? null : Number.parseInt(String(coreResetRaw), 10);
+    const graphqlRemaining =
+      graphqlRemainingRaw === undefined
+        ? null
+        : Number.parseInt(String(graphqlRemainingRaw), 10);
+    if (
+      (coreRemaining !== null && Number.isNaN(coreRemaining)) ||
+      (coreResetUnix !== null && Number.isNaN(coreResetUnix)) ||
+      (graphqlRemaining !== null && Number.isNaN(graphqlRemaining))
+    ) {
+      return null;
+    }
+    return { coreRemaining, coreResetUnix, graphqlRemaining };
+  } catch {
+    return null;
+  }
+}
+
+export function probeGithubRateLimit(
+  scmCall: ScmCallFn,
+  cwd?: string,
+): RateLimitProbe | null {
+  let result: CompletedProcess;
+  try {
+    result = scmCall("github-issue", "api", ["rate_limit"], { timeout: 30, cwd });
+  } catch {
+    return null;
+  }
+  if (result.returncode !== 0 || result.stdout.trim().length === 0) {
+    return null;
+  }
+  return parseRateLimitProbe(result.stdout);
+}
+
+export function computeRateLimitSleepSeconds(
+  stderr: string,
+  probe: RateLimitProbe | null,
+  nowSec: number,
+): number {
+  const [isRateLimit, retryAfter] = detectRateLimit(stderr);
+  if (!isRateLimit) {
+    return 0;
+  }
+  let candidate = retryAfter;
+  const resetMatch = X_RATE_LIMIT_RESET_RE.exec(stderr);
+  if (resetMatch?.[1]) {
+    const resetAt = Number.parseInt(resetMatch[1], 10);
+    if (!Number.isNaN(resetAt)) {
+      candidate = Math.max(0, resetAt - nowSec + 1);
+    }
+  } else if (probe !== null && probe.coreResetUnix !== null) {
+    candidate = Math.max(0, probe.coreResetUnix - nowSec + 1);
+  }
+  return Math.min(Math.max(1, candidate), MAX_RATE_LIMIT_RETRY_SLEEP_S);
+}
+
+export function formatRateLimitFailureDetails(
+  probe: RateLimitProbe | null,
+  rateLimitRelated: boolean,
+): string {
+  const lines: string[] = [];
+  if (probe !== null) {
+    const resetHint =
+      probe.coreResetUnix !== null
+        ? `core resets at ${new Date(probe.coreResetUnix * 1000).toISOString()}`
+        : "run `gh api rate_limit` for reset time";
+    lines.push(
+      `GitHub rate limit probe: core.remaining=${probe.coreRemaining ?? "?"} graphql.remaining=${probe.graphqlRemaining ?? "?"} (${resetHint})`,
+    );
+  } else {
+    lines.push("Probe `gh api rate_limit` for core.remaining and reset time.");
+  }
+  if (rateLimitRelated) {
+    lines.push(
+      "Recovery: wait for the REST core bucket to reset, then re-run `task release`.",
+    );
+    lines.push(
+      "If local lifecycle validation is clean (`task vbrief:validate` exits 0), you may pass `--allow-vbrief-drift` to skip Step 3 for this cut.",
+    );
+  }
+  return lines.join("\n");
+}
+
+export function fetchIssueStatesForRelease(
+  repo: string,
+  issueNumbers: ReadonlySet<number>,
+  options: FetchIssueStatesForReleaseOptions = {},
+): FetchIssueStatesForReleaseResult {
+  const sleepFn = options.sleep ?? defaultSleep;
+  const nowFn = options.now ?? (() => Math.floor(Date.now() / 1000));
+  const baseScmCall = options.scmCall ?? call;
+  const cwd = options.cwd ?? undefined;
+  let sawRateLimit = false;
+  let lastRateLimitStderr = "";
+
+  const trackingScmCall: ScmCallFn = (source, verb, args, callOptions) => {
+    const result = baseScmCall(source, verb, args, callOptions);
+    if (result.returncode !== 0 && detectRateLimit(result.stderr)[0]) {
+      sawRateLimit = true;
+      lastRateLimitStderr = result.stderr;
+    }
+    return result;
+  };
+
+  let states = fetchIssueStates(repo, issueNumbers, { ...options, scmCall: trackingScmCall });
+  if (states !== null) {
+    return { ok: true, states };
+  }
+
+  if (sawRateLimit) {
+    const probe = probeGithubRateLimit(baseScmCall, cwd);
+    const sleepS = computeRateLimitSleepSeconds(lastRateLimitStderr, probe, nowFn());
+    process.stderr.write(
+      `[release Step 3] GitHub REST rate limit hit; sleeping ${sleepS}s before one retry\n`,
+    );
+    sleepFn(sleepS);
+    sawRateLimit = false;
+    lastRateLimitStderr = "";
+    states = fetchIssueStates(repo, issueNumbers, { ...options, scmCall: trackingScmCall });
+    if (states !== null) {
+      return { ok: true, states };
+    }
+  }
+
+  const rateLimitRelated = sawRateLimit || lastRateLimitStderr.length > 0;
+  const probe = probeGithubRateLimit(baseScmCall, cwd);
+  const details = formatRateLimitFailureDetails(probe, rateLimitRelated);
+  process.stderr.write(`${details}\n`);
+  const reason = rateLimitRelated
+    ? "GitHub REST rate limit exhausted (see stderr for recovery steps)"
+    : "failed to fetch issue states from gh";
+  return { ok: false, reason };
+}

--- a/packages/core/src/release/issue-state-fetch.ts
+++ b/packages/core/src/release/issue-state-fetch.ts
@@ -2,11 +2,8 @@
  * Release Step 3 issue-state fetch with capped rate-limit retry (#2577).
  */
 import { detectRateLimit } from "../cache/fetch.js";
-import {
-  fetchIssueStates,
-  type FetchIssueStatesOptions,
-} from "../intake/reconcile-issues.js";
-import { call, type CallOptions, type CompletedProcess } from "../scm/call.js";
+import { type FetchIssueStatesOptions, fetchIssueStates } from "../intake/reconcile-issues.js";
+import { type CallOptions, type CompletedProcess, call } from "../scm/call.js";
 
 export type ScmCallFn = (
   source: string,
@@ -34,7 +31,10 @@ export interface FetchIssueStatesForReleaseOptions extends FetchIssueStatesOptio
 }
 
 export type FetchIssueStatesForReleaseResult =
-  | { readonly ok: true; readonly states: Map<number, import("../intake/reconcile-issues.js").IssueState> }
+  | {
+      readonly ok: true;
+      readonly states: Map<number, import("../intake/reconcile-issues.js").IssueState>;
+    }
   | { readonly ok: false; readonly reason: string };
 
 function defaultSleep(seconds: number): void {
@@ -76,9 +76,7 @@ function parseRateLimitProbe(stdout: string): RateLimitProbe | null {
     const coreResetUnix =
       coreResetRaw === undefined ? null : Number.parseInt(String(coreResetRaw), 10);
     const graphqlRemaining =
-      graphqlRemainingRaw === undefined
-        ? null
-        : Number.parseInt(String(graphqlRemainingRaw), 10);
+      graphqlRemainingRaw === undefined ? null : Number.parseInt(String(graphqlRemainingRaw), 10);
     if (
       (coreRemaining !== null && Number.isNaN(coreRemaining)) ||
       (coreResetUnix !== null && Number.isNaN(coreResetUnix)) ||
@@ -92,10 +90,7 @@ function parseRateLimitProbe(stdout: string): RateLimitProbe | null {
   }
 }
 
-export function probeGithubRateLimit(
-  scmCall: ScmCallFn,
-  cwd?: string,
-): RateLimitProbe | null {
+export function probeGithubRateLimit(scmCall: ScmCallFn, cwd?: string): RateLimitProbe | null {
   let result: CompletedProcess;
   try {
     result = scmCall("github-issue", "api", ["rate_limit"], { timeout: 30, cwd });
@@ -147,9 +142,7 @@ export function formatRateLimitFailureDetails(
     lines.push("Probe `gh api rate_limit` for core.remaining and reset time.");
   }
   if (rateLimitRelated) {
-    lines.push(
-      "Recovery: wait for the REST core bucket to reset, then re-run `task release`.",
-    );
+    lines.push("Recovery: wait for the REST core bucket to reset, then re-run `task release`.");
     lines.push(
       "If local lifecycle validation is clean (`task vbrief:validate` exits 0), you may pass `--allow-vbrief-drift` to skip Step 3 for this cut.",
     );

--- a/packages/core/src/release/issue-state-fetch.ts
+++ b/packages/core/src/release/issue-state-fetch.ts
@@ -192,11 +192,14 @@ export function fetchIssueStatesForRelease(
   }
 
   const rateLimitRelated = sawRateLimit || lastRateLimitStderr.length > 0;
-  const probe = probeGithubRateLimit(baseScmCall, cwd);
-  const details = formatRateLimitFailureDetails(probe, rateLimitRelated);
-  process.stderr.write(`${details}\n`);
-  const reason = rateLimitRelated
-    ? "GitHub REST rate limit exhausted (see stderr for recovery steps)"
-    : "failed to fetch issue states from gh";
-  return { ok: false, reason };
+  if (rateLimitRelated) {
+    const probe = probeGithubRateLimit(baseScmCall, cwd);
+    const details = formatRateLimitFailureDetails(probe, true);
+    process.stderr.write(`${details}\n`);
+    return {
+      ok: false,
+      reason: "GitHub REST rate limit exhausted (see stderr for recovery steps)",
+    };
+  }
+  return { ok: false, reason: "failed to fetch issue states from gh" };
 }

--- a/packages/core/src/release/native-steps.test.ts
+++ b/packages/core/src/release/native-steps.test.ts
@@ -137,16 +137,6 @@ describe("native release steps", () => {
     expect(msg).toContain("scan boom");
   });
 
-  it("checkVbriefLifecycleSyncNative handles entry without vbrief_files", () => {
-    // Entry with undefined vbrief_files — exercises the `?? []` branch
-    mockScanVbriefDir.mockReturnValue(new Map());
-    mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
-    mockReconcile.mockReturnValue({ no_open_issue: [{}] });
-    const [ok, count] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
-    expect(ok).toBe(true);
-    expect(count).toBe(0);
-  });
-
   it("checkVbriefLifecycleSyncNative catches non-Error throws", () => {
     // Exercises the String(err) branch in catch (err instanceof Error = false)
     mockScanVbriefDir.mockImplementation(() => {

--- a/packages/core/src/release/native-steps.test.ts
+++ b/packages/core/src/release/native-steps.test.ts
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockRenderRoadmap = vi.fn();
 const mockScanVbriefDir = vi.fn();
-const mockFetchIssueStates = vi.fn();
 const mockReconcile = vi.fn();
 const mockIsTerminalLifecyclePath = vi.fn();
 
@@ -16,9 +15,14 @@ vi.mock("../render/roadmap-render.js", () => ({
 
 vi.mock("../intake/reconcile-issues.js", () => ({
   scanVbriefDir: (...args: unknown[]) => mockScanVbriefDir(...args),
-  fetchIssueStates: (...args: unknown[]) => mockFetchIssueStates(...args),
   reconcile: (...args: unknown[]) => mockReconcile(...args),
   isTerminalLifecyclePath: (...args: unknown[]) => mockIsTerminalLifecyclePath(...args),
+}));
+
+const mockFetchIssueStatesForRelease = vi.fn();
+
+vi.mock("./issue-state-fetch.js", () => ({
+  fetchIssueStatesForRelease: (...args: unknown[]) => mockFetchIssueStatesForRelease(...args),
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -53,7 +57,7 @@ describe("native release steps", () => {
 
   it("checkVbriefLifecycleSyncNative reports no mismatches", () => {
     mockScanVbriefDir.mockReturnValue(new Map());
-    mockFetchIssueStates.mockReturnValue({});
+    mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
     mockReconcile.mockReturnValue({ no_open_issue: [] });
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
     expect(ok).toBe(true);
@@ -76,16 +80,31 @@ describe("native release steps", () => {
 
   it("checkVbriefLifecycleSyncNative fails when gh fetch returns null", () => {
     mockScanVbriefDir.mockReturnValue(new Map([[1, []]]));
-    mockFetchIssueStates.mockReturnValue(null);
+    mockFetchIssueStatesForRelease.mockReturnValue({
+      ok: false,
+      reason: "failed to fetch issue states from gh",
+    });
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
     expect(ok).toBe(false);
     expect(count).toBe(-1);
     expect(msg).toContain("failed to fetch issue states");
   });
 
+  it("checkVbriefLifecycleSyncNative surfaces rate-limit failure reason", () => {
+    mockScanVbriefDir.mockReturnValue(new Map([[1, []]]));
+    mockFetchIssueStatesForRelease.mockReturnValue({
+      ok: false,
+      reason: "GitHub REST rate limit exhausted (see stderr for recovery steps)",
+    });
+    const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
+    expect(ok).toBe(false);
+    expect(count).toBe(-1);
+    expect(msg).toContain("rate limit exhausted");
+  });
+
   it("checkVbriefLifecycleSyncNative reports lifecycle mismatches", () => {
     mockScanVbriefDir.mockReturnValue(new Map());
-    mockFetchIssueStates.mockReturnValue({});
+    mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
     mockReconcile.mockReturnValue({
       no_open_issue: [{ vbrief_files: ["xbrief/active/a.xbrief.json"] }],
     });
@@ -99,7 +118,7 @@ describe("native release steps", () => {
   it("checkVbriefLifecycleSyncNative truncates mismatch preview beyond five", () => {
     const files = Array.from({ length: 6 }, (_, i) => `xbrief/active/story-${i}.xbrief.json`);
     mockScanVbriefDir.mockReturnValue(new Map());
-    mockFetchIssueStates.mockReturnValue({});
+    mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
     mockReconcile.mockReturnValue({ no_open_issue: [{ vbrief_files: files }] });
     mockIsTerminalLifecyclePath.mockReturnValue(false);
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
@@ -121,7 +140,7 @@ describe("native release steps", () => {
   it("checkVbriefLifecycleSyncNative handles entry without vbrief_files", () => {
     // Entry with undefined vbrief_files — exercises the `?? []` branch
     mockScanVbriefDir.mockReturnValue(new Map());
-    mockFetchIssueStates.mockReturnValue({});
+    mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
     mockReconcile.mockReturnValue({ no_open_issue: [{}] });
     const [ok, count] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
     expect(ok).toBe(true);
@@ -142,7 +161,7 @@ describe("native release steps", () => {
   it("checkVbriefLifecycleSyncNative handles entry without vbrief_files", () => {
     // Entry with undefined vbrief_files — exercises the `?? []` branch
     mockScanVbriefDir.mockReturnValue(new Map());
-    mockFetchIssueStates.mockReturnValue({});
+    mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
     mockReconcile.mockReturnValue({ no_open_issue: [{}] });
     const [ok, count] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
     expect(ok).toBe(true);

--- a/packages/core/src/release/native-steps.ts
+++ b/packages/core/src/release/native-steps.ts
@@ -7,11 +7,11 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  fetchIssueStates,
   isTerminalLifecyclePath,
   reconcile,
   scanVbriefDir,
 } from "../intake/reconcile-issues.js";
+import { fetchIssueStatesForRelease } from "./issue-state-fetch.js";
 import {
   LEGACY_ARTIFACT_DIR,
   MIGRATED_ARTIFACT_DIR,
@@ -53,12 +53,13 @@ export function checkVbriefLifecycleSyncNative(
   }
   try {
     const issueToVbriefs = scanVbriefDir(vbriefDir);
-    const issueStateMap = fetchIssueStates(repo, new Set(issueToVbriefs.keys()), {
+    const fetchResult = fetchIssueStatesForRelease(repo, new Set(issueToVbriefs.keys()), {
       cwd: projectRoot,
     });
-    if (issueStateMap === null) {
-      return [false, -1, "failed to fetch issue states from gh"];
+    if (!fetchResult.ok) {
+      return [false, -1, fetchResult.reason];
     }
+    const issueStateMap = fetchResult.states;
     const report = reconcile(issueToVbriefs, issueStateMap);
     const mismatches: string[] = [];
     for (const entry of report.no_open_issue) {

--- a/packages/core/src/release/native-steps.ts
+++ b/packages/core/src/release/native-steps.ts
@@ -6,12 +6,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  isTerminalLifecyclePath,
-  reconcile,
-  scanVbriefDir,
-} from "../intake/reconcile-issues.js";
-import { fetchIssueStatesForRelease } from "./issue-state-fetch.js";
+import { isTerminalLifecyclePath, reconcile, scanVbriefDir } from "../intake/reconcile-issues.js";
 import {
   LEGACY_ARTIFACT_DIR,
   MIGRATED_ARTIFACT_DIR,
@@ -19,6 +14,7 @@ import {
   resolveLifecycleRoot,
 } from "../layout/resolve.js";
 import { renderRoadmap } from "../render/roadmap-render.js";
+import { fetchIssueStatesForRelease } from "./issue-state-fetch.js";
 import type { ReleaseSeams } from "./types.js";
 
 const BUILD_DIST_RUNNER = join(dirname(fileURLToPath(import.meta.url)), "build-dist-runner.js");

--- a/xbrief/active/2026-07-15-2577-release-step3-rate-limit-backoff.xbrief.json
+++ b/xbrief/active/2026-07-15-2577-release-step3-rate-limit-backoff.xbrief.json
@@ -1,0 +1,76 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF from GitHub issue #2577 (swarm cohort afk-wave1-2566-2581)",
+    "updated": "2026-07-15T20:00:00Z"
+  },
+  "plan": {
+    "title": "release: Step 3 lifecycle sync hard-fails when GitHub REST core rate limit is exhausted",
+    "status": "running",
+    "narratives": {
+      "Description": "Add capped sleep+retry on HTTP 403 rate-limit during release Step 3 issue-state fetch, actionable FAIL text with rate_limit probe, and document --allow-vbrief-drift escape after local vbrief:validate is green.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2577",
+      "Overview": "## Problem\n\n`task release` Step 3 (`Pre-flight vBRIEF lifecycle sync`) hard-failed during the v0.78.0 cut when gh REST returned HTTP 403 API rate limit exceeded while `core.remaining: 0`.\n\n## Expected\n\n- One capped sleep+retry on HTTP 403 rate-limit during issue-state fetch\n- Actionable FAIL text with remaining/reset + `gh api rate_limit` probe\n- `--allow-vbrief-drift` documented as escape after local `vbrief:validate` is green\n",
+      "Labels": "bug, blocks-release-tag, operational, scm, github, area:release, release",
+      "UserStory": "As a release operator, I want Step 3 lifecycle sync to retry once on REST core rate-limit exhaustion and emit actionable recovery guidance, so that a transient bucket stall does not force a multi-hour cut with no in-pipeline backoff.",
+      "ImplementationPlan": "1. Add release/issue-state-fetch.ts with capped rate-limit retry and actionable failure formatting.\n2. Wire checkVbriefLifecycleSyncNative to use the release fetch wrapper.\n3. Document --allow-vbrief-drift rate-limit escape in content/commands.md.\n4. Add unit tests and CHANGELOG entry.",
+      "Acceptance": "1. Capped retry on HTTP 403 rate-limit during Step 3 issue-state fetch\n2. Actionable FAIL text with rate_limit probe guidance\n3. Drift escape documented in commands.md\n4. Tests and CHANGELOG"
+    },
+    "items": [
+      {
+        "title": "Capped rate-limit retry",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given REST core rate-limit exhaustion (HTTP 403), when Step 3 fetches issue states, then it sleeps once (capped) and retries before failing."
+        }
+      },
+      {
+        "title": "Actionable FAIL text",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given retry still fails, when Step 3 emits FAIL, then stderr includes core remaining/reset from gh api rate_limit and recovery guidance including --allow-vbrief-drift after vbrief:validate green."
+        }
+      },
+      {
+        "title": "Docs and regression tests",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given commands.md and unit tests, when operators read release docs or CI runs, then drift escape and retry behavior are covered."
+        }
+      }
+    ],
+    "tags": ["bug", "blocks-release-tag", "operational", "scm", "github", "area:release", "release"],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2577",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2577: release Step 3 lifecycle sync hard-fails when GitHub REST core rate limit is exhausted"
+      }
+    ],
+    "updated": "2026-07-15T20:00:00Z",
+    "id": "release-step3-rate-limit-backoff",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/release/",
+          "content/commands.md"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- issue-state-fetch",
+          "pnpm --filter @deftai/directive-core test -- native-steps"
+        ],
+        "expected_outputs": [
+          "Capped retry on REST 403 rate-limit",
+          "Actionable FAIL with rate_limit probe",
+          "commands.md drift escape docs"
+        ],
+        "depends_on": [],
+        "conflict_group": "release-step3",
+        "size": "S"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release Step 3 (`Pre-flight vBRIEF lifecycle sync`) now handles GitHub REST core rate-limit exhaustion without immediately hard-failing the cut.

## Changes

- Add `packages/core/src/release/issue-state-fetch.ts` with one capped (120s) sleep+retry on HTTP 403 rate-limit during issue-state fetch
- Wire `checkVbriefLifecycleSyncNative` through the new wrapper
- On persistent failure, emit actionable stderr with `gh api rate_limit` probe output and recovery guidance (including `--allow-vbrief-drift` after local `task vbrief:validate` is green)
- Document the rate-limit recovery path in `content/commands.md`
- Add unit tests and CHANGELOG entry

Closes #2577
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba98f118-384e-44c8-93ba-71ff76cd2681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba98f118-384e-44c8-93ba-71ff76cd2681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

