### PR TITLE
fix(intake): harden issue-emit create/stamp durability for dual failure (#2880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Issue-emit dual ledger+stamp failure and umbrella partial-failure no longer re-create GitHub issues on retry (#2880).** After remote create, the URL is always recorded in process-local + OS-temp recovery (in addition to the project pending ledger) before the xBRIEF stamp; `IssueEmitError.createdUrl` is structured; `emitUmbrella` shares the same reconcile contract and reuses a sibling recovered URL instead of filing a second issue. Residual reliability after #2871 AppSec/ledger baseline. Closes #2880.
 - **Issue emit uses a contained pending-URL ledger to prevent duplicate GitHub issues (#2869 / #2871).** After remote create, the issue URL is recorded under \.deft-cache/issue-emit-pending.json\ (gated by projection containment) before the vBRIEF stamp; retries reconcile the pending URL without re-creating the issue.
 - **Issue-emit recovery never bypasses projection containment (#2869 / #2871).** Post-create local stamp failures no longer fall through to unguarded \writeFileSync\; the remote URL is still returned so retries cannot create duplicate issues without reopening a symlink write sink.
 - **Issue emit never orphans a remote create without returning the URL (#2869 / #2871).** \mitSingle\ / \mitUmbrella\ pre-persist the local xBRIEF, create the GitHub issue only after that write succeeds, then stamp the URL; if the post-create stamp fails the URL is still returned so retries cannot create duplicates.

--- a/packages/core/src/intake/issue-emit-pending.test.ts
+++ b/packages/core/src/intake/issue-emit-pending.test.ts
@@ -16,6 +16,7 @@ import {
   emitSingle,
   emitUmbrella,
   existingGithubIssueRef,
+  GITHUB_ISSUE_REF_TYPE,
   IssueEmitError,
   loadPendingEmitUrls,
   loadRecoveredUrl,
@@ -207,6 +208,71 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
     expect(existingGithubIssueRef(loadVbrief(a))).toBe("https://github.com/o/r/issues/881");
     expect(existingGithubIssueRef(loadVbrief(b))).toBe("https://github.com/o/r/issues/881");
 
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("umbrella reuses already-stamped sibling URL without re-create", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-umb-stamped-"));
+    const a = join(dir, "a.xbrief.json");
+    const b = join(dir, "b.xbrief.json");
+    writeVbrief(
+      a,
+      {
+        plan: {
+          title: "Child A",
+          references: [{ type: GITHUB_ISSUE_REF_TYPE, uri: "https://github.com/o/r/issues/900" }],
+        },
+      },
+      dir,
+    );
+    writeVbrief(b, { plan: { title: "Child B" } }, dir);
+    clearRecoveredUrl(b);
+    const action = emitUmbrella([a, b], {
+      repo: "o/r",
+      projectRoot: dir,
+      scmCall: (() => {
+        throw new Error("must reuse stamped sibling URL");
+      }) as never,
+      displayPaths: ["a", "b"],
+    });
+    expect(action.result).toBe("created");
+    expect(existingGithubIssueRef(loadVbrief(a))).toBe("https://github.com/o/r/issues/900");
+    expect(existingGithubIssueRef(loadVbrief(b))).toBe("https://github.com/o/r/issues/900");
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("umbrella rejects recovery URL that conflicts with already-stamped sibling", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-umb-stamped-conflict-"));
+    const a = join(dir, "a.xbrief.json");
+    const b = join(dir, "b.xbrief.json");
+    writeVbrief(
+      a,
+      {
+        plan: {
+          title: "Child A",
+          references: [{ type: GITHUB_ISSUE_REF_TYPE, uri: "https://github.com/o/r/issues/901" }],
+        },
+      },
+      dir,
+    );
+    writeVbrief(b, { plan: { title: "Child B" } }, dir);
+    clearRecoveredUrl(b);
+    savePendingEmitUrl(dir, b, "https://github.com/o/r/issues/902");
+    expect(() =>
+      emitUmbrella([a, b], {
+        repo: "o/r",
+        projectRoot: dir,
+        scmCall: (() => {
+          throw new Error("must not create on stamped conflict");
+        }) as never,
+        displayPaths: ["a", "b"],
+      }),
+    ).toThrow(/conflicting issue URLs/);
+    expect(existingGithubIssueRef(loadVbrief(b))).toBeUndefined();
     clearRecoveredUrl(a);
     clearRecoveredUrl(b);
     rmSync(dir, { recursive: true, force: true });

--- a/packages/core/src/intake/issue-emit-pending.test.ts
+++ b/packages/core/src/intake/issue-emit-pending.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -239,6 +247,7 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
     writeFileSync(victim, "keep-me\n", "utf8");
     try {
       // Prefer junction/file symlink; skip when platform forbids symlink without elevation.
+      mkdirSync(join(side, ".."), { recursive: true });
       symlinkSync(victim, side);
     } catch {
       rmSync(dir, { recursive: true, force: true });
@@ -251,6 +260,51 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
     expect(loadRecoveredUrl(path)).toBe("https://github.com/o/r/issues/9");
     // Victim must remain unpolluted if link was replaced/refused.
     expect(readFileSync(victim, "utf8")).not.toContain("issues/9");
+    clearRecoveredUrl(path);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("recovery load refuses group/other-writable forged sidecars", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-forge-"));
+    const path = join(dir, "story.xbrief.json");
+    writeVbrief(path, { plan: { title: "Forge" } }, dir);
+    clearRecoveredUrl(path);
+    // Plant a world-writable forged sidecar under the recovery path.
+    const side = recoverySidecarPath(path);
+    mkdirSync(join(side, ".."), { recursive: true, mode: 0o777 });
+    writeFileSync(
+      side,
+      `${JSON.stringify({ path: resolve(path), url: "https://github.com/evil/r/issues/666" }, null, 2)}\n`,
+      "utf8",
+    );
+    try {
+      chmodSync(side, 0o666);
+    } catch {
+      // Platform may ignore mode bits; ownership path still exercises.
+    }
+    // Clear process map so load only sees disk (forged) state.
+    clearRecoveredUrl(path);
+    // Re-plant after clearRecoveredUrl may have unlinked.
+    writeFileSync(
+      side,
+      `${JSON.stringify({ path: resolve(path), url: "https://github.com/evil/r/issues/666" }, null, 2)}\n`,
+      "utf8",
+    );
+    try {
+      chmodSync(side, 0o666);
+    } catch {
+      // ignore
+    }
+    // If mode is still group/other writable, load must refuse.
+    // On platforms where chmod is a no-op (win32), isTrustedStat may still accept —
+    // then at least URL must not stamp from process-cleared path without our write.
+    const recovered = loadRecoveredUrl(path);
+    if (process.platform !== "win32") {
+      expect(recovered).toBeUndefined();
+    } else if (recovered !== undefined) {
+      // win32 often ignores mode; still must not be stamped without emitSingle.
+      expect(existingGithubIssueRef(loadVbrief(path))).toBeUndefined();
+    }
     clearRecoveredUrl(path);
     rmSync(dir, { recursive: true, force: true });
   });

--- a/packages/core/src/intake/issue-emit-pending.test.ts
+++ b/packages/core/src/intake/issue-emit-pending.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -9,18 +9,22 @@ import {
   emitUmbrella,
   existingGithubIssueRef,
   IssueEmitError,
-  issueEmitTestHooks,
   loadPendingEmitUrls,
   loadRecoveredUrl,
   loadVbrief,
+  recoverySidecarPath,
   rememberCreatedUrl,
-  resetIssueEmitTestHooks,
   savePendingEmitUrl,
   writeVbrief,
 } from "./issue-emit.js";
 
+function clearTestFailEnv(): void {
+  delete process.env.DEFT_ISSUE_EMIT_TEST_FAIL_LEDGER;
+  delete process.env.DEFT_ISSUE_EMIT_TEST_FAIL_STAMP;
+}
+
 afterEach(() => {
-  resetIssueEmitTestHooks();
+  clearTestFailEnv();
 });
 
 describe("issue-emit pending ledger (#2871)", () => {
@@ -82,8 +86,8 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
       };
     };
 
-    issueEmitTestHooks.failProjectLedger = true;
-    issueEmitTestHooks.failStamp = true;
+    process.env.DEFT_ISSUE_EMIT_TEST_FAIL_LEDGER = "1";
+    process.env.DEFT_ISSUE_EMIT_TEST_FAIL_STAMP = "1";
     let thrown: unknown;
     try {
       emitSingle(path, { repo: "o/r", projectRoot: dir, scmCall: scmCall as never });
@@ -97,7 +101,7 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
     expect(loadRecoveredUrl(path)).toBe("https://github.com/o/r/issues/501");
 
     // Retry: recovery holds URL — must not file a second issue.
-    resetIssueEmitTestHooks();
+    clearTestFailEnv();
     const action = emitSingle(path, {
       repo: "o/r",
       projectRoot: dir,
@@ -134,8 +138,7 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
       };
     };
 
-    // First pass: remote create + durable record, but stamp fails for all.
-    issueEmitTestHooks.failStamp = true;
+    process.env.DEFT_ISSUE_EMIT_TEST_FAIL_STAMP = "1";
     let thrown: unknown;
     try {
       emitUmbrella([a, b], {
@@ -153,8 +156,7 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
     expect(existingGithubIssueRef(loadVbrief(a))).toBeUndefined();
     expect(existingGithubIssueRef(loadVbrief(b))).toBeUndefined();
 
-    // Retry: both paths reconcile from ledger/recovery — no second remote create.
-    resetIssueEmitTestHooks();
+    clearTestFailEnv();
     const action = emitUmbrella([a, b], {
       repo: "o/r",
       projectRoot: dir,
@@ -183,11 +185,8 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
     clearRecoveredUrl(a);
     clearRecoveredUrl(b);
 
-    // Simulate post-create partial: A has durable URL, B has neither stamp nor ledger.
     savePendingEmitUrl(dir, a, "https://github.com/o/r/issues/881");
     rememberCreatedUrl(a, "https://github.com/o/r/issues/881");
-    // B lost local records except we still expect sibling reconcile — put recovery only on A.
-    // With sibling recovery, B should inherit A's URL without scm.
     const action = emitUmbrella([a, b], {
       repo: "o/r",
       projectRoot: dir,
@@ -202,6 +201,57 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
 
     clearRecoveredUrl(a);
     clearRecoveredUrl(b);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("umbrella rejects conflicting recovered sibling URLs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-umb-conflict-"));
+    const a = join(dir, "a.xbrief.json");
+    const b = join(dir, "b.xbrief.json");
+    writeVbrief(a, { plan: { title: "Child A" } }, dir);
+    writeVbrief(b, { plan: { title: "Child B" } }, dir);
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
+    savePendingEmitUrl(dir, a, "https://github.com/o/r/issues/1");
+    savePendingEmitUrl(dir, b, "https://github.com/o/r/issues/2");
+    expect(() =>
+      emitUmbrella([a, b], {
+        repo: "o/r",
+        projectRoot: dir,
+        scmCall: (() => {
+          throw new Error("must not create when conflict detected");
+        }) as never,
+        displayPaths: ["a", "b"],
+      }),
+    ).toThrow(/conflicting issue URLs/);
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("recovery load refuses symlink sidecars", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-symlink-"));
+    const path = join(dir, "story.xbrief.json");
+    writeVbrief(path, { plan: { title: "S" } }, dir);
+    clearRecoveredUrl(path);
+    const side = recoverySidecarPath(path);
+    const victim = join(dir, "victim.txt");
+    writeFileSync(victim, "keep-me\n", "utf8");
+    try {
+      // Prefer junction/file symlink; skip when platform forbids symlink without elevation.
+      symlinkSync(victim, side);
+    } catch {
+      rmSync(dir, { recursive: true, force: true });
+      return;
+    }
+    // Process map empty after clear; load must not follow symlink to victim.
+    expect(loadRecoveredUrl(path)).toBeUndefined();
+    // rememberCreatedUrl must not follow symlink into victim content.
+    rememberCreatedUrl(path, "https://github.com/o/r/issues/9");
+    expect(loadRecoveredUrl(path)).toBe("https://github.com/o/r/issues/9");
+    // Victim must remain unpolluted if link was replaced/refused.
+    expect(readFileSync(victim, "utf8")).not.toContain("issues/9");
+    clearRecoveredUrl(path);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/intake/issue-emit-pending.test.ts
+++ b/packages/core/src/intake/issue-emit-pending.test.ts
@@ -1,16 +1,27 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   clearPendingEmitUrl,
+  clearRecoveredUrl,
   emitSingle,
+  emitUmbrella,
   existingGithubIssueRef,
+  IssueEmitError,
+  issueEmitTestHooks,
   loadPendingEmitUrls,
+  loadRecoveredUrl,
   loadVbrief,
+  rememberCreatedUrl,
+  resetIssueEmitTestHooks,
   savePendingEmitUrl,
   writeVbrief,
 } from "./issue-emit.js";
+
+afterEach(() => {
+  resetIssueEmitTestHooks();
+});
 
 describe("issue-emit pending ledger (#2871)", () => {
   it("records and clears pending emit URLs under project root", () => {
@@ -39,6 +50,158 @@ describe("issue-emit pending ledger (#2871)", () => {
     expect(action.result).toBe("created");
     expect(action.url).toBe("https://github.com/o/r/issues/99");
     expect(existingGithubIssueRef(loadVbrief(path))).toBe("https://github.com/o/r/issues/99");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("issue-emit dual-failure + recovery durability (#2880)", () => {
+  it("rememberCreatedUrl survives process recovery load without project ledger", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-rec-"));
+    const path = join(dir, "story.xbrief.json");
+    writeVbrief(path, { plan: { title: "R" } }, dir);
+    clearRecoveredUrl(path);
+    rememberCreatedUrl(path, "https://github.com/o/r/issues/77");
+    expect(loadRecoveredUrl(path)).toBe("https://github.com/o/r/issues/77");
+    clearRecoveredUrl(path);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("dual ledger+stamp failure keeps URL; retry stamps without re-create", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-dual-"));
+    const path = join(dir, "story.xbrief.json");
+    writeVbrief(path, { plan: { title: "Dual" } }, dir);
+    clearRecoveredUrl(path);
+
+    let scmCalls = 0;
+    const scmCall = () => {
+      scmCalls += 1;
+      return {
+        returncode: 0,
+        stdout: "https://github.com/o/r/issues/501\n",
+        stderr: "",
+      };
+    };
+
+    issueEmitTestHooks.failProjectLedger = true;
+    issueEmitTestHooks.failStamp = true;
+    let thrown: unknown;
+    try {
+      emitSingle(path, { repo: "o/r", projectRoot: dir, scmCall: scmCall as never });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(IssueEmitError);
+    expect((thrown as IssueEmitError).createdUrl).toBe("https://github.com/o/r/issues/501");
+    expect(scmCalls).toBe(1);
+    expect(existingGithubIssueRef(loadVbrief(path))).toBeUndefined();
+    expect(loadRecoveredUrl(path)).toBe("https://github.com/o/r/issues/501");
+
+    // Retry: recovery holds URL — must not file a second issue.
+    resetIssueEmitTestHooks();
+    const action = emitSingle(path, {
+      repo: "o/r",
+      projectRoot: dir,
+      scmCall: (() => {
+        throw new Error("retry must not re-create remote issue");
+      }) as never,
+    });
+    expect(action.result).toBe("created");
+    expect(action.url).toBe("https://github.com/o/r/issues/501");
+    expect(existingGithubIssueRef(loadVbrief(path))).toBe("https://github.com/o/r/issues/501");
+    expect(scmCalls).toBe(1);
+    expect(loadRecoveredUrl(path)).toBeUndefined();
+
+    clearRecoveredUrl(path);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("umbrella mid-loop stamp failure reconciles all artifacts to original URL on retry", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-umb-"));
+    const a = join(dir, "a.xbrief.json");
+    const b = join(dir, "b.xbrief.json");
+    writeVbrief(a, { plan: { title: "Child A" } }, dir);
+    writeVbrief(b, { plan: { title: "Child B" } }, dir);
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
+
+    let scmCalls = 0;
+    const scmCall = () => {
+      scmCalls += 1;
+      return {
+        returncode: 0,
+        stdout: "https://github.com/o/r/issues/880\n",
+        stderr: "",
+      };
+    };
+
+    // First pass: remote create + durable record, but stamp fails for all.
+    issueEmitTestHooks.failStamp = true;
+    let thrown: unknown;
+    try {
+      emitUmbrella([a, b], {
+        repo: "o/r",
+        projectRoot: dir,
+        scmCall: scmCall as never,
+        displayPaths: ["a", "b"],
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(IssueEmitError);
+    expect((thrown as IssueEmitError).createdUrl).toBe("https://github.com/o/r/issues/880");
+    expect(scmCalls).toBe(1);
+    expect(existingGithubIssueRef(loadVbrief(a))).toBeUndefined();
+    expect(existingGithubIssueRef(loadVbrief(b))).toBeUndefined();
+
+    // Retry: both paths reconcile from ledger/recovery — no second remote create.
+    resetIssueEmitTestHooks();
+    const action = emitUmbrella([a, b], {
+      repo: "o/r",
+      projectRoot: dir,
+      scmCall: (() => {
+        throw new Error("umbrella retry must not re-create remote issue");
+      }) as never,
+      displayPaths: ["a", "b"],
+    });
+    expect(action.result).toBe("created");
+    expect(action.url).toBe("https://github.com/o/r/issues/880");
+    expect(existingGithubIssueRef(loadVbrief(a))).toBe("https://github.com/o/r/issues/880");
+    expect(existingGithubIssueRef(loadVbrief(b))).toBe("https://github.com/o/r/issues/880");
+    expect(scmCalls).toBe(1);
+
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("umbrella partial stamp: one child pending still uses sibling URL without re-create", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-umb-part-"));
+    const a = join(dir, "a.xbrief.json");
+    const b = join(dir, "b.xbrief.json");
+    writeVbrief(a, { plan: { title: "Child A" } }, dir);
+    writeVbrief(b, { plan: { title: "Child B" } }, dir);
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
+
+    // Simulate post-create partial: A has durable URL, B has neither stamp nor ledger.
+    savePendingEmitUrl(dir, a, "https://github.com/o/r/issues/881");
+    rememberCreatedUrl(a, "https://github.com/o/r/issues/881");
+    // B lost local records except we still expect sibling reconcile — put recovery only on A.
+    // With sibling recovery, B should inherit A's URL without scm.
+    const action = emitUmbrella([a, b], {
+      repo: "o/r",
+      projectRoot: dir,
+      scmCall: (() => {
+        throw new Error("partial umbrella must reuse sibling URL");
+      }) as never,
+      displayPaths: ["a", "b"],
+    });
+    expect(action.result).toBe("created");
+    expect(existingGithubIssueRef(loadVbrief(a))).toBe("https://github.com/o/r/issues/881");
+    expect(existingGithubIssueRef(loadVbrief(b))).toBe("https://github.com/o/r/issues/881");
+
+    clearRecoveredUrl(a);
+    clearRecoveredUrl(b);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/intake/issue-emit-pending.test.ts
+++ b/packages/core/src/intake/issue-emit-pending.test.ts
@@ -212,7 +212,7 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("umbrella rejects conflicting recovered sibling URLs", () => {
+  it("umbrella rejects conflicting recovered sibling URLs before stamping either", () => {
     const dir = mkdtempSync(join(tmpdir(), "emit-umb-conflict-"));
     const a = join(dir, "a.xbrief.json");
     const b = join(dir, "b.xbrief.json");
@@ -232,6 +232,11 @@ describe("issue-emit dual-failure + recovery durability (#2880)", () => {
         displayPaths: ["a", "b"],
       }),
     ).toThrow(/conflicting issue URLs/);
+    // Neither sibling stamped; both recovery/ledger entries remain for operator resolve.
+    expect(existingGithubIssueRef(loadVbrief(a))).toBeUndefined();
+    expect(existingGithubIssueRef(loadVbrief(b))).toBeUndefined();
+    expect(loadPendingEmitUrls(dir)[resolve(a)]).toBe("https://github.com/o/r/issues/1");
+    expect(loadPendingEmitUrls(dir)[resolve(b)]).toBe("https://github.com/o/r/issues/2");
     clearRecoveredUrl(a);
     clearRecoveredUrl(b);
     rmSync(dir, { recursive: true, force: true });

--- a/packages/core/src/intake/issue-emit.ts
+++ b/packages/core/src/intake/issue-emit.ts
@@ -1,5 +1,18 @@
 import { createHash } from "node:crypto";
-import { globSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  globSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { referenceTypeMatches } from "@deftai/directive-types";
@@ -32,37 +45,82 @@ export class IssueEmitError extends Error {
 
 /**
  * Process-local fallback for post-create URL when project ledger and xBRIEF stamp both fail (#2880).
- * Survives same-process retry without re-create; paired with OS-temp sidecar for process restarts.
+ * Survives same-process retry without re-create; paired with private OS-temp sidecar for restarts.
  */
 const processPendingUrls = new Map<string, string>();
 
-/** Test-only failure injection for dual-failure / partial-stamp paths. Always empty in production. */
-export const issueEmitTestHooks: {
-  failProjectLedger?: boolean;
-  failStamp?: boolean;
-} = {};
+/** Vitest-only failure injection via env (not a production export surface). */
+function testFailProjectLedger(): boolean {
+  return process.env.VITEST === "true" && process.env.DEFT_ISSUE_EMIT_TEST_FAIL_LEDGER === "1";
+}
 
-export function resetIssueEmitTestHooks(): void {
-  delete issueEmitTestHooks.failProjectLedger;
-  delete issueEmitTestHooks.failStamp;
+function testFailStamp(): boolean {
+  return process.env.VITEST === "true" && process.env.DEFT_ISSUE_EMIT_TEST_FAIL_STAMP === "1";
+}
+
+function privateRecoveryRoot(): string {
+  const base =
+    typeof process.env.XDG_RUNTIME_DIR === "string" && process.env.XDG_RUNTIME_DIR.length > 0
+      ? process.env.XDG_RUNTIME_DIR
+      : tmpdir();
+  const uid = typeof process.getuid === "function" ? String(process.getuid()) : "u";
+  return join(base, `deft-issue-emit-recovery-${uid}`);
 }
 
 export function recoverySidecarPath(vbriefAbsPath: string): string {
   const key = createHash("sha256").update(resolve(vbriefAbsPath)).digest("hex").slice(0, 40);
-  return join(tmpdir(), "deft-issue-emit-recovery", `${key}.json`);
+  return join(privateRecoveryRoot(), `${key}.json`);
 }
 
 /**
- * Always-on recovery after remote create: process memory + OS-temp sidecar.
+ * Write recovery sidecar without following symlinks (#2880 Greptile P1).
+ * Private per-uid dir + lstat refusal + O_EXCL|O_NOFOLLOW create.
+ */
+function writeRecoverySidecarSafe(sidePath: string, payload: string): void {
+  const dir = dirname(sidePath);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const dirStat = lstatSync(dir);
+  if (dirStat.isSymbolicLink()) {
+    throw new Error("issue-emit recovery dir is a symlink");
+  }
+  try {
+    const existing = lstatSync(sidePath);
+    if (existing.isSymbolicLink() || existing.isFile()) {
+      // unlink of a symlink removes the link itself (does not follow).
+      unlinkSync(sidePath);
+    } else {
+      throw new Error("issue-emit recovery path exists and is not a regular file");
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      throw err;
+    }
+  }
+  let flags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
+  if (typeof constants.O_NOFOLLOW === "number") {
+    flags |= constants.O_NOFOLLOW;
+  }
+  const fd = openSync(sidePath, flags, 0o600);
+  try {
+    writeSync(fd, payload, undefined, "utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Always-on recovery after remote create: process memory + private OS-temp sidecar.
  * Independent of project-contained ledger so dual local failure still reconciles on retry (#2880).
  */
 export function rememberCreatedUrl(vbriefAbsPath: string, url: string): void {
   const key = resolve(vbriefAbsPath);
   processPendingUrls.set(key, url);
   try {
-    const side = recoverySidecarPath(key);
-    mkdirSync(dirname(side), { recursive: true });
-    writeFileSync(side, `${JSON.stringify({ path: key, url }, null, 2)}\n`, "utf8");
+    writeRecoverySidecarSafe(
+      recoverySidecarPath(key),
+      `${JSON.stringify({ path: key, url }, null, 2)}\n`,
+    );
   } catch {
     // Best-effort disk mirror; process map still holds the URL for same-process retry.
   }
@@ -75,7 +133,12 @@ export function loadRecoveredUrl(vbriefAbsPath: string): string | undefined {
     return mem;
   }
   try {
-    const raw = readFileSync(recoverySidecarPath(key), "utf8");
+    const side = recoverySidecarPath(key);
+    const st = lstatSync(side);
+    if (st.isSymbolicLink() || !st.isFile()) {
+      return undefined;
+    }
+    const raw = readFileSync(side, "utf8");
     const parsed = JSON.parse(raw) as unknown;
     if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
       const obj = parsed as Record<string, unknown>;
@@ -99,7 +162,15 @@ export function clearRecoveredUrl(vbriefAbsPath: string): void {
   const key = resolve(vbriefAbsPath);
   processPendingUrls.delete(key);
   try {
-    rmSync(recoverySidecarPath(key), { force: true });
+    const side = recoverySidecarPath(key);
+    try {
+      const st = lstatSync(side);
+      if (st.isSymbolicLink() || st.isFile()) {
+        unlinkSync(side);
+      }
+    } catch {
+      rmSync(side, { force: true });
+    }
   } catch {
     // Best-effort clear.
   }
@@ -128,7 +199,7 @@ export function recordCreatedUrlDurable(
   url: string,
 ): void {
   rememberCreatedUrl(vbriefAbsPath, url);
-  if (issueEmitTestHooks.failProjectLedger === true) {
+  if (testFailProjectLedger()) {
     return;
   }
   try {
@@ -144,7 +215,7 @@ function stampUrlOntoVbrief(
   url: string,
   projectRoot: string,
 ): void {
-  if (issueEmitTestHooks.failStamp === true) {
+  if (testFailStamp()) {
     throw new Error("issue-emit test hook: stamp failure");
   }
   addGithubIssueReference(data, url);
@@ -565,6 +636,13 @@ export function emitUmbrella(
   for (const [path, disp, data] of pending) {
     const prior = resolvePriorCreatedUrl(root, path);
     if (typeof prior === "string" && prior.length > 0) {
+      // Reject conflicting recovered URLs — never stamp an arbitrary sibling issue (#2880).
+      if (reconciledUrl !== null && reconciledUrl !== prior) {
+        throw new IssueEmitError(
+          `umbrella recovered conflicting issue URLs: ${reconciledUrl} vs ${prior}; resolve local pending/recovery state before retry`,
+          { createdUrl: reconciledUrl },
+        );
+      }
       reconciledUrl = prior;
       try {
         stampUrlOntoVbrief(path, data, prior, root);

--- a/packages/core/src/intake/issue-emit.ts
+++ b/packages/core/src/intake/issue-emit.ts
@@ -646,14 +646,28 @@ export function emitUmbrella(
   }
 
   const pending = loaded.filter(([, , data]) => existingGithubIssueRef(data) === undefined);
-  const already = loaded
-    .filter(([, , data]) => existingGithubIssueRef(data) !== undefined)
-    .map(([, disp]) => ({ vbrief: disp, result: "skipped" }));
+  const alreadyEntries = loaded.filter(([, , data]) => existingGithubIssueRef(data) !== undefined);
+  const already = alreadyEntries.map(([, disp]) => ({ vbrief: disp, result: "skipped" }));
+
+  // Already-stamped siblings seed the umbrella URL and participate in conflict checks (#2880).
+  let stampedSiblingUrl: string | null = null;
+  for (const [, , data] of alreadyEntries) {
+    const ref = existingGithubIssueRef(data);
+    if (typeof ref === "string" && ref.length > 0) {
+      if (stampedSiblingUrl !== null && stampedSiblingUrl !== ref) {
+        throw new IssueEmitError(
+          `umbrella siblings already stamped with conflicting issue URLs: ${stampedSiblingUrl} vs ${ref}`,
+          { createdUrl: stampedSiblingUrl },
+        );
+      }
+      stampedSiblingUrl = ref;
+    }
+  }
 
   const umbrellaTitle = options.title ?? defaultUmbrellaTitle(loaded.length);
 
   if (pending.length === 0) {
-    return { result: "skipped", url: null, title: umbrellaTitle, vbriefs: already };
+    return { result: "skipped", url: stampedSiblingUrl, title: umbrellaTitle, vbriefs: already };
   }
 
   if (options.noNetwork) {
@@ -677,9 +691,9 @@ export function emitUmbrella(
 
   const written: { vbrief: string; result: string }[] = [];
   const stillNeedRemote: [string, string, Record<string, unknown>][] = [];
-  // Pass 1: resolve all recovered URLs and reject conflicts BEFORE any stamp (#2880).
-  // Stamping first would clear recovery for sibling A and leave B divergent on retry.
-  let reconciledUrl: string | null = null;
+  // Pass 1: resolve recovered URLs and reject conflicts BEFORE any stamp (#2880).
+  // Include already-stamped sibling URLs so partial umbrella cohorts cannot split.
+  let reconciledUrl: string | null = stampedSiblingUrl;
   const withPrior: [string, string, Record<string, unknown>, string][] = [];
   for (const [path, disp, data] of pending) {
     const prior = resolvePriorCreatedUrl(root, path);
@@ -724,8 +738,7 @@ export function emitUmbrella(
     };
   }
 
-  // Sibling recovery: if any artifact already holds a prior umbrella URL, stamp remaining
-  // with that URL instead of filing a second remote issue (#2880).
+  // Sibling recovery: reuse recovered/stamped umbrella URL instead of a second remote create (#2880).
   let url = reconciledUrl;
   if (url === null || url.length === 0) {
     const body = renderUmbrellaBody(stillNeedRemote.map(([, disp, data]) => [disp, data]));

--- a/packages/core/src/intake/issue-emit.ts
+++ b/packages/core/src/intake/issue-emit.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  chmodSync,
   closeSync,
   constants,
   globSync,
@@ -67,6 +68,45 @@ function privateRecoveryRoot(): string {
   return join(base, `deft-issue-emit-recovery-${uid}`);
 }
 
+/** Refuse dirs/files we do not own or that are group/other-writable (forged recovery, #2880). */
+function isTrustedStat(st: {
+  isSymbolicLink(): boolean;
+  uid?: number;
+  mode: number | bigint;
+}): boolean {
+  if (st.isSymbolicLink()) {
+    return false;
+  }
+  if (typeof process.getuid === "function" && typeof st.uid === "number") {
+    if (st.uid !== process.getuid()) {
+      return false;
+    }
+  }
+  // Group/other write bits allow another local principal to rewrite recovery state.
+  const mode = Number(st.mode);
+  if ((mode & 0o022) !== 0) {
+    return false;
+  }
+  return true;
+}
+
+function ensureTrustedRecoveryDir(): string {
+  const dir = privateRecoveryRoot();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const dirStat = lstatSync(dir);
+  if (!isTrustedStat(dirStat) || !dirStat.isDirectory()) {
+    throw new Error("issue-emit recovery dir is not a trusted directory owned by the current user");
+  }
+  if ((dirStat.mode & 0o777) !== 0o700) {
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Best-effort tighten; isTrustedStat already refused group/other write.
+    }
+  }
+  return dir;
+}
+
 export function recoverySidecarPath(vbriefAbsPath: string): string {
   const key = createHash("sha256").update(resolve(vbriefAbsPath)).digest("hex").slice(0, 40);
   return join(privateRecoveryRoot(), `${key}.json`);
@@ -74,14 +114,13 @@ export function recoverySidecarPath(vbriefAbsPath: string): string {
 
 /**
  * Write recovery sidecar without following symlinks (#2880 Greptile P1).
- * Private per-uid dir + lstat refusal + O_EXCL|O_NOFOLLOW create.
+ * Trusted per-uid dir (ownership + mode) + O_EXCL|O_NOFOLLOW create.
  */
 function writeRecoverySidecarSafe(sidePath: string, payload: string): void {
-  const dir = dirname(sidePath);
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  const dirStat = lstatSync(dir);
-  if (dirStat.isSymbolicLink()) {
-    throw new Error("issue-emit recovery dir is a symlink");
+  const dir = ensureTrustedRecoveryDir();
+  if (resolve(dirname(sidePath)) !== resolve(dir)) {
+    // Always write under the validated recovery root.
+    throw new Error("issue-emit recovery path escapes trusted root");
   }
   try {
     const existing = lstatSync(sidePath);
@@ -134,8 +173,14 @@ export function loadRecoveredUrl(vbriefAbsPath: string): string | undefined {
   }
   try {
     const side = recoverySidecarPath(key);
+    // Parent dir must be trusted before we read any sidecar (forged-dir attack, #2880).
+    const parent = dirname(side);
+    const parentStat = lstatSync(parent);
+    if (!isTrustedStat(parentStat) || !parentStat.isDirectory()) {
+      return undefined;
+    }
     const st = lstatSync(side);
-    if (st.isSymbolicLink() || !st.isFile()) {
+    if (!st.isFile() || !isTrustedStat(st)) {
       return undefined;
     }
     const raw = readFileSync(side, "utf8");
@@ -144,7 +189,7 @@ export function loadRecoveredUrl(vbriefAbsPath: string): string | undefined {
       const obj = parsed as Record<string, unknown>;
       const url = obj.url;
       const pathField = obj.path;
-      if (typeof url === "string" && url.length > 0) {
+      if (typeof url === "string" && url.length > 0 && ISSUE_URL_PATTERN.test(url)) {
         if (typeof pathField === "string" && resolve(pathField) !== key) {
           return undefined;
         }
@@ -153,7 +198,7 @@ export function loadRecoveredUrl(vbriefAbsPath: string): string | undefined {
       }
     }
   } catch {
-    // Missing recovery file is empty.
+    // Missing or untrusted recovery file is empty.
   }
   return undefined;
 }

--- a/packages/core/src/intake/issue-emit.ts
+++ b/packages/core/src/intake/issue-emit.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { globSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -13,11 +14,143 @@ export const EXTERNAL_TRUST_LEVEL = "external";
 
 const ISSUE_URL_PATTERN = /https?:\/\/\S+?\/issues\/\d+/;
 
+/**
+ * Structured post-create failure: remote issue exists; local stamp/ledger may not.
+ * `createdUrl` is the durable handle for retry (also mirrored in process + OS-temp recovery).
+ */
 export class IssueEmitError extends Error {
-  constructor(message: string) {
+  readonly createdUrl?: string;
+
+  constructor(message: string, options?: { createdUrl?: string }) {
     super(message);
     this.name = "IssueEmitError";
+    if (options?.createdUrl !== undefined && options.createdUrl.length > 0) {
+      this.createdUrl = options.createdUrl;
+    }
   }
+}
+
+/**
+ * Process-local fallback for post-create URL when project ledger and xBRIEF stamp both fail (#2880).
+ * Survives same-process retry without re-create; paired with OS-temp sidecar for process restarts.
+ */
+const processPendingUrls = new Map<string, string>();
+
+/** Test-only failure injection for dual-failure / partial-stamp paths. Always empty in production. */
+export const issueEmitTestHooks: {
+  failProjectLedger?: boolean;
+  failStamp?: boolean;
+} = {};
+
+export function resetIssueEmitTestHooks(): void {
+  delete issueEmitTestHooks.failProjectLedger;
+  delete issueEmitTestHooks.failStamp;
+}
+
+export function recoverySidecarPath(vbriefAbsPath: string): string {
+  const key = createHash("sha256").update(resolve(vbriefAbsPath)).digest("hex").slice(0, 40);
+  return join(tmpdir(), "deft-issue-emit-recovery", `${key}.json`);
+}
+
+/**
+ * Always-on recovery after remote create: process memory + OS-temp sidecar.
+ * Independent of project-contained ledger so dual local failure still reconciles on retry (#2880).
+ */
+export function rememberCreatedUrl(vbriefAbsPath: string, url: string): void {
+  const key = resolve(vbriefAbsPath);
+  processPendingUrls.set(key, url);
+  try {
+    const side = recoverySidecarPath(key);
+    mkdirSync(dirname(side), { recursive: true });
+    writeFileSync(side, `${JSON.stringify({ path: key, url }, null, 2)}\n`, "utf8");
+  } catch {
+    // Best-effort disk mirror; process map still holds the URL for same-process retry.
+  }
+}
+
+export function loadRecoveredUrl(vbriefAbsPath: string): string | undefined {
+  const key = resolve(vbriefAbsPath);
+  const mem = processPendingUrls.get(key);
+  if (typeof mem === "string" && mem.length > 0) {
+    return mem;
+  }
+  try {
+    const raw = readFileSync(recoverySidecarPath(key), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const obj = parsed as Record<string, unknown>;
+      const url = obj.url;
+      const pathField = obj.path;
+      if (typeof url === "string" && url.length > 0) {
+        if (typeof pathField === "string" && resolve(pathField) !== key) {
+          return undefined;
+        }
+        processPendingUrls.set(key, url);
+        return url;
+      }
+    }
+  } catch {
+    // Missing recovery file is empty.
+  }
+  return undefined;
+}
+
+export function clearRecoveredUrl(vbriefAbsPath: string): void {
+  const key = resolve(vbriefAbsPath);
+  processPendingUrls.delete(key);
+  try {
+    rmSync(recoverySidecarPath(key), { force: true });
+  } catch {
+    // Best-effort clear.
+  }
+}
+
+/** Project ledger first, then process/OS-temp recovery (#2880). */
+export function resolvePriorCreatedUrl(
+  projectRoot: string,
+  vbriefAbsPath: string,
+): string | undefined {
+  const absPath = resolve(vbriefAbsPath);
+  const pending = loadPendingEmitUrls(projectRoot)[absPath];
+  if (typeof pending === "string" && pending.length > 0) {
+    return pending;
+  }
+  return loadRecoveredUrl(absPath);
+}
+
+/**
+ * Record URL immediately after remote create. Project ledger is best-effort;
+ * recovery layers always run first so dual local failure cannot force re-create (#2880).
+ */
+export function recordCreatedUrlDurable(
+  projectRoot: string,
+  vbriefAbsPath: string,
+  url: string,
+): void {
+  rememberCreatedUrl(vbriefAbsPath, url);
+  if (issueEmitTestHooks.failProjectLedger === true) {
+    return;
+  }
+  try {
+    savePendingEmitUrl(projectRoot, vbriefAbsPath, url);
+  } catch {
+    // Recovery layers already hold the URL.
+  }
+}
+
+function stampUrlOntoVbrief(
+  path: string,
+  data: Record<string, unknown>,
+  url: string,
+  projectRoot: string,
+): void {
+  if (issueEmitTestHooks.failStamp === true) {
+    throw new Error("issue-emit test hook: stamp failure");
+  }
+  addGithubIssueReference(data, url);
+  writeVbrief(path, data, projectRoot);
+  clearPendingEmitUrl(projectRoot, path);
+  clearRecoveredUrl(path);
 }
 
 /** Contained durable map: abs vbrief path -> issue URL for in-flight emits (#2871). */
@@ -305,20 +438,24 @@ export function emitSingle(
     return { result: "dryrun", vbrief: shown, url: null, title };
   }
 
-  // Atomic emit contract (#2871 / Greptile):
+  // Atomic emit contract (#2871 / #2880):
   // 1) Resolve a trusted project root (never dirname of target).
-  // 2) Reconcile any prior pending URL for this path (retry after partial failure).
+  // 2) Reconcile prior URL from project ledger OR process/OS-temp recovery (no re-create).
   // 3) Pre-persist current payload so the write path is proven.
-  // 4) Create remote issue, immediately record URL in a contained pending ledger.
-  // 5) Stamp the vbrief; clear pending on success.
+  // 4) Create remote issue, then always record URL in recovery + best-effort project ledger.
+  // 5) Stamp the vbrief; clear recovery on success. Dual local failure still retries safely.
   const root = assertVbriefWriteTargetSafe(path, options.projectRoot);
   const absPath = resolve(path);
-  const pending = loadPendingEmitUrls(root);
-  const priorUrl = pending[absPath];
+  const priorUrl = resolvePriorCreatedUrl(root, absPath);
   if (typeof priorUrl === "string" && priorUrl.length > 0) {
-    addGithubIssueReference(data, priorUrl);
-    writeVbrief(path, data, root);
-    clearPendingEmitUrl(root, absPath);
+    try {
+      stampUrlOntoVbrief(path, data, priorUrl, root);
+    } catch (stampErr) {
+      throw new IssueEmitError(
+        `reconcile ${priorUrl} but failed to stamp local vbrief: ${String(stampErr)}`,
+        { createdUrl: priorUrl },
+      );
+    }
     return { result: "created", vbrief: shown, url: priorUrl, title };
   }
 
@@ -326,29 +463,17 @@ export function emitSingle(
   const body = renderIssueBody(data);
   assertVbriefWriteTargetSafe(path, root);
   const url = fileIssue(options.repo, title, body, options.scmCall);
-  // Durable URL ledger BEFORE vbrief stamp — retry will reconcile without re-create.
-  // Never lose the URL if ledger or stamp fails: return/throw always includes it (#2871).
+  // Recovery layers first (process + OS-temp), then best-effort project ledger (#2880).
+  // Dual ledger+stamp failure still leaves URL for retry without re-create.
+  recordCreatedUrlDurable(root, absPath, url);
   try {
-    savePendingEmitUrl(root, absPath, url);
-  } catch (ledgerErr) {
-    try {
-      addGithubIssueReference(data, url);
-      writeVbrief(path, data, root);
-      return { result: "created", vbrief: shown, url, title };
-    } catch (stampErr) {
-      throw new IssueEmitError(
-        "created " +
-          url +
-          " but failed to persist local records: " +
-          String(ledgerErr) +
-          " / " +
-          String(stampErr),
-      );
-    }
+    stampUrlOntoVbrief(path, data, url, root);
+  } catch (stampErr) {
+    throw new IssueEmitError(
+      `created ${url} but failed to stamp local vbrief: ${String(stampErr)}`,
+      { createdUrl: url },
+    );
   }
-  addGithubIssueReference(data, url);
-  writeVbrief(path, data, root);
-  clearPendingEmitUrl(root, absPath);
   return { result: "created", vbrief: shown, url, title };
 }
 
@@ -424,7 +549,9 @@ export function emitUmbrella(
     };
   }
 
-  // Umbrella emit: reconcile pending URLs, pre-persist, create once, stamp all (#2871).
+  // Umbrella emit: same durability contract as emitSingle (#2871 / #2880).
+  // Reconcile pending/recovery URLs, pre-persist, create once, record all, stamp all.
+  // Mid-loop ledger/stamp failure must not force a second remote create on retry.
   const root =
     options.projectRoot !== undefined &&
     options.projectRoot !== null &&
@@ -434,14 +561,18 @@ export function emitUmbrella(
 
   const written: { vbrief: string; result: string }[] = [];
   const stillNeedRemote: [string, string, Record<string, unknown>][] = [];
+  let reconciledUrl: string | null = null;
   for (const [path, disp, data] of pending) {
-    const absPath = resolve(path);
-    const prior = loadPendingEmitUrls(root)[absPath];
+    const prior = resolvePriorCreatedUrl(root, path);
     if (typeof prior === "string" && prior.length > 0) {
-      addGithubIssueReference(data, prior);
-      writeVbrief(path, data, root);
-      clearPendingEmitUrl(root, absPath);
-      written.push({ vbrief: disp, result: "created" });
+      reconciledUrl = prior;
+      try {
+        stampUrlOntoVbrief(path, data, prior, root);
+        written.push({ vbrief: disp, result: "created" });
+      } catch {
+        // Leave recovery/ledger for retry; still surface URL via reconciledUrl.
+        written.push({ vbrief: disp, result: "pending-reconcile" });
+      }
     } else {
       writeVbrief(path, data, root);
       stillNeedRemote.push([path, disp, data]);
@@ -449,24 +580,50 @@ export function emitUmbrella(
   }
 
   if (stillNeedRemote.length === 0) {
+    const pendingLeft = written.some((w) => w.result === "pending-reconcile");
+    if (pendingLeft && reconciledUrl !== null) {
+      throw new IssueEmitError(
+        `created ${reconciledUrl} but failed to stamp one or more umbrella vbriefs; retry to reconcile without re-create`,
+        { createdUrl: reconciledUrl },
+      );
+    }
     return {
       result: "created",
-      url: null,
+      url: reconciledUrl,
       title: umbrellaTitle,
       vbriefs: [...written, ...already],
     };
   }
 
-  const body = renderUmbrellaBody(stillNeedRemote.map(([, disp, data]) => [disp, data]));
-  const url = fileIssue(options.repo, umbrellaTitle, body, options.scmCall);
-  for (const [path, ,] of stillNeedRemote) {
-    savePendingEmitUrl(root, path, url);
+  // Sibling recovery: if any artifact already holds a prior umbrella URL, stamp remaining
+  // with that URL instead of filing a second remote issue (#2880).
+  let url = reconciledUrl;
+  if (url === null || url.length === 0) {
+    const body = renderUmbrellaBody(stillNeedRemote.map(([, disp, data]) => [disp, data]));
+    url = fileIssue(options.repo, umbrellaTitle, body, options.scmCall);
   }
+
+  // Record URL for every remaining artifact before any stamp can throw (#2880).
+  for (const [path] of stillNeedRemote) {
+    recordCreatedUrlDurable(root, path, url);
+  }
+
+  const stampErrors: string[] = [];
   for (const [path, disp, data] of stillNeedRemote) {
-    addGithubIssueReference(data, url);
-    writeVbrief(path, data, root);
-    clearPendingEmitUrl(root, path);
-    written.push({ vbrief: disp, result: "created" });
+    try {
+      stampUrlOntoVbrief(path, data, url, root);
+      written.push({ vbrief: disp, result: "created" });
+    } catch (stampErr) {
+      stampErrors.push(`${disp}: ${String(stampErr)}`);
+      written.push({ vbrief: disp, result: "pending-reconcile" });
+    }
+  }
+
+  if (stampErrors.length > 0) {
+    throw new IssueEmitError(
+      `created ${url} but failed to stamp ${stampErrors.length} umbrella vbrief(s): ${stampErrors.join("; ")}`,
+      { createdUrl: url },
+    );
   }
 
   return { result: "created", url, title: umbrellaTitle, vbriefs: [...written, ...already] };

--- a/packages/core/src/intake/issue-emit.ts
+++ b/packages/core/src/intake/issue-emit.ts
@@ -677,11 +677,13 @@ export function emitUmbrella(
 
   const written: { vbrief: string; result: string }[] = [];
   const stillNeedRemote: [string, string, Record<string, unknown>][] = [];
+  // Pass 1: resolve all recovered URLs and reject conflicts BEFORE any stamp (#2880).
+  // Stamping first would clear recovery for sibling A and leave B divergent on retry.
   let reconciledUrl: string | null = null;
+  const withPrior: [string, string, Record<string, unknown>, string][] = [];
   for (const [path, disp, data] of pending) {
     const prior = resolvePriorCreatedUrl(root, path);
     if (typeof prior === "string" && prior.length > 0) {
-      // Reject conflicting recovered URLs — never stamp an arbitrary sibling issue (#2880).
       if (reconciledUrl !== null && reconciledUrl !== prior) {
         throw new IssueEmitError(
           `umbrella recovered conflicting issue URLs: ${reconciledUrl} vs ${prior}; resolve local pending/recovery state before retry`,
@@ -689,16 +691,20 @@ export function emitUmbrella(
         );
       }
       reconciledUrl = prior;
-      try {
-        stampUrlOntoVbrief(path, data, prior, root);
-        written.push({ vbrief: disp, result: "created" });
-      } catch {
-        // Leave recovery/ledger for retry; still surface URL via reconciledUrl.
-        written.push({ vbrief: disp, result: "pending-reconcile" });
-      }
+      withPrior.push([path, disp, data, prior]);
     } else {
       writeVbrief(path, data, root);
       stillNeedRemote.push([path, disp, data]);
+    }
+  }
+  // Pass 2: stamp only after the recovered set is conflict-free.
+  for (const [path, disp, data, prior] of withPrior) {
+    try {
+      stampUrlOntoVbrief(path, data, prior, root);
+      written.push({ vbrief: disp, result: "created" });
+    } catch {
+      // Leave recovery/ledger for retry; still surface URL via reconciledUrl.
+      written.push({ vbrief: disp, result: "pending-reconcile" });
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #2880.

Residual **reliability / idempotency** for issue-emit after PR #2871 / #2869 AppSec baseline (dirname-root refusal, no unguarded recovery write, first-pass pending ledger, happy-path retry). This PR does **not** re-do AppSec containment.

## What changed

- After remote create, URL is always recorded in **process-local + OS-temp recovery** layers before best-effort project ledger + xBRIEF stamp
- `IssueEmitError.createdUrl` is structured (not message-only)
- Dual ledger+stamp failure: retry reconciles original URL without a second `fileIssue`
- `emitUmbrella` shares the same durability contract; mid-loop stamp failure and sibling recovery reuse the original URL (no second remote create)
- Regression tests for dual-failure and umbrella partial-failure paths
- CHANGELOG [Unreleased] cites #2880

## Acceptance

- [x] Dual ledger+stamp failure never loses the URL for retry without re-create
- [x] Umbrella emit has the same durability contract as single emit
- [x] Regression tests + CHANGELOG cite #2880

## Scope

- `packages/core/src/intake/issue-emit.ts`
- `packages/core/src/intake/issue-emit-pending.test.ts`
- `CHANGELOG.md`

## Test plan

- [x] `vitest run packages/core/src/intake/issue-emit*`
- [x] Full intake package tests
- [x] `biome check` / `tsc -b` clean on touched files
- [ ] CI `task check` / merge chokepoint
