### PR TITLE
chore(security): split synthetic ghp_ fixtures for secret scanning (#2792)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Synthetic secret-shaped test fixtures no longer trip GitHub secret scanning (#2792).** Product-signal, cache-scanner, and umbrella-current-shape tests now assemble `ghp_`-shaped placeholders at runtime (split-literal #1070 precedent) so no single source line matches secret scanning while validators still reject the concatenated strings. Closes #2792.
+
 - **Cursor failClosed empty-allow stdout no longer blocks Write tools (#2779).** Cursor `preToolUse` deposits use `failClosed: true`, which treats empty/null hook stdout as failure. `renderHostDecision` now emits `{"permission":"allow"}` for Cursor allow decisions (denials unchanged; Claude/Grok/Codex keep empty allow). The deposited ApplyPatch adapter also normalizes empty success stdout to an explicit allow so Windows/ApplyPatch paths cannot fail closed after a clean ritual. Closes #2779.
 
 - **Vitest branch coverage restored above 85% (#2762).** Added focused `evaluateSkillExternalFetchGate` fixture coverage for non-Error read failures, clearing the v0.82.0 `--allow-coverage-debt` citation without a consecutive soft-pass. Closes #2762.

--- a/packages/core/src/cache/scanner-branches.test.ts
+++ b/packages/core/src/cache/scanner-branches.test.ts
@@ -7,6 +7,10 @@ import { lineHasShellVector, scan } from "./scanner.js";
 const OLD_BODY_VECTOR_RE =
   /(?:curl|wget|fetch)\s+[^|\n]*\|\s*(?:sh|bash|zsh|ksh)\b|\bbase64\s+(?:-d|--decode|-D)\b|\beval\s*[($"'`]/i;
 
+// Synthetic credential-shaped fixtures split across literals (#2792 / #1070 precedent).
+const SYNTHETIC_GHP_TOKEN = `ghp_${"12345678901234567890123456789012"}`;
+const SYNTHETIC_SK_TOKEN = `sk-${"1234567890123456789012"}`;
+
 describe("scanner branches", () => {
   it("handles empty and whitespace-only bodies", () => {
     expect(scan("").passed).toBe(true);
@@ -18,7 +22,7 @@ describe("scanner branches", () => {
   });
 
   it("detects multiple credential patterns", () => {
-    const body = "ghp_12345678901234567890123456789012 and sk-1234567890123456789012";
+    const body = `${SYNTHETIC_GHP_TOKEN} and ${SYNTHETIC_SK_TOKEN}`;
     const result = scan(body);
     expect(result.passed).toBe(false);
     expect(result.flags.length).toBeGreaterThan(0);
@@ -36,7 +40,7 @@ describe("scanner branches", () => {
   });
 
   it("detects assorted credential shapes", () => {
-    expect(scan("ghp_12345678901234567890123456789012").passed).toBe(false);
+    expect(scan(SYNTHETIC_GHP_TOKEN).passed).toBe(false);
     expect(scan("sk-ant-api03-1234567890123456789012").passed).toBe(false);
     expect(scan("xoxb-1234567890123456789012345678901234567890").passed).toBe(false);
     expect(scan("Bearer abcdefghijklmnopqrstuvwxyz").passed).toBe(false);

--- a/packages/core/src/product-signal/payload.test.ts
+++ b/packages/core/src/product-signal/payload.test.ts
@@ -9,6 +9,9 @@ import {
 } from "./payload.js";
 import { assembleProductSignalPayload } from "./submit.js";
 
+// Synthetic GitHub PAT-shaped token split across literals (#2792 / #1070 precedent).
+const SYNTHETIC_GHP_TOKEN = `ghp_${"1234567890123456789012345678901234"}`;
+
 const roots: string[] = [];
 afterEach(() => {
   for (const root of roots.splice(0)) {
@@ -31,7 +34,7 @@ describe("validateProductSignalPayload", () => {
       human: {
         nps: 8,
         answers: [],
-        freeText: "token ghp_1234567890123456789012345678901234",
+        freeText: `token ${SYNTHETIC_GHP_TOKEN}`,
       },
     });
     expect(validateProductSignalPayload(payload).length).toBeGreaterThan(0);

--- a/packages/core/src/umbrella-current-shape/index.test.ts
+++ b/packages/core/src/umbrella-current-shape/index.test.ts
@@ -31,6 +31,9 @@ const SAMPLE_BODY =
   "### Reading order for fresh contributors\n\n" +
   "1. Body\n2. This comment\n3. Amendments";
 
+// Synthetic GitHub PAT-shaped token split across literals (#2792 / #1070 precedent).
+const SYNTHETIC_GHP_TOKEN = `ghp_${"0123456789012345678901234567890123"}`;
+
 // Single options object for the optional fields (pass override + provenance)
 // so every call site passes at most three arguments and never a positional
 // `undefined` placeholder — keeps the helper's arity unambiguous.
@@ -298,7 +301,7 @@ describe("runCurrentShape", () => {
     // Structurally valid, maintainer-authored, but carries a credential the
     // scanner flags (hard-fail) — detectCredentials does NOT redact it, so the
     // emit MUST refuse rather than forward the raw secret to stdout.
-    const withCredential = `${SAMPLE_BODY}\n\nAPI key: ghp_0123456789012345678901234567890123\n`;
+    const withCredential = `${SAMPLE_BODY}\n\nAPI key: ${SYNTHETIC_GHP_TOKEN}\n`;
     const code = runCurrentShape({
       issueNumber: 1119,
       projectRoot: "/tmp",
@@ -313,13 +316,13 @@ describe("runCurrentShape", () => {
     expect(err).toContain("quarantine scanner hard-fail");
     expect(err).toContain("nothing written");
     // The raw credential MUST NOT appear anywhere in the output surfaces.
-    expect(`${outLines.join("")}${err}`).not.toContain("ghp_0123456789012345678901234567890123");
+    expect(`${outLines.join("")}${err}`).not.toContain(SYNTHETIC_GHP_TOKEN);
   });
 
   it("(e, #2307) fails closed in JSON mode too — no credential in stdout", () => {
     const outLines: string[] = [];
     const errLines: string[] = [];
-    const withCredential = `${SAMPLE_BODY}\n\nleaked: ghp_0123456789012345678901234567890123\n`;
+    const withCredential = `${SAMPLE_BODY}\n\nleaked: ${SYNTHETIC_GHP_TOKEN}\n`;
     const code = runCurrentShape({
       issueNumber: 1119,
       projectRoot: "/tmp",

--- a/xbrief/active/2026-07-23-2792-choresecurity-split-synthetic-ghp-fixtures.xbrief.json
+++ b/xbrief/active/2026-07-23-2792-choresecurity-split-synthetic-ghp-fixtures.xbrief.json
@@ -1,0 +1,77 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2792 — split synthetic ghp_ test fixtures to avoid secret-scanning false positives"
+  },
+  "plan": {
+    "id": "2026-07-23-2792-choresecurity-split-synthetic-ghp-fixtures",
+    "title": "chore(security): split synthetic ghp_ fixtures that trip secret-scanning alert #1",
+    "status": "running",
+    "narratives": {
+      "Description": "GitHub secret-scanning alert #1 flagged synthetic ghp_ fixtures in product-signal tests. Split literals at runtime per #1070 precedent so no single source line matches secret scanning while detection coverage stays unchanged.",
+      "Origin": "https://github.com/deftai/directive/issues/2792",
+      "ImplementationPlan": "1) Split ghp_/sk- shaped fixtures via string concatenation in payload.test.ts, scanner-branches.test.ts, umbrella-current-shape/index.test.ts. 2) Add CHANGELOG [Unreleased] entry. 3) Run targeted vitest + task check. 4) Open PR with Closes #2792.",
+      "UserStory": "As a maintainer, I want synthetic secret-shaped test fixtures split across source lines so GitHub secret scanning does not flag false positives while validators still reject assembled strings."
+    },
+    "items": [
+      {
+        "title": "Split ghp_ fixtures in payload.test.ts",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "No contiguous ghp_ literal on a single source line; validateProductSignalPayload still rejects the assembled freeText."
+        }
+      },
+      {
+        "title": "Split ghp_/sk- fixtures in scanner-branches.test.ts",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Runtime-concatenated tokens still fail scan(); no contiguous ghp_/sk- literals on single source lines."
+        }
+      },
+      {
+        "title": "Split ghp_ fixtures in umbrella-current-shape/index.test.ts",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Credential hard-fail tests still pass; assembled token not echoed to stdout/stderr."
+        }
+      },
+      {
+        "title": "CHANGELOG and PR",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Brief [Unreleased] entry; PR body contains Closes #2792."
+        }
+      }
+    ],
+    "tags": [
+      "chore",
+      "security"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2792",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2792"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/product-signal/payload.test.ts",
+          "packages/core/src/cache/scanner-branches.test.ts",
+          "packages/core/src/umbrella-current-shape/index.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/product-signal/payload.test.ts packages/core/src/cache/scanner-branches.test.ts packages/core/src/umbrella-current-shape/index.test.ts",
+          "task check"
+        ]
+      },
+      "capacityBucket": "technical-debt"
+    },
+    "updated": "2026-07-23T21:31:11Z"
+  }
+}


### PR DESCRIPTION
## Summary

- Split synthetic `ghp_`-shaped test fixtures via runtime string concatenation (#1070 split-literal precedent) so no single source line triggers GitHub secret scanning.
- Touched product-signal payload validation, cache scanner branches, and umbrella-current-shape hard-fail tests; detection coverage unchanged.
- Added brief CHANGELOG `[Unreleased]` entry.

Closes #2792

## Test plan

- [x] `pnpm exec vitest run packages/core/src/product-signal/payload.test.ts packages/core/src/cache/scanner-branches.test.ts packages/core/src/umbrella-current-shape/index.test.ts` (61 tests passed)
- [x] `task verify:branch`
- [x] `task check`
