### PR TITLE
feat(harness): add Codex lifecycle hook adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Codex project hooks now enforce the existing direct-write mutation gate (#2596).** `directive init` / `deft update` idempotently merge `SessionStart` and direct-write `PreToolUse` commands into `.codex/hooks.json`, preserving unrelated hooks and leaving `.codex/config.toml` untouched. The shared dispatcher emits Codex's canonical deny envelope; verify/doctor report structural registration separately from user-controlled runtime trust and direct users to `/hooks`. Closes #2596. Refs #2437, #2438.
 - **Empty triage cache auto-populates from GitHub before queue reads (#2575).** `verify:cache-fresh`, `triage:queue`, `triage:summary`, and `triage:welcome` now run an idempotent fetch-all when `.deft-cache/github-issue/` has zero entries (repo inferred from git/`$DEFT_TRIAGE_REPO`), then proceed — without weakening the 24h freshness gate for non-empty caches. Closes #2575.
 - **Explicit coverage-debt escape hatch for release preflight (#2573).** `task release … --allow-coverage-debt=#N` is the only soft-pass path when Vitest metrics sit below the 85% goal; the pipeline emits loud attribution (measured vs goal, issue `#N`) and warns when recent releases overuse the flag. Raw env bypass is scoped to release Step 5 only — no auto near-miss band, no open-debt oracle.
 

--- a/content/commands.md
+++ b/content/commands.md
@@ -181,13 +181,15 @@ Current status: the validation, extractor, provider, registry, generated MAP, an
 
 Use `task --list` for the exact current verify namespace.
 
-### Agent-host direct-write hooks (#2438)
+### Agent-host direct-write hooks (#2438, #2596)
 
-`directive init` and `deft update` idempotently merge Directive-owned entries into `.claude/settings.json`, `.grok/hooks/deft.json`, and `.cursor/hooks.json` while preserving unrelated settings. `SessionStart` refreshes resume bookkeeping on a non-blocking path. `PreToolUse` covers direct edit/write tools and denies them until both existing gates pass: a fresh gated session ritual and an active/running xBRIEF accepted by canonical preflight.
+`directive init` and `deft update` idempotently merge Directive-owned entries into `.claude/settings.json`, `.grok/hooks/deft.json`, `.cursor/hooks.json`, and `.codex/hooks.json` while preserving unrelated settings. `SessionStart` refreshes resume bookkeeping on a non-blocking path. `PreToolUse` covers direct edit/write tools and denies them until both existing gates pass: a fresh gated session ritual and an active/running xBRIEF accepted by canonical preflight.
 
 - Verify registration: `deft verify:hooks-installed --scope=agent` (or `--scope=all` for git + agent hooks).
 - Repair missing/drifted entries: `deft update`.
-- The P0 hook slice does not classify shell-mediated writes, MCP mutations, compact re-arm, or subagent routing; those remain owned by their dedicated follow-up issues.
+- Codex project hooks are trust-gated by Codex. Directive verifies only that the registrations are structurally current; after an install or changed hook hash, open `/hooks` in Codex and review/approve the project hook commands. Runtime trust cannot be inferred from the file alone.
+- Directive writes only `.codex/hooks.json`; it does not parse or modify `.codex/config.toml`. Codex can also load inline hooks from `config.toml`, so avoid defining duplicate Directive commands there or they may run more than once. See the [Codex hooks documentation](https://learn.chatgpt.com/docs/hooks).
+- The P0 hook slice does not classify shell-mediated writes, MCP mutations, richer unified-exec calls, WebSearch, compact re-arm, or subagent routing; those remain owned by their dedicated follow-up issues.
 
 ## Session-start ritual (#1149)
 

--- a/packages/cli/src/gates-cli/verify-env-cli.test.ts
+++ b/packages/cli/src/gates-cli/verify-env-cli.test.ts
@@ -58,7 +58,8 @@ describe("deft-ts verify-hooks-installed (maps tests/cli/test_verify_hooks_insta
 
     const result = runDeftTs("verify-hooks-installed", ["--scope=agent", "--project-root", root]);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Claude, Grok, Cursor");
+    expect(result.stdout).toContain("Claude, Grok, Cursor, Codex");
+    expect(result.stdout).toContain("runtime trust is user-controlled");
   });
 
   it("rejects an unknown hook scope", () => {

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -7,6 +7,10 @@ describe("hook-dispatch CLI", () => {
     expect(
       parseArgs(["--host", "grok", "--event", "tool.before", "--project-root=/project"]),
     ).toEqual({ host: "grok", event: "tool.before", projectRoot: "/project" });
+    expect(parseArgs(["--host", "codex", "--event", "session.start"])).toEqual({
+      host: "codex",
+      event: "session.start",
+    });
   });
 
   it("rejects unsupported providers and events as configuration errors", () => {
@@ -46,6 +50,24 @@ describe("hook-dispatch CLI", () => {
     expect(code).toBe(0);
     expect(JSON.parse(out.join(""))).toMatchObject({ decision: "deny" });
     expect(err).toEqual([]);
+  });
+
+  it("fails closed with a Codex-native denial when matched tool input is malformed", () => {
+    const out: string[] = [];
+    const code = run(["--host", "codex", "--event", "tool.before"], {
+      readStdin: () => "{bad-json",
+      writeOut: (text) => out.push(text),
+      writeErr: () => undefined,
+      cwd: () => "/project",
+    });
+
+    expect(code).toBe(0);
+    expect(JSON.parse(out.join(""))).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+      },
+    });
   });
 
   it("keeps SessionStart non-blocking and silent", () => {

--- a/packages/core/src/doctor/agent-hooks.test.ts
+++ b/packages/core/src/doctor/agent-hooks.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { runAgentHooksHealthCheck } from "./main.js";
+import { createPlainSink } from "./output.js";
+import type { DoctorSeams, Finding } from "./types.js";
+
+describe("runAgentHooksHealthCheck", () => {
+  it("records structural health and leaves Codex runtime trust unverifiable", () => {
+    const lines: string[] = [];
+    const findings: Finding[] = [];
+    const registrations = [
+      {
+        host: "codex" as const,
+        path: ".codex/hooks.json" as const,
+        status: "healthy" as const,
+        detail: "registrations are current",
+      },
+    ];
+    const seams: DoctorSeams = {
+      evaluateAgentHooks: () => ({
+        code: 0,
+        message: "registered",
+        stream: "stdout",
+        registrations,
+      }),
+    };
+
+    runAgentHooksHealthCheck(
+      "/project",
+      true,
+      createPlainSink({ write: (text) => lines.push(text) }),
+      (finding) => findings.push(finding),
+      seams,
+    );
+
+    expect(lines.join("")).toContain("registered and structurally valid");
+    expect(lines.join("")).toContain("`/hooks`");
+    expect(findings).toEqual([
+      expect.objectContaining({
+        severity: "skip",
+        check: "agent-hooks-registration",
+        status: "registered",
+        trust_status: "not-verifiable",
+        registrations,
+      }),
+    ]);
+  });
+
+  it("reports registration drift without claiming runtime non-functionality", () => {
+    const findings: Finding[] = [];
+    runAgentHooksHealthCheck(
+      "/project",
+      true,
+      createPlainSink({ write: () => undefined }),
+      (finding) => findings.push(finding),
+      {
+        evaluateAgentHooks: () => ({
+          code: 1,
+          message: "registration incomplete",
+          stream: "stderr",
+          registrations: [],
+        }),
+      },
+    );
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        severity: "warning",
+        status: "incomplete",
+      }),
+    ]);
+  });
+
+  it("distinguishes a registration probe configuration error", () => {
+    const findings: Finding[] = [];
+    runAgentHooksHealthCheck(
+      "/project",
+      true,
+      createPlainSink({ write: () => undefined }),
+      (finding) => findings.push(finding),
+      {
+        evaluateAgentHooks: () => ({
+          code: 2,
+          message: "project root unavailable",
+          stream: "stderr",
+          registrations: [],
+        }),
+      },
+    );
+
+    expect(findings).toEqual([expect.objectContaining({ status: "unavailable" })]);
+  });
+
+  it("reports a thrown registration probe without crashing doctor", () => {
+    const findings: Finding[] = [];
+    runAgentHooksHealthCheck(
+      "/project",
+      true,
+      createPlainSink({ write: () => undefined }),
+      (finding) => findings.push(finding),
+      {
+        evaluateAgentHooks: () => {
+          throw new Error("probe failed");
+        },
+      },
+    );
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        severity: "warning",
+        message: expect.stringContaining("probe failed"),
+      }),
+    ]);
+  });
+});

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -426,7 +426,19 @@ export function runAgentHooksHealthCheck(
   try {
     const result = (seams.evaluateAgentHooks ?? evaluateAgentHooks)(projectRoot);
     if (result.code === 0) {
-      sink.success(`${checkName}: healthy`);
+      const message =
+        `${checkName}: registered and structurally valid; ` +
+        "Codex runtime trust is user-controlled and must be reviewed with `/hooks`";
+      sink.success(message);
+      addFinding({
+        severity: "skip",
+        message,
+        check: checkName,
+        status: "registered",
+        registrations: result.registrations,
+        trust_status: "not-verifiable",
+        trust_review: "Open `/hooks` in Codex and review the project hook commands.",
+      });
       return;
     }
     const message = `${checkName}: ${result.message.replace(/\s+/g, " ").trim()}`;
@@ -435,7 +447,7 @@ export function runAgentHooksHealthCheck(
       severity: "warning",
       message,
       check: checkName,
-      status: result.code === 2 ? "unavailable" : "non-functional",
+      status: result.code === 2 ? "unavailable" : "incomplete",
       registrations: result.registrations,
       suggestion: "deft update",
     });

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -269,6 +269,16 @@ describe("provider codecs", () => {
     });
   });
 
+  it("renders Codex's canonical hookSpecificOutput denial", () => {
+    expect(JSON.parse(renderHostDecision("codex", deny))).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: deny.message,
+      },
+    });
+  });
+
   it("emits no provider override for an allow decision", () => {
     const allow = decideHook(
       {
@@ -282,6 +292,7 @@ describe("provider codecs", () => {
     expect(renderHostDecision("claude", allow)).toBe("");
     expect(renderHostDecision("grok", allow)).toBe("");
     expect(renderHostDecision("cursor", allow)).toBe("");
+    expect(renderHostDecision("codex", allow)).toBe("");
   });
 });
 
@@ -324,6 +335,7 @@ describe("provider input normalization", () => {
 
   it("validates public host and event identifiers", () => {
     expect(isHookHost("cursor")).toBe(true);
+    expect(isHookHost("codex")).toBe(true);
     expect(isHookHost("opencode")).toBe(false);
     expect(isHookEvent("session.start")).toBe(true);
     expect(isHookEvent("tool.after")).toBe(false);

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -6,7 +6,7 @@ import { isDirectWriteTool } from "./tools.js";
 
 export { DIRECT_WRITE_TOOL_NAMES, isDirectWriteTool } from "./tools.js";
 
-export const HOOK_HOSTS = ["claude", "grok", "cursor"] as const;
+export const HOOK_HOSTS = ["claude", "grok", "cursor", "codex"] as const;
 export type HookHost = (typeof HOOK_HOSTS)[number];
 
 export const HOOK_EVENTS = ["session.start", "tool.before"] as const;
@@ -229,21 +229,23 @@ export function decideHook(input: HookDispatchInput, seams: HookPolicySeams = {}
 /** Render only authoritative denials; allow preserves the host's own permission flow. */
 export function renderHostDecision(host: HookHost, decision: HookDecision): string {
   if (decision.verdict === "allow") return "";
-  if (host === "claude") {
-    return JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: decision.message,
-      },
-    });
+  switch (host) {
+    case "claude":
+    case "codex":
+      return JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: decision.message,
+        },
+      });
+    case "grok":
+      return JSON.stringify({ decision: "deny", reason: decision.message });
+    case "cursor":
+      return JSON.stringify({
+        permission: "deny",
+        user_message: decision.message,
+        agent_message: decision.message,
+      });
   }
-  if (host === "grok") {
-    return JSON.stringify({ decision: "deny", reason: decision.message });
-  }
-  return JSON.stringify({
-    permission: "deny",
-    user_message: decision.message,
-    agent_message: decision.message,
-  });
 }

--- a/packages/core/src/init-deposit/agent-hooks.test.ts
+++ b/packages/core/src/init-deposit/agent-hooks.test.ts
@@ -1,4 +1,12 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -22,7 +30,7 @@ function project(): string {
 }
 
 describe("writeAgentHookDeposit", () => {
-  it("deposits native Claude, Grok, and Cursor SessionStart/direct-write hooks", () => {
+  it("deposits native Claude, Grok, Cursor, and Codex SessionStart/direct-write hooks", () => {
     const root = project();
     const lines: string[] = [];
     const result = writeAgentHookDeposit(root, { printf: (text) => lines.push(text) });
@@ -37,6 +45,9 @@ describe("writeAgentHookDeposit", () => {
     );
     expect(readFileSync(join(root, ".cursor/hooks.json"), "utf8")).toContain(
       "--host cursor --event tool.before",
+    );
+    expect(readFileSync(join(root, ".codex/hooks.json"), "utf8")).toContain(
+      "--host codex --event tool.before",
     );
     expect(DIRECT_WRITE_HOOK_MATCHER.split("|")).toEqual([...DIRECT_WRITE_TOOL_NAMES]);
     expect(DIRECT_WRITE_HOOK_MATCHER.split("|").every(isDirectWriteTool)).toBe(true);
@@ -79,6 +90,52 @@ describe("writeAgentHookDeposit", () => {
     expect(second[0]).toContain("./custom-check.sh");
   });
 
+  it("preserves unrelated Codex hook groups while replacing only Directive-owned entries", () => {
+    const root = project();
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(
+      join(root, ".codex/hooks.json"),
+      `${JSON.stringify(
+        {
+          hooks: {
+            SessionStart: [
+              {
+                matcher: "resume",
+                hooks: [{ type: "command", command: "./resume-check.sh" }],
+              },
+            ],
+            PreToolUse: [
+              {
+                matcher: "Bash",
+                hooks: [{ type: "command", command: "./custom-codex-check.sh" }],
+              },
+              {
+                matcher: "stale",
+                hooks: [
+                  {
+                    type: "command",
+                    command: "deft hook:dispatch --host codex --event tool.before --old",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    writeAgentHookDeposit(root);
+    const codex = readFileSync(join(root, ".codex/hooks.json"), "utf8");
+
+    expect(codex).toContain("./resume-check.sh");
+    expect(codex).toContain("./custom-codex-check.sh");
+    expect(codex).not.toContain("--old");
+    expect(codex.match(/--host codex --event tool\.before/g)).toHaveLength(1);
+  });
+
   it("refuses to overwrite malformed user JSON", () => {
     const root = project();
     mkdirSync(join(root, ".cursor"), { recursive: true });
@@ -86,15 +143,72 @@ describe("writeAgentHookDeposit", () => {
 
     expect(() => writeAgentHookDeposit(root)).toThrow(/not valid JSON/);
     expect(readFileSync(join(root, ".cursor/hooks.json"), "utf8")).toBe("{not-json\n");
+    expect(inspectAgentHookDeposit(root).find((entry) => entry.host === "cursor")).toMatchObject({
+      status: "drifted",
+      detail: expect.stringContaining("not valid JSON"),
+    });
     expect(() => readFileSync(join(root, ".claude/settings.json"), "utf8")).toThrow();
     expect(() => readFileSync(join(root, ".grok/hooks/deft.json"), "utf8")).toThrow();
   });
+
+  it("refuses a non-object Codex hooks member before writing any host deposit", () => {
+    const root = project();
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(join(root, ".codex/hooks.json"), '{"hooks":[]}\n', "utf8");
+
+    expect(() => writeAgentHookDeposit(root)).toThrow(/hooks must be a JSON object/);
+    expect(inspectAgentHookDeposit(root).find((entry) => entry.host === "codex")).toMatchObject({
+      status: "drifted",
+    });
+    for (const path of AGENT_HOOK_PATHS.slice(0, 3)) {
+      expect(existsSync(join(root, path))).toBe(false);
+    }
+  });
+
+  it("refuses a non-array Codex event before writing any host deposit", () => {
+    const root = project();
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(join(root, ".codex/hooks.json"), '{"hooks":{"SessionStart":{}}}\n', "utf8");
+
+    expect(() => writeAgentHookDeposit(root)).toThrow(/hooks\.SessionStart must be an array/);
+    for (const path of AGENT_HOOK_PATHS.slice(0, 3)) {
+      expect(existsSync(join(root, path))).toBe(false);
+    }
+  });
+
+  it("refuses malformed Codex JSON before writing any host deposit", () => {
+    const root = project();
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(join(root, ".codex/hooks.json"), "[]\n", "utf8");
+
+    expect(() => writeAgentHookDeposit(root)).toThrow(/must contain a JSON object/);
+    expect(readFileSync(join(root, ".codex/hooks.json"), "utf8")).toBe("[]\n");
+    for (const path of AGENT_HOOK_PATHS.slice(0, 3)) {
+      expect(existsSync(join(root, path))).toBe(false);
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "refuses a Codex directory symlink escape before writing any host deposit",
+    () => {
+      const root = project();
+      const outside = project();
+      symlinkSync(outside, join(root, ".codex"), "dir");
+
+      expect(() => writeAgentHookDeposit(root)).toThrow(/symlink escaping the project tree/);
+      for (const path of AGENT_HOOK_PATHS.slice(0, 3)) {
+        expect(existsSync(join(root, path))).toBe(false);
+      }
+      expect(existsSync(join(outside, "hooks.json"))).toBe(false);
+    },
+  );
 });
 
 describe("inspectAgentHookDeposit", () => {
   it("distinguishes missing and drifted registrations", () => {
     const root = project();
     expect(inspectAgentHookDeposit(root).map((entry) => entry.status)).toEqual([
+      "missing",
       "missing",
       "missing",
       "missing",

--- a/packages/core/src/init-deposit/agent-hooks.ts
+++ b/packages/core/src/init-deposit/agent-hooks.ts
@@ -11,6 +11,7 @@ export const AGENT_HOOK_PATHS = [
   ".claude/settings.json",
   ".grok/hooks/deft.json",
   ".cursor/hooks.json",
+  ".codex/hooks.json",
 ] as const;
 
 export type AgentHookPath = (typeof AGENT_HOOK_PATHS)[number];
@@ -90,7 +91,9 @@ function isManagedCursorEntry(value: unknown): boolean {
   return typeof entry?.command === "string" && entry.command.includes(DEFT_HOOK_COMMAND_MARKER);
 }
 
-function nestedGroup(host: "claude" | "grok", event: "session.start" | "tool.before") {
+type NestedHookHost = "claude" | "grok" | "codex";
+
+function nestedGroup(host: NestedHookHost, event: "session.start" | "tool.before") {
   return {
     ...(event === "tool.before" ? { matcher: DIRECT_WRITE_HOOK_MATCHER } : {}),
     hooks: [
@@ -106,7 +109,7 @@ function nestedGroup(host: "claude" | "grok", event: "session.start" | "tool.bef
 function mergeNestedConfig(
   config: Record<string, unknown>,
   path: string,
-  host: "claude" | "grok",
+  host: NestedHookHost,
 ): Record<string, unknown> {
   const hooks = hooksObject(config, path);
   const session = eventArray(hooks, "SessionStart", path).filter(
@@ -170,6 +173,10 @@ export function writeAgentHookDeposit(
       merge: (config, path) => mergeNestedConfig(config, path, "grok"),
     },
     { path: AGENT_HOOK_PATHS[2], merge: mergeCursorConfig },
+    {
+      path: AGENT_HOOK_PATHS[3],
+      merge: (config, path) => mergeNestedConfig(config, path, "codex"),
+    },
   ];
 
   const prepared = definitions.map((definition) => {
@@ -192,7 +199,7 @@ export function writeAgentHookDeposit(
   return { changed: changedPaths.length > 0, changedPaths };
 }
 
-function hasNestedRegistration(config: Record<string, unknown>, host: "claude" | "grok"): boolean {
+function hasNestedRegistration(config: Record<string, unknown>, host: NestedHookHost): boolean {
   const hooks = object(config.hooks);
   if (hooks === null) return false;
   const session = Array.isArray(hooks.SessionStart) ? hooks.SessionStart : [];
@@ -246,6 +253,11 @@ export function inspectAgentHookDeposit(projectRoot: string): AgentHookInspectio
       valid: (config) => hasNestedRegistration(config, "grok"),
     },
     { host: "cursor", path: AGENT_HOOK_PATHS[2], valid: hasCursorRegistration },
+    {
+      host: "codex",
+      path: AGENT_HOOK_PATHS[3],
+      valid: (config) => hasNestedRegistration(config, "codex"),
+    },
   ];
 
   return definitions.map((definition) => {

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -19,6 +19,21 @@ describe("installer-managed allowlist (#1576)", () => {
     expect(installerManagedGuardEre()).toContain("Taskfile\\.yml");
   });
 
+  it("allowlists and stages the project-scoped Codex hook deposit", () => {
+    const root = mkdtempSync(join(tmpdir(), "hygiene-codex-hook-"));
+    try {
+      mkdirSync(join(root, ".deft", "core"), { recursive: true });
+      mkdirSync(join(root, ".codex"), { recursive: true });
+      writeFileSync(join(root, ".codex", "hooks.json"), "{}\n", "utf8");
+
+      expect(isInstallerManagedPath(".codex/hooks.json")).toBe(true);
+      expect(installerManagedGuardEre()).toContain("\\.codex/hooks\\.json");
+      expect(frameworkStagePaths(root, join(root, ".deft", "core"))).toContain(".codex/hooks.json");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("includes Taskfile.yml in framework stage paths when present", () => {
     const root = mkdtempSync(join(tmpdir(), "hygiene-stage-"));
     try {

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -33,6 +33,7 @@ export function installerManagedMatchers(): InstallerManagedMatcher[] {
     { exact: ".claude/settings.json" },
     { exact: ".grok/hooks/deft.json" },
     { exact: ".cursor/hooks.json" },
+    { exact: ".codex/hooks.json" },
     { exact: ".gitattributes" },
     { exact: ".gitignore" },
     { exact: "greptile.json" },

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -170,6 +170,9 @@ describe("runInitDeposit", () => {
     );
     expect(readFileSync(join(project, "greptile.json"), "utf8")).toContain(".deft/core/**");
     expect(readFileSync(join(project, ".gitignore"), "utf8")).toContain(".deft/core/");
+    expect(readFileSync(join(project, ".codex", "hooks.json"), "utf8")).toContain(
+      "deft hook:dispatch --host codex --event tool.before",
+    );
     expect(result.taskfileWired).toBe(true);
     expect(lines.join("")).toContain("AGENTS.md created");
     expect(spawnSpy).not.toHaveBeenCalled();

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -191,6 +191,22 @@ describe("runRefreshDeposit", () => {
       `# Operator prose\n\n<!-- deft:managed-section v2 -->\nOld body\n${AGENTS_MANAGED_CLOSE}\n`,
       "utf8",
     );
+    mkdirSync(join(project, ".codex"), { recursive: true });
+    writeFileSync(
+      join(project, ".codex", "hooks.json"),
+      `${JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [{ type: "command", command: "./consumer-check.sh" }],
+            },
+          ],
+        },
+      })}\n`,
+      "utf8",
+    );
+    writeFileSync(join(project, ".codex", "config.toml"), 'model = "gpt-5"\n', "utf8");
 
     const lines: string[] = [];
     const result = await runRefreshDeposit(
@@ -211,6 +227,10 @@ describe("runRefreshDeposit", () => {
     expect(result.agentsMdUpdated).toBe(true);
     expect(lines.join("")).toContain("refresh side effects (#1671)");
     expect(existsSync(join(result.deftDir, "main.md"))).toBe(true);
+    const codexHooks = readFileSync(join(project, ".codex", "hooks.json"), "utf8");
+    expect(codexHooks).toContain("./consumer-check.sh");
+    expect(codexHooks).toContain("deft hook:dispatch --host codex --event tool.before");
+    expect(readFileSync(join(project, ".codex", "config.toml"), "utf8")).toBe('model = "gpt-5"\n');
   });
 
   it("is idempotent on a second run (no AGENTS.md rewrite)", async () => {

--- a/packages/core/src/verify-env/agent-hooks.test.ts
+++ b/packages/core/src/verify-env/agent-hooks.test.ts
@@ -17,21 +17,24 @@ function project(): string {
 }
 
 describe("evaluateAgentHooks", () => {
-  it("passes when all P0 registrations are healthy", () => {
+  it("passes when all P0 registrations are structurally healthy", () => {
     const root = project();
     writeAgentHookDeposit(root);
 
     const result = evaluateAgentHooks(root);
     expect(result.code).toBe(0);
-    expect(result.message).toContain("Claude, Grok, Cursor");
+    expect(result.message).toContain("Claude, Grok, Cursor, Codex");
+    expect(result.message).toContain("runtime trust is user-controlled");
+    expect(result.message).toContain("`/hooks`");
     expect(result.message).toContain("direct-write tools only");
   });
 
   it("reports missing registrations separately from git hooks", () => {
     const result = evaluateAgentHooks(project());
     expect(result.code).toBe(1);
-    expect(result.message).toContain("agent hooks NON-FUNCTIONAL");
+    expect(result.message).toContain("agent hook registration INCOMPLETE");
     expect(result.message).toContain(".grok/hooks/deft.json");
+    expect(result.message).toContain(".codex/hooks.json");
     expect(result.stream).toBe("stderr");
   });
 

--- a/packages/core/src/verify-env/agent-hooks.ts
+++ b/packages/core/src/verify-env/agent-hooks.ts
@@ -36,7 +36,7 @@ export function evaluateAgentHooks(projectRoot: string): AgentHookHealthResult {
     return {
       code: 1,
       message:
-        "❌ deft agent hooks NON-FUNCTIONAL:\n" +
+        "❌ deft agent hook registration INCOMPLETE:\n" +
         unhealthy
           .map((entry) => `  - ${entry.host}: ${entry.status} at ${entry.path} — ${entry.detail}`)
           .join("\n") +
@@ -49,8 +49,9 @@ export function evaluateAgentHooks(projectRoot: string): AgentHookHealthResult {
   return {
     code: 0,
     message:
-      "✓ deft agent hooks installed and functional for Claude, Grok, Cursor " +
-      "(SessionStart + PreToolUse direct-write tools only; shell/MCP policy is deferred).",
+      "✓ deft agent hooks registered and structurally valid for Claude, Grok, Cursor, Codex " +
+      "(SessionStart + PreToolUse direct-write tools only; Codex runtime trust is " +
+      "user-controlled and must be reviewed with `/hooks`; shell/MCP policy is deferred).",
     stream: "stdout",
     registrations,
   };

--- a/xbrief/completed/2026-07-15-2596-codex-hook-adapter.xbrief.json
+++ b/xbrief/completed/2026-07-15-2596-codex-hook-adapter.xbrief.json
@@ -1,0 +1,122 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Thin Codex hook adapter, project deposit, and trust-aware health reporting for issue #2596",
+    "created": "2026-07-15T21:00:00Z",
+    "updated": "2026-07-16T01:53:43Z"
+  },
+  "plan": {
+    "id": "2596-codex-hook-adapter",
+    "title": "feat(harness): add Codex lifecycle hook adapter + project deposit",
+    "status": "completed",
+    "narratives": {
+      "Description": "Extend Directive's existing P0 agent-hook bridge to Codex with a host-native decision codec, an idempotent project-scoped .codex/hooks.json deposit, and health output that distinguishes structural registration from runtime trust.",
+      "UserStory": "As a Directive user working in Codex, I want direct write tools to use the same gated ritual and active xBRIEF enforcement already available in other supported hosts, without losing unrelated Codex hook configuration.",
+      "ImplementationPlan": "1. Add Codex to the provider-neutral hook host contract and render canonical Codex PreToolUse deny output while preserving allow as no override. 2. Deposit Directive-owned SessionStart and PreToolUse registrations into .codex/hooks.json with atomic, idempotent merge and existing containment guarantees. 3. Extend verify-env and doctor to report structural Codex registration while explicitly noting that runtime trust is user-controlled and cannot be verified statically. 4. Exercise init/update, malformed configuration, symlink escape, and CLI dispatch paths. 5. Document the supported surface and intentional deferrals: no .codex/config.toml mutation and no expansion to Bash, MCP, unified_exec, or WebSearch policy.",
+      "Origin": "GitHub issue #2596 under epic #2437, following the P0 hook bridge delivered by #2438; implementation approved by the operator with /deft:change codex-hook-adapter.",
+      "Acceptance": "1. hook:dispatch accepts host=codex and emits the canonical Codex deny envelope for gated direct-write tools. 2. init/update idempotently merge Directive registrations into .codex/hooks.json without overwriting unrelated hooks or touching .codex/config.toml. 3. malformed or escaping Codex targets fail before partial writes. 4. verify-env and doctor distinguish structural registration from runtime hook trust. 5. focused and full regression checks pass with documentation and changelog coverage."
+    },
+    "items": [
+      {
+        "id": "2596-a1",
+        "title": "Codex host decision codec",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given a Codex SessionStart or PreToolUse event, when hook:dispatch evaluates it, then allow remains non-blocking and a denied direct write uses Codex's canonical hookSpecificOutput permissionDecision schema."
+        }
+      },
+      {
+        "id": "2596-a2",
+        "title": "Codex project deposit and containment",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given init or update runs in a project, when .codex/hooks.json is absent or contains unrelated hooks, then Directive registrations are merged atomically and idempotently; malformed JSON or symlink escape prevents all staged hook writes."
+        }
+      },
+      {
+        "id": "2596-a3",
+        "title": "Trust-aware health reporting",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given structurally valid Codex registration, when verify-env or doctor runs, then it reports registration health without claiming runtime functionality and identifies Codex hook trust as user-controlled and statically unverifiable."
+        }
+      },
+      {
+        "id": "2596-a4",
+        "title": "Init, update, and documentation integration",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given supported lifecycle commands and user documentation, when Codex support is inspected, then init/update include .codex/hooks.json and docs explain trust review, config coexistence, and the intentionally narrow P0 tool surface."
+        }
+      },
+      {
+        "id": "2596-a5",
+        "title": "Codex adapter regression verification",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the Codex adapter test matrix, when focused and repository checks run, then codec, malformed input, merge preservation, byte idempotence, containment, health, init, and update branches pass."
+        }
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "harness",
+      "codex",
+      "agent-experience"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2596",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2596"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2437",
+        "type": "x-xbrief/refs",
+        "title": "Parent epic #2437"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2438",
+        "type": "x-xbrief/refs",
+        "title": "P0 hook bridge #2438"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "sequential",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/core/src/hooks/",
+          "packages/core/src/init-deposit/",
+          "packages/core/src/verify-env/",
+          "packages/core/src/doctor/",
+          "packages/cli/src/",
+          "content/commands.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- hooks agent-hooks doctor",
+          "pnpm --filter @deftai/directive test -- hook init-deposit refresh verify-env",
+          "task check",
+          "task verify:forward-coverage"
+        ],
+        "expected_outputs": [
+          "Codex host-native hook decision codec",
+          "Idempotent .codex/hooks.json project deposit",
+          "Trust-aware Codex registration health",
+          "Init/update and documentation coverage"
+        ],
+        "depends_on": [],
+        "conflict_group": "agent-host-hooks-p0",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "high",
+        "missing_traces_justification": "Issue #2596 is the approved implementation record and #2438 defines the existing provider-neutral hook policy this adapter reuses."
+      },
+      "completedAt": "2026-07-16T01:54:13Z",
+      "capacityBucket": "new-capability"
+    },
+    "updated": "2026-07-16T01:54:13Z"
+  }
+}


### PR DESCRIPTION
## Summary

- add a Codex-native hook decision codec for the existing direct-write mutation gate
- idempotently merge Directive-owned SessionStart and PreToolUse registrations into `.codex/hooks.json` while preserving consumer hooks and `.codex/config.toml`
- report structural registration separately from user-controlled Codex runtime trust, with init/update, malformed-config, containment, CLI, and doctor coverage

## Related Issues

Closes #2596
Refs #2437, #2438

## Checklist

- [x] `/deft:change <name>` — exact operator approval `approve /deft:change codex-hook-adapter` is captured in the lifecycle xBRIEF Origin. A separate `history/changes/codex-hook-adapter/proposal.xbrief.json` is N/A: #2596 and `xbrief/completed/2026-07-15-2596-codex-hook-adapter.xbrief.json` are the scope record, so no unrelated proposal artifact was added retroactively.
- [x] `CHANGELOG.md` — added an entry under `[Unreleased]`.
- [x] `ROADMAP.md` — N/A; #2596 is not a separate ROADMAP entry, and the existing #2438 entry is already completed.
- [x] Tests pass locally — the full Vitest suite is green. `task check` reaches green tests and coverage, then exits in `vbrief:validate` on the base branch's unrelated invalid #2575/#2576 active xBRIEF; tracked as #2598 and byte-identical at base `665c8c6b`.

## Verification

- `pnpm exec vitest run --coverage --maxWorkers=4 --reporter=dot` (652 files, 9,487 tests; 85% branch coverage)
- `pnpm exec tsc -b --pretty false`
- `pnpm exec biome check` on all changed supported source/test files
- `task verify:forward-coverage`
- `task check` — green tests and coverage; final `vbrief:validate` failure is the pre-existing base-branch defect tracked by #2598

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm #2596 closed. If still open, close it manually with a comment referencing #2597.
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
