### PR TITLE
fix(session): print working cache fetch-all recovery for gated ritual (#2574)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Gated session ritual `cache_fresh` failures now print a runnable recovery command (`deft cache fetch-all --source github-issue --repo OWNER/NAME`) instead of the unknown `deft cache:fetch-all` colon alias. Closes #2574.
 - **completed/ lifecycle moves stamp terminal plan.status atomically (#2578).** `scope:complete` and `scope:fail` now write `plan.status=completed|failed` directly at the destination path instead of pre-stamping the source file before rename, so xBRIEFs never appear under `completed/` with non-terminal status. `task reconcile:issues` reports `completed/` D2 drift and `--apply-lifecycle-fixes` repairs in-place. Closes #2578.
 - **pr-wait-mergeable unit tests no longer inherit parent-shell `GH_REPO`.** `main.test.ts` clears `GH_REPO` in `beforeEach` so config-error cases stay deterministic when maintainers or release Step 5 run `task check` with orchestration env set. Closes #2579.
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` mid-suite (#2580).** Native Windows `task check` coverage runs now pre-create and keep `coverage/.tmp` via globalSetup, serialize v8 `processingConcurrency`, and cap fork workers when `--coverage` is active so green suites are not blocked by temp-directory races; coverage thresholds still fail closed. Closes #2580.

--- a/packages/core/src/preflight-cache/evaluate.test.ts
+++ b/packages/core/src/preflight-cache/evaluate.test.ts
@@ -205,7 +205,9 @@ describe("evaluate -- fresh cache", () => {
     expect(result.message).toContain("❌");
     expect(result.message).toContain("25.0h old");
     expect(result.message).toContain("oldest in-scope entry");
-    expect(result.message).toContain("cache fetch-all --source github-issue --repo owner/repo --force");
+    expect(result.message).toContain(
+      "cache fetch-all --source github-issue --repo owner/repo --force",
+    );
     expect(result.message).not.toContain("cache:fetch-all");
   });
 
@@ -376,10 +378,7 @@ describe("recoveryHintForStaleFailure -- branch-aware (#1953 / #2574)", () => {
   });
 
   it("mixed age+drift prefers cache fetch-all --force", () => {
-    const hint = recoveryHintForStaleFailure(
-      { ageStale: true, driftDetected: true },
-      "owner/repo",
-    );
+    const hint = recoveryHintForStaleFailure({ ageStale: true, driftDetected: true }, "owner/repo");
     expect(hint).toContain("cache fetch-all --source github-issue --repo owner/repo --force");
     expect(hint).not.toContain("cache:fetch-all");
   });

--- a/packages/core/src/preflight-cache/evaluate.test.ts
+++ b/packages/core/src/preflight-cache/evaluate.test.ts
@@ -205,7 +205,8 @@ describe("evaluate -- fresh cache", () => {
     expect(result.message).toContain("❌");
     expect(result.message).toContain("25.0h old");
     expect(result.message).toContain("oldest in-scope entry");
-    expect(result.message).toContain("cache:fetch-all --force");
+    expect(result.message).toContain("cache fetch-all --source github-issue --repo owner/repo --force");
+    expect(result.message).not.toContain("cache:fetch-all");
   });
 
   it("uses oldest in-scope entry age when newer entries exist", () => {
@@ -244,8 +245,9 @@ describe("evaluate -- fresh cache", () => {
     });
     expect(result.code).toBe(1);
     expect(result.message).toContain("stale-by-drift");
-    expect(result.message).toContain("cache:fetch-all");
-    expect(result.message).not.toContain("cache:fetch-all --force");
+    expect(result.message).toContain("cache fetch-all --source github-issue --repo owner/repo");
+    expect(result.message).not.toContain("cache:fetch-all");
+    expect(result.message).not.toContain("--force");
   });
 
   it("returns stale-by-drift for TTL-fresh content drift only", () => {
@@ -266,8 +268,9 @@ describe("evaluate -- fresh cache", () => {
     });
     expect(result.code).toBe(1);
     expect(result.message).toContain("TTL-fresh issue(s) with upstream content drift");
-    expect(result.message).toContain("cache:fetch-all");
-    expect(result.message).not.toContain("cache:fetch-all --force");
+    expect(result.message).toContain("cache fetch-all --source github-issue --repo owner/repo");
+    expect(result.message).not.toContain("cache:fetch-all");
+    expect(result.message).not.toContain("--force");
   });
 
   it("allows stale cache with drift when allowStale=true", () => {
@@ -352,21 +355,33 @@ describe("evaluate -- fresh cache", () => {
   });
 });
 
-describe("recoveryHintForStaleFailure -- branch-aware (#1953)", () => {
-  it("age-only failure names cache:fetch-all --force", () => {
-    const hint = recoveryHintForStaleFailure({ ageStale: true, driftDetected: false });
-    expect(hint).toContain("cache:fetch-all --force");
+describe("recoveryHintForStaleFailure -- branch-aware (#1953 / #2574)", () => {
+  it("age-only failure names cache fetch-all --force", () => {
+    const hint = recoveryHintForStaleFailure(
+      { ageStale: true, driftDetected: false },
+      "owner/repo",
+    );
+    expect(hint).toContain("cache fetch-all --source github-issue --repo owner/repo --force");
+    expect(hint).not.toContain("cache:fetch-all");
   });
 
-  it("drift-only failure names plain cache:fetch-all", () => {
-    const hint = recoveryHintForStaleFailure({ ageStale: false, driftDetected: true });
-    expect(hint).toContain("cache:fetch-all");
-    expect(hint).not.toContain("cache:fetch-all --force");
+  it("drift-only failure names plain cache fetch-all", () => {
+    const hint = recoveryHintForStaleFailure(
+      { ageStale: false, driftDetected: true },
+      "owner/repo",
+    );
+    expect(hint).toContain("cache fetch-all --source github-issue --repo owner/repo");
+    expect(hint).not.toContain("--force");
+    expect(hint).not.toContain("cache:fetch-all");
   });
 
-  it("mixed age+drift prefers cache:fetch-all --force", () => {
-    const hint = recoveryHintForStaleFailure({ ageStale: true, driftDetected: true });
-    expect(hint).toContain("cache:fetch-all --force");
+  it("mixed age+drift prefers cache fetch-all --force", () => {
+    const hint = recoveryHintForStaleFailure(
+      { ageStale: true, driftDetected: true },
+      "owner/repo",
+    );
+    expect(hint).toContain("cache fetch-all --source github-issue --repo owner/repo --force");
+    expect(hint).not.toContain("cache:fetch-all");
   });
 });
 

--- a/packages/core/src/preflight-cache/evaluate.ts
+++ b/packages/core/src/preflight-cache/evaluate.ts
@@ -18,6 +18,7 @@ import { isTriageCacheEmpty, maybeAutoPopulateEmptyCache } from "../cache/empty-
 import { type CacheDriftProbeResult, probeCacheDrift } from "../cache/fetch.js";
 import { resolveProjectDefinitionPath } from "../layout/resolve.js";
 import { recoveryHintForStaleFailure } from "../session/cache-recovery.js";
+
 export { recoveryHintForStaleFailure } from "../session/cache-recovery.js";
 
 import { readPlanPolicy } from "../policy/plan-extensions.js";

--- a/packages/core/src/preflight-cache/evaluate.ts
+++ b/packages/core/src/preflight-cache/evaluate.ts
@@ -17,6 +17,9 @@ import { join, relative } from "node:path";
 import { isTriageCacheEmpty, maybeAutoPopulateEmptyCache } from "../cache/empty-populate.js";
 import { type CacheDriftProbeResult, probeCacheDrift } from "../cache/fetch.js";
 import { resolveProjectDefinitionPath } from "../layout/resolve.js";
+import { recoveryHintForStaleFailure } from "../session/cache-recovery.js";
+export { recoveryHintForStaleFailure } from "../session/cache-recovery.js";
+
 import { readPlanPolicy } from "../policy/plan-extensions.js";
 import { latestDecisionForIssue as auditLatestDecisionForIssue } from "../triage/actions/candidates-log.js";
 import { resolveCandidatesLogPath } from "../triage/cache-path.js";
@@ -322,27 +325,6 @@ const REMEDIATION_NO_CACHE = ["  Recovery: run `deft triage:bootstrap` to seed t
   "\n",
 );
 
-const REMEDIATION_STALE_FORCE = [
-  "  Recovery: run `deft cache:fetch-all --force` to refresh and reconcile upstream state.",
-].join("\n");
-
-const REMEDIATION_STALE_PLAIN = [
-  "  Recovery: run `deft cache:fetch-all` to refresh and reconcile upstream state.",
-].join("\n");
-
-/**
- * Branch-aware recovery hint (#1953 Option 3).
- * Age-stale (or age+drift mixed) → --force bypasses TTL; drift-only → plain refetch.
- */
-export function recoveryHintForStaleFailure(
-  causes: Readonly<{ ageStale: boolean; driftDetected: boolean }>,
-): string {
-  if (causes.ageStale) {
-    return REMEDIATION_STALE_FORCE;
-  }
-  return REMEDIATION_STALE_PLAIN;
-}
-
 function formatDriftFailure(repo: string, drift: CacheDriftProbeResult): GateResult {
   const parts: string[] = [];
   if (drift.stateDriftNumbers.length > 0) {
@@ -357,7 +339,7 @@ function formatDriftFailure(repo: string, drift: CacheDriftProbeResult): GateRes
     code: 1,
     message: [
       `❌ deft cache-fresh: stale-by-drift -- ${parts.join("; ")} (${repo}).`,
-      recoveryHintForStaleFailure({ ageStale: false, driftDetected: true }),
+      recoveryHintForStaleFailure({ ageStale: false, driftDetected: true }, repo),
     ].join("\n"),
   };
 }
@@ -553,7 +535,7 @@ function evaluateWithContext(
       code: 1,
       message: [
         `❌ deft cache-fresh: cache is ${ageH.toFixed(1)}h old (max-age=${maxAgeHours}h); oldest in-scope entry ${display}.`,
-        recoveryHintForStaleFailure({ ageStale: true, driftDetected: false }),
+        recoveryHintForStaleFailure({ ageStale: true, driftDetected: false }, resolvedRepo),
       ].join("\n"),
     };
   }

--- a/packages/core/src/session/cache-recovery.test.ts
+++ b/packages/core/src/session/cache-recovery.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCacheFetchAllRecoveryCommand,
+  recoveryHintForStaleFailure,
+} from "./cache-recovery.js";
+
+describe("formatCacheFetchAllRecoveryCommand (#2574)", () => {
+  it("uses the space-separated CLI surface with required source and repo", () => {
+    expect(formatCacheFetchAllRecoveryCommand("deftai/directive")).toBe(
+      "deft cache fetch-all --source github-issue --repo deftai/directive",
+    );
+  });
+
+  it("appends --force when age-stale recovery is requested", () => {
+    expect(formatCacheFetchAllRecoveryCommand("deftai/cartograph", { force: true })).toBe(
+      "deft cache fetch-all --source github-issue --repo deftai/cartograph --force",
+    );
+  });
+
+  it("falls back to OWNER/NAME when repo is unresolved", () => {
+    expect(formatCacheFetchAllRecoveryCommand(null, { force: true })).toBe(
+      "deft cache fetch-all --source github-issue --repo OWNER/NAME --force",
+    );
+  });
+
+  it("never emits the unknown cache:fetch-all colon alias", () => {
+    const plain = formatCacheFetchAllRecoveryCommand("owner/repo");
+    const forced = formatCacheFetchAllRecoveryCommand("owner/repo", { force: true });
+    for (const cmd of [plain, forced]) {
+      expect(cmd).not.toContain("cache:fetch-all");
+      expect(cmd).toContain("cache fetch-all");
+      expect(cmd).toContain("--source github-issue");
+      expect(cmd).toContain("--repo");
+    }
+  });
+});
+
+describe("recoveryHintForStaleFailure -- branch-aware (#1953 / #2574)", () => {
+  it("age-only failure names cache fetch-all --force with repo slug", () => {
+    const hint = recoveryHintForStaleFailure(
+      { ageStale: true, driftDetected: false },
+      "deftai/directive",
+    );
+    expect(hint).toContain("cache fetch-all --source github-issue --repo deftai/directive --force");
+    expect(hint).not.toContain("cache:fetch-all");
+  });
+
+  it("drift-only failure names plain cache fetch-all without --force", () => {
+    const hint = recoveryHintForStaleFailure(
+      { ageStale: false, driftDetected: true },
+      "deftai/directive",
+    );
+    expect(hint).toContain("cache fetch-all --source github-issue --repo deftai/directive");
+    expect(hint).not.toContain("--force");
+    expect(hint).not.toContain("cache:fetch-all");
+  });
+
+  it("mixed age+drift prefers cache fetch-all --force", () => {
+    const hint = recoveryHintForStaleFailure(
+      { ageStale: true, driftDetected: true },
+      "deftai/directive",
+    );
+    expect(hint).toContain("--force");
+    expect(hint).not.toContain("cache:fetch-all");
+  });
+});

--- a/packages/core/src/session/cache-recovery.ts
+++ b/packages/core/src/session/cache-recovery.ts
@@ -1,0 +1,34 @@
+import { formatFrameworkCommand } from "../render/framework-commands.js";
+
+const CACHE_FETCH_SOURCE = "github-issue";
+
+/**
+ * Format a consumer-runnable `deft cache fetch-all` recovery command (#2574).
+ *
+ * Uses the space-separated CLI surface (not the colon task alias) and always
+ * includes required `--source` / `--repo` flags so following the hint literally
+ * reaches the handler instead of `unknown verb 'cache:fetch-all'`.
+ */
+export function formatCacheFetchAllRecoveryCommand(
+  repo: string | null,
+  options: { force?: boolean } = {},
+): string {
+  const repoSlug = repo ?? "OWNER/NAME";
+  const args = ["cache", "fetch-all", "--source", CACHE_FETCH_SOURCE, "--repo", repoSlug];
+  if (options.force) {
+    args.push("--force");
+  }
+  return formatFrameworkCommand(args);
+}
+
+/**
+ * Branch-aware recovery hint (#1953 Option 3, #2574 argv fix).
+ * Age-stale (or age+drift mixed) → --force bypasses TTL; drift-only → plain refetch.
+ */
+export function recoveryHintForStaleFailure(
+  causes: Readonly<{ ageStale: boolean; driftDetected: boolean }>,
+  repo: string | null = null,
+): string {
+  const command = formatCacheFetchAllRecoveryCommand(repo, { force: causes.ageStale });
+  return `  Recovery: run \`${command}\` to refresh and reconcile upstream state.`;
+}

--- a/packages/core/src/session/verify-session-ritual-messages.test.ts
+++ b/packages/core/src/session/verify-session-ritual-messages.test.ts
@@ -2,11 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  CACHE_DIR_NAME,
-  CANDIDATES_RELPATH,
-  DEFAULT_SOURCE,
-} from "../preflight-cache/evaluate.js";
+import { CACHE_DIR_NAME, CANDIDATES_RELPATH, DEFAULT_SOURCE } from "../preflight-cache/evaluate.js";
 import type { GitRunner } from "./git.js";
 import { newRitualStatePayload, ritualStep, writeRitualState } from "./ritual-sentinel.js";
 import { verifySessionRitual } from "./verify-session-ritual.js";

--- a/packages/core/src/session/verify-session-ritual-messages.test.ts
+++ b/packages/core/src/session/verify-session-ritual-messages.test.ts
@@ -2,6 +2,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  CACHE_DIR_NAME,
+  CANDIDATES_RELPATH,
+  DEFAULT_SOURCE,
+} from "../preflight-cache/evaluate.js";
 import type { GitRunner } from "./git.js";
 import { newRitualStatePayload, ritualStep, writeRitualState } from "./ritual-sentinel.js";
 import { verifySessionRitual } from "./verify-session-ritual.js";
@@ -178,6 +183,62 @@ describe("verify-session-ritual failed-step messaging", () => {
     });
     expect(result.code).toBe(1);
     expect(result.message).toContain("doctor");
+  });
+
+  it("reports gated cache_fresh stale recovery with runnable cache fetch-all (#2574)", () => {
+    const { root, head } = initRoot();
+    const repo = "deftai/cartograph";
+    const fetchedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    const [owner, name] = repo.split("/") as [string, string];
+    const entryDir = join(root, CACHE_DIR_NAME, DEFAULT_SOURCE, owner, name, "62");
+    mkdirSync(entryDir, { recursive: true });
+    mkdirSync(join(root, "xbrief", ".triage-cache"), { recursive: true });
+    writeFileSync(join(entryDir, "meta.json"), JSON.stringify({ fetched_at: fetchedAt }), "utf8");
+    writeFileSync(
+      join(entryDir, "raw.json"),
+      JSON.stringify({ number: 62, state: "open" }),
+      "utf8",
+    );
+    writeFileSync(
+      join(root, CANDIDATES_RELPATH),
+      JSON.stringify({
+        issue: 62,
+        repo,
+        decision: "accept",
+        ts: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+    writeRitualState(
+      root,
+      newRitualStatePayload({
+        sessionId: "s",
+        gitHead: head,
+        worktreePath: resolve(root),
+        startedAt: NOW,
+        quickSteps: {
+          alignment: ritualStep({ ok: true, ts: NOW }),
+          branch_policy: ritualStep({ ok: true, ts: NOW }),
+          triage_welcome: ritualStep({ ok: true, ts: NOW }),
+        },
+        gatedSteps: {
+          doctor: ritualStep({ ok: true, ts: NOW }),
+        },
+      }),
+    );
+    const result = verifySessionRitual(root, {
+      bypass: false,
+      tier: "gated",
+      posture: "mutation",
+      now: NOW,
+      runGit: fakeGit(head, resolve(root)),
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("cache_fresh");
+    expect(result.message).toContain(
+      "cache fetch-all --source github-issue --repo deftai/cartograph --force",
+    );
+    expect(result.message).not.toContain("cache:fetch-all");
   });
 
   it("honours an explicit envSkip bypass that records a would-fail code", () => {

--- a/packages/core/src/session/verify-session-ritual.ts
+++ b/packages/core/src/session/verify-session-ritual.ts
@@ -20,7 +20,10 @@ import {
 import { GATED_STEPS, QUICK_STEPS } from "./session-start.js";
 import { resolveSessionRitualStalenessHours } from "./staleness.js";
 
-export { formatCacheFetchAllRecoveryCommand, recoveryHintForStaleFailure } from "./cache-recovery.js";
+export {
+  formatCacheFetchAllRecoveryCommand,
+  recoveryHintForStaleFailure,
+} from "./cache-recovery.js";
 export const ENV_SKIP = "DEFT_SESSION_RITUAL_SKIP";
 export {
   ENTRYPOINT_TIMEOUT_EXIT_CODE,

--- a/packages/core/src/session/verify-session-ritual.ts
+++ b/packages/core/src/session/verify-session-ritual.ts
@@ -20,6 +20,7 @@ import {
 import { GATED_STEPS, QUICK_STEPS } from "./session-start.js";
 import { resolveSessionRitualStalenessHours } from "./staleness.js";
 
+export { formatCacheFetchAllRecoveryCommand, recoveryHintForStaleFailure } from "./cache-recovery.js";
 export const ENV_SKIP = "DEFT_SESSION_RITUAL_SKIP";
 export {
   ENTRYPOINT_TIMEOUT_EXIT_CODE,

--- a/xbrief/active/2026-07-15-2574-cache-fresh-recovery-verb-fix.xbrief.json
+++ b/xbrief/active/2026-07-15-2574-cache-fresh-recovery-verb-fix.xbrief.json
@@ -1,0 +1,48 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for GitHub issue #2574 — cache-fresh recovery verb fix"
+  },
+  "plan": {
+    "id": "2574-cache-fresh-recovery-verb-fix",
+    "title": "bug(cache,session): gated ritual recovery prints working cache fetch-all command",
+    "status": "running",
+    "narratives": {
+      "Description": "Gated session ritual cache_fresh failures print `deft cache:fetch-all --force`, which is unknown on the npm CLI and omits required --source/--repo flags. Recovery text must use the space-separated `deft cache fetch-all --source github-issue --repo OWNER/NAME` surface.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2574",
+      "Overview": "Fix prescriptive recovery strings emitted when verify:cache-fresh fails during gated session ritual. Contract-test against the broken colon alias.",
+      "UserStory": "As an operator with a stale cache, I want the gated ritual failure to print a recovery command I can run literally, so I do not have to defer cache_fresh or guess argv shape.",
+      "ImplementationPlan": "1. Add formatCacheFetchAllRecoveryCommand in packages/core/src/session/cache-recovery.ts. 2. Route preflight-cache recovery hints through it with resolved repo. 3. Add verify-session-ritual-messages contract test. 4. CHANGELOG [Unreleased].",
+      "Labels": "bug, agent-experience, area:session"
+    },
+    "items": [
+      {
+        "id": "2574-working-recovery-text",
+        "title": "Recovery text uses runnable deft cache fetch-all with --source and --repo",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a stale cache_fresh gated failure, when the recovery hint is printed, then it names `deft cache fetch-all --source github-issue --repo <slug>` (with --force when age-stale) and never the unknown `cache:fetch-all` colon alias."
+        }
+      }
+    ],
+    "tags": ["bug", "agent-experience", "area:session"],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2574",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2574: gated ritual recovery prints unknown cache:fetch-all verb"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/session/",
+          "packages/core/src/preflight-cache/evaluate.ts"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fix gated `cache_fresh` recovery text: stop printing unknown `deft cache:fetch-all --force`
- Emit working `deft cache fetch-all --source github-issue --repo OWNER/NAME [--force]` (repo-aware)
- Contract tests lock recovery text against the colon form; CHANGELOG `[Unreleased]`

Closes #2574

## Test plan
- [x] Focused vitest on cache-recovery / verify-session-ritual-messages / preflight-cache evaluate (46 passed)
- [ ] CI green on PR
- [ ] Greptile CLEAN on HEAD
