### PR TITLE
docs: short controlled English bar for docs and issues (#2927)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,10 @@ Same as managed below; `task verify:story-ready`, `task scope:promote -- <path>`
 
 ! Brief release-notes — `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § CHANGELOG entry style (#1242).
 
+## Controlled English (#2927)
+
+! Short sentences, active voice, one term = one meaning, first-use definitions for docs/issues/PRs — `content/docs/writing-ste100.md` (#2927). ⊗ Full STE certification theater; ⊗ big-bang corpus rewrite; ⊗ red CI style gate in v1.
+
 ## Contextual guardrails (runtime-detect lazy-load)
 
 Same as managed below; `task verify:encoding`, `task verify:scm-boundary`, `task pr:wait-mergeable-and-merge`; `content/scm/github.md` (#2157 / #2369).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,7 @@ Same as managed below; `task verify:story-ready`, `task scope:promote -- <path>`
 
 ! Brief release-notes — `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § CHANGELOG entry style (#1242).
 
-## Controlled English (#2927)
-
-! Short sentences, active voice, one term = one meaning, first-use definitions for docs/issues/PRs — `content/docs/writing-ste100.md` (#2927). ⊗ Full STE certification theater; ⊗ big-bang corpus rewrite; ⊗ red CI style gate in v1.
+! Controlled English for docs/issues/PRs — `content/docs/writing-ste100.md` (#2927). ⊗ Full STE cert; ⊗ big-bang rewrite; ⊗ red CI style gate v1.
 
 ## Contextual guardrails (runtime-detect lazy-load)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Controlled English writing bar for docs and issues (#2927).** Canonical short page states four pragmatic rules (short sentences, active voice, one term = one meaning, first-use definitions) plus non-goals (no full STE certification, no big-bang rewrite, no red CI style gate in v1). Linked from `AGENTS.md`, `content/docs/getting-started.md`, and `content/QUICK-START.md`. Closes #2927.
+
 ### Changed
 
 ### Fixed

--- a/content/QUICK-START.md
+++ b/content/QUICK-START.md
@@ -153,6 +153,8 @@ Read and follow `../AGENTS.md`. This starts the normal first-session flow (user 
 
 **OpenClaw agent-host pointer:** Running Directive under OpenClaw persistent-memory agents? See [docs/openclaw-agent-host.md](./docs/openclaw-agent-host.md) for Control UI / identity notes, the executable babysit path (installed review-cycle skill), and the epic babysit → `sessions_spawn` Approach 1 expectation — skill and register contracts stay in shipped skills (#2877 / epic #2874).
 
+**Writing pointer:** For docs, issues, and PR prose that maintainers or agents author, follow [docs/writing-ste100.md](./docs/writing-ste100.md) (short controlled English; #2927).
+
 **Contributor pointer (non-blocking):** Working on Deft itself (a `deftai/directive` source checkout)? See [CONTRIBUTING.md](../CONTRIBUTING.md) and use the maintainer install path (`deft-install --yes --upgrade --maintainer --repo-root . --json`). The repo's root `AGENTS.md` has contributor instructions — you do not need the consumer first-session flow above.
 
 ## Update notifications

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -141,3 +141,5 @@ Full command reference for every triage and cache verb lives in [`commands.md` �
 <!-- TODO: Cover AGENTS.md, skill routing, Warp Drive integration, and cloud agent dispatch -->
 
 **OpenClaw:** If your agent host is OpenClaw (persistent-memory agents, Control UI, `sessions_spawn`), read [openclaw-agent-host.md](./openclaw-agent-host.md) for the host mental model, executable babysit path (installed skills), and the epic babysit → `sessions_spawn` Approach 1 expectation. Skill gate text remains in `deft-directive-review-cycle` / `deft-directive-swarm` — the host doc only points.
+
+**Writing:** For docs, issues, and PR prose, follow [writing-ste100.md](./writing-ste100.md) (short controlled English; #2927).

--- a/content/docs/writing-ste100.md
+++ b/content/docs/writing-ste100.md
@@ -1,0 +1,53 @@
+# Controlled English for docs and issues
+
+Directive uses a short **controlled-English** bar for product docs, issues, PRs, and agent-facing prose.
+
+**ASD-STE100** is Simplified Technical English (aerospace controlled language). Here it means a practical subset. It is not a certification program.
+
+Legend (RFC2119): `!`=MUST, `~`=SHOULD, `≉`=SHOULD NOT, `⊗`=MUST NOT, `?`=MAY.
+
+Tracker: [#2927](https://github.com/deftai/directive/issues/2927).
+
+---
+
+## Rules (minimum bar)
+
+1. **Short sentences.** Prefer one main idea per sentence.
+2. **Active voice.** Prefer "The agent runs the gate" over "The gate is run by the agent."
+3. **One term = one meaning.** Keep product terms stable (`xbrief`, host, skill pack, swarm, deposit). Do not reuse one word for two concepts.
+4. **First-use definitions.** Define a tech term the first time it appears when the reader may not know it.
+
+! Apply these four rules to **new and touched** prose that maintainers or agents author for this repo.
+
+~ Prefer clarity over ceremony. When a product term already has a glossary or category note, reuse that meaning.
+
+---
+
+## Where it applies
+
+- Agent and maintainer communications about Directive
+- Product docs (including `content/docs/` and related guides)
+- GitHub issues, PRs, and review comments that maintainers or agents author here
+- Skill and strategy prose where clarity matters for agent load
+
+---
+
+## Non-goals
+
+- ⊗ Full ASD-STE100 dictionary compliance or formal STE tooling certification
+- ⊗ A big-bang rewrite of the historical issue corpus
+- ⊗ A red CI style gate in v1 that blocks merges on style nitpicks
+
+Process expectation only: follow the bar by default. Do not invent a merge blocker from this page alone.
+
+---
+
+## Related
+
+| Issue | Role |
+|-------|------|
+| [#740](https://github.com/deftai/directive/issues/740) | Plain-English UX pass (closed; interview-focused) |
+| [#865](https://github.com/deftai/directive/issues/865) | Every rule is a token tax |
+| [#847](https://github.com/deftai/directive/issues/847) | Lean context first |
+| [#2484](https://github.com/deftai/directive/issues/2484) | Progressive disclosure for large skills |
+| [#2905](https://github.com/deftai/directive/issues/2905) | Category terms (host vs skill pack vs practice layer) |

--- a/xbrief/completed/2026-07-29-2927-docs-use-short-controlled-english-for-docs-and-issues-asd-st.xbrief.json
+++ b/xbrief/completed/2026-07-29-2927-docs-use-short-controlled-english-for-docs-and-issues-asd-st.xbrief.json
@@ -1,0 +1,59 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF completed for GitHub issue #2927",
+    "updated": "2026-07-29T20:59:05Z"
+  },
+  "plan": {
+    "title": "docs: use short controlled English for docs and issues (ASD-STE100)",
+    "status": "completed",
+    "narratives": {
+      "Description": "docs: use short controlled English for docs and issues (ASD-STE100)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2927",
+      "Overview": "## Summary\n\n**Request (Scott 2026-07-29):** Apply **ASD-STE100** pragmatically to Directive writing.\n\n**ASD-STE100** = Simplified Technical English (aerospace controlled language). Here it means a practical subset, not full certification.\n\n## Scope\n\nApply to:\n\n- Agent and maintainer communications about Directive\n- Product docs\n- GitHub issues, PRs, and review comments that agents or maintainers author for this repo\n- Skill and strategy prose where clarity matters for agent load\n\n## Pragmatic rules (minimum bar)\n\n1. **Short sentences.** Prefer one main idea per sentence.\n2. **Active voice.** Prefer \"The agent runs the gate\" over \"The gate is run by the agent.\"\n3. **One term = one meaning.** Especially product terms (`xbrief`, host, skill pack, swarm, deposit). Do not reuse one word for two concepts.\n4. **First-use definitions.** Define tech terms the first time they appear in a doc or issue body when the reader may not share the jargon.\n\n## Non-goals\n\n- Full ASD-STE100 dictionary compliance or formal STE tooling certification\n- Rewriting the entire historical issue corpus in one pass\n- Blocking merges solely on STE style nitpicks without a written standard\n\n## Why\n\nLong multi-clause prose and shifting terms raise agent misread risk and human review cost. Controlled English cuts that cost without a new process religion.\n\n## Proposed approach\n\n1. Add a short writing note (e.g. `docs/writing-ste100.md` or a section under contribution / coding docs) with the four rules above.\n2. Link it from contributor / agent entry points (README or AGENTS / main.md as appropriate).\n3. Apply on new and touched prose; no big-bang rewrite required.\n4. Optional later: light checklist in write-skill or article-review \u2014 only if it stays small (see token-tax patterns #865).\n\n## Acceptance\n\n- [ ] Canonical short page or section states the four pragmatic rules + non-goals\n- [ ] Discoverable from maintainer/agent entry docs\n- [ ] New issues/docs from maintainers and agents follow the bar by default (process expectation, not a red CI gate in v1)\n\n## Related\n\n- #740 plain-English UX pass (closed; interview-focused)\n- #865 every-rule-is-a-token-tax\n- #847 lean-context-first\n- #2484 progressive disclosure for large skills\n- #2905 category terms (host vs skill pack vs practice layer)\n\n## Source\n\nOperator request to APE 2026-07-29: standing preference for all communications with Scott and for documents/issues APE authors; file as product request.",
+      "Labels": "documentation, docs, agent-experience, urgent"
+    },
+    "items": [
+      {
+        "title": "Canonical short page or section states the four pragmatic rules + non-goals",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given #2927, when verification runs, then: Canonical short page or section states the four pragmatic rules + non-goals."
+        }
+      },
+      {
+        "title": "Discoverable from maintainer/agent entry docs",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given #2927, when verification runs, then: Discoverable from maintainer/agent entry docs."
+        }
+      },
+      {
+        "title": "New issues/docs from maintainers and agents follow the bar by default (process expectation, not a red CI gate in v1)",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given #2927, when verification runs, then: New issues/docs from maintainers and agents follow the bar by default (process expectation, not a red CI gate in v1)."
+        }
+      }
+    ],
+    "tags": [
+      "documentation",
+      "docs",
+      "agent-experience",
+      "urgent"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2927",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2927: docs: use short controlled English for docs and issues (ASD-STE100)"
+      }
+    ],
+    "updated": "2026-07-29T20:59:05Z",
+    "id": "story-2927",
+    "metadata": {
+      "kind": "story",
+      "completedAt": "2026-07-29T20:59:05Z"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add a short controlled-English writing bar for Directive docs, issues, and PR prose (practical ASD-STE100 subset).

## Changes

- Canonical page: `content/docs/writing-ste100.md`
  - Four rules: short sentences, active voice, one term = one meaning, first-use definitions
  - Non-goals: no full STE certification, no big-bang rewrite, no red CI style gate in v1
- Discoverability links from `AGENTS.md`, `content/docs/getting-started.md`, and `content/QUICK-START.md`
- CHANGELOG `[Unreleased]` Added entry
- Scope xBRIEF completed for #2927

## Non-goals (this PR)

- No pack-generated write-skill edit (optional; token-tax aware; skipped to keep slice small)
- No historical corpus rewrite
- No CI style gate

## Checklist

- [x] `CHANGELOG.md` — `[Unreleased]` entry
- [x] Links resolve to the new page
- [x] New prose uses short controlled English
- [x] xBRIEF completed (status, items, `metadata.completedAt`, active→completed)
- [x] Identity: ape-deft

## Related Issues

Closes #2927

## Testing

- File presence + relative link targets verified
- `git diff` reviewed
- Commit hooks: branch protection, encoding, forward-coverage, vbrief conformance, xbrief drift
