### PR TITLE
fix: pr:merge-ready fails closed on unresolved Greptile inline P0/P1 (#2620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **issue:sync-from-xbrief cross-repo confused deputy (#2633).** `task issue:sync-from-xbrief` now gates comment POSTs with `isRepoMutationAllowed` (same cross-repo mutation gate as #2601 reconcile writers); cross-repo targets are refused unless `--allow-cross-repo` or an allowlist entry permits them. Closes #2633.
 - **Hook write-gate hints normalize Windows-style proposed paths on Linux CI (#2625).** Backslash `xbrief\proposed\...` targets now receive the lifecycle-artifact planning hint instead of the generic recovery message.
 - **Branch coverage meets the 85% floor on native Windows without coverage-debt (#2630).** Targeted tests for `capacity/show`, `story-quality`, and doctor-state branches lift win32 branch coverage above the release gate; `vitest.config.ts` documents that win32 runner caps affect timing only — the branch threshold matches Linux CI. Skill discovery uses repo-relative exclusion so `.deft-scratch` worktrees still find `content/skills`. Closes #2630.
+- **`task pr:merge-ready` fails closed on unresolved Greptile inline P0/P1 (#2620).** Merge-ready now hard-blocks when Greptile has unresolved inline P0/P1 review threads on the current HEAD, even when rolling-summary badge counts are zero. Closes #2620.
 
 ### Removed
 

--- a/packages/core/src/pr-merge-readiness/compute.test.ts
+++ b/packages/core/src/pr-merge-readiness/compute.test.ts
@@ -18,17 +18,35 @@ function cleanGreptileBody(sha: string): string {
   );
 }
 
+const GREEN_THREADS = JSON.stringify({
+  data: {
+    repository: {
+      pullRequest: {
+        reviewThreads: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    },
+  },
+});
+
 interface FakeOpts {
   readonly commentBody?: string;
   readonly mergeableState?: string;
   readonly mergeable?: boolean | null;
   readonly checks?: string;
+  readonly reviewThreads?: string;
 }
 
 function fakeRunGh(opts: FakeOpts): RunGhFn {
   const checks = opts.checks ?? GREEN_CHECKS;
+  const reviewThreads = opts.reviewThreads ?? GREEN_THREADS;
   return (cmd) => {
     const joined = cmd.join(" ");
+    if (joined.includes("graphql")) {
+      return { returncode: 0, stdout: reviewThreads, stderr: "" };
+    }
     if (joined.includes("headRefOid")) {
       return { returncode: 0, stdout: `${HEAD}\n`, stderr: "" };
     }
@@ -182,5 +200,50 @@ describe("computeGateResult #2260 reconciliation", () => {
     );
     expect(called).toBe(true);
     expect(result.failures).toEqual([]);
+  });
+
+  it("blocks merge-ready when summary is clean but unresolved inline P1 remains (#2620)", () => {
+    const inlineP1Body =
+      '<img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"> ' +
+      "**Path traversal via `..` in owner/repo segments**";
+    const reviewThreads = JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  isResolved: false,
+                  isOutdated: false,
+                  comments: {
+                    nodes: [
+                      {
+                        author: { login: "greptile-apps[bot]" },
+                        body: inlineP1Body,
+                        path: "server/src/register/github.ts",
+                        commit: { oid: HEAD },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const result = computeGateResult(
+      120,
+      "deftai/statusreport",
+      fakeRunGh({
+        commentBody: cleanGreptileBody(HEAD),
+        mergeableState: "clean",
+        mergeable: true,
+        reviewThreads,
+      }),
+    );
+    expect(result.failures.some((f) => f.includes("unresolved inline P1"))).toBe(true);
+    expect((result.partialData as Record<string, unknown>).verdict_override).toBeUndefined();
   });
 });

--- a/packages/core/src/pr-merge-readiness/compute.test.ts
+++ b/packages/core/src/pr-merge-readiness/compute.test.ts
@@ -45,6 +45,9 @@ function fakeRunGh(opts: FakeOpts): RunGhFn {
   return (cmd) => {
     const joined = cmd.join(" ");
     if (joined.includes("graphql")) {
+      if (opts.reviewThreads === "") {
+        return { returncode: 1, stdout: "", stderr: "graphql unavailable" };
+      }
       return { returncode: 0, stdout: reviewThreads, stderr: "" };
     }
     if (joined.includes("headRefOid")) {
@@ -244,6 +247,21 @@ describe("computeGateResult #2260 reconciliation", () => {
       }),
     );
     expect(result.failures.some((f) => f.includes("unresolved inline P1"))).toBe(true);
+    expect((result.partialData as Record<string, unknown>).verdict_override).toBeUndefined();
+  });
+
+  it("fails closed when inline reviewThreads fetch errors on a clean summary (#2620)", () => {
+    const result = computeGateResult(
+      120,
+      "deftai/directive",
+      fakeRunGh({
+        commentBody: cleanGreptileBody(HEAD),
+        reviewThreads: "",
+      }),
+    );
+    expect(
+      result.failures.some((f) => f.includes("Could not verify Greptile inline review comments")),
+    ).toBe(true);
     expect((result.partialData as Record<string, unknown>).verdict_override).toBeUndefined();
   });
 });

--- a/packages/core/src/pr-merge-readiness/compute.ts
+++ b/packages/core/src/pr-merge-readiness/compute.ts
@@ -173,10 +173,16 @@ function loadInlineGreptileFindings(
   repo: string | null,
   headSha: string,
   runGh: RunGhFn,
-): InlineGreptileFindings | null {
+): InlineGreptileFindings {
   const resolved = resolveRepo(repo, runGh);
   if (resolved.repo === null) {
-    return null;
+    return {
+      p0Count: 0,
+      p1Count: 0,
+      unresolvedThreadCount: 0,
+      error:
+        resolved.error || "repo unresolved for inline reviewThreads lookup; pass --repo OWNER/REPO",
+    };
   }
   return fetchUnresolvedGreptileInlineFindings(prNumber, resolved.repo, headSha, runGh);
 }
@@ -190,12 +196,10 @@ function finalizeVerdictGate(
   options: ComputeGateOptions,
 ): { failures: string[]; partialData: Record<string, unknown> } {
   const partialData: Record<string, unknown> = {};
-  const inline = loadInlineGreptileFindings(prNumber, repo, headSha, runGh);
-  if (inline !== null) {
-    partialData.greptile_inline = inlineFindingsToDict(inline);
-  }
-  const failures = evaluateGates(prNumber, headSha, verdict, inline);
   const resolved = resolveRepo(repo, runGh);
+  const inline = loadInlineGreptileFindings(prNumber, repo, headSha, runGh);
+  partialData.greptile_inline = inlineFindingsToDict(inline);
+  const failures = evaluateGates(prNumber, headSha, verdict, inline);
 
   if (failures.length === 0) {
     const ci = applyCiGateForHead(resolved.repo, headSha, runGh, options);
@@ -260,6 +264,9 @@ function computePrimary(
   }
   partial.head_sha = headSha;
 
+  const resolved = resolveRepo(repo, runGh);
+  const effectiveRepo = resolved.repo ?? repo;
+
   const body = fetchGreptileCommentBody(prNumber, repo, runGh);
   if (body === null) {
     partial.primary_error = "gh api /issues/<N>/comments --jq returned non-zero";
@@ -269,7 +276,7 @@ function computePrimary(
   const verdict = parseGreptileBody(body);
   const { failures, partialData } = finalizeVerdictGate(
     prNumber,
-    repo,
+    effectiveRepo,
     headSha,
     verdict,
     runGh,
@@ -278,7 +285,7 @@ function computePrimary(
   return {
     result: {
       prNumber,
-      repo,
+      repo: effectiveRepo,
       headSha,
       verdict,
       failures,

--- a/packages/core/src/pr-merge-readiness/compute.ts
+++ b/packages/core/src/pr-merge-readiness/compute.ts
@@ -18,6 +18,11 @@ import {
   resolveRepo,
 } from "./gh.js";
 import {
+  fetchUnresolvedGreptileInlineFindings,
+  type InlineGreptileFindings,
+  inlineFindingsToDict,
+} from "./greptile-inline.js";
+import {
   fetchMergeability,
   isGithubMergeableClean,
   type MergeabilitySignal,
@@ -38,9 +43,10 @@ function buildGateResult(
   via: string,
   partialData: Record<string, unknown> = {},
   error: string | null = null,
+  inline: InlineGreptileFindings | null = null,
 ): GateResult {
   const verdict = parseGreptileBody(body);
-  const failures = evaluateGates(prNumber, headSha, verdict);
+  const failures = evaluateGates(prNumber, headSha, verdict, inline);
   return {
     prNumber,
     repo,
@@ -162,6 +168,19 @@ function applyCiGateForHead(
  * is only soft-blocked -- absent or stale for the current head) reconcile
  * against GitHub's own mergeability (#2260). Shared by primary + fallback1.
  */
+function loadInlineGreptileFindings(
+  prNumber: number,
+  repo: string | null,
+  headSha: string,
+  runGh: RunGhFn,
+): InlineGreptileFindings | null {
+  const resolved = resolveRepo(repo, runGh);
+  if (resolved.repo === null) {
+    return null;
+  }
+  return fetchUnresolvedGreptileInlineFindings(prNumber, resolved.repo, headSha, runGh);
+}
+
 function finalizeVerdictGate(
   prNumber: number,
   repo: string | null,
@@ -170,8 +189,12 @@ function finalizeVerdictGate(
   runGh: RunGhFn,
   options: ComputeGateOptions,
 ): { failures: string[]; partialData: Record<string, unknown> } {
-  const failures = evaluateGates(prNumber, headSha, verdict);
   const partialData: Record<string, unknown> = {};
+  const inline = loadInlineGreptileFindings(prNumber, repo, headSha, runGh);
+  if (inline !== null) {
+    partialData.greptile_inline = inlineFindingsToDict(inline);
+  }
+  const failures = evaluateGates(prNumber, headSha, verdict, inline);
   const resolved = resolveRepo(repo, runGh);
 
   if (failures.length === 0) {
@@ -188,7 +211,7 @@ function finalizeVerdictGate(
   if (
     options.disableMergeabilityReconcile === true ||
     resolved.repo === null ||
-    !verdictBlockIsSoftOnly(verdict, headSha)
+    !verdictBlockIsSoftOnly(verdict, headSha, inline)
   ) {
     return { failures, partialData };
   }

--- a/packages/core/src/pr-merge-readiness/evaluate.ts
+++ b/packages/core/src/pr-merge-readiness/evaluate.ts
@@ -1,4 +1,5 @@
 import { INFORMAL_CLEAN_DIAGNOSTIC } from "./constants.js";
+import type { InlineGreptileFindings } from "./greptile-inline.js";
 import type { GreptileVerdict } from "./types.js";
 
 /** Return failure messages (empty list == merge-ready). */
@@ -6,6 +7,7 @@ export function evaluateGates(
   _prNumber: number,
   headSha: string | null,
   verdict: GreptileVerdict,
+  inline: InlineGreptileFindings | null = null,
 ): string[] {
   const failures: string[] = [];
 
@@ -69,6 +71,22 @@ export function evaluateGates(
         "on the current HEAD. All P0 / P1 findings MUST be addressed before merge " +
         "(P2 findings are non-blocking).",
     );
+  }
+
+  if (inline !== null) {
+    if (inline.error !== null) {
+      failures.push(
+        "Could not verify Greptile inline review comments on the current HEAD (#2620). " +
+          `Root cause: ${inline.error}`,
+      );
+    } else if (inline.p0Count > 0 || inline.p1Count > 0) {
+      failures.push(
+        `Greptile has ${inline.p0Count} unresolved inline P0 and ${inline.p1Count} unresolved inline P1 ` +
+          `review comment(s) on the current HEAD across ${inline.unresolvedThreadCount} open thread(s). ` +
+          "Resolve or address all blocking inline threads before merge -- rolling-summary badge counts alone " +
+          "are insufficient (#2620).",
+      );
+    }
   }
 
   return failures;

--- a/packages/core/src/pr-merge-readiness/evaluate.ts
+++ b/packages/core/src/pr-merge-readiness/evaluate.ts
@@ -20,75 +20,77 @@ export function evaluateGates(
     return failures;
   }
 
-  if (verdict.excludedAuthor) {
-    return failures;
-  }
-
-  if (verdict.errored) {
-    failures.push(
-      "Greptile review is in the ERRORED state on the current HEAD (#526). " +
-        "Retry via @greptileai or escalate per " +
-        "skills/deft-directive-swarm/SKILL.md Phase 6 Step 1.",
-    );
-  }
-
-  if (verdict.informalClean) {
-    failures.push(INFORMAL_CLEAN_DIAGNOSTIC);
-    return failures;
-  }
-
-  if (verdict.lastReviewedSha === null) {
-    failures.push(
-      "Could not parse `Last reviewed commit:` from Greptile body. " +
-        "The comment may be malformed or Greptile may still be writing it -- re-fetch.",
-    );
-  } else if (
-    headSha &&
-    !(headSha.startsWith(verdict.lastReviewedSha) || verdict.lastReviewedSha.startsWith(headSha))
-  ) {
-    failures.push(
-      `Greptile last reviewed ${verdict.lastReviewedSha} but PR HEAD is ${headSha}. ` +
-        "Review is stale -- wait for Greptile to re-review the latest commit.",
-    );
-  }
-
-  if (verdict.confidence === null) {
-    failures.push(
-      "Could not parse `Confidence Score: X/5` from Greptile body. " +
-        "Confidence is a required exit-condition input per " +
-        "skills/deft-directive-review-cycle/SKILL.md Phase 2 Step 6.",
-    );
-  } else if (verdict.confidence <= 3) {
-    failures.push(
-      `Greptile confidence is ${verdict.confidence}/5; exit condition requires > 3. ` +
-        "Address remaining findings or push clarifying changes.",
-    );
-  }
-
-  if (verdict.p0Count > 0 || verdict.p1Count > 0) {
-    failures.push(
-      `Greptile reports ${verdict.p0Count} P0 and ${verdict.p1Count} P1 findings ` +
-        "on the current HEAD. All P0 / P1 findings MUST be addressed before merge " +
-        "(P2 findings are non-blocking).",
-    );
-  }
-
-  if (inline !== null) {
-    if (inline.error !== null) {
+  if (!verdict.excludedAuthor) {
+    if (verdict.errored) {
       failures.push(
-        "Could not verify Greptile inline review comments on the current HEAD (#2620). " +
-          `Root cause: ${inline.error}`,
+        "Greptile review is in the ERRORED state on the current HEAD (#526). " +
+          "Retry via @greptileai or escalate per " +
+          "skills/deft-directive-swarm/SKILL.md Phase 6 Step 1.",
       );
-    } else if (inline.p0Count > 0 || inline.p1Count > 0) {
+    }
+
+    if (verdict.informalClean) {
+      failures.push(INFORMAL_CLEAN_DIAGNOSTIC);
+      return appendInlineFailures(failures, inline);
+    }
+
+    if (verdict.lastReviewedSha === null) {
       failures.push(
-        `Greptile has ${inline.p0Count} unresolved inline P0 and ${inline.p1Count} unresolved inline P1 ` +
-          `review comment(s) on the current HEAD across ${inline.unresolvedThreadCount} open thread(s). ` +
-          "Resolve or address all blocking inline threads before merge -- rolling-summary badge counts alone " +
-          "are insufficient (#2620).",
+        "Could not parse `Last reviewed commit:` from Greptile body. " +
+          "The comment may be malformed or Greptile may still be writing it -- re-fetch.",
+      );
+    } else if (
+      headSha &&
+      !(headSha.startsWith(verdict.lastReviewedSha) || verdict.lastReviewedSha.startsWith(headSha))
+    ) {
+      failures.push(
+        `Greptile last reviewed ${verdict.lastReviewedSha} but PR HEAD is ${headSha}. ` +
+          "Review is stale -- wait for Greptile to re-review the latest commit.",
+      );
+    }
+
+    if (verdict.confidence === null) {
+      failures.push(
+        "Could not parse `Confidence Score: X/5` from Greptile body. " +
+          "Confidence is a required exit-condition input per " +
+          "skills/deft-directive-review-cycle/SKILL.md Phase 2 Step 6.",
+      );
+    } else if (verdict.confidence <= 3) {
+      failures.push(
+        `Greptile confidence is ${verdict.confidence}/5; exit condition requires > 3. ` +
+          "Address remaining findings or push clarifying changes.",
+      );
+    }
+
+    if (verdict.p0Count > 0 || verdict.p1Count > 0) {
+      failures.push(
+        `Greptile reports ${verdict.p0Count} P0 and ${verdict.p1Count} P1 findings ` +
+          "on the current HEAD. All P0 / P1 findings MUST be addressed before merge " +
+          "(P2 findings are non-blocking).",
       );
     }
   }
 
+  return appendInlineFailures(failures, inline);
+}
+
+function appendInlineFailures(failures: string[], inline: InlineGreptileFindings | null): string[] {
+  if (inline === null) {
+    return failures;
+  }
+  if (inline.error !== null) {
+    failures.push(
+      "Could not verify Greptile inline review comments on the current HEAD (#2620). " +
+        `Root cause: ${inline.error}`,
+    );
+  } else if (inline.p0Count > 0 || inline.p1Count > 0) {
+    failures.push(
+      `Greptile has ${inline.p0Count} unresolved inline P0 and ${inline.p1Count} unresolved inline P1 ` +
+        `review comment(s) on the current HEAD across ${inline.unresolvedThreadCount} open thread(s). ` +
+        "Resolve or address all blocking inline threads before merge -- rolling-summary badge counts alone " +
+        "are insufficient (#2620).",
+    );
+  }
   return failures;
 }
 

--- a/packages/core/src/pr-merge-readiness/greptile-inline.test.ts
+++ b/packages/core/src/pr-merge-readiness/greptile-inline.test.ts
@@ -184,4 +184,22 @@ describe("fetchUnresolvedGreptileInlineFindings", () => {
     const findings = fetchUnresolvedGreptileInlineFindings(120, "deftai/statusreport", HEAD, runGh);
     expect(findings.error).toContain("graphql reviewThreads failed");
   });
+
+  it("fails closed when pagination reports hasNextPage without endCursor", () => {
+    const payload = {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: true, endCursor: null },
+              nodes: [],
+            },
+          },
+        },
+      },
+    };
+    const runGh: RunGhFn = () => ({ returncode: 0, stdout: JSON.stringify(payload), stderr: "" });
+    const findings = fetchUnresolvedGreptileInlineFindings(120, "deftai/statusreport", HEAD, runGh);
+    expect(findings.error).toContain("missing endCursor");
+  });
 });

--- a/packages/core/src/pr-merge-readiness/greptile-inline.test.ts
+++ b/packages/core/src/pr-merge-readiness/greptile-inline.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateInlineReviewThreads,
+  fetchUnresolvedGreptileInlineFindings,
+  headShaMatches,
+  type InlineReviewThread,
+} from "./greptile-inline.js";
+import type { RunGhFn } from "./types.js";
+
+const HEAD = "3a277b7ab847f0baeba85a673dea811027d9634f";
+const OLD = "b5f89c30435a428acffe4b989f633854f6261786";
+
+const INLINE_P1_BODY =
+  '<img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"> ' +
+  "**Path traversal via `..` in owner/repo segments**";
+
+function thread(
+  overrides: Partial<InlineReviewThread> & { comments?: InlineReviewThread["comments"] },
+): InlineReviewThread {
+  return {
+    isResolved: false,
+    isOutdated: false,
+    comments: [],
+    ...overrides,
+  };
+}
+
+describe("headShaMatches", () => {
+  it("matches full and short SHAs in either direction", () => {
+    expect(headShaMatches(HEAD.slice(0, 7), HEAD)).toBe(true);
+    expect(headShaMatches(HEAD, HEAD.slice(0, 7))).toBe(true);
+  });
+
+  it("rejects unrelated SHAs", () => {
+    expect(headShaMatches(OLD, HEAD)).toBe(false);
+  });
+});
+
+describe("evaluateInlineReviewThreads", () => {
+  it("counts unresolved Greptile inline P1 on current HEAD (#2620)", () => {
+    const findings = evaluateInlineReviewThreads(
+      [
+        thread({
+          comments: [
+            {
+              authorLogin: "greptile-apps[bot]",
+              body: INLINE_P1_BODY,
+              path: "server/src/register/github.ts",
+              commitOid: HEAD,
+            },
+          ],
+        }),
+      ],
+      HEAD,
+    );
+    expect(findings).toEqual({
+      p0Count: 0,
+      p1Count: 1,
+      unresolvedThreadCount: 1,
+      error: null,
+    });
+  });
+
+  it("ignores resolved threads even when summary badge counts are zero", () => {
+    const findings = evaluateInlineReviewThreads(
+      [
+        thread({
+          isResolved: true,
+          comments: [
+            {
+              authorLogin: "greptile-apps[bot]",
+              body: INLINE_P1_BODY,
+              path: "server/src/register/github.ts",
+              commitOid: HEAD,
+            },
+          ],
+        }),
+      ],
+      HEAD,
+    );
+    expect(findings.p0Count).toBe(0);
+    expect(findings.p1Count).toBe(0);
+  });
+
+  it("ignores outdated threads on prior HEAD SHAs", () => {
+    const findings = evaluateInlineReviewThreads(
+      [
+        thread({
+          isOutdated: true,
+          comments: [
+            {
+              authorLogin: "greptile-apps[bot]",
+              body: INLINE_P1_BODY,
+              path: "server/src/cli/program.ts",
+              commitOid: OLD,
+            },
+          ],
+        }),
+      ],
+      HEAD,
+    );
+    expect(findings.p1Count).toBe(0);
+  });
+
+  it("ignores Greptile inline comments pinned to a stale commit on current HEAD", () => {
+    const findings = evaluateInlineReviewThreads(
+      [
+        thread({
+          comments: [
+            {
+              authorLogin: "greptile-apps[bot]",
+              body: INLINE_P1_BODY,
+              path: "server/src/cli/program.ts",
+              commitOid: OLD,
+            },
+          ],
+        }),
+      ],
+      HEAD,
+    );
+    expect(findings.p1Count).toBe(0);
+  });
+
+  it("ignores non-Greptile inline comments", () => {
+    const findings = evaluateInlineReviewThreads(
+      [
+        thread({
+          comments: [
+            {
+              authorLogin: "deft-slizard[bot]",
+              body: "**P1** inline from SLizard",
+              path: "server/src/register/github.ts",
+              commitOid: HEAD,
+            },
+          ],
+        }),
+      ],
+      HEAD,
+    );
+    expect(findings.p1Count).toBe(0);
+  });
+});
+
+describe("fetchUnresolvedGreptileInlineFindings", () => {
+  it("parses GraphQL reviewThreads payload", () => {
+    const payload = {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  isResolved: false,
+                  isOutdated: false,
+                  comments: {
+                    nodes: [
+                      {
+                        author: { login: "greptile-apps[bot]" },
+                        body: INLINE_P1_BODY,
+                        path: "server/src/register/github.ts",
+                        commit: { oid: HEAD },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const runGh: RunGhFn = (cmd) => {
+      expect(cmd.join(" ")).toContain("graphql");
+      return { returncode: 0, stdout: JSON.stringify(payload), stderr: "" };
+    };
+    const findings = fetchUnresolvedGreptileInlineFindings(120, "deftai/statusreport", HEAD, runGh);
+    expect(findings.p1Count).toBe(1);
+    expect(findings.error).toBeNull();
+  });
+
+  it("surfaces GraphQL transport errors", () => {
+    const runGh: RunGhFn = () => ({ returncode: 1, stdout: "", stderr: "rate limit" });
+    const findings = fetchUnresolvedGreptileInlineFindings(120, "deftai/statusreport", HEAD, runGh);
+    expect(findings.error).toContain("graphql reviewThreads failed");
+  });
+});

--- a/packages/core/src/pr-merge-readiness/greptile-inline.ts
+++ b/packages/core/src/pr-merge-readiness/greptile-inline.ts
@@ -270,6 +270,12 @@ export function fetchUnresolvedGreptileInlineFindings(
     if (!pageResult.hasNextPage) {
       break;
     }
+    if (pageResult.endCursor === null) {
+      return {
+        ...EMPTY_INLINE,
+        error: "graphql reviewThreads pagination missing endCursor while hasNextPage=true",
+      };
+    }
     after = pageResult.endCursor;
   }
 

--- a/packages/core/src/pr-merge-readiness/greptile-inline.ts
+++ b/packages/core/src/pr-merge-readiness/greptile-inline.ts
@@ -1,0 +1,277 @@
+import { detect } from "../content-contracts/skills/greptile-detector.js";
+import { GREPTILE_LOGIN } from "./constants.js";
+import type { RunGhFn } from "./types.js";
+
+/** Unresolved Greptile inline P0/P1 on the current PR HEAD (#2620). */
+export interface InlineGreptileFindings {
+  readonly p0Count: number;
+  readonly p1Count: number;
+  readonly unresolvedThreadCount: number;
+  readonly error: string | null;
+}
+
+export interface InlineReviewComment {
+  readonly authorLogin: string;
+  readonly body: string;
+  readonly path: string | null;
+  readonly commitOid: string | null;
+}
+
+export interface InlineReviewThread {
+  readonly isResolved: boolean;
+  readonly isOutdated: boolean;
+  readonly comments: readonly InlineReviewComment[];
+}
+
+const REVIEW_THREADS_QUERY = `
+query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 50) {
+            nodes {
+              author { login }
+              body
+              path
+              commit { oid }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const EMPTY_INLINE: InlineGreptileFindings = {
+  p0Count: 0,
+  p1Count: 0,
+  unresolvedThreadCount: 0,
+  error: null,
+};
+
+/** True when a review comment commit SHA matches the current PR head (#2620 AC-2). */
+export function headShaMatches(commentSha: string, headSha: string): boolean {
+  return headSha.startsWith(commentSha) || commentSha.startsWith(headSha);
+}
+
+export function inlineFindingsToDict(findings: InlineGreptileFindings): Record<string, unknown> {
+  return {
+    p0_count: findings.p0Count,
+    p1_count: findings.p1Count,
+    unresolved_thread_count: findings.unresolvedThreadCount,
+    error: findings.error,
+  };
+}
+
+function parseOwnerRepo(ownerRepo: string): { owner: string; repo: string } | null {
+  const slash = ownerRepo.indexOf("/");
+  if (slash <= 0 || slash >= ownerRepo.length - 1) {
+    return null;
+  }
+  return { owner: ownerRepo.slice(0, slash), repo: ownerRepo.slice(slash + 1) };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseReviewComment(node: unknown): InlineReviewComment | null {
+  const record = asRecord(node);
+  if (record === null) {
+    return null;
+  }
+  const author = asRecord(record.author);
+  const login = author?.login;
+  if (typeof login !== "string" || login.length === 0) {
+    return null;
+  }
+  const body = record.body;
+  if (typeof body !== "string") {
+    return null;
+  }
+  const commit = asRecord(record.commit);
+  const oid = commit?.oid;
+  const path = record.path;
+  return {
+    authorLogin: login,
+    body,
+    path: typeof path === "string" ? path : null,
+    commitOid: typeof oid === "string" && oid.length > 0 ? oid : null,
+  };
+}
+
+function parseReviewThread(node: unknown): InlineReviewThread | null {
+  const record = asRecord(node);
+  if (record === null) {
+    return null;
+  }
+  const commentsBlock = asRecord(record.comments);
+  const commentNodes = commentsBlock?.nodes;
+  const comments: InlineReviewComment[] = [];
+  if (Array.isArray(commentNodes)) {
+    for (const commentNode of commentNodes) {
+      const parsed = parseReviewComment(commentNode);
+      if (parsed !== null) {
+        comments.push(parsed);
+      }
+    }
+  }
+  return {
+    isResolved: record.isResolved === true,
+    isOutdated: record.isOutdated === true,
+    comments,
+  };
+}
+
+interface GraphqlReviewThreadsPage {
+  readonly threads: InlineReviewThread[];
+  readonly hasNextPage: boolean;
+  readonly endCursor: string | null;
+  readonly error: string | null;
+}
+
+function parseGraphqlReviewThreadsPage(stdout: string): GraphqlReviewThreadsPage {
+  if (!stdout.trim()) {
+    return { threads: [], hasNextPage: false, endCursor: null, error: "empty GraphQL body" };
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stdout) as unknown;
+  } catch (exc: unknown) {
+    const message = exc instanceof Error ? exc.message : String(exc);
+    return {
+      threads: [],
+      hasNextPage: false,
+      endCursor: null,
+      error: `could not parse GraphQL JSON: ${message}`,
+    };
+  }
+  const root = asRecord(payload);
+  const errors = root?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    const first = errors[0];
+    const message =
+      typeof first === "object" && first !== null && "message" in first
+        ? String((first as Record<string, unknown>).message)
+        : "GraphQL errors present";
+    return { threads: [], hasNextPage: false, endCursor: null, error: message };
+  }
+  const data = asRecord(root?.data);
+  const repository = asRecord(data?.repository);
+  const pullRequest = asRecord(repository?.pullRequest);
+  const reviewThreads = asRecord(pullRequest?.reviewThreads);
+  const nodes = reviewThreads?.nodes;
+  const pageInfo = asRecord(reviewThreads?.pageInfo);
+  const threads: InlineReviewThread[] = [];
+  if (Array.isArray(nodes)) {
+    for (const node of nodes) {
+      const parsed = parseReviewThread(node);
+      if (parsed !== null) {
+        threads.push(parsed);
+      }
+    }
+  }
+  return {
+    threads,
+    hasNextPage: pageInfo?.hasNextPage === true,
+    endCursor: typeof pageInfo?.endCursor === "string" ? pageInfo.endCursor : null,
+    error: null,
+  };
+}
+
+/** Score unresolved Greptile inline P0/P1 threads pinned to the current HEAD (#2620). */
+export function evaluateInlineReviewThreads(
+  threads: readonly InlineReviewThread[],
+  headSha: string,
+): InlineGreptileFindings {
+  let p0Count = 0;
+  let p1Count = 0;
+  let unresolvedThreadCount = 0;
+
+  for (const thread of threads) {
+    if (thread.isResolved || thread.isOutdated) {
+      continue;
+    }
+
+    let threadP0 = 0;
+    let threadP1 = 0;
+    for (const comment of thread.comments) {
+      if (comment.authorLogin !== GREPTILE_LOGIN) {
+        continue;
+      }
+      if (comment.commitOid === null || !headShaMatches(comment.commitOid, headSha)) {
+        continue;
+      }
+      const findings = detect(comment.body);
+      threadP0 += findings.p0_count;
+      threadP1 += findings.p1_count;
+    }
+
+    if (threadP0 + threadP1 > 0) {
+      p0Count += threadP0;
+      p1Count += threadP1;
+      unresolvedThreadCount += 1;
+    }
+  }
+
+  return { p0Count, p1Count, unresolvedThreadCount, error: null };
+}
+
+/** Fetch unresolved Greptile inline P0/P1 on the current HEAD via reviewThreads GraphQL (#2620). */
+export function fetchUnresolvedGreptileInlineFindings(
+  prNumber: number,
+  repo: string,
+  headSha: string,
+  runGh: RunGhFn,
+): InlineGreptileFindings {
+  const parsed = parseOwnerRepo(repo);
+  if (parsed === null) {
+    return { ...EMPTY_INLINE, error: `invalid repo: ${repo}` };
+  }
+
+  const allThreads: InlineReviewThread[] = [];
+  let after: string | null = null;
+  for (let page = 0; page < 10; page += 1) {
+    const cmd = [
+      "gh",
+      "api",
+      "graphql",
+      "-f",
+      `query=${REVIEW_THREADS_QUERY}`,
+      "-f",
+      `owner=${parsed.owner}`,
+      "-f",
+      `repo=${parsed.repo}`,
+      "-F",
+      `pr=${String(prNumber)}`,
+    ];
+    if (after !== null) {
+      cmd.push("-f", `after=${after}`);
+    }
+    const rc = runGh(cmd);
+    if (rc.returncode !== 0) {
+      return {
+        ...EMPTY_INLINE,
+        error: `graphql reviewThreads failed: ${rc.stderr.trim() || rc.stdout.trim()}`,
+      };
+    }
+    const pageResult = parseGraphqlReviewThreadsPage(rc.stdout);
+    if (pageResult.error !== null) {
+      return { ...EMPTY_INLINE, error: pageResult.error };
+    }
+    allThreads.push(...pageResult.threads);
+    if (!pageResult.hasNextPage) {
+      break;
+    }
+    after = pageResult.endCursor;
+  }
+
+  return evaluateInlineReviewThreads(allThreads, headSha);
+}

--- a/packages/core/src/pr-merge-readiness/greptile-inline.ts
+++ b/packages/core/src/pr-merge-readiness/greptile-inline.ts
@@ -238,7 +238,9 @@ export function fetchUnresolvedGreptileInlineFindings(
 
   const allThreads: InlineReviewThread[] = [];
   let after: string | null = null;
-  for (let page = 0; page < 10; page += 1) {
+  const maxPages = 10;
+  let hasNextPage = true;
+  for (let page = 0; hasNextPage && page < maxPages; page += 1) {
     const cmd = [
       "gh",
       "api",
@@ -267,7 +269,8 @@ export function fetchUnresolvedGreptileInlineFindings(
       return { ...EMPTY_INLINE, error: pageResult.error };
     }
     allThreads.push(...pageResult.threads);
-    if (!pageResult.hasNextPage) {
+    hasNextPage = pageResult.hasNextPage;
+    if (!hasNextPage) {
       break;
     }
     if (pageResult.endCursor === null) {
@@ -277,6 +280,13 @@ export function fetchUnresolvedGreptileInlineFindings(
       };
     }
     after = pageResult.endCursor;
+  }
+
+  if (hasNextPage) {
+    return {
+      ...EMPTY_INLINE,
+      error: `graphql reviewThreads pagination exceeded ${maxPages} pages`,
+    };
   }
 
   return evaluateInlineReviewThreads(allThreads, headSha);

--- a/packages/core/src/pr-merge-readiness/index.ts
+++ b/packages/core/src/pr-merge-readiness/index.ts
@@ -3,6 +3,15 @@ export { type ComputeGateOptions, computeGateResult, type FetchMergeabilityFn } 
 export * from "./constants.js";
 export { evaluateGates, isMergeReady } from "./evaluate.js";
 export { defaultRunGh } from "./gh.js";
+export {
+  evaluateInlineReviewThreads,
+  fetchUnresolvedGreptileInlineFindings,
+  headShaMatches,
+  type InlineGreptileFindings,
+  type InlineReviewComment,
+  type InlineReviewThread,
+  inlineFindingsToDict,
+} from "./greptile-inline.js";
 export { cmdPrMergeReadiness, parseArgs, run } from "./main.js";
 export {
   fetchMergeability,

--- a/packages/core/src/pr-merge-readiness/mergeability.test.ts
+++ b/packages/core/src/pr-merge-readiness/mergeability.test.ts
@@ -175,4 +175,15 @@ describe("verdictBlockIsSoftOnly", () => {
       true,
     );
   });
+
+  it("unresolved inline P0/P1 is a HARD block (#2620)", () => {
+    expect(
+      verdictBlockIsSoftOnly(verdict({ found: true, lastReviewedSha: HEAD, confidence: 5 }), HEAD, {
+        p0Count: 0,
+        p1Count: 1,
+        unresolvedThreadCount: 1,
+        error: null,
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/pr-merge-readiness/mergeability.test.ts
+++ b/packages/core/src/pr-merge-readiness/mergeability.test.ts
@@ -186,4 +186,15 @@ describe("verdictBlockIsSoftOnly", () => {
       }),
     ).toBe(false);
   });
+
+  it("inline fetch error is a HARD block (#2620)", () => {
+    expect(
+      verdictBlockIsSoftOnly(verdict({ found: true, lastReviewedSha: HEAD, confidence: 5 }), HEAD, {
+        p0Count: 0,
+        p1Count: 0,
+        unresolvedThreadCount: 0,
+        error: "graphql reviewThreads failed",
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/pr-merge-readiness/mergeability.ts
+++ b/packages/core/src/pr-merge-readiness/mergeability.ts
@@ -106,6 +106,9 @@ export function verdictBlockIsSoftOnly(
   headSha: string | null,
   inline: InlineGreptileFindings | null = null,
 ): boolean {
+  if (inline !== null && inline.error !== null) {
+    return false;
+  }
   if (inline !== null && inline.error === null && (inline.p0Count > 0 || inline.p1Count > 0)) {
     return false;
   }

--- a/packages/core/src/pr-merge-readiness/mergeability.ts
+++ b/packages/core/src/pr-merge-readiness/mergeability.ts
@@ -1,3 +1,4 @@
+import type { InlineGreptileFindings } from "./greptile-inline.js";
 import type { GreptileVerdict, RunGhFn } from "./types.js";
 
 /**
@@ -100,7 +101,15 @@ export function verdictShaIsStale(verdict: GreptileVerdict, headSha: string | nu
  * regardless of GitHub mergeability (guardrail: do not merge a PR with a real
  * P0/P1 review finding).
  */
-export function verdictBlockIsSoftOnly(verdict: GreptileVerdict, headSha: string | null): boolean {
+export function verdictBlockIsSoftOnly(
+  verdict: GreptileVerdict,
+  headSha: string | null,
+  inline: InlineGreptileFindings | null = null,
+): boolean {
+  if (inline !== null && inline.error === null && (inline.p0Count > 0 || inline.p1Count > 0)) {
+    return false;
+  }
+
   // Absent: no Greptile rolling-summary comment at all.
   if (!verdict.found) {
     return true;

--- a/packages/core/src/pr-merge-readiness/parse.test.ts
+++ b/packages/core/src/pr-merge-readiness/parse.test.ts
@@ -198,14 +198,50 @@ describe("evaluateGates", () => {
       ),
     ).toEqual([]);
   });
+
+  it("fails when unresolved inline P1 remains on current HEAD (#2620)", () => {
+    const failures = evaluateGates(1, HEAD, verdict(), {
+      p0Count: 0,
+      p1Count: 1,
+      unresolvedThreadCount: 1,
+      error: null,
+    });
+    expect(failures.some((f) => f.includes("unresolved inline P1"))).toBe(true);
+  });
+
+  it("fails closed when inline review comments cannot be verified", () => {
+    const failures = evaluateGates(1, HEAD, verdict(), {
+      p0Count: 0,
+      p1Count: 0,
+      unresolvedThreadCount: 0,
+      error: "graphql reviewThreads failed: rate limit",
+    });
+    expect(
+      failures.some((f) => f.includes("Could not verify Greptile inline review comments")),
+    ).toBe(true);
+  });
 });
 
 describe("computeGateResult layered fallbacks", () => {
+  const EMPTY_THREADS = JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+      },
+    },
+  });
+
   function installFakeGh(
     responses: Record<string, { returncode: number; stdout?: string; stderr?: string }>,
   ): RunGhFn {
     const classify = (cmd: readonly string[]): string => {
       const joined = cmd.join(" ");
+      if (joined.includes("graphql")) return "graphql";
       if (joined.includes("nameWithOwner")) return "repo-view";
       if (joined.includes("headRefOid")) return "head-sha";
       if (joined.includes("/check-runs")) return "check-runs";
@@ -219,20 +255,22 @@ describe("computeGateResult layered fallbacks", () => {
       const label = classify(cmd);
       const resp =
         responses[label] ??
-        (label === "check-runs"
-          ? {
-              returncode: 0,
-              stdout: JSON.stringify({
-                check_runs: [
-                  {
-                    name: "TypeScript (build + lint + test)",
-                    status: "completed",
-                    conclusion: "success",
-                  },
-                ],
-              }),
-            }
-          : { returncode: 1, stderr: `unexpected ${label}` });
+        (label === "graphql"
+          ? { returncode: 0, stdout: EMPTY_THREADS }
+          : label === "check-runs"
+            ? {
+                returncode: 0,
+                stdout: JSON.stringify({
+                  check_runs: [
+                    {
+                      name: "TypeScript (build + lint + test)",
+                      status: "completed",
+                      conclusion: "success",
+                    },
+                  ],
+                }),
+              }
+            : { returncode: 1, stderr: `unexpected ${label}` });
       return {
         returncode: resp.returncode,
         stdout: resp.stdout ?? "",

--- a/packages/core/src/pr-merge-readiness/parse.test.ts
+++ b/packages/core/src/pr-merge-readiness/parse.test.ts
@@ -220,6 +220,21 @@ describe("evaluateGates", () => {
       failures.some((f) => f.includes("Could not verify Greptile inline review comments")),
     ).toBe(true);
   });
+
+  it("blocks excluded-author PRs when unresolved inline P1 remains (#2620)", () => {
+    const failures = evaluateGates(
+      1,
+      HEAD,
+      verdict({ excludedAuthor: true, lastReviewedSha: null, confidence: null }),
+      {
+        p0Count: 0,
+        p1Count: 1,
+        unresolvedThreadCount: 1,
+        error: null,
+      },
+    );
+    expect(failures.some((f) => f.includes("unresolved inline P1"))).toBe(true);
+  });
 });
 
 describe("computeGateResult layered fallbacks", () => {


### PR DESCRIPTION
## Summary
- Add \greptile-inline\ probe that reads GitHub \eviewThreads\ for unresolved Greptile inline P0/P1 on the current HEAD SHA.
- Wire the probe into \pr:merge-ready\ so summary badge counts of zero cannot pass while open inline security threads remain.
- Block #2260 mergeability reconciliation when unresolved inline findings are present.

## Test plan
- [x] \pnpm -w exec vitest run packages/core/src/pr-merge-readiness/greptile-inline.test.ts packages/core/src/pr-merge-readiness/compute.test.ts packages/core/src/pr-merge-readiness/mergeability.test.ts packages/core/src/pr-merge-readiness/parse.test.ts\
- [x] \	ask verify:forward-coverage\
- [x] \pnpm run build\ + biome on changed paths

Closes #2620

Made with [Cursor](https://cursor.com)