### PR TITLE
fix(security): gate three symlink write sinks (#2781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three medium symlink write sinks contained (#2781).** `scope:decompose`, `swarm:routing-set` / `writeModelDecision`, and session readback history appends (`value/readback`, `eval/readback`) now call `assertWriteTargetSafe` before write/append so leaf symlinks cannot divert operator-controlled paths outside the repo. Closes #2781.
+
 ### Removed
 
 ## [0.83.0] - 2026-07-23

--- a/packages/core/src/eval/readback.test.ts
+++ b/packages/core/src/eval/readback.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -172,5 +180,24 @@ describe("emitSessionEvalReadback", () => {
 describe("EVAL_READBACK_SUPPRESSION_HOURS", () => {
   it("matches value-readback debounce parity", () => {
     expect(EVAL_READBACK_SUPPRESSION_HOURS).toBe(4);
+  });
+});
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("eval readback history symlink containment (#2781)", () => {
+  itSymlink("does not append when history path is a symlink to an external victim file", () => {
+    const root = tempRoot();
+    const escapeDir = mkdtempSync(join(tmpdir(), "eval-readback-victim-"));
+    const victim = join(escapeDir, "eval-readback-history.jsonl");
+    writeFileSync(victim, "victim\n", "utf8");
+    mkdirSync(join(root, ".deft-cache"), { recursive: true });
+    symlinkSync(victim, join(root, ".deft-cache", "eval-readback-history.jsonl"));
+    renderSessionEvalReadback(root, {
+      now: new Date("2026-07-05T12:00:00Z"),
+      evaluate: () => ({ report: sampleReport() }),
+    });
+    expect(readFileSync(victim, "utf8")).toBe("victim\n");
+    rmSync(escapeDir, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/eval/readback.ts
+++ b/packages/core/src/eval/readback.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { assertWriteTargetSafe } from "../fs/projection-containment.js";
+import { assertWriteTargetSafe, ProjectionContainmentError } from "../fs/projection-containment.js";
 import { MAX_LINE_CHARS } from "../triage/welcome/constants.js";
 import { evaluateHealth, type HealthReport, healthHistoryPath } from "./health.js";
 
@@ -149,7 +149,10 @@ function appendEvalReadbackHistory(
     assertWriteTargetSafe(projectRoot, path);
     mkdirSync(join(path, ".."), { recursive: true });
     appendFileSync(path, `${JSON.stringify(record)}\n`, "utf8");
-  } catch {
+  } catch (err) {
+    if (err instanceof ProjectionContainmentError) {
+      throw err;
+    }
     // observability only
   }
 }

--- a/packages/core/src/eval/readback.ts
+++ b/packages/core/src/eval/readback.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { MAX_LINE_CHARS } from "../triage/welcome/constants.js";
 import { evaluateHealth, type HealthReport, healthHistoryPath } from "./health.js";
 
@@ -145,6 +146,7 @@ function appendEvalReadbackHistory(
     line,
   };
   try {
+    assertWriteTargetSafe(projectRoot, path);
     mkdirSync(join(path, ".."), { recursive: true });
     appendFileSync(path, `${JSON.stringify(record)}\n`, "utf8");
   } catch {

--- a/packages/core/src/scope/decompose.test.ts
+++ b/packages/core/src/scope/decompose.test.ts
@@ -3,10 +3,11 @@
  * tests/cli/test_scope_decompose_unit.py including non-happy-path/edge cases.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import {
   acceptanceTextsFromItems,
   applyDecomposition,
@@ -409,6 +410,37 @@ describe("applyDecomposition", () => {
       }),
     ).toThrow("already exists");
   });
+});
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("applyDecomposition symlink containment (#2781)", () => {
+  itSymlink(
+    "refuses parent update when parent path is a symlink to an external victim file",
+    () => {
+      const proj = tmpProject();
+      const escapeDir = join(tmpdir(), `decompose-victim-${Date.now()}`);
+      mkdirSync(escapeDir, { recursive: true });
+      const victim = join(escapeDir, "parent.xbrief.json");
+      writeFileSync(victim, JSON.stringify({ plan: { references: [] } }), "utf8");
+      const parentPath = join(proj, "xbrief", "pending", "2026-05-12-parent.xbrief.json");
+      symlinkSync(victim, parentPath);
+      const draftPath = join(proj, "xbrief", ".triage-cache", "draft.json");
+      mkdirSync(join(proj, "xbrief", ".triage-cache"), { recursive: true });
+      writeJson(draftPath, goodDraft());
+      expect(() =>
+        applyDecomposition({
+          projectRoot: proj,
+          parentPath,
+          draftPath,
+          checkOnly: false,
+          date: "2026-06-01",
+        }),
+      ).toThrow(ProjectionContainmentError);
+      const victimAfter = JSON.parse(readFileSync(victim, "utf8")) as Record<string, unknown>;
+      expect((victimAfter.plan as Record<string, unknown>).references).toEqual([]);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/scope/decompose.ts
+++ b/packages/core/src/scope/decompose.ts
@@ -10,6 +10,7 @@
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { referenceTypeMatches } from "@deftai/directive-types";
+import { assertWriteTargetSafe, ProjectionContainmentError } from "../fs/projection-containment.js";
 import {
   hasArtifactSuffix,
   LEGACY_ARTIFACT_DIR,
@@ -69,7 +70,8 @@ function loadJson(path: string): JsonObj {
   return data as JsonObj;
 }
 
-function writeJson(path: string, data: JsonObj): void {
+function writeJson(projectRoot: string, path: string, data: JsonObj): void {
+  assertWriteTargetSafe(projectRoot, path);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, formatBriefJson(data), "utf8");
 }
@@ -998,7 +1000,7 @@ export function applyDecomposition(opts: ApplyDecompositionOptions): string[] {
   }
   for (let i = 0; i < childPaths.length; i += 1) {
     // biome-ignore lint/style/noNonNullAssertion: loop bound ensures these exist
-    writeJson(childPaths[i]!.target, childDocs[i]!);
+    writeJson(projectRoot, childPaths[i]!.target, childDocs[i]!);
   }
 
   let parentPlan = parent.plan;
@@ -1045,7 +1047,7 @@ export function applyDecomposition(opts: ApplyDecompositionOptions): string[] {
       .map((r) => r as JsonObj),
   );
 
-  writeJson(parentPath, parent);
+  writeJson(projectRoot, parentPath, parent);
   actions.push(`UPDATE ${parentRel} references`);
   return actions;
 }
@@ -1163,6 +1165,10 @@ export function decomposeMain(argv: string[]): number {
     if (err instanceof DecompositionError) {
       process.stderr.write(`ERROR: ${err.message}\n`);
       return 1;
+    }
+    if (err instanceof ProjectionContainmentError) {
+      process.stderr.write(`ERROR: ${err.message}\n`);
+      return 2;
     }
     process.stderr.write(`ERROR: ${String(err)}\n`);
     return 1;

--- a/packages/core/src/swarm/routing-set-cli.ts
+++ b/packages/core/src/swarm/routing-set-cli.ts
@@ -83,8 +83,9 @@ export function routingSetMain(argv: string[] = process.argv.slice(2)): number {
     return EXIT_CONFIG_ERROR;
   }
 
-  const path = resolveRoutingPath(resolve(projectRoot));
-  writeModelDecision(path, resolvedProvider, role, {
+  const root = resolve(projectRoot);
+  const path = resolveRoutingPath(root);
+  writeModelDecision(root, path, resolvedProvider, role, {
     model,
     mode: harnessDefault ? ROUTING_MODE_HARNESS_DEFAULT : ROUTING_MODE_PINNED,
   });

--- a/packages/core/src/swarm/routing-set-cli.ts
+++ b/packages/core/src/swarm/routing-set-cli.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  PROJECTION_CONTAINMENT_REFUSED_EXIT_CODE,
+  ProjectionContainmentError,
+} from "../fs/projection-containment.js";
 import { getPlatformCapabilities } from "../intake/platform-capabilities.js";
 import { EXIT_CONFIG_ERROR, EXIT_OK } from "./constants.js";
 import {
@@ -85,10 +89,18 @@ export function routingSetMain(argv: string[] = process.argv.slice(2)): number {
 
   const root = resolve(projectRoot);
   const path = resolveRoutingPath(root);
-  writeModelDecision(root, path, resolvedProvider, role, {
-    model,
-    mode: harnessDefault ? ROUTING_MODE_HARNESS_DEFAULT : ROUTING_MODE_PINNED,
-  });
+  try {
+    writeModelDecision(root, path, resolvedProvider, role, {
+      model,
+      mode: harnessDefault ? ROUTING_MODE_HARNESS_DEFAULT : ROUTING_MODE_PINNED,
+    });
+  } catch (err) {
+    if (err instanceof ProjectionContainmentError) {
+      process.stderr.write(`ERROR: ${err.message}\n`);
+      return PROJECTION_CONTAINMENT_REFUSED_EXIT_CODE;
+    }
+    throw err;
+  }
 
   const modelText = model ?? "<harness default>";
   process.stdout.write(

--- a/packages/core/src/swarm/routing.test.ts
+++ b/packages/core/src/swarm/routing.test.ts
@@ -1,8 +1,9 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ProjectionContainmentError } from "../fs/projection-containment.js";
 import {
   dispatchProviderFromRuntime,
   loadRoutingFile,
@@ -187,7 +188,7 @@ describe("writeModelDecision", () => {
   });
 
   it("creates the file + parent dir and stamps decidedAt", () => {
-    writeModelDecision(path, "cursor", "leaf-implementation", { model: "composer-2.5-fast" });
+    writeModelDecision(dir, path, "cursor", "leaf-implementation", { model: "composer-2.5-fast" });
     const data = loadRoutingFile(path).data;
     expect(data?.cursor?.["leaf-implementation"]?.model).toBe("composer-2.5-fast");
     expect(data?.cursor?.["leaf-implementation"]?.mode).toBe(ROUTING_MODE_PINNED);
@@ -195,15 +196,15 @@ describe("writeModelDecision", () => {
   });
 
   it("records an explicit harness default (model null)", () => {
-    writeModelDecision(path, "cursor", "review-monitor", { model: null });
+    writeModelDecision(dir, path, "cursor", "review-monitor", { model: null });
     const data = loadRoutingFile(path).data;
     expect(data?.cursor?.["review-monitor"]?.model).toBeNull();
     expect(data?.cursor?.["review-monitor"]?.mode).toBe(ROUTING_MODE_HARNESS_DEFAULT);
   });
 
   it("merges additional roles without clobbering existing ones", () => {
-    writeModelDecision(path, "cursor", "leaf-implementation", { model: "composer-2.5-fast" });
-    writeModelDecision(path, "cursor", "orchestrator", { model: "gpt-5.5-medium" });
+    writeModelDecision(dir, path, "cursor", "leaf-implementation", { model: "composer-2.5-fast" });
+    writeModelDecision(dir, path, "cursor", "orchestrator", { model: "gpt-5.5-medium" });
     const data = loadRoutingFile(path).data;
     expect(data?.cursor?.["leaf-implementation"]?.model).toBe("composer-2.5-fast");
     expect(data?.cursor?.orchestrator?.model).toBe("gpt-5.5-medium");
@@ -212,8 +213,10 @@ describe("writeModelDecision", () => {
 
   it("rejects prototype-polluting provider/role keys (CodeQL #52)", () => {
     for (const key of ["__proto__", "constructor", "prototype"]) {
-      expect(() => writeModelDecision(path, key, "leaf-implementation", { model: "x" })).toThrow();
-      expect(() => writeModelDecision(path, "cursor", key, { model: "x" })).toThrow();
+      expect(() =>
+        writeModelDecision(dir, path, key, "leaf-implementation", { model: "x" }),
+      ).toThrow();
+      expect(() => writeModelDecision(dir, path, "cursor", key, { model: "x" })).toThrow();
     }
     // Object.prototype must be untouched by the attempted injection.
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
@@ -227,10 +230,32 @@ describe("writeModelDecision", () => {
     // legitimate write must land on the null-prototype targets, never reach
     // Object.prototype, and must preserve the real providers.
     writeFileSync(path, JSON.stringify({ __proto__: { polluted: true }, cursor: {} }), "utf8");
-    writeModelDecision(path, "cursor", "leaf-implementation", { model: "composer-2.5-fast" });
+    writeModelDecision(dir, path, "cursor", "leaf-implementation", { model: "composer-2.5-fast" });
     expect(Object.prototype).not.toHaveProperty("polluted");
     const data = loadRoutingFile(path).data;
     expect(data?.cursor?.["leaf-implementation"]?.model).toBe("composer-2.5-fast");
+  });
+});
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("writeModelDecision symlink containment (#2781)", () => {
+  itSymlink("refuses routing.local.json when it is a symlink to an external victim file", () => {
+    const root = mkdtempSync(join(tmpdir(), "routing-symlink-target-"));
+    const escapeDir = mkdtempSync(join(tmpdir(), "routing-symlink-victim-"));
+    const victim = join(escapeDir, "routing.local.json");
+    writeFileSync(victim, "victim\n", "utf8");
+    mkdirSync(join(root, ".deft"), { recursive: true });
+    const routePath = join(root, ".deft", "routing.local.json");
+    symlinkSync(victim, routePath);
+    expect(() =>
+      writeModelDecision(root, routePath, "cursor", "leaf-implementation", {
+        model: "composer-2.5-fast",
+      }),
+    ).toThrow(ProjectionContainmentError);
+    expect(readFileSync(victim, "utf8")).toBe("victim\n");
+    rmSync(root, { recursive: true, force: true });
+    rmSync(escapeDir, { recursive: true, force: true });
   });
 });
 

--- a/packages/core/src/swarm/routing.ts
+++ b/packages/core/src/swarm/routing.ts
@@ -16,6 +16,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 
 /**
  * The fixed worker-role vocabulary (reused from #1531). No separate tier
@@ -250,6 +251,7 @@ function assertSafeRoutingKey(kind: "provider" | "role", key: string): void {
  * resolver path (resolver step 5) and the `swarm:routing-set` task.
  */
 export function writeModelDecision(
+  projectRoot: string,
   path: string,
   provider: string,
   role: string,
@@ -257,6 +259,7 @@ export function writeModelDecision(
 ): void {
   assertSafeRoutingKey("provider", provider);
   assertSafeRoutingKey("role", role);
+  assertWriteTargetSafe(projectRoot, path);
   const { data } = loadRoutingFile(path);
   // Null-prototype write targets so a computed provider/role key can only ever
   // set an own property and can never reach `Object.prototype`, even if the

--- a/packages/core/src/value/readback.test.ts
+++ b/packages/core/src/value/readback.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
@@ -344,5 +352,24 @@ describe("debounce history persistence", () => {
     const parsed = parseJsonObject(readFileSync(hist, "utf8").trim());
     expect(parsed.event_id).toBe("evt-0");
     expect(String(parsed.line).length).toBeGreaterThan(0);
+  });
+});
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+describe("value readback history symlink containment (#2781)", () => {
+  itSymlink("does not append when history path is a symlink to an external victim file", () => {
+    const root = makeRepo({
+      valueFeedback: { enabled: true, sessionLine: true },
+      events: [{ event: "value:gate-catch", payload: { source: "verify:branch", detail: "x" } }],
+    });
+    const escapeDir = mkdtempSync(join(tmpdir(), "value-readback-victim-"));
+    const victim = join(escapeDir, "value-readback-history.jsonl");
+    writeFileSync(victim, "victim\n", "utf8");
+    mkdirSync(join(root, ".deft-cache"), { recursive: true });
+    symlinkSync(victim, join(root, VALUE_READBACK_HISTORY_REL));
+    renderSessionReadback(root, { now: new Date("2026-07-05T10:00:00Z") });
+    expect(readFileSync(victim, "utf8")).toBe("victim\n");
+    rmSync(escapeDir, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/value/readback.ts
+++ b/packages/core/src/value/readback.ts
@@ -2,7 +2,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { runningInsideDeftRepo } from "../doctor/paths.js";
 import { ALL_ATTRIBUTION_EVENT_NAMES } from "../events/attribution-constants.js";
-import { assertWriteTargetSafe } from "../fs/projection-containment.js";
+import { assertWriteTargetSafe, ProjectionContainmentError } from "../fs/projection-containment.js";
 import { type BehavioralEventRecord, DEFAULT_EVENT_LOG, readEvents } from "../lifecycle/events.js";
 import { policyColonInvocation } from "../policy/policy-invocation.js";
 import {
@@ -297,7 +297,10 @@ function appendReadbackHistory(
     assertWriteTargetSafe(projectRoot, path);
     mkdirSync(join(path, ".."), { recursive: true });
     appendFileSync(path, `${JSON.stringify(record)}\n`, "utf8");
-  } catch {
+  } catch (err) {
+    if (err instanceof ProjectionContainmentError) {
+      throw err;
+    }
     // observability only
   }
 }

--- a/packages/core/src/value/readback.ts
+++ b/packages/core/src/value/readback.ts
@@ -2,6 +2,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { runningInsideDeftRepo } from "../doctor/paths.js";
 import { ALL_ATTRIBUTION_EVENT_NAMES } from "../events/attribution-constants.js";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { type BehavioralEventRecord, DEFAULT_EVENT_LOG, readEvents } from "../lifecycle/events.js";
 import { policyColonInvocation } from "../policy/policy-invocation.js";
 import {
@@ -293,6 +294,7 @@ function appendReadbackHistory(
     line,
   };
   try {
+    assertWriteTargetSafe(projectRoot, path);
     mkdirSync(join(path, ".."), { recursive: true });
     appendFileSync(path, `${JSON.stringify(record)}\n`, "utf8");
   } catch {


### PR DESCRIPTION
## Summary

- Gate `scope:decompose` parent/child xBRIEF writes with `assertWriteTargetSafe` before `writeJson`.
- Gate `swarm:routing-set` / `writeModelDecision` writes to `.deft/routing.local.json` with the same containment helper (threading `projectRoot`).
- Gate value and eval session readback history appends under `.deft-cache/*-readback-history.jsonl`.
- Add symlink-diversion regression tests for each site.

Closes #2781

## Test plan

- [x] `task check` green (fmt + lint + typecheck + tests + coverage)
- [x] Focused vitest on decompose, routing, value/readback, eval/readback
- [x] Symlink regression tests (skipped on win32; CI runs on Linux)

## PR checklist

- [x] Scope xBRIEF: `xbrief/active/2026-07-23-2781-appsec-review-3-new-medium-findings-4610adc9.xbrief.json`
- [x] CHANGELOG `[Unreleased]` entry
- [x] Feature branch (not master)
- [x] Pre-PR RWLDL / `task check` before push