### PR TITLE
fix(cli): deft update --help must not mutate (#2828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependabot brace-expansion DoS advisories closed via pnpm overrides.** Pin transitive `brace-expansion@2` → `2.1.2` and `@5` → `5.0.7` (minimatch/glob via vitest coverage and archiver) so lockfile consumers no longer resolve the vulnerable 2.1.1 / 5.0.6 lines.
 - **Cursor review-monitor ownership is now explicit (#2797).** Cursor `Task` leaves no longer treat nested Task dispatch or a backgrounded `task pr:watch` shell as an active Approach 1 monitor. A merge-ready leaf blocks in its own review loop, or exits at PR open so its orchestrator can launch and register a sibling monitor; the unregistered-monitor claim is a fail-closed regression condition. Closes #2797.
 - **Agent-host edit hooks no longer boot the full CLI for every tool call (#2790).** `directive init` and `deft update` now deposit the lightweight `deft-hook` entrypoint for Claude, Grok, Cursor, and Codex. Cursor ApplyPatch shares the direct-write hook rather than probing and spawning a second CLI process; the same ritual, scope, runtime-authority, and fail-closed decisions remain enforced. Upgrade `@deftai/directive` and run `deft update` to refresh existing deposits—`hostHooks` opt-out is not the performance fix.
+- **`directive update --help` no longer mutates the working tree (#2828).** `--help` / `-h` on `update`, `init`, and `migrate` now print usage and exit 0 without refreshing the deposit, rewriting AGENTS.md, or staging git changes.
 
 ### Removed
 

--- a/packages/cli/src/init-cli/help.test.ts
+++ b/packages/cli/src/init-cli/help.test.ts
@@ -1,0 +1,132 @@
+import * as initDeposit from "@deftai/directive-core/init-deposit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { routeAndDispatch } from "../cli-router/index.js";
+import type { DispatchIo } from "../dispatch.js";
+import { argvWantsHelp, printInitHelp, printMigrateHelp, printUpdateHelp } from "./help.js";
+import { runInit } from "./init.js";
+import { runMigrate } from "./migrate.js";
+import { runUpdate } from "./update.js";
+
+function captureIo(): { io: DispatchIo; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    io: {
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: (text) => {
+        err.push(text);
+      },
+    },
+  };
+}
+
+describe("argvWantsHelp (#2828)", () => {
+  it("detects --help and -h", () => {
+    expect(argvWantsHelp(["--help"])).toBe(true);
+    expect(argvWantsHelp(["-h"])).toBe(true);
+    expect(argvWantsHelp(["--repo-root", ".", "--help"])).toBe(true);
+  });
+
+  it("is false for normal argv", () => {
+    expect(argvWantsHelp([])).toBe(false);
+    expect(argvWantsHelp(["--repo-root", "."])).toBe(false);
+    expect(argvWantsHelp(["--dry-run"])).toBe(false);
+  });
+});
+
+describe("init-cli --help is non-mutating (#2828)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("update --help prints usage and does not call runRefreshDepositCli", async () => {
+    const refresh = vi.spyOn(initDeposit, "runRefreshDepositCli");
+    const { io, out } = captureIo();
+
+    const code = await runUpdate(["--help"], io);
+
+    expect(code).toBe(0);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(out.join("")).toContain("Usage: directive update");
+    expect(out.join("")).toContain("--dry-run, --plan");
+  });
+
+  it("update -h prints usage and does not call runRefreshDepositCli", async () => {
+    const refresh = vi.spyOn(initDeposit, "runRefreshDepositCli");
+    const { io } = captureIo();
+
+    expect(await runUpdate(["-h"], io)).toBe(0);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("init --help prints usage and does not dispatch", async () => {
+    const dispatch = vi.spyOn(initDeposit, "runInitDispatchCli");
+    const headless = vi.spyOn(initDeposit, "runInitHeadlessCli");
+    const { io, out } = captureIo();
+
+    const code = await runInit(["--help"], io);
+
+    expect(code).toBe(0);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(headless).not.toHaveBeenCalled();
+    expect(out.join("")).toContain("Usage: directive init");
+    expect(out.join("")).toContain("--headless");
+  });
+
+  it("init --help wins over --headless (no manifest emit)", async () => {
+    const headless = vi.spyOn(initDeposit, "runInitHeadlessCli");
+    const { io } = captureIo();
+
+    expect(await runInit(["--headless", "--help"], io)).toBe(0);
+    expect(headless).not.toHaveBeenCalled();
+  });
+
+  it("migrate --help prints usage and does not call runMigrateCli", () => {
+    const migrate = vi.spyOn(initDeposit, "runMigrateCli");
+    const untrack = vi.spyOn(initDeposit, "runUntrackCoreCli");
+    const { io, out } = captureIo();
+
+    const code = runMigrate(["--help"], io);
+
+    expect(code).toBe(0);
+    expect(migrate).not.toHaveBeenCalled();
+    expect(untrack).not.toHaveBeenCalled();
+    expect(out.join("")).toContain("Usage: directive migrate");
+    expect(out.join("")).toContain("--untrack-core");
+  });
+
+  it("routeAndDispatch update --help exits 0 without refresh", async () => {
+    const refresh = vi.spyOn(initDeposit, "runRefreshDepositCli");
+    const { io, out } = captureIo();
+
+    const code = await routeAndDispatch(["update", "--help"], io);
+
+    expect(code).toBe(0);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(out.join("")).toContain("directive update");
+  });
+});
+
+describe("init-cli help printers", () => {
+  it("printUpdateHelp mentions deft alias", () => {
+    const { io, out } = captureIo();
+    printUpdateHelp(io);
+    expect(out.join("")).toContain("deft update");
+  });
+
+  it("printInitHelp mentions headless mode", () => {
+    const { io, out } = captureIo();
+    printInitHelp(io);
+    expect(out.join("")).toContain("--headless");
+  });
+
+  it("printMigrateHelp mentions untrack-core", () => {
+    const { io, out } = captureIo();
+    printMigrateHelp(io);
+    expect(out.join("")).toContain("--untrack-core");
+  });
+});

--- a/packages/cli/src/init-cli/help.ts
+++ b/packages/cli/src/init-cli/help.ts
@@ -1,0 +1,53 @@
+import type { DispatchIo } from "../dispatch.js";
+
+/** Flags that request usage text without executing a mutating install path (#2828). */
+export const INIT_CLI_HELP_FLAGS = ["--help", "-h", "/help", "/h"] as const;
+
+/** True when argv includes a help flag anywhere in the token list. */
+export function argvWantsHelp(argv: readonly string[]): boolean {
+  const flags = INIT_CLI_HELP_FLAGS as readonly string[];
+  return argv.some((arg) => flags.includes(arg));
+}
+
+export function printUpdateHelp(io: DispatchIo): void {
+  io.writeOut(
+    "Usage: directive update [options]\n" +
+      "       deft update [options]\n\n" +
+      "Refresh the framework deposit in an existing Directive project and self-heal the engine.\n\n" +
+      "Options:\n" +
+      "  --repo-root <path>          Project root (default: current directory)\n" +
+      "  --json                      Machine-readable summary on stdout\n" +
+      "  --yes, --non-interactive  Run without prompts\n" +
+      "  --dry-run, --plan           Classify and print the refresh plan without writing\n" +
+      "  -h, --help                  Show this help\n",
+  );
+}
+
+export function printInitHelp(io: DispatchIo): void {
+  io.writeOut(
+    "Usage: directive init [options]\n" +
+      "       deft init [options]\n\n" +
+      "Set up Directive in the current project (greenfield scaffold or brownfield adoption).\n\n" +
+      "Options:\n" +
+      "  --repo-root <path>          Project root (default: current directory)\n" +
+      "  --json                      Machine-readable summary on stdout\n" +
+      "  --yes, --non-interactive  Run without prompts\n" +
+      "  --dry-run, --plan           Classify and print the dispatch plan without writing\n" +
+      "  --headless                  Emit a { version, files } manifest with no side effects\n" +
+      "  --output <path>             Manifest output path for --headless (default: stdout)\n" +
+      "  -h, --help                  Show this help\n",
+  );
+}
+
+export function printMigrateHelp(io: DispatchIo): void {
+  io.writeOut(
+    "Usage: directive migrate [options]\n" +
+      "       deft migrate [options]\n\n" +
+      "Stamp a canonical-vendored .deft/core deposit as npm-managed (provenance only).\n\n" +
+      "Options:\n" +
+      "  --repo-root <path>          Project root (default: current directory)\n" +
+      "  --json                      Machine-readable summary on stdout\n" +
+      "  --untrack-core              Un-commit .deft/core from git (destructive index mutation)\n" +
+      "  -h, --help                  Show this help\n",
+  );
+}

--- a/packages/cli/src/init-cli/init.ts
+++ b/packages/cli/src/init-cli/init.ts
@@ -12,6 +12,7 @@ import {
   INIT_HEADLESS_FLAGS,
   INIT_OUTPUT_FLAGS,
 } from "./constants.js";
+import { argvWantsHelp, printInitHelp } from "./help.js";
 
 /** True when the user argv asked for a classify-only dispatch plan (`--dry-run`/`--plan`). */
 export function isInitDryRun(argv: readonly string[]): boolean {
@@ -72,6 +73,10 @@ export function runInit(
   seams?: InitDispatchSeams,
   headlessSeams?: HeadlessManifestSeams,
 ): Promise<number> {
+  if (argvWantsHelp(argv)) {
+    printInitHelp(io);
+    return Promise.resolve(0);
+  }
   if (isInitHeadless(argv)) {
     return runInitHeadlessCli({
       outputPath: parseInitOutputPath(argv),

--- a/packages/cli/src/init-cli/migrate.ts
+++ b/packages/cli/src/init-cli/migrate.ts
@@ -5,6 +5,7 @@ import {
 } from "@deftai/directive-core/init-deposit";
 import type { DispatchIo } from "../dispatch.js";
 import { CANONICAL_MIGRATE_ARGV, MIGRATE_UNTRACK_CORE_FLAG } from "./constants.js";
+import { argvWantsHelp, printMigrateHelp } from "./help.js";
 
 /**
  * `directive migrate` (alias `deft migrate`) -- stage-2 provenance verb (#1941):
@@ -29,6 +30,10 @@ function hasUntrackCoreFlag(argv: readonly string[]): boolean {
 }
 
 export function runMigrate(argv: readonly string[], io: DispatchIo): number {
+  if (argvWantsHelp(argv)) {
+    printMigrateHelp(io);
+    return 0;
+  }
   const args = parseInitArgv(CANONICAL_MIGRATE_ARGV, argv);
 
   // `migrate --untrack-core` selects the destructive un-track subcommand;

--- a/packages/cli/src/init-cli/update.ts
+++ b/packages/cli/src/init-cli/update.ts
@@ -1,6 +1,7 @@
 import { parseUpdateArgv, runRefreshDepositCli } from "@deftai/directive-core/init-deposit";
 import type { DispatchIo } from "../dispatch.js";
 import { CANONICAL_UPDATE_ARGV, UPDATE_DRY_RUN_FLAGS } from "./constants.js";
+import { argvWantsHelp, printUpdateHelp } from "./help.js";
 
 /** True when the user argv asked for a classify-only dry-run (`--dry-run`/`--plan`). */
 export function isUpdateDryRun(argv: readonly string[]): boolean {
@@ -9,6 +10,10 @@ export function isUpdateDryRun(argv: readonly string[]): boolean {
 }
 
 export function runUpdate(argv: readonly string[], io: DispatchIo): Promise<number> {
+  if (argvWantsHelp(argv)) {
+    printUpdateHelp(io);
+    return Promise.resolve(0);
+  }
   const args = parseUpdateArgv(CANONICAL_UPDATE_ARGV, argv);
   return runRefreshDepositCli({
     ...args,

--- a/xbrief/active/2026-07-24-2828-deft-update-help-performs-the-update-instead-of-printing-hel.xbrief.json
+++ b/xbrief/active/2026-07-24-2828-deft-update-help-performs-the-update-instead-of-printing-hel.xbrief.json
@@ -1,0 +1,81 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Story xBRIEF for GitHub issue #2828 — deft update --help must print help without mutating."
+  },
+  "plan": {
+    "id": "2828-update-help-no-mutation",
+    "title": "bug(cli): deft update --help performs the update instead of printing help",
+    "status": "running",
+    "narratives": {
+      "Description": "`deft update --help` / `directive update --help` currently runs the full deposit refresh (payload swap, AGENTS.md rewrite, git index staging) because parseUpdateArgv / runUpdate never intercepts --help/-h before mutation. Fix by printing usage and exiting 0 with zero filesystem or git side effects; audit sibling top-level mutators (init/migrate) for the same pattern.",
+      "ImplementationPlan": "1. Intercept --help/-h in packages/cli/src/init-cli/update.ts (and/or parseUpdateArgv / parseInitArgv) before runRefreshDepositCli. 2. Print update usage and return 0. 3. Add a focused test that update --help does not call refresh / does not write deposit files. 4. Quick audit of init/migrate --help for the same fall-through; fix if same bug. 5. CHANGELOG [Unreleased].",
+      "UserStory": "As an operator or agent probing flags, I want `deft update --help` to print usage only, so that discovery never upgrades or stages my working tree.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2828",
+      "Overview": "Reproduced on @deftai/directive 0.84.0: update --help swapped .deft/core, rewrote AGENTS.md, modified .gitignore, and staged index changes. parseUpdateArgv in refresh.ts has no help branch.",
+      "Labels": "bug, adoption-blocker, agent-experience, area:cli, area:installer",
+      "Traces": "#2828"
+    },
+    "items": [
+      {
+        "id": "2828-a1",
+        "title": "Given update --help, when the CLI runs, then it prints help and exits 0 with no deposit mutation.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given an initialized Directive project, when `directive update --help` (or `-h`) is invoked, then usage text is printed, the process exits 0, and `.deft/core`, AGENTS.md, `.gitignore`, and the git index are unchanged.",
+          "Traces": "#2828"
+        }
+      },
+      {
+        "id": "2828-a2",
+        "title": "Given init/migrate --help audit, when the same fall-through exists, then it is fixed or explicitly documented as already safe.",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given a quick audit of top-level `init` and `migrate` help handling, when the same mutate-on-help pattern exists, then it is fixed in this story; otherwise the PR notes they already intercept help safely.",
+          "Traces": "#2828"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "adoption-blocker",
+      "agent-experience",
+      "area:cli",
+      "area:installer"
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/init-cli/update.ts",
+          "packages/core/src/init-deposit/refresh.ts",
+          "packages/core/src/init-deposit/refresh.test.ts",
+          "packages/cli/src/init-cli",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/init-deposit/refresh.test.ts packages/cli/src/init-cli"
+        ],
+        "expected_outputs": [
+          "update --help exits 0 without mutation",
+          "init/migrate help audit noted or fixed"
+        ],
+        "depends_on": [],
+        "conflict_group": "update-help",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      }
+    },
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2828",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2828"
+      }
+    ],
+    "updated": "2026-07-24T21:59:10Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Intercept `--help` / `-h` in `update`, `init`, and `migrate` CLI handlers before any mutating orchestrator runs
- Print focused usage text and exit 0 with zero deposit/git side effects
- Add regression tests proving `runRefreshDepositCli` / dispatch paths are not invoked on help

## Test plan
- [x] `pnpm exec vitest run packages/cli/src/init-cli/help.test.ts packages/cli/src/init-cli/update.test.ts packages/cli/src/init-cli/migrate.test.ts`
- [x] `update --help` / `-h` does not call `runRefreshDepositCli`
- [x] `init --help` does not dispatch or emit headless manifest
- [x] `migrate --help` does not call `runMigrateCli` or `runUntrackCoreCli`
- [x] `routeAndDispatch update --help` routing parity

Closes #2828
