### PR TITLE
docs(product): xbrief sole public work-state name (#2907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **xBRIEF is the sole public work-state name; vBRIEF is legacy (#2907).** Product guidance (README, CONCEPTS, ARCHITECTURE, glossary, UPGRADING, getting-started) teaches `xbrief/` / `.xbrief.json` / scope xBRIEF only. Single authoritative rename/history note in `content/UPGRADING.md` (migrate path, old extensions, deprecated `vbrief:*` aliases). Glossary lifecycle terms rewritten under xBRIEF with a **vBRIEF (legacy)** pointer. Schema reference `content/vbrief/vbrief.md` labeled legacy/schema-lineage. Content contracts guard public-canon surfaces. Closes #2907. Refs #2034, #2110.
 - **Swarm skill host-adapter progressive load + OpenClaw isolation/handoff gates (#2928, #2929, #2934).** `deft-directive-swarm` is split into a thin SKILL (detect + route table + hard gates) and hand-authored `references/core-*.md` + `references/host-*.md` adapters. Default load is core + **one** host adapter after detect; loading all hosts “just in case” is forbidden. OpenClaw adapter hard-requires worktree/worktree-map before parallel `sessions_spawn` and blocks shared-checkout DIY dispatch (#2929). After coding cohort complete, same-turn next-phase tool dispatch or explicit terminal status is required — prose-only “I will spawn…” handoff is forbidden (#2934). Write-skill documents the multi-host convention; `openclaw-agent-host.md` links the adapter without forking SoT. Content contracts read the ordered skill surface. Closes #2928. Closes #2929. Closes #2934.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ deft-install --yes --upgrade --maintainer --repo-root /path/to/directive --json
 
 This mode checks maintainer tooling without projecting consumer-managed files
 such as `AGENTS.md`, `.gitignore`, `.gitattributes`, guard workflows, or
-consumer `vbrief/` scaffolding into the framework repository. See
+consumer `xbrief/` scaffolding into the framework repository. See
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) for maintainer setup details.
 
 ### 2. Set Up Your Preferences
 
-Deft offers two setup paths that produce the same output (`USER.md` + `vbrief/PROJECT-DEFINITION.vbrief.json` + scope vBRIEFs) but adapt to different users:
+Deft offers two setup paths that produce the same output (`USER.md` + `xbrief/PROJECT-DEFINITION.xbrief.json` + scope xBRIEFs) but adapt to different users:
 
 - **Agent-driven** (recommended for most users) — Tell your agent `read AGENTS.md and follow it`, or run `directive bootstrap` to deposit the framework and hand off to the setup skill.
 - **CLI launcher** (for terminal operators) — `directive bootstrap` deposits `.deft/core/` when absent and routes into the agent-driven setup flow (Phases 1–3). Use `--project` or `--strategy <name>` to jump to a later phase; `--reconfigure` / `--force` control re-entry when artifacts already exist.
@@ -187,16 +187,16 @@ Deft offers two setup paths that produce the same output (`USER.md` + `vbrief/PR
 - Windows: `%APPDATA%\deft\USER.md`
 - Override: set `DEFT_USER_PATH` environment variable
 
-### 3. Generate a Scope vBRIEF
+### 3. Generate a Scope xBRIEF
 
-`directive bootstrap` walks the full setup chain (user preferences → project definition → scope vBRIEF interview). Jump to a later phase when re-entering:
+`directive bootstrap` walks the full setup chain (user preferences → project definition → scope xBRIEF interview). Jump to a later phase when re-entering:
 
 ```bash
-directive bootstrap --strategy interview   # Phase 3 — scope vBRIEF interview
+directive bootstrap --strategy interview   # Phase 3 — scope xBRIEF interview
 directive bootstrap --project              # Phase 2 — project configuration only
 ```
 
-The interview writes a **scope vBRIEF** to `vbrief/proposed/`. `vbrief/*.vbrief.json` files are the source of truth; `.md` files (`PRD.md`, `SPECIFICATION.md`, `ROADMAP.md`) are rendered views generated on demand via `task *:render`. Direct edits to the rendered `.md` files are overwritten on the next render — edit the underlying `.vbrief.json` instead.
+The interview writes a **scope xBRIEF** to `xbrief/proposed/`. `xbrief/*.xbrief.json` files are the source of truth; `.md` files (`PRD.md`, `SPECIFICATION.md`, `ROADMAP.md`) are rendered views generated on demand via `task *:render`. Direct edits to the rendered `.md` files are overwritten on the next render — edit the underlying `.xbrief.json` instead.
 
 Other commands:
 
@@ -209,17 +209,17 @@ directive agents:refresh       # Refresh AGENTS.md managed section
 
 ### 4. Build With AI
 
-Ask your AI to build the product/project from your scope vBRIEFs and away you go:
+Ask your AI to build the product/project from your scope xBRIEFs and away you go:
 
 ```
-Read vbrief/PROJECT-DEFINITION.vbrief.json and the scope vBRIEFs in
-vbrief/active/ (or vbrief/pending/ if none are active yet) and implement
+Read xbrief/PROJECT-DEFINITION.xbrief.json and the scope xBRIEFs in
+xbrief/active/ (or xbrief/pending/ if none are active yet) and implement
 the project following deft/main.md standards.
 ```
 
 ### 5. Backlog triage (working an existing backlog)
 
-Already have a populated backlog — an existing project, a brownfield migration, or an upstream issue tracker that has been accumulating? Trigger the refinement workflow's pre-ingest **Phase 0 action menu** with words like **"triage"**, **"work the cache"**, or **"pre-ingest"**. The agent walks each cached candidate through the menu (`accept | reject | defer | needs-ac | mark-duplicate`) and only **accepted** items land in `vbrief/proposed/` — rejected and deferred items are recorded in the audit log without polluting the backlog.
+Already have a populated backlog — an existing project, a brownfield migration, or an upstream issue tracker that has been accumulating? Trigger the refinement workflow's pre-ingest **Phase 0 action menu** with words like **"triage"**, **"work the cache"**, or **"pre-ingest"**. The agent walks each cached candidate through the menu (`accept | reject | defer | needs-ac | mark-duplicate`) and only **accepted** items land in `xbrief/proposed/` — rejected and deferred items are recorded in the audit log without polluting the backlog.
 
 First populate is scoped via flags so the upstream rate limit does not bite:
 
@@ -239,7 +239,7 @@ When a spec, PRD, or plan is ready to hand off — especially to multiple agents
 - **AFK vs HITL** — each slice is tagged AFK (mergeable with no human interaction — preferred) or HITL (needs a decision/review first), and declares what blocks it so issues are filed in dependency order.
 - **Durable cohorts** — when a plan slices into an umbrella + child issues, the cohort is recorded in `<lifecycle-root>/.triage-cache/slices.jsonl` (e.g. `xbrief/.triage-cache/slices.jsonl`; tracked in git, with per-child wave numbers). This lets `task triage:audit --orphans | --slice-stalled | --slice-coverage` detect children stranded when an umbrella closes early, stalled siblings, and per-umbrella completion. Hand-filed cohorts are backfilled with `task slice:record-existing`; list recorded cohorts with `task slice:list`.
 
-Slices become GitHub issues, which triage into vBRIEFs, which flow through the `proposed/ → pending/ → active/ → completed/` lifecycle and can be allocated to parallel agents (the [`deft-directive-swarm`](./content/skills/deft-directive-swarm/SKILL.md) skill). Architectural refactors follow the same slicing path via [`deft-directive-gh-arch`](./content/skills/deft-directive-gh-arch/SKILL.md).
+Slices become GitHub issues, which triage into xBRIEFs, which flow through the `proposed/ → pending/ → active/ → completed/` lifecycle and can be allocated to parallel agents (the [`deft-directive-swarm`](./content/skills/deft-directive-swarm/SKILL.md) skill). Architectural refactors follow the same slicing path via [`deft-directive-gh-arch`](./content/skills/deft-directive-gh-arch/SKILL.md).
 
 ## 🪜 Layered Architecture (at a glance)
 
@@ -250,16 +250,16 @@ Deft separates **how the AI behaves** (the rule ladder) from **what to build** (
 Rules cascade with precedence (highest first). This is the **how-the-AI-behaves** ladder:
 
 1. **USER.md** (highest) — your personal overrides (`~/.config/deft/USER.md` on Unix/macOS, `%APPDATA%\deft\USER.md` on Windows)
-2. **vbrief/PROJECT-DEFINITION.vbrief.json** — project-specific rules and identity gestalt
+2. **xbrief/PROJECT-DEFINITION.xbrief.json** — project-specific rules and identity gestalt
 3. **Language files** (`languages/python.md`, `languages/go.md`, ...) — language standards
 4. **Tool files** (`tools/taskfile.md`, ...) — tool guidelines
 5. **main.md** (lowest) — general AI behavior
 
-Note: project **requirements** (`vbrief/specification.vbrief.json` + scope vBRIEFs in `vbrief/{proposed,pending,active,completed,cancelled}/`) describe **what to build** and are deliberately kept on a separate ladder from the rule cascade above. `ROADMAP.md` is the rendered backlog view of those requirements.
+Note: project **requirements** (`xbrief/specification.xbrief.json` + scope xBRIEFs in `xbrief/{proposed,pending,active,completed,cancelled}/`) describe **what to build** and are deliberately kept on a separate ladder from the rule cascade above. `ROADMAP.md` is the rendered backlog view of those requirements.
 
 ## 🌲 Branch policy
 
-Deft enforces a feature-branch policy by default (#746, #747): direct commits to `master`/`main` are blocked and PRs whose `head_ref` equals `base_ref` are refused at the CI gate. The policy is governed by a typed flag on `vbrief/PROJECT-DEFINITION.vbrief.json`:
+Deft enforces a feature-branch policy by default (#746, #747): direct commits to `master`/`main` are blocked and PRs whose `head_ref` equals `base_ref` are refused at the CI gate. The policy is governed by a typed flag on `xbrief/PROJECT-DEFINITION.xbrief.json`:
 
 ```json
 {
@@ -295,7 +295,7 @@ Security posture, audit cadence, and vulnerability-reporting flow live in [`docs
 
 **ghx (recommended proxy):** When `gh` is on PATH, Deft automatically prefers [ghx](https://github.com/brunoborges/ghx) — a read-only cache proxy for `gh` — if it is installed. ghx speeds up repeated GitHub API reads and helps multi-agent swarms stay under rate limits. Install it with consent via `directive setup:ghx` (or `task setup:ghx`); `task setup` nudges you when `gh` is present but `ghx` is missing. Consumer projects only require `gh`; ghx is optional but supported.
 
-The migration script (`task migrate:vbrief`) defaults origin provenance to `x-vbrief/github-issue` type. Non-GitHub users should manually adjust `references[].type` in generated vBRIEFs after migration.
+The migration path (`deft migrate:xbrief`; legacy `task migrate:vbrief` alias) remains for historical layouts. Non-GitHub users should manually adjust `references[].type` in generated xBRIEFs after migration. **vBRIEF** is legacy — see [UPGRADING.md — xBRIEF rename](./content/UPGRADING.md#xbrief-rename-2034--2110--2907).
 
 ## 📦 Content packs
 
@@ -312,15 +312,15 @@ Slices are addressed by a **stable, versioned slice name** (e.g. `recent`, `by-t
 ## 📚 Learn More
 
 - **[docs/CATEGORY.md](./docs/CATEGORY.md)** — Category decision aid: hosts vs skill packs vs practice layer vs orchestrators
-- **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)** — Current Taskfile-first architecture, rule authority, vBRIEF state, installer layout, and codeStructure projection boundary
-- **[docs/CONCEPTS.md](./docs/CONCEPTS.md)** — Current operating concepts: vBRIEF source of truth, deterministic gates, cache-backed triage, lifecycle folders, and projections
-- **[docs/FILES.md](./docs/FILES.md)** — Current directory tree, task includes, skills, vBRIEF state, and consumer artifact locations
+- **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)** — Current Taskfile-first architecture, rule authority, xBRIEF state, installer layout, and codeStructure projection boundary
+- **[docs/CONCEPTS.md](./docs/CONCEPTS.md)** — Current operating concepts: xBRIEF source of truth, deterministic gates, cache-backed triage, lifecycle folders, and projections
+- **[docs/FILES.md](./docs/FILES.md)** — Current directory tree, task includes, skills, xBRIEF state, and consumer artifact locations
 - **[docs/RELEASING.md](./docs/RELEASING.md)** — Release & smoke-test workflow
-- **[docs/BROWNFIELD.md](./content/docs/BROWNFIELD.md)** — Brownfield adoption (pre-v0.20 → vBRIEF migration)
+- **[docs/BROWNFIELD.md](./content/docs/BROWNFIELD.md)** — Brownfield adoption (pre-v0.20 → xBRIEF migration; vBRIEF layout is legacy)
 - **[docs/security.md](./docs/security.md)** — Security posture, audit baseline, cadence, vulnerability-reporting flow
 - **[main.md](./main.md)** — Comprehensive AI guidelines (general behavior layer)
 - **[commands.md](./content/commands.md)** — Taskfile-first command lifecycle with compatibility `run` surfaces
-- **[glossary.md](./content/glossary.md)** — Canonical v0.20 vocabulary
+- **[glossary.md](./content/glossary.md)** — Canonical xBRIEF / v0.20+ vocabulary
 
 ## 🎓 Philosophy
 

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -8,7 +8,29 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 <!-- xbrief-backcompat-2111 -->
 
-> **xBRIEF rename (#2034 / #2110):** Projects still on the legacy `vbrief/` layout and `x-vbrief/` reference tokens remain read-accepted until you run `deft migrate:xbrief` (or `task migrate:xbrief`). `deft doctor` and `deft update` signpost unmigrated layouts.
+### xBRIEF rename (#2034 / #2110 / #2907)
+
+> **Single authoritative rename/history note.** Public product voice uses **xBRIEF** / `xbrief/` only. **vBRIEF** is **legacy**.
+
+| Legacy (historical) | Current public canon |
+| --- | --- |
+| `vbrief/` lifecycle root | `xbrief/` |
+| `*.vbrief.json` | `*.xbrief.json` |
+| `vBRIEF` / “scope vBRIEF” in guidance | `xBRIEF` / “scope xBRIEF” |
+| `x-vbrief/*` reference tokens | `x-xbrief/*` (and migrate-accepted legacy tokens) |
+| `task vbrief:*` / `migrate:vbrief` aliases | Prefer `task xbrief:*` / `deft migrate:xbrief`; keep `vbrief:*` only as deprecated aliases when required for back-compat |
+| Envelope keys `vBRIEFInfo` | `xBRIEFInfo` (legacy keys still read-accepted on unmigrated files) |
+
+**Why two names existed:** consumer layout and disk SoT moved to `xbrief/` while docs, glossary, and marketing still taught vBRIEF as current. That dual present-day naming is retired (#2907). Schema lineage, fixtures, migrate paths, changelog history, and archive prose may still say vBRIEF — always as **legacy/historical**, never as competing current guidance.
+
+**What to do:**
+
+1. Prefer `xbrief/` and `.xbrief.json` in all new docs, skills, CLI help, and agent prose.
+2. On projects still on disk under `vbrief/`, run `deft migrate:xbrief` (or `task migrate:xbrief`). `deft doctor` and `deft update` signpost unmigrated layouts.
+3. Do **not** tell users to “prefer vBRIEF” or treat xbrief and vBRIEF as two current models.
+4. Deep schema conventions still live under `content/vbrief/` (path name is historical for the schema package); public work-state name remains xBRIEF.
+
+Refs: [#2034](https://github.com/deftai/directive/issues/2034), [#2110](https://github.com/deftai/directive/issues/2110), [#2907](https://github.com/deftai/directive/issues/2907).
 
 ---
 
@@ -927,7 +949,7 @@ After you update `deft/` to v0.20.0, `vbrief/*.vbrief.json` files are the source
 - [docs/BROWNFIELD.md](./docs/BROWNFIELD.md) — detailed brownfield adoption / migration walkthrough.
 - [QUICK-START.md](./QUICK-START.md) — agent-facing bootstrap + upgrade detection.
 - [vbrief/vbrief.md](./vbrief/vbrief.md) — canonical vBRIEF file taxonomy.
-- [glossary.md](./glossary.md) — canonical v0.20 vocabulary (Scope vBRIEF, lifecycle folder, canonical narrative keys, rendered export, source of truth, ...).
+- [glossary.md](./glossary.md) — canonical xBRIEF / v0.20+ vocabulary (Scope xBRIEF, lifecycle folder, canonical narrative keys, rendered export, source of truth; vBRIEF marked legacy).
 - [CHANGELOG.md](../CHANGELOG.md) — full v0.20.0 change list.
 
 ---

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -64,11 +64,11 @@ These concepts originate from [GSD](https://github.com/gsd-build/get-shit-done) 
 
 ## Framework Design Terms
 
-**Bounded context** (framework sense) — A file or directory in directive that owns a specific rule domain. Other files reference it; they do not restate its rules.
+**Bounded context** (framework sense) — A file or directory in directive that owns a specific rule domain. Other files reference it; they do not restate its rules. Prevents rule drift through duplication. Examples: `coding/hygiene.md` owns hygiene rules; `coding/testing.md` owns universal testing standards.
 
-**Rule ownership** — Each concept has exactly one owning file. Link to the owner rather than duplicating the rule.
+**Rule ownership** — The principle that each concept in directive has exactly one owning file. When multiple files need to reference the concept, they link to the owner rather than duplicating the rule.
 
-**Ubiquitous language** — The shared vocabulary across all directive files. This glossary is the source of truth.
+**Ubiquitous language** — The shared, precisely defined vocabulary used consistently across all directive files and by all agents. This glossary is the source of truth. Synonyms and informal restatements of defined terms are not permitted.
 
 **Coding host** (host) · **skill pack** · **practice layer** · **orchestrator** — Buyer/evaluator category map. Canonical aid: [docs/CATEGORY.md](../docs/CATEGORY.md) (#2905).
 

--- a/content/glossary.md
+++ b/content/glossary.md
@@ -40,7 +40,7 @@ These concepts originate from [GSD](https://github.com/gsd-build/get-shit-done) 
 
 **Fractal summaries** — Hierarchical memory compression: task summaries compress into feature summaries, which compress into release summaries. Iron rule: never summarize summaries — regenerate each level from the level below + code state. See [context/fractal-summaries.md](./context/fractal-summaries.md).
 
-**Specification vbrief** — The source-of-truth pattern for project intent. `./vbrief/specification.vbrief.json` is the canonical specification file; `SPECIFICATION.md` is a generated artifact rendered from it. The spec vbrief is created via interview (`templates/make-spec.md`), reviewed by the user, approved (`status: approved`), then rendered. Never edit the `.md` directly — edit the source vbrief. See [vbrief/vbrief.md](./vbrief/vbrief.md).
+**Specification xbrief** — The source-of-truth pattern for project intent. `./xbrief/specification.xbrief.json` is the canonical specification file; `SPECIFICATION.md` is a generated artifact rendered from it. Never edit the `.md` directly — edit the source xbrief. See [vbrief/vbrief.md](./vbrief/vbrief.md) (schema reference; public name is xBRIEF).
 
 **Stub detection** — Scanning completed code for incomplete implementations: `TODO`/`FIXME` markers, `return null`/`return {}`/`pass` placeholders, functions under ~8 lines returning hardcoded values. See [verification/verification.md](./verification/verification.md).
 
@@ -48,100 +48,96 @@ These concepts originate from [GSD](https://github.com/gsd-build/get-shit-done) 
 
 **Zero discovery calls** — The principle that agents should never spend tokens figuring out where they are, what exists, or what was decided. All of that should be pre-assembled in context before the task starts. See [resilience/context-pruning.md](./resilience/context-pruning.md).
 
-**Brownfield mapping** — Structured reconnaissance of an existing codebase before modifying it. Produces four artifacts: STACK (languages, frameworks, infrastructure), ARCHITECTURE (layers, entry points, data flow), CONVENTIONS (naming, patterns, file layout), and CONCERNS (tech debt, fragile areas, missing tests). See [strategies/map.md](./strategies/map.md). Invoked via `/deft:run:map`.
+**Brownfield mapping** — Structured reconnaissance of an existing codebase before modifying it. Produces four artifacts: STACK, ARCHITECTURE, CONVENTIONS, and CONCERNS. See [strategies/map.md](./strategies/map.md). Invoked via `/deft:run:map`.
 
 **Integration checking** — Cross-feature wiring verification that every export has a matching import, every API endpoint has a consumer, auth gates protect all required routes, and at least one E2E flow traces through the full stack. See [verification/integration.md](./verification/integration.md).
 
-**Plan checking** — Pre-execution verification of a plan across four dimensions: (1) coverage — every acceptance criterion maps to at least one task, (2) completeness — every task has a verify command, (3) wiring — cross-feature dependencies declared in boundary maps, (4) scope — task count within sanity thresholds (2–3 ideal, 5+ requires split). See [verification/plan-checking.md](./verification/plan-checking.md).
+**Plan checking** — Pre-execution verification of a plan across four dimensions: coverage, completeness, wiring, scope. See [verification/plan-checking.md](./verification/plan-checking.md).
 
-**Scope sanity** — A threshold-based guard against over-scoped plans that degrade context window quality. 1–3 tasks per plan is ideal; 4 is a warning; 5+ is a blocker requiring plan split. Part of plan checking dimension 4. See [verification/plan-checking.md](./verification/plan-checking.md).
+**Scope sanity** — Threshold guard against over-scoped plans (1–3 tasks ideal; 5+ requires split). Part of plan checking. See [verification/plan-checking.md](./verification/plan-checking.md).
 
-**Spec delta** — A scoped document capturing how a change modifies existing requirements. Shows new requirements and was/now diffs for modified ones. Linked to the baseline spec via vBRIEF `references` with `type: "x-vbrief/plan"`. Lives in `history/changes/<name>/specs/`. See [context/spec-deltas.md](./context/spec-deltas.md). Invoked as part of `/deft:change`.
+**Spec delta** — Scoped document capturing how a change modifies existing requirements. Linked via xBRIEF `references`. Lives in `history/changes/<name>/specs/`. See [context/spec-deltas.md](./context/spec-deltas.md).
 
-**Verify command** — A concrete, runnable command specified per task that confirms the task's work is correct (e.g., `pytest tests/test_auth.py`, `curl localhost:8080/health`). Required by plan checking dimension 2 (completeness). Tasks without a verify command fail the plan check.
+**Verify command** — A concrete, runnable command per task that confirms the work is correct. Required by plan checking dimension 2.
 
 ---
 
 ## Framework Design Terms
 
-Terms describing how directive itself is structured and governed.
+**Bounded context** (framework sense) — A file or directory in directive that owns a specific rule domain. Other files reference it; they do not restate its rules.
 
-**Bounded context** (framework sense) — A file or directory in directive that owns a specific rule domain. Other files reference it; they do not restate its rules. Prevents rule drift through duplication. Examples: `coding/hygiene.md` owns hygiene rules; `coding/testing.md` owns universal testing standards.
+**Rule ownership** — Each concept has exactly one owning file. Link to the owner rather than duplicating the rule.
 
-**Rule ownership** — The principle that each concept in directive has exactly one owning file. When multiple files need to reference the concept, they link to the owner rather than duplicating the rule.
+**Ubiquitous language** — The shared vocabulary across all directive files. This glossary is the source of truth.
 
-**Ubiquitous language** — The shared, precisely defined vocabulary used consistently across all directive files and by all agents. This glossary is the source of truth. Synonyms and informal restatements of defined terms are not permitted.
-
-**Coding host** (host) · **skill pack** · **practice layer** · **orchestrator** — Buyer/evaluator category map (not framework internals). Hosts run agents; skill packs improve one session and **stack**; Directive is the repo **practice layer**; **orchestrators** run multi-agent apps (≠ Directive swarm skills). Canonical aid: [docs/CATEGORY.md](../docs/CATEGORY.md) (#2905).
+**Coding host** (host) · **skill pack** · **practice layer** · **orchestrator** — Buyer/evaluator category map. Canonical aid: [docs/CATEGORY.md](../docs/CATEGORY.md) (#2905).
 
 ---
 
 ## Hygiene Terms
 
-Terms used in [coding/hygiene.md](./coding/hygiene.md).
+**Hygiene** — Keeping a codebase clean beyond what individual changes introduce: dead code, circular deps, hidden errors, legacy paths. See [coding/hygiene.md](./coding/hygiene.md).
 
-**Hygiene** — The ongoing practice of keeping a codebase clean beyond what individual changes introduce: removing dead code, eliminating circular dependencies, surfacing hidden errors, and removing legacy/deprecated code paths. Distinct from per-change quality gates, which only govern new code.
+**Dead code** — Code defined but never executed.
 
-**Dead code** — Code that is defined but never executed: unused functions, unreachable branches, stale feature flags, and commented-out blocks. Distinct from deprecated code, which may still execute on a legacy path.
+**Error hiding** — Patterns that prevent errors from being observed by the caller or operator.
 
-**Error hiding** — Any pattern that prevents an error from being observed by the caller or operator: empty catch blocks, silent fallbacks, returning neutral/zero values to mask failures, or log-and-continue without surfacing the error upstream.
+**Legacy code** — Superseded path not yet removed.
 
-**Legacy code** — A code path, implementation, or feature flag that has been superseded but not removed. Identified by markers such as `LEGACY`, `COMPAT`, `OLD_`, `TODO: remove`, or the presence of two parallel implementations without a migration path.
-
-**Circular dependency** — An import cycle where module A depends on module B which depends (directly or transitively) on module A. Indicates architectural coupling that prevents modular testing and signals a layering violation.
+**Circular dependency** — Import cycle A→B→A (directly or transitively).
 
 ---
 
 ## GSD → Deft Term Mapping
-
-For readers familiar with [GSD](https://github.com/gsd-build/get-shit-done):
 
 | GSD Term | Deft Term | Notes |
 |----------|-----------|-------|
 | Milestone | **Release** | Shippable version |
 | Slice | **Feature** | Vertical capability with demo sentence |
 | Task | **Task** | Same — add "fits in one context window" |
-| Must-haves | **Acceptance criteria** | With subcategories: truths, artifacts, key links |
-| Continue file | **Continue checkpoint** | `./vbrief/continue.vbrief.json` (singular) |
-| Discuss phase | **Interview** (extended) | Adds decision locking + Feynman technique |
-| Boundary map | **Contract** (at planning level) | Extension of Contract-First |
+| Must-haves | **Acceptance criteria** | truths, artifacts, key links |
+| Continue file | **Continue checkpoint** | `./xbrief/continue.xbrief.json` |
+| Discuss phase | **Interview** (extended) | decision locking + Feynman |
+| Boundary map | **Contract** (planning) | Extension of Contract-First |
 | Wave execution | **Parallel group** | Speckit `[P]`/`[S]` markers |
 | Research phase | **Research** | Already in speckit |
 
 ---
 
-## vBRIEF Lifecycle Terms (v0.20+)
+## xBRIEF Lifecycle Terms
 
-Canonical vocabulary for the vBRIEF lifecycle. (Merged from the former top-level `glossary.md` during the #1875 content/ move; deduplicated to a single canonical glossary.)
+Canonical vocabulary for the xBRIEF lifecycle. **xBRIEF** / `xbrief/` is the sole public current name (#2907). **vBRIEF** is legacy — see [UPGRADING.md — xBRIEF rename](./UPGRADING.md#xbrief-rename-2034--2110--2907).
 
-- **Scope vBRIEF** -- A durable unit-of-work record, one per feature / bug / initiative, stored as `YYYY-MM-DD-slug.vbrief.json` inside a [lifecycle folder](#terms). Scope vBRIEFs are the primary work artifact in v0.20 (see [vbrief/vbrief.md -- Scope vBRIEFs and Lifecycle Folders](./vbrief/vbrief.md#scope-vbriefs-and-lifecycle-folders)).
+- **Scope xBRIEF** -- A durable unit-of-work record, one per feature / bug / initiative, stored as `YYYY-MM-DD-slug.xbrief.json` inside a [lifecycle folder](#xbrief-lifecycle-terms). Primary work artifact (schema detail: [vbrief/vbrief.md](./vbrief/vbrief.md)).
 
-- **Lifecycle folder** -- One of the five subdirectories under `vbrief/`: `proposed/`, `pending/`, `active/`, `completed/`, `cancelled/`. Folder location reflects (but does not define) `plan.status`; see [vbrief/vbrief.md -- Directory Structure](./vbrief/vbrief.md#directory-structure) and [Status-Driven Moves](./vbrief/vbrief.md#status-driven-moves).
+- **Lifecycle folder** -- One of five subdirectories under `xbrief/`: `proposed/`, `pending/`, `active/`, `completed/`, `cancelled/`. Folder location reflects (but does not define) `plan.status`. See [vbrief/vbrief.md](./vbrief/vbrief.md).
 
-- **Plan-level narrative** -- A key under `plan.narratives` in a vBRIEF file, describing the scope/plan as a whole (e.g. `Description`, `Acceptance`, `Traces`). Plan-level narratives describe the *what and why*; see [vbrief/vbrief.md -- Narratives](./vbrief/vbrief.md#narratives).
+- **Plan-level narrative** -- A key under `plan.narratives` in an xBRIEF (e.g. `Description`, `Acceptance`, `Traces`). Plain strings only. See [vbrief/vbrief.md](./vbrief/vbrief.md).
 
-- **Item-level narrative** -- A narrative string under `plan.items[].narrative` describing a single `PlanItem` (a task / subtask within a scope). Both plan-level and item-level narratives MUST be plain strings -- never objects (see [vbrief/vbrief.md -- Narratives](./vbrief/vbrief.md#narratives)).
+- **Item-level narrative** -- A narrative string under `plan.items[].narrative` for one PlanItem. Plain strings only. See [vbrief/vbrief.md](./vbrief/vbrief.md).
 
-- **Filename stem** -- The portion of a vBRIEF filename before `.vbrief.json`. For scope vBRIEFs the stem follows `YYYY-MM-DD-<slug>`; for speckit Phase 4 emissions the stem is `YYYY-MM-DD-ip<NNN>-<slug>` with `NNN` zero-padded to 3 digits (see [vbrief/vbrief.md -- Filename Convention](./vbrief/vbrief.md#filename-convention)).
+- **Filename stem** -- The portion of an xBRIEF filename before `.xbrief.json`. Scope stems: `YYYY-MM-DD-<slug>`; speckit Phase 4: `YYYY-MM-DD-ip<NNN>-<slug>`. See [vbrief/vbrief.md](./vbrief/vbrief.md).
 
-- **Cross-scope dependency** -- A dependency between two scope vBRIEFs (rather than between items inside a single scope). Cross-scope dependencies live at `plan.metadata.dependencies` as an array of dependency IDs -- plan-level by design (see [vbrief/vbrief.md -- Plan-level metadata](./vbrief/vbrief.md#plan-level-metadata)).
+- **Cross-scope dependency** -- Dependency between two scope xBRIEFs at `plan.metadata.dependencies` (array of dependency IDs). See [vbrief/vbrief.md](./vbrief/vbrief.md).
 
-- **Exit Commands** -- The seven deterministic `task scope:*` commands that transition a scope vBRIEF between lifecycle folders: `scope:promote`, `scope:activate`, `scope:complete`, `scope:cancel`, `scope:restore`, `scope:block`, `scope:unblock` (see [tasks/scope.yml](../tasks/scope.yml)). Agents MUST use these instead of moving files by hand.
+- **Exit Commands** -- The seven deterministic `task scope:*` commands that transition a scope xBRIEF between lifecycle folders: `scope:promote`, `scope:activate`, `scope:complete`, `scope:cancel`, `scope:restore`, `scope:block`, `scope:unblock` (see [tasks/scope.yml](../tasks/scope.yml)).
 
-- **Origin provenance** -- A `references` entry on a scope vBRIEF linking back to the issue / ticket / user-request that spawned it (`type: github-issue`, `jira-ticket`, or `user-request`). Required for ingestion dedup; see [vbrief/vbrief.md -- Origin Provenance](./vbrief/vbrief.md#origin-provenance).
+- **Origin provenance** -- A `references` entry linking a scope xBRIEF to its origin issue / ticket / user-request. Required for ingestion dedup. See [vbrief/vbrief.md](./vbrief/vbrief.md).
 
-- **Canonical narrative key** -- One of the small set of reserved plan-level narrative keys (`Description`, `Acceptance`, `Traces`) that tooling (`task roadmap:render`, swarm allocator) reads by name. See [vbrief/vbrief.md -- Scope vBRIEF narrative keys](./vbrief/vbrief.md#scope-vbrief-narrative-keys).
+- **Canonical narrative key** -- Reserved plan-level keys (`Description`, `Acceptance`, `Traces`) that tooling reads by name. See [vbrief/vbrief.md](./vbrief/vbrief.md).
 
-- **Preparatory strategy** -- A [strategies/](./strategies/) workflow that gathers context without producing a spec directly (e.g. `research.md`, `discuss.md`, `map.md`, `bdd.md`). Preparatory strategies chain into a [spec-generating strategy](#terms).
+- **Preparatory strategy** -- A [strategies/](./strategies/) workflow that gathers context without producing a spec directly (e.g. `research.md`, `discuss.md`, `map.md`).
 
-- **Spec-generating strategy** -- A [strategies/](./strategies/) workflow that emits `vbrief/specification.vbrief.json` (and optionally scope vBRIEFs) as its authoritative output (e.g. `interview.md`, `speckit.md`, `enterprise.md`, `rapid.md`, `yolo.md`).
+- **Spec-generating strategy** -- A [strategies/](./strategies/) workflow that emits `xbrief/specification.xbrief.json` (and optionally scope xBRIEFs) as authoritative output.
 
-- **Rendered export** -- A human-readable `.md` file (`SPECIFICATION.md`, `PRD.md`, `ROADMAP.md`) generated on demand by a `task *:render` command from the underlying `.vbrief.json` file. Rendered exports are read-only views; direct edits are overwritten on the next render (see [UPGRADING.md -- What to expect](./UPGRADING.md#what-to-expect)).
+- **Rendered export** -- A human-readable `.md` file (`SPECIFICATION.md`, `PRD.md`, `ROADMAP.md`) generated by `task *:render` from the underlying `.xbrief.json`. Read-only views; edit the source, not the export. See [UPGRADING.md](./UPGRADING.md).
 
-- **Source of truth** -- The file that tooling treats as authoritative for a given piece of information. In v0.20 the `.vbrief.json` files are the source of truth; the corresponding `.md` files are [rendered exports](#terms). Editing a rendered export does not change the source of truth -- edit the `.vbrief.json` instead.
+- **Source of truth** -- The file tooling treats as authoritative. Current: `.xbrief.json` files under `xbrief/`; corresponding `.md` files are [rendered exports](#xbrief-lifecycle-terms).
 
-- **Deterministic mode** -- The interaction shape used by every Deft skill that asks the user structured questions (via `ask_user_question` single-select / multi-select) or numbered-menu prompts in skill prose. Every deterministic-mode prompt MUST include `Discuss` and `Back` as the final two numbered options (#767). The canonical rule and verbatim Discuss-pause semantic live at [`contracts/deterministic-questions.md`](./contracts/deterministic-questions.md); skill prose `!` cross-references that contract instead of duplicating the rule body.
+- **Deterministic mode** -- Interaction shape for structured questions. Every deterministic-mode prompt MUST include `Discuss` and `Back` as the final two options (#767). Canonical rule: [`contracts/deterministic-questions.md`](./contracts/deterministic-questions.md).
 
-- **Branch-protection policy** -- The Deft policy surface that controls whether direct commits to the default branch (master/main) are allowed. The typed flag is `plan.policy.allowDirectCommitsToMaster` on `vbrief/PROJECT-DEFINITION.vbrief.json` (#746); default `false` (enforce feature branches). Three enforcement surfaces back the policy: skill-level guards at the entry of `deft-directive-{swarm,review-cycle,pre-pr,release}` (#746 part C), the detection-bound `scripts/preflight_branch.py` reachable via `task verify:branch` and the `.githooks/pre-commit` + `.githooks/pre-push` hooks (#747), and the CI `branch-gate` workflow asserting `head_ref != base_ref` (#747 part E). Reconfigure via `task policy:show` / `task policy:enforce-branches` / `task policy:allow-direct-commits -- --confirm`. Emergency bypass: `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1`.
+- **Branch-protection policy** -- Controls direct commits to master/main. Typed flag `plan.policy.allowDirectCommitsToMaster` on `xbrief/PROJECT-DEFINITION.xbrief.json` (#746); default `false`. Surfaces: skill guards, `task verify:branch` + hooks (#747), CI `branch-gate`. Reconfigure via `task policy:*`. Emergency: `DEFT_ALLOW_DEFAULT_BRANCH_COMMIT=1`.
 
-- **Policy audit log** -- One-line append-only ledger at `meta/policy-changes.log` recording every transition of `plan.policy.allowDirectCommitsToMaster`. Written by `scripts/policy_set.py` whenever `task policy:enforce-branches` or `task policy:allow-direct-commits -- --confirm` is invoked, including the actor, previous value, and any operator-supplied `--note`. Surface introduced by #746 acceptance criterion G2.
+- **Policy audit log** -- Append-only ledger at `meta/policy-changes.log` for transitions of `allowDirectCommitsToMaster` (#746 / #747).
+
+- **vBRIEF (legacy)** -- Historical name for xBRIEF / `xbrief/` work-state. On-disk `vbrief/`, `*.vbrief.json`, `x-vbrief/*` tokens, and `vbrief:*` task aliases remain read-accepted until `deft migrate:xbrief`. ⊗ Teach vBRIEF as the current product name. Authoritative map: [UPGRADING.md — xBRIEF rename](./UPGRADING.md#xbrief-rename-2034--2110--2907).

--- a/content/vbrief/vbrief.md
+++ b/content/vbrief/vbrief.md
@@ -1,10 +1,12 @@
 # vBRIEF Usage in Deft
 
-Canonical reference for vBRIEF file conventions within Deft-managed projects.
+> **Public name (#2907):** The sole current work-state name is **xBRIEF** under `xbrief/` (`.xbrief.json`). **vBRIEF** / `vbrief/` / `.vbrief.json` in this document are **legacy / schema-lineage** names (this path still hosts core schemas). Prefer xbrief in product docs and new guidance. Authoritative rename/history: [UPGRADING.md — xBRIEF rename](../UPGRADING.md#xbrief-rename-2034--2110--2907). Migrate on-disk layouts with `deft migrate:xbrief`.
+
+Canonical **schema and convention** reference for durable work-state files within Deft-managed projects (historical filename: vBRIEF).
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
-**⚠️ See also**: [context/working-memory.md](../context/working-memory.md) | [resilience/continue-here.md](../resilience/continue-here.md) | [context/long-horizon.md](../context/long-horizon.md) | [glossary.md](../glossary.md)
+**⚠️ See also**: [glossary.md](../glossary.md) | [UPGRADING.md — xBRIEF rename](../UPGRADING.md#xbrief-rename-2034--2110--2907) | [context/working-memory.md](../context/working-memory.md) | [resilience/continue-here.md](../resilience/continue-here.md)
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,8 @@
 # Deft Architecture
 
-How the Deft framework is wired today: authority layers, command surfaces, vBRIEF state, automation modules, generated artifacts, and the boundary between authored source of truth and derived views.
+How the Deft framework is wired today: authority layers, command surfaces, xBRIEF state, automation modules, generated artifacts, and the boundary between authored source of truth and derived views.
+
+> **Naming (#2907):** **xBRIEF** / `xbrief/` is the sole public work-state name; **vBRIEF** is legacy. See [UPGRADING.md — xBRIEF rename](../content/UPGRADING.md#xbrief-rename-2034--2110--2907).
 
 > **See also**: [CONCEPTS.md](./CONCEPTS.md) (operating principles) | [FILES.md](./FILES.md) (directory map) | [code-structure-profile.md](./code-structure-profile.md) | [codebase-map-source-of-truth.md](./codebase-map-source-of-truth.md) | [../README.md](../README.md)
 
@@ -12,7 +14,7 @@ Deft Directive is a self-dogfooded framework for AI-assisted software work. It i
 - A Taskfile-first deterministic command graph.
 - Python tooling plus the TypeScript package engine for validation, rendering, lifecycle movement, cache/triage/scope automation, doctor checks, release support, codebase extraction contracts, CLI shims, and parity harnesses.
 - npm packages (`@deftai/directive` + `@deftai/directive-content`) with TS-native `directive init` / `directive update` resolve-and-copy deposit into gitignored `.deft/core/`, plus a frozen Go binary retained only as a legacy layout bridge and node-independent health gate.
-- vBRIEF files as durable project, specification, lifecycle, policy, and architecture metadata.
+- xBRIEF files as durable project, specification, lifecycle, policy, and architecture metadata.
 - Local cache/audit surfaces for backlog triage and GitHub issue ingestion.
 - PR, release, swarm, branch-policy, and verification gates.
 - Content packs for sliceable agent memory.
@@ -29,14 +31,14 @@ flowchart LR
     A["Agent entry<br/>AGENTS.md, SKILL.md, main.md"] --> B["Guidance layer<br/>skills, standards, strategies, templates"]
     B --> C["Taskfile command graph<br/>task --list, task check, task verify:*"]
     C --> D["Automation layer<br/>scripts/*.py, packages/, run compatibility, Go installer"]
-    D --> E["Durable state<br/>PROJECT-DEFINITION, specification, scope vBRIEFs"]
+    D --> E["Durable state<br/>PROJECT-DEFINITION, specification, scope xBRIEFs"]
     E --> F["Generated views<br/>SPECIFICATION.md, PRD.md, ROADMAP.md, MAP.md"]
     E --> C
     C --> G["Enforcement surfaces<br/>tests, hooks, CI, release and PR gates"]
     G --> B
 ```
 
-The loop is deliberate. Guidance tells agents how to behave, tasks make that behavior executable, vBRIEF files preserve state, generated views make state readable, and gates feed back into the guidance when the framework learns a better rule.
+The loop is deliberate. Guidance tells agents how to behave, tasks make that behavior executable, xBRIEF files preserve state, generated views make state readable, and gates feed back into the guidance when the framework learns a better rule.
 
 ## Entry Surfaces
 
@@ -44,7 +46,7 @@ The loop is deliberate. Guidance tells agents how to behave, tasks make that beh
 - `SKILL.md` is the alternate loader convention for platforms that discover skills directly.
 - `main.md` holds general AI behavior and the current rule-authority axiom.
 - `~/.config/deft/USER.md` stores personal preferences, with its Personal section taking precedence for user-defined preferences.
-- `vbrief/PROJECT-DEFINITION.vbrief.json` stores project identity, policy, lifecycle registry, and authored architecture metadata.
+- `xbrief/PROJECT-DEFINITION.xbrief.json` stores project identity, policy, lifecycle registry, and authored architecture metadata.
 
 Consumer installs point agents at `.deft/core/main.md`. The canonical path is `npm i -g @deftai/directive` followed by `directive init` (greenfield) or `directive update` (refresh) — both resolve the locally installed `@deftai/directive-content` package and copy it into gitignored `.deft/core/`. Legacy Go-installer and git-clone layouts are migration inputs, not the preferred target state.
 
@@ -54,13 +56,13 @@ Rules use the strongest applicable layer:
 
 ```mermaid
 flowchart TD
-    D["Deterministic checks<br/>tests, scripts, hooks, CI"] --> T["Taskfile targets<br/>task check, verify:*, vbrief:*"]
-    T --> V["vBRIEF metadata<br/>project policy, lifecycle state"]
+    D["Deterministic checks<br/>tests, scripts, hooks, CI"] --> T["Taskfile targets<br/>task check, verify:*, xbrief:*"]
+    T --> V["xBRIEF metadata<br/>project policy, lifecycle state"]
     V --> R["RFC2119 rules<br/>AGENTS.md, main.md, skills"]
     R --> P["Plain prose<br/>explanation and rationale"]
 ```
 
-This is the current `main.md` rule-authority axiom: deterministic > Taskfile > vBRIEF > RFC2119 > prose. Prose explains rules but does not outrank executable gates.
+This is the current `main.md` rule-authority axiom: deterministic > Taskfile > xBRIEF > RFC2119 > prose. Prose explains rules but does not outrank executable gates.
 
 Personal preferences from `USER.md` still matter, but when a rule has an executable check, the check is the rule body. For example, branch policy is described in prose, exposed by `task verify:branch`, enforced by hooks, and repeated in CI.
 
@@ -68,19 +70,19 @@ Personal preferences from `USER.md` still matter, but when a rule has an executa
 
 Requirements describe what to build. Rules describe how agents should behave while doing the work.
 
-- `vbrief/specification.vbrief.json` is the project specification source of truth.
+- `xbrief/specification.xbrief.json` is the project specification source of truth.
 - `SPECIFICATION.md` is a rendered view generated by `task spec:render`.
 - `PRD.md` is a rendered stakeholder view generated by `task prd:render`.
 - `ROADMAP.md` is a rendered backlog view generated by roadmap tasks.
-- Scope vBRIEFs live in `vbrief/{proposed,pending,active,completed,cancelled}/`.
+- Scope xBRIEFs live in `xbrief/{proposed,pending,active,completed,cancelled}/`.
 
-Generated markdown files carry machine-generated banners. Edit the vBRIEF source first, then render.
+Generated markdown files carry machine-generated banners. Edit the xBRIEF source first, then render.
 
 ```mermaid
 flowchart LR
-    S["vbrief/specification.vbrief.json"] -->|"task spec:render"| SM["SPECIFICATION.md"]
+    S["xbrief/specification.xbrief.json"] -->|"task spec:render"| SM["SPECIFICATION.md"]
     S -->|"task prd:render"| PRD["PRD.md"]
-    L["Lifecycle scope vBRIEFs"] -->|"task roadmap:render"| RM["ROADMAP.md"]
+    L["Lifecycle scope xBRIEFs"] -->|"task roadmap:render"| RM["ROADMAP.md"]
     P["PROJECT-DEFINITION<br/>codeStructure"] -->|"task codebase:map"| MAP[".planning/codebase/MAP.md"]
     Skills["Skills and standards"] -->|"task packs:render"| Packs["Rendered content packs"]
 ```
@@ -94,7 +96,7 @@ flowchart LR
 | Python tooling | `scripts/*.py`, `run`, `run.py`, `run.bat` | Validators, renderers, lifecycle tools, issue/cache/triage automation, doctor/session gates, codebase provider contracts, and compatibility routing. |
 | TypeScript engine | `packages/`, `package.json`, `pnpm-workspace.yaml`, `tsconfig*.json`, `vitest.config.ts` | Migrated deterministic gates, CLI shims, and Python-oracle parity harnesses for the #1530 engine migration. |
 | Go installer (legacy bridge) | `cmd/deft-install/`, `go.mod` | Frozen cross-platform tarball deposit for offline/air-gapped and legacy layout migration; superseded by TS-native `directive init` / `directive update` for normal installs (#1942). |
-| vBRIEF metadata | `vbrief/**/*.json`, `vbrief/**/*.md` | Project identity, scope lifecycle, schemas, policy, specification source, and authored `codeStructure`. |
+| xBRIEF metadata | `xbrief/**/*.json`, `xbrief/**/*.md` | Project identity, scope lifecycle, schemas, policy, specification source, and authored `codeStructure`. |
 | Content packs | `packs/` | Curated agent memory packs rendered and checked through `task packs:*`. |
 | CI/release automation | `.github/`, `.githooks/`, `tasks/pr.yml`, `tasks/release.yml`, release scripts | Branch policy, PR readiness, release, publish, rollback, and local hook enforcement. |
 | Tests | `tests/` | CLI, content, contract, lifecycle, and regression coverage. |
@@ -109,14 +111,14 @@ Distribution splits into two npm packages and a thin local materialization step.
 ```mermaid
 flowchart LR
     npm["npm i -g @deftai/directive"] --> Global["Global npm tree<br/>node_modules/@deftai/directive + @deftai/directive-content"]
-    Global -->|"directive init / update<br/>resolve-and-copy (no re-download)"| Proj["Project ./.deft/core/<br/>+ AGENTS.md, vbrief/, .githooks/"]
+    Global -->|"directive init / update<br/>resolve-and-copy (no re-download)"| Proj["Project ./.deft/core/<br/>+ AGENTS.md, xbrief/, .githooks/"]
     Global --> Gate["Frozen Go gate (bundled)<br/>node-independent pre-engine health probe"]
     Gate -->|"health probe / legacy layout reshape"| Proj
 ```
 
 Key properties of the current model:
 
-- **Global install ≠ project deposit.** `npm i -g` only places versioned files in the global npm tree; it never touches a project directory. `directive init` is the materialization step that **resolves the locally-installed `@deftai/directive-content` and copies its tree** into this project's `./.deft/core/`, then renders `AGENTS.md`, scaffolds `vbrief/`, wires `.githooks/` when present in the content tree, deposits #1430 neutralization, and stamps provenance. `directive update` refreshes the same way. This is **resolve-and-copy, not re-download** — the on-machine content package is the source (the `node_modules` model).
+- **Global install ≠ project deposit.** `npm i -g` only places versioned files in the global npm tree; it never touches a project directory. `directive init` is the materialization step that **resolves the locally-installed `@deftai/directive-content` and copies its tree** into this project's `./.deft/core/`, then renders `AGENTS.md`, scaffolds `xbrief/`, wires `.githooks/` when present in the content tree, deposits #1430 neutralization, and stamps provenance. `directive update` refreshes the same way. This is **resolve-and-copy, not re-download** — the on-machine content package is the source (the `node_modules` model).
 - **`.deft/core/` is gitignored** on greenfield installs and is reconstituted by `directive init` on fresh checkouts (like `node_modules`). Existing tracked deposits are migrated to hybrid by [#1941](https://github.com/deftai/directive/issues/1941).
 - **Per-project version pinning** via `devDependencies` + `npx` gives teams/CI a reproducible engine↔content pair.
 - **Frozen Go binary** stays bundled per-platform inside the npm package, but only as a **node-independent, read-only health gate** (every-session pre-engine probe) and a **legacy on-disk-layout reshaper**. It no longer fetches payloads or performs first-start installs (#1933).
@@ -128,8 +130,8 @@ Key properties of the current model:
 The command graph is broad; use `task --list` for the exact current surface. The important architectural groups are:
 
 - `task check`, `task check:framework-source`, `task check:consumer`, `task check:slow` for quality gates.
-- `task verify:*` for branch, hooks, encoding, vBRIEF conformance, session ritual, story readiness, capacity, cache freshness, and investigation gates.
-- `task vbrief:*`, `task spec:*`, `task project:*`, `task roadmap:*`, and `task prd:*` for source validation and generated views.
+- `task verify:*` for branch, hooks, encoding, xBRIEF conformance, session ritual, story readiness, capacity, cache freshness, and investigation gates.
+- `task xbrief:*`, `task spec:*`, `task project:*`, `task roadmap:*`, and `task prd:*` for source validation and generated views.
 - `task scope:*` and `task scope:undo:*` for lifecycle movement.
 - `task triage:*` and `task cache:*` for cache-backed backlog work.
 - `task codebase:*` for authored `codeStructure` validation, default extraction, provider-map validation, MAP generation, and projection registry lookup.
@@ -152,7 +154,7 @@ flowchart TD
     State --> Intent["Implementation intent or start_agent dispatch?"]
     Intent --> Gated["task verify:session-ritual -- --tier=gated"]
     Gated --> Story["task verify:story-ready<br/>active scope and clean/allowed tree"]
-    Story --> Preflight["task vbrief:preflight<br/>active + running"]
+    Story --> Preflight["task xbrief:preflight<br/>active + running"]
     Preflight --> Cache["task verify:cache-fresh"]
     Cache --> Branch["task verify:branch"]
     Branch --> Work["Implement or dispatch agent"]
@@ -162,15 +164,15 @@ The ordering is architectural, not ceremony. Each gate can assume the previous o
 
 ## Lifecycle State
 
-Work moves through vBRIEF lifecycle folders:
+Work moves through xBRIEF lifecycle folders:
 
-- `vbrief/proposed/` -- candidate work.
-- `vbrief/pending/` -- accepted backlog.
-- `vbrief/active/` -- running work.
-- `vbrief/completed/` -- completed work.
-- `vbrief/cancelled/` -- rejected or abandoned work.
+- `xbrief/proposed/` -- candidate work.
+- `xbrief/pending/` -- accepted backlog.
+- `xbrief/active/` -- running work.
+- `xbrief/completed/` -- completed work.
+- `xbrief/cancelled/` -- rejected or abandoned work.
 
-The folder and `plan.status` must agree. The scope tasks update both together. `task verify:story-ready` and `task vbrief:preflight` are the implementation-intent gates for active work.
+The folder and `plan.status` must agree. The scope tasks update both together. `task verify:story-ready` and `task xbrief:preflight` are the implementation-intent gates for active work.
 
 ```mermaid
 flowchart LR
@@ -200,14 +202,14 @@ flowchart TD
     Fetch --> Cache[".deft-cache/<source>/<key>"]
     Cache --> Queue["task triage:queue<br/>ranked candidates"]
     Queue --> Decision{"Operator or agent decision"}
-    Decision -->|"accept"| Scope["task triage:accept<br/>proposed scope vBRIEF"]
-    Decision -->|"reject/defer/needs-ac"| Audit["vbrief/.eval<br/>decision audit"]
+    Decision -->|"accept"| Scope["task triage:accept<br/>proposed scope xBRIEF"]
+    Decision -->|"reject/defer/needs-ac"| Audit["xbrief/.eval<br/>decision audit"]
     Scope --> Audit
 ```
 
 ## Codebase Architecture Metadata
 
-`vbrief/PROJECT-DEFINITION.vbrief.json` contains `plan.architecture.codeStructure`, the authored codebase-structure profile. That profile is the durable source of truth for intended module boundaries.
+`xbrief/PROJECT-DEFINITION.xbrief.json` contains `plan.architecture.codeStructure`, the authored codebase-structure profile. That profile is the durable source of truth for intended module boundaries.
 
 Implemented today:
 
@@ -232,6 +234,6 @@ The generated MAP is a projection. It must not become the canonical architecture
 - `SPECIFICATION.md`, `PRD.md`, and `ROADMAP.md` are generated views.
 - `.planning/codebase/MAP.md` is a generated codebase orientation projection.
 - `.planning/codebase/ARCHITECTURE.md`, `CONVENTIONS.md`, and related files are historical planning notes unless they carry a generated-source banner.
-- `PROJECT.md` is a deprecated redirect; current project identity lives in `vbrief/PROJECT-DEFINITION.vbrief.json`.
+- `PROJECT.md` is a deprecated redirect; current project identity lives in `xbrief/PROJECT-DEFINITION.xbrief.json`.
 
-When in doubt, prefer the vBRIEF source and the Taskfile gate over a prose file.
+When in doubt, prefer the xBRIEF source and the Taskfile gate over a prose file.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ Rules use the strongest applicable layer:
 
 ```mermaid
 flowchart TD
-    D["Deterministic checks<br/>tests, scripts, hooks, CI"] --> T["Taskfile targets<br/>task check, verify:*, xbrief:*"]
+    D["Deterministic checks<br/>tests, scripts, hooks, CI"] --> T["Taskfile targets<br/>task check, verify:*, vbrief:validate, xbrief:preflight"]
     T --> V["xBRIEF metadata<br/>project policy, lifecycle state"]
     V --> R["RFC2119 rules<br/>AGENTS.md, main.md, skills"]
     R --> P["Plain prose<br/>explanation and rationale"]
@@ -131,7 +131,7 @@ The command graph is broad; use `task --list` for the exact current surface. The
 
 - `task check`, `task check:framework-source`, `task check:consumer`, `task check:slow` for quality gates.
 - `task verify:*` for branch, hooks, encoding, xBRIEF conformance, session ritual, story readiness, capacity, cache freshness, and investigation gates.
-- `task xbrief:*`, `task spec:*`, `task project:*`, `task roadmap:*`, and `task prd:*` for source validation and generated views.
+- `task vbrief:validate`, `task xbrief:preflight` (prefer; `vbrief:preflight` remains as alias), `task spec:*`, `task project:*`, `task roadmap:*`, and `task prd:*` for source validation and generated views.
 - `task scope:*` and `task scope:undo:*` for lifecycle movement.
 - `task triage:*` and `task cache:*` for cache-backed backlog work.
 - `task codebase:*` for authored `codeStructure` validation, default extraction, provider-map validation, MAP generation, and projection registry lookup.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -26,7 +26,7 @@ Taskfile is the discoverable command contract for the framework. Start with:
 ```bash
 task --list
 task check
-task xbrief:validate
+task vbrief:validate
 task codebase:validate-structure
 ```
 
@@ -90,7 +90,7 @@ Good specifications expose decisions, dependencies, non-goals, and acceptance cr
 Deft favors enforceable rules over remembered rules:
 
 1. Deterministic checks: tests, scripts, hooks, CI.
-2. Taskfile targets: `task check`, `task verify:*`, `task xbrief:*`.
+2. Taskfile targets: `task check`, `task verify:*`, `task vbrief:validate`, `task xbrief:preflight` (and related lifecycle verbs).
 3. xBRIEF policy and lifecycle metadata.
 4. RFC2119 instructions in `AGENTS.md`, skills, and standards.
 5. Plain prose and rationale.
@@ -108,11 +108,11 @@ task check:framework-source
 task check:consumer
 task check:slow
 task verify:session-ritual
-task verify:story-ready -- --xbrief-path <path>
+task verify:story-ready -- --vbrief-path <path>
 task xbrief:preflight -- <path>
 ```
 
-New source files require forward coverage. Documentation-only changes still need validation appropriate to the touched surface, usually `task xbrief:validate`, `task codebase:validate-structure` when architecture metadata changes, and enough content checks to catch broken links or stale generated files.
+New source files require forward coverage. Documentation-only changes still need validation appropriate to the touched surface, usually `task vbrief:validate`, `task codebase:validate-structure` when architecture metadata changes, and enough content checks to catch broken links or stale generated files.
 
 ## Test-Driven Development
 

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,8 +1,10 @@
 # Deft Key Concepts
 
-Core principles behind the current Deft workflow: Taskfile-first automation, vBRIEF as source of truth, deterministic gates, cache-backed triage, source/projection boundaries, and small auditable changes.
+Core principles behind the current Deft workflow: Taskfile-first automation, **xBRIEF** as durable work-state source of truth, deterministic gates, cache-backed triage, source/projection boundaries, and small auditable changes.
 
 > **See also**: [ARCHITECTURE.md](./ARCHITECTURE.md) | [FILES.md](./FILES.md) | [codebase-map-source-of-truth.md](./codebase-map-source-of-truth.md) | [directive-lifecycle.md](../content/docs/directive-lifecycle.md) | [../README.md](../README.md)
+
+> **Naming (#2907):** **xBRIEF** / `xbrief/` is the sole public canonical work-state name. **vBRIEF** / `vbrief/` is **legacy** (schema lineage, migrate paths, old extensions). Authoritative rename/history: [UPGRADING.md — xBRIEF rename](../content/UPGRADING.md#xbrief-rename-2034--2110--2907).
 
 ## From Vibe To Repeatable Practice
 
@@ -12,7 +14,7 @@ The current implementation expresses that idea with stronger machinery:
 
 - Modular guidance instead of one overloaded prompt.
 - Lazy loading instead of reading every standard every time.
-- vBRIEF state instead of transient chat memory.
+- xBRIEF state instead of transient chat memory.
 - Taskfile gates instead of "remember to run checks" prose.
 - Small, reversible scopes instead of unbounded work sessions.
 - Lessons, ideas, and suggestions that let the framework improve over time.
@@ -24,7 +26,7 @@ Taskfile is the discoverable command contract for the framework. Start with:
 ```bash
 task --list
 task check
-task vbrief:validate
+task xbrief:validate
 task codebase:validate-structure
 ```
 
@@ -43,7 +45,7 @@ flowchart LR
     Core --> Decide{"What kind of work?"}
     Decide -->|"Python code"| Py["languages/python.md"]
     Decide -->|"GitHub/PR work"| SCM["scm/github.md<br/>skills/deft-directive-pre-pr"]
-    Decide -->|"Spec or scope"| Strategy["strategies/interview.md<br/>vbrief/vbrief.md"]
+    Decide -->|"Spec or scope"| Strategy["strategies/interview.md<br/>xBRIEF lifecycle"]
     Decide -->|"Release"| Release["skills/deft-directive-release"]
     Py --> Gate["task check"]
     SCM --> Gate
@@ -53,26 +55,28 @@ flowchart LR
 
 This keeps context focused while preserving consistent standards across projects.
 
-## vBRIEF Is The Durable State
+## xBRIEF Is The Durable State
 
-Deft uses vBRIEF files for project and work state:
+Deft uses **xBRIEF** files for project and work state (public canonical name; on-disk root `xbrief/`):
 
-- `vbrief/PROJECT-DEFINITION.vbrief.json` -- project identity, policy, scope registry, and authored architecture metadata.
-- `vbrief/specification.vbrief.json` -- project specification source.
-- `vbrief/plan.vbrief.json` -- tactical session plan when present.
-- `vbrief/continue.vbrief.json` -- interruption recovery checkpoint when present.
-- `vbrief/{proposed,pending,active,completed,cancelled}/` -- scope lifecycle folders.
+- `xbrief/PROJECT-DEFINITION.xbrief.json` -- project identity, policy, scope registry, and authored architecture metadata.
+- `xbrief/specification.xbrief.json` -- project specification source.
+- `xbrief/plan.xbrief.json` -- tactical session plan when present.
+- `xbrief/continue.xbrief.json` -- interruption recovery checkpoint when present.
+- `xbrief/{proposed,pending,active,completed,cancelled}/` -- scope lifecycle folders.
 
-Markdown files such as `SPECIFICATION.md`, `PRD.md`, and `ROADMAP.md` are generated views. The safe pattern is: edit vBRIEF source, run the render task, then validate.
+Markdown files such as `SPECIFICATION.md`, `PRD.md`, and `ROADMAP.md` are generated views. The safe pattern is: edit xBRIEF source, run the render task, then validate.
+
+**Legacy:** `vbrief/`, `*.vbrief.json`, and older `vbrief:*` task aliases remain read-accepted until `deft migrate:xbrief` (or `task migrate:xbrief`). Do not teach them as the current model.
 
 ## Spec-Driven Development
 
-Deft still treats specification as a first-class act. The exact storage format evolved from early markdown/spec examples into vBRIEF sources and lifecycle scopes, but the core idea is unchanged: clarify work before implementation so agents can execute with less ambiguity.
+Deft still treats specification as a first-class act. The exact storage format evolved from early markdown/spec examples into xBRIEF sources and lifecycle scopes, but the core idea is unchanged: clarify work before implementation so agents can execute with less ambiguity.
 
 ```mermaid
 flowchart LR
     Idea["Idea or issue"] --> Interview["Interview, discuss, research, or triage"]
-    Interview --> Spec["vBRIEF source<br/>specification or scope"]
+    Interview --> Spec["xBRIEF source<br/>specification or scope"]
     Spec --> Plan["Accepted scope<br/>pending or active"]
     Plan --> Build["Implementation"]
     Build --> Render["Rendered views<br/>SPECIFICATION, PRD, ROADMAP"]
@@ -86,8 +90,8 @@ Good specifications expose decisions, dependencies, non-goals, and acceptance cr
 Deft favors enforceable rules over remembered rules:
 
 1. Deterministic checks: tests, scripts, hooks, CI.
-2. Taskfile targets: `task check`, `task verify:*`, `task vbrief:*`.
-3. vBRIEF policy and lifecycle metadata.
+2. Taskfile targets: `task check`, `task verify:*`, `task xbrief:*`.
+3. xBRIEF policy and lifecycle metadata.
 4. RFC2119 instructions in `AGENTS.md`, skills, and standards.
 5. Plain prose and rationale.
 
@@ -95,7 +99,7 @@ This keeps high-impact behavior out of fragile narrative-only guidance.
 
 ## Quality Gates
 
-`task check` is the directive repo's pre-commit gate. It combines regression checks with structural checks such as branch policy, encoding, vBRIEF validation, and content tests.
+`task check` is the directive repo's pre-commit gate. It combines regression checks with structural checks such as branch policy, encoding, xBRIEF validation, and content tests.
 
 Use narrower gates while developing:
 
@@ -104,11 +108,11 @@ task check:framework-source
 task check:consumer
 task check:slow
 task verify:session-ritual
-task verify:story-ready -- --vbrief-path <path>
-task vbrief:preflight -- <path>
+task verify:story-ready -- --xbrief-path <path>
+task xbrief:preflight -- <path>
 ```
 
-New source files require forward coverage. Documentation-only changes still need validation appropriate to the touched surface, usually `task vbrief:validate`, `task codebase:validate-structure` when architecture metadata changes, and enough content checks to catch broken links or stale generated files.
+New source files require forward coverage. Documentation-only changes still need validation appropriate to the touched surface, usually `task xbrief:validate`, `task codebase:validate-structure` when architecture metadata changes, and enough content checks to catch broken links or stale generated files.
 
 ## Test-Driven Development
 
@@ -125,7 +129,7 @@ For source changes, that usually means adding or updating tests before relying o
 
 ## Scope Lifecycle
 
-Work is represented as a scope vBRIEF. The normal path is:
+Work is represented as a scope xBRIEF. The normal path is:
 
 ```mermaid
 flowchart LR
@@ -157,9 +161,9 @@ flowchart TD
     External["External issue body<br/>untrusted data"] --> Cache["Content cache"]
     Cache --> Queue["triage queue"]
     Queue --> Decision{"Decision"}
-    Decision -->|"accept"| VBrief["proposed scope vBRIEF"]
-    Decision -->|"reject/defer/needs-ac"| Eval["vbrief/.eval audit log"]
-    VBrief --> Eval
+    Decision -->|"accept"| XBrief["proposed scope xBRIEF"]
+    Decision -->|"reject/defer/needs-ac"| Eval["xbrief/.eval audit log"]
+    XBrief --> Eval
 ```
 
 ## Source Of Truth Vs Projection
@@ -168,8 +172,8 @@ Deft keeps authored source and generated views separate.
 
 | Source of truth | Projection |
 | --- | --- |
-| `vbrief/specification.vbrief.json` | `SPECIFICATION.md`, `PRD.md` |
-| lifecycle scope vBRIEFs | `ROADMAP.md` |
+| `xbrief/specification.xbrief.json` | `SPECIFICATION.md`, `PRD.md` |
+| lifecycle scope xBRIEFs | `ROADMAP.md` |
 | `plan.architecture.codeStructure` | `.planning/codebase/MAP.md` |
 | skills and standards | rendered content packs |
 
@@ -212,7 +216,7 @@ Deft's early docs emphasized self-improving guidelines. That remains true, but t
 ```mermaid
 flowchart TD
     Work["Daily work"] --> Lesson["Observed pattern or failure"]
-    Lesson --> Record["meta/lessons, ideas, suggestions<br/>or a scope vBRIEF"]
+    Lesson --> Record["meta/lessons, ideas, suggestions<br/>or a scope xBRIEF"]
     Record --> Rule{"Should this become enforceable?"}
     Rule -->|"yes"| Strong["Task, test, hook, schema, or skill rule"]
     Rule -->|"not yet"| Prose["Documentation or content-pack guidance"]
@@ -226,7 +230,7 @@ The important distinction is promotion. A useful observation can start as prose,
 
 For implementation work:
 
-1. Resolve or create a scope vBRIEF.
+1. Resolve or create a scope xBRIEF.
 2. Promote and activate it.
 3. Run story/session preflight gates.
 4. Implement the smallest coherent change.
@@ -237,7 +241,7 @@ For implementation work:
 For documentation work:
 
 1. Identify the authoritative source.
-2. Update source docs or vBRIEF narratives.
+2. Update source docs or xBRIEF narratives.
 3. Regenerate derived views.
-4. Validate links, vBRIEF shape, and any touched architecture profile.
+4. Validate links, xBRIEF shape, and any touched architecture profile.
 5. Keep stale historical notes clearly labeled.

--- a/packages/core/src/content-contracts/skills/glossary.test.ts
+++ b/packages/core/src/content-contracts/skills/glossary.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { readRepoFile, repoFileExists } from "./helpers.js";
 
-/** Port of tests/content/test_glossary.py (#1838 #457) */
+/** Port of tests/content/test_glossary.py (#1838 #457); xbrief public canon (#2907) */
 
 const REQUIRED_TERMS = [
-  "Scope vBRIEF",
+  "Scope xBRIEF",
   "Lifecycle folder",
   "Plan-level narrative",
   "Item-level narrative",
@@ -55,6 +55,16 @@ describe("test_glossary", () => {
         const block = stop === -1 ? remainder : remainder.slice(0, stop);
         expect(block).toContain("](");
       }
+    });
+
+    it("lifecycle_terms_use_xbrief_public_canon", () => {
+      expect(glossaryText).toContain("## xBRIEF Lifecycle Terms");
+      expect(glossaryText).toContain("xbrief/");
+      expect(glossaryText).toContain(".xbrief.json");
+      expect(glossaryText).toMatch(/\*\*vBRIEF \(legacy\)\*\*/);
+      expect(glossaryText).toContain("#2907");
+      // Current-guidance term names must not keep Scope vBRIEF as the bold canon
+      expect(glossaryText).not.toContain("**Scope vBRIEF**");
     });
   });
 

--- a/packages/core/src/content-contracts/skills/xbrief_public_canon.test.ts
+++ b/packages/core/src/content-contracts/skills/xbrief_public_canon.test.ts
@@ -42,6 +42,10 @@ function currentGuidanceVbriefHits(text: string, rel: string): string[] {
     ) {
       continue;
     }
+    // Shipped Taskfile/CLI ids still use vbrief:validate / --vbrief-path even when product prose says xBRIEF.
+    if (/task vbrief:|vbrief:validate|vbrief:preflight|--vbrief-path|verify:vbrief/.test(line)) {
+      continue;
+    }
     // Schema package still lives under content/vbrief/ (historical path); links are not current product naming.
     if (
       /vbrief\/vbrief\.md|content\/vbrief\/|vbrief\/schemas\//.test(line) &&

--- a/packages/core/src/content-contracts/skills/xbrief_public_canon.test.ts
+++ b/packages/core/src/content-contracts/skills/xbrief_public_canon.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { REPO_ROOT, readRepoFile } from "./helpers.js";
@@ -43,7 +43,10 @@ function currentGuidanceVbriefHits(text: string, rel: string): string[] {
       continue;
     }
     // Schema package still lives under content/vbrief/ (historical path); links are not current product naming.
-    if (/vbrief\/vbrief\.md|content\/vbrief\/|vbrief\/schemas\//.test(line) && !/\bvbrief\/(?:proposed|pending|active)\//.test(line)) {
+    if (
+      /vbrief\/vbrief\.md|content\/vbrief\/|vbrief\/schemas\//.test(line) &&
+      !/\bvbrief\/(?:proposed|pending|active)\//.test(line)
+    ) {
       continue;
     }
     // Table header row in UPGRADING that maps Legacy → Current is OK

--- a/packages/core/src/content-contracts/skills/xbrief_public_canon.test.ts
+++ b/packages/core/src/content-contracts/skills/xbrief_public_canon.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { REPO_ROOT, readRepoFile } from "./helpers.js";
+
+/**
+ * #2907 — xbrief is the sole public canonical work-state name in current
+ * product guidance. vBRIEF may appear only when labeled legacy/historical
+ * or on migrate/archive surfaces.
+ */
+
+const PUBLIC_GUIDANCE_REL = [
+  "docs/CONCEPTS.md",
+  "docs/ARCHITECTURE.md",
+  "README.md",
+  "content/docs/getting-started.md",
+  "content/glossary.md",
+  "content/UPGRADING.md",
+] as const;
+
+function readRoot(rel: string): string {
+  if (rel.startsWith("content/")) {
+    return readRepoFile(rel.slice("content/".length));
+  }
+  const abs = join(REPO_ROOT, rel);
+  expect(existsSync(abs), `missing ${rel}`).toBe(true);
+  return readFileSync(abs, "utf8").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/** Lines that still teach vBRIEF/vbrief as present-day work-state without legacy framing. */
+function currentGuidanceVbriefHits(text: string, rel: string): string[] {
+  const hits: string[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (!/vBRIEF|vbrief/.test(line)) continue;
+    // Allow explicitly legacy / historical / migrate / alias framing
+    if (
+      /legacy|historical|history|migrate:vbrief|migrate:xbrief|deprecated|back-compat|backcompat|alias|rename|#2034|#2110|#2907|x-vbrief|schema lineage|schema-lineage|schema detail|schema package|read-accepted|until you run|until `deft migrate/i.test(
+        line,
+      )
+    ) {
+      continue;
+    }
+    // Schema package still lives under content/vbrief/ (historical path); links are not current product naming.
+    if (/vbrief\/vbrief\.md|content\/vbrief\/|vbrief\/schemas\//.test(line) && !/\bvbrief\/(?:proposed|pending|active)\//.test(line)) {
+      continue;
+    }
+    // Table header row in UPGRADING that maps Legacy → Current is OK
+    if (rel.includes("UPGRADING") && /Legacy \(historical\)|Current public canon/.test(line)) {
+      continue;
+    }
+    hits.push(`${rel}:${i + 1}: ${line.trim().slice(0, 160)}`);
+  }
+  return hits;
+}
+
+describe("xbrief_public_canon #2907", () => {
+  it("public_guidance_files_exist", () => {
+    for (const rel of PUBLIC_GUIDANCE_REL) {
+      if (rel.startsWith("content/")) {
+        expect(existsSync(join(REPO_ROOT, "content", rel.slice("content/".length)))).toBe(true);
+      } else {
+        expect(existsSync(join(REPO_ROOT, rel))).toBe(true);
+      }
+    }
+  });
+
+  it("concepts_and_architecture_teach_xbrief_not_vbrief_as_current", () => {
+    const concepts = readRoot("docs/CONCEPTS.md");
+    const arch = readRoot("docs/ARCHITECTURE.md");
+    for (const text of [concepts, arch]) {
+      expect(text).toMatch(/xBRIEF/i);
+      expect(text).toContain("xbrief/");
+      expect(text).toContain("#2907");
+    }
+    expect(concepts).toMatch(/xBRIEF Is The Durable State/i);
+    expect(currentGuidanceVbriefHits(concepts, "docs/CONCEPTS.md")).toEqual([]);
+    expect(currentGuidanceVbriefHits(arch, "docs/ARCHITECTURE.md")).toEqual([]);
+  });
+
+  it("readme_current_paths_are_xbrief", () => {
+    const readme = readRoot("README.md");
+    expect(readme).toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+    expect(readme).toContain("xbrief/proposed/");
+    expect(readme).toContain("scope xBRIEF");
+    expect(readme).not.toContain("vbrief/PROJECT-DEFINITION.vbrief.json");
+    expect(readme).not.toContain("vbrief/proposed/");
+    expect(currentGuidanceVbriefHits(readme, "README.md")).toEqual([]);
+  });
+
+  it("glossary_and_upgrading_carry_legacy_map", () => {
+    const glossary = readRoot("content/glossary.md");
+    const upgrading = readRoot("content/UPGRADING.md");
+    expect(glossary).toContain("xBRIEF Lifecycle Terms");
+    expect(glossary).toMatch(/vBRIEF \(legacy\)/);
+    expect(upgrading).toContain("xBRIEF rename");
+    expect(upgrading).toContain("#2907");
+    expect(upgrading).toContain("deft migrate:xbrief");
+    expect(upgrading).toMatch(/sole public|public canon|Public product voice uses \*\*xBRIEF\*\*/i);
+    expect(currentGuidanceVbriefHits(glossary, "content/glossary.md")).toEqual([]);
+    // UPGRADING retains historical version notes that mention vbrief paths by design;
+    // the authoritative rename section must state public canon + legacy map (#2907).
+    const renameIdx = upgrading.indexOf("xBRIEF rename");
+    expect(renameIdx).toBeGreaterThanOrEqual(0);
+    const renameSection = upgrading.slice(renameIdx, renameIdx + 2500);
+    expect(renameSection).toContain("legacy");
+    expect(renameSection).toContain("xbrief/");
+    expect(renameSection).toContain("vbrief/");
+  });
+
+  it("getting_started_uses_xbrief_lifecycle", () => {
+    const gs = readRoot("content/docs/getting-started.md");
+    expect(gs).toContain("xbrief/");
+    expect(gs).toMatch(/xBRIEF/i);
+    expect(currentGuidanceVbriefHits(gs, "content/docs/getting-started.md")).toEqual([]);
+  });
+});

--- a/packages/core/src/content-contracts/standards/readme_brownfield.test.ts
+++ b/packages/core/src/content-contracts/standards/readme_brownfield.test.ts
@@ -19,17 +19,18 @@ function gitignoreClaim(): string {
 
 describe("test_readme_brownfield.py", () => {
   describe("TestReadmeVbriefCentric", () => {
+    // #2907: public README teaches xbrief sole canon (vBRIEF is legacy elsewhere).
     it("test_setup_step_references_vbrief_project_definition", () => {
-      expect(readme()).toContain("vbrief/PROJECT-DEFINITION.vbrief.json");
+      expect(readme()).toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
     });
     it("test_scope_vbrief_section_replaces_specification_md_language", () => {
       const content = readme();
-      expect(content).toContain("Generate a Scope vBRIEF");
+      expect(content).toContain("Generate a Scope xBRIEF");
       expect(content).not.toContain("creating a `SPECIFICATION.md`");
     });
     it("test_build_example_reads_project_definition_not_specification", () => {
       const content = readme();
-      expect(content).toContain("Read vbrief/PROJECT-DEFINITION.vbrief.json");
+      expect(content).toContain("Read xbrief/PROJECT-DEFINITION.xbrief.json");
       expect(content).not.toContain("Read SPECIFICATION.md and implement");
     });
     it("test_source_of_truth_note_exists", () => {
@@ -41,8 +42,8 @@ describe("test_readme_brownfield.py", () => {
       const m = readme().match(/### Rule Hierarchy\s*\n(.+?)(?=\n### |\n## )/s);
       expect(m).not.toBeNull();
       const section = m?.[1] ?? "";
-      expect(section).toContain("vbrief/PROJECT-DEFINITION.vbrief.json");
-      expect(section).toContain("vbrief/specification.vbrief.json");
+      expect(section).toContain("xbrief/PROJECT-DEFINITION.xbrief.json");
+      expect(section).toContain("xbrief/specification.xbrief.json");
     });
     it("test_brownfield_link_from_readme", () => {
       expect(readme()).toContain("docs/BROWNFIELD.md");

--- a/packages/core/src/policy/no-deft-directive.test.ts
+++ b/packages/core/src/policy/no-deft-directive.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
 import {
@@ -74,7 +74,8 @@ describe("detectNoDeftDirective (#2926)", () => {
 
   it("honors injectable seams without touching the filesystem", () => {
     const root = "/virtual/project";
-    const files = new Set([join(root, NO_DEFT_DIRECTIVE_FLAG_NAME)]);
+    // Flag path uses path.resolve (absolute); deposit probe uses path.join — match both (#2926 / win32).
+    const files = new Set([resolve(root, NO_DEFT_DIRECTIVE_FLAG_NAME)]);
     const dirs = new Set([join(root, CANONICAL_INSTALL_ROOT)]);
     const state = detectNoDeftDirective(root, {
       isFile: (p) => files.has(p),


### PR DESCRIPTION
## Summary

Make **xBRIEF** / `xbrief/` the sole public canonical work-state name. Mark **vBRIEF** as legacy in product guidance so agents and consumers no longer treat two present-day models as current (#2907).

## Changes

- README, CONCEPTS, ARCHITECTURE: current paths and vocabulary use `xbrief/` / `.xbrief.json` / scope xBRIEF
- Glossary: lifecycle terms rewritten under **xBRIEF**; **vBRIEF (legacy)** pointer
- UPGRADING: single authoritative rename/history map (#2034 / #2110 / #2907)
- Schema reference `content/vbrief/vbrief.md`: legacy/schema-lineage banner
- Content contracts: glossary terms + `xbrief_public_canon` guards; README brownfield expects xbrief
- CHANGELOG [Unreleased] cites #2907
- Tiny win32 test seam fix for `.no-deft-directive` injectable paths (unblocks local `task check:merge`)

Out of scope: `content/strategies/*` (owned by #2899 Graduation Wave A). Migrate paths and historical upgrade notes keep vbrief as labeled history.

## Test plan

- [x] `vitest` content-contracts (full) green
- [x] `xbrief_public_canon` + glossary contracts green
- [x] no-deft-directive seams test green on win32
- [ ] CI check:merge / framework-source

Closes #2907
