### PR TITLE
chore(release): v0.87.0 -- promote CHANGELOG + ROADMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.87.0] - 2026-07-29
+
+> OpenClaw Tier-1 host adapter, triage operator briefs, gates readiness, and consent-prompt test isolation.
+
+### Added
+
 - **Triage Phase 3 operator brief contract + `triage:show --format=operator` (#2890).** Skill requires a same-turn candidate brief (id/title/link, labels, summary, AC or thin-body note, lean+why) before every Phase 3 decision menu; forbids menu-only/chip-only turns; documents host `ask_user`/chips adapter (OpenClaw named); clarifies Phase 2.3 queue non-annotation does not forbid Phase 3 briefs. `task triage:show --format=operator` emits a pasteable cache-backed brief backbone (agent still owns lean). Closes #2890.
 - **OpenClaw is a first-class Tier-1 dispatch provider in the swarm capability matrix and routing (#2875).** Phase 3 probes OpenClaw `sessions_spawn` (descriptor `openclaw`) before Grok Build `spawn_subagent`, adds Step 2f launch / monitor / Phase 6 paths with parent-announce completion (not Grok poll output), accepts `openclaw` as a routing-gated `dispatch_provider`, and ships `task verify:openclaw-tier1` so the OpenClaw → Tier-1 mapping cannot silently regress to grok-build or generic-terminal. Closes #2875. Refs #2874, #1877, #1342, #1531.
 - **OpenClaw agent-host operator docs (#2877).** Discoverable `content/docs/openclaw-agent-host.md` covers Control UI / Telegram / TUI roles, bot vs human GitHub identity, executable babysit path (always follow installed review-cycle skill), and the epic **babysit → `sessions_spawn` Approach 1** expectation as design north star — no invented gate or register-primitive contracts; skill/engine wiring remains #2875/#2876. Cross-linked from `content/QUICK-START.md` and `content/docs/getting-started.md`. Closes #2877.
@@ -4707,7 +4719,8 @@ If you have custom scripts or references to deft files, update these paths:
 
 
 
-[Unreleased]: https://github.com/deftai/directive/compare/v0.86.0...HEAD
+[Unreleased]: https://github.com/deftai/directive/compare/v0.87.0...HEAD
+[0.87.0]: https://github.com/deftai/directive/compare/v0.86.0...v0.87.0
 [0.86.0]: https://github.com/deftai/directive/compare/v0.85.0...v0.86.0
 [0.85.0]: https://github.com/deftai/directive/compare/v0.84.0...v0.85.0
 [0.84.0]: https://github.com/deftai/directive/compare/v0.83.0...v0.84.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1054,6 +1054,19 @@
 - **#2852** -- doctor: live-probe agent hooks (empty/unparseable stdout is currently invisible) -- `[completed]`
 - **#2858** -- bug(render): core:validate capture walks process.cwd()/node_modules (hangs task check) -- `[completed]`
 - **#2859** -- release: on task check failure, file-and-merge the blocker — do not lead with inline hotfix (AGENTS.md bulk rejected) -- `[completed]`
+- **#2862** -- bug(scope): scope:complete leaves the completing brief's own plan.items[].status pending and xBRIEFInfo.updated stale -- `[completed]`
+- **#2864** -- bug(hooks): Cursor tool.before intermittently blocks Task spawns on macOS — host reports "exit code 1" but no hook:dispatch path exits 1 -- `[completed]`
 - **#2865** -- test(coverage): restore branches >= 85% (84.99% blocks v0.86.0 release Step 5) -- `[completed]`
 - **#2866** -- release: prefer --allow-coverage-debt=#N when no open coverage-debt issue (don't interrupt cut for hairlines) -- `[completed]`
+- **#2869** -- AppSec review — 5 new medium findings (db39366e) -- `[completed]`
+- **#2875** -- feat(swarm): OpenClaw platform descriptor + capability matrix (Tier 1 sessions_spawn) -- `[completed]`
+- **#2876** -- feat(review-cycle): OpenClaw babysit/review-monitor → sessions_spawn (Approach 1) -- `[completed]`
+- **#2877** -- docs(interfaces): agent-host OpenClaw + Directive-for-OpenClaw-users -- `[completed]`
+- **#2878** -- feat(consumers): statusreport pr:watch / review-monitor or official gh-fallback -- `[completed]`
+- **#2879** -- feat(templates): OpenClaw poller/preamble + heartbeat mapping -- `[completed]`
+- **#2881** -- bug(process): babysit/review must not expand active story scope past xbrief AC -- `[completed]`
+- **#2885** -- bug(hooks): active-scope write gate skips outside-project-root targets -- `[completed]`
+- **#2890** -- feat(skills,triage): Phase 3 operator brief contract + triage:show --format=operator -- `[completed]`
+- **#2893** -- bug(doctor/skills): gates-surface broken for consumers — dual deft/task invoke -- `[completed]`
+- **#2880** -- bug(intake): issue-emit create/stamp durability — no orphan remote / no duplicate on retry -- `[completed]`
 


### PR DESCRIPTION
## Summary
Production cut for **v0.87.0**. `task release` completed Steps 1–10 locally; Step 11 atomic push was rejected by org ruleset **Require Greptile Review** (GH013) — ape-deft is maintain, not admin, so cannot bypass.

This PR carries the release commit already created by the pipeline:
- CHANGELOG: Unreleased → `[0.87.0] - 2026-07-29` + summary blockquote
- ROADMAP re-render

## After merge
1. Push annotated tag `v0.87.0` (local tag already points at this commit; retag if squash)
2. `gh release create v0.87.0 --draft` (or finish pipeline Steps 12–13)
3. npm publish fires on tag push (irrevocable)
4. `task release:publish` after draft QA
5. Restore branch policy: `task policy:enforce-branches` + commit

## Test plan
- [x] Phase 3 `task release:e2e` OK (incl. npm dry-run)
- [x] Step 5 `task check` OK inside release
- [x] Build `dist/deft-0.87.0.tar.gz` OK
- [ ] CI + Greptile on this PR
- [ ] Merge then tag push

Refs release skill Phase 4 recovery (ruleset vs typed allow-direct-commits).