### PR TITLE
feat(scm): fail-closed issue-body postcondition verify + fetch-to-file (#2607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Safe issue-body fetch and fail-closed postcondition verify (#2607).** `task scm:body:issue:fetch` writes the live issue body to a UTF-8 `--out-file` for read-modify-write without PowerShell capture; `scm:body:*` mutators now fail non-zero when re-fetched bodies are flattened or mojibaked vs the intended payload. Closes #2607.
+
 ### Changed
 
 ### Fixed

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -92,6 +92,7 @@ export const SUBCOMMAND_ROUTES: Readonly<Record<string, readonly [string, string
   "slice:list": ["slice", "list"],
   "github-body:issue-create": ["github-body", "issue-create"],
   "github-body:issue-edit": ["github-body", "issue-edit"],
+  "github-body:issue-fetch": ["github-body", "issue-fetch"],
   "github-body:comment-create": ["github-body", "comment-create"],
   "github-body:comment-edit": ["github-body", "comment-edit"],
   "github-body:pr-edit": ["github-body", "pr-edit"],

--- a/packages/core/src/intake/github-body-cli.ts
+++ b/packages/core/src/intake/github-body-cli.ts
@@ -12,6 +12,7 @@ function parseArgs(argv: string[]): GitHubBodyCliArgs {
     else if (arg === "--comment") out.comment = Number.parseInt(argv[++i] as string, 10);
     else if (arg === "--pr") out.pr = Number.parseInt(argv[++i] as string, 10);
     else if (arg === "--body-file") out.bodyFile = argv[++i];
+    else if (arg === "--out-file") out.outFile = argv[++i];
   }
   return out;
 }

--- a/packages/core/src/intake/github-body.test.ts
+++ b/packages/core/src/intake/github-body.test.ts
@@ -1,5 +1,17 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { type RunGhApiFn, readBody, resolveLiveGh } from "./github-body.js";
+import {
+  editIssueBody,
+  fetchIssueBody,
+  GitHubBodyError,
+  type RunGhApiFn,
+  readBody,
+  resolveLiveGh,
+  verifyBodyPostcondition,
+  writeIssueBodyToFile,
+} from "./github-body.js";
 
 describe("github-body", () => {
   it("reads body from stdin sentinel", () => {
@@ -12,11 +24,16 @@ describe("github-body", () => {
 
   it("createIssue uses runFn seam", async () => {
     const { createIssue } = await import("./github-body.js");
-    const runFn: RunGhApiFn = (args) => {
-      if (args.length === 1) {
-        return { number: 42, html_url: "https://github.com/o/r/issues/42" };
+    let lastBody = "";
+    const runFn: RunGhApiFn = (args, options) => {
+      if (args.includes("--method")) {
+        if (options?.inputText) {
+          const parsed = JSON.parse(options.inputText) as { body?: string };
+          if (typeof parsed.body === "string") lastBody = parsed.body;
+        }
+        return { number: 42 };
       }
-      return { number: 42 };
+      return { number: 42, body: lastBody, html_url: "https://github.com/o/r/issues/42" };
     };
     const result = createIssue("o/r", {
       title: "t",
@@ -25,5 +42,80 @@ describe("github-body", () => {
       binary: "gh",
     });
     expect(result.number).toBe(42);
+  });
+
+  it("verifyBodyPostcondition passes on exact match", () => {
+    expect(() => verifyBodyPostcondition("line1\nline2", "line1\nline2")).not.toThrow();
+  });
+
+  it("verifyBodyPostcondition passes on CRLF normalization", () => {
+    expect(() => verifyBodyPostcondition("line1\nline2", "line1\r\nline2")).not.toThrow();
+  });
+
+  it("verifyBodyPostcondition fails on flattened newlines", () => {
+    expect(() => verifyBodyPostcondition("line1\nline2", "line1 line2")).toThrow(GitHubBodyError);
+    expect(() => verifyBodyPostcondition("line1\nline2", "line1 line2")).toThrow(
+      /collapsed to spaces/,
+    );
+  });
+
+  it("verifyBodyPostcondition fails on mojibake marker", () => {
+    expect(() => verifyBodyPostcondition("arrow → dash", "arrow \uFFFD dash")).toThrow(
+      GitHubBodyError,
+    );
+    expect(() => verifyBodyPostcondition("arrow → dash", "arrow \uFFFD dash")).toThrow(/U\+FFFD/);
+  });
+
+  it("editIssueBody fails closed when read-back body is flattened", () => {
+    const intended = "section one\nsection two";
+    const runFn: RunGhApiFn = (args, _options) => {
+      if (args.includes("--method")) {
+        return { number: 7 };
+      }
+      if (args.length === 1 && args[0] === "repos/o/r/issues/7") {
+        return { body: "section one section two" };
+      }
+      throw new Error(`unexpected args: ${args.join(" ")}`);
+    };
+    expect(() => editIssueBody("o/r", 7, { body: intended, runFn, binary: "gh" })).toThrow(
+      /body postcondition failed/,
+    );
+  });
+
+  it("editIssueBody succeeds when read-back matches intended body", () => {
+    const intended = "section one\nsection two → em-dash";
+    const runFn: RunGhApiFn = (args) => {
+      if (args.includes("--method")) {
+        return { number: 7 };
+      }
+      if (args.length === 1 && args[0] === "repos/o/r/issues/7") {
+        return { body: intended };
+      }
+      throw new Error(`unexpected args: ${args.join(" ")}`);
+    };
+    const result = editIssueBody("o/r", 7, { body: intended, runFn, binary: "gh" });
+    expect(result.body).toBe(intended);
+  });
+
+  it("fetchIssueBody returns live body via runFn", () => {
+    const body = "line one\nline two — unicode";
+    const runFn: RunGhApiFn = (args) => {
+      expect(args).toEqual(["repos/o/r/issues/42"]);
+      return { body };
+    };
+    expect(fetchIssueBody("o/r", 42, { runFn, binary: "gh" })).toBe(body);
+  });
+
+  it("writeIssueBodyToFile writes exact UTF-8 body", () => {
+    const dir = mkdtempSync(join(tmpdir(), "github-body-"));
+    const outFile = join(dir, "body.md");
+    const body = "line one\nline two → em-dash";
+    const runFn: RunGhApiFn = () => ({ body });
+    try {
+      writeIssueBodyToFile("o/r", 42, outFile, { runFn, binary: "gh" });
+      expect(readFileSync(outFile, "utf8")).toBe(body);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/src/intake/github-body.ts
+++ b/packages/core/src/intake/github-body.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { defaultWhich } from "../scm/binary.js";
 import { type CompletedProcess, call } from "../scm/call.js";
 
@@ -95,6 +95,63 @@ function requireIntField(obj: Record<string, unknown>, field: string): number {
   return value;
 }
 
+function requireStringField(obj: Record<string, unknown>, field: string): string {
+  const value = obj[field];
+  if (typeof value !== "string") {
+    throw new GitHubBodyError(`response did not include string field ${JSON.stringify(field)}`);
+  }
+  return value;
+}
+
+function countNewlines(text: string): number {
+  let count = 0;
+  for (const ch of text) {
+    if (ch === "\n") count += 1;
+  }
+  return count;
+}
+
+function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, "\n");
+}
+
+/** Fail closed when live read-back body is flattened or mojibaked vs intended payload (#2607). */
+export function verifyBodyPostcondition(intended: string, live: string): void {
+  if (intended === live) {
+    return;
+  }
+  if (normalizeNewlines(intended) === normalizeNewlines(live)) {
+    return;
+  }
+
+  const diagnoses: string[] = [];
+  if (live.includes("\uFFFD") && !intended.includes("\uFFFD")) {
+    diagnoses.push(
+      "live body contains U+FFFD replacement character not present in intended payload",
+    );
+  }
+
+  const intendedNl = countNewlines(intended);
+  const liveNl = countNewlines(live);
+  if (intendedNl > 0 && liveNl < intendedNl) {
+    diagnoses.push(`newline count mismatch (intended ${intendedNl}, live ${liveNl})`);
+  }
+
+  if (intended.includes("\n") && intended.replace(/\n/g, " ") === live) {
+    diagnoses.push(
+      "live body looks like intended newlines were collapsed to spaces (PowerShell string[] join)",
+    );
+  }
+
+  if (diagnoses.length > 0) {
+    throw new GitHubBodyError(`body postcondition failed: ${diagnoses.join("; ")}`);
+  }
+
+  throw new GitHubBodyError(
+    `body postcondition failed: re-fetched body does not match intended payload (length intended=${intended.length}, live=${live.length})`,
+  );
+}
+
 function mutateWithReadback(
   mutationEndpoint: string,
   method: string,
@@ -102,6 +159,7 @@ function mutateWithReadback(
   readbackEndpoint: string | ((response: Record<string, unknown>) => string),
   options: { binary?: string | null; runFn?: RunGhApiFn } = {},
 ): Record<string, unknown> {
+  const intendedBody = typeof payload.body === "string" ? payload.body : undefined;
   const mutation = runGhApiJson([mutationEndpoint, "--method", method, "--input", "-"], {
     inputText: jsonInput(payload),
     binary: options.binary,
@@ -109,7 +167,11 @@ function mutateWithReadback(
   });
   const endpoint =
     typeof readbackEndpoint === "function" ? readbackEndpoint(mutation) : readbackEndpoint;
-  return runGhApiJson([endpoint], { binary: options.binary, runFn: options.runFn });
+  const readback = runGhApiJson([endpoint], { binary: options.binary, runFn: options.runFn });
+  if (intendedBody !== undefined) {
+    verifyBodyPostcondition(intendedBody, requireStringField(readback, "body"));
+  }
+  return readback;
 }
 
 export function createIssue(
@@ -182,6 +244,28 @@ export function editPrBody(
   });
 }
 
+export function fetchIssueBody(
+  repo: string,
+  issue: number,
+  options: { binary?: string | null; runFn?: RunGhApiFn } = {},
+): string {
+  const [owner, name] = splitRepo(repo);
+  const endpoint = `repos/${owner}/${name}/issues/${issue}`;
+  const response = runGhApiJson([endpoint], { binary: options.binary, runFn: options.runFn });
+  return requireStringField(response, "body");
+}
+
+export function writeIssueBodyToFile(
+  repo: string,
+  issue: number,
+  outFile: string,
+  options: { binary?: string | null; runFn?: RunGhApiFn } = {},
+): string {
+  const body = fetchIssueBody(repo, issue, options);
+  writeFileSync(outFile, body, { encoding: "utf8" });
+  return body;
+}
+
 export interface GitHubBodyCliArgs {
   command: string;
   repo?: string;
@@ -190,34 +274,47 @@ export interface GitHubBodyCliArgs {
   comment?: number;
   pr?: number;
   bodyFile?: string;
+  outFile?: string;
 }
 
 export function githubBodyMain(args: GitHubBodyCliArgs): number {
   try {
-    const body = readBody(args.bodyFile ?? "-");
-    let result: Record<string, unknown>;
     switch (args.command) {
-      case "issue-create":
-        result = createIssue(args.repo as string, { title: args.title as string, body });
-        break;
-      case "issue-edit":
-        result = editIssueBody(args.repo as string, args.issue as number, { body });
-        break;
-      case "comment-create":
-        result = createIssueComment(args.repo as string, args.issue as number, { body });
-        break;
-      case "comment-edit":
-        result = editIssueCommentBody(args.repo as string, args.comment as number, { body });
-        break;
-      case "pr-edit":
-        result = editPrBody(args.repo as string, args.pr as number, { body });
-        break;
-      default:
-        process.stderr.write(`error: unknown command ${JSON.stringify(args.command)}\n`);
-        return 1;
+      case "issue-fetch": {
+        if (args.repo === undefined || args.issue === undefined || args.outFile === undefined) {
+          process.stderr.write("error: issue-fetch requires --repo, --issue, and --out-file\n");
+          return 1;
+        }
+        writeIssueBodyToFile(args.repo, args.issue, args.outFile);
+        return 0;
+      }
+      default: {
+        const body = readBody(args.bodyFile ?? "-");
+        let result: Record<string, unknown>;
+        switch (args.command) {
+          case "issue-create":
+            result = createIssue(args.repo as string, { title: args.title as string, body });
+            break;
+          case "issue-edit":
+            result = editIssueBody(args.repo as string, args.issue as number, { body });
+            break;
+          case "comment-create":
+            result = createIssueComment(args.repo as string, args.issue as number, { body });
+            break;
+          case "comment-edit":
+            result = editIssueCommentBody(args.repo as string, args.comment as number, { body });
+            break;
+          case "pr-edit":
+            result = editPrBody(args.repo as string, args.pr as number, { body });
+            break;
+          default:
+            process.stderr.write(`error: unknown command ${JSON.stringify(args.command)}\n`);
+            return 1;
+        }
+        process.stdout.write(`${JSON.stringify(result)}\n`);
+        return 0;
+      }
     }
-    process.stdout.write(`${JSON.stringify(result)}\n`);
-    return 0;
   } catch (exc) {
     process.stderr.write(`error: ${String(exc)}\n`);
     return 1;

--- a/packages/core/src/intake/intake-cli-and-branches.test.ts
+++ b/packages/core/src/intake/intake-cli-and-branches.test.ts
@@ -11,7 +11,7 @@ import {
   validateGithubAuth,
 } from "./github-auth-modes.js";
 import { mainEntry as authCliMain } from "./github-auth-modes-cli.js";
-import { createIssue, githubBodyMain } from "./github-body.js";
+import { createIssue, githubBodyMain, type RunGhApiFn } from "./github-body.js";
 import { mainEntry as bodyCliMain } from "./github-body-cli.js";
 import {
   emitUmbrella,
@@ -453,9 +453,18 @@ describe("intake cli and branch coverage", () => {
     });
 
     it("githubBodyMain issue-create and createIssue readback", () => {
-      const callSpy = vi
-        .spyOn(scm, "call")
-        .mockImplementation(() => completed(JSON.stringify({ number: 9, body: "created" }), "", 0));
+      let lastBody = "";
+      const callSpy = vi.spyOn(scm, "call").mockImplementation((_domain, _verb, args, opts) => {
+        if (args.includes("--method")) {
+          const input = opts?.input;
+          if (typeof input === "string") {
+            const parsed = JSON.parse(input) as { body?: string };
+            if (typeof parsed.body === "string") lastBody = parsed.body;
+          }
+          return completed(JSON.stringify({ number: 9 }), "", 0);
+        }
+        return completed(JSON.stringify({ number: 9, body: lastBody }), "", 0);
+      });
       const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
       expect(
         githubBodyMain({
@@ -465,8 +474,17 @@ describe("intake cli and branch coverage", () => {
           bodyFile: "-",
         }),
       ).toBe(0);
-      const runFn = (args: readonly string[]) =>
-        args.includes("--method") ? { number: 11 } : { number: 11, body: "b" };
+      let createBody = "";
+      const runFn: RunGhApiFn = (args, options) => {
+        if (args.includes("--method")) {
+          if (options?.inputText) {
+            const parsed = JSON.parse(options.inputText) as { body?: string };
+            if (typeof parsed.body === "string") createBody = parsed.body;
+          }
+          return { number: 11 };
+        }
+        return { number: 11, body: createBody };
+      };
       expect(createIssue("o/r", { title: "t", body: "b", runFn, binary: "gh" }).number).toBe(11);
       callSpy.mockRestore();
       stdout.mockRestore();

--- a/packages/core/src/intake/intake-coverage-boost.test.ts
+++ b/packages/core/src/intake/intake-coverage-boost.test.ts
@@ -30,6 +30,7 @@ import {
   editPrBody,
   GitHubBodyError,
   githubBodyMain,
+  type RunGhApiFn,
   readBody,
 } from "./github-body.js";
 import {
@@ -815,18 +816,22 @@ describe("intake coverage boost", () => {
   });
 
   describe("github-body", () => {
-    const runFn = (args: readonly string[], _input?: string) => {
-      if (args.includes("--method")) {
-        return { number: 7, id: 99 };
-      }
-      return { number: 7, body: "ok", id: 99 };
-    };
-
     it("mutations round-trip via runFn seam", () => {
-      expect(editIssueBody("o/r", 7, { body: "b", runFn, binary: "gh" }).body).toBe("ok");
+      let lastBody = "";
+      const runFn: RunGhApiFn = (args, options) => {
+        if (args.includes("--method")) {
+          if (options?.inputText) {
+            const parsed = JSON.parse(options.inputText) as { body?: string };
+            if (typeof parsed.body === "string") lastBody = parsed.body;
+          }
+          return { number: 7, id: 99 };
+        }
+        return { number: 7, body: lastBody, id: 99 };
+      };
+      expect(editIssueBody("o/r", 7, { body: "b", runFn, binary: "gh" }).body).toBe("b");
       expect(createIssueComment("o/r", 7, { body: "c", runFn, binary: "gh" }).id).toBe(99);
       expect(editIssueCommentBody("o/r", 99, { body: "d", runFn, binary: "gh" }).id).toBe(99);
-      expect(editPrBody("o/r", 3, { body: "e", runFn, binary: "gh" }).body).toBe("ok");
+      expect(editPrBody("o/r", 3, { body: "e", runFn, binary: "gh" }).body).toBe("e");
     });
 
     it("readBody and githubBodyMain", () => {
@@ -835,11 +840,18 @@ describe("intake coverage boost", () => {
       writeFileSync(bodyPath, "hello", "utf8");
       expect(readBody(bodyPath)).toBe("hello");
       expect(readBody("-", "stdin")).toBe("stdin");
-      const callSpy = vi
-        .spyOn(scm, "call")
-        .mockImplementation(() =>
-          completed(JSON.stringify({ number: 1, body: "ok", id: 99 }), "", 0),
-        );
+      let lastBody = "";
+      const callSpy = vi.spyOn(scm, "call").mockImplementation((_domain, _verb, args, opts) => {
+        if (args.includes("--method")) {
+          const input = opts?.input;
+          if (typeof input === "string") {
+            const parsed = JSON.parse(input) as { body?: string };
+            if (typeof parsed.body === "string") lastBody = parsed.body;
+          }
+          return completed(JSON.stringify({ number: 1, id: 99 }), "", 0);
+        }
+        return completed(JSON.stringify({ number: 1, body: lastBody, id: 99 }), "", 0);
+      });
       const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
       const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
       try {

--- a/packages/core/src/issue-sync/sync-from-xbrief.test.ts
+++ b/packages/core/src/issue-sync/sync-from-xbrief.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RunGhApiFn } from "../intake/github-body.js";
 import {
   buildSyncComment,
   extractSyncSnapshot,
@@ -13,6 +14,21 @@ import {
   syncFromXbrief,
 } from "./sync-from-xbrief.js";
 import { parseArgs } from "./sync-from-xbrief-cli.js";
+
+function mockCommentRunFn(id: number): RunGhApiFn {
+  let lastBody = "";
+  const fn: RunGhApiFn = (args, options) => {
+    if (args.includes("--method")) {
+      if (options?.inputText) {
+        const parsed = JSON.parse(options.inputText) as { body?: string };
+        if (typeof parsed.body === "string") lastBody = parsed.body;
+      }
+      return { id };
+    }
+    return { id, body: lastBody };
+  };
+  return vi.fn(fn) as unknown as RunGhApiFn;
+}
 
 const itSymlink = it.skipIf(process.platform === "win32");
 const tempRoots: string[] = [];
@@ -228,7 +244,7 @@ describe("issue-sync dry-run and missing origin", () => {
 
   it("posts comment and persists fingerprint on happy path", () => {
     const { xbriefPath, projectRoot } = writeTempXbrief(ORIGIN_XBRIEF);
-    const runFn = vi.fn(() => ({ id: 999 }));
+    const runFn = mockCommentRunFn(999);
     const code = syncFromXbrief({
       xbriefPath,
       projectRoot,
@@ -252,7 +268,7 @@ describe("issue-sync dry-run and missing origin", () => {
       xbriefPath,
       projectRoot,
       repo: "deftai/directive",
-      runFn: () => ({ id: 1001 }),
+      runFn: mockCommentRunFn(1001),
       writeFingerprint: () => {
         throw new Error("read-only");
       },
@@ -282,7 +298,7 @@ describe("issue-sync dry-run and missing origin", () => {
 
   it("allows cross-repo comment mutation when allowCrossRepo is set (#2633)", () => {
     const { xbriefPath, projectRoot } = writeTempXbrief(CROSS_REPO_XBRIEF);
-    const runFn = vi.fn(() => ({ id: 1002 }));
+    const runFn = mockCommentRunFn(1002);
     const code = syncFromXbrief({
       xbriefPath,
       projectRoot,
@@ -296,7 +312,7 @@ describe("issue-sync dry-run and missing origin", () => {
 
   it("allows cross-repo comment mutation when target is allowlisted (#2633)", () => {
     const { xbriefPath, projectRoot } = writeTempXbrief(CROSS_REPO_XBRIEF);
-    const runFn = vi.fn(() => ({ id: 1003 }));
+    const runFn = mockCommentRunFn(1003);
     const code = syncFromXbrief({
       xbriefPath,
       projectRoot,
@@ -327,7 +343,7 @@ describe("issue-sync dry-run and missing origin", () => {
 
   it("allows same-repo sync when --repo is a full GitHub URL (#2633)", () => {
     const { xbriefPath, projectRoot } = writeTempXbrief(ORIGIN_XBRIEF);
-    const runFn = vi.fn(() => ({ id: 1004 }));
+    const runFn = mockCommentRunFn(1004);
     const code = syncFromXbrief({
       xbriefPath,
       projectRoot,
@@ -359,7 +375,7 @@ describe("issue-sync dry-run and missing origin", () => {
       const linkedPath = join(root, "xbrief", "active", "scope.xbrief.json");
       symlinkSync(victim, linkedPath);
 
-      const runFn = vi.fn(() => ({ id: 2001 }));
+      const runFn = mockCommentRunFn(2001);
       const err: string[] = [];
       const code = syncFromXbrief({
         xbriefPath: linkedPath,

--- a/tasks/scm.yml
+++ b/tasks/scm.yml
@@ -113,6 +113,16 @@ tasks:
         vars:
           ENGINE_CMD: 'github-body issue-edit {{.CLI_ARGS}}'
 
+  body:issue:fetch:
+    desc: "[#2607] Fetch live issue body to UTF-8 --out-file for safe read-modify-write"
+    dir: '{{.USER_WORKING_DIR}}'
+    deps:
+      - task: :engine:_ts-build
+    cmds:
+      - task: :engine:invoke
+        vars:
+          ENGINE_CMD: 'github-body issue-fetch {{.CLI_ARGS}}'
+
   body:comment:create:
     desc: "[#1555] Safely create an issue/PR comment body from --body-file and live gh read-back"
     dir: '{{.USER_WORKING_DIR}}'

--- a/xbrief/active/2026-07-21-2607-safe-issue-body-patch-helper.xbrief.json
+++ b/xbrief/active/2026-07-21-2607-safe-issue-body-patch-helper.xbrief.json
@@ -1,0 +1,92 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Strengthen scm:body issue-edit with fail-closed postcondition verify + safe body fetch-to-file for win32 RMW.",
+    "created": "2026-07-22T01:35:00Z",
+    "updated": "2026-07-22T02:20:00Z"
+  },
+  "plan": {
+    "id": "2607-safe-issue-body-patch-helper",
+    "title": "feat(scm): issue-body postcondition verify + safe fetch-to-file (#2607)",
+    "status": "running",
+    "narratives": {
+      "Description": "Existing scm:body:* (#1555) PATCHes via body-file and re-fetches, but does not fail closed when the stored body is flattened or mojibaked. Win32 agents still destroy live issue bodies on read-modify-write by capturing gh api --jq .body into a PowerShell string[] and joining with OFS. Directive needs stronger postconditions and a fetch-to-file path so agents never rebuild bodies via PS array coercion.",
+      "ImplementationPlan": "1. In packages/core/src/intake/github-body.ts mutateWithReadback / editIssueBody (and sibling body mutators as appropriate), after re-fetch compare intended body to live body (equality or structural: newline count, no U+FFFD / space-joined collapse heuristics) and throw GitHubBodyError on mismatch. 2. Add github-body issue-fetch (or scm:body:issue:fetch) that writes the live body to a UTF-8 file for safe RMW. 3. Wire CLI/task in packages/core/src/intake/github-body-cli.ts, packages/cli route, tasks/scm.yml. 4. Unit tests with mocked runFn covering flattened/mojibake fail-closed and happy path. 5. CHANGELOG [Unreleased]. Docs always-load forbid for PS capture-concat is #2744 (depends on this helper).",
+      "UserStory": "As a win32 agent amending an issue body, I want a helper that patches via body-file with fail-closed re-fetch verify and a fetch-to-file read path, so that newlines and Unicode are not silently destroyed."
+    },
+    "items": [
+      {
+        "id": "ac1",
+        "title": "Fail-closed postcondition verify on body mutate",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a PATCH whose re-fetched body is flattened or mojibaked relative to the intended payload, when scm:body:issue:edit / editIssueBody runs, then it exits non-zero with a short diagnosis and does not report success."
+        }
+      },
+      {
+        "id": "ac2",
+        "title": "Safe fetch-to-file for RMW",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an issue with a multi-line Unicode body, when the fetch-to-file verb runs, then a UTF-8 file contains the exact live body without PowerShell string[] join."
+        }
+      },
+      {
+        "id": "ac3",
+        "title": "Tests + CHANGELOG",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given mocked gh responses, when github-body tests run, then flattened/mojibake cases fail closed and happy path passes; CHANGELOG [Unreleased] notes the verify + fetch path."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "enhancement",
+      "x-tracking": {
+        "parent_issue": "#2607",
+        "decomposition_origin": "#2607"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/intake/github-body.ts",
+          "packages/core/src/intake/github-body-cli.ts",
+          "packages/core/src/intake/github-body.test.ts",
+          "packages/cli/src/cli-router/route-argv.ts",
+          "packages/cli/src/dispatch.ts",
+          "tasks/scm.yml",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm --filter @deftai/directive-core test -- github-body"
+        ],
+        "expected_outputs": [
+          "postcondition verify fail-closed",
+          "fetch-to-file verb",
+          "CHANGELOG"
+        ],
+        "depends_on": [],
+        "conflict_group": "scm-body-2607",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": "Enhancement from GitHub issue #2607 extending #1555; no FR trace registry for hotfix cohort."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2607",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2607: safe issue-body patch helper + postcondition verify"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2744",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2744: always-load RMW guidance (follow-on docs)"
+      }
+    ],
+    "updated": "2026-07-22T02:17:45Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Add fail-closed postcondition verify after all `scm:body:*` mutators (equality preferred; newline-count, U+FFFD, and PowerShell string[] collapse heuristics).
- Add `task scm:body:issue:fetch` / `github-body issue-fetch` to write the live issue body to a UTF-8 `--out-file` for safe read-modify-write on win32.
- Unit tests with mocked `runFn`; update dependent test mocks for postcondition verify.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/intake/github-body.test.ts`
- [x] `task check`
- [x] `task verify:forward-coverage`

Closes #2607
