### PR TITLE
fix(product-signal): bootstrap sink as internal visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Consented product check-in to a private partner sink (#2693).** Opt-in typed policy `plan.policy.productSignal` (default off) with `task product-signal:enable -- --confirm`, install-level consent file, CLI `task product-signal:status|consent|submit`, skill `deft-directive-product-signal`, versioned payload with minimized `localSignalSummary` (value/health/helped) and optional `skillsSummary` hook. Submits pulse/portrait standing threads to private `deftai/product-signal` via `GitHubPrivateSinkAdapter`; fail-open on headless and sink unreachable. Refs #2603.
+- **Consented product check-in to an internal partner sink (#2693).** Opt-in typed policy `plan.policy.productSignal` (default off) with `task product-signal:enable -- --confirm`, install-level consent file, CLI `task product-signal:status|consent|submit`, skill `deft-directive-product-signal`, versioned payload with minimized `localSignalSummary` (value/health/helped) and optional `skillsSummary` hook. Submits pulse/portrait standing threads to internal `deftai/product-signal` via `GitHubPrivateSinkAdapter`; fail-open on headless and sink unreachable. Refs #2603.
 
 ### Changed
+
+- **`product-signal:bootstrap-sink` sets visibility to internal** after create (org-visible, not public). Docs match. Refs #2693.
 
 ### Fixed
 

--- a/content/docs/product-signal.md
+++ b/content/docs/product-signal.md
@@ -31,13 +31,13 @@ task product-signal:submit -- --surface pulse|portrait [--dry-run] [--json] [--n
 
 ## Sink bootstrap (maintainers)
 
-Private inbox: `deftai/product-signal` (overridable via `plan.policy.productSignal.sinkRepo`).
+Internal (org) inbox: `deftai/product-signal` (overridable via `plan.policy.productSignal.sinkRepo`). Not public.
 
 ```bash
 task product-signal:bootstrap-sink [-- --dry-run]
 ```
 
-Bootstraps D20 labels (`surface:*`, `nps:*`, `signal:gap`). Standing threads keyed by `(installId, actorName)`.
+Creates the repo if needed, sets visibility to **internal**, and bootstraps D20 labels (`surface:*`, `nps:*`, `signal:gap`). Standing threads keyed by `(installId, actorName)`.
 
 ## Skill
 

--- a/packages/core/src/product-signal/sink-bootstrap.test.ts
+++ b/packages/core/src/product-signal/sink-bootstrap.test.ts
@@ -4,7 +4,9 @@ import { bootstrapProductSignalLabels, bootstrapProductSignalSink } from "./sink
 
 describe("sink-bootstrap", () => {
   it("dry-run bootstrap sink", () => {
-    expect(bootstrapProductSignalSink({ dryRun: true }).stdout).toContain("dry-run");
+    const out = bootstrapProductSignalSink({ dryRun: true }).stdout;
+    expect(out).toContain("dry-run");
+    expect(out).toContain("internal sink");
   });
 
   it("skips existing labels", () => {

--- a/packages/core/src/product-signal/sink-bootstrap.ts
+++ b/packages/core/src/product-signal/sink-bootstrap.ts
@@ -109,21 +109,13 @@ export function bootstrapProductSignalSink(
   // Org "internal" visibility: gh create has no --internal; set after create.
   const visibility = spawnSync(
     "gh",
-    [
-      "repo",
-      "edit",
-      repo,
-      "--visibility",
-      "internal",
-      "--accept-visibility-change-consequences",
-    ],
+    ["repo", "edit", repo, "--visibility", "internal", "--accept-visibility-change-consequences"],
     { encoding: "utf8" },
   );
   if (visibility.status !== 0) {
     return {
       exitCode: 2,
-      stdout:
-        `sink repo created but failed to set visibility=internal: ${visibility.stderr || visibility.stdout}\n`,
+      stdout: `sink repo created but failed to set visibility=internal: ${visibility.stderr || visibility.stdout}\n`,
       repo,
     };
   }

--- a/packages/core/src/product-signal/sink-bootstrap.ts
+++ b/packages/core/src/product-signal/sink-bootstrap.ts
@@ -19,7 +19,7 @@ export const PRODUCT_SIGNAL_BOOTSTRAP_LABELS: readonly {
 
 export const PRODUCT_SIGNAL_SINK_README = `# deftai/product-signal
 
-Private operator inbox for consented Directive product-improvement signal (Phase 1 under epic #2603).
+Internal (org) operator inbox for consented Directive product-improvement signal (Phase 1 under epic #2603).
 
 ## Standing threads
 
@@ -71,7 +71,10 @@ export function bootstrapProductSignalLabels(
   return { created, skipped, errors };
 }
 
-/** Create private sink repo + README + labels via gh CLI (#2693 D6/D20). */
+/**
+ * Create sink repo + labels via gh CLI (#2693 D6/D20).
+ * Creates as private then sets visibility to **internal** (org-visible, not public).
+ */
 export function bootstrapProductSignalSink(
   options: { repo?: string; dryRun?: boolean; seams?: GhRestSeams } = {},
 ): BootstrapSinkResult {
@@ -79,7 +82,7 @@ export function bootstrapProductSignalSink(
   if (options.dryRun) {
     return {
       exitCode: 0,
-      stdout: `[dry-run] would bootstrap private sink ${repo} with README + ${PRODUCT_SIGNAL_BOOTSTRAP_LABELS.length} labels\n`,
+      stdout: `[dry-run] would bootstrap internal sink ${repo} with README + ${PRODUCT_SIGNAL_BOOTSTRAP_LABELS.length} labels\n`,
       repo,
     };
   }
@@ -91,7 +94,7 @@ export function bootstrapProductSignalSink(
       repo,
       "--private",
       "--description",
-      "Private product-improvement signal inbox for Directive partners (Refs #2693)",
+      "Internal product-improvement signal inbox for Directive partners (Refs #2693)",
       "--add-readme",
     ],
     { encoding: "utf8" },
@@ -103,9 +106,30 @@ export function bootstrapProductSignalSink(
       repo,
     };
   }
+  // Org "internal" visibility: gh create has no --internal; set after create.
+  const visibility = spawnSync(
+    "gh",
+    [
+      "repo",
+      "edit",
+      repo,
+      "--visibility",
+      "internal",
+      "--accept-visibility-change-consequences",
+    ],
+    { encoding: "utf8" },
+  );
+  if (visibility.status !== 0) {
+    return {
+      exitCode: 2,
+      stdout:
+        `sink repo created but failed to set visibility=internal: ${visibility.stderr || visibility.stdout}\n`,
+      repo,
+    };
+  }
   const labelResult = bootstrapProductSignalLabels(repo, options.seams);
   const lines = [
-    `product-signal sink ${repo} ready (or already existed).`,
+    `product-signal sink ${repo} ready (visibility=internal).`,
     `labels: created=${labelResult.created} skipped=${labelResult.skipped}`,
   ];
   if (labelResult.errors.length > 0) {


### PR DESCRIPTION
## Summary
- `task product-signal:bootstrap-sink` now sets the sink repo to **internal** after create
- Docs + CHANGELOG wording: internal inbox (not public / not forever-private)

## Ops note
`deftai/product-signal` already created and set to `visibility=internal`; labels bootstrapped; README updated.

## Test plan
- [x] dry-run stdout mentions internal sink
- [ ] CI green

Refs #2693