### PR TITLE
fix(hooks): skip active-scope deny for outside-project-root writes (#2885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Active-scope write gate skips outside-project-root targets (#2885).** `inspectMutationGates` no longer denies Write/Edit with `scope-not-ready` when `toProjectRelativePosix` resolves outside `projectRoot` (agent memory, temp files, user config). Null/unparseable write targets stay fail-closed; spawn tools still require active scope. Closes #2885.
 - **Issue-emit dual ledger+stamp failure and umbrella partial-failure no longer re-create GitHub issues on retry (#2880).** After remote create, the URL is always recorded in process-local + OS-temp recovery (in addition to the project pending ledger) before the xBRIEF stamp; `IssueEmitError.createdUrl` is structured; `emitUmbrella` shares the same reconcile contract and reuses a sibling recovered URL instead of filing a second issue. Residual reliability after #2871 AppSec/ledger baseline. Closes #2880.
 - **Issue emit uses a contained pending-URL ledger to prevent duplicate GitHub issues (#2869 / #2871).** After remote create, the issue URL is recorded under \.deft-cache/issue-emit-pending.json\ (gated by projection containment) before the vBRIEF stamp; retries reconcile the pending URL without re-creating the issue.
 - **Issue-emit recovery never bypasses projection containment (#2869 / #2871).** Post-create local stamp failures no longer fall through to unguarded \writeFileSync\; the remote URL is still returned so retries cannot create duplicate issues without reopening a symlink write sink.

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -1,5 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ritualStatePath } from "../session/ritual-sentinel.js";
 import {
   DIRECT_WRITE_TOOL_NAMES,
@@ -11,6 +13,8 @@ import {
   isDirectWriteTool,
   isHookEvent,
   isHookHost,
+  isLexicalOutsideProjectRoot,
+  isOutsideProjectRootWrite,
   isProposedLifecycleWrite,
   isSpawnTool,
   normalizeHookProjectRoot,
@@ -19,6 +23,13 @@ import {
   renderHostDecision,
   SPAWN_TOOL_NAMES,
 } from "./index.js";
+
+// Symlinks require elevated privileges on Windows (SeCreateSymbolicLink); skip there.
+const itSymlink = it.skipIf(process.platform === "win32");
+const hookTemps: string[] = [];
+afterEach(() => {
+  for (const t of hookTemps.splice(0)) rmSync(t, { recursive: true, force: true });
+});
 
 function hasDoubledWindowsDrivePrefix(path: string): boolean {
   return /^[A-Za-z]:\\[A-Za-z]:\\/i.test(path.replace(/\//g, "\\"));
@@ -195,6 +206,49 @@ describe("direct-write hook policy", () => {
           tool_name: "Write",
           cwd: "/project",
           tool_input: { file_path: "/project/..secret" },
+        },
+      },
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active xBRIEF artifact was found under xbrief/active/",
+        }),
+      }),
+    );
+
+    expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
+  });
+
+  it("classifies lexical outside-root shapes for #2885", () => {
+    expect(isLexicalOutsideProjectRoot("..")).toBe(true);
+    expect(isLexicalOutsideProjectRoot("../tmp/x")).toBe(true);
+    expect(isLexicalOutsideProjectRoot("..secret")).toBe(false);
+    expect(isLexicalOutsideProjectRoot("src/foo.ts")).toBe(false);
+    expect(isLexicalOutsideProjectRoot("D:/tmp/x")).toBe(true);
+  });
+
+  itSymlink("denies outside-root symlink that re-enters the project (#2885)", () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hook-2885-proj-"));
+    const outsideDir = mkdtempSync(join(tmpdir(), "hook-2885-out-"));
+    hookTemps.push(projectDir, outsideDir);
+    mkdirSync(join(projectDir, "src"), { recursive: true });
+    writeFileSync(join(projectDir, "src", "inside.ts"), "inside", "utf8");
+    // Lexically outside path aliases into project via dir symlink.
+    symlinkSync(join(projectDir, "src"), join(outsideDir, "alias"), "dir");
+    const aliasedTarget = join(outsideDir, "alias", "inside.ts");
+
+    expect(isOutsideProjectRootWrite(projectDir, aliasedTarget)).toBe(false);
+
+    const decision = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: projectDir,
+        payload: {
+          tool_name: "Write",
+          cwd: projectDir,
+          tool_input: { file_path: aliasedTarget },
         },
       },
       readySeams({

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -225,7 +225,33 @@ describe("direct-write hook policy", () => {
     expect(isLexicalOutsideProjectRoot("../tmp/x")).toBe(true);
     expect(isLexicalOutsideProjectRoot("..secret")).toBe(false);
     expect(isLexicalOutsideProjectRoot("src/foo.ts")).toBe(false);
-    expect(isLexicalOutsideProjectRoot("D:/tmp/x")).toBe(true);
+    // Drive-letter relatives are outside only on win32 (cross-drive path.relative).
+    // On POSIX, `D:/tmp/x` is a valid in-project child path segment.
+    expect(isLexicalOutsideProjectRoot("D:/tmp/x")).toBe(process.platform === "win32");
+  });
+
+  it("denies in-repo drive-like POSIX child path without active scope (#2885)", () => {
+    if (process.platform === "win32") return;
+    const decision = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Write",
+          cwd: "/project",
+          tool_input: { file_path: "/project/D:/tmp/x" },
+        },
+      },
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active xBRIEF artifact was found under xbrief/active/",
+        }),
+      }),
+    );
+    expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
   });
 
   itSymlink("denies outside-root symlink that re-enters the project (#2885)", () => {

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -110,6 +110,104 @@ describe("direct-write hook policy", () => {
     expect(decision.message).toContain("deft scope:activate");
   });
 
+  it("allows Write outside projectRoot when no active scope (#2885)", () => {
+    const decision = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Write",
+          cwd: "/project",
+          tool_input: {
+            file_path: "/home/user/.claude/projects/slug/memory/note.md",
+          },
+        },
+      },
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active xBRIEF artifact was found under xbrief/active/",
+        }),
+      }),
+    );
+
+    expect(decision.verdict).toBe("allow");
+    expect(decision.code).not.toBe("scope-not-ready");
+  });
+
+  it("allows Edit outside projectRoot when no active scope (#2885)", () => {
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Edit",
+          tool_input: { path: "/tmp/agent-scratch/note.md" },
+        },
+      },
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active xBRIEF artifact was found under xbrief/active/",
+        }),
+      }),
+    );
+
+    expect(decision.verdict).toBe("allow");
+    expect(decision.code).not.toBe("scope-not-ready");
+  });
+
+  it("denies unparseable Write target when no active scope (fail-closed, #2885)", () => {
+    const decision = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Write",
+          cwd: "/project",
+          // No extractable path — must not skip the gate via unparseable payload.
+        },
+      },
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active xBRIEF artifact was found under xbrief/active/",
+        }),
+      }),
+    );
+
+    expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
+  });
+
+  it("still denies spawn when no active scope even without a write target (#2885)", () => {
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Task",
+          tool_input: { subagent_type: "generalPurpose", prompt: "implement" },
+        },
+      },
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active/running xBRIEF is available.",
+        }),
+      }),
+    );
+
+    expect(decision).toMatchObject({ verdict: "deny", code: "spawn-not-ready" });
+  });
+
   it("allows Write of xbrief/proposed/*.xbrief.json with no active scope (#2625)", () => {
     const inspectScope = vi.fn(() => ({
       ready: false,

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -185,6 +185,30 @@ describe("direct-write hook policy", () => {
     expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
   });
 
+  it("does not treat in-repo '..'-prefixed filenames as outside root (#2885)", () => {
+    const decision = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Write",
+          cwd: "/project",
+          tool_input: { file_path: "/project/..secret" },
+        },
+      },
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active xBRIEF artifact was found under xbrief/active/",
+        }),
+      }),
+    );
+
+    expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
+  });
+
   it("still denies spawn when no active scope even without a write target (#2885)", () => {
     const decision = decideHook(
       {

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -456,24 +456,30 @@ function inspectMutationGates(
     const writeTarget = hookWriteTargetPath(input.payload);
     const relTarget =
       writeTarget !== null ? toProjectRelativePosix(projectRoot, writeTarget) : null;
-    const proposedPathHint =
-      options.proposedLifecycleExempt &&
-      relTarget !== null &&
-      (relTarget.startsWith("xbrief/proposed/") || relTarget.startsWith("vbrief/proposed/"))
-        ? " For a new proposal under xbrief/proposed/, include a lifecycle artifact " +
-          "filename (*.xbrief.json) in the Write/Edit payload so the gate can exempt " +
-          "planning writes (#2625)."
-        : " Recovery: run `deft scope:activate -- <path>` for the approved xBRIEF, " +
-          (options.proposedLifecycleExempt
-            ? "or Write a new proposal to xbrief/proposed/*.xbrief.json (planning exemption)."
-            : "then re-run the pre-start_agent gate stack.");
-    const denyCode = isSpawnTool(toolName) ? "spawn-not-ready" : "scope-not-ready";
-    return deny(
-      input,
-      denyCode,
-      toolName,
-      `Directive denied ${toolName}: ${scope.message}${proposedPathHint}`,
-    );
+    // Active-scope governs in-repo lifecycle work only. Outside-root Write/Edit
+    // (agent memory, $TMPDIR, user config) skips the deny; null/unparseable
+    // targets stay fail-closed. Spawn has no write target → still requires scope (#2885).
+    const outsideRoot = relTarget !== null && relTarget.startsWith("..");
+    if (!outsideRoot || isSpawnTool(toolName)) {
+      const proposedPathHint =
+        options.proposedLifecycleExempt &&
+        relTarget !== null &&
+        (relTarget.startsWith("xbrief/proposed/") || relTarget.startsWith("vbrief/proposed/"))
+          ? " For a new proposal under xbrief/proposed/, include a lifecycle artifact " +
+            "filename (*.xbrief.json) in the Write/Edit payload so the gate can exempt " +
+            "planning writes (#2625)."
+          : " Recovery: run `deft scope:activate -- <path>` for the approved xBRIEF, " +
+            (options.proposedLifecycleExempt
+              ? "or Write a new proposal to xbrief/proposed/*.xbrief.json (planning exemption)."
+              : "then re-run the pre-start_agent gate stack.");
+      const denyCode = isSpawnTool(toolName) ? "spawn-not-ready" : "scope-not-ready";
+      return deny(
+        input,
+        denyCode,
+        toolName,
+        `Directive denied ${toolName}: ${scope.message}${proposedPathHint}`,
+      );
+    }
   }
 
   const allowCode = isSpawnTool(toolName) ? "spawn-ready" : "write-ready";

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -1,4 +1,5 @@
-import { relative, resolve, sep } from "node:path";
+import { realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { hasArtifactSuffix } from "../layout/resolve.js";
 import {
   evaluateRuntimeAuthorityDirectWrite,
@@ -264,6 +265,56 @@ export function toProjectRelativePosix(projectRoot: string, targetPath: string):
   return rel.split(sep).join("/").replace(/\\/g, "/");
 }
 
+function posixRelative(fromAbs: string, toAbs: string): string {
+  return relative(fromAbs, toAbs).split(sep).join("/").replace(/\\/g, "/");
+}
+
+/**
+ * Lexical "outside project root" predicate used by #2885.
+ * - `".."` / `"../…"` are outside (not bare `startsWith("..")` — that matches `..secret`).
+ * - Absolute / drive-letter relatives (win32 cross-drive) are outside.
+ */
+export function isLexicalOutsideProjectRoot(relPosix: string): boolean {
+  return (
+    relPosix === ".." ||
+    relPosix.startsWith("../") ||
+    isAbsolute(relPosix) ||
+    /^[A-Za-z]:\//.test(relPosix)
+  );
+}
+
+/**
+ * True when a write target is outside `projectRoot` for the active-scope skip (#2885).
+ * Lexically outside paths still fail the skip when a symlink/junction re-enters the project.
+ * When the project root cannot be realpath'd (unit fixtures), lexical classification wins.
+ */
+export function isOutsideProjectRootWrite(projectRoot: string, targetPath: string): boolean {
+  const projectAbs = resolve(projectRoot);
+  const targetAbs = resolve(projectRoot, targetPath.replace(/\\/g, "/"));
+  const rel = posixRelative(projectAbs, targetAbs);
+  if (!isLexicalOutsideProjectRoot(rel)) return false;
+
+  try {
+    const projectReal = realpathSync(projectAbs);
+    let probe = targetAbs;
+    for (;;) {
+      try {
+        const probeReal = realpathSync(probe);
+        const reenter = posixRelative(projectReal, probeReal);
+        // Empty reenter ⇒ probeReal === projectReal (inside). Lexical-outside reenter ⇒ truly out.
+        if (reenter === "" || !isLexicalOutsideProjectRoot(reenter)) return false;
+        return true;
+      } catch {
+        const parent = dirname(probe);
+        if (parent === probe) return true;
+        probe = parent;
+      }
+    }
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Proposing a scope under xbrief/proposed/ (or legacy vbrief/proposed/) is
  * planning, not implementation dispatch — exempt from the active-scope gate (#2625).
@@ -459,9 +510,8 @@ function inspectMutationGates(
     // Active-scope governs in-repo lifecycle work only. Outside-root Write/Edit
     // (agent memory, $TMPDIR, user config) skips the deny; null/unparseable
     // targets stay fail-closed. Spawn has no write target → still requires scope (#2885).
-    // Use ".." / "../" only — startsWith("..") alone matches in-repo names like "..secret".
-    const outsideRoot =
-      relTarget !== null && (relTarget === ".." || relTarget.startsWith("../"));
+    // Lexical ../ + realpath re-entry guard (not bare startsWith(".."); not symlink aliases).
+    const outsideRoot = writeTarget !== null && isOutsideProjectRootWrite(projectRoot, writeTarget);
     if (!outsideRoot || isSpawnTool(toolName)) {
       const proposedPathHint =
         options.proposedLifecycleExempt &&

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -272,15 +272,15 @@ function posixRelative(fromAbs: string, toAbs: string): string {
 /**
  * Lexical "outside project root" predicate used by #2885.
  * - `".."` / `"../…"` are outside (not bare `startsWith("..")` — that matches `..secret`).
- * - Absolute / drive-letter relatives (win32 cross-drive) are outside.
+ * - Absolute relatives and win32 cross-drive paths (`D:/…`) are outside.
+ * - Drive-letter form is win32-only so POSIX children like `D:/tmp/x` stay in-repo.
  */
 export function isLexicalOutsideProjectRoot(relPosix: string): boolean {
-  return (
-    relPosix === ".." ||
-    relPosix.startsWith("../") ||
-    isAbsolute(relPosix) ||
-    /^[A-Za-z]:\//.test(relPosix)
-  );
+  if (relPosix === ".." || relPosix.startsWith("../") || isAbsolute(relPosix)) {
+    return true;
+  }
+  // path.relative returns absolute drive paths across volumes on Windows only.
+  return process.platform === "win32" && /^[A-Za-z]:\//.test(relPosix);
 }
 
 /**

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -459,7 +459,9 @@ function inspectMutationGates(
     // Active-scope governs in-repo lifecycle work only. Outside-root Write/Edit
     // (agent memory, $TMPDIR, user config) skips the deny; null/unparseable
     // targets stay fail-closed. Spawn has no write target → still requires scope (#2885).
-    const outsideRoot = relTarget !== null && relTarget.startsWith("..");
+    // Use ".." / "../" only — startsWith("..") alone matches in-repo names like "..secret".
+    const outsideRoot =
+      relTarget !== null && (relTarget === ".." || relTarget.startsWith("../"));
     if (!outsideRoot || isSpawnTool(toolName)) {
       const proposedPathHint =
         options.proposedLifecycleExempt &&


### PR DESCRIPTION
## Summary

Skip active-scope `scope-not-ready` deny for Write/Edit when the resolved write target is outside the project checkout. Out-of-repo agent memory and temp writes no longer require activating an unrelated scope when the active lifecycle folder is empty.

## Changes

- `inspectMutationGates`: outside-project write targets skip active-scope deny for non-spawn tools
- Predicate uses `..` / `../` (not bare `startsWith("..")`), treats win32 cross-drive absolutes as outside, and realpath-guards symlink re-entry into the project
- Null/unparseable write targets remain fail-closed
- Spawn tools still require active scope (`spawn-not-ready`)
- Regression tests in `dispatcher.test.ts`
- CHANGELOG [Unreleased] entry

## Test plan

- [x] `pnpm exec vitest run packages/core/src/hooks/dispatcher.test.ts` (90 pass, 1 symlink skipped on win32)
- [ ] CI `task check:merge`

Closes #2885
