### PR TITLE
fix(coverage): clear win32 branch residual for v0.79.1 cut (#2630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deft-core-guard allowlists installer-deposited `.prettierignore` (#2629).** Framework-only deposit PRs that include the #2534 Prettier gate exclusion no longer fail `no-mixed-core-and-app`. Closes #2629.
 - **issue:sync-from-xbrief cross-repo confused deputy (#2633).** `task issue:sync-from-xbrief` now gates comment POSTs with `isRepoMutationAllowed` (same cross-repo mutation gate as #2601 reconcile writers); cross-repo targets are refused unless `--allow-cross-repo` or an allowlist entry permits them. Closes #2633.
 - **Hook write-gate hints normalize Windows-style proposed paths on Linux CI (#2625).** Backslash `xbrief\proposed\...` targets now receive the lifecycle-artifact planning hint instead of the generic recovery message.
+- **Branch coverage meets the 85% floor on native Windows without coverage-debt (#2630).** Targeted tests for `capacity/show`, `story-quality`, and doctor-state branches lift win32 branch coverage above the release gate; `vitest.config.ts` documents that win32 runner caps affect timing only — the branch threshold matches Linux CI. Skill discovery uses repo-relative exclusion so `.deft-scratch` worktrees still find `content/skills`. Closes #2630.
 
 ### Removed
 

--- a/packages/core/src/capacity/show.test.ts
+++ b/packages/core/src/capacity/show.test.ts
@@ -1,13 +1,45 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { computeReport, renderReport } from "./show.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { recommendAutonomyLevel } from "../policy/autonomy.js";
+import { CAPACITY_UNIT_COST, resolveCapacityAllocation } from "../policy/capacity.js";
+import {
+  bucketDeficit,
+  classifyRecord,
+  computeReport,
+  evaluate,
+  iterVbriefPlans,
+  renderReport,
+  runCapacityShowCli,
+} from "./show.js";
 
-function makeProject(root: string): void {
+const NOW = new Date("2026-06-04T12:00:00Z");
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-cap-show-"));
+  roots.push(root);
+  return root;
+}
+
+function makeProject(root: string, capacity?: Record<string, unknown>): void {
   for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
     mkdirSync(join(root, "xbrief", folder), { recursive: true });
   }
+  const policy: Record<string, unknown> = {
+    capacityAllocation: capacity ?? {
+      unit: "vbrief-count",
+      window: 30,
+      enforcement: "advise",
+      minSampleSize: 5,
+      defaultBucket: "feature",
+      buckets: [
+        { id: "debt", target: 0.4 },
+        { id: "feature", target: 0.6 },
+      ],
+    },
+  };
   writeFileSync(
     join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
     `${JSON.stringify(
@@ -17,19 +49,7 @@ function makeProject(root: string): void {
           title: "Capacity test",
           status: "running",
           items: [],
-          policy: {
-            capacityAllocation: {
-              unit: "vbrief-count",
-              window: 30,
-              enforcement: "advise",
-              minSampleSize: 5,
-              defaultBucket: "feature",
-              buckets: [
-                { id: "debt", target: 0.4 },
-                { id: "feature", target: 0.6 },
-              ],
-            },
-          },
+          policy,
         },
       },
       null,
@@ -39,11 +59,17 @@ function makeProject(root: string): void {
   );
 }
 
+afterEach(() => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
 describe("capacity show", () => {
   it("reports advisory mode below minSampleSize", () => {
-    const root = mkdtempSync(join(tmpdir(), "deft-cap-show-"));
+    const root = tempRoot();
     makeProject(root);
-    const now = new Date("2026-06-04T12:00:00.000Z");
     writeFileSync(
       join(root, "xbrief", "completed", "done-0.xbrief.json"),
       `${JSON.stringify({
@@ -60,8 +86,184 @@ describe("capacity show", () => {
       })}\n`,
       { encoding: "utf8" },
     );
-    const report = computeReport(root, { now });
+    const report = computeReport(root, { now: NOW });
     expect(report.advisory_mode).toBe(true);
     expect(renderReport(report)).toContain("ADVISORY");
+  });
+
+  it("classifyRecord covers bucket, epic, rework, and cost branches", () => {
+    const allocation = resolveCapacityAllocation(tempRoot());
+    expect(classifyRecord({ metadata: {} }, "completed", allocation, NOW).bucket).toBe(
+      "unassigned",
+    );
+
+    const defaultBucketAlloc = {
+      ...allocation,
+      default_bucket: "feature",
+      buckets: [{ bucket_id: "feature", target: 1 }],
+    };
+    expect(classifyRecord({ metadata: {} }, "pending", defaultBucketAlloc, NOW).bucket).toBe(
+      "feature",
+    );
+
+    const decomposed = classifyRecord(
+      {
+        metadata: { kind: "epic", estimatedChildren: 2, outcome: "rework", cost: true },
+        references: [{ type: "x-vbrief/plan", uri: "child" }],
+      },
+      "completed",
+      allocation,
+      NOW,
+    );
+    expect(decomposed.weight).toBe(0);
+    expect(decomposed.is_rework).toBe(true);
+    expect(decomposed.cost).toBeNull();
+
+    const epicEstimate = classifyRecord(
+      { metadata: { kind: "epic", estimatedChildren: -1, cost: 3.5 } },
+      "pending",
+      allocation,
+      NOW,
+    );
+    expect(epicEstimate.weight).toBe(allocation.default_epic_estimate);
+    expect(epicEstimate.cost).toBe(3.5);
+
+    const inWindow = classifyRecord(
+      {
+        metadata: {
+          capacityBucket: "feature",
+          completedAt: "2026-06-03T12:00:00Z",
+        },
+      },
+      "completed",
+      allocation,
+      NOW,
+    );
+    expect(inWindow.in_window).toBe(true);
+    expect(inWindow.completed_at_present).toBe(true);
+  });
+
+  it("iterVbriefPlans skips missing folders and malformed artifacts", () => {
+    const root = tempRoot();
+    mkdirSync(join(root, "xbrief", "pending"), { recursive: true });
+    writeFileSync(join(root, "xbrief", "pending", "bad.xbrief.json"), "not-json");
+    writeFileSync(join(root, "xbrief", "pending", "note.txt"), "x");
+    writeFileSync(
+      join(root, "xbrief", "pending", "2026-06-03-good.xbrief.json"),
+      JSON.stringify({ xBRIEFInfo: { version: "0.8" }, plan: { metadata: {} } }),
+    );
+    expect(iterVbriefPlans(join(root, "xbrief")).length).toBe(1);
+    expect(iterVbriefPlans(join(root, "missing"))).toEqual([]);
+  });
+
+  it("computeReport covers cost-unit fallback and unclassified advisory reasons", () => {
+    const root = tempRoot();
+    makeProject(root, {
+      unit: CAPACITY_UNIT_COST,
+      window: 30,
+      enforcement: "advise",
+      minSampleSize: 5,
+      defaultBucket: "feature",
+      buckets: [{ id: "feature", target: 1 }],
+    });
+    writeFileSync(
+      join(root, "xbrief", "completed", "2026-06-03-a.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: { metadata: { capacityBucket: "feature", completedAt: "2026-06-03T12:00:00Z" } },
+      }),
+    );
+    writeFileSync(
+      join(root, "xbrief", "completed", "2026-06-03-unclassified.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: { metadata: { completedAt: "2026-06-03T12:00:00Z" } },
+      }),
+    );
+    const projectAllocation = resolveCapacityAllocation(root);
+    const report = computeReport(root, {
+      now: NOW,
+      allocation: { ...projectAllocation, unit: CAPACITY_UNIT_COST },
+    });
+    expect(report.unit_effective).toBe("vbrief-count");
+    expect(report.cost_fallback).toBe(true);
+    expect(report.advisory_reasons.some((r) => r.includes("unclassified"))).toBe(true);
+  });
+
+  it("renderReport covers backlog, autonomy, deficit, and empty bucket table", () => {
+    const root = tempRoot();
+    makeProject(root);
+    const report = computeReport(root, { now: NOW });
+    const negativeDeficitReport = {
+      ...report,
+      total_backward: 10,
+      buckets: [
+        {
+          bucket_id: "feature",
+          target: 0.1,
+          forward_weight: 0,
+          backward_weight: 5,
+          rework_weight: 0,
+          cost_actual: null,
+        },
+      ],
+      pending_by_kind: { gate: 2 },
+      autonomy_enabled: true,
+      autonomy: recommendAutonomyLevel("observe", {
+        override_rate: 0,
+        rework_rate: 0,
+        sample_size: 0,
+      }),
+      policy_error: "bad config",
+      cost_fallback: true,
+      unit_requested: CAPACITY_UNIT_COST,
+    };
+    const rendered = renderReport(negativeDeficitReport);
+    expect(rendered).toContain("by kind: gate=2");
+    expect(rendered).toContain("CONFIG ERROR");
+    expect(rendered).toContain("cost fallback active");
+    expect(rendered).toContain("Autonomy dial");
+    const [featureBucket] = negativeDeficitReport.buckets;
+    expect(featureBucket).toBeDefined();
+    if (!featureBucket) return;
+    expect(bucketDeficit(negativeDeficitReport, featureBucket)).toBeLessThan(0);
+    expect(renderReport({ ...report, buckets: [] })).toContain("no buckets configured");
+  });
+
+  it("evaluate and runCapacityShowCli cover CLI entry branches", () => {
+    const root = tempRoot();
+    makeProject(root);
+    writeFileSync(
+      join(root, "xbrief", "completed", "done-0.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: {
+          metadata: { capacityBucket: "feature", completedAt: "2026-06-03T12:00:00Z" },
+        },
+      }),
+    );
+
+    const fileRoot = tempRoot();
+    const notDir = join(fileRoot, "file.txt");
+    writeFileSync(notDir, "x");
+    const [badCode, badReport, badMessage] = evaluate(notDir);
+    expect(badCode).toBe(2);
+    expect(badReport).toBeNull();
+    expect(badMessage).toContain("not a directory");
+
+    const [okCode, okReport] = evaluate(root, { now: NOW });
+    expect(okCode).toBe(0);
+    expect(okReport).not.toBeNull();
+
+    const missingArg = runCapacityShowCli(["--project-root"]);
+    expect(missingArg.exitCode).toBe(2);
+    expect(missingArg.stderr).toContain("expected one argument");
+
+    const okCli = runCapacityShowCli(["--project-root", root]);
+    expect(okCli.exitCode).toBe(0);
+    expect(okCli.stdout).toContain("Capacity allocation");
+
+    const eqCli = runCapacityShowCli([`--project-root=${root}`]);
+    expect(eqCli.exitCode).toBe(0);
   });
 });

--- a/packages/core/src/content-contracts/skills/skill-frontmatter.ts
+++ b/packages/core/src/content-contracts/skills/skill-frontmatter.ts
@@ -40,8 +40,12 @@ function parseOsArray(fm: string): string[] | null {
   return [...body.matchAll(OS_TOKEN)].map((m) => m[1] ?? "");
 }
 
-function pathHasExcludedPart(filePath: string): boolean {
-  const parts = filePath.split(/[/\\]/);
+function pathHasExcludedPart(filePath: string, repoRoot: string = REPO_ROOT): boolean {
+  const rel = relative(repoRoot, filePath).replace(/\\/g, "/");
+  if (rel.startsWith("..") || rel.length === 0) {
+    return true;
+  }
+  const parts = rel.split("/");
   return parts.some((part) => EXCLUDED_PARTS.has(part));
 }
 

--- a/packages/core/src/doctor/doctor-branches.test.ts
+++ b/packages/core/src/doctor/doctor-branches.test.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { decideThrottle, formatIsoZ, readState, renderDoctorStatusLine } from "./doctor-state.js";
+
+describe("doctor branch coverage residual (#2630)", () => {
+  it("covers throttle skip reasons and status rendering", () => {
+    const dirtySkip = decideThrottle(
+      {
+        lastRunAt: new Date("2026-01-01T12:00:00Z"),
+        lastExitCode: 1,
+        lastFindingCount: 2,
+        lastErrorCount: 1,
+      },
+      new Date("2026-01-01T12:30:00Z"),
+    );
+    expect(dirtySkip.skip).toBe(true);
+    expect(renderDoctorStatusLine(dirtySkip)).toContain("UNRESOLVED");
+
+    const allow = decideThrottle(
+      {
+        lastRunAt: new Date("2020-01-01T00:00:00Z"),
+        lastExitCode: 0,
+        lastFindingCount: 0,
+        lastErrorCount: 0,
+      },
+      new Date("2030-01-01T00:00:00Z"),
+    );
+    expect(allow.skip).toBe(false);
+    expect(formatIsoZ(new Date("2026-01-01T00:00:00Z"))).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("readState returns null for missing cache dir", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-doc-branch-"));
+    try {
+      expect(readState(root)).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/vbrief-validation/story-quality-branches.test.ts
+++ b/packages/core/src/vbrief-validation/story-quality-branches.test.ts
@@ -139,4 +139,45 @@ describe("story-quality branch matrix", () => {
       }).some((i) => i.includes("file_scope_confidence above low")),
     ).toBe(true);
   });
+
+  it("covers userStory, acceptance count, and non-concurrent readiness skips", () => {
+    expect(
+      storyQualityIssues({ ...BASE, userStory: "Bad format" }).some((i) =>
+        i.includes("UserStory must match"),
+      ),
+    ).toBe(true);
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        acceptanceTexts: [BASE.acceptanceTexts[0] ?? ""],
+        acceptanceCountJustification: "",
+      }),
+    ).toContain("2-5 acceptance criteria required unless justified");
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        concurrentReady: false,
+        swarm: { ...BASE.swarm, parallel_safe: false, file_scope_confidence: "low" },
+      }).some((i) => i.includes("parallel_safe=true")),
+    ).toBe(false);
+  });
+
+  it("covers nested helpers and missing swarm fields", () => {
+    expect(asStrList(null)).toEqual([]);
+    expect(asStrList("  only  ")).toEqual(["only"]);
+    expect(
+      acceptanceTextsFromItems([
+        null,
+        { narrative: { Acceptance: " nested " } },
+        { items: [{ narrative: { Acceptance: "child" } }] },
+      ]),
+    ).toEqual(["nested", "child"]);
+    expect(itemHasTraces({ items: [{ narrative: { Traces: "FR-2" } }] })).toBe(true);
+    expect(missingRequiredSwarmFields({ file_scope: ["a"] })).toContain(
+      "plan.metadata.swarm.verify_commands",
+    );
+    expect(
+      deprecatedSubitemsIssues([{ subItems: [{ narrative: { Acceptance: "x" } }] }]),
+    ).toContain("plan.items[0].subItems is deprecated; use items");
+  });
 });

--- a/packages/core/src/vitest-runner/vitest-config-contract.test.ts
+++ b/packages/core/src/vitest-runner/vitest-config-contract.test.ts
@@ -94,3 +94,19 @@ describe("vitest.config.ts coverage threshold contract (#2573)", () => {
     expect(source).toMatch(/resolveCoverageDebtIssue/);
   });
 });
+
+describe("vitest.config.ts Windows vs CI branch parity (#2630)", () => {
+  const source = readFileSync(configPath, "utf8");
+
+  it("uses the same 85% branch threshold on win32 and Linux CI", () => {
+    expect(source).toContain("#2630");
+    expect(source).toMatch(/branches:\s*85/);
+    expect(source).not.toMatch(/isWin32\s*\?\s*84\.85/);
+  });
+
+  it("documents that win32 runner caps affect timing only, not the coverage floor", () => {
+    expect(source).toMatch(/Native Windows full-suite \+ coverage/);
+    expect(source).toMatch(/coverageEnabled/);
+    expect(source).toMatch(/coverageThresholds/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,9 @@ const coverageThresholds = {
   lines: 85,
   functions: 85,
   // Fail-closed at 85 on all platforms; hairline misses use --allow-coverage-debt=#N (#2573).
+  // Win32 uses capped workers under --coverage (#2546/#2634) for coordinator headroom, but the
+  // floor is identical to Linux CI — a local 84.91% vs CI-green gap was uncovered branches, not
+  // threshold asymmetry (#2630).
   branches: 85,
   statements: 85,
 } as const;


### PR DESCRIPTION
## Summary
- Add targeted branch-coverage tests for `capacity/show`, `story-quality`, and `doctor-state` so native Windows `pnpm run test --coverage` meets the 85% floor (measured 85.00% on win32) without `--allow-coverage-debt`.
- Document Windows-vs-CI threshold parity in `vitest.config.ts` and extend the vitest config contract tests (#2630).
- Fix skill `SKILL.md` discovery to apply exclusion checks on repo-relative paths so `.deft-scratch` worktrees still find `content/skills`.

## Test plan
- [x] `task check` green on native Windows (branches 85.00%)
- [x] `pnpm exec vitest run packages/core/src/capacity/show.test.ts packages/core/src/vbrief-validation/story-quality-branches.test.ts packages/core/src/doctor/doctor-branches.test.ts`
- [x] Greptile CLEAN on current HEAD

Closes #2630
