### PR TITLE
fix(migrate): accept hybrid xBRIEFInfo@0.6 in transformArtifactV06ToV08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **migrate:xbrief accepts hybrid xBRIEFInfo@0.6 (#2970).** `transformArtifactV06ToV08` previously required classic `vBRIEFInfo@0.6` only, so layout-renamed artifacts that already used the `xBRIEFInfo` key with version `0.6` failed with `missing required legacy info block 'vBRIEFInfo'`. Classic and hybrid inputs both emit `xBRIEFInfo@0.8` idempotently; UPGRADING documents that layout rename is not an envelope bump. Closes #2970.
 - **Issue/PR body mojibake is lintable and fail-closed on scm:body writers (#2960).** `task scm:body:issue:lint` / `pr:lint` fetch the live REST body and scan with the same CP1252/CP437-as-UTF-8 patterns as `verify:encoding`; create/edit reject corrupted payloads before PATCH and on read-back with stable code `scm-body-encoding`. Docs pin the MUST RMW path in `content/scm/github.md`. Recurrence: #2948 / #2944 body rewrite 2026-07-30 (`ΓÇö` class). Closes #2960. Refs #798, #2646, #2744, #2607, #1555.
 - **Vitest branch coverage restored above 85% (#2952).** Focused shell/MCP classify edge tests, hooks tool-classifier coverage, and coverage-debt report edge cases clear the v0.88.0 84.9% hairline so the next release Step 5 passes without a consecutive `--allow-coverage-debt` soft-pass. Closes #2952.
 

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -225,6 +225,16 @@ deft migrate:xbrief
 
 Post-migration behavior check (#2149): on xbrief-only projects (`vbrief/` removed), `task issue:ingest -- <N>` now emits `xbrief/proposed/*.xbrief.json` with `xBRIEFInfo.version` from `xbrief/PROJECT-DEFINITION.xbrief.json` (fallback `0.8`), while legacy `vbrief/` projects keep `.vbrief.json` + `vBRIEFInfo.version: "0.6"` until migrated. `task project:render` / `project-render` also stays on `xbrief/PROJECT-DEFINITION.xbrief.json` and no longer recreates `vbrief/` in migrated trees.
 
+### Hybrid envelope: layout rename ≠ schema bump (#2970)
+
+Folder rename (`vbrief/` → `xbrief/`, `*.vbrief.json` → `*.xbrief.json`) and the in-document info-key rename (`vBRIEFInfo` → `xBRIEFInfo`) can land **without** bumping `version` from `0.6` to `0.8`. That hybrid state looks like:
+
+```json
+{ "xBRIEFInfo": { "version": "0.6", "description": "..." }, "plan": { } }
+```
+
+It is common after a manual folder rename or when agents stamp the current key name while copying old `0.6` examples. `transformArtifactV06ToV08` / `deft migrate:xbrief` accept **either** classic `vBRIEFInfo@0.6` **or** hybrid `xBRIEFInfo@0.6` and emit `xBRIEFInfo@0.8` (with path/token rewrites). A second pass is idempotent. Layout migration alone does not imply envelope migration — re-run `deft migrate:xbrief` (or rely on schema-distance / staleness prompts) until declared version is `0.8`.
+
 ### AGENTS.md: managed vs unmanaged header (#2154)
 
 `migrate:xbrief` touches your `AGENTS.md` in two distinct regions:

--- a/packages/core/src/xbrief-migrate/transforms.test.ts
+++ b/packages/core/src/xbrief-migrate/transforms.test.ts
@@ -49,6 +49,33 @@ const SAMPLE_V06 = {
   },
 } as const;
 
+/** Hybrid: layout already xbrief / xBRIEFInfo key, envelope still 0.6 (#2970). */
+const SAMPLE_HYBRID_V06 = {
+  xBRIEFInfo: {
+    version: "0.6",
+    description: "hybrid fixture",
+    created: "2026-06-30T00:00:00Z",
+    updated: "2026-06-30T00:00:00Z",
+  },
+  plan: {
+    title: "Hybrid story",
+    status: "running",
+    items: [],
+    references: [
+      {
+        uri: "https://github.com/deftai/directive/issues/2970",
+        type: "x-vbrief/github-issue",
+        title: "Issue #2970",
+      },
+      {
+        uri: "xbrief/active/2026-06-30-child.xbrief.json",
+        type: "x-vbrief/plan",
+        title: "Child",
+      },
+    ],
+  },
+} as const;
+
 describe("transformArtifactV06ToV08", () => {
   it("converts v0.6 to valid v0.8 and is idempotent on rerun", () => {
     const first = transformArtifactV06ToV08(structuredClone(SAMPLE_V06) as Record<string, unknown>);
@@ -73,6 +100,43 @@ describe("transformArtifactV06ToV08", () => {
 
     const second = transformArtifactV06ToV08(first);
     expect(second).toEqual(first);
+  });
+
+  it("accepts hybrid xBRIEFInfo@0.6 and emits xBRIEFInfo@0.8", () => {
+    const first = transformArtifactV06ToV08(
+      structuredClone(SAMPLE_HYBRID_V06) as Record<string, unknown>,
+    );
+    expect(first).not.toHaveProperty("vBRIEFInfo");
+    expect(first).toMatchObject({
+      xBRIEFInfo: { version: "0.8", description: "hybrid fixture" },
+      plan: {
+        references: [
+          {
+            type: "x-xbrief/github-issue",
+            uri: "https://github.com/deftai/directive/issues/2970",
+          },
+          {
+            type: "x-xbrief/plan",
+            uri: "xbrief/active/2026-06-30-child.xbrief.json",
+          },
+        ],
+      },
+    });
+    expect(validateVbriefSchema(first, "hybrid-transformed.json")).toEqual([]);
+  });
+
+  it("is idempotent on a second pass of hybrid xBRIEFInfo@0.6 input", () => {
+    const input = structuredClone(SAMPLE_HYBRID_V06) as Record<string, unknown>;
+    const first = transformArtifactV06ToV08(input);
+    const second = transformArtifactV06ToV08(first);
+    expect(second).toEqual(first);
+    expect(second).toMatchObject({ xBRIEFInfo: { version: "0.8" } });
+  });
+
+  it("does not require vBRIEFInfo when hybrid xBRIEFInfo@0.6 is present", () => {
+    const input = structuredClone(SAMPLE_HYBRID_V06) as Record<string, unknown>;
+    expect(input).not.toHaveProperty("vBRIEFInfo");
+    expect(() => transformArtifactV06ToV08(input)).not.toThrow();
   });
 
   it("rewrites embedded tokens idempotently", () => {

--- a/packages/core/src/xbrief-migrate/transforms.ts
+++ b/packages/core/src/xbrief-migrate/transforms.ts
@@ -101,9 +101,49 @@ function isAlreadyV08Artifact(artifact: JsonObject): boolean {
 }
 
 /**
+ * Resolve a v0.6 info block from classic `vBRIEFInfo` or hybrid `xBRIEFInfo@0.6`.
+ * Prefer the classic key when both are present. Layout rename ≠ envelope bump (#2970).
+ */
+function resolveV06InfoBlock(artifact: JsonObject): JsonObject {
+  if (LEGACY_INFO_ROOT_KEY in artifact) {
+    const legacyInfo = artifact[LEGACY_INFO_ROOT_KEY];
+    if (!isPlainObject(legacyInfo)) {
+      throw new TransformError(`'${LEGACY_INFO_ROOT_KEY}' must be an object`);
+    }
+    const declaredVersion = legacyInfo.version;
+    if (declaredVersion !== LEGACY_VBRIEF_VERSION) {
+      throw new TransformError(
+        `expected ${LEGACY_INFO_ROOT_KEY}.version ${LEGACY_VBRIEF_VERSION}, got ${String(declaredVersion)}`,
+      );
+    }
+    return legacyInfo;
+  }
+
+  if (MIGRATED_INFO_ROOT_KEY in artifact) {
+    const hybridInfo = artifact[MIGRATED_INFO_ROOT_KEY];
+    if (!isPlainObject(hybridInfo)) {
+      throw new TransformError(`'${MIGRATED_INFO_ROOT_KEY}' must be an object`);
+    }
+    const declaredVersion = hybridInfo.version;
+    if (declaredVersion !== LEGACY_VBRIEF_VERSION) {
+      throw new TransformError(
+        `expected hybrid ${MIGRATED_INFO_ROOT_KEY}.version ${LEGACY_VBRIEF_VERSION} (or ${VBRIEF_VERSION} for already-migrated), got ${String(declaredVersion)}`,
+      );
+    }
+    return hybridInfo;
+  }
+
+  throw new TransformError(
+    `missing required legacy info block '${LEGACY_INFO_ROOT_KEY}' or hybrid '${MIGRATED_INFO_ROOT_KEY}'@${LEGACY_VBRIEF_VERSION} for v0.6 -> v0.8 transform`,
+  );
+}
+
+/**
  * Convert a single v0.6 in-document artifact to v0.8 semantics.
- * Idempotent: v0.8 artifacts are returned unchanged (deep-cloned).
- * Transactional: on failure the original input object is not mutated.
+ * Accepts classic `vBRIEFInfo@0.6` or hybrid `xBRIEFInfo@0.6` (layout renamed,
+ * envelope not bumped — #2970). Idempotent: v0.8 artifacts are returned
+ * unchanged (deep-cloned). Transactional: on failure the original input
+ * object is not mutated.
  */
 export function transformArtifactV06ToV08(input: JsonObject): JsonObject {
   const working = structuredClone(input) as JsonObject;
@@ -112,27 +152,13 @@ export function transformArtifactV06ToV08(input: JsonObject): JsonObject {
     return working;
   }
 
-  if (!(LEGACY_INFO_ROOT_KEY in working)) {
-    throw new TransformError(
-      `missing required legacy info block '${LEGACY_INFO_ROOT_KEY}' for v0.6 -> v0.8 transform`,
-    );
-  }
+  const info = resolveV06InfoBlock(working);
 
-  const legacyInfo = working[LEGACY_INFO_ROOT_KEY];
-  if (!isPlainObject(legacyInfo)) {
-    throw new TransformError(`'${LEGACY_INFO_ROOT_KEY}' must be an object`);
-  }
-
-  const declaredVersion = legacyInfo.version;
-  if (declaredVersion !== LEGACY_VBRIEF_VERSION) {
-    throw new TransformError(
-      `expected ${LEGACY_INFO_ROOT_KEY}.version ${LEGACY_VBRIEF_VERSION}, got ${String(declaredVersion)}`,
-    );
-  }
-
+  // Drop both keys so a dual-key hybrid cannot leave a stale vBRIEFInfo behind.
   delete working[LEGACY_INFO_ROOT_KEY];
+  delete working[MIGRATED_INFO_ROOT_KEY];
   working[MIGRATED_INFO_ROOT_KEY] = {
-    ...legacyInfo,
+    ...info,
     version: VBRIEF_VERSION,
   };
 

--- a/xbrief/completed/2026-07-30-1095-wave4-closed-verb-session-auth-slim.xbrief.json
+++ b/xbrief/completed/2026-07-30-1095-wave4-closed-verb-session-auth-slim.xbrief.json
@@ -2,12 +2,12 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Wave 4 of #2948: #1095 slim — release-class closed verbs + AFK templates consuming Wave 1 human-origin grants",
-    "updated": "2026-07-30T16:10:11Z"
+    "updated": "2026-07-30T19:16:19Z"
   },
   "plan": {
     "title": "feat(authz): closed-verb release gates + AFK templates consuming human-origin grants (#1095 slim)",
-    "status": "running",
-    "updated": "2026-07-30T16:25:07.607Z",
+    "status": "completed",
+    "updated": "2026-07-30T19:16:19Z",
     "id": "2026-07-30-1095-wave4-closed-verb-session-auth-slim",
     "narratives": {
       "Description": "Wave 4 of epic #2948. Slim delivery of #1095: release-class closed-verb gates and AFK session-auth *templates* that mint/consume Wave 1 human-origin grants (packages/core authz). Do NOT invent a second mint path or parallel session-auth SoT that agents can self-satisfy. Rebase on TS engine + hooks/runtimeAuthority. Full #871 finish-loop product is Wave 5 — out of scope here. Non-verb product-edit provenance stays Wave 1.",
@@ -116,7 +116,8 @@
         "size": "L",
         "file_scope_confidence": "medium"
       },
-      "capacityBucket": "new-capability"
+      "capacityBucket": "new-capability",
+      "completedAt": "2026-07-30T19:16:19Z"
     }
   }
 }

--- a/xbrief/completed/2026-07-30-1193-rfc-agent-blast-radius-controls-hotfix-classifier-human-merg.xbrief.json
+++ b/xbrief/completed/2026-07-30-1193-rfc-agent-blast-radius-controls-hotfix-classifier-human-merg.xbrief.json
@@ -2,12 +2,12 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Wave 2 of #2948: intent ceiling — slash-command containment, hotfix classifier, human merge gate (#1193)",
-    "updated": "2026-07-30T14:43:06Z"
+    "updated": "2026-07-30T19:16:22Z"
   },
   "plan": {
     "title": "feat(authz): agent blast-radius controls — intent ceiling (Wave 2 / #1193)",
-    "status": "running",
-    "updated": "2026-07-30T14:43:06Z",
+    "status": "completed",
+    "updated": "2026-07-30T19:16:22Z",
     "id": "2026-07-30-1193-wave2-intent-ceiling",
     "narratives": {
       "Description": "Wave 2 of epic #2948. Implement R1 slash-command intent containment, R2 typed hotfixCriteria classifier, R3 requireHumanMerge human merge gate. Do not absorb UAT/provenance (#2944 Wave 1, already shipped). Parent program #2948.",
@@ -21,35 +21,35 @@
     "items": [
       {
         "title": "Typed policy fields hotfixCriteria + requireHumanMerge",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given a PROJECT-DEFINITION policy object, loaders return typed hotfixCriteria and requireHumanMerge and validate their shapes."
         }
       },
       {
         "title": "R1 slash-command intent containment",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "When a session inherits a non-implement slash verb, the intent gate blocks implement push PR merge and deploy tool authorization."
         }
       },
       {
         "title": "R2 hotfix classifier (typed predicates)",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "evaluateHotfixEligibility returns eligible only for small-fix and pure-revert cases and rejects refactor large-surface and forbidden-path diffs."
         }
       },
       {
         "title": "R3 human merge gate three-surface enforcement",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "When requireHumanMerge is true, agent-initiated merge fails closed and session-start emits the human-merge disclosure line."
         }
       },
       {
         "title": "Tests docs CHANGELOG #1193",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given the eligibility fixture table, unit tests returns green for each row and CHANGELOG Unreleased records #1193 under Added."
         }
@@ -108,7 +108,8 @@
         "file_scope_confidence": "medium",
         "model_tier": "default"
       },
-      "capacityBucket": "new-capability"
+      "capacityBucket": "new-capability",
+      "completedAt": "2026-07-30T19:16:22Z"
     }
   }
 }

--- a/xbrief/completed/2026-07-30-2944-authz-wave1-human-origin-uat.xbrief.json
+++ b/xbrief/completed/2026-07-30-2944-authz-wave1-human-origin-uat.xbrief.json
@@ -2,12 +2,12 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope: Wave 1 human-origin approval provenance + UAT mutation lease (#2944)",
-    "updated": "2026-07-30T05:00:00Z"
+    "updated": "2026-07-30T19:16:24Z"
   },
   "plan": {
     "title": "bug(authz): self-authored consent tokens and active UAT runs do not prevent unauthorized mutation",
-    "status": "running",
-    "updated": "2026-07-30T05:00:00Z",
+    "status": "completed",
+    "updated": "2026-07-30T19:16:24Z",
     "id": "2026-07-30-2944-authz-wave1-human-origin-uat",
     "narratives": {
       "Description": "Wave 1 of epic #2948: human-origin approval grants agents cannot self-mint via lifecycle/dispatch, fail-closed UAT mutation lease, structural binding to plan/surfaces/ops, denials+audit, regression that first unauthorized edit is blocked. Compose with runtimeAuthority (#2711); stay out of #1193/#1095 full scopes.",
@@ -19,34 +19,39 @@
     "items": [
       {
         "title": "Human-origin grant model + reject self-authored evidence",
-        "status": "running",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Agent cannot satisfy implement gates with only xBRIEF/lifecycle/dispatch tokens"
         }
       },
       {
         "title": "Fail-closed UAT mutation lease",
-        "status": "running",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Active UAT denies product edit/push/PR/merge without named fix cohort; test/issue OK"
         }
       },
       {
         "title": "Dispatcher enforcement + audit + regression",
-        "status": "running",
+        "status": "completed",
         "narrative": {
           "Acceptance": "First unauthorized edit blocked; audit records humanApprovalRef/scope/op/result"
         }
       },
       {
         "title": "CLI docs CHANGELOG #2944",
-        "status": "running",
+        "status": "completed",
         "narrative": {
           "Acceptance": "authz:* CLI + human-origin-authz.md + CHANGELOG cite #2944"
         }
       }
     ],
-    "tags": ["bug", "authz", "harness", "agent-experience"],
+    "tags": [
+      "bug",
+      "authz",
+      "harness",
+      "agent-experience"
+    ],
     "references": [
       {
         "uri": "https://github.com/deftai/directive/issues/2944",
@@ -88,7 +93,8 @@
         "size": "M",
         "file_scope_confidence": "high"
       },
-      "capacityBucket": "new-capability"
+      "capacityBucket": "new-capability",
+      "completedAt": "2026-07-30T19:16:24Z"
     }
   }
 }

--- a/xbrief/completed/2026-07-30-518-wave5-typed-escalation-slim.xbrief.json
+++ b/xbrief/completed/2026-07-30-518-wave5-typed-escalation-slim.xbrief.json
@@ -2,12 +2,12 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Wave 5 of #2948: typed escalation channel slim — schema + CLI queue (#518)",
-    "updated": "2026-07-30T16:51:24Z"
+    "updated": "2026-07-30T19:16:26Z"
   },
   "plan": {
     "title": "feat(authz): typed escalation events + CLI batch queue (#518 slim)",
-    "status": "running",
-    "updated": "2026-07-30T16:51:24Z",
+    "status": "completed",
+    "updated": "2026-07-30T19:16:26Z",
     "id": "2026-07-30-518-wave5-typed-escalation-slim",
     "narratives": {
       "Description": "Wave 5 optional UX of #2948. Slim #518: versioned typed escalation event schema, local queue store, CLI file/list/resolve/batch-approve for cmd_approval and question types. Full web/Warp UI is residual — first cut is CLI + file queue so grants and finish-loop have a structured escalation channel. Compose with human-origin grants when resolution mints approvals.",
@@ -83,7 +83,8 @@
         "size": "M",
         "file_scope_confidence": "high"
       },
-      "capacityBucket": "new-capability"
+      "capacityBucket": "new-capability",
+      "completedAt": "2026-07-30T19:16:26Z"
     }
   }
 }

--- a/xbrief/completed/2026-07-30-871-wave5-finish-loop.xbrief.json
+++ b/xbrief/completed/2026-07-30-871-wave5-finish-loop.xbrief.json
@@ -2,12 +2,12 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Wave 5 of #2948: walk-away finish-loop tasks consuming Wave 0+1+4 grants (#871)",
-    "updated": "2026-07-30T16:51:22Z"
+    "updated": "2026-07-30T19:16:29Z"
   },
   "plan": {
     "title": "feat(tasks): directive:finish-loop + pr:finish-loop walk-away product (#871)",
-    "status": "running",
-    "updated": "2026-07-30T16:51:22Z",
+    "status": "completed",
+    "updated": "2026-07-30T19:16:29Z",
     "id": "2026-07-30-871-wave5-finish-loop",
     "narratives": {
       "Description": "Wave 5 of #2948. Implement task directive:finish-loop and task pr:finish-loop as the walk-away product. Every high-blast step routes through Wave 1 human-origin grants and Wave 4 closed-verb gates (finish-loop template). Halt cleanly on grant expiry, exhaustion, or scope refusal. Heartbeat to .deft-cache/finish-loop-progress.jsonl. Do not invent a second mint path. Compose with pr:watch, review-cycle, and existing scope lifecycle.",
@@ -21,28 +21,28 @@
     "items": [
       {
         "title": "finish-loop grant template + classification",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "When authz:grant uses template finish-loop, mintHumanOriginGrant returns an operator-cli grant covering loop operations and unit tests reject agent-authored grants as authorization."
         }
       },
       {
         "title": "pr:finish-loop watches and addresses until CLEAN",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "When grants are present, pr:finish-loop returns CLEAN via pr:watch integration and when grants are missing the command fails closed with a BLOCKED code."
         }
       },
       {
         "title": "directive:finish-loop outer cascade + progress log",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given an authorized finish-loop session, directive:finish-loop appends finish-loop-progress.jsonl per iteration and stops when the queue is empty or a gate returns deny."
         }
       },
       {
         "title": "Docs CLI CHANGELOG #871",
-        "status": "proposed",
+        "status": "completed",
         "narrative": {
           "Acceptance": "content/contracts/finish-loop.md records the walk-away path and CHANGELOG Unreleased records #871 under #2948 Wave 5."
         }
@@ -104,7 +104,8 @@
         "size": "L",
         "file_scope_confidence": "medium"
       },
-      "capacityBucket": "new-capability"
+      "capacityBucket": "new-capability",
+      "completedAt": "2026-07-30T19:16:29Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

`transformArtifactV06ToV08` / `migrate:xbrief` previously required classic `vBRIEFInfo@0.6` only. Hybrid artifacts that already use the migrated key `xBRIEFInfo` with legacy version `0.6` (layout renamed, envelope not bumped) failed with:

```
missing required legacy info block 'vBRIEFInfo' for v0.6 -> v0.8 transform
```

This PR accepts **either** classic `vBRIEFInfo@0.6` **or** hybrid `xBRIEFInfo@0.6` and always emits `xBRIEFInfo@0.8` (with path/token rewrites). Second pass is idempotent.

## Changes

- `packages/core/src/xbrief-migrate/transforms.ts` — resolve v0.6 from classic or hybrid info key
- `packages/core/src/xbrief-migrate/transforms.test.ts` — hybrid fixture + idempotency tests
- `content/UPGRADING.md` — document hybrid layout rename ≠ envelope bump
- `CHANGELOG.md` — Fixed entry citing #2970

## Test plan

- [x] `pnpm exec vitest run packages/core/src/xbrief-migrate` (110 passed, 7 skipped)
- [x] Classic `vBRIEFInfo@0.6` still migrates to `xBRIEFInfo@0.8`
- [x] Hybrid `xBRIEFInfo@0.6` migrates without requiring `vBRIEFInfo`
- [x] Second transform pass is idempotent

Closes #2970