### PR TITLE
fix(xbrief-migrate): omit stale vbrief.md on migrate and update (#2806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **migrate:xbrief no longer copies obsolete framework `vbrief.md` into `xbrief/` (#2806).** Legacy migration skips the lifecycle-root framework support narrative so consumers are not left with broken-link Markdown litter; `directive update` removes a stale `xbrief/vbrief.md` from earlier migrations while preserving project JSON records and `xbrief/schemas/`.
 - **Corporate npm mirrors no longer hide the public Directive release path (#2808).** `directive doctor` now warns when the effective `@deftai` registry is not public npm without exposing configured URLs, its network-gated release lookup explicitly targets `registry.npmjs.org`, and the upgrade/bootstrap docs cover `E404`, `ETARGET`, silently stale `@latest`, scoped `.npmrc` routing, and organization-policy-safe recovery.
 - **Dependabot brace-expansion DoS advisories closed via pnpm overrides.** Pin transitive `brace-expansion@2` → `2.1.2` and `@5` → `5.0.7` (minimatch/glob via vitest coverage and archiver) so lockfile consumers no longer resolve the vulnerable 2.1.1 / 5.0.6 lines.
 - **Cursor review-monitor ownership is now explicit (#2797).** Cursor `Task` leaves no longer treat nested Task dispatch or a backgrounded `task pr:watch` shell as an active Approach 1 monitor. A merge-ready leaf blocks in its own review loop, or exits at PR open so its orchestrator can launch and register a sibling monitor; the unregistered-monitor claim is a fail-closed regression condition. Closes #2797.

--- a/packages/core/src/init-deposit/refresh.ts
+++ b/packages/core/src/init-deposit/refresh.ts
@@ -34,6 +34,7 @@ import {
   resolveEngine,
 } from "../resolution/index.js";
 import { gitPorcelain } from "../story-ready/git.js";
+import { removeStaleMigratedFrameworkNarrative } from "../xbrief-migrate/migrate-project.js";
 import { writeAgentHookDeposit } from "./agent-hooks.js";
 import { ensureInitGitignoreLines, type GitLsFiles, isDepositTrackedInGit } from "./gitignore.js";
 import {
@@ -640,6 +641,7 @@ export async function runRefreshDeposit(
   // lifecycle content before migrate:xbrief can transactionally converge it.
   if (hasCanonicalXbriefLifecycle(projectDir)) {
     syncConsumerXbriefSchemas(projectDir, deftDir);
+    removeStaleMigratedFrameworkNarrative(projectDir);
   }
 
   const agentsMdUpdated = writeAgentsMd(projectDir, deftDir, io);

--- a/packages/core/src/xbrief-migrate/constants.ts
+++ b/packages/core/src/xbrief-migrate/constants.ts
@@ -16,6 +16,13 @@ export const V08_CONTAINER_ITEM_TYPES = new Set(
 export const LEGACY_ARTIFACT_DIR = "vbrief" as const;
 export const MIGRATED_ARTIFACT_DIR = "xbrief" as const;
 
+/**
+ * Obsolete framework support narrative at the lifecycle root. Legacy
+ * `migrate:xbrief` copied this to `xbrief/vbrief.md` with broken framework
+ * links; consumer projections use `xbrief.md` instead (#2806).
+ */
+export const OBSOLETE_FRAMEWORK_NARRATIVE_FILENAME = "vbrief.md" as const;
+
 export const LEGACY_ARTIFACT_SUFFIX = ".vbrief.json" as const;
 export const MIGRATED_ARTIFACT_SUFFIX = ".xbrief.json" as const;
 

--- a/packages/core/src/xbrief-migrate/index.ts
+++ b/packages/core/src/xbrief-migrate/index.ts
@@ -11,6 +11,7 @@ export {
   type StaleHeaderDetection,
 } from "./agents-header.js";
 export {
+  OBSOLETE_FRAMEWORK_NARRATIVE_FILENAME,
   VBRIEF_DEPRECATION_MARKER_BODY,
   VBRIEF_DEPRECATION_MARKER_FILENAME,
   VBRIEF_DEPRECATION_MARKER_SENTINEL,
@@ -40,8 +41,10 @@ export {
 export {
   convergeLegacyVbriefRoot,
   emitXbriefMigration,
+  removeStaleMigratedFrameworkNarrative,
   runXbriefMigration,
   runXbriefMigrationCli,
+  shouldOmitLegacyMigrationFile,
   type VbriefConvergeAction,
   type XbriefMigrationArgs,
   type XbriefMigrationIo,

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -22,8 +22,10 @@ import { detectXbriefConvergence } from "./detect.js";
 import {
   convergeLegacyVbriefRoot,
   emitXbriefMigration,
+  removeStaleMigratedFrameworkNarrative,
   runXbriefMigration,
   runXbriefMigrationCli,
+  shouldOmitLegacyMigrationFile,
 } from "./migrate-project.js";
 
 const itSymlink = it.skipIf(process.platform === "win32");
@@ -222,6 +224,45 @@ describe("runXbriefMigration", () => {
     );
     expect(outcome.kind).toBe("config");
     expect(existsSync(join(project, LEGACY_ARTIFACT_DIR))).toBe(true);
+  });
+
+  it("omits framework vbrief.md during migrate:xbrief (#2806) [2806-a1]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-omit-vbrief-md-"));
+    temps.push(base);
+    const project = scaffoldLegacyProject(base);
+    writeFileSync(
+      join(project, LEGACY_ARTIFACT_DIR, "vbrief.md"),
+      "# Framework narrative\nsee ../context/working-memory.md\n",
+      "utf8",
+    );
+
+    const outcome = runXbriefMigration({ projectRoot: project, force: true }, SILENT_IO);
+    expect(outcome.kind).toBe("migrated");
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "vbrief.md"))).toBe(false);
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"))).toBe(
+      true,
+    );
+  });
+
+  it("still migrates project JSON and schemas when no framework narrative is present (#2806) [2806-a3]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-schemas-only-"));
+    temps.push(base);
+    const project = scaffoldLegacyProject(base);
+    mkdirSync(join(project, LEGACY_ARTIFACT_DIR, "schemas"), { recursive: true });
+    writeFileSync(
+      join(project, LEGACY_ARTIFACT_DIR, "schemas", "scope.schema.json"),
+      '{"title":"scope"}\n',
+      "utf8",
+    );
+
+    const outcome = runXbriefMigration({ projectRoot: project, force: true }, SILENT_IO);
+    expect(outcome.kind).toBe("migrated");
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"))).toBe(
+      true,
+    );
+    expect(
+      readFileSync(join(project, MIGRATED_ARTIFACT_DIR, "schemas", "scope.schema.json"), "utf8"),
+    ).toBe('{"title":"scope"}\n');
   });
 
   it("rewrites non-json text files during migration", () => {
@@ -597,6 +638,48 @@ describe("convergeLegacyVbriefRoot (#2270)", () => {
     expect(existsSync(join(base, LEGACY_ARTIFACT_DIR, VBRIEF_DEPRECATION_MARKER_FILENAME))).toBe(
       true,
     );
+  });
+});
+
+describe("framework narrative hygiene (#2806)", () => {
+  it("shouldOmitLegacyMigrationFile matches only the lifecycle-root narrative", () => {
+    expect(shouldOmitLegacyMigrationFile("vbrief.md")).toBe(true);
+    expect(shouldOmitLegacyMigrationFile("active/story.xbrief.json")).toBe(false);
+    expect(shouldOmitLegacyMigrationFile("schemas/scope.schema.json")).toBe(false);
+    expect(shouldOmitLegacyMigrationFile("notes.txt")).toBe(false);
+  });
+
+  it("removeStaleMigratedFrameworkNarrative drops xbrief/vbrief.md but keeps records (#2806) [2806-a2]", () => {
+    const base = mkdtempSync(join(tmpdir(), "xbrief-remove-stale-vbrief-md-"));
+    temps.push(base);
+    const project = join(base, "consumer");
+    mkdirSync(join(project, MIGRATED_ARTIFACT_DIR, "active"), { recursive: true });
+    mkdirSync(join(project, MIGRATED_ARTIFACT_DIR, "schemas"), { recursive: true });
+    writeFileSync(
+      join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"),
+      JSON.stringify(SAMPLE_V06),
+      "utf8",
+    );
+    writeFileSync(
+      join(project, MIGRATED_ARTIFACT_DIR, "schemas", "xbrief-core-0.8.schema.json"),
+      "{}\n",
+      "utf8",
+    );
+    writeFileSync(
+      join(project, MIGRATED_ARTIFACT_DIR, "vbrief.md"),
+      "# stale migrated framework narrative\n",
+      "utf8",
+    );
+
+    expect(removeStaleMigratedFrameworkNarrative(project)).toBe(true);
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "vbrief.md"))).toBe(false);
+    expect(existsSync(join(project, MIGRATED_ARTIFACT_DIR, "active", "story.xbrief.json"))).toBe(
+      true,
+    );
+    expect(
+      existsSync(join(project, MIGRATED_ARTIFACT_DIR, "schemas", "xbrief-core-0.8.schema.json")),
+    ).toBe(true);
+    expect(removeStaleMigratedFrameworkNarrative(project)).toBe(false);
   });
 });
 

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -16,6 +16,7 @@ import {
   LEGACY_ARTIFACT_SUFFIX,
   MIGRATED_ARTIFACT_DIR,
   MIGRATED_ARTIFACT_SUFFIX,
+  OBSOLETE_FRAMEWORK_NARRATIVE_FILENAME,
   VBRIEF_DEPRECATION_MARKER_BODY,
   VBRIEF_DEPRECATION_MARKER_FILENAME,
 } from "./constants.js";
@@ -70,6 +71,22 @@ function collectFiles(root: string, acc: string[] = []): string[] {
     }
   }
   return acc;
+}
+
+/** True when a legacy lifecycle file is an obsolete framework narrative (#2806). */
+export function shouldOmitLegacyMigrationFile(relativePath: string): boolean {
+  return relativePath.replace(/\\/g, "/") === OBSOLETE_FRAMEWORK_NARRATIVE_FILENAME;
+}
+
+/**
+ * Remove a stale `xbrief/vbrief.md` left by an earlier migrate:xbrief run.
+ * Project JSON records and `xbrief/schemas/` are untouched (#2806).
+ */
+export function removeStaleMigratedFrameworkNarrative(projectRoot: string): boolean {
+  const stale = join(projectRoot, MIGRATED_ARTIFACT_DIR, OBSOLETE_FRAMEWORK_NARRATIVE_FILENAME);
+  if (!existsSync(stale)) return false;
+  rmSync(stale, { force: true });
+  return true;
 }
 
 function mapRelativePath(relativePath: string): string {
@@ -147,6 +164,7 @@ function migrateLegacyTree(
   try {
     for (const srcPath of files) {
       const rel = relative(legacyDir, srcPath);
+      if (shouldOmitLegacyMigrationFile(rel)) continue;
       const destPath = join(stagedDir, mapRelativePath(rel));
       writeMigratedFile(srcPath, destPath);
     }

--- a/xbrief/active/2026-07-24-2806-bug-migratexbrief-carries-stale-vbriefmd-into-xbrief-with-br.xbrief.json
+++ b/xbrief/active/2026-07-24-2806-bug-migratexbrief-carries-stale-vbriefmd-into-xbrief-with-br.xbrief.json
@@ -1,0 +1,86 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Story xBRIEF for GitHub issue #2806 — stop migrate:xbrief from copying obsolete framework vbrief.md into consumer xbrief/."
+  },
+  "plan": {
+    "id": "2806-migrate-omit-vbrief-md",
+    "title": "bug: migrate:xbrief carries stale vbrief.md into xbrief with broken links",
+    "status": "running",
+    "narratives": {
+      "Description": "`deft migrate:xbrief` copies every non-JSON file from the legacy lifecycle root, so a framework-deposited `vbrief/vbrief.md` lands at `xbrief/vbrief.md` with broken framework-relative links. That narrative is not a current consumer projection and is not cleaned by later updates. This story omits obsolete framework-support narratives during migration and cleans a known stale `xbrief/vbrief.md` on update when present.",
+      "ImplementationPlan": "1. Update `packages/core/src/xbrief-migrate/migrate-project.ts` so the legacy tree copy skips framework-support narratives such as `vbrief.md` (or projects a consumer-valid replacement with a canonical filename). 2. Add or extend update hygiene to remove a known stale `xbrief/vbrief.md` left by earlier migrations while preserving project JSON records and `xbrief/schemas/`. 3. Add focused regression coverage in `packages/core/src/xbrief-migrate/migrate-project.test.ts` that fixtures `vbrief/vbrief.md` beside project records and asserts it is omitted from `xbrief/`.",
+      "UserStory": "As a Directive consumer migrating from vbrief/ to xbrief/, I want obsolete framework narrative files omitted, so that my lifecycle root does not contain broken-link Markdown litter.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2806",
+      "Overview": "## Summary\n\n`deft migrate:xbrief` copies every non-JSON file from the legacy lifecycle root without path-specific filtering. When an earlier update/bridge has deposited the framework support narrative as `vbrief/vbrief.md`, migration carries it to `xbrief/vbrief.md` unchanged apart from token rewriting.\n\n## Expected\n\nMigration should omit obsolete framework-support narratives from the lifecycle record copy, or explicitly project a current xBRIEF narrative with consumer-valid links and a canonical filename. A later `directive update` should also clean up the known stale projection if it was created by an earlier migration.\n",
+      "Labels": "bug, area:cli, area:vbrief",
+      "Traces": "#2806"
+    },
+    "items": [
+      {
+        "id": "2806-a1",
+        "title": "Given vbrief/vbrief.md beside project records, when migrate:xbrief runs, then xbrief/vbrief.md is not created.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a legacy `vbrief/` tree that contains both project `.vbrief.json` records and a framework `vbrief.md` narrative, when `deft migrate:xbrief` runs, then project records are migrated into `xbrief/` and `xbrief/vbrief.md` is not created.",
+          "Traces": "#2806"
+        }
+      },
+      {
+        "id": "2806-a2",
+        "title": "Given a stale xbrief/vbrief.md from an earlier migration, when directive update runs, then that stale narrative is removed.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a consumer that already has a stale `xbrief/vbrief.md` from an earlier migration, when `directive update` runs, then that known stale narrative is removed while `xbrief/schemas/` and project JSON records remain.",
+          "Traces": "#2806"
+        }
+      },
+      {
+        "id": "2806-a3",
+        "title": "Given only project JSON and schemas under vbrief/, when migrate:xbrief runs, then migration still succeeds without omitting required records.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a legacy `vbrief/` tree that contains only project JSON records and schemas with no framework narrative, when `deft migrate:xbrief` runs, then migration still succeeds and required records appear under `xbrief/`.",
+          "Traces": "#2806"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "area:cli",
+      "area:vbrief"
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/xbrief-migrate/migrate-project.ts",
+          "packages/core/src/xbrief-migrate/migrate-project.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/xbrief-migrate/migrate-project.test.ts"
+        ],
+        "expected_outputs": [
+          "migrate-project tests pass",
+          "vbrief.md omitted from migrated xbrief/"
+        ],
+        "depends_on": [],
+        "conflict_group": "xbrief-migrate",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2806",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2806: bug: migrate:xbrief carries stale vbrief.md into xbrief with broken links",
+        "TrustLevel": "external"
+      }
+    ],
+    "updated": "2026-07-24T17:32:12Z"
+  }
+}


### PR DESCRIPTION
## Summary

- `migrate:xbrief` skips copying the obsolete lifecycle-root `vbrief.md` framework narrative so it is not projected to `xbrief/vbrief.md` with broken framework-relative links.
- `directive update` removes a stale `xbrief/vbrief.md` left by earlier migrations while preserving project JSON records and `xbrief/schemas/`.
- Regression coverage added in `migrate-project.test.ts` for all three acceptance criteria.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/xbrief-migrate/migrate-project.test.ts`
- [x] `task verify:branch` / `task verify:forward-coverage`
- [ ] CI green on PR

Closes #2806
