### PR TITLE
fix(pr-watch): no premature STALL on stale-SHA re-review (#2313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Release preflight no longer blocks cuts when a closed secondary `references[]` issue remains on an open-parent xBRIEF (#2745).** Step 3 lifecycle sync now anchors closed-issue mismatch detection on the primary lifecycle issue (`parent_issue` / `planRef`), not every GitHub reference on the file.
 - **triage:queue honors cache quarantine for issue titles (#2433).** Queue loading now omits entries whose `meta.json` scan failed or whose approved `content.md` is missing, and end-to-end render never surfaces quarantined raw titles from `raw.json`. Closes #2433. Refs #2435.
+- **`pr:watch` no longer STALLs early on stale-SHA confidence during re-review (#2313).** The stall counter now follows the #1039 wedged-HEAD signature (`!has_blocking && !is_clean` with a holdout other than `sha_match`), not consecutive stale-SHA polls — aligning with #1259 `INCOMPLETE_BUT_RATED` semantics so a fresh push waits for HEAD reviews instead of exiting at ~90s. Closes #2313.
 
 ### Removed
 

--- a/packages/core/src/pr-watch/constants.ts
+++ b/packages/core/src/pr-watch/constants.ts
@@ -66,10 +66,10 @@ export const WATCH_HELP =
   "  1  NEW_P0_P1   Blocking findings on the current (SHA-matched) review\n" +
   "  2  ERRORED | STALL | TIMEOUT | CI_BLOCKED | RUNNER_CAPACITY_STALL | config / usage error\n";
 /**
- * Consecutive polls with a review PRESENT but stuck on a stale (non-HEAD)
- * commit before the loop surfaces STALL instead of waiting the full cap. Keeps
- * a Greptile review that never re-reviews the new HEAD from silently eating the
- * whole 30-minute budget (#1039 STALL terminal).
+ * Consecutive polls where the CLEAN gate is wedged on HEAD (!has_blocking &&
+ * !is_clean with a holdout other than sha_match) before STALL (#1039). Stale-SHA
+ * reads (sha_match holdout) do NOT advance this counter — re-review in flight
+ * waits until max-wait cap (#2313 / #1259 INCOMPLETE_BUT_RATED).
  */
 export const DEFAULT_STALL_THRESHOLD = 3;
 /**

--- a/packages/core/src/pr-watch/watch.test.ts
+++ b/packages/core/src/pr-watch/watch.test.ts
@@ -226,17 +226,45 @@ describe("watch blocking loop (injected clock + sleep)", () => {
     expect(r.pollCount).toBe(3);
   });
 
-  it("STALL after stallThreshold consecutive non-HEAD reviews", () => {
+  it("does NOT STALL on stale-SHA confidence during re-review (#2313)", () => {
     const clock = new FakeClock();
     const sleep = vi.fn(makeSleep(clock));
-    const stale = makeProbe({
+    const staleReReview = makeProbe({
       lastReviewedSha: STALE,
       shaMatch: false,
       hasBlocking: false,
       isClean: false,
       cleanGateHoldout: "sha_match",
+      confidence: 4,
     });
-    const { fn } = makeProbeSeq(stale);
+    const { fn } = makeProbeSeq(staleReReview);
+
+    const r = watch(9, "deftai/directive", {
+      pollSeconds: 1,
+      maxWaitMinutes: 0.1,
+      stallThreshold: 3,
+      probeFn: fn,
+      clockFn: clock,
+      sleepFn: sleep,
+    });
+
+    expect(r.verdict).toBe(VERDICT_TIMEOUT);
+    expect(r.exitCode).toBe(EXIT_TERMINAL_ERROR);
+    expect(r.pollCount).toBeGreaterThan(3);
+  });
+
+  it("STALL after stallThreshold wedged HEAD holdouts (#1039)", () => {
+    const clock = new FakeClock();
+    const sleep = vi.fn(makeSleep(clock));
+    const wedged = makeProbe({
+      shaMatch: true,
+      hasBlocking: false,
+      isClean: false,
+      cleanGateHoldout: "terminal_check_run",
+      confidence: 5,
+      terminalCheckRun: false,
+    });
+    const { fn } = makeProbeSeq(wedged);
 
     const r = watch(9, "deftai/directive", {
       pollSeconds: 30,

--- a/packages/core/src/pr-watch/watch.ts
+++ b/packages/core/src/pr-watch/watch.ts
@@ -145,9 +145,11 @@ export function watch(
       return build(VERDICT_CI_BLOCKED, EXIT_TERMINAL_ERROR, probe, poll);
     }
 
-    // Stall = a review IS present but stuck on a non-HEAD commit; surface it
-    // rather than burning the whole cap waiting for a re-review that isn't coming.
-    if (probe.found && !probe.shaMatch) {
+    // STALL (#1039): wedged CLEAN-gate on HEAD — !has_blocking && !is_clean for N
+    // consecutive polls with a holdout OTHER than sha_match. Stale-SHA reads
+    // (clean_gate_holdout=sha_match) are INCOMPLETE for HEAD per #1259 / #2313 —
+    // keep polling until cap, not early STALL while re-review is in flight.
+    if (!probe.hasBlocking && !probe.isClean && probe.cleanGateHoldout !== "sha_match") {
       stallStreak += 1;
     } else {
       stallStreak = 0;

--- a/xbrief/active/2026-07-21-2313-pr-watch-premature-stall.xbrief.json
+++ b/xbrief/active/2026-07-21-2313-pr-watch-premature-stall.xbrief.json
@@ -1,0 +1,83 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Stop pr:watch from premature STALL on stale-SHA confidence while re-review is in flight.",
+    "created": "2026-07-22T01:25:00Z",
+    "updated": "2026-07-22T01:30:00Z"
+  },
+  "plan": {
+    "id": "2313-pr-watch-premature-stall",
+    "title": "bug(pr:watch): no premature STALL on stale-SHA confidence during re-review",
+    "status": "running",
+    "narratives": {
+      "Description": "task pr:watch fires a premature STALL (exit 2) within about 90 to 106 seconds when a fresh commit has just been pushed and bots are still mid-review. It classifies confidence from a stale prior-SHA review (sha_match == false) as stall-eligible after a few polls instead of honoring the roughly 10-minute Stall Detection Rubric.",
+      "ImplementationPlan": "1. Align packages/core/src/pr-watch/watch.ts stall counter with sha_match gates and #1259 INCOMPLETE_BUT_RATED semantics so stale-SHA confidence does not accelerate early STALL. 2. Adjust packages/core/src/pr-watch/probe.ts / constants.ts if thresholds are shared. 3. Add regression covering fresh push + stale prior review remaining non-STALL until rubric threshold. 4. Verify with pnpm --filter @deftai/directive-core test -- pr-watch; CHANGELOG [Unreleased].",
+      "UserStory": "As a review-cycle owner waiting on Greptile after a push, I want pr:watch to wait for HEAD reviews instead of stalling within about 90 seconds on a stale SHA, so that legitimate in-flight re-reviews are not aborted early."
+    },
+    "items": [
+      {
+        "id": "ac1",
+        "title": "Exclude stale-SHA confidence from early stall counter",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given sha_match == false on a prior-SHA confidence score, when pr:watch polls during re-review, then that score does not accelerate STALL before the rubric threshold."
+        }
+      },
+      {
+        "id": "ac2",
+        "title": "Regression for premature STALL class",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a fixture that reproduces the #2311-class premature STALL, when pr-watch tests run, then they fail before the fix and pass after."
+        }
+      },
+      {
+        "id": "ac3",
+        "title": "CHANGELOG Unreleased entry",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the fix lands, when CHANGELOG is reviewed, then [Unreleased] has a brief note for pr:watch stall behavior."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "bug-fix",
+      "x-tracking": {
+        "parent_issue": "#2313",
+        "decomposition_origin": "#2313"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/pr-watch/watch.ts",
+          "packages/core/src/pr-watch/probe.ts",
+          "packages/core/src/pr-watch/constants.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- pr-watch"
+        ],
+        "expected_outputs": [
+          "no premature STALL on stale SHA",
+          "regression test",
+          "CHANGELOG"
+        ],
+        "depends_on": [],
+        "conflict_group": "pr-watch-2313",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": "Bug-fix from GitHub issue #2313; no FR trace registry for hotfix cohort."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2313",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2313: pr:watch premature STALL on stale-SHA confidence"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Stop `pr:watch` from counting stale-SHA polls toward the STALL terminal; stale prior-SHA confidence is treated as INCOMPLETE for HEAD (#1259), not wedged.
- Align stall detection with the #1039 poller signature: only consecutive HEAD holdouts other than `sha_match` advance the counter.
- Add regression coverage for re-review-in-flight and wedged `terminal_check_run` cases.

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/pr-watch --no-coverage`
- [x] `task check`
- [x] `task verify:forward-coverage`

Closes #2313
