### PR TITLE
fix(hooks): strip UTF-8 BOM before Cursor preToolUse JSON.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cursor `preToolUse` stdin for bare `deft hook:dispatch --host cursor --event tool.before` no longer fail-closes on UTF-8 BOM-prefixed JSON — `parsePayload` strips the BOM before `JSON.parse` while preserving empty-stdin and invalid-JSON distinctions. Refs #2734.
+
 ### Removed
 
 ## [0.80.0] - 2026-07-21

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -121,6 +121,44 @@ describe("hook-dispatch CLI", () => {
     expect(parsePayload("{bad-json")).toEqual({ payload: {}, context: { parseFailed: true } });
   });
 
+  it("strips UTF-8 BOM before JSON.parse (#2734)", () => {
+    const writePayload = {
+      tool_name: "Write",
+      tool_input: { content: "x", file_path: "a.txt" },
+      workspace_roots: ["/p"],
+    };
+    const bomWrite = `\uFEFF${JSON.stringify(writePayload)}`;
+    expect(parsePayload(bomWrite)).toEqual({ payload: writePayload, context: {} });
+    expect(parsePayload("\uFEFF")).toEqual({ payload: {}, context: { stdinEmpty: true } });
+    expect(parsePayload("\uFEFF{bad-json")).toEqual({
+      payload: {},
+      context: { parseFailed: true },
+    });
+  });
+
+  it("allows Cursor Write payloads prefixed with UTF-8 BOM (#2734)", () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const writePayload = {
+      tool_name: "Write",
+      tool_input: { content: "x", file_path: "a.txt" },
+      workspace_roots: ["/project"],
+    };
+    const code = run(["--host=cursor", "--event=tool.before"], {
+      readStdin: () => `\uFEFF${JSON.stringify(writePayload)}`,
+      writeOut: (text) => out.push(text),
+      writeErr: (text) => err.push(text),
+      cwd: () => "/project",
+    });
+    expect(code).toBe(0);
+    const rendered = out.join("");
+    expect(rendered).not.toContain("not valid JSON");
+    expect(rendered).not.toContain("omitted a recognizable tool name");
+    if (rendered.length > 0) {
+      expect(JSON.parse(rendered).user_message).toContain("Write");
+    }
+  });
+
   it("logs Cursor payload keys and distinct empty-stdin messaging (#2669)", () => {
     const emptyOut: string[] = [];
     const emptyErr: string[] = [];

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -86,12 +86,22 @@ export interface ParsedPayload {
   readonly context: HookPayloadContext;
 }
 
+const UTF8_BOM = "\uFEFF";
+
+function stripUtf8Bom(raw: string): string {
+  return raw.startsWith(UTF8_BOM) ? raw.slice(UTF8_BOM.length) : raw;
+}
+
 export function parsePayload(raw: string): ParsedPayload {
   if (raw.trim().length === 0) {
     return { payload: {}, context: { stdinEmpty: true } };
   }
+  const normalized = stripUtf8Bom(raw);
+  if (normalized.trim().length === 0) {
+    return { payload: {}, context: { stdinEmpty: true } };
+  }
   try {
-    return { payload: JSON.parse(raw) as unknown, context: {} };
+    return { payload: JSON.parse(normalized) as unknown, context: {} };
   } catch {
     // tool.before is installed only on direct-write matchers, so an unreadable
     // payload becomes a missing-tool denial rather than a fail-open crash.


### PR DESCRIPTION
## Summary

- Strip UTF-8 BOM (EF BB BF) from Cursor preToolUse stdin before JSON.parse in parsePayload
- Preserve existing stdinEmpty / parseFailed fail-closed distinctions
- Add regression tests for BOM+valid Write, BOM-only empty, and BOM+garbage payloads

## Test plan

- [x] 	ask check green
- [x] Unit tests: BOM+valid Write JSON parses; BOM-only → stdinEmpty; BOM+garbage → parseFailed
- [x] Integration test: BOM+Write reaches tool identity (not "not valid JSON" denial)

Refs #2734