### PR TITLE
fix(security): contain three medium symlink write sinks (#2710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release preflight no longer blocks cuts when a closed secondary `references[]` issue remains on an open-parent xBRIEF (#2745).** Step 3 lifecycle sync now anchors closed-issue mismatch detection on the primary lifecycle issue (`parent_issue` / `planRef`), not every GitHub reference on the file.
 - **triage:queue honors cache quarantine for issue titles (#2433).** Queue loading now omits entries whose `meta.json` scan failed or whose approved `content.md` is missing, and end-to-end render never surfaces quarantined raw titles from `raw.json`. Closes #2433. Refs #2435.
 - **`pr:watch` no longer STALLs early on stale-SHA confidence during re-review (#2313).** The stall counter now follows the #1039 wedged-HEAD signature (`!has_blocking && !is_clean` with a holdout other than `sha_match`), not consecutive stale-SHA polls — aligning with #1259 `INCOMPLETE_BUT_RATED` semantics so a fresh push waits for HEAD reviews instead of exiting at ~90s. Closes #2313.
+- **Three medium symlink write sinks contained (#2710).** Staleness-tickler state persistence now routes through `resolveTriageCachePath`; vendored upgrade `regenerateBareVersionMarker` calls `assertConsumerProjectionContained` before writing `vbrief/.deft-version`; `issue:sync-from-xbrief` fingerprint writes call `assertWriteTargetSafe` before persisting stamped metadata. Closes #2710.
 
 ### Removed
 

--- a/cmd/deft-install/upgrade.go
+++ b/cmd/deft-install/upgrade.go
@@ -320,11 +320,17 @@ func regenerateBareVersionMarker(projectDir, tag string) (string, error) {
 	if bare == "" {
 		return "", nil
 	}
+	if err := assertConsumerProjectionContained(projectDir, "vbrief/.deft-version"); err != nil {
+		return "", err
+	}
 	vbriefDir := filepath.Join(projectDir, "vbrief")
 	if err := os.MkdirAll(vbriefDir, 0o755); err != nil {
 		return "", fmt.Errorf("could not create vbrief/ for .deft-version: %w", err)
 	}
 	path := filepath.Join(vbriefDir, ".deft-version")
+	if err := assertDestinationNotSymlink(path); err != nil {
+		return "", err
+	}
 	if err := os.WriteFile(path, []byte(bare+"\n"), 0o644); err != nil {
 		return "", fmt.Errorf("could not write vbrief/.deft-version: %w", err)
 	}

--- a/cmd/deft-install/upgrade_test.go
+++ b/cmd/deft-install/upgrade_test.go
@@ -819,6 +819,60 @@ func TestRegenerateBareVersionMarker(t *testing.T) {
 	})
 }
 
+// TestRegenerateBareVersionMarker_SymlinkOutside_RejectsProjection pins #2710:
+// when vbrief/.deft-version is a repo-controlled symlink pointing outside the
+// checkout, regenerateBareVersionMarker refuses before writing through the link.
+func TestRegenerateBareVersionMarker_SymlinkOutside_RejectsProjection(t *testing.T) {
+	proj := t.TempDir()
+	vbriefDir := filepath.Join(proj, "vbrief")
+	if err := os.MkdirAll(vbriefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := seedOutsideSymlinkTarget(t)
+	symlinkOrSkip(t, outside, filepath.Join(vbriefDir, ".deft-version"))
+
+	_, err := regenerateBareVersionMarker(proj, "v0.39.3")
+	if err == nil {
+		t.Fatal("expected regenerateBareVersionMarker to refuse symlink .deft-version, got nil")
+	}
+	if !strings.Contains(err.Error(), "consumer projection refused") {
+		t.Fatalf("expected containment refusal, got: %v", err)
+	}
+	got, readErr := os.ReadFile(outside)
+	if readErr != nil {
+		t.Fatalf("read outside target: %v", readErr)
+	}
+	if string(got) != "untouched-sensitive-content\n" {
+		t.Fatalf("outside target was modified through symlink; got %q", got)
+	}
+}
+
+// TestRegenerateBareVersionMarker_SymlinkVbriefDir_RejectsProjection pins #2710:
+// when vbrief/ itself is a symlink escaping the project tree, marker regen refuses.
+func TestRegenerateBareVersionMarker_SymlinkVbriefDir_RejectsProjection(t *testing.T) {
+	proj := t.TempDir()
+	outsideDir := filepath.Join(t.TempDir(), "outside-vbrief")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkOrSkip(t, outsideDir, filepath.Join(proj, "vbrief"))
+
+	_, err := regenerateBareVersionMarker(proj, "v0.39.3")
+	if err == nil {
+		t.Fatal("expected regenerateBareVersionMarker to refuse symlink vbrief/, got nil")
+	}
+	if !strings.Contains(err.Error(), "consumer projection refused") {
+		t.Fatalf("expected containment refusal, got: %v", err)
+	}
+	entries, err := os.ReadDir(outsideDir)
+	if err != nil {
+		t.Fatalf("read outside vbrief dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no .deft-version written through symlink vbrief/, found %d entries", len(entries))
+	}
+}
+
 // TestRefreshVendoredCore_RegeneratesBareVersionMarker is the #1437 Bug B
 // regression: the vendored file-swap upgrade refreshes .deft/core/** AND now
 // regenerates the bare vbrief/.deft-version derivative from the resolved tag, so

--- a/packages/core/src/issue-sync/sync-from-xbrief.test.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildSyncComment,
   extractSyncSnapshot,
@@ -13,6 +13,16 @@ import {
   syncFromXbrief,
 } from "./sync-from-xbrief.js";
 import { parseArgs } from "./sync-from-xbrief-cli.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
 
 const ORIGIN_XBRIEF = {
   xBRIEFInfo: { version: "0.8" },
@@ -161,8 +171,9 @@ describe("issue-sync dry-run and missing origin", () => {
     const out: string[] = [];
     const err: string[] = [];
     const runFn = vi.fn();
+    const { xbriefPath } = writeTempXbrief(ORIGIN_XBRIEF);
     const code = syncFromXbrief({
-      xbriefPath: writeTempXbrief(ORIGIN_XBRIEF),
+      xbriefPath,
       dryRun: true,
       repo: "deftai/directive",
       writeOut: (line) => out.push(line),
@@ -178,10 +189,11 @@ describe("issue-sync dry-run and missing origin", () => {
 
   it("missing origin exits non-zero", () => {
     const err: string[] = [];
+    const { xbriefPath } = writeTempXbrief({
+      plan: { title: "orphan", status: "running", items: [] },
+    });
     const code = syncFromXbrief({
-      xbriefPath: writeTempXbrief({
-        plan: { title: "orphan", status: "running", items: [] },
-      }),
+      xbriefPath,
       dryRun: true,
       writeErr: (line) => err.push(line),
     });
@@ -191,7 +203,7 @@ describe("issue-sync dry-run and missing origin", () => {
 
   it("skips posting when fingerprint matches stored metadata", () => {
     const snapshot = extractSyncSnapshot(ORIGIN_XBRIEF);
-    const path = writeTempXbrief({
+    const { xbriefPath, projectRoot } = writeTempXbrief({
       ...ORIGIN_XBRIEF,
       plan: {
         ...ORIGIN_XBRIEF.plan,
@@ -203,7 +215,8 @@ describe("issue-sync dry-run and missing origin", () => {
     const out: string[] = [];
     const runFn = vi.fn();
     const code = syncFromXbrief({
-      xbriefPath: path,
+      xbriefPath,
+      projectRoot,
       repo: "deftai/directive",
       writeOut: (line) => out.push(line),
       runFn,
@@ -214,16 +227,17 @@ describe("issue-sync dry-run and missing origin", () => {
   });
 
   it("posts comment and persists fingerprint on happy path", () => {
-    const path = writeTempXbrief(ORIGIN_XBRIEF);
+    const { xbriefPath, projectRoot } = writeTempXbrief(ORIGIN_XBRIEF);
     const runFn = vi.fn(() => ({ id: 999 }));
     const code = syncFromXbrief({
-      xbriefPath: path,
+      xbriefPath,
+      projectRoot,
       repo: "deftai/directive",
       runFn,
     });
     expect(code).toBe(0);
     expect(runFn).toHaveBeenCalled();
-    const saved = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    const saved = JSON.parse(readFileSync(xbriefPath, "utf8")) as Record<string, unknown>;
     const plan = saved.plan as Record<string, unknown>;
     const metadata = plan.metadata as Record<string, unknown>;
     const issueSync = metadata.issueSync as Record<string, unknown>;
@@ -232,10 +246,11 @@ describe("issue-sync dry-run and missing origin", () => {
   });
 
   it("reports fingerprint persistence failure separately after posting", () => {
-    const path = writeTempXbrief(ORIGIN_XBRIEF);
+    const { xbriefPath, projectRoot } = writeTempXbrief(ORIGIN_XBRIEF);
     const err: string[] = [];
     const code = syncFromXbrief({
-      xbriefPath: path,
+      xbriefPath,
+      projectRoot,
       repo: "deftai/directive",
       runFn: () => ({ id: 1001 }),
       writeFingerprint: () => {
@@ -252,8 +267,10 @@ describe("issue-sync dry-run and missing origin", () => {
   it("refuses cross-repo comment mutation without allowCrossRepo (#2633)", () => {
     const err: string[] = [];
     const runFn = vi.fn();
+    const { xbriefPath, projectRoot } = writeTempXbrief(CROSS_REPO_XBRIEF);
     const code = syncFromXbrief({
-      xbriefPath: writeTempXbrief(CROSS_REPO_XBRIEF),
+      xbriefPath,
+      projectRoot,
       repo: "deftai/directive",
       writeErr: (line) => err.push(line),
       runFn,
@@ -264,10 +281,11 @@ describe("issue-sync dry-run and missing origin", () => {
   });
 
   it("allows cross-repo comment mutation when allowCrossRepo is set (#2633)", () => {
-    const path = writeTempXbrief(CROSS_REPO_XBRIEF);
+    const { xbriefPath, projectRoot } = writeTempXbrief(CROSS_REPO_XBRIEF);
     const runFn = vi.fn(() => ({ id: 1002 }));
     const code = syncFromXbrief({
-      xbriefPath: path,
+      xbriefPath,
+      projectRoot,
       repo: "deftai/directive",
       allowCrossRepo: true,
       runFn,
@@ -277,10 +295,11 @@ describe("issue-sync dry-run and missing origin", () => {
   });
 
   it("allows cross-repo comment mutation when target is allowlisted (#2633)", () => {
-    const path = writeTempXbrief(CROSS_REPO_XBRIEF);
+    const { xbriefPath, projectRoot } = writeTempXbrief(CROSS_REPO_XBRIEF);
     const runFn = vi.fn(() => ({ id: 1003 }));
     const code = syncFromXbrief({
-      xbriefPath: path,
+      xbriefPath,
+      projectRoot,
       repo: "deftai/directive",
       repoAllowlist: ["other/victim"],
       runFn,
@@ -292,8 +311,10 @@ describe("issue-sync dry-run and missing origin", () => {
   it("refuses cross-repo dry-run without allowCrossRepo (#2633)", () => {
     const err: string[] = [];
     const runFn = vi.fn();
+    const { xbriefPath, projectRoot } = writeTempXbrief(CROSS_REPO_XBRIEF);
     const code = syncFromXbrief({
-      xbriefPath: writeTempXbrief(CROSS_REPO_XBRIEF),
+      xbriefPath,
+      projectRoot,
       dryRun: true,
       repo: "deftai/directive",
       writeErr: (line) => err.push(line),
@@ -305,21 +326,72 @@ describe("issue-sync dry-run and missing origin", () => {
   });
 
   it("allows same-repo sync when --repo is a full GitHub URL (#2633)", () => {
-    const path = writeTempXbrief(ORIGIN_XBRIEF);
+    const { xbriefPath, projectRoot } = writeTempXbrief(ORIGIN_XBRIEF);
     const runFn = vi.fn(() => ({ id: 1004 }));
     const code = syncFromXbrief({
-      xbriefPath: path,
+      xbriefPath,
+      projectRoot,
       repo: "https://github.com/deftai/directive",
       runFn,
     });
     expect(code).toBe(0);
     expect(runFn).toHaveBeenCalled();
   });
+
+  itSymlink(
+    "refuses fingerprint persist when xBRIEF is a symlink outside the project (#2710)",
+    () => {
+      const root = mkdtempSync(join(tmpdir(), "issue-sync-project-"));
+      tempRoots.push(root);
+      mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+      writeFileSync(
+        join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+        `${JSON.stringify({
+          xBRIEFInfo: { version: "0.8" },
+          plan: { title: "Project", status: "running", items: [] },
+        })}\n`,
+        "utf8",
+      );
+      const escapeDir = mkdtempSync(join(tmpdir(), "issue-sync-escape-"));
+      tempRoots.push(escapeDir);
+      const victim = join(escapeDir, "scope.xbrief.json");
+      writeFileSync(victim, `${JSON.stringify(ORIGIN_XBRIEF, null, 2)}\n`, "utf8");
+      const linkedPath = join(root, "xbrief", "active", "scope.xbrief.json");
+      symlinkSync(victim, linkedPath);
+
+      const runFn = vi.fn(() => ({ id: 2001 }));
+      const err: string[] = [];
+      const code = syncFromXbrief({
+        xbriefPath: linkedPath,
+        projectRoot: root,
+        repo: "deftai/directive",
+        runFn,
+        writeErr: (line) => err.push(line),
+      });
+      expect(code).toBe(1);
+      expect(runFn).toHaveBeenCalled();
+      expect(err.join("\n")).toMatch(/projection write refused|symlink/);
+      expect(readFileSync(victim, "utf8")).not.toContain('"issueSync"');
+    },
+  );
 });
 
-function writeTempXbrief(data: Record<string, unknown>): string {
-  const dir = mkdtempSync(join(tmpdir(), "issue-sync-"));
-  const path = join(dir, "scope.xbrief.json");
-  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  return path;
+function writeTempXbrief(data: Record<string, unknown>): {
+  xbriefPath: string;
+  projectRoot: string;
+} {
+  const projectRoot = mkdtempSync(join(tmpdir(), "issue-sync-"));
+  tempRoots.push(projectRoot);
+  mkdirSync(join(projectRoot, "xbrief", "active"), { recursive: true });
+  writeFileSync(
+    join(projectRoot, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    `${JSON.stringify({
+      xBRIEFInfo: { version: "0.8" },
+      plan: { title: "Fixture", status: "running", items: [] },
+    })}\n`,
+    "utf8",
+  );
+  const xbriefPath = join(projectRoot, "xbrief", "active", "scope.xbrief.json");
+  writeFileSync(xbriefPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  return { xbriefPath, projectRoot };
 }

--- a/packages/core/src/issue-sync/sync-from-xbrief.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { createIssueComment, type RunGhApiFn } from "../intake/github-body.js";
 import { provenanceIssueNumber, repoSlugFromUrl } from "../intake/issue-ingest.js";
 import {
@@ -276,10 +277,12 @@ export function syncFromXbrief(options: SyncFromXbriefOptions): number {
   const writeFingerprint =
     options.writeFingerprint ??
     ((targetPath, stamped) => {
+      assertWriteTargetSafe(projectRoot, targetPath);
       writeFileSync(targetPath, `${JSON.stringify(stamped, null, 2)}\n`, "utf8");
     });
 
   try {
+    assertWriteTargetSafe(projectRoot, absPath);
     writeFingerprint(absPath, stampIssueSyncFingerprint(data, origin));
   } catch (exc) {
     writeErr(

--- a/packages/core/src/staleness-tickler/state.test.ts
+++ b/packages/core/src/staleness-tickler/state.test.ts
@@ -1,0 +1,66 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadStalenessTicklerState, saveStalenessTicklerState } from "./state.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("staleness tickler state containment (#2710)", () => {
+  let root: string;
+  const temps: string[] = [];
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "deft-staleness-state-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "s.xbrief.json"),
+      JSON.stringify({ plan: { id: "s", status: "running", items: [] } }),
+      "utf8",
+    );
+  });
+
+  afterEach(() => {
+    for (const dir of temps.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshEscape(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    temps.push(dir);
+    return dir;
+  }
+
+  itSymlink("save refuses without out-of-tree write when .triage-cache is a symlink", () => {
+    const escapeDir = freshEscape("deft-staleness-escape-");
+    const victim = join(escapeDir, "staleness-tickler-state.json");
+    writeFileSync(victim, "untouched\n", "utf8");
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    symlinkSync(victim, join(root, "xbrief", ".triage-cache"));
+
+    saveStalenessTicklerState(root, { lastPromptAt: "2026-01-01T00:00:00.000Z" });
+
+    expect(readFileSync(victim, "utf8")).toBe("untouched\n");
+    expect(existsSync(join(root, "xbrief", ".triage-cache", "staleness-tickler-state.json"))).toBe(
+      false,
+    );
+  });
+
+  itSymlink("load returns empty state when .triage-cache is a symlink escape", () => {
+    const escapeDir = freshEscape("deft-staleness-load-escape-");
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    symlinkSync(escapeDir, join(root, "xbrief", ".triage-cache"), "dir");
+
+    expect(loadStalenessTicklerState(root)).toEqual({});
+  });
+});

--- a/packages/core/src/staleness-tickler/state.ts
+++ b/packages/core/src/staleness-tickler/state.ts
@@ -1,8 +1,14 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { resolveTriageCachePath } from "../triage/cache-path.js";
 import type { StalenessTicklerState } from "./types.js";
 
 export const STATE_RELATIVE_PATH = join("xbrief", ".triage-cache", "staleness-tickler-state.json");
+const STATE_FILE_NAME = "staleness-tickler-state.json";
+
+function resolveStalenessTicklerStatePath(projectRoot: string): string {
+  return resolveTriageCachePath(projectRoot, STATE_FILE_NAME);
+}
 
 export interface StateIo {
   readonly readText?: (path: string) => string | null;
@@ -43,7 +49,12 @@ export function loadStalenessTicklerState(
   projectRoot: string,
   io: StateIo = {},
 ): StalenessTicklerState {
-  const path = join(projectRoot, STATE_RELATIVE_PATH);
+  let path: string;
+  try {
+    path = resolveStalenessTicklerStatePath(projectRoot);
+  } catch {
+    return {};
+  }
   return parseStalenessTicklerState((io.readText ?? defaultReadText)(path));
 }
 
@@ -52,7 +63,12 @@ export function saveStalenessTicklerState(
   state: StalenessTicklerState,
   io: StateIo = {},
 ): void {
-  const path = join(projectRoot, STATE_RELATIVE_PATH);
+  let path: string;
+  try {
+    path = resolveStalenessTicklerStatePath(projectRoot);
+  } catch {
+    return;
+  }
   try {
     (io.writeText ?? defaultWriteText)(path, `${JSON.stringify(state, null, 2)}\n`);
   } catch {


### PR DESCRIPTION
## Summary
- Route staleness-tickler state persistence through `resolveTriageCachePath` so triage-cache symlink escapes are refused.
- Gate vendored upgrade `regenerateBareVersionMarker` with `assertConsumerProjectionContained` before writing `vbrief/.deft-version`.
- Guard `issue:sync-from-xbrief` fingerprint writes with `assertWriteTargetSafe` before persisting stamped metadata.
- Add regression tests for all three sinks and a CHANGELOG [Unreleased] security note.

## Test plan
- [x] `pnpm -w exec vitest run packages/core/src/staleness-tickler/state.test.ts packages/core/src/issue-sync/sync-from-xbrief.test.ts`
- [x] `go test ./cmd/deft-install/ -run RegenerateBareVersionMarker`
- [x] `task check`

Closes #2710
