### PR TITLE
security(cache): hard-fail fine-grained github_pat_ tokens in scanner (#2910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Quarantine-scan issue labels/tags before xBRIEF Labels/tags (#2916, cache-quarantine-06).** `buildIssueVbrief` previously copied issue label names unchanged into `narratives.Labels` and `plan.tags` while scanning title/body/comments/plan-item titles — leaving agent-authoritative fields unscanned. Label strings now run through `scanUntrustedIngestText` under the same fail-closed contract as titles: credential-shaped labels hard-fail (nothing written); injection-shaped labels are fenced/quarantined. Tests assert credential hard-fail plus injection-fence for object- and string-form labels. Closes #2916. Refs #2904.
+- **Cache scanner hard-fails fine-grained `github_pat_` tokens (#2910, cache-quarantine-01).** `CREDENTIAL_PATTERNS` in `packages/core/src/cache/scanner.ts` matched classic `gh[pousr]_…` but not modern fine-grained PATs, so leaked `github_pat_…` tokens in issue title/body/comments passed into `content.md`, xBRIEF narratives, and downstream LLM-facing sinks (cache put, `issue:ingest`, umbrella) instead of failing closed. A `github-fine-grained-pat` pattern (`\bgithub_pat_[A-Za-z0-9_]{20,}\b`) now hard-fails in `scan()`/`detectCredentials`, aligned with product-signal `SECRET_PATTERNS`. `SCANNER_VERSION` bumped to `2.2.0`; scanner tests add fine-grained PAT fixtures. Closes #2910. Refs #2904.
 
 ### Removed
 

--- a/packages/core/src/cache/index.test.ts
+++ b/packages/core/src/cache/index.test.ts
@@ -5,6 +5,6 @@ describe("cache barrel", () => {
   it("exports core symbols", () => {
     expect(typeof cache.cachePut).toBe("function");
     expect(typeof cache.main).toBe("function");
-    expect(cache.SCANNER_VERSION).toBe("2.1.0");
+    expect(cache.SCANNER_VERSION).toBe("2.2.0");
   });
 });

--- a/packages/core/src/cache/scanner-branches.test.ts
+++ b/packages/core/src/cache/scanner-branches.test.ts
@@ -10,6 +10,8 @@ const OLD_BODY_VECTOR_RE =
 // Synthetic credential-shaped fixtures split across literals (#2792 / #1070 precedent).
 const SYNTHETIC_GHP_TOKEN = `ghp_${"12345678901234567890123456789012"}`;
 const SYNTHETIC_SK_TOKEN = `sk-${"1234567890123456789012"}`;
+// #2910: fine-grained PAT (`github_pat_...`), split across literals.
+const SYNTHETIC_FINE_GRAINED_PAT = `github_pat_${"11ABCDE"}${"0123456789_abcXYZ"}`;
 
 describe("scanner branches", () => {
   it("handles empty and whitespace-only bodies", () => {
@@ -39,8 +41,17 @@ describe("scanner branches", () => {
     expect(result.flags.find((f) => f.category === "injection-heading")).toBeUndefined();
   });
 
+  it("hard-fails fine-grained github_pat_ tokens (#2910)", () => {
+    const result = scan(`token ${SYNTHETIC_FINE_GRAINED_PAT}`);
+    expect(result.passed).toBe(false);
+    const credFlag = result.flags.find((f) => f.category === "credentials");
+    expect(credFlag?.severity).toBe("hard-fail");
+    expect(credFlag?.detail).toContain("github-fine-grained-pat");
+  });
+
   it("detects assorted credential shapes", () => {
     expect(scan(SYNTHETIC_GHP_TOKEN).passed).toBe(false);
+    expect(scan(SYNTHETIC_FINE_GRAINED_PAT).passed).toBe(false);
     expect(scan("sk-ant-api03-1234567890123456789012").passed).toBe(false);
     expect(scan("xoxb-1234567890123456789012345678901234567890").passed).toBe(false);
     expect(scan("Bearer abcdefghijklmnopqrstuvwxyz").passed).toBe(false);

--- a/packages/core/src/cache/scanner.test.ts
+++ b/packages/core/src/cache/scanner.test.ts
@@ -15,6 +15,16 @@ describe("scan", () => {
     expect(result.flags.some((f) => f.category === "credentials")).toBe(true);
   });
 
+  it("hard-fails fine-grained github_pat_ tokens (#2910)", () => {
+    // Synthetic fine-grained PAT split across literals so no live secret ships.
+    const finePat = `github_pat_${"11ABCDEFG"}${"0123456789_ABCDEFGHIJKL"}`;
+    const result = scan(`gh token: ${finePat}`);
+    expect(result.passed).toBe(false);
+    const credFlag = result.flags.find((f) => f.category === "credentials");
+    expect(credFlag?.severity).toBe("hard-fail");
+    expect(credFlag?.detail).toContain("github-fine-grained-pat");
+  });
+
   it("strips invisible unicode", () => {
     const result = scan("hello\u200bworld");
     expect(result.passed).toBe(true);

--- a/packages/core/src/cache/scanner.ts
+++ b/packages/core/src/cache/scanner.ts
@@ -4,7 +4,7 @@ import { parseMarkdownHeading } from "../text/redos-safe.js";
  * Quarantine scanner v2 port (mirrors `scripts/cache_scanner.py`).
  * SCANNER_VERSION must stay in lockstep with the Python module.
  */
-export const SCANNER_VERSION = "2.1.0";
+export const SCANNER_VERSION = "2.2.0";
 
 export interface ScanFlag {
   category: string;
@@ -23,6 +23,9 @@ export interface ScanResult {
 
 const CREDENTIAL_PATTERNS: ReadonlyArray<[string, RegExp]> = [
   ["github-pat", /\bgh[pousr]_[A-Za-z0-9]{30,}\b/],
+  // #2910: fine-grained PATs (`github_pat_...`) — aligned with product-signal
+  // SECRET_PATTERNS so cache/ingest fail-closes on modern GitHub tokens.
+  ["github-fine-grained-pat", /\bgithub_pat_[A-Za-z0-9_]{20,}\b/],
   ["anthropic-api-key", /\bsk-ant-[A-Za-z0-9_-]{20,}\b/],
   ["openai-api-key", /\bsk-[A-Za-z0-9]{20,}\b/],
   ["slack-token", /\bxox[bp]-[A-Za-z0-9-]{20,}\b/],
@@ -337,7 +340,7 @@ function detectInjectionHeading(text: string): [string, ScanFlag | null] {
     {
       category: "injection-heading",
       severity: "fence-and-pass",
-      detail: `wrapped ${sectionsWrapped} injection-shaped section(s) in \`quarantined\` fence (v2.1.0 strict-signal policy)`,
+      detail: `wrapped ${sectionsWrapped} injection-shaped section(s) in \`quarantined\` fence (v2.2.0 strict-signal policy)`,
       match_count: sectionsWrapped,
     },
   ];

--- a/xbrief/completed/2026-07-29-2916-securityingest-quarantine-scan-issue-labelstags-before-xbrie.xbrief.json
+++ b/xbrief/completed/2026-07-29-2916-securityingest-quarantine-scan-issue-labelstags-before-xbrie.xbrief.json
@@ -2,15 +2,15 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2916",
-    "updated": "2026-07-29T15:06:46Z"
+    "updated": "2026-07-29T18:36:46Z"
   },
   "plan": {
     "title": "security(ingest): quarantine-scan issue labels/tags before xBRIEF Labels/tags (cache-quarantine-06)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "security(ingest): quarantine-scan issue labels/tags before xBRIEF Labels/tags (cache-quarantine-06). This story remediates a confirmed AppSec finding from tracker #2904 with fail-closed tests and CHANGELOG citation. Parent umbrella remains open until all batch children merge.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2916",
-      "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch D** (quarantine completeness).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `cache-quarantine-06` |\n| **Severity** | **Low** |\n| **Dimension** | `cache-quarantine` |\n| **File** | [`packages/core/src/intake/issue-ingest.ts`](https://github.com/deftai/directive/blob/master/packages/core/src/intake/issue-ingest.ts) |\n\n## Issue\n`buildIssueVbrief` scans title/body/comments/plan-item titles but copies **label names unchanged** into `narratives.Labels` and `plan.tags` \u2014 unscanned agent-authoritative fields.\n\n## Remediation\n1. Run label strings through `scanUntrustedIngestText` (hard-fail credentials; fence/omit injection-shaped labels) before writing Labels/tags.\n2. Tests for credential-shaped / injection-shaped labels.\n\n## Acceptance\n- [ ] Labels follow same hard-fail/fence contract as titles\n- [ ] Tests assert label scan\n- [ ] CHANGELOG if needed\n\n## Refs\n- Tracker #2904\n- Batch D sibling: cache-quarantine-03",
+      "Overview": "## Parent\nPart of AppSec scan tracker **#2904** (2026-07-29). Remediation **Batch D** (quarantine completeness).\n\n## Finding\n| | |\n| --- | --- |\n| **ID** | `cache-quarantine-06` |\n| **Severity** | **Low** |\n| **Dimension** | `cache-quarantine` |\n| **File** | [`packages/core/src/intake/issue-ingest.ts`](https://github.com/deftai/directive/blob/master/packages/core/src/intake/issue-ingest.ts) |\n\n## Issue\n`buildIssueVbrief` scans title/body/comments/plan-item titles but copies **label names unchanged** into `narratives.Labels` and `plan.tags` — unscanned agent-authoritative fields.\n\n## Remediation\n1. Run label strings through `scanUntrustedIngestText` (hard-fail credentials; fence/omit injection-shaped labels) before writing Labels/tags.\n2. Tests for credential-shaped / injection-shaped labels.\n\n## Acceptance\n- [ ] Labels follow same hard-fail/fence contract as titles\n- [ ] Tests assert label scan\n- [ ] CHANGELOG if needed\n\n## Refs\n- Tracker #2904\n- Batch D sibling: cache-quarantine-03",
       "Labels": "bug, security",
       "UserStory": "As a security engineer, I want quarantine-scan issue labels and tags before they enter xBRIEF Labels/tags, so that credential- or injection-shaped labels cannot bypass title/body scanning.",
       "ImplementationPlan": "1. Open the source module files under packages/core/src/intake/issue-ingest.ts (and related paths: packages/core/src/intake/issue-ingest.ts, packages/core/src/intake/, CHANGELOG.md) and implement the fail-closed fix described in issue #2916. 2. Add or extend unit tests/fixtures that assert the security property; run verify commands: task test -- packages/core/src/intake; task check:merge. 3. Update CHANGELOG.md and docs/security.md when the finding changes documented trust boundaries; collect evidence from test output before opening the PR."
@@ -19,7 +19,7 @@
       {
         "id": "labels-follow-same-hard-fail-fence-contr",
         "title": "Labels follow same hard-fail/fence contract as titles",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the #2904 remediation for #2916, when verification runs, then: Labels follow same hard-fail/fence contract as titles."
         }
@@ -27,7 +27,7 @@
       {
         "id": "tests-assert-label-scan",
         "title": "Tests assert label scan",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the #2904 remediation for #2916, when verification runs, then: Tests assert label scan."
         }
@@ -35,7 +35,7 @@
       {
         "id": "changelog-if-needed",
         "title": "CHANGELOG if needed",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the #2904 remediation for #2916, when verification runs, then: CHANGELOG if needed."
         }
@@ -52,7 +52,7 @@
         "title": "Issue #2916: security(ingest): quarantine-scan issue labels/tags before xBRIEF Labels/tags (cache-quarantine-06)"
       }
     ],
-    "updated": "2026-07-29T15:00:07Z",
+    "updated": "2026-07-29T18:36:46Z",
     "id": "story-2916",
     "metadata": {
       "kind": "story",
@@ -78,7 +78,9 @@
         "file_scope_confidence": "high",
         "model_tier": "standard",
         "missing_traces_justification": "No formal FR identifiers; remediation acceptance is defined by #2904 finding text and GitHub issue #2916."
-      }
+      },
+      "completedAt": "2026-07-29T18:36:46Z",
+      "capacityBucket": "technical-debt"
     }
   }
 }


### PR DESCRIPTION
## Summary
Remediates AppSec finding **`cache-quarantine-01`** (High) from tracker #2904, Batch B.

`CREDENTIAL_PATTERNS` in `packages/core/src/cache/scanner.ts` matched classic `gh[pousr]_…` tokens but **not** modern fine-grained PATs (`github_pat_…`). Product-signal `SECRET_PATTERNS` already knows `github_pat_`, so coverage was inconsistent — leaked fine-grained PATs in an issue title/body/comment would pass into `content.md`, xBRIEF narratives, and downstream LLM-facing sinks instead of failing closed.

## Changes
- **Add `github-fine-grained-pat` pattern** `\bgithub_pat_[A-Za-z0-9_]{20,}\b` to `CREDENTIAL_PATTERNS`, aligned with product-signal `SECRET_PATTERNS`.
- **Bump `SCANNER_VERSION`** `2.1.0` → `2.2.0` (and the strict-signal detail string) so sinks (cache put, `issue:ingest`, umbrella) inherit the fail-closed behavior via version-stamped scan results.
- **Tests:** fine-grained PAT fixtures in `scanner.test.ts` and `scanner-branches.test.ts` (synthetic tokens split across literals — no live secrets); updated the `SCANNER_VERSION` barrel assertion in `index.test.ts`.
- **CHANGELOG** `[Unreleased]` entry citing #2910 / #2904.

## Acceptance
- [x] `github_pat_` hard-fails in `scan()` / `detectCredentials`
- [x] Tests cover fine-grained PAT fixtures
- [x] `SCANNER_VERSION` bumped; sinks inherit fail-closed

## Test evidence
- `npx vitest run packages/core/src/cache` → **189 passed** (includes new fixtures)
- `npx vitest run packages/core/src/triage/queue packages/core/src/intake integration-e2e/cache-e2e` → **276 passed** (no version-skew coupling regression)
- `npx tsc --noEmit` → clean
- `npx biome check` (scoped) → clean
- `task change:changelog:check` → OK
- `task check:merge` passed all content/xbrief/vbrief/encoding gates; only `toolchain:check` failed on `pnpm: NOT FOUND` (pre-existing environment limitation, unrelated to this change)

## Notes
The legacy `scripts/cache_scanner.py` referenced in the scanner header no longer exists; no Python mirror to update.

Closes #2910
Refs #2904