### PR TITLE
fix(cli): route scope:promote colon and dash aliases (#2654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`deft scope:promote` / `scope:activate` / `scope:complete` now resolve on the npm CLI (#2654).** Colon- and dash-style scope lifecycle verbs advertised in `deft help` and `deft commands` route through `scope-lifecycle` the same way as `deft scope promote`; previously only the two-token form worked and colon tokens returned `unknown verb`. Closes #2654.
 - **Vitest coverage / release Step 5 no longer hangs indefinitely (#2652).** Fixed an infinite `pr-monitor` poll loop when Greptile inline GraphQL was unmocked in unit tests; added Step 5 and GHA vitest hard timeouts (20m), production `--skip-ci` incident citation (`--allow-skip-ci=#N`), and recovery docs. Also: `task pr:watch -- --help` / `-h` print usage (flags + exits 0/1/2); `directive pr:watch` alias; swarm skill aligned to the #1056 three-state contract. Closes #2652.
 
 ### Removed

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -209,6 +209,28 @@ function routeNamespaceVerb(ns: string, verb: string, rest: string[]): RoutedArg
   return null;
 }
 
+/** Split `namespace:verb` task keys (e.g. scope:promote) for namespace routing (#2654). */
+function tryColonNamespaceRoute(first: string, rest: readonly string[]): RoutedArgv | null {
+  // Registered colon aliases (policy:show, pr:watch, …) stay on the flat path.
+  if (resolveCanonicalVerb(first) !== null) return null;
+  const colon = first.indexOf(":");
+  if (colon <= 0) return null;
+  const ns = first.slice(0, colon);
+  const verb = first.slice(colon + 1);
+  if (verb.length === 0) return null;
+  return routeNamespaceVerb(ns, verb, [...rest]);
+}
+
+/** Split `scope-<verb>` dash aliases (e.g. scope-promote) for namespace routing (#2654). */
+function tryScopeDashRoute(first: string, rest: readonly string[]): RoutedArgv | null {
+  if (resolveCanonicalVerb(first) !== null) return null;
+  const prefix = "scope-";
+  if (!first.startsWith(prefix)) return null;
+  const verb = first.slice(prefix.length);
+  if (verb.length === 0) return null;
+  return routeNamespaceVerb("scope", verb, [...rest]);
+}
+
 function routeThreeToken(
   ns: string,
   verb: string,
@@ -256,6 +278,12 @@ export function routeArgv(argv: readonly string[]): RoutedArgv {
 
   const topLevel = routeTopLevel(first, argv.slice(1));
   if (topLevel !== null) return topLevel;
+
+  const colonRoute = tryColonNamespaceRoute(first, argv.slice(1));
+  if (colonRoute !== null) return colonRoute;
+
+  const scopeDashRoute = tryScopeDashRoute(first, argv.slice(1));
+  if (scopeDashRoute !== null) return scopeDashRoute;
 
   if (argv.length === 1 && resolveCanonicalVerb(first) !== null) {
     return { kind: "dispatch", argv: [first] };

--- a/packages/cli/src/cli-router/router.test.ts
+++ b/packages/cli/src/cli-router/router.test.ts
@@ -43,6 +43,35 @@ describe("routeArgv", () => {
     ]);
   });
 
+  it("maps scope:promote colon alias to scope-lifecycle promote (#2654)", () => {
+    expect(routeArgv(["scope:promote", "path.xbrief.json"]).argv).toEqual([
+      "scope-lifecycle",
+      "promote",
+      "path.xbrief.json",
+    ]);
+    expect(routeArgv(["scope:promote"]).argv).toEqual(["scope-lifecycle", "promote"]);
+    expect(routeArgv(["scope:activate", "xbrief/pending/story.xbrief.json"]).argv).toEqual([
+      "scope-lifecycle",
+      "activate",
+      "xbrief/pending/story.xbrief.json",
+    ]);
+    expect(routeArgv(["scope:complete", "xbrief/active/story.xbrief.json"]).argv).toEqual([
+      "scope-lifecycle",
+      "complete",
+      "xbrief/active/story.xbrief.json",
+    ]);
+  });
+
+  it("maps scope-promote dash alias to scope-lifecycle promote (#2654)", () => {
+    expect(routeArgv(["scope-promote", "path.xbrief.json"]).argv).toEqual([
+      "scope-lifecycle",
+      "promote",
+      "path.xbrief.json",
+    ]);
+    expect(routeArgv(["scope-activate"]).argv).toEqual(["scope-lifecycle", "activate"]);
+    expect(routeArgv(["scope-demote"]).argv).toEqual(["scope-demote"]);
+  });
+
   it("maps triage queue to triage:queue", () => {
     expect(routeArgv(["triage", "queue", "--limit", "5"]).argv).toEqual([
       "triage:queue",
@@ -192,6 +221,20 @@ describe("routeAndDispatch", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("routes scope:promote colon alias to scope-lifecycle handler (#2654)", async () => {
+    const handler = vi.fn(() => 0);
+    vi.doMock("../scope-lifecycle.js", () => ({ run: handler }));
+    resetHandlerCacheForTests();
+
+    await routeAndDispatch(["scope:promote", "--help"], {
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0]?.[0]).toEqual(["promote", "--help"]);
   });
 
   it("routes verify branch to the same handler as verify:branch", async () => {


### PR DESCRIPTION
## Summary

- Route single-token colon forms (`scope:promote`, `scope:activate`, `scope:complete`) and dash aliases (`scope-promote`, etc.) through the existing `scope-lifecycle` namespace handler in `routeArgv`, matching help/commands and the two-token `deft scope promote` surface.
- Skip colon splitting when the token is already a registered flat alias (e.g. `policy:show`, `pr:watch`) so #2367 / #2652 behavior is preserved.
- Add router regression tests and CHANGELOG entry.

Closes #2654

## Test plan

- [x] `pnpm exec vitest run packages/cli/src/cli-router/router.test.ts packages/cli/src/dispatch.test.ts`
- [x] `node packages/cli/dist/bin.js scope:promote` routes to scope-lifecycle (usage error, not unknown verb)
- [x] `node packages/cli/dist/bin.js scope-promote` same
- [ ] CI `task check`
