### PR TITLE
fix(triage): bootstrap cache via TypeScript cacheFetchAll (#2684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`triage:bootstrap` populates the issue cache via TypeScript `cacheFetchAll` (#2684).** Packaged npm consumers no longer defer with a `scripts/cache.py` / rebase recovery message; bootstrap uses the same TS fetch path as empty-cache auto-populate. Closes #2684.
 - **Branch coverage clears the 85% release floor again (#2666).** Targeted unit tests for review-monitor gate branches, mergeability JSON parse failures, ts-check-lane signal-kill messaging, and shell-context account-shell detection lift measured branch coverage above the global threshold without `--allow-coverage-debt`. Closes #2666.
 - **`scope:undo` and `migrate:xbrief` AGENTS.md header patch refuse symlink escape writes (#2668).** `scope:undo` now calls `assertWriteTargetSafe` before lifecycle xBRIEF writes (parity with `scope:demote`); the migrate header patch resolves `AGENTS.md` via projection containment before write (parity with init-deposit `writeAgentsMd`). Closes #2668.
 - **Cursor Write/StrReplace hooks infer tool identity from more payload shapes (#2669).** `hookToolName` now recognizes OpenAI-style `arguments`, `tool_call.name`, and object `tool.name` nestings that still returned `null` on 0.79.3; empty stdin, invalid JSON, and unknown-shape denies emit distinct host-integration messages, with top-level payload keys logged on Cursor `invalid-input`. Closes #2669.

--- a/packages/core/src/integration-e2e/bootstrap-cache-module.ts
+++ b/packages/core/src/integration-e2e/bootstrap-cache-module.ts
@@ -1,27 +1,2 @@
-import type { FetchAllReportImpl } from "../cache/fetch.js";
-import type { CacheModule } from "../triage/bootstrap/types.js";
-
-/** Adapt TS cache reports to the bootstrap `FetchAllReport` shape. */
-export function bootstrapCacheModule(
-  cacheFetchAll: (
-    options: Parameters<typeof import("../cache/fetch.js").cacheFetchAll>[0],
-  ) => FetchAllReportImpl,
-): CacheModule {
-  return {
-    cacheFetchAll(kwargs) {
-      const report = cacheFetchAll({
-        source: kwargs.source,
-        repo: kwargs.repo,
-        batchSize: kwargs.batchSize,
-        delayMs: kwargs.delayMs,
-        cacheRoot: kwargs.cacheRoot,
-      });
-      return Promise.resolve({
-        succeeded: report.issuesWritten,
-        failed: report.issuesFailed,
-        skipped: report.alreadyFresh,
-        summaryLine: (source: string, repo: string) => report.summaryLine(source, repo),
-      });
-    },
-  };
-}
+/** Re-export bootstrap TS cache adapter (canonical home: triage/bootstrap). */
+export { bootstrapCacheModule } from "../triage/bootstrap/cache-module.js";

--- a/packages/core/src/triage/bootstrap/cache-module.test.ts
+++ b/packages/core/src/triage/bootstrap/cache-module.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { bootstrapCacheModule, loadDefaultCacheModule } from "./cache-module.js";
+
+describe("bootstrap cache-module (#2684)", () => {
+  it("loadDefaultCacheModule always returns a module (no Python gate)", () => {
+    expect(loadDefaultCacheModule()).not.toBeNull();
+  });
+
+  it("forwards bootstrap kwargs into cacheFetchAll", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const mod = bootstrapCacheModule((options) => {
+      seen.push({ ...options });
+      return {
+        issuesWritten: 1,
+        issuesFailed: 0,
+        alreadyFresh: 0,
+        summaryLine: () => "ok",
+      } as ReturnType<typeof import("../../cache/fetch.js").cacheFetchAll>;
+    });
+    const report = await mod.cacheFetchAll({
+      source: "github-issue",
+      repo: "deftai/directive",
+      cacheRoot: "/tmp/cache",
+      batchSize: 5,
+      delayMs: 1,
+      state: "open",
+      limit: 3,
+      labels: ["triage"],
+      author: "bob",
+    });
+    expect(report.succeeded).toBe(1);
+    expect(seen[0]).toMatchObject({
+      source: "github-issue",
+      repo: "deftai/directive",
+      cacheRoot: "/tmp/cache",
+      force: true,
+      batchSize: 5,
+      delayMs: 1,
+      state: "open",
+      limit: 3,
+      labels: ["triage"],
+      author: "bob",
+    });
+  });
+});

--- a/packages/core/src/triage/bootstrap/cache-module.ts
+++ b/packages/core/src/triage/bootstrap/cache-module.ts
@@ -1,0 +1,55 @@
+/**
+ * TypeScript default cache module for triage:bootstrap (#2684).
+ *
+ * npm / packaged consumers never ship scripts/cache.py; bootstrap must use the
+ * same cacheFetchAll path as empty-cache auto-populate (#2575).
+ */
+
+import { cacheFetchAll, type FetchAllReportImpl } from "../../cache/fetch.js";
+import type { CacheFetchAllKwargs, CacheModule } from "./types.js";
+
+export type CacheFetchAllFn = (options: {
+  source: string;
+  repo: string;
+  batchSize?: number;
+  delayMs?: number;
+  state?: string;
+  limit?: number;
+  labels?: readonly string[];
+  author?: string | null;
+  cacheRoot?: string;
+  force?: boolean;
+}) => FetchAllReportImpl;
+
+/** Adapt TS cache reports to the bootstrap `FetchAllReport` shape. */
+export function bootstrapCacheModule(fetchAll: CacheFetchAllFn = cacheFetchAll): CacheModule {
+  return {
+    cacheFetchAll(kwargs: CacheFetchAllKwargs) {
+      const report = fetchAll({
+        source: kwargs.source,
+        repo: kwargs.repo,
+        cacheRoot: kwargs.cacheRoot,
+        force: true,
+        ...(kwargs.batchSize !== undefined ? { batchSize: kwargs.batchSize } : {}),
+        ...(kwargs.delayMs !== undefined ? { delayMs: kwargs.delayMs } : {}),
+        ...(kwargs.state !== undefined ? { state: kwargs.state } : {}),
+        ...(kwargs.limit !== undefined ? { limit: kwargs.limit } : {}),
+        ...(kwargs.labels !== undefined && kwargs.labels.length > 0
+          ? { labels: kwargs.labels }
+          : {}),
+        ...(kwargs.author !== undefined ? { author: kwargs.author } : {}),
+      });
+      return Promise.resolve({
+        succeeded: report.issuesWritten,
+        failed: report.issuesFailed,
+        skipped: report.alreadyFresh,
+        summaryLine: (source: string, repo: string) => report.summaryLine(source, repo),
+      });
+    },
+  };
+}
+
+/** Default module for packaged and source checkouts — never gates on Python. */
+export function loadDefaultCacheModule(): CacheModule {
+  return bootstrapCacheModule();
+}

--- a/packages/core/src/triage/bootstrap/index.test.ts
+++ b/packages/core/src/triage/bootstrap/index.test.ts
@@ -167,11 +167,48 @@ describe("stepPopulateCache", () => {
     expect(outcome.message).toContain("succeeded=1");
   });
 
-  it("defers when cache module missing", async () => {
+  it("defers only when cache module explicitly disabled", async () => {
     const root = makeRoot();
-    const outcome = await stepPopulateCache(root, "deftai/directive", { deftRoot: root });
+    const outcome = await stepPopulateCache(root, "deftai/directive", {
+      cacheModule: null,
+      deftRoot: root,
+    });
     expect(outcome.ok).toBe(true);
-    expect(outcome.details.deferred).toBe("cache-module-missing");
+    expect(outcome.details.deferred).toBe("cache-module-disabled");
+    expect(String(outcome.message)).not.toContain("scripts/cache.py");
+    expect(String(outcome.message)).not.toContain("rebase");
+  });
+
+  it("defaults to TypeScript cacheFetchAll without scripts/cache.py (#2684)", async () => {
+    const root = makeRoot();
+    const seen: Array<Record<string, unknown>> = [];
+    const { bootstrapCacheModule } = await import("./cache-module.js");
+    const cacheModule = bootstrapCacheModule((options) => {
+      seen.push({ ...options });
+      return {
+        issuesWritten: 2,
+        issuesFailed: 0,
+        alreadyFresh: 1,
+        summaryLine: (source: string, repo: string) =>
+          `cache:fetch-all source=${source} repo=${repo} succeeded=2 failed=0 skipped=1`,
+      } as ReturnType<typeof import("../../cache/fetch.js").cacheFetchAll>;
+    });
+    const outcome = await stepPopulateCache(root, "deftai/directive", {
+      cacheModule,
+      state: "open",
+      limit: 10,
+      labels: ["bug"],
+      author: "alice",
+    });
+    expect(outcome.ok).toBe(true);
+    expect(outcome.details.deferred).toBeUndefined();
+    expect(outcome.message).toContain("succeeded=2");
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.force).toBe(true);
+    expect(seen[0]?.state).toBe("open");
+    expect(seen[0]?.limit).toBe(10);
+    expect(seen[0]?.labels).toEqual(["bug"]);
+    expect(seen[0]?.author).toBe("alice");
   });
 });
 

--- a/packages/core/src/triage/bootstrap/index.ts
+++ b/packages/core/src/triage/bootstrap/index.ts
@@ -1,11 +1,10 @@
-import { execFile, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { promisify } from "node:util";
 import { hasArtifactSuffix, resolveLifecycleRoot } from "../../layout/resolve.js";
-import { SUBPROCESS_MAX_BUFFER } from "../../subprocess/max-buffer.js";
 import { resolveCandidatesLogPath } from "../cache-path.js";
+import { loadDefaultCacheModule } from "./cache-module.js";
 import {
   stepEnsureGitignoreEntry,
   stepEnsureGitignoreEvalEntries,
@@ -22,6 +21,7 @@ import type {
 } from "./types.js";
 import { PROGRESS_DEFAULT } from "./types.js";
 
+export * from "./cache-module.js";
 export * from "./gitignore.js";
 export * from "./types.js";
 
@@ -40,8 +40,6 @@ const GIT_ORIGIN_RE =
 const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 const RUNNER_UNSET = Symbol("runner-unset");
-
-const execFileAsync = promisify(execFile);
 
 function defaultWhich(name: string): string | null {
   const locator = process.platform === "win32" ? "where" : "which";
@@ -156,91 +154,6 @@ export async function runWithTimeout<T>(
   };
 }
 
-function resolveDeftRoot(explicit?: string): string {
-  if (explicit !== undefined && explicit.length > 0) return resolve(explicit);
-  if (process.env.DEFT_ROOT !== undefined && process.env.DEFT_ROOT.length > 0) {
-    return resolve(process.env.DEFT_ROOT);
-  }
-  return resolve(process.cwd());
-}
-
-function cacheModulePresent(deftRoot: string): boolean {
-  return existsSync(join(deftRoot, "scripts", "cache.py"));
-}
-
-async function invokePythonCacheFetchAll(
-  deftRoot: string,
-  kwargs: CacheFetchAllKwargs,
-): Promise<FetchAllReport> {
-  const payload = JSON.stringify({
-    source: kwargs.source,
-    repo: kwargs.repo,
-    cache_root: kwargs.cacheRoot,
-    batch_size: kwargs.batchSize ?? null,
-    delay_ms: kwargs.delayMs ?? null,
-    state: kwargs.state ?? null,
-    limit: kwargs.limit ?? null,
-    labels: kwargs.labels ?? null,
-    author: kwargs.author ?? null,
-  });
-  const script = `
-import json, sys
-sys.path.insert(0, ${JSON.stringify(join(deftRoot, "scripts"))})
-from cache import cache_fetch_all
-raw = json.loads(sys.argv[1])
-kwargs = {
-    "source": raw["source"],
-    "repo": raw["repo"],
-    "cache_root": raw["cache_root"],
-}
-for key in ("batch_size", "delay_ms", "state", "limit", "author"):
-    if raw[key] is not None:
-        kwargs[key] = raw[key]
-if raw["labels"]:
-    kwargs["labels"] = tuple(raw["labels"])
-report = cache_fetch_all(**kwargs)
-out = {
-    "succeeded": getattr(report, "succeeded", None),
-    "failed": getattr(report, "failed", None),
-    "skipped": getattr(report, "skipped", None),
-}
-summary_line = getattr(report, "summary_line", None)
-if callable(summary_line):
-    try:
-        out["summary_message"] = summary_line(source=raw["source"], repo=raw["repo"])
-    except TypeError:
-        pass
-print(json.dumps(out))
-`;
-  const { stdout } = await execFileAsync("uv", ["run", "python", "-c", script, payload], {
-    cwd: deftRoot,
-    encoding: "utf8",
-    maxBuffer: SUBPROCESS_MAX_BUFFER,
-  });
-  const parsed = JSON.parse(String(stdout).trim()) as {
-    succeeded?: number | null;
-    failed?: number | null;
-    skipped?: number | null;
-    summary_message?: string;
-  };
-  const summaryMessage = parsed.summary_message;
-  return {
-    succeeded: parsed.succeeded,
-    failed: parsed.failed,
-    skipped: parsed.skipped,
-    summaryLine: typeof summaryMessage === "string" ? () => summaryMessage : null,
-  };
-}
-
-function loadDefaultCacheModule(deftRoot: string): CacheModule | null {
-  if (!cacheModulePresent(deftRoot)) return null;
-  return {
-    cacheFetchAll(kwargs: CacheFetchAllKwargs): Promise<FetchAllReport> {
-      return invokePythonCacheFetchAll(deftRoot, kwargs);
-    },
-  };
-}
-
 function nowIsoDefault(): string {
   return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
@@ -294,14 +207,16 @@ export async function stepPopulateCache(
     );
   }
 
-  const deftRoot = resolveDeftRoot(options.deftRoot);
-  const cacheMod = options.cacheModule ?? loadDefaultCacheModule(deftRoot);
+  // #2684: default is TypeScript cacheFetchAll — never gate on scripts/cache.py.
+  // Explicit null still skips populate (tests / callers that inject empty cache).
+  const cacheMod =
+    options.cacheModule !== undefined ? options.cacheModule : loadDefaultCacheModule();
   if (cacheMod === null) {
     return stepOutcome(
       "populate_cache",
       true,
-      "deferred (scripts/cache.py not present on this branch; re-run after rebase to populate via task cache:fetch-all)",
-      { deferred: "cache-module-missing", repo: effectiveRepo },
+      "deferred (cache module explicitly disabled; pass a cacheModule or omit the override to populate via cache:fetch-all)",
+      { deferred: "cache-module-disabled", repo: effectiveRepo },
     );
   }
 

--- a/xbrief/active/2026-07-20-2684-bug-triage-bootstrap-cache-py.xbrief.json
+++ b/xbrief/active/2026-07-20-2684-bug-triage-bootstrap-cache-py.xbrief.json
@@ -1,0 +1,85 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for GitHub issue #2684"
+  },
+  "plan": {
+    "title": "Bootstrap cache populate via TypeScript cacheFetchAll (drop scripts/cache.py gate)",
+    "status": "running",
+    "narratives": {
+      "Description": "triage:bootstrap defers cache population when scripts/cache.py is absent and tells operators to rebase. npm consumers never have that Python script. Default loadDefaultCacheModule to the existing TypeScript cacheFetchAll path (same pattern as empty-populate #2575), forward bootstrap kwargs, remove the rebase defer message, update tests.",
+      "Origin": "https://github.com/deftai/directive/issues/2684",
+      "Overview": "Adoption blocker: empty triage queue after triage:bootstrap on @deftai/directive 0.79.3 consumers.",
+      "Labels": "bug, adoption-blocker, triage, agent-experience, area:cli",
+      "ImplementationPlan": "1. Add triage/bootstrap cache-module adapter wrapping cacheFetchAll with full kwargs. 2. loadDefaultCacheModule always returns TS module (optional Python fallback only if cache.py exists). 3. Remove rebase defer message path for missing Python. 4. Update index.test.ts. 5. CHANGELOG Fixed entry citing #2684.",
+      "UserStory": "As an npm consumer, I want triage:bootstrap to populate the GitHub issue cache without requiring scripts/cache.py, so triage:queue returns ranked work."
+    },
+    "items": [
+      {
+        "title": "AC1",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "stepPopulateCache without injected cacheModule and without scripts/cache.py invokes TypeScript cacheFetchAll (or an injected adapter) and does not return deferred=cache-module-missing."
+        }
+      },
+      {
+        "title": "AC2",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "No user-facing bootstrap message tells operators to rebase to recover scripts/cache.py."
+        }
+      },
+      {
+        "title": "AC3",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Regression tests + CHANGELOG [Unreleased] Fixed cite #2684."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "triage",
+      "agent-experience",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2684",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2684: bootstrap recovery references removed scripts/cache.py"
+      }
+    ],
+    "updated": "2026-07-20T19:25:16Z",
+    "id": "2684-bootstrap-ts-cache",
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#2684"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/triage/bootstrap/index.ts",
+          "packages/core/src/triage/bootstrap/cache-module.ts",
+          "packages/core/src/triage/bootstrap/index.test.ts",
+          "packages/core/src/integration-e2e/bootstrap-cache-module.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task check -- --filter triage/bootstrap"
+        ],
+        "expected_outputs": [
+          "Default cache module uses TS cacheFetchAll",
+          "No rebase/scripts/cache.py defer message"
+        ],
+        "depends_on": [],
+        "conflict_group": "2684-bootstrap-cache",
+        "size": "S",
+        "file_scope_confidence": "high"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `triage:bootstrap` defaults to TypeScript `cacheFetchAll` instead of gating on removed `scripts/cache.py`.
- Removes the consumer-facing "rebase to recover cache.py" defer path; kwargs (state/limit/labels/author) forward through the adapter.
- Closes #2684.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/triage/bootstrap/cache-module.test.ts packages/core/src/triage/bootstrap/index.test.ts`
- [ ] Consumer-style: `deft triage:bootstrap` without `scripts/cache.py` populates `.deft-cache` / non-empty `triage:queue`
