### PR TITLE
chore(policy): restore branch protection after v0.79.0

### DIFF
--- a/meta/policy-changes.log
+++ b/meta/policy-changes.log
@@ -104,3 +104,4 @@
 2026-07-15T17:31:12Z actor=deft policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
 2026-07-15T19:05:36Z actor=deft policy:enforce-branches allowDirectCommitsToMaster=false previous=True
 2026-07-16T20:58:20Z actor=deft policy:allow-direct-commits allowDirectCommitsToMaster=true previous=False
+2026-07-16T23:24:56Z actor=deft policy:enforce-branches allowDirectCommitsToMaster=false previous=True

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -16780,7 +16780,7 @@
           }
         ]
       },
-      "allowDirectCommitsToMaster": true,
+      "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
         "managedMaxLines": 103,
         "unmanagedMaxLines": 161,


### PR DESCRIPTION
## Summary
- Restore `allowDirectCommitsToMaster=false` after the v0.79.0 release session.

## Test plan
- [x] `task policy:enforce-branches` already applied locally; this commits the audit + PROJECT-DEFINITION flip.

Made with [Cursor](https://cursor.com)