### PR TITLE
fix(scope): reconcile own plan.items and envelope updated on complete (#2862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`scope:complete` reconciles the completing brief's own `plan.items` and envelope `updated` (#2862).** Terminal transitions (`complete` / `fail` / `cancel`) now advance non-terminal own items (and nested `subItems`) to the terminal status while preserving already-terminal items (`cancelled` / `failed` / `completed`), and stamp `xBRIEFInfo.updated` or `vBRIEFInfo.updated` alongside `plan.updated`. Closes #2862.
+
 ### Removed
 
 ## [0.86.0] - 2026-07-27

--- a/packages/core/src/scope/transition.test.ts
+++ b/packages/core/src/scope/transition.test.ts
@@ -89,6 +89,203 @@ describe("runTransition", () => {
     expect(data.plan.metadata.completedAt).toMatch(/Z$/);
   });
 
+  it("advances non-terminal own plan.items and stamps xBRIEFInfo.updated on complete (#2862)", () => {
+    root = makeRepo();
+    const path = join(root, "xbrief", "active", "mixed-items.xbrief.json");
+    const staleEnvelope = "2026-01-01T00:00:00Z";
+    writeFile(path, {
+      xBRIEFInfo: { version: "0.8", updated: staleEnvelope },
+      plan: {
+        title: "mixed",
+        status: "running",
+        updated: staleEnvelope,
+        items: [
+          { title: "pending-item", status: "pending" },
+          { title: "proposed-item", status: "proposed" },
+          { title: "running-item", status: "running" },
+          { title: "cancelled-item", status: "cancelled" },
+          { title: "failed-item", status: "failed" },
+          { title: "already-completed", status: "completed" },
+          {
+            title: "parent-with-sub",
+            status: "pending",
+            subItems: [
+              { title: "sub-pending", status: "pending" },
+              { title: "sub-cancelled", status: "cancelled" },
+            ],
+          },
+        ],
+      },
+    });
+    const fixed = new Date("2026-07-27T15:30:00.000Z");
+    const result = runTransition("complete", path, fixed);
+    expect(result.ok).toBe(true);
+    const dest = join(root, "xbrief", "completed", "mixed-items.xbrief.json");
+    const data = JSON.parse(readFileSync(dest, "utf8")) as {
+      xBRIEFInfo: { updated: string };
+      plan: {
+        status: string;
+        updated: string;
+        items: Array<{
+          title: string;
+          status: string;
+          subItems?: Array<{ title: string; status: string }>;
+        }>;
+      };
+    };
+    expect(data.plan.status).toBe("completed");
+    expect(data.plan.updated).toBe("2026-07-27T15:30:00Z");
+    expect(data.xBRIEFInfo.updated).toBe(data.plan.updated);
+    expect(data.xBRIEFInfo.updated).not.toBe(staleEnvelope);
+    const byTitle = Object.fromEntries(data.plan.items.map((i) => [i.title, i]));
+    expect(byTitle["pending-item"].status).toBe("completed");
+    expect(byTitle["proposed-item"].status).toBe("completed");
+    expect(byTitle["running-item"].status).toBe("completed");
+    expect(byTitle["cancelled-item"].status).toBe("cancelled");
+    expect(byTitle["failed-item"].status).toBe("failed");
+    expect(byTitle["already-completed"].status).toBe("completed");
+    expect(byTitle["parent-with-sub"].status).toBe("completed");
+    expect(byTitle["parent-with-sub"].subItems?.[0].status).toBe("completed");
+    expect(byTitle["parent-with-sub"].subItems?.[1].status).toBe("cancelled");
+  });
+
+  it("stamps vBRIEFInfo.updated on terminal transition for v0.6 envelopes (#2862)", () => {
+    root = makeRepo();
+    const path = join(root, "xbrief", "active", "v06.xbrief.json");
+    writeFile(path, {
+      vBRIEFInfo: { version: "0.6", updated: "2026-01-01T00:00:00Z" },
+      plan: {
+        title: "v06",
+        status: "running",
+        items: [{ title: "a", status: "pending" }],
+      },
+    });
+    const fixed = new Date("2026-07-27T16:00:00.000Z");
+    expect(runTransition("complete", path, fixed).ok).toBe(true);
+    const dest = join(root, "xbrief", "completed", "v06.xbrief.json");
+    const data = JSON.parse(readFileSync(dest, "utf8")) as {
+      vBRIEFInfo: { updated: string };
+      plan: { updated: string; items: Array<{ status: string }> };
+    };
+    expect(data.vBRIEFInfo.updated).toBe("2026-07-27T16:00:00Z");
+    expect(data.vBRIEFInfo.updated).toBe(data.plan.updated);
+    expect(data.plan.items[0].status).toBe("completed");
+  });
+
+  it("advances non-terminal own items on fail and cancel (#2862)", () => {
+    root = makeRepo();
+    const failPath = join(root, "xbrief", "active", "fail-items.xbrief.json");
+    writeFile(failPath, {
+      xBRIEFInfo: { version: "0.8", updated: "2026-01-01T00:00:00Z" },
+      plan: {
+        title: "fail",
+        status: "running",
+        items: [
+          { title: "p", status: "pending" },
+          { title: "c", status: "cancelled" },
+        ],
+      },
+    });
+    expect(runTransition("fail", failPath).ok).toBe(true);
+    const failed = JSON.parse(
+      readFileSync(join(root, "xbrief", "completed", "fail-items.xbrief.json"), "utf8"),
+    ) as { plan: { status: string; items: Array<{ status: string }> } };
+    expect(failed.plan.status).toBe("failed");
+    expect(failed.plan.items[0].status).toBe("failed");
+    expect(failed.plan.items[1].status).toBe("cancelled");
+
+    const cancelPath = join(root, "xbrief", "active", "cancel-items.xbrief.json");
+    writeFile(cancelPath, {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "cancel",
+        status: "running",
+        items: [
+          { title: "p", status: "proposed" },
+          { title: "f", status: "failed" },
+        ],
+      },
+    });
+    expect(runTransition("cancel", cancelPath).ok).toBe(true);
+    const cancelled = JSON.parse(
+      readFileSync(join(root, "xbrief", "cancelled", "cancel-items.xbrief.json"), "utf8"),
+    ) as { plan: { status: string; items: Array<{ status: string }> } };
+    expect(cancelled.plan.status).toBe("cancelled");
+    expect(cancelled.plan.items[0].status).toBe("cancelled");
+    expect(cancelled.plan.items[1].status).toBe("failed");
+  });
+
+  it("handles empty/nested items and skip-invalid item entries on complete (#2862)", () => {
+    root = makeRepo();
+    const fixed = new Date("2026-07-27T17:00:00.000Z");
+
+    const emptyPath = join(root, "xbrief", "active", "empty-items.xbrief.json");
+    writeFile(emptyPath, {
+      xBRIEFInfo: { version: "0.8", updated: "2026-01-01T00:00:00Z" },
+      plan: { title: "empty", status: "running", items: [] },
+    });
+    expect(runTransition("complete", emptyPath, fixed).ok).toBe(true);
+    const emptyDest = join(root, "xbrief", "completed", "empty-items.xbrief.json");
+    const emptyData = JSON.parse(readFileSync(emptyDest, "utf8")) as {
+      xBRIEFInfo: { updated: string };
+      plan: { updated: string; items: unknown[] };
+    };
+    expect(emptyData.xBRIEFInfo.updated).toBe(emptyData.plan.updated);
+    expect(emptyData.plan.items).toEqual([]);
+
+    const nestedPath = join(root, "xbrief", "active", "nested-items.xbrief.json");
+    writeFile(nestedPath, {
+      xBRIEFInfo: { version: "0.8", updated: "2026-01-01T00:00:00Z" },
+      plan: {
+        title: "nested",
+        status: "running",
+        items: [
+          {
+            title: "parent",
+            status: "pending",
+            // Nested under items[] (not only subItems) advances recursively.
+            items: [{ title: "child-pending", status: "pending" }],
+          },
+          { title: "blocked-item", status: "blocked" },
+        ],
+      },
+    });
+    expect(runTransition("complete", nestedPath, fixed).ok).toBe(true);
+    const nested = JSON.parse(
+      readFileSync(join(root, "xbrief", "completed", "nested-items.xbrief.json"), "utf8"),
+    ) as {
+      plan: {
+        items: Array<{
+          title: string;
+          status: string;
+          items?: Array<{ status: string }>;
+        }>;
+      };
+    };
+    expect(nested.plan.items[0].status).toBe("completed");
+    expect(nested.plan.items[0].items?.[0].status).toBe("completed");
+    expect(nested.plan.items[1].status).toBe("blocked");
+
+    // Exercise skip branches for non-array items / non-object entries (write may fail closed).
+    const nonArrayPath = join(root, "xbrief", "active", "non-array-items.xbrief.json");
+    writeFile(nonArrayPath, {
+      xBRIEFInfo: { version: "0.8" },
+      plan: { title: "bad-items", status: "running", items: "not-an-array" },
+    });
+    expect(runTransition("complete", nonArrayPath, fixed).ok).toBe(false);
+
+    const junkPath = join(root, "xbrief", "active", "junk-entries.xbrief.json");
+    writeFile(junkPath, {
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "junk",
+        status: "running",
+        items: [null, "skip", ["arr"], { title: "ok", status: "pending" }],
+      },
+    });
+    expect(runTransition("complete", junkPath, fixed).ok).toBe(false);
+  });
+
   it("does not leave non-terminal status in active/ during complete (#2578)", () => {
     root = makeRepo();
     const file = writeVbrief(root, "active", "running", "atomic-complete.xbrief.json");

--- a/packages/core/src/scope/transition.ts
+++ b/packages/core/src/scope/transition.ts
@@ -32,6 +32,47 @@ export interface TransitionResult {
   readonly message: string;
 }
 
+/** Item statuses that still represent unfinished work and should advance on terminal transitions (#2862). */
+const NON_TERMINAL_ITEM_STATUSES = new Set(["pending", "proposed", "running"]);
+
+/** Terminal lifecycle actions that reconcile the brief's own plan.items (#2862). */
+const OWN_ITEMS_RECONCILE_ACTIONS = new Set<ScopeAction>(["complete", "fail", "cancel"]);
+
+/**
+ * Advance non-terminal plan.items / subItems to the terminal target status.
+ * Leaves cancelled / failed / completed / other non-pending-proposed-running items alone (#2862).
+ */
+function advanceNonTerminalOwnItems(items: unknown, targetStatus: string): void {
+  if (!Array.isArray(items)) {
+    return;
+  }
+  for (const item of items) {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      continue;
+    }
+    const obj = item as Record<string, unknown>;
+    const status = String(obj.status ?? "");
+    if (NON_TERMINAL_ITEM_STATUSES.has(status)) {
+      obj.status = targetStatus;
+    }
+    advanceNonTerminalOwnItems(obj.subItems, targetStatus);
+    advanceNonTerminalOwnItems(obj.items, targetStatus);
+  }
+}
+
+/**
+ * Refresh the document envelope `updated` stamp to match `plan.updated`.
+ * Stamps whichever of xBRIEFInfo (v0.8) / vBRIEFInfo (v0.6) is present — never creates one (#2862 / #2346).
+ */
+function stampEnvelopeUpdated(data: Record<string, unknown>, nowIso: string): void {
+  for (const key of ["xBRIEFInfo", "vBRIEFInfo"] as const) {
+    const env = data[key];
+    if (typeof env === "object" && env !== null && !Array.isArray(env)) {
+      (env as Record<string, unknown>).updated = nowIso;
+    }
+  }
+}
+
 export function runTransition(
   action: string,
   filePath: string,
@@ -132,6 +173,13 @@ export function runTransition(
   const nowIso = utcNowIso(now);
   planObj.status = targetStatus;
   planObj.updated = nowIso;
+  // Keep the envelope clock aligned with plan.updated on every mutating transition (#2862).
+  stampEnvelopeUpdated(data, nowIso);
+
+  // Reconcile the completing brief's own plan.items (mirrors #1527 / #2566 registry sync) (#2862).
+  if (OWN_ITEMS_RECONCILE_ACTIONS.has(act)) {
+    advanceNonTerminalOwnItems(planObj.items, targetStatus);
+  }
 
   if (act === "complete") {
     stampCompletionMetadata(planObj, projectRoot, nowIso);


### PR DESCRIPTION
## Summary

`scope:complete` (and terminal `fail` / `cancel`) set `plan.status` and `plan.updated` but left the completing brief's own `plan.items[].status` on pending and never refreshed the envelope `updated` stamp. Mirror registry sync already fixed PROJECT-DEFINITION (#1527) and specification (#2566); the source brief itself was the remaining gap.

## Changes

- On terminal transitions in `runTransition`, advance non-terminal own `plan.items` / nested `subItems` and `items` to the terminal status when still `pending` / `proposed` / `running`
- Preserve already-terminal item statuses (`cancelled` / `failed` / `completed` / `blocked`, etc.)
- Stamp `xBRIEFInfo.updated` (v0.8) or `vBRIEFInfo.updated` (v0.6) in the same write as `plan.updated` without creating the other envelope key
- Unit tests for mixed statuses, envelope stamp (v0.8 + v0.6), fail/cancel symmetry, and edge cases
- CHANGELOG [Unreleased] cites #2862

## Test plan

- [x] `pnpm exec vitest run packages/core/src/scope/transition.test.ts`
- [x] `pnpm exec vitest run packages/core/src/scope/`
- [x] `task check:merge`

Closes #2862