### PR TITLE
ci: run TypeScript and Go jobs on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ env:
 jobs:
   ts:
     name: TypeScript (build + lint + test)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted: Blacksmith `blacksmith-4vcpu-ubuntu-2404` left required CI
+    # queued for hours with nothing in_progress (2026-07-19 cohort #2658–#2660).
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -76,7 +78,8 @@ jobs:
 
   go:
     name: Go (test + build)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # See ts job: GitHub-hosted until Blacksmith capacity is reliable again.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI TypeScript and Go jobs run on GitHub-hosted `ubuntu-latest`.** Required `CI` had been stuck `queued` for hours on Blacksmith `blacksmith-4vcpu-ubuntu-2404` with nothing `in_progress`; Windows already used `windows-latest`. Unblocks PR CI when Blacksmith capacity stalls.
 - **Release-tag parsing lives in one module (#2525).** `packages/core/src/release/version.ts` now owns parse, publishability, PEP 440 normalization, and prerelease ordering; platform latest-tag selection and doctor release checks consume that contract instead of a duplicate parser in `resolve-version.ts`. Closes #2525.
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/ci.yml` TypeScript and Go jobs from `blacksmith-4vcpu-ubuntu-2404` to GitHub-hosted `ubuntu-latest`.
- Windows job already uses `windows-latest`.
- Unblocks required CI that was stuck `queued` for hours with nothing `in_progress` (cohort PRs #2658 / #2659).

## Test plan
- [ ] CI TypeScript + Go jobs start on `ubuntu-latest` (not Blacksmith)
- [ ] Suite green on this PR
- [ ] Rebase open cohort PRs onto master after merge
