### PR TITLE
fix(review-cycle): expose lifecycle:event plan:approved recorder on consumer surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`lifecycle:event` approval recorder on the consumer Taskfile/CLI surface (#2631).** Review-cycle merge-gate approval now records `plan:approved` via `task lifecycle:event` / `deft lifecycle:event`, with idempotent dedupe for repeated approvals on the same PR and HEAD SHA. Closes #2631.
+
 ### Changed
 
 ### Fixed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,6 +152,9 @@ includes:
   session:
     taskfile: ./tasks/session.yml
     optional: true
+  lifecycle:
+    taskfile: ./tasks/lifecycle.yml
+    optional: true
   plan-sequence:
     taskfile: ./tasks/plan-sequence.yml
     optional: true

--- a/content/commands.md
+++ b/content/commands.md
@@ -234,6 +234,17 @@ flowchart TD
 
 ---
 
+## Framework behavioral events (#635 / #2631)
+
+Review-cycle merge-gate approval is recorded as a structural artifact, not prose-only.
+
+- `task lifecycle:event -- emit plan:approved --plan-ref <pr-url> --approver <login> --approval-phrase <yes|confirmed|approve> --pr-number <N> [--head-sha <sha>]`
+- `deft lifecycle:event emit plan:approved --plan-ref <pr-url> --approver <login> --approval-phrase <yes|confirmed|approve> --pr-number <N> [--head-sha <sha>]`
+
+Writes a `plan:approved` record to `.deft-cache/events.jsonl` with repository (derived from the PR URL when available), approver, optional PR number and approved HEAD SHA, and a timestamp envelope. Repeating the same approval for the same PR/approver/HEAD SHA is idempotent.
+
+---
+
 ## Backlog Triage And Cache Tasks
 
 User-facing surface for the Phase 0 triage workflow and the unified content cache. These commands let agents work an existing backlog locally without repeatedly draining shared GitHub rate limits.

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -103,6 +103,7 @@ export const CLI_MODULE_VERBS = [
   "release-publish",
   "release-rollback",
   "scope-lifecycle",
+  "lifecycle-event",
   "session-start",
   "plan-sequence",
   "slice",
@@ -306,6 +307,7 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = {
   "issue:sync-from-xbrief": "issue-sync-from-xbrief",
   upgrade: "install-upgrade",
   "session:start": "session-start",
+  "lifecycle:event": "lifecycle-event",
   "toolchain:check": "toolchain-check",
   "ts:check-lane": "ts-check-lane",
   "spec:validate": "spec-validate",
@@ -2826,7 +2828,13 @@ const CURATED_HELP_GROUPS: readonly HelpGroup[] = [
   },
   {
     title: "Session & ritual",
-    commands: [{ name: "session:start", summary: "Record session-start ritual state" }],
+    commands: [
+      { name: "session:start", summary: "Record session-start ritual state" },
+      {
+        name: "lifecycle:event",
+        summary: "Record review-cycle plan:approved approval events",
+      },
+    ],
   },
   {
     title: "Quality & gates",

--- a/packages/cli/src/lifecycle-event.ts
+++ b/packages/cli/src/lifecycle-event.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runLifecycleEvent } from "@deftai/directive-core/lifecycle";
+
+export interface ParsedLifecycleEventArgs {
+  projectRoot: string;
+  rest: string[];
+  error?: string;
+}
+
+/** Parse lifecycle:event CLI args. */
+export function parseArgs(argv: readonly string[]): ParsedLifecycleEventArgs {
+  const parsed: ParsedLifecycleEventArgs = {
+    projectRoot: ".",
+    rest: [],
+  };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --project-root: expected one argument" };
+      }
+      parsed.projectRoot = value;
+      i += 2;
+      continue;
+    }
+    if (arg?.startsWith("--project-root=")) {
+      parsed.projectRoot = arg.slice("--project-root=".length);
+      i += 1;
+      continue;
+    }
+    parsed.rest = argv.slice(i);
+    break;
+  }
+  return parsed;
+}
+
+/** Native lifecycle:event handler (#2631). */
+export function run(argv: readonly string[]): number {
+  const args = parseArgs(argv);
+  if (args.error !== undefined) {
+    process.stderr.write(`lifecycle_event: ${args.error}\n`);
+    return 2;
+  }
+  return runLifecycleEvent(args.rest, { projectRoot: resolve(args.projectRoot) });
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/core/src/content-contracts/skills/review_cycle_skill.test.ts
+++ b/packages/core/src/content-contracts/skills/review_cycle_skill.test.ts
@@ -183,4 +183,14 @@ describe("test_review_cycle_skill", () => {
   it("phase2_step1_no_cp1252_mojibake", () => {
     expect(phase2Step1Section()).not.toContain("\u0393\u00E8\u00F9");
   });
+
+  it("plan_approved_lifecycle_event_command_documented", () => {
+    const text = readReviewCycleSkill();
+    expect(text).toContain("task lifecycle:event");
+    expect(text).toContain("emit plan:approved");
+    expect(text).toContain("--plan-ref");
+    expect(text).toContain("--approver");
+    expect(text).toContain("--approval-phrase");
+    expect(text).toContain("--pr-number");
+  });
 });

--- a/packages/core/src/content-contracts/standards/taskfile_lifecycle_event.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_lifecycle_event.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./_helpers.js";
+import { iterTaskBlocks, readTaskfile } from "./_taskfile-helpers.js";
+
+const REVIEW_CYCLE_SKILL = "skills/deft-directive-review-cycle/SKILL.md";
+const REQUIRED_TASK = "lifecycle:event";
+
+function parseIncludes(text: string): Map<string, string> {
+  const includes = new Map<string, string>();
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  let inIncludes = false;
+  let currentKey: string | null = null;
+  const includeLine = /^\s{2}([A-Za-z][\w-]*):\s*$/;
+  const taskfileLine = /^\s{4}taskfile:\s+\.\/tasks\/([\w-]+\.ya?ml)\s*$/;
+  for (const line of lines) {
+    if (line.startsWith("includes:")) {
+      inIncludes = true;
+      continue;
+    }
+    if (inIncludes && line && !line.startsWith(" ") && !line.startsWith("\t")) {
+      inIncludes = false;
+      currentKey = null;
+      continue;
+    }
+    if (!inIncludes) continue;
+    const keyMatch = line.match(includeLine);
+    if (keyMatch?.[1]) {
+      currentKey = keyMatch[1];
+      continue;
+    }
+    const fileMatch = line.match(taskfileLine);
+    if (fileMatch?.[1] && currentKey) {
+      includes.set(currentKey, fileMatch[1]);
+      currentKey = null;
+    }
+  }
+  return includes;
+}
+
+function collectTaskSurface(): Set<string> {
+  const names = new Set<string>();
+  const rootText = readFileSync(join(repoRoot(), "Taskfile.yml"), { encoding: "utf8" })
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+  for (const { name } of iterTaskBlocks(rootText)) {
+    names.add(name);
+  }
+  for (const [namespace, fileName] of parseIncludes(rootText)) {
+    const fragmentText = readFileSync(join(repoRoot(), "tasks", fileName), { encoding: "utf8" })
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n");
+    for (const { name, start, end } of iterTaskBlocks(fragmentText)) {
+      const body = fragmentText.split("\n").slice(start, end).join("\n");
+      if (/^\s+internal:\s*true\s*$/m.test(body)) {
+        continue;
+      }
+      names.add(`${namespace}:${name}`);
+    }
+  }
+  return names;
+}
+
+describe("taskfile lifecycle:event approval recorder (#2631)", () => {
+  it("registers lifecycle:event on the deposited Taskfile surface", () => {
+    expect(collectTaskSurface().has(REQUIRED_TASK)).toBe(true);
+  });
+
+  it("lifecycle.yml forwards review-cycle args through engine:invoke", () => {
+    const text = readTaskfile("lifecycle.yml");
+    const block = iterTaskBlocks(text).find((entry) => entry.name === "event");
+    expect(block).toBeDefined();
+    const body = text.split("\n").slice(block?.start, block?.end).join("\n");
+    expect(body).toContain(":engine:invoke");
+    expect(body).toContain("lifecycle:event");
+    expect(body).toContain("{{.CLI_ARGS}}");
+    expect(body).not.toMatch(/^\s{4}(sources|generates)\s*:/m);
+  });
+
+  it("directive lifecycle:event resolves to lifecycle-event handler", () => {
+    const dispatchText = readFileSync(join(repoRoot(), "packages/cli/src/dispatch.ts"), {
+      encoding: "utf8",
+    });
+    expect(dispatchText).toContain('"lifecycle-event"');
+    expect(dispatchText).toContain('"lifecycle:event": "lifecycle-event"');
+  });
+
+  it("review-cycle skill documents the same task spelling", () => {
+    const text = readFileSync(join(repoRoot(), "content", REVIEW_CYCLE_SKILL), {
+      encoding: "utf8",
+    });
+    expect(text).toContain("task lifecycle:event");
+    expect(text).toContain("emit plan:approved");
+    expect(text).toContain("--plan-ref");
+    expect(text).toContain("--approver");
+    expect(text).toContain("--approval-phrase");
+    expect(text).toContain("--pr-number");
+  });
+});

--- a/packages/core/src/content-contracts/standards/taskfile_runtime_session.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_runtime_session.test.ts
@@ -27,6 +27,8 @@ const RUNTIME_SESSION_TASKFILES: Readonly<
 const RUNTIME_VERB_TOKENS = [
   "session:start",
   "session-start",
+  "lifecycle:event",
+  "lifecycle-event",
   "verify:session-ritual",
   "verify-session-ritual",
   "verify:tools",

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -87,7 +87,8 @@ export function hookWriteTargetPath(payload: unknown): string | null {
 
 /** POSIX-ish project-relative path for lifecycle matching. */
 export function toProjectRelativePosix(projectRoot: string, targetPath: string): string {
-  const abs = resolve(projectRoot, targetPath);
+  const normalized = targetPath.replace(/\\/g, "/");
+  const abs = resolve(projectRoot, normalized);
   const rel = relative(resolve(projectRoot), abs);
   return rel.split(sep).join("/");
 }

--- a/packages/core/src/lifecycle/event.test.ts
+++ b/packages/core/src/lifecycle/event.test.ts
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseEmitInvocation, runLifecycleEvent } from "./event.js";
+import { clearRegistryCache, readEvents } from "./events.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  clearRegistryCache();
+  delete process.env.DEFT_EVENT_LOG;
+  const cwd = process.cwd();
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root === undefined) {
+      continue;
+    }
+    try {
+      if (cwd.startsWith(root)) {
+        process.chdir(tmpdir());
+      }
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup on Windows file locks.
+    }
+  }
+});
+
+function makeTempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+}
+
+describe("lifecycle event approval recorder (#2631)", () => {
+  it("parseEmitInvocation accepts documented review-cycle flags", () => {
+    const parsed = parseEmitInvocation([
+      "plan:approved",
+      "--plan-ref",
+      "https://github.com/deftai/directive/pull/42",
+      "--approver",
+      "msadams",
+      "--approval-phrase",
+      "yes",
+      "--pr-number",
+      "42",
+      "--head-sha",
+      "abc123",
+    ]);
+    expect(parsed.name).toBe("plan:approved");
+    expect(parsed.payload).toMatchObject({
+      plan_ref: "https://github.com/deftai/directive/pull/42",
+      approver: "msadams",
+      approval_phrase: "yes",
+      pr_number: 42,
+      head_sha: "abc123",
+    });
+  });
+
+  it("records plan:approved with repository and timestamp envelope", () => {
+    const root = makeTempRoot("lifecycle-event-");
+    const log = join(root, "events.jsonl");
+    const rc = runLifecycleEvent(
+      [
+        "emit",
+        "plan:approved",
+        "--log",
+        log,
+        "--plan-ref",
+        "https://github.com/deftai/directive/pull/99",
+        "--approver",
+        "operator",
+        "--approval-phrase",
+        "confirmed",
+        "--pr-number",
+        "99",
+        "--head-sha",
+        "deadbeef",
+      ],
+      { projectRoot: root },
+    );
+    expect(rc).toBe(0);
+    const records = readEvents(log);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.event).toBe("plan:approved");
+    expect(records[0]?.payload).toMatchObject({
+      repository: "deftai/directive",
+      plan_ref: "https://github.com/deftai/directive/pull/99",
+      approver: "operator",
+      approval_phrase: "confirmed",
+      pr_number: 99,
+      head_sha: "deadbeef",
+    });
+    expect(records[0]?.detected_at.endsWith("Z")).toBe(true);
+  });
+
+  it("repeating the same approval is idempotent", () => {
+    const root = makeTempRoot("lifecycle-event-dedupe-");
+    const log = join(root, "events.jsonl");
+    const argv = [
+      "emit",
+      "plan:approved",
+      "--log",
+      log,
+      "--plan-ref",
+      "https://github.com/deftai/directive/pull/7",
+      "--approver",
+      "operator",
+      "--approval-phrase",
+      "approve",
+      "--pr-number",
+      "7",
+      "--head-sha",
+      "sha1",
+    ] as const;
+    expect(runLifecycleEvent([...argv], { projectRoot: root })).toBe(0);
+    expect(runLifecycleEvent([...argv], { projectRoot: root })).toBe(0);
+    expect(readEvents(log)).toHaveLength(1);
+  });
+
+  it("rejects invalid approval phrase before writing", () => {
+    const root = makeTempRoot("lifecycle-event-invalid-");
+    const log = join(root, "events.jsonl");
+    const rc = runLifecycleEvent(
+      [
+        "emit",
+        "plan:approved",
+        "--log",
+        log,
+        "--plan-ref",
+        "https://github.com/deftai/directive/pull/1",
+        "--approver",
+        "operator",
+        "--approval-phrase",
+        "maybe",
+      ],
+      { projectRoot: root },
+    );
+    expect(rc).toBe(2);
+    expect(readEvents(log)).toHaveLength(0);
+  });
+
+  it("delegates non-plan emit invocations to events cli", () => {
+    const root = makeTempRoot("lifecycle-event-delegate-");
+    const log = join(root, "events.jsonl");
+    const rc = runLifecycleEvent(
+      ["emit", "session:interrupted", "--log", log, "--session-id", "s1", "--reason", "probe"],
+      { projectRoot: root },
+    );
+    expect(rc).toBe(0);
+    expect(readEvents(log)[0]?.event).toBe("session:interrupted");
+  });
+});

--- a/packages/core/src/lifecycle/event.ts
+++ b/packages/core/src/lifecycle/event.ts
@@ -1,0 +1,191 @@
+import { resolve } from "node:path";
+import { type BehavioralEventRecord, emit, main as eventsMain, readEvents } from "./events.js";
+
+const APPROVAL_PHRASES = new Set(["yes", "confirmed", "approve", "other"]);
+
+function parseBooleanFlag(value: string): boolean {
+  return ["1", "true", "yes"].includes(value.toLowerCase());
+}
+
+interface ParsedEmitInvocation {
+  readonly name: string;
+  readonly payload: Record<string, unknown>;
+  readonly log?: string;
+}
+
+function repositoryFromPlanRef(planRef: string): string | undefined {
+  const match = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/i.exec(planRef.trim());
+  return match?.[1];
+}
+
+function dedupeKey(payload: Record<string, unknown>): string | null {
+  const planRef = payload.plan_ref;
+  const approver = payload.approver;
+  if (typeof planRef !== "string" || typeof approver !== "string") {
+    return null;
+  }
+  const parts = [planRef, approver];
+  if (typeof payload.pr_number === "number") {
+    parts.push(String(payload.pr_number));
+  }
+  if (typeof payload.head_sha === "string" && payload.head_sha.length > 0) {
+    parts.push(payload.head_sha);
+  }
+  return parts.join("|");
+}
+
+function findExistingPlanApproved(
+  key: string,
+  logPath?: string | null,
+): BehavioralEventRecord | null {
+  for (const record of readEvents(logPath)) {
+    if (record.event !== "plan:approved") {
+      continue;
+    }
+    if (dedupeKey(record.payload) === key) {
+      return record;
+    }
+  }
+  return null;
+}
+
+function validatePlanApprovedPayload(payload: Record<string, unknown>): void {
+  const phrase = payload.approval_phrase;
+  if (phrase === undefined) {
+    return;
+  }
+  if (typeof phrase !== "string") {
+    throw new Error("approval_phrase must be a string");
+  }
+  const normalized = phrase.toLowerCase();
+  if (!APPROVAL_PHRASES.has(normalized)) {
+    throw new Error(
+      `invalid approval_phrase '${phrase}'; expected one of yes, confirmed, approve, other`,
+    );
+  }
+}
+
+/** Parse `emit <event> ...` argv for lifecycle:event approval recording. */
+export function parseEmitInvocation(args: readonly string[]): ParsedEmitInvocation {
+  const payload: Record<string, unknown> = {};
+  let name: string | undefined;
+  let log: string | undefined;
+  let i = 0;
+  if (args.length > 0 && !args[0]?.startsWith("--")) {
+    name = args[0];
+    i = 1;
+  }
+  if (name === undefined) {
+    throw new Error("event name required");
+  }
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === "--payload") {
+      const raw = args[i + 1];
+      if (raw === undefined) {
+        throw new Error("--payload requires a value");
+      }
+      const data = JSON.parse(raw) as unknown;
+      if (typeof data !== "object" || data === null || Array.isArray(data)) {
+        throw new Error("--payload must be a JSON object");
+      }
+      Object.assign(payload, data);
+      i += 2;
+      continue;
+    }
+    if (arg === "--log") {
+      log = args[i + 1];
+      i += 2;
+      continue;
+    }
+    const flagMap: Record<string, string> = {
+      "--plan-ref": "plan_ref",
+      "--approver": "approver",
+      "--approval-phrase": "approval_phrase",
+      "--head-sha": "head_sha",
+    };
+    if (arg === "--pr-number") {
+      payload.pr_number = Number.parseInt(args[i + 1] ?? "", 10);
+      i += 2;
+      continue;
+    }
+    const field = flagMap[arg ?? ""];
+    if (field !== undefined) {
+      payload[field] = args[i + 1];
+      i += 2;
+      continue;
+    }
+    if (arg === "--inline") {
+      payload.inline = parseBooleanFlag(args[i + 1] ?? "");
+      i += 2;
+      continue;
+    }
+    throw new Error(`unrecognized arguments: ${arg}`);
+  }
+  return { name, payload, log };
+}
+
+function enrichPlanApprovedPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...payload };
+  if (typeof next.plan_ref === "string" && next.repository === undefined) {
+    const repository = repositoryFromPlanRef(next.plan_ref);
+    if (repository !== undefined) {
+      next.repository = repository;
+    }
+  }
+  return next;
+}
+
+function emitPlanApprovedIdempotent(
+  payload: Record<string, unknown>,
+  options: { logPath?: string | null } = {},
+): BehavioralEventRecord {
+  const enriched = enrichPlanApprovedPayload(payload);
+  validatePlanApprovedPayload(enriched);
+  const key = dedupeKey(enriched);
+  if (key !== null) {
+    const existing = findExistingPlanApproved(key, options.logPath ?? null);
+    if (existing !== null) {
+      return existing;
+    }
+  }
+  return emit("plan:approved", enriched, options);
+}
+
+/** CLI entry for `lifecycle:event` / review-cycle approval recorder (#2631). */
+export function runLifecycleEvent(
+  argv: readonly string[],
+  options: { projectRoot?: string } = {},
+): number {
+  if (options.projectRoot !== undefined) {
+    process.chdir(resolve(options.projectRoot));
+  }
+  if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help" || argv[0] === "help") {
+    process.stderr.write(
+      "usage: lifecycle:event emit plan:approved --plan-ref <url> --approver <login> " +
+        "[--approval-phrase yes|confirmed|approve] [--pr-number N] [--head-sha SHA]\n",
+    );
+    return argv.length === 0 ? 2 : 0;
+  }
+  if (argv[0] !== "emit") {
+    return eventsMain(argv);
+  }
+  if (argv[1] !== "plan:approved") {
+    return eventsMain(argv);
+  }
+  try {
+    const parsed = parseEmitInvocation(argv.slice(1));
+    const record = emitPlanApprovedIdempotent(parsed.payload, { logPath: parsed.log ?? null });
+    process.stdout.write(`${JSON.stringify(record)}\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`lifecycle:event failed: ${message}\n`);
+    return 2;
+  }
+}
+
+/** Process entrypoint mirroring other lifecycle CLI modules. */
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  return runLifecycleEvent(argv);
+}

--- a/packages/core/src/lifecycle/index.ts
+++ b/packages/core/src/lifecycle/index.ts
@@ -1,3 +1,4 @@
+export * from "./event.js";
 export * as eventDetect from "./event-detect.js";
 export * as events from "./events.js";
 export * as lifecycleHygiene from "./lifecycle-hygiene.js";

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -230,6 +230,7 @@ tasks:
           is_runtime_verb=0
           case " ${first_token} " in
             " session:start "|" session-start "|\
+            " lifecycle:event "|" lifecycle-event "|\
             " verify:session-ritual "|" verify-session-ritual "|\
             " verify:tools "|" verify-tools "|\
             " triage:summary "|" triage-summary "|\

--- a/tasks/lifecycle.yml
+++ b/tasks/lifecycle.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+# tasks/lifecycle.yml -- behavioral framework event recorder (#2631 / #635).
+#
+# Review-cycle merge-gate approval uses `task lifecycle:event -- emit plan:approved ...`.
+# Per conventions/task-caching.md: no sources/generates because the task forwards
+# user-facing flags via CLI_ARGS.
+
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+tasks:
+  event:
+    desc: "Emit behavioral framework events (review-cycle plan:approved recorder). -- task lifecycle:event -- emit plan:approved --plan-ref <url> --approver <login> --approval-phrase <yes|confirmed|approve> --pr-number <N> [--head-sha <sha>]"
+    dir: '{{.USER_WORKING_DIR}}'
+    # Runtime dispatch: no engine:_ts-build / pnpm build (#2181 / consumer npm deposit).
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'lifecycle:event {{.CLI_ARGS}}'

--- a/tasks/lifecycle.yml
+++ b/tasks/lifecycle.yml
@@ -1,6 +1,7 @@
 version: '3'
 
 # tasks/lifecycle.yml -- behavioral framework event recorder (#2631 / #635).
+# Consumer npm deposits invoke via engine:invoke without a local build (#2181).
 #
 # Review-cycle merge-gate approval uses `task lifecycle:event -- emit plan:approved ...`.
 # Per conventions/task-caching.md: no sources/generates because the task forwards

--- a/xbrief/active/2026-07-19-2631-bugreview-cycle-documented-lifecycleevent-approval-recorder.xbrief.json
+++ b/xbrief/active/2026-07-19-2631-bugreview-cycle-documented-lifecycleevent-approval-recorder.xbrief.json
@@ -1,0 +1,89 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Swarm-ready scope xBRIEF for GitHub issue #2631",
+    "updated": "2026-07-19T14:44:06Z"
+  },
+  "plan": {
+    "title": "bug(review-cycle): documented lifecycle:event approval recorder is absent from consumer surface",
+    "status": "running",
+    "narratives": {
+      "Description": "Review-cycle documents a lifecycle:event approval recorder that is absent from the consumer Taskfile/CLI surface. Real merge-gate approval after operator consent fails when the mandatory command is missing.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2631",
+      "Overview": "## Summary\n\nThe shipped `deft-directive-review-cycle` skill mandates a structural approval event through `task lifecycle:event`, but the 0.79.0 npm consumer deposit exposes neither that Task target nor a corresponding CLI verb. An agent following the mandatory Phase 5 to Phase 6 gate cannot record `plan:approved` as instructed.\n\n## Environment\n\n- `@deftai/directive` / `@deftai/directive-core` 0.79.0\n- canonical npm consumer deposit under `.deft/core/`\n- macOS, Node 24.18.0, Task 3.50.0\n\n## Shipped contract\n\n`.deft/core/skills/deft-directive-review-cycle/SKILL.md` says:\n\n```text\nWhen the user replies yes / confirmed / approve on a ready-to-merge PR thread,\nemit a plan:approved framework event via task lifecycle:event so the approval is\ncaptured as a structural artifact rather than prose-only.\n```\n\nIt then prescribes:\n\n```text\ntask lifecycle:event -- emit plan:approved ...\n```\n\nThis is a mandatory review-cycle step, not optional guidance.\n\n## Reproduction\n\n```text\n$ task --list-all | rg 'lifecycle:event'\n# no result\n\n$ task lifecycle:event -- --help\ntask: Task \"lifecycle:event\" does not exist\n```\n\nThe global 0.79.0 CLI dispatch registry likewise has no `lifecycle:event` verb.\n\n## Expected\n\nOne authoritative, npm-consumer-safe surface must exist and match the skill exactly. Either:\n\n1. ship `task lifecycle:event` plus the corresponding Directive CLI handler for `emit plan:approved`; or\n2. update the skill to name an existing structural event recorder that is present in the consumer deposit.\n\nThe command should be idempotent for a repeated approval of the same PR and HEAD SHA, write to the documented structural artifact, and fail before any merge when its payload is invalid.\n\n## Acceptance criteria\n\n- [ ] A clean 0.79+ consumer install can execute the approval-recording command named by the review-cycle skill.\n- [ ] `task --list-all` exposes the documented target and `directive --help` exposes the corresponding verb.\n- [ ] The command records `plan:approved` with repository, PR, approved HEAD SHA, actor, and timestamp.\n- [ ] Repeating the same event is idempotent or deterministically deduplicated.\n- [ ] Review-cycle contract tests fail if the mandatory command disappears from the deposited Taskfile/CLI surface.\n- [ ] The skill, commands reference, task description, and CLI help use the same spelling and argument shape.\n\n## Related\n\n- #1670 owns the unified Directive verb vocabulary.\n- The defect surfaced during a real consumer PR merge gate after the operator explicitly approved the merge.\n\n",
+      "Labels": "bug",
+      "UserStory": "As a consumer agent running review-cycle, I want the documented lifecycle:event approval recorder available on the deposited Taskfile/CLI surface, so that merge-gate approval recording does not fail as a missing command.",
+      "ImplementationPlan": "1. Locate the documented lifecycle:event approval recorder in review-cycle skill/docs and reconcile with the deposited Taskfile/CLI.\n2. Expose or rename the command so skill, commands.md, task description, and CLI help share one spelling/argument shape.\n3. Add a contract test that fails if the mandatory command disappears from the deposited surface.\n4. CHANGELOG [Unreleased]."
+    },
+    "items": [
+      {
+        "id": "ac1",
+        "title": "Command on consumer surface",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a consumer .deft/core deposit, when the documented approval recorder is invoked, then the command exists on Taskfile/CLI."
+        }
+      },
+      {
+        "id": "ac2",
+        "title": "Consistent spelling",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given skill, commands reference, task description, and CLI help, when compared, then they use the same spelling and argument shape."
+        }
+      },
+      {
+        "id": "ac3",
+        "title": "Contract test",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the deposited surface, when contract tests run, then they fail if the mandatory command disappears."
+        }
+      }
+    ],
+    "tags": [
+      "bug"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2631",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2631: bug(review-cycle): documented lifecycle:event approval recorder is absent from consumer surface"
+      }
+    ],
+    "updated": "2026-07-19T14:44:06Z",
+    "id": "lifecycle-event-approval-recorder-surface",
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "bug-fix",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/skills/deft-directive-review-cycle/SKILL.md",
+          "content/commands.md",
+          "tasks/lifecycle.yml",
+          "packages/core/src/lifecycle/event.ts",
+          "packages/core/src/lifecycle/event.test.ts",
+          "packages/cli/src/commands/"
+        ],
+        "verify_commands": [
+          "task --list",
+          "pnpm --filter @deftai/directive-core test -- lifecycle"
+        ],
+        "expected_outputs": [
+          "approval recorder on consumer surface",
+          "consistent docs",
+          "contract test",
+          "CHANGELOG"
+        ],
+        "depends_on": [],
+        "conflict_group": "review-cycle-lifecycle-event",
+        "size": "M",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium",
+        "missing_traces_justification": "Bug-fix / security remediation from GitHub issue #2631; no FR trace registry for hotfix cohort."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `task lifecycle:event` / `deft lifecycle:event` to record review-cycle `plan:approved` merge-gate approvals as structural JSONL events.
- Implement idempotent dedupe for repeated approvals on the same PR/approver/HEAD SHA and enrich payloads with repository + timestamp.
- Add Taskfile/CLI wiring, commands reference docs, and contract tests that fail if the mandatory command disappears from the deposited surface.

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/lifecycle/event.test.ts packages/core/src/content-contracts/standards/taskfile_lifecycle_event.test.ts packages/core/src/content-contracts/skills/review_cycle_skill.test.ts`
- [x] `task --list-all` shows `lifecycle:event`
- [x] `pnpm run build`
- [ ] CI green on PR

Closes #2631