### PR TITLE
fix(guard): allowlist installer-deposited .prettierignore (#2629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Windows CI retries transient Install Task flakes (#2624).** The task-dispatch regression job pins an exact Task release and automatically retries `arduino/setup-task` once before failing; operator rerun-failed-jobs recovery is documented in the workflow. Closes #2624.
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` after green full-suite runs (#2634).** Hardens the #2580 keepalive with a globalSetup write guard that mkdirs before Vitest 3.2.x chunk writes (upstream fix: vitest-dev/vitest#10117 in vitest 4.x); coverage thresholds still fail closed. Closes #2634.
+- **deft-core-guard allowlists installer-deposited `.prettierignore` (#2629).** Framework-only deposit PRs that include the #2534 Prettier gate exclusion no longer fail `no-mixed-core-and-app`. Closes #2629.
 
 ### Removed
 

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -87,7 +87,7 @@ export function hookWriteTargetPath(payload: unknown): string | null {
 
 /** POSIX-ish project-relative path for lifecycle matching. */
 export function toProjectRelativePosix(projectRoot: string, targetPath: string): string {
-  const abs = resolve(projectRoot, targetPath);
+  const abs = resolve(projectRoot, targetPath.replace(/\\/g, "/"));
   const rel = relative(resolve(projectRoot), abs);
   return rel.split(sep).join("/");
 }

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -59,6 +59,13 @@ describe("installer-managed allowlist (#1576)", () => {
   });
 });
 
+describe(".prettierignore allowlist (#2629)", () => {
+  it("treats installer-deposited .prettierignore as installer-managed", () => {
+    expect(isInstallerManagedPath(".prettierignore")).toBe(true);
+    expect(installerManagedGuardEre()).toContain("\\.prettierignore$");
+  });
+});
+
 describe("xbrief/ allowlist parity (#2277)", () => {
   const xbriefLifecycleDirs = ["proposed", "pending", "active", "completed", "cancelled"] as const;
 

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -36,6 +36,9 @@ export function installerManagedMatchers(): InstallerManagedMatcher[] {
     { exact: ".codex/hooks.json" },
     { exact: ".gitattributes" },
     { exact: ".gitignore" },
+    // Installer-deposited Prettier gate exclusion (#2534); must be allowlisted or
+    // framework-only deposit PRs trip no-mixed-core-and-app (#2629).
+    { exact: ".prettierignore" },
     { exact: "greptile.json" },
     { exact: CODEQL_CONFIG_REL },
     { exact: CORE_GUARD_WORKFLOW_REL },


### PR DESCRIPTION
## Summary

- Add `.prettierignore` to `installerManagedMatchers()` so the deposited `deft-core-guard.yml` allowlist treats the #2534 installer projection as framework-managed.
- Framework-only deposit PRs that change `.deft/core/**` plus `.prettierignore` no longer trip `no-mixed-core-and-app`.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/init-deposit/hygiene.test.ts`
- [x] `task verify:forward-coverage`

Closes #2629
