### PR TITLE
fix(coverage): restore branch coverage to 85% floor (#2666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Branch coverage clears the 85% release floor again (#2666).** Targeted unit tests for review-monitor gate branches, mergeability JSON parse failures, ts-check-lane signal-kill messaging, and shell-context account-shell detection lift measured branch coverage above the global threshold without `--allow-coverage-debt`. Closes #2666.
 - **`scope:undo` and `migrate:xbrief` AGENTS.md header patch refuse symlink escape writes (#2668).** `scope:undo` now calls `assertWriteTargetSafe` before lifecycle xBRIEF writes (parity with `scope:demote`); the migrate header patch resolves `AGENTS.md` via projection containment before write (parity with init-deposit `writeAgentsMd`). Closes #2668.
 - **Cursor Write/StrReplace hooks infer tool identity from more payload shapes (#2669).** `hookToolName` now recognizes OpenAI-style `arguments`, `tool_call.name`, and object `tool.name` nestings that still returned `null` on 0.79.3; empty stdin, invalid JSON, and unknown-shape denies emit distinct host-integration messages, with top-level payload keys logged on Cursor `invalid-input`. Closes #2669.
 - **`deft verify:session-ritual -- --tier=gated` accepts the documented separator (#2680).** `parseArgs` now skips a lone `--` so the task-style invocation matches direct `--tier=gated`. Closes #2680.

--- a/packages/cli/src/verify-session-ritual.test.ts
+++ b/packages/cli/src/verify-session-ritual.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { parseArgs } from "./verify-session-ritual.js";
+import { describe, expect, it, vi } from "vitest";
+import { parseArgs, run } from "./verify-session-ritual.js";
 
 describe("parseArgs", () => {
   it("defaults to quick tier with project root .", () => {
@@ -26,5 +26,30 @@ describe("parseArgs", () => {
   it("errors on missing values and unknown flags", () => {
     expect(parseArgs(["--tier"]).error).toBeDefined();
     expect(parseArgs(["--bogus"]).error).toBeDefined();
+    expect(parseArgs(["--project-root"]).error).toMatch(/project-root/);
+    expect(parseArgs(["--posture"]).error).toMatch(/posture/);
+  });
+
+  it("parses equals-form project root and posture aliases (#2666)", () => {
+    expect(parseArgs(["--project-root=/tmp/work"]).projectRoot).toBe("/tmp/work");
+    expect(parseArgs(["--posture=mutating"]).posture).toBe("mutation");
+    expect(parseArgs(["--posture", "mutation"]).posture).toBe("mutation");
+    expect(parseArgs(["--posture=read-only"]).posture).toBe("read-only");
+    expect(parseArgs(["--json"]).emitJson).toBe(true);
+  });
+
+  it("rejects invalid tier and posture choices", () => {
+    expect(parseArgs(["--tier=invalid"]).error).toMatch(/invalid choice/);
+    expect(parseArgs(["--tier", "invalid"]).error).toMatch(/invalid choice/);
+    expect(parseArgs(["--posture=nope"]).error).toMatch(/invalid choice/);
+  });
+});
+
+describe("run (#2666)", () => {
+  it("exits 2 and prints parse errors", () => {
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    expect(run(["--bogus"])).toBe(2);
+    expect(err.mock.calls.join("")).toContain("unrecognized argument");
+    err.mockRestore();
   });
 });

--- a/packages/core/src/cache/validate.test.ts
+++ b/packages/core/src/cache/validate.test.ts
@@ -34,4 +34,13 @@ describe("validateMeta", () => {
     (meta.scan_result as Record<string, unknown>).scanner_version = "bad";
     expect(() => validateMeta(meta)).toThrow(/SemVer/);
   });
+
+  it("rejects non-string etag when present (#2666)", () => {
+    expect(() => validateMeta({ ...goodMeta(), etag: 42 })).toThrow(/\.etag/);
+  });
+
+  it("rejects non-object meta root (#2666)", () => {
+    expect(() => validateMeta(null)).toThrow(/expected object/);
+    expect(() => validateMeta([])).toThrow(/array/);
+  });
 });

--- a/packages/core/src/init-deposit/xbrief-projections.test.ts
+++ b/packages/core/src/init-deposit/xbrief-projections.test.ts
@@ -99,6 +99,13 @@ describe("xbrief consumer projections (#2595)", () => {
     );
   });
 
+  it("assertProjectedSchemaDescriptionsRooted no-ops when destination is not a directory (#2666)", () => {
+    const { project } = fixture();
+    const file = join(project, "not-a-schema-dir");
+    writeFileSync(file, "plain file\n", "utf8");
+    expect(() => assertProjectedSchemaDescriptionsRooted(project, file)).not.toThrow();
+  });
+
   it("self-check runs after obsolete vbrief-core.schema.json is removed", () => {
     const { project, deftDir } = fixture();
     const consumerSchemas = join(project, "xbrief", "schemas");

--- a/packages/core/src/platform/shell-context.test.ts
+++ b/packages/core/src/platform/shell-context.test.ts
@@ -50,6 +50,13 @@ describe("detectEnvironmentContext", () => {
     });
   });
 
+  it("uses os.userInfo when neither userShell nor readUserShell is supplied (#2666)", () => {
+    const context = detectEnvironmentContext({ environ: {}, platform: "linux" });
+    expect(
+      context.shell.source === "os.userInfo().shell" || context.shell.source === "unknown",
+    ).toBe(true);
+  });
+
   it("reads the POSIX account shell through the injectable platform seam", () => {
     expect(
       detectEnvironmentContext({

--- a/packages/core/src/pr-merge-readiness/mergeability-branches.test.ts
+++ b/packages/core/src/pr-merge-readiness/mergeability-branches.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { fetchMergeability } from "./mergeability.js";
+
+describe("mergeability branch coverage (#2666)", () => {
+  it("fetchMergeability stringifies non-Error JSON parse failures", () => {
+    const signal = fetchMergeability(1, "deftai/directive", () => ({
+      returncode: 0,
+      stdout: "{not-json",
+      stderr: "",
+    }));
+    expect(signal.error).toMatch(/could not parse PR JSON/);
+    expect(signal.mergeable).toBeNull();
+  });
+
+  it("fetchMergeability reports empty gh api bodies", () => {
+    const signal = fetchMergeability(2, "deftai/directive", () => ({
+      returncode: 0,
+      stdout: "   ",
+      stderr: "",
+    }));
+    expect(signal.error).toBe("empty body from gh api /pulls/<N>");
+  });
+
+  it("fetchMergeability reports gh api failures", () => {
+    const signal = fetchMergeability(3, "deftai/directive", () => ({
+      returncode: 1,
+      stdout: "",
+      stderr: "rate limit",
+    }));
+    expect(signal.error).toMatch(/gh api \/pulls\/3 failed/);
+  });
+
+  it("fetchMergeability reports unexpected JSON shapes", () => {
+    const signal = fetchMergeability(4, "deftai/directive", () => ({
+      returncode: 0,
+      stdout: "[]",
+      stderr: "",
+    }));
+    expect(signal.error).toBe("unexpected PR JSON shape (not a dict)");
+  });
+});

--- a/packages/core/src/review-monitor/record-branches.test.ts
+++ b/packages/core/src/review-monitor/record-branches.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { findActiveMonitorForPr, readReviewMonitorFile, registerReviewMonitor } from "./record.js";
+
+describe("review-monitor record branch coverage (#2666)", () => {
+  it("registerReviewMonitor throws when the monitor file cannot be read", () => {
+    const root = mkdtempSync(join(tmpdir(), "rm-reg-throw-"));
+    mkdirSync(join(root, ".deft"), { recursive: true });
+    writeFileSync(join(root, ".deft", "review-monitor.json"), "{bad", "utf8");
+    expect(() =>
+      registerReviewMonitor({
+        pr: 3,
+        platformPrimitive: "cursor-task",
+        monitorAgentId: "rm-3",
+        projectRoot: root,
+      }),
+    ).toThrow(/invalid JSON/);
+  });
+
+  it("readReviewMonitorFile preserves ended_at and defaults schema_version", () => {
+    const root = mkdtempSync(join(tmpdir(), "rm-rec-parse-"));
+    mkdirSync(join(root, ".deft"), { recursive: true });
+    writeFileSync(
+      join(root, ".deft", "review-monitor.json"),
+      JSON.stringify({
+        records: [
+          {
+            pr: 5,
+            monitor_agent_id: "rm-5",
+            platform_primitive: "cursor-task",
+            started_at: "2026-07-20T12:00:00Z",
+            worktree_path: root,
+            ended_at: "2026-07-20T13:00:00Z",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    const { data } = readReviewMonitorFile(join(root, ".deft", "review-monitor.json"));
+    expect(data?.schema_version).toBe(1);
+    expect(data?.records[0]?.ended_at).toBe("2026-07-20T13:00:00Z");
+    expect(findActiveMonitorForPr(data as NonNullable<typeof data>, 5, {})).toBeNull();
+  });
+});

--- a/packages/core/src/review-monitor/verify-branches.test.ts
+++ b/packages/core/src/review-monitor/verify-branches.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { registerReviewMonitor } from "./record.js";
+import {
+  evaluateReviewMonitorGate,
+  hasActivePollingHeartbeat,
+  verifyResultToJson,
+} from "./verify.js";
+
+describe("review-monitor verify branch coverage (#2666)", () => {
+  it("includes swarm-phase5-6 call-site hint when failing closed on Tier 1", () => {
+    const root = mkdtempSync(join(tmpdir(), "rm-cs-p56-"));
+    const result = evaluateReviewMonitorGate({
+      pr: 11,
+      projectRoot: root,
+      callSite: "swarm-phase5-6",
+      environ: { CURSOR_COMPOSER: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Swarm Phase 5→6 handoff");
+  });
+
+  it("includes swarm-phase6-cascade call-site hint when failing closed on Tier 1", () => {
+    const root = mkdtempSync(join(tmpdir(), "rm-cs-p6c-"));
+    const result = evaluateReviewMonitorGate({
+      pr: 12,
+      projectRoot: root,
+      callSite: "swarm-phase6-cascade",
+      environ: { CURSOR_COMPOSER: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("Swarm Phase 6 post force-push");
+  });
+
+  it("verifyResultToJson surfaces monitor_agent_id from an active record", () => {
+    const root = mkdtempSync(join(tmpdir(), "rm-json-agent-"));
+    registerReviewMonitor({
+      pr: 21,
+      platformPrimitive: "cursor-task",
+      monitorAgentId: "review-monitor-pr-21",
+      projectRoot: root,
+    });
+    const result = evaluateReviewMonitorGate({
+      pr: 21,
+      projectRoot: root,
+      environ: { CURSOR_COMPOSER: "1" },
+    });
+    const json = verifyResultToJson(result);
+    expect(json.monitor_agent_id).toBe("review-monitor-pr-21");
+    expect(json.ready).toBe(true);
+  });
+
+  it("accepts a starting-phase polling heartbeat as monitor evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "rm-hb-start-"));
+    const statusDir = join(root, ".deft-scratch", "subagent-status");
+    mkdirSync(statusDir, { recursive: true });
+    writeFileSync(
+      join(statusDir, "poller-pr-77.json"),
+      JSON.stringify({
+        agent_id: "poller-pr-77",
+        parent_id: "parent-1",
+        last_heartbeat_at: new Date().toISOString(),
+        last_message: "starting",
+        phase: "starting",
+        terminal_state: null,
+        pr_number: 77,
+      }),
+      "utf8",
+    );
+    expect(hasActivePollingHeartbeat(root, 77)).toBe(true);
+  });
+});

--- a/packages/core/src/ts-check-lane/run-lane.test.ts
+++ b/packages/core/src/ts-check-lane/run-lane.test.ts
@@ -136,6 +136,17 @@ describe("runTsLane", () => {
     expect(messages.some((m) => m.includes("killed by SIGTERM"))).toBe(true);
   });
 
+  it("treats a null status without a signal name as a generic kill", () => {
+    const messages: string[] = [];
+    const rc = runTsLane("/repo", {
+      pnpm: "pnpm",
+      runner: () => ({ status: null }),
+      out: (m) => messages.push(m),
+    });
+    expect(rc).toBe(1);
+    expect(messages.some((m) => m.includes("killed by a signal"))).toBe(true);
+  });
+
   it("reports subprocess start errors separately from signal kills", () => {
     const messages: string[] = [];
     const rc = runTsLane("/repo", {

--- a/packages/core/src/verify-env/branches.test.ts
+++ b/packages/core/src/verify-env/branches.test.ts
@@ -119,7 +119,9 @@ describe("verify-tools branches", () => {
     expect(defaultRun(["definitely-missing-binary-xyz"]).returncode).toBe(1);
   });
 
-  it("covers install path using defaultRun when installer fails", () => {
+  it("covers install path when installer fails (#2666 CI flake)", () => {
+    // Inject a failing runFn so Linux CI never shells out to a real apt-get install
+    // (defaultRun coverage is already exercised by the prior test).
     const result = verifyRequiredTools({
       install: true,
       assumeYes: true,
@@ -127,6 +129,7 @@ describe("verify-tools branches", () => {
       platformId: "linux",
       probe: (c) =>
         ["git", "uv", "python3", "gh", "apt-get"].includes(c) ? `/usr/bin/${c}` : null,
+      runFn: () => ({ returncode: 1, stdout: "", stderr: "install failed" }),
     });
     expect(result.exitCode).toBe(1);
   });


### PR DESCRIPTION
## Summary
- Add targeted branch-coverage tests for review-monitor gate call-site hints, record parsing, mergeability JSON failures, ts-check-lane signal-kill messaging, and shell-context account-shell detection.
- Restores global branch coverage to the 85% release floor without `--allow-coverage-debt` (was 84.98% on v0.79.3 cut).

## Test plan
- [x] `pnpm run test` reports branch coverage >= 85%
- [x] `task check` passes (lint, typecheck, tests, coverage)

Closes #2666
