### PR TITLE
fix(release): anchor lifecycle sync on primary issue (#2745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release preflight no longer blocks cuts when a closed secondary `references[]` issue remains on an open-parent xBRIEF (#2745).** Step 3 lifecycle sync now anchors closed-issue mismatch detection on the primary lifecycle issue (`parent_issue` / `planRef`), not every GitHub reference on the file.
+
 ### Removed
 
 ## [0.81.0] - 2026-07-22

--- a/packages/core/src/release/native-steps.test.ts
+++ b/packages/core/src/release/native-steps.test.ts
@@ -5,8 +5,8 @@ import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockRenderRoadmap = vi.fn();
-const mockScanVbriefDir = vi.fn();
-const mockReconcile = vi.fn();
+const mockScanLifecycleAnchors = vi.fn();
+const mockBuildLifecycleReport = vi.fn();
 const mockIsTerminalLifecyclePath = vi.fn();
 
 vi.mock("../render/roadmap-render.js", () => ({
@@ -14,8 +14,8 @@ vi.mock("../render/roadmap-render.js", () => ({
 }));
 
 vi.mock("../intake/reconcile-issues.js", () => ({
-  scanVbriefDir: (...args: unknown[]) => mockScanVbriefDir(...args),
-  reconcile: (...args: unknown[]) => mockReconcile(...args),
+  scanLifecycleAnchors: (...args: unknown[]) => mockScanLifecycleAnchors(...args),
+  buildLifecycleReport: (...args: unknown[]) => mockBuildLifecycleReport(...args),
   isTerminalLifecyclePath: (...args: unknown[]) => mockIsTerminalLifecyclePath(...args),
 }));
 
@@ -56,10 +56,37 @@ describe("native release steps", () => {
   });
 
   it("checkVbriefLifecycleSyncNative reports no mismatches", () => {
-    mockScanVbriefDir.mockReturnValue(new Map());
+    mockScanLifecycleAnchors.mockReturnValue([]);
     mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
-    mockReconcile.mockReturnValue({ no_open_issue: [] });
+    mockBuildLifecycleReport.mockReturnValue({ no_open_issue: [] });
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
+    expect(ok).toBe(true);
+    expect(count).toBe(0);
+    expect(msg).toBe("no mismatches");
+  });
+
+  it("checkVbriefLifecycleSyncNative ignores closed secondary refs when parent anchor is open", () => {
+    mockScanLifecycleAnchors.mockReturnValue([
+      {
+        rel_path: "active/story.xbrief.json",
+        issue_number: 2745,
+        axis: "parent_issue",
+      },
+    ]);
+    mockFetchIssueStatesForRelease.mockReturnValue({
+      ok: true,
+      states: new Map([
+        [2745, "OPEN"],
+        [1234, "CLOSED"],
+      ]),
+    });
+    mockBuildLifecycleReport.mockReturnValue({ no_open_issue: [] });
+    const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
+    expect(mockFetchIssueStatesForRelease).toHaveBeenCalledWith(
+      "deftai/directive",
+      new Set([2745]),
+      { cwd: "/proj" },
+    );
     expect(ok).toBe(true);
     expect(count).toBe(0);
     expect(msg).toBe("no mismatches");
@@ -79,7 +106,9 @@ describe("native release steps", () => {
   });
 
   it("checkVbriefLifecycleSyncNative fails when gh fetch returns null", () => {
-    mockScanVbriefDir.mockReturnValue(new Map([[1, []]]));
+    mockScanLifecycleAnchors.mockReturnValue([
+      { rel_path: "active/a.xbrief.json", issue_number: 1, axis: "parent_issue" },
+    ]);
     mockFetchIssueStatesForRelease.mockReturnValue({
       ok: false,
       reason: "failed to fetch issue states from gh",
@@ -91,7 +120,9 @@ describe("native release steps", () => {
   });
 
   it("checkVbriefLifecycleSyncNative surfaces rate-limit failure reason", () => {
-    mockScanVbriefDir.mockReturnValue(new Map([[1, []]]));
+    mockScanLifecycleAnchors.mockReturnValue([
+      { rel_path: "active/a.xbrief.json", issue_number: 1, axis: "parent_issue" },
+    ]);
     mockFetchIssueStatesForRelease.mockReturnValue({
       ok: false,
       reason: "GitHub REST rate limit exhausted (see stderr for recovery steps)",
@@ -103,10 +134,10 @@ describe("native release steps", () => {
   });
 
   it("checkVbriefLifecycleSyncNative reports lifecycle mismatches", () => {
-    mockScanVbriefDir.mockReturnValue(new Map());
+    mockScanLifecycleAnchors.mockReturnValue([]);
     mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
-    mockReconcile.mockReturnValue({
-      no_open_issue: [{ vbrief_files: ["xbrief/active/a.xbrief.json"] }],
+    mockBuildLifecycleReport.mockReturnValue({
+      no_open_issue: [{ vbrief_files: ["active/a.xbrief.json"] }],
     });
     mockIsTerminalLifecyclePath.mockReturnValue(false);
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
@@ -116,10 +147,10 @@ describe("native release steps", () => {
   });
 
   it("checkVbriefLifecycleSyncNative truncates mismatch preview beyond five", () => {
-    const files = Array.from({ length: 6 }, (_, i) => `xbrief/active/story-${i}.xbrief.json`);
-    mockScanVbriefDir.mockReturnValue(new Map());
+    const files = Array.from({ length: 6 }, (_, i) => `active/story-${i}.xbrief.json`);
+    mockScanLifecycleAnchors.mockReturnValue([]);
     mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
-    mockReconcile.mockReturnValue({ no_open_issue: [{ vbrief_files: files }] });
+    mockBuildLifecycleReport.mockReturnValue({ no_open_issue: [{ vbrief_files: files }] });
     mockIsTerminalLifecyclePath.mockReturnValue(false);
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
     expect(ok).toBe(false);
@@ -128,7 +159,7 @@ describe("native release steps", () => {
   });
 
   it("checkVbriefLifecycleSyncNative catches scan errors", () => {
-    mockScanVbriefDir.mockImplementation(() => {
+    mockScanLifecycleAnchors.mockImplementation(() => {
       throw new Error("scan boom");
     });
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
@@ -139,7 +170,7 @@ describe("native release steps", () => {
 
   it("checkVbriefLifecycleSyncNative catches non-Error throws", () => {
     // Exercises the String(err) branch in catch (err instanceof Error = false)
-    mockScanVbriefDir.mockImplementation(() => {
+    mockScanLifecycleAnchors.mockImplementation(() => {
       throw "string-error-value";
     });
     const [ok, count, msg] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
@@ -150,9 +181,9 @@ describe("native release steps", () => {
 
   it("checkVbriefLifecycleSyncNative handles entry without vbrief_files", () => {
     // Entry with undefined vbrief_files — exercises the `?? []` branch
-    mockScanVbriefDir.mockReturnValue(new Map());
+    mockScanLifecycleAnchors.mockReturnValue([]);
     mockFetchIssueStatesForRelease.mockReturnValue({ ok: true, states: new Map() });
-    mockReconcile.mockReturnValue({ no_open_issue: [{}] });
+    mockBuildLifecycleReport.mockReturnValue({ no_open_issue: [{}] });
     const [ok, count] = checkVbriefLifecycleSyncNative("/proj", "deftai/directive");
     expect(ok).toBe(true);
     expect(count).toBe(0);

--- a/packages/core/src/release/native-steps.ts
+++ b/packages/core/src/release/native-steps.ts
@@ -6,7 +6,11 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { isTerminalLifecyclePath, reconcile, scanVbriefDir } from "../intake/reconcile-issues.js";
+import {
+  buildLifecycleReport,
+  isTerminalLifecyclePath,
+  scanLifecycleAnchors,
+} from "../intake/reconcile-issues.js";
 import {
   LEGACY_ARTIFACT_DIR,
   MIGRATED_ARTIFACT_DIR,
@@ -48,15 +52,22 @@ export function checkVbriefLifecycleSyncNative(
     vbriefDir = join(projectRoot, MIGRATED_ARTIFACT_DIR);
   }
   try {
-    const issueToVbriefs = scanVbriefDir(vbriefDir);
-    const fetchResult = fetchIssueStatesForRelease(repo, new Set(issueToVbriefs.keys()), {
+    const anchors = scanLifecycleAnchors(vbriefDir);
+    const anchorIssueNumbers = new Set<number>();
+    for (const anchor of anchors) {
+      const num = anchor.issue_number as number | null;
+      if (num !== null) {
+        anchorIssueNumbers.add(num);
+      }
+    }
+    const fetchResult = fetchIssueStatesForRelease(repo, anchorIssueNumbers, {
       cwd: projectRoot,
     });
     if (!fetchResult.ok) {
       return [false, -1, fetchResult.reason];
     }
     const issueStateMap = fetchResult.states;
-    const report = reconcile(issueToVbriefs, issueStateMap);
+    const report = buildLifecycleReport(anchors, issueStateMap, false);
     const mismatches: string[] = [];
     for (const entry of report.no_open_issue) {
       const files = (entry.vbrief_files ?? []) as string[];


### PR DESCRIPTION
## Summary

- Release Step 3 lifecycle sync (checkVbriefLifecycleSyncNative) now uses scanLifecycleAnchors + uildLifecycleReport instead of indexing every eferences[] GitHub issue.
- Closed secondary references no longer block release cuts when the primary lifecycle anchor (parent_issue / planRef) is still open.
- Adds regression coverage for open-parent + closed-secondary.

Closes #2745

## Test plan

- [x] pnpm -w exec vitest run packages/core/src/release/native-steps.test.ts
- [x] 	ask check

## PR checklist

- [x] Scope xBRIEF covers this change
- [x] CHANGELOG [Unreleased] entry added
- [x] Feature branch (not master)
- [x] pre-pr RWLDL cycle completed