### PR TITLE
fix(ci): harden Windows Install Task step against transient flakes (#2624)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,27 @@ jobs:
       - name: Enable corepack (pnpm)
         run: corepack enable
 
+      # #2624: arduino/setup-task can flake on transient GitHub API / CDN errors
+      # (rate limits, network blips). Product assertions in this job run only
+      # AFTER Task is on PATH — a failed install must still fail the job.
+      # Mitigations: pin an exact Task release (avoid resolving 3.x each run),
+      # authenticate GitHub API requests via repo-token, and auto-retry once.
+      # Operator recovery when only Install Task failed (no code change needed):
+      #   gh run rerun <run_id> --failed
+      #   gh api -X POST repos/<owner>/<repo>/actions/runs/<run_id>/rerun-failed-jobs
       - name: Install Task
+        id: install_task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        continue-on-error: true
+        with:
+          version: 3.52.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Task (retry transient failure)
+        if: steps.install_task.outcome == 'failure'
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
+          version: 3.52.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Node + pnpm are required because the Wave 8 flip (#1828) repointed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Windows CI retries transient Install Task flakes (#2624).** The task-dispatch regression job pins an exact Task release and automatically retries `arduino/setup-task` once before failing; operator rerun-failed-jobs recovery is documented in the workflow. Closes #2624.
+
 ### Removed
 
 ## [0.79.1] - 2026-07-18


### PR DESCRIPTION
## Summary
- Pin Task to 3.52.0 in the Windows task-dispatch regression job to avoid resolving \3.x\ on every run.
- Auto-retry \rduino/setup-task\ once on transient failure before failing the job.
- Document operator recovery via \gh run rerun --failed\ / \gh api .../rerun-failed-jobs\ in workflow comments.

Product assertions in the job still fail closed when Task is unavailable or downstream steps fail.

## Test plan
- [x] \	ask verify:encoding -- --all\
- [ ] CI green on Windows (task dispatch regression) job
- [ ] Greptile CLEAN

Closes #2624

Made with [Cursor](https://cursor.com)