### PR TITLE
docs(agents): always-load win32 issue-body RMW footgun (#2744)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=3c6585edb7fa refreshed=2026-07-20T21:21:57Z session=2fcd19cd3b40 -->
+<!-- deft:managed-section v3 sha=3bd115f734c8 refreshed=2026-07-22T03:01:23Z session=4f90b612ea8a -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -241,9 +241,9 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ! When `plan.policy.allowDirectCommitsToMaster = true`, surface via `deft policy:show --field=allowDirectCommitsToMaster` (#746) — `.deft/core/scm/github.md` § Branch policy.
 
-## Windows PowerShell: multi-line git/gh bodies (#2646)
+## Windows PowerShell: multi-line git/gh bodies (#2646 / #2744)
 
-! Multi-line git commit / gh issue|pr|comment bodies: write UTF-8 (no BOM) to OS temp, then `git commit -F` / `gh --body-file` / `deft scm:body:* --body-file`. ⊗ bash heredocs, `<<<`, or inline multi-line `--body` on Windows PowerShell. Detail: `.deft/core/scm/github.md` § #2646. `ghx` is read-only — mutations stay on live `gh`.
+! Multi-line git commit / gh issue|pr|comment bodies: write UTF-8 (no BOM) to OS temp, then `git commit -F` / `gh --body-file` / `deft scm:body:* --body-file`. Issue-body RMW on win32: `deft scm:body:issue:fetch --out-file` then edit the file then `deft scm:body:issue:edit --body-file` (#2607 postcondition verify). ⊗ bash heredocs, `<<<`, inline multi-line `--body`, or PS capture-concat of `gh api --jq .body` (string[]/$OFS destroys bodies — #2087, #2741, #1492). Detail: `.deft/core/scm/github.md` § #2646 / #2744. `ghx` is read-only — mutations stay on live `gh`.
 
 ## Contextual guardrails (runtime-detect lazy-load)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Safe issue-body fetch and fail-closed postcondition verify (#2607).** `task scm:body:issue:fetch` writes the live issue body to a UTF-8 `--out-file` for read-modify-write without PowerShell capture; `scm:body:*` mutators now fail non-zero when re-fetched bodies are flattened or mojibaked vs the intended payload. Closes #2607.
+- **Always-load win32 issue-body RMW footgun guidance (#2744).** AGENTS.md, agent preamble, and `scm/github.md` now forbid PowerShell capture-concat of `gh api --jq .body` (string[]/$OFS newline collapse) and prescribe `scm:body:issue:fetch --out-file` plus verified `scm:body:issue:edit`. Closes #2744.
 
 ### Changed
 

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -70,6 +70,42 @@ task scm:body:comment:edit -- \
 
 The helper's stdout is the live post-mutation GitHub object, so inspect the `body` field from that output first. If you need a second manual verification, use live REST through `gh api repos/OWNER/REPO/issues/comments/<id>` or `gh api repos/OWNER/REPO/issues/<number>`; do not use `ghx` for immediate read-back after the mutation because it may return a cached GET.
 
+### Win32 issue-body read-modify-write footgun (#2744 / #2607)
+
+#2646 covers safe **write** delivery (`--body-file`). A distinct failure mode persists on **read-modify-write** (amending an existing issue body): capturing `gh api repos/OWNER/REPO/issues/<N> --jq .body` into a PowerShell variable, concatenating amended text, writing a temp file, and PATCHing.
+
+When `--jq` emits JSON with embedded newlines, PowerShell 5.x/7+ often stores the result as a **string array** (`string[]`). String interpolation or `$body + $append` coerces via `$OFS` (Output Field Separator, default single space), collapsing paragraph breaks into one line. The PATCH then persists a flattened body; agents may treat a zero exit code as success unless postcondition verify catches the damage (#2607).
+
+**Canonical RMW recipe (all platforms; mandatory on win32):**
+
+1. Fetch the live body to a UTF-8 file — no shell capture:
+
+```bash
+task scm:body:issue:fetch -- \
+  --repo OWNER/REPO \
+  --issue <N> \
+  --out-file "$bodyFile"
+```
+
+2. Edit `$bodyFile` with the editor/Write tool or Python `pathlib` — not PowerShell string concat on captured `gh` output.
+
+3. PATCH via verified edit:
+
+```bash
+task scm:body:issue:edit -- \
+  --repo OWNER/REPO \
+  --issue <N> \
+  --body-file "$bodyFile"
+```
+
+`scm:body:issue:edit` re-fetches after PATCH and fails closed when the live body is flattened, mojibaked, or otherwise mismatched vs the intended payload (#2607).
+
+- ! For issue-body RMW on win32, MUST use `task scm:body:issue:fetch --out-file` then file edit then `task scm:body:issue:edit --body-file` — never rebuild the body from PowerShell-captured `gh api --jq .body` output
+- ⊗ Capture-concat of `gh api repos/.../issues/<N> --jq .body` (or `$body = (gh api ... | ConvertFrom-Json).body`) into PowerShell variables for amendment — the string[]/$OFS join destroys multi-line Markdown bodies silently
+- ⊗ Treat a successful `gh api -X PATCH` exit code as proof the body survived intact without read-back — use `scm:body:issue:edit` postcondition verify instead
+
+**Incident record:** #2087 (automation-declaration body corruption), #2741 (win32 RMW flattening during issue amend), #1492 (issue-body integrity class). Parent helper: #2607 / PR #2750.
+
 ## PR Workflow Conventions
 
 ### Merge Strategy

--- a/content/templates/agent-prompt-preamble.md
+++ b/content/templates/agent-prompt-preamble.md
@@ -233,6 +233,8 @@ Reference: issue #2563; swarm skill Platform Requirements; env scrub + stdio inh
 
 ! Multi-line git commit / gh issue|pr|comment bodies: write UTF-8 (no BOM) to OS temp, then `git commit -F` / `gh --body-file` / `deft scm:body:* --body-file`. ⊗ bash heredocs, `<<<`, inline multi-line `--body`, or multi-line PS here-strings in the agent command box on Windows PowerShell — those patterns fail at parse time, split arguments, or get rewritten by host shell wrappers before git/gh runs. This applies to your own commit and PR tooling on win32; do not use bash heredocs even when user rules show POSIX patterns. `ghx` is read-only — mutations stay on live `gh`. Detail: `content/scm/github.md` § #2646 (#1417, #240, #798).
 
+! Issue-body read-modify-write on win32: `task scm:body:issue:fetch --out-file` then edit the body file then `task scm:body:issue:edit --body-file` (fail-closed postcondition verify, #2607). ⊗ Capture-concat of `gh api repos/.../issues/<N> --jq .body` into PowerShell variables — PS string[]/$OFS collapses newlines to spaces and silently destroys live bodies (#2744, #2087, #2741, #1492). Detail: `content/scm/github.md` § #2744.
+
 ## 4. pre-pr and review-cycle skills
 
 Before pushing any branch:
@@ -326,6 +328,7 @@ Use the canonical safe wrapper for issue bodies, PR bodies, and issue/PR comment
 task scm:body:comment:create -- --repo OWNER/REPO --issue 1555 --body-file "$bodyFile"
 task scm:body:comment:edit -- --repo OWNER/REPO --comment 123456789 --body-file "$bodyFile"
 task scm:body:issue:create -- --repo OWNER/REPO --title "Title" --body-file "$bodyFile"
+task scm:body:issue:fetch -- --repo OWNER/REPO --issue 1555 --out-file "$bodyFile"
 task scm:body:issue:edit -- --repo OWNER/REPO --issue 1555 --body-file "$bodyFile"
 task scm:body:pr:edit -- --repo OWNER/REPO --pr 42 --body-file "$bodyFile"
 ```

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -83,9 +83,9 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ! When `plan.policy.allowDirectCommitsToMaster = true`, surface via `deft policy:show --field=allowDirectCommitsToMaster` (#746) — `.deft/core/scm/github.md` § Branch policy.
 
-## Windows PowerShell: multi-line git/gh bodies (#2646)
+## Windows PowerShell: multi-line git/gh bodies (#2646 / #2744)
 
-! Multi-line git commit / gh issue|pr|comment bodies: write UTF-8 (no BOM) to OS temp, then `git commit -F` / `gh --body-file` / `deft scm:body:* --body-file`. ⊗ bash heredocs, `<<<`, or inline multi-line `--body` on Windows PowerShell. Detail: `.deft/core/scm/github.md` § #2646. `ghx` is read-only — mutations stay on live `gh`.
+! Multi-line git commit / gh issue|pr|comment bodies: write UTF-8 (no BOM) to OS temp, then `git commit -F` / `gh --body-file` / `deft scm:body:* --body-file`. Issue-body RMW on win32: `deft scm:body:issue:fetch --out-file` then edit the file then `deft scm:body:issue:edit --body-file` (#2607 postcondition verify). ⊗ bash heredocs, `<<<`, inline multi-line `--body`, or PS capture-concat of `gh api --jq .body` (string[]/$OFS destroys bodies — #2087, #2741, #1492). Detail: `.deft/core/scm/github.md` § #2646 / #2744. `ghx` is read-only — mutations stay on live `gh`.
 
 ## Contextual guardrails (runtime-detect lazy-load)
 

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -21687,9 +21687,9 @@
       },
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
-        "managedMaxLines": 107,
+        "managedMaxLines": 109,
         "unmanagedMaxLines": 161,
-        "absoluteMaxBytes": 8024,
+        "absoluteMaxBytes": 8273,
         "skillFrontmatterTier": "daily-core",
         "skillFrontmatterMaxBytes": 2260
       }

--- a/xbrief/active/2026-07-21-2744-win32-issue-body-rmw-guidance.xbrief.json
+++ b/xbrief/active/2026-07-21-2744-win32-issue-body-rmw-guidance.xbrief.json
@@ -1,0 +1,90 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Always-load win32 issue-body RMW footgun guidance pointing at #2607 scm:body:issue:fetch + postcondition verify.",
+    "created": "2026-07-22T01:35:00Z",
+    "updated": "2026-07-22T02:55:00Z"
+  },
+  "plan": {
+    "id": "2744-win32-issue-body-rmw-guidance",
+    "title": "docs/process: always-load win32 issue-body RMW footgun (PS string[]/OFS)",
+    "status": "running",
+    "narratives": {
+      "Description": "Win32 agents keep destroying live GitHub issue bodies on amend even after #2646 (safe write via --body-file). The failure mode is read-modify-write: capture gh api --jq .body into a PowerShell variable, concatenate, write temp, PATCH. #2607 shipped fail-closed postcondition verify and scm:body:issue:fetch; this issue closes the always-load process gap so agents stop taking the capture-concat path.",
+      "ImplementationPlan": "1. Edit content/scm/github.md to add an always-load section naming the win32 PowerShell string[]/$OFS issue-body RMW footgun; include ⊗ capture-concat of gh api --jq .body and ! recipe using task scm:body:issue:fetch --out-file plus task scm:body:issue:edit (postcondition verify from #2607 packages/core/src/intake/github-body.ts). 2. Mirror the same !/⊗ into content/templates/agents-entry.md and content/templates/agent-prompt-preamble.md § Windows PowerShell bodies; run task agents:refresh and confirm AGENTS.md managed-section refresh. 3. Cite incidents #2087 / #2741 / #1492 in the scm note. 4. Append CHANGELOG.md [Unreleased]; verify with task agents:refresh exit 0.",
+      "UserStory": "As a win32 agent amending issue bodies, I want always-loaded RMW guidance forbidding PS string capture-concat, so that I use scm:body fetch-to-file plus verified edit instead of silent body corruption."
+    },
+    "items": [
+      {
+        "id": "ac1",
+        "title": "Always-load RMW footgun guidance",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given AGENTS.md / scm/github.md / preamble surfaces, when an agent loads them, then the PS string[]/OFS RMW footgun is named, capture-concat is forbidden, and the recipe points at scm:body:issue:fetch plus scm:body:issue:edit (postcondition verify)."
+        }
+      },
+      {
+        "id": "ac2",
+        "title": "agents-entry propagation",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given consumer-relevant rule text lands, when task agents:refresh runs, then agents-entry contract markers remain satisfied."
+        }
+      },
+      {
+        "id": "ac3",
+        "title": "CHANGELOG Unreleased entry",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the docs land, when CHANGELOG is reviewed, then [Unreleased] notes the always-load RMW guidance."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "capacityBucket": "docs",
+      "x-tracking": {
+        "parent_issue": "#2744",
+        "decomposition_origin": "#2744"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/scm/github.md",
+          "content/templates/agents-entry.md",
+          "content/templates/agent-prompt-preamble.md",
+          "AGENTS.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task agents:refresh"
+        ],
+        "expected_outputs": [
+          "always-load RMW guidance",
+          "agents-entry refresh",
+          "CHANGELOG"
+        ],
+        "depends_on": [],
+        "conflict_group": "scm-body-2744",
+        "size": "S",
+        "file_scope_confidence": "high",
+        "model_tier": "medium",
+        "missing_traces_justification": "Documentation/process gap from GitHub issue #2744 after #2607 helper landed; no FR trace registry for hotfix cohort."
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2744",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2744: always-load win32 issue-body RMW footgun"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2607",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2607: safe issue-body patch helper (parent, merged)"
+      }
+    ],
+    "updated": "2026-07-22T02:48:15Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Add always-load win32 issue-body RMW footgun guidance naming the PowerShell string[]/$OFS capture-concat failure mode when agents amend GitHub issue bodies.
- Forbid gh api --jq .body capture-concat; prescribe 	ask scm:body:issue:fetch --out-file then file edit then 	ask scm:body:issue:edit with fail-closed postcondition verify (#2607).
- Mirror into gents-entry.md, gent-prompt-preamble.md, and content/scm/github.md (refs #2087, #2741, #1492); re-seed gentsMdBudget ratchet.

## Test plan

- [x] 
ode packages/cli/dist/bin.js agents:refresh
- [x] pnpm exec vitest run packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
- [x] 
ode packages/cli/dist/bin.js verify-agents-md-budget --project-root .

Closes #2744