### PR TITLE
fix(deposit): rewrite xbrief schema descriptions off vbrief/.eval paths (#2670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Pre-PR ordered-plan gate uses the current entry kind (#2662).** `deft-directive-pre-pr` no longer hardcodes `--target-kind pr`; agents resolve `kind` and `id` via `task plan-sequence:current` before `task verify:plan-sequence`, so story-backed PRs pass the gate when the target id matches. Closes #2662.
 - **AGENTS always-loads the #2646 body-file recipe (#2671).** Multi-line git/gh bodies on Windows PowerShell are now an inline MUST/⊗ rule in the managed AGENTS section (not a lazy index pointer to `scm/github.md`). Closes #2671.
+- **Deposited `xbrief/schemas/` descriptions no longer regress to `vbrief/.eval/` paths (#2670).** `deft update` now rewrites legacy eval-path references to `xbrief/.eval/` when projecting framework schemas into the consumer tree, and a deposit self-check fails if any projected schema description still cites `vbrief/.eval/`. Upstream `vbrief/schemas/` source copies keep the legacy paths. Closes #2670.
 
 ### Removed
 

--- a/packages/core/src/init-deposit/xbrief-projections.test.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.test.ts
@@ -12,6 +12,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import {
+  assertProjectedSchemaDescriptionsRooted,
+  rewriteProjectedSchemaContent,
   syncBareVersionMarker,
   syncConsumerXbriefSchemas,
   syncExistingBareVersionMarker,
@@ -45,6 +47,11 @@ describe("xbrief consumer projections (#2595)", () => {
     const consumerSchemas = join(project, "xbrief", "schemas");
     mkdirSync(join(schemas, "nested"), { recursive: true });
     writeFileSync(join(schemas, "nested", "child.schema.json"), "child\n", "utf8");
+    writeFileSync(
+      join(schemas, "candidates.schema.json"),
+      '{"description":"one line in vbrief/.eval/candidates.jsonl"}\n',
+      "utf8",
+    );
     mkdirSync(consumerSchemas, { recursive: true });
     writeFileSync(join(consumerSchemas, "vbrief-core.schema.json"), "stale\n", "utf8");
     writeFileSync(join(consumerSchemas, "shared.schema.json"), "shared-stale\n", "utf8");
@@ -64,7 +71,32 @@ describe("xbrief consumer projections (#2595)", () => {
     expect(readFileSync(join(consumerSchemas, "nested", "child.schema.json"), "utf8")).toBe(
       "child\n",
     );
+    expect(readFileSync(join(consumerSchemas, "candidates.schema.json"), "utf8")).toBe(
+      '{"description":"one line in xbrief/.eval/candidates.jsonl"}\n',
+    );
     expect(syncConsumerXbriefSchemas(project, deftDir)).toBe(false);
+  });
+
+  it("rewriteProjectedSchemaContent rewrites every vbrief/.eval/ mention", () => {
+    const input = "vbrief/.eval/slices.jsonl and vbrief/.eval/README.md per vbrief/.eval/ policy";
+    expect(rewriteProjectedSchemaContent(input)).toBe(
+      "xbrief/.eval/slices.jsonl and xbrief/.eval/README.md per xbrief/.eval/ policy",
+    );
+    expect(rewriteProjectedSchemaContent("no legacy paths here")).toBe("no legacy paths here");
+  });
+
+  it("assertProjectedSchemaDescriptionsRooted rejects leftover vbrief/.eval/ paths", () => {
+    const { project } = fixture();
+    const consumerSchemas = join(project, "xbrief", "schemas");
+    mkdirSync(consumerSchemas, { recursive: true });
+    writeFileSync(
+      join(consumerSchemas, "bad.schema.json"),
+      '{"description":"still vbrief/.eval/candidates.jsonl"}\n',
+      "utf8",
+    );
+    expect(() => assertProjectedSchemaDescriptionsRooted(project, consumerSchemas)).toThrow(
+      /projected xbrief schema still cites vbrief\/\.eval\//,
+    );
   });
 
   it("repairs a stale lifecycle version marker and then performs no second write", () => {

--- a/packages/core/src/init-deposit/xbrief-projections.test.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.test.ts
@@ -99,6 +99,20 @@ describe("xbrief consumer projections (#2595)", () => {
     );
   });
 
+  it("self-check runs after obsolete vbrief-core.schema.json is removed", () => {
+    const { project, deftDir } = fixture();
+    const consumerSchemas = join(project, "xbrief", "schemas");
+    mkdirSync(consumerSchemas, { recursive: true });
+    writeFileSync(
+      join(consumerSchemas, "vbrief-core.schema.json"),
+      '{"description":"legacy vbrief/.eval/candidates.jsonl"}\n',
+      "utf8",
+    );
+
+    expect(syncConsumerXbriefSchemas(project, deftDir)).toBe(true);
+    expect(existsSync(join(consumerSchemas, "vbrief-core.schema.json"))).toBe(false);
+  });
+
   it("repairs a stale lifecycle version marker and then performs no second write", () => {
     const { project } = fixture();
     mkdirSync(join(project, "xbrief", "active"), { recursive: true });

--- a/packages/core/src/init-deposit/xbrief-projections.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.ts
@@ -124,14 +124,15 @@ export function syncConsumerXbriefSchemas(projectDir: string, deftDir: string): 
     changed = writeFileIfChanged(projectDir, destination, projected) || changed;
   }
 
-  assertProjectedSchemaDescriptionsRooted(projectDir, destinationDir);
-
   const obsoleteDestination = join(destinationDir, OBSOLETE_CORE_SCHEMA);
   assertProjectionContained(projectDir, obsoleteDestination);
   if (existsSync(obsoleteDestination)) {
     rmSync(obsoleteDestination, { force: true });
     changed = true;
   }
+
+  assertProjectedSchemaDescriptionsRooted(projectDir, destinationDir);
+
   return changed;
 }
 

--- a/packages/core/src/init-deposit/xbrief-projections.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.ts
@@ -23,6 +23,10 @@ import { MIGRATED_ARTIFACT_DIR } from "../xbrief-migrate/constants.js";
 
 const OBSOLETE_CORE_SCHEMA = "vbrief-core.schema.json";
 const CURRENT_CORE_SCHEMA = "xbrief-core-0.8.schema.json";
+/** Legacy lifecycle eval prefix in framework vbrief/schemas source copies. */
+const LEGACY_EVAL_PATH_PREFIX = "vbrief/.eval/";
+/** Consumer xbrief/schemas projection must root description paths here (#2670). */
+const XBRIEF_EVAL_PATH_PREFIX = "xbrief/.eval/";
 
 function normalizeVersion(version: string): string {
   return version.trim().replace(/^v/, "");
@@ -49,6 +53,35 @@ function collectSchemaFiles(root: string, dir = root, files: string[] = []): str
     }
   }
   return files;
+}
+
+/** Rewrite legacy vbrief/.eval description paths for xbrief/schemas projection (#2670). */
+export function rewriteProjectedSchemaContent(content: string): string {
+  return content.includes(LEGACY_EVAL_PATH_PREFIX)
+    ? content.replaceAll(LEGACY_EVAL_PATH_PREFIX, XBRIEF_EVAL_PATH_PREFIX)
+    : content;
+}
+
+/**
+ * Fail closed when a projected xbrief/schemas file still cites vbrief/.eval/.
+ * Upstream vbrief/schemas/ may keep legacy paths; consumer copies must not (#2670).
+ */
+export function assertProjectedSchemaDescriptionsRooted(
+  projectDir: string,
+  destinationDir: string,
+): void {
+  assertProjectionContained(projectDir, destinationDir);
+  if (!isDirectory(destinationDir)) return;
+
+  for (const rel of collectSchemaFiles(destinationDir)) {
+    const full = join(destinationDir, rel);
+    const text = readFileSync(full, "utf8");
+    if (text.includes(LEGACY_EVAL_PATH_PREFIX)) {
+      throw new Error(
+        `projected xbrief schema still cites ${LEGACY_EVAL_PATH_PREFIX}: ${join(MIGRATED_ARTIFACT_DIR, "schemas", rel)}`,
+      );
+    }
+  }
 }
 
 function writeFileIfChanged(projectDir: string, target: string, content: Buffer | string): boolean {
@@ -87,8 +120,11 @@ export function syncConsumerXbriefSchemas(projectDir: string, deftDir: string): 
     if (rel === OBSOLETE_CORE_SCHEMA) continue;
     const source = join(sourceDir, rel);
     const destination = join(destinationDir, rel);
-    changed = writeFileIfChanged(projectDir, destination, readFileSync(source)) || changed;
+    const projected = rewriteProjectedSchemaContent(readFileSync(source, "utf8"));
+    changed = writeFileIfChanged(projectDir, destination, projected) || changed;
   }
+
+  assertProjectedSchemaDescriptionsRooted(projectDir, destinationDir);
 
   const obsoleteDestination = join(destinationDir, OBSOLETE_CORE_SCHEMA);
   assertProjectionContained(projectDir, obsoleteDestination);


### PR DESCRIPTION
## Summary
- Rewrite `vbrief/.eval/` to `xbrief/.eval/` when projecting framework schemas into consumer `xbrief/schemas/` during `deft update`.
- Add a deposit self-check that throws if any projected schema file still cites `vbrief/.eval/`.
- Upstream `vbrief/schemas/` source copies keep legacy paths unchanged.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/init-deposit/xbrief-projections.test.ts`
- [x] `task verify:forward-coverage`
- [x] `task verify:branch`
- [ ] CI green (note: global branch coverage hairline miss on base is tracked separately in #2666)

Closes #2670
