### PR TITLE
chore(scope): complete #2790 xbrief after merge

### DIFF
--- a/xbrief/completed/2026-07-23-2790-perfharness-pretooluse-hookdispatch-cold-cli-boot-071s-per-e.xbrief.json
+++ b/xbrief/completed/2026-07-23-2790-perfharness-pretooluse-hookdispatch-cold-cli-boot-071s-per-e.xbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "perf(harness): PreToolUse hook:dispatch cold CLI boot ~0.7–1s per edit on Windows",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "perf(harness): PreToolUse hook:dispatch cold CLI boot ~0.7–1s per edit on Windows",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2790",
@@ -52,6 +52,10 @@
         "title": "Issue #2790: perf(harness): PreToolUse hook:dispatch cold CLI boot ~0.7–1s per edit on Windows"
       }
     ],
-    "updated": "2026-07-23T20:58:01Z"
+    "updated": "2026-07-23T22:15:24Z",
+    "metadata": {
+      "completedAt": "2026-07-23T22:15:24Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
Post-merge scope:complete for #2790 after PR #2795 merged. Moves active xBRIEF to completed/ so verify:orphan-active stays green.