### PR TITLE
fix(hooks): normalize Windows Cursor Write ritual project roots (#2787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cursor Write hook ritual path no longer doubles Windows drive prefix (#2787).** Hook project-root resolution now scans all Cursor payload workspace fields (not just the first drive-only `C:` entry), normalizes MSYS `/c/...` shapes, and collapses `C:\\c:\\...` doubled-drive paths before ritual-state lookup so Write PreToolUse matches `deft session:start` on Windows consumer trees like `C:\\Repos\\...`. Closes #2787.
+
 - **Three medium symlink write sinks contained (#2781).** `scope:decompose`, `swarm:routing-set` / `writeModelDecision`, and session readback history appends (`value/readback`, `eval/readback`) now call `assertWriteTargetSafe` before write/append so leaf symlinks cannot divert operator-controlled paths outside the repo. Closes #2781.
 
 ### Removed

--- a/packages/cli/src/hook-dispatch.test.ts
+++ b/packages/cli/src/hook-dispatch.test.ts
@@ -311,12 +311,7 @@ describe("hook-dispatch CLI", () => {
       };
       const out: string[] = [];
       const code = run(
-        [
-          "--host=cursor",
-          "--event=tool.before",
-          "--project-root",
-          "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture",
-        ],
+        ["--host=cursor", "--event=tool.before", "--project-root", "C:\\Repos\\deft\\statusreport"],
         {
           readStdin: () => JSON.stringify(payload),
           writeOut: (text) => out.push(text),
@@ -325,7 +320,34 @@ describe("hook-dispatch CLI", () => {
         },
       );
       expect(code).toBe(0);
-      expect(out.join("")).not.toContain("C:\\\\C:\\\\");
+      expect(out.join("")).not.toMatch(/[A-Za-z]:\\[A-Za-z]:\\/i);
+    },
+  );
+
+  it.skipIf(process.platform !== "win32")(
+    "normalizes doubled-drive --project-root before ritual lookup (#2787)",
+    () => {
+      const out: string[] = [];
+      const code = run(
+        [
+          "--host=cursor",
+          "--event=tool.before",
+          "--project-root",
+          "C:\\c:\\Repos\\deft\\statusreport",
+        ],
+        {
+          readStdin: () =>
+            JSON.stringify({
+              tool_name: "Write",
+              tool_input: { file_path: "src/a.ts", content: "x" },
+            }),
+          writeOut: (text) => out.push(text),
+          writeErr: () => undefined,
+          cwd: () => "C:\\Repos\\deft\\statusreport",
+        },
+      );
+      expect(code).toBe(0);
+      expect(out.join("")).not.toMatch(/[A-Za-z]:\\[A-Za-z]:\\/i);
     },
   );
 

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -10,6 +10,7 @@ import {
   hookPayloadTopLevelKeys,
   isHookEvent,
   isHookHost,
+  normalizeHookProjectRoot,
   projectRootFromHookPayload,
   renderHostDecision,
 } from "@deftai/directive-core/hooks";
@@ -151,9 +152,9 @@ export function run(argv: string[], seams: HookDispatchCliSeams = {}): number {
   const readStdin = seams.readStdin ?? (() => readFileSync(0, "utf8"));
   const cwd = (seams.cwd ?? process.cwd)();
   const { payload, context: payloadContext } = parsePayload(readStdin());
-  const projectRoot = args.projectRoot
-    ? resolve(args.projectRoot)
-    : projectRootFromHookPayload(payload, cwd);
+  const projectRoot = normalizeHookProjectRoot(
+    args.projectRoot ? resolve(args.projectRoot) : projectRootFromHookPayload(payload, cwd),
+  );
   const decision = decideHook({
     host: args.host,
     event: args.event,

--- a/packages/core/src/hooks/cursor-hooks.test.ts
+++ b/packages/core/src/hooks/cursor-hooks.test.ts
@@ -78,11 +78,28 @@ describe("cursor hook projection (#2764)", () => {
   it.skipIf(process.platform !== "win32")(
     "avoids Windows C:\\C:\\ ritual paths when payload carries a drive-only root",
     () => {
-      const fallback = "C:\\Users\\nicol\\OneDrive\\Documents\\Projects\\Aperture";
+      const fallback = "C:\\Repos\\deft\\statusreport";
       const resolved = projectRootFromHookPayload({ workspace_roots: ["C:"], cwd: "C:" }, fallback);
       expect(resolved).toBe(resolve(fallback));
       expect(ritualStatePath(resolved)).toBe(join(resolve(fallback), ".deft", "ritual-state.json"));
-      expect(ritualStatePath(resolved)).not.toContain("C:\\C:\\");
+      expect(ritualStatePath(resolved)).not.toMatch(/[A-Za-z]:\\[A-Za-z]:\\/i);
+    },
+  );
+
+  it.skipIf(process.platform !== "win32")(
+    "resolves statusreport-shaped Write payloads without C:\\c:\\ doubling (#2787)",
+    () => {
+      const fallback = "C:\\Repos\\deft\\statusreport";
+      const payload = {
+        tool_name: "Write",
+        workspace_root: "C:",
+        cwd: "c:\\Repos\\deft\\statusreport",
+        workspace_roots: ["C:", "c:\\Repos\\deft\\statusreport"],
+      };
+      const root = projectRootFromHookPayload(payload, fallback);
+      expect(root).toBe(resolve(fallback));
+      expect(ritualStatePath(root)).toBe(join(resolve(fallback), ".deft", "ritual-state.json"));
+      expect(ritualStatePath(root)).not.toMatch(/[A-Za-z]:\\[A-Za-z]:\\/i);
     },
   );
 

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -1,5 +1,6 @@
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { ritualStatePath } from "../session/ritual-sentinel.js";
 import {
   DIRECT_WRITE_TOOL_NAMES,
   decideHook,
@@ -12,11 +13,16 @@ import {
   isHookHost,
   isProposedLifecycleWrite,
   isSpawnTool,
+  normalizeHookProjectRoot,
   projectRootFromHookPayload,
   READ_ONLY_HOOK_ENV,
   renderHostDecision,
   SPAWN_TOOL_NAMES,
 } from "./index.js";
+
+function hasDoubledWindowsDrivePrefix(path: string): boolean {
+  return /^[A-Za-z]:\\[A-Za-z]:\\/i.test(path.replace(/\//g, "\\"));
+}
 
 const READY_RITUAL = {
   code: 0,
@@ -995,6 +1001,61 @@ describe("provider input normalization", () => {
       );
       expect(projectRootFromHookPayload({ workspace_root: "C:/" }, "/fallback")).toBe(
         resolve("/fallback"),
+      );
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")(
+    "collapses C:\\c:\\ doubled-drive ritual paths (#2787)",
+    () => {
+      const fallback = "C:\\Repos\\deft\\statusreport";
+      const expectStatusreportRoot = (payload: unknown) => {
+        const root = projectRootFromHookPayload(payload, fallback);
+        expect(root).toBe(resolve(fallback));
+        expect(hasDoubledWindowsDrivePrefix(root)).toBe(false);
+        expect(hasDoubledWindowsDrivePrefix(ritualStatePath(root))).toBe(false);
+        expect(ritualStatePath(root)).toBe(join(resolve(fallback), ".deft", "ritual-state.json"));
+      };
+
+      expectStatusreportRoot({ workspace_root: "C:\\c:\\Repos\\deft\\statusreport" });
+      expectStatusreportRoot({
+        workspace_root: "C:",
+        cwd: "c:\\Repos\\deft\\statusreport",
+      });
+      expectStatusreportRoot({
+        workspace_roots: ["C:", "c:\\Repos\\deft\\statusreport"],
+        cwd: "C:",
+      });
+      expectStatusreportRoot({ workspace_root: "C:\\Repos\\deft\\statusreport" });
+      expectStatusreportRoot({ cwd: "c:\\Repos\\deft\\statusreport" });
+
+      expect(normalizeHookProjectRoot("C:\\c:\\Repos\\deft\\statusreport")).toBe(resolve(fallback));
+      expect(normalizeHookProjectRoot("/c/Repos/deft/statusreport")).toBe(resolve(fallback));
+      expect(normalizeHookProjectRoot("C:\\Repos\\deft\\statusreport")).toBe(resolve(fallback));
+    },
+  );
+
+  it("keeps non-win32 hook roots on resolve-only path", () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+    try {
+      expect(normalizeHookProjectRoot("/tmp/statusreport")).toBe(resolve("/tmp/statusreport"));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("ignores non-string workspace root entries when scanning payload candidates", () => {
+    const fallback = "C:\\Repos\\deft\\statusreport";
+    if (process.platform === "win32") {
+      expect(
+        projectRootFromHookPayload(
+          { workspace_roots: ["C:", 42, null, "c:\\Repos\\deft\\statusreport"] },
+          fallback,
+        ),
+      ).toBe(resolve(fallback));
+    } else {
+      expect(projectRootFromHookPayload({ workspace_roots: ["/project", 42] }, "/fallback")).toBe(
+        resolve("/project"),
       );
     }
   });

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -280,21 +280,61 @@ function isWindowsDriveOnlyRoot(value: string): boolean {
   return /^[A-Za-z]:[/\\]?$/.test(value.trim());
 }
 
-export function projectRootFromHookPayload(payload: unknown, fallback: string): string {
-  const input = record(payload);
-  const fallbackResolved = resolve(fallback);
-  if (input === null) return fallbackResolved;
+function hookPayloadRootCandidates(input: Record<string, unknown>): string[] {
+  const candidates: string[] = [];
+  const push = (value: unknown): void => {
+    if (typeof value === "string" && value.trim().length > 0) {
+      candidates.push(value.trim());
+    }
+  };
+  push(input.workspaceRoot);
+  push(input.workspace_root);
   const workspaceRoots = input.workspace_roots;
-  const candidate = firstString(
-    input.workspaceRoot,
-    input.workspace_root,
-    Array.isArray(workspaceRoots) ? workspaceRoots[0] : null,
-    input.cwd,
-  );
-  if (candidate === null || isWindowsDriveOnlyRoot(candidate)) {
-    return fallbackResolved;
+  if (Array.isArray(workspaceRoots)) {
+    for (const entry of workspaceRoots) push(entry);
   }
-  return resolve(candidate);
+  push(input.cwd);
+  return candidates;
+}
+
+/** Collapse join('C:', 'c:\\...') doubled drive prefix on Windows (#2787). */
+function collapseDoubledWindowsDrivePrefix(path: string): string {
+  return path.replace(/^([A-Za-z]:\\)(?=[A-Za-z]:\\)/i, "");
+}
+
+function msysPathToWin32(path: string): string | null {
+  const match = /^\/([a-zA-Z])\/(.*)$/.exec(path.trim());
+  if (match === null || match[1] === undefined || match[2] === undefined) return null;
+  return `${match[1].toUpperCase()}:\\${match[2].replace(/\//g, "\\")}`;
+}
+
+/** Normalize hook project-root resolution on Windows (doubled drive + MSYS `/c/...`). */
+export function normalizeHookProjectRoot(path: string): string {
+  if (process.platform !== "win32") return resolve(path);
+  const trimmed = path.trim();
+  const msys = msysPathToWin32(trimmed);
+  let resolved = resolve(msys ?? trimmed);
+  const collapsed = collapseDoubledWindowsDrivePrefix(resolved);
+  if (collapsed !== resolved) {
+    resolved = resolve(collapsed);
+  }
+  if (/^[a-z]:\\/.test(resolved)) {
+    resolved = `${resolved.charAt(0).toUpperCase()}${resolved.slice(1)}`;
+  }
+  return resolved;
+}
+
+export function projectRootFromHookPayload(payload: unknown, fallback: string): string {
+  const fallbackResolved = normalizeHookProjectRoot(fallback);
+  const input = record(payload);
+  if (input === null) return fallbackResolved;
+  const usable = hookPayloadRootCandidates(input).find(
+    (candidate) => !isWindowsDriveOnlyRoot(candidate),
+  );
+  if (usable !== undefined) {
+    return normalizeHookProjectRoot(usable);
+  }
+  return fallbackResolved;
 }
 
 export function isHookHost(value: string): value is HookHost {


### PR DESCRIPTION
## Summary
- Normalize Windows hook project-root resolution so Cursor Write PreToolUse no longer looks for ritual state under doubled-drive paths like `C:\c:\Repos\...`.
- Scan all Cursor payload workspace fields (not just the first drive-only `C:` entry) and collapse MSYS `/c/...` plus doubled-drive prefixes before ritual lookup.
- Apply the same normalization to explicit `--project-root` in `hook:dispatch`.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/hooks/dispatcher.test.ts packages/core/src/hooks/cursor-hooks.test.ts packages/cli/src/hook-dispatch.test.ts`
- [x] `pnpm run test` (branch coverage 85.07%)
- [x] `task verify:branch` / `task verify:forward-coverage`

Closes #2787
