### PR TITLE
refactor(version): consolidate duplicate release-tag parsers (#2525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Release-tag parsing lives in one module (#2525).** `packages/core/src/release/version.ts` now owns parse, publishability, PEP 440 normalization, and prerelease ordering; platform latest-tag selection and doctor release checks consume that contract instead of a duplicate parser in `resolve-version.ts`. Closes #2525.
+
 ### Fixed
 
 - **Vitest coverage / release Step 5 no longer hangs indefinitely (#2652).** Fixed an infinite `pr-monitor` poll loop when Greptile inline GraphQL was unmocked in unit tests; added Step 5 and GHA vitest hard timeouts (20m), production `--skip-ci` incident citation (`--allow-skip-ci=#N`), and recovery docs. Also: `task pr:watch -- --help` / `-h` print usage (flags + exits 0/1/2); `directive pr:watch` alias; swarm skill aligned to the #1056 three-state contract. Closes #2652.

--- a/packages/core/src/platform/branch-coverage.test.ts
+++ b/packages/core/src/platform/branch-coverage.test.ts
@@ -121,15 +121,18 @@ describe("resolve-version parse + classify branch coverage", () => {
     const prevRoot = process.env.DEFT_ROOT;
     const prevEnv = process.env[ENV_VAR];
     delete process.env[ENV_VAR];
-    withTempDir((dir) => {
-      writeFileSync(join(dir, ".deft-version"), "v4.5.6\n", "utf8");
-      process.env.DEFT_ROOT = dir;
-      expect(resolveVersion()).toBe("4.5.6");
-    });
-    if (prevRoot === undefined) delete process.env.DEFT_ROOT;
-    else process.env.DEFT_ROOT = prevRoot;
-    if (prevEnv === undefined) delete process.env[ENV_VAR];
-    else process.env[ENV_VAR] = prevEnv;
+    try {
+      withTempDir((dir) => {
+        writeFileSync(join(dir, ".deft-version"), "v4.5.6\n", "utf8");
+        process.env.DEFT_ROOT = dir;
+        expect(resolveVersion()).toBe("4.5.6");
+      });
+    } finally {
+      if (prevRoot === undefined) delete process.env.DEFT_ROOT;
+      else process.env.DEFT_ROOT = prevRoot;
+      if (prevEnv === undefined) delete process.env[ENV_VAR];
+      else process.env[ENV_VAR] = prevEnv;
+    }
   });
 
   it("resolveVersion default seams read manifest / deft-version / env", () => {

--- a/packages/core/src/platform/branch-coverage.test.ts
+++ b/packages/core/src/platform/branch-coverage.test.ts
@@ -110,8 +110,26 @@ describe("resolve-version parse + classify branch coverage", () => {
     expect(latestPublishableTag(["v1.2.0-rc.1", "v1.2.0"])).toBe("v1.2.0");
     expect(latestPublishableTag([])).toBeNull();
     expect(latestPublishableTag(["nope", "v0.0.0-test.9"])).toBeNull();
-    // Two identical keys exercise the compareTuple "all equal" (return 0) branch.
+    // Two identical keys exercise the compare "all equal" (return 0) branch.
     expect(latestPublishableTag(["v1.0.0", "v1.0.0"])).toBe("v1.0.0");
+    expect(latestPublishableTag(["v1.0.0-alpha.1", "v1.0.0-beta.1", "v1.0.0-rc.1"])).toBe(
+      "v1.0.0-rc.1",
+    );
+  });
+
+  it("resolveVersion honors DEFT_ROOT when frameworkRoot seam omitted", () => {
+    const prevRoot = process.env.DEFT_ROOT;
+    const prevEnv = process.env[ENV_VAR];
+    delete process.env[ENV_VAR];
+    withTempDir((dir) => {
+      writeFileSync(join(dir, ".deft-version"), "v4.5.6\n", "utf8");
+      process.env.DEFT_ROOT = dir;
+      expect(resolveVersion()).toBe("4.5.6");
+    });
+    if (prevRoot === undefined) delete process.env.DEFT_ROOT;
+    else process.env.DEFT_ROOT = prevRoot;
+    if (prevEnv === undefined) delete process.env[ENV_VAR];
+    else process.env[ENV_VAR] = prevEnv;
   });
 
   it("resolveVersion default seams read manifest / deft-version / env", () => {

--- a/packages/core/src/platform/resolve-version.ts
+++ b/packages/core/src/platform/resolve-version.ts
@@ -2,113 +2,20 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  comparePublishableVersions,
+  isPublishable,
+  NonPublishableVersionError,
+  toPep440,
+} from "../release/version.js";
 import { DEV_FALLBACK, ENV_VAR } from "./constants.js";
 
-export { DEV_FALLBACK, ENV_VAR };
-
-export class NonPublishableVersionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "NonPublishableVersionError";
-  }
-}
-
-const PRE_KIND_MAP: Record<string, string> = {
-  alpha: "a",
-  beta: "b",
-  rc: "rc",
-};
-
-const NON_PUBLISHABLE_KINDS = new Set(["test"]);
-
-const PRERELEASE_RANK: Record<string, number> = {
-  alpha: 0,
-  beta: 1,
-  rc: 2,
-  "": 3,
-};
+export { DEV_FALLBACK, ENV_VAR, isPublishable, NonPublishableVersionError, toPep440 };
 
 function frameworkRoot(): string {
   const envRoot = process.env.DEFT_ROOT?.trim();
   if (envRoot) return resolve(envRoot);
   return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
-}
-
-/** Parse `[v]X.Y.Z[-(rc|alpha|beta|test).N]` via linear scan. */
-function parsePep440Tag(
-  version: string,
-): { major: number; minor: number; patch: number; kind: string | null; num: number | null } | null {
-  let i = 0;
-  if (version[i] === "v" || version[i] === "V") i += 1;
-  const readInt = (): number | null => {
-    const ch = version[i] ?? "";
-    if (i >= version.length || ch < "0" || ch > "9") return null;
-    let n = 0;
-    while (i < version.length) {
-      const digit = version[i] ?? "";
-      if (digit < "0" || digit > "9") break;
-      n = n * 10 + Number(digit);
-      i += 1;
-    }
-    return n;
-  };
-  const major = readInt();
-  if (major === null || version[i] !== ".") return null;
-  i += 1;
-  const minor = readInt();
-  if (minor === null || version[i] !== ".") return null;
-  i += 1;
-  const patch = readInt();
-  if (patch === null) return null;
-  if (i >= version.length) return { major, minor, patch, kind: null, num: null };
-  if (version[i] !== "-") return null;
-  i += 1;
-  const kindStart = i;
-  while (i < version.length && version[i] !== ".") i += 1;
-  if (i >= version.length || version[i] !== ".") return null;
-  const kind = version.slice(kindStart, i);
-  if (!["rc", "alpha", "beta", "test"].includes(kind)) return null;
-  i += 1;
-  const num = readInt();
-  if (num === null || i !== version.length) return null;
-  return { major, minor, patch, kind, num };
-}
-
-export function toPep440(version: string): string {
-  if (typeof version !== "string") {
-    throw new Error(`version must be a string, got ${typeof version}`);
-  }
-  const candidate = version.trim();
-  if (!candidate) throw new Error("version must be a non-empty string");
-  const parsed = parsePep440Tag(candidate);
-  if (parsed === null) {
-    throw new Error(
-      `Cannot normalize ${JSON.stringify(candidate)} to PEP 440: expected [v]X.Y.Z or [v]X.Y.Z-(rc|alpha|beta|test).N`,
-    );
-  }
-  const base = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
-  if (parsed.kind === null) return base;
-  if (NON_PUBLISHABLE_KINDS.has(parsed.kind)) {
-    throw new NonPublishableVersionError(
-      `Version ${JSON.stringify(candidate)} carries non-publishable pre-release tag ${JSON.stringify(parsed.kind)}.${parsed.num} -- release pipeline MUST skip pyproject.toml [project].version sync for this tag.`,
-    );
-  }
-  const pepKind = PRE_KIND_MAP[parsed.kind];
-  if (pepKind === undefined) {
-    throw new Error(
-      `Unmapped pre-release kind ${JSON.stringify(parsed.kind)} for version ${JSON.stringify(candidate)}; add it to PRE_KIND_MAP or NON_PUBLISHABLE_KINDS to keep parser in lockstep with the publishability classifier.`,
-    );
-  }
-  return `${base}${pepKind}${parsed.num}`;
-}
-
-export function isPublishable(version: string): boolean {
-  try {
-    toPep440(version);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export function tagNameFromRef(ref: string): string {
@@ -122,53 +29,18 @@ export function tagNameFromRef(ref: string): string {
   return candidate.trim();
 }
 
-function publishableTagSortKey(version: string): [number, number, number, number, number] {
-  const candidate = version.trim();
-  const parsed = parsePep440Tag(candidate);
-  if (parsed === null) {
-    throw new Error(
-      `Cannot sort ${JSON.stringify(candidate)}: expected [v]X.Y.Z or [v]X.Y.Z-(rc|alpha|beta).N`,
-    );
-  }
-  if (parsed.kind !== null && NON_PUBLISHABLE_KINDS.has(parsed.kind)) {
-    throw new NonPublishableVersionError(
-      `Version ${JSON.stringify(candidate)} carries non-publishable pre-release tag ${JSON.stringify(parsed.kind)}.`,
-    );
-  }
-  const kind = parsed.kind ?? "";
-  const prereleaseRank = PRERELEASE_RANK[kind];
-  if (prereleaseRank === undefined) {
-    throw new Error(
-      `Unmapped pre-release kind ${JSON.stringify(parsed.kind)} for ${JSON.stringify(candidate)}`,
-    );
-  }
-  return [parsed.major, parsed.minor, parsed.patch, prereleaseRank, parsed.num ?? 0];
-}
-
 export function latestPublishableTag(tags: Iterable<string>): string | null {
   let bestTag: string | null = null;
-  let bestKey: [number, number, number, number, number] | null = null;
   for (const raw of tags) {
     const tag = tagNameFromRef(raw);
     if (!tag || !isPublishable(tag)) continue;
     try {
-      const key = publishableTagSortKey(tag);
-      if (bestKey === null || compareTuple(key, bestKey) > 0) {
+      if (bestTag === null || comparePublishableVersions(tag, bestTag) > 0) {
         bestTag = tag;
-        bestKey = key;
       }
     } catch {}
   }
   return bestTag;
-}
-
-function compareTuple(a: readonly number[], b: readonly number[]): number {
-  for (let i = 0; i < a.length; i += 1) {
-    const av = a[i] ?? 0;
-    const bv = b[i] ?? 0;
-    if (av !== bv) return av > bv ? 1 : -1;
-  }
-  return 0;
 }
 
 function readManifestTag(baseDir: string): string | null {

--- a/packages/core/src/release/version.test.ts
+++ b/packages/core/src/release/version.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   comparePublishableVersions,
   isPrereleaseTag,
+  isPublishable,
   NonPublishableVersionError,
   toPep440,
   validateVersion,
@@ -39,6 +40,7 @@ describe("isPrereleaseTag", () => {
 describe("toPep440", () => {
   it.each([
     ["v0.22.0", "0.22.0"],
+    ["V1.2.3", "1.2.3"],
     ["0.20.0-rc.3", "0.20.0rc3"],
     ["0.20.0-beta.2", "0.20.0b2"],
     ["0.20.0-alpha.1", "0.20.0a1"],
@@ -53,6 +55,31 @@ describe("toPep440", () => {
   it("rejects garbage input", () => {
     expect(() => toPep440("")).toThrow(/non-empty/);
     expect(() => toPep440("not-a-version")).toThrow(/Cannot normalize/);
+    expect(() => toPep440(123 as unknown as string)).toThrow(/must be a string/);
+    for (const bad of [
+      "abc",
+      "1",
+      "1.2",
+      "1.x",
+      "1.2.",
+      "1.2.x",
+      "1.2.3extra",
+      "1.2.3-rcX",
+      "1.2.3-foo.1",
+      "1.2.3-rc.X",
+      "1.2.3-rc.1x",
+    ]) {
+      expect(() => toPep440(bad), bad).toThrow(/Cannot normalize/);
+    }
+  });
+});
+
+describe("isPublishable", () => {
+  it("classifies publishability", () => {
+    expect(isPublishable("1.0.0")).toBe(true);
+    expect(isPublishable("1.3.0-rc.1")).toBe(true);
+    expect(isPublishable("0.0.0-test.1")).toBe(false);
+    expect(isPublishable("bad")).toBe(false);
   });
 });
 

--- a/packages/core/src/release/version.ts
+++ b/packages/core/src/release/version.ts
@@ -1,6 +1,3 @@
-const PEP440_TAG_RE =
-  /^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<kind>rc|alpha|beta|test)\.(?<num>\d+))?$/;
-
 const PRE_KIND_MAP: Record<string, string> = {
   alpha: "a",
   beta: "b",
@@ -23,6 +20,52 @@ export class NonPublishableVersionError extends Error {
   }
 }
 
+interface ParsedReleaseTag {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly kind: string | null;
+  readonly num: number | null;
+}
+
+/** Parse `[v]X.Y.Z[-(rc|alpha|beta|test).N]` via linear scan. */
+function parseReleaseTag(version: string): ParsedReleaseTag | null {
+  let i = 0;
+  if (version[i] === "v" || version[i] === "V") i += 1;
+  const readInt = (): number | null => {
+    const ch = version[i] ?? "";
+    if (i >= version.length || ch < "0" || ch > "9") return null;
+    let n = 0;
+    while (i < version.length) {
+      const digit = version[i] ?? "";
+      if (digit < "0" || digit > "9") break;
+      n = n * 10 + Number(digit);
+      i += 1;
+    }
+    return n;
+  };
+  const major = readInt();
+  if (major === null || version[i] !== ".") return null;
+  i += 1;
+  const minor = readInt();
+  if (minor === null || version[i] !== ".") return null;
+  i += 1;
+  const patch = readInt();
+  if (patch === null) return null;
+  if (i >= version.length) return { major, minor, patch, kind: null, num: null };
+  if (version[i] !== "-") return null;
+  i += 1;
+  const kindStart = i;
+  while (i < version.length && version[i] !== ".") i += 1;
+  if (i >= version.length || version[i] !== ".") return null;
+  const kind = version.slice(kindStart, i);
+  if (!["rc", "alpha", "beta", "test"].includes(kind)) return null;
+  i += 1;
+  const num = readInt();
+  if (num === null || i !== version.length) return null;
+  return { major, minor, patch, kind, num };
+}
+
 /** Raise Error when version does not match strict X.Y.Z semver. */
 export function validateVersion(version: string): void {
   if (!/^\d+\.\d+\.\d+$/.test(version)) {
@@ -36,7 +79,7 @@ export function validateVersion(version: string): void {
 /** Return true when version carries a SemVer pre-release suffix (#425). */
 export function isPrereleaseTag(version: string): boolean {
   let candidate = version.trim();
-  if (candidate.startsWith("v")) {
+  if (candidate.startsWith("v") || candidate.startsWith("V")) {
     candidate = candidate.slice(1);
   }
   return candidate.includes("-");
@@ -51,38 +94,31 @@ export function toPep440(version: string): string {
   if (!candidate) {
     throw new Error("version must be a non-empty string");
   }
-  const match = PEP440_TAG_RE.exec(candidate);
-  if (match?.groups === undefined) {
+  const parsed = parseReleaseTag(candidate);
+  if (parsed === null) {
     throw new Error(
       `Cannot normalize '${candidate}' to PEP 440: expected ` +
         "[v]X.Y.Z or [v]X.Y.Z-(rc|alpha|beta|test).N",
     );
   }
-  const major = Number(match.groups.major);
-  const minor = Number(match.groups.minor);
-  const patch = Number(match.groups.patch);
-  const base = `${major}.${minor}.${patch}`;
-  const kind = match.groups.kind;
-  if (kind === undefined) {
-    return base;
-  }
-  if (NON_PUBLISHABLE_KINDS.has(kind)) {
+  const base = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+  if (parsed.kind === null) return base;
+  if (NON_PUBLISHABLE_KINDS.has(parsed.kind)) {
     throw new NonPublishableVersionError(
       `Version '${candidate}' carries non-publishable pre-release ` +
-        `tag '${kind}'.${match.groups.num} -- release pipeline MUST ` +
+        `tag '${parsed.kind}'.${parsed.num} -- release pipeline MUST ` +
         "skip pyproject.toml [project].version sync for this tag.",
     );
   }
-  const pepKind = PRE_KIND_MAP[kind];
+  const pepKind = PRE_KIND_MAP[parsed.kind];
   if (pepKind === undefined) {
     throw new Error(
-      `Unmapped pre-release kind '${kind}' for version '${candidate}'; ` +
-        "add it to _PRE_KIND_MAP or _NON_PUBLISHABLE_KINDS to keep " +
-        "_PEP440_TAG_RE in lockstep with the publishability classifier.",
+      `Unmapped pre-release kind '${parsed.kind}' for version '${candidate}'; ` +
+        "add it to PRE_KIND_MAP or NON_PUBLISHABLE_KINDS to keep the parser " +
+        "in lockstep with the publishability classifier.",
     );
   }
-  const pepNum = Number(match.groups.num);
-  return `${base}${pepKind}${pepNum}`;
+  return `${base}${pepKind}${parsed.num}`;
 }
 
 export function isPublishable(version: string): boolean {
@@ -98,29 +134,23 @@ function publishableVersionSortKey(
   version: string,
 ): readonly [number, number, number, number, number] {
   const candidate = version.trim();
-  const match = PEP440_TAG_RE.exec(candidate);
-  if (match?.groups === undefined) {
+  const parsed = parseReleaseTag(candidate);
+  if (parsed === null) {
     throw new Error(
-      `Cannot compare '${candidate}': expected ` + "[v]X.Y.Z or [v]X.Y.Z-(rc|alpha|beta).N",
+      `Cannot compare '${candidate}': expected [v]X.Y.Z or [v]X.Y.Z-(rc|alpha|beta).N`,
     );
   }
-  const kind = match.groups.kind ?? "";
-  if (NON_PUBLISHABLE_KINDS.has(kind)) {
+  if (parsed.kind !== null && NON_PUBLISHABLE_KINDS.has(parsed.kind)) {
     throw new NonPublishableVersionError(
-      `Version '${candidate}' carries non-publishable pre-release tag '${kind}'.${match.groups.num}.`,
+      `Version '${candidate}' carries non-publishable pre-release tag '${parsed.kind}'.${parsed.num}.`,
     );
   }
+  const kind = parsed.kind ?? "";
   const rank = PRERELEASE_RANK[kind];
   if (rank === undefined) {
     throw new Error(`Cannot compare '${candidate}': unsupported pre-release kind '${kind}'.`);
   }
-  return [
-    Number(match.groups.major),
-    Number(match.groups.minor),
-    Number(match.groups.patch),
-    rank,
-    Number(match.groups.num ?? 0),
-  ];
+  return [parsed.major, parsed.minor, parsed.patch, rank, parsed.num ?? 0];
 }
 
 /** Compare two publishable Deft release versions using stable/prerelease ordering. */

--- a/xbrief/active/2026-07-20-2525-refactorversion-consolidate-duplicate-release-tag-parsers.xbrief.json
+++ b/xbrief/active/2026-07-20-2525-refactorversion-consolidate-duplicate-release-tag-parsers.xbrief.json
@@ -1,0 +1,31 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2525"
+  },
+  "plan": {
+    "title": "refactor(version): consolidate duplicate release-tag parsers",
+    "status": "running",
+    "narratives": {
+      "Description": "refactor(version): consolidate duplicate release-tag parsers",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2525",
+      "Overview": "## Summary\n\nRelease-tag parsing and publishability ordering are implemented twice:\n\n- `packages/core/src/release/version.ts` owns #425 prerelease classification and PEP 440 normalization.\n- `packages/core/src/platform/resolve-version.ts` carries a separate private parser, publishability classifier, prerelease rank, and PEP 440 normalization.\n\nThe duplicate contracts can drift on accepted syntax, error behavior, and ordering.\n\n## Proposed direction\n\nMake one low-level release-version module own parsing, publishability, normalization, and comparison. Have platform tag selection and doctor release availability consume that contract without circular imports.\n\n## Acceptance\n\n- One parser defines supported stable/alpha/beta/rc/test syntax.\n- Platform latest-tag selection and release publication keep their current behavior.\n- Existing branch/coverage tests remain green and direct comparison tests cover prerelease ordering.\n\n## Source\n\nDiscovered while implementing #1692. That PR will use the release module cited by #425 and will not broaden into this refactor.",
+      "Labels": "operational, refactor, area:release, release"
+    },
+    "items": [],
+    "tags": [
+      "operational",
+      "refactor",
+      "area:release",
+      "release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2525",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2525: refactor(version): consolidate duplicate release-tag parsers"
+      }
+    ],
+    "updated": "2026-07-20T00:25:13Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Consolidate release-tag parsing into `packages/core/src/release/version.ts` as the single owner of parse, publishability, PEP 440 normalization, and prerelease ordering.
- `platform/resolve-version.ts` now re-exports the release contract and uses `comparePublishableVersions` for latest-tag selection instead of a duplicate private parser.
- Platform latest-tag behavior, doctor release checks, and existing branch/coverage tests remain green; added uppercase `V` prefix and DEFT_ROOT default-path coverage.

## Test plan

- [x] `vitest run packages/core/src/release/version.test.ts`
- [x] `vitest run packages/core/src/platform/branch-coverage.test.ts`
- [x] `vitest run packages/core/src/content-contracts/standards/pyproject_version_freshness.test.ts`
- [x] Biome lint on changed files

Closes #2525
