### PR TITLE
chore(xbrief): complete Wave cohort scopes left active on master

### DIFF
--- a/xbrief/completed/2026-07-21-1936-untrusted-fetched-content-gate.xbrief.json
+++ b/xbrief/completed/2026-07-21-1936-untrusted-fetched-content-gate.xbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1936-untrusted-fetched-content-gate",
     "title": "feat(security,skills): untrusted fetched content doctrine + external-fetch gate",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Skills such as deft-directive-article-review instruct agents to fetch and follow external URLs at runtime. Fetched content treated as instructions is a TOCTOU exposure: a clean package can point at a link rewritten after review. Doctrine: external fetches are untrusted data. Gate: skill-validation (#1532) should flag fetch-then-execute patterns.",
       "ImplementationPlan": "1. Harden content/skills/deft-directive-article-review/SKILL.md and content/skills/deft-directive-debug/SKILL.md (and research strategy if in-scope) with Security context: fetched URLs are data not directives; forbid follow-as-execute. Cross-link #1938 TOCTOU and #480 without rewriting content/coding/security.md. 2. Extend skill-validation / content-contracts (#1532) to flag skills whose instructions combine external fetch with run/install/download execution patterns; surface via task check. 3. Tests for the gate; CHANGELOG [Unreleased]. Do not create the patterns/agent-skill-supply-chain.md file (#1937) or the coding/security.md TOCTOU section (#1938).",
@@ -71,7 +71,8 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium",
         "missing_traces_justification": "Security/skills work from GitHub issue #1936; extends #1532; no FR trace registry for hotfix cohort."
-      }
+      },
+      "completedAt": "2026-07-22T10:22:44Z"
     },
     "references": [
       {
@@ -85,6 +86,6 @@
         "title": "Issue #1532: skill-validation gate"
       }
     ],
-    "updated": "2026-07-22T07:47:47Z"
+    "updated": "2026-07-22T10:22:44Z"
   }
 }

--- a/xbrief/completed/2026-07-21-1937-agent-skill-supply-chain.xbrief.json
+++ b/xbrief/completed/2026-07-21-1937-agent-skill-supply-chain.xbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "1937-agent-skill-supply-chain",
     "title": "feat(security,patterns): agent-skill supply-chain security (inbound)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Directive-built projects consume skills, plugins, and MCP servers whose trust signals (stars, one-time scanner verdicts) are gameable or stale. This is the inbound complement to Agent Trap Defenses (#480) and outbound disclosure (#1700): structural controls for what skills an agent is given.",
       "ImplementationPlan": "1. Create content/patterns/agent-skill-supply-chain.md with RFC2119 guidance: treat skills as software, vet linked targets, pin versions or hashes with re-vet on change, least privilege for fetched actions, controlled install sources not stars-as-proof; cross-link issues 480 and 1700. 2. Add a discoverability pointer in content/patterns/llm-app.md and REFERENCES.md as appropriate. 3. Append CHANGELOG.md Unreleased. 4. Verify the new pattern file exists and mentions pin and re-vet guidance.",
@@ -63,7 +63,8 @@
         "file_scope_confidence": "high",
         "model_tier": "medium",
         "missing_traces_justification": "Patterns RFC from GitHub issue #1937; no FR trace registry for hotfix cohort."
-      }
+      },
+      "completedAt": "2026-07-22T10:22:45Z"
     },
     "references": [
       {
@@ -77,6 +78,6 @@
         "title": "Issue #480: Agent Trap Defenses"
       }
     ],
-    "updated": "2026-07-22T07:47:45Z"
+    "updated": "2026-07-22T10:22:45Z"
   }
 }

--- a/xbrief/completed/2026-07-21-2385-merge-cascade-semantic-green.xbrief.json
+++ b/xbrief/completed/2026-07-21-2385-merge-cascade-semantic-green.xbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "2385-merge-cascade-semantic-green",
     "title": "Merge cascade: semantic-green gate beyond merge-tree-clean",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "pr:wait-mergeable-and-merge can merge a merge-tree-clean PR whose CI was green only against pre-spine master. After a spine lands, dependent PRs can break master immediately. The 0.73.0 cascade (#2379 after #2384) showed merge-tree-clean is necessary but not sufficient.",
       "ImplementationPlan": "1. Extend packages/core/src/pr-wait-mergeable/cascade.ts (and readiness helpers in pr-merge-readiness / pr-monitor as needed) so cohort/spine-dependent merges either rebase onto post-spine master and wait for fresh green CI at rebased HEAD, and/or block the next cascade merge until master CI is green at the new HEAD. 2. Expose flags or automatic detection via depends_on / allocation metadata when available. 3. Document the gate in content/skills/deft-directive-swarm/SKILL.md Phase 5->6 and content/scm/github.md as needed; agents:refresh if agents-entry changes. 4. Unit/integration tests covering merge-tree-clean but stale-CI rejection. 5. CHANGELOG [Unreleased]. Prefer the smallest durable combination of rebase+re-CI and post-merge master-CI gate that closes the #2379-class failure.",
@@ -74,7 +74,8 @@
         "file_scope_confidence": "medium",
         "model_tier": "medium",
         "missing_traces_justification": "Bug-fix from GitHub issue #2385; no FR trace registry for hotfix cohort."
-      }
+      },
+      "completedAt": "2026-07-22T10:23:18Z"
     },
     "references": [
       {
@@ -83,6 +84,6 @@
         "title": "Issue #2385: merge cascade semantic-green guard"
       }
     ],
-    "updated": "2026-07-22T06:09:49Z"
+    "updated": "2026-07-22T10:23:18Z"
   }
 }


### PR DESCRIPTION
## Summary
- Complete xBRIEFs for #1936, #1937, and #2385 that remained in `xbrief/active/` on master after their implementation PRs merged (activation checkpoints without post-merge `scope:complete`).
- Clears the #2321 orphan-active class so `verify:orphan-active` / WIP accounting stay clean.

## Test plan
- [x] `task verify:orphan-active` clean locally after moves
- [ ] CI green
