### PR TITLE
test(coverage): restore branches >= 85% for v0.86.0 (#2865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vitest branch coverage restored above 85% (#2865).** Focused win32 coverage setup and coverage-debt argv branch tests clear the 84.99% hairline so v0.86.0 Step 5 passes without a consecutive `--allow-coverage-debt` soft-pass. Closes #2865.
 - **`core:validate` honors the dispatcher cwd and skips junk trees (#2858).** Inline `core:validate` now walks the resolved framework root instead of ambient `process.cwd()`, and `collectMarkdownFiles` skips `node_modules` and `.deft-scratch` so `task check` no longer hangs on maintainer clones with swarm worktrees. Closes #2858.
 - **Doctor no longer misclassifies a maintainer clone as a consumer when using the global CLI (#2850).** `frameworkRoot` now resolves via `resolveFrameworkRootForProject(projectRoot)` so hooks and Deft structure checks skip on a source checkout like install-integrity already does; `EXPECTED_FRAMEWORK_DIRS` expects `xbrief/` instead of legacy `vbrief/`. Closes #2850.
 - **deft-hook and guarded CLI bins now run through npm bin symlinks (#2846).** Global npm bins are symlinks; the entrypoint guard compared raw `process.argv[1]` to `import.meta.url`, so `main()` never ran (empty stdout exit 0). Cursor failClosed blocked all edits; other hosts silently dropped deny decisions. Shared `isDirectEntrypoint` realpath-compares both sides. Closes #2846.

--- a/packages/core/src/vitest-runner/coverage-debt.test.ts
+++ b/packages/core/src/vitest-runner/coverage-debt.test.ts
@@ -34,6 +34,13 @@ describe("parseCoverageDebtArgv", () => {
     expect(parseCoverageDebtArgv(["vitest", "run"])).toEqual({ kind: "none" });
   });
 
+  it("ignores sparse argv holes while scanning for the debt flag", () => {
+    const sparse: string[] = [];
+    sparse[2] = "--allow-coverage-debt";
+    sparse[3] = "2865";
+    expect(parseCoverageDebtArgv(sparse)).toEqual({ kind: "valid", issue: 2865 });
+  });
+
   it("parses equals and spaced forms", () => {
     expect(parseCoverageDebtArgv(["vitest", "--allow-coverage-debt=#2573"])).toEqual({
       kind: "valid",

--- a/packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts
+++ b/packages/core/src/vitest-runner/win32-coverage-tmp-setup.test.ts
@@ -62,9 +62,26 @@ describe("win32-coverage-tmp-setup (#2634)", () => {
   });
 
   it("default setup is a no-op teardown on non-win32 platforms", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const teardown = win32CoverageTmpSetup();
     expect(typeof teardown).toBe("function");
     expect(() => teardown()).not.toThrow();
+    platformSpy.mockRestore();
+  });
+
+  it("installCoverageTmpWriteGuard mkdirs parent when path is a Buffer", async () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-cov-buffer-"));
+    tempRoots.push(root);
+    const chunkPath = join(root, "coverage", ".tmp", "coverage-0.json");
+    const uninstall = installCoverageTmpWriteGuard();
+
+    try {
+      const { promises } = await import("node:fs");
+      await promises.writeFile(Buffer.from(chunkPath, "utf8"), '{"buffer":true}\n', "utf8");
+      expect(readFileSync(chunkPath, "utf8")).toBe('{"buffer":true}\n');
+    } finally {
+      uninstall();
+    }
   });
 
   it("default setup installs the write guard on win32", () => {


### PR DESCRIPTION
## Summary

- Restore global vitest branch coverage from 84.99% to >= 85% so 	ask check / release Step 5 passes without --allow-coverage-debt.
- Add focused branch tests for win32 coverage tmp setup (non-win32 no-op platform mock, Buffer path write guard) and coverage-debt sparse argv scanning.
- Update CHANGELOG [Unreleased] citing #2865.

## Test plan

- [x] pnpm exec vitest run packages/core/src/vitest-runner --coverage
- [x] pnpm exec vitest run --coverage — branches 85.00% (28714/33780)
- [x] 	ask check

Closes #2865
