### PR TITLE
fix(appsec): gate migrate:xbrief and policy writes against symlink escape (#2847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **migrate:xbrief and policy wip-cap/subagent-backend refuse symlink write targets (#2847).** `runAgentsRefresh` during `migrate:xbrief` and the `policy set wip-cap` / `policy set subagent-backend` writers now gate AGENTS.md and PROJECT-DEFINITION paths with `assertWriteTargetSafe` and atomic write helpers instead of bare `writeFileSync`, so a malicious repo cannot redirect trusted CLI writes outside the checkout. Closes #2847.
 - **Vitest branch coverage restored above 85% (#2836).** Added focused tests for coverage-debt teardown, GitHub review-owner default fetch, org force-on edge paths, and win32 coverage setup, clearing the v0.85.0 `--allow-coverage-debt` citation without a consecutive soft-pass. Closes #2836.
 - **Swarm monitors no longer self-implement after a false DONE from a blocked merge-ready leaf (#2843).** Preamble §11 reserves `DONE` for merge-ready on `drive-to: merge-ready` envelopes and requires `BLOCKED` + `REDISPATCH_OK` mid-cycle; swarm Phase 5 and review-cycle skills require Tier 1 monitors to background-dispatch ONE continuation leaf instead of inline Greptile fixes. Closes #2843.
 

--- a/packages/cli/src/dispatch.test.ts
+++ b/packages/cli/src/dispatch.test.ts
@@ -1,6 +1,14 @@
 import type { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { engineInfo } from "@deftai/directive-core";
@@ -1061,6 +1069,7 @@ describe("native pack-migrate handlers (#2022)", () => {
 // ---------------------------------------------------------------------------
 
 describe("native policy-set handler (#2022)", () => {
+  const itSymlink = it.skipIf(process.platform === "win32");
   let root: string;
 
   function projectDefPath(): string {
@@ -1363,6 +1372,55 @@ describe("native policy-set handler (#2022)", () => {
     expect(result.code).toBe(2);
     expect(result.err).toContain("required: --set");
   });
+
+  itSymlink(
+    "wip-cap refuses when PROJECT-DEFINITION is a symlink outside the project (#2847)",
+    async () => {
+      const escapeDir = mkdtempSync(join(tmpdir(), "deft-policy-wip-cap-victim-"));
+      const victim = join(escapeDir, "PROJECT-DEFINITION.xbrief.json");
+      writeFileSync(victim, readFileSync(projectDefPath(), "utf8"), "utf8");
+      rmSync(projectDefPath());
+      symlinkSync(victim, projectDefPath());
+
+      const result = await runPolicy([
+        "wip-cap",
+        "--set",
+        "5",
+        "--confirm",
+        "--project-root",
+        root,
+      ]);
+      expect(result.code).toBe(2);
+      expect(result.err).toMatch(/Config error:.*symlink/);
+      expect(readPolicyBlock().wipCap).toBeUndefined();
+      expect(readFileSync(victim, "utf8")).not.toContain('"wipCap": 5');
+      rmSync(escapeDir, { recursive: true, force: true });
+    },
+  );
+
+  itSymlink(
+    "subagent-backend refuses when PROJECT-DEFINITION is a symlink outside the project (#2847)",
+    async () => {
+      const escapeDir = mkdtempSync(join(tmpdir(), "deft-policy-backend-victim-"));
+      const victim = join(escapeDir, "PROJECT-DEFINITION.xbrief.json");
+      writeFileSync(victim, readFileSync(projectDefPath(), "utf8"), "utf8");
+      rmSync(projectDefPath());
+      symlinkSync(victim, projectDefPath());
+
+      const result = await runPolicy([
+        "subagent-backend",
+        "--set",
+        "composer",
+        "--project-root",
+        root,
+      ]);
+      expect(result.code).toBe(2);
+      expect(result.err).toMatch(/Config error:.*symlink/);
+      expect(readPolicyBlock().swarmSubagentBackend).toBeUndefined();
+      expect(readFileSync(victim, "utf8")).not.toContain('"swarmSubagentBackend"');
+      rmSync(escapeDir, { recursive: true, force: true });
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -19,6 +19,7 @@ import {
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { engineInfo, userConfig } from "@deftai/directive-core";
+import { assertWriteTargetSafe } from "@deftai/directive-core/dist/fs/projection-containment.js";
 import { parseInitArgv, runInitDepositCli } from "@deftai/directive-core/init-deposit";
 import {
   appendAuditLog,
@@ -39,6 +40,7 @@ import {
   resolveSwarmSubagentBackend,
   type SubagentBackendDescriptor,
 } from "@deftai/directive-core/swarm";
+import { atomicWriteProjectDefinition } from "@deftai/directive-core/vbrief-build";
 
 export type CommandHandler = (argv: string[]) => number | Promise<number>;
 
@@ -2374,7 +2376,8 @@ function writeWipCap(
   const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
   const previous = policyBlock.wipCap;
   policyBlock.wipCap = cap;
-  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  assertWriteTargetSafe(projectRoot, path);
+  atomicWriteProjectDefinition(path, data);
   const changed = previous !== cap;
   const parts = [`actor=${actor}`, `wipCap=${cap}`, `previous=${pyRepr(previous)}`];
   if (note) parts.push(`note=${sanitizeNote(note)}`);
@@ -2393,7 +2396,8 @@ function writeSubagentBackend(
   const { path, data, policyBlock } = loadProjectDefinitionForWrite(projectRoot);
   const previous = policyBlock.swarmSubagentBackend;
   policyBlock.swarmSubagentBackend = backendId;
-  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  assertWriteTargetSafe(projectRoot, path);
+  atomicWriteProjectDefinition(path, data);
   const changed = previous !== backendId;
   const parts = [
     `actor=${actor}`,

--- a/packages/core/src/xbrief-migrate/migrate-project.test.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.test.ts
@@ -432,6 +432,29 @@ describe("runXbriefMigrationCli", () => {
     expect(code).toBe(2);
     expect(errs.join("")).toContain("agents:refresh failed");
   });
+
+  itSymlink(
+    "refuses agents:refresh when AGENTS.md is a symlink outside the project (#2847)",
+    () => {
+      const base = mkdtempSync(join(tmpdir(), "xbrief-migrate-cli-agents-symlink-"));
+      temps.push(base);
+      const escapeDir = mkdtempSync(join(tmpdir(), "xbrief-migrate-cli-agents-victim-"));
+      temps.push(escapeDir);
+      const project = scaffoldLegacyProject(base);
+      const victim = join(escapeDir, "AGENTS.md");
+      writeFileSync(victim, "# victim\nKeep me\n", "utf8");
+      symlinkSync(victim, join(project, "AGENTS.md"));
+
+      const errs: string[] = [];
+      const code = runXbriefMigrationCli(
+        { projectRoot: project, frameworkRoot: join(project, ".deft", "core"), force: true },
+        { writeOut: () => {}, writeErr: (t) => errs.push(t) },
+      );
+      expect(code).toBe(2);
+      expect(errs.join("")).toMatch(/agents:refresh failed.*symlink/);
+      expect(readFileSync(victim, "utf8")).toBe("# victim\nKeep me\n");
+    },
+  );
 });
 
 const SILENT_IO = { writeOut: () => {}, writeErr: () => {} };

--- a/packages/core/src/xbrief-migrate/migrate-project.ts
+++ b/packages/core/src/xbrief-migrate/migrate-project.ts
@@ -8,8 +8,9 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
+import { assertWriteTargetSafe, ProjectionContainmentError } from "../fs/projection-containment.js";
 import { checkGitClean } from "../migrate-preflight/index.js";
-import { agentsRefreshPlan } from "../platform/agents-md.js";
+import { applyAgentsRefresh } from "../platform/agents-md.js";
 import { patchAgentsMdHeader, renderHeaderPatchSummary } from "./agents-header.js";
 import {
   LEGACY_ARTIFACT_DIR,
@@ -237,25 +238,32 @@ function runAgentsRefresh(
   frameworkRoot: string | undefined,
   io: XbriefMigrationIo,
 ): number {
-  const plan = agentsRefreshPlan(projectRoot, { frameworkRoot }) as Record<string, unknown>;
-  const state = String(plan.state ?? "unknown");
-  if (state === "current") {
-    io.writeOut("AGENTS.md managed section is current — no changes.\n");
+  try {
+    assertWriteTargetSafe(projectRoot, join(projectRoot, "AGENTS.md"));
+    const { state, wrote, writable } = applyAgentsRefresh(projectRoot, {}, { frameworkRoot });
+    if (state === "current") {
+      io.writeOut("AGENTS.md managed section is current — no changes.\n");
+      return 0;
+    }
+    if (state === "template-missing" || state === "template-malformed" || state === "unreadable") {
+      io.writeErr(`agents:refresh failed: ${state}\n`);
+      return 2;
+    }
+    if (!writable) {
+      io.writeErr("agents:refresh failed: plan produced no new_content\n");
+      return 2;
+    }
+    if (wrote) {
+      io.writeOut(`AGENTS.md updated (state=${state}).\n`);
+    }
     return 0;
+  } catch (err) {
+    if (err instanceof ProjectionContainmentError) {
+      io.writeErr(`agents:refresh failed: ${err.message}\n`);
+      return 2;
+    }
+    throw err;
   }
-  if (state === "template-missing" || state === "template-malformed" || state === "unreadable") {
-    io.writeErr(`agents:refresh failed: ${state}\n`);
-    return 2;
-  }
-  const newContent = plan.new_content;
-  if (typeof newContent !== "string") {
-    io.writeErr("agents:refresh failed: plan produced no new_content\n");
-    return 2;
-  }
-  const path = String(plan.path ?? join(projectRoot, "AGENTS.md"));
-  writeFileSync(path, newContent, "utf8");
-  io.writeOut(`AGENTS.md updated (state=${state}).\n`);
-  return 0;
 }
 
 /** Core orchestrator for the consumer xbrief rename (#2110) + convergence (#2270). */


### PR DESCRIPTION
## Summary
- Gate `migrate:xbrief` `runAgentsRefresh` with `assertWriteTargetSafe` and `applyAgentsRefresh` instead of bare `writeFileSync` on AGENTS.md.
- Route `policy set wip-cap` and `policy set subagent-backend` through `assertWriteTargetSafe` + `atomicWriteProjectDefinition` instead of bare `writeFileSync` on PROJECT-DEFINITION.
- Add committed-symlink regression tests for both paths (Unix; skipped on win32).

## Test plan
- [x] `pnpm exec vitest run packages/core/src/xbrief-migrate/migrate-project.test.ts`
- [x] `pnpm exec vitest run packages/cli/src/dispatch.test.ts -t "native policy-set"`
- [x] `task check`

Closes #2847
