### PR TITLE
chore(deps): pin brace-expansion for Dependabot DoS advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dependabot brace-expansion DoS advisories closed via pnpm overrides.** Pin transitive `brace-expansion@2` → `2.1.2` and `@5` → `5.0.7` (minimatch/glob via vitest coverage and archiver) so lockfile consumers no longer resolve the vulnerable 2.1.1 / 5.0.6 lines.
 - **Agent-host edit hooks no longer boot the full CLI for every tool call (#2790).** `directive init` and `deft update` now deposit the lightweight `deft-hook` entrypoint for Claude, Grok, Cursor, and Codex. Cursor ApplyPatch shares the direct-write hook rather than probing and spawning a second CLI process; the same ritual, scope, runtime-authority, and fail-closed decisions remain enforced. Upgrade `@deftai/directive` and run `deft update` to refresh existing deposits—`hostHooks` opt-out is not the performance fix.
 
 ### Removed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   vite: ^7.3.6
   esbuild: ^0.28.1
+  brace-expansion@2: 2.1.2
+  brace-expansion@5: 5.0.7
 
 importers:
 
@@ -609,11 +611,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-crc32@1.0.0:
@@ -1495,11 +1497,11 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1704,11 +1706,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,11 @@ packages:
 overrides:
   vite: "^7.3.6"
   esbuild: "^0.28.1"
+  # Dependabot high: brace-expansion DoS via consecutive non-expanding {} groups
+  # (alerts #6/#7). Arrives via minimatch@9 (glob/test-exclude/vitest coverage)
+  # and minimatch@10 (archiver + test-exclude). Pin both major lines.
+  "brace-expansion@2": "2.1.2"
+  "brace-expansion@5": "5.0.7"
 
 # pnpm 11 defaults to strictDepBuilds and blocks dependency build scripts
 # unless explicitly allowed via the `allowBuilds` map (it replaced the old
@@ -22,3 +27,5 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - vite@7.3.6
+  - brace-expansion@2.1.2
+  - brace-expansion@5.0.7


### PR DESCRIPTION
## Summary
- Pin transitive `brace-expansion@2` → `2.1.2` and `@5` → `5.0.7` in `pnpm-workspace.yaml` overrides (pnpm 11 home for overrides).
- Clears Dependabot high alerts [#6](https://github.com/deftai/directive/security/dependabot/6) and [#7](https://github.com/deftai/directive/security/dependabot/7) (DoS via consecutive non-expanding `{}` groups).
- Arrives via `minimatch` → `glob`/`test-exclude` (vitest coverage) and `archiver` (core).

## Test plan
- [x] `pnpm why brace-expansion` shows only 2.1.2 and 5.0.7
- [ ] CI merge gate / Dependabot alerts auto-close after merge to master

