### PR TITLE
fix(hooks): remove orphaned Cursor adapter test on update (#2838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`deft update` removes orphaned Cursor adapter test (#2838).** Hook deposit refresh now deletes leftover `.cursor/hooks/deft-cursor-hook-adapter.test.mjs` alongside the retired adapter script so `node --test .cursor/hooks/` does not fail on dead imports after upgrade.
+
 ### Removed
 
 ## [0.85.0] - 2026-07-25

--- a/packages/core/src/hooks/cursor-hooks.test.ts
+++ b/packages/core/src/hooks/cursor-hooks.test.ts
@@ -95,4 +95,26 @@ describe("cursor hook projection", () => {
     expect(refreshed.changed).toBe(true);
     expect(existsSync(adapterPath)).toBe(false);
   });
+
+  it("removes legacy adapter and companion test on refresh (#2838)", () => {
+    const root = project();
+    const hooksDir = join(root, ".cursor", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    const adapterPath = join(hooksDir, "deft-cursor-hook-adapter.mjs");
+    const adapterTestPath = join(hooksDir, "deft-cursor-hook-adapter.test.mjs");
+    writeFileSync(adapterPath, "export const removed = true;\n", "utf8");
+    writeFileSync(
+      adapterTestPath,
+      "import { removed } from './deft-cursor-hook-adapter.mjs';\n",
+      "utf8",
+    );
+
+    writeAgentHookDeposit(root);
+    const hooksJson = readFileSync(join(root, ".cursor/hooks.json"), "utf8");
+
+    expect(existsSync(adapterPath)).toBe(false);
+    expect(existsSync(adapterTestPath)).toBe(false);
+    expect(hooksJson).toContain(`"matcher": "${DIRECT_WRITE_HOOK_MATCHER}"`);
+    expect(hooksJson).toContain("--host cursor --event tool.before");
+  });
 });

--- a/packages/core/src/init-deposit/agent-hooks.ts
+++ b/packages/core/src/init-deposit/agent-hooks.ts
@@ -329,13 +329,21 @@ export function writeAgentHookDeposit(
     }
   }
 
-  const adapterAbsolute = join(projectRoot, ".cursor/hooks/deft-cursor-hook-adapter.mjs");
-  assertDepositContained(projectRoot, adapterAbsolute);
-  if (existsSync(adapterAbsolute)) {
-    rmSync(adapterAbsolute, { force: true });
-    if (!changedPaths.includes(AGENT_HOOK_PATHS[2])) {
-      changedPaths.push(AGENT_HOOK_PATHS[2]);
+  const legacyAdapterPaths = [
+    ".cursor/hooks/deft-cursor-hook-adapter.mjs",
+    ".cursor/hooks/deft-cursor-hook-adapter.test.mjs",
+  ] as const;
+  let removedLegacyAdapter = false;
+  for (const relative of legacyAdapterPaths) {
+    const absolute = join(projectRoot, relative);
+    assertDepositContained(projectRoot, absolute);
+    if (existsSync(absolute)) {
+      rmSync(absolute, { force: true });
+      removedLegacyAdapter = true;
     }
+  }
+  if (removedLegacyAdapter && !changedPaths.includes(AGENT_HOOK_PATHS[2])) {
+    changedPaths.push(AGENT_HOOK_PATHS[2]);
   }
 
   if (changedPaths.length > 0) {

--- a/xbrief/active/2026-07-26-2838-bughooks-deft-update-leaves-orphaned-deft-cursor-hook-adapte.xbrief.json
+++ b/xbrief/active/2026-07-26-2838-bughooks-deft-update-leaves-orphaned-deft-cursor-hook-adapte.xbrief.json
@@ -1,0 +1,79 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2838 — remove orphaned Cursor adapter companion test on update"
+  },
+  "plan": {
+    "id": "2026-07-26-2838-bughooks-deft-update-leaves-orphaned-deft-cursor-hook-adapte",
+    "title": "bug(hooks): deft update leaves orphaned deft-cursor-hook-adapter.test.mjs",
+    "status": "running",
+    "narratives": {
+      "Description": "After #2790, deft update deletes legacy deft-cursor-hook-adapter.mjs but leaves the companion .test.mjs. That orphaned test imports removed exports and fails node --test in consumer repositories.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2838",
+      "Overview": "Residual follow-up after adapter retirement. Extend writeAgentHookDeposit cleanup to remove .cursor/hooks/deft-cursor-hook-adapter.test.mjs when present, with regression coverage. Shell-quoting defect on the old adapter is out of scope (superseded by #2790).",
+      "Labels": "bug",
+      "ImplementationPlan": "1) In packages/core/src/init-deposit/agent-hooks.ts, rmSync the companion .test.mjs beside the existing adapter .mjs cleanup. 2) Extend cursor-hooks/agent-hooks tests to seed both files and assert both are removed on refresh. 3) CHANGELOG Unreleased note.",
+      "UserStory": "As a consumer running deft update, I want orphaned Cursor adapter tests removed with the adapter, so that node --test .cursor/hooks/ does not fail on dead imports."
+    },
+    "items": [
+      {
+        "title": "Given a leftover adapter test, when hooks deposit refreshes, then the test file is removed.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given .cursor/hooks/deft-cursor-hook-adapter.test.mjs present, when writeAgentHookDeposit / deft update runs, then that file is removed along with the legacy .mjs adapter."
+        }
+      },
+      {
+        "title": "Given seeded adapter and test files, when refresh runs, then both are gone and hooks.json stays current.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given both adapter and companion test seeded, when deposit refresh runs, then both are gone and Cursor direct-write hooks.json registration remains current."
+        }
+      },
+      {
+        "title": "Given the cleanup, when CHANGELOG is updated, then Unreleased notes the orphan removal.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the orphan cleanup lands, when CHANGELOG [Unreleased] is reviewed, then it notes removal of leftover deft-cursor-hook-adapter.test.mjs on update."
+        }
+      }
+    ],
+    "tags": ["bug"],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2838",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2838: bug(hooks): deft update leaves orphaned deft-cursor-hook-adapter.test.mjs"
+      }
+    ],
+    "updated": "2026-07-26T02:35:00Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/init-deposit/agent-hooks.ts",
+          "packages/core/src/init-deposit/agent-hooks.test.ts",
+          "packages/core/src/hooks/cursor-hooks.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/init-deposit/agent-hooks.test.ts packages/core/src/hooks/cursor-hooks.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "orphaned adapter test removed on refresh",
+          "regression test green",
+          "CHANGELOG Unreleased note"
+        ],
+        "depends_on": [],
+        "conflict_group": "hooks-adapter-orphan-2838",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to narrowed GitHub issue #2838 acceptance after #2790 supersession rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "bugfix"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Extend `writeAgentHookDeposit` to remove leftover `.cursor/hooks/deft-cursor-hook-adapter.test.mjs` alongside the retired adapter script during hook refresh / `deft update`.
- Add regression test: seed both adapter and companion test, run refresh, assert both are gone and `hooks.json` stays current.
- CHANGELOG [Unreleased] note.

Closes #2838

## Test plan

- [x] `pnpm exec vitest run packages/core/src/init-deposit/agent-hooks.test.ts packages/core/src/hooks/cursor-hooks.test.ts`
- [x] `task verify:forward-coverage`
- [ ] `task check` (branches 84.94% vs 85% floor — pre-existing #2836 cohort debt)