### PR TITLE
chore(xbrief): fix #2904 AppSec cohort swarm readiness

### DIFF
--- a/xbrief/active/2026-07-29-2908-securityinstall-pinverify-git-for-windows-download-before-si.xbrief.json
+++ b/xbrief/active/2026-07-29-2908-securityinstall-pinverify-git-for-windows-download-before-si.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2908",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(install): pin+verify Git-for-Windows download before silent exec (install-deposit-01)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch A** (installer authenticity).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `install-deposit-01` |\n| **Severity** | **High** |\n| **Dimension** | `install-deposit` |\n| **File** | [`cmd/deft-install/git.go`](https://github.com/deftai/directive/blob/master/cmd/deft-install/git.go) |\n\n## Issue\nOn Windows, when winget fails, `deft-install` downloads the latest git-for-windows 64-bit `.exe` via GitHub API and runs it `/SILENT` `/NORESTART` with **no SHA-256 or Authenticode pin**. Trust is TLS+GitHub-latest only.\n\n## Impact\nCompromised git-for-windows release, asset, or MitM yields arbitrary code execution as the installing user during automated install.\n\n## Remediation\n1. Pin a known-good Git.Git version; verify SHA-256 (and ideally Authenticode) before exec.\n2. Prefer winget with a pinned package version.\n3. Refuse silent install when verification fails.\n4. Document trust boundary if pinning is deferred.\n\n## Acceptance\n- [ ] No Git-for-Windows download-and-exec path runs without pinned digest (or documented residual + non-silent opt-in)\n- [ ] Tests or installer dry-run fixtures cover fail-closed mismatch\n- [ ] CHANGELOG / docs/security.md updated as needed\n\n## Refs\n- Tracker #2904\n- Batch A sibling: install-deposit-02\n- Prior partial harden: #1303 (non-2xx/timeout only)",
       "Labels": "bug, security, urgent",
       "UserStory": "As a security engineer, I want pin and SHA-256 verify Git-for-Windows installer assets before silent exec, so that Windows deft-install cannot run a compromised latest release.",
-      "ImplementationPlan": "Locate installGitWindows / downloadGitInstaller in cmd/deft-install/git.go. Add a pinned version + expected SHA-256 (and optional Authenticode note) for the 64-bit non-portable exe. Verify digest after download; refuse silent install on mismatch. Prefer winget pinned path when available. Add tests or table-driven verify helpers; document trust boundary in docs/security.md. CHANGELOG cites #2908.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2908; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under cmd/deft-install/git.go (and related paths: cmd/deft-install/git.go, cmd/deft-install/, docs/security.md, CHANGELOG.md) and implement the fail-closed fix described in issue #2908. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: cd cmd/deft-install && go test ./...; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -64,8 +63,7 @@
         "file_scope": [
           "cmd/deft-install/git.go",
           "cmd/deft-install/",
-          "docs/security.md",
-          "CHANGELOG.md"
+          "docs/security.md"
         ],
         "verify_commands": [
           "cd cmd/deft-install && go test ./...",
@@ -80,7 +78,8 @@
         "conflict_group": "appsec-install-go",
         "size": "M",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2908."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2909-securityinstall-pinverify-linux-yes-uvtaskgh-bootstrap-insta.xbrief.json
+++ b/xbrief/active/2026-07-29-2909-securityinstall-pinverify-linux-yes-uvtaskgh-bootstrap-insta.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2909",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(install): pin+verify Linux --yes uv/task/gh bootstrap (install-deposit-02)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch A** (installer authenticity).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `install-deposit-02` |\n| **Severity** | **High** |\n| **Dimension** | `install-deposit` |\n| **File** | [`cmd/deft-install/setup.go`](https://github.com/deftai/directive/blob/master/cmd/deft-install/setup.go) |\n\n## Issue\nLinux non-interactive `EnsureCoreTools` bootstraps uv, task, and gh by downloading **unpinned** install scripts / latest tarballs into `~/.local/bin` with no checksum or signed-release verification.\n\n## Impact\nCompromise of astral.sh, taskfile.dev, or latest gh release (or MitM) yields arbitrary code under the user account on Linux `--yes` installs.\n\n## Remediation\n1. Mirror CI ghx pattern: download-to-temp + pinned SHA-256 (+ version-pinned assets) before execute/install.\n2. Fail closed on mismatch.\n3. Consider distro packages or pre-staged verified binaries for `--yes`.\n\n## Acceptance\n- [ ] uv/task/gh bootstrap paths under `cmd/deft-install` require pinned digests (or explicit documented residual)\n- [ ] Fail closed on verify failure\n- [ ] CHANGELOG / docs/security.md as needed\n\n## Refs\n- Tracker #2904\n- Batch A sibling: install-deposit-01\n- Contrast: CI `GHX_INSTALL_SH_SHA256` / #1070 class",
       "Labels": "bug, security, urgent",
       "UserStory": "As a security engineer, I want pin and SHA-256 verify Linux --yes uv/task/gh bootstrap assets before exec, so that non-interactive EnsureCoreTools cannot run unpinned remote install scripts.",
-      "ImplementationPlan": "In cmd/deft-install/setup.go, replace floating curl|sh / latest tarball paths for uv, task, and gh with download-to-temp + pinned version + SHA-256 verify (mirror CI ghx pattern). Fail closed on mismatch. Document --yes trust boundary. Tests for pin table and verify failure. CHANGELOG cites #2909.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2909; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under cmd/deft-install/setup.go (and related paths: cmd/deft-install/setup.go, cmd/deft-install/, docs/security.md, CHANGELOG.md) and implement the fail-closed fix described in issue #2909. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: cd cmd/deft-install && go test ./...; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -59,13 +58,12 @@
     "metadata": {
       "kind": "story",
       "swarm": {
-        "readiness": "ready",
+        "readiness": "sequential",
         "parallel_safe": false,
         "file_scope": [
           "cmd/deft-install/setup.go",
           "cmd/deft-install/",
-          "docs/security.md",
-          "CHANGELOG.md"
+          "docs/security.md"
         ],
         "verify_commands": [
           "cd cmd/deft-install && go test ./...",
@@ -80,7 +78,8 @@
         "conflict_group": "appsec-install-go",
         "size": "M",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2909."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2910-securitycache-hard-fail-fine-grained-github-pat-tokens-in-sc.xbrief.json
+++ b/xbrief/active/2026-07-29-2910-securitycache-hard-fail-fine-grained-github-pat-tokens-in-sc.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2910",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(cache): hard-fail fine-grained github_pat_ tokens in scanner (cache-quarantine-01)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch B** (Windows shell + PAT scanner).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `cache-quarantine-01` |\n| **Severity** | **High** |\n| **Dimension** | `cache-quarantine` |\n| **File** | [`packages/core/src/cache/scanner.ts`](https://github.com/deftai/directive/blob/master/packages/core/src/cache/scanner.ts) |\n\n## Issue\n`CREDENTIAL_PATTERNS` matches classic `gh[pousr]_\u2026` but **not** fine-grained `github_pat_\u2026`. Product-signal already knows `github_pat_` \u2014 inconsistent coverage. Fine-grained PATs pass into `content.md` and xBRIEF narratives.\n\n## Impact\nLeaked fine-grained PAT in issue title/body/comment lands in LLM-facing cache/ingest instead of fail-closed.\n\n## Remediation\n1. Add `github_pat_` pattern aligned with product-signal.\n2. Extend scanner tests; bump `SCANNER_VERSION`.\n3. Optionally re-scan existing cache on version skew.\n\n## Acceptance\n- [ ] `github_pat_` hard-fails in `scan()` / detectCredentials\n- [ ] Tests cover fine-grained PAT fixtures\n- [ ] `SCANNER_VERSION` bumped; sinks (cache put, issue:ingest, umbrella) inherit fail-closed\n\n## Refs\n- Tracker #2904\n- Batch B sibling: subprocess-scm-01\n- `packages/core/src/product-signal/payload.ts` SECRET_PATTERNS",
       "Labels": "bug, security, urgent",
       "UserStory": "As a security engineer, I want hard-fail fine-grained github_pat_ tokens in the cache scanner, so that issue ingest and cache content cannot persist modern GitHub PATs for agents.",
-      "ImplementationPlan": "Add github_pat_ pattern to CREDENTIAL_PATTERNS in packages/core/src/cache/scanner.ts aligned with product-signal SECRET_PATTERNS. Bump SCANNER_VERSION. Extend unit tests with fine-grained PAT fixtures. Confirm cache put / issue-ingest / umbrella sinks inherit hard-fail. CHANGELOG cites #2910.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2910; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under packages/core/src/cache/scanner.ts (and related paths: packages/core/src/cache/scanner.ts, packages/core/src/cache/, packages/core/src/product-signal/payload.ts, CHANGELOG.md) and implement the fail-closed fix described in issue #2910. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: task test -- packages/core/src/cache; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -64,8 +63,7 @@
         "file_scope": [
           "packages/core/src/cache/scanner.ts",
           "packages/core/src/cache/",
-          "packages/core/src/product-signal/payload.ts",
-          "CHANGELOG.md"
+          "packages/core/src/product-signal/payload.ts"
         ],
         "verify_commands": [
           "task test -- packages/core/src/cache",
@@ -80,7 +78,8 @@
         "conflict_group": "appsec-cache-scanner",
         "size": "S",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2910."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2911-securitywin32-engine-invoke-shellfalse-stop-cmdexe-reparse-o.xbrief.json
+++ b/xbrief/active/2026-07-29-2911-securitywin32-engine-invoke-shellfalse-stop-cmdexe-reparse-o.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2911",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(win32): engine-invoke shell:false \u2014 stop cmd.exe reparse of DEFT_ENGINE_CMD_JSON (subprocess-scm-01)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch B** (Windows shell + PAT scanner).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `subprocess-scm-01` |\n| **Severity** | **High** |\n| **Dimension** | `subprocess-scm` |\n| **File** | [`tasks/engine-invoke.cjs`](https://github.com/deftai/directive/blob/master/tasks/engine-invoke.cjs) |\n\n## Issue\nWindows global engine-invoke still uses `shell:true` with free-text tokens from `DEFT_ENGINE_CMD_JSON` (including CLI_ARGS). Args are re-parsed by `cmd.exe` when spawning the global deft/directive `.cmd` shim \u2014 injection / metacharacter surface after #2547 argv work.\n\n## Impact\nOperator/agent free-text args can inject via cmd.exe reparse on win32 global path.\n\n## Remediation\n1. Align with `engine-pm-run`: `shell:false` or tightly quoted `cmd.exe /d /s /c`.\n2. Metacharacter regression tests for free-text CLI args on win32 global path.\n\n## Acceptance\n- [ ] Free-text `DEFT_ENGINE_CMD_JSON` tokens never reach `shell:true` on win32 global path\n- [ ] Regression test for metacharacters / injection-shaped args\n- [ ] CHANGELOG\n\n## Refs\n- Tracker #2904\n- Batch B sibling: cache-quarantine-01\n- #2547 ENGINE_CMD JSON + argv spawn (partial)",
       "Labels": "bug, security, urgent",
       "UserStory": "As a security engineer, I want spawn global engine-invoke on Windows without shell:true reparse of free-text argv, so that DEFT_ENGINE_CMD_JSON tokens cannot break out via cmd.exe.",
-      "ImplementationPlan": "In tasks/engine-invoke.cjs, stop using shell:true for mode===global && win32 with free-form argv. Align with engine-pm-run.cjs executeAllowlisted (shell:false or tightly quoted cmd.exe /d /s /c). Add regression test that metacharacters in DEFT_ENGINE_CMD_JSON remain a single argv token. CHANGELOG cites #2911.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2911; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under tasks/engine-invoke.cjs (and related paths: tasks/engine-invoke.cjs, tasks/engine-pm-run.cjs, tasks/, CHANGELOG.md) and implement the fail-closed fix described in issue #2911. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: node --test tasks/; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -64,8 +63,7 @@
         "file_scope": [
           "tasks/engine-invoke.cjs",
           "tasks/engine-pm-run.cjs",
-          "tasks/",
-          "CHANGELOG.md"
+          "tasks/"
         ],
         "verify_commands": [
           "node --test tasks/",
@@ -80,7 +78,8 @@
         "conflict_group": "appsec-engine-invoke",
         "size": "M",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2911."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2912-securitydeposit-refuse-in-tree-dest-symlinks-on-consumer-pro.xbrief.json
+++ b/xbrief/active/2026-07-29-2912-securitydeposit-refuse-in-tree-dest-symlinks-on-consumer-pro.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2912",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(deposit): refuse in-tree dest symlinks on consumer projection writers (install-deposit-04)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch C** (deposit write integrity).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `install-deposit-04` |\n| **Severity** | **Medium** |\n| **Dimension** | `install-deposit` |\n| **Files** | Consumer projection writers (AGENTS.md, .githooks, .gitignore, etc.) |\n\n## Issue\nConsumer projection writers follow **in-tree destination symlinks**, so a malicious or mistaken symlink can divert writes outside intended projection targets under operator credentials.\n\n## Remediation\n1. `assertWriteTargetSafe` / `assertDestinationNotSymlink` / `O_NOFOLLOW` on every projection sink including `.gitignore`.\n2. Tests for in-tree dest symlinks.\n\n## Acceptance\n- [ ] No projection sink follows dest leaf/parent symlink escapes\n- [ ] Regression tests for AGENTS.md / .githooks / .gitignore class sinks\n- [ ] CHANGELOG\n\n## Refs\n- Tracker #2904\n- Batch C siblings: install-deposit-06, skill-pack-supply-01",
       "Labels": "bug, security",
       "UserStory": "As a security engineer, I want refuse in-tree destination symlinks on every consumer projection write, so that init/update cannot overwrite arbitrary project files via planted symlinks.",
-      "ImplementationPlan": "Apply assertWriteTargetSafe / assertDestinationNotSymlink (or O_NOFOLLOW) on TS scaffold projection writes (AGENTS.md, .githooks, Taskfile, gitignore) and Go writers that still only contain. Align Go copyFile with TS copyTree. Add tests for in-tree dest symlink refusal. CHANGELOG cites #2912.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2912; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under packages/core/src/init-deposit/scaffold.ts (and related paths: packages/core/src/init-deposit/scaffold.ts, packages/core/src/fs/projection-containment.ts, packages/core/src/deposit/, cmd/deft-install/, CHANGELOG.md) and implement the fail-closed fix described in issue #2912. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: task test -- packages/core/src/init-deposit; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -64,8 +63,7 @@
           "packages/core/src/init-deposit/scaffold.ts",
           "packages/core/src/fs/projection-containment.ts",
           "packages/core/src/deposit/",
-          "cmd/deft-install/",
-          "CHANGELOG.md"
+          "cmd/deft-install/"
         ],
         "verify_commands": [
           "task test -- packages/core/src/init-deposit",
@@ -80,7 +78,8 @@
         "conflict_group": "appsec-deposit-ts",
         "size": "M",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2912."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2913-securitydeposit-npm-update-full-tree-replace-no-stale-deftco.xbrief.json
+++ b/xbrief/active/2026-07-29-2913-securitydeposit-npm-update-full-tree-replace-no-stale-deftco.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2913",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(deposit): npm update full-tree replace \u2014 no stale .deft/core survival (install-deposit-06)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch C** (deposit write integrity).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `install-deposit-06` |\n| **Severity** | **Medium** |\n| **Dimension** | `install-deposit` |\n| **Surface** | npm `directive update` / deposit refresh |\n\n## Issue\nnpm `directive update` is **additive copy**. Stale or malicious files under `.deft/core` can **survive** upgrade. Go install path does full swap \u2014 inconsistent integrity.\n\n## Remediation\n1. Full tree replace or delete-not-in-source on npm refresh.\n2. Refuse VERSION stamp until reconcile succeeds.\n\n## Acceptance\n- [ ] Update leaves no dst-only agent content under `.deft/core` after refresh\n- [ ] Parity with Go full-swap integrity model (or documented intentional residual)\n- [ ] Tests / CHANGELOG\n\n## Refs\n- Tracker #2904\n- Batch C siblings: install-deposit-04, skill-pack-supply-01",
       "Labels": "bug, security",
       "UserStory": "As a security engineer, I want npm directive update to fully replace .deft/core so stale agent content cannot survive, so that content VERSION stamps match a reconciled deposit without dst-only leftovers.",
-      "ImplementationPlan": "In packages/core/src/init-deposit/refresh.ts, replace additive copyTree merge with full tree replace (stage + atomic swap or delete-not-in-source reconcile like Go swapInCore / prunePackageAbsentDepositPaths expanded beyond packages). Refuse VERSION stamp until reconcile succeeds. Tests for dst-only file removal. CHANGELOG cites #2913. Note any existing prunePackageAbsentDepositPaths work and complete the gap.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2913; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under packages/core/src/init-deposit/refresh.ts (and related paths: packages/core/src/init-deposit/refresh.ts, packages/core/src/init-deposit/, packages/core/src/deposit/, CHANGELOG.md) and implement the fail-closed fix described in issue #2913. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: task test -- packages/core/src/init-deposit; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -58,13 +57,12 @@
     "metadata": {
       "kind": "story",
       "swarm": {
-        "readiness": "ready",
+        "readiness": "sequential",
         "parallel_safe": false,
         "file_scope": [
           "packages/core/src/init-deposit/refresh.ts",
           "packages/core/src/init-deposit/",
-          "packages/core/src/deposit/",
-          "CHANGELOG.md"
+          "packages/core/src/deposit/"
         ],
         "verify_commands": [
           "task test -- packages/core/src/init-deposit",
@@ -79,7 +77,8 @@
         "conflict_group": "appsec-deposit-ts",
         "size": "L",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2913."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2914-securitypacks-contain-pack-render-path-fields-under-content.xbrief.json
+++ b/xbrief/active/2026-07-29-2914-securitypacks-contain-pack-render-path-fields-under-content.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2914",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(packs): contain pack-render path fields under CONTENT_ROOT + schema (skill-pack-supply-01)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch C** (deposit write integrity).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `skill-pack-supply-01` |\n| **Severity** | **Medium** |\n| **Dimension** | `skill-pack-supply` |\n| **Surface** | multipack `packs:render` path fields |\n\n## Issue\nPack-render builds `outPath` as `join(CONTENT_ROOT, record[pathField])` **without** containment/schema. Absolute/`../` paths can escape or overwrite agent-policy files when render runs without `--check`.\n\n## Remediation\n1. Resolve each `outPath` with realpath semantics; refuse unless contained under `CONTENT_ROOT` (mirror `deposit/contain.ts`).\n2. Enforce pack schemas (path patterns) before render.\n3. Sanitize YAML frontmatter fields; deny absolute paths / null bytes.\n\n## Acceptance\n- [ ] Multipack render refuses escape paths\n- [ ] Schema/path tests; no write outside CONTENT_ROOT\n- [ ] CHANGELOG\n\n## Refs\n- Tracker #2904\n- Batch C siblings: install-deposit-04, install-deposit-06",
       "Labels": "bug, security",
       "UserStory": "As a security engineer, I want contain pack-render output paths under CONTENT_ROOT and enforce pack schema, so that malicious pack JSON cannot write outside content/ or inject unescaped frontmatter.",
-      "ImplementationPlan": "In packages/core/src/packs/pack-render.ts, resolve outPath with containment under CONTENT_ROOT; refuse absolute paths and .. escapes. Enforce pack schema path patterns before render. Sanitize YAML frontmatter fields. Tests for escape attempts. CHANGELOG cites #2914.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2914; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under packages/core/src/packs/pack-render.ts (and related paths: packages/core/src/packs/pack-render.ts, packages/core/src/packs/, CHANGELOG.md) and implement the fail-closed fix described in issue #2914. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: task test -- packages/core/src/packs; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -62,8 +61,7 @@
         "parallel_safe": true,
         "file_scope": [
           "packages/core/src/packs/pack-render.ts",
-          "packages/core/src/packs/",
-          "CHANGELOG.md"
+          "packages/core/src/packs/"
         ],
         "verify_commands": [
           "task test -- packages/core/src/packs",
@@ -78,7 +76,8 @@
         "conflict_group": "appsec-packs",
         "size": "M",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2914."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2915-securitycache-neutralize-nested-fences-inside-quarantine-wra.xbrief.json
+++ b/xbrief/active/2026-07-29-2915-securitycache-neutralize-nested-fences-inside-quarantine-wra.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2915",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(cache): neutralize nested fences inside quarantine wrappers (cache-quarantine-03)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch D** (quarantine completeness).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `cache-quarantine-03` |\n| **Severity** | **Low** |\n| **Dimension** | `cache-quarantine` |\n| **File** | [`packages/core/src/cache/scanner.ts`](https://github.com/deftai/directive/blob/master/packages/core/src/cache/scanner.ts) (also packs quarantine-ext) |\n\n## Issue\nQuarantine wraps sections with `` `quarantined `` fences but includes body lines verbatim. A nested bare `` ` `` can **early-close** the fence so following attacker text renders outside the quarantined info-string.\n\n## Remediation\n1. Escape/neutralize triple-backtick lines inside wrapped sections.\n2. Regression tests for nested fence pairs inside injection sections.\n\n## Acceptance\n- [ ] Nested ` cannot early-close quarantine in transformed content\n- [ ] Regression tests pass\n- [ ] CHANGELOG if user-visible\n\n## Refs\n- Tracker #2904\n- Batch D sibling: cache-quarantine-06",
       "Labels": "bug, security",
       "UserStory": "As a security engineer, I want neutralize nested triple-backtick lines inside quarantine wrappers, so that attacker body cannot early-close quarantined fences in agent-facing markdown.",
-      "ImplementationPlan": "In packages/core/src/cache/scanner.ts (and packs/quarantine-ext.ts if shared), escape/neutralize ``` lines inside wrapped sections. Add regression tests for nested fence pairs remaining enclosed. CHANGELOG cites #2915.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2915; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under packages/core/src/cache/scanner.ts (and related paths: packages/core/src/cache/scanner.ts, packages/core/src/packs/quarantine-ext.ts, packages/core/src/cache/, CHANGELOG.md) and implement the fail-closed fix described in issue #2915. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: task test -- packages/core/src/cache; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -58,13 +57,12 @@
     "metadata": {
       "kind": "story",
       "swarm": {
-        "readiness": "ready",
+        "readiness": "sequential",
         "parallel_safe": false,
         "file_scope": [
           "packages/core/src/cache/scanner.ts",
           "packages/core/src/packs/quarantine-ext.ts",
-          "packages/core/src/cache/",
-          "CHANGELOG.md"
+          "packages/core/src/cache/"
         ],
         "verify_commands": [
           "task test -- packages/core/src/cache",
@@ -79,7 +77,8 @@
         "conflict_group": "appsec-cache-scanner",
         "size": "S",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2915."
       }
     }
   }

--- a/xbrief/active/2026-07-29-2916-securityingest-quarantine-scan-issue-labelstags-before-xbrie.xbrief.json
+++ b/xbrief/active/2026-07-29-2916-securityingest-quarantine-scan-issue-labelstags-before-xbrie.xbrief.json
@@ -2,7 +2,7 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2916",
-    "updated": "2026-07-29T15:01:56Z"
+    "updated": "2026-07-29T15:06:46Z"
   },
   "plan": {
     "title": "security(ingest): quarantine-scan issue labels/tags before xBRIEF Labels/tags (cache-quarantine-06)",
@@ -13,8 +13,7 @@
       "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch D** (quarantine completeness).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `cache-quarantine-06` |\n| **Severity** | **Low** |\n| **Dimension** | `cache-quarantine` |\n| **File** | [`packages/core/src/intake/issue-ingest.ts`](https://github.com/deftai/directive/blob/master/packages/core/src/intake/issue-ingest.ts) |\n\n## Issue\n`buildIssueVbrief` scans title/body/comments/plan-item titles but copies **label names unchanged** into `narratives.Labels` and `plan.tags` \u2014 unscanned agent-authoritative fields.\n\n## Remediation\n1. Run label strings through `scanUntrustedIngestText` (hard-fail credentials; fence/omit injection-shaped labels) before writing Labels/tags.\n2. Tests for credential-shaped / injection-shaped labels.\n\n## Acceptance\n- [ ] Labels follow same hard-fail/fence contract as titles\n- [ ] Tests assert label scan\n- [ ] CHANGELOG if needed\n\n## Refs\n- Tracker #2904\n- Batch D sibling: cache-quarantine-03",
       "Labels": "bug, security",
       "UserStory": "As a security engineer, I want quarantine-scan issue labels and tags before they enter xBRIEF Labels/tags, so that credential- or injection-shaped labels cannot bypass title/body scanning.",
-      "ImplementationPlan": "In packages/core/src/intake/issue-ingest.ts, run label strings through scanUntrustedIngestText before narratives.Labels and plan.tags. Tests for credential-shaped labels hard-fail and injection fence. CHANGELOG cites #2916.",
-      "missing_traces_justification": "Acceptance derived from #2904 confirmed finding and child issue #2916; file paths named in ImplementationPlan are the authoritative touch list."
+      "ImplementationPlan": "1. Open the source module files under packages/core/src/intake/issue-ingest.ts (and related paths: packages/core/src/intake/issue-ingest.ts, packages/core/src/intake/, CHANGELOG.md) and implement the fail-closed fix described in issue #2916. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: task test -- packages/core/src/intake; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
     },
     "items": [
       {
@@ -62,8 +61,7 @@
         "parallel_safe": true,
         "file_scope": [
           "packages/core/src/intake/issue-ingest.ts",
-          "packages/core/src/intake/",
-          "CHANGELOG.md"
+          "packages/core/src/intake/"
         ],
         "verify_commands": [
           "task test -- packages/core/src/intake",
@@ -78,7 +76,8 @@
         "conflict_group": "appsec-ingest",
         "size": "S",
         "file_scope_confidence": "high",
-        "model_tier": "standard"
+        "model_tier": "standard",
+        "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2916."
       }
     }
   }


### PR DESCRIPTION
Follow-up to #2917: missing_traces under swarm metadata, ImplementationPlan code-path/verify terms, sequential readiness for conflict-group seconds.