### PR TITLE
chore(xbrief): complete stale active scopes for closed cohort issues

### DIFF
--- a/xbrief/completed/2026-07-15-2566-scope-complete-syncs-specification-statuses.xbrief.json
+++ b/xbrief/completed/2026-07-15-2566-scope-complete-syncs-specification-statuses.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "scope:complete syncs specification.xbrief.json item statuses",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Mirror #1527 PROJECT-DEFINITION sync for specification.xbrief.json roadmap/registry items on scope terminal transitions.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2566",
@@ -31,7 +31,9 @@
         }
       }
     ],
-    "tags": ["bug"],
+    "tags": [
+      "bug"
+    ],
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/2566",
@@ -50,14 +52,21 @@
           "packages/core/src/scope/specification-sync.test.ts",
           "packages/core/src/scope/transition.ts"
         ],
-        "verify_commands": ["pnpm exec vitest run packages/core/src/scope/specification-sync.test.ts"],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/scope/specification-sync.test.ts"
+        ],
         "expected_outputs": [
           "specification item statuses sync on scope:complete, scope:fail, and scope:cancel"
         ],
-        "depends_on": ["2578"],
+        "depends_on": [
+          "2578"
+        ],
         "conflict_group": "specification-registry-sync",
         "size": "medium"
-      }
-    }
+      },
+      "completedAt": "2026-07-16T16:54:13Z",
+      "capacityBucket": "technical-debt"
+    },
+    "updated": "2026-07-16T16:54:13Z"
   }
 }

--- a/xbrief/completed/2026-07-15-2572-release-e2e-report-temp-repo-no-delete.xbrief.json
+++ b/xbrief/completed/2026-07-15-2572-release-e2e-report-temp-repo-no-delete.xbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "release-e2e: do not attempt temp-repo delete during agent release; report for manual cleanup",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Default release-e2e to keep+report temp repos instead of attempting gh repo delete. Agents lack delete_repo permission; failed deletes stall releases. Optional --destroy-repo for privileged environments.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2572",
@@ -39,7 +39,10 @@
         }
       }
     ],
-    "tags": ["bug", "release"],
+    "tags": [
+      "bug",
+      "release"
+    ],
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/2572",
@@ -47,7 +50,7 @@
         "title": "Issue #2572: release-e2e temp-repo keep+report"
       }
     ],
-    "updated": "2026-07-15T18:30:00Z",
+    "updated": "2026-07-16T16:54:44Z",
     "id": "release-e2e-keep-report",
     "metadata": {
       "kind": "story",
@@ -65,7 +68,9 @@
           "Default path skips gh repo delete",
           "Phase 3 skill documents keep+report"
         ]
-      }
+      },
+      "completedAt": "2026-07-16T16:54:44Z",
+      "capacityBucket": "technical-debt"
     }
   }
 }

--- a/xbrief/completed/2026-07-15-2573-allow-coverage-debt-flag-restore-85.xbrief.json
+++ b/xbrief/completed/2026-07-15-2573-allow-coverage-debt-flag-restore-85.xbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "allow-coverage-debt-flag-restore-85",
     "title": "Release coverage soft-pass only via --allow-coverage-debt=#N; restore win32 branches floor to 85",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Hard fail coverage by default at 85%. Soft-pass only with explicit task release --allow-coverage-debt=#N (loud, attributable). Remove isWin32 branches carve; thresholds.branches = 85 on all platforms. Warn when debt flag is overused.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2573",
@@ -42,8 +42,9 @@
     ],
     "metadata": {
       "kind": "story",
-      "capacityBucket": "technical-debt"
+      "capacityBucket": "technical-debt",
+      "completedAt": "2026-07-16T16:54:45Z"
     },
-    "updated": "2026-07-15T20:20:00Z"
+    "updated": "2026-07-16T16:54:45Z"
   }
 }

--- a/xbrief/completed/2026-07-15-2574-cache-fresh-recovery-verb-fix.xbrief.json
+++ b/xbrief/completed/2026-07-15-2574-cache-fresh-recovery-verb-fix.xbrief.json
@@ -6,7 +6,7 @@
   "plan": {
     "id": "2574-cache-fresh-recovery-verb-fix",
     "title": "bug(cache,session): gated ritual recovery prints working cache fetch-all command",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Gated session ritual cache_fresh failures print `deft cache:fetch-all --force`, which is unknown on the npm CLI and omits required --source/--repo flags. Recovery text must use the space-separated `deft cache fetch-all --source github-issue --repo OWNER/NAME` surface.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2574",
@@ -25,7 +25,11 @@
         }
       }
     ],
-    "tags": ["bug", "agent-experience", "area:session"],
+    "tags": [
+      "bug",
+      "agent-experience",
+      "area:session"
+    ],
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/2574",
@@ -42,7 +46,10 @@
           "packages/core/src/session/",
           "packages/core/src/preflight-cache/evaluate.ts"
         ]
-      }
-    }
+      },
+      "completedAt": "2026-07-16T16:54:48Z",
+      "capacityBucket": "technical-debt"
+    },
+    "updated": "2026-07-16T16:54:48Z"
   }
 }

--- a/xbrief/completed/2026-07-15-2577-release-step3-rate-limit-backoff.xbrief.json
+++ b/xbrief/completed/2026-07-15-2577-release-step3-rate-limit-backoff.xbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "release: Step 3 lifecycle sync hard-fails when GitHub REST core rate limit is exhausted",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Add capped sleep+retry on HTTP 403 rate-limit during release Step 3 issue-state fetch, actionable FAIL text with rate_limit probe, and document --allow-vbrief-drift escape after local vbrief:validate is green.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2577",
@@ -39,7 +39,15 @@
         }
       }
     ],
-    "tags": ["bug", "blocks-release-tag", "operational", "scm", "github", "area:release", "release"],
+    "tags": [
+      "bug",
+      "blocks-release-tag",
+      "operational",
+      "scm",
+      "github",
+      "area:release",
+      "release"
+    ],
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/2577",
@@ -47,7 +55,7 @@
         "title": "Issue #2577: release Step 3 lifecycle sync hard-fails when GitHub REST core rate limit is exhausted"
       }
     ],
-    "updated": "2026-07-15T20:00:00Z",
+    "updated": "2026-07-16T16:54:49Z",
     "id": "release-step3-rate-limit-backoff",
     "metadata": {
       "kind": "story",
@@ -70,7 +78,9 @@
         "depends_on": [],
         "conflict_group": "release-step3",
         "size": "S"
-      }
+      },
+      "completedAt": "2026-07-16T16:54:49Z",
+      "capacityBucket": "technical-debt"
     }
   }
 }

--- a/xbrief/completed/2026-07-15-2578-completed-xbriefs-stamp-plan-status.xbrief.json
+++ b/xbrief/completed/2026-07-15-2578-completed-xbriefs-stamp-plan-status.xbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "bug(scope): completed/ xBRIEFs must stamp plan.status completed|failed atomically with the folder move",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "During v0.78.0 release, D2 validate failed because six files under xbrief/completed/ retained non-terminal plan.status (proposed/running). Lifecycle folder and JSON status drift blocks release/CI.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2578",
@@ -49,7 +49,7 @@
         "title": "Issue #2578: completed/ xBRIEFs must stamp plan.status atomically with folder move"
       }
     ],
-    "updated": "2026-07-15T20:00:00Z",
+    "updated": "2026-07-16T16:54:51Z",
     "id": "completed-xbriefs-stamp-plan-status",
     "metadata": {
       "kind": "story",
@@ -74,7 +74,9 @@
         "depends_on": [],
         "conflict_group": "scope-lifecycle",
         "size": "S"
-      }
+      },
+      "completedAt": "2026-07-16T16:54:51Z",
+      "capacityBucket": "technical-debt"
     }
   }
 }

--- a/xbrief/completed/2026-07-15-2579-gh-repo-env-isolates-pr-wait-tests.xbrief.json
+++ b/xbrief/completed/2026-07-15-2579-gh-repo-env-isolates-pr-wait-tests.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "GH_REPO in parent shell breaks pr-wait-mergeable tests during task check / release",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "GH_REPO in parent shell breaks pr-wait-mergeable tests during task check / release",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2579",
@@ -28,6 +28,10 @@
         "title": "Issue #2579: GH_REPO in parent shell breaks pr-wait-mergeable tests during task check / release"
       }
     ],
-    "updated": "2026-07-15T20:00:43Z"
+    "updated": "2026-07-16T16:54:53Z",
+    "metadata": {
+      "completedAt": "2026-07-16T16:54:53Z",
+      "capacityBucket": "technical-debt"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Move seven `xbrief/active/` scopes whose GitHub issues already closed (#2566, #2572, #2573, #2574, #2577, #2578, #2579) into `completed/` via `task scope:complete`.
- Clears false WIP (was 7/20 in-flight with no real open work).

## Test plan
- [x] `task triage:summary` shows WIP 0/20 after completes
- [ ] CI green on this lifecycle-only PR
