### PR TITLE
fix(test): isolate GH_REPO in pr-wait-mergeable tests (#2579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **pr-wait-mergeable unit tests no longer inherit parent-shell `GH_REPO`.** `main.test.ts` clears `GH_REPO` in `beforeEach` so config-error cases stay deterministic when maintainers or release Step 5 run `task check` with orchestration env set. Closes #2579.
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` mid-suite (#2580).** Native Windows `task check` coverage runs now pre-create and keep `coverage/.tmp` via globalSetup, serialize v8 `processingConcurrency`, and cap fork workers when `--coverage` is active so green suites are not blocked by temp-directory races; coverage thresholds still fail closed. Closes #2580.
 
 ### Removed

--- a/packages/core/src/pr-wait-mergeable/main.test.ts
+++ b/packages/core/src/pr-wait-mergeable/main.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EXIT_CONFIG_ERROR, EXIT_MERGED } from "./constants.js";
 import { cmdPrWaitMergeable, parseWaitMergeableArgs, runWaitMergeable } from "./main.js";
 import type { MergeFn, MonitorFn, ProtectedCheckFn } from "./types.js";
@@ -60,16 +60,28 @@ describe("parseWaitMergeableArgs", () => {
 });
 
 describe("runWaitMergeable", () => {
-  it("main without repo exits two", () => {
-    const prev = process.env.GH_REPO;
+  let savedGhRepo: string | undefined;
+
+  beforeEach(() => {
+    savedGhRepo = process.env.GH_REPO;
     delete process.env.GH_REPO;
+  });
+
+  afterEach(() => {
+    if (savedGhRepo === undefined) {
+      delete process.env.GH_REPO;
+    } else {
+      process.env.GH_REPO = savedGhRepo;
+    }
+  });
+
+  it("main without repo exits two", () => {
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     expect(runWaitMergeable(["1370"])).toBe(EXIT_CONFIG_ERROR);
     expect(stderr.mock.calls[0]?.[0]).toContain("--repo");
     stderr.mockRestore();
     stdout.mockRestore();
-    if (prev !== undefined) process.env.GH_REPO = prev;
   });
 
   it("malformed protected token exits two", () => {
@@ -108,13 +120,10 @@ describe("runWaitMergeable", () => {
   });
 
   it("cmdPrWaitMergeable delegates to runWaitMergeable", () => {
-    const prev = process.env.GH_REPO;
-    delete process.env.GH_REPO;
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     expect(cmdPrWaitMergeable(["1370"])).toBe(EXIT_CONFIG_ERROR);
     stderr.mockRestore();
     stdout.mockRestore();
-    if (prev !== undefined) process.env.GH_REPO = prev;
   });
 });

--- a/xbrief/active/2026-07-15-2579-gh-repo-env-isolates-pr-wait-tests.xbrief.json
+++ b/xbrief/active/2026-07-15-2579-gh-repo-env-isolates-pr-wait-tests.xbrief.json
@@ -1,0 +1,33 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2579"
+  },
+  "plan": {
+    "title": "GH_REPO in parent shell breaks pr-wait-mergeable tests during task check / release",
+    "status": "running",
+    "narratives": {
+      "Description": "GH_REPO in parent shell breaks pr-wait-mergeable tests during task check / release",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2579",
+      "Overview": "## Summary\n\nFirst v0.78.0 production `task release` Step 5 failed `task check` in part because `packages/core/src/pr-wait-mergeable/main.test.ts` failed when the parent shell had `GH_REPO` set. Clearing `GH_REPO` made the targeted re-run pass.\n\n## Fix\n\nClear `GH_REPO` in `beforeEach` of `main.test.ts` (or pin fixtures via args that win). Exclusive file: `main.test.ts` — do not edit `main.ts` (owned by #2581).\n\n## Acceptance\n\n- Tests pass with `GH_REPO` set in parent shell\n- Sibling audit documented\n- CHANGELOG entry",
+      "Labels": "bug, ci-cd, test-debt, scm, github, area:release"
+    },
+    "items": [],
+    "tags": [
+      "bug",
+      "ci-cd",
+      "test-debt",
+      "scm",
+      "github",
+      "area:release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2579",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2579: GH_REPO in parent shell breaks pr-wait-mergeable tests during task check / release"
+      }
+    ],
+    "updated": "2026-07-15T20:00:43Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Isolate `GH_REPO` in `pr-wait-mergeable` tests via `beforeEach`/`afterEach` so parent-shell exports cannot break `task check` / release Step 5
- Sibling audit: other pr-wait-mergeable tests already pass explicit repo args

Closes #2579

## Test plan
- [x] `GH_REPO=deftai/directive pnpm exec vitest run packages/core/src/pr-wait-mergeable` (50/50)
- [ ] CI green on PR
- [ ] Greptile CLEAN on HEAD