### PR TITLE
fix(hooks): classify Cursor free-form ApplyPatch in parsePayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Cursor `preToolUse` stdin for bare `deft hook:dispatch --host cursor --event tool.before` no longer fail-closes on UTF-8 BOM-prefixed JSON — `parsePayload` strips the BOM before `JSON.parse` while preserving empty-stdin and invalid-JSON distinctions. Refs #2734.
+- Cursor free-form `ApplyPatch` stdin (`*** Begin Patch` with a single `Add File` or `Update File` path) is synthesized into a normalized payload in `parsePayload` instead of failing as invalid JSON; multi-file and other unparseable free-form input still fail closed. Closes #2738.
 
 ### Removed
 

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -239,7 +239,10 @@ describe("hook-dispatch CLI", () => {
     expect(parsePayload("{bad-json")).toEqual({ payload: {}, context: { parseFailed: true } });
 
     const addFileWithoutBegin = ["*** Add File: only.txt", "+x"].join("\n");
-    expect(parsePayload(addFileWithoutBegin)).toEqual({ payload: {}, context: { parseFailed: true } });
+    expect(parsePayload(addFileWithoutBegin)).toEqual({
+      payload: {},
+      context: { parseFailed: true },
+    });
   });
 
   it("allows Cursor JSON ApplyPatch through hook-dispatch (#2738)", () => {

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -233,6 +233,9 @@ describe("hook-dispatch CLI", () => {
     const markerOnly = "*** Begin Patch\n*** End Patch";
     expect(parsePayload(markerOnly)).toEqual({ payload: {}, context: { parseFailed: true } });
 
+    const emptyPath = ["*** Begin Patch", "*** Add File: ", "+a", "*** End Patch"].join("\n");
+    expect(parsePayload(emptyPath)).toEqual({ payload: {}, context: { parseFailed: true } });
+
     expect(parsePayload("{bad-json")).toEqual({ payload: {}, context: { parseFailed: true } });
   });
 

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -159,6 +159,126 @@ describe("hook-dispatch CLI", () => {
     }
   });
 
+  it("synthesizes Cursor free-form ApplyPatch stdin after JSON.parse fails (#2738)", () => {
+    const freeFormAdd = [
+      "*** Begin Patch",
+      "*** Add File: xbrief/proposed/_probe-applypatch-only.txt",
+      "+probe",
+      "*** End Patch",
+    ].join("\n");
+    expect(parsePayload(freeFormAdd)).toEqual({
+      payload: {
+        tool_name: "ApplyPatch",
+        tool_input: {
+          path: "xbrief/proposed/_probe-applypatch-only.txt",
+          patch: freeFormAdd,
+        },
+      },
+      context: {},
+    });
+
+    const freeFormUpdate = [
+      "*** Begin Patch",
+      "*** Update File: src/example.ts",
+      "@@",
+      "-old",
+      "+new",
+      "*** End Patch",
+    ].join("\n");
+    expect(parsePayload(freeFormUpdate)).toEqual({
+      payload: {
+        tool_name: "ApplyPatch",
+        tool_input: {
+          path: "src/example.ts",
+          patch: freeFormUpdate,
+        },
+      },
+      context: {},
+    });
+
+    const bomFreeForm = `\uFEFF${freeFormAdd}`;
+    expect(parsePayload(bomFreeForm)).toEqual({
+      payload: {
+        tool_name: "ApplyPatch",
+        tool_input: {
+          path: "xbrief/proposed/_probe-applypatch-only.txt",
+          patch: freeFormAdd,
+        },
+      },
+      context: {},
+    });
+  });
+
+  it("keeps multi-file and unparseable free-form ApplyPatch fail-closed (#2738)", () => {
+    const multiFile = [
+      "*** Begin Patch",
+      "*** Add File: a.txt",
+      "+a",
+      "*** Add File: b.txt",
+      "+b",
+      "*** End Patch",
+    ].join("\n");
+    expect(parsePayload(multiFile)).toEqual({ payload: {}, context: { parseFailed: true } });
+
+    const addAndUpdate = [
+      "*** Begin Patch",
+      "*** Add File: a.txt",
+      "+a",
+      "*** Update File: b.txt",
+      "@@",
+      "*** End Patch",
+    ].join("\n");
+    expect(parsePayload(addAndUpdate)).toEqual({ payload: {}, context: { parseFailed: true } });
+
+    const markerOnly = "*** Begin Patch\n*** End Patch";
+    expect(parsePayload(markerOnly)).toEqual({ payload: {}, context: { parseFailed: true } });
+
+    expect(parsePayload("{bad-json")).toEqual({ payload: {}, context: { parseFailed: true } });
+  });
+
+  it("allows Cursor free-form ApplyPatch through hook-dispatch without JSON parse denial (#2738)", () => {
+    const freeForm = [
+      "*** Begin Patch",
+      "*** Add File: xbrief/proposed/_probe-applypatch-only.xbrief.json",
+      "+probe",
+      "*** End Patch",
+    ].join("\n");
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = run(["--host=cursor", "--event=tool.before"], {
+      readStdin: () => freeForm,
+      writeOut: (text) => out.push(text),
+      writeErr: (text) => err.push(text),
+      cwd: () => "/project",
+    });
+    expect(code).toBe(0);
+    const rendered = out.join("");
+    expect(rendered).not.toContain("not valid JSON");
+    expect(rendered).not.toContain("omitted a recognizable tool name");
+  });
+
+  it("denies Cursor multi-file free-form ApplyPatch as invalid JSON (#2738)", () => {
+    const multiFile = [
+      "*** Begin Patch",
+      "*** Add File: a.txt",
+      "+a",
+      "*** Add File: b.txt",
+      "+b",
+      "*** End Patch",
+    ].join("\n");
+    const out: string[] = [];
+    const code = run(["--host=cursor", "--event=tool.before"], {
+      readStdin: () => multiFile,
+      writeOut: (text) => out.push(text),
+      writeErr: () => undefined,
+      cwd: () => "/project",
+    });
+    expect(code).toBe(0);
+    const decision = JSON.parse(out.join(""));
+    expect(decision.permission).toBe("deny");
+    expect(decision.user_message).toContain("not valid JSON");
+  });
+
   it("logs Cursor payload keys and distinct empty-stdin messaging (#2669)", () => {
     const emptyOut: string[] = [];
     const emptyErr: string[] = [];

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -243,6 +243,19 @@ describe("hook-dispatch CLI", () => {
       payload: {},
       context: { parseFailed: true },
     });
+
+    // One Add + Delete must not synthesize — policy would only see the Add path.
+    const addPlusDelete = [
+      "*** Begin Patch",
+      "*** Add File: xbrief/proposed/a.xbrief.json",
+      "+probe",
+      "*** Delete File: src/secret.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(parsePayload(addPlusDelete)).toEqual({ payload: {}, context: { parseFailed: true } });
+
+    const deleteOnly = ["*** Begin Patch", "*** Delete File: src/a.ts", "*** End Patch"].join("\n");
+    expect(parsePayload(deleteOnly)).toEqual({ payload: {}, context: { parseFailed: true } });
   });
 
   it("allows Cursor JSON ApplyPatch through hook-dispatch (#2738)", () => {

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -237,6 +237,29 @@ describe("hook-dispatch CLI", () => {
     expect(parsePayload(emptyPath)).toEqual({ payload: {}, context: { parseFailed: true } });
 
     expect(parsePayload("{bad-json")).toEqual({ payload: {}, context: { parseFailed: true } });
+
+    const addFileWithoutBegin = ["*** Add File: only.txt", "+x"].join("\n");
+    expect(parsePayload(addFileWithoutBegin)).toEqual({ payload: {}, context: { parseFailed: true } });
+  });
+
+  it("allows Cursor JSON ApplyPatch through hook-dispatch (#2738)", () => {
+    const payload = {
+      tool_name: "ApplyPatch",
+      tool_input: {
+        path: "xbrief/proposed/_probe-applypatch-only.xbrief.json",
+        patch: "*** Begin Patch\n*** Add File: x\n+probe\n*** End Patch",
+      },
+      workspace_roots: ["/project"],
+    };
+    const out: string[] = [];
+    const code = run(["--host=cursor", "--event=tool.before"], {
+      readStdin: () => JSON.stringify(payload),
+      writeOut: (text) => out.push(text),
+      writeErr: () => undefined,
+      cwd: () => "/project",
+    });
+    expect(code).toBe(0);
+    expect(out.join("")).not.toContain("not valid JSON");
   });
 
   it("allows Cursor free-form ApplyPatch through hook-dispatch without JSON parse denial (#2738)", () => {
@@ -280,6 +303,18 @@ describe("hook-dispatch CLI", () => {
     const decision = JSON.parse(out.join(""));
     expect(decision.permission).toBe("deny");
     expect(decision.user_message).toContain("not valid JSON");
+  });
+
+  it("writes session.compact bookkeeping to stderr (#2113)", () => {
+    const err: string[] = [];
+    const code = run(["--host=cursor", "--event=session.compact", "--project-root=/project"], {
+      readStdin: () => "{}",
+      writeOut: () => undefined,
+      writeErr: (text) => err.push(text),
+      cwd: () => "/project",
+    });
+    expect(code).toBe(0);
+    expect(err.join("")).toMatch(/compaction|ritual/i);
   });
 
   it("logs Cursor payload keys and distinct empty-stdin messaging (#2669)", () => {

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -102,7 +102,8 @@ function extractSingleApplyPatchFilePath(normalized: string): string | null {
     if (path !== undefined && path.length > 0) paths.push(path);
   }
   if (paths.length !== 1) return null;
-  return paths[0];
+  const sole = paths[0];
+  return sole ?? null;
 }
 
 function synthesizeFreeFormApplyPatchPayload(normalized: string): Record<string, unknown> | null {

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -94,30 +94,6 @@ function stripUtf8Bom(raw: string): string {
   return raw.startsWith(UTF8_BOM) ? raw.slice(UTF8_BOM.length) : raw;
 }
 
-function extractSingleApplyPatchFilePath(normalized: string): string | null {
-  if (!normalized.includes(APPLY_PATCH_BEGIN_MARKER)) return null;
-  const paths: string[] = [];
-  for (const match of normalized.matchAll(APPLY_PATCH_FILE_LINE_RE)) {
-    const path = match[1]?.trim();
-    if (path !== undefined && path.length > 0) paths.push(path);
-  }
-  if (paths.length !== 1) return null;
-  const sole = paths[0];
-  return sole ?? null;
-}
-
-function synthesizeFreeFormApplyPatchPayload(normalized: string): Record<string, unknown> | null {
-  const path = extractSingleApplyPatchFilePath(normalized);
-  if (path === null) return null;
-  return {
-    tool_name: "ApplyPatch",
-    tool_input: {
-      path,
-      patch: normalized,
-    },
-  };
-}
-
 export function parsePayload(raw: string): ParsedPayload {
   if (raw.trim().length === 0) {
     return { payload: {}, context: { stdinEmpty: true } };
@@ -129,9 +105,25 @@ export function parsePayload(raw: string): ParsedPayload {
   try {
     return { payload: JSON.parse(normalized) as unknown, context: {} };
   } catch {
-    const synthesized = synthesizeFreeFormApplyPatchPayload(normalized);
-    if (synthesized !== null) {
-      return { payload: synthesized, context: {} };
+    if (normalized.includes(APPLY_PATCH_BEGIN_MARKER)) {
+      const paths: string[] = [];
+      for (const match of normalized.matchAll(APPLY_PATCH_FILE_LINE_RE)) {
+        const path = match[1]?.trim();
+        if (path) paths.push(path);
+      }
+      if (paths.length === 1) {
+        const [targetPath] = paths;
+        return {
+          payload: {
+            tool_name: "ApplyPatch",
+            tool_input: {
+              path: targetPath,
+              patch: normalized,
+            },
+          },
+          context: {},
+        };
+      }
     }
     // tool.before is installed only on direct-write matchers, so an unreadable
     // payload becomes a missing-tool denial rather than a fail-open crash.

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -101,7 +101,8 @@ function extractSingleApplyPatchFilePath(normalized: string): string | null {
     const path = match[1]?.trim();
     if (path !== undefined && path.length > 0) paths.push(path);
   }
-  return paths.length === 1 ? paths[0]! : null;
+  if (paths.length !== 1) return null;
+  return paths[0];
 }
 
 function synthesizeFreeFormApplyPatchPayload(normalized: string): Record<string, unknown> | null {

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -87,9 +87,33 @@ export interface ParsedPayload {
 }
 
 const UTF8_BOM = "\uFEFF";
+const APPLY_PATCH_BEGIN_MARKER = "*** Begin Patch";
+const APPLY_PATCH_FILE_LINE_RE = /^\*\*\* (?:Add File|Update File): (.+)$/gm;
 
 function stripUtf8Bom(raw: string): string {
   return raw.startsWith(UTF8_BOM) ? raw.slice(UTF8_BOM.length) : raw;
+}
+
+function extractSingleApplyPatchFilePath(normalized: string): string | null {
+  if (!normalized.includes(APPLY_PATCH_BEGIN_MARKER)) return null;
+  const paths: string[] = [];
+  for (const match of normalized.matchAll(APPLY_PATCH_FILE_LINE_RE)) {
+    const path = match[1]?.trim();
+    if (path !== undefined && path.length > 0) paths.push(path);
+  }
+  return paths.length === 1 ? paths[0]! : null;
+}
+
+function synthesizeFreeFormApplyPatchPayload(normalized: string): Record<string, unknown> | null {
+  const path = extractSingleApplyPatchFilePath(normalized);
+  if (path === null) return null;
+  return {
+    tool_name: "ApplyPatch",
+    tool_input: {
+      path,
+      patch: normalized,
+    },
+  };
 }
 
 export function parsePayload(raw: string): ParsedPayload {
@@ -103,6 +127,10 @@ export function parsePayload(raw: string): ParsedPayload {
   try {
     return { payload: JSON.parse(normalized) as unknown, context: {} };
   } catch {
+    const synthesized = synthesizeFreeFormApplyPatchPayload(normalized);
+    if (synthesized !== null) {
+      return { payload: synthesized, context: {} };
+    }
     // tool.before is installed only on direct-write matchers, so an unreadable
     // payload becomes a missing-tool denial rather than a fail-open crash.
     return { payload: {}, context: { parseFailed: true } };

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -88,10 +88,36 @@ export interface ParsedPayload {
 
 const UTF8_BOM = "\uFEFF";
 const APPLY_PATCH_BEGIN_MARKER = "*** Begin Patch";
-const APPLY_PATCH_FILE_LINE_RE = /^\*\*\* (?:Add File|Update File): (.+)$/gm;
+/** Single-file Add/Update only — other *** … File: ops must fail closed (#2738 Greptile). */
+const APPLY_PATCH_MUTATION_LINE_RE =
+  /^\*\*\* (Add File|Update File|Delete File|Move File|Rename File): (.+)$/gm;
 
 function stripUtf8Bom(raw: string): string {
   return raw.startsWith(UTF8_BOM) ? raw.slice(UTF8_BOM.length) : raw;
+}
+
+function trySynthesizeFreeFormApplyPatch(normalized: string): ParsedPayload | null {
+  if (!normalized.includes(APPLY_PATCH_BEGIN_MARKER)) return null;
+  const mutations: { op: string; path: string }[] = [];
+  for (const match of normalized.matchAll(APPLY_PATCH_MUTATION_LINE_RE)) {
+    const op = match[1];
+    const path = match[2]?.trim();
+    if (op === undefined || !path) continue;
+    mutations.push({ op, path });
+  }
+  if (mutations.length !== 1) return null;
+  const sole = mutations[0];
+  if (sole === undefined || (sole.op !== "Add File" && sole.op !== "Update File")) return null;
+  return {
+    payload: {
+      tool_name: "ApplyPatch",
+      tool_input: {
+        path: sole.path,
+        patch: normalized,
+      },
+    },
+    context: {},
+  };
 }
 
 export function parsePayload(raw: string): ParsedPayload {
@@ -105,26 +131,8 @@ export function parsePayload(raw: string): ParsedPayload {
   try {
     return { payload: JSON.parse(normalized) as unknown, context: {} };
   } catch {
-    if (normalized.includes(APPLY_PATCH_BEGIN_MARKER)) {
-      const paths: string[] = [];
-      for (const match of normalized.matchAll(APPLY_PATCH_FILE_LINE_RE)) {
-        const path = match[1]?.trim();
-        if (path) paths.push(path);
-      }
-      if (paths.length === 1) {
-        const [targetPath] = paths;
-        return {
-          payload: {
-            tool_name: "ApplyPatch",
-            tool_input: {
-              path: targetPath,
-              patch: normalized,
-            },
-          },
-          context: {},
-        };
-      }
-    }
+    const synthesized = trySynthesizeFreeFormApplyPatch(normalized);
+    if (synthesized !== null) return synthesized;
     // tool.before is installed only on direct-write matchers, so an unreadable
     // payload becomes a missing-tool denial rather than a fail-open crash.
     return { payload: {}, context: { parseFailed: true } };

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -346,6 +346,8 @@ describe("direct-write hook policy", () => {
     expect(hookToolName({ tool_input: { path: "src/a.ts", diff: "diff" } }, "cursor")).toBe(
       "ApplyPatch",
     );
+    expect(hookToolName({ tool_input: { path: "a.ts", edits: [] } }, "cursor")).toBe("MultiEdit");
+    expect(hookToolName({ tool_input: { cell_id: "cell-1" } }, "cursor")).toBe("NotebookEdit");
     expect(
       hookWriteTargetPath({
         tool_name: "ApplyPatch",

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -337,12 +337,12 @@ describe("direct-write hook policy", () => {
         "cursor",
       ),
     ).toBe("ApplyPatch");
-    expect(
-      hookToolName({ tool_input: { path: "src/a.ts", patch: "diff" } }, "cursor"),
-    ).toBe("ApplyPatch");
-    expect(
-      hookToolName({ tool_input: { path: "src/a.ts", unified_diff: "diff" } }, "cursor"),
-    ).toBe("ApplyPatch");
+    expect(hookToolName({ tool_input: { path: "src/a.ts", patch: "diff" } }, "cursor")).toBe(
+      "ApplyPatch",
+    );
+    expect(hookToolName({ tool_input: { path: "src/a.ts", unified_diff: "diff" } }, "cursor")).toBe(
+      "ApplyPatch",
+    );
     expect(hookToolName({ tool_input: { path: "src/a.ts", diff: "diff" } }, "cursor")).toBe(
       "ApplyPatch",
     );

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -130,6 +130,32 @@ describe("direct-write hook policy", () => {
     expect(inspectScope).not.toHaveBeenCalled();
   });
 
+  it("allows ApplyPatch of xbrief/proposed/*.xbrief.json with no active scope (#2738)", () => {
+    const inspectScope = vi.fn(() => ({
+      ready: false,
+      path: null,
+      message: "No active xBRIEF artifact was found under xbrief/active/",
+    }));
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "ApplyPatch",
+          tool_input: {
+            path: "xbrief/proposed/2026-07-17-story.xbrief.json",
+            patch: "*** Begin Patch\n*** Add File: x\n+probe\n*** End Patch",
+          },
+        },
+      },
+      readySeams({ inspectScope }),
+    );
+
+    expect(decision).toMatchObject({ verdict: "allow", code: "write-propose-ready" });
+    expect(inspectScope).not.toHaveBeenCalled();
+  });
+
   it("allows Write of legacy vbrief/proposed/*.vbrief.json with no active scope (#2625)", () => {
     const decision = decideHook(
       {
@@ -305,6 +331,27 @@ describe("direct-write hook policy", () => {
         "cursor",
       ),
     ).toBe("StrReplace");
+    expect(
+      hookToolName(
+        { tool_name: "ApplyPatch", tool_input: { path: "src/a.ts", patch: "*** Begin Patch" } },
+        "cursor",
+      ),
+    ).toBe("ApplyPatch");
+    expect(
+      hookToolName({ tool_input: { path: "src/a.ts", patch: "diff" } }, "cursor"),
+    ).toBe("ApplyPatch");
+    expect(
+      hookToolName({ tool_input: { path: "src/a.ts", unified_diff: "diff" } }, "cursor"),
+    ).toBe("ApplyPatch");
+    expect(hookToolName({ tool_input: { path: "src/a.ts", diff: "diff" } }, "cursor")).toBe(
+      "ApplyPatch",
+    );
+    expect(
+      hookWriteTargetPath({
+        tool_name: "ApplyPatch",
+        tool_input: { path: "xbrief/proposed/a.xbrief.json", patch: "patch" },
+      }),
+    ).toBe("xbrief/proposed/a.xbrief.json");
     expect(
       decideHook(
         {

--- a/xbrief/completed/2026-07-21-2738-fixhooks-classify-cursor-free-form-applypatch-in-parsepayloa.xbrief.json
+++ b/xbrief/completed/2026-07-21-2738-fixhooks-classify-cursor-free-form-applypatch-in-parsepayloa.xbrief.json
@@ -1,0 +1,61 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2738 — classify Cursor free-form ApplyPatch in parsePayload"
+  },
+  "plan": {
+    "title": "fix(hooks): classify Cursor free-form ApplyPatch in parsePayload",
+    "status": "completed",
+    "narratives": {
+      "Description": "Normalize Cursor free-form ApplyPatch stdin in parsePayload so stock hook:dispatch does not fail-closed as parseFailed before tool-name inference.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2738; locked decisions from issue body 2026-07-21.",
+      "Overview": "## Why\n\nFree-form `*** Begin Patch` stdin never becomes JSON, so BOM-stripped parse still yields parseFailed. JSON ApplyPatch already works via inferCursorDirectWriteToolName.\n\n## Locked decisions (issue body — do not reopen)\n\n- **D1** In `packages/cli/src/hook-dispatch.ts` `parsePayload`: after BOM strip + failed JSON.parse, if stdin has `*** Begin Patch` and exactly one `Add File` or `Update File` path, synthesize `{ tool_name: \"ApplyPatch\", tool_input: { path, patch: post-BOM stdin } }` with empty context (not parseFailed).\n- **D2** Multi-file / unparseable free-form / other garbage → keep parseFailed fail-closed.\n- **D3** Regression tests in `hook-dispatch.test.ts` (+ dispatcher path as needed): free-form → ApplyPatch identity; multi-file deny; empty/invalid/BOM cases unchanged.\n- **D4** CHANGELOG `[Unreleased]`.\n- **D5** Out of scope: Cursor parent ApplyPatch absence; project adapters; #2734 BOM rework; relaxing fail-closed for true garbage.\n\n## Acceptance\n\n- Free-form single-file ApplyPatch does not yield parseFailed / \"not valid JSON\"\n- Synthesized payload recognized as ApplyPatch and reaches ritual/scope/allow like JSON today\n- Multi-file + non-patch garbage still fail closed\n- Tests + CHANGELOG; Closes #2738",
+      "Labels": "bug, agent-experience, area:cli"
+    },
+    "items": [
+      {
+        "title": "parsePayload free-form ApplyPatch synthesis (single-file)",
+        "status": "proposed"
+      },
+      {
+        "title": "Multi-file / garbage still parseFailed",
+        "status": "proposed"
+      },
+      {
+        "title": "hook-dispatch regression tests",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG [Unreleased]",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-experience",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2738",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2738: fix(hooks): classify Cursor free-form ApplyPatch in parsePayload"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2713",
+        "type": "x-xbrief/reference",
+        "title": "Parent tracker #2713"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2734",
+        "type": "x-xbrief/reference",
+        "title": "BOM strip #2734 (shipped)"
+      }
+    ],
+    "updated": "2026-07-21T22:10:52Z",
+    "metadata": {
+      "completedAt": "2026-07-21T22:10:52Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Cursor free-form `ApplyPatch` stdin (`*** Begin Patch` with exactly one Add/Update File path) is synthesized in `parsePayload` into a normalized `{ tool_name: ApplyPatch, tool_input: { path, patch } }` payload instead of failing as invalid JSON.
- Multi-file and unparseable free-form input remain fail-closed (`parseFailed`).
- Regression tests cover synthesis, multi-file deny, BOM strip interaction, and dispatcher recognition; CHANGELOG `[Unreleased]`.

Closes #2738

## Test plan
- [x] `hook-dispatch.test.ts`: single-file Add/Update synthesis; multi-file/garbage `parseFailed`; CLI path avoids "not valid JSON"
- [x] `dispatcher.test.ts`: ApplyPatch identity + proposed lifecycle write-ready
- [x] Branch coverage >= 85%
- [ ] CI green on PR
