### PR TITLE
fix(test,windows): harden coverage/.tmp write guard (#2634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Windows CI retries transient Install Task flakes (#2624).** The task-dispatch regression job pins an exact Task release and automatically retries `arduino/setup-task` once before failing; operator rerun-failed-jobs recovery is documented in the workflow. Closes #2624.
+- **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` after green full-suite runs (#2634).** Hardens the #2580 keepalive with a globalSetup write guard that mkdirs before Vitest 3.2.x chunk writes (upstream fix: vitest-dev/vitest#10117 in vitest 4.x); coverage thresholds still fail closed. Closes #2634.
 
 ### Removed
 

--- a/packages/core/src/vitest-runner/vitest-config-contract.test.ts
+++ b/packages/core/src/vitest-runner/vitest-config-contract.test.ts
@@ -55,6 +55,31 @@ describe("vitest.config.ts Windows coverage tmp contract (#2580)", () => {
   });
 });
 
+describe("vitest.config.ts Windows coverage tmp regression (#2634)", () => {
+  const source = readFileSync(configPath, "utf8");
+
+  it("documents vitest 4 upgrade path for upstream mkdir fix", () => {
+    expect(source).toContain("#2634");
+    expect(source).toMatch(/vitest-dev\/vitest#10117/);
+  });
+
+  it("win32-coverage-tmp-setup guards chunk writes before mkdir", () => {
+    const setupPath = join(repoRoot, "packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts");
+    const setupSource = readFileSync(setupPath, "utf8");
+    expect(setupSource).toContain("#2634");
+    expect(setupSource).toMatch(/installCoverageTmpWriteGuard/);
+    expect(setupSource).toMatch(/isCoverageTmpChunkPath/);
+  });
+
+  it("has focused regression tests for coverage tmp hardening", () => {
+    const testPath = join(
+      repoRoot,
+      "packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts",
+    );
+    expect(readFileSync(testPath, "utf8")).toContain("#2634");
+  });
+});
+
 describe("vitest.config.ts coverage threshold contract (#2573)", () => {
   const source = readFileSync(configPath, "utf8");
 

--- a/packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts
+++ b/packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts
@@ -1,0 +1,56 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ensureCoverageTmpDir,
+  installCoverageTmpWriteGuard,
+  isCoverageTmpChunkPath,
+} from "./win32-coverage-tmp-setup.ts";
+
+describe("win32-coverage-tmp-setup (#2634)", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("recognizes Vitest coverage chunk paths on posix and win32 spellings", () => {
+    expect(isCoverageTmpChunkPath("/repo/coverage/.tmp/coverage-0.json")).toBe(true);
+    expect(isCoverageTmpChunkPath("C:\\repo\\coverage\\.tmp\\coverage-12.json")).toBe(
+      true,
+    );
+    expect(isCoverageTmpChunkPath("/repo/coverage/coverage-final.json")).toBe(false);
+    expect(isCoverageTmpChunkPath("/repo/coverage/.tmp/other.json")).toBe(false);
+  });
+
+  it("ensureCoverageTmpDir creates coverage/.tmp", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-cov-tmp-"));
+    tempRoots.push(root);
+    const coverageTmp = join(root, "coverage", ".tmp");
+
+    ensureCoverageTmpDir(coverageTmp);
+    expect(existsSync(coverageTmp)).toBe(true);
+  });
+
+  it("installCoverageTmpWriteGuard mkdirs parent before chunk write", async () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-cov-write-"));
+    tempRoots.push(root);
+    const chunkPath = join(root, "coverage", ".tmp", "coverage-0.json");
+    const uninstall = installCoverageTmpWriteGuard();
+
+    try {
+      await fsPromisesWrite(chunkPath, '{"ok":true}\n');
+      expect(readFileSync(chunkPath, "utf8")).toBe('{"ok":true}\n');
+    } finally {
+      uninstall();
+    }
+  });
+});
+
+async function fsPromisesWrite(path: string, data: string): Promise<void> {
+  const { promises } = await import("node:fs");
+  await promises.writeFile(path, data, "utf8");
+}

--- a/packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts
+++ b/packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts
@@ -19,9 +19,7 @@ describe("win32-coverage-tmp-setup (#2634)", () => {
 
   it("recognizes Vitest coverage chunk paths on posix and win32 spellings", () => {
     expect(isCoverageTmpChunkPath("/repo/coverage/.tmp/coverage-0.json")).toBe(true);
-    expect(isCoverageTmpChunkPath("C:\\repo\\coverage\\.tmp\\coverage-12.json")).toBe(
-      true,
-    );
+    expect(isCoverageTmpChunkPath("C:\\repo\\coverage\\.tmp\\coverage-12.json")).toBe(true);
     expect(isCoverageTmpChunkPath("/repo/coverage/coverage-final.json")).toBe(false);
     expect(isCoverageTmpChunkPath("/repo/coverage/.tmp/other.json")).toBe(false);
   });

--- a/packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts
+++ b/packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts
@@ -1,9 +1,8 @@
-import { mkdirSync, promises as fsPromises } from "node:fs";
+import { promises as fsPromises, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 /** Matches Vitest v8 chunk paths such as coverage/.tmp/coverage-0.json (#2580 / #2634). */
-export const COVERAGE_TMP_CHUNK_RE =
-  /[/\\]coverage[/\\]\.tmp[/\\]coverage-\d+\.json$/;
+export const COVERAGE_TMP_CHUNK_RE = /[/\\]coverage[/\\]\.tmp[/\\]coverage-\d+\.json$/;
 
 const defaultCoverageTmp = resolve(process.cwd(), "coverage", ".tmp");
 
@@ -11,9 +10,7 @@ export function isCoverageTmpChunkPath(filePath: string): boolean {
   return COVERAGE_TMP_CHUNK_RE.test(filePath.replace(/\\/g, "/"));
 }
 
-export function ensureCoverageTmpDir(
-  coverageTmpDir: string = defaultCoverageTmp,
-): void {
+export function ensureCoverageTmpDir(coverageTmpDir: string = defaultCoverageTmp): void {
   mkdirSync(coverageTmpDir, { recursive: true });
 }
 

--- a/packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts
+++ b/packages/core/src/vitest-runner/win32-coverage-tmp-setup.ts
@@ -1,27 +1,63 @@
-import { mkdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdirSync, promises as fsPromises } from "node:fs";
+import { dirname, resolve } from "node:path";
 
-const COVERAGE_TMP = resolve(process.cwd(), "coverage", ".tmp");
+/** Matches Vitest v8 chunk paths such as coverage/.tmp/coverage-0.json (#2580 / #2634). */
+export const COVERAGE_TMP_CHUNK_RE =
+  /[/\\]coverage[/\\]\.tmp[/\\]coverage-\d+\.json$/;
 
-function ensureCoverageTmpDir(): void {
-  mkdirSync(COVERAGE_TMP, { recursive: true });
+const defaultCoverageTmp = resolve(process.cwd(), "coverage", ".tmp");
+
+export function isCoverageTmpChunkPath(filePath: string): boolean {
+  return COVERAGE_TMP_CHUNK_RE.test(filePath.replace(/\\/g, "/"));
+}
+
+export function ensureCoverageTmpDir(
+  coverageTmpDir: string = defaultCoverageTmp,
+): void {
+  mkdirSync(coverageTmpDir, { recursive: true });
 }
 
 /**
- * Win32 globalSetup for coverage runs (#2580).
- *
- * Vitest's v8 provider writes per-suite JSON under coverage/.tmp without always
- * re-mkdir'ing before writeFile. Under parallel fork load the directory can
- * disappear mid-suite, surfacing as ENOENT after an otherwise green run.
- * Keep the directory present for the coordinator process; late ENOENT flakes
- * are tolerated via vitest dangerouslyIgnoreUnhandledErrors (#2546) without
- * soft-failing real coverage threshold failures.
+ * Vitest 3.2.x writes coverage chunks without mkdir'ing the parent directory
+ * (fixed upstream in vitest 4.x — vitest-dev/vitest#10117). On Windows the
+ * directory can disappear between clean() and writeFile under release-scale
+ * load; mkdir immediately before chunk writes closes that race without
+ * soft-failing real threshold failures (#2634).
  */
-export default function setup(): void {
-  if (process.platform !== "win32") return;
+export function installCoverageTmpWriteGuard(): () => void {
+  const originalWriteFile = fsPromises.writeFile.bind(fsPromises);
+
+  const patchedWriteFile: typeof fsPromises.writeFile = async (path, ...args) => {
+    const target = typeof path === "string" ? path : String(path);
+    if (isCoverageTmpChunkPath(target)) {
+      mkdirSync(dirname(target), { recursive: true });
+    }
+    return originalWriteFile(path, ...args);
+  };
+  fsPromises.writeFile = patchedWriteFile;
+
+  return () => {
+    fsPromises.writeFile = originalWriteFile;
+  };
+}
+
+/**
+ * Win32 globalSetup for coverage runs (#2580, hardened #2634).
+ *
+ * Keepalive mkdir plus a writeFile guard mirror vitest 4's defensive mkdir until
+ * directive upgrades past vitest@3 (see vitest.config.ts #2634 upgrade note).
+ */
+export default function setup(): () => void {
+  if (process.platform !== "win32") return () => {};
 
   ensureCoverageTmpDir();
+  const uninstallWriteGuard = installCoverageTmpWriteGuard();
 
-  const keepalive = setInterval(ensureCoverageTmpDir, 100);
+  const keepalive = setInterval(() => ensureCoverageTmpDir(), 50);
   keepalive.unref?.();
+
+  return () => {
+    clearInterval(keepalive);
+    uninstallWriteGuard();
+  };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,8 +20,10 @@ const winMaxWorkers = Math.max(1, Math.min(12, Math.floor(cpus().length * 0.25))
 
 // Coverage chunk writes land in coverage/.tmp; on win32 parallel forks can race the
 // directory away mid-suite (ENOENT after a green run). Serialize coverage processing,
-// tighten fork caps when --coverage is on, and globalSetup keeps .tmp present.
-// Refs #2580.
+// tighten fork caps when --coverage is on, and globalSetup keeps .tmp present plus
+// mkdir-before-chunk-write (vitest 3.2.x gap; upstream fix vitest-dev/vitest#10117
+// in vitest 4.x — upgrade path tracked in #2634).
+// Refs #2580, #2634.
 const coverageEnabled = process.argv.some(
   (arg) => arg === "--coverage" || arg.startsWith("--coverage."),
 );


### PR DESCRIPTION
## Summary
- Hardens the #2580 Windows coverage/.tmp mitigation with a globalSetup \s.promises.writeFile\ guard that mkdirs immediately before Vitest 3.2.x v8 chunk writes (\coverage/.tmp/coverage-*.json\).
- Keeps the keepalive mkdir (50ms) and existing worker serialization; coverage thresholds still fail closed.
- Adds focused regression tests plus contract guards documenting the vitest 4 upgrade path (vitest-dev/vitest#10117).

## Test plan
- [x] \pnpm exec vitest run packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts packages/core/src/vitest-runner/vitest-config-contract.test.ts\
- [x] \	ask verify:branch\ / \	ask verify:forward-coverage\
- [ ] CI green on ubuntu + windows lanes

Closes #2634

Made with [Cursor](https://cursor.com)