### PR TITLE
feat(doctor): advisory TS7 side-by-side hint (#2591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TypeScript 7 side-by-side guidance for Deft TypeScript projects (#2591).** `languages/typescript.md` documents the Cartograph alias pattern (`@typescript/native` → TS 7, `typescript` → `@typescript/typescript6`), Dependabot major-ignore for the alias, and links to the TS 7 announcement + typescript-eslint#12518. `UPGRADING.md` carries a short applies-when pointer. Scaffold bake and doctor hints explicitly deferred (docs-only). Closes #2591.
 - **Consented product check-in to an internal partner sink (#2693).** Opt-in typed policy `plan.policy.productSignal` (default off) with `task product-signal:enable -- --confirm`, install-level consent file, CLI `task product-signal:status|consent|submit`, skill `deft-directive-product-signal`, versioned payload with minimized `localSignalSummary` (value/health/helped) and optional `skillsSummary` hook. Submits pulse/portrait standing threads to internal `deftai/product-signal` via `GitHubPrivateSinkAdapter`; fail-open on headless and sink unreachable. Refs #2603.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **TypeScript 7 side-by-side guidance for Deft TypeScript projects (#2591).** `languages/typescript.md` documents the Cartograph alias pattern (`@typescript/native` → TS 7, `typescript` → `@typescript/typescript6`), Dependabot major-ignore for the alias, and links to the TS 7 announcement + typescript-eslint#12518. `UPGRADING.md` carries a short applies-when pointer. Scaffold bake and doctor hints explicitly deferred (docs-only). Closes #2591.
+- **TypeScript 7 side-by-side guidance for Deft TypeScript projects (#2591).** `languages/typescript.md` documents the Cartograph alias pattern (`@typescript/native` → TS 7, `typescript` → `@typescript/typescript6`), Dependabot major-ignore for the alias, and links to the TS 7 announcement + typescript-eslint#12518. `UPGRADING.md` carries a short applies-when pointer. Advisory `deft doctor` install-integrity check warns when bare `typescript@7` coexists with typescript-eslint without the alias (exit-exempt). Scaffold bake remains deferred. Closes #2591.
 - **Consented product check-in to an internal partner sink (#2693).** Opt-in typed policy `plan.policy.productSignal` (default off) with `task product-signal:enable -- --confirm`, install-level consent file, CLI `task product-signal:status|consent|submit`, skill `deft-directive-product-signal`, versioned payload with minimized `localSignalSummary` (value/health/helped) and optional `skillsSummary` hook. Submits pulse/portrait standing threads to internal `deftai/product-signal` via `GitHubPrivateSinkAdapter`; fail-open on headless and sink unreachable. Refs #2603.
 
 ### Changed

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -12,6 +12,20 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 ---
 
+## TypeScript 7 side-by-side (pre-7.1) (#2591)
+
+- **Applies when:** a Deft TypeScript project (or agent upgrading its toolchain) needs TypeScript 7 before ~7.1, while `typescript-eslint` and other programmatic consumers still require the TS 6 compiler API. This is **not** a Directive framework-version migration — read [languages/typescript.md](./languages/typescript.md) instead of treating it like a `deft update` step.
+- **Safe to auto-run:** Yes for the alias + Dependabot-ignore edits in the project's own `package.json` / `.github/dependabot.yml` when following the documented pattern.
+- **Restart required:** No. Re-run `task check` / `npm install` (or your package manager equivalent) after changing devDependencies.
+- **Commands:**
+  - Read the full pattern: [languages/typescript.md — TypeScript 7 side-by-side (pre-7.1)](./languages/typescript.md#typescript-7-side-by-side-pre-71)
+  - After edits: `npm install` (or `pnpm install` / `yarn`) then `task check`
+- **References:**
+  - [#2591](https://github.com/deftai/directive/issues/2591) — document side-by-side setup for Deft TypeScript projects.
+  - [deftai/cartograph#111](https://github.com/deftai/cartograph/pull/111) — precedent implementation.
+
+---
+
 ## Helped + health metrics relocation (#2545)
 
 - **Applies when:** any project that upgraded to a release shipping #2545 and still has append logs under `<lifecycle-root>/.eval/results/crud-metrics.jsonl` or `health-history.jsonl` inside the git worktree.

--- a/content/languages/typescript.md
+++ b/content/languages/typescript.md
@@ -124,6 +124,46 @@ Key settings: `@typescript-eslint/parser`, extends `recommended` + `recommended-
 - ⊗ Empty `catch` blocks or `catch (e) {}` — log or re-throw
 - ⊗ Returning `null`, `undefined`, or a neutral default to mask a thrown error
 
+## TypeScript 7 side-by-side (pre-7.1)
+
+TypeScript 7.0 ships without a stable programmatic compiler API. A direct `typescript` major bump to 7 breaks `typescript-eslint` (for example `ModuleKind.Cjs` is undefined). Until ~7.1, ! run TS 7 side-by-side with a TS 6 alias for tooling that still needs the compiler API — the same pattern as [deftai/cartograph#111](https://github.com/deftai/cartograph/pull/111).
+
+### package.json aliases
+
+Keep `typescript` on the TS 6 API for ESLint, `tsc --noEmit`, and other programmatic consumers. Install TS 7 under `@typescript/native`:
+
+```json
+{
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}
+```
+
+Use `@typescript/native` (or `pnpm exec tsgo`) for TS 7-native typechecking when you opt in; keep existing `typescript` / `tsc` scripts on the alias until typescript-eslint and your toolchain support TS 7's programmatic surface.
+
+### Dependabot
+
+Because `typescript` is aliased to `@typescript/typescript6`, ! ignore Dependabot major bumps on the `typescript` dependency name until you intentionally migrate off the side-by-side layout:
+
+```yaml
+ignore:
+  - dependency-name: "typescript"
+    update-types: ["version-update:semver-major"]
+```
+
+### Scaffold and doctor coverage
+
+**Scaffold bake — deferred (#2591):** Directive does not ship a Deft-owned TypeScript `package.json` scaffold to mutate. New TypeScript projects copy the alias snippet from this section into their own `package.json`.
+
+**Doctor / verify hint — deferred (#2591):** This release is docs-only. Reopen a follow-up if consumer Dependabot breakage recurs after this guidance lands.
+
+### References
+
+- [Announcing TypeScript 7.0 — side-by-side install](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#side-by-side-installation) — official TS 7 side-by-side guidance.
+- [typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518) — typescript-eslint TS 7 / compiler API tracking.
+
 ## Compliance Checklist
 
 - ! Include TSDoc comments for all exported APIs

--- a/content/languages/typescript.md
+++ b/content/languages/typescript.md
@@ -157,7 +157,7 @@ ignore:
 
 **Scaffold bake — deferred (#2591):** Directive does not ship a Deft-owned TypeScript `package.json` scaffold to mutate. New TypeScript projects copy the alias snippet from this section into their own `package.json`.
 
-**Doctor / verify hint — deferred (#2591):** This release is docs-only. Reopen a follow-up if consumer Dependabot breakage recurs after this guidance lands.
+**Doctor hint — shipped (#2591):** `deft doctor` warns (advisory, exit-exempt) when `package.json` declares typescript-eslint (`typescript-eslint` or `@typescript-eslint/*`) and `eslint`, and `typescript` resolves to 7.x without the `@typescript/typescript6` alias — pointing here and at the Cartograph alias pattern above. Scaffold bake remains deferred.
 
 ### References
 

--- a/packages/core/src/content-contracts/standards/typescript_ts7_side_by_side.test.ts
+++ b/packages/core/src/content-contracts/standards/typescript_ts7_side_by_side.test.ts
@@ -30,9 +30,10 @@ describe("test_typescript_ts7_side_by_side.py", () => {
     expect(typescriptMd).toContain("typescript-eslint/typescript-eslint/issues/12518");
   });
 
-  it("test_typescript_md_records_scaffold_and_doctor_deferral", () => {
+  it("test_typescript_md_records_scaffold_deferred_and_doctor_shipped", () => {
     expect(typescriptMd).toContain("Scaffold bake — deferred");
-    expect(typescriptMd).toContain("Doctor / verify hint — deferred");
+    expect(typescriptMd).toContain("Doctor hint — shipped");
+    expect(typescriptMd).not.toContain("Doctor / verify hint — deferred");
     expect(typescriptMd).toContain("#2591");
   });
 

--- a/packages/core/src/content-contracts/standards/typescript_ts7_side_by_side.test.ts
+++ b/packages/core/src/content-contracts/standards/typescript_ts7_side_by_side.test.ts
@@ -17,7 +17,7 @@ describe("test_typescript_ts7_side_by_side.py", () => {
     '"@typescript/native": "npm:typescript@^7.0.2"',
     '"typescript": "npm:@typescript/typescript6@^6.0.2"',
     "@typescript/typescript6",
-    "dependency-name: \"typescript\"",
+    'dependency-name: "typescript"',
     "version-update:semver-major",
   ]) {
     it(`test_typescript_md_pins_required_alias_tokens ${alias}`, () => {
@@ -26,9 +26,7 @@ describe("test_typescript_ts7_side_by_side.py", () => {
   }
 
   it("test_typescript_md_links_official_and_typescript_eslint_refs", () => {
-    expect(typescriptMd).toContain(
-      "devblogs.microsoft.com/typescript/announcing-typescript-7-0",
-    );
+    expect(typescriptMd).toContain("devblogs.microsoft.com/typescript/announcing-typescript-7-0");
     expect(typescriptMd).toContain("typescript-eslint/typescript-eslint/issues/12518");
   });
 

--- a/packages/core/src/content-contracts/standards/typescript_ts7_side_by_side.test.ts
+++ b/packages/core/src/content-contracts/standards/typescript_ts7_side_by_side.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { isFile, readText } from "./_helpers.js";
+
+const typescriptMd = readText("languages/typescript.md");
+const upgradingMd = readText("UPGRADING.md");
+
+describe("test_typescript_ts7_side_by_side.py", () => {
+  it("test_typescript_md_file_exists", () => {
+    expect(isFile("languages/typescript.md")).toBe(true);
+  });
+
+  it("test_typescript_md_carries_ts7_side_by_side_heading", () => {
+    expect(typescriptMd).toMatch(/^## TypeScript 7 side-by-side \(pre-7\.1\)/m);
+  });
+
+  for (const alias of [
+    '"@typescript/native": "npm:typescript@^7.0.2"',
+    '"typescript": "npm:@typescript/typescript6@^6.0.2"',
+    "@typescript/typescript6",
+    "dependency-name: \"typescript\"",
+    "version-update:semver-major",
+  ]) {
+    it(`test_typescript_md_pins_required_alias_tokens ${alias}`, () => {
+      expect(typescriptMd).toContain(alias);
+    });
+  }
+
+  it("test_typescript_md_links_official_and_typescript_eslint_refs", () => {
+    expect(typescriptMd).toContain(
+      "devblogs.microsoft.com/typescript/announcing-typescript-7-0",
+    );
+    expect(typescriptMd).toContain("typescript-eslint/typescript-eslint/issues/12518");
+  });
+
+  it("test_typescript_md_records_scaffold_and_doctor_deferral", () => {
+    expect(typescriptMd).toContain("Scaffold bake — deferred");
+    expect(typescriptMd).toContain("Doctor / verify hint — deferred");
+    expect(typescriptMd).toContain("#2591");
+  });
+
+  it("test_upgrading_md_carries_ts7_pointer_heading", () => {
+    expect(upgradingMd).toMatch(/^## TypeScript 7 side-by-side \(pre-7\.1\) \(#2591\)/m);
+  });
+
+  for (const field of ["Applies when", "Safe to auto-run", "Restart required", "Commands"]) {
+    it(`test_upgrading_pointer_has_${field.replace(/ /g, "_").toLowerCase()}`, () => {
+      const start = upgradingMd.indexOf("## TypeScript 7 side-by-side (pre-7.1) (#2591)");
+      expect(start).toBeGreaterThanOrEqual(0);
+      const section = upgradingMd.slice(start, upgradingMd.indexOf("\n---", start));
+      expect(section).toContain(`**${field}:**`);
+    });
+  }
+
+  it("test_upgrading_pointer_links_typescript_md_section", () => {
+    expect(upgradingMd).toContain("./languages/typescript.md");
+    expect(upgradingMd).toContain("typescript-7-side-by-side-pre-71");
+  });
+});

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -363,6 +363,51 @@ describe("checkTypescript7SideBySide (#2591)", () => {
     expect(result.detail).toContain("package.json not found");
   });
 
+  it("skips when package.json is unreadable", () => {
+    const result = checkTypescript7SideBySide("/proj", seamsFor("{not-json"));
+    expect(result.status).toBe("skip");
+    expect(result.detail).toContain("unreadable");
+  });
+
+  it("skips when package.json has no dependency sections", () => {
+    const result = checkTypescript7SideBySide("/proj", seamsFor(JSON.stringify({ name: "demo" })));
+    expect(result.status).toBe("skip");
+    expect(result.detail).toContain("no dependency sections");
+  });
+
+  it("passes when typescript-eslint is absent", () => {
+    const pkg = JSON.stringify({
+      devDependencies: { eslint: "^9.0.0", typescript: "^7.0.2" },
+    });
+    const result = checkTypescript7SideBySide("/proj", seamsFor(pkg));
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("No typescript-eslint packages");
+  });
+
+  it("passes when eslint and typescript-eslint are present but typescript is missing", () => {
+    const pkg = JSON.stringify({
+      devDependencies: {
+        eslint: "^9.0.0",
+        "typescript-eslint": "^8.0.0",
+      },
+    });
+    const result = checkTypescript7SideBySide("/proj", seamsFor(pkg));
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("No typescript dependency");
+  });
+
+  it("reads typescript from dependencies when devDependencies omits it", () => {
+    const pkg = JSON.stringify({
+      dependencies: { typescript: "^7.0.2" },
+      devDependencies: {
+        eslint: "^9.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+      },
+    });
+    const result = checkTypescript7SideBySide("/proj", seamsFor(pkg));
+    expect(result.status).toBe("fail");
+  });
+
   it("passes when typescript uses the @typescript/typescript6 alias", () => {
     const pkg = JSON.stringify({
       devDependencies: {

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -12,6 +12,7 @@ import {
   checkQuickStartResolves,
   checkSkillPathsResolve,
   checkStaleXbriefSchemaDeposit,
+  checkTypescript7SideBySide,
   deriveExitCode,
   runChecks,
   runChecksImpl,
@@ -344,6 +345,84 @@ describe("checkGitignoreCoverage (#2206)", () => {
 
   it("is advisory: does NOT change the doctor exit code", () => {
     const fail = checkGitignoreCoverage("/proj", seamsFor("node_modules/\n"));
+    expect(fail.status).toBe("fail");
+    expect(deriveExitCode([fail], [])).toBe(0);
+  });
+});
+
+describe("checkTypescript7SideBySide (#2591)", () => {
+  function seamsFor(packageJsonText: string | null): { readText: (path: string) => string | null } {
+    return {
+      readText: (p: string) => (p.endsWith("package.json") ? packageJsonText : null),
+    };
+  }
+
+  it("skips when package.json is absent", () => {
+    const result = checkTypescript7SideBySide("/proj", seamsFor(null));
+    expect(result.status).toBe("skip");
+    expect(result.detail).toContain("package.json not found");
+  });
+
+  it("passes when typescript uses the @typescript/typescript6 alias", () => {
+    const pkg = JSON.stringify({
+      devDependencies: {
+        eslint: "^9.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        typescript: "npm:@typescript/typescript6@^6.0.2",
+        "@typescript/native": "npm:typescript@^7.0.2",
+      },
+    });
+    const result = checkTypescript7SideBySide("/proj", seamsFor(pkg));
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails for bare typescript@7 with @typescript-eslint/parser and eslint", () => {
+    const pkg = JSON.stringify({
+      devDependencies: {
+        eslint: "^9.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        typescript: "^7.0.2",
+      },
+    });
+    const result = checkTypescript7SideBySide("/proj", seamsFor(pkg));
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("languages/typescript.md");
+    expect(result.detail).toContain("@typescript/typescript6");
+  });
+
+  it("passes for typescript@5 with eslint and typescript-eslint", () => {
+    const pkg = JSON.stringify({
+      devDependencies: {
+        eslint: "^9.0.0",
+        "typescript-eslint": "^8.0.0",
+        typescript: "^5.7.0",
+      },
+    });
+    const result = checkTypescript7SideBySide("/proj", seamsFor(pkg));
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes for ts7 without eslint", () => {
+    const pkg = JSON.stringify({
+      devDependencies: {
+        "@typescript-eslint/parser": "^8.0.0",
+        typescript: "^7.0.2",
+      },
+    });
+    const result = checkTypescript7SideBySide("/proj", seamsFor(pkg));
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("eslint is not declared");
+  });
+
+  it("is advisory: does NOT change the doctor exit code", () => {
+    const pkg = JSON.stringify({
+      devDependencies: {
+        eslint: "^9.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        typescript: "npm:typescript@^7.0.2",
+      },
+    });
+    const fail = checkTypescript7SideBySide("/proj", seamsFor(pkg));
     expect(fail.status).toBe("fail");
     expect(deriveExitCode([fail], [])).toBe(0);
   });

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -606,6 +606,165 @@ export function checkStaleXbriefSchemaDeposit(
   };
 }
 
+const TS7_SIDE_BY_SIDE_CHECK = "typescript-7-side-by-side";
+
+function depKeyIsTypescriptEslint(key: string): boolean {
+  return key === "typescript-eslint" || key.startsWith("@typescript-eslint/");
+}
+
+function depKeysIncludeTypescriptEslint(keys: readonly string[]): boolean {
+  return keys.some(depKeyIsTypescriptEslint);
+}
+
+function depKeysIncludeEslint(keys: readonly string[]): boolean {
+  return keys.includes("eslint");
+}
+
+function typescriptValueIs7Bound(value: string): boolean {
+  const v = value.trim();
+  if (!v || v.includes("@typescript/typescript6")) {
+    return false;
+  }
+  if (/npm:typescript@(?:[\^~>=<]*|\d*)7/i.test(v)) {
+    return true;
+  }
+  if (/^[\^~>=<]*7(?:\.\d|$)/.test(v)) {
+    return true;
+  }
+  if (/^7\.\d/.test(v)) {
+    return true;
+  }
+  return false;
+}
+
+function resolveTypescriptDepValue(
+  deps: Record<string, string>,
+  devDeps: Record<string, string>,
+): string | null {
+  if (typeof devDeps.typescript === "string") {
+    return devDeps.typescript;
+  }
+  if (typeof deps.typescript === "string") {
+    return deps.typescript;
+  }
+  return null;
+}
+
+/**
+ * #2591: advisory hint when a TypeScript project pins bare `typescript@7` alongside
+ * typescript-eslint without the `@typescript/typescript6` alias. Exit-exempt (like
+ * gitignore-coverage) — adoption guidance, not a broken install.
+ */
+export function checkTypescript7SideBySide(projectRoot: string, seams: CheckSeams = {}): CheckResult {
+  const packageJsonPath = join(projectRoot, "package.json");
+  const text = readText(packageJsonPath, seams);
+
+  if (text === null) {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "skip",
+      detail: "package.json not found; nothing to inspect for TypeScript side-by-side layout.",
+      data: { package_json_path: packageJsonPath },
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "skip",
+      detail: "package.json is unreadable; skipping TypeScript side-by-side check.",
+      data: { package_json_path: packageJsonPath },
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "skip",
+      detail: "package.json has no dependency sections; skipping TypeScript side-by-side check.",
+      data: { package_json_path: packageJsonPath },
+    };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const deps =
+    typeof record.dependencies === "object" && record.dependencies !== null
+      ? (record.dependencies as Record<string, string>)
+      : {};
+  const devDeps =
+    typeof record.devDependencies === "object" && record.devDependencies !== null
+      ? (record.devDependencies as Record<string, string>)
+      : {};
+  const depKeys = [...Object.keys(deps), ...Object.keys(devDeps)];
+
+  if (depKeys.length === 0) {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "skip",
+      detail: "package.json has no dependency sections; skipping TypeScript side-by-side check.",
+      data: { package_json_path: packageJsonPath },
+    };
+  }
+
+  if (!depKeysIncludeTypescriptEslint(depKeys)) {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "pass",
+      detail: "No typescript-eslint packages declared; TypeScript 7 side-by-side alias not required.",
+      data: { package_json_path: packageJsonPath },
+    };
+  }
+
+  if (!depKeysIncludeEslint(depKeys)) {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "pass",
+      detail: "eslint is not declared; TypeScript 7 side-by-side alias not required.",
+      data: { package_json_path: packageJsonPath },
+    };
+  }
+
+  const typescriptValue = resolveTypescriptDepValue(deps, devDeps);
+  if (typescriptValue === null) {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "pass",
+      detail: "No typescript dependency declared; TypeScript 7 side-by-side alias not required.",
+      data: { package_json_path: packageJsonPath },
+    };
+  }
+
+  if (!typescriptValueIs7Bound(typescriptValue)) {
+    return {
+      name: TS7_SIDE_BY_SIDE_CHECK,
+      status: "pass",
+      detail:
+        "typescript is not pinned to 7.x (or uses the @typescript/typescript6 alias); side-by-side layout not required.",
+      data: {
+        package_json_path: packageJsonPath,
+        typescript: typescriptValue,
+      },
+    };
+  }
+
+  return {
+    name: TS7_SIDE_BY_SIDE_CHECK,
+    status: "fail",
+    detail:
+      "typescript resolves to 7.x without the @typescript/typescript6 alias while typescript-eslint and eslint are present. " +
+      "Until TS 7.1, use the side-by-side alias pattern in languages/typescript.md § TypeScript 7 side-by-side (pre-7.1) " +
+      "(Cartograph #111: keep typescript on npm:@typescript/typescript6 and install TS 7 under @typescript/native).",
+    data: {
+      package_json_path: packageJsonPath,
+      typescript: typescriptValue,
+      suggested_fix: "languages/typescript.md#typescript-7-side-by-side-pre-71",
+    },
+  };
+}
+
 /**
  * #2206: check that the consumer `.gitignore` carries the canonical Deft baseline
  * entries. Advisory (exit-exempt) because missing entries are an adoption risk, not
@@ -669,6 +828,7 @@ export function deriveExitCode(checks: readonly CheckResult[], errors: readonly 
     "manifest-version-reportable",
     "gitignore-coverage",
     "stale-xbrief-schema-deposit",
+    "typescript-7-side-by-side",
   ]);
   if (errors.length > 0 || checks.some((c) => c.status === "error")) {
     return 2;
@@ -715,6 +875,7 @@ export function runChecksImpl(
     checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));
     checks.push(checkStaleXbriefSchemaDeposit(projectRoot, seams));
     checks.push(checkGitignoreCoverage(projectRoot, seams));
+    checks.push(checkTypescript7SideBySide(projectRoot, seams));
     return {
       projectRoot,
       installRoot: null,
@@ -732,6 +893,7 @@ export function runChecksImpl(
   checks.push(checkCanonicalVendoredNpmSignpost(projectRoot, seams));
   checks.push(checkStaleXbriefSchemaDeposit(projectRoot, seams));
   checks.push(checkGitignoreCoverage(projectRoot, seams));
+  checks.push(checkTypescript7SideBySide(projectRoot, seams));
   return {
     projectRoot,
     installRoot,

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -655,7 +655,10 @@ function resolveTypescriptDepValue(
  * typescript-eslint without the `@typescript/typescript6` alias. Exit-exempt (like
  * gitignore-coverage) — adoption guidance, not a broken install.
  */
-export function checkTypescript7SideBySide(projectRoot: string, seams: CheckSeams = {}): CheckResult {
+export function checkTypescript7SideBySide(
+  projectRoot: string,
+  seams: CheckSeams = {},
+): CheckResult {
   const packageJsonPath = join(projectRoot, "package.json");
   const text = readText(packageJsonPath, seams);
 
@@ -713,7 +716,8 @@ export function checkTypescript7SideBySide(projectRoot: string, seams: CheckSeam
     return {
       name: TS7_SIDE_BY_SIDE_CHECK,
       status: "pass",
-      detail: "No typescript-eslint packages declared; TypeScript 7 side-by-side alias not required.",
+      detail:
+        "No typescript-eslint packages declared; TypeScript 7 side-by-side alias not required.",
       data: { package_json_path: packageJsonPath },
     };
   }

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -509,7 +509,8 @@ function runInstallIntegrityChecks(
           name === "canonical-vendored-npm-signpost" ||
           name === "manifest-version-reportable" ||
           name === "gitignore-coverage" ||
-          name === "stale-xbrief-schema-deposit") &&
+          name === "stale-xbrief-schema-deposit" ||
+          name === "typescript-7-side-by-side") &&
         status === "fail"
       ) {
         sink.warn(`${name}: ${detail}`);

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -972,10 +972,10 @@
       {
         "id": "2026-07-21-2734-fixhooks-strip-utf-8-bom-before-cursor-pretooluse-jsonparse",
         "title": "fix(hooks): strip UTF-8 BOM before Cursor preToolUse JSON.parse",
-        "status": "pending",
+        "status": "completed",
         "metadata": {
-          "source_path": "pending/2026-07-21-2734-fixhooks-strip-utf-8-bom-before-cursor-pretooluse-jsonparse.xbrief.json",
-          "lifecycle_folder": "pending",
+          "source_path": "completed/2026-07-21-2734-fixhooks-strip-utf-8-bom-before-cursor-pretooluse-jsonparse.xbrief.json",
+          "lifecycle_folder": "completed",
           "references": [
             {
               "uri": "https://github.com/deftai/directive/issues/2734",

--- a/xbrief/completed/2026-07-21-2591-document-typescript-7-side-by-side-setup-for-deft-typescript.xbrief.json
+++ b/xbrief/completed/2026-07-21-2591-document-typescript-7-side-by-side-setup-for-deft-typescript.xbrief.json
@@ -1,32 +1,28 @@
 {
   "xBRIEFInfo": {
     "version": "0.8",
-    "description": "Scope xBRIEF for #2591 — TypeScript 7 side-by-side guidance for Deft TypeScript projects"
+    "description": "Scope xBRIEF for #2591 — TypeScript 7 side-by-side guidance + doctor hint"
   },
   "plan": {
     "title": "Document TypeScript 7 side-by-side setup for Deft TypeScript projects",
     "status": "completed",
     "narratives": {
-      "Description": "Ship agent-facing TypeScript 7 side-by-side install guidance (Cartograph #111 pattern) so Dependabot/agents do not merge a broken `typescript` 6→7 major while typescript-eslint still needs the TS 6 API. Explicitly decide scaffold + doctor coverage.",
-      "Origin": "Ingested from https://github.com/deftai/directive/issues/2591; refined with locked decisions 2026-07-21.",
-      "Overview": "## Why\n\nTS 7.0 has no stable programmatic API. A direct `typescript` major to 7 breaks `typescript-eslint` (`ModuleKind.Cjs` undefined). Official guidance is side-by-side until ~7.1.\n\n## Locked decisions\n\n- **D1 — Primary surface:** Add a `## TypeScript 7 side-by-side (pre-7.1)` section to `content/languages/typescript.md` with the Cartograph alias pattern (`@typescript/native` → `typescript@^7`, `typescript` → `@typescript/typescript6@^6`), Dependabot ignore for major bumps on the `typescript` alias, and links to the TS 7 announcement + typescript-eslint#12518.\n- **D2 — UPGRADING pointer:** Add a short top-of-`content/UPGRADING.md` note (applies-when / commands / references) pointing agents/operators at D1; not a framework-version migration.\n- **D3 — Scaffold bake: DEFER.** There is no Deft-owned TypeScript `package.json` scaffold to mutate; agents follow the language-pack snippet. Record deferral in the doc section and CHANGELOG.\n- **D4 — Doctor / verify hint: DEFER.** Docs-only close for #2591; reopen a follow-up if consumer Dependabot breakage recurs after guidance lands.\n- **D5 — Contract test:** Content test pins the new typescript.md section heading + required alias package names (and UPGRADING heading if that suite pattern exists).\n- **D6 — CHANGELOG:** Brief `[Unreleased]` notes entry (#1242 style).\n- **D7 — Out of scope:** Changing this repo's own `package.json` typescript pin; Cartograph already fixed; no warehouse/doctor code in this PR.\n\n## Acceptance\n\n- [ ] Documented pattern in `content/languages/typescript.md` agents can follow\n- [ ] UPGRADING.md short pointer shipped\n- [ ] Scaffold bake explicitly deferred in docs + CHANGELOG\n- [ ] Doctor hint explicitly deferred in docs + CHANGELOG\n- [ ] Content contract test green; `task check` green; issue #2591 closed by PR",
+      "Description": "Ship agent-facing TypeScript 7 side-by-side install guidance (Cartograph #111 pattern) plus an advisory deft doctor hint when typescript resolves to 7.x with typescript-eslint and without the @typescript/typescript6 alias. Scaffold bake remains deferred.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2591; D4 flipped to SHIP by operator 2026-07-21.",
+      "Overview": "## Why\n\nTS 7.0 has no stable programmatic API. A direct `typescript` major to 7 breaks `typescript-eslint`. Official guidance is side-by-side until ~7.1.\n\n## Locked decisions\n\n- **D1 — Primary surface:** `## TypeScript 7 side-by-side (pre-7.1)` in `content/languages/typescript.md` (aliases + Dependabot ignore + links). ALREADY SHIPPED on branch.\n- **D2 — UPGRADING pointer:** Short top-of-`content/UPGRADING.md` note. ALREADY SHIPPED.\n- **D3 — Scaffold bake: DEFER.** Unchanged — no Deft-owned TS package.json scaffold.\n- **D4 — Doctor / verify hint: SHIP (operator flip).** Advisory `deft doctor` check (install-integrity / checks.ts): when package.json has typescript-eslint (`typescript-eslint` or `@typescript-eslint/*`) AND `typescript` declares a 7.x range (or npm:typescript@7) AND the `typescript` value is NOT the `@typescript/typescript6` alias → warning pointing at languages/typescript.md side-by-side section. Exit-exempt (like gitignore-coverage). Wire into runChecksImpl + main.ts advisory warning list + unit tests. Update docs/CHANGELOG that previously said doctor deferred.\n- **D5 — Contract test:** Update content contract — doctor shipped, scaffold still deferred.\n- **D6 — CHANGELOG:** Update `[Unreleased]` entry for #2591 to mention doctor hint shipped; scaffold still deferred.\n- **D7 — Out of scope:** Changing this repo's root package.json typescript pin; scaffold bake.\n\n## Remaining work (this amendment)\n\n- [ ] Doctor check + tests + exit-exempt wiring\n- [ ] Flip typescript.md / UPGRADING / CHANGELOG / content-contract text from doctor-deferred → doctor-shipped\n- [ ] `task scope:complete`, PR Closes #2591, merge",
       "Labels": "enhancement, docs, coding-standards, agent-experience, area:guidance"
     },
     "items": [
       {
-        "title": "typescript.md TS7 side-by-side section + Dependabot ignore example",
+        "title": "Advisory doctor check for TS7 without typescript6 alias when typescript-eslint present",
         "status": "proposed"
       },
       {
-        "title": "UPGRADING.md short pointer section",
+        "title": "Docs/CHANGELOG/contract: doctor shipped; scaffold still deferred",
         "status": "proposed"
       },
       {
-        "title": "Explicit scaffold + doctor deferral recorded",
-        "status": "proposed"
-      },
-      {
-        "title": "Content contract test + CHANGELOG [Unreleased]",
+        "title": "PR Closes #2591 through merge",
         "status": "proposed"
       }
     ],
@@ -49,9 +45,9 @@
         "title": "Cartograph TS7 side-by-side precedent"
       }
     ],
-    "updated": "2026-07-21T22:04:47Z",
+    "updated": "2026-07-21T22:14:42Z",
     "metadata": {
-      "completedAt": "2026-07-21T22:04:47Z",
+      "completedAt": "2026-07-21T22:14:42Z",
       "capacityBucket": "new-capability"
     }
   }

--- a/xbrief/completed/2026-07-21-2591-document-typescript-7-side-by-side-setup-for-deft-typescript.xbrief.json
+++ b/xbrief/completed/2026-07-21-2591-document-typescript-7-side-by-side-setup-for-deft-typescript.xbrief.json
@@ -1,0 +1,58 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2591 — TypeScript 7 side-by-side guidance for Deft TypeScript projects"
+  },
+  "plan": {
+    "title": "Document TypeScript 7 side-by-side setup for Deft TypeScript projects",
+    "status": "completed",
+    "narratives": {
+      "Description": "Ship agent-facing TypeScript 7 side-by-side install guidance (Cartograph #111 pattern) so Dependabot/agents do not merge a broken `typescript` 6→7 major while typescript-eslint still needs the TS 6 API. Explicitly decide scaffold + doctor coverage.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2591; refined with locked decisions 2026-07-21.",
+      "Overview": "## Why\n\nTS 7.0 has no stable programmatic API. A direct `typescript` major to 7 breaks `typescript-eslint` (`ModuleKind.Cjs` undefined). Official guidance is side-by-side until ~7.1.\n\n## Locked decisions\n\n- **D1 — Primary surface:** Add a `## TypeScript 7 side-by-side (pre-7.1)` section to `content/languages/typescript.md` with the Cartograph alias pattern (`@typescript/native` → `typescript@^7`, `typescript` → `@typescript/typescript6@^6`), Dependabot ignore for major bumps on the `typescript` alias, and links to the TS 7 announcement + typescript-eslint#12518.\n- **D2 — UPGRADING pointer:** Add a short top-of-`content/UPGRADING.md` note (applies-when / commands / references) pointing agents/operators at D1; not a framework-version migration.\n- **D3 — Scaffold bake: DEFER.** There is no Deft-owned TypeScript `package.json` scaffold to mutate; agents follow the language-pack snippet. Record deferral in the doc section and CHANGELOG.\n- **D4 — Doctor / verify hint: DEFER.** Docs-only close for #2591; reopen a follow-up if consumer Dependabot breakage recurs after guidance lands.\n- **D5 — Contract test:** Content test pins the new typescript.md section heading + required alias package names (and UPGRADING heading if that suite pattern exists).\n- **D6 — CHANGELOG:** Brief `[Unreleased]` notes entry (#1242 style).\n- **D7 — Out of scope:** Changing this repo's own `package.json` typescript pin; Cartograph already fixed; no warehouse/doctor code in this PR.\n\n## Acceptance\n\n- [ ] Documented pattern in `content/languages/typescript.md` agents can follow\n- [ ] UPGRADING.md short pointer shipped\n- [ ] Scaffold bake explicitly deferred in docs + CHANGELOG\n- [ ] Doctor hint explicitly deferred in docs + CHANGELOG\n- [ ] Content contract test green; `task check` green; issue #2591 closed by PR",
+      "Labels": "enhancement, docs, coding-standards, agent-experience, area:guidance"
+    },
+    "items": [
+      {
+        "title": "typescript.md TS7 side-by-side section + Dependabot ignore example",
+        "status": "proposed"
+      },
+      {
+        "title": "UPGRADING.md short pointer section",
+        "status": "proposed"
+      },
+      {
+        "title": "Explicit scaffold + doctor deferral recorded",
+        "status": "proposed"
+      },
+      {
+        "title": "Content contract test + CHANGELOG [Unreleased]",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "docs",
+      "coding-standards",
+      "agent-experience",
+      "area:guidance"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2591",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2591: Document TypeScript 7 side-by-side setup for Deft TypeScript projects"
+      },
+      {
+        "uri": "https://github.com/deftai/cartograph/pull/111",
+        "type": "x-xbrief/reference",
+        "title": "Cartograph TS7 side-by-side precedent"
+      }
+    ],
+    "updated": "2026-07-21T22:04:47Z",
+    "metadata": {
+      "completedAt": "2026-07-21T22:04:47Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add advisory, exit-exempt deft doctor install-integrity check 	ypescript-7-side-by-side: warns when bare 	ypescript@7 coexists with typescript-eslint and eslint without the @typescript/typescript6 alias.
- Flip languages/typescript.md, CHANGELOG, and content-contract tests to doctor **shipped**; scaffold bake remains **deferred**.

## Test plan

- [x] Unit tests in packages/core/src/doctor/checks.test.ts (skip/pass/fail/exit-exempt paths)
- [x] Content contract 	ypescript_ts7_side_by_side.test.ts expects doctor shipped wording
- [x] pnpm run test passes locally (coverage branches >= 85%)

Closes #2591