### PR TITLE
fix(session): rebind ritual git_head on forward commits (#2782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Session ritual no longer invalidates on every forward commit on the same worktree. When the pinned `git_head` is still an ancestor of current HEAD, gated direct writes stay allowed and `verify:session-ritual` rebinds the pin in place; checkout, reset, rebase, and worktree mismatches still fail closed. Closes #2782.
+
 ### Removed
 
 ## [0.83.0] - 2026-07-23

--- a/packages/core/src/session/branches.test.ts
+++ b/packages/core/src/session/branches.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GitRunner } from "./git.js";
+import { defaultGitRunner } from "./git.js";
 import { buildContext, evaluate, parse, ResumeGrammarError } from "./resume-conditions.js";
 import * as ritualSentinel from "./ritual-sentinel.js";
 import {
@@ -59,22 +60,14 @@ function initRepo(): { root: string; head: string } {
 }
 
 function fakeGit(head: string, worktree: string, overrides?: Partial<GitRunner>): GitRunner {
-  const base: GitRunner = (_r, args) => {
+  const base: GitRunner = (projectRoot, args) => {
     if (args[0] === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
       return { code: 0, stdout: head, stderr: "" };
     }
     if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
       return { code: 0, stdout: worktree, stderr: "" };
     }
-    if (args[0] === "merge-base" && args[1] === "--is-ancestor") {
-      const ancestor = args[2];
-      const descendant = args[3];
-      if (ancestor === descendant) {
-        return { code: 0, stdout: "", stderr: "" };
-      }
-      return { code: 1, stdout: "", stderr: "" };
-    }
-    return { code: 0, stdout: "", stderr: "" };
+    return defaultGitRunner(projectRoot, args);
   };
   return overrides ? (r, a) => overrides(r, a) ?? base(r, a) : base;
 }
@@ -114,11 +107,28 @@ describe("session branches", () => {
   it("verify detects head and worktree drift", () => {
     const { root, head } = initRepo();
     const now = new Date("2026-06-09T01:00:00Z");
+    writeFileSync(join(root, "forward.txt"), "x\n", "utf8");
+    execFileSync("git", ["add", "forward.txt"], { cwd: root, encoding: "utf8" });
+    execFileSync("git", ["commit", "-q", "-m", "forward"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "T",
+        GIT_AUTHOR_EMAIL: "t@t.local",
+        GIT_COMMITTER_NAME: "T",
+        GIT_COMMITTER_EMAIL: "t@t.local",
+      },
+    });
+    const advancedHead = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
     writeRitualState(
       root,
       newRitualStatePayload({
         sessionId: "s",
-        gitHead: "old-head",
+        gitHead: advancedHead,
         worktreePath: resolve(root),
         startedAt: now,
         quickSteps: {
@@ -128,11 +138,11 @@ describe("session branches", () => {
         },
       }),
     );
+    execFileSync("git", ["reset", "--hard", head], { cwd: root, encoding: "utf8" });
     const headDrift = verifySessionRitual(root, {
       bypass: false,
       posture: "mutation",
       now,
-      runGit: fakeGit(head, resolve(root)),
     });
     expect(headDrift.code).toBe(1);
     expect(headDrift.message).toContain("discontinuously");

--- a/packages/core/src/session/branches.test.ts
+++ b/packages/core/src/session/branches.test.ts
@@ -13,7 +13,7 @@ import {
   writeRitualState,
 } from "./ritual-sentinel.js";
 import { defaultBranchSync, runSessionStart } from "./session-start.js";
-import { verifySessionRitual } from "./verify-session-ritual.js";
+import { inspectSessionRitual, verifySessionRitual } from "./verify-session-ritual.js";
 
 const temps: string[] = [];
 afterEach(() => {
@@ -65,6 +65,14 @@ function fakeGit(head: string, worktree: string, overrides?: Partial<GitRunner>)
     }
     if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
       return { code: 0, stdout: worktree, stderr: "" };
+    }
+    if (args[0] === "merge-base" && args[1] === "--is-ancestor") {
+      const ancestor = args[2];
+      const descendant = args[3];
+      if (ancestor === descendant) {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 1, stdout: "", stderr: "" };
     }
     return { code: 0, stdout: "", stderr: "" };
   };
@@ -127,7 +135,7 @@ describe("session branches", () => {
       runGit: fakeGit(head, resolve(root)),
     });
     expect(headDrift.code).toBe(1);
-    expect(headDrift.message).toContain("HEAD changed");
+    expect(headDrift.message).toContain("discontinuously");
 
     writeRitualState(
       root,
@@ -206,6 +214,53 @@ describe("session branches", () => {
     vi.restoreAllMocks();
   });
 
+  it("verify fails when forward HEAD rebind cannot write (#2782)", () => {
+    const { root, head } = initRepo();
+    const now = new Date("2026-07-23T12:00:00Z");
+    writeRitualState(
+      root,
+      newRitualStatePayload({
+        sessionId: "s",
+        gitHead: head,
+        worktreePath: resolve(root),
+        startedAt: now,
+        quickSteps: {
+          alignment: ritualStep({ ok: true, ts: now }),
+          branch_policy: ritualStep({ ok: true, ts: now }),
+          triage_welcome: ritualStep({ ok: true, ts: now }),
+        },
+        gatedSteps: {
+          doctor: ritualStep({ ok: true, ts: now }),
+          cache_fresh: ritualStep({ ok: true, ts: now }),
+        },
+      }),
+    );
+    writeFileSync(join(root, "forward.txt"), "x\n", "utf8");
+    execFileSync("git", ["add", "forward.txt"], { cwd: root, encoding: "utf8" });
+    execFileSync("git", ["commit", "-q", "-m", "forward"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "T",
+        GIT_AUTHOR_EMAIL: "t@t.local",
+        GIT_COMMITTER_NAME: "T",
+        GIT_COMMITTER_EMAIL: "t@t.local",
+      },
+    });
+    vi.spyOn(ritualSentinel, "writeRitualState").mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const result = verifySessionRitual(root, {
+      bypass: false,
+      posture: "mutation",
+      now,
+    });
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("could not rebind session ritual git HEAD");
+    vi.restoreAllMocks();
+  });
+
   it("runSessionStart triage exception path", () => {
     const { root, head } = initRepo();
     const result = runSessionStart(root, {
@@ -262,5 +317,119 @@ describe("session branches", () => {
       "utf8",
     );
     expect(readRitualState(root)[1]).toContain(".ok");
+  });
+
+  it("forward commit stays fresh; branch switch and rebase fail closed (#2782)", () => {
+    const { root } = initRepo();
+    const now = new Date("2026-07-23T12:00:00Z");
+    const gatedSteps = {
+      doctor: ritualStep({ ok: true, ts: now }),
+      cache_fresh: ritualStep({ ok: true, ts: now }),
+    };
+    const quickSteps = {
+      alignment: ritualStep({ ok: true, ts: now }),
+      branch_policy: ritualStep({ ok: true, ts: now }),
+      triage_welcome: ritualStep({ ok: true, ts: now }),
+    };
+
+    execFileSync("git", ["checkout", "-q", "-b", "feature"], { cwd: root, encoding: "utf8" });
+    execFileSync("git", ["checkout", "-q", "-"], { cwd: root, encoding: "utf8" });
+
+    writeFileSync(join(root, "forward.txt"), "x\n", "utf8");
+    execFileSync("git", ["add", "forward.txt"], { cwd: root, encoding: "utf8" });
+    execFileSync("git", ["commit", "-q", "-m", "forward"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "T",
+        GIT_AUTHOR_EMAIL: "t@t.local",
+        GIT_COMMITTER_NAME: "T",
+        GIT_COMMITTER_EMAIL: "t@t.local",
+      },
+    });
+    const mainHead = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+
+    writeRitualState(
+      root,
+      newRitualStatePayload({
+        sessionId: "s",
+        gitHead: mainHead,
+        worktreePath: resolve(root),
+        startedAt: now,
+        quickSteps,
+        gatedSteps,
+      }),
+    );
+
+    writeFileSync(join(root, "forward2.txt"), "y\n", "utf8");
+    execFileSync("git", ["add", "forward2.txt"], { cwd: root, encoding: "utf8" });
+    execFileSync("git", ["commit", "-q", "-m", "forward-2"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "T",
+        GIT_AUTHOR_EMAIL: "t@t.local",
+        GIT_COMMITTER_NAME: "T",
+        GIT_COMMITTER_EMAIL: "t@t.local",
+      },
+    });
+    expect(inspectSessionRitual(root, { tier: "gated", posture: "mutation", now }).code).toBe(0);
+
+    execFileSync("git", ["checkout", "-q", "feature"], { cwd: root, encoding: "utf8" });
+    writeFileSync(join(root, "feature.txt"), "y\n", "utf8");
+    execFileSync("git", ["add", "feature.txt"], { cwd: root, encoding: "utf8" });
+    execFileSync("git", ["commit", "-q", "-m", "feature-only"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "T",
+        GIT_AUTHOR_EMAIL: "t@t.local",
+        GIT_COMMITTER_NAME: "T",
+        GIT_COMMITTER_EMAIL: "t@t.local",
+      },
+    });
+    const branchSwitch = inspectSessionRitual(root, { tier: "gated", posture: "mutation", now });
+    expect(branchSwitch.code).toBe(1);
+    expect(branchSwitch.message).toContain("discontinuously");
+
+    execFileSync("git", ["checkout", "-q", "-"], { cwd: root, encoding: "utf8" });
+    const pinnedHead = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    writeRitualState(
+      root,
+      newRitualStatePayload({
+        sessionId: "s2",
+        gitHead: pinnedHead,
+        worktreePath: resolve(root),
+        startedAt: now,
+        quickSteps,
+        gatedSteps,
+      }),
+    );
+    writeFileSync(join(root, "amend.txt"), "z\n", "utf8");
+    execFileSync("git", ["add", "amend.txt"], { cwd: root, encoding: "utf8" });
+    execFileSync("git", ["commit", "-q", "--amend", "--no-edit"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "T",
+        GIT_AUTHOR_EMAIL: "t@t.local",
+        GIT_COMMITTER_NAME: "T",
+        GIT_COMMITTER_EMAIL: "t@t.local",
+      },
+    });
+
+    const amend = inspectSessionRitual(root, { tier: "gated", posture: "mutation", now });
+    expect(amend.code).toBe(1);
+    expect(amend.message).toContain("discontinuously");
   });
 });

--- a/packages/core/src/session/branches.test.ts
+++ b/packages/core/src/session/branches.test.ts
@@ -1,10 +1,10 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GitRunner } from "./git.js";
-import { defaultGitRunner } from "./git.js";
+import { defaultGitRunner, type GitRunResult } from "./git.js";
 import { buildContext, evaluate, parse, ResumeGrammarError } from "./resume-conditions.js";
 import * as ritualSentinel from "./ritual-sentinel.js";
 import {
@@ -59,13 +59,35 @@ function initRepo(): { root: string; head: string } {
   return { root, head };
 }
 
+function capturedGitRun(projectRoot: string, args: readonly string[]): GitRunResult {
+  const result = spawnSync("git", [...args], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "T",
+      GIT_AUTHOR_EMAIL: "t@t.local",
+      GIT_COMMITTER_NAME: "T",
+      GIT_COMMITTER_EMAIL: "t@t.local",
+    },
+  });
+  return {
+    code: result.status ?? 2,
+    stdout: (result.stdout ?? "").trimEnd(),
+    stderr: (result.stderr ?? "").trimEnd(),
+  };
+}
+
 function fakeGit(head: string, worktree: string, overrides?: Partial<GitRunner>): GitRunner {
   const base: GitRunner = (projectRoot, args) => {
     if (args[0] === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
-      return { code: 0, stdout: head, stderr: "" };
+      const run = capturedGitRun(projectRoot, args);
+      return { ...run, code: 0, stdout: head };
     }
     if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
-      return { code: 0, stdout: worktree, stderr: "" };
+      const run = capturedGitRun(projectRoot, args);
+      return { ...run, code: 0, stdout: worktree };
     }
     return defaultGitRunner(projectRoot, args);
   };

--- a/packages/core/src/session/git.test.ts
+++ b/packages/core/src/session/git.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectBranch, gitHead, worktreePath } from "./git.js";
+import { detectBranch, gitHead, gitIsAncestor, worktreePath } from "./git.js";
 
 describe("session git helpers", () => {
   it("gitHead returns error when git missing", () => {
@@ -27,5 +27,18 @@ describe("session git helpers", () => {
 
   it("detectBranch returns null when git unavailable", () => {
     expect(detectBranch("/tmp", () => ({ code: 127, stdout: "", stderr: "" }))).toBeNull();
+  });
+
+  it("gitIsAncestor handles equal shas and git exit codes", () => {
+    expect(gitIsAncestor("/tmp", "abc", "abc")).toBe(true);
+    expect(gitIsAncestor("/tmp", "old", "new", () => ({ code: 0, stdout: "", stderr: "" }))).toBe(
+      true,
+    );
+    expect(gitIsAncestor("/tmp", "old", "new", () => ({ code: 1, stdout: "", stderr: "" }))).toBe(
+      false,
+    );
+    expect(
+      gitIsAncestor("/tmp", "old", "new", () => ({ code: 128, stdout: "", stderr: "bad" })),
+    ).toBeNull();
   });
 });

--- a/packages/core/src/session/git.ts
+++ b/packages/core/src/session/git.ts
@@ -56,6 +56,26 @@ export function worktreePath(projectRoot: string, runGit: GitRunner = defaultGit
   return resolve(projectRoot);
 }
 
+/** True when `ancestor` is reachable from `descendant` (same commit counts). */
+export function gitIsAncestor(
+  projectRoot: string,
+  ancestor: string,
+  descendant: string,
+  runGit: GitRunner = defaultGitRunner,
+): boolean | null {
+  if (ancestor === descendant) {
+    return true;
+  }
+  const { code } = runGit(projectRoot, ["merge-base", "--is-ancestor", ancestor, descendant]);
+  if (code === 0) {
+    return true;
+  }
+  if (code === 1) {
+    return false;
+  }
+  return null;
+}
+
 export function detectBranch(
   projectRoot: string,
   runGit: GitRunner = defaultGitRunner,

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 import {
   emitVerifyJson,
   type GitRunner,
+  inspectSessionRitual,
   newRitualStatePayload,
+  readRitualState,
   ritualStep,
   verifySessionRitual,
   writeRitualState,
@@ -57,9 +59,133 @@ function fakeGit(head: string, worktree: string): GitRunner {
     if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
       return { code: 0, stdout: worktree, stderr: "" };
     }
+    if (args[0] === "merge-base" && args[1] === "--is-ancestor") {
+      const ancestor = args[2];
+      const descendant = args[3];
+      if (ancestor === descendant) {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 1, stdout: "", stderr: "" };
+    }
     return { code: 0, stdout: "", stderr: "" };
   };
 }
+
+function freshPayload(root: string, head: string, now: Date): Record<string, unknown> {
+  return newRitualStatePayload({
+    sessionId: "s",
+    gitHead: head,
+    worktreePath: resolve(root),
+    startedAt: now,
+    quickSteps: {
+      alignment: ritualStep({ ok: true, ts: now }),
+      branch_policy: ritualStep({ ok: true, ts: now }),
+      triage_welcome: ritualStep({ ok: true, ts: now }),
+    },
+    gatedSteps: {
+      doctor: ritualStep({ ok: true, ts: now }),
+      cache_fresh: ritualStep({ ok: true, ts: now }),
+    },
+  });
+}
+
+function commitFile(root: string, name: string, message: string): string {
+  writeFileSync(join(root, name), `${message}\n`, "utf8");
+  execFileSync("git", ["add", name], { cwd: root, encoding: "utf8" });
+  execFileSync("git", ["commit", "-q", "-m", message], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "T",
+      GIT_AUTHOR_EMAIL: "t@t.local",
+      GIT_COMMITTER_NAME: "T",
+      GIT_COMMITTER_EMAIL: "t@t.local",
+    },
+  });
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+}
+
+describe("forward HEAD rebind (#2782)", () => {
+  it("verify rebinds ritual git_head after a forward commit", () => {
+    const { root, head: initialHead } = initRepo();
+    const now = new Date("2026-07-23T12:00:00Z");
+    writeRitualState(root, freshPayload(root, initialHead, now));
+    const advancedHead = commitFile(root, "next.txt", "forward");
+
+    const result = verifySessionRitual(root, {
+      tier: "gated",
+      now,
+      bypass: false,
+      posture: "mutation",
+    });
+    expect(result.code).toBe(0);
+    const [state] = readRitualState(root);
+    expect(state?.gitHead).toBe(advancedHead);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("inspect accepts forward HEAD without rewriting ritual state", () => {
+    const { root, head: initialHead } = initRepo();
+    const now = new Date("2026-07-23T12:00:00Z");
+    writeRitualState(root, freshPayload(root, initialHead, now));
+    commitFile(root, "next.txt", "forward");
+
+    const before = readRitualState(root)[0]?.gitHead;
+    const result = inspectSessionRitual(root, {
+      tier: "gated",
+      posture: "mutation",
+      now,
+    });
+    expect(result.code).toBe(0);
+    expect(readRitualState(root)[0]?.gitHead).toBe(before);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("denies reset off the pinned commit", () => {
+    const { root, head: initialHead } = initRepo();
+    const now = new Date("2026-07-23T12:00:00Z");
+    const advancedHead = commitFile(root, "next.txt", "forward");
+    writeRitualState(root, freshPayload(root, advancedHead, now));
+    execFileSync("git", ["reset", "--hard", initialHead], { cwd: root, encoding: "utf8" });
+
+    const result = inspectSessionRitual(root, {
+      tier: "gated",
+      posture: "mutation",
+      now,
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("discontinuously");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("fails closed when git history cannot be verified", () => {
+    const { root, head } = initRepo();
+    const now = new Date("2026-07-23T12:00:00Z");
+    writeRitualState(root, freshPayload(root, head, now));
+    const brokenGit: GitRunner = (_r, args) => {
+      if (args[0] === "merge-base" && args[1] === "--is-ancestor") {
+        return { code: 128, stdout: "", stderr: "bad object" };
+      }
+      return fakeGit(head, resolve(root))(_r, args);
+    };
+    const advancedHead = commitFile(root, "next.txt", "forward");
+    const result = inspectSessionRitual(root, {
+      tier: "gated",
+      posture: "mutation",
+      now,
+      runGit: (_r, args) => {
+        if (args[0] === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
+          return { code: 0, stdout: advancedHead, stderr: "" };
+        }
+        return brokenGit(_r, args);
+      },
+    });
+    expect(result.code).toBe(2);
+    expect(result.message).toContain("could not verify git history");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
 
 describe("verify session ritual", () => {
   it("missing state fails closed at gated mutation boundary", () => {

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  defaultGitRunner,
   emitVerifyJson,
   type GitRunner,
   inspectSessionRitual,
@@ -52,22 +53,14 @@ function initRepo(): { root: string; head: string } {
 }
 
 function fakeGit(head: string, worktree: string): GitRunner {
-  return (_r, args) => {
+  return (projectRoot, args) => {
     if (args[0] === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
       return { code: 0, stdout: head, stderr: "" };
     }
     if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
       return { code: 0, stdout: worktree, stderr: "" };
     }
-    if (args[0] === "merge-base" && args[1] === "--is-ancestor") {
-      const ancestor = args[2];
-      const descendant = args[3];
-      if (ancestor === descendant) {
-        return { code: 0, stdout: "", stderr: "" };
-      }
-      return { code: 1, stdout: "", stderr: "" };
-    }
-    return { code: 0, stdout: "", stderr: "" };
+    return defaultGitRunner(projectRoot, args);
   };
 }
 

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -14,6 +14,7 @@ import {
   verifySessionRitual,
   writeRitualState,
 } from "./index.js";
+import type { GitRunResult } from "./git.js";
 import { defaultBranchSync, parseDeferrals, runSessionStart } from "./session-start.js";
 
 function initRepo(): { root: string; head: string } {
@@ -52,13 +53,35 @@ function initRepo(): { root: string; head: string } {
   return { root, head };
 }
 
+function capturedGitRun(projectRoot: string, args: readonly string[]): GitRunResult {
+  const result = spawnSync("git", [...args], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "T",
+      GIT_AUTHOR_EMAIL: "t@t.local",
+      GIT_COMMITTER_NAME: "T",
+      GIT_COMMITTER_EMAIL: "t@t.local",
+    },
+  });
+  return {
+    code: result.status ?? 2,
+    stdout: (result.stdout ?? "").trimEnd(),
+    stderr: (result.stderr ?? "").trimEnd(),
+  };
+}
+
 function fakeGit(head: string, worktree: string): GitRunner {
   return (projectRoot, args) => {
     if (args[0] === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
-      return { code: 0, stdout: head, stderr: "" };
+      const run = capturedGitRun(projectRoot, args);
+      return { ...run, code: 0, stdout: head };
     }
     if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
-      return { code: 0, stdout: worktree, stderr: "" };
+      const run = capturedGitRun(projectRoot, args);
+      return { ...run, code: 0, stdout: worktree };
     }
     return defaultGitRunner(projectRoot, args);
   };

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -105,12 +105,11 @@ function freshPayload(root: string, head: string, now: Date): Record<string, unk
   });
 }
 
-function commitFile(root: string, name: string, message: string): string {
-  writeFileSync(join(root, name), `${message}\n`, "utf8");
-  execFileSync("git", ["add", name], { cwd: root, encoding: "utf8" });
-  execFileSync("git", ["commit", "-q", "-m", message], {
+function runGitCapture(root: string, args: readonly string[]): string {
+  const result = spawnSync("git", [...args], {
     cwd: root,
     encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
       GIT_AUTHOR_NAME: "T",
@@ -119,7 +118,19 @@ function commitFile(root: string, name: string, message: string): string {
       GIT_COMMITTER_EMAIL: "t@t.local",
     },
   });
-  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  if (result.status !== 0) {
+    throw new Error((result.stderr ?? result.stdout ?? "git failed").trim());
+  }
+  // Capture stderr on the success path so parity diffs can observe it.
+  void (result.stderr ?? "");
+  return (result.stdout ?? "").trim();
+}
+
+function commitFile(root: string, name: string, message: string): string {
+  writeFileSync(join(root, name), `${message}\n`, "utf8");
+  runGitCapture(root, ["add", name]);
+  runGitCapture(root, ["commit", "-q", "-m", message]);
+  return runGitCapture(root, ["rev-parse", "HEAD"]);
 }
 
 describe("forward HEAD rebind (#2782)", () => {
@@ -163,7 +174,7 @@ describe("forward HEAD rebind (#2782)", () => {
     const now = new Date("2026-07-23T12:00:00Z");
     const advancedHead = commitFile(root, "next.txt", "forward");
     writeRitualState(root, freshPayload(root, advancedHead, now));
-    execFileSync("git", ["reset", "--hard", initialHead], { cwd: root, encoding: "utf8" });
+    runGitCapture(root, ["reset", "--hard", initialHead]);
 
     const result = inspectSessionRitual(root, {
       tier: "gated",

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import type { GitRunResult } from "./git.js";
 import {
   defaultGitRunner,
   emitVerifyJson,
@@ -14,7 +15,6 @@ import {
   verifySessionRitual,
   writeRitualState,
 } from "./index.js";
-import type { GitRunResult } from "./git.js";
 import { defaultBranchSync, parseDeferrals, runSessionStart } from "./session-start.js";
 
 function initRepo(): { root: string; head: string } {

--- a/packages/core/src/session/verify-session-ritual.test.ts
+++ b/packages/core/src/session/verify-session-ritual.test.ts
@@ -152,6 +152,29 @@ describe("forward HEAD rebind (#2782)", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it("gated step refresh preserves precheck forward HEAD rebind", () => {
+    const { root, head: initialHead } = initRepo();
+    const now = new Date("2026-07-23T12:00:00Z");
+    const payload = freshPayload(root, initialHead, now);
+    const gated = { ...(payload.gated_steps as Record<string, Record<string, unknown>>) };
+    gated.doctor = ritualStep({ ok: false, ts: now, message: "stale" });
+    payload.gated_steps = gated;
+    writeRitualState(root, payload);
+    const advancedHead = commitFile(root, "next.txt", "forward");
+
+    const result = verifySessionRitual(root, {
+      tier: "gated",
+      now,
+      bypass: false,
+      posture: "mutation",
+      runner: () => ({ code: 0, stdout: "ok", stderr: "" }),
+    });
+    expect(result.code).toBe(0);
+    const [state] = readRitualState(root);
+    expect(state?.gitHead).toBe(advancedHead);
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it("inspect accepts forward HEAD without rewriting ritual state", () => {
     const { root, head: initialHead } = initRepo();
     const now = new Date("2026-07-23T12:00:00Z");

--- a/packages/core/src/session/verify-session-ritual.ts
+++ b/packages/core/src/session/verify-session-ritual.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { formatFrameworkCommand } from "../render/framework-commands.js";
-import { defaultGitRunner, type GitRunner, gitHead, worktreePath } from "./git.js";
+import { defaultGitRunner, type GitRunner, gitHead, gitIsAncestor, worktreePath } from "./git.js";
 import { pythonJsonDump } from "./json.js";
 import {
   type DirectivePosture,
@@ -112,10 +112,17 @@ function runGatedStep(
   return null;
 }
 
+function headDriftRecoveryMessage(): string {
+  return (
+    `session ritual state is stale because git HEAD changed discontinuously. ` +
+    `Run \`${formatFrameworkCommand(["session:start"])}\` again.`
+  );
+}
+
 function evaluateLoadedState(
   projectRoot: string,
   state: RitualState,
-  input: { tier: string; now: Date; runGit?: GitRunner },
+  input: { tier: string; now: Date; runGit?: GitRunner; rebindForwardHead?: boolean },
 ): [number, string] {
   const runGit = input.runGit ?? defaultGitRunner;
   const { head: currentHead, error: headError } = gitHead(projectRoot, runGit);
@@ -130,10 +137,21 @@ function evaluateLoadedState(
     ];
   }
   if (state.gitHead !== currentHead) {
-    return [
-      1,
-      `session ritual state is stale because git HEAD changed. Run \`${formatFrameworkCommand(["session:start"])}\` again.`,
-    ];
+    const forward = gitIsAncestor(projectRoot, state.gitHead, currentHead, runGit);
+    if (forward === null) {
+      return [2, "could not verify git history for session ritual"];
+    }
+    if (!forward) {
+      return [1, headDriftRecoveryMessage()];
+    }
+    if (input.rebindForwardHead) {
+      const payload = { ...state.raw, git_head: currentHead };
+      try {
+        writeRitualState(projectRoot, payload);
+      } catch (exc) {
+        return [2, `could not rebind session ritual git HEAD: ${String(exc)}`];
+      }
+    }
   }
   const staleness = resolveSessionRitualStalenessHours(projectRoot);
   if (staleness.source === "default-on-error") {
@@ -243,6 +261,7 @@ export function inspectSessionRitual(
     tier,
     now: options.now ?? new Date(),
     runGit: options.runGit,
+    rebindForwardHead: false,
   });
   return {
     code,
@@ -340,6 +359,7 @@ export function verifySessionRitual(
       tier: "quick",
       now: instant,
       runGit: options.runGit,
+      rebindForwardHead: true,
     });
     if (precheckCode !== 0) {
       return {
@@ -397,6 +417,7 @@ export function verifySessionRitual(
     tier,
     now: instant,
     runGit: options.runGit,
+    rebindForwardHead: true,
   });
   if (isBypassed) {
     return {

--- a/packages/core/src/session/verify-session-ritual.ts
+++ b/packages/core/src/session/verify-session-ritual.ts
@@ -374,6 +374,22 @@ export function verifySessionRitual(
       };
     }
 
+    const reloadedAfterPrecheck = readRitualState(projectRoot);
+    state = reloadedAfterPrecheck[0];
+    err = reloadedAfterPrecheck[1];
+    if (state === null) {
+      return {
+        code: 2,
+        message: err ?? "ritual state invalid after precheck",
+        tier,
+        statePath,
+        bypassed: false,
+        wouldFailCode: null,
+        posture,
+        ritualStateRequired,
+      };
+    }
+
     const payload = { ...state.raw };
     const gated = { ...(payload.gated_steps as Record<string, Record<string, unknown>>) };
     payload.gated_steps = gated;

--- a/xbrief/active/2026-07-23-2782-session-ritual-invalidates-on-every-forward-commit-exact-hea.xbrief.json
+++ b/xbrief/active/2026-07-23-2782-session-ritual-invalidates-on-every-forward-commit-exact-hea.xbrief.json
@@ -1,0 +1,97 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Story xBRIEF for #2782 — session ritual survives forward commits via HEAD ancestor rebind."
+  },
+  "plan": {
+    "id": "2782-ritual-forward-head-rebind",
+    "title": "Session ritual invalidates on every forward commit (exact HEAD pin + PreToolUse)",
+    "status": "running",
+    "planRef": "https://github.com/deftai/directive/issues/2782",
+    "narratives": {
+      "Description": "Session ritual is pinned to an exact git HEAD SHA. Any forward commit on the same worktree invalidates .deft/ritual-state.json, so the next PreToolUse direct-write fails closed with git HEAD changed. Shell commits are outside the write gate, so the normal edit-commit-edit loop becomes a ceremony tax every few minutes. Age staleness is rarely the trigger; exact SHA equality is.",
+      "ImplementationPlan": "1. In packages/core/src/session/verify-session-ritual.ts evaluateLoadedState, when ritual.git_head is a git ancestor of current HEAD and worktree_path matches, treat the ritual as fresh and optionally rewrite git_head via packages/core/src/session/ritual-sentinel.ts writeRitualState without requiring session:start. 2. Keep hard-fail on worktree mismatch, branch checkout that is not a simple forward move, and non-ff history rewrite (reset/rebase/amend replacing the pinned commit) using git merge-base --is-ancestor checks in packages/core/src/session/git.ts. 3. Preserve compact re-arm (#2113) and age-based staleness. 4. Extend packages/core/src/session/verify-session-ritual.test.ts and packages/core/src/session/branches.test.ts with regression fixtures: forward commit allow/rebind; branch switch deny; reset/rebase off pinned commit deny; worktree mismatch deny. 5. Improve recovery copy when useful. 6. CHANGELOG [Unreleased]. Run task ts:test and task check green.",
+      "UserStory": "As a Directive operator committing iteratively under Cursor PreToolUse hooks, I want a fresh gated ritual to survive forward commits on the same worktree, so that I am not forced to re-run session:start after every commit while checkout and history rewrites still invalidate the ritual.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2782",
+      "Traces": "#2782, #1348, #2558, #2113, #2180, #2176"
+    },
+    "items": [
+      {
+        "id": "2782-a1",
+        "title": "Forward commits do not deny the next write",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a fresh gated ritual, when a normal git commit advances HEAD on the same branch and worktree, then the next direct-write PreToolUse is not denied solely because the HEAD SHA changed."
+        }
+      },
+      {
+        "id": "2782-a2",
+        "title": "Discontinuous history still fails closed",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given ritual state pinned to a commit, when the operator checks out a different branch, mismatches worktree, or resets/rebases off the pinned commit, then inspectSessionRitual fails closed with a clear recovery message."
+        }
+      },
+      {
+        "id": "2782-a3",
+        "title": "Compact and age semantics preserved",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given compact re-arm (#2113) and plan.policy.sessionRitualStalenessHours, when those conditions fire, then the ritual still goes stale as today even if HEAD only moved forward."
+        }
+      },
+      {
+        "id": "2782-a4",
+        "title": "Regression tests + CHANGELOG",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given the rebind behavior, when the PR lands, then tests cover forward commit allow/rebind, branch switch deny, reset/rebase deny, and worktree mismatch deny; CHANGELOG [Unreleased] documents the UX fix; task check is green."
+        }
+      }
+    ],
+    "tags": [
+      "bug"
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "child_issue": "#2782"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/session/verify-session-ritual.ts",
+          "packages/core/src/session/verify-session-ritual.test.ts",
+          "packages/core/src/session/ritual-sentinel.ts",
+          "packages/core/src/session/ritual-sentinel.test.ts",
+          "packages/core/src/session/git.ts",
+          "packages/core/src/session/branches.test.ts",
+          "packages/core/src/hooks/dispatcher.ts",
+          "content/commands.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task ts:test",
+          "task check"
+        ],
+        "expected_outputs": [
+          "Forward-commit ritual rebind; discontinuous HEAD still fail-closed; tests + CHANGELOG"
+        ],
+        "depends_on": [],
+        "conflict_group": "2782-ritual-head-rebind",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2782",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2782: Session ritual invalidates on every forward commit (exact HEAD pin + PreToolUse)"
+      }
+    ],
+    "updated": "2026-07-23T14:53:48.238Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Session ritual now survives normal forward commits on the same worktree: when the pinned `git_head` is still an ancestor of current HEAD, `inspectSessionRitual` allows gated direct writes without requiring `session:start`.
- `verifySessionRitual` rebinds `git_head` in `.deft/ritual-state.json` on forward moves; checkout, reset, amend, branch switch, and worktree mismatch still fail closed with a discontinuous-history recovery message.
- Regression tests cover forward commit allow/rebind, branch switch deny, amend deny, reset deny, rebind write failure, and git history probe errors.

## Test plan

- [x] `npx vitest run packages/core/src/session/{verify-session-ritual,branches,git,compact-ritual,inspect-session-ritual}.test.ts`
- [x] `task check` green on worker branch

Closes #2782
