### PR TITLE
fix(update): repair stale xbrief derivatives (#2595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Current updates repair stale xBRIEF derivatives (#2595).** `directive update` now refreshes `xbrief/.deft-version` and framework-owned schemas even when the core payload is already current; `migrate:xbrief` treats cache-only canonical trees as support state, preserves both cache sources transactionally, and the packaged Taskfile contains no trailing whitespace.
 - Gated session ritual `cache_fresh` failures now print a runnable recovery command (`deft cache fetch-all --source github-issue --repo OWNER/NAME`) instead of the unknown `deft cache:fetch-all` colon alias. Closes #2574.
 - **scope terminal transitions sync specification.xbrief.json item statuses (#2566).** `scope:complete`, `scope:fail`, and `scope:cancel` now mirror the #1527 PROJECT-DEFINITION contract for matching `plan.items[]` entries in `xbrief/specification.xbrief.json` — statuses and lifecycle metadata update on folder moves instead of leaving stale `[proposed]` roadmap entries. Closes #2566.
 - **completed/ lifecycle moves stamp terminal plan.status atomically (#2578).** `scope:complete` and `scope:fail` now write `plan.status=completed|failed` directly at the destination path instead of pre-stamping the source file before rename, so xBRIEFs never appear under `completed/` with non-terminal status. `task reconcile:issues` reports `completed/` D2 drift and `--apply-lifecycle-fixes` repairs in-place. Closes #2578.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -361,7 +361,7 @@ tasks:
     cmds:
       - task: engine:invoke
         vars:
-          ENGINE_CMD: 'check --framework-root "{{.TASKFILE_DIR}}" --project-root "{{.USER_WORKING_DIR}}"' 
+          ENGINE_CMD: 'check --framework-root "{{.TASKFILE_DIR}}" --project-root "{{.USER_WORKING_DIR}}"'
 
   check:framework-source:
     desc: "Run all framework source-repo pre-commit checks (TS-only after #1860). Sole wired consumer of maintainer-only core:build / core:clean."
@@ -460,7 +460,7 @@ tasks:
     cmds:
       - task: engine:invoke
         vars:
-          ENGINE_CMD: 'validate-strategy-output --project-root "{{.USER_WORKING_DIR}}"' 
+          ENGINE_CMD: 'validate-strategy-output --project-root "{{.USER_WORKING_DIR}}"'
 
   # Pack-projection drift gate (#1294 / #1283, ADR-001). User-facing alias for
   # `packs:verify-drift`, defined at the root Taskfile so it carries the

--- a/packages/cli/src/install-upgrade.test.ts
+++ b/packages/cli/src/install-upgrade.test.ts
@@ -78,6 +78,7 @@ describe("install-upgrade <-> directive update parity (#2064)", () => {
     const project = freshRoot(prefix);
     const pkgDir = join(project, "node_modules", "@deftai", "directive-content");
     mkdirSync(join(pkgDir, "templates"), { recursive: true });
+    mkdirSync(join(pkgDir, "vbrief", "schemas"), { recursive: true });
     writeFileSync(
       join(pkgDir, "package.json"),
       JSON.stringify({ name: CONTENT_PACKAGE_NAME, version }),
@@ -88,6 +89,7 @@ describe("install-upgrade <-> directive update parity (#2064)", () => {
       join(pkgDir, "templates/agents-entry.md"),
     );
     writeFileSync(join(pkgDir, "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(pkgDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"), "{}\n", "utf8");
 
     // A stale vendored deposit so a real refresh has work to do.
     const deftDir = join(project, ".deft", "core");

--- a/packages/core/src/init-deposit/init-deposit.test.ts
+++ b/packages/core/src/init-deposit/init-deposit.test.ts
@@ -99,7 +99,7 @@ describe("runInitDeposit", () => {
   function installFakeContentPackage(projectRoot: string): string {
     const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
     mkdirSync(join(pkgDir, "templates"), { recursive: true });
-    mkdirSync(join(pkgDir, "xbrief", "schemas"), { recursive: true });
+    mkdirSync(join(pkgDir, "vbrief", "schemas"), { recursive: true });
     mkdirSync(join(pkgDir, ".githooks"), { recursive: true });
     writeFileSync(
       join(pkgDir, "package.json"),
@@ -111,8 +111,9 @@ describe("runInitDeposit", () => {
       join(pkgDir, "templates/agents-entry.md"),
     );
     writeFileSync(join(pkgDir, "main.md"), "# Deft\n", "utf8");
-    writeFileSync(join(pkgDir, "xbrief", "schemas", "cache-meta.schema.json"), "{}\n", "utf8");
-    writeFileSync(join(pkgDir, "xbrief", "vbrief.md"), "# vbrief\n", "utf8");
+    writeFileSync(join(pkgDir, "vbrief", "schemas", "cache-meta.schema.json"), "{}\n", "utf8");
+    writeFileSync(join(pkgDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"), "{}\n", "utf8");
+    writeFileSync(join(pkgDir, "vbrief", "vbrief.md"), "# vbrief\n", "utf8");
     writeFileSync(
       join(pkgDir, ".githooks", "pre-commit"),
       readFileSync(join(process.cwd(), ".githooks/pre-commit"), "utf8"),

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -18,6 +18,7 @@ import { CONTENT_PACKAGE_NAME } from "../deposit/resolve-content.js";
 import { runChecksImpl } from "../doctor/checks.js";
 import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import type { ClassifySeams } from "../resolution/index.js";
+import { detectXbriefConvergence } from "../xbrief-migrate/detect.js";
 import { type LegacyLayoutDetection, LegacyLayoutRefusedError } from "./legacy-detect.js";
 import {
   buildVersionSkewNotice,
@@ -337,6 +338,52 @@ describe("runRefreshDeposit", () => {
     expect(
       doctor.checks.find((check) => check.name === "stale-xbrief-schema-deposit")?.status,
     ).not.toBe("fail");
+  });
+
+  it.each([
+    ["legacy-only", false],
+    ["legacy plus cache-only support", true],
+  ])("does not project schemas before xbrief migration (%s) (#2595)", async (_label, cacheOnly) => {
+    const project = freshRoot("refresh-pre-migration-projections-");
+    const contentRoot = installFakeContentPackage(project, "0.78.0");
+    mkdirSync(join(project, "vbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(project, "vbrief", "active", "seed.vbrief.json"),
+      JSON.stringify({
+        vBRIEFInfo: { version: "0.6", description: "legacy fixture" },
+        plan: { title: "Legacy seed", status: "running", items: [] },
+      }),
+      "utf8",
+    );
+    if (cacheOnly) {
+      mkdirSync(join(project, "xbrief", ".triage-cache", "issues"), { recursive: true });
+      writeFileSync(join(project, "xbrief", ".triage-cache", "issues", "2595.json"), "{}\n");
+    }
+
+    const io = { printf: vi.fn() };
+    const args = {
+      projectDir: project,
+      jsonOut: false,
+      nonInteractive: true,
+      upgrade: true,
+    };
+    const seams = {
+      resolveContentRoot: async () => contentRoot,
+      readEngineVersion: () => "0.78.0",
+      nowIso: () => "2026-07-16T12:00:00Z",
+      gitPorcelain: () => "",
+    };
+
+    await runRefreshDeposit(args, io, seams);
+    await runRefreshDeposit(args, io, {
+      ...seams,
+      copyContent: async () => {
+        throw new Error("copyContent must not run for an already-current refresh");
+      },
+    });
+
+    expect(existsSync(join(project, "xbrief", "schemas"))).toBe(false);
+    expect(detectXbriefConvergence(project).state).toBe("legacy-only");
   });
 
   it("discloses core side-effects when AGENTS.md is already current", async () => {

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -243,6 +243,7 @@ describe("runRefreshDeposit", () => {
     await runRefreshDeposit(args, io, seams);
     const firstAgents = readFileSync(join(project, "AGENTS.md"), "utf8");
     const firstVersion = readFileSync(join(project, ".deft", "core", "VERSION"), "utf8");
+    rmSync(join(project, ".deft-version"), { force: true });
 
     io.printf.mockClear();
     const copyContent = vi.fn(async () => {
@@ -261,6 +262,7 @@ describe("runRefreshDeposit", () => {
 
     expect(secondAgents).toBe(firstAgents);
     expect(secondVersion).toBe(firstVersion);
+    expect(existsSync(join(project, ".deft-version"))).toBe(false);
     expect(second.agentsMdUpdated).toBe(false);
     expect(second.alreadyCurrent).toBe(true);
     expect(second.strategy).toBe("no-op");

--- a/packages/core/src/init-deposit/refresh.test.ts
+++ b/packages/core/src/init-deposit/refresh.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -14,6 +15,7 @@ import type { ResolutionFacts } from "@deftai/directive-types";
 import { RESOLUTION_PLAN_SCHEMA_VERSION } from "@deftai/directive-types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CONTENT_PACKAGE_NAME } from "../deposit/resolve-content.js";
+import { runChecksImpl } from "../doctor/checks.js";
 import { AGENTS_MANAGED_CLOSE } from "../platform/constants.js";
 import type { ClassifySeams } from "../resolution/index.js";
 import { type LegacyLayoutDetection, LegacyLayoutRefusedError } from "./legacy-detect.js";
@@ -162,6 +164,7 @@ describe("runRefreshDeposit", () => {
   function installFakeContentPackage(projectRoot: string, version = "0.53.0"): string {
     const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
     mkdirSync(join(pkgDir, "templates"), { recursive: true });
+    mkdirSync(join(pkgDir, "vbrief", "schemas"), { recursive: true });
     writeFileSync(
       join(pkgDir, "package.json"),
       JSON.stringify({ name: CONTENT_PACKAGE_NAME, version }),
@@ -172,6 +175,12 @@ describe("runRefreshDeposit", () => {
       join(pkgDir, "templates/agents-entry.md"),
     );
     writeFileSync(join(pkgDir, "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(pkgDir, "vbrief", "schemas", "vbrief-core.schema.json"), "legacy\n", "utf8");
+    writeFileSync(
+      join(pkgDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"),
+      "current\n",
+      "utf8",
+    );
     return pkgDir;
   }
 
@@ -263,6 +272,69 @@ describe("runRefreshDeposit", () => {
     expect(out).toContain("Windows line-ending note (#2118)");
     expect(out).not.toContain("Commit hygiene");
     expect(out).not.toContain("framework deposit commit");
+  });
+
+  it("repairs stale xbrief derivatives without copying an already-current payload (#2595)", async () => {
+    const project = freshRoot("refresh-current-projections-");
+    const contentRoot = installFakeContentPackage(project, "0.78.0");
+    mkdirSync(join(project, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(project, "xbrief", "active", "seed.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8", description: "fixture" },
+        plan: { title: "Seed", status: "running", items: [] },
+      }),
+      "utf8",
+    );
+    const io = { printf: vi.fn() };
+    const args = {
+      projectDir: project,
+      jsonOut: false,
+      nonInteractive: true,
+      upgrade: true,
+    };
+    const seams = {
+      resolveContentRoot: async () => contentRoot,
+      readEngineVersion: () => "0.78.0",
+      nowIso: () => "2026-07-16T12:00:00Z",
+      gitPorcelain: () => "",
+    };
+
+    await runRefreshDeposit(args, io, seams);
+    mkdirSync(join(project, "xbrief", "schemas"), { recursive: true });
+    writeFileSync(join(project, "xbrief", ".deft-version"), "0.72.0\n", "utf8");
+    writeFileSync(join(project, "xbrief", "schemas", "vbrief-core.schema.json"), "stale\n", "utf8");
+    rmSync(join(project, "xbrief", "schemas", "xbrief-core-0.8.schema.json"), { force: true });
+
+    const copyContent = vi.fn(async () => {
+      throw new Error("copyContent must not run for an already-current refresh");
+    });
+    const repaired = await runRefreshDeposit(args, io, { ...seams, copyContent });
+
+    expect(repaired.strategy).toBe("no-op");
+    expect(copyContent).not.toHaveBeenCalled();
+    expect(readFileSync(join(project, "xbrief", ".deft-version"), "utf8")).toBe("0.78.0\n");
+    expect(existsSync(join(project, "xbrief", "schemas", "vbrief-core.schema.json"))).toBe(false);
+    expect(
+      readFileSync(join(project, "xbrief", "schemas", "xbrief-core-0.8.schema.json"), "utf8"),
+    ).toBe("current\n");
+
+    await runRefreshDeposit(args, io, { ...seams, copyContent });
+    expect(copyContent).not.toHaveBeenCalled();
+
+    const doctor = runChecksImpl(project, {
+      isDir: (path) => {
+        try {
+          return statSync(path).isDirectory();
+        } catch {
+          return false;
+        }
+      },
+    });
+    expect(doctor.checks.find((check) => check.name === "manifest-agreement")?.status).toBe("pass");
+    expect(
+      doctor.checks.find((check) => check.name === "stale-xbrief-schema-deposit")?.status,
+    ).not.toBe("fail");
   });
 
   it("discloses core side-effects when AGENTS.md is already current", async () => {
@@ -728,6 +800,7 @@ describe("directive update refresh-only + self-heal (#2266)", () => {
   function installFakeContentPackage(projectRoot: string, version = "0.53.0"): string {
     const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
     mkdirSync(join(pkgDir, "templates"), { recursive: true });
+    mkdirSync(join(pkgDir, "vbrief", "schemas"), { recursive: true });
     writeFileSync(
       join(pkgDir, "package.json"),
       JSON.stringify({ name: CONTENT_PACKAGE_NAME, version }),
@@ -738,6 +811,11 @@ describe("directive update refresh-only + self-heal (#2266)", () => {
       join(pkgDir, "templates/agents-entry.md"),
     );
     writeFileSync(join(pkgDir, "main.md"), "# Deft\n", "utf8");
+    writeFileSync(
+      join(pkgDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"),
+      "current\n",
+      "utf8",
+    );
     return pkgDir;
   }
 
@@ -748,12 +826,18 @@ describe("directive update refresh-only + self-heal (#2266)", () => {
   ): void {
     const deftDir = join(project, ".deft", "core");
     mkdirSync(join(deftDir, "templates"), { recursive: true });
+    mkdirSync(join(deftDir, "vbrief", "schemas"), { recursive: true });
     writeFileSync(
       join(deftDir, "VERSION"),
       `tag: 'v${opts.contentVersion}'\nsha: abc\ninstall_root: '.deft/core'\n`,
       "utf8",
     );
     writeFileSync(join(deftDir, "main.md"), "# Deft\n", "utf8");
+    writeFileSync(
+      join(deftDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"),
+      "current\n",
+      "utf8",
+    );
     copyFileSync(
       join(process.cwd(), "content/templates/agents-entry.md"),
       join(deftDir, "templates/agents-entry.md"),

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, statSync } from "node:fs";
 import { platform as osPlatform } from "node:os";
 import { join, resolve } from "node:path";
 import type { ResolutionFacts, ResolutionPlan } from "@deftai/directive-types";
@@ -19,8 +19,6 @@ import { prunePythonArtifactsFromDeposit } from "../deposit/python-free.js";
 import { resolveInstalledContentRoot } from "../deposit/resolve-content.js";
 import { manifestTagToVersion, parseInstallManifest } from "../doctor/manifest.js";
 import { readCorePackageVersion } from "../engine-version.js";
-import { resolveLifecycleRoot } from "../layout/resolve.js";
-import { DEV_FALLBACK } from "../platform/constants.js";
 import {
   type ClassifySeams,
   checkLocalEngineIntegrity,
@@ -62,6 +60,7 @@ import {
   writeAgentsMd,
   writeInstallManifest,
 } from "./scaffold.js";
+import { syncBareVersionMarker, syncConsumerXbriefSchemas } from "./xbrief-projections.js";
 
 export interface RefreshDepositArgs extends InitDepositArgs {
   readonly upgrade: boolean;
@@ -259,35 +258,6 @@ function readRecordedManagedBy(deftDir: string): string | null {
     return value || null;
   } catch {
     return null;
-  }
-}
-
-/**
- * Regenerate the bare `.deft-version` derivative from the deposited content
- * version in the same transaction as the payload swap (#2055). The canonical
- * marker lives at `vbrief/.deft-version`; fall back to the project root only
- * when `vbrief/` is absent. Never persist the dev fallback.
- */
-function syncBareVersionMarker(projectDir: string, version: string): void {
-  const normalized = normalizeVersion(version);
-  if (!normalized || normalized === DEV_FALLBACK) return;
-  let vbriefDir: string | null = null;
-  try {
-    vbriefDir = resolveLifecycleRoot(projectDir);
-  } catch {
-    // No xbrief/ layout present — write the root-level derivative instead.
-  }
-  let targetDir = projectDir;
-  try {
-    if (vbriefDir !== null && statSync(vbriefDir).isDirectory()) targetDir = vbriefDir;
-  } catch {
-    // xbrief/ absent — write the root-level derivative instead
-  }
-  try {
-    mkdirSync(targetDir, { recursive: true });
-    writeFileSync(join(targetDir, ".deft-version"), `${normalized}\n`, "utf8");
-  } catch {
-    // best-effort, mirrors install-upgrade marker write
   }
 }
 
@@ -638,13 +608,12 @@ export async function runRefreshDeposit(
     // .deft/core/VERSION has been rewritten (folded in from install-upgrade so no
     // manifest behavior is lost by the redirect). Best-effort; never fatal.
     migrateLegacyInstallManifest(projectDir, writtenManifestPath);
-
-    // #2055: regenerate the bare .deft-version derivative so it agrees with the
-    // freshly written manifest tag (otherwise doctor's manifest-agreement check
-    // fails and the operator must hand-edit the marker). No-op refreshes skip
-    // this projection because the manifest tag was not rewritten (#2118).
-    syncBareVersionMarker(projectDir, contentVersion);
   }
+
+  // #2595: payload freshness and consumer derivative freshness are independent.
+  // Always repair these cheap projections, including on the #2118 no-op path.
+  syncBareVersionMarker(projectDir, contentVersion);
+  syncConsumerXbriefSchemas(projectDir, deftDir);
 
   const agentsMdUpdated = writeAgentsMd(projectDir, deftDir, io);
   writeAgentHookDeposit(projectDir, io);

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -19,6 +19,7 @@ import { prunePythonArtifactsFromDeposit } from "../deposit/python-free.js";
 import { resolveInstalledContentRoot } from "../deposit/resolve-content.js";
 import { manifestTagToVersion, parseInstallManifest } from "../doctor/manifest.js";
 import { readCorePackageVersion } from "../engine-version.js";
+import { resolveLifecycleRoot } from "../layout/resolve.js";
 import {
   type ClassifySeams,
   checkLocalEngineIntegrity,
@@ -83,6 +84,15 @@ export interface RefreshDepositResult {
   readonly legacyLayout: boolean;
   readonly taskfileWired: boolean;
   readonly stagedPaths: string[];
+}
+
+function hasCanonicalXbriefLifecycle(projectDir: string): boolean {
+  try {
+    resolveLifecycleRoot(projectDir);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export type RefreshDepositStrategy = "file-swap" | "no-op";
@@ -621,7 +631,11 @@ export async function runRefreshDeposit(
   } else {
     syncBareVersionMarker(projectDir, contentVersion);
   }
-  syncConsumerXbriefSchemas(projectDir, deftDir);
+  // Do not turn a legacy-only or cache-only support tree into canonical
+  // lifecycle content before migrate:xbrief can transactionally converge it.
+  if (hasCanonicalXbriefLifecycle(projectDir)) {
+    syncConsumerXbriefSchemas(projectDir, deftDir);
+  }
 
   const agentsMdUpdated = writeAgentsMd(projectDir, deftDir, io);
   writeAgentHookDeposit(projectDir, io);

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -612,7 +612,7 @@ export async function runRefreshDeposit(
 
   // #2595: payload freshness and consumer derivative freshness are independent.
   // Always repair these cheap projections, including on the #2118 no-op path.
-  syncBareVersionMarker(projectDir, contentVersion);
+  syncBareVersionMarker(projectDir, contentVersion, { allowRootFallback: !alreadyCurrent });
   syncConsumerXbriefSchemas(projectDir, deftDir);
 
   const agentsMdUpdated = writeAgentsMd(projectDir, deftDir, io);

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -60,7 +60,11 @@ import {
   writeAgentsMd,
   writeInstallManifest,
 } from "./scaffold.js";
-import { syncBareVersionMarker, syncConsumerXbriefSchemas } from "./xbrief-projections.js";
+import {
+  syncBareVersionMarker,
+  syncConsumerXbriefSchemas,
+  syncExistingBareVersionMarker,
+} from "./xbrief-projections.js";
 
 export interface RefreshDepositArgs extends InitDepositArgs {
   readonly upgrade: boolean;
@@ -612,7 +616,11 @@ export async function runRefreshDeposit(
 
   // #2595: payload freshness and consumer derivative freshness are independent.
   // Always repair these cheap projections, including on the #2118 no-op path.
-  syncBareVersionMarker(projectDir, contentVersion, { allowRootFallback: !alreadyCurrent });
+  if (alreadyCurrent) {
+    syncExistingBareVersionMarker(projectDir, contentVersion);
+  } else {
+    syncBareVersionMarker(projectDir, contentVersion);
+  }
   syncConsumerXbriefSchemas(projectDir, deftDir);
 
   const agentsMdUpdated = writeAgentsMd(projectDir, deftDir, io);

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -75,6 +75,16 @@ describe("init-deposit scaffold", () => {
     );
     mkdirSync(join(deftDir, "vbrief", "schemas"), { recursive: true });
     writeFileSync(join(deftDir, "vbrief", "schemas", "example.schema.json"), "{}\n", "utf8");
+    writeFileSync(
+      join(deftDir, "vbrief", "schemas", "vbrief-core.schema.json"),
+      "legacy\n",
+      "utf8",
+    );
+    writeFileSync(
+      join(deftDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"),
+      "current\n",
+      "utf8",
+    );
     writeFileSync(join(deftDir, "vbrief", "vbrief.md"), "# vbrief\n", "utf8");
     mkdirSync(join(deftDir, ".githooks"), { recursive: true });
     writeFileSync(
@@ -122,6 +132,10 @@ describe("init-deposit scaffold", () => {
       expect(existsSync(join(project, "xbrief", sub, ".gitkeep"))).toBe(true);
     }
     expect(existsSync(join(project, "xbrief", "schemas", "example.schema.json"))).toBe(true);
+    expect(existsSync(join(project, "xbrief", "schemas", "vbrief-core.schema.json"))).toBe(false);
+    expect(existsSync(join(project, "xbrief", "schemas", "xbrief-core-0.8.schema.json"))).toBe(
+      true,
+    );
     expect(readFileSync(join(project, "xbrief", "vbrief.md"), "utf8")).toContain("# vbrief");
   });
 

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -18,7 +18,6 @@ import {
 import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { platform } from "node:os";
 import { dirname, join, relative } from "node:path";
-import { copyTree } from "../deposit/copy-tree.js";
 import {
   assertProjectionContained,
   ProjectionContainmentError,
@@ -27,6 +26,7 @@ import { agentsRefreshPlan } from "../platform/agents-md.js";
 import { MIGRATED_ARTIFACT_DIR } from "../xbrief-migrate/constants.js";
 import { CANONICAL_INSTALL_ROOT, type InitDepositIo } from "./constants.js";
 import { installerManagedGuardEre } from "./hygiene.js";
+import { syncConsumerXbriefSchemas } from "./xbrief-projections.js";
 
 export type { InitDepositIo };
 export { CANONICAL_INSTALL_ROOT };
@@ -411,21 +411,17 @@ export async function writeConsumerVbrief(
   const schemasPresent = existsSync(schemasDst) && statSync(schemasDst).isDirectory();
   const vbriefMdPresent = existsSync(vbriefMdDst) && statSync(vbriefMdDst).isFile();
   const lifecyclePresent = vbriefLifecycleDirsPresent(consumerVbrief);
+  const schemasChanged = syncConsumerXbriefSchemas(projectDir, deftDir);
   if (schemasPresent && vbriefMdPresent && lifecyclePresent) {
-    io.printf("vbrief/ already present at project root — skipping.\n");
-    return false;
+    io.printf(
+      schemasChanged
+        ? "vbrief/ schemas refreshed at project root.\n"
+        : "vbrief/ already present at project root — skipping.\n",
+    );
+    return schemasChanged;
   }
 
   mkdirSync(consumerVbrief, { recursive: true });
-
-  if (!schemasPresent) {
-    const fwSchemas = join(deftDir, "vbrief", "schemas");
-    if (existsSync(fwSchemas) && statSync(fwSchemas).isDirectory()) {
-      await copyTree(fwSchemas, schemasDst);
-    } else {
-      mkdirSync(schemasDst, { recursive: true });
-    }
-  }
 
   if (!vbriefMdPresent) {
     const fwVbriefMd = join(deftDir, "vbrief", "vbrief.md");

--- a/packages/core/src/init-deposit/xbrief-projections.test.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.test.ts
@@ -106,6 +106,16 @@ describe("xbrief consumer projections (#2595)", () => {
     expect(syncBareVersionMarker(project, "0.78.0")).toBe(false);
   });
 
+  it("does not create a root fallback during a no-op repair, but repairs one that exists", () => {
+    const { project } = fixture();
+    expect(syncBareVersionMarker(project, "0.78.0", { allowRootFallback: false })).toBe(false);
+    expect(existsSync(join(project, ".deft-version"))).toBe(false);
+
+    writeFileSync(join(project, ".deft-version"), "0.72.0\n", "utf8");
+    expect(syncBareVersionMarker(project, "0.78.0", { allowRootFallback: false })).toBe(true);
+    expect(readFileSync(join(project, ".deft-version"), "utf8")).toBe("0.78.0\n");
+  });
+
   itSymlink("refuses schema symlinks in the framework payload", () => {
     const { project, deftDir, schemas } = fixture();
     const outside = join(project, "outside.schema.json");

--- a/packages/core/src/init-deposit/xbrief-projections.test.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.test.ts
@@ -11,7 +11,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ProjectionContainmentError } from "../fs/projection-containment.js";
-import { syncBareVersionMarker, syncConsumerXbriefSchemas } from "./xbrief-projections.js";
+import {
+  syncBareVersionMarker,
+  syncConsumerXbriefSchemas,
+  syncExistingBareVersionMarker,
+} from "./xbrief-projections.js";
 
 const itSymlink = it.skipIf(process.platform === "win32");
 
@@ -108,11 +112,11 @@ describe("xbrief consumer projections (#2595)", () => {
 
   it("does not create a root fallback during a no-op repair, but repairs one that exists", () => {
     const { project } = fixture();
-    expect(syncBareVersionMarker(project, "0.78.0", { allowRootFallback: false })).toBe(false);
+    expect(syncExistingBareVersionMarker(project, "0.78.0")).toBe(false);
     expect(existsSync(join(project, ".deft-version"))).toBe(false);
 
     writeFileSync(join(project, ".deft-version"), "0.72.0\n", "utf8");
-    expect(syncBareVersionMarker(project, "0.78.0", { allowRootFallback: false })).toBe(true);
+    expect(syncExistingBareVersionMarker(project, "0.78.0")).toBe(true);
     expect(readFileSync(join(project, ".deft-version"), "utf8")).toBe("0.78.0\n");
   });
 

--- a/packages/core/src/init-deposit/xbrief-projections.test.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.test.ts
@@ -1,0 +1,128 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
+import { syncBareVersionMarker, syncConsumerXbriefSchemas } from "./xbrief-projections.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("xbrief consumer projections (#2595)", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function fixture(): { project: string; deftDir: string; schemas: string } {
+    const project = mkdtempSync(join(tmpdir(), "xbrief-projections-"));
+    created.push(project);
+    const deftDir = join(project, ".deft", "core");
+    const schemas = join(deftDir, "vbrief", "schemas");
+    mkdirSync(schemas, { recursive: true });
+    writeFileSync(join(schemas, "vbrief-core.schema.json"), "legacy\n", "utf8");
+    writeFileSync(join(schemas, "xbrief-core-0.8.schema.json"), "current\n", "utf8");
+    writeFileSync(join(schemas, "shared.schema.json"), "shared-current\n", "utf8");
+    return { project, deftDir, schemas };
+  }
+
+  it("reprojects framework schemas, removes only the obsolete root, and is idempotent", () => {
+    const { project, deftDir, schemas } = fixture();
+    const consumerSchemas = join(project, "xbrief", "schemas");
+    mkdirSync(join(schemas, "nested"), { recursive: true });
+    writeFileSync(join(schemas, "nested", "child.schema.json"), "child\n", "utf8");
+    mkdirSync(consumerSchemas, { recursive: true });
+    writeFileSync(join(consumerSchemas, "vbrief-core.schema.json"), "stale\n", "utf8");
+    writeFileSync(join(consumerSchemas, "shared.schema.json"), "shared-stale\n", "utf8");
+    writeFileSync(join(consumerSchemas, "consumer-owned.schema.json"), "keep\n", "utf8");
+
+    expect(syncConsumerXbriefSchemas(project, deftDir)).toBe(true);
+    expect(existsSync(join(consumerSchemas, "vbrief-core.schema.json"))).toBe(false);
+    expect(readFileSync(join(consumerSchemas, "xbrief-core-0.8.schema.json"), "utf8")).toBe(
+      "current\n",
+    );
+    expect(readFileSync(join(consumerSchemas, "shared.schema.json"), "utf8")).toBe(
+      "shared-current\n",
+    );
+    expect(readFileSync(join(consumerSchemas, "consumer-owned.schema.json"), "utf8")).toBe(
+      "keep\n",
+    );
+    expect(readFileSync(join(consumerSchemas, "nested", "child.schema.json"), "utf8")).toBe(
+      "child\n",
+    );
+    expect(syncConsumerXbriefSchemas(project, deftDir)).toBe(false);
+  });
+
+  it("repairs a stale lifecycle version marker and then performs no second write", () => {
+    const { project } = fixture();
+    mkdirSync(join(project, "xbrief", "active"), { recursive: true });
+    writeFileSync(join(project, "xbrief", "active", "seed.xbrief.json"), "{}\n", "utf8");
+    writeFileSync(join(project, "xbrief", ".deft-version"), "0.72.0\n", "utf8");
+
+    expect(syncBareVersionMarker(project, "v0.78.0")).toBe(true);
+    expect(readFileSync(join(project, "xbrief", ".deft-version"), "utf8")).toBe("0.78.0\n");
+    expect(syncBareVersionMarker(project, "0.78.0")).toBe(false);
+  });
+
+  it("fails loudly when the current core schema is absent", () => {
+    const { project, deftDir, schemas } = fixture();
+    rmSync(join(schemas, "xbrief-core-0.8.schema.json"));
+    expect(() => syncConsumerXbriefSchemas(project, deftDir)).toThrow(
+      /xbrief-core-0\.8\.schema\.json/,
+    );
+  });
+
+  it("fails loudly when the schema source directory is absent or malformed", () => {
+    const missing = fixture();
+    rmSync(missing.schemas, { recursive: true });
+    expect(() => syncConsumerXbriefSchemas(missing.project, missing.deftDir)).toThrow(
+      /missing xbrief-core-0\.8\.schema\.json/,
+    );
+
+    const malformed = fixture();
+    rmSync(join(malformed.schemas, "xbrief-core-0.8.schema.json"));
+    mkdirSync(join(malformed.schemas, "xbrief-core-0.8.schema.json"));
+    expect(() => syncConsumerXbriefSchemas(malformed.project, malformed.deftDir)).toThrow(
+      /missing xbrief-core-0\.8\.schema\.json/,
+    );
+  });
+
+  it("uses the root marker fallback before a lifecycle artifact exists and ignores dev versions", () => {
+    const { project } = fixture();
+    expect(syncBareVersionMarker(project, "")).toBe(false);
+    expect(syncBareVersionMarker(project, "0.0.0-dev")).toBe(false);
+    expect(syncBareVersionMarker(project, "0.78.0")).toBe(true);
+    expect(readFileSync(join(project, ".deft-version"), "utf8")).toBe("0.78.0\n");
+    expect(syncBareVersionMarker(project, "0.78.0")).toBe(false);
+  });
+
+  itSymlink("refuses schema symlinks in the framework payload", () => {
+    const { project, deftDir, schemas } = fixture();
+    const outside = join(project, "outside.schema.json");
+    writeFileSync(outside, "outside\n", "utf8");
+    symlinkSync(outside, join(schemas, "linked.schema.json"));
+    expect(() => syncConsumerXbriefSchemas(project, deftDir)).toThrow(
+      /refusing xbrief schema projection from symlink/,
+    );
+  });
+
+  itSymlink("refuses an xbrief projection path that escapes the project", () => {
+    const { project, deftDir } = fixture();
+    const outside = mkdtempSync(join(tmpdir(), "xbrief-projections-outside-"));
+    created.push(outside);
+    symlinkSync(outside, join(project, "xbrief"));
+
+    expect(() => syncConsumerXbriefSchemas(project, deftDir)).toThrow(ProjectionContainmentError);
+    expect(() => syncBareVersionMarker(project, "0.78.0")).toThrow(ProjectionContainmentError);
+  });
+});

--- a/packages/core/src/init-deposit/xbrief-projections.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.ts
@@ -1,0 +1,119 @@
+/**
+ * Idempotent consumer xBRIEF derivatives maintained by init/update (#2595).
+ *
+ * The framework payload manifest and consumer projections have independent
+ * freshness. A current `.deft/core/VERSION` therefore cannot short-circuit
+ * these repairs.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, relative } from "node:path";
+import { assertProjectionContained } from "../fs/projection-containment.js";
+import { resolveLifecycleRoot } from "../layout/resolve.js";
+import { DEV_FALLBACK } from "../platform/constants.js";
+import { MIGRATED_ARTIFACT_DIR } from "../xbrief-migrate/constants.js";
+
+const OBSOLETE_CORE_SCHEMA = "vbrief-core.schema.json";
+const CURRENT_CORE_SCHEMA = "xbrief-core-0.8.schema.json";
+
+function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/, "");
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function collectSchemaFiles(root: string, dir = root, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`refusing xbrief schema projection from symlink: ${full}`);
+    }
+    if (entry.isDirectory()) {
+      collectSchemaFiles(root, full, files);
+    } else if (entry.isFile()) {
+      files.push(relative(root, full));
+    }
+  }
+  return files;
+}
+
+function writeFileIfChanged(projectDir: string, target: string, content: Buffer | string): boolean {
+  assertProjectionContained(projectDir, target);
+  const desired = Buffer.isBuffer(content) ? content : Buffer.from(content, "utf8");
+  try {
+    if (readFileSync(target).equals(desired)) return false;
+  } catch {
+    // Missing or unreadable target is replaced below.
+  }
+  mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, desired);
+  return true;
+}
+
+/**
+ * Synchronize framework-owned xBRIEF schemas while preserving unknown consumer
+ * files. The obsolete v0.6 root schema is the only destination-only file this
+ * repair removes.
+ */
+export function syncConsumerXbriefSchemas(projectDir: string, deftDir: string): boolean {
+  const sourceDir = join(deftDir, "vbrief", "schemas");
+  const currentSource = join(sourceDir, CURRENT_CORE_SCHEMA);
+  if (!isDirectory(sourceDir) || !existsSync(currentSource) || !statSync(currentSource).isFile()) {
+    throw new Error(
+      `cannot project xbrief schemas: framework payload is missing ${CURRENT_CORE_SCHEMA}`,
+    );
+  }
+
+  const destinationDir = join(projectDir, MIGRATED_ARTIFACT_DIR, "schemas");
+  assertProjectionContained(projectDir, destinationDir);
+  mkdirSync(destinationDir, { recursive: true });
+
+  let changed = false;
+  for (const rel of collectSchemaFiles(sourceDir)) {
+    if (rel === OBSOLETE_CORE_SCHEMA) continue;
+    const source = join(sourceDir, rel);
+    const destination = join(destinationDir, rel);
+    changed = writeFileIfChanged(projectDir, destination, readFileSync(source)) || changed;
+  }
+
+  const obsoleteDestination = join(destinationDir, OBSOLETE_CORE_SCHEMA);
+  assertProjectionContained(projectDir, obsoleteDestination);
+  if (existsSync(obsoleteDestination)) {
+    rmSync(obsoleteDestination, { force: true });
+    changed = true;
+  }
+  return changed;
+}
+
+/** Regenerate the bare consumer version derivative without rewriting it when current. */
+export function syncBareVersionMarker(projectDir: string, version: string): boolean {
+  const normalized = normalizeVersion(version);
+  if (!normalized || normalized === DEV_FALLBACK) return false;
+
+  const canonicalRoot = join(projectDir, MIGRATED_ARTIFACT_DIR);
+  if (existsSync(canonicalRoot)) {
+    assertProjectionContained(projectDir, join(canonicalRoot, ".deft-version"));
+  }
+  let targetDir = projectDir;
+  try {
+    targetDir = resolveLifecycleRoot(projectDir);
+  } catch {
+    // No canonical artifact layout yet; retain the historical root fallback.
+  }
+  const target = join(targetDir, ".deft-version");
+  return writeFileIfChanged(projectDir, target, `${normalized}\n`);
+}

--- a/packages/core/src/init-deposit/xbrief-projections.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.ts
@@ -99,15 +99,10 @@ export function syncConsumerXbriefSchemas(projectDir: string, deftDir: string): 
   return changed;
 }
 
-/**
- * Regenerate the bare consumer version derivative without rewriting it when
- * current. A no-op payload refresh may repair an existing root fallback, but
- * must not create one in a greenfield scaffold that has no lifecycle artifact.
- */
-export function syncBareVersionMarker(
+function syncBareVersionMarkerWithPolicy(
   projectDir: string,
   version: string,
-  options: { allowRootFallback?: boolean } = {},
+  allowRootFallback: boolean,
 ): boolean {
   const normalized = normalizeVersion(version);
   if (!normalized || normalized === DEV_FALLBACK) return false;
@@ -124,8 +119,18 @@ export function syncBareVersionMarker(
     // and repair an existing fallback on no-op refreshes without creating new
     // untracked state (#2118 / #2595).
     const rootMarker = join(projectDir, ".deft-version");
-    if (options.allowRootFallback === false && !existsSync(rootMarker)) return false;
+    if (!allowRootFallback && !existsSync(rootMarker)) return false;
   }
   const target = join(targetDir, ".deft-version");
   return writeFileIfChanged(projectDir, target, `${normalized}\n`);
+}
+
+/** Regenerate the bare consumer version derivative, retaining the historical root fallback. */
+export function syncBareVersionMarker(projectDir: string, version: string): boolean {
+  return syncBareVersionMarkerWithPolicy(projectDir, version, true);
+}
+
+/** Repair an existing marker without creating root state when no lifecycle artifact exists. */
+export function syncExistingBareVersionMarker(projectDir: string, version: string): boolean {
+  return syncBareVersionMarkerWithPolicy(projectDir, version, false);
 }

--- a/packages/core/src/init-deposit/xbrief-projections.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.ts
@@ -99,8 +99,16 @@ export function syncConsumerXbriefSchemas(projectDir: string, deftDir: string): 
   return changed;
 }
 
-/** Regenerate the bare consumer version derivative without rewriting it when current. */
-export function syncBareVersionMarker(projectDir: string, version: string): boolean {
+/**
+ * Regenerate the bare consumer version derivative without rewriting it when
+ * current. A no-op payload refresh may repair an existing root fallback, but
+ * must not create one in a greenfield scaffold that has no lifecycle artifact.
+ */
+export function syncBareVersionMarker(
+  projectDir: string,
+  version: string,
+  options: { allowRootFallback?: boolean } = {},
+): boolean {
   const normalized = normalizeVersion(version);
   if (!normalized || normalized === DEV_FALLBACK) return false;
 
@@ -112,7 +120,11 @@ export function syncBareVersionMarker(projectDir: string, version: string): bool
   try {
     targetDir = resolveLifecycleRoot(projectDir);
   } catch {
-    // No canonical artifact layout yet; retain the historical root fallback.
+    // Preserve the historical root fallback for payload-changing refreshes,
+    // and repair an existing fallback on no-op refreshes without creating new
+    // untracked state (#2118 / #2595).
+    const rootMarker = join(projectDir, ".deft-version");
+    if (options.allowRootFallback === false && !existsSync(rootMarker)) return false;
   }
   const target = join(targetDir, ".deft-version");
   return writeFileIfChanged(projectDir, target, `${normalized}\n`);

--- a/packages/core/src/release-e2e/content-prepack.test.ts
+++ b/packages/core/src/release-e2e/content-prepack.test.ts
@@ -127,6 +127,17 @@ describe("@deftai/directive-content prepack (#1967 / #2022 Phase 3)", () => {
     expect(existsSync(join(pkgDir, "tasks", "swarm.yml"))).toBe(true);
   });
 
+  it("packages a Taskfile with no trailing whitespace (#2595)", () => {
+    const sourceTaskfile = readFileSync(join(process.cwd(), "Taskfile.yml"), "utf8");
+    expect(sourceTaskfile.match(/[ \t]+$/gm)).toBeNull();
+
+    const { root, pkgDir } = buildFakeRepo();
+    created.push(root);
+    writeFileSync(join(root, "Taskfile.yml"), sourceTaskfile, "utf8");
+    runPrepack(pkgDir);
+    expect(readFileSync(join(pkgDir, "Taskfile.yml"), "utf8").match(/[ \t]+$/gm)).toBeNull();
+  });
+
   it("does not bundle scripts/ or .py files even when present upstream (#2022 Phase 3)", () => {
     const { root, pkgDir } = buildFakeRepo();
     created.push(root);

--- a/packages/core/src/release-e2e/npm-ops.test.ts
+++ b/packages/core/src/release-e2e/npm-ops.test.ts
@@ -28,7 +28,7 @@ import type { E2ESeams } from "./types.js";
 function installFakeContentPackage(projectRoot: string, version = "0.53.0"): string {
   const pkgDir = join(projectRoot, "node_modules", "@deftai", "directive-content");
   mkdirSync(join(pkgDir, "templates"), { recursive: true });
-  mkdirSync(join(pkgDir, "xbrief", "schemas"), { recursive: true });
+  mkdirSync(join(pkgDir, "vbrief", "schemas"), { recursive: true });
   mkdirSync(join(pkgDir, ".githooks"), { recursive: true });
   // tasks/ + scripts/ mirror the engine dirs the #1967 prepack bundles
   // alongside .githooks/ + Taskfile.yml so the deposited .deft/core/Taskfile.yml
@@ -44,8 +44,9 @@ function installFakeContentPackage(projectRoot: string, version = "0.53.0"): str
     join(pkgDir, "templates/agents-entry.md"),
   );
   writeFileSync(join(pkgDir, "main.md"), "# Deft\n", "utf8");
-  writeFileSync(join(pkgDir, "xbrief", "schemas", "cache-meta.schema.json"), "{}\n", "utf8");
-  writeFileSync(join(pkgDir, "xbrief", "vbrief.md"), "# vbrief\n", "utf8");
+  writeFileSync(join(pkgDir, "vbrief", "schemas", "cache-meta.schema.json"), "{}\n", "utf8");
+  writeFileSync(join(pkgDir, "vbrief", "schemas", "xbrief-core-0.8.schema.json"), "{}\n", "utf8");
+  writeFileSync(join(pkgDir, "vbrief", "vbrief.md"), "# vbrief\n", "utf8");
   writeFileSync(join(pkgDir, ".githooks", "pre-commit"), "#!/bin/sh\nexit 0\n", "utf8");
   chmodSync(join(pkgDir, ".githooks", "pre-commit"), 0o755);
   writeFileSync(join(pkgDir, ".githooks", "pre-push"), "#!/bin/sh\nexit 0\n", "utf8");

--- a/packages/core/src/resolution/cold-clone-reconstitution.test.ts
+++ b/packages/core/src/resolution/cold-clone-reconstitution.test.ts
@@ -113,6 +113,7 @@ function makeColdCloneFixture(options: MakeColdCloneOptions = {}): ColdCloneFixt
 
   // Fake content package the update seam re-projects .deft/core from.
   mkdirSync(join(contentRoot, "templates"), { recursive: true });
+  mkdirSync(join(contentRoot, "vbrief", "schemas"), { recursive: true });
   writeFileSync(
     join(contentRoot, "package.json"),
     JSON.stringify({ name: CONTENT_PACKAGE_NAME, version: contentVersion }),
@@ -123,6 +124,11 @@ function makeColdCloneFixture(options: MakeColdCloneOptions = {}): ColdCloneFixt
     join(contentRoot, "templates", "agents-entry.md"),
   );
   writeFileSync(join(contentRoot, "main.md"), "# Deft\n", "utf8");
+  writeFileSync(
+    join(contentRoot, "vbrief", "schemas", "xbrief-core-0.8.schema.json"),
+    "{}\n",
+    "utf8",
+  );
 
   if (options.withWorkspaceUserMd) {
     mkdirSync(join(projectDir, ".deft"), { recursive: true });

--- a/packages/core/src/xbrief-migrate/detect.test.ts
+++ b/packages/core/src/xbrief-migrate/detect.test.ts
@@ -172,6 +172,53 @@ describe("detectXbriefConvergence (#2270)", () => {
     expect(detectXbriefConvergence(root).state).toBe("legacy-only");
   });
 
+  it("treats a cache-only xbrief tree as support state, not canonical content (#2595)", () => {
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(
+      join(root, LEGACY_ARTIFACT_DIR, "active", `story${LEGACY_ARTIFACT_SUFFIX}`),
+      JSON.stringify({ xBRIEFInfo: { version: "0.8" }, plan: { title: "t", items: [] } }),
+      "utf8",
+    );
+    mkdirSync(join(root, MIGRATED_ARTIFACT_DIR, ".triage-cache", "issues"), { recursive: true });
+    writeFileSync(
+      join(root, MIGRATED_ARTIFACT_DIR, ".triage-cache", "issues", "2595.json"),
+      "{}\n",
+    );
+    mkdirSync(join(root, MIGRATED_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(join(root, MIGRATED_ARTIFACT_DIR, "active", ".gitkeep"), "", "utf8");
+
+    const result = detectXbriefConvergence(root);
+    expect(result.state).toBe("legacy-only");
+    expect(result.xbriefPresent).toBe(true);
+    expect(result.xbriefHasContent).toBe(false);
+  });
+
+  it("still treats unknown xbrief files as canonical content", () => {
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(
+      join(root, LEGACY_ARTIFACT_DIR, "active", `story${LEGACY_ARTIFACT_SUFFIX}`),
+      JSON.stringify({ xBRIEFInfo: { version: "0.8" }, plan: { title: "t", items: [] } }),
+      "utf8",
+    );
+    mkdirSync(join(root, MIGRATED_ARTIFACT_DIR), { recursive: true });
+    writeFileSync(join(root, MIGRATED_ARTIFACT_DIR, "operator-note.txt"), "do not overwrite\n");
+    expect(detectXbriefConvergence(root).state).toBe("dual-populated");
+  });
+
+  itSymlink("does not hide a cache symlink as support-only state", () => {
+    mkdirSync(join(root, LEGACY_ARTIFACT_DIR, "active"), { recursive: true });
+    writeFileSync(
+      join(root, LEGACY_ARTIFACT_DIR, "active", `story${LEGACY_ARTIFACT_SUFFIX}`),
+      JSON.stringify({ xBRIEFInfo: { version: "0.8" }, plan: { title: "t", items: [] } }),
+      "utf8",
+    );
+    mkdirSync(join(root, MIGRATED_ARTIFACT_DIR, ".triage-cache"), { recursive: true });
+    const outside = join(root, "outside-cache.json");
+    writeFileSync(outside, "{}\n", "utf8");
+    symlinkSync(outside, join(root, MIGRATED_ARTIFACT_DIR, ".triage-cache", "linked.json"));
+    expect(detectXbriefConvergence(root).state).toBe("dual-populated");
+  });
+
   itSymlink(
     "does not treat a vbrief/ holding only a symlink as empty (never wipes symlinked content)",
     () => {

--- a/packages/core/src/xbrief-migrate/detect.ts
+++ b/packages/core/src/xbrief-migrate/detect.ts
@@ -80,6 +80,44 @@ function walkJsonFiles(root: string, acc: string[] = []): string[] {
   return acc;
 }
 
+/** Cache support state may contain only ordinary files/directories, never links or special files. */
+function containsUnsupportedCacheEntry(root: string): boolean {
+  if (!isDirectory(root)) return false;
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) return true;
+    if (entry.isDirectory()) {
+      if (containsUnsupportedCacheEntry(join(root, entry.name))) return true;
+      continue;
+    }
+    if (!entry.isFile()) return true;
+  }
+  return false;
+}
+
+/**
+ * A top-level `.triage-cache/` is operational support state, not evidence that
+ * project artifacts have already migrated. Everything else keeps the generic
+ * empty-tree semantics; unknown files and symlinks remain real content.
+ */
+function xbriefHasProjectContent(root: string): boolean {
+  if (!isDirectory(root)) return false;
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = join(root, entry.name);
+    if (entry.name === ".triage-cache" && entry.isDirectory()) {
+      if (containsUnsupportedCacheEntry(full)) return true;
+      continue;
+    }
+    if (entry.isSymbolicLink()) return true;
+    if (entry.isDirectory()) {
+      if (!isEffectivelyEmptyDir(full)) return true;
+      continue;
+    }
+    if (entry.isFile() && (entry.name === ".gitkeep" || entry.name === ".keep")) continue;
+    return true;
+  }
+  return false;
+}
+
 function scanFileContent(path: string, content: string, reasons: Set<string>): void {
   if (path.endsWith(LEGACY_ARTIFACT_SUFFIX)) {
     reasons.add(`legacy artifact filename: ${path}`);
@@ -149,7 +187,7 @@ export function detectXbriefConvergence(projectRoot: string): XbriefConvergenceD
   const vbriefHasMarker = vbriefPresent && hasVbriefDeprecationMarker(legacyDir);
   const vbriefEmpty = vbriefPresent && !vbriefHasMarker && isEffectivelyEmptyDir(legacyDir);
   const xbriefPresent = isDirectory(migratedDir);
-  const xbriefHasContent = xbriefPresent && !isEffectivelyEmptyDir(migratedDir);
+  const xbriefHasContent = xbriefPresent && xbriefHasProjectContent(migratedDir);
 
   let state: XbriefConvergenceState;
   if (vbriefHasMarker) {

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -151,6 +151,38 @@ describe("runXbriefMigration", () => {
     expect(outcome.kind).toBe("config");
   });
 
+  it("migrates through a cache-only xbrief tree and preserves both cache sources (#2595)", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-cache-only-"));
+    temps.push(base);
+    const project = scaffoldLegacyProject(base);
+    const legacyCache = join(project, LEGACY_ARTIFACT_DIR, ".triage-cache", "issues");
+    const canonicalCache = join(project, MIGRATED_ARTIFACT_DIR, ".triage-cache", "issues");
+    mkdirSync(legacyCache, { recursive: true });
+    mkdirSync(canonicalCache, { recursive: true });
+    writeFileSync(join(legacyCache, "legacy-only.json"), "legacy-only\n", "utf8");
+    writeFileSync(join(legacyCache, "collision.json"), "legacy\n", "utf8");
+    writeFileSync(join(canonicalCache, "canonical-only.json"), "canonical-only\n", "utf8");
+    writeFileSync(join(canonicalCache, "collision.json"), "canonical\n", "utf8");
+
+    const outcome = runXbriefMigration({ projectRoot: project, force: true }, SILENT_IO);
+    expect(outcome.kind).toBe("migrated");
+    if (outcome.kind !== "migrated") return;
+
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"))).toBe(
+      true,
+    );
+    expect(readFileSync(join(canonicalCache, "legacy-only.json"), "utf8")).toBe("legacy-only\n");
+    expect(readFileSync(join(canonicalCache, "canonical-only.json"), "utf8")).toBe(
+      "canonical-only\n",
+    );
+    expect(readFileSync(join(canonicalCache, "collision.json"), "utf8")).toBe("canonical\n");
+    expect(existsSync(join(outcome.backupDir, LEGACY_ARTIFACT_DIR))).toBe(true);
+    expect(
+      existsSync(join(outcome.backupDir, MIGRATED_ARTIFACT_DIR, ".triage-cache", "issues")),
+    ).toBe(true);
+    expect(runXbriefMigration({ projectRoot: project, force: true }, SILENT_IO).kind).toBe("noop");
+  });
+
   it("returns config when a legacy artifact cannot be transformed", () => {
     const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-bad-json-"));
     temps.push(base);

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -98,12 +98,26 @@ function writeMigratedFile(srcPath: string, destPath: string): void {
   writeFileSync(destPath, rewriteEmbeddedTokens(raw), "utf8");
 }
 
-function backupLegacyTree(projectRoot: string, legacyDir: string): string {
+function backupMigrationInputs(
+  projectRoot: string,
+  legacyDir: string,
+  migratedDir: string,
+): string {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const backupRoot = join(projectRoot, ".deft", `xbrief-migrate-backup-${stamp}`);
   mkdirSync(backupRoot, { recursive: true });
   cpSync(legacyDir, join(backupRoot, LEGACY_ARTIFACT_DIR), { recursive: true });
+  if (existsSync(migratedDir)) {
+    cpSync(migratedDir, join(backupRoot, MIGRATED_ARTIFACT_DIR), { recursive: true });
+  }
   return backupRoot;
+}
+
+/** Overlay the already-canonical cache last so it wins collisions. */
+function overlayCanonicalTriageCache(migratedDir: string, stagedDir: string): void {
+  const source = join(migratedDir, ".triage-cache");
+  if (!isDirectory(source)) return;
+  cpSync(source, join(stagedDir, ".triage-cache"), { recursive: true, force: true });
 }
 
 function migrateLegacyTree(
@@ -112,13 +126,15 @@ function migrateLegacyTree(
   options: { keepLegacy: boolean },
 ): { backupDir: string; files: number } {
   const migratedDir = join(projectRoot, MIGRATED_ARTIFACT_DIR);
-  if (existsSync(migratedDir)) {
+  const convergence = detectXbriefConvergence(projectRoot);
+  const hasCanonicalCache = isDirectory(join(migratedDir, ".triage-cache"));
+  if (existsSync(migratedDir) && (convergence.xbriefHasContent || !hasCanonicalCache)) {
     throw new Error(
-      `refusing to migrate: '${MIGRATED_ARTIFACT_DIR}/' already exists alongside '${LEGACY_ARTIFACT_DIR}/'`,
+      `refusing to migrate: '${MIGRATED_ARTIFACT_DIR}/' already exists alongside '${LEGACY_ARTIFACT_DIR}/' and is not a cache-only support tree`,
     );
   }
 
-  const backupDir = backupLegacyTree(projectRoot, legacyDir);
+  const backupDir = backupMigrationInputs(projectRoot, legacyDir, migratedDir);
   const stagedDir = join(projectRoot, `.${MIGRATED_ARTIFACT_DIR}.migrate-staging`);
   if (existsSync(stagedDir)) {
     rmSync(stagedDir, { recursive: true, force: true });
@@ -132,6 +148,7 @@ function migrateLegacyTree(
       const destPath = join(stagedDir, mapRelativePath(rel));
       writeMigratedFile(srcPath, destPath);
     }
+    overlayCanonicalTriageCache(migratedDir, stagedDir);
     renameOrReplace(stagedDir, migratedDir);
     // Converge to a single unambiguous root: the fully-migrated legacy tree is
     // either removed (default) or retained for read-compat behind an explicit

--- a/xbrief/active/2026-07-15-2575-2576-empty-cache-auto-refresh-and-triage-queue-routing.xbrief.json
+++ b/xbrief/active/2026-07-15-2575-2576-empty-cache-auto-refresh-and-triage-queue-routing.xbrief.json
@@ -12,6 +12,7 @@
       "AcceptanceCriteria": "AC1. Empty cache auto-fetches immediately. AC2. Healthy non-empty fresh cache still skips live list. AC3. AGENTS/skills/triage guidance mandates triage:queue after ordered-plan (#2402); forbid concluding empty from xBRIEF-only or GH-only. AC4. Tests + CHANGELOG; Closes #2575 and #2576.",
       "ImplementationPlan": "Add maybeAutoPopulateEmptyCache in packages/core/src/cache/; hook verify:cache-fresh, triage:queue, triage:summary, triage:welcome; update agents-entry, triage skill, commands.md; tests and CHANGELOG."
     },
+    "items": [],
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/2575",

--- a/xbrief/completed/2026-07-16-2595-v078-update-leaves-migrated-xbrief-schema-and-version-deriva.xbrief.json
+++ b/xbrief/completed/2026-07-16-2595-v078-update-leaves-migrated-xbrief-schema-and-version-deriva.xbrief.json
@@ -1,0 +1,66 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2595"
+  },
+  "plan": {
+    "title": "v0.78 update leaves migrated xbrief schema and version derivative stale",
+    "status": "completed",
+    "narratives": {
+      "Description": "v0.78 update leaves migrated xbrief schema and version derivative stale",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2595",
+      "Overview": "Consumer upgrade from v0.72 to v0.78 reproduced two post-migration drifts: (1) xbrief/.deft-version remains 0.72.0 even after directive update reports current 0.78.0; (2) xbrief/schemas/vbrief-core.schema.json retains the vBRIEFInfo v0.6 root schema after migrate:xbrief, and a subsequent directive update no-ops instead of refreshing it. directive doctor --full reports manifest-agreement failure and stale-xbrief-schema-deposit. Also, a cache-only xbrief/.triage-cache directory caused the first migrate:xbrief --force invocation to report converged without migrating project artifacts. Refs #2034/#2110/#2149.\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @dbcall2 (2026-07-16T00:04:19Z)\n\nAdditional v0.78.0 deposit defect: .deft/core/Taskfile.yml contains trailing whitespace on generated ENGINE_CMD lines 364 and 463, causing git diff --check to fail in consumer pre-PR validation."
+    },
+    "items": [
+      {
+        "id": "2595-a1",
+        "title": "Current update repairs xBRIEF schema and version derivatives",
+        "status": "running",
+        "narrative": {
+          "Acceptance": "Given a current 0.78 core payload and manifest with a stale xbrief/.deft-version plus vbrief-core.schema.json, when directive update runs, then the payload copy and manifest rewrite remain no-ops while the marker becomes 0.78, the obsolete schema is removed, the current schema is present, doctor clears both reported drifts, and a second run performs no projection writes."
+        }
+      },
+      {
+        "id": "2595-a2",
+        "title": "Greenfield schema projection excludes the obsolete v0.6 root",
+        "status": "running",
+        "narrative": {
+          "Acceptance": "Given the framework schema deposit contains both legacy and current roots, when consumer xBRIEF scaffolding runs, then it projects current framework schemas, omits vbrief-core.schema.json, preserves unrelated consumer schemas, and rejects unsafe projection paths."
+        }
+      },
+      {
+        "id": "2595-a3",
+        "title": "Cache-only canonical state does not suppress legacy migration",
+        "status": "running",
+        "narrative": {
+          "Acceptance": "Given legacy vbrief project artifacts and an xbrief tree containing only .triage-cache plus placeholders, when migrate:xbrief --force runs, then project artifacts migrate, both input trees are backed up, unique cache records survive, canonical cache records win collisions, and a rerun is idempotent; unknown canonical files still prevent destructive migration."
+        }
+      },
+      {
+        "id": "2595-a4",
+        "title": "Published Taskfile is free of trailing whitespace",
+        "status": "running",
+        "narrative": {
+          "Acceptance": "Given the repository Taskfile and content-package prepack, when packaging and git diff checks run, then neither the source nor packaged Taskfile contains trailing spaces and CHANGELOG [Unreleased] records the repair."
+        }
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2595",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2595: v0.78 update leaves migrated xbrief schema and version derivative stale"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2034",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2034"
+      }
+    ],
+    "updated": "2026-07-16T11:44:31Z",
+    "metadata": {
+      "completedAt": "2026-07-16T11:44:31Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the v0.78 upgrade path so consumer xBRIEF derivatives are repaired independently of payload freshness.

- refreshes `xbrief/.deft-version` and framework-owned schemas even when `directive update` skips an already-current payload
- omits and removes the obsolete v0.6 root schema while preserving consumer-owned schemas
- treats cache-only `xbrief/.triage-cache` as support state so legacy artifacts migrate transactionally, with both inputs backed up and canonical cache entries winning collisions
- removes trailing whitespace from the packaged root Taskfile
- repairs the pre-existing #2575/#2576 lifecycle record by adding the schema-required empty `plan.items`

Root cause: payload-current detection short-circuited independent consumer projections, and migration classified any canonical cache content as already-migrated project state.

## Related Issues

Closes #2595

## Validation

- `env NODE_OPTIONS=--max-old-space-size=8192 task check`
  - 652/652 test files passed
  - 9,491/9,491 tests passed
  - coverage: 88.58% statements, 85% branches, 95.93% functions, 88.58% lines
- `git diff --check`
- `task vbrief:validate`
- `task verify:forward-coverage`

## Checklist

- [x] `/deft:change <name>` — N/A: one issue-scoped bug repair with a completed scope xBRIEF; no architectural contract or unrelated feature bundle
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A: #2595 is a release-regression fix not represented as a roadmap item
- [x] Tests pass locally

## Post-Merge

- [ ] Verify #2595 auto-closes after squash merge
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
