### PR TITLE
fix(issue-sync): gate sync-from-xbrief with isRepoMutationAllowed (#2633)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Windows CI retries transient Install Task flakes (#2624).** The task-dispatch regression job pins an exact Task release and automatically retries `arduino/setup-task` once before failing; operator rerun-failed-jobs recovery is documented in the workflow. Closes #2624.
 - **Windows Vitest coverage no longer ENOENTs on `coverage/.tmp` after green full-suite runs (#2634).** Hardens the #2580 keepalive with a globalSetup write guard that mkdirs before Vitest 3.2.x chunk writes (upstream fix: vitest-dev/vitest#10117 in vitest 4.x); coverage thresholds still fail closed. Closes #2634.
 - **deft-core-guard allowlists installer-deposited `.prettierignore` (#2629).** Framework-only deposit PRs that include the #2534 Prettier gate exclusion no longer fail `no-mixed-core-and-app`. Closes #2629.
+- **issue:sync-from-xbrief cross-repo confused deputy (#2633).** `task issue:sync-from-xbrief` now gates comment POSTs with `isRepoMutationAllowed` (same cross-repo mutation gate as #2601 reconcile writers); cross-repo targets are refused unless `--allow-cross-repo` or an allowlist entry permits them. Closes #2633.
 
 ### Removed
 

--- a/content/commands.md
+++ b/content/commands.md
@@ -95,7 +95,7 @@ Common commands:
 - `task scope:fail -- xbrief/active/<file>.xbrief.json` -- mark running work failed when the scope cannot complete.
 - `task scope:cancel -- <path>` -- move a scope to `cancelled/`.
 - `task scope:restore`, `task scope:block`, `task scope:unblock`, `task scope:demote`, and `task scope:undo:*` -- repair or reverse lifecycle transitions.
-- `task issue:sync-from-xbrief -- <path>` -- post a GitHub issue comment summarizing material AC/status changes for an origin-linked scope xBRIEF (`plan.references` with `x-xbrief/github-issue`). Supports `--dry-run` (print without posting) and `--repo OWNER/NAME` when the reference URI lacks a repo slug. Skips when no material changes since the last successful sync. Closes the reverse-sync gap after `task issue:ingest` (#2540).
+- `task issue:sync-from-xbrief -- <path>` -- post a GitHub issue comment summarizing material AC/status changes for an origin-linked scope xBRIEF (`plan.references` with `x-xbrief/github-issue`). Supports `--dry-run` (print without posting), `--repo OWNER/NAME` when the reference URI lacks a repo slug, and `--allow-cross-repo` for intentional cross-repo sync (refused by default; #2633). Skips when no material changes since the last successful sync. Closes the reverse-sync gap after `task issue:ingest` (#2540).
 - `task issue:ingest -- <N>` / `task issue:ingest -- --all [--label L] [--status S] [--dry-run]` -- ingest GitHub issues as scope xBRIEFs (deduplicates via existing references).
 - `task reconcile:issues [-- --apply-lifecycle-fixes]` -- scan origin-linked xBRIEFs for stale or closed GitHub issues.
 

--- a/packages/core/src/issue-sync/sync-from-xbrief-cli.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief-cli.ts
@@ -7,6 +7,7 @@ export interface ParsedSyncFromXbriefCliArgs {
   dryRun?: boolean;
   projectRoot?: string;
   repo?: string;
+  allowCrossRepo?: boolean;
   error?: string;
 }
 
@@ -16,6 +17,8 @@ export function parseArgs(argv: readonly string[]): ParsedSyncFromXbriefCliArgs 
     const arg = argv[i] as string;
     if (arg === "--dry-run") {
       out.dryRun = true;
+    } else if (arg === "--allow-cross-repo") {
+      out.allowCrossRepo = true;
     } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined) {

--- a/packages/core/src/issue-sync/sync-from-xbrief.test.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief.test.ts
@@ -303,6 +303,18 @@ describe("issue-sync dry-run and missing origin", () => {
     expect(err.join("\n")).toMatch(/refusing cross-repo mutation/);
     expect(runFn).not.toHaveBeenCalled();
   });
+
+  it("allows same-repo sync when --repo is a full GitHub URL (#2633)", () => {
+    const path = writeTempXbrief(ORIGIN_XBRIEF);
+    const runFn = vi.fn(() => ({ id: 1004 }));
+    const code = syncFromXbrief({
+      xbriefPath: path,
+      repo: "https://github.com/deftai/directive",
+      runFn,
+    });
+    expect(code).toBe(0);
+    expect(runFn).toHaveBeenCalled();
+  });
 });
 
 function writeTempXbrief(data: Record<string, unknown>): string {

--- a/packages/core/src/issue-sync/sync-from-xbrief.test.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief.test.ts
@@ -37,6 +37,20 @@ const ORIGIN_XBRIEF = {
   },
 };
 
+const CROSS_REPO_XBRIEF = {
+  ...ORIGIN_XBRIEF,
+  plan: {
+    ...ORIGIN_XBRIEF.plan,
+    references: [
+      {
+        uri: "https://github.com/other/victim/issues/99",
+        type: "x-xbrief/github-issue",
+        title: "Issue #99",
+      },
+    ],
+  },
+};
+
 describe("issue-sync resolveOriginIssue", () => {
   it("resolves github-issue origin from references", () => {
     const origin = resolveOriginIssue(ORIGIN_XBRIEF);
@@ -233,6 +247,61 @@ describe("issue-sync dry-run and missing origin", () => {
     expect(err.join("\n")).toContain("comment posted (id: 1001)");
     expect(err.join("\n")).toContain("failed to persist sync fingerprint");
     expect(err.join("\n")).not.toContain("failed to post comment");
+  });
+
+  it("refuses cross-repo comment mutation without allowCrossRepo (#2633)", () => {
+    const err: string[] = [];
+    const runFn = vi.fn();
+    const code = syncFromXbrief({
+      xbriefPath: writeTempXbrief(CROSS_REPO_XBRIEF),
+      repo: "deftai/directive",
+      writeErr: (line) => err.push(line),
+      runFn,
+    });
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/refusing cross-repo mutation/);
+    expect(runFn).not.toHaveBeenCalled();
+  });
+
+  it("allows cross-repo comment mutation when allowCrossRepo is set (#2633)", () => {
+    const path = writeTempXbrief(CROSS_REPO_XBRIEF);
+    const runFn = vi.fn(() => ({ id: 1002 }));
+    const code = syncFromXbrief({
+      xbriefPath: path,
+      repo: "deftai/directive",
+      allowCrossRepo: true,
+      runFn,
+    });
+    expect(code).toBe(0);
+    expect(runFn).toHaveBeenCalled();
+  });
+
+  it("allows cross-repo comment mutation when target is allowlisted (#2633)", () => {
+    const path = writeTempXbrief(CROSS_REPO_XBRIEF);
+    const runFn = vi.fn(() => ({ id: 1003 }));
+    const code = syncFromXbrief({
+      xbriefPath: path,
+      repo: "deftai/directive",
+      repoAllowlist: ["other/victim"],
+      runFn,
+    });
+    expect(code).toBe(0);
+    expect(runFn).toHaveBeenCalled();
+  });
+
+  it("refuses cross-repo dry-run without allowCrossRepo (#2633)", () => {
+    const err: string[] = [];
+    const runFn = vi.fn();
+    const code = syncFromXbrief({
+      xbriefPath: writeTempXbrief(CROSS_REPO_XBRIEF),
+      dryRun: true,
+      repo: "deftai/directive",
+      writeErr: (line) => err.push(line),
+      runFn,
+    });
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/refusing cross-repo mutation/);
+    expect(runFn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/issue-sync/sync-from-xbrief.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief.ts
@@ -10,6 +10,7 @@ import {
 } from "../intake/reconcile-issues.js";
 import { resolveProjectRoot } from "../scope/project-context.js";
 import { resolveProjectRepo } from "../slice/project-context.js";
+import { isRepoMutationAllowed } from "../vbrief-reconcile/repo-guard.js";
 
 export const SYNC_COMMENT_HEADER = "## xBRIEF sync (deft issue:sync-from-xbrief)";
 
@@ -176,6 +177,8 @@ export interface SyncFromXbriefOptions {
   readonly dryRun?: boolean;
   readonly projectRoot?: string;
   readonly repo?: string;
+  readonly allowCrossRepo?: boolean;
+  readonly repoAllowlist?: readonly string[];
   readonly runFn?: RunGhApiFn;
   readonly writeErr?: (message: string) => void;
   readonly writeOut?: (message: string) => void;
@@ -230,6 +233,18 @@ export function syncFromXbrief(options: SyncFromXbriefOptions): number {
     return 0;
   }
 
+  const mutateGate = isRepoMutationAllowed(origin.repo, projectRoot, {
+    allowCrossRepo: options.allowCrossRepo,
+    allowlist: options.repoAllowlist,
+    explicitRepo: options.repo ?? null,
+  });
+  if (!mutateGate.allowed) {
+    writeErr(
+      `issue:sync-from-xbrief: ${mutateGate.reason ?? `refusing cross-repo mutation on ${origin.repo}`}`,
+    );
+    return 1;
+  }
+
   const relPath = options.xbriefPath.replace(/\\/g, "/");
   const comment = buildSyncComment(data, relPath);
 
@@ -280,6 +295,8 @@ export interface SyncFromXbriefCliArgs {
   readonly dryRun?: boolean;
   readonly projectRoot?: string;
   readonly repo?: string;
+  readonly allowCrossRepo?: boolean;
+  readonly repoAllowlist?: readonly string[];
 }
 
 export function syncFromXbriefMain(args: SyncFromXbriefCliArgs): number {
@@ -292,5 +309,7 @@ export function syncFromXbriefMain(args: SyncFromXbriefCliArgs): number {
     dryRun: args.dryRun,
     projectRoot: args.projectRoot,
     repo: args.repo,
+    allowCrossRepo: args.allowCrossRepo,
+    repoAllowlist: args.repoAllowlist,
   });
 }

--- a/packages/core/src/issue-sync/sync-from-xbrief.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief.ts
@@ -236,7 +236,7 @@ export function syncFromXbrief(options: SyncFromXbriefOptions): number {
   const mutateGate = isRepoMutationAllowed(origin.repo, projectRoot, {
     allowCrossRepo: options.allowCrossRepo,
     allowlist: options.repoAllowlist,
-    explicitRepo: options.repo ?? null,
+    explicitRepo: fallbackRepo,
   });
   if (!mutateGate.allowed) {
     writeErr(


### PR DESCRIPTION
## Summary
- Gate `task issue:sync-from-xbrief` comment POSTs with `isRepoMutationAllowed` before any GitHub mutation, matching the #2601 reconcile writers.
- Refuse cross-repo targets by default; add `--allow-cross-repo` CLI opt-in and programmatic `repoAllowlist` support for intentional sync.
- Add regression tests for refuse / same-repo / opt-in / allowlist paths.

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/issue-sync/sync-from-xbrief.test.ts` (19 passed)
- [x] `task verify:forward-coverage`
- [ ] CI green on PR

Closes #2633
