### PR TITLE
fix(cascade): keep heartbeats and merge path after update-branch (#2581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **completed/ lifecycle moves stamp terminal plan.status atomically (#2578).** `scope:complete` and `scope:fail` now write `plan.status=completed|failed` directly at the destination path instead of pre-stamping the source file before rename, so xBRIEFs never appear under `completed/` with non-terminal status. `task reconcile:issues` reports `completed/` D2 drift and `--apply-lifecycle-fixes` repairs in-place. Closes #2578.
 - **pr-wait-mergeable unit tests no longer inherit parent-shell `GH_REPO`.** `main.test.ts` clears `GH_REPO` in `beforeEach` so config-error cases stay deterministic when maintainers or release Step 5 run `task check` with orchestration env set. Closes #2579.
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` mid-suite (#2580).** Native Windows `task check` coverage runs now pre-create and keep `coverage/.tmp` via globalSetup, serialize v8 `processingConcurrency`, and cap fork workers when `--coverage` is active so green suites are not blocked by temp-directory races; coverage thresholds still fail closed. Closes #2580.
-<<<<<<< HEAD
 - **Release Step 3 retries once when GitHub REST core rate limit is exhausted (#2577).** `task release` Step 3 (`Pre-flight vBRIEF lifecycle sync`) now sleeps once (capped at 120s) and retries issue-state fetch on HTTP 403 rate-limit errors instead of failing immediately. Persistent exhaustion emits actionable stderr with `gh api rate_limit` probe output and documents that `--allow-vbrief-drift` is appropriate after local `task vbrief:validate` is green. Closes #2577.
-<<<<<<< HEAD
 - **fix(release-e2e): default to keep+report temp repo instead of gh repo delete (#2572).** Agent-driven releases typically lack `delete_repo` permission (#1019); attempting destroy produced noisy failures and stalled Phase 3. `task release:e2e` now keeps the rehearsal repo by default and always emits `owner/slug` plus a copy-paste `gh repo delete` cleanup hint. Privileged environments may pass `--destroy-repo`; destroy failure still emits WARN and does not block Phase 4 when the rehearsal succeeded. Release skill Phase 3 documents the keep+report contract.
-=======
-=======
 - **Merge cascade no longer goes silent after update-branch.** `pr:wait-mergeable-and-merge` keeps emitting wait heartbeats when cadence tiers jump (no >2× prior-cadence gap without escalation), runs until the cap instead of stopping after a fixed poll budget, and preserves distinguishable Greptile/HEAD SHA prefixes in blocked-on heartbeats during update-branch races. Closes #2581. Refs #2260.
->>>>>>> 7ba57705 (fix(cascade): keep merge-monitor heartbeats alive after update-branch (#2581))
->>>>>>> 097b55c5 (fix(cascade): keep merge-monitor heartbeats alive after update-branch (#2581))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **completed/ lifecycle moves stamp terminal plan.status atomically (#2578).** `scope:complete` and `scope:fail` now write `plan.status=completed|failed` directly at the destination path instead of pre-stamping the source file before rename, so xBRIEFs never appear under `completed/` with non-terminal status. `task reconcile:issues` reports `completed/` D2 drift and `--apply-lifecycle-fixes` repairs in-place. Closes #2578.
 - **pr-wait-mergeable unit tests no longer inherit parent-shell `GH_REPO`.** `main.test.ts` clears `GH_REPO` in `beforeEach` so config-error cases stay deterministic when maintainers or release Step 5 run `task check` with orchestration env set. Closes #2579.
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` mid-suite (#2580).** Native Windows `task check` coverage runs now pre-create and keep `coverage/.tmp` via globalSetup, serialize v8 `processingConcurrency`, and cap fork workers when `--coverage` is active so green suites are not blocked by temp-directory races; coverage thresholds still fail closed. Closes #2580.
+<<<<<<< HEAD
 - **Release Step 3 retries once when GitHub REST core rate limit is exhausted (#2577).** `task release` Step 3 (`Pre-flight vBRIEF lifecycle sync`) now sleeps once (capped at 120s) and retries issue-state fetch on HTTP 403 rate-limit errors instead of failing immediately. Persistent exhaustion emits actionable stderr with `gh api rate_limit` probe output and documents that `--allow-vbrief-drift` is appropriate after local `task vbrief:validate` is green. Closes #2577.
+<<<<<<< HEAD
 - **fix(release-e2e): default to keep+report temp repo instead of gh repo delete (#2572).** Agent-driven releases typically lack `delete_repo` permission (#1019); attempting destroy produced noisy failures and stalled Phase 3. `task release:e2e` now keeps the rehearsal repo by default and always emits `owner/slug` plus a copy-paste `gh repo delete` cleanup hint. Privileged environments may pass `--destroy-repo`; destroy failure still emits WARN and does not block Phase 4 when the rehearsal succeeded. Release skill Phase 3 documents the keep+report contract.
+=======
+=======
+- **Merge cascade no longer goes silent after update-branch.** `pr:wait-mergeable-and-merge` keeps emitting wait heartbeats when cadence tiers jump (no >2× prior-cadence gap without escalation), runs until the cap instead of stopping after a fixed poll budget, and preserves distinguishable Greptile/HEAD SHA prefixes in blocked-on heartbeats during update-branch races. Closes #2581. Refs #2260.
+>>>>>>> 7ba57705 (fix(cascade): keep merge-monitor heartbeats alive after update-branch (#2581))
+>>>>>>> 097b55c5 (fix(cascade): keep merge-monitor heartbeats alive after update-branch (#2581))
 
 ### Removed
 

--- a/packages/core/src/pr-monitor/cadence.ts
+++ b/packages/core/src/pr-monitor/cadence.ts
@@ -12,3 +12,20 @@ export function cadenceIntervals(
   }
   return intervals;
 }
+
+/**
+ * Seconds to sleep after poll `pollIndex` (1-based). Repeats the final cadence
+ * tier once the configured repeats are exhausted so the monitor can run until
+ * the cap instead of stopping after a fixed poll budget (#2581).
+ */
+export function cadenceIntervalAfterPoll(
+  pollIndex: number,
+  cadence: ReadonlyArray<readonly [number, number]> = DEFAULT_CADENCE,
+): number {
+  const intervals = cadenceIntervals(cadence);
+  if (intervals.length === 0) {
+    return 60;
+  }
+  const idx = Math.min(Math.max(pollIndex, 1) - 1, intervals.length - 1);
+  return intervals[idx] ?? intervals[intervals.length - 1] ?? 60;
+}

--- a/packages/core/src/pr-monitor/coverage-boost.test.ts
+++ b/packages/core/src/pr-monitor/coverage-boost.test.ts
@@ -20,10 +20,17 @@ describe("coverage boost", () => {
 
   it("forwards readiness stderr after poll status", () => {
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let reads = 0;
+    const clockFn = {
+      now(): number {
+        reads += 1;
+        return reads <= 2 ? 0 : 1000;
+      },
+    };
     monitor(1, "deftai/directive", {
-      capMinutes: 10,
+      capMinutes: 0.001,
       sleepFn: () => undefined,
-      clockFn: { now: () => 0 },
+      clockFn,
       callReadinessFn: (): PollResult => ({
         exitCode: 1,
         payload: { via: "error", merge_ready: false, failures: ["x"] },
@@ -63,12 +70,19 @@ describe("coverage boost", () => {
     expect(result.pollCount).toBe(1);
   });
 
-  it("returns CONFIG_ERROR when loop exhausts with config exit", () => {
+  it("returns CONFIG_ERROR when cap expires after config-error poll (#2581)", () => {
+    let reads = 0;
+    const clockFn = {
+      now(): number {
+        reads += 1;
+        return reads <= 2 ? 0 : 1;
+      },
+    };
     const result = monitor(1, "deftai/directive", {
-      capMinutes: 120,
+      capMinutes: 0.001,
       cadence: [[1, 1]],
       sleepFn: () => undefined,
-      clockFn: { now: () => 0 },
+      clockFn,
       callReadinessFn: (): PollResult => ({
         exitCode: EXIT_CONFIG_ERROR,
         payload: { via: "error", merge_ready: false },

--- a/packages/core/src/pr-monitor/index.ts
+++ b/packages/core/src/pr-monitor/index.ts
@@ -1,4 +1,4 @@
-export { cadenceIntervals } from "./cadence.js";
+export { cadenceIntervalAfterPoll, cadenceIntervals } from "./cadence.js";
 export {
   DEFAULT_CADENCE,
   EXIT_CAP_REACHED,

--- a/packages/core/src/pr-monitor/monitor.test.ts
+++ b/packages/core/src/pr-monitor/monitor.test.ts
@@ -150,6 +150,15 @@ describe("truncateBlockedOn", () => {
   it("falls back to plain truncation for non-SHA failures", () => {
     expect(truncateBlockedOn("x".repeat(120), 40)).toHaveLength(40);
   });
+
+  it("falls back when compact SHA message still exceeds maxLen", () => {
+    const oldSha = "a".repeat(40);
+    const newSha = "b".repeat(40);
+    const failure = `Greptile last reviewed ${oldSha} but PR HEAD is ${newSha}.`;
+    const out = truncateBlockedOn(failure, 30);
+    expect(out).toHaveLength(30);
+    expect(out).toBe(failure.slice(0, 30));
+  });
 });
 
 describe("sleepWithCadenceHeartbeats", () => {

--- a/packages/core/src/pr-monitor/monitor.test.ts
+++ b/packages/core/src/pr-monitor/monitor.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { RunGhFn } from "../pr-merge-readiness/types.js";
-import { cadenceIntervals } from "./cadence.js";
+import { cadenceIntervalAfterPoll, cadenceIntervals } from "./cadence.js";
 import { DEFAULT_CADENCE, EXIT_CAP_REACHED, EXIT_CLEAN, EXIT_PR_TERMINAL } from "./constants.js";
-import { formatPollStatus, isTerminalPrState, mergeStateFromPayload, monitor } from "./monitor.js";
+import { formatPollStatus, isTerminalPrState, mergeStateFromPayload, monitor, sleepWithCadenceHeartbeats, truncateBlockedOn } from "./monitor.js";
 import type { PollResult } from "./types.js";
 
 const HEAD_SHA = "abc1234567890def1234567890abcdef12345678";
@@ -45,6 +45,17 @@ describe("cadenceIntervals", () => {
     expect(intervals.has(180)).toBe(true);
     expect(intervals.has(300)).toBe(true);
   });
+
+  it("repeats the final cadence tier after configured repeats (#2581)", () => {
+    const cadence = [
+      [60, 2],
+      [180, 1],
+    ] as const;
+    expect(cadenceIntervalAfterPoll(1, cadence)).toBe(60);
+    expect(cadenceIntervalAfterPoll(2, cadence)).toBe(60);
+    expect(cadenceIntervalAfterPoll(3, cadence)).toBe(180);
+    expect(cadenceIntervalAfterPoll(99, cadence)).toBe(180);
+  });
 });
 
 describe("formatPollStatus", () => {
@@ -76,6 +87,25 @@ describe("formatPollStatus", () => {
     expect(line).toContain("blocked-on: something went wrong");
   });
 
+  it("preserves Greptile stale SHA prefixes in blocked-on (#2581)", () => {
+    const oldSha = "f5e0d8d5bb4284481f7895930ca8f88a102a38ad";
+    const newSha = "b4ba195f2c35abcdef1234567890abcdef12345678";
+    const line = formatPollStatus(1, {
+      exitCode: 1,
+      payload: {
+        via: "primary",
+        merge_ready: false,
+        head_sha: newSha,
+        failures: [`Greptile last reviewed ${oldSha} but PR HEAD is ${newSha}. Review is stale`],
+      },
+      rawStdout: "",
+      rawStderr: "",
+    });
+    expect(line).toContain("f5e0d8d5bb42");
+    expect(line).toContain("b4ba195f2c35");
+    expect(line).not.toMatch(/PR HEAD is b$/);
+  });
+
   it("emits elapsed + GitHub merge-state heartbeat fields (#2260)", () => {
     const line = formatPollStatus(
       3,
@@ -95,6 +125,38 @@ describe("formatPollStatus", () => {
     );
     expect(line).toContain("t=65s");
     expect(line).toContain("mergeState=clean");
+  });
+});
+
+describe("truncateBlockedOn", () => {
+  it("compacts Greptile stale SHA messages with distinguishable prefixes", () => {
+    const oldSha = "f5e0d8d5bb4284481f7895930ca8f88a102a38ad";
+    const newSha = "b4ba195f2c35abcdef1234567890abcdef12345678";
+    const compact = truncateBlockedOn(
+      `Greptile last reviewed ${oldSha} but PR HEAD is ${newSha}. Review is stale`,
+    );
+    expect(compact).toContain("f5e0d8d5bb42");
+    expect(compact).toContain("b4ba195f2c35");
+    expect(compact.length).toBeLessThanOrEqual(80);
+  });
+
+  it("falls back to plain truncation for non-SHA failures", () => {
+    expect(truncateBlockedOn("x".repeat(120), 40)).toHaveLength(40);
+  });
+});
+
+describe("sleepWithCadenceHeartbeats", () => {
+  it("chunks long sleeps so no gap exceeds 2x prior cadence", () => {
+    const sleeps: number[] = [];
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    sleepWithCadenceHeartbeats(180, 60, 5, (s) => {
+      sleeps.push(s);
+    });
+    expect(sleeps).toEqual([120, 60]);
+    const emitted = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(emitted).toContain("waiting 180s until poll #5");
+    expect(emitted).toContain("still waiting 60s until poll #5");
+    stderr.mockRestore();
   });
 });
 
@@ -182,19 +244,20 @@ describe("monitor loop", () => {
       clock.value += s;
     };
     const result = monitor(1363, "deftai/directive", {
-      capMinutes: 120,
-      cadence: [[1, 3]],
+      capMinutes: 0.01,
+      cadence: [[0.1, 10]],
       sleepFn: advancingSleep,
       clockFn: clock,
-      callReadinessFn: makeCallLog(
-        { via: "fallback2", merge_ready: true, failures: [] },
-        { via: "fallback2", merge_ready: true, failures: [] },
-        { via: "fallback2", merge_ready: true, failures: [] },
-      ),
+      callReadinessFn: (): PollResult => ({
+        exitCode: 1,
+        payload: { via: "fallback2", merge_ready: true, failures: [] },
+        rawStdout: "",
+        rawStderr: "",
+      }),
     });
     expect(result.exitCode).toBe(EXIT_CAP_REACHED);
     expect(result.payload.via).toBe("fallback2");
-    expect(result.pollCount).toBe(3);
+    expect(result.pollCount).toBeGreaterThan(0);
   });
 
   it("short-circuits on terminal PR state", () => {
@@ -337,5 +400,82 @@ describe("monitor loop", () => {
     expect(result.exitCode).toBe(EXIT_CLEAN);
     expect(result.payload.via).toBe("fallback1");
     expect(result.pollCount).toBe(3);
+  });
+
+  it("continues through update-branch race and reaches CLEAN (#2581)", () => {
+    const oldSha = "f5e0d8d5bb4284481f7895930ca8f88a102a38ad";
+    const newSha = "b4ba195f2c35abcdef1234567890abcdef12345678";
+    const clock = new FakeClock();
+    const advancingSleep = (s: number) => {
+      clock.value += s;
+    };
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const result = monitor(2571, "deftai/directive", {
+      capMinutes: 120,
+      cadence: [[1, 3], [2, 2]],
+      sleepFn: advancingSleep,
+      clockFn: clock,
+      callReadinessFn: makeCallLog(
+        {
+          via: "primary",
+          merge_ready: false,
+          head_sha: newSha,
+          failures: [`Greptile last reviewed ${oldSha} but PR HEAD is ${newSha}. Review is stale`],
+          partial_data: { mergeability: { mergeable_state: "blocked", mergeable: false } },
+        },
+        {
+          via: "primary",
+          merge_ready: false,
+          head_sha: newSha,
+          failures: [`Greptile last reviewed ${oldSha} but PR HEAD is ${newSha}. Review is stale`],
+          partial_data: { mergeability: { mergeable_state: "blocked", mergeable: false } },
+        },
+        {
+          via: "primary",
+          merge_ready: false,
+          head_sha: newSha,
+          failures: [`Greptile last reviewed ${oldSha} but PR HEAD is ${newSha}. Review is stale`],
+          partial_data: { mergeability: { mergeable_state: "blocked", mergeable: false } },
+        },
+        { via: "primary", merge_ready: true, head_sha: newSha, failures: [] },
+      ),
+    });
+    const emitted = stderr.mock.calls.map((c) => String(c[0])).join("");
+    stderr.mockRestore();
+
+    expect(result.exitCode).toBe(EXIT_CLEAN);
+    expect(result.pollCount).toBe(4);
+    expect(emitted).toContain("f5e0d8d5bb42");
+    expect(emitted).toContain("b4ba195f2c35");
+  });
+
+  it("emits wait heartbeats when cadence tier jumps beyond 2x prior (#2581)", () => {
+    const clock = new FakeClock();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const result = monitor(2571, "deftai/directive", {
+      capMinutes: 120,
+      cadence: [
+        [1, 3],
+        [3, 2],
+      ],
+      sleepFn: (s) => {
+        clock.value += s;
+      },
+      clockFn: clock,
+      callReadinessFn: makeCallLog(
+        { via: "primary", merge_ready: false, failures: ["blocked"] },
+        { via: "primary", merge_ready: false, failures: ["blocked"] },
+        { via: "primary", merge_ready: false, failures: ["blocked"] },
+        { via: "primary", merge_ready: false, failures: ["blocked"] },
+        { via: "primary", merge_ready: true, failures: [] },
+      ),
+    });
+    const emitted = stderr.mock.calls.map((c) => String(c[0])).join("");
+    stderr.mockRestore();
+
+    expect(result.exitCode).toBe(EXIT_CLEAN);
+    expect(result.pollCount).toBe(5);
+    expect(emitted).toContain("waiting");
+    expect(emitted).toContain("poll #5");
   });
 });

--- a/packages/core/src/pr-monitor/monitor.test.ts
+++ b/packages/core/src/pr-monitor/monitor.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import type { RunGhFn } from "../pr-merge-readiness/types.js";
 import { cadenceIntervalAfterPoll, cadenceIntervals } from "./cadence.js";
 import { DEFAULT_CADENCE, EXIT_CAP_REACHED, EXIT_CLEAN, EXIT_PR_TERMINAL } from "./constants.js";
-import { formatPollStatus, isTerminalPrState, mergeStateFromPayload, monitor, sleepWithCadenceHeartbeats, truncateBlockedOn } from "./monitor.js";
+import {
+  formatPollStatus,
+  isTerminalPrState,
+  mergeStateFromPayload,
+  monitor,
+  sleepWithCadenceHeartbeats,
+  truncateBlockedOn,
+} from "./monitor.js";
 import type { PollResult } from "./types.js";
 
 const HEAD_SHA = "abc1234567890def1234567890abcdef12345678";
@@ -412,7 +419,10 @@ describe("monitor loop", () => {
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const result = monitor(2571, "deftai/directive", {
       capMinutes: 120,
-      cadence: [[1, 3], [2, 2]],
+      cadence: [
+        [1, 3],
+        [2, 2],
+      ],
       sleepFn: advancingSleep,
       clockFn: clock,
       callReadinessFn: makeCallLog(

--- a/packages/core/src/pr-monitor/monitor.ts
+++ b/packages/core/src/pr-monitor/monitor.ts
@@ -23,8 +23,7 @@ function defaultSleep(seconds: number): void {
   }
 }
 
-const GREPTILE_STALE_SHA_RE =
-  /^Greptile last reviewed ([0-9a-f]+) but PR HEAD is ([0-9a-f]+)\./i;
+const GREPTILE_STALE_SHA_RE = /^Greptile last reviewed ([0-9a-f]+) but PR HEAD is ([0-9a-f]+)\./i;
 
 /**
  * Truncate blocked-on text for one-line heartbeats while preserving

--- a/packages/core/src/pr-monitor/monitor.ts
+++ b/packages/core/src/pr-monitor/monitor.ts
@@ -33,12 +33,15 @@ const GREPTILE_STALE_SHA_RE =
 export function truncateBlockedOn(failure: string, maxLen = 80): string {
   const match = GREPTILE_STALE_SHA_RE.exec(failure);
   if (match !== null) {
-    const [, reviewedSha, headSha] = match;
-    const compact =
-      `Greptile last reviewed ${reviewedSha.slice(0, 12)}... ` +
-      `but PR HEAD is ${headSha.slice(0, 12)}...`;
-    if (compact.length <= maxLen) {
-      return compact;
+    const reviewedSha = match[1];
+    const headSha = match[2];
+    if (reviewedSha !== undefined && headSha !== undefined) {
+      const compact =
+        `Greptile last reviewed ${reviewedSha.slice(0, 12)}... ` +
+        `but PR HEAD is ${headSha.slice(0, 12)}...`;
+      if (compact.length <= maxLen) {
+        return compact;
+      }
     }
   }
   return failure.slice(0, maxLen);

--- a/packages/core/src/pr-monitor/monitor.ts
+++ b/packages/core/src/pr-monitor/monitor.ts
@@ -1,4 +1,4 @@
-import { cadenceIntervals } from "./cadence.js";
+import { cadenceIntervalAfterPoll } from "./cadence.js";
 import {
   DEFAULT_CADENCE,
   EXIT_CAP_REACHED,
@@ -20,6 +20,63 @@ function defaultSleep(seconds: number): void {
   const target = start + seconds * 1000;
   while (Date.now() < target) {
     // busy-wait fallback when no injectable sleep in production CLI path
+  }
+}
+
+const GREPTILE_STALE_SHA_RE =
+  /^Greptile last reviewed ([0-9a-f]+) but PR HEAD is ([0-9a-f]+)\./i;
+
+/**
+ * Truncate blocked-on text for one-line heartbeats while preserving
+ * distinguishable SHA prefixes during update-branch races (#2581).
+ */
+export function truncateBlockedOn(failure: string, maxLen = 80): string {
+  const match = GREPTILE_STALE_SHA_RE.exec(failure);
+  if (match !== null) {
+    const [, reviewedSha, headSha] = match;
+    const compact =
+      `Greptile last reviewed ${reviewedSha.slice(0, 12)}... ` +
+      `but PR HEAD is ${headSha.slice(0, 12)}...`;
+    if (compact.length <= maxLen) {
+      return compact;
+    }
+  }
+  return failure.slice(0, maxLen);
+}
+
+/** Emit interim stderr heartbeats during long sleeps (#2581 / #2260). */
+export function sleepWithCadenceHeartbeats(
+  totalSeconds: number,
+  priorCadenceSeconds: number,
+  nextPollIndex: number,
+  sleepFn: (seconds: number) => void,
+): void {
+  if (totalSeconds <= 0) {
+    return;
+  }
+  const maxSilentGap = Math.max(1, priorCadenceSeconds * 2);
+  if (totalSeconds <= maxSilentGap) {
+    sleepFn(totalSeconds);
+    return;
+  }
+
+  let remaining = totalSeconds;
+  let emittedWait = false;
+  while (remaining > 0) {
+    const chunk = Math.min(remaining, maxSilentGap);
+    if (!emittedWait) {
+      process.stderr.write(
+        `[monitor_pr] waiting ${Math.ceil(remaining)}s until poll #${nextPollIndex} ` +
+          `(heartbeat cap ${maxSilentGap}s)\n`,
+      );
+      emittedWait = true;
+    } else {
+      process.stderr.write(
+        `[monitor_pr] still waiting ${Math.ceil(remaining)}s until poll #${nextPollIndex}\n`,
+      );
+    }
+    sleepFn(chunk);
+    remaining -= chunk;
   }
 }
 
@@ -80,7 +137,7 @@ export function formatPollStatus(
     `[monitor_pr] poll #${pollIndex} t=${elapsed}s via=${via} head=${headDisplay} ` +
     `mergeState=${mergeState} ${label} (${failures.length} failures)`;
   if (firstFailure.length > 0) {
-    line += ` -- blocked-on: ${firstFailure.slice(0, 80)}`;
+    line += ` -- blocked-on: ${truncateBlockedOn(firstFailure)}`;
   }
   return line;
 }
@@ -101,7 +158,7 @@ export function monitor(
   repo: string,
   options: MonitorOptions = {},
 ): MonitorRunResult {
-  const intervals = cadenceIntervals(options.cadence ?? DEFAULT_CADENCE);
+  const cadence = options.cadence ?? DEFAULT_CADENCE;
   const capSeconds = (options.capMinutes ?? 60) * 60;
   const clockFn = options.clockFn ?? systemMonotonicClock;
   const sleepFn = options.sleepFn ?? defaultSleep;
@@ -112,8 +169,9 @@ export function monitor(
   let pollIndex = 0;
   let lastPayload: Record<string, unknown> = {};
   let lastExit = EXIT_CAP_REACHED;
+  let priorCadenceSeconds = cadenceIntervalAfterPoll(1, cadence);
 
-  for (const interval of intervals) {
+  while (true) {
     pollIndex += 1;
     const elapsed = clockFn.now() - startedAt;
     if (elapsed > capSeconds) {
@@ -141,18 +199,20 @@ export function monitor(
       return { exitCode: EXIT_PR_TERMINAL, payload: lastPayload, pollCount: pollIndex };
     }
 
-    if (pollIndex < intervals.length) {
-      const elapsedAfterPoll = clockFn.now() - startedAt;
-      const remaining = capSeconds - elapsedAfterPoll;
-      if (remaining <= 0) {
-        return { exitCode: EXIT_CAP_REACHED, payload: lastPayload, pollCount: pollIndex };
-      }
-      sleepFn(Math.min(interval, Math.max(1, Math.trunc(remaining))));
+    const elapsedAfterPoll = clockFn.now() - startedAt;
+    const remaining = capSeconds - elapsedAfterPoll;
+    if (remaining <= 0) {
+      const finalExit = lastExit === EXIT_CONFIG_ERROR ? EXIT_CONFIG_ERROR : EXIT_CAP_REACHED;
+      return { exitCode: finalExit, payload: lastPayload, pollCount: pollIndex };
     }
-  }
 
-  const finalExit = lastExit === EXIT_CONFIG_ERROR ? EXIT_CONFIG_ERROR : EXIT_CAP_REACHED;
-  return { exitCode: finalExit, payload: lastPayload, pollCount: pollIndex };
+    const sleepSeconds = Math.min(
+      cadenceIntervalAfterPoll(pollIndex, cadence),
+      Math.max(1, Math.trunc(remaining)),
+    );
+    sleepWithCadenceHeartbeats(sleepSeconds, priorCadenceSeconds, pollIndex + 1, sleepFn);
+    priorCadenceSeconds = sleepSeconds;
+  }
 }
 
 export const summaryLabelForExit = (exitCode: number): string => {


### PR DESCRIPTION
## Summary
- Cap-driven pr-monitor loop with sleep heartbeats so update-branch races no longer go silent between cadence tiers
- SHA-aware `blocked-on` truncation preserving Greptile reviewed + HEAD prefixes
- Regression coverage for the post-update-branch stall class (#2581)

Closes #2581

## Test plan
- [x] Focused pr-monitor vitest (37 passed)
- [ ] CI green on PR
- [ ] Greptile CLEAN on HEAD