### PR TITLE
fix(doctor): live-probe agent hooks under --full (#2852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Doctor `--full` live-probes deposited agent hooks (#2852).** After structural registration checks pass, doctor spawns the configured `deft-hook` command with Cursor `tool.before` allow and deny fixtures and warns when stdout is empty, unparseable, or missing an expected deny — surfacing #2846-class packaging failures that structurally valid deposits hide. Closes #2852.
+
 ### Changed
 
 ### Fixed

--- a/packages/core/src/doctor/agent-hooks.test.ts
+++ b/packages/core/src/doctor/agent-hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { runAgentHooksHealthCheck } from "./main.js";
+import { runAgentHooksHealthCheck, runAgentHooksLiveProbeCheck } from "./main.js";
 import { createPlainSink } from "./output.js";
 import type { DoctorSeams, Finding } from "./types.js";
 
@@ -24,15 +24,15 @@ describe("runAgentHooksHealthCheck", () => {
       }),
     };
 
-    runAgentHooksHealthCheck(
-      "/project",
-      true,
-      false,
-      createPlainSink({ write: (text) => lines.push(text) }),
-      (finding) => findings.push(finding),
-      seams,
-    );
-
+    expect(
+      runAgentHooksHealthCheck(
+        "/project",
+        true,
+        createPlainSink({ write: (text) => lines.push(text) }),
+        (finding) => findings.push(finding),
+        seams,
+      ),
+    ).toBe(true);
     expect(lines.join("")).toContain("registered and structurally valid");
     expect(lines.join("")).toContain("`/hooks`");
     expect(findings).toEqual([
@@ -46,56 +46,139 @@ describe("runAgentHooksHealthCheck", () => {
     ]);
   });
 
-  it("runs the live probe only under doctor --full", () => {
+  it("can defer the registered finding when a live probe will follow", () => {
+    const findings: Finding[] = [];
+    expect(
+      runAgentHooksHealthCheck(
+        "/project",
+        true,
+        createPlainSink({ write: () => undefined }),
+        (finding) => findings.push(finding),
+        {
+          evaluateAgentHooks: () => ({
+            code: 0,
+            message: "registered",
+            stream: "stdout",
+            registrations: [],
+          }),
+        },
+        false,
+      ),
+    ).toBe(true);
+    expect(findings).toEqual([]);
+  });
+
+  it("reports registration drift without claiming runtime non-functionality", () => {
+    const findings: Finding[] = [];
+    expect(
+      runAgentHooksHealthCheck(
+        "/project",
+        true,
+        createPlainSink({ write: () => undefined }),
+        (finding) => findings.push(finding),
+        {
+          evaluateAgentHooks: () => ({
+            code: 1,
+            message: "registration incomplete",
+            stream: "stderr",
+            registrations: [],
+          }),
+        },
+      ),
+    ).toBe(false);
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        severity: "warning",
+        status: "incomplete",
+      }),
+    ]);
+  });
+
+  it("distinguishes a registration probe configuration error", () => {
+    const findings: Finding[] = [];
+    expect(
+      runAgentHooksHealthCheck(
+        "/project",
+        true,
+        createPlainSink({ write: () => undefined }),
+        (finding) => findings.push(finding),
+        {
+          evaluateAgentHooks: () => ({
+            code: 2,
+            message: "project root unavailable",
+            stream: "stderr",
+            registrations: [],
+          }),
+        },
+      ),
+    ).toBe(false);
+
+    expect(findings).toEqual([expect.objectContaining({ status: "unavailable" })]);
+  });
+
+  it("reports a thrown registration probe without crashing doctor", () => {
+    const findings: Finding[] = [];
+    expect(
+      runAgentHooksHealthCheck(
+        "/project",
+        true,
+        createPlainSink({ write: () => undefined }),
+        (finding) => findings.push(finding),
+        {
+          evaluateAgentHooks: () => {
+            throw new Error("probe failed");
+          },
+        },
+      ),
+    ).toBe(false);
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        severity: "warning",
+        message: expect.stringContaining("probe failed"),
+      }),
+    ]);
+  });
+});
+
+describe("runAgentHooksLiveProbeCheck", () => {
+  it("records a passing live probe under doctor --full", () => {
     const findings: Finding[] = [];
     const liveProbe = vi.fn(() => ({
       code: 0 as const,
       message: "live probe passed",
       cases: [],
     }));
-    const seams: DoctorSeams = {
-      evaluateAgentHooks: () => ({
-        code: 0,
-        message: "registered",
-        stream: "stdout",
-        registrations: [],
-      }),
-      probeAgentHooksLive: liveProbe,
-    };
 
-    runAgentHooksHealthCheck(
+    runAgentHooksLiveProbeCheck(
       "/project",
-      true,
-      false,
       createPlainSink({ write: () => undefined }),
       (finding) => findings.push(finding),
-      seams,
+      {
+        evaluateAgentHooks: () => ({
+          code: 0,
+          message: "registered",
+          stream: "stdout",
+          registrations: [],
+        }),
+        probeAgentHooksLive: liveProbe,
+      },
     );
-    expect(liveProbe).not.toHaveBeenCalled();
 
-    runAgentHooksHealthCheck(
-      "/project",
-      true,
-      true,
-      createPlainSink({ write: () => undefined }),
-      (finding) => findings.push(finding),
-      seams,
-    );
     expect(liveProbe).toHaveBeenCalledTimes(1);
-    expect(findings.at(-1)).toEqual(
+    expect(findings).toEqual([
       expect.objectContaining({
         status: "registered-and-functional",
         live_probe: "passed",
       }),
-    );
+    ]);
   });
 
-  it("surfaces empty-stdout hook bins as non-functional under --full", () => {
+  it("surfaces empty-stdout hook bins as non-functional", () => {
     const findings: Finding[] = [];
-    runAgentHooksHealthCheck(
+    runAgentHooksLiveProbeCheck(
       "/project",
-      true,
-      true,
       createPlainSink({ write: () => undefined }),
       (finding) => findings.push(finding),
       {
@@ -126,76 +209,6 @@ describe("runAgentHooksHealthCheck", () => {
         check: "agent-hooks-live-probe",
         status: "non-functional",
         severity: "warning",
-      }),
-    ]);
-  });
-
-  it("reports registration drift without claiming runtime non-functionality", () => {
-    const findings: Finding[] = [];
-    runAgentHooksHealthCheck(
-      "/project",
-      true,
-      false,
-      createPlainSink({ write: () => undefined }),
-      (finding) => findings.push(finding),
-      {
-        evaluateAgentHooks: () => ({
-          code: 1,
-          message: "registration incomplete",
-          stream: "stderr",
-          registrations: [],
-        }),
-      },
-    );
-
-    expect(findings).toEqual([
-      expect.objectContaining({
-        severity: "warning",
-        status: "incomplete",
-      }),
-    ]);
-  });
-
-  it("distinguishes a registration probe configuration error", () => {
-    const findings: Finding[] = [];
-    runAgentHooksHealthCheck(
-      "/project",
-      true,
-      false,
-      createPlainSink({ write: () => undefined }),
-      (finding) => findings.push(finding),
-      {
-        evaluateAgentHooks: () => ({
-          code: 2,
-          message: "project root unavailable",
-          stream: "stderr",
-          registrations: [],
-        }),
-      },
-    );
-
-    expect(findings).toEqual([expect.objectContaining({ status: "unavailable" })]);
-  });
-
-  it("reports a thrown registration probe without crashing doctor", () => {
-    const findings: Finding[] = [];
-    runAgentHooksHealthCheck(
-      "/project",
-      true,
-      false,
-      createPlainSink({ write: () => undefined }),
-      (finding) => findings.push(finding),
-      {
-        evaluateAgentHooks: () => {
-          throw new Error("probe failed");
-        },
-      },
-    );
-
-    expect(findings).toEqual([
-      expect.objectContaining({
-        severity: "warning",
-        message: expect.stringContaining("probe failed"),
       }),
     ]);
   });

--- a/packages/core/src/doctor/agent-hooks.test.ts
+++ b/packages/core/src/doctor/agent-hooks.test.ts
@@ -1,31 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runAgentHooksHealthCheck } from "./main.js";
 import { createPlainSink } from "./output.js";
 import type { DoctorSeams, Finding } from "./types.js";
 
 describe("runAgentHooksHealthCheck", () => {
-  it("skips agent-hooks registration on maintainer source checkout", () => {
-    const lines: string[] = [];
-    const findings: Finding[] = [];
-
-    runAgentHooksHealthCheck(
-      "/project",
-      false,
-      createPlainSink({ write: (text) => lines.push(text) }),
-      (finding) => findings.push(finding),
-      {},
-    );
-
-    expect(lines.join("")).toContain("skip -- maintainer source checkout");
-    expect(findings).toEqual([
-      expect.objectContaining({
-        severity: "skip",
-        check: "agent-hooks-registration",
-        status: "skip",
-      }),
-    ]);
-  });
-
   it("records structural health and leaves Codex runtime trust unverifiable", () => {
     const lines: string[] = [];
     const findings: Finding[] = [];
@@ -49,6 +27,7 @@ describe("runAgentHooksHealthCheck", () => {
     runAgentHooksHealthCheck(
       "/project",
       true,
+      false,
       createPlainSink({ write: (text) => lines.push(text) }),
       (finding) => findings.push(finding),
       seams,
@@ -67,11 +46,96 @@ describe("runAgentHooksHealthCheck", () => {
     ]);
   });
 
+  it("runs the live probe only under doctor --full", () => {
+    const findings: Finding[] = [];
+    const liveProbe = vi.fn(() => ({
+      code: 0 as const,
+      message: "live probe passed",
+      cases: [],
+    }));
+    const seams: DoctorSeams = {
+      evaluateAgentHooks: () => ({
+        code: 0,
+        message: "registered",
+        stream: "stdout",
+        registrations: [],
+      }),
+      probeAgentHooksLive: liveProbe,
+    };
+
+    runAgentHooksHealthCheck(
+      "/project",
+      true,
+      false,
+      createPlainSink({ write: () => undefined }),
+      (finding) => findings.push(finding),
+      seams,
+    );
+    expect(liveProbe).not.toHaveBeenCalled();
+
+    runAgentHooksHealthCheck(
+      "/project",
+      true,
+      true,
+      createPlainSink({ write: () => undefined }),
+      (finding) => findings.push(finding),
+      seams,
+    );
+    expect(liveProbe).toHaveBeenCalledTimes(1);
+    expect(findings.at(-1)).toEqual(
+      expect.objectContaining({
+        status: "registered-and-functional",
+        live_probe: "passed",
+      }),
+    );
+  });
+
+  it("surfaces empty-stdout hook bins as non-functional under --full", () => {
+    const findings: Finding[] = [];
+    runAgentHooksHealthCheck(
+      "/project",
+      true,
+      true,
+      createPlainSink({ write: () => undefined }),
+      (finding) => findings.push(finding),
+      {
+        evaluateAgentHooks: () => ({
+          code: 0,
+          message: "registered",
+          stream: "stdout",
+          registrations: [],
+        }),
+        probeAgentHooksLive: () => ({
+          code: 1,
+          message: "deft agent hooks live probe FAILED: allow: empty-stdout (empty stdout)",
+          cases: [
+            {
+              host: "cursor",
+              event: "tool.before",
+              fixture: "allow",
+              issue: "empty-stdout",
+              detail: "empty stdout",
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        check: "agent-hooks-live-probe",
+        status: "non-functional",
+        severity: "warning",
+      }),
+    ]);
+  });
+
   it("reports registration drift without claiming runtime non-functionality", () => {
     const findings: Finding[] = [];
     runAgentHooksHealthCheck(
       "/project",
       true,
+      false,
       createPlainSink({ write: () => undefined }),
       (finding) => findings.push(finding),
       {
@@ -97,6 +161,7 @@ describe("runAgentHooksHealthCheck", () => {
     runAgentHooksHealthCheck(
       "/project",
       true,
+      false,
       createPlainSink({ write: () => undefined }),
       (finding) => findings.push(finding),
       {
@@ -117,6 +182,7 @@ describe("runAgentHooksHealthCheck", () => {
     runAgentHooksHealthCheck(
       "/project",
       true,
+      false,
       createPlainSink({ write: () => undefined }),
       (finding) => findings.push(finding),
       {

--- a/packages/core/src/doctor/agent-hooks.test.ts
+++ b/packages/core/src/doctor/agent-hooks.test.ts
@@ -46,8 +46,9 @@ describe("runAgentHooksHealthCheck", () => {
     ]);
   });
 
-  it("can defer the registered finding when a live probe will follow", () => {
+  it("returns true without emitting a registered finding when cmdDoctor replaces it", () => {
     const findings: Finding[] = [];
+    const before = findings.length;
     expect(
       runAgentHooksHealthCheck(
         "/project",
@@ -62,10 +63,36 @@ describe("runAgentHooksHealthCheck", () => {
             registrations: [],
           }),
         },
-        false,
       ),
     ).toBe(true);
-    expect(findings).toEqual([]);
+    expect(findings.length).toBe(before + 1);
+    if (findings.length > before) {
+      findings.pop();
+    }
+    runAgentHooksLiveProbeCheck(
+      "/project",
+      createPlainSink({ write: () => undefined }),
+      (finding) => findings.push(finding),
+      {
+        evaluateAgentHooks: () => ({
+          code: 0,
+          message: "registered",
+          stream: "stdout",
+          registrations: [],
+        }),
+        probeAgentHooksLive: () => ({
+          code: 0,
+          message: "live probe passed",
+          cases: [],
+        }),
+      },
+    );
+    expect(findings.at(-1)).toEqual(
+      expect.objectContaining({
+        check: "agent-hooks-live-probe",
+        status: "registered-and-functional",
+      }),
+    );
   });
 
   it("reports registration drift without claiming runtime non-functionality", () => {
@@ -169,6 +196,7 @@ describe("runAgentHooksLiveProbeCheck", () => {
     expect(liveProbe).toHaveBeenCalledTimes(1);
     expect(findings).toEqual([
       expect.objectContaining({
+        check: "agent-hooks-live-probe",
         status: "registered-and-functional",
         live_probe: "passed",
       }),

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -18,6 +18,7 @@ import {
 } from "../resolution/index.js";
 import { type ResolveUserMdResult, resolveUserMdPath } from "../user-config/resolve-user-md.js";
 import { evaluateAgentHooks } from "../verify-env/agent-hooks.js";
+import { probeAgentHooksLive } from "../verify-env/agent-hooks-live-probe.js";
 import { agentsRefreshPlan, hasV3ManagedMarker } from "./agents-md.js";
 import { runChecks } from "./checks.js";
 import {
@@ -223,7 +224,7 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
     sink.blank();
   }
   sink.info("Checking agent-host hook registration...");
-  runAgentHooksHealthCheck(projectRoot, consumerContext, sink, addFinding, seams);
+  runAgentHooksHealthCheck(projectRoot, consumerContext, fullMode, sink, addFinding, seams);
 
   if (consumerContext) {
     if (!jsonMode) {
@@ -422,11 +423,13 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
 export function runAgentHooksHealthCheck(
   projectRoot: string,
   consumerContext: boolean,
+  fullMode: boolean,
   sink: ReturnType<typeof createPlainSink>,
   addFinding: (finding: Finding) => void,
   seams: DoctorSeams,
 ): void {
   const checkName = "agent-hooks-registration";
+  const liveCheckName = "agent-hooks-live-probe";
   if (!consumerContext) {
     const reason = "maintainer source checkout; project hook deposit is consumer-only";
     sink.info(`${checkName}: skip -- ${reason}`);
@@ -435,31 +438,64 @@ export function runAgentHooksHealthCheck(
   }
   try {
     const result = (seams.evaluateAgentHooks ?? evaluateAgentHooks)(projectRoot);
-    if (result.code === 0) {
+    if (result.code !== 0) {
+      const message = `${checkName}: ${result.message.replace(/\s+/g, " ").trim()}`;
+      sink.warn(message);
+      addFinding({
+        severity: "warning",
+        message,
+        check: checkName,
+        status: result.code === 2 ? "unavailable" : "incomplete",
+        registrations: result.registrations,
+        suggestion: "deft update",
+      });
+      return;
+    }
+
+    if (fullMode) {
+      const liveResult = (seams.probeAgentHooksLive ?? probeAgentHooksLive)(projectRoot);
+      if (liveResult.code !== 0) {
+        const message = `${liveCheckName}: ${liveResult.message.replace(/\s+/g, " ").trim()}`;
+        sink.warn(message);
+        addFinding({
+          severity: "warning",
+          message,
+          check: liveCheckName,
+          status: liveResult.code === 2 ? "unavailable" : "non-functional",
+          cases: liveResult.cases,
+          suggestion: "npm i -g @deftai/directive@latest && deft update",
+        });
+        return;
+      }
       const message =
-        `${checkName}: registered and structurally valid; ` +
+        `${checkName}: registered, structurally valid, and live probe passed; ` +
         "Codex runtime trust is user-controlled and must be reviewed with `/hooks`";
       sink.success(message);
       addFinding({
         severity: "skip",
         message,
         check: checkName,
-        status: "registered",
+        status: "registered-and-functional",
         registrations: result.registrations,
         trust_status: "not-verifiable",
         trust_review: "Open `/hooks` in Codex and review the project hook commands.",
+        live_probe: "passed",
       });
       return;
     }
-    const message = `${checkName}: ${result.message.replace(/\s+/g, " ").trim()}`;
-    sink.warn(message);
+
+    const message =
+      `${checkName}: registered and structurally valid; ` +
+      "Codex runtime trust is user-controlled and must be reviewed with `/hooks`";
+    sink.success(message);
     addFinding({
-      severity: "warning",
+      severity: "skip",
       message,
       check: checkName,
-      status: result.code === 2 ? "unavailable" : "incomplete",
+      status: "registered",
       registrations: result.registrations,
-      suggestion: "deft update",
+      trust_status: "not-verifiable",
+      trust_review: "Open `/hooks` in Codex and review the project hook commands.",
     });
   } catch (cause) {
     const message = `${checkName}: probe failed -- ${String(cause)}`;

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -224,7 +224,17 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
     sink.blank();
   }
   sink.info("Checking agent-host hook registration...");
-  runAgentHooksHealthCheck(projectRoot, consumerContext, fullMode, sink, addFinding, seams);
+  const hooksHealthy = runAgentHooksHealthCheck(
+    projectRoot,
+    consumerContext,
+    sink,
+    addFinding,
+    seams,
+    !fullMode,
+  );
+  if (fullMode && hooksHealthy) {
+    runAgentHooksLiveProbeCheck(projectRoot, sink, addFinding, seams);
+  }
 
   if (consumerContext) {
     if (!jsonMode) {
@@ -423,18 +433,17 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
 export function runAgentHooksHealthCheck(
   projectRoot: string,
   consumerContext: boolean,
-  fullMode: boolean,
   sink: ReturnType<typeof createPlainSink>,
   addFinding: (finding: Finding) => void,
   seams: DoctorSeams,
-): void {
+  emitRegisteredFinding = true,
+): boolean {
   const checkName = "agent-hooks-registration";
-  const liveCheckName = "agent-hooks-live-probe";
   if (!consumerContext) {
     const reason = "maintainer source checkout; project hook deposit is consumer-only";
     sink.info(`${checkName}: skip -- ${reason}`);
     addFinding({ severity: "skip", message: reason, check: checkName, status: "skip" });
-    return;
+    return false;
   }
   try {
     const result = (seams.evaluateAgentHooks ?? evaluateAgentHooks)(projectRoot);
@@ -449,58 +458,75 @@ export function runAgentHooksHealthCheck(
         registrations: result.registrations,
         suggestion: "deft update",
       });
-      return;
+      return false;
     }
 
-    if (fullMode) {
-      const liveResult = (seams.probeAgentHooksLive ?? probeAgentHooksLive)(projectRoot);
-      if (liveResult.code !== 0) {
-        const message = `${liveCheckName}: ${liveResult.message.replace(/\s+/g, " ").trim()}`;
-        sink.warn(message);
-        addFinding({
-          severity: "warning",
-          message,
-          check: liveCheckName,
-          status: liveResult.code === 2 ? "unavailable" : "non-functional",
-          cases: liveResult.cases,
-          suggestion: "npm i -g @deftai/directive@latest && deft update",
-        });
-        return;
-      }
-      const message =
-        `${checkName}: registered, structurally valid, and live probe passed; ` +
-        "Codex runtime trust is user-controlled and must be reviewed with `/hooks`";
+    const message =
+      `${checkName}: registered and structurally valid; ` +
+      "Codex runtime trust is user-controlled and must be reviewed with `/hooks`";
+    if (emitRegisteredFinding) {
       sink.success(message);
       addFinding({
         severity: "skip",
         message,
         check: checkName,
-        status: "registered-and-functional",
+        status: "registered",
         registrations: result.registrations,
         trust_status: "not-verifiable",
         trust_review: "Open `/hooks` in Codex and review the project hook commands.",
-        live_probe: "passed",
+      });
+    }
+    return true;
+  } catch (cause) {
+    const message = `${checkName}: probe failed -- ${String(cause)}`;
+    sink.warn(message);
+    addFinding({ severity: "warning", message, check: checkName, suggestion: "deft update" });
+    return false;
+  }
+}
+
+export function runAgentHooksLiveProbeCheck(
+  projectRoot: string,
+  sink: ReturnType<typeof createPlainSink>,
+  addFinding: (finding: Finding) => void,
+  seams: DoctorSeams,
+): void {
+  const checkName = "agent-hooks-registration";
+  const liveCheckName = "agent-hooks-live-probe";
+  try {
+    const result = (seams.evaluateAgentHooks ?? evaluateAgentHooks)(projectRoot);
+    const liveResult = (seams.probeAgentHooksLive ?? probeAgentHooksLive)(projectRoot);
+    if (liveResult.code !== 0) {
+      const message = `${liveCheckName}: ${liveResult.message.replace(/\s+/g, " ").trim()}`;
+      sink.warn(message);
+      addFinding({
+        severity: "warning",
+        message,
+        check: liveCheckName,
+        status: liveResult.code === 2 ? "unavailable" : "non-functional",
+        cases: liveResult.cases,
+        suggestion: "npm i -g @deftai/directive@latest && deft update",
       });
       return;
     }
-
     const message =
-      `${checkName}: registered and structurally valid; ` +
+      `${checkName}: registered, structurally valid, and live probe passed; ` +
       "Codex runtime trust is user-controlled and must be reviewed with `/hooks`";
     sink.success(message);
     addFinding({
       severity: "skip",
       message,
       check: checkName,
-      status: "registered",
+      status: "registered-and-functional",
       registrations: result.registrations,
       trust_status: "not-verifiable",
       trust_review: "Open `/hooks` in Codex and review the project hook commands.",
+      live_probe: "passed",
     });
   } catch (cause) {
-    const message = `${checkName}: probe failed -- ${String(cause)}`;
+    const message = `${liveCheckName}: probe failed -- ${String(cause)}`;
     sink.warn(message);
-    addFinding({ severity: "warning", message, check: checkName, suggestion: "deft update" });
+    addFinding({ severity: "warning", message, check: liveCheckName, suggestion: "deft update" });
   }
 }
 

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -224,15 +224,23 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
     sink.blank();
   }
   sink.info("Checking agent-host hook registration...");
+  const findingCountBeforeHooks = findings.length;
   const hooksHealthy = runAgentHooksHealthCheck(
     projectRoot,
     consumerContext,
     sink,
     addFinding,
     seams,
-    !fullMode,
   );
   if (fullMode && hooksHealthy) {
+    const lastFinding = findings[findings.length - 1];
+    if (
+      findings.length > findingCountBeforeHooks &&
+      lastFinding?.check === "agent-hooks-registration" &&
+      lastFinding?.status === "registered"
+    ) {
+      findings.pop();
+    }
     runAgentHooksLiveProbeCheck(projectRoot, sink, addFinding, seams);
   }
 
@@ -436,7 +444,6 @@ export function runAgentHooksHealthCheck(
   sink: ReturnType<typeof createPlainSink>,
   addFinding: (finding: Finding) => void,
   seams: DoctorSeams,
-  emitRegisteredFinding = true,
 ): boolean {
   const checkName = "agent-hooks-registration";
   if (!consumerContext) {
@@ -464,18 +471,16 @@ export function runAgentHooksHealthCheck(
     const message =
       `${checkName}: registered and structurally valid; ` +
       "Codex runtime trust is user-controlled and must be reviewed with `/hooks`";
-    if (emitRegisteredFinding) {
-      sink.success(message);
-      addFinding({
-        severity: "skip",
-        message,
-        check: checkName,
-        status: "registered",
-        registrations: result.registrations,
-        trust_status: "not-verifiable",
-        trust_review: "Open `/hooks` in Codex and review the project hook commands.",
-      });
-    }
+    sink.success(message);
+    addFinding({
+      severity: "skip",
+      message,
+      check: checkName,
+      status: "registered",
+      registrations: result.registrations,
+      trust_status: "not-verifiable",
+      trust_review: "Open `/hooks` in Codex and review the project hook commands.",
+    });
     return true;
   } catch (cause) {
     const message = `${checkName}: probe failed -- ${String(cause)}`;
@@ -516,7 +521,7 @@ export function runAgentHooksLiveProbeCheck(
     addFinding({
       severity: "skip",
       message,
-      check: checkName,
+      check: liveCheckName,
       status: "registered-and-functional",
       registrations: result.registrations,
       trust_status: "not-verifiable",

--- a/packages/core/src/doctor/types.ts
+++ b/packages/core/src/doctor/types.ts
@@ -4,6 +4,7 @@ import type { EngineProbeResult } from "../resolution/classify.js";
 import type { ResolutionMode } from "../resolution/index.js";
 import type { ResolveUserMdResult } from "../user-config/resolve-user-md.js";
 import type { AgentHookHealthResult } from "../verify-env/agent-hooks.js";
+import type { AgentHookLiveProbeResult } from "../verify-env/agent-hooks-live-probe.js";
 
 export const EXIT_CLEAN = 0;
 export const EXIT_DRIFT = 1;
@@ -156,4 +157,6 @@ export interface DoctorSeams {
   readonly detectPlanExtensionShadows?: (projectRoot: string) => readonly ShadowedPlanExtension[];
   /** Read-only agent-host hook registration probe (#2438). */
   readonly evaluateAgentHooks?: (projectRoot: string) => AgentHookHealthResult;
+  /** Live hook spawn probe for doctor --full (#2852). */
+  readonly probeAgentHooksLive?: (projectRoot: string) => AgentHookLiveProbeResult;
 }

--- a/packages/core/src/verify-env/agent-hooks-live-probe.test.ts
+++ b/packages/core/src/verify-env/agent-hooks-live-probe.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { probeAgentHooksLive } from "./agent-hooks-live-probe.js";
+import { probeAgentHooksLive, quoteWindowsCmdArg } from "./agent-hooks-live-probe.js";
 
 describe("probeAgentHooksLive", () => {
   it("reports empty stdout on allow fixture as non-functional (#2852)", () => {
@@ -104,5 +104,10 @@ describe("probeAgentHooksLive", () => {
 
     expect(result.code).toBe(2);
     expect(result.cases[0]?.issue).toBe("hook-command-missing");
+  });
+
+  it("escapes percent signs for Windows cmd shell arguments", () => {
+    expect(quoteWindowsCmdArg("C:/Repos/deft%directive")).toBe("C:/Repos/deft%%directive");
+    expect(quoteWindowsCmdArg("C:/Repos/with spaces")).toBe('"C:/Repos/with spaces"');
   });
 });

--- a/packages/core/src/verify-env/agent-hooks-live-probe.test.ts
+++ b/packages/core/src/verify-env/agent-hooks-live-probe.test.ts
@@ -76,6 +76,27 @@ describe("probeAgentHooksLive", () => {
     expect(result.cases).toEqual([]);
   });
 
+  it("uses read-only Task spawn for the deny fixture", () => {
+    let denyEnv: NodeJS.ProcessEnv | undefined;
+    const result = probeAgentHooksLive("/project", {
+      resolveCommand: () => "/usr/bin/deft-hook",
+      spawnHook: ({ stdin, env }) => {
+        if (stdin.includes("Task")) {
+          denyEnv = env;
+          return {
+            status: 0,
+            stdout: '{"permission":"deny","user_message":"denied"}',
+            stderr: "",
+          };
+        }
+        return { status: 0, stdout: '{"permission":"allow"}', stderr: "" };
+      },
+    });
+
+    expect(result.code).toBe(0);
+    expect(denyEnv?.DEFT_HOOK_READ_ONLY).toBe("1");
+  });
+
   it("returns unavailable when the hook command is missing from PATH", () => {
     const result = probeAgentHooksLive("/project", {
       resolveCommand: () => null,

--- a/packages/core/src/verify-env/agent-hooks-live-probe.test.ts
+++ b/packages/core/src/verify-env/agent-hooks-live-probe.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { probeAgentHooksLive } from "./agent-hooks-live-probe.js";
+
+describe("probeAgentHooksLive", () => {
+  it("reports empty stdout on allow fixture as non-functional (#2852)", () => {
+    const result = probeAgentHooksLive("/project", {
+      resolveCommand: () => "/usr/bin/deft-hook",
+      spawnHook: () => ({ status: 0, stdout: "", stderr: "" }),
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.cases).toEqual([
+      expect.objectContaining({
+        fixture: "allow",
+        issue: "empty-stdout",
+      }),
+      expect.objectContaining({
+        fixture: "deny",
+        issue: "empty-stdout",
+      }),
+    ]);
+    expect(result.message).toContain("live probe FAILED");
+  });
+
+  it("reports unparseable stdout", () => {
+    const result = probeAgentHooksLive("/project", {
+      resolveCommand: () => "/usr/bin/deft-hook",
+      spawnHook: ({ stdin }) => ({
+        status: 0,
+        stdout: stdin.includes("Read") ? "not-json" : '{"permission":"deny"}',
+        stderr: "",
+      }),
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.cases).toEqual([
+      expect.objectContaining({
+        fixture: "allow",
+        issue: "unparseable-json",
+      }),
+    ]);
+  });
+
+  it("reports missing deny on a known-deny fixture", () => {
+    const result = probeAgentHooksLive("/project", {
+      resolveCommand: () => "/usr/bin/deft-hook",
+      spawnHook: () => ({
+        status: 0,
+        stdout: '{"permission":"allow"}',
+        stderr: "",
+      }),
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.cases).toEqual([
+      expect.objectContaining({
+        fixture: "deny",
+        issue: "missing-deny",
+      }),
+    ]);
+  });
+
+  it("passes when allow and deny fixtures produce parseable decisions", () => {
+    const result = probeAgentHooksLive("/project", {
+      resolveCommand: () => "/usr/bin/deft-hook",
+      spawnHook: ({ stdin }) => ({
+        status: 0,
+        stdout: stdin.includes("Read")
+          ? '{"permission":"allow"}'
+          : '{"permission":"deny","user_message":"denied"}',
+        stderr: "",
+      }),
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.cases).toEqual([]);
+  });
+
+  it("returns unavailable when the hook command is missing from PATH", () => {
+    const result = probeAgentHooksLive("/project", {
+      resolveCommand: () => null,
+    });
+
+    expect(result.code).toBe(2);
+    expect(result.cases[0]?.issue).toBe("hook-command-missing");
+  });
+});

--- a/packages/core/src/verify-env/agent-hooks-live-probe.ts
+++ b/packages/core/src/verify-env/agent-hooks-live-probe.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import type { HookEvent, HookHost } from "../hooks/dispatcher.js";
+import { READ_ONLY_HOOK_ENV } from "../hooks/tools.js";
 import { DEFT_HOOK_COMMAND_MARKER } from "../init-deposit/agent-hooks.js";
 import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
 import {
@@ -38,6 +39,7 @@ export interface AgentHookLiveProbeSeams {
     readonly args: readonly string[];
     readonly stdin: string;
     readonly cwd: string;
+    readonly env?: NodeJS.ProcessEnv;
   }) => { readonly status: number; readonly stdout: string; readonly stderr: string };
 }
 
@@ -72,18 +74,47 @@ function resolveHookCommand(seams: AgentHookLiveProbeSeams): ResolvedHookCommand
   return null;
 }
 
+function quoteWindowsCmdArg(value: string): string {
+  if (!/[\s"&|<>^()]/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
 function spawnHookWithStdin(
   command: string,
   args: readonly string[],
   stdin: string,
   cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): { status: number; stdout: string; stderr: string } {
   const shell = shouldUseShellForCommand(command);
+  if (shell && process.platform === "win32") {
+    const cmdLine = [quoteWin32CommandForShell(command), ...args.map(quoteWindowsCmdArg)].join(" ");
+    const proc = spawnSync(cmdLine, [], {
+      input: stdin,
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: true,
+      windowsHide: true,
+      maxBuffer: SUBPROCESS_MAX_BUFFER,
+    });
+    const status = proc.status ?? (proc.error ? 2 : proc.signal ? 128 : 0);
+    return {
+      status,
+      stdout: typeof proc.stdout === "string" ? proc.stdout : "",
+      stderr: typeof proc.stderr === "string" ? proc.stderr : "",
+    };
+  }
+
   const spawnCmd =
     shell && process.platform === "win32" ? quoteWin32CommandForShell(command) : command;
   const proc = spawnSync(spawnCmd, [...args], {
     input: stdin,
     cwd,
+    env,
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"],
     shell,
@@ -108,10 +139,15 @@ function allowFixture(projectRoot: string): string {
 
 function denyFixture(projectRoot: string): string {
   return JSON.stringify({
-    tool_name: "StrReplace",
+    tool_name: "Task",
     cwd: projectRoot,
     workspace_roots: [projectRoot],
+    tool_input: { subagent_type: "generalPurpose", prompt: "implement" },
   });
+}
+
+function denyProbeEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, [READ_ONLY_HOOK_ENV]: "1" };
 }
 
 function parseCursorDecision(stdout: string): CursorDecision {
@@ -148,6 +184,7 @@ function runFixtureProbe(
   projectRoot: string,
   fixture: "allow" | "deny",
   stdin: string,
+  env: NodeJS.ProcessEnv,
   spawnHook: NonNullable<AgentHookLiveProbeSeams["spawnHook"]>,
 ): AgentHookLiveProbeCase | null {
   const args = [
@@ -164,6 +201,7 @@ function runFixtureProbe(
     args,
     stdin,
     cwd: projectRoot,
+    env,
   });
   if (spawned.status !== 0) {
     return {
@@ -238,13 +276,21 @@ export function probeAgentHooksLive(
       readonly args: readonly string[];
       readonly stdin: string;
       readonly cwd: string;
-    }) => spawnHookWithStdin(input.command, input.args, input.stdin, input.cwd));
+      readonly env?: NodeJS.ProcessEnv;
+    }) =>
+      spawnHookWithStdin(
+        input.command,
+        input.args,
+        input.stdin,
+        input.cwd,
+        input.env ?? process.env,
+      ));
   const failures: AgentHookLiveProbeCase[] = [];
-  for (const [fixture, stdin] of [
-    ["allow", allowFixture(root)] as const,
-    ["deny", denyFixture(root)] as const,
+  for (const [fixture, stdin, env] of [
+    ["allow", allowFixture(root), process.env] as const,
+    ["deny", denyFixture(root), denyProbeEnv()] as const,
   ]) {
-    const failure = runFixtureProbe(resolved, root, fixture, stdin, spawnHook);
+    const failure = runFixtureProbe(resolved, root, fixture, stdin, env, spawnHook);
     if (failure !== null) failures.push(failure);
   }
 

--- a/packages/core/src/verify-env/agent-hooks-live-probe.ts
+++ b/packages/core/src/verify-env/agent-hooks-live-probe.ts
@@ -1,0 +1,267 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import type { HookEvent, HookHost } from "../hooks/dispatcher.js";
+import { DEFT_HOOK_COMMAND_MARKER } from "../init-deposit/agent-hooks.js";
+import { SUBPROCESS_MAX_BUFFER } from "../subprocess/max-buffer.js";
+import {
+  quoteWin32CommandForShell,
+  resolveCommandOnPath,
+  shouldUseShellForCommand,
+} from "./command-spawn.js";
+
+export type AgentHookLiveProbeIssue =
+  | "hook-command-missing"
+  | "spawn-failed"
+  | "empty-stdout"
+  | "unparseable-json"
+  | "missing-allow"
+  | "missing-deny";
+
+export interface AgentHookLiveProbeCase {
+  readonly host: HookHost;
+  readonly event: HookEvent;
+  readonly fixture: "allow" | "deny";
+  readonly issue: AgentHookLiveProbeIssue;
+  readonly detail: string;
+}
+
+export interface AgentHookLiveProbeResult {
+  readonly code: 0 | 1 | 2;
+  readonly message: string;
+  readonly cases: readonly AgentHookLiveProbeCase[];
+}
+
+export interface AgentHookLiveProbeSeams {
+  readonly resolveCommand?: (name: string) => string | null;
+  readonly spawnHook?: (input: {
+    readonly command: string;
+    readonly args: readonly string[];
+    readonly stdin: string;
+    readonly cwd: string;
+  }) => { readonly status: number; readonly stdout: string; readonly stderr: string };
+}
+
+interface ResolvedHookCommand {
+  readonly command: string;
+  readonly argsPrefix: readonly string[];
+}
+
+interface CursorDecision {
+  readonly ok: boolean;
+  readonly permission?: "allow" | "deny";
+  readonly detail: string;
+}
+
+const LIVE_PROBE_HOST: HookHost = "cursor";
+const LIVE_PROBE_EVENT: HookEvent = "tool.before";
+
+function resolveHookCommand(seams: AgentHookLiveProbeSeams): ResolvedHookCommand | null {
+  const resolveCommand = seams.resolveCommand ?? resolveCommandOnPath;
+  const deftHook = resolveCommand(DEFT_HOOK_COMMAND_MARKER);
+  if (deftHook !== null) {
+    return { command: deftHook, argsPrefix: [] };
+  }
+  const deft = resolveCommand("deft");
+  if (deft !== null) {
+    return { command: deft, argsPrefix: ["hook:dispatch"] };
+  }
+  const directive = resolveCommand("directive");
+  if (directive !== null) {
+    return { command: directive, argsPrefix: ["hook:dispatch"] };
+  }
+  return null;
+}
+
+function spawnHookWithStdin(
+  command: string,
+  args: readonly string[],
+  stdin: string,
+  cwd: string,
+): { status: number; stdout: string; stderr: string } {
+  const shell = shouldUseShellForCommand(command);
+  const spawnCmd =
+    shell && process.platform === "win32" ? quoteWin32CommandForShell(command) : command;
+  const proc = spawnSync(spawnCmd, [...args], {
+    input: stdin,
+    cwd,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    shell,
+    windowsHide: true,
+    maxBuffer: SUBPROCESS_MAX_BUFFER,
+  });
+  const status = proc.status ?? (proc.error ? 2 : proc.signal ? 128 : 0);
+  return {
+    status,
+    stdout: typeof proc.stdout === "string" ? proc.stdout : "",
+    stderr: typeof proc.stderr === "string" ? proc.stderr : "",
+  };
+}
+
+function allowFixture(projectRoot: string): string {
+  return JSON.stringify({
+    tool_name: "Read",
+    cwd: projectRoot,
+    workspace_roots: [projectRoot],
+  });
+}
+
+function denyFixture(projectRoot: string): string {
+  return JSON.stringify({
+    tool_name: "StrReplace",
+    cwd: projectRoot,
+    workspace_roots: [projectRoot],
+  });
+}
+
+function parseCursorDecision(stdout: string): CursorDecision {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, detail: "empty stdout" };
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      (parsed as Record<string, unknown>).permission === "allow"
+    ) {
+      return { ok: true, permission: "allow", detail: "permission allow" };
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      (parsed as Record<string, unknown>).permission === "deny"
+    ) {
+      return { ok: true, permission: "deny", detail: "permission deny" };
+    }
+    return { ok: false, detail: "stdout JSON missing permission allow/deny" };
+  } catch {
+    return { ok: false, detail: "stdout is not valid JSON" };
+  }
+}
+
+function runFixtureProbe(
+  resolved: ResolvedHookCommand,
+  projectRoot: string,
+  fixture: "allow" | "deny",
+  stdin: string,
+  spawnHook: NonNullable<AgentHookLiveProbeSeams["spawnHook"]>,
+): AgentHookLiveProbeCase | null {
+  const args = [
+    ...resolved.argsPrefix,
+    "--host",
+    LIVE_PROBE_HOST,
+    "--event",
+    LIVE_PROBE_EVENT,
+    "--project-root",
+    projectRoot,
+  ];
+  const spawned = spawnHook({
+    command: resolved.command,
+    args,
+    stdin,
+    cwd: projectRoot,
+  });
+  if (spawned.status !== 0) {
+    return {
+      host: LIVE_PROBE_HOST,
+      event: LIVE_PROBE_EVENT,
+      fixture,
+      issue: "spawn-failed",
+      detail: `hook command exited ${spawned.status}${spawned.stderr.trim() ? `: ${spawned.stderr.trim()}` : ""}`,
+    };
+  }
+
+  const decision = parseCursorDecision(spawned.stdout);
+  if (!decision.ok) {
+    return {
+      host: LIVE_PROBE_HOST,
+      event: LIVE_PROBE_EVENT,
+      fixture,
+      issue: decision.detail.includes("JSON") ? "unparseable-json" : "empty-stdout",
+      detail: decision.detail,
+    };
+  }
+
+  if (fixture === "allow" && decision.permission !== "allow") {
+    return {
+      host: LIVE_PROBE_HOST,
+      event: LIVE_PROBE_EVENT,
+      fixture,
+      issue: "missing-allow",
+      detail: `expected permission allow, got ${decision.permission ?? "none"}`,
+    };
+  }
+  if (fixture === "deny" && decision.permission !== "deny") {
+    return {
+      host: LIVE_PROBE_HOST,
+      event: LIVE_PROBE_EVENT,
+      fixture,
+      issue: "missing-deny",
+      detail: `expected permission deny, got ${decision.permission ?? "none"}`,
+    };
+  }
+  return null;
+}
+
+/** Spawn the configured hook command and assert Cursor tool.before allow/deny behavior. */
+export function probeAgentHooksLive(
+  projectRoot: string,
+  seams: AgentHookLiveProbeSeams = {},
+): AgentHookLiveProbeResult {
+  const root = resolve(projectRoot);
+  const resolved = resolveHookCommand(seams);
+  if (resolved === null) {
+    return {
+      code: 2,
+      message:
+        "deft agent hooks live probe unavailable: neither deft-hook nor deft/directive hook:dispatch is on PATH.",
+      cases: [
+        {
+          host: LIVE_PROBE_HOST,
+          event: LIVE_PROBE_EVENT,
+          fixture: "allow",
+          issue: "hook-command-missing",
+          detail: `${DEFT_HOOK_COMMAND_MARKER} not found on PATH`,
+        },
+      ],
+    };
+  }
+
+  const spawnHook =
+    seams.spawnHook ??
+    ((input: {
+      readonly command: string;
+      readonly args: readonly string[];
+      readonly stdin: string;
+      readonly cwd: string;
+    }) => spawnHookWithStdin(input.command, input.args, input.stdin, input.cwd));
+  const failures: AgentHookLiveProbeCase[] = [];
+  for (const [fixture, stdin] of [
+    ["allow", allowFixture(root)] as const,
+    ["deny", denyFixture(root)] as const,
+  ]) {
+    const failure = runFixtureProbe(resolved, root, fixture, stdin, spawnHook);
+    if (failure !== null) failures.push(failure);
+  }
+
+  if (failures.length === 0) {
+    return {
+      code: 0,
+      message: "deft agent hooks live probe passed for Cursor tool.before allow and deny fixtures.",
+      cases: [],
+    };
+  }
+
+  const summary = failures
+    .map((entry) => `${entry.fixture}: ${entry.issue} (${entry.detail})`)
+    .join("; ");
+  return {
+    code: 1,
+    message: `deft agent hooks live probe FAILED: ${summary}. Recovery: reinstall @deftai/directive and run \`deft update\`.`,
+    cases: failures,
+  };
+}

--- a/packages/core/src/verify-env/agent-hooks-live-probe.ts
+++ b/packages/core/src/verify-env/agent-hooks-live-probe.ts
@@ -74,11 +74,12 @@ function resolveHookCommand(seams: AgentHookLiveProbeSeams): ResolvedHookCommand
   return null;
 }
 
-function quoteWindowsCmdArg(value: string): string {
-  if (!/[\s"&|<>^()]/.test(value)) {
-    return value;
+export function quoteWindowsCmdArg(value: string): string {
+  const escaped = value.replace(/%/g, "%%");
+  if (!/[\s"&|<>^()]/.test(escaped)) {
+    return escaped;
   }
-  return `"${value.replace(/"/g, '""')}"`;
+  return `"${escaped.replace(/"/g, '""')}"`;
 }
 
 function spawnHookWithStdin(

--- a/packages/core/src/verify-env/index.ts
+++ b/packages/core/src/verify-env/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent-hooks.js";
+export * from "./agent-hooks-live-probe.js";
 export * from "./command-spawn.js";
 export * from "./node-runtime.js";
 export * from "./toolchain-check.js";


### PR DESCRIPTION
## Summary
- Add probeAgentHooksLive to spawn the configured deft-hook command with Cursor 	ool.before allow and deny fixtures.
- Gate the live probe behind deft doctor --full; structural registration checks remain unchanged for throttled/offline runs.
- Warn when stdout is empty, unparseable, or missing an expected deny so #2846-class packaging failures are visible after install.

## Test plan
- [x] pnpm exec vitest run packages/core/src/doctor/agent-hooks.test.ts packages/core/src/verify-env/agent-hooks-live-probe.test.ts
- [x] 	ask verify:forward-coverage
- [ ] CI 	ask check

Closes #2852
