### PR TITLE
fix(hooks): disjoint Cursor ApplyPatch preToolUse matchers (#2764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Corepack packageManager dispatch hardened against shell injection (#2765).** Extracted `tasks/engine-pm-run.cjs` from duplicated inline paths in `tasks/engine.yml`; validates `pnpm@<SemVer>` pins and script names before spawn, uses argv execution without `shell: true` on POSIX, and routes Windows `.cmd` shims through a quoted `cmd.exe` boundary. Closes #2765. Parent #2761.
 
+- **Cursor ApplyPatch preToolUse double-dispatch (#2764).** Cursor hook deposit now routes ApplyPatch through a dedicated project adapter and excludes ApplyPatch from the generic direct-write matcher, preventing overlapping preToolUse handlers from fail-closing Windows writes after a successful ritual. Hook project-root resolution ignores drive-only Windows `workspace_roots`/`cwd` values that produced `C:\\C:\\...` ritual paths. Closes #2764.
+
 ### Removed
 
 ## [0.82.0] - 2026-07-22

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -299,6 +299,32 @@ describe("hook-dispatch CLI", () => {
     expect(rendered).not.toContain("omitted a recognizable tool name");
   });
 
+  it("honors explicit --project-root over drive-only payload workspace roots (#2764)", () => {
+    const payload = {
+      tool_name: "Write",
+      tool_input: { file_path: "src/a.ts", content: "x" },
+      workspace_roots: ["C:"],
+      cwd: "C:",
+    };
+    const out: string[] = [];
+    const code = run(
+      [
+        "--host=cursor",
+        "--event=tool.before",
+        "--project-root",
+        "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture",
+      ],
+      {
+        readStdin: () => JSON.stringify(payload),
+        writeOut: (text) => out.push(text),
+        writeErr: () => undefined,
+        cwd: () => "C:",
+      },
+    );
+    expect(code).toBe(0);
+    expect(out.join("")).not.toContain("C:\\\\C:\\\\");
+  });
+
   it("denies Cursor multi-file free-form ApplyPatch as invalid JSON (#2738)", () => {
     const multiFile = [
       "*** Begin Patch",

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -299,31 +299,34 @@ describe("hook-dispatch CLI", () => {
     expect(rendered).not.toContain("omitted a recognizable tool name");
   });
 
-  it("honors explicit --project-root over drive-only payload workspace roots (#2764)", () => {
-    const payload = {
-      tool_name: "Write",
-      tool_input: { file_path: "src/a.ts", content: "x" },
-      workspace_roots: ["C:"],
-      cwd: "C:",
-    };
-    const out: string[] = [];
-    const code = run(
-      [
-        "--host=cursor",
-        "--event=tool.before",
-        "--project-root",
-        "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture",
-      ],
-      {
-        readStdin: () => JSON.stringify(payload),
-        writeOut: (text) => out.push(text),
-        writeErr: () => undefined,
-        cwd: () => "C:",
-      },
-    );
-    expect(code).toBe(0);
-    expect(out.join("")).not.toContain("C:\\\\C:\\\\");
-  });
+  it.skipIf(process.platform !== "win32")(
+    "honors explicit --project-root over drive-only payload workspace roots (#2764)",
+    () => {
+      const payload = {
+        tool_name: "Write",
+        tool_input: { file_path: "src/a.ts", content: "x" },
+        workspace_roots: ["C:"],
+        cwd: "C:",
+      };
+      const out: string[] = [];
+      const code = run(
+        [
+          "--host=cursor",
+          "--event=tool.before",
+          "--project-root",
+          "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture",
+        ],
+        {
+          readStdin: () => JSON.stringify(payload),
+          writeOut: (text) => out.push(text),
+          writeErr: () => undefined,
+          cwd: () => "C:",
+        },
+      );
+      expect(code).toBe(0);
+      expect(out.join("")).not.toContain("C:\\\\C:\\\\");
+    },
+  );
 
   it("denies Cursor multi-file free-form ApplyPatch as invalid JSON (#2738)", () => {
     const multiFile = [

--- a/packages/core/src/hooks/cursor-hooks.test.ts
+++ b/packages/core/src/hooks/cursor-hooks.test.ts
@@ -1,0 +1,104 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFT_CURSOR_ADAPTER_COMMAND_MARKER,
+  writeAgentHookDeposit,
+} from "../init-deposit/agent-hooks.js";
+import { ritualStatePath } from "../session/ritual-sentinel.js";
+import {
+  APPLY_PATCH_HOOK_MATCHER,
+  CURSOR_APPLY_PATCH_ADAPTER_COMMAND,
+  CURSOR_APPLY_PATCH_ADAPTER_RELATIVE,
+  CURSOR_APPLY_PATCH_ADAPTER_SOURCE,
+  CURSOR_GENERIC_WRITE_HOOK_MATCHER,
+  cursorApplyPatchAdapterEntry,
+  cursorApplyPatchMatchersDisjoint,
+} from "./cursor-hooks.js";
+import { projectRootFromHookPayload } from "./dispatcher.js";
+import { DIRECT_WRITE_HOOK_MATCHER } from "./tools.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const root of temps.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function project(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-cursor-hooks-"));
+  temps.push(root);
+  return root;
+}
+
+describe("cursor hook projection (#2764)", () => {
+  it("keeps ApplyPatch out of the generic Cursor write matcher", () => {
+    expect(cursorApplyPatchMatchersDisjoint()).toBe(true);
+    expect(CURSOR_GENERIC_WRITE_HOOK_MATCHER).not.toContain("ApplyPatch");
+    expect(CURSOR_GENERIC_WRITE_HOOK_MATCHER).not.toContain("apply_patch");
+    expect(APPLY_PATCH_HOOK_MATCHER).toBe("ApplyPatch|apply_patch");
+    expect(DIRECT_WRITE_HOOK_MATCHER).toContain("ApplyPatch");
+  });
+
+  it("builds the adapter preToolUse entry expected by hooks.json", () => {
+    expect(cursorApplyPatchAdapterEntry()).toEqual({
+      command: CURSOR_APPLY_PATCH_ADAPTER_COMMAND,
+      matcher: APPLY_PATCH_HOOK_MATCHER,
+      failClosed: true,
+      timeout: 5,
+    });
+    expect(CURSOR_APPLY_PATCH_ADAPTER_COMMAND).toContain(DEFT_CURSOR_ADAPTER_COMMAND_MARKER);
+  });
+
+  it("deposits adapter script and disjoint matchers into .cursor/hooks.json", () => {
+    const root = project();
+    writeAgentHookDeposit(root);
+    const hooksJson = readFileSync(join(root, ".cursor/hooks.json"), "utf8");
+    const adapterPath = join(root, CURSOR_APPLY_PATCH_ADAPTER_RELATIVE);
+
+    expect(existsSync(adapterPath)).toBe(true);
+    expect(readFileSync(adapterPath, "utf8")).toBe(CURSOR_APPLY_PATCH_ADAPTER_SOURCE);
+    expect(hooksJson).toContain(CURSOR_APPLY_PATCH_ADAPTER_COMMAND);
+    expect(hooksJson).toContain(CURSOR_GENERIC_WRITE_HOOK_MATCHER);
+    expect(hooksJson).not.toMatch(
+      new RegExp(
+        `"matcher": "${CURSOR_GENERIC_WRITE_HOOK_MATCHER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*ApplyPatch`,
+      ),
+    );
+    expect(hooksJson).toContain('"matcher": "ApplyPatch|apply_patch"');
+  });
+
+  it("avoids Windows C:\\C:\\ ritual paths when payload carries a drive-only root", () => {
+    const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
+    const resolved = projectRootFromHookPayload({ workspace_roots: ["C:"], cwd: "C:" }, fallback);
+    expect(resolved).toBe(resolve(fallback));
+    expect(ritualStatePath(resolved)).toBe(join(resolve(fallback), ".deft", "ritual-state.json"));
+    expect(ritualStatePath(resolved)).not.toContain("C:\\C:\\");
+  });
+
+  it("treats trailing-backslash drive roots as drive-only on Windows", () => {
+    const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
+    expect(projectRootFromHookPayload({ workspace_root: "C:\\" }, fallback)).toBe(
+      resolve(fallback),
+    );
+  });
+
+  it("leaves adapter deposit byte-idempotent on repeat refresh", () => {
+    const root = project();
+    writeAgentHookDeposit(root);
+    const first = readFileSync(join(root, CURSOR_APPLY_PATCH_ADAPTER_RELATIVE), "utf8");
+    const second = writeAgentHookDeposit(root);
+    expect(second.changed).toBe(false);
+    expect(readFileSync(join(root, CURSOR_APPLY_PATCH_ADAPTER_RELATIVE), "utf8")).toBe(first);
+  });
+
+  it("rewrites a drifted adapter script even when hooks.json is already current", () => {
+    const root = project();
+    writeAgentHookDeposit(root);
+    writeAgentHookDeposit(root);
+    const adapterPath = join(root, CURSOR_APPLY_PATCH_ADAPTER_RELATIVE);
+    writeFileSync(adapterPath, "// stale adapter\n", "utf8");
+    const refreshed = writeAgentHookDeposit(root);
+    expect(refreshed.changed).toBe(true);
+    expect(readFileSync(adapterPath, "utf8")).toBe(CURSOR_APPLY_PATCH_ADAPTER_SOURCE);
+  });
+});

--- a/packages/core/src/hooks/cursor-hooks.test.ts
+++ b/packages/core/src/hooks/cursor-hooks.test.ts
@@ -9,6 +9,7 @@ import {
 import { ritualStatePath } from "../session/ritual-sentinel.js";
 import {
   APPLY_PATCH_HOOK_MATCHER,
+  assertCursorApplyPatchMatchersDisjoint,
   CURSOR_APPLY_PATCH_ADAPTER_COMMAND,
   CURSOR_APPLY_PATCH_ADAPTER_RELATIVE,
   CURSOR_APPLY_PATCH_ADAPTER_SOURCE,
@@ -32,6 +33,7 @@ function project(): string {
 
 describe("cursor hook projection (#2764)", () => {
   it("keeps ApplyPatch out of the generic Cursor write matcher", () => {
+    assertCursorApplyPatchMatchersDisjoint();
     expect(cursorApplyPatchMatchersDisjoint()).toBe(true);
     expect(CURSOR_GENERIC_WRITE_HOOK_MATCHER).not.toContain("ApplyPatch");
     expect(CURSOR_GENERIC_WRITE_HOOK_MATCHER).not.toContain("apply_patch");
@@ -67,17 +69,23 @@ describe("cursor hook projection (#2764)", () => {
     expect(hooksJson).toContain('"matcher": "ApplyPatch|apply_patch"');
   });
 
-  it("avoids Windows C:\\C:\\ ritual paths when payload carries a drive-only root", () => {
-    const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
-    const resolved = projectRootFromHookPayload({ workspace_roots: ["C:"], cwd: "C:" }, fallback);
-    expect(resolved).toBe(resolve(fallback));
-    expect(ritualStatePath(resolved)).toBe(join(resolve(fallback), ".deft", "ritual-state.json"));
-    expect(ritualStatePath(resolved)).not.toContain("C:\\C:\\");
-  });
+  it.skipIf(process.platform !== "win32")(
+    "avoids Windows C:\\C:\\ ritual paths when payload carries a drive-only root",
+    () => {
+      const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
+      const resolved = projectRootFromHookPayload({ workspace_roots: ["C:"], cwd: "C:" }, fallback);
+      expect(resolved).toBe(resolve(fallback));
+      expect(ritualStatePath(resolved)).toBe(join(resolve(fallback), ".deft", "ritual-state.json"));
+      expect(ritualStatePath(resolved)).not.toContain("C:\\C:\\");
+    },
+  );
 
-  it("treats trailing-backslash drive roots as drive-only on Windows", () => {
+  it.skipIf(process.platform !== "win32")("treats trailing-backslash drive roots as drive-only on Windows", () => {
     const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
     expect(projectRootFromHookPayload({ workspace_root: "C:\\" }, fallback)).toBe(
+      resolve(fallback),
+    );
+    expect(projectRootFromHookPayload({ workspace_root: "C:/" }, fallback)).toBe(
       resolve(fallback),
     );
   });

--- a/packages/core/src/hooks/cursor-hooks.test.ts
+++ b/packages/core/src/hooks/cursor-hooks.test.ts
@@ -80,15 +80,18 @@ describe("cursor hook projection (#2764)", () => {
     },
   );
 
-  it.skipIf(process.platform !== "win32")("treats trailing-backslash drive roots as drive-only on Windows", () => {
-    const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
-    expect(projectRootFromHookPayload({ workspace_root: "C:\\" }, fallback)).toBe(
-      resolve(fallback),
-    );
-    expect(projectRootFromHookPayload({ workspace_root: "C:/" }, fallback)).toBe(
-      resolve(fallback),
-    );
-  });
+  it.skipIf(process.platform !== "win32")(
+    "treats trailing-backslash drive roots as drive-only on Windows",
+    () => {
+      const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
+      expect(projectRootFromHookPayload({ workspace_root: "C:\\" }, fallback)).toBe(
+        resolve(fallback),
+      );
+      expect(projectRootFromHookPayload({ workspace_root: "C:/" }, fallback)).toBe(
+        resolve(fallback),
+      );
+    },
+  );
 
   it("leaves adapter deposit byte-idempotent on repeat refresh", () => {
     const root = project();

--- a/packages/core/src/hooks/cursor-hooks.ts
+++ b/packages/core/src/hooks/cursor-hooks.ts
@@ -1,0 +1,97 @@
+import { DIRECT_WRITE_TOOL_NAMES } from "./tools.js";
+
+/** Cursor ApplyPatch spellings handled by the project adapter, not generic write dispatch. */
+export const APPLY_PATCH_TOOL_NAMES = ["ApplyPatch", "apply_patch"] as const;
+export const APPLY_PATCH_HOOK_MATCHER = APPLY_PATCH_TOOL_NAMES.join("|");
+
+const APPLY_PATCH_TOOLS = new Set<string>(APPLY_PATCH_TOOL_NAMES);
+
+/** Generic Cursor write matcher excludes ApplyPatch — adapter owns it (#2764). */
+export const CURSOR_GENERIC_WRITE_TOOL_NAMES = DIRECT_WRITE_TOOL_NAMES.filter(
+  (name) => !APPLY_PATCH_TOOLS.has(name),
+);
+export const CURSOR_GENERIC_WRITE_HOOK_MATCHER = CURSOR_GENERIC_WRITE_TOOL_NAMES.join("|");
+
+export const CURSOR_APPLY_PATCH_ADAPTER_RELATIVE = ".cursor/hooks/deft-cursor-hook-adapter.mjs";
+export const DEFT_CURSOR_ADAPTER_COMMAND_MARKER = "deft-cursor-hook-adapter.mjs";
+export const CURSOR_APPLY_PATCH_ADAPTER_COMMAND = `node ${CURSOR_APPLY_PATCH_ADAPTER_RELATIVE} ApplyPatch`;
+
+/** Deposited adapter forwards free-form ApplyPatch stdin to hook:dispatch with explicit project root. */
+export const CURSOR_APPLY_PATCH_ADAPTER_SOURCE = `#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const projectRoot = resolve(process.cwd());
+const stdin = readFileSync(0, "utf8");
+
+function deftCommand() {
+  for (const candidate of ["deft", "directive"]) {
+    const probe = spawnSync(candidate, ["--version"], {
+      encoding: "utf8",
+      stdio: "ignore",
+      shell: process.platform === "win32",
+      windowsHide: true,
+    });
+    if (probe.error === undefined && probe.status === 0) return candidate;
+  }
+  process.stderr.write(
+    "Directive ApplyPatch adapter: neither deft nor directive is on PATH.\\n",
+  );
+  process.exit(2);
+}
+
+const cli = deftCommand();
+const result = spawnSync(
+  cli,
+  [
+    "hook:dispatch",
+    "--host",
+    "cursor",
+    "--event",
+    "tool.before",
+    "--project-root",
+    projectRoot,
+  ],
+  {
+    input: stdin,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    windowsHide: true,
+  },
+);
+
+if (result.stdout) process.stdout.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+if (result.error) {
+  process.stderr.write(String(result.error));
+  process.exit(2);
+}
+process.exit(result.status ?? 0);
+`;
+
+export interface CursorPreToolUseEntry {
+  readonly command: string;
+  readonly matcher?: string;
+  readonly failClosed?: boolean;
+  readonly timeout?: number;
+}
+
+export function cursorApplyPatchAdapterEntry(): CursorPreToolUseEntry {
+  return {
+    command: CURSOR_APPLY_PATCH_ADAPTER_COMMAND,
+    matcher: APPLY_PATCH_HOOK_MATCHER,
+    failClosed: true,
+    timeout: 5,
+  };
+}
+
+/** True when generic and adapter matchers share no tool tokens. */
+export function cursorApplyPatchMatchersDisjoint(): boolean {
+  const generic = new Set(CURSOR_GENERIC_WRITE_HOOK_MATCHER.split("|"));
+  for (const token of APPLY_PATCH_HOOK_MATCHER.split("|")) {
+    if (generic.has(token)) return false;
+  }
+  return true;
+}

--- a/packages/core/src/hooks/cursor-hooks.ts
+++ b/packages/core/src/hooks/cursor-hooks.ts
@@ -68,7 +68,10 @@ if (result.error) {
   process.stderr.write(String(result.error));
   process.exit(2);
 }
-process.exit(result.status ?? 0);
+if (result.status !== 0 && result.status !== null) {
+  process.exit(result.status);
+}
+process.exit(0);
 `;
 
 export interface CursorPreToolUseEntry {
@@ -94,4 +97,13 @@ export function cursorApplyPatchMatchersDisjoint(): boolean {
     if (generic.has(token)) return false;
   }
   return true;
+}
+
+/** Fail closed when Cursor hook projection would double-dispatch ApplyPatch (#2764). */
+export function assertCursorApplyPatchMatchersDisjoint(): void {
+  if (!cursorApplyPatchMatchersDisjoint()) {
+    throw new Error(
+      "Cursor ApplyPatch and generic direct-write matchers overlap — refusing hook deposit (#2764).",
+    );
+  }
 }

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -966,6 +966,18 @@ describe("provider input normalization", () => {
     );
     expect(projectRootFromHookPayload({ cwd: "/cwd" }, "/fallback")).toBe(resolve("/cwd"));
     expect(projectRootFromHookPayload({}, "/fallback")).toBe(resolve("/fallback"));
+    expect(
+      projectRootFromHookPayload(
+        { workspace_roots: ["C:"], cwd: "C:" },
+        "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture",
+      ),
+    ).toBe(resolve("C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture"));
+    expect(projectRootFromHookPayload({ workspaceRoot: "C:" }, "/fallback")).toBe(
+      resolve("/fallback"),
+    );
+    expect(projectRootFromHookPayload({ workspace_root: "D:" }, "/fallback")).toBe(
+      resolve("/fallback"),
+    );
   });
 
   it("validates public host and event identifiers", () => {

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -966,18 +966,23 @@ describe("provider input normalization", () => {
     );
     expect(projectRootFromHookPayload({ cwd: "/cwd" }, "/fallback")).toBe(resolve("/cwd"));
     expect(projectRootFromHookPayload({}, "/fallback")).toBe(resolve("/fallback"));
-    expect(
-      projectRootFromHookPayload(
-        { workspace_roots: ["C:"], cwd: "C:" },
-        "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture",
-      ),
-    ).toBe(resolve("C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture"));
-    expect(projectRootFromHookPayload({ workspaceRoot: "C:" }, "/fallback")).toBe(
-      resolve("/fallback"),
-    );
-    expect(projectRootFromHookPayload({ workspace_root: "D:" }, "/fallback")).toBe(
-      resolve("/fallback"),
-    );
+    if (process.platform === "win32") {
+      expect(
+        projectRootFromHookPayload(
+          { workspace_roots: ["C:"], cwd: "C:" },
+          "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture",
+        ),
+      ).toBe(resolve("C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture"));
+      expect(projectRootFromHookPayload({ workspaceRoot: "C:" }, "/fallback")).toBe(
+        resolve("/fallback"),
+      );
+      expect(projectRootFromHookPayload({ workspace_root: "D:" }, "/fallback")).toBe(
+        resolve("/fallback"),
+      );
+      expect(projectRootFromHookPayload({ workspace_root: "C:/" }, "/fallback")).toBe(
+        resolve("/fallback"),
+      );
+    }
   });
 
   it("validates public host and event identifiers", () => {

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -277,7 +277,7 @@ export function isProposedLifecycleWrite(projectRoot: string, targetPath: string
 }
 
 function isWindowsDriveOnlyRoot(value: string): boolean {
-  return /^[A-Za-z]:\\?$/.test(value.trim());
+  return /^[A-Za-z]:[/\\]?$/.test(value.trim());
 }
 
 export function projectRootFromHookPayload(payload: unknown, fallback: string): string {

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -276,18 +276,25 @@ export function isProposedLifecycleWrite(projectRoot: string, targetPath: string
   return posix.startsWith("xbrief/proposed/") || posix.startsWith("vbrief/proposed/");
 }
 
+function isWindowsDriveOnlyRoot(value: string): boolean {
+  return /^[A-Za-z]:\\?$/.test(value.trim());
+}
+
 export function projectRootFromHookPayload(payload: unknown, fallback: string): string {
   const input = record(payload);
-  if (input === null) return resolve(fallback);
+  const fallbackResolved = resolve(fallback);
+  if (input === null) return fallbackResolved;
   const workspaceRoots = input.workspace_roots;
-  const root = firstString(
+  const candidate = firstString(
     input.workspaceRoot,
     input.workspace_root,
     Array.isArray(workspaceRoots) ? workspaceRoots[0] : null,
     input.cwd,
-    fallback,
   );
-  return resolve(root ?? fallback);
+  if (candidate === null || isWindowsDriveOnlyRoot(candidate)) {
+    return fallbackResolved;
+  }
+  return resolve(candidate);
 }
 
 export function isHookHost(value: string): value is HookHost {

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from "./cursor-hooks.js";
 export * from "./dispatcher.js";
 export * from "./scope.js";

--- a/packages/core/src/init-deposit/agent-hooks.test.ts
+++ b/packages/core/src/init-deposit/agent-hooks.test.ts
@@ -11,6 +11,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  APPLY_PATCH_HOOK_MATCHER,
+  CURSOR_APPLY_PATCH_ADAPTER_COMMAND,
+  CURSOR_APPLY_PATCH_ADAPTER_RELATIVE,
+} from "../hooks/cursor-hooks.js";
+import {
   DIRECT_WRITE_TOOL_NAMES,
   isDirectWriteTool,
   isSpawnTool,
@@ -19,6 +24,7 @@ import {
 import { DEFAULT_HOST_HOOKS_POLICY } from "../policy/host-hooks.js";
 import {
   AGENT_HOOK_PATHS,
+  CURSOR_GENERIC_WRITE_HOOK_MATCHER,
   DIRECT_WRITE_HOOK_MATCHER,
   inspectAgentHookDeposit,
   SPAWN_HOOK_MATCHER,
@@ -68,6 +74,19 @@ describe("writeAgentHookDeposit", () => {
     expect(readFileSync(join(root, ".cursor/hooks.json"), "utf8")).toContain(
       "--host cursor --event session.compact",
     );
+    expect(readFileSync(join(root, ".cursor/hooks.json"), "utf8")).toContain(
+      CURSOR_GENERIC_WRITE_HOOK_MATCHER,
+    );
+    expect(readFileSync(join(root, ".cursor/hooks.json"), "utf8")).toContain(
+      CURSOR_APPLY_PATCH_ADAPTER_COMMAND,
+    );
+    expect(readFileSync(join(root, ".cursor/hooks.json"), "utf8")).toContain(
+      APPLY_PATCH_HOOK_MATCHER,
+    );
+    expect(readFileSync(join(root, ".cursor/hooks.json"), "utf8")).not.toContain(
+      `"matcher": "${DIRECT_WRITE_HOOK_MATCHER}"`,
+    );
+    expect(existsSync(join(root, CURSOR_APPLY_PATCH_ADAPTER_RELATIVE))).toBe(true);
     expect(readFileSync(join(root, ".claude/settings.json"), "utf8")).toContain(
       "--host claude --event session.compact",
     );
@@ -82,6 +101,52 @@ describe("writeAgentHookDeposit", () => {
     expect(inspectAgentHookDeposit(root).find((entry) => entry.host === "codex")).toMatchObject({
       compactSupport: "unsupported",
     });
+  });
+
+  it("replaces stale overlapping Cursor ApplyPatch registrations on refresh (#2764)", () => {
+    const root = project();
+    mkdirSync(join(root, ".cursor", "hooks"), { recursive: true });
+    writeFileSync(
+      join(root, ".cursor/hooks.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          hooks: {
+            sessionStart: [
+              { command: "deft hook:dispatch --host cursor --event session.start", timeout: 5 },
+            ],
+            preToolUse: [
+              {
+                command: "deft hook:dispatch --host cursor --event tool.before",
+                matcher: DIRECT_WRITE_HOOK_MATCHER,
+                failClosed: true,
+                timeout: 5,
+              },
+              {
+                command: "node .cursor/hooks/deft-cursor-hook-adapter.mjs ApplyPatch",
+                matcher: APPLY_PATCH_HOOK_MATCHER,
+                failClosed: true,
+                timeout: 5,
+              },
+            ],
+            preCompact: [
+              { command: "deft hook:dispatch --host cursor --event session.compact", timeout: 5 },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    writeAgentHookDeposit(root);
+    const cursor = readFileSync(join(root, ".cursor/hooks.json"), "utf8");
+    expect(cursor).toContain(CURSOR_GENERIC_WRITE_HOOK_MATCHER);
+    expect(cursor).not.toContain(`"matcher": "${DIRECT_WRITE_HOOK_MATCHER}"`);
+    expect(inspectAgentHookDeposit(root).find((entry) => entry.host === "cursor")?.status).toBe(
+      "healthy",
+    );
   });
 
   it("preserves unrelated settings and is byte-idempotent", () => {
@@ -309,6 +374,55 @@ describe("inspectAgentHookDeposit", () => {
     ).toMatchObject({
       status: "healthy",
       detail: expect.stringContaining("hostHooks.claude is false"),
+    });
+  });
+
+  it("marks Cursor registration drifted when generic matcher still includes ApplyPatch (#2764)", () => {
+    const root = project();
+    writeAgentHookDeposit(root);
+    const cursorPath = join(root, ".cursor/hooks.json");
+    const cursor = JSON.parse(readFileSync(cursorPath, "utf8")) as {
+      hooks: { preToolUse: Array<Record<string, unknown>> };
+    };
+    cursor.hooks.preToolUse = cursor.hooks.preToolUse.map((entry) =>
+      entry.matcher === CURSOR_GENERIC_WRITE_HOOK_MATCHER
+        ? { ...entry, matcher: DIRECT_WRITE_HOOK_MATCHER }
+        : entry,
+    );
+    writeFileSync(cursorPath, `${JSON.stringify(cursor, null, 2)}\n`, "utf8");
+
+    expect(inspectAgentHookDeposit(root).find((entry) => entry.host === "cursor")).toMatchObject({
+      status: "drifted",
+    });
+  });
+
+  it("marks Cursor registration drifted when ApplyPatch adapter entry is missing (#2764)", () => {
+    const root = project();
+    writeAgentHookDeposit(root);
+    const cursorPath = join(root, ".cursor/hooks.json");
+    const cursor = JSON.parse(readFileSync(cursorPath, "utf8")) as {
+      hooks: { preToolUse: Array<Record<string, unknown>> };
+    };
+    cursor.hooks.preToolUse = cursor.hooks.preToolUse.filter(
+      (entry) => entry.matcher !== APPLY_PATCH_HOOK_MATCHER,
+    );
+    writeFileSync(cursorPath, `${JSON.stringify(cursor, null, 2)}\n`, "utf8");
+
+    expect(inspectAgentHookDeposit(root).find((entry) => entry.host === "cursor")).toMatchObject({
+      status: "drifted",
+    });
+  });
+
+  it("marks Cursor registration drifted when hooks.json version is not 1", () => {
+    const root = project();
+    writeAgentHookDeposit(root);
+    const cursorPath = join(root, ".cursor/hooks.json");
+    const cursor = JSON.parse(readFileSync(cursorPath, "utf8")) as { version: number };
+    cursor.version = 2;
+    writeFileSync(cursorPath, `${JSON.stringify(cursor, null, 2)}\n`, "utf8");
+
+    expect(inspectAgentHookDeposit(root).find((entry) => entry.host === "cursor")).toMatchObject({
+      status: "drifted",
     });
   });
 });

--- a/packages/core/src/init-deposit/agent-hooks.ts
+++ b/packages/core/src/init-deposit/agent-hooks.ts
@@ -5,6 +5,7 @@ import {
   CURSOR_APPLY_PATCH_ADAPTER_RELATIVE,
   CURSOR_APPLY_PATCH_ADAPTER_SOURCE,
   CURSOR_GENERIC_WRITE_HOOK_MATCHER,
+  assertCursorApplyPatchMatchersDisjoint,
   cursorApplyPatchAdapterEntry,
   DEFT_CURSOR_ADAPTER_COMMAND_MARKER,
 } from "../hooks/cursor-hooks.js";
@@ -214,6 +215,7 @@ function stripManagedCursorConfig(
 }
 
 function mergeCursorConfig(config: Record<string, unknown>, path: string): Record<string, unknown> {
+  assertCursorApplyPatchMatchersDisjoint();
   const hooks = hooksObject(config, path);
   const session = eventArray(hooks, "sessionStart", path).filter(
     (entry) => !isManagedCursorEntry(entry),
@@ -413,6 +415,7 @@ function hasCursorRegistration(config: Record<string, unknown>): boolean {
   const session = Array.isArray(hooks.sessionStart) ? hooks.sessionStart : [];
   const preTool = Array.isArray(hooks.preToolUse) ? hooks.preToolUse : [];
   const preCompact = Array.isArray(hooks.preCompact) ? hooks.preCompact : [];
+  const adapter = cursorApplyPatchAdapterEntry();
   return (
     session.some((entry) => object(entry)?.command === command("cursor", "session.start")) &&
     preTool.some((entry) => {
@@ -426,8 +429,8 @@ function hasCursorRegistration(config: Record<string, unknown>): boolean {
     preTool.some((entry) => {
       const hook = object(entry);
       return (
-        hook?.command === cursorApplyPatchAdapterEntry().command &&
-        hook.matcher === cursorApplyPatchAdapterEntry().matcher &&
+        hook?.command === adapter.command &&
+        hook.matcher === adapter.matcher &&
         hook.failClosed === true
       );
     }) &&

--- a/packages/core/src/init-deposit/agent-hooks.ts
+++ b/packages/core/src/init-deposit/agent-hooks.ts
@@ -2,10 +2,10 @@ import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync 
 import { dirname, join } from "node:path";
 import { assertDepositContained } from "../deposit/contain.js";
 import {
+  assertCursorApplyPatchMatchersDisjoint,
   CURSOR_APPLY_PATCH_ADAPTER_RELATIVE,
   CURSOR_APPLY_PATCH_ADAPTER_SOURCE,
   CURSOR_GENERIC_WRITE_HOOK_MATCHER,
-  assertCursorApplyPatchMatchersDisjoint,
   cursorApplyPatchAdapterEntry,
   DEFT_CURSOR_ADAPTER_COMMAND_MARKER,
 } from "../hooks/cursor-hooks.js";

--- a/packages/core/src/init-deposit/agent-hooks.ts
+++ b/packages/core/src/init-deposit/agent-hooks.ts
@@ -1,6 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { assertDepositContained } from "../deposit/contain.js";
+import {
+  CURSOR_APPLY_PATCH_ADAPTER_RELATIVE,
+  CURSOR_APPLY_PATCH_ADAPTER_SOURCE,
+  CURSOR_GENERIC_WRITE_HOOK_MATCHER,
+  cursorApplyPatchAdapterEntry,
+  DEFT_CURSOR_ADAPTER_COMMAND_MARKER,
+} from "../hooks/cursor-hooks.js";
 import type { HookEvent, HookHost } from "../hooks/dispatcher.js";
 import { DIRECT_WRITE_HOOK_MATCHER, SPAWN_HOOK_MATCHER } from "../hooks/tools.js";
 import {
@@ -10,6 +17,10 @@ import {
 } from "../policy/host-hooks.js";
 import type { InitDepositIo } from "./constants.js";
 
+export {
+  CURSOR_GENERIC_WRITE_HOOK_MATCHER,
+  DEFT_CURSOR_ADAPTER_COMMAND_MARKER,
+} from "../hooks/cursor-hooks.js";
 export { DIRECT_WRITE_HOOK_MATCHER, SPAWN_HOOK_MATCHER } from "../hooks/tools.js";
 export const DEFT_HOOK_COMMAND_MARKER = "deft hook:dispatch";
 export const AGENT_HOOK_PATHS = [
@@ -103,16 +114,15 @@ function isManagedNestedGroupForHost(value: unknown, host: NestedHookHost): bool
 
 function isManagedCursorEntry(value: unknown): boolean {
   const entry = object(value);
-  return typeof entry?.command === "string" && entry.command.includes(DEFT_HOOK_COMMAND_MARKER);
+  if (typeof entry?.command !== "string") return false;
+  return (
+    entry.command.includes(DEFT_HOOK_COMMAND_MARKER) ||
+    entry.command.includes(DEFT_CURSOR_ADAPTER_COMMAND_MARKER)
+  );
 }
 
 function isManagedCursorEntryForHost(value: unknown): boolean {
-  const entry = object(value);
-  return (
-    typeof entry?.command === "string" &&
-    entry.command.includes(DEFT_HOOK_COMMAND_MARKER) &&
-    entry.command.includes("--host cursor")
-  );
+  return isManagedCursorEntry(value);
 }
 
 type NestedHookHost = "claude" | "grok" | "codex";
@@ -217,9 +227,10 @@ function mergeCursorConfig(config: Record<string, unknown>, path: string): Recor
   hooks.sessionStart = [...session, { command: command("cursor", "session.start"), timeout: 5 }];
   hooks.preToolUse = [
     ...preTool,
+    cursorApplyPatchAdapterEntry(),
     {
       command: command("cursor", "tool.before"),
-      matcher: DIRECT_WRITE_HOOK_MATCHER,
+      matcher: CURSOR_GENERIC_WRITE_HOOK_MATCHER,
       failClosed: true,
       timeout: 5,
     },
@@ -232,6 +243,15 @@ function mergeCursorConfig(config: Record<string, unknown>, path: string): Recor
   ];
   hooks.preCompact = [...preCompact, { command: command("cursor", "session.compact"), timeout: 5 }];
   return { ...config, version: 1, hooks };
+}
+
+function writeTextIfChanged(path: string, contents: string): boolean {
+  if (existsSync(path) && readFileSync(path, "utf8") === contents) return false;
+  mkdirSync(dirname(path), { recursive: true });
+  const temporary = `${path}.deft-${process.pid}.tmp`;
+  writeFileSync(temporary, contents, "utf8");
+  renameSync(temporary, path);
+  return true;
 }
 
 function writeJsonIfChanged(path: string, payload: Record<string, unknown>): boolean {
@@ -320,6 +340,22 @@ export function writeAgentHookDeposit(
       else changedPaths.push(item.path);
     }
   }
+
+  const adapterAbsolute = join(projectRoot, CURSOR_APPLY_PATCH_ADAPTER_RELATIVE);
+  assertDepositContained(projectRoot, adapterAbsolute);
+  if (isHostHookDepositEnabled("cursor", hostHooksPolicy)) {
+    if (writeTextIfChanged(adapterAbsolute, CURSOR_APPLY_PATCH_ADAPTER_SOURCE)) {
+      if (!changedPaths.includes(AGENT_HOOK_PATHS[2])) {
+        changedPaths.push(AGENT_HOOK_PATHS[2]);
+      }
+    }
+  } else if (existsSync(adapterAbsolute)) {
+    rmSync(adapterAbsolute, { force: true });
+    if (!strippedPaths.includes(AGENT_HOOK_PATHS[2])) {
+      strippedPaths.push(AGENT_HOOK_PATHS[2]);
+    }
+  }
+
   if (changedPaths.length > 0) {
     io.printf(`Installed Directive agent hooks: ${changedPaths.join(", ")}\n`);
   }
@@ -383,7 +419,15 @@ function hasCursorRegistration(config: Record<string, unknown>): boolean {
       const hook = object(entry);
       return (
         hook?.command === command("cursor", "tool.before") &&
-        hook.matcher === DIRECT_WRITE_HOOK_MATCHER &&
+        hook.matcher === CURSOR_GENERIC_WRITE_HOOK_MATCHER &&
+        hook.failClosed === true
+      );
+    }) &&
+    preTool.some((entry) => {
+      const hook = object(entry);
+      return (
+        hook?.command === cursorApplyPatchAdapterEntry().command &&
+        hook.matcher === cursorApplyPatchAdapterEntry().matcher &&
         hook.failClosed === true
       );
     }) &&

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -33,6 +33,7 @@ export function installerManagedMatchers(): InstallerManagedMatcher[] {
     { exact: ".claude/settings.json" },
     { exact: ".grok/hooks/deft.json" },
     { exact: ".cursor/hooks.json" },
+    { exact: ".cursor/hooks/deft-cursor-hook-adapter.mjs" },
     { exact: ".codex/hooks.json" },
     { exact: ".gitattributes" },
     { exact: ".gitignore" },

--- a/xbrief/active/2026-07-22-2764-bug-cursor-applypatch-double-dispatch-blocks-windows-writes.xbrief.json
+++ b/xbrief/active/2026-07-22-2764-bug-cursor-applypatch-double-dispatch-blocks-windows-writes.xbrief.json
@@ -1,0 +1,84 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2764"
+  },
+  "plan": {
+    "title": "bug: Cursor ApplyPatch double-dispatch blocks Windows writes",
+    "status": "running",
+    "narratives": {
+      "Description": "Fix overlapping Cursor preToolUse matchers so ApplyPatch is not double-dispatched through the generic write hook. Restore Windows ApplyPatch writes after ritual when adapter and generic hooks both match.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2764",
+      "Overview": "## Summary\r\n\r\nDirective v0.82.0 generates overlapping Cursor preToolUse matchers for ApplyPatch. The adapter hook and the generic write hook both match the same tool call, causing the generic hook to process Cursor's free-form patch payload directly and fail closed.\r\n\r\n## Environment\r\n\r\n- Directive engine/content: v0.82.0\r\n- Host: Cursor\r\n- OS: Windows 10 (win32 10.0.26200)\r\n- Shell: PowerShell\r\n- Upgrade path: npm i -g @deftai/directive@latest, then directive update\r\n\r\n## Reproduction\r\n\r\n1. Upgrade an existing Directive project using the documented npm upgrade path.\r\n2. Run deft session:start.\r\n3. Run deft verify:session-ritual -- --tier=gated and confirm it passes.\r\n4. Invoke Cursor ApplyPatch against any repository file.\r\n\r\n## Generated hook configuration\r\n\r\nThe refreshed .cursor/hooks.json contains both:\r\n\r\n- Adapter matcher: ApplyPatch|apply_patch -> node .cursor/hooks/deft-cursor-hook-adapter.mjs ApplyPatch\r\n- Generic matcher: Edit|Write|WriteFile|CreateFile|MultiEdit|NotebookEdit|StrReplace|SearchReplace|Delete|DeleteFile|ApplyPatch|apply_patch -> deft hook:dispatch --host cursor --event tool.before\r\n\r\n## Actual result\r\n\r\nThe write is denied even though the ritual passed:\r\n\r\n    Directive denied Write: ritual state missing at C:\\C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture\\.deft\\ritual-state.json.\r\n\r\nBefore upgrading, the same integration also surfaced the generic raw-payload failure:\r\n\r\n    Directive denied this Cursor preToolUse event because the host payload was not valid JSON ... the host payload omitted its tool name.\r\n\r\n## Expected result\r\n\r\nApplyPatch should be handled exactly once by the Cursor adapter. A valid Windows absolute project path should not be prefixed with a second C:\\ segment, and a fresh successful session ritual should authorize the write.\r\n\r\n## Likely correction\r\n\r\n- Exclude ApplyPatch/apply_patch from the generic write matcher when the dedicated adapter hook is installed.\r\n- Add a generated-hooks regression test proving exactly one preToolUse hook handles ApplyPatch.\r\n- Add a Windows integration test covering an absolute cwd and ritual-state resolution without C:\\C:\\ duplication.\r\n\r\n## Impact\r\n\r\nAll Cursor file-edit operations using ApplyPatch are fail-closed after the documented v0.82.0 update, blocking normal coding and PR preparation.",
+      "Labels": "bug, adoption-blocker, agent-experience, harness, area:cli",
+      "ImplementationPlan": "1) Update the Cursor hooks projection module/file under packages/core/src so ApplyPatch is owned only by the adapter matcher. 2) Add fixture tests that verify generated hooks.json matcher disjointness and that the generic write matcher no longer lists ApplyPatch.",
+      "UserStory": "As a Cursor user on Windows, I want ApplyPatch to hit only the adapter hook after ritual, so that writes are not fail-closed by the generic write dispatcher."
+    },
+    "items": [
+      {
+        "title": "Given a refreshed .cursor/hooks.json projection, when matchers are inspected, then the generic write matcher rejects App",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a refreshed .cursor/hooks.json projection, when matchers are inspected, then the generic write matcher rejects ApplyPatch ownership and the adapter matcher alone owns ApplyPatch."
+        }
+      },
+      {
+        "title": "Given a gated ritual pass, when ApplyPatch is dispatched, then the generic write hook does not fail closed solely due to",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a gated ritual pass, when ApplyPatch is dispatched, then the generic write hook does not fail closed solely due to double-dispatch."
+        }
+      },
+      {
+        "title": "Given the matcher fixture tests, when the suite runs, then it returns green proving disjoint ApplyPatch routing.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the matcher fixture tests, when the suite runs, then it returns green proving disjoint ApplyPatch routing."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "agent-experience",
+      "harness",
+      "area:cli"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2764",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2764: bug: Cursor ApplyPatch double-dispatch blocks Windows writes"
+      }
+    ],
+    "updated": "2026-07-22T23:08:10Z",
+    "id": "2026-07-22-2764-bug-cursor-applypatch-double-dispatch-blocks-windows",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/hooks/cursor-hooks.ts",
+          "packages/core/src/hooks/cursor-hooks.test.ts",
+          "packages/core/src/agent-hosts/cursor.ts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/hooks",
+          "task check"
+        ],
+        "expected_outputs": [
+          "ApplyPatch matcher owned solely by adapter path",
+          "no double-dispatch deny after ritual",
+          "task check passes"
+        ],
+        "depends_on": [],
+        "conflict_group": "harness-cursor-hooks",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue acceptance criteria and AppSec/planning comments rather than a SPECIFICATION section."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Route Cursor `ApplyPatch` through a dedicated project adapter hook and exclude `ApplyPatch`/`apply_patch` from the generic direct-write preToolUse matcher, preventing double-dispatch fail-closed writes on Windows after ritual.
- Deposit `.cursor/hooks/deft-cursor-hook-adapter.mjs` with explicit `--project-root` forwarding to `deft hook:dispatch`.
- Ignore drive-only Windows `workspace_roots`/`cwd` values in hook project-root resolution that produced `C:\C:\...` ritual paths.
- Respect `plan.policy.hostHooks.cursor` opt-out from #2752 when depositing or stripping the adapter script.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/hooks/cursor-hooks.test.ts packages/core/src/init-deposit/agent-hooks.test.ts`
- [x] `task check`

Closes #2764
