### PR TITLE
fix(cli): accept -- separator in verify:session-ritual (#2680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`deft verify:session-ritual -- --tier=gated` accepts the documented separator (#2680).** `parseArgs` now skips a lone `--` so the task-style invocation matches direct `--tier=gated`. Closes #2680.
 - **Pre-PR ordered-plan gate uses the current entry kind (#2662).** `deft-directive-pre-pr` no longer hardcodes `--target-kind pr`; agents resolve `kind` and `id` via `task plan-sequence:current` before `task verify:plan-sequence`, so story-backed PRs pass the gate when the target id matches. Closes #2662.
 - **AGENTS always-loads the #2646 body-file recipe (#2671).** Multi-line git/gh bodies on Windows PowerShell are now an inline MUST/⊗ rule in the managed AGENTS section (not a lazy index pointer to `scm/github.md`). Closes #2671.
 - **Deposited `xbrief/schemas/` descriptions no longer regress to `vbrief/.eval/` paths (#2670).** `deft update` now rewrites legacy eval-path references to `xbrief/.eval/` when projecting framework schemas into the consumer tree, and a deposit self-check fails if any projected schema description still cites `vbrief/.eval/`. Upstream `vbrief/schemas/` source copies keep the legacy paths. Closes #2670.

--- a/packages/cli/src/verify-session-ritual.test.ts
+++ b/packages/cli/src/verify-session-ritual.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "./verify-session-ritual.js";
+
+describe("parseArgs", () => {
+  it("defaults to quick tier with project root .", () => {
+    expect(parseArgs([])).toMatchObject({
+      projectRoot: ".",
+      tier: "quick",
+      posture: null,
+      emitJson: false,
+    });
+    expect(parseArgs([]).error).toBeUndefined();
+  });
+
+  it("parses --tier=gated", () => {
+    expect(parseArgs(["--tier=gated"])).toMatchObject({ tier: "gated" });
+    expect(parseArgs(["--tier=gated"]).error).toBeUndefined();
+  });
+
+  it("accepts a lone -- separator before flags (#2680)", () => {
+    expect(parseArgs(["--", "--tier=gated"])).toMatchObject({ tier: "gated" });
+    expect(parseArgs(["--", "--tier=gated"]).error).toBeUndefined();
+    expect(parseArgs(["--", "--tier=gated"])).toEqual(parseArgs(["--tier=gated"]));
+  });
+
+  it("errors on missing values and unknown flags", () => {
+    expect(parseArgs(["--tier"]).error).toBeDefined();
+    expect(parseArgs(["--bogus"]).error).toBeDefined();
+  });
+});

--- a/packages/cli/src/verify-session-ritual.ts
+++ b/packages/cli/src/verify-session-ritual.ts
@@ -32,6 +32,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (arg === "--") {
+      continue;
+    }
     if (arg === "--json") {
       parsed.emitJson = true;
     } else if (arg === "--project-root") {

--- a/xbrief/active/2026-07-20-2680-bugritual-documented-separator-rejects-tier-flag.xbrief.json
+++ b/xbrief/active/2026-07-20-2680-bugritual-documented-separator-rejects-tier-flag.xbrief.json
@@ -1,0 +1,85 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2680"
+  },
+  "plan": {
+    "title": "Accept documented -- separator in verify:session-ritual",
+    "status": "completed",
+    "narratives": {
+      "Description": "Documented form `deft verify:session-ritual -- --tier=gated` fails with unrecognized argument: -- while the direct flag form works. Task strips -- so task invocations pass. Always-loaded AGENTS/commands/hook copy prescribe the separator form for deft as well. This story closes GitHub issue #2680 with a narrowly scoped CLI parse fix and regression coverage.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2680",
+      "Overview": "## Reproduction\n\nOn macOS with `@deftai/directive` engine `0.79.3`:\n\n```sh\ndeft verify:session-ritual -- --tier=gated\n```\n\nResult:\n\n```text\nverify_session_ritual: unrecognized argument: --\n```\n\nThe direct option form succeeds:\n\n```sh\ndeft verify:session-ritual --tier=gated\n```\n\n```text\nOK session ritual gated tier is fresh.\n```\n\n## Expected\n\nEither the documented task-style separator form should be accepted, or the managed `AGENTS.md` / command documentation should prescribe the direct CLI syntax.\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @MScottAdams (2026-07-20T15:19:55Z)\n\n## Triage analysis (accuracy)\n\n**Verdict: confirmed accurate.**\n\n### Reproduced (local `packages/cli/dist/bin.js` + docs on master)\n\n| Invocation | Result |\n| --- | --- |\n| `deft verify:session-ritual -- --tier=gated` | `verify_session_ritual: unrecognized argument: --` |\n| `deft verify:session-ritual --tier=gated` | accepted (flag parsed) |\n| `task verify:session-ritual -- --tier=gated` | accepted (`task` strips `--` before `CLI_ARGS`) |\n\n### Why docs look \"wrong\" but aren't accidental\n\nAlways-loaded surfaces prescribe the separator form for **both** `task` and `deft`:\n\n- `AGENTS.md` / `content/templates/agents-entry.md`: `deft verify:session-ritual -- --tier=gated`\n- `content/commands.md` pre-`start_agent` stack\n- Hook deny copy in `packages/core/src/hooks/dispatcher.ts` (and its test) embeds the same string\n\n`packages/cli/src/verify-session-ritual.ts` `parseArgs` has no `arg === \"--\"` skip, so a lone `--` falls through to `unrecognized argument`.\n\n### Preferred fix\n\nAccept and skip a lone `--` in `parseArgs` (and any sibling ritual parsers that share the documented form). Keep documenting the separator form so `task … -- --tier=gated` and `deft … -- --tier=gated` stay interchangeable. Add a regression test that `verify-session-ritual -- --tier=gated` exits the same path as without the separator.\n\n**Cohort:** folding into `bugs-2662-2671` swarm as an additive leaf.",
+      "Labels": "bug, adoption-blocker, agent-experience, area:cli",
+      "ImplementationPlan": "1. Edit packages/cli/src/verify-session-ritual.ts parseArgs to skip a lone -- separator (continue). 2. Add a unit/integration test file asserting `-- --tier=gated` parses the same as `--tier=gated`. 3. Verify with task check filter session-ritual and note #2680 in CHANGELOG.",
+      "UserStory": "As a directive agent following AGENTS.md, I want `deft verify:session-ritual -- --tier=gated` to be accepted, so that documented ritual commands do not fail closed on a bare separator."
+    },
+    "items": [
+      {
+        "title": "AC1",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "parseArgs skips a lone -- and returns tier=gated for argv [--, --tier=gated] the same as [--tier=gated]."
+        }
+      },
+      {
+        "title": "AC2",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Running deft verify:session-ritual -- --tier=gated no longer emits unrecognized argument: -- and fails closed only on real ritual-state problems."
+        }
+      },
+      {
+        "title": "AC3",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "CHANGELOG Unreleased records the separator acceptance for issue 2680."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "agent-experience",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2680",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2680: bug(ritual): documented -- separator rejects --tier flag"
+      }
+    ],
+    "updated": "2026-07-20T15:17:38Z",
+    "id": "2680-session-ritual-double-dash",
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#2680"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/verify-session-ritual.ts",
+          "packages/cli/src/gates-cli/",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive test -- session-ritual"
+        ],
+        "expected_outputs": [
+          "lone -- accepted in parseArgs",
+          "regression test for -- --tier=gated",
+          "CHANGELOG notes #2680"
+        ],
+        "depends_on": [],
+        "conflict_group": "2680-ritual-double-dash",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf",
+        "missing_traces_justification": "Bug-fix from GitHub issue #2680; no FR trace registry for hotfix cohort."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Accept a lone `--` separator in `verify:session-ritual` `parseArgs` so `deft verify:session-ritual -- --tier=gated` matches documented AGENTS/task-style invocations.
- Add regression unit tests for `-- --tier=gated` parsing parity with `--tier=gated`.

## Related Issues

Closes #2680

## Checklist

- [x] `/deft:change` — N/A (<3 production surfaces; narrow CLI parse fix)
- [x] `CHANGELOG.md` — Unreleased entry added
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally (session-ritual unit tests; full `task check` branch coverage hairline on win32 only)

## Test plan

- [x] `pnpm exec vitest run verify-session-ritual.test`
- [x] `node packages/cli/dist/bin.js verify-session-ritual -- --tier=gated` no longer emits `unrecognized argument: --`
- [x] `task verify:forward-coverage`

## Post-Merge

- [ ] Verify issue auto-close for #2680
