### PR TITLE
test(product-signal): isolate consent-prompt eligibility from host grant (#2897)

### DIFF
--- a/packages/core/src/product-signal/consent-prompt.test.ts
+++ b/packages/core/src/product-signal/consent-prompt.test.ts
@@ -1,7 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { isolatedConsentEnv } from "./consent-env.test.js";
 import {
   isProductSignalConsentEligible,
   maybeFormatProductSignalConsentPrompt,
@@ -9,6 +10,12 @@ import {
 } from "./consent-prompt.js";
 
 const temps: string[] = [];
+const consentHomes: string[] = [];
+afterEach(() => {
+  for (const h of consentHomes.splice(0)) {
+    rmSync(h, { recursive: true, force: true });
+  }
+});
 afterAll(() => {
   for (const t of temps) {
     rmSync(t, { recursive: true, force: true });
@@ -38,16 +45,18 @@ function makeRepo(enabled: boolean): string {
 describe("product-signal consent prompt (#2822 D17)", () => {
   it("surfaces prompt when enabled and consent missing in interactive session", () => {
     const root = makeRepo(true);
+    // Isolate HOME/APPDATA so a real operator grant on the host cannot leak (#2897).
+    const env = isolatedConsentEnv(consentHomes, false);
     expect(
       isProductSignalConsentEligible({
         projectRoot: root,
-        env: {},
+        env,
         stdinIsTTY: true,
       }),
     ).toBe(true);
     const text = maybeFormatProductSignalConsentPrompt({
       projectRoot: root,
-      env: {},
+      env,
       stdinIsTTY: true,
     });
     expect(text).toContain(PRODUCT_SIGNAL_CONSENT_PROMPT.slice(0, 40));
@@ -56,17 +65,18 @@ describe("product-signal consent prompt (#2822 D17)", () => {
 
   it("stays silent in headless sessions (fail-open)", () => {
     const root = makeRepo(true);
+    const env = { ...isolatedConsentEnv(consentHomes, false), CI: "true" };
     expect(
       isProductSignalConsentEligible({
         projectRoot: root,
-        env: { CI: "true" },
+        env,
         stdinIsTTY: false,
       }),
     ).toBe(false);
     expect(
       maybeFormatProductSignalConsentPrompt({
         projectRoot: root,
-        env: { CI: "true" },
+        env,
         stdinIsTTY: false,
       }),
     ).toBe("");
@@ -74,10 +84,23 @@ describe("product-signal consent prompt (#2822 D17)", () => {
 
   it("does not prompt when product signal disabled", () => {
     const root = makeRepo(false);
+    const env = isolatedConsentEnv(consentHomes, false);
     expect(
       isProductSignalConsentEligible({
         projectRoot: root,
-        env: {},
+        env,
+        stdinIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not prompt when isolated env already has consent", () => {
+    const root = makeRepo(true);
+    const env = isolatedConsentEnv(consentHomes, true);
+    expect(
+      isProductSignalConsentEligible({
+        projectRoot: root,
+        env,
         stdinIsTTY: true,
       }),
     ).toBe(false);


### PR DESCRIPTION
## Summary
Fixes `consent-prompt.test.ts` leaking real `~/.config/deft/product-signal-consent.json` when operators have granted product-signal.

## Changes
- Use `isolatedConsentEnv` for eligibility cases
- Add coverage for granted isolated env → not eligible

## Test plan
- [x] `pnpm exec vitest run packages/core/src/product-signal/consent-prompt.test.ts`
- [ ] CI green
- [ ] Resume v0.87.0 release Phase 1 `task check`

Closes #2897