### PR TITLE
chore(xbrief): complete #2684 and #2688 after merge

### DIFF
--- a/xbrief/completed/2026-07-20-2684-bug-triage-bootstrap-cache-py.xbrief.json
+++ b/xbrief/completed/2026-07-20-2684-bug-triage-bootstrap-cache-py.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Bootstrap cache populate via TypeScript cacheFetchAll (drop scripts/cache.py gate)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "triage:bootstrap defers cache population when scripts/cache.py is absent and tells operators to rebase. npm consumers never have that Python script. Default loadDefaultCacheModule to the existing TypeScript cacheFetchAll path (same pattern as empty-populate #2575), forward bootstrap kwargs, remove the rebase defer message, update tests.",
       "Origin": "https://github.com/deftai/directive/issues/2684",
@@ -51,7 +51,7 @@
         "title": "Issue #2684: bootstrap recovery references removed scripts/cache.py"
       }
     ],
-    "updated": "2026-07-20T19:25:16Z",
+    "updated": "2026-07-20T19:54:15Z",
     "id": "2684-bootstrap-ts-cache",
     "metadata": {
       "kind": "story",
@@ -79,7 +79,9 @@
         "conflict_group": "2684-bootstrap-cache",
         "size": "S",
         "file_scope_confidence": "high"
-      }
+      },
+      "completedAt": "2026-07-20T19:54:15Z",
+      "capacityBucket": "technical-debt"
     }
   }
 }

--- a/xbrief/completed/2026-07-20-2688-bug-review-cycle-ci-failures.xbrief.json
+++ b/xbrief/completed/2026-07-20-2688-bug-review-cycle-ci-failures.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Review-cycle: Greptile CLEAN + ci_failures forces CI fix (no idle-poll)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "drive-to:merge-ready workers idle-poll when Greptile is CLEAN and clean_gate_holdout=ci_failures. Add review-cycle skill doctrine (CI annotation fetch + fix batch; checkboxes != merge-ready; review-monitor carve-out). Optionally surface failing check names in pr:watch JSON and fail-loud (CI_BLOCKED/STALL) instead of burning max-wait.",
       "Origin": "https://github.com/deftai/directive/issues/2688",
@@ -49,7 +49,7 @@
         "title": "Issue #2688: Greptile CLEAN + ci_failures idle-poll"
       }
     ],
-    "updated": "2026-07-20T19:29:22Z",
+    "updated": "2026-07-20T19:54:09Z",
     "id": "2688-review-cycle-ci-holdout",
     "metadata": {
       "kind": "story",
@@ -78,7 +78,9 @@
         "conflict_group": "2688-review-ci",
         "size": "M",
         "file_scope_confidence": "high"
-      }
+      },
+      "completedAt": "2026-07-20T19:54:09Z",
+      "capacityBucket": "technical-debt"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Move #2684 / #2688 scope xBRIEFs from `active/` to `completed/` after PRs #2689 and #2690 merged (squash left them active on master).

## Test plan
- [x] Confirm issues #2684 and #2688 are closed
- [ ] Spot-check `xbrief/active/` no longer lists these stories
