### PR TITLE
fix(hooks): map Cursor preToolUse payloads missing tool_name (#2628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cursor preToolUse write payloads without `tool_name` no longer fail as generic invalid-input (#2628).** The hook dispatcher infers direct-write tool identity from Cursor `tool_input` shapes when the host omits `tool_name`/`toolName`/`tool`, and host-integration denials distinguish that mismatch from ritual/scope failures. Closes #2628.
+
 ### Removed
 
 ## [0.79.1] - 2026-07-18

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -167,6 +167,67 @@ describe("direct-write hook policy", () => {
   it("fails closed when a matched tool event omits its tool name", () => {
     const decision = decideHook(
       {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {},
+      },
+      readySeams(),
+    );
+
+    expect(decision).toMatchObject({ verdict: "deny", code: "invalid-input" });
+    expect(decision.message).toContain("omitted its tool name");
+    expect(decision.message).not.toContain("host-integration");
+  });
+
+  it("maps Cursor write payloads that omit tool_name from tool_input shape (#2628)", () => {
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_input: {
+            path: "/project/src/index.ts",
+            contents: "export {}",
+          },
+          workspace_roots: ["/project"],
+        },
+      },
+      readySeams(),
+    );
+
+    expect(decision).toMatchObject({ verdict: "allow", code: "write-ready", toolName: "Write" });
+  });
+
+  it("maps Cursor StrReplace payloads that omit tool_name (#2628)", () => {
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_input: {
+            path: "/project/src/index.ts",
+            old_string: "foo",
+            new_string: "bar",
+          },
+          workspace_roots: ["/project"],
+        },
+      },
+      readySeams(),
+    );
+
+    expect(decision).toMatchObject({
+      verdict: "allow",
+      code: "write-ready",
+      toolName: "StrReplace",
+    });
+  });
+
+  it("surfaces a Cursor host-integration deny when tool identity cannot be mapped (#2628)", () => {
+    const decision = decideHook(
+      {
         host: "cursor",
         event: "tool.before",
         projectRoot: "/project",
@@ -176,6 +237,8 @@ describe("direct-write hook policy", () => {
     );
 
     expect(decision).toMatchObject({ verdict: "deny", code: "invalid-input" });
+    expect(decision.message).toContain("host-integration mismatch");
+    expect(decision.message).not.toContain("deft session:start");
   });
 
   it("surfaces a failed SessionStart result without blocking the session", () => {
@@ -369,6 +432,28 @@ describe("provider input normalization", () => {
     expect(hookToolName({ tool: "Delete" })).toBe("Delete");
     expect(hookToolName(null)).toBeNull();
     expect(hookToolName({ tool_name: "  " })).toBeNull();
+  });
+
+  it("infers Cursor direct-write tools when tool_name is omitted (#2628)", () => {
+    expect(
+      hookToolName(
+        {
+          tool_input: { path: "src/a.ts", contents: "x" },
+        },
+        "cursor",
+      ),
+    ).toBe("Write");
+    expect(
+      hookToolName(
+        {
+          toolInput: { file_path: "src/a.ts", old_string: "a", new_string: "b" },
+        },
+        "cursor",
+      ),
+    ).toBe("StrReplace");
+    expect(hookToolName({ tool_input: { path: "src/a.ts" } }, "cursor")).toBe("Write");
+    expect(hookToolName({}, "cursor")).toBeNull();
+    expect(hookToolName({ tool_input: { path: "src/a.ts" } })).toBeNull();
   });
 
   it("resolves supported workspace-root spellings with a fallback", () => {

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -452,6 +452,9 @@ describe("provider input normalization", () => {
       ),
     ).toBe("StrReplace");
     expect(hookToolName({ tool_input: { path: "src/a.ts" } }, "cursor")).toBe("Write");
+    expect(
+      hookToolName({ tool_input: { path: "src/a.ts", new_string: "prepend" } }, "cursor"),
+    ).toBe("StrReplace");
     expect(hookToolName({}, "cursor")).toBeNull();
     expect(hookToolName({ tool_input: { path: "src/a.ts" } })).toBeNull();
   });

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -61,6 +61,18 @@ function firstString(...values: unknown[]): string | null {
   return null;
 }
 
+function fieldPresent(input: Record<string, unknown>, ...keys: readonly string[]): boolean {
+  return keys.some((key) => key in input);
+}
+
+function fieldString(input: Record<string, unknown>, ...keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
 function toolInputRecord(payload: Record<string, unknown>): Record<string, unknown> | null {
   return record(payload.tool_input) ?? record(payload.toolInput) ?? record(payload.input);
 }
@@ -72,21 +84,20 @@ function toolInputRecord(payload: Record<string, unknown>): Record<string, unkno
 function inferCursorDirectWriteToolName(payload: Record<string, unknown>): string | null {
   const toolInput = toolInputRecord(payload);
   if (toolInput !== null) {
-    const hasOldNew =
-      firstString(toolInput.old_string, toolInput.oldString) !== null &&
-      firstString(toolInput.new_string, toolInput.newString) !== null;
-    if (hasOldNew) return "StrReplace";
+    if (fieldPresent(toolInput, "new_string", "newString", "old_string", "oldString")) {
+      return "StrReplace";
+    }
 
-    if (firstString(toolInput.contents, toolInput.content, toolInput.text) !== null) {
+    if (fieldString(toolInput, "contents", "content", "text") !== null) {
       return "Write";
     }
 
-    if (firstString(toolInput.patch, toolInput.unified_diff, toolInput.diff) !== null) {
+    if (fieldString(toolInput, "patch", "unified_diff", "diff") !== null) {
       return "ApplyPatch";
     }
 
     if (Array.isArray(toolInput.edits)) return "MultiEdit";
-    if (Array.isArray(toolInput.cells) || toolInput.cell_id !== undefined) {
+    if (Array.isArray(toolInput.cells) || toolInput.cell_id != null) {
       return "NotebookEdit";
     }
   }

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -123,9 +123,7 @@ export function hookToolName(payload: unknown, host?: HookHost): string | null {
   const input = record(payload);
   if (input === null) return null;
   const direct =
-    fieldString(input, "tool_name") ??
-    fieldString(input, "toolName") ??
-    fieldString(input, "tool");
+    fieldString(input, "tool_name") ?? fieldString(input, "toolName") ?? fieldString(input, "tool");
   if (direct !== null) return direct;
   if (host === "cursor") return inferCursorDirectWriteToolName(input);
   return null;

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -61,15 +61,13 @@ function firstString(...values: unknown[]): string | null {
   return null;
 }
 
-function fieldPresent(input: Record<string, unknown>, ...keys: readonly string[]): boolean {
-  return keys.some((key) => key in input);
+function fieldPresent(input: Record<string, unknown>, key: string): boolean {
+  return key in input;
 }
 
-function fieldString(input: Record<string, unknown>, ...keys: readonly string[]): string | null {
-  for (const key of keys) {
-    const value = input[key];
-    if (typeof value === "string" && value.trim().length > 0) return value.trim();
-  }
+function fieldString(input: Record<string, unknown>, key: string): string | null {
+  const value = input[key];
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
   return null;
 }
 
@@ -84,15 +82,28 @@ function toolInputRecord(payload: Record<string, unknown>): Record<string, unkno
 function inferCursorDirectWriteToolName(payload: Record<string, unknown>): string | null {
   const toolInput = toolInputRecord(payload);
   if (toolInput !== null) {
-    if (fieldPresent(toolInput, "new_string", "newString", "old_string", "oldString")) {
+    if (
+      fieldPresent(toolInput, "new_string") ||
+      fieldPresent(toolInput, "newString") ||
+      fieldPresent(toolInput, "old_string") ||
+      fieldPresent(toolInput, "oldString")
+    ) {
       return "StrReplace";
     }
 
-    if (fieldString(toolInput, "contents", "content", "text") !== null) {
+    if (
+      fieldString(toolInput, "contents") !== null ||
+      fieldString(toolInput, "content") !== null ||
+      fieldString(toolInput, "text") !== null
+    ) {
       return "Write";
     }
 
-    if (fieldString(toolInput, "patch", "unified_diff", "diff") !== null) {
+    if (
+      fieldString(toolInput, "patch") !== null ||
+      fieldString(toolInput, "unified_diff") !== null ||
+      fieldString(toolInput, "diff") !== null
+    ) {
       return "ApplyPatch";
     }
 
@@ -111,7 +122,10 @@ function inferCursorDirectWriteToolName(payload: Record<string, unknown>): strin
 export function hookToolName(payload: unknown, host?: HookHost): string | null {
   const input = record(payload);
   if (input === null) return null;
-  const direct = firstString(input.tool_name, input.toolName, input.tool);
+  const direct =
+    fieldString(input, "tool_name") ??
+    fieldString(input, "toolName") ??
+    fieldString(input, "tool");
   if (direct !== null) return direct;
   if (host === "cursor") return inferCursorDirectWriteToolName(input);
   return null;

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -139,7 +139,7 @@ export function hookWriteTargetPath(payload: unknown): string | null {
 export function toProjectRelativePosix(projectRoot: string, targetPath: string): string {
   const abs = resolve(projectRoot, targetPath);
   const rel = relative(resolve(projectRoot), abs);
-  return rel.split(sep).join("/");
+  return rel.split(sep).join("/").replace(/\\/g, "/");
 }
 
 /**

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -61,10 +61,60 @@ function firstString(...values: unknown[]): string | null {
   return null;
 }
 
-export function hookToolName(payload: unknown): string | null {
+function toolInputRecord(payload: Record<string, unknown>): Record<string, unknown> | null {
+  return record(payload.tool_input) ?? record(payload.toolInput) ?? record(payload.input);
+}
+
+/**
+ * Cursor preToolUse payloads sometimes omit `tool_name` even when the hook matcher
+ * fired for a direct-write tool (#2628). Infer from nested tool input when possible.
+ */
+function inferCursorDirectWriteToolName(payload: Record<string, unknown>): string | null {
+  const toolInput = toolInputRecord(payload);
+  if (toolInput !== null) {
+    const hasOldNew =
+      firstString(toolInput.old_string, toolInput.oldString) !== null &&
+      firstString(toolInput.new_string, toolInput.newString) !== null;
+    if (hasOldNew) return "StrReplace";
+
+    if (firstString(toolInput.contents, toolInput.content, toolInput.text) !== null) {
+      return "Write";
+    }
+
+    if (firstString(toolInput.patch, toolInput.unified_diff, toolInput.diff) !== null) {
+      return "ApplyPatch";
+    }
+
+    if (Array.isArray(toolInput.edits)) return "MultiEdit";
+    if (Array.isArray(toolInput.cells) || toolInput.cell_id !== undefined) {
+      return "NotebookEdit";
+    }
+  }
+
+  // Cursor maps Claude Edit → Write; a write target without contents is still a direct write.
+  if (hookWriteTargetPath(payload) !== null) return "Write";
+
+  return null;
+}
+
+export function hookToolName(payload: unknown, host?: HookHost): string | null {
   const input = record(payload);
   if (input === null) return null;
-  return firstString(input.tool_name, input.toolName, input.tool);
+  const direct = firstString(input.tool_name, input.toolName, input.tool);
+  if (direct !== null) return direct;
+  if (host === "cursor") return inferCursorDirectWriteToolName(input);
+  return null;
+}
+
+function missingToolNameMessage(host: HookHost): string {
+  if (host === "cursor") {
+    return (
+      "Directive denied this Cursor preToolUse event because the host payload omitted a " +
+      "recognizable tool name (host-integration mismatch — not a session ritual or scope failure). " +
+      "If write tools should pass, update Directive or report the payload shape from Cursor."
+    );
+  }
+  return "Directive denied this matched write event because the host payload omitted its tool name.";
 }
 
 /**
@@ -74,7 +124,7 @@ export function hookToolName(payload: unknown): string | null {
 export function hookWriteTargetPath(payload: unknown): string | null {
   const input = record(payload);
   if (input === null) return null;
-  const toolInput = record(input.tool_input) ?? record(input.toolInput) ?? record(input.input);
+  const toolInput = toolInputRecord(input);
   return firstString(
     toolInput?.file_path,
     toolInput?.filePath,
@@ -191,14 +241,9 @@ export function decideHook(input: HookDispatchInput, seams: HookPolicySeams = {}
     };
   }
 
-  const toolName = hookToolName(input.payload);
+  const toolName = hookToolName(input.payload, input.host);
   if (toolName === null) {
-    return deny(
-      input,
-      "invalid-input",
-      null,
-      "Directive denied this matched write event because the host payload omitted its tool name.",
-    );
+    return deny(input, "invalid-input", null, missingToolNameMessage(input.host));
   }
   if (!isDirectWriteTool(toolName)) {
     return {


### PR DESCRIPTION
## Summary
- Infer Cursor direct-write tool identity from \	ool_input\ shapes when the host omits \	ool_name\/\	oolName\/\	ool\
- Distinguish host-integration \invalid-input\ denials from ritual/scope failures with clearer Cursor-specific messaging
- Regression tests + CHANGELOG

## Test plan
- [x] \pnpm -w exec vitest run packages/core/src/hooks/dispatcher.test.ts packages/cli/src/hook-dispatch.test.ts --no-coverage\
- [x] \	ask verify:branch\

Closes #2628

Made with [Cursor](https://cursor.com)