### PR TITLE
fix(doctor): classify maintainer clone correctly for global CLI (#2850)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Doctor no longer misclassifies a maintainer clone as a consumer when using the global CLI (#2850).** `frameworkRoot` now resolves via `resolveFrameworkRootForProject(projectRoot)` so hooks and Deft structure checks skip on a source checkout like install-integrity already does; `EXPECTED_FRAMEWORK_DIRS` expects `xbrief/` instead of legacy `vbrief/`. Closes #2850.
 - **deft-hook and guarded CLI bins now run through npm bin symlinks (#2846).** Global npm bins are symlinks; the entrypoint guard compared raw `process.argv[1]` to `import.meta.url`, so `main()` never ran (empty stdout exit 0). Cursor failClosed blocked all edits; other hosts silently dropped deny decisions. Shared `isDirectEntrypoint` realpath-compares both sides. Closes #2846.
 - **migrate:xbrief and policy wip-cap/subagent-backend refuse symlink write targets (#2847).** `runAgentsRefresh` during `migrate:xbrief` and the `policy set wip-cap` / `policy set subagent-backend` writers now gate AGENTS.md and PROJECT-DEFINITION paths with `assertWriteTargetSafe` and atomic write helpers instead of bare `writeFileSync`, so a malicious repo cannot redirect trusted CLI writes outside the checkout. Closes #2847.
 - **Vitest branch coverage restored above 85% (#2836).** Added focused tests for coverage-debt teardown, GitHub review-owner default fetch, org force-on edge paths, and win32 coverage setup, clearing the v0.85.0 `--allow-coverage-debt` citation without a consecutive soft-pass. Closes #2836.

--- a/packages/core/src/doctor/agent-hooks.test.ts
+++ b/packages/core/src/doctor/agent-hooks.test.ts
@@ -4,6 +4,28 @@ import { createPlainSink } from "./output.js";
 import type { DoctorSeams, Finding } from "./types.js";
 
 describe("runAgentHooksHealthCheck", () => {
+  it("skips agent-hooks registration on maintainer source checkout", () => {
+    const lines: string[] = [];
+    const findings: Finding[] = [];
+
+    runAgentHooksHealthCheck(
+      "/project",
+      false,
+      createPlainSink({ write: (text) => lines.push(text) }),
+      (finding) => findings.push(finding),
+      {},
+    );
+
+    expect(lines.join("")).toContain("skip -- maintainer source checkout");
+    expect(findings).toEqual([
+      expect.objectContaining({
+        severity: "skip",
+        check: "agent-hooks-registration",
+        status: "skip",
+      }),
+    ]);
+  });
+
   it("records structural health and leaves Codex runtime trust unverifiable", () => {
     const lines: string[] = [];
     const findings: Finding[] = [];

--- a/packages/core/src/doctor/agents-md-advisory.test.ts
+++ b/packages/core/src/doctor/agents-md-advisory.test.ts
@@ -28,7 +28,7 @@ function makeConsumerDeposit(options: {
   const framework = mkdtempSync(join(tmpdir(), "deft-doc-advisory-fw-"));
   temps.push(root, framework);
   const deposit = join(root, ".deft", "core");
-  for (const dir of ["languages", "strategies", "skills", "templates", "tasks", "vbrief"]) {
+  for (const dir of ["languages", "strategies", "skills", "templates", "tasks", "xbrief"]) {
     mkdirSync(join(deposit, dir), { recursive: true });
   }
   const lines: string[] = [];

--- a/packages/core/src/doctor/constants.ts
+++ b/packages/core/src/doctor/constants.ts
@@ -64,10 +64,10 @@ export const PAYLOAD_STALENESS_OFFLINE_SKIP_MESSAGE =
 
 // Engine / lifecycle dirs that stay at the framework root (NOT relocated by
 // #1875). Shippable-content dirs moved under content/ -- see EXPECTED_CONTENT_DIRS.
-export const EXPECTED_FRAMEWORK_DIRS = ["tasks", "scripts", "vbrief"] as const;
+export const EXPECTED_FRAMEWORK_DIRS = ["tasks", "scripts", "xbrief"] as const;
 
 /** npm consumer deposit after #2022 Phase 3 -- Python scripts/ tree is intentionally absent. */
-export const CONSUMER_FRAMEWORK_DIRS = ["tasks", "vbrief"] as const;
+export const CONSUMER_FRAMEWORK_DIRS = ["tasks", "xbrief"] as const;
 
 // Post-#1875 content/ move: these framework-internal markers now live under
 // content/ in the SOURCE repo. They identify a deft source checkout (a consumer

--- a/packages/core/src/doctor/coverage-boost.test.ts
+++ b/packages/core/src/doctor/coverage-boost.test.ts
@@ -151,7 +151,7 @@ describe("doctor branch coverage boost", () => {
     const framework = mkdtempSync(join(tmpdir(), "deft-doc-framework-layout-"));
     const deposit = join(root, ".deft", "core");
     try {
-      for (const dir of ["languages", "strategies", "skills", "templates", "tasks", "vbrief"]) {
+      for (const dir of ["languages", "strategies", "skills", "templates", "tasks", "xbrief"]) {
         mkdirSync(join(deposit, dir), { recursive: true });
       }
       writeFileSync(

--- a/packages/core/src/doctor/main.test.ts
+++ b/packages/core/src/doctor/main.test.ts
@@ -113,6 +113,59 @@ describe("cmdDoctor", () => {
   });
 });
 
+describe("cmdDoctor maintainer clone classification (#2850)", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeMaintainerClone(): string {
+    const root = mkdtempSync(join(tmpdir(), "deft-doctor-2850-"));
+    created.push(root);
+    writeFileSync(join(root, "main.md"), "# Deft\n", "utf8");
+    writeFileSync(join(root, "AGENTS.md"), "# Agents\n", "utf8");
+    mkdirSync(join(root, "content", "templates"), { recursive: true });
+    mkdirSync(join(root, "content", "skills", "deft-directive-build"), { recursive: true });
+    writeFileSync(join(root, "content", "templates", "agents-entry.md"), "# agents\n", "utf8");
+    writeFileSync(
+      join(root, "content", "skills", "deft-directive-build", "SKILL.md"),
+      "# build\n",
+      "utf8",
+    );
+    for (const dir of ["languages", "strategies", "skills", "templates"]) {
+      mkdirSync(join(root, "content", dir), { recursive: true });
+    }
+    for (const dir of ["tasks", "scripts", "xbrief"]) {
+      mkdirSync(join(root, dir), { recursive: true });
+    }
+    return root;
+  }
+
+  it("skips hooks and structure warnings when global CLI targets a maintainer clone", () => {
+    const root = makeMaintainerClone();
+    const stdout: string[] = [];
+    const write = (t: string) => stdout.push(t);
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = write as typeof process.stdout.write;
+    try {
+      const exit = cmdDoctor(["--full", "--json", "--project-root", root], {
+        whichFn: () => "/usr/bin/x",
+      });
+      expect(exit).toBe(0);
+      const payload = stdout.join("");
+      expect(payload).toContain('"check": "agent-hooks-registration"');
+      expect(payload).toContain("maintainer source checkout");
+      expect(payload).not.toContain('"check": "framework-layout"');
+      expect(payload).not.toContain("Missing directory:");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+});
+
 describe("parseDoctorFlags", () => {
   it("parses project-root forms", () => {
     expect(parseDoctorFlags(["--project-root", "/tmp"]).projectRoot).toBe("/tmp");

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -43,7 +43,7 @@ import { runNpmRegistryMirrorCheck } from "./npm-registry.js";
 import { createPlainSink } from "./output.js";
 import {
   readTextSafe,
-  resolveDefaultFrameworkRoot,
+  resolveFrameworkRootForProject,
   resolvePath,
   resolveVersion,
   runningInsideDeftRepo,
@@ -99,7 +99,7 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
   const quietMode = flags.quiet;
   const fullMode = flags.full;
   const projectRoot = resolvePath(flags.projectRoot ?? process.cwd());
-  const frameworkRoot = seams.frameworkRoot ?? resolveDefaultFrameworkRoot();
+  const frameworkRoot = seams.frameworkRoot ?? resolveFrameworkRootForProject(projectRoot);
   const consumerContext = resolve(projectRoot) !== resolve(frameworkRoot);
   const whichFn = seams.whichFn ?? defaultWhich;
   const nowFn = seams.now ?? (() => new Date());


### PR DESCRIPTION
## Summary
- Resolve doctor `frameworkRoot` via `resolveFrameworkRootForProject(projectRoot)` so global CLI runs against a maintainer clone are not misclassified as consumer context (#2850).
- Update `EXPECTED_FRAMEWORK_DIRS` / `CONSUMER_FRAMEWORK_DIRS` to expect `xbrief/` instead of legacy `vbrief/`.
- Add regression tests for maintainer clone classification and agent-hooks skip.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/doctor`
- [x] `task check`

Closes #2850