### PR TITLE
feat(release): coverage debt flag + restore branches 85 (#2573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Empty triage cache auto-populates from GitHub before queue reads (#2575).** `verify:cache-fresh`, `triage:queue`, `triage:summary`, and `triage:welcome` now run an idempotent fetch-all when `.deft-cache/github-issue/` has zero entries (repo inferred from git/`$DEFT_TRIAGE_REPO`), then proceed — without weakening the 24h freshness gate for non-empty caches. Closes #2575.
+- **Explicit coverage-debt escape hatch for release preflight (#2573).** `task release … --allow-coverage-debt=#N` is the only soft-pass path when Vitest metrics sit below the 85% goal; the pipeline emits loud attribution (measured vs goal, issue `#N`) and warns when recent releases overuse the flag. Raw env bypass is scoped to release Step 5 only — no auto near-miss band, no open-debt oracle.
 
 ### Changed
 
 - **Agents must route bare "what's next?" through `triage:queue`, not xBRIEF- or GitHub-only scans (#2576).** AGENTS.md, the triage skill, and `commands.md` anti-patterns forbid concluding an empty backlog from lifecycle folder walks or live issue lists without the cache-backed ranked queue. Closes #2576.
+- **Branch-coverage floor is 85% on every platform.** Removed the Windows-only `84.85` branches carve in `vitest.config.ts`; hairline win32 misses are operator-owned via `--allow-coverage-debt=#N`, not config nibble.
 
 ### Fixed
 

--- a/packages/core/src/release/constants.ts
+++ b/packages/core/src/release/constants.ts
@@ -36,13 +36,16 @@ export const BRANCH_GATE_BYPASS_ENV = "DEFT_ALLOW_DEFAULT_BRANCH_COMMIT";
 export const DESTRUCTIVE_GH_GATE_BYPASS_ENV = "DEFT_ALLOW_DESTRUCTIVE_GH_VERBS";
 /** Set by releaseSubprocessEnv() so Step-5 pre-flight skips triage-cache staleness (#2386). */
 export const RELEASE_PREFLIGHT_ENV = "DEFT_RELEASE_PREFLIGHT";
+/** Set only by release Step-5 preflight when --allow-coverage-debt=#N is supplied (#2573). */
+export const COVERAGE_DEBT_ENV = "DEFT_ALLOW_COVERAGE_DEBT";
 
 export const PYPROJECT_VERSION_LINE_RE = /version\s*=\s*"[^"]*"/;
 
 /** Byte-identical argparse --help from scripts/release.py (Python 3.12). */
 export const RELEASE_HELP =
   "usage: release [-h] [--dry-run] [--skip-tag] [--skip-release] [--allow-dirty]\n" +
-  "               [--allow-vbrief-drift] [--skip-ci] [--skip-build] [--no-draft]\n" +
+  "               [--allow-vbrief-drift] [--allow-coverage-debt #N]\n" +
+  "               [--skip-ci] [--skip-build] [--no-draft]\n" +
   "               [--repo OWNER/REPO] [--base-branch BRANCH]\n" +
   "               [--project-root PATH] [--summary TEXT]\n" +
   "               version\n" +
@@ -70,6 +73,10 @@ export const RELEASE_HELP =
   "                        may still live in non-terminal folders. The clean path\n" +
   "                        is to run `task reconcile:issues -- --apply-lifecycle-\n" +
   "                        fixes` first.\n" +
+  "  --allow-coverage-debt #N\n" +
+  "                        Acknowledge a hairline coverage miss: Step 5 passes\n" +
+  "                        only when metrics sit below the 85% goal and this\n" +
+  "                        flag cites an operator-owned issue number (#2573).\n" +
   "  --skip-ci             Skip Step 3 (task ci:local / task check fallback).\n" +
   "                        Used by `task release:e2e` to keep wall-clock\n" +
   "                        manageable inside the auto-created temp repo (CI\n" +

--- a/packages/core/src/release/coverage-boost.test.ts
+++ b/packages/core/src/release/coverage-boost.test.ts
@@ -279,6 +279,7 @@ describe("runPipeline additional branches", () => {
     skipBuild: true,
     summary: "Hello",
     allowVbriefDrift: false,
+    allowCoverageDebtIssue: null,
   };
 
   it("runs vbrief drift failure path", () => {
@@ -345,6 +346,7 @@ describe("runPipeline violation branches", () => {
     skipBuild: true,
     summary: null,
     allowVbriefDrift: true,
+    allowCoverageDebtIssue: null,
   };
 
   it("fails on dirty tree", () => {

--- a/packages/core/src/release/coverage-extra.test.ts
+++ b/packages/core/src/release/coverage-extra.test.ts
@@ -92,6 +92,7 @@ describe("pipeline branches extra", () => {
       skipBuild: true,
       summary: null,
       allowVbriefDrift: false,
+      allowCoverageDebtIssue: null,
     };
     const seams: ReleaseSeams = {
       spawnText: (_c, a) => {
@@ -125,6 +126,7 @@ describe("pipeline branches extra", () => {
       skipBuild: true,
       summary: null,
       allowVbriefDrift: true,
+      allowCoverageDebtIssue: null,
     };
     const seams: ReleaseSeams = {
       spawnText: (_c, a) => {
@@ -133,7 +135,7 @@ describe("pipeline branches extra", () => {
         return { status: 0, stdout: "", stderr: "" };
       },
       checkTagAvailable: () => [true, "ok"],
-      runCi: () => [false, "ci:local failed (exit 1)"],
+      runCi: (_root, _debt) => [false, "ci:local failed (exit 1)"],
     };
     expect(runPipeline(config, seams)).toBe(1);
   });

--- a/packages/core/src/release/coverage-final.test.ts
+++ b/packages/core/src/release/coverage-final.test.ts
@@ -32,6 +32,7 @@ describe("pipeline write path", () => {
     skipBuild: true,
     summary: null,
     allowVbriefDrift: true,
+    allowCoverageDebtIssue: null,
   };
 
   it("writes changelog on happy path", () => {

--- a/packages/core/src/release/flags.test.ts
+++ b/packages/core/src/release/flags.test.ts
@@ -58,6 +58,21 @@ describe("parseReleaseFlags", () => {
     expect(flags.unknown.length).toBeGreaterThan(0);
   });
 
+  it("parses --allow-coverage-debt issue number", () => {
+    expect(
+      parseReleaseFlags(["0.21.0", "--allow-coverage-debt=#2573"]).allowCoverageDebtIssue,
+    ).toBe(2573);
+    expect(parseReleaseFlags(["0.21.0", "--allow-coverage-debt=2573"]).allowCoverageDebtIssue).toBe(
+      2573,
+    );
+  });
+
+  it("records malformed --allow-coverage-debt values as unknown", () => {
+    const flags = parseReleaseFlags(["0.21.0", "--allow-coverage-debt=#"]);
+    expect(flags.allowCoverageDebtIssue).toBeNull();
+    expect(flags.unknown.some((u) => u.includes("allow-coverage-debt"))).toBe(true);
+  });
+
   it("sets help flag", () => {
     expect(parseReleaseFlags(["--help"]).help).toBe(true);
     expect(parseReleaseFlags(["-h"]).help).toBe(true);

--- a/packages/core/src/release/flags.ts
+++ b/packages/core/src/release/flags.ts
@@ -1,3 +1,4 @@
+import { parseCoverageDebtIssueNumber } from "../vitest-runner/coverage-debt.js";
 import { DEFAULT_BASE_BRANCH, RELEASE_HELP } from "./constants.js";
 import type { ReleaseFlags } from "./types.js";
 
@@ -8,6 +9,7 @@ export function parseReleaseFlags(args: readonly string[]): ReleaseFlags {
   let skipRelease = false;
   let allowDirty = false;
   let allowVbriefDrift = false;
+  let allowCoverageDebtIssue: number | null = null;
   let skipCi = false;
   let skipBuild = false;
   let draft = true;
@@ -41,6 +43,25 @@ export function parseReleaseFlags(args: readonly string[]): ReleaseFlags {
       allowDirty = true;
     } else if (token === "--allow-vbrief-drift") {
       allowVbriefDrift = true;
+    } else if (token === "--allow-coverage-debt") {
+      const value = takeValue(token, i);
+      if (value !== null) {
+        const issue = parseCoverageDebtIssueNumber(value);
+        if (issue === null) {
+          unknown.push(`${token} (malformed issue number)`);
+        } else {
+          allowCoverageDebtIssue = issue;
+        }
+        i += 1;
+      }
+    } else if (token.startsWith("--allow-coverage-debt=")) {
+      const value = token.slice("--allow-coverage-debt=".length);
+      const issue = parseCoverageDebtIssueNumber(value);
+      if (issue === null) {
+        unknown.push("--allow-coverage-debt= (malformed issue number)");
+      } else {
+        allowCoverageDebtIssue = issue;
+      }
     } else if (token === "--skip-ci") {
       skipCi = true;
     } else if (token === "--skip-build") {
@@ -96,6 +117,7 @@ export function parseReleaseFlags(args: readonly string[]): ReleaseFlags {
     skipRelease,
     allowDirty,
     allowVbriefDrift,
+    allowCoverageDebtIssue,
     skipCi,
     skipBuild,
     draft,

--- a/packages/core/src/release/main.test.ts
+++ b/packages/core/src/release/main.test.ts
@@ -61,6 +61,7 @@ describe("pipeline verify flip failure", () => {
       skipBuild: true,
       summary: null,
       allowVbriefDrift: true,
+      allowCoverageDebtIssue: null,
     };
     const seams: ReleaseSeams = {
       spawnText: (_c, a) => {

--- a/packages/core/src/release/main.ts
+++ b/packages/core/src/release/main.ts
@@ -48,6 +48,7 @@ export function cmdRelease(args: readonly string[], seams: ReleaseSeams = {}): n
     skipBuild: flags.skipBuild,
     summary: flags.summary,
     allowVbriefDrift: flags.allowVbriefDrift,
+    allowCoverageDebtIssue: flags.allowCoverageDebtIssue,
   };
 
   return runPipeline(config, seams);

--- a/packages/core/src/release/pipeline-branches.test.ts
+++ b/packages/core/src/release/pipeline-branches.test.ts
@@ -42,6 +42,7 @@ const baseConfig: ReleaseConfig = {
   skipBuild: false,
   summary: null,
   allowVbriefDrift: true,
+  allowCoverageDebtIssue: null,
 };
 
 describe("spawnText", () => {

--- a/packages/core/src/release/pipeline.test.ts
+++ b/packages/core/src/release/pipeline.test.ts
@@ -62,6 +62,7 @@ describe("runPipeline dry-run", () => {
     skipBuild: false,
     summary: null,
     allowVbriefDrift: true,
+    allowCoverageDebtIssue: null,
   };
 
   it("emits DRYRUN steps and returns 0", () => {
@@ -106,6 +107,7 @@ describe("runPipeline dry-run", () => {
       skipCi: false,
       skipBuild: true,
       allowVbriefDrift: true,
+      allowCoverageDebtIssue: null,
     };
     const seams: ReleaseSeams = {
       todayIso: () => "2026-04-28",
@@ -115,7 +117,7 @@ describe("runPipeline dry-run", () => {
         return { status: 0, stdout: "", stderr: "" };
       },
       checkTagAvailable: () => [true, "ok"],
-      runCi: () => {
+      runCi: (_root, _debt) => {
         runCiInvoked = true;
         return [true, "ran native TypeScript task check"];
       },
@@ -168,6 +170,7 @@ describe("release markdown containment (#2470)", () => {
           skipBuild: true,
           summary: null,
           allowVbriefDrift: true,
+          allowCoverageDebtIssue: null,
         };
         const seams: ReleaseSeams = {
           todayIso: () => "2026-04-28",

--- a/packages/core/src/release/pipeline.ts
+++ b/packages/core/src/release/pipeline.ts
@@ -44,7 +44,9 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
   const writeFile = seams.writeFile ?? ((p: string, c: string) => writeFileSync(p, c, "utf8"));
   const fileExists = seams.fileExists ?? ((p: string) => existsSync(p));
 
-  const runCiFn = seams.runCi ?? ((root: string) => runReleaseCheck(root));
+  const runCiFn =
+    seams.runCi ??
+    ((root: string, debtIssue: number | null) => runReleaseCheck(root, {}, debtIssue));
   const refreshRoadmapFn = seams.refreshRoadmap ?? ((root: string) => refreshRoadmapNative(root));
   const checkVbriefFn =
     seams.checkVbriefLifecycleSync ??
@@ -137,13 +139,25 @@ export function runPipeline(config: ReleaseConfig, seams: ReleaseSeams = {}): nu
   if (config.skipCi) {
     emit(5, label, "SKIP (--skip-ci)");
   } else if (config.dryRun) {
-    emit(5, label, "DRYRUN (would run task ci:local with task check fallback)");
+    const debtNote =
+      config.allowCoverageDebtIssue !== null
+        ? `; would pass --allow-coverage-debt=#${config.allowCoverageDebtIssue} to task check`
+        : "";
+    emit(5, label, `DRYRUN (would run task ci:local with task check fallback${debtNote})`);
   } else {
-    const [ok, reason] = runCiFn(projectRoot);
+    const [ok, reason] = runCiFn(projectRoot, config.allowCoverageDebtIssue);
     if (ok) {
-      emit(5, label, `OK (${reason})`);
+      const debtNote =
+        config.allowCoverageDebtIssue !== null
+          ? ` (coverage-debt acknowledged #${config.allowCoverageDebtIssue})`
+          : "";
+      emit(5, label, `OK (${reason}${debtNote})`);
     } else {
-      emit(5, label, `FAIL (${reason})`);
+      const debtHint =
+        config.allowCoverageDebtIssue === null
+          ? "; pass --allow-coverage-debt=#N only after operator review"
+          : "";
+      emit(5, label, `FAIL (${reason}${debtHint})`);
       return EXIT_VIOLATION;
     }
   }

--- a/packages/core/src/release/preflight.test.ts
+++ b/packages/core/src/release/preflight.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { BRANCH_GATE_BYPASS_ENV, RELEASE_PREFLIGHT_ENV } from "./constants.js";
+import { BRANCH_GATE_BYPASS_ENV, COVERAGE_DEBT_ENV, RELEASE_PREFLIGHT_ENV } from "./constants.js";
 import { runReleaseCheck } from "./preflight.js";
 
 describe("runReleaseCheck (#2022 Phase 1 native Step-5 pre-flight)", () => {
@@ -61,5 +61,23 @@ describe("runReleaseCheck (#2022 Phase 1 native Step-5 pre-flight)", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.env?.[BRANCH_GATE_BYPASS_ENV]).toBe("1");
     expect(calls[0]?.env?.[RELEASE_PREFLIGHT_ENV]).toBe("1");
+    expect(calls[0]?.env?.[COVERAGE_DEBT_ENV]).toBeUndefined();
+  });
+
+  it("passes allowCoverageDebtIssue into releaseCheckEnv (#2573)", () => {
+    const calls: Array<{ env?: NodeJS.ProcessEnv }> = [];
+    runReleaseCheck(
+      "/proj",
+      {
+        dispatchCheck: (_fw, _pr, checkSeams) => {
+          calls.push({ env: checkSeams?.env });
+          return 0;
+        },
+      },
+      2573,
+    );
+    expect(calls[0]?.env?.[COVERAGE_DEBT_ENV]).toBe("2573");
+    expect(calls[0]?.env?.[RELEASE_PREFLIGHT_ENV]).toBe("1");
+    expect(calls[0]?.env?.[BRANCH_GATE_BYPASS_ENV]).toBe("1");
   });
 });

--- a/packages/core/src/release/preflight.ts
+++ b/packages/core/src/release/preflight.ts
@@ -8,15 +8,22 @@
  * dispatches `check:framework-source`.
  */
 import { type CheckOrchestratorSeams, dispatchTaskCheck } from "../check/orchestrator.js";
-import { RELEASE_PREFLIGHT_ENV } from "./constants.js";
+import { COVERAGE_DEBT_ENV, RELEASE_PREFLIGHT_ENV } from "./constants.js";
 import { releaseSubprocessEnv } from "./git.js";
 
 /** Step-5-only env: branch bypass plus release pre-flight cache staleness tolerance (#2386). */
-export function releaseCheckEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  return {
+export function releaseCheckEnv(
+  base: NodeJS.ProcessEnv = process.env,
+  allowCoverageDebtIssue: number | null = null,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
     ...releaseSubprocessEnv(base),
     [RELEASE_PREFLIGHT_ENV]: "1",
   };
+  if (allowCoverageDebtIssue !== null) {
+    env[COVERAGE_DEBT_ENV] = String(allowCoverageDebtIssue);
+  }
+  return env;
 }
 
 /** Seams for test isolation of the native release pre-flight. */
@@ -42,11 +49,12 @@ export interface ReleasePreflightSeams {
 export function runReleaseCheck(
   projectRoot: string,
   seams: ReleasePreflightSeams = {},
+  allowCoverageDebtIssue: number | null = null,
 ): [boolean, string] {
   const dispatch = seams.dispatchCheck ?? dispatchTaskCheck;
   const checkSeams: CheckOrchestratorSeams = {
     ...seams.checkSeams,
-    env: releaseCheckEnv(seams.checkSeams?.env ?? process.env),
+    env: releaseCheckEnv(seams.checkSeams?.env ?? process.env, allowCoverageDebtIssue),
   };
   const code = dispatch(projectRoot, projectRoot, checkSeams);
   if (code === 0) {

--- a/packages/core/src/release/preflight.ts
+++ b/packages/core/src/release/preflight.ts
@@ -11,11 +11,15 @@ import { type CheckOrchestratorSeams, dispatchTaskCheck } from "../check/orchest
 import { COVERAGE_DEBT_ENV, RELEASE_PREFLIGHT_ENV } from "./constants.js";
 import { releaseSubprocessEnv } from "./git.js";
 
+export interface ReleaseCheckEnvOptions {
+  readonly base?: NodeJS.ProcessEnv;
+  readonly allowCoverageDebtIssue?: number | null;
+}
+
 /** Step-5-only env: branch bypass plus release pre-flight cache staleness tolerance (#2386). */
-export function releaseCheckEnv(
-  base: NodeJS.ProcessEnv = process.env,
-  allowCoverageDebtIssue: number | null = null,
-): NodeJS.ProcessEnv {
+export function releaseCheckEnv(options: ReleaseCheckEnvOptions = {}): NodeJS.ProcessEnv {
+  const base = options.base ?? process.env;
+  const allowCoverageDebtIssue = options.allowCoverageDebtIssue ?? null;
   const env: NodeJS.ProcessEnv = {
     ...releaseSubprocessEnv(base),
     [RELEASE_PREFLIGHT_ENV]: "1",
@@ -54,7 +58,10 @@ export function runReleaseCheck(
   const dispatch = seams.dispatchCheck ?? dispatchTaskCheck;
   const checkSeams: CheckOrchestratorSeams = {
     ...seams.checkSeams,
-    env: releaseCheckEnv(seams.checkSeams?.env ?? process.env, allowCoverageDebtIssue),
+    env: releaseCheckEnv({
+      base: seams.checkSeams?.env ?? process.env,
+      allowCoverageDebtIssue,
+    }),
   };
   const code = dispatch(projectRoot, projectRoot, checkSeams);
   if (code === 0) {

--- a/packages/core/src/release/types.ts
+++ b/packages/core/src/release/types.ts
@@ -13,6 +13,7 @@ export interface ReleaseConfig {
   readonly skipBuild: boolean;
   readonly summary: string | null;
   readonly allowVbriefDrift: boolean;
+  readonly allowCoverageDebtIssue: number | null;
 }
 
 export interface ReleaseFlags {
@@ -30,6 +31,7 @@ export interface ReleaseFlags {
   readonly skipBuild: boolean;
   readonly draft: boolean;
   readonly summary: string | null;
+  readonly allowCoverageDebtIssue: number | null;
   readonly unknown: readonly string[];
 }
 
@@ -56,7 +58,10 @@ export interface ReleaseSeams {
   readonly writeFile?: (path: string, content: string) => void;
   readonly readFile?: (path: string) => string;
   readonly fileExists?: (path: string) => boolean;
-  readonly runCi?: (projectRoot: string) => [boolean, string];
+  readonly runCi?: (
+    projectRoot: string,
+    allowCoverageDebtIssue: number | null,
+  ) => [boolean, string];
   readonly refreshRoadmap?: (projectRoot: string) => [boolean, string];
   readonly checkVbriefLifecycleSync?: (
     projectRoot: string,

--- a/packages/core/src/vitest-runner/coverage-debt-teardown.ts
+++ b/packages/core/src/vitest-runner/coverage-debt-teardown.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  COVERAGE_GOAL,
+  countRecentCoverageDebtMentions,
+  formatCoverageAttribution,
+  formatOveruseWarning,
+  metricsBelowGoal,
+  readCoverageTotalsFromReport,
+  resolveCoverageDebtIssue,
+} from "./coverage-debt.js";
+
+/** Vitest globalTeardown: enforce coverage goal or debt soft-pass (#2573). */
+export default async function coverageDebtTeardown(): Promise<void> {
+  const resolution = resolveCoverageDebtIssue(process.argv, process.env);
+  if (resolution.kind === "none") return;
+  if (resolution.kind === "invalid") {
+    throw new Error(`coverage-debt: ${resolution.reason}`);
+  }
+
+  const repoRoot = join(import.meta.dirname, "..", "..", "..", "..");
+  const totals = readCoverageTotalsFromReport(join(repoRoot, "coverage"));
+  if (totals === null) {
+    throw new Error("coverage-debt: could not read coverage/coverage-final.json");
+  }
+
+  const missed = metricsBelowGoal(totals);
+  if (missed.length === 0) {
+    process.stderr.write(
+      `coverage-debt: note — --allow-coverage-debt=#${resolution.issue} set but all metrics meet the ${COVERAGE_GOAL.branches}% goal\n`,
+    );
+    return;
+  }
+
+  process.stderr.write(`${formatCoverageAttribution(resolution.issue, totals)}\n`);
+
+  try {
+    const changelog = readFileSync(join(repoRoot, "CHANGELOG.md"), "utf8");
+    const overuse = formatOveruseWarning(countRecentCoverageDebtMentions(changelog));
+    if (overuse) process.stderr.write(`${overuse}\n`);
+  } catch {
+    // CHANGELOG unreadable — debt attribution still stands.
+  }
+}

--- a/packages/core/src/vitest-runner/coverage-debt.test.ts
+++ b/packages/core/src/vitest-runner/coverage-debt.test.ts
@@ -105,8 +105,13 @@ describe("attribution + overuse warning", () => {
 
   it("warns when multiple recent releases cite coverage debt", () => {
     const changelog =
-      "## [Unreleased]\n\n## [0.2.0]\ncoverage-debt soft-pass\n\n## [0.1.0]\nallow-coverage-debt\n";
+      "## [Unreleased]\n\n## [0.2.0]\ncoverage-debt soft-pass\n\n## [0.1.0]\nallow-coverage-debt=#1234\n";
     expect(countRecentCoverageDebtMentions(changelog)).toBe(2);
     expect(formatOveruseWarning(2)).toMatch(/WARN/);
+  });
+
+  it("does not count feature documentation without a debt acknowledgment", () => {
+    const changelog = "## [0.1.0]\nAdded allow-coverage-debt flag for release pipeline\n";
+    expect(countRecentCoverageDebtMentions(changelog)).toBe(0);
   });
 });

--- a/packages/core/src/vitest-runner/coverage-debt.test.ts
+++ b/packages/core/src/vitest-runner/coverage-debt.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  COVERAGE_GOAL,
+  countRecentCoverageDebtMentions,
+  formatCoverageAttribution,
+  formatOveruseWarning,
+  metricsBelowGoal,
+  parseCoverageDebtArgv,
+  parseCoverageDebtIssueNumber,
+  resolveCoverageDebtIssue,
+  summarizeCoverageFinal,
+} from "./coverage-debt.js";
+
+describe("parseCoverageDebtIssueNumber", () => {
+  it("accepts #N and bare N", () => {
+    expect(parseCoverageDebtIssueNumber("#2573")).toBe(2573);
+    expect(parseCoverageDebtIssueNumber("2573")).toBe(2573);
+  });
+
+  it("rejects malformed values", () => {
+    expect(parseCoverageDebtIssueNumber("")).toBeNull();
+    expect(parseCoverageDebtIssueNumber("#")).toBeNull();
+    expect(parseCoverageDebtIssueNumber("abc")).toBeNull();
+    expect(parseCoverageDebtIssueNumber("0")).toBeNull();
+  });
+});
+
+describe("parseCoverageDebtArgv", () => {
+  it("parses equals and spaced forms", () => {
+    expect(parseCoverageDebtArgv(["vitest", "--allow-coverage-debt=#2573"])).toEqual({
+      kind: "valid",
+      issue: 2573,
+    });
+    expect(parseCoverageDebtArgv(["vitest", "--allow-coverage-debt", "2573"])).toEqual({
+      kind: "valid",
+      issue: 2573,
+    });
+  });
+
+  it("fails closed on missing or malformed flag values", () => {
+    expect(parseCoverageDebtArgv(["vitest", "--allow-coverage-debt"])).toEqual({
+      kind: "invalid",
+      reason: "--allow-coverage-debt requires an issue number (#N)",
+    });
+    expect(parseCoverageDebtArgv(["vitest", "--allow-coverage-debt=#"])).toEqual({
+      kind: "invalid",
+      reason: "--allow-coverage-debt= value must be #N or N",
+    });
+  });
+});
+
+describe("resolveCoverageDebtIssue env scoping (#1553)", () => {
+  it("ignores raw env without release preflight", () => {
+    expect(resolveCoverageDebtIssue(["vitest"], { DEFT_ALLOW_COVERAGE_DEBT: "2573" })).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("accepts env only during release preflight", () => {
+    expect(
+      resolveCoverageDebtIssue(["vitest"], {
+        DEFT_ALLOW_COVERAGE_DEBT: "2573",
+        DEFT_RELEASE_PREFLIGHT: "1",
+      }),
+    ).toEqual({ kind: "valid", issue: 2573 });
+  });
+});
+
+describe("summarizeCoverageFinal + metricsBelowGoal", () => {
+  it("detects metrics below the 85% goal", () => {
+    const totals = summarizeCoverageFinal({
+      "a.ts": {
+        s: { "0": 1, "1": 0 },
+        f: { "0": 1 },
+        b: { "0": [1, 0] },
+      },
+    });
+    expect(metricsBelowGoal(totals)).toContain("statements");
+    expect(metricsBelowGoal(totals)).toContain("branches");
+  });
+
+  it("passes when all metrics meet goal", () => {
+    const totals = {
+      lines: 90,
+      functions: 90,
+      branches: 90,
+      statements: 90,
+    };
+    expect(metricsBelowGoal(totals)).toEqual([]);
+  });
+});
+
+describe("attribution + overuse warning", () => {
+  it("formats measured vs goal with issue number", () => {
+    const text = formatCoverageAttribution(2573, {
+      lines: 84.5,
+      branches: 84.9,
+      functions: 86,
+      statements: 84.5,
+    });
+    expect(text).toContain("#2573");
+    expect(text).toContain("84.90%");
+    expect(text).toContain(`${COVERAGE_GOAL.branches}%`);
+  });
+
+  it("warns when multiple recent releases cite coverage debt", () => {
+    const changelog =
+      "## [Unreleased]\n\n## [0.2.0]\ncoverage-debt soft-pass\n\n## [0.1.0]\nallow-coverage-debt\n";
+    expect(countRecentCoverageDebtMentions(changelog)).toBe(2);
+    expect(formatOveruseWarning(2)).toMatch(/WARN/);
+  });
+});

--- a/packages/core/src/vitest-runner/coverage-debt.ts
+++ b/packages/core/src/vitest-runner/coverage-debt.ts
@@ -135,11 +135,15 @@ export function summarizeCoverageFinal(
   const functions = pct(fnCovered, fnTotal);
   const branches = pct(branchCovered, branchTotal);
 
+  // Istanbul coverage-final.json does not carry pre-aggregated line hit counts —
+  // `l` (line map) is optional and its format differs from `s`/`f`/`b`. Using
+  // statements as a proxy may overstate line coverage when multiple statements
+  // share a single uncovered line.
   return {
     statements,
     functions,
     branches,
-    lines: statements,
+    lines: statements, // approximation: actual line coverage may differ
   };
 }
 
@@ -164,11 +168,13 @@ export function metricsBelowGoal(totals: CoverageTotals): CoverageMetric[] {
   return missed;
 }
 
+const sanitizeMetric = (value: string | number): string => String(value).replace(/\r?\n/g, " ");
+
 export function formatCoverageAttribution(issue: number, totals: CoverageTotals): string {
   const lines = [
     `coverage-debt: soft-pass acknowledged for issue #${issue}`,
-    `  measured: branches ${totals.branches.toFixed(2)}% | lines ${totals.lines.toFixed(2)}% | functions ${totals.functions.toFixed(2)}% | statements ${totals.statements.toFixed(2)}%`,
-    `  goal:     branches ${COVERAGE_GOAL.branches}% | lines ${COVERAGE_GOAL.lines}% | functions ${COVERAGE_GOAL.functions}% | statements ${COVERAGE_GOAL.statements}%`,
+    `  measured: branches ${sanitizeMetric(totals.branches.toFixed(2))}% | lines ${sanitizeMetric(totals.lines.toFixed(2))}% | functions ${sanitizeMetric(totals.functions.toFixed(2))}% | statements ${sanitizeMetric(totals.statements.toFixed(2))}%`,
+    `  goal:     branches ${sanitizeMetric(COVERAGE_GOAL.branches)}% | lines ${sanitizeMetric(COVERAGE_GOAL.lines)}% | functions ${sanitizeMetric(COVERAGE_GOAL.functions)}% | statements ${sanitizeMetric(COVERAGE_GOAL.statements)}%`,
   ];
   return lines.join("\n");
 }
@@ -177,7 +183,7 @@ export function formatCoverageAttribution(issue: number, totals: CoverageTotals)
 export function countRecentCoverageDebtMentions(changelog: string, maxSections = 5): number {
   const versionHeader = /^## \[(?!Unreleased)/m;
   const sections = changelog.split(versionHeader).slice(1, maxSections + 1);
-  const pattern = /coverage[- ]debt|allow-coverage-debt/i;
+  const pattern = /coverage[- ]debt soft[- ]pass|allow-coverage-debt=#?\d/i;
   return sections.filter((section) => pattern.test(section)).length;
 }
 

--- a/packages/core/src/vitest-runner/coverage-debt.ts
+++ b/packages/core/src/vitest-runner/coverage-debt.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Shared coverage goal (vitest thresholds). */
+export const COVERAGE_GOAL = {
+  lines: 85,
+  functions: 85,
+  branches: 85,
+  statements: 85,
+} as const;
+
+export type CoverageMetric = keyof typeof COVERAGE_GOAL;
+
+export interface CoverageTotals {
+  readonly lines: number;
+  readonly functions: number;
+  readonly branches: number;
+  readonly statements: number;
+}
+
+export type CoverageDebtResolution =
+  | { readonly kind: "none" }
+  | { readonly kind: "valid"; readonly issue: number }
+  | { readonly kind: "invalid"; readonly reason: string };
+
+const DEBT_FLAG = "--allow-coverage-debt";
+const DEBT_ENV = "DEFT_ALLOW_COVERAGE_DEBT";
+const RELEASE_PREFLIGHT_ENV = "DEFT_RELEASE_PREFLIGHT";
+
+/** Parse `#2573`, `2573`, or bare numeric strings. */
+export function parseCoverageDebtIssueNumber(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (!/^\d+$/.test(normalized)) return null;
+  const issue = Number.parseInt(normalized, 10);
+  return Number.isFinite(issue) && issue > 0 ? issue : null;
+}
+
+/** Parse `--allow-coverage-debt=#N` tokens from argv. */
+export function parseCoverageDebtArgv(argv: readonly string[]): CoverageDebtResolution {
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i] ?? "";
+    if (token === DEBT_FLAG) {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("-")) {
+        return { kind: "invalid", reason: `${DEBT_FLAG} requires an issue number (#N)` };
+      }
+      const issue = parseCoverageDebtIssueNumber(next);
+      return issue === null
+        ? { kind: "invalid", reason: `${DEBT_FLAG} value must be #N or N` }
+        : { kind: "valid", issue };
+    }
+    if (token.startsWith(`${DEBT_FLAG}=`)) {
+      const value = token.slice(DEBT_FLAG.length + 1);
+      const issue = parseCoverageDebtIssueNumber(value);
+      return issue === null
+        ? { kind: "invalid", reason: `${DEBT_FLAG}= value must be #N or N` }
+        : { kind: "valid", issue };
+    }
+  }
+  return { kind: "none" };
+}
+
+/**
+ * Resolve coverage-debt issue from argv or release-scoped env (#2573 / #1553).
+ * Raw env bypass is accepted only during release Step-5 preflight.
+ */
+export function resolveCoverageDebtIssue(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): CoverageDebtResolution {
+  const fromArgv = parseCoverageDebtArgv(argv);
+  if (fromArgv.kind !== "none") return fromArgv;
+
+  const rawEnv = env[DEBT_ENV];
+  if (rawEnv && env[RELEASE_PREFLIGHT_ENV] === "1") {
+    const issue = parseCoverageDebtIssueNumber(rawEnv);
+    return issue === null
+      ? { kind: "invalid", reason: `${DEBT_ENV} must be a positive integer` }
+      : { kind: "valid", issue };
+  }
+
+  return { kind: "none" };
+}
+
+interface IstanbulBranchHits {
+  readonly [branchId: string]: readonly number[];
+}
+
+interface IstanbulFileCoverage {
+  readonly s?: Readonly<Record<string, number>>;
+  readonly f?: Readonly<Record<string, number>>;
+  readonly b?: IstanbulBranchHits;
+}
+
+/** Aggregate global coverage percentages from istanbul coverage-final.json. */
+export function summarizeCoverageFinal(
+  coverageFinal: Readonly<Record<string, IstanbulFileCoverage>>,
+): CoverageTotals {
+  let stmtTotal = 0;
+  let stmtCovered = 0;
+  let fnTotal = 0;
+  let fnCovered = 0;
+  let branchTotal = 0;
+  let branchCovered = 0;
+
+  for (const file of Object.values(coverageFinal)) {
+    if (file.s) {
+      for (const hits of Object.values(file.s)) {
+        stmtTotal += 1;
+        if (hits > 0) stmtCovered += 1;
+      }
+    }
+    if (file.f) {
+      for (const hits of Object.values(file.f)) {
+        fnTotal += 1;
+        if (hits > 0) fnCovered += 1;
+      }
+    }
+    if (file.b) {
+      for (const paths of Object.values(file.b)) {
+        for (const hits of paths) {
+          branchTotal += 1;
+          if (hits > 0) branchCovered += 1;
+        }
+      }
+    }
+  }
+
+  const pct = (covered: number, total: number): number =>
+    total === 0 ? 100 : (covered / total) * 100;
+
+  const statements = pct(stmtCovered, stmtTotal);
+  const functions = pct(fnCovered, fnTotal);
+  const branches = pct(branchCovered, branchTotal);
+
+  return {
+    statements,
+    functions,
+    branches,
+    lines: statements,
+  };
+}
+
+export function readCoverageTotalsFromReport(coverageDir: string): CoverageTotals | null {
+  const finalPath = join(coverageDir, "coverage-final.json");
+  try {
+    const raw = readFileSync(finalPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, IstanbulFileCoverage>;
+    return summarizeCoverageFinal(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function metricsBelowGoal(totals: CoverageTotals): CoverageMetric[] {
+  const missed: CoverageMetric[] = [];
+  for (const metric of Object.keys(COVERAGE_GOAL) as CoverageMetric[]) {
+    if (totals[metric] + 1e-9 < COVERAGE_GOAL[metric]) {
+      missed.push(metric);
+    }
+  }
+  return missed;
+}
+
+export function formatCoverageAttribution(issue: number, totals: CoverageTotals): string {
+  const lines = [
+    `coverage-debt: soft-pass acknowledged for issue #${issue}`,
+    `  measured: branches ${totals.branches.toFixed(2)}% | lines ${totals.lines.toFixed(2)}% | functions ${totals.functions.toFixed(2)}% | statements ${totals.statements.toFixed(2)}%`,
+    `  goal:     branches ${COVERAGE_GOAL.branches}% | lines ${COVERAGE_GOAL.lines}% | functions ${COVERAGE_GOAL.functions}% | statements ${COVERAGE_GOAL.statements}%`,
+  ];
+  return lines.join("\n");
+}
+
+/** Count recent release sections citing coverage-debt (CHANGELOG scan). */
+export function countRecentCoverageDebtMentions(changelog: string, maxSections = 5): number {
+  const versionHeader = /^## \[(?!Unreleased)/m;
+  const sections = changelog.split(versionHeader).slice(1, maxSections + 1);
+  const pattern = /coverage[- ]debt|allow-coverage-debt/i;
+  return sections.filter((section) => pattern.test(section)).length;
+}
+
+export function formatOveruseWarning(recentCount: number): string | null {
+  if (recentCount < 2) return null;
+  return (
+    `coverage-debt WARN: ${recentCount} of the last release sections already cite coverage debt — ` +
+    "consider restoring real coverage instead of reusing the escape hatch."
+  );
+}

--- a/packages/core/src/vitest-runner/vitest-config-contract.test.ts
+++ b/packages/core/src/vitest-runner/vitest-config-contract.test.ts
@@ -54,3 +54,18 @@ describe("vitest.config.ts Windows coverage tmp contract (#2580)", () => {
     expect(setupSource).toMatch(/ensureCoverageTmpDir/);
   });
 });
+
+describe("vitest.config.ts coverage threshold contract (#2573)", () => {
+  const source = readFileSync(configPath, "utf8");
+
+  it("sets branches threshold to 85 on all platforms (no win32 carve)", () => {
+    expect(source).toContain("#2573");
+    expect(source).toMatch(/branches:\s*85/);
+    expect(source).not.toMatch(/isWin32\s*\?\s*84\.85/);
+  });
+
+  it("documents coverage-debt soft-pass gate", () => {
+    expect(source).toMatch(/coverage-debt-teardown/);
+    expect(source).toMatch(/resolveCoverageDebtIssue/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { realpathSync } from "node:fs";
 import { cpus, tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
+import { resolveCoverageDebtIssue } from "./packages/core/src/vitest-runner/coverage-debt.ts";
 
 // macOS exposes the same temporary directory through /var and /private/var.
 // Give test workers the canonical spelling so cwd/git comparisons and cleanup
@@ -24,6 +25,22 @@ const winMaxWorkers = Math.max(1, Math.min(12, Math.floor(cpus().length * 0.25))
 const coverageEnabled = process.argv.some(
   (arg) => arg === "--coverage" || arg.startsWith("--coverage."),
 );
+const coverageDebt = resolveCoverageDebtIssue(process.argv, process.env);
+if (coverageDebt.kind === "invalid") {
+  throw new Error(`coverage-debt: ${coverageDebt.reason}`);
+}
+const coverageDebtIssue = coverageDebt.kind === "valid" ? coverageDebt.issue : null;
+const coverageDebtTeardown = resolve(
+  import.meta.dirname,
+  "packages/core/src/vitest-runner/coverage-debt-teardown.ts",
+);
+const coverageThresholds = {
+  lines: 85,
+  functions: 85,
+  // Fail-closed at 85 on all platforms; hairline misses use --allow-coverage-debt=#N (#2573).
+  branches: 85,
+  statements: 85,
+} as const;
 const winActiveMaxWorkers =
   isWin32 && coverageEnabled ? Math.max(1, Math.min(4, winMaxWorkers)) : winMaxWorkers;
 const win32CoverageTmpSetup = resolve(
@@ -159,6 +176,9 @@ export default defineConfig({
           },
         }
       : {}),
+    ...(coverageEnabled && coverageDebtIssue !== null
+      ? { globalTeardown: [coverageDebtTeardown] }
+      : {}),
     coverage: {
       provider: "v8",
       include: ["packages/*/src/**/*.ts"],
@@ -170,14 +190,10 @@ export default defineConfig({
       ],
       reporter: ["text", "text-summary"],
       ...(isWin32 && coverageEnabled ? { processingConcurrency: 1 } : {}),
-      thresholds: {
-        lines: 85,
-        functions: 85,
-        // Windows skips symlink/chmod suites (#2467), which trims ~0.01–0.05pt
-        // of branch coverage vs Linux CI. Keep Linux fail-closed at 85.
-        branches: isWin32 ? 84.85 : 85,
-        statements: 85,
-      },
+      thresholds:
+        coverageDebtIssue !== null
+          ? { lines: 0, functions: 0, branches: 0, statements: 0 }
+          : coverageThresholds,
     },
   },
 });

--- a/xbrief/active/2026-07-15-2573-allow-coverage-debt-flag-restore-85.xbrief.json
+++ b/xbrief/active/2026-07-15-2573-allow-coverage-debt-flag-restore-85.xbrief.json
@@ -1,0 +1,49 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for GitHub issue #2573 — coverage debt flag + restore branches 85"
+  },
+  "plan": {
+    "id": "allow-coverage-debt-flag-restore-85",
+    "title": "Release coverage soft-pass only via --allow-coverage-debt=#N; restore win32 branches floor to 85",
+    "status": "running",
+    "narratives": {
+      "Description": "Hard fail coverage by default at 85%. Soft-pass only with explicit task release --allow-coverage-debt=#N (loud, attributable). Remove isWin32 branches carve; thresholds.branches = 85 on all platforms. Warn when debt flag is overused.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2573",
+      "Overview": "Operator locks: no auto near-miss; no open-debt oracle. #2580 shipped win32 coverage/.tmp fixes — only change thresholds + debt flag surface.",
+      "UserStory": "As a release operator, I want an explicit --allow-coverage-debt=#N escape hatch so hairline coverage misses do not require threshold nibble or admin merge.",
+      "ImplementationPlan": "1. Restore vitest thresholds.branches to 85 on all platforms.\n2. Add coverage-debt parser + vitest globalTeardown gate (scoped env via release preflight only).\n3. Wire --allow-coverage-debt=#N through release flags → Step 5 env.\n4. Emit attribution + overuse warning.\n5. Tests + CHANGELOG.",
+      "Acceptance": "Under threshold without flag fails; malformed flag fails; flag+#N under threshold passes with attribution; at/above threshold succeeds; branches=85 everywhere."
+    },
+    "items": [
+      {
+        "id": "2573-a1",
+        "title": "branches threshold is 85 on all platforms",
+        "status": "running",
+        "narrative": {
+          "Acceptance": "vitest.config.ts thresholds.branches = 85 with no isWin32 carve."
+        }
+      },
+      {
+        "id": "2573-a2",
+        "title": "coverage debt flag contract",
+        "status": "running",
+        "narrative": {
+          "Acceptance": "Under threshold + no flag fails; flag+#N soft-passes with attribution; malformed flag fails closed."
+        }
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2573",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2573: Release coverage soft-pass via --allow-coverage-debt=#N"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "technical-debt"
+    },
+    "updated": "2026-07-15T20:20:00Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Restore `thresholds.branches` to **85** on all platforms (remove win32 84.85 carve)
- Add release escape hatch `--allow-coverage-debt=#N` (loud, attributable; no auto near-miss / no open-debt oracle)
- Soft-pass path attributes measured vs goal + `#N` and warns on overuse

Closes #2573

## Test plan
- [x] coverage-debt / vitest-config-contract / release tests
- [ ] CI green on PR
- [ ] Greptile CLEAN on HEAD