### PR TITLE
feat(hooks): pure classifier extraction + fixture skeleton (Phase A of #2950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Hooks pure classifier + host×OS×tool fixture skeleton (Phase A of #2950).** Extract `packages/core/src/hooks/classify/` (payload → tool identity + write intent + path set, no process I/O), including stdin parse (BOM strip, free-form ApplyPatch). Dispatcher is thin orchestration over classify for tool-name/path helpers; CLI `parsePayload` delegates to `parseHookStdin`. Shared fixture corpus under `packages/core/src/hooks/fixtures/` covers Cursor × win32/posix × Write/ApplyPatch/Task plus recent regression classes; coupled-surface rule documented in fixtures README. Implements Phase A of #2950 (epic remains open for Phase B/C).
+
 ### Changed
 
 ### Fixed

--- a/packages/cli/src/hook-dispatch.ts
+++ b/packages/cli/src/hook-dispatch.ts
@@ -11,6 +11,7 @@ import {
   isHookEvent,
   isHookHost,
   normalizeHookProjectRoot,
+  parseHookStdin,
   projectRootFromHookPayload,
   renderHostDecision,
 } from "@deftai/directive-core/hooks";
@@ -149,62 +150,19 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   return parsed;
 }
 
+/** @deprecated Prefer ParsedHookPayload from @deftai/directive-core/hooks (#2950). */
 export interface ParsedPayload {
   readonly payload: unknown;
   readonly context: HookPayloadContext;
 }
 
-const UTF8_BOM = "\uFEFF";
-const APPLY_PATCH_BEGIN_MARKER = "*** Begin Patch";
-/** Single-file Add/Update only — other *** … File: ops must fail closed (#2738 Greptile). */
-const APPLY_PATCH_MUTATION_LINE_RE =
-  /^\*\*\* (Add File|Update File|Delete File|Move File|Rename File): (.+)$/gm;
-
-function stripUtf8Bom(raw: string): string {
-  return raw.startsWith(UTF8_BOM) ? raw.slice(UTF8_BOM.length) : raw;
-}
-
-function trySynthesizeFreeFormApplyPatch(normalized: string): ParsedPayload | null {
-  if (!normalized.includes(APPLY_PATCH_BEGIN_MARKER)) return null;
-  const mutations: { op: string; path: string }[] = [];
-  for (const match of normalized.matchAll(APPLY_PATCH_MUTATION_LINE_RE)) {
-    const op = match[1];
-    const path = match[2]?.trim();
-    if (op === undefined || !path) continue;
-    mutations.push({ op, path });
-  }
-  if (mutations.length !== 1) return null;
-  const sole = mutations[0];
-  if (sole === undefined || (sole.op !== "Add File" && sole.op !== "Update File")) return null;
-  return {
-    payload: {
-      tool_name: "ApplyPatch",
-      tool_input: {
-        path: sole.path,
-        patch: normalized,
-      },
-    },
-    context: {},
-  };
-}
-
+/**
+ * Parse host hook stdin into payload + context.
+ * Pure implementation lives in core classify (`parseHookStdin`); CLI re-exports
+ * for backward-compatible imports in tests (#2734 / #2738 / #2950).
+ */
 export function parsePayload(raw: string): ParsedPayload {
-  if (raw.trim().length === 0) {
-    return { payload: {}, context: { stdinEmpty: true } };
-  }
-  const normalized = stripUtf8Bom(raw);
-  if (normalized.trim().length === 0) {
-    return { payload: {}, context: { stdinEmpty: true } };
-  }
-  try {
-    return { payload: JSON.parse(normalized) as unknown, context: {} };
-  } catch {
-    const synthesized = trySynthesizeFreeFormApplyPatch(normalized);
-    if (synthesized !== null) return synthesized;
-    // tool.before is installed only on direct-write matchers, so an unreadable
-    // payload becomes a missing-tool denial rather than a fail-open crash.
-    return { payload: {}, context: { parseFailed: true } };
-  }
+  return parseHookStdin(raw);
 }
 
 /**

--- a/packages/core/src/hooks/classify/classify.test.ts
+++ b/packages/core/src/hooks/classify/classify.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { fixtureCasesFor, HOOK_FIXTURE_CASES } from "../fixtures/index.js";
+import { classifyHookPayload } from "./classify.js";
+import { hookWriteTargetPath } from "./paths.js";
+import { parseHookStdin } from "./stdin.js";
+import { hookToolName } from "./tool-name.js";
+
+describe("classifyHookPayload (pure, #2950)", () => {
+  it("classifies Cursor Write without process I/O", () => {
+    const result = classifyHookPayload({
+      host: "cursor",
+      payload: {
+        tool_name: "Write",
+        tool_input: { contents: "x", path: "src/a.ts" },
+      },
+    });
+    expect(result).toMatchObject({
+      toolName: "Write",
+      writeIntent: "direct-write",
+      writeTargetPath: "src/a.ts",
+      paths: ["src/a.ts"],
+    });
+  });
+
+  it("infers Cursor tool name when omitted (#2628)", () => {
+    expect(
+      classifyHookPayload({
+        host: "cursor",
+        payload: { arguments: { contents: "x", path: "a.py" } },
+      }).toolName,
+    ).toBe("Write");
+  });
+
+  it("classifies Task as spawn intent", () => {
+    expect(
+      classifyHookPayload({
+        host: "cursor",
+        payload: { tool_name: "Task", tool_input: { prompt: "go" } },
+      }).writeIntent,
+    ).toBe("spawn");
+  });
+
+  it("parseHookStdin synthesizes free-form ApplyPatch (#2738)", () => {
+    const freeForm = [
+      "*** Begin Patch",
+      "*** Add File: xbrief/proposed/a.txt",
+      "+probe",
+      "*** End Patch",
+    ].join("\n");
+    const parsed = parseHookStdin(freeForm);
+    expect(parsed.context).toEqual({});
+    expect(classifyHookPayload({ host: "cursor", payload: parsed.payload })).toMatchObject({
+      toolName: "ApplyPatch",
+      writeIntent: "direct-write",
+      writeTargetPath: "xbrief/proposed/a.txt",
+    });
+  });
+
+  it("parseHookStdin tags empty and bad JSON", () => {
+    expect(parseHookStdin("")).toEqual({ payload: {}, context: { stdinEmpty: true } });
+    expect(parseHookStdin("{bad")).toEqual({ payload: {}, context: { parseFailed: true } });
+  });
+});
+
+describe("shared fixture corpus (#2950 Phase A)", () => {
+  it("includes Cursor × win32/posix × Write/ApplyPatch/Task coverage", () => {
+    const need = [
+      ["cursor", "posix", "Write"],
+      ["cursor", "win32", "Write"],
+      ["cursor", "posix", "ApplyPatch"],
+      ["cursor", "win32", "ApplyPatch"],
+      ["cursor", "posix", "Task"],
+      ["cursor", "win32", "Task"],
+    ] as const;
+    for (const [host, os, tool] of need) {
+      const hits = fixtureCasesFor({ host, os, tool });
+      expect(hits.length, `${host}/${os}/${tool}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("every fixture case matches pure classify (and stdin parse when raw)", () => {
+    expect(HOOK_FIXTURE_CASES.length).toBeGreaterThanOrEqual(12);
+
+    for (const c of HOOK_FIXTURE_CASES) {
+      let payload = c.payload;
+      if (c.raw !== undefined) {
+        const parsed = parseHookStdin(c.raw);
+        if (c.expected.stdinEmpty === true) {
+          expect(parsed.context.stdinEmpty, c.id).toBe(true);
+        }
+        if (c.expected.parseFailed === true) {
+          expect(parsed.context.parseFailed, c.id).toBe(true);
+        }
+        if (c.expected.parseFailed !== true && c.expected.stdinEmpty !== true) {
+          expect(parsed.context.parseFailed, c.id).toBeUndefined();
+          expect(parsed.context.stdinEmpty, c.id).toBeUndefined();
+        }
+        payload = parsed.payload;
+      }
+
+      const classified = classifyHookPayload({ host: c.host, payload });
+      expect(classified.toolName, c.id).toBe(c.expected.toolName);
+      expect(classified.writeIntent, c.id).toBe(c.expected.writeIntent);
+      expect(classified.writeTargetPath, c.id).toBe(c.expected.writeTargetPath);
+      // helpers stay consistent with classify
+      expect(hookToolName(payload, c.host), c.id).toBe(c.expected.toolName);
+      expect(hookWriteTargetPath(payload), c.id).toBe(c.expected.writeTargetPath);
+    }
+  });
+});

--- a/packages/core/src/hooks/classify/classify.ts
+++ b/packages/core/src/hooks/classify/classify.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure classify entry: payload → tool identity + write intent + paths (#2950 Phase A).
+ * No process I/O, no ritual/scope/policy evaluation.
+ */
+
+import { isDirectWriteTool, isMcpTool, isShellTool, isSpawnTool } from "../tools.js";
+import { hookPathSet, hookShellCommand, hookWriteTargetPath } from "./paths.js";
+import { hookPayloadTopLevelKeys } from "./payload.js";
+import { hookToolName } from "./tool-name.js";
+import type { ClassifyHookPayloadInput, HookClassification, HookWriteIntent } from "./types.js";
+
+function writeIntentForTool(toolName: string | null): HookWriteIntent {
+  if (toolName === null) return "unknown";
+  if (isDirectWriteTool(toolName)) return "direct-write";
+  if (isSpawnTool(toolName)) return "spawn";
+  if (isShellTool(toolName)) return "shell";
+  if (isMcpTool(toolName)) return "mcp";
+  return "other";
+}
+
+/**
+ * Classify a host hook payload without policy or filesystem access.
+ */
+export function classifyHookPayload(input: ClassifyHookPayloadInput): HookClassification {
+  const toolName = hookToolName(input.payload, input.host);
+  const writeTargetPath = hookWriteTargetPath(input.payload);
+  return {
+    toolName,
+    writeIntent: writeIntentForTool(toolName),
+    writeTargetPath,
+    shellCommand: hookShellCommand(input.payload),
+    topLevelKeys: hookPayloadTopLevelKeys(input.payload),
+    paths: hookPathSet(input.payload),
+  };
+}

--- a/packages/core/src/hooks/classify/index.test.ts
+++ b/packages/core/src/hooks/classify/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { classifyHookPayload, parseHookStdin } from "./index.js";
+
+describe("classify barrel (#2950)", () => {
+  it("re-exports pure entrypoints", () => {
+    expect(typeof classifyHookPayload).toBe("function");
+    expect(typeof parseHookStdin).toBe("function");
+    expect(
+      classifyHookPayload({ host: "cursor", payload: { tool_name: "Read" } }).writeIntent,
+    ).toBe("other");
+  });
+});

--- a/packages/core/src/hooks/classify/index.ts
+++ b/packages/core/src/hooks/classify/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure hook payload classification (#2950 Phase A).
+ *
+ * Payload → tool identity + write intent + path set. No process I/O.
+ * Policy / ritual / scope / permission emission stay in dispatcher + CLI adapter.
+ */
+
+export { classifyHookPayload } from "./classify.js";
+export {
+  hookMcpArgsText,
+  hookPathSet,
+  hookShellCommand,
+  hookWriteTargetPath,
+} from "./paths.js";
+export {
+  fieldPresent,
+  fieldString,
+  firstString,
+  hookPayloadTopLevelKeys,
+  record,
+  toolInputRecord,
+} from "./payload.js";
+export { parseHookStdin, stripUtf8Bom } from "./stdin.js";
+export {
+  hookToolName,
+  inferCursorDirectWriteToolName,
+  type MissingToolNameInput,
+  missingToolNameMessage,
+} from "./tool-name.js";
+export type {
+  ClassifyHookHost,
+  ClassifyHookPayloadInput,
+  HookClassification,
+  HookPayloadContext,
+  HookWriteIntent,
+  ParsedHookPayload,
+} from "./types.js";
+export { CLASSIFY_HOOK_HOSTS } from "./types.js";

--- a/packages/core/src/hooks/classify/paths.test.ts
+++ b/packages/core/src/hooks/classify/paths.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { hookMcpArgsText, hookPathSet, hookShellCommand, hookWriteTargetPath } from "./paths.js";
+
+describe("path/shell extractors (#2950)", () => {
+  it("hookWriteTargetPath reads nested and top-level spellings", () => {
+    expect(hookWriteTargetPath({ tool_input: { file_path: "a.ts" } })).toBe("a.ts");
+    expect(hookWriteTargetPath({ path: "b.ts" })).toBe("b.ts");
+    expect(hookWriteTargetPath({})).toBeNull();
+  });
+
+  it("hookShellCommand and hookMcpArgsText", () => {
+    expect(hookShellCommand({ tool_input: { command: "git push" } })).toBe("git push");
+    expect(hookMcpArgsText({ tool_input: { x: 1 } })).toBe('{"x":1}');
+    expect(hookPathSet({ tool_input: { path: "p.ts" } })).toEqual(["p.ts"]);
+  });
+});

--- a/packages/core/src/hooks/classify/paths.ts
+++ b/packages/core/src/hooks/classify/paths.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure write-target / shell-command extraction from host payloads (#2950).
+ * No process I/O — does not resolve against projectRoot or realpath.
+ */
+
+import { firstString, record, toolInputRecord } from "./payload.js";
+
+/**
+ * Best-effort write-target path from host PreToolUse payloads (#2625).
+ * Hosts disagree on nesting (`tool_input.file_path` vs top-level `path`).
+ */
+export function hookWriteTargetPath(payload: unknown): string | null {
+  const input = record(payload);
+  if (input === null) return null;
+  const toolInput = toolInputRecord(input);
+  return firstString([
+    toolInput?.file_path,
+    toolInput?.filePath,
+    toolInput?.path,
+    input.file_path,
+    input.filePath,
+    input.path,
+  ]);
+}
+
+/**
+ * Best-effort shell command string from host PreToolUse payloads (#2711).
+ * Hosts disagree on nesting (`tool_input.command` vs top-level `command`).
+ */
+export function hookShellCommand(payload: unknown): string | null {
+  const input = record(payload);
+  if (input === null) return null;
+  const toolInput = toolInputRecord(input);
+  return firstString([
+    toolInput !== null ? toolInput.command : null,
+    toolInput !== null ? toolInput.cmd : null,
+    toolInput !== null ? toolInput.shell_command : null,
+    input.command,
+    input.cmd,
+  ]);
+}
+
+/** Serialize tool args for MCP classification when nested objects are present (#2711). */
+export function hookMcpArgsText(payload: unknown): string | null {
+  const input = record(payload);
+  if (input === null) return null;
+  const toolInput = toolInputRecord(input);
+  if (toolInput === null) return null;
+  try {
+    return JSON.stringify(toolInput);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Collect distinct path-like strings from a payload for fixture assertions.
+ * Write target first when present; does not invent paths from free text.
+ */
+export function hookPathSet(payload: unknown): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (value: string | null): void => {
+    if (value === null || value.length === 0 || seen.has(value)) return;
+    seen.add(value);
+    out.push(value);
+  };
+  push(hookWriteTargetPath(payload));
+  return out;
+}

--- a/packages/core/src/hooks/classify/payload.test.ts
+++ b/packages/core/src/hooks/classify/payload.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  fieldPresent,
+  fieldString,
+  firstString,
+  hookPayloadTopLevelKeys,
+  record,
+  toolInputRecord,
+} from "./payload.js";
+
+describe("payload helpers (#2950)", () => {
+  it("record rejects null/array", () => {
+    expect(record(null)).toBeNull();
+    expect(record([])).toBeNull();
+    expect(record({ a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("firstString and fieldString trim non-empty", () => {
+    expect(firstString([null, "  x  ", "y"])).toBe("x");
+    expect(fieldString({ k: "  v  " }, "k")).toBe("v");
+    expect(fieldString({ k: "" }, "k")).toBeNull();
+    expect(fieldPresent({ k: undefined }, "k")).toBe(true);
+  });
+
+  it("toolInputRecord prefers nested tool_input", () => {
+    const input = {
+      tool_input: { path: "a.ts" },
+      arguments: { path: "b.ts" },
+    };
+    expect(toolInputRecord(input)?.path).toBe("a.ts");
+  });
+
+  it("hookPayloadTopLevelKeys sorts keys", () => {
+    expect(hookPayloadTopLevelKeys({ b: 1, a: 2 })).toEqual(["a", "b"]);
+    expect(hookPayloadTopLevelKeys(null)).toEqual([]);
+  });
+});

--- a/packages/core/src/hooks/classify/payload.ts
+++ b/packages/core/src/hooks/classify/payload.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure payload field accessors for host PreToolUse shapes (#2950).
+ * No process I/O.
+ */
+
+export function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** First non-empty trimmed string from candidates. */
+export function firstString(values: readonly unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+export function fieldPresent(input: Record<string, unknown>, key: string): boolean {
+  return key in input;
+}
+
+export function fieldString(input: Record<string, unknown>, key: string): string | null {
+  const value = input[key];
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  return null;
+}
+
+/**
+ * Nested tool input record across host spellings
+ * (`tool_input` / `arguments` / `tool_call.arguments` / …).
+ */
+export function toolInputRecord(payload: Record<string, unknown>): Record<string, unknown> | null {
+  const toolCall = record(payload.tool_call) ?? record(payload.toolCall);
+  return (
+    record(payload.tool_input) ??
+    record(payload.toolInput) ??
+    record(payload.input) ??
+    record(payload.arguments) ??
+    (toolCall !== null ? record(toolCall.arguments) : null)
+  );
+}
+
+export function hookPayloadTopLevelKeys(payload: unknown): string[] {
+  const input = record(payload);
+  if (input === null) return [];
+  return Object.keys(input).sort();
+}

--- a/packages/core/src/hooks/classify/stdin.test.ts
+++ b/packages/core/src/hooks/classify/stdin.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { parseHookStdin, stripUtf8Bom } from "./stdin.js";
+
+describe("parseHookStdin (#2734 / #2738 / #2950)", () => {
+  it("strips BOM and parses JSON", () => {
+    expect(stripUtf8Bom("\uFEFFhi")).toBe("hi");
+    const payload = { tool_name: "Write", tool_input: { path: "a.txt" } };
+    expect(parseHookStdin(`\uFEFF${JSON.stringify(payload)}`)).toEqual({
+      payload,
+      context: {},
+    });
+  });
+
+  it("tags empty and parse failures", () => {
+    expect(parseHookStdin("")).toEqual({ payload: {}, context: { stdinEmpty: true } });
+    expect(parseHookStdin("\uFEFF")).toEqual({ payload: {}, context: { stdinEmpty: true } });
+    expect(parseHookStdin("{bad")).toEqual({ payload: {}, context: { parseFailed: true } });
+  });
+
+  it("synthesizes single-file free-form ApplyPatch", () => {
+    const freeForm = ["*** Begin Patch", "*** Add File: only.txt", "+x", "*** End Patch"].join(
+      "\n",
+    );
+    expect(parseHookStdin(freeForm)).toEqual({
+      payload: {
+        tool_name: "ApplyPatch",
+        tool_input: { path: "only.txt", patch: freeForm },
+      },
+      context: {},
+    });
+  });
+});

--- a/packages/core/src/hooks/classify/stdin.ts
+++ b/packages/core/src/hooks/classify/stdin.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure stdin → payload parse for hook-dispatch (#2734 / #2738 / #2950).
+ * No process I/O — operates on an already-read string.
+ */
+
+import type { ParsedHookPayload } from "./types.js";
+
+const UTF8_BOM = "\uFEFF";
+const APPLY_PATCH_BEGIN_MARKER = "*** Begin Patch";
+/** Single-file Add/Update only — other *** … File: ops must fail closed (#2738 Greptile). */
+const APPLY_PATCH_MUTATION_LINE_RE =
+  /^\*\*\* (Add File|Update File|Delete File|Move File|Rename File): (.+)$/gm;
+
+export function stripUtf8Bom(raw: string): string {
+  return raw.startsWith(UTF8_BOM) ? raw.slice(UTF8_BOM.length) : raw;
+}
+
+function trySynthesizeFreeFormApplyPatch(normalized: string): ParsedHookPayload | null {
+  if (!normalized.includes(APPLY_PATCH_BEGIN_MARKER)) return null;
+  const mutations: { op: string; path: string }[] = [];
+  for (const match of normalized.matchAll(APPLY_PATCH_MUTATION_LINE_RE)) {
+    const op = match[1];
+    const path = match[2]?.trim();
+    if (op === undefined || !path) continue;
+    mutations.push({ op, path });
+  }
+  if (mutations.length !== 1) return null;
+  const sole = mutations[0];
+  if (sole === undefined || (sole.op !== "Add File" && sole.op !== "Update File")) return null;
+  return {
+    payload: {
+      tool_name: "ApplyPatch",
+      tool_input: {
+        path: sole.path,
+        patch: normalized,
+      },
+    },
+    context: {},
+  };
+}
+
+/**
+ * Parse host hook stdin text into a payload + parse context.
+ * Empty → stdinEmpty; invalid JSON without free-form ApplyPatch → parseFailed.
+ */
+export function parseHookStdin(raw: string): ParsedHookPayload {
+  if (raw.trim().length === 0) {
+    return { payload: {}, context: { stdinEmpty: true } };
+  }
+  const normalized = stripUtf8Bom(raw);
+  if (normalized.trim().length === 0) {
+    return { payload: {}, context: { stdinEmpty: true } };
+  }
+  try {
+    return { payload: JSON.parse(normalized) as unknown, context: {} };
+  } catch {
+    const synthesized = trySynthesizeFreeFormApplyPatch(normalized);
+    if (synthesized !== null) return synthesized;
+    // tool.before is installed only on direct-write matchers, so an unreadable
+    // payload becomes a missing-tool denial rather than a fail-open crash.
+    return { payload: {}, context: { parseFailed: true } };
+  }
+}

--- a/packages/core/src/hooks/classify/tool-name.test.ts
+++ b/packages/core/src/hooks/classify/tool-name.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { hookToolName, missingToolNameMessage } from "./tool-name.js";
+
+describe("hookToolName (#2628 / #2669 / #2950)", () => {
+  it("reads direct tool_name and nested tool_call", () => {
+    expect(hookToolName({ tool_name: "Write" })).toBe("Write");
+    expect(hookToolName({ tool_call: { name: "Task" } })).toBe("Task");
+  });
+
+  it("infers Cursor direct-write names when omitted", () => {
+    expect(hookToolName({ arguments: { contents: "x", path: "a.py" } }, "cursor")).toBe("Write");
+    expect(hookToolName({ tool_input: { path: "a.ts", patch: "diff" } }, "cursor")).toBe(
+      "ApplyPatch",
+    );
+    expect(hookToolName({ tool_input: { old_string: "a", new_string: "b" } }, "cursor")).toBe(
+      "StrReplace",
+    );
+  });
+
+  it("missingToolNameMessage distinguishes stdin-empty and keys", () => {
+    expect(
+      missingToolNameMessage({ host: "cursor", payload: {}, context: { stdinEmpty: true } }),
+    ).toContain("empty payload");
+    expect(missingToolNameMessage({ host: "cursor", payload: { host_version: "1" } })).toContain(
+      "host_version",
+    );
+    expect(missingToolNameMessage({ host: "claude", payload: {} })).toContain(
+      "omitted its tool name",
+    );
+  });
+});

--- a/packages/core/src/hooks/classify/tool-name.ts
+++ b/packages/core/src/hooks/classify/tool-name.ts
@@ -1,0 +1,116 @@
+/**
+ * Pure tool-name resolution from host PreToolUse payloads (#2950 / #2628 / #2669).
+ * No process I/O.
+ */
+
+import { hookWriteTargetPath } from "./paths.js";
+import {
+  fieldPresent,
+  fieldString,
+  hookPayloadTopLevelKeys,
+  record,
+  toolInputRecord,
+} from "./payload.js";
+import type { ClassifyHookHost, HookPayloadContext } from "./types.js";
+
+/**
+ * Cursor preToolUse payloads sometimes omit `tool_name` even when the hook matcher
+ * fired for a direct-write tool (#2628). Infer from nested tool input when possible.
+ */
+export function inferCursorDirectWriteToolName(payload: Record<string, unknown>): string | null {
+  const toolInput = toolInputRecord(payload);
+  if (toolInput !== null) {
+    if (
+      fieldPresent(toolInput, "new_string") ||
+      fieldPresent(toolInput, "newString") ||
+      fieldPresent(toolInput, "old_string") ||
+      fieldPresent(toolInput, "oldString")
+    ) {
+      return "StrReplace";
+    }
+
+    if (
+      fieldString(toolInput, "contents") !== null ||
+      fieldString(toolInput, "content") !== null ||
+      fieldString(toolInput, "text") !== null
+    ) {
+      return "Write";
+    }
+
+    if (
+      fieldString(toolInput, "patch") !== null ||
+      fieldString(toolInput, "unified_diff") !== null ||
+      fieldString(toolInput, "diff") !== null
+    ) {
+      return "ApplyPatch";
+    }
+
+    if (Array.isArray(toolInput.edits)) return "MultiEdit";
+    if (Array.isArray(toolInput.cells) || toolInput.cell_id != null) {
+      return "NotebookEdit";
+    }
+  }
+
+  // Cursor maps Claude Edit → Write; a write target without contents is still a direct write.
+  if (hookWriteTargetPath(payload) !== null) return "Write";
+
+  return null;
+}
+
+export function hookToolName(payload: unknown, host?: ClassifyHookHost | string): string | null {
+  const input = record(payload);
+  if (input === null) return null;
+  const toolObject = record(input.tool);
+  const toolCall = record(input.tool_call) ?? record(input.toolCall);
+  // OpenAI-style nestings are host-agnostic; checked before Cursor-only inference.
+  const direct =
+    fieldString(input, "tool_name") ??
+    fieldString(input, "toolName") ??
+    fieldString(input, "tool") ??
+    (toolObject !== null ? fieldString(toolObject, "name") : null) ??
+    (toolCall !== null ? fieldString(toolCall, "name") : null);
+  if (direct !== null) return direct;
+  if (host === "cursor") return inferCursorDirectWriteToolName(input);
+  return null;
+}
+
+export interface MissingToolNameInput {
+  readonly host: ClassifyHookHost | string;
+  readonly payload: unknown;
+  readonly context?: HookPayloadContext;
+}
+
+export function missingToolNameMessage(input: MissingToolNameInput): string {
+  const { host, payload, context } = input;
+  if (host === "cursor") {
+    if (context?.stdinEmpty) {
+      return (
+        "Directive denied this Cursor preToolUse event because the host sent an empty payload " +
+        "(stdin was empty — not a session ritual or scope failure). " +
+        "If write tools should pass, update Directive or report the payload shape from Cursor."
+      );
+    }
+    if (context?.parseFailed) {
+      return (
+        "Directive denied this Cursor preToolUse event because the host payload was not valid JSON " +
+        "(host-integration mismatch — not a session ritual or scope failure). " +
+        "If write tools should pass, update Directive or report the payload shape from Cursor."
+      );
+    }
+    const keys = hookPayloadTopLevelKeys(payload);
+    if (keys.length > 0) {
+      return (
+        "Directive denied this Cursor preToolUse event because the host payload omitted a " +
+        "recognizable tool name (host-integration mismatch — not a session ritual or scope failure). " +
+        `Top-level payload keys: ${keys.join(", ")}. ` +
+        "If write tools should pass, update Directive or report the payload shape from Cursor."
+      );
+    }
+    return (
+      "Directive denied this Cursor preToolUse event because the host payload omitted a " +
+      "recognizable tool name (host-integration mismatch — not a session ritual or scope failure). " +
+      "If write tools should pass, update Directive or report the payload shape from Cursor."
+    );
+  }
+  return "Directive denied this matched write event because the host payload omitted its tool name.";
+}

--- a/packages/core/src/hooks/classify/types.test.ts
+++ b/packages/core/src/hooks/classify/types.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { CLASSIFY_HOOK_HOSTS } from "./types.js";
+
+describe("classify types (#2950)", () => {
+  it("enumerates known hosts", () => {
+    expect(CLASSIFY_HOOK_HOSTS).toContain("cursor");
+    expect(CLASSIFY_HOOK_HOSTS).toContain("claude");
+  });
+});

--- a/packages/core/src/hooks/classify/types.ts
+++ b/packages/core/src/hooks/classify/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure hook classification types (#2950 Phase A).
+ * No process I/O — payload/shape only.
+ */
+
+/** Host ids that PreToolUse / SessionStart dispatch understands. */
+export const CLASSIFY_HOOK_HOSTS = ["claude", "grok", "cursor", "codex"] as const;
+export type ClassifyHookHost = (typeof CLASSIFY_HOOK_HOSTS)[number];
+
+/**
+ * Write / mutation intent derived from tool identity alone (before policy gates).
+ * Decision codes (allow/deny) live in the dispatcher; this layer only classifies.
+ */
+export type HookWriteIntent = "direct-write" | "spawn" | "shell" | "mcp" | "other" | "unknown";
+
+/** Stdin parse metadata from hook-dispatch; absent when callers supply payload directly. */
+export interface HookPayloadContext {
+  readonly stdinEmpty?: boolean;
+  readonly parseFailed?: boolean;
+}
+
+export interface ParsedHookPayload {
+  readonly payload: unknown;
+  readonly context: HookPayloadContext;
+}
+
+/**
+ * Pure classification of a host PreToolUse (or equivalent) payload.
+ * Paths are extracted as raw host strings — project-relative normalization is
+ * dispatcher-owned (needs projectRoot + optional realpath).
+ */
+export interface HookClassification {
+  readonly toolName: string | null;
+  readonly writeIntent: HookWriteIntent;
+  readonly writeTargetPath: string | null;
+  readonly shellCommand: string | null;
+  readonly topLevelKeys: readonly string[];
+  /** Distinct path-like strings found on the payload (write target first when present). */
+  readonly paths: readonly string[];
+}
+
+export interface ClassifyHookPayloadInput {
+  readonly payload: unknown;
+  /** Host id; Cursor enables tool-name inference when `tool_name` is omitted. */
+  readonly host?: ClassifyHookHost | string;
+}

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -18,9 +18,21 @@ import {
 import { markRitualStaleAfterCompact } from "../session/ritual-sentinel.js";
 import { runSessionStartHookWrite } from "../session/session-start-hook.js";
 import { inspectSessionRitual, type VerifyResult } from "../session/verify-session-ritual.js";
+import {
+  type HookPayloadContext,
+  hookMcpArgsText,
+  hookShellCommand,
+  hookToolName,
+  hookWriteTargetPath,
+  missingToolNameMessage,
+  record,
+} from "./classify/index.js";
 import { isExploreSpawn, isReadOnlyHookContext } from "./readonly.js";
 import { type ActiveScopeInspection, inspectActiveScope } from "./scope.js";
 import { isDirectWriteTool, isMcpTool, isShellTool, isSpawnTool } from "./tools.js";
+
+// Pure parse/classify helpers are defined in ./classify/ and re-exported from
+// ./index.ts (#2950). Dispatcher is orchestration: classify → policy → decision.
 
 export { hookReadOnlyFromPayload, isExploreSpawn, isReadOnlyHookContext } from "./readonly.js";
 export {
@@ -90,12 +102,6 @@ export interface HookDecision {
   readonly scopePath: string | null;
 }
 
-/** Stdin parse metadata from hook-dispatch; absent when callers supply payload directly. */
-export interface HookPayloadContext {
-  readonly stdinEmpty?: boolean;
-  readonly parseFailed?: boolean;
-}
-
 export interface HookDispatchInput {
   readonly host: HookHost;
   readonly event: HookEvent;
@@ -118,167 +124,6 @@ export interface HookPolicySeams {
     message: string;
   };
   readonly loadRuntimeAuthority?: (projectRoot: string) => RuntimeAuthorityPolicy;
-}
-
-function record(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-/** First non-empty trimmed string from candidates (array form — clear arity for static tools). */
-function firstString(values: readonly unknown[]): string | null {
-  for (const value of values) {
-    if (typeof value === "string" && value.trim().length > 0) return value.trim();
-  }
-  return null;
-}
-
-function fieldPresent(input: Record<string, unknown>, key: string): boolean {
-  return key in input;
-}
-
-function fieldString(input: Record<string, unknown>, key: string): string | null {
-  const value = input[key];
-  if (typeof value === "string" && value.trim().length > 0) return value.trim();
-  return null;
-}
-
-function toolInputRecord(payload: Record<string, unknown>): Record<string, unknown> | null {
-  const toolCall = record(payload.tool_call) ?? record(payload.toolCall);
-  return (
-    record(payload.tool_input) ??
-    record(payload.toolInput) ??
-    record(payload.input) ??
-    record(payload.arguments) ??
-    (toolCall !== null ? record(toolCall.arguments) : null)
-  );
-}
-
-/**
- * Cursor preToolUse payloads sometimes omit `tool_name` even when the hook matcher
- * fired for a direct-write tool (#2628). Infer from nested tool input when possible.
- */
-function inferCursorDirectWriteToolName(payload: Record<string, unknown>): string | null {
-  const toolInput = toolInputRecord(payload);
-  if (toolInput !== null) {
-    if (
-      fieldPresent(toolInput, "new_string") ||
-      fieldPresent(toolInput, "newString") ||
-      fieldPresent(toolInput, "old_string") ||
-      fieldPresent(toolInput, "oldString")
-    ) {
-      return "StrReplace";
-    }
-
-    if (
-      fieldString(toolInput, "contents") !== null ||
-      fieldString(toolInput, "content") !== null ||
-      fieldString(toolInput, "text") !== null
-    ) {
-      return "Write";
-    }
-
-    if (
-      fieldString(toolInput, "patch") !== null ||
-      fieldString(toolInput, "unified_diff") !== null ||
-      fieldString(toolInput, "diff") !== null
-    ) {
-      return "ApplyPatch";
-    }
-
-    if (Array.isArray(toolInput.edits)) return "MultiEdit";
-    if (Array.isArray(toolInput.cells) || toolInput.cell_id != null) {
-      return "NotebookEdit";
-    }
-  }
-
-  // Cursor maps Claude Edit → Write; a write target without contents is still a direct write.
-  if (hookWriteTargetPath(payload) !== null) return "Write";
-
-  return null;
-}
-
-export function hookPayloadTopLevelKeys(payload: unknown): string[] {
-  const input = record(payload);
-  if (input === null) return [];
-  return Object.keys(input).sort();
-}
-
-export function hookToolName(payload: unknown, host?: HookHost): string | null {
-  const input = record(payload);
-  if (input === null) return null;
-  const toolObject = record(input.tool);
-  const toolCall = record(input.tool_call) ?? record(input.toolCall);
-  // OpenAI-style nestings are host-agnostic; checked before Cursor-only inference.
-  const direct =
-    fieldString(input, "tool_name") ??
-    fieldString(input, "toolName") ??
-    fieldString(input, "tool") ??
-    (toolObject !== null ? fieldString(toolObject, "name") : null) ??
-    (toolCall !== null ? fieldString(toolCall, "name") : null);
-  if (direct !== null) return direct;
-  if (host === "cursor") return inferCursorDirectWriteToolName(input);
-  return null;
-}
-
-interface MissingToolNameInput {
-  readonly host: HookHost;
-  readonly payload: unknown;
-  readonly context?: HookPayloadContext;
-}
-
-function missingToolNameMessage(input: MissingToolNameInput): string {
-  const { host, payload, context } = input;
-  if (host === "cursor") {
-    if (context?.stdinEmpty) {
-      return (
-        "Directive denied this Cursor preToolUse event because the host sent an empty payload " +
-        "(stdin was empty — not a session ritual or scope failure). " +
-        "If write tools should pass, update Directive or report the payload shape from Cursor."
-      );
-    }
-    if (context?.parseFailed) {
-      return (
-        "Directive denied this Cursor preToolUse event because the host payload was not valid JSON " +
-        "(host-integration mismatch — not a session ritual or scope failure). " +
-        "If write tools should pass, update Directive or report the payload shape from Cursor."
-      );
-    }
-    const keys = hookPayloadTopLevelKeys(payload);
-    if (keys.length > 0) {
-      return (
-        "Directive denied this Cursor preToolUse event because the host payload omitted a " +
-        "recognizable tool name (host-integration mismatch — not a session ritual or scope failure). " +
-        `Top-level payload keys: ${keys.join(", ")}. ` +
-        "If write tools should pass, update Directive or report the payload shape from Cursor."
-      );
-    }
-    return (
-      "Directive denied this Cursor preToolUse event because the host payload omitted a " +
-      "recognizable tool name (host-integration mismatch — not a session ritual or scope failure). " +
-      "If write tools should pass, update Directive or report the payload shape from Cursor."
-    );
-  }
-  return "Directive denied this matched write event because the host payload omitted its tool name.";
-}
-
-/**
- * Best-effort write-target path from host PreToolUse payloads (#2625).
- * Hosts disagree on nesting (`tool_input.file_path` vs top-level `path`).
- */
-export function hookWriteTargetPath(payload: unknown): string | null {
-  const input = record(payload);
-  if (input === null) return null;
-  const toolInput = toolInputRecord(input);
-  return firstString([
-    toolInput?.file_path,
-    toolInput?.filePath,
-    toolInput?.path,
-    input.file_path,
-    input.filePath,
-    input.path,
-  ]);
 }
 
 /** POSIX-ish project-relative path for lifecycle matching. */
@@ -465,36 +310,6 @@ function runtimeAuthorityForDirectWrite(
     verdict.reason ?? "Directive denied this direct write under runtime authority policy.",
     scopePath,
   );
-}
-
-/**
- * Best-effort shell command string from host PreToolUse payloads (#2711).
- * Hosts disagree on nesting (`tool_input.command` vs top-level `command`).
- */
-export function hookShellCommand(payload: unknown): string | null {
-  const input = record(payload);
-  if (input === null) return null;
-  const toolInput = toolInputRecord(input);
-  return firstString([
-    toolInput !== null ? toolInput.command : null,
-    toolInput !== null ? toolInput.cmd : null,
-    toolInput !== null ? toolInput.shell_command : null,
-    input.command,
-    input.cmd,
-  ]);
-}
-
-/** Serialize tool args for MCP classification when nested objects are present (#2711). */
-function hookMcpArgsText(payload: unknown): string | null {
-  const input = record(payload);
-  if (input === null) return null;
-  const toolInput = toolInputRecord(input);
-  if (toolInput === null) return null;
-  try {
-    return JSON.stringify(toolInput);
-  } catch {
-    return null;
-  }
 }
 
 function loadRuntimeAuthorityPolicySafe(

--- a/packages/core/src/hooks/fixtures/README.md
+++ b/packages/core/src/hooks/fixtures/README.md
@@ -1,0 +1,32 @@
+# Hooks fixture corpus (#2950)
+
+Shared **host × OS × tool** golden cases for PreToolUse classification.
+
+## Coupled surface (TPA thrash cluster)
+
+Hooks classification and permission decisions form a **coupled surface**. When you change host payload handling or write-path gates, plan these three together — do not land a primary-only drive-by:
+
+1. `packages/core/src/hooks/dispatcher.ts` (orchestration + policy)
+2. `packages/core/src/hooks/dispatcher.test.ts` (core policy cases)
+3. `packages/cli/src/hook-dispatch.test.ts` (CLI stdin / host adapter)
+
+Pure parse/classify lives under `packages/core/src/hooks/classify/`. Prefer:
+
+1. **Add or update a fixture** here for the new host edge case.
+2. Fix the pure classifier (`classify/`) when the bug is identity/path shape.
+3. Fix the dispatcher only for policy / ritual / scope / permission emission.
+4. Keep CLI tests thin over `parseHookStdin` + `decideHook` + `renderHostDecision`.
+
+New host edge bugs should land as a fixture first, then the classifier (or policy) fix.
+
+## Layout
+
+```
+fixtures/
+  cases.ts          # typed corpus + helpers
+  cursor/
+    win32/          # Windows-flavored path spellings
+    posix/          # POSIX path spellings
+```
+
+Each case records: `id`, `host`, `os`, `tool`, `regression` (issue tags), `raw` or `payload`, and expected classification fields.

--- a/packages/core/src/hooks/fixtures/cases.test.ts
+++ b/packages/core/src/hooks/fixtures/cases.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { classifyHookPayload, parseHookStdin } from "../classify/index.js";
+import { fixtureCasesFor, HOOK_FIXTURE_CASES } from "./cases.js";
+
+describe("HOOK_FIXTURE_CASES corpus (#2950)", () => {
+  it("covers Cursor × win32/posix × Write/ApplyPatch/Task", () => {
+    for (const tool of ["Write", "ApplyPatch", "Task"] as const) {
+      for (const os of ["win32", "posix"] as const) {
+        expect(fixtureCasesFor({ host: "cursor", os, tool }).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("each case matches pure classify", () => {
+    expect(HOOK_FIXTURE_CASES.length).toBeGreaterThanOrEqual(12);
+    for (const c of HOOK_FIXTURE_CASES) {
+      let payload = c.payload;
+      if (c.raw !== undefined) {
+        const parsed = parseHookStdin(c.raw);
+        if (c.expected.stdinEmpty) expect(parsed.context.stdinEmpty, c.id).toBe(true);
+        if (c.expected.parseFailed) expect(parsed.context.parseFailed, c.id).toBe(true);
+        payload = parsed.payload;
+      }
+      const result = classifyHookPayload({ host: c.host, payload });
+      expect(result.toolName, c.id).toBe(c.expected.toolName);
+      expect(result.writeIntent, c.id).toBe(c.expected.writeIntent);
+      expect(result.writeTargetPath, c.id).toBe(c.expected.writeTargetPath);
+    }
+  });
+});

--- a/packages/core/src/hooks/fixtures/cases.ts
+++ b/packages/core/src/hooks/fixtures/cases.ts
@@ -1,0 +1,357 @@
+/**
+ * Shared host × OS × tool fixture corpus skeleton (#2950 Phase A).
+ *
+ * Cases are pure data: raw stdin or structured payload → expected classification.
+ * Core tests import this module; CLI may re-use the same cases later (Phase C).
+ */
+
+import type { ClassifyHookHost, HookWriteIntent } from "../classify/types.js";
+
+export type FixtureOs = "win32" | "posix";
+
+export type FixtureToolFamily = "Write" | "ApplyPatch" | "Task" | "StrReplace" | "other";
+
+export interface HookFixtureCase {
+  readonly id: string;
+  readonly host: ClassifyHookHost;
+  readonly os: FixtureOs;
+  readonly tool: FixtureToolFamily;
+  /** Closed-issue tags for the regression class this case freezes. */
+  readonly regression: readonly string[];
+  /** Structured payload when the host sends JSON. */
+  readonly payload?: unknown;
+  /** Raw stdin when testing BOM / free-form ApplyPatch parse. */
+  readonly raw?: string;
+  readonly expected: {
+    readonly toolName: string | null;
+    readonly writeIntent: HookWriteIntent;
+    readonly writeTargetPath: string | null;
+    /** When raw is set: after parseHookStdin. */
+    readonly stdinEmpty?: boolean;
+    readonly parseFailed?: boolean;
+  };
+  readonly notes?: string;
+}
+
+const freeFormAddPosix = [
+  "*** Begin Patch",
+  "*** Add File: xbrief/proposed/_probe-applypatch-only.txt",
+  "+probe",
+  "*** End Patch",
+].join("\n");
+
+const freeFormUpdateWin32 = [
+  "*** Begin Patch",
+  "*** Update File: src\\example.ts",
+  "@@",
+  "-old",
+  "+new",
+  "*** End Patch",
+].join("\n");
+
+/**
+ * Phase A skeleton: Cursor × {win32, posix} × {Write, ApplyPatch, Task}
+ * plus recent regression classes (BOM, free-form, missing tool name, outside-root).
+ */
+export const HOOK_FIXTURE_CASES: readonly HookFixtureCase[] = [
+  // --- Cursor × posix × Write ---
+  {
+    id: "cursor-posix-write-structured",
+    host: "cursor",
+    os: "posix",
+    tool: "Write",
+    regression: ["#2669", "#2950"],
+    payload: {
+      tool_name: "Write",
+      tool_input: { contents: "hello", path: "src/a.ts" },
+      cwd: "/project",
+    },
+    expected: {
+      toolName: "Write",
+      writeIntent: "direct-write",
+      writeTargetPath: "src/a.ts",
+    },
+  },
+  {
+    id: "cursor-posix-write-infer-name",
+    host: "cursor",
+    os: "posix",
+    tool: "Write",
+    regression: ["#2628", "#2669"],
+    payload: {
+      arguments: { contents: "x", path: "a.py" },
+    },
+    expected: {
+      toolName: "Write",
+      writeIntent: "direct-write",
+      writeTargetPath: "a.py",
+    },
+    notes: "Cursor omits tool_name; infer from contents+path",
+  },
+  {
+    id: "cursor-posix-write-outside-root",
+    host: "cursor",
+    os: "posix",
+    tool: "Write",
+    regression: ["#2885"],
+    payload: {
+      tool_name: "Write",
+      tool_input: {
+        file_path: "/home/user/.claude/projects/slug/memory/note.md",
+      },
+      cwd: "/project",
+    },
+    expected: {
+      toolName: "Write",
+      writeIntent: "direct-write",
+      writeTargetPath: "/home/user/.claude/projects/slug/memory/note.md",
+    },
+  },
+
+  // --- Cursor × win32 × Write ---
+  {
+    id: "cursor-win32-write-structured",
+    host: "cursor",
+    os: "win32",
+    tool: "Write",
+    regression: ["#2787", "#2950"],
+    payload: {
+      tool_name: "Write",
+      tool_input: {
+        contents: "x",
+        path: "C:\\Repos\\deft\\statusreport\\src\\a.ts",
+      },
+      workspace_roots: ["C:\\Repos\\deft\\statusreport"],
+    },
+    expected: {
+      toolName: "Write",
+      writeIntent: "direct-write",
+      writeTargetPath: "C:\\Repos\\deft\\statusreport\\src\\a.ts",
+    },
+  },
+  {
+    id: "cursor-win32-write-statusreport-shape",
+    host: "cursor",
+    os: "win32",
+    tool: "Write",
+    regression: ["#2787"],
+    payload: {
+      tool_name: "Write",
+      tool_input: { content: "x", file_path: "notes.md" },
+      workspace_roots: ["C:\\Repos\\deft\\statusreport"],
+      cwd: "C:\\Repos\\deft\\statusreport",
+    },
+    expected: {
+      toolName: "Write",
+      writeIntent: "direct-write",
+      writeTargetPath: "notes.md",
+    },
+    notes: "Ritual-root normalization is dispatcher-owned; classify keeps raw path",
+  },
+  {
+    id: "cursor-win32-write-bom-raw",
+    host: "cursor",
+    os: "win32",
+    tool: "Write",
+    regression: ["#2734"],
+    raw: `\uFEFF${JSON.stringify({
+      tool_name: "Write",
+      tool_input: { content: "x", file_path: "a.txt" },
+      workspace_roots: ["C:\\\\Repos\\\\deft"],
+    })}`,
+    expected: {
+      toolName: "Write",
+      writeIntent: "direct-write",
+      writeTargetPath: "a.txt",
+      stdinEmpty: false,
+      parseFailed: false,
+    },
+  },
+
+  // --- Cursor × posix × ApplyPatch ---
+  {
+    id: "cursor-posix-applypatch-structured",
+    host: "cursor",
+    os: "posix",
+    tool: "ApplyPatch",
+    regression: ["#2738", "#2790"],
+    payload: {
+      tool_name: "ApplyPatch",
+      tool_input: {
+        path: "xbrief/proposed/a.xbrief.json",
+        patch: "*** Begin Patch\n*** Add File: x\n+probe\n*** End Patch",
+      },
+    },
+    expected: {
+      toolName: "ApplyPatch",
+      writeIntent: "direct-write",
+      writeTargetPath: "xbrief/proposed/a.xbrief.json",
+    },
+  },
+  {
+    id: "cursor-posix-applypatch-freeform",
+    host: "cursor",
+    os: "posix",
+    tool: "ApplyPatch",
+    regression: ["#2738"],
+    raw: freeFormAddPosix,
+    expected: {
+      toolName: "ApplyPatch",
+      writeIntent: "direct-write",
+      writeTargetPath: "xbrief/proposed/_probe-applypatch-only.txt",
+      parseFailed: false,
+    },
+  },
+  {
+    id: "cursor-posix-applypatch-infer-from-patch-field",
+    host: "cursor",
+    os: "posix",
+    tool: "ApplyPatch",
+    regression: ["#2669"],
+    payload: {
+      tool_input: { path: "src/a.ts", patch: "diff" },
+    },
+    expected: {
+      toolName: "ApplyPatch",
+      writeIntent: "direct-write",
+      writeTargetPath: "src/a.ts",
+    },
+  },
+
+  // --- Cursor × win32 × ApplyPatch ---
+  {
+    id: "cursor-win32-applypatch-structured",
+    host: "cursor",
+    os: "win32",
+    tool: "ApplyPatch",
+    regression: ["#2738", "#2790"],
+    payload: {
+      tool_name: "ApplyPatch",
+      tool_input: {
+        path: "C:\\Repos\\proj\\src\\a.ts",
+        patch: "*** Begin Patch",
+      },
+      workspace_roots: ["C:\\Repos\\proj"],
+    },
+    expected: {
+      toolName: "ApplyPatch",
+      writeIntent: "direct-write",
+      writeTargetPath: "C:\\Repos\\proj\\src\\a.ts",
+    },
+  },
+  {
+    id: "cursor-win32-applypatch-freeform",
+    host: "cursor",
+    os: "win32",
+    tool: "ApplyPatch",
+    regression: ["#2738"],
+    raw: freeFormUpdateWin32,
+    expected: {
+      toolName: "ApplyPatch",
+      writeIntent: "direct-write",
+      writeTargetPath: "src\\example.ts",
+      parseFailed: false,
+    },
+  },
+
+  // --- Cursor × posix × Task ---
+  {
+    id: "cursor-posix-task-spawn",
+    host: "cursor",
+    os: "posix",
+    tool: "Task",
+    regression: ["#1185", "#2864", "#2950"],
+    payload: {
+      tool_name: "Task",
+      tool_input: { description: "explore", prompt: "scan hooks" },
+      cwd: "/project",
+    },
+    expected: {
+      toolName: "Task",
+      writeIntent: "spawn",
+      writeTargetPath: null,
+    },
+  },
+
+  // --- Cursor × win32 × Task ---
+  {
+    id: "cursor-win32-task-spawn",
+    host: "cursor",
+    os: "win32",
+    tool: "Task",
+    regression: ["#1185", "#2864", "#2950"],
+    payload: {
+      tool_name: "Task",
+      tool_input: { description: "implement", prompt: "fix write path" },
+      workspace_roots: ["C:\\Repos\\deft\\statusreport"],
+    },
+    expected: {
+      toolName: "Task",
+      writeIntent: "spawn",
+      writeTargetPath: null,
+    },
+  },
+
+  // --- Regression: empty / missing tool name ---
+  {
+    id: "cursor-posix-stdin-empty",
+    host: "cursor",
+    os: "posix",
+    tool: "other",
+    regression: ["#2864"],
+    raw: "",
+    expected: {
+      toolName: null,
+      writeIntent: "unknown",
+      writeTargetPath: null,
+      stdinEmpty: true,
+    },
+  },
+  {
+    id: "cursor-posix-missing-tool-name-keys",
+    host: "cursor",
+    os: "posix",
+    tool: "other",
+    regression: ["#2669", "#2864"],
+    payload: { host_version: "1.2.3" },
+    expected: {
+      toolName: null,
+      writeIntent: "unknown",
+      writeTargetPath: null,
+    },
+  },
+  {
+    id: "cursor-posix-applypatch-multifile-fail-closed",
+    host: "cursor",
+    os: "posix",
+    tool: "ApplyPatch",
+    regression: ["#2738"],
+    raw: [
+      "*** Begin Patch",
+      "*** Add File: a.txt",
+      "+a",
+      "*** Add File: b.txt",
+      "+b",
+      "*** End Patch",
+    ].join("\n"),
+    expected: {
+      toolName: null,
+      writeIntent: "unknown",
+      writeTargetPath: null,
+      parseFailed: true,
+    },
+  },
+];
+
+export function fixtureCasesFor(filter: {
+  host?: ClassifyHookHost;
+  os?: FixtureOs;
+  tool?: FixtureToolFamily;
+}): HookFixtureCase[] {
+  return HOOK_FIXTURE_CASES.filter((c) => {
+    if (filter.host !== undefined && c.host !== filter.host) return false;
+    if (filter.os !== undefined && c.os !== filter.os) return false;
+    if (filter.tool !== undefined && c.tool !== filter.tool) return false;
+    return true;
+  });
+}

--- a/packages/core/src/hooks/fixtures/index.test.ts
+++ b/packages/core/src/hooks/fixtures/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { fixtureCasesFor, HOOK_FIXTURE_CASES } from "./index.js";
+
+describe("fixtures barrel (#2950)", () => {
+  it("re-exports corpus helpers", () => {
+    expect(HOOK_FIXTURE_CASES.length).toBeGreaterThan(0);
+    expect(fixtureCasesFor({ host: "cursor" }).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/hooks/fixtures/index.ts
+++ b/packages/core/src/hooks/fixtures/index.ts
@@ -1,0 +1,7 @@
+export {
+  type FixtureOs,
+  type FixtureToolFamily,
+  fixtureCasesFor,
+  HOOK_FIXTURE_CASES,
+  type HookFixtureCase,
+} from "./cases.js";

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,3 +1,5 @@
+export * from "./classify/index.js";
 export * from "./cursor-hooks.js";
 export * from "./dispatcher.js";
+export * from "./fixtures/index.js";
 export * from "./scope.js";

--- a/xbrief/active/2026-07-29-2950-hooks-classify-phase-a.xbrief.json
+++ b/xbrief/active/2026-07-29-2950-hooks-classify-phase-a.xbrief.json
@@ -1,0 +1,112 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Phase A of epic #2950: pure hook payload classifier extraction + host×OS×tool fixture matrix skeleton.",
+    "created": "2026-07-29T12:00:00Z",
+    "updated": "2026-07-30T04:40:11Z"
+  },
+  "plan": {
+    "id": "2026-07-29-2950-hooks-classify-phase-a",
+    "title": "feat(hooks): pure classifier extraction + fixture matrix skeleton (Phase A of #2950)",
+    "status": "running",
+    "narratives": {
+      "Description": "Extract pure parse/classify (payload → tool identity + write intent + paths, no process I/O) under packages/core/src/hooks/classify/, thin the dispatcher over it, land a Cursor×win32/posix×Write/ApplyPatch/Task fixture skeleton shared by core tests, document the coupled-surface rule, and CHANGELOG #2950. Full epic AC (CLI share, decision-code docs expansion) remains for later phases.",
+      "Overview": "TPA surprise_rework cluster 4: stabilize hooks thrash triad via pure classifier + shared fixtures.",
+      "Origin": "https://github.com/deftai/directive/issues/2950",
+      "UserStory": "As a maintainer fixing host harness edge cases, I want a pure classifier and shared fixture corpus so host×OS×tool regressions land as fixtures first instead of one-off dispatcher patches.",
+      "ImplementationPlan": "1) packages/core/src/hooks/classify/ pure module (types, payload helpers, tool-name, paths, stdin parse including free-form ApplyPatch, classifyHookPayload). 2) dispatcher.ts re-exports and uses classify. 3) packages/cli hook-dispatch delegates parsePayload to core. 4) fixtures/{host}/{os}/ corpus + matrix loader tests. 5) brief coupled-surface doc. 6) CHANGELOG cites #2950. Verification: vitest on hooks/classify + dispatcher; task check:merge scoped if available.",
+      "Labels": "feat, harness, tooling, tech-debt",
+      "Traces": "Phase A AC of #2950; leave epic open unless full AC met."
+    },
+    "items": [
+      {
+        "title": "Pure classify module under hooks/classify/",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "packages/core/src/hooks/classify/ exports classifyHookPayload / parseHookStdin / hookToolName / hookWriteTargetPath with no fs/process I/O in the pure path; unit-tested without spawning CLI."
+        }
+      },
+      {
+        "title": "Dispatcher uses classify (thin orchestration)",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "dispatcher.ts imports tool-name/path/parse helpers from classify (re-export for compat); decideHook still owns policy/ritual/scope seams."
+        }
+      },
+      {
+        "title": "Fixture corpus skeleton Cursor×win32/posix×Write/ApplyPatch/Task",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Shared fixtures cover at least Cursor win32 and posix for Write, ApplyPatch (structured + free-form), and Task; regression classes (BOM, doubled drive, missing tool name, outside-root) represented."
+        }
+      },
+      {
+        "title": "Shared fixtures used by core tests + coupled-surface rule",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Core tests load fixtures via a single import path; README or coding note states hooks thrash triad (dispatcher + dispatcher.test + hook-dispatch.test) is a coupled surface."
+        }
+      },
+      {
+        "title": "CHANGELOG cites #2950 Phase A",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "CHANGELOG [Unreleased] Added entry cites #2950 and describes pure classifier + fixture skeleton."
+        }
+      }
+    ],
+    "tags": [
+      "feat",
+      "harness",
+      "tooling",
+      "tech-debt"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2950",
+        "type": "x-xbrief/github-issue",
+        "TrustLevel": "external"
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "x-tracking": {
+        "parent_issue": "#2950",
+        "decomposition_origin": "#2950"
+      },
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": false,
+        "file_scope": [
+          "packages/core/src/hooks/classify/",
+          "packages/core/src/hooks/fixtures/",
+          "packages/core/src/hooks/dispatcher.ts",
+          "packages/core/src/hooks/dispatcher.test.ts",
+          "packages/core/src/hooks/index.ts",
+          "packages/cli/src/hook-dispatch.ts",
+          "packages/cli/src/hook-dispatch.test.ts",
+          "CHANGELOG.md",
+          "content/coding/hygiene.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/hooks",
+          "pnpm exec vitest run packages/cli/src/hook-dispatch.test.ts"
+        ],
+        "expected_outputs": [
+          "Pure classify module under hooks/classify/",
+          "Dispatcher uses classify (thin orchestration)",
+          "Fixture corpus skeleton Cursor×win32/posix×Write/ApplyPatch/Task",
+          "Shared fixtures used by core tests + coupled-surface rule",
+          "CHANGELOG cites #2950 Phase A"
+        ],
+        "depends_on": [],
+        "conflict_group": "story-2950-phase-a",
+        "size": "M",
+        "file_scope_confidence": "high",
+        "model_tier": "standard"
+      },
+      "capacityBucket": "technical-debt"
+    },
+    "updated": "2026-07-30T04:40:11Z"
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Phase A** of epic #2950 (TPA hooks thrash cluster): pure payload classifier extraction and a host×OS×tool fixture skeleton.

Does **not** close the epic — Phase B/C (full matrix CI, CLI/core corpus collapse, decision-code docs expansion) remain.

## Landed

1. **Pure classify** under `packages/core/src/hooks/classify/` — payload → tool identity + write intent + paths; stdin parse (BOM, free-form ApplyPatch); no process I/O
2. **Dispatcher** imports pure helpers; still owns ritual/scope/policy/permission emission
3. **Fixture corpus** Cursor × win32/posix × Write/ApplyPatch/Task + recent regression classes (`#2734`, `#2738`, `#2628`, `#2885`, `#2864`)
4. **Coupled-surface rule** in `packages/core/src/hooks/fixtures/README.md` (dispatcher + dispatcher.test + hook-dispatch.test)
5. **CLI** `parsePayload` delegates to core `parseHookStdin`
6. **CHANGELOG** cites Phase A of #2950

## Test plan

- [x] `pnpm exec vitest run packages/core/src/hooks packages/cli/src/hook-dispatch.test.ts` (169 pass)
- [x] `pnpm exec biome check` on hooks paths
- [x] `task verify:forward-coverage`
- [x] `task change:changelog:check`
- [ ] CI `task check` on PR

Implements Phase A of #2950