### PR TITLE
fix(security): contain symlink write sinks in eval:run and migrate:category-b (#2626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Symlink write sinks in eval:run golden-run ledger and migrate:category-b (#2626).** `persistGoldenRun` and Category B corpus writers now call shared projection-containment helpers (`assertWriteTargetSafe`, lifecycle-root checks) before append/write; symlink lifecycle roots are rejected and symlink entries are skipped during traversal. Closes #2626.
+
 ### Removed
 
 ## [0.79.1] - 2026-07-18

--- a/packages/core/src/category-b-namespace/index.test.ts
+++ b/packages/core/src/category-b-namespace/index.test.ts
@@ -121,7 +121,9 @@ describe("migrateCategoryBCorpus (#1650)", () => {
     expect(result.changed).toEqual([]);
     expect(result.conflicts).toHaveLength(1);
     expect(result.conflicts[0]?.message).toMatch(/must not be a symlink|symlink escaping/);
-    expect(JSON.parse(readFileSync(outsideFile, "utf8"))).toEqual({ plan: { policy: { wipCap: 9 } } });
+    expect(JSON.parse(readFileSync(outsideFile, "utf8"))).toEqual({
+      plan: { policy: { wipCap: 9 } },
+    });
   });
 
   itSymlink("skips symlink entries during traversal (#2626)", () => {
@@ -130,15 +132,13 @@ describe("migrateCategoryBCorpus (#1650)", () => {
     });
     const escapeDir = mkdtempSync(join(tmpdir(), "catb-entry-escape-"));
     const outsideFile = join(escapeDir, "linked.xbrief.json");
-    writeFileSync(
-      outsideFile,
-      `${JSON.stringify({ plan: { policy: { wipCap: 99 } } })}\n`,
-      "utf8",
-    );
+    writeFileSync(outsideFile, `${JSON.stringify({ plan: { policy: { wipCap: 99 } } })}\n`, "utf8");
     symlinkSync(outsideFile, join(root, "xbrief", "active", "linked.xbrief.json"));
 
     const result = migrateCategoryBCorpus(root);
     expect(result.changed).toEqual(["xbrief/active/real.xbrief.json"]);
-    expect(JSON.parse(readFileSync(outsideFile, "utf8"))).toEqual({ plan: { policy: { wipCap: 99 } } });
+    expect(JSON.parse(readFileSync(outsideFile, "utf8"))).toEqual({
+      plan: { policy: { wipCap: 99 } },
+    });
   });
 });

--- a/packages/core/src/category-b-namespace/index.test.ts
+++ b/packages/core/src/category-b-namespace/index.test.ts
@@ -1,8 +1,10 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CategoryBConflictError, migrateCategoryBCorpus, namespaceCategoryBPlan } from "./index.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
 
 describe("namespaceCategoryBPlan (#1650)", () => {
   it("renames bare policy + completedNote to the x-directive/ namespace", () => {
@@ -106,5 +108,37 @@ describe("migrateCategoryBCorpus (#1650)", () => {
     expect(result.conflicts).toHaveLength(1);
     expect(result.conflicts[0]?.path).toBe("xbrief/active/conflict.xbrief.json");
     expect(result.changed).toEqual([]);
+  });
+
+  itSymlink("rejects a symlinked lifecycle root without rewriting files (#2626)", () => {
+    const escapeDir = mkdtempSync(join(tmpdir(), "catb-escape-"));
+    const outsideFile = join(escapeDir, "outside.xbrief.json");
+    writeFileSync(outsideFile, `${JSON.stringify({ plan: { policy: { wipCap: 9 } } })}\n`, "utf8");
+    symlinkSync(escapeDir, join(root, "xbrief"), "dir");
+
+    const result = migrateCategoryBCorpus(root);
+    expect(result.scanned).toBe(0);
+    expect(result.changed).toEqual([]);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.message).toMatch(/must not be a symlink|symlink escaping/);
+    expect(JSON.parse(readFileSync(outsideFile, "utf8"))).toEqual({ plan: { policy: { wipCap: 9 } } });
+  });
+
+  itSymlink("skips symlink entries during traversal (#2626)", () => {
+    write("xbrief/active/real.xbrief.json", {
+      plan: { id: "real", policy: { wipCap: 3 } },
+    });
+    const escapeDir = mkdtempSync(join(tmpdir(), "catb-entry-escape-"));
+    const outsideFile = join(escapeDir, "linked.xbrief.json");
+    writeFileSync(
+      outsideFile,
+      `${JSON.stringify({ plan: { policy: { wipCap: 99 } } })}\n`,
+      "utf8",
+    );
+    symlinkSync(outsideFile, join(root, "xbrief", "active", "linked.xbrief.json"));
+
+    const result = migrateCategoryBCorpus(root);
+    expect(result.changed).toEqual(["xbrief/active/real.xbrief.json"]);
+    expect(JSON.parse(readFileSync(outsideFile, "utf8"))).toEqual({ plan: { policy: { wipCap: 99 } } });
   });
 });

--- a/packages/core/src/category-b-namespace/index.test.ts
+++ b/packages/core/src/category-b-namespace/index.test.ts
@@ -111,6 +111,7 @@ describe("migrateCategoryBCorpus (#1650)", () => {
   });
 
   itSymlink("rejects a symlinked lifecycle root without rewriting files (#2626)", () => {
+    rmSync(join(root, "xbrief"), { recursive: true, force: true });
     const escapeDir = mkdtempSync(join(tmpdir(), "catb-escape-"));
     const outsideFile = join(escapeDir, "outside.xbrief.json");
     writeFileSync(outsideFile, `${JSON.stringify({ plan: { policy: { wipCap: 9 } } })}\n`, "utf8");

--- a/packages/core/src/category-b-namespace/index.ts
+++ b/packages/core/src/category-b-namespace/index.ts
@@ -9,15 +9,12 @@
  * order-preserving (the namespaced key takes the legacy key's slot, keeping
  * artifact diffs minimal).
  */
-import {
-  type Dirent,
-  existsSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { type Dirent, existsSync, lstatSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
+import {
+  assertDirectoryNotSymlink,
+  assertWriteTargetSafe,
+} from "../fs/projection-containment.js";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../layout/resolve.js";
 import {
   LEGACY_PLAN_COMPLETED_NOTE_KEY,
@@ -114,9 +111,18 @@ function collectVbriefFiles(dir: string, acc: string[] = []): string[] {
   }
   for (const entry of entries) {
     const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
+    let info: ReturnType<typeof lstatSync>;
+    try {
+      info = lstatSync(full);
+    } catch {
+      continue;
+    }
+    if (info.isSymbolicLink()) {
+      continue;
+    }
+    if (info.isDirectory()) {
       collectVbriefFiles(full, acc);
-    } else if (entry.isFile() && hasArtifactSuffix(entry.name)) {
+    } else if (info.isFile() && hasArtifactSuffix(entry.name)) {
       acc.push(full);
     }
   }
@@ -143,14 +149,18 @@ export function migrateCategoryBCorpus(projectRoot: string): CorpusMigrationResu
       return { scanned: 0, changed: [], conflicts: [] };
     }
   }
+  try {
+    assertDirectoryNotSymlink(root, vbriefDir, "lifecycle root");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { scanned: 0, changed: [], conflicts: [{ path: relative(root, vbriefDir), message }] };
+  }
+
   let scanned = 0;
   const changed: string[] = [];
   const conflicts: CorpusMigrationConflict[] = [];
 
   for (const file of collectVbriefFiles(vbriefDir)) {
-    if (!statSync(file).isFile()) {
-      continue;
-    }
     scanned += 1;
     let parsed: unknown;
     try {
@@ -167,6 +177,15 @@ export function migrateCategoryBCorpus(projectRoot: string): CorpusMigrationResu
       continue;
     }
     if (result.changed) {
+      try {
+        assertWriteTargetSafe(root, file);
+      } catch (err) {
+        conflicts.push({
+          path: relPath,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
       writeFileSync(file, `${JSON.stringify(result.doc, null, 2)}\n`, "utf8");
       changed.push(relPath);
     }

--- a/packages/core/src/category-b-namespace/index.ts
+++ b/packages/core/src/category-b-namespace/index.ts
@@ -9,12 +9,16 @@
  * order-preserving (the namespaced key takes the legacy key's slot, keeping
  * artifact diffs minimal).
  */
-import { type Dirent, existsSync, lstatSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
 import {
-  assertDirectoryNotSymlink,
-  assertWriteTargetSafe,
-} from "../fs/projection-containment.js";
+  type Dirent,
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { assertDirectoryNotSymlink, assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../layout/resolve.js";
 import {
   LEGACY_PLAN_COMPLETED_NOTE_KEY,

--- a/packages/core/src/eval/run.test.ts
+++ b/packages/core/src/eval/run.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/core/src/eval/run.test.ts
+++ b/packages/core/src/eval/run.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -6,9 +6,12 @@ import {
   GOLDEN_CORPUS,
   goldenRunsHistoryPath,
   holdoutRotationIndex,
+  persistGoldenRun,
   runGoldenEval,
   selectRotatingHoldoutTask,
 } from "./run.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
 
 const temps: string[] = [];
 afterEach(() => {
@@ -79,5 +82,61 @@ describe("runGoldenEval", () => {
   it("returns config error when model is missing", () => {
     const result = runGoldenEval({ projectRoot: seedProject(), model: "  " });
     expect(result.code).toBe(2);
+  });
+
+  itSymlink("refuses to persist when xbrief/.eval is a symlink outside the project (#2626)", () => {
+    const root = seedProject();
+    const escapeDir = mkdtempSync(join(tmpdir(), "deft-golden-escape-"));
+    temps.push(escapeDir);
+    const escapeLedger = join(escapeDir, "golden-runs.jsonl");
+    writeFileSync(escapeLedger, "victim\n", "utf8");
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    symlinkSync(escapeDir, join(root, "xbrief", ".eval"), "dir");
+
+    const result = runGoldenEval({
+      projectRoot: root,
+      model: "composer-fixture",
+      seeds: [1],
+      directiveVersion: "0.70.0-golden-test",
+      persist: true,
+    });
+
+    expect(result.code).toBe(2);
+    expect(result.message).toMatch(/projection write refused|symlink escaping/);
+    expect(readFileSync(escapeLedger, "utf8")).toBe("victim\n");
+  });
+});
+
+describe("persistGoldenRun containment (#2626)", () => {
+  itSymlink("refuses append when the golden-run ledger is a symlink outside the project", () => {
+    const root = seedProject();
+    const escapeDir = mkdtempSync(join(tmpdir(), "deft-golden-ledger-escape-"));
+    temps.push(escapeDir);
+    const escapeLedger = join(escapeDir, "golden-runs.jsonl");
+    writeFileSync(escapeLedger, "victim\n", "utf8");
+    mkdirSync(join(root, "xbrief", ".eval", "results"), { recursive: true });
+    symlinkSync(escapeLedger, goldenRunsHistoryPath(root));
+
+    expect(() =>
+      persistGoldenRun(root, {
+        schemaVersion: 1,
+        runId: "x",
+        directiveVersion: "0.70.0",
+        model: "m",
+        harness: "h",
+        seeds: [1],
+        corpusVersion: "c",
+        recordedAt: "2026-07-05T00:00:00Z",
+        results: [],
+        summary: {
+          primaryPassRate: 0,
+          holdoutPassRate: 0,
+          passRate: 0,
+          primaryTotal: 0,
+          holdoutTotal: 0,
+        },
+      }),
+    ).toThrow(/projection write refused|symlink escaping/);
+    expect(readFileSync(escapeLedger, "utf8")).toBe("victim\n");
   });
 });

--- a/packages/core/src/eval/run.ts
+++ b/packages/core/src/eval/run.ts
@@ -3,6 +3,7 @@ import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "n
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { readCorePackageVersion } from "../engine-version.js";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { resolveEvalPath } from "../layout/resolve.js";
 import { BYTE_DIFF_WHOLE_FILE_THRESHOLD, InstrumentedVbriefCrud } from "./crud-telemetry.js";
 import { evaluateHealth } from "./health.js";
@@ -293,6 +294,7 @@ export function goldenRunsHistoryPath(projectRoot: string): string {
 /** Append one golden run to the versioned ledger (#1703 Tier 2). */
 export function persistGoldenRun(projectRoot: string, record: GoldenRunRecord): void {
   const path = goldenRunsHistoryPath(projectRoot);
+  assertWriteTargetSafe(projectRoot, path);
   mkdirSync(dirname(path), { recursive: true });
   appendFileSync(path, `${JSON.stringify(record)}\n`, "utf8");
 }

--- a/packages/core/src/fs/projection-containment.ts
+++ b/packages/core/src/fs/projection-containment.ts
@@ -14,7 +14,7 @@
  * Refs #2413.
  */
 
-import { lstatSync, realpathSync } from "node:fs";
+import { type Dirent, lstatSync, readdirSync, realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 /** Non-zero exit code for a projection-containment refusal (needs-action). */
@@ -142,5 +142,81 @@ export function assertProjectionContained(projectDir: string, targetPath: string
         `(${deepestExistingReal} is outside ${projectReal})`,
       { projectDir: projectAbs, targetPath: targetAbs, offendingPath: deepestExistingReal },
     );
+  }
+}
+
+/**
+ * Refuse writes when the resolved target already exists as a symlink (#2626 / #2632).
+ * Pair with {@link assertProjectionContained} before read/write/mkdir/append.
+ */
+export function assertWriteTargetSafe(projectDir: string, targetPath: string): void {
+  assertProjectionContained(projectDir, targetPath);
+  const targetAbs = resolve(targetPath);
+  let info: ReturnType<typeof lstatSync>;
+  try {
+    info = lstatSync(targetAbs);
+  } catch {
+    return;
+  }
+  if (info.isSymbolicLink()) {
+    throw new ProjectionContainmentError(
+      `projection write refused: ${targetAbs} is a symlink on the write path`,
+      { projectDir: resolve(projectDir), targetPath: targetAbs, offendingPath: targetAbs },
+    );
+  }
+}
+
+/**
+ * Refuse when a lifecycle corpus root is itself a symlink (#2626 category-b).
+ */
+export function assertDirectoryNotSymlink(
+  projectDir: string,
+  dirPath: string,
+  label: string,
+): void {
+  assertProjectionContained(projectDir, dirPath);
+  const dirAbs = resolve(dirPath);
+  let info: ReturnType<typeof lstatSync>;
+  try {
+    info = lstatSync(dirAbs);
+  } catch {
+    throw new ProjectionContainmentError(
+      `projection write refused: ${label} ${dirAbs} does not exist`,
+      { projectDir: resolve(projectDir), targetPath: dirAbs, offendingPath: dirAbs },
+    );
+  }
+  if (info.isSymbolicLink()) {
+    throw new ProjectionContainmentError(
+      `projection write refused: ${label} ${dirAbs} must not be a symlink`,
+      { projectDir: resolve(projectDir), targetPath: dirAbs, offendingPath: dirAbs },
+    );
+  }
+}
+
+/** Walk a directory tree and refuse any symlink entry (#2601 / #2626). */
+export function walkDirectoryRejectSymlinks(root: string): void {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(root, entry.name);
+    let info: ReturnType<typeof lstatSync>;
+    try {
+      info = lstatSync(full);
+    } catch {
+      continue;
+    }
+    if (info.isSymbolicLink()) {
+      throw new ProjectionContainmentError(
+        `projection write refused: symlink on traversal path: ${full}`,
+        { projectDir: resolve(root), targetPath: full, offendingPath: full },
+      );
+    }
+    if (info.isDirectory()) {
+      walkDirectoryRejectSymlinks(full);
+    }
   }
 }

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -87,7 +87,7 @@ export function hookWriteTargetPath(payload: unknown): string | null {
 
 /** POSIX-ish project-relative path for lifecycle matching. */
 export function toProjectRelativePosix(projectRoot: string, targetPath: string): string {
-  const abs = resolve(projectRoot, targetPath);
+  const abs = resolve(projectRoot, targetPath.replace(/\\/g, "/"));
   const rel = relative(resolve(projectRoot), abs);
   return rel.split(sep).join("/");
 }

--- a/packages/core/src/xbrief-migrate/migration-containment.ts
+++ b/packages/core/src/xbrief-migrate/migration-containment.ts
@@ -1,6 +1,8 @@
-import { type Dirent, lstatSync, readdirSync } from "node:fs";
-import { join } from "node:path";
-import { assertProjectionContained } from "../fs/projection-containment.js";
+import {
+  assertProjectionContained,
+  ProjectionContainmentError,
+  walkDirectoryRejectSymlinks,
+} from "../fs/projection-containment.js";
 
 /**
  * Refuse migrate:xbrief when legacy `vbrief/` (or any traversed entry) escapes
@@ -8,29 +10,15 @@ import { assertProjectionContained } from "../fs/projection-containment.js";
  */
 export function assertMigrationSourceSafe(projectRoot: string, legacyDir: string): void {
   assertProjectionContained(projectRoot, legacyDir);
-  walkMigrationTreeRejectSymlinks(legacyDir);
-}
-
-function walkMigrationTreeRejectSymlinks(root: string): void {
-  let entries: Dirent[];
   try {
-    entries = readdirSync(root, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
-    const full = join(root, entry.name);
-    let info: ReturnType<typeof lstatSync>;
-    try {
-      info = lstatSync(full);
-    } catch {
-      continue;
+    walkDirectoryRejectSymlinks(legacyDir);
+  } catch (err) {
+    if (err instanceof ProjectionContainmentError) {
+      const nested = err.message.match(/symlink on traversal path: (.+)$/);
+      if (nested) {
+        throw new Error(`refusing to migrate: symlink on migration path: ${nested[1]}`);
+      }
     }
-    if (info.isSymbolicLink()) {
-      throw new Error(`refusing to migrate: symlink on migration path: ${full}`);
-    }
-    if (info.isDirectory()) {
-      walkMigrationTreeRejectSymlinks(full);
-    }
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary
- Guard `persistGoldenRun` with `assertWriteTargetSafe` before appending golden-run JSONL under `xbrief/.eval`.
- Harden `migrate:category-b` with lifecycle-root symlink rejection, symlink-entry skipping during traversal, and `assertWriteTargetSafe` before each rewrite.
- Export reusable containment helpers (`assertWriteTargetSafe`, `assertDirectoryNotSymlink`, `walkDirectoryRejectSymlinks`) for wave-2 #2632.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/eval/run.test.ts packages/core/src/category-b-namespace/index.test.ts packages/core/src/xbrief-migrate/migration-containment.test.ts packages/core/src/fs/projection-containment.test.ts`
- [ ] CI green

Closes #2626