### PR TITLE
docs: category decision aid — hosts vs skill packs vs practice layer (#2905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Category decision aid — hosts vs skill packs vs practice layer vs orchestrators (#2905).** Canonical short page `docs/CATEGORY.md` with the four-way fit table, what Directive is / is not, skill-pack stacking, host-as-runtime boundary, swarm-skills ≠ app orchestrators, and star-count misuse warning (category demand ≠ substitute size). README TL;DR and Getting Started link it above install; glossary defines the four terms with cross-links. No invented traction. Refs #1597, #878, #392. Closes #2905.
 - **Official per-project `.no-deft-directive` opt-out flag (#2926).** Root-only file presence disables Directive install pressure, `session:start` ritual, doctor setup path, and `init`/`update` mutations, with one-line message `Directive disabled via ".no-deft-directive"`. Flag wins locally over trusted-org/product-signal force-on in v1. Flag+deposit is inconsistent: doctor warns; mutating paths fail closed. Docs in `content/docs/no-deft-directive.md`; optional `directive policy:disable-directive` / `policy:enable-directive`. Setup skill checks the flag early. Closes #2926.
 - **Controlled English writing bar for docs and issues (#2927).** Canonical short page states four pragmatic rules (short sentences, active voice, one term = one meaning, first-use definitions) plus non-goals (no full STE certification, no big-bang rewrite, no red CI style gate in v1). Linked from `AGENTS.md`, `content/docs/getting-started.md`, and `content/QUICK-START.md`. Closes #2927.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Deft is a **layered set of standards files plus deterministic `task` tooling** t
 
 **Context-efficient:** Deft keeps AI context windows lean through the [Notation Legend](#-notation-legend) above and lazy-loading — agents only read the files relevant to the current task, not everything at once.
 
+**Category fit:** Directive is a **repo practice layer** (standards + durable work state + gates) — not a coding host, not only a skill pack, and not an app orchestrator. See **[docs/CATEGORY.md](./docs/CATEGORY.md)** before you compare substitutes by star count.
+
 **📍 Roadmap:** See [ROADMAP.md](./ROADMAP.md) for the development timeline, open issues, and planned work.
 
 ## Deft & Directive (naming)
@@ -45,6 +47,8 @@ Deft is a **layered set of standards files plus deterministic `task` tooling** t
 **Deft is the company; Directive is the product.** In docs and on npm, *Deft* names the organization and the on-disk footprint (`.deft/`, `@deftai/*` scope, `deft.md`). *Directive* names the framework you install and run — the published npm package is `@deftai/directive`, and the primary CLI command is `directive` (`deft` is retained as an alias). Existing `deft-install` / `deft` wording in older paths refers to the same product during the staged transition to the npm-first channel ([#423](https://github.com/deftai/directive/issues/423), [#11](https://github.com/deftai/directive/issues/11)).
 
 ## 🚀 Getting Started
+
+**New here?** Read **[docs/CATEGORY.md](./docs/CATEGORY.md)** first — the four-way map (coding host vs skill pack vs Directive practice layer vs orchestrator) so you install the right job.
 
 Directive is driven by **three commands** — `init`, `update`, and `doctor`. You never have to choose between a half-dozen setup verbs; pick the single command that matches your situation:
 
@@ -307,6 +311,7 @@ Slices are addressed by a **stable, versioned slice name** (e.g. `recent`, `by-t
 
 ## 📚 Learn More
 
+- **[docs/CATEGORY.md](./docs/CATEGORY.md)** — Category decision aid: hosts vs skill packs vs practice layer vs orchestrators
 - **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)** — Current Taskfile-first architecture, rule authority, vBRIEF state, installer layout, and codeStructure projection boundary
 - **[docs/CONCEPTS.md](./docs/CONCEPTS.md)** — Current operating concepts: vBRIEF source of truth, deterministic gates, cache-backed triage, lifecycle folders, and projections
 - **[docs/FILES.md](./docs/FILES.md)** — Current directory tree, task includes, skills, vBRIEF state, and consumer artifact locations

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -72,6 +72,8 @@ Terms describing how directive itself is structured and governed.
 
 **Ubiquitous language** — The shared, precisely defined vocabulary used consistently across all directive files and by all agents. This glossary is the source of truth. Synonyms and informal restatements of defined terms are not permitted.
 
+**Coding host** (host) · **skill pack** · **practice layer** · **orchestrator** — Buyer/evaluator category map (not framework internals). Hosts run agents; skill packs improve one session and **stack**; Directive is the repo **practice layer**; **orchestrators** run multi-agent apps (≠ Directive swarm skills). Canonical aid: [docs/CATEGORY.md](../docs/CATEGORY.md) (#2905).
+
 ---
 
 ## Hygiene Terms

--- a/docs/CATEGORY.md
+++ b/docs/CATEGORY.md
@@ -1,0 +1,101 @@
+# Category decision aid
+
+**What job is Directive?** Use this page before you compare tools by stars or marketing labels.
+
+Related research and naming (do not replace this map):
+
+- [#1597](https://github.com/deftai/directive/issues/1597) — Superpowers vs Directive capability gap (peer deep-dive)
+- [#878](https://github.com/deftai/directive/issues/878) — practices vs processes content split
+- [#392](https://github.com/deftai/directive/issues/392) — Deft brand vs Directive product namespace
+
+---
+
+## Four-way fit table
+
+| Need | Fit | Examples (illustrative) |
+|------|-----|-------------------------|
+| Run the agent in an editor or CLI | **Coding host** | Cursor, Claude Code, Codex, OpenClaw |
+| Improve methodology inside one session | **Skill pack** | Superpowers-class host plugins / skill sets |
+| Shared standards + durable work state + hard gates **in this repo** | **Directive practice layer** | `@deftai/directive` (this product) |
+| Multi-agent product / swarm runtime **in app code** | **Orchestrator** | LangGraph, CrewAI, AutoGen, Ruflo-class |
+
+Pick the row that matches the job. Do not buy three products that claim the same row.
+
+---
+
+## What Directive is
+
+**One sentence:** Directive is an installable practice layer for a git repository so humans and coding agents share the same rules, durable work items, and automated checks.
+
+It deposits practice **with the code**:
+
+1. **Standards** — versioned rules and guidance agents load on demand  
+2. **Work state** — durable vBRIEF/xBRIEF lifecycle records (not chat memory alone)  
+3. **Gates** — Taskfile/CI checks that fail closed before merge or release  
+
+**Deft** is the company and on-disk footprint (`.deft/`, `@deftai/*`). **Directive** is the product you install and run. See the [README naming note](../README.md#deft--directive-naming).
+
+---
+
+## What Directive is not
+
+| Not this | Why |
+|----------|-----|
+| A **coding host** | Hosts run the agent UI/runtime. Directive **feeds** hosts; it does not replace Cursor, Claude Code, Codex, or similar. |
+| Only a **skill pack** | Skill packs improve one session or one host. Directive is a **repo deposit** with lifecycle state and hard gates. |
+| An app **orchestrator** | Orchestrators run multi-agent products **inside application code**. That is a different job from repo practice. |
+| A substitute measured by **star count peers** | Category demand is not the same as substitute size. See [Star-count misuse](#star-count-misuse). |
+
+---
+
+## How the four categories relate
+
+```text
+Skill packs ──stack with──► Coding hosts ◄──practice deposit── Directive
+                                      │
+                                      │  different job
+                                      ▼
+                               Orchestrators (agent apps / in-app swarms)
+```
+
+### Skill packs stack
+
+You can use a skill pack **and** Directive. A pack improves session methodology on a host. Directive still owns shared standards, durable work state, and gates in the repository. Closest methodology peers are complementary, not automatic replacements.
+
+### Hosts are runtimes
+
+Hosts are where the agent runs. Directive does not compete to be your editor or agent CLI. Install Directive in the project; keep the host you already use.
+
+### Directive swarm skills ≠ multi-agent app orchestrators
+
+Directive ships work-ops skills (including swarm-style allocation of GitHub/repo work). Those skills coordinate **how humans and agents ship this repository**.
+
+They are **not** the same class as multi-agent application runtimes or host meta-harness orchestrators (LangGraph, CrewAI, AutoGen, Ruflo-class). “Swarm” in Directive docs means work-ops allocation, not “build an agent product runtime.”
+
+---
+
+## Star-count misuse
+
+**Category demand ≠ substitute size.**
+
+Large star counts on skill packs, spec kits, or orchestrators show that buyers want structure for AI coding. They do **not** mean those tools are like-for-like substitutes for a repo practice layer, or that star rank equals the same job.
+
+When you compare tools:
+
+1. Match **job** first (table above).  
+2. Then compare depth inside that job.  
+3. Do not rank a skill pack against Directive by stars alone.
+
+This page does not claim commercial traction, seat counts, or revenue. Re-check public metrics on the date of your decision.
+
+---
+
+## See also
+
+| Doc | Role |
+|-----|------|
+| [README.md](../README.md) | Install and product entry |
+| [CONCEPTS.md](./CONCEPTS.md) | Operating concepts (vBRIEF, gates, triage) |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | Technical architecture |
+| [glossary.md](../content/glossary.md) | Canonical vocabulary (host, skill pack, practice layer, orchestrator) |
+| [content/docs/writing-ste100.md](../content/docs/writing-ste100.md) | Controlled-English bar for product prose |


### PR DESCRIPTION
## Summary

Public materials under-explain what job **Directive** is versus adjacent tools. This PR adds a short category decision aid so buyers and agents stop treating star-count peers as like-for-like substitutes.

## Changes

- **`docs/CATEGORY.md`** — canonical four-way table (coding host | skill pack | Directive practice layer | orchestrator); what Directive is / is not; skill packs stack; hosts are runtimes; Directive swarm skills ≠ multi-agent app orchestrators; star-count misuse warning (category demand ≠ substitute size). See also #1597 #878 #392. No invented traction.
- **`README.md`** — TL;DR + Getting Started link to `docs/CATEGORY.md` above install (surgical). License line unchanged.
- **`content/glossary.md`** — compact cross-links for host / skill pack / practice layer / orchestrator → CATEGORY.md (stays under 150-line contract).
- **`CHANGELOG.md`** — `[Unreleased]` #2905.

## Non-goals

- #1597 research depth
- docs-site work (#2906)
- LICENSE packaging (#2902)
- Graduation / Now+Later body (#2899)

## Test plan

- [x] `test -f docs/CATEGORY.md`
- [x] `grep docs/CATEGORY.md README.md`
- [x] `task check:merge` green
- [x] Glossary line count < 150

Closes #2905