### PR TITLE
chore(xbrief): complete cohort lifecycle xBRIEFs post-merge

### DIFF
--- a/xbrief/completed/2026-07-26-2836-testcoverage-restore-branches-85-after-v0850-hairline-miss-8.xbrief.json
+++ b/xbrief/completed/2026-07-26-2836-testcoverage-restore-branches-85-after-v0850-hairline-miss-8.xbrief.json
@@ -1,0 +1,81 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2836 — restore branch coverage ≥85% after v0.85.0 debt hatch"
+  },
+  "plan": {
+    "id": "2026-07-26-2836-testcoverage-restore-branches-85-after-v0850-hairline-miss-8",
+    "title": "test(coverage): restore branches >=85% after v0.85.0 hairline miss (84.95%)",
+    "status": "completed",
+    "narratives": {
+      "Description": "v0.85.0 shipped with --allow-coverage-debt=2836 after branches landed at 84.95% versus the 85% floor. Restore real branch coverage so the next release cut does not reuse the debt hatch.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2836",
+      "Overview": "Local task check / vitest coverage for the v0.85.0 cut reports branches 84.95% vs the global 85% floor. Follow-up MUST restore branches ≥85% without debt (same class as #2762 / #2630).",
+      "Labels": "bug, testing",
+      "ImplementationPlan": "1) Run vitest coverage and task coverage:hotspots to list lowest src/ modules and uncovered branch samples in the report. 2) Add focused unit tests under packages/core/src and packages/cli/src for those branch gaps (~17 hits) with fixture asserts. 3) Re-run the coverage report and confirm branches >=85% without --allow-coverage-debt=2836.",
+      "UserStory": "As a maintainer, I want branch coverage back at or above 85% without a debt hatch, so that release cuts enforce the real quality floor."
+    },
+    "items": [
+      {
+        "title": "Given the current suite, when coverage is measured, then branches are at least 85%.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the current suite, when task check runs without --allow-coverage-debt, then reported branch coverage is at least 85%."
+        }
+      },
+      {
+        "title": "Given the debt hatch for 2836, when coverage is restored, then the hatch is no longer required.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the v0.85.0 debt allowance for #2836, when coverage is restored, then release/check paths no longer need --allow-coverage-debt=2836."
+        }
+      },
+      {
+        "title": "Given new branch-hitting tests, when the suite runs, then they stay green and raise coverage.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given focused tests targeting the uncovered branches, when vitest runs those paths, then they pass and contribute the missing branch hits."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "testing"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2836",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2836: test(coverage): restore branches >=85% after v0.85.0 hairline miss (84.95%)"
+      }
+    ],
+    "updated": "2026-07-26T05:59:41Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "vitest.config.ts",
+          "packages/core/src/ts-check-lane/run-lane.ts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run --coverage",
+          "task coverage:hotspots"
+        ],
+        "expected_outputs": [
+          "branch coverage >=85% without debt hatch",
+          "CHANGELOG Unreleased note if hatch retirement is user-visible"
+        ],
+        "depends_on": [],
+        "conflict_group": "coverage-2836",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2836 acceptance and the v0.85.0 release debt comment rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "technical-debt",
+      "completedAt": "2026-07-26T05:59:41Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-26-2837-bugcli-documented-xbriefpreflight-separator-form-fails-on-v0.xbrief.json
+++ b/xbrief/completed/2026-07-26-2837-bugcli-documented-xbriefpreflight-separator-form-fails-on-v0.xbrief.json
@@ -1,0 +1,96 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2837 — accept documented xbrief:preflight -- <path> form"
+  },
+  "plan": {
+    "id": "2026-07-26-2837-bugcli-documented-xbriefpreflight-separator-form-fails-on-v0",
+    "title": "bug(cli): documented xbrief:preflight separator form fails on v0.84.0",
+    "status": "completed",
+    "narratives": {
+      "Description": "The documented deft xbrief:preflight -- <path> form fails with unrecognized argument: -- while --vbrief-path works. Align the parser with verify:session-ritual (#2681) and fix --help so it does not evaluate a null path.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2837",
+      "Overview": "Consumer AGENTS.md and commands.md prescribe task-style separator-plus-positional syntax for the #810 implementation-intent gate. On v0.84.0 the CLI rejects the lone -- before lifecycle validation, blocking agents that follow generated instructions.",
+      "Labels": "bug",
+      "ImplementationPlan": "1) In packages/cli/src/vbrief-preflight.ts parseArgs, accept a lone -- separator (same as verify-session-ritual). 2) Make --help print usage and exit without calling evaluate. 3) Add regression tests for separator+path, --vbrief-path parity, help, and fail-closed unknowns.",
+      "UserStory": "As an agent following AGENTS.md, I want deft xbrief:preflight -- <active-path> to work like --vbrief-path, so that the Implementation Intent Gate does not block on a parser mismatch."
+    },
+    "items": [
+      {
+        "title": "Given an active running xBRIEF, when preflight uses -- <path>, then it matches --vbrief-path success.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an active running xBRIEF path, when deft xbrief:preflight -- <path> runs, then exit code and readiness match the same --vbrief-path invocation."
+        }
+      },
+      {
+        "title": "Given missing or non-running paths, when either form is used, then lifecycle failures match.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given missing, non-active, or non-running xBRIEFs, when either documented form is used, then both produce equivalent non-zero lifecycle failures."
+        }
+      },
+      {
+        "title": "Given --help, when xbrief:preflight is invoked, then usage prints without null path evaluation.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given deft xbrief:preflight --help, when the command runs, then it prints valid usage and exits successfully with no null path errors."
+        }
+      },
+      {
+        "title": "Given unknown args or missing path, when parse runs, then it fails closed without null placeholders.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given unknown arguments or a missing path, when parse/run executes, then it fails closed with actionable messages and never emits a null path in the error text."
+        }
+      },
+      {
+        "title": "Given managed docs, when syntax is checked, then AGENTS/commands/help agree on supported forms.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given managed AGENTS.md, agents-entry, commands.md, and CLI help, when syntax is reviewed, then they agree on the supported separator and flag forms."
+        }
+      }
+    ],
+    "tags": [
+      "bug"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2837",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2837: bug(cli): documented xbrief:preflight separator form fails on v0.84.0"
+      }
+    ],
+    "updated": "2026-07-26T03:16:28Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/vbrief-preflight.ts",
+          "packages/cli/src/vbrief-preflight.test.ts",
+          "content/commands.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/cli/src/vbrief-preflight.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "separator form accepted",
+          "--help usage without null path",
+          "CHANGELOG Unreleased note"
+        ],
+        "depends_on": [],
+        "conflict_group": "cli-preflight-2837",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2837 acceptance criteria and sibling fix #2681 rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "bugfix",
+      "completedAt": "2026-07-26T03:16:28Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-26-2838-bughooks-deft-update-leaves-orphaned-deft-cursor-hook-adapte.xbrief.json
+++ b/xbrief/completed/2026-07-26-2838-bughooks-deft-update-leaves-orphaned-deft-cursor-hook-adapte.xbrief.json
@@ -1,0 +1,82 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2838 — remove orphaned Cursor adapter companion test on update"
+  },
+  "plan": {
+    "id": "2026-07-26-2838-bughooks-deft-update-leaves-orphaned-deft-cursor-hook-adapte",
+    "title": "bug(hooks): deft update leaves orphaned deft-cursor-hook-adapter.test.mjs",
+    "status": "completed",
+    "narratives": {
+      "Description": "After #2790, deft update deletes legacy deft-cursor-hook-adapter.mjs but leaves the companion .test.mjs. That orphaned test imports removed exports and fails node --test in consumer repositories.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2838",
+      "Overview": "Residual follow-up after adapter retirement. Extend writeAgentHookDeposit cleanup to remove .cursor/hooks/deft-cursor-hook-adapter.test.mjs when present, with regression coverage. Shell-quoting defect on the old adapter is out of scope (superseded by #2790).",
+      "Labels": "bug",
+      "ImplementationPlan": "1) In packages/core/src/init-deposit/agent-hooks.ts, rmSync the companion .test.mjs beside the existing adapter .mjs cleanup. 2) Extend cursor-hooks/agent-hooks tests to seed both files and assert both are removed on refresh. 3) CHANGELOG Unreleased note.",
+      "UserStory": "As a consumer running deft update, I want orphaned Cursor adapter tests removed with the adapter, so that node --test .cursor/hooks/ does not fail on dead imports."
+    },
+    "items": [
+      {
+        "title": "Given a leftover adapter test, when hooks deposit refreshes, then the test file is removed.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given .cursor/hooks/deft-cursor-hook-adapter.test.mjs present, when writeAgentHookDeposit / deft update runs, then that file is removed along with the legacy .mjs adapter."
+        }
+      },
+      {
+        "title": "Given seeded adapter and test files, when refresh runs, then both are gone and hooks.json stays current.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given both adapter and companion test seeded, when deposit refresh runs, then both are gone and Cursor direct-write hooks.json registration remains current."
+        }
+      },
+      {
+        "title": "Given the cleanup, when CHANGELOG is updated, then Unreleased notes the orphan removal.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the orphan cleanup lands, when CHANGELOG [Unreleased] is reviewed, then it notes removal of leftover deft-cursor-hook-adapter.test.mjs on update."
+        }
+      }
+    ],
+    "tags": [
+      "bug"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2838",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2838: bug(hooks): deft update leaves orphaned deft-cursor-hook-adapter.test.mjs"
+      }
+    ],
+    "updated": "2026-07-26T02:55:28Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/init-deposit/agent-hooks.ts",
+          "packages/core/src/init-deposit/agent-hooks.test.ts",
+          "packages/core/src/hooks/cursor-hooks.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/init-deposit/agent-hooks.test.ts packages/core/src/hooks/cursor-hooks.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "orphaned adapter test removed on refresh",
+          "regression test green",
+          "CHANGELOG Unreleased note"
+        ],
+        "depends_on": [],
+        "conflict_group": "hooks-adapter-orphan-2838",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to narrowed GitHub issue #2838 acceptance after #2790 supersession rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "bugfix",
+      "completedAt": "2026-07-26T02:55:28Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-26-2839-appsec-review-4-new-medium-findings-4f570263.xbrief.json
+++ b/xbrief/completed/2026-07-26-2839-appsec-review-4-new-medium-findings-4f570263.xbrief.json
@@ -1,0 +1,91 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2839 — contain four medium symlink write sinks"
+  },
+  "plan": {
+    "id": "2026-07-26-2839-appsec-review-4-new-medium-findings-4f570263",
+    "title": "AppSec review — 4 new medium findings (4f570263)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Four medium symlink / confused-deputy write sinks remain ungated: rule-map render, org-force-on marker, init-deposit gitignore, and roadmap:render. Gate each with assertWriteTargetSafe / assertProjectionContained before write.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2839",
+      "Overview": "AppSec review at 4f570263 found four MEDIUM write sinks where repo-controlled leaf symlinks divert writeFileSync outside the project. Same pattern as #2807 / projection-containment helpers.",
+      "Labels": "bug, security",
+      "ImplementationPlan": "1) Gate writeFileSync in rule-map.ts (md+html), org-force-on-migration.ts writeOrgForceOnMarker, init-deposit/gitignore.ts, and roadmap-render.ts with assertWriteTargetSafe or assertProjectionContained. 2) Add symlink-diversion regression tests per sink. 3) CHANGELOG Unreleased note.",
+      "UserStory": "As an operator, I want symlink-escaping write targets refused on rule-map org-force-on gitignore and roadmap sinks, so that routine commands cannot overwrite files outside the checkout."
+    },
+    "items": [
+      {
+        "title": "Given the four write sites, when they mutate the filesystem, then they call containment helpers first.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the four listed write sites, when they call writeFileSync, then each has already called assertWriteTargetSafe or equivalent projection containment."
+        }
+      },
+      {
+        "title": "Given a leaf symlink diversion, when each sink writes, then the write is refused with a clear error.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a symlink-at-leaf diverting each output path, when the sink runs, then it rejects with a clear error and does not overwrite the outside target."
+        }
+      },
+      {
+        "title": "Given regression tests per sink, when the suite runs, then symlink diversion cases are covered.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given regression tests for rule-map md+html, org-force-on marker, init-deposit gitignore, and roadmap:render, when vitest runs those suites, then symlink diversion cases pass."
+        }
+      },
+      {
+        "title": "Given a pattern audit, when same-class sinks are reviewed, then none remain unguarded without follow-up.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a short pattern audit of the same trust-class write paths, when the PR lands, then no sibling unguarded writeFileSync remains without a follow-up issue or documented exception."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "security"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2839",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2839: AppSec review — 4 new medium findings (4f570263)"
+      }
+    ],
+    "updated": "2026-07-26T03:51:18Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/render/rule-map.ts",
+          "packages/core/src/policy/org-force-on-migration.ts",
+          "packages/core/src/init-deposit/gitignore.ts",
+          "packages/core/src/render/roadmap-render.ts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/render packages/core/src/policy packages/core/src/init-deposit/gitignore",
+          "task check"
+        ],
+        "expected_outputs": [
+          "four sinks gated",
+          "symlink diversion tests green",
+          "CHANGELOG Unreleased note"
+        ],
+        "depends_on": [],
+        "conflict_group": "appsec-symlink-2839",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2839 AppSec acceptance criteria and prior containment pattern #2807 rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "security",
+      "completedAt": "2026-07-26T03:51:18Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-26-2843-swarm-monitor-must-not-self-implement-after-drive-tomerge-re.xbrief.json
+++ b/xbrief/completed/2026-07-26-2843-swarm-monitor-must-not-self-implement-after-drive-tomerge-re.xbrief.json
@@ -1,0 +1,95 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2843 — close monitor-as-implementer Gap C/D hole after blocked drive-to:merge-ready DONE"
+  },
+  "plan": {
+    "id": "2026-07-26-2843-swarm-monitor-must-not-self-implement-after-drive-tomerge-re",
+    "title": "swarm: monitor must not self-implement after drive-to:merge-ready leaf exits BLOCKED/DONE-with-blockers",
+    "status": "completed",
+    "narratives": {
+      "Description": "A Cursor drive-to:merge-ready leaf that exits with DONE while still blocked pulls the cohort monitor into inline Greptile fixes and pr:watch. Close the doctrine hole so Tier-1 monitors must resume or background-dispatch ONE continuation leaf instead of self-implementing.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2843; recurrence in cohort-2026-07-26-hooks-appsec-coverage after #2839 PR #2842.",
+      "Overview": "False-terminal DONE plus swarm Phase 5 'monitor MAY run review-cycle itself' licensed Gap D violation. Align preamble, swarm skill, and review-cycle on BLOCKED+REDISPATCH_OK and a Tier-1-only continuation playbook.",
+      "Labels": "bug, agent-experience, harness, agent-safety",
+      "ImplementationPlan": "1) Edit the agent-prompt-preamble.md template file §11 DONE/BLOCKED contract module so drive-to:merge-ready reserves DONE for merge-ready (or merge+scope:complete) and requires BLOCKED with PR/SHA/blocker class/worktree/REDISPATCH_OK otherwise. 2) Edit the deft-directive-swarm/SKILL.md skill file Phase 5 Gap C fallback: replace 'monitor MAY run review-cycle itself' with Tier-1 MUST background-dispatch ONE continuation leaf; add a completion-notification decision tree; keep monitor-inline only for Tier 3 or explicit operator consent. 3) Mirror Worker-owns-lifecycle wording in the deft-directive-review-cycle/SKILL.md skill file. 4) If consumer-facing, update the agents-entry.md template file and run task agents:refresh. 5) Verify with rg evidence on those files plus CHANGELOG [Unreleased] and meta/lessons.md citing #2843; optional eval/contract test for DONE-with-blockers.",
+      "UserStory": "As a swarm monitor, I want blocked merge-ready leaves to force a single continuation dispatch instead of inline fixes, so that the parent conversation stays interactive and Gap C lifecycle ownership stays intact."
+    },
+    "items": [
+      {
+        "title": "Given a drive-to:merge-ready worker, when it exits mid-cycle, then status is BLOCKED with REDISPATCH_OK not DONE.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a worker scoped drive-to:merge-ready, when Greptile/CI/behind still blocks merge-ready, then the exit message uses BLOCKED (not DONE) and includes PR number, HEAD SHA, blocker class, worktree path, and REDISPATCH_OK."
+        }
+      },
+      {
+        "title": "Given Tier 1 is available, when a leaf exits blocked, then the monitor must dispatch one continuation leaf.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given Cursor Task or another Tier-1 primitive is available, when a cohort leaf exits BLOCKED or DONE-with-blockers, then the swarm skill requires background-dispatch of ONE continuation leaf owning fix batches + pr:watch + merge readiness, and forbids monitor-inline implementation without operator consent."
+        }
+      },
+      {
+        "title": "Given host completion notifications, when the monitor parses status, then the follow-up playbook is explicit.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a subagent completion notification, when the monitor follows Phase 4/5, then DONE+merge-ready may merge/scope:complete, BLOCKED must resume or redispatch one leaf, and FAILED/silent uses verify:subagent-alive REDISPATCH_OK — with no code edits in the monitor turn on Tier 1."
+        }
+      },
+      {
+        "title": "Given the doctrine change, when it ships, then CHANGELOG and a short lesson name the recurrence.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given preamble/swarm/review-cycle updates land, when the PR opens, then CHANGELOG [Unreleased] and a short meta/lessons (or packs:slice) entry name the monitor-as-implementer recurrence and point at #2843."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "agent-experience",
+      "harness",
+      "agent-safety"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2843",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2843: swarm: monitor must not self-implement after drive-to:merge-ready leaf exits BLOCKED/DONE-with-blockers"
+      }
+    ],
+    "updated": "2026-07-26T04:08:38Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/templates/agent-prompt-preamble.md",
+          "content/skills/deft-directive-swarm/SKILL.md",
+          "content/skills/deft-directive-review-cycle/SKILL.md",
+          "content/templates/agents-entry.md",
+          "CHANGELOG.md",
+          "meta/lessons.md"
+        ],
+        "verify_commands": [
+          "task agents:refresh",
+          "rg -n \"monitor MAY run|DONE-with-blockers|REDISPATCH_OK\" content/skills/deft-directive-swarm/SKILL.md content/templates/agent-prompt-preamble.md"
+        ],
+        "expected_outputs": [
+          "DONE reserved for merge-ready on drive-to:merge-ready",
+          "Tier-1 monitor continuation playbook",
+          "CHANGELOG Unreleased + lesson naming #2843"
+        ],
+        "depends_on": [],
+        "conflict_group": "swarm-monitor-posture-2843",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2843 acceptance criteria and Gap C/D doctrine in #1880 rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "bugfix",
+      "completedAt": "2026-07-26T04:08:38Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-26-2846-bughooks-deft-hook-symlink-shim-never-runs-main-argv1-realpa.xbrief.json
+++ b/xbrief/completed/2026-07-26-2846-bughooks-deft-hook-symlink-shim-never-runs-main-argv1-realpa.xbrief.json
@@ -1,0 +1,93 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2846 — fix deft-hook / guarded bins so symlink argv[1] still runs main()"
+  },
+  "plan": {
+    "id": "2026-07-26-2846-bughooks-deft-hook-symlink-shim-never-runs-main-argv1-realpa",
+    "title": "bug(hooks): deft-hook symlink shim never runs main() (argv[1] realpath mismatch)",
+    "status": "completed",
+    "narratives": {
+      "Description": "In v0.85.0 the deft-hook entrypoint guard compares raw process.argv[1] to fileURLToPath(import.meta.url). npm global bins are symlinks, so main() never runs: empty stdout exit 0. Cursor failClosed blocks all edits; Claude/Grok/Codex silently fail open and lose deny.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2846",
+      "Overview": "Reproduce via symlink vs realpath node invocation. Fix with shared realpath-aware isDirectEntrypoint helper applied to hook-bin, verify-encoding, and the latent guarded modules. Add hermetic symlink smoke tests and prefer a doctor live probe for empty stdout.",
+      "Labels": "bug, security, test-debt",
+      "ImplementationPlan": "1) Add a shared helper module file (e.g. packages/cli/src/entrypoint.ts) exporting isDirectEntrypoint(moduleUrl) that realpathSync-compares process.argv[1] and fileURLToPath(moduleUrl) with try/catch. 2) Wire packages/cli/src/hook-bin.ts and packages/cli/src/verify-encoding.ts (and remaining guarded bin/latent CLI files sharing the raw-string guard) to call that helper. 3) Add a hermetic regression test that creates a temp symlink to dist/hook-bin.js, pipes a Cursor allow payload, and asserts non-empty JSON permission=allow plus a deny-path assertion through the same symlink. 4) Verify with pnpm exec vitest run on the new/updated tests and a manual symlink smoke if needed; CHANGELOG [Unreleased] citing #2846. 5) Optional: extend agent-hooks doctor probe to spawn the configured hook and warn on empty/unparseable stdout.",
+      "UserStory": "As a Cursor or multi-host operator, I want deft-hook decisions to reach the host when invoked through the npm bin symlink, so that fail-closed edits are not blocked and deny decisions are not silently dropped."
+    },
+    "items": [
+      {
+        "title": "Given a symlink to hook-bin, when the host invokes deft-hook, then main runs and stdout is a decision document.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a temporary symlink to dist/hook-bin.js, when invoked with --host cursor --event tool.before and a Write payload, then stdout is non-empty parseable JSON with permission allow (not empty exit 0)."
+        }
+      },
+      {
+        "title": "Given a deny payload through the symlink, when deft-hook runs, then a host-shaped deny is emitted.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given an empty or omit-tool-name payload through the symlink for --host claude (or cursor), when deft-hook runs, then stdout contains a deny decision (not empty allow-shaped silence)."
+        }
+      },
+      {
+        "title": "Given verify-encoding and other guarded bins, when invoked via symlink, then their entrypoints also run.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the shared isDirectEntrypoint helper, when deft-verify-encoding (and other declared guarded bins) are invoked via symlink, then main runs instead of silent no-op exit 0."
+        }
+      },
+      {
+        "title": "Given the fix lands, when CHANGELOG is updated, then #2846 is cited under Unreleased.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the entrypoint realpath fix, when the PR opens, then CHANGELOG [Unreleased] describes the symlink shim bug and cites #2846."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "security",
+      "test-debt"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2846",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2846: bug(hooks): deft-hook symlink shim never runs main() (argv[1] realpath mismatch)"
+      }
+    ],
+    "updated": "2026-07-26T22:25:34Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/cli/src/hook-bin.ts",
+          "packages/cli/src/hook-bin.test.ts",
+          "packages/cli/src/verify-encoding.ts",
+          "packages/cli/src/entrypoint.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/cli/src/hook-bin.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "realpath-aware isDirectEntrypoint helper",
+          "hermetic symlink regression test for deft-hook",
+          "CHANGELOG Unreleased note citing #2846"
+        ],
+        "depends_on": [],
+        "conflict_group": "hooks-entrypoint-realpath-2846",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2846 reproduction and proposed shared helper rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "bugfix",
+      "completedAt": "2026-07-26T22:25:34Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-26-2847-appsec-medium-symlink-follow-writes-in-migratexbrief-policy.xbrief.json
+++ b/xbrief/completed/2026-07-26-2847-appsec-medium-symlink-follow-writes-in-migratexbrief-policy.xbrief.json
@@ -1,0 +1,90 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2847 — gate migrate:xbrief AGENTS refresh and policy PROJECT-DEFINITION writers against symlink escape"
+  },
+  "plan": {
+    "id": "2026-07-26-2847-appsec-medium-symlink-follow-writes-in-migratexbrief-policy",
+    "title": "AppSec: medium symlink-follow writes in migrate:xbrief + policy wip-cap/subagent-backend",
+    "status": "completed",
+    "narratives": {
+      "Description": "At d90e2d50, migrate:xbrief local runAgentsRefresh and policy writeWipCap/writeSubagentBackend still use bare writeFileSync. A committed AGENTS.md or PROJECT-DEFINITION symlink lets a malicious repo overwrite outside paths when the operator runs trusted CLI verbs.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2847",
+      "Overview": "Two medium TOCTOU/symlink-escape sinks remain after the #2839 AppSec pass. Gate both with assertWriteTargetSafe / atomicWrite helpers already used by sibling writers, plus committed-symlink regression tests.",
+      "Labels": "security",
+      "ImplementationPlan": "1) In packages/core/src/xbrief-migrate/migrate-project.ts runAgentsRefresh, replace bare writeFileSync with assertWriteTargetSafe + atomicWriteText (or applyAgentsRefresh) so AGENTS.md symlink/outside targets fail closed. 2) In packages/cli/src/dispatch.ts, route writeWipCap and writeSubagentBackend through atomicWriteProjectDefinition (with assertWriteTargetSafe) instead of bare writeFileSync on PROJECT-DEFINITION. 3) Add regression tests with committed symlinks for both paths under packages/core/src/xbrief-migrate and packages/cli (or existing dispatch/policy tests). 4) Verify with pnpm exec vitest on the touched suites and CHANGELOG [Unreleased] citing #2847. 5) Leave sibling writers already on safe helpers unchanged.",
+      "UserStory": "As an operator running migrate:xbrief or policy verbs in an untrusted clone, I want AGENTS.md and PROJECT-DEFINITION writes to refuse symlink escape targets, so that a malicious repo cannot overwrite files outside the project under my identity."
+    },
+    "items": [
+      {
+        "title": "Given a symlinked AGENTS.md, when migrate:xbrief refreshes agents, then the write is refused.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given AGENTS.md is a symlink to an outside file, when migrate:xbrief runAgentsRefresh runs, then the outside target is not overwritten and the path fails closed via assertWriteTargetSafe / safe writer parity with agents:refresh."
+        }
+      },
+      {
+        "title": "Given a symlinked PROJECT-DEFINITION, when policy wip-cap or subagent-backend writes, then the write is refused.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given xbrief/PROJECT-DEFINITION.xbrief.json is a symlink outside the project, when writeWipCap or writeSubagentBackend runs, then both use atomicWriteProjectDefinition and do not follow the symlink with bare writeFileSync."
+        }
+      },
+      {
+        "title": "Given committed-symlink fixtures, when regression tests run, then both sinks are covered.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given committed-symlink write-target fixtures for AGENTS.md and PROJECT-DEFINITION, when the new/extended vitest suites run, then they fail closed for unsafe targets and pass for normal files."
+        }
+      },
+      {
+        "title": "Given the fix lands, when CHANGELOG is updated, then #2847 is cited.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given both sinks are gated, when the PR opens, then CHANGELOG [Unreleased] describes the AppSec fix and cites #2847."
+        }
+      }
+    ],
+    "tags": [
+      "security"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2847",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2847: AppSec medium symlink-follow writes in migrate:xbrief + policy wip-cap/subagent-backend"
+      }
+    ],
+    "updated": "2026-07-26T18:44:17Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/xbrief-migrate/migrate-project.ts",
+          "packages/core/src/xbrief-migrate/migrate-project.test.ts",
+          "packages/cli/src/dispatch.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/xbrief-migrate/migrate-project.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "migrate:xbrief AGENTS refresh fails closed on symlink",
+          "writeWipCap/writeSubagentBackend via atomicWriteProjectDefinition",
+          "CHANGELOG Unreleased citing #2847"
+        ],
+        "depends_on": [],
+        "conflict_group": "appsec-symlink-writes-2847",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2847 AppSec findings at d90e2d50 rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "security",
+      "completedAt": "2026-07-26T18:44:17Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-27-2850-bugdoctor-checking-deft-structure-agent-host-hook-checks-fir.xbrief.json
+++ b/xbrief/completed/2026-07-27-2850-bugdoctor-checking-deft-structure-agent-host-hook-checks-fir.xbrief.json
@@ -1,0 +1,94 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2850 — fix doctor consumerContext misclassification when global CLI runs against a maintainer clone"
+  },
+  "plan": {
+    "id": "2026-07-27-2850-bugdoctor-checking-deft-structure-agent-host-hook-checks-fir",
+    "title": "bug(doctor): Deft structure + agent-host hook checks fire spurious warnings in framework maintainer clone",
+    "status": "completed",
+    "narratives": {
+      "Description": "Global directive doctor --full against a clean deftai/directive clone emits 7 false warnings (hooks incomplete + six Missing directory). install-integrity and Taskfile already skip via runningInsideDeftRepo; hooks and structure use consumerContext derived from frameworkRoot = resolveDefaultFrameworkRoot() (installed package), so the clone is misclassified as a consumer.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2850; treat the issue comment correction as authoritative over the original path-heuristic suggestion.",
+      "Overview": "Resolve doctor frameworkRoot with resolveFrameworkRootForProject(projectRoot) so maintainer clones get consumerContext=false. Align hooks/structure skip signaling with other maintainer skips. Separately update EXPECTED_FRAMEWORK_DIRS so vbrief is not required post-xbrief migration.",
+      "Labels": "bug, doctor, agent-experience",
+      "ImplementationPlan": "1) In packages/core/src/doctor/main.ts (frameworkRoot assignment ~line 103), prefer resolveFrameworkRootForProject(projectRoot) from packages/core/src/doctor/paths.ts over resolveDefaultFrameworkRoot() so a maintainer clone is not treated as a consumer when using the global CLI. 2) Confirm runAgentHooksHealthCheck and Deft structure checks skip with auditable info lines when consumerContext is false / runningInsideDeftRepo. 3) Update EXPECTED_FRAMEWORK_DIRS to drop or replace vbrief for post-xbrief layout. 4) Add regression tests covering global-CLI-style seams where projectRoot is a maintainer clone and installed frameworkRoot would otherwise diverge. 5) Verify with pnpm exec vitest on doctor suites + CHANGELOG [Unreleased] citing #2850.",
+      "UserStory": "As a maintainer running global directive doctor --full inside the framework clone, I want hooks and structure checks to skip like install-integrity already does, so that a clean clone reports zero spurious warnings."
+    },
+    "items": [
+      {
+        "title": "Given a maintainer clone and global CLI, when doctor resolves frameworkRoot, then consumerContext is false.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given projectRoot is a deftai/directive source checkout and the doctor package is installed elsewhere, when doctor runs, then frameworkRoot resolves via resolveFrameworkRootForProject(projectRoot) and consumerContext is false."
+        }
+      },
+      {
+        "title": "Given maintainer context, when hooks and structure checks run, then they emit skip info not warnings.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given consumerContext false on a clean maintainer clone, when agent-hooks-registration and Deft structure checks run, then they print auditable skip lines and do not emit the 7 spurious warnings from the issue repro."
+        }
+      },
+      {
+        "title": "Given post-xbrief layout, when EXPECTED_FRAMEWORK_DIRS is evaluated, then vbrief is not required.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given current master layout with xbrief/ and no vbrief/, when maintainer structure check runs after consumerContext fix, then it does not warn solely for missing vbrief/."
+        }
+      },
+      {
+        "title": "Given the fix lands, when CHANGELOG is updated, then #2850 is cited.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the doctor classification fix, when the PR opens, then CHANGELOG [Unreleased] cites #2850."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "doctor",
+      "agent-experience"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2850",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2850: bug(doctor) spurious warnings in framework maintainer clone"
+      }
+    ],
+    "updated": "2026-07-27T00:31:05Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/doctor/main.ts",
+          "packages/core/src/doctor/paths.ts",
+          "packages/core/src/doctor/main.test.ts",
+          "packages/core/src/doctor/agent-hooks.test.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/doctor",
+          "task check"
+        ],
+        "expected_outputs": [
+          "frameworkRoot via resolveFrameworkRootForProject",
+          "maintainer skip for hooks + structure",
+          "EXPECTED_FRAMEWORK_DIRS without required vbrief",
+          "CHANGELOG Unreleased citing #2850"
+        ],
+        "depends_on": [],
+        "conflict_group": "doctor-maintainer-context-2850",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2850 body + correction comment rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "bugfix",
+      "completedAt": "2026-07-27T00:31:05Z"
+    }
+  }
+}

--- a/xbrief/completed/2026-07-27-2852-doctor-live-probe-agent-hooks-emptyunparseable-stdout-is-cur.xbrief.json
+++ b/xbrief/completed/2026-07-27-2852-doctor-live-probe-agent-hooks-emptyunparseable-stdout-is-cur.xbrief.json
@@ -1,0 +1,93 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #2852 — doctor live-probe of agent hooks for empty/unparseable stdout"
+  },
+  "plan": {
+    "id": "2026-07-27-2852-doctor-live-probe-agent-hooks-emptyunparseable-stdout-is-cur",
+    "title": "doctor: live-probe agent hooks (empty/unparseable stdout is currently invisible)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Doctor agent-hooks-registration only checks deposit shape. A broken hook bin that exits 0 with empty stdout still reports registered and structurally valid — the #2846 class failure. Add a live probe under --full that spawns the configured hook command and fails closed on empty/unparseable stdout or missing deny.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2852; split from #2846 so the symlink entrypoint fix was not blocked.",
+      "Overview": "Extend evaluateAgentHooks or a sibling doctor check to pipe synthetic allow and deny payloads through the deposited/configured hook command (prefer bin/symlink invocation). Keep structural checks; gate the live probe behind --full so quick doctor stays offline-friendly.",
+      "Labels": "bug, security, test-debt, doctor",
+      "ImplementationPlan": "1) Locate evaluateAgentHooks / runAgentHooksHealthCheck in packages/core/src/doctor and packages/core/src/verify-env (or sibling). 2) Add a live probe that resolves the configured hook command as hosts invoke it and spawns --host cursor --event tool.before with allow + empty/deny fixtures. 3) Warn/fail P0-high on empty Cursor stdout, unparseable JSON, or missing deny; keep structural registration checks. 4) Gate the probe behind doctor --full (or explicit opt-in); do not break --quick. 5) Add a regression test with a stub command that exits 0 with empty stdout; CHANGELOG [Unreleased] citing #2852.",
+      "UserStory": "As an operator running deft doctor --full, I want a non-functional hook bin to surface as unhealthy, so that empty-stdout packaging failures cannot hide behind a structurally valid deposit."
+    },
+    "items": [
+      {
+        "title": "Given doctor --full, when the configured hook returns empty stdout, then the check warns or fails.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a deposited hook command that exits 0 with empty stdout, when doctor --full runs the live probe, then agent-hooks health is not reported as registered-and-valid and an actionable finding is emitted."
+        }
+      },
+      {
+        "title": "Given allow and deny fixtures, when the live probe runs, then both paths are asserted.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given a working hook bin, when the live probe pipes allow and empty/deny payloads for Cursor tool.before, then allow yields parseable permission allow and deny yields a deny decision."
+        }
+      },
+      {
+        "title": "Given doctor --quick, when doctor runs, then the live probe is not required.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given offline or --quick doctor, when doctor runs, then structural hooks checks still work and the live spawn probe is skipped unless --full (or explicit opt-in) is set."
+        }
+      },
+      {
+        "title": "Given the fix lands, when CHANGELOG is updated, then #2852 is cited.",
+        "status": "pending",
+        "narrative": {
+          "Acceptance": "Given the live probe ships, when the PR opens, then CHANGELOG [Unreleased] cites #2852."
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "security",
+      "test-debt",
+      "doctor"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2852",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2852: doctor live-probe agent hooks"
+      }
+    ],
+    "updated": "2026-07-27T01:16:18Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/doctor/main.ts",
+          "packages/core/src/doctor/agent-hooks.test.ts",
+          "packages/core/src/verify-env/agent-hooks.ts",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/doctor/agent-hooks.test.ts",
+          "task check"
+        ],
+        "expected_outputs": [
+          "live probe under doctor --full",
+          "stub empty-stdout regression",
+          "CHANGELOG Unreleased citing #2852"
+        ],
+        "depends_on": [],
+        "conflict_group": "doctor-hooks-live-probe-2852",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "leaf-implementation",
+        "missing_traces_justification": "Traced to GitHub issue #2852 acceptance criteria rather than a SPECIFICATION section."
+      },
+      "capacityBucket": "security",
+      "completedAt": "2026-07-27T01:16:18Z"
+    }
+  }
+}


### PR DESCRIPTION
chore(xbrief): complete cohort lifecycle xBRIEFs post-merge

Land active→completed moves for the 2026-07-26 hooks/AppSec/doctor cohort so release lifecycle sync is clean.
