### PR TITLE
feat(check): in-engine content-hash task cache (#1713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **In-engine content-hash task cache (#1713).** `deft check` replays prior exit-0 results for unchanged cacheable gates from `.deft/cache/task/`; `--no-cache` and `deft cache:clear` escape hatches; `codeVersion` invalidates on upgrade; volatile gates opt out; runner auto-detect documents vitest/jest/go/pytest fast-lane conventions (full suite remains the merge gate per #1704). Public `@deft/types` contract deferred to #2784.
+
 ### Changed
 
 ### Fixed

--- a/content/docs/task-cache.md
+++ b/content/docs/task-cache.md
@@ -1,0 +1,37 @@
+# In-engine content-hash task cache (#1713)
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ⊗=MUST NOT.
+
+**See also**: [Issue #1713](https://github.com/deftai/directive/issues/1713) | [Issue #1704](https://github.com/deftai/directive/issues/1704) (process face) | [Issue #2784](https://github.com/deftai/directive/issues/2784) (public types follow-up)
+
+## Overview
+
+`deft check` can skip unchanged cacheable gates by replaying prior exit-0 results from a local content-hash cache. The cache ships inside the CLI — zero extra install for consumers — and directive dogfoods the same layer for its own gate stack.
+
+Cache entries live under `.deft/cache/task/` (gitignored, local-only).
+
+## Correctness guards
+
+- ! Cache only passes (exit `0`). Failures always re-run.
+- ! `codeVersion` (installed directive version) is part of every cache key.
+- ! Volatile gates opt out via `cacheable: false` on the internal registry.
+- ! Fail open to running when inputs cannot be enumerated — never fail open to passing.
+- Escape hatches: `deft check --no-cache`, `deft cache:clear`.
+
+## Runner affected-test delegation
+
+Affected-test **selection** stays with the consumer test runner. Directive detects the runner and documents the fast-lane convention; the merge gate still runs the full suite (#1704).
+
+| Runner | Detection | Fast-lane convention |
+| --- | --- | --- |
+| vitest | `package.json` lists `vitest`, or `plan.policy.testRunner = vitest` | `vitest --changed` |
+| jest | `package.json` lists `jest` / `@jest/core`, or policy override | `jest --onlyChanged` |
+| go | `go.mod` present, or policy override | `go test` (native package cache) |
+| pytest | `pytest.ini` / `pyproject.toml` / `requirements.txt`, or policy override | `pytest --testmon` |
+| none | No match after config + heuristics | Full suite at merge gate |
+
+Override: set `plan.policy.testRunner` in `PROJECT-DEFINITION.xbrief.json` to `vitest`, `jest`, `go`, `pytest`, or `none`.
+
+## Internal registry (v1)
+
+Gate contracts (`inputs`, `outputs`, `cacheable`, `codeVersion`) are **internal** to `@deftai/directive-core` until #2784 promotes a public `@deft/types` shape. Under-declaration lint runs over known read sets; incomplete enumeration disables caching for that task.

--- a/packages/cli/src/cache.test.ts
+++ b/packages/cli/src/cache.test.ts
@@ -9,6 +9,10 @@ describe("cache CLI wrapper", () => {
   it("invalidate on missing entry exits 0", () => {
     expect(main(["invalidate", "github-issue", "deftai/directive/99999"])).toBe(0);
   });
+
+  it("clear removes the task cache directory", () => {
+    expect(main(["clear", "--project-root", process.cwd()])).toBe(0);
+  });
 });
 
 describe("cache.ts entry", () => {

--- a/packages/cli/src/check.test.ts
+++ b/packages/cli/src/check.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@deftai/directive-core/check", () => ({
+  dispatchTaskCheck: vi.fn(() => 0),
+}));
+
+import { parseArgs } from "./check.js";
+
+describe("check CLI", () => {
+  it("parses --no-cache", () => {
+    expect(
+      parseArgs(["--framework-root", "/fw", "--project-root", "/proj", "--no-cache"]),
+    ).toEqual({
+      frameworkRoot: "/fw",
+      projectRoot: "/proj",
+      noCache: true,
+    });
+  });
+
+  it("rejects unknown flags", () => {
+    expect(parseArgs(["--wat"]).error).toMatch(/unrecognized argument/);
+  });
+});

--- a/packages/cli/src/check.test.ts
+++ b/packages/cli/src/check.test.ts
@@ -8,13 +8,13 @@ import { parseArgs } from "./check.js";
 
 describe("check CLI", () => {
   it("parses --no-cache", () => {
-    expect(
-      parseArgs(["--framework-root", "/fw", "--project-root", "/proj", "--no-cache"]),
-    ).toEqual({
-      frameworkRoot: "/fw",
-      projectRoot: "/proj",
-      noCache: true,
-    });
+    expect(parseArgs(["--framework-root", "/fw", "--project-root", "/proj", "--no-cache"])).toEqual(
+      {
+        frameworkRoot: "/fw",
+        projectRoot: "/proj",
+        noCache: true,
+      },
+    );
   });
 
   it("rejects unknown flags", () => {

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 /**
- * check.ts -- CLI wrapper for the context-aware `task check` orchestrator (#1854).
+ * check.ts -- CLI wrapper for the context-aware `task check` orchestrator (#1854, #1713).
  *
- * Usage: deft-ts check --framework-root <path> --project-root <path>
- *
- * Thin shim: parses args and delegates to dispatchTaskCheck in @deftai/directive-core/check.
+ * Usage: deft-ts check --framework-root <path> --project-root <path> [--no-cache]
  */
 import { fileURLToPath } from "node:url";
 import { dispatchTaskCheck } from "@deftai/directive-core/check";
@@ -12,6 +10,7 @@ import { dispatchTaskCheck } from "@deftai/directive-core/check";
 interface ParsedArgs {
   frameworkRoot?: string;
   projectRoot?: string;
+  noCache?: boolean;
   error?: string;
 }
 
@@ -37,6 +36,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       i++;
     } else if (arg.startsWith("--project-root=")) {
       parsed.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg === "--no-cache") {
+      parsed.noCache = true;
     } else {
       return { ...parsed, error: `unrecognized argument: ${arg}` };
     }
@@ -54,7 +55,7 @@ export function run(argv: string[]): number {
     process.stderr.write("check: --framework-root and --project-root are required\n");
     return 2;
   }
-  return dispatchTaskCheck(args.frameworkRoot, args.projectRoot);
+  return dispatchTaskCheck(args.frameworkRoot, args.projectRoot, { noCache: args.noCache });
 }
 
 /* v8 ignore start -- entry guard */

--- a/packages/cli/src/cli-router/route-argv.ts
+++ b/packages/cli/src/cli-router/route-argv.ts
@@ -76,6 +76,7 @@ export const SUBCOMMAND_ROUTES: Readonly<Record<string, readonly [string, string
   "cache:invalidate": ["cache", "invalidate"],
   "cache:fetch-all": ["cache", "fetch-all"],
   "cache:prune": ["cache", "prune"],
+  "cache:clear": ["cache", "clear"],
   "policy:show": ["policy", "show"],
   "policy:enforce-branches": ["policy", "enforce-branches"],
   "policy:allow-direct-commits": ["policy", "allow-direct-commits"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/cache/index.d.ts",
       "default": "./dist/cache/index.js"
     },
+    "./cache/task-cache": {
+      "types": "./dist/cache/task-cache/index.d.ts",
+      "default": "./dist/cache/task-cache/index.js"
+    },
     "./doctor": {
       "types": "./dist/doctor/index.d.ts",
       "default": "./dist/doctor/index.js"

--- a/packages/core/src/cache/main.ts
+++ b/packages/core/src/cache/main.ts
@@ -49,12 +49,16 @@ function cmdClear(args: string[]): number {
       throw new CacheError(`unexpected argument: ${arg}`);
     }
   }
-  const code = clearTaskCache(projectRoot);
-  if (code !== 0) {
+  const result = clearTaskCache(projectRoot);
+  if (result.code !== 0) {
     process.stderr.write("cache clear: failed to remove task cache directory\n");
     return 1;
   }
-  process.stdout.write(`cache clear: removed task cache under ${projectRoot}\n`);
+  if (result.removed) {
+    process.stdout.write(`cache clear: removed task cache under ${projectRoot}\n`);
+  } else {
+    process.stdout.write(`cache clear: no task cache present under ${projectRoot}\n`);
+  }
   return 0;
 }
 

--- a/packages/core/src/cache/main.ts
+++ b/packages/core/src/cache/main.ts
@@ -16,8 +16,8 @@ import {
 import { cacheFetchAll, cacheRefreshClosed } from "./fetch.js";
 import { pythonBool, pythonJsonPretty } from "./json.js";
 import { cacheGet, cacheInvalidate, cachePrune, cachePruneToCap, cachePut } from "./operations.js";
-import { clearTaskCache } from "./task-cache/store.js";
 import { resolveCaps } from "./quota.js";
+import { clearTaskCache } from "./task-cache/store.js";
 
 function usage(): void {
   process.stderr.write("usage: cache [-h] {put,get,invalidate,fetch-all,prune,clear} ...\n");

--- a/packages/core/src/cache/main.ts
+++ b/packages/core/src/cache/main.ts
@@ -16,7 +16,12 @@ import {
 import { cacheFetchAll, cacheRefreshClosed } from "./fetch.js";
 import { pythonBool, pythonJsonPretty } from "./json.js";
 import { cacheGet, cacheInvalidate, cachePrune, cachePruneToCap, cachePut } from "./operations.js";
+import { clearTaskCache } from "./task-cache/store.js";
 import { resolveCaps } from "./quota.js";
+
+function usage(): void {
+  process.stderr.write("usage: cache [-h] {put,get,invalidate,fetch-all,prune,clear} ...\n");
+}
 
 function normaliseLabelFilter(raw: string[] | undefined): string[] {
   if (!raw || raw.length === 0) return [];
@@ -28,8 +33,29 @@ function normaliseLabelFilter(raw: string[] | undefined): string[] {
   );
 }
 
-function usage(): void {
-  process.stderr.write("usage: cache [-h] {put,get,invalidate,fetch-all,prune} ...\n");
+function cmdClear(args: string[]): number {
+  let projectRoot = process.cwd();
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--project-root") {
+      const next = args[i + 1];
+      if (next !== undefined) {
+        projectRoot = next;
+      }
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      projectRoot = arg.slice("--project-root=".length);
+    } else {
+      throw new CacheError(`unexpected argument: ${arg}`);
+    }
+  }
+  const code = clearTaskCache(projectRoot);
+  if (code !== 0) {
+    process.stderr.write("cache clear: failed to remove task cache directory\n");
+    return 1;
+  }
+  process.stdout.write(`cache clear: removed task cache under ${projectRoot}\n`);
+  return 0;
 }
 
 function cmdPut(args: string[]): number {
@@ -309,6 +335,8 @@ export function main(argv: readonly string[]): number {
         return cmdFetchAll(rest);
       case "prune":
         return cmdPrune(rest);
+      case "clear":
+        return cmdClear(rest);
       default:
         usage();
         process.stderr.write(`cache: error: argument cmd: invalid choice: '${cmd}'\n`);

--- a/packages/core/src/cache/task-cache/constants.ts
+++ b/packages/core/src/cache/task-cache/constants.ts
@@ -1,0 +1,4 @@
+/** On-disk root for content-hash task cache entries (#1713). */
+export const DEFAULT_TASK_CACHE_ROOT = ".deft/cache/task";
+
+export const TASK_CACHE_MANIFEST = "entry.json";

--- a/packages/core/src/cache/task-cache/executor.ts
+++ b/packages/core/src/cache/task-cache/executor.ts
@@ -9,14 +9,7 @@ import type { RunWithCacheOptions, TaskRunResult } from "./types.js";
  * - Non-cacheable / incomplete inputs fail open to running.
  */
 export function runWithCache(options: RunWithCacheOptions): TaskRunResult {
-  const {
-    projectRoot,
-    contract,
-    codeVersion,
-    noCache = false,
-    cacheRoot,
-    runner,
-  } = options;
+  const { projectRoot, contract, codeVersion, noCache = false, cacheRoot, runner } = options;
 
   if (noCache || !contract.cacheable) {
     const live = runner();

--- a/packages/core/src/cache/task-cache/executor.ts
+++ b/packages/core/src/cache/task-cache/executor.ts
@@ -1,0 +1,68 @@
+import { composeCacheKey, hashTaskInputs } from "./hash.js";
+import { readCachedTaskRecord, writeCachedTaskRecord } from "./store.js";
+import type { RunWithCacheOptions, TaskRunResult } from "./types.js";
+
+/**
+ * Run a task with content-hash caching (#1713).
+ * - Only exit-0 results are stored.
+ * - Failures always re-run.
+ * - Non-cacheable / incomplete inputs fail open to running.
+ */
+export function runWithCache(options: RunWithCacheOptions): TaskRunResult {
+  const {
+    projectRoot,
+    contract,
+    codeVersion,
+    noCache = false,
+    cacheRoot,
+    runner,
+  } = options;
+
+  if (noCache || !contract.cacheable) {
+    const live = runner();
+    return { ...live, fromCache: false };
+  }
+
+  const effectiveVersion = contract.codeVersion ?? codeVersion;
+  const enumeration = hashTaskInputs(projectRoot, contract, process.env);
+  if (!enumeration.complete) {
+    const live = runner();
+    return { ...live, fromCache: false };
+  }
+
+  const cacheKey = composeCacheKey(contract.id, enumeration.digest, effectiveVersion);
+  const cached = readCachedTaskRecord(projectRoot, cacheKey, cacheRoot);
+  if (cached !== null && cached.codeVersion === effectiveVersion) {
+    if (cached.stdout.length > 0) {
+      process.stdout.write(cached.stdout);
+    }
+    if (cached.stderr.length > 0) {
+      process.stderr.write(cached.stderr);
+    }
+    return {
+      exitCode: cached.exitCode,
+      stdout: cached.stdout,
+      stderr: cached.stderr,
+      fromCache: true,
+    };
+  }
+
+  const live = runner();
+  if (live.exitCode === 0) {
+    writeCachedTaskRecord(
+      projectRoot,
+      cacheKey,
+      {
+        taskId: contract.id,
+        inputsHash: enumeration.digest,
+        codeVersion: effectiveVersion,
+        exitCode: live.exitCode,
+        stdout: live.stdout,
+        stderr: live.stderr,
+        storedAt: new Date().toISOString(),
+      },
+      cacheRoot,
+    );
+  }
+  return { ...live, fromCache: false };
+}

--- a/packages/core/src/cache/task-cache/hash.ts
+++ b/packages/core/src/cache/task-cache/hash.ts
@@ -87,7 +87,12 @@ export function hashTaskInputs(
   const fileHashes: Record<string, string> = {};
   for (const rel of files) {
     const abs = resolve(projectRoot, rel);
-    fileHashes[rel] = hashFile(abs);
+    try {
+      fileHashes[rel] = hashFile(abs);
+    } catch {
+      // Fail open: a file removed/unreadable between glob and read must not crash check.
+      return { complete: false, digest: "" };
+    }
   }
 
   const payload = {

--- a/packages/core/src/cache/task-cache/hash.ts
+++ b/packages/core/src/cache/task-cache/hash.ts
@@ -1,0 +1,104 @@
+import { createHash } from "node:crypto";
+import { globSync, readFileSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import type { TaskContract, TaskInputSpec } from "./types.js";
+
+export interface InputEnumeration {
+  readonly complete: boolean;
+  readonly digest: string;
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableJson(obj[key])}`).join(",")}}`;
+}
+
+function hashFile(path: string): string {
+  const hash = createHash("sha256");
+  hash.update(readFileSync(path));
+  return hash.digest("hex");
+}
+
+/** Expand declared globs under projectRoot; returns sorted relative paths. */
+export function expandInputGlobs(projectRoot: string, spec: TaskInputSpec): string[] {
+  const root = resolve(projectRoot);
+  const globs = spec.globs ?? [];
+  const paths = new Set<string>();
+  for (const pattern of globs) {
+    let matches: string[];
+    try {
+      matches = globSync(pattern, { cwd: root }).filter((match) => {
+        try {
+          return !statSync(resolve(root, match)).isDirectory();
+        } catch {
+          return true;
+        }
+      });
+    } catch {
+      return [];
+    }
+    for (const match of matches) {
+      paths.add(relative(root, resolve(root, match)).replace(/\\/g, "/"));
+    }
+  }
+  return [...paths].sort();
+}
+
+/** Collect env values for declared keys (missing vars map to empty string). */
+export function collectEnvValues(spec: TaskInputSpec, env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of spec.env ?? []) {
+    out[key] = env[key] ?? "";
+  }
+  return out;
+}
+
+/**
+ * Hash declared inputs. Returns `complete: false` when no inputs are declared
+ * (fail open to running — never cache without explicit enumeration).
+ */
+export function hashTaskInputs(
+  projectRoot: string,
+  contract: TaskContract,
+  env: NodeJS.ProcessEnv,
+): InputEnumeration {
+  const spec = contract.inputs;
+  const hasGlobs = (spec.globs?.length ?? 0) > 0;
+  const hasEnv = (spec.env?.length ?? 0) > 0;
+  if (!hasGlobs && !hasEnv) {
+    return { complete: false, digest: "" };
+  }
+
+  const files = expandInputGlobs(projectRoot, spec);
+  if (hasGlobs && files.length === 0) {
+    return { complete: false, digest: "" };
+  }
+
+  const fileHashes: Record<string, string> = {};
+  for (const rel of files) {
+    const abs = resolve(projectRoot, rel);
+    fileHashes[rel] = hashFile(abs);
+  }
+
+  const payload = {
+    taskId: contract.id,
+    files: fileHashes,
+    env: collectEnvValues(spec, env),
+  };
+  const digest = createHash("sha256").update(stableJson(payload)).digest("hex");
+  return { complete: true, digest };
+}
+
+/** Compose the final cache key digest including codeVersion. */
+export function composeCacheKey(taskId: string, inputsHash: string, codeVersion: string): string {
+  return createHash("sha256")
+    .update(stableJson({ taskId, inputsHash, codeVersion }))
+    .digest("hex");
+}

--- a/packages/core/src/cache/task-cache/hash.ts
+++ b/packages/core/src/cache/task-cache/hash.ts
@@ -52,7 +52,10 @@ export function expandInputGlobs(projectRoot: string, spec: TaskInputSpec): stri
 }
 
 /** Collect env values for declared keys (missing vars map to empty string). */
-export function collectEnvValues(spec: TaskInputSpec, env: NodeJS.ProcessEnv): Record<string, string> {
+export function collectEnvValues(
+  spec: TaskInputSpec,
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
   const out: Record<string, string> = {};
   for (const key of spec.env ?? []) {
     out[key] = env[key] ?? "";
@@ -98,7 +101,5 @@ export function hashTaskInputs(
 
 /** Compose the final cache key digest including codeVersion. */
 export function composeCacheKey(taskId: string, inputsHash: string, codeVersion: string): string {
-  return createHash("sha256")
-    .update(stableJson({ taskId, inputsHash, codeVersion }))
-    .digest("hex");
+  return createHash("sha256").update(stableJson({ taskId, inputsHash, codeVersion })).digest("hex");
 }

--- a/packages/core/src/cache/task-cache/index.ts
+++ b/packages/core/src/cache/task-cache/index.ts
@@ -1,0 +1,29 @@
+import { lintTaskRegistry } from "./lint.js";
+import { TASK_REGISTRY } from "./registry.js";
+
+export { clearTaskCache, readCachedTaskRecord, taskCacheRoot, writeCachedTaskRecord } from "./store.js";
+export { composeCacheKey, expandInputGlobs, hashTaskInputs } from "./hash.js";
+export { runWithCache } from "./executor.js";
+export {
+  defaultNonCacheableContract,
+  lookupTaskContract,
+  resolveTaskContract,
+  TASK_REGISTRY,
+} from "./registry.js";
+export { lintTaskContract, lintTaskRegistry } from "./lint.js";
+export type {
+  CachedTaskRecord,
+  RegistryLintFinding,
+  RunWithCacheOptions,
+  TaskContract,
+  TaskInputSpec,
+  TaskRunResult,
+} from "./types.js";
+export { DEFAULT_TASK_CACHE_ROOT, TASK_CACHE_MANIFEST } from "./constants.js";
+
+/** Lint the shipped registry; under-declared cacheable tasks fail closed. */
+export function lintShippedRegistry(): { ok: boolean; findings: ReturnType<typeof lintTaskRegistry> } {
+  const findings = lintTaskRegistry(TASK_REGISTRY);
+  const blocking = findings.filter((f) => f.kind === "under-declared-input");
+  return { ok: blocking.length === 0, findings };
+}

--- a/packages/core/src/cache/task-cache/index.ts
+++ b/packages/core/src/cache/task-cache/index.ts
@@ -1,16 +1,22 @@
 import { lintTaskRegistry } from "./lint.js";
 import { TASK_REGISTRY } from "./registry.js";
 
-export { clearTaskCache, readCachedTaskRecord, taskCacheRoot, writeCachedTaskRecord } from "./store.js";
-export { composeCacheKey, expandInputGlobs, hashTaskInputs } from "./hash.js";
+export { DEFAULT_TASK_CACHE_ROOT, TASK_CACHE_MANIFEST } from "./constants.js";
 export { runWithCache } from "./executor.js";
+export { composeCacheKey, expandInputGlobs, hashTaskInputs } from "./hash.js";
+export { lintTaskContract, lintTaskRegistry } from "./lint.js";
 export {
   defaultNonCacheableContract,
   lookupTaskContract,
   resolveTaskContract,
   TASK_REGISTRY,
 } from "./registry.js";
-export { lintTaskContract, lintTaskRegistry } from "./lint.js";
+export {
+  clearTaskCache,
+  readCachedTaskRecord,
+  taskCacheRoot,
+  writeCachedTaskRecord,
+} from "./store.js";
 export type {
   CachedTaskRecord,
   RegistryLintFinding,
@@ -19,10 +25,12 @@ export type {
   TaskInputSpec,
   TaskRunResult,
 } from "./types.js";
-export { DEFAULT_TASK_CACHE_ROOT, TASK_CACHE_MANIFEST } from "./constants.js";
 
 /** Lint the shipped registry; under-declared cacheable tasks fail closed. */
-export function lintShippedRegistry(): { ok: boolean; findings: ReturnType<typeof lintTaskRegistry> } {
+export function lintShippedRegistry(): {
+  ok: boolean;
+  findings: ReturnType<typeof lintTaskRegistry>;
+} {
   const findings = lintTaskRegistry(TASK_REGISTRY);
   const blocking = findings.filter((f) => f.kind === "under-declared-input");
   return { ok: blocking.length === 0, findings };

--- a/packages/core/src/cache/task-cache/lint.test.ts
+++ b/packages/core/src/cache/task-cache/lint.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { lintShippedRegistry, lintTaskContract } from "./index.js";
+
+describe("task-cache registry lint", () => {
+  it("passes for the shipped registry", () => {
+    const { ok, findings } = lintShippedRegistry();
+    expect(ok).toBe(true);
+    expect(findings.filter((f) => f.kind === "under-declared-input")).toHaveLength(0);
+  });
+
+  it("flags under-declared cacheable tasks", () => {
+    const findings = lintTaskContract({
+      id: "bad",
+      cacheable: true,
+      inputs: { globs: ["a.txt"] },
+      knownReadSet: { globs: ["a.txt", "b.txt"] },
+    });
+    expect(findings.some((f) => f.kind === "under-declared-input")).toBe(true);
+  });
+});

--- a/packages/core/src/cache/task-cache/lint.ts
+++ b/packages/core/src/cache/task-cache/lint.ts
@@ -1,0 +1,51 @@
+import type { RegistryLintFinding, TaskContract, TaskInputSpec } from "./types.js";
+
+function diffSpec(superset: TaskInputSpec, declared: TaskInputSpec): string[] {
+  const findings: string[] = [];
+  for (const glob of superset.globs ?? []) {
+    const covered = (declared.globs ?? []).some(
+      (decl) => decl === glob || glob.startsWith(decl.replace(/\*+$/, "")),
+    );
+    if (!covered) {
+      findings.push(`glob '${glob}' missing from declared inputs`);
+    }
+  }
+  for (const envKey of superset.env ?? []) {
+    if (!(declared.env ?? []).includes(envKey)) {
+      findings.push(`env '${envKey}' missing from declared inputs`);
+    }
+  }
+  return findings;
+}
+
+export function lintTaskContract(contract: TaskContract): RegistryLintFinding[] {
+  const findings: RegistryLintFinding[] = [];
+  if (!contract.knownReadSet) {
+    return findings;
+  }
+  const missing = diffSpec(contract.knownReadSet, contract.inputs);
+  for (const detail of missing) {
+    if (contract.cacheable) {
+      findings.push({
+        taskId: contract.id,
+        kind: "under-declared-input",
+        detail,
+      });
+    } else {
+      findings.push({
+        taskId: contract.id,
+        kind: "non-cacheable",
+        detail: `${detail} (task marked non-cacheable)`,
+      });
+    }
+  }
+  return findings;
+}
+
+export function lintTaskRegistry(contracts: readonly TaskContract[]): RegistryLintFinding[] {
+  const all: RegistryLintFinding[] = [];
+  for (const contract of contracts) {
+    all.push(...lintTaskContract(contract));
+  }
+  return all;
+}

--- a/packages/core/src/cache/task-cache/lint.ts
+++ b/packages/core/src/cache/task-cache/lint.ts
@@ -1,10 +1,19 @@
 import type { RegistryLintFinding, TaskContract, TaskInputSpec } from "./types.js";
 
+/** Strip trailing `*` glob wildcards without regex (CodeQL ReDoS-safe). */
+function stripTrailingGlobStars(pattern: string): string {
+  let end = pattern.length;
+  while (end > 0 && pattern[end - 1] === "*") {
+    end--;
+  }
+  return pattern.slice(0, end);
+}
+
 function diffSpec(superset: TaskInputSpec, declared: TaskInputSpec): string[] {
   const findings: string[] = [];
   for (const glob of superset.globs ?? []) {
     const covered = (declared.globs ?? []).some(
-      (decl) => decl === glob || glob.startsWith(decl.replace(/\*+$/, "")),
+      (decl) => decl === glob || glob.startsWith(stripTrailingGlobStars(decl)),
     );
     if (!covered) {
       findings.push(`glob '${glob}' missing from declared inputs`);

--- a/packages/core/src/cache/task-cache/registry.ts
+++ b/packages/core/src/cache/task-cache/registry.ts
@@ -1,0 +1,72 @@
+import type { TaskContract } from "./types.js";
+
+/** Internal gate/task registry for directive dogfood (#1713). */
+export const TASK_REGISTRY: readonly TaskContract[] = [
+  {
+    id: "verify:biome-config",
+    cacheable: true,
+    inputs: { globs: ["biome.json", "biome.jsonc"] },
+    knownReadSet: { globs: ["biome.json", "biome.jsonc"] },
+  },
+  {
+    id: "verify:encoding",
+    cacheable: true,
+    inputs: {
+      globs: ["biome.json", "packages/**/*.ts", "packages/**/*.tsx", "content/**/*"],
+    },
+    knownReadSet: {
+      globs: ["biome.json", "packages/**/*.ts", "packages/**/*.tsx", "content/**/*"],
+    },
+  },
+  {
+    id: "toolchain:check",
+    cacheable: true,
+    inputs: {
+      globs: ["package.json", "pnpm-lock.yaml", ".nvmrc", ".node-version"],
+      env: ["PATH"],
+    },
+    knownReadSet: {
+      globs: ["package.json", "pnpm-lock.yaml", ".nvmrc", ".node-version"],
+      env: ["PATH"],
+    },
+  },
+  {
+    id: "verify:branch",
+    cacheable: false,
+    inputs: { env: ["GIT_BRANCH", "DEFT_ALLOW_DEFAULT_BRANCH_COMMIT"] },
+    knownReadSet: {
+      globs: [".git/HEAD"],
+      env: ["GIT_BRANCH", "DEFT_ALLOW_DEFAULT_BRANCH_COMMIT"],
+    },
+  },
+  {
+    id: "verify:cache-fresh",
+    cacheable: false,
+    inputs: {},
+    knownReadSet: { globs: [".deft-cache/**/*", "xbrief/.triage-cache/**/*"] },
+  },
+  {
+    id: "doctor",
+    cacheable: false,
+    inputs: {},
+    knownReadSet: { globs: ["**/*"] },
+  },
+];
+
+const REGISTRY_MAP = new Map(TASK_REGISTRY.map((entry) => [entry.id, entry]));
+
+export function lookupTaskContract(taskId: string): TaskContract | undefined {
+  return REGISTRY_MAP.get(taskId);
+}
+
+export function defaultNonCacheableContract(taskId: string): TaskContract {
+  return {
+    id: taskId,
+    cacheable: false,
+    inputs: {},
+  };
+}
+
+export function resolveTaskContract(taskId: string): TaskContract {
+  return lookupTaskContract(taskId) ?? defaultNonCacheableContract(taskId);
+}

--- a/packages/core/src/cache/task-cache/store.ts
+++ b/packages/core/src/cache/task-cache/store.ts
@@ -4,7 +4,11 @@ import { assertWriteTargetSafe } from "../../fs/projection-containment.js";
 import { DEFAULT_TASK_CACHE_ROOT, TASK_CACHE_MANIFEST } from "./constants.js";
 import type { CachedTaskRecord } from "./types.js";
 
-function entryDir(projectRoot: string, cacheKey: string, cacheRoot = DEFAULT_TASK_CACHE_ROOT): string {
+function entryDir(
+  projectRoot: string,
+  cacheKey: string,
+  cacheRoot = DEFAULT_TASK_CACHE_ROOT,
+): string {
   return join(resolve(projectRoot), cacheRoot, cacheKey.slice(0, 2), cacheKey);
 }
 

--- a/packages/core/src/cache/task-cache/store.ts
+++ b/packages/core/src/cache/task-cache/store.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { assertWriteTargetSafe } from "../../fs/projection-containment.js";
 import { DEFAULT_TASK_CACHE_ROOT, TASK_CACHE_MANIFEST } from "./constants.js";
@@ -46,13 +46,24 @@ export function writeCachedTaskRecord(
   writeFileSync(manifest, `${JSON.stringify(record, null, 2)}\n`, "utf8");
 }
 
-export function clearTaskCache(projectRoot: string, cacheRoot = DEFAULT_TASK_CACHE_ROOT): number {
+export interface ClearTaskCacheResult {
+  readonly code: number;
+  readonly removed: boolean;
+}
+
+export function clearTaskCache(
+  projectRoot: string,
+  cacheRoot = DEFAULT_TASK_CACHE_ROOT,
+): ClearTaskCacheResult {
   const root = join(resolve(projectRoot), cacheRoot);
+  if (!existsSync(root)) {
+    return { code: 0, removed: false };
+  }
   try {
     rmSync(root, { recursive: true, force: true });
-    return 0;
+    return { code: 0, removed: true };
   } catch {
-    return 1;
+    return { code: 1, removed: false };
   }
 }
 

--- a/packages/core/src/cache/task-cache/store.ts
+++ b/packages/core/src/cache/task-cache/store.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { assertWriteTargetSafe } from "../../fs/projection-containment.js";
+import { DEFAULT_TASK_CACHE_ROOT, TASK_CACHE_MANIFEST } from "./constants.js";
+import type { CachedTaskRecord } from "./types.js";
+
+function entryDir(projectRoot: string, cacheKey: string, cacheRoot = DEFAULT_TASK_CACHE_ROOT): string {
+  return join(resolve(projectRoot), cacheRoot, cacheKey.slice(0, 2), cacheKey);
+}
+
+export function readCachedTaskRecord(
+  projectRoot: string,
+  cacheKey: string,
+  cacheRoot = DEFAULT_TASK_CACHE_ROOT,
+): CachedTaskRecord | null {
+  const manifest = join(entryDir(projectRoot, cacheKey, cacheRoot), TASK_CACHE_MANIFEST);
+  try {
+    const raw = JSON.parse(readFileSync(manifest, "utf8")) as CachedTaskRecord;
+    if (raw.exitCode !== 0) {
+      return null;
+    }
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedTaskRecord(
+  projectRoot: string,
+  cacheKey: string,
+  record: CachedTaskRecord,
+  cacheRoot = DEFAULT_TASK_CACHE_ROOT,
+): void {
+  if (record.exitCode !== 0) {
+    return;
+  }
+  const dir = entryDir(projectRoot, cacheKey, cacheRoot);
+  const manifest = join(dir, TASK_CACHE_MANIFEST);
+  assertWriteTargetSafe(resolve(projectRoot), dir);
+  mkdirSync(dirname(manifest), { recursive: true });
+  assertWriteTargetSafe(resolve(projectRoot), manifest);
+  writeFileSync(manifest, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+}
+
+export function clearTaskCache(projectRoot: string, cacheRoot = DEFAULT_TASK_CACHE_ROOT): number {
+  const root = join(resolve(projectRoot), cacheRoot);
+  try {
+    rmSync(root, { recursive: true, force: true });
+    return 0;
+  } catch {
+    return 1;
+  }
+}
+
+export function taskCacheRoot(projectRoot: string, cacheRoot = DEFAULT_TASK_CACHE_ROOT): string {
+  return join(resolve(projectRoot), cacheRoot);
+}

--- a/packages/core/src/cache/task-cache/task-cache.test.ts
+++ b/packages/core/src/cache/task-cache/task-cache.test.ts
@@ -1,0 +1,174 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { composeCacheKey, hashTaskInputs } from "./hash.js";
+import { runWithCache } from "./executor.js";
+import { readCachedTaskRecord } from "./store.js";
+import type { TaskContract } from "./types.js";
+
+describe("task-cache hash", () => {
+  it("returns incomplete when no inputs are declared", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-task-cache-"));
+    const contract: TaskContract = { id: "demo", cacheable: true, inputs: {} };
+    expect(hashTaskInputs(root, contract, process.env).complete).toBe(false);
+  });
+
+  it("hashes declared files deterministically", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-task-cache-"));
+    writeFileSync(join(root, "alpha.txt"), "one", "utf8");
+    const contract: TaskContract = {
+      id: "demo",
+      cacheable: true,
+      inputs: { globs: ["alpha.txt"] },
+    };
+    const first = hashTaskInputs(root, contract, process.env);
+    const second = hashTaskInputs(root, contract, process.env);
+    expect(first.complete).toBe(true);
+    expect(first.digest).toBe(second.digest);
+  });
+
+  it("changes digest when file content changes", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-task-cache-"));
+    const file = join(root, "alpha.txt");
+    writeFileSync(file, "one", "utf8");
+    const contract: TaskContract = {
+      id: "demo",
+      cacheable: true,
+      inputs: { globs: ["alpha.txt"] },
+    };
+    const before = hashTaskInputs(root, contract, process.env).digest;
+    writeFileSync(file, "two", "utf8");
+    const after = hashTaskInputs(root, contract, process.env).digest;
+    expect(before).not.toBe(after);
+  });
+});
+
+describe("runWithCache", () => {
+  it("replays exit-0 cache hits and skips the runner", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-task-cache-"));
+    writeFileSync(join(root, "input.txt"), "stable", "utf8");
+    const contract: TaskContract = {
+      id: "demo-hit",
+      cacheable: true,
+      inputs: { globs: ["input.txt"] },
+    };
+    const enumeration = hashTaskInputs(root, contract, process.env);
+    const cacheKey = composeCacheKey("demo-hit", enumeration.digest, "1.0.0");
+    mkdirSync(join(root, ".deft", "cache", "task", cacheKey.slice(0, 2), cacheKey), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(root, ".deft", "cache", "task", cacheKey.slice(0, 2), cacheKey, "entry.json"),
+      JSON.stringify({
+        taskId: "demo-hit",
+        inputsHash: enumeration.digest,
+        codeVersion: "1.0.0",
+        exitCode: 0,
+        stdout: "cached-output\n",
+        stderr: "",
+        storedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+
+    let runs = 0;
+    const result = runWithCache({
+      projectRoot: root,
+      contract,
+      codeVersion: "1.0.0",
+      runner: () => {
+        runs += 1;
+        return { exitCode: 0, stdout: "live\n", stderr: "" };
+      },
+    });
+    expect(result.fromCache).toBe(true);
+    expect(result.stdout).toBe("cached-output\n");
+    expect(runs).toBe(0);
+  });
+
+  it("always re-runs failures and never stores them", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-task-cache-"));
+    writeFileSync(join(root, "input.txt"), "stable", "utf8");
+    const contract: TaskContract = {
+      id: "demo-fail",
+      cacheable: true,
+      inputs: { globs: ["input.txt"] },
+    };
+    let runs = 0;
+    const result = runWithCache({
+      projectRoot: root,
+      contract,
+      codeVersion: "1.0.0",
+      runner: () => {
+        runs += 1;
+        return { exitCode: 1, stdout: "", stderr: "boom" };
+      },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(runs).toBe(1);
+    const enumeration = hashTaskInputs(root, contract, process.env);
+    const cacheKey = composeCacheKey("demo-fail", enumeration.digest, "1.0.0");
+    expect(readCachedTaskRecord(root, cacheKey)).toBeNull();
+  });
+
+  it("invalidates when codeVersion changes", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-task-cache-"));
+    writeFileSync(join(root, "input.txt"), "stable", "utf8");
+    const contract: TaskContract = {
+      id: "demo-version",
+      cacheable: true,
+      inputs: { globs: ["input.txt"] },
+    };
+    let runs = 0;
+    runWithCache({
+      projectRoot: root,
+      contract,
+      codeVersion: "1.0.0",
+      runner: () => {
+        runs += 1;
+        return { exitCode: 0, stdout: "v1\n", stderr: "" };
+      },
+    });
+    const second = runWithCache({
+      projectRoot: root,
+      contract,
+      codeVersion: "2.0.0",
+      runner: () => {
+        runs += 1;
+        return { exitCode: 0, stdout: "v2\n", stderr: "" };
+      },
+    });
+    expect(second.fromCache).toBe(false);
+    expect(runs).toBe(2);
+  });
+
+  it("opts volatile tasks out via cacheable false", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-task-cache-"));
+    const contract: TaskContract = {
+      id: "demo-volatile",
+      cacheable: false,
+      inputs: { globs: ["input.txt"] },
+    };
+    let runs = 0;
+    runWithCache({
+      projectRoot: root,
+      contract,
+      codeVersion: "1.0.0",
+      runner: () => {
+        runs += 1;
+        return { exitCode: 0, stdout: "live\n", stderr: "" };
+      },
+    });
+    runWithCache({
+      projectRoot: root,
+      contract,
+      codeVersion: "1.0.0",
+      runner: () => {
+        runs += 1;
+        return { exitCode: 0, stdout: "live\n", stderr: "" };
+      },
+    });
+    expect(runs).toBe(2);
+  });
+});

--- a/packages/core/src/cache/task-cache/task-cache.test.ts
+++ b/packages/core/src/cache/task-cache/task-cache.test.ts
@@ -1,9 +1,9 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { composeCacheKey, hashTaskInputs } from "./hash.js";
 import { runWithCache } from "./executor.js";
+import { composeCacheKey, hashTaskInputs } from "./hash.js";
 import { readCachedTaskRecord } from "./store.js";
 import type { TaskContract } from "./types.js";
 

--- a/packages/core/src/cache/task-cache/types.ts
+++ b/packages/core/src/cache/task-cache/types.ts
@@ -1,0 +1,53 @@
+/** Internal gate/task contract (#1713). Public promotion deferred to #2784. */
+
+export interface TaskInputSpec {
+  /** Glob patterns relative to the project root. */
+  readonly globs?: readonly string[];
+  /** Environment variable names whose values affect the task outcome. */
+  readonly env?: readonly string[];
+}
+
+export interface TaskContract {
+  readonly id: string;
+  /** When false the task always runs and never stores a cache entry. */
+  readonly cacheable: boolean;
+  /** Override engine version in the cache key; defaults to installed directive version. */
+  readonly codeVersion?: string;
+  readonly inputs: TaskInputSpec;
+  /** Output globs for under-declaration lint (optional). */
+  readonly outputs?: readonly string[];
+  /** Superset of reads used by under-declaration lint. */
+  readonly knownReadSet?: TaskInputSpec;
+}
+
+export interface TaskRunResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly fromCache: boolean;
+}
+
+export interface CachedTaskRecord {
+  readonly taskId: string;
+  readonly inputsHash: string;
+  readonly codeVersion: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly storedAt: string;
+}
+
+export interface RunWithCacheOptions {
+  readonly projectRoot: string;
+  readonly contract: TaskContract;
+  readonly codeVersion: string;
+  readonly noCache?: boolean;
+  readonly cacheRoot?: string;
+  readonly runner: () => Pick<TaskRunResult, "exitCode" | "stdout" | "stderr">;
+}
+
+export interface RegistryLintFinding {
+  readonly taskId: string;
+  readonly kind: "under-declared-input" | "non-cacheable";
+  readonly detail: string;
+}

--- a/packages/core/src/check/cached-orchestrator.ts
+++ b/packages/core/src/check/cached-orchestrator.ts
@@ -1,0 +1,91 @@
+import { spawnSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { readCorePackageVersion } from "../engine-version.js";
+import { resolveTaskContract, runWithCache } from "../cache/task-cache/index.js";
+import type { TaskRunResult } from "../cache/task-cache/types.js";
+import { gatesForCheckTarget } from "./gate-lists.js";
+import { resolveCheckTarget, type CheckOrchestratorSeams } from "./orchestrator.js";
+
+export interface CachedCheckOptions extends CheckOrchestratorSeams {
+  readonly onGateStart?: (gateId: string) => void;
+  readonly onGateComplete?: (gateId: string, exitCode: number, fromCache: boolean) => void;
+  readonly gateSpawnFn?: (
+    gateId: string,
+    taskBin: string,
+    taskArgs: string[],
+    opts: { cwd: string; env?: NodeJS.ProcessEnv },
+  ) => Pick<TaskRunResult, "exitCode" | "stdout" | "stderr">;
+}
+
+function captureSpawn(
+  taskBin: string,
+  args: string[],
+  opts: { cwd: string; env?: NodeJS.ProcessEnv },
+): { exitCode: number; stdout: string; stderr: string } {
+  const result = spawnSync(taskBin, args, {
+    cwd: opts.cwd,
+    encoding: "utf8",
+    env: opts.env ?? process.env,
+  });
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+/**
+ * Run check gates sequentially with content-hash caching (#1713).
+ * Falls back to fail-open execution for undeclared / non-cacheable gates.
+ */
+export function dispatchCachedTaskCheck(
+  frameworkRoot: string,
+  projectRoot: string,
+  options: CachedCheckOptions = {},
+): number {
+  const resolvedFramework = resolve(frameworkRoot);
+  const resolvedProject = resolve(projectRoot);
+  const taskfilePath = join(resolvedFramework, "Taskfile.yml");
+  const taskBin = options.taskBin ?? "task";
+  const target = resolveCheckTarget(resolvedFramework, resolvedProject);
+  const cwd = target === "check:framework-source" ? resolvedFramework : resolvedProject;
+  const gates = gatesForCheckTarget(target);
+  const codeVersion = readCorePackageVersion();
+
+  if (gates.length === 0) {
+    process.stderr.write(`check: no gate list for target ${target}\n`);
+    return 2;
+  }
+
+  for (const gateId of gates) {
+    options.onGateStart?.(gateId);
+    const contract = resolveTaskContract(gateId);
+    const result = runWithCache({
+      projectRoot: cwd,
+      contract,
+      codeVersion,
+      noCache: options.noCache,
+      runner: () => {
+        const spawned = options.gateSpawnFn
+          ? options.gateSpawnFn(gateId, taskBin, [gateId, "--taskfile", taskfilePath], {
+              cwd,
+              env: options.env,
+            })
+          : captureSpawn(taskBin, [gateId, "--taskfile", taskfilePath], { cwd, env: options.env });
+        if (spawned.stdout.length > 0) {
+          process.stdout.write(spawned.stdout);
+        }
+        if (spawned.stderr.length > 0) {
+          process.stderr.write(spawned.stderr);
+        }
+        return spawned;
+      },
+    });
+    options.onGateComplete?.(gateId, result.exitCode, result.fromCache);
+    if (result.exitCode !== 0) {
+      return result.exitCode;
+    }
+  }
+
+  return 0;
+}

--- a/packages/core/src/check/cached-orchestrator.ts
+++ b/packages/core/src/check/cached-orchestrator.ts
@@ -1,10 +1,14 @@
 import { spawnSync } from "node:child_process";
 import { join, resolve } from "node:path";
-import { readCorePackageVersion } from "../engine-version.js";
-import { resolveTaskContract, runWithCache } from "../cache/task-cache/index.js";
+import {
+  lintShippedRegistry,
+  resolveTaskContract,
+  runWithCache,
+} from "../cache/task-cache/index.js";
 import type { TaskRunResult } from "../cache/task-cache/types.js";
+import { readCorePackageVersion } from "../engine-version.js";
+import { type CheckOrchestratorSeams, resolveCheckTarget } from "./context.js";
 import { gatesForCheckTarget } from "./gate-lists.js";
-import { resolveCheckTarget, type CheckOrchestratorSeams } from "./orchestrator.js";
 
 export interface CachedCheckOptions extends CheckOrchestratorSeams {
   readonly onGateStart?: (gateId: string) => void;
@@ -51,6 +55,16 @@ export function dispatchCachedTaskCheck(
   const cwd = target === "check:framework-source" ? resolvedFramework : resolvedProject;
   const gates = gatesForCheckTarget(target);
   const codeVersion = readCorePackageVersion();
+
+  const registryLint = lintShippedRegistry();
+  if (!registryLint.ok) {
+    for (const finding of registryLint.findings.filter((f) => f.kind === "under-declared-input")) {
+      process.stderr.write(
+        `check: task registry lint failed for ${finding.taskId}: ${finding.detail}\n`,
+      );
+    }
+    return 2;
+  }
 
   if (gates.length === 0) {
     process.stderr.write(`check: no gate list for target ${target}\n`);

--- a/packages/core/src/check/context.ts
+++ b/packages/core/src/check/context.ts
@@ -1,0 +1,52 @@
+import { existsSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+
+export interface CheckOrchestratorOptions {
+  readonly noCache?: boolean;
+  readonly useTaskCache?: boolean;
+}
+
+export interface CheckOrchestratorSeams extends CheckOrchestratorOptions {
+  /** Override the `task` binary path (default: "task"). */
+  readonly taskBin?: string;
+  /** Override the spawnSync implementation for unit testing. */
+  readonly spawnFn?: (
+    cmd: string,
+    args: string[],
+    opts: { cwd: string; stdio: string; env?: NodeJS.ProcessEnv; timeoutMs?: number },
+  ) => { status: number | null; signal?: NodeJS.Signals | null; error?: Error };
+  /** Child-process environment (default: process.env). */
+  readonly env?: NodeJS.ProcessEnv;
+  /** Wall-clock spawn timeout in milliseconds (default: none). */
+  readonly timeoutMs?: number;
+}
+
+/** True when `path` is the directive framework source checkout root. */
+export function isFrameworkRepoRoot(path: string): boolean {
+  const root = resolve(path);
+  return (
+    existsSync(join(root, "packages", "cli", "package.json")) &&
+    existsSync(join(root, "biome.json")) &&
+    existsSync(join(root, "Taskfile.yml"))
+  );
+}
+
+/** Return true when running in the framework's own source checkout (#1519). */
+export function isFrameworkSourceContext(frameworkRoot: string, projectRoot: string): boolean {
+  const fw = resolve(frameworkRoot);
+  const pr = resolve(projectRoot);
+  if (fw === pr) {
+    return true;
+  }
+  if (!isFrameworkRepoRoot(fw)) {
+    return false;
+  }
+  return pr.startsWith(`${fw}${sep}`);
+}
+
+/** Select the Taskfile target for the given context. */
+export function resolveCheckTarget(frameworkRoot: string, projectRoot: string): string {
+  return isFrameworkSourceContext(frameworkRoot, projectRoot)
+    ? "check:framework-source"
+    : "check:consumer";
+}

--- a/packages/core/src/check/gate-lists.ts
+++ b/packages/core/src/check/gate-lists.ts
@@ -1,0 +1,56 @@
+/** Gate execution order mirrors Taskfile.yml check targets (#1713 dogfood). */
+
+export const FRAMEWORK_CHECK_GATES: readonly string[] = [
+  "ts:check-lane",
+  "toolchain:check",
+  "verify:stubs",
+  "verify:links",
+  "verify:rule-ownership",
+  "verify:biome-config",
+  "verify:content-manifest",
+  "verify:skill-external-fetch-gate",
+  "verify:contract-drift",
+  "verify:cursor-tier1",
+  "verify:go-freeze",
+  "verify:bridge-drift",
+  "verify:branch",
+  "verify:encoding",
+  "verify:forward-coverage",
+  "verify:vbrief-conformance",
+  "verify:destructive-gh-verbs",
+  "verify:scm-boundary",
+  "verify:xbrief-drift",
+  "verify:no-task-runtime",
+  "verify:cache-fresh",
+  "verify:pack-drift",
+  "verify-wip-cap-framework-self-check",
+  "verify:orphan-active",
+  "verify:agents-md-budget",
+  "verify-eval-health-relocation-framework-check",
+  "verify-eval-triggers-relocation-framework-check",
+  "vbrief:validate",
+  "codebase:validate-structure",
+  "verify:codebase-map-fresh",
+  "verify-strategy-output",
+];
+
+export const CONSUMER_CHECK_GATES: readonly string[] = [
+  "doctor",
+  "toolchain:check-consumer",
+  "verify:branch",
+  "verify:cache-fresh",
+  "verify:wip-cap",
+  "verify:orphan-active",
+  "vbrief:validate",
+  "verify-strategy-output",
+];
+
+export function gatesForCheckTarget(target: string): readonly string[] {
+  if (target === "check:framework-source") {
+    return FRAMEWORK_CHECK_GATES;
+  }
+  if (target === "check:consumer") {
+    return CONSUMER_CHECK_GATES;
+  }
+  return [];
+}

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -1,7 +1,15 @@
-export type { CheckOrchestratorSeams } from "./orchestrator.js";
+export type { CheckOrchestratorOptions, CheckOrchestratorSeams } from "./orchestrator.js";
 export {
   dispatchTaskCheck,
   isFrameworkRepoRoot,
   isFrameworkSourceContext,
   resolveCheckTarget,
 } from "./orchestrator.js";
+export { dispatchCachedTaskCheck } from "./cached-orchestrator.js";
+export { CONSUMER_CHECK_GATES, FRAMEWORK_CHECK_GATES, gatesForCheckTarget } from "./gate-lists.js";
+export {
+  detectTestRunner,
+  runnerDetectionTable,
+  type RunnerDetectResult,
+  type TestRunnerKind,
+} from "./runner-detect.js";

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -1,3 +1,5 @@
+export { dispatchCachedTaskCheck } from "./cached-orchestrator.js";
+export { CONSUMER_CHECK_GATES, FRAMEWORK_CHECK_GATES, gatesForCheckTarget } from "./gate-lists.js";
 export type { CheckOrchestratorOptions, CheckOrchestratorSeams } from "./orchestrator.js";
 export {
   dispatchTaskCheck,
@@ -5,11 +7,9 @@ export {
   isFrameworkSourceContext,
   resolveCheckTarget,
 } from "./orchestrator.js";
-export { dispatchCachedTaskCheck } from "./cached-orchestrator.js";
-export { CONSUMER_CHECK_GATES, FRAMEWORK_CHECK_GATES, gatesForCheckTarget } from "./gate-lists.js";
 export {
   detectTestRunner,
-  runnerDetectionTable,
   type RunnerDetectResult,
+  runnerDetectionTable,
   type TestRunnerKind,
 } from "./runner-detect.js";

--- a/packages/core/src/check/orchestrator.test.ts
+++ b/packages/core/src/check/orchestrator.test.ts
@@ -202,7 +202,11 @@ describe("dispatchTaskCheck", () => {
       _opts: { cwd: string; stdio: string; timeoutMs?: number },
     ) => ({ status: null, signal: "SIGTERM" as const });
 
-    const code = dispatchTaskCheck("/root", "/root", { spawnFn, useTaskCache: false, timeoutMs: 60_000 });
+    const code = dispatchTaskCheck("/root", "/root", {
+      spawnFn,
+      useTaskCache: false,
+      timeoutMs: 60_000,
+    });
     expect(code).toBe(124);
     errWrite.mockRestore();
   });

--- a/packages/core/src/check/orchestrator.test.ts
+++ b/packages/core/src/check/orchestrator.test.ts
@@ -71,7 +71,7 @@ describe("dispatchTaskCheck", () => {
     };
 
     const root = "/home/user/deft";
-    const code = dispatchTaskCheck(root, root, { spawnFn });
+    const code = dispatchTaskCheck(root, root, { spawnFn, useTaskCache: false });
     expect(code).toBe(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]?.args[0]).toBe("check:framework-source");
@@ -87,7 +87,7 @@ describe("dispatchTaskCheck", () => {
 
     const framework = "/home/user/deft";
     const project = "/home/user/consumer-project";
-    const code = dispatchTaskCheck(framework, project, { spawnFn });
+    const code = dispatchTaskCheck(framework, project, { spawnFn, useTaskCache: false });
     expect(code).toBe(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]?.args[0]).toBe("check:consumer");
@@ -101,7 +101,7 @@ describe("dispatchTaskCheck", () => {
     };
 
     const root = "/home/user/deft";
-    dispatchTaskCheck(root, root, { spawnFn });
+    dispatchTaskCheck(root, root, { spawnFn, useTaskCache: false });
     expect(calls[0]?.cwd).toBe(resolve(root));
   });
 
@@ -114,7 +114,7 @@ describe("dispatchTaskCheck", () => {
 
     const framework = "/home/user/deft";
     const project = "/home/user/consumer";
-    dispatchTaskCheck(framework, project, { spawnFn });
+    dispatchTaskCheck(framework, project, { spawnFn, useTaskCache: false });
     expect(calls[0]?.cwd).toBe(resolve(project));
   });
 
@@ -125,7 +125,7 @@ describe("dispatchTaskCheck", () => {
       return { status: 0 };
     };
 
-    dispatchTaskCheck("/root", "/root", { taskBin: "my-task", spawnFn });
+    dispatchTaskCheck("/root", "/root", { taskBin: "my-task", spawnFn, useTaskCache: false });
     expect(calls[0]?.cmd).toBe("my-task");
   });
 
@@ -135,7 +135,7 @@ describe("dispatchTaskCheck", () => {
       return { status: null, error: new Error("task not found") };
     };
 
-    const code = dispatchTaskCheck("/root", "/root", { spawnFn });
+    const code = dispatchTaskCheck("/root", "/root", { spawnFn, useTaskCache: false });
     expect(code).toBe(2);
     errWrite.mockRestore();
   });
@@ -145,7 +145,7 @@ describe("dispatchTaskCheck", () => {
       return { status: null };
     };
 
-    const code = dispatchTaskCheck("/root", "/root", { spawnFn });
+    const code = dispatchTaskCheck("/root", "/root", { spawnFn, useTaskCache: false });
     expect(code).toBe(1);
   });
 
@@ -156,7 +156,7 @@ describe("dispatchTaskCheck", () => {
       return { status: 0 };
     };
 
-    dispatchTaskCheck("/my/framework", "/my/consumer", { spawnFn });
+    dispatchTaskCheck("/my/framework", "/my/consumer", { spawnFn, useTaskCache: false });
     const taskfileIdx = calls[0]?.args.indexOf("--taskfile") ?? -1;
     expect(taskfileIdx).toBeGreaterThan(-1);
     const taskfilePath = calls[0]?.args[taskfileIdx + 1];
@@ -168,7 +168,7 @@ describe("dispatchTaskCheck", () => {
       return { status: 42 };
     };
 
-    const code = dispatchTaskCheck("/root", "/root", { spawnFn });
+    const code = dispatchTaskCheck("/root", "/root", { spawnFn, useTaskCache: false });
     expect(code).toBe(42);
   });
 
@@ -188,7 +188,7 @@ describe("dispatchTaskCheck", () => {
       DEFT_ALLOW_DEFAULT_BRANCH_COMMIT: "1",
       DEFT_RELEASE_PREFLIGHT: "1",
     };
-    dispatchTaskCheck("/root", "/root", { spawnFn, env });
+    dispatchTaskCheck("/root", "/root", { spawnFn, useTaskCache: false, env });
     expect(calls[0]?.env?.FOO).toBe("bar");
     expect(calls[0]?.env?.DEFT_ALLOW_DEFAULT_BRANCH_COMMIT).toBe("1");
     expect(calls[0]?.env?.DEFT_RELEASE_PREFLIGHT).toBe("1");
@@ -202,7 +202,7 @@ describe("dispatchTaskCheck", () => {
       _opts: { cwd: string; stdio: string; timeoutMs?: number },
     ) => ({ status: null, signal: "SIGTERM" as const });
 
-    const code = dispatchTaskCheck("/root", "/root", { spawnFn, timeoutMs: 60_000 });
+    const code = dispatchTaskCheck("/root", "/root", { spawnFn, useTaskCache: false, timeoutMs: 60_000 });
     expect(code).toBe(124);
     errWrite.mockRestore();
   });
@@ -214,6 +214,7 @@ describe("dispatchTaskCheck", () => {
     const errWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const code = dispatchTaskCheck("/tmp/fake-fw", "/tmp/fake-fw", {
       taskBin: "/absolutely-nonexistent-binary-that-cannot-exist",
+      useTaskCache: false,
     });
     expect(code).toBe(2);
     errWrite.mockRestore();

--- a/packages/core/src/check/orchestrator.ts
+++ b/packages/core/src/check/orchestrator.ts
@@ -17,7 +17,14 @@ import { existsSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 
 /** Seams for test isolation (allow injecting a custom task runner). */
-export interface CheckOrchestratorSeams {
+import { dispatchCachedTaskCheck } from "./cached-orchestrator.js";
+
+export interface CheckOrchestratorOptions {
+  readonly noCache?: boolean;
+  readonly useTaskCache?: boolean;
+}
+
+export interface CheckOrchestratorSeams extends CheckOrchestratorOptions {
   /** Override the `task` binary path (default: "task"). */
   readonly taskBin?: string;
   /** Override the spawnSync implementation for unit testing. */
@@ -96,6 +103,12 @@ export function dispatchTaskCheck(
 ): number {
   const resolvedFramework = resolve(frameworkRoot);
   const resolvedProject = resolve(projectRoot);
+  const useTaskCache = seams.useTaskCache !== false && !seams.noCache;
+
+  if (useTaskCache) {
+    return dispatchCachedTaskCheck(resolvedFramework, resolvedProject, seams);
+  }
+
   const taskfilePath = join(resolvedFramework, "Taskfile.yml");
   const taskBin = seams.taskBin ?? "task";
 

--- a/packages/core/src/check/orchestrator.ts
+++ b/packages/core/src/check/orchestrator.ts
@@ -13,80 +13,12 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
-
-/** Seams for test isolation (allow injecting a custom task runner). */
+import { join, resolve } from "node:path";
 import { dispatchCachedTaskCheck } from "./cached-orchestrator.js";
+import { type CheckOrchestratorSeams, resolveCheckTarget } from "./context.js";
 
-export interface CheckOrchestratorOptions {
-  readonly noCache?: boolean;
-  readonly useTaskCache?: boolean;
-}
-
-export interface CheckOrchestratorSeams extends CheckOrchestratorOptions {
-  /** Override the `task` binary path (default: "task"). */
-  readonly taskBin?: string;
-  /** Override the spawnSync implementation for unit testing. */
-  readonly spawnFn?: (
-    cmd: string,
-    args: string[],
-    opts: { cwd: string; stdio: string; env?: NodeJS.ProcessEnv; timeoutMs?: number },
-  ) => { status: number | null; signal?: NodeJS.Signals | null; error?: Error };
-  /** Child-process environment (default: process.env). */
-  readonly env?: NodeJS.ProcessEnv;
-  /** Wall-clock spawn timeout in milliseconds (default: none). */
-  readonly timeoutMs?: number;
-}
-
-/**
- * True when `path` is the directive framework source checkout root (not a
- * vendored `.deft/core` content deposit). Used to distinguish a maintainer
- * running `task check` from a subdirectory (#2220) from a consumer install.
- */
-export function isFrameworkRepoRoot(path: string): boolean {
-  const root = resolve(path);
-  return (
-    existsSync(join(root, "packages", "cli", "package.json")) &&
-    existsSync(join(root, "biome.json")) &&
-    existsSync(join(root, "Taskfile.yml"))
-  );
-}
-
-/**
- * Return true when running in the framework's own source checkout (#1519).
- *
- * Mirrors `is_framework_source_context` from _project_context.py with one
- * extension (#2220): when the Taskfile lives at the framework repo root,
- * `task check` may be invoked from a subdirectory (`USER_WORKING_DIR` !=
- * `TASKFILE_DIR`). Those invocations must still route to
- * `check:framework-source` so the biome lane runs. We do NOT resolve
- * symlinks on the framework root -- a consumer project may symlink
- * `.deft/core` to a local framework checkout and should still run the
- * consumer-safe gate (the deposit path lacks `packages/cli`).
- */
-export function isFrameworkSourceContext(frameworkRoot: string, projectRoot: string): boolean {
-  const fw = resolve(frameworkRoot);
-  const pr = resolve(projectRoot);
-  if (fw === pr) {
-    return true;
-  }
-  if (!isFrameworkRepoRoot(fw)) {
-    return false;
-  }
-  return pr.startsWith(`${fw}${sep}`);
-}
-
-/**
- * Select the Taskfile target for the given context.
- *
- * Mirrors _project_context.py::dispatch_task_check target selection.
- */
-export function resolveCheckTarget(frameworkRoot: string, projectRoot: string): string {
-  return isFrameworkSourceContext(frameworkRoot, projectRoot)
-    ? "check:framework-source"
-    : "check:consumer";
-}
+export type { CheckOrchestratorOptions, CheckOrchestratorSeams } from "./context.js";
+export { isFrameworkRepoRoot, isFrameworkSourceContext, resolveCheckTarget } from "./context.js";
 
 /**
  * Dispatch to the context-appropriate `task check` aggregate target.

--- a/packages/core/src/check/runner-detect.test.ts
+++ b/packages/core/src/check/runner-detect.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -23,6 +23,25 @@ describe("runner-detect", () => {
     const result = detectTestRunner({ projectRoot: root, override: "jest" });
     expect(result.kind).toBe("jest");
     expect(result.source).toBe("config");
+  });
+
+  it("honors plan.policy.testRunner = none", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-runner-"));
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ devDependencies: { vitest: "^3.0.0" } }),
+      "utf8",
+    );
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({ plan: { policy: { testRunner: "none" } } }),
+      "utf8",
+    );
+    const result = detectTestRunner({ projectRoot: root });
+    expect(result.kind).toBe("none");
+    expect(result.source).toBe("config");
+    expect(result.affectedArgs).toEqual([]);
   });
 
   it("falls back to full-suite-only when nothing matches", () => {

--- a/packages/core/src/check/runner-detect.test.ts
+++ b/packages/core/src/check/runner-detect.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { detectTestRunner } from "./runner-detect.js";
 

--- a/packages/core/src/check/runner-detect.test.ts
+++ b/packages/core/src/check/runner-detect.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { detectTestRunner } from "./runner-detect.js";
+
+describe("runner-detect", () => {
+  it("detects vitest from package.json heuristics", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-runner-"));
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ devDependencies: { vitest: "^3.0.0" } }),
+      "utf8",
+    );
+    const result = detectTestRunner({ projectRoot: root });
+    expect(result.kind).toBe("vitest");
+    expect(result.affectedArgs).toEqual(["--changed"]);
+    expect(result.source).toBe("heuristic");
+  });
+
+  it("honors explicit override", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-runner-"));
+    const result = detectTestRunner({ projectRoot: root, override: "jest" });
+    expect(result.kind).toBe("jest");
+    expect(result.source).toBe("config");
+  });
+
+  it("falls back to full-suite-only when nothing matches", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-runner-"));
+    const result = detectTestRunner({ projectRoot: root });
+    expect(result.kind).toBe("none");
+    expect(result.source).toBe("fallback");
+  });
+});

--- a/packages/core/src/check/runner-detect.ts
+++ b/packages/core/src/check/runner-detect.ts
@@ -43,7 +43,7 @@ function detectFromPolicy(projectRoot: string): TestRunnerKind | null {
     const planPath = projectDefinitionPath(projectRoot);
     const plan = readJson(planPath) as { plan?: { policy?: { testRunner?: unknown } } } | null;
     const raw = plan?.plan?.policy?.testRunner;
-    if (raw === "vitest" || raw === "jest" || raw === "go" || raw === "pytest") {
+    if (raw === "vitest" || raw === "jest" || raw === "go" || raw === "pytest" || raw === "none") {
       return raw;
     }
   } catch {

--- a/packages/core/src/check/runner-detect.ts
+++ b/packages/core/src/check/runner-detect.ts
@@ -1,0 +1,161 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { projectDefinitionPath } from "../policy/index.js";
+
+export type TestRunnerKind = "vitest" | "jest" | "go" | "pytest" | "none";
+
+export interface RunnerDetectResult {
+  readonly kind: TestRunnerKind;
+  readonly affectedArgs: readonly string[];
+  readonly source: "config" | "heuristic" | "fallback";
+  readonly message?: string;
+}
+
+export interface RunnerDetectOptions {
+  readonly projectRoot: string;
+  readonly override?: TestRunnerKind;
+}
+
+const RUNNER_AFFECTED: Readonly<Record<Exclude<TestRunnerKind, "none">, readonly string[]>> = {
+  vitest: ["--changed"],
+  jest: ["--onlyChanged"],
+  go: [],
+  pytest: ["--testmon"],
+};
+
+function affectedArgsFor(kind: TestRunnerKind): readonly string[] {
+  if (kind === "none") {
+    return [];
+  }
+  return RUNNER_AFFECTED[kind];
+}
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function detectFromPolicy(projectRoot: string): TestRunnerKind | null {
+  try {
+    const planPath = projectDefinitionPath(projectRoot);
+    const plan = readJson(planPath) as { plan?: { policy?: { testRunner?: unknown } } } | null;
+    const raw = plan?.plan?.policy?.testRunner;
+    if (raw === "vitest" || raw === "jest" || raw === "go" || raw === "pytest") {
+      return raw;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function detectFromHeuristics(projectRoot: string): TestRunnerKind | null {
+  const root = resolve(projectRoot);
+  if (existsSync(join(root, "go.mod"))) {
+    return "go";
+  }
+  const pkgPath = join(root, "package.json");
+  if (existsSync(pkgPath)) {
+    const pkg = readJson(pkgPath) as {
+      devDependencies?: Record<string, string>;
+      dependencies?: Record<string, string>;
+    } | null;
+    const deps = { ...(pkg?.dependencies ?? {}), ...(pkg?.devDependencies ?? {}) };
+    if ("vitest" in deps) {
+      return "vitest";
+    }
+    if ("jest" in deps || "@jest/core" in deps) {
+      return "jest";
+    }
+  }
+  if (
+    existsSync(join(root, "pytest.ini")) ||
+    existsSync(join(root, "pyproject.toml")) ||
+    existsSync(join(root, "requirements.txt"))
+  ) {
+    return "pytest";
+  }
+  return null;
+}
+
+/** Auto-detect consumer test runner with explicit override (#1713). */
+export function detectTestRunner(options: RunnerDetectOptions): RunnerDetectResult {
+  if (options.override !== undefined) {
+    if (options.override === "none") {
+      return {
+        kind: "none",
+        affectedArgs: [],
+        source: "config",
+        message: "Runner override set to full-suite-only.",
+      };
+    }
+    return {
+      kind: options.override,
+      affectedArgs: affectedArgsFor(options.override),
+      source: "config",
+    };
+  }
+
+  const fromPolicy = detectFromPolicy(options.projectRoot);
+  if (fromPolicy !== null) {
+    return {
+      kind: fromPolicy,
+      affectedArgs: affectedArgsFor(fromPolicy),
+      source: "config",
+    };
+  }
+
+  const fromHeuristics = detectFromHeuristics(options.projectRoot);
+  if (fromHeuristics !== null) {
+    return {
+      kind: fromHeuristics,
+      affectedArgs: affectedArgsFor(fromHeuristics),
+      source: "heuristic",
+    };
+  }
+
+  return {
+    kind: "none",
+    affectedArgs: [],
+    source: "fallback",
+    message: "No supported test runner detected — merge gate uses the full suite.",
+  };
+}
+
+/** Human-readable detection table rows for docs. */
+export function runnerDetectionTable(): ReadonlyArray<{
+  runner: TestRunnerKind;
+  detection: string;
+  affectedConvention: string;
+}> {
+  return [
+    {
+      runner: "vitest",
+      detection: "package.json lists vitest, or plan.policy.testRunner = vitest",
+      affectedConvention: "vitest --changed",
+    },
+    {
+      runner: "jest",
+      detection: "package.json lists jest / @jest/core, or plan.policy.testRunner = jest",
+      affectedConvention: "jest --onlyChanged",
+    },
+    {
+      runner: "go",
+      detection: "go.mod present, or plan.policy.testRunner = go",
+      affectedConvention: "go test (native package cache)",
+    },
+    {
+      runner: "pytest",
+      detection: "pytest.ini / pyproject.toml / requirements.txt, or plan.policy.testRunner = pytest",
+      affectedConvention: "pytest --testmon",
+    },
+    {
+      runner: "none",
+      detection: "No match after config + heuristics",
+      affectedConvention: "Full suite at merge gate",
+    },
+  ];
+}

--- a/packages/core/src/check/runner-detect.ts
+++ b/packages/core/src/check/runner-detect.ts
@@ -149,7 +149,8 @@ export function runnerDetectionTable(): ReadonlyArray<{
     },
     {
       runner: "pytest",
-      detection: "pytest.ini / pyproject.toml / requirements.txt, or plan.policy.testRunner = pytest",
+      detection:
+        "pytest.ini / pyproject.toml / requirements.txt, or plan.policy.testRunner = pytest",
       affectedConvention: "pytest --testmon",
     },
     {

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -289,6 +289,7 @@ describe("checkGitignoreCoverage (#2206)", () => {
   it("passes when all canonical entries are present", () => {
     const lines = [
       ".deft-cache/",
+      ".deft/cache/",
       ".deft/.cli/",
       ".deft/ritual-state.json",
       ".deft/last-session.json",

--- a/packages/core/src/init-deposit/gitignore.ts
+++ b/packages/core/src/init-deposit/gitignore.ts
@@ -30,6 +30,7 @@ const DEFT_CORE_COVERING_LINES = new Set([".deft/core/", ".deft/core"]);
  */
 export const CANONICAL_GITIGNORE_BASELINE: readonly string[] = [
   ".deft-cache/",
+  ".deft/cache/",
   ".deft/.cli/",
   ".deft/ritual-state.json",
   ".deft/last-session.json",


### PR DESCRIPTION
## Summary
- Add internal gate/task registry with content-hash caching under .deft/cache/task/ (exit-0 replay only, codeVersion invalidation, volatile opt-out, fail-open to running).
- Wire deft check to run gates through the cache layer by default; expose --no-cache and deft cache:clear.
- Add runner auto-detect (vitest/jest/go/pytest) with policy override and document the fast-lane convention. Public @deft/types contract remains deferred to #2784.

## Test plan
- [x] itest run on task-cache, check CLI, runner-detect, orchestrator tests
- [x] 	sc -b for packages/core
- [ ] Full 	ask check on CI

Closes #1713
