### PR TITLE
feat(security): contained-writes scanner hygiene + Go-deferred docs (#2980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Contained-writes scanner hygiene — exclude e2e/parity harness noise (#2980).** `verify:contained-writes` drops `release-e2e/**`, `integration-e2e/**`, and `**/parity-scenarios.ts` from product findings via `NON_PRODUCT_HARNESS_PATH_MARKERS` so `--enforce` targets real product sinks. Docs state Go installer contained-write is deferred/frozen; residual scope is TS product + enforce. Implements scanner hygiene + docs of #2980 (epic #2951 residual; product migration waves remain open).
 - **Routine release cuts skip scratch/worktree noise by default (#2953).** Content/link, codebase-map, stub, and build-dist walks default-exclude `.deft-scratch/` and legacy `swarm-worktrees/` so Step 5 / Step 8 no longer enumerate swarm worktrees. Docs in `docs/RELEASING.md` and the release skill describe routine vs hard cut: both keep full Step 5 coverage unless an explicit hatch (`--allow-coverage-debt=#N` or incident `--skip-ci` + `--allow-skip-ci=#N`) is used — no silent soft-pass. Closes #2953.
 
 ### Fixed

--- a/docs/reference/contained-write.md
+++ b/docs/reference/contained-write.md
@@ -12,7 +12,7 @@ AppSec mediums kept reappearing as “N more symlink / path-escape write sinks�
 2. Migration of product sinks onto that API.
 3. Enforcement so new raw `writeFileSync` / similar outside an allowlist cannot land silently.
 
-Phase 1 landed the **TS API + tests + docs + fail-open inventory gate** and one product sink. **Phase 2** migrates additional high-risk product sinks onto `containedWrite`, shrinks the allowlist, and keeps `--enforce` as the fail-closed path (still optional until mass migration completes).
+Phase 1 landed the **TS API + tests + docs + fail-open inventory gate** and one product sink. **Phase 2** migrates additional high-risk product sinks onto `containedWrite`, shrinks the allowlist, and keeps `--enforce` as the fail-closed path (still optional until mass migration completes). Residual work (#2980) is **TS product sink migration + fail-closed inventory**; the **Go installer contained-write API is deferred/frozen** and is not required to close residual acceptance.
 
 ## Contract (normative)
 
@@ -76,18 +76,20 @@ task verify:contained-writes -- --enforce   # fail closed on findings
 ```
 
 - Scans `packages/core/src` for raw write patterns (`writeFileSync`, `appendFileSync`, `fs.writeFile`, `createWriteStream`, …).
-- Skips `*.test.ts` and a **shrinking allowlist** of residual implementation modules.
+- Skips `*.test.ts`, fixtures, and **non-product harness** path markers (`release-e2e/**`, `integration-e2e/**`, `**/parity-scenarios.ts`) so e2e/parity noise does not block `--enforce` (#2980).
+- Skips a **shrinking allowlist** of residual implementation modules (containment primitives).
 - **Default: fail-open** — prints an advisory report and exits **0** even when findings remain (mass migration incomplete).
-- Pass `--enforce` to exit **1** on findings (Phase 2 path; not yet wired into `task check`).
+- Pass `--enforce` to exit **1** on findings (Phase 2+ path; not yet wired into `task check`).
 - Phase 2 removed `cache/io.ts` and `lifecycle/events.ts` from the allowlist after migration.
 - Residual wave C (#2980) migrates eval ledgers, doctor-state, residual cache self-heal, xbrief-migrate product writes, and PROJECT-DEFINITION atomic write onto `containedWrite` (no allowlist growth). Lock/temp `openSync` patterns (e.g. project-definition mutation lock) remain residual for later hygiene.
 
-Allowlist lives in `packages/core/src/verify-source/contained-writes.ts` (`CONTAINED_WRITES_ALLOWLIST`). New exceptions need a comment + allowlist entry with issue citation.
+Allowlist lives in `packages/core/src/verify-source/contained-writes.ts` (`CONTAINED_WRITES_ALLOWLIST`). Harness exclusions live in `NON_PRODUCT_HARNESS_PATH_MARKERS` (prefer exclusion over permanent product allowlist). New allowlist exceptions need a comment + entry with issue citation.
 
-## Residual risk
+## Residual risk and scope (#2980)
 
+- **Residual scope for epic close:** TypeScript **product** sinks under `packages/core/src` + fail-closed inventory (`--enforce`, then CI / `task check` when findings are near zero). E2E/parity harness paths are excluded by design (#2980 scanner hygiene), not treated as product.
+- **Go installer / `cmd/deft-install` contained-write API is deferred/frozen.** It is **not** required to close residual #2980 / finish #2951 for the TS engine. A Go equivalent may return as a later optional issue if the freeze lifts.
 - TOCTOU between check and open is mitigated on platforms that honor `O_NOFOLLOW` on open; residual races can remain on some Windows paths. Document rather than claim zero residual risk (epic non-goal).
-- Go installer / `cmd/deft-install` sinks remain residual (epic still lists a Go equivalent for a later phase).
 - Reads are not covered by this API.
 
 ## Migration checklist
@@ -100,6 +102,7 @@ Allowlist lives in `packages/core/src/verify-source/contained-writes.ts` (`CONTA
 ## Related
 
 - Epic: https://github.com/deftai/directive/issues/2951
+- Residual (TS product + enforce; Go frozen): https://github.com/deftai/directive/issues/2980
 - Projection containment: `packages/core/src/fs/projection-containment.ts`
 - Security posture: [docs/security.md](../security.md)
 - Contributing note: [CONTRIBUTING.md](../../CONTRIBUTING.md) § Contained writes

--- a/packages/core/src/verify-source/contained-writes.test.ts
+++ b/packages/core/src/verify-source/contained-writes.test.ts
@@ -5,7 +5,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { CONTAINED_WRITES_ALLOWLIST, evaluateContainedWrites } from "./contained-writes.js";
+import {
+  CONTAINED_WRITES_ALLOWLIST,
+  evaluateContainedWrites,
+  NON_PRODUCT_HARNESS_PATH_MARKERS,
+} from "./contained-writes.js";
 
 const temps: string[] = [];
 afterEach(() => {
@@ -104,5 +108,38 @@ describe("evaluateContainedWrites (#2951)", () => {
     const result = evaluateContainedWrites({ projectRoot: root, enforce: true });
     expect(result.code).toBe(1);
     expect(result.findings.length).toBeGreaterThan(0);
+  });
+
+  it("excludes release-e2e, integration-e2e, and parity-scenarios harness paths (#2980)", () => {
+    expect(NON_PRODUCT_HARNESS_PATH_MARKERS).toEqual(
+      expect.arrayContaining(["/release-e2e/", "/integration-e2e/", "parity-scenarios.ts"]),
+    );
+    const root = freshDir("cw-verify-harness-");
+    const base = join(root, "packages", "core", "src");
+    const releaseE2e = join(base, "release-e2e");
+    const integrationE2e = join(base, "integration-e2e");
+    const vbrief = join(base, "vbrief-validation");
+    const product = join(base, "product");
+    mkdirSync(releaseE2e, { recursive: true });
+    mkdirSync(integrationE2e, { recursive: true });
+    mkdirSync(vbrief, { recursive: true });
+    mkdirSync(product, { recursive: true });
+    writeFileSync(join(releaseE2e, "npm-ops.ts"), 'writeFileSync("/tmp/e2e", "x");\n', "utf8");
+    writeFileSync(join(integrationE2e, "helpers.ts"), 'writeFileSync("/tmp/ie2e", "x");\n', "utf8");
+    writeFileSync(join(vbrief, "parity-scenarios.ts"), 'writeFileSync("/tmp/parity", "x");\n', "utf8");
+    writeFileSync(join(product, "sink.ts"), 'writeFileSync("/tmp/product", "x");\n', "utf8");
+
+    const open = evaluateContainedWrites({ projectRoot: root });
+    expect(open.findings.every((f) => !f.path.includes("release-e2e"))).toBe(true);
+    expect(open.findings.every((f) => !f.path.includes("integration-e2e"))).toBe(true);
+    expect(open.findings.every((f) => !f.path.includes("parity-scenarios"))).toBe(true);
+    expect(open.findings.some((f) => f.path.includes("product/sink.ts"))).toBe(true);
+
+    const enforced = evaluateContainedWrites({ projectRoot: root, enforce: true });
+    expect(enforced.code).toBe(1);
+    expect(enforced.findings.some((f) => f.path.includes("product/sink.ts"))).toBe(true);
+    expect(enforced.findings.some((f) => f.path.includes("release-e2e"))).toBe(false);
+    expect(enforced.findings.some((f) => f.path.includes("integration-e2e"))).toBe(false);
+    expect(enforced.findings.some((f) => f.path.includes("parity-scenarios"))).toBe(false);
   });
 });

--- a/packages/core/src/verify-source/contained-writes.test.ts
+++ b/packages/core/src/verify-source/contained-writes.test.ts
@@ -126,7 +126,11 @@ describe("evaluateContainedWrites (#2951)", () => {
     mkdirSync(product, { recursive: true });
     writeFileSync(join(releaseE2e, "npm-ops.ts"), 'writeFileSync("/tmp/e2e", "x");\n', "utf8");
     writeFileSync(join(integrationE2e, "helpers.ts"), 'writeFileSync("/tmp/ie2e", "x");\n', "utf8");
-    writeFileSync(join(vbrief, "parity-scenarios.ts"), 'writeFileSync("/tmp/parity", "x");\n', "utf8");
+    writeFileSync(
+      join(vbrief, "parity-scenarios.ts"),
+      'writeFileSync("/tmp/parity", "x");\n',
+      "utf8",
+    );
     writeFileSync(join(product, "sink.ts"), 'writeFileSync("/tmp/product", "x");\n', "utf8");
 
     const open = evaluateContainedWrites({ projectRoot: root });

--- a/packages/core/src/verify-source/contained-writes.ts
+++ b/packages/core/src/verify-source/contained-writes.ts
@@ -14,7 +14,7 @@
  *   1 — findings under `--enforce` (fail-closed)
  *   2 — config error (project root missing)
  *
- * Refs #2951.
+ * Refs #2951, #2980 (e2e/parity harness exclusions).
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
@@ -65,6 +65,18 @@ const TEST_PATH_MARKERS: readonly string[] = [
   "\\fixtures\\",
 ];
 
+/**
+ * Non-product harness path markers excluded from the product inventory (#2980).
+ * Prefer exclusion over permanent CONTAINED_WRITES_ALLOWLIST entries for e2e/parity noise.
+ * Paths are matched as posix substrings after `toPosix` (always `/` separators).
+ */
+export const NON_PRODUCT_HARNESS_PATH_MARKERS: readonly string[] = [
+  "/release-e2e/",
+  "/integration-e2e/",
+  "parity-scenarios.ts",
+  "parity-scenarios.tsx",
+];
+
 export interface ContainedWriteFinding {
   readonly path: string;
   readonly line: number;
@@ -98,6 +110,11 @@ function isTestPath(relPosix: string): boolean {
   return TEST_PATH_MARKERS.some((m) => relPosix.includes(m.replace(/\\/g, "/")));
 }
 
+/** E2E / parity harness under src/ — not product sinks (#2980 scanner hygiene). */
+function isNonProductHarnessPath(relPosix: string): boolean {
+  return NON_PRODUCT_HARNESS_PATH_MARKERS.some((m) => relPosix.includes(m));
+}
+
 /** Strip trailing `/` without regex (CodeQL js/polynomial-redos safe). */
 function stripTrailingSlashes(path: string): string {
   let end = path.length;
@@ -108,7 +125,7 @@ function stripTrailingSlashes(path: string): string {
 }
 
 function isAllowlisted(relPosix: string, allow: readonly string[]): boolean {
-  if (isTestPath(relPosix)) {
+  if (isTestPath(relPosix) || isNonProductHarnessPath(relPosix)) {
     return true;
   }
   return allow.some((entry) => {


### PR DESCRIPTION
## Summary

Scanner hygiene slice of residual #2980 / epic #2951:

- Exclude non-product e2e/parity harness paths from `verify:contained-writes` product inventory via `NON_PRODUCT_HARNESS_PATH_MARKERS` (`release-e2e/**`, `integration-e2e/**`, `**/parity-scenarios.ts`).
- Tests assert harness exclusions and that a product raw write still fails under `--enforce`.
- Docs: Go installer contained-write is deferred/frozen; residual = TS product + enforce.
- CHANGELOG Unreleased entry cites #2980 hygiene.

Inventory noise on current tree: 164 -> 138 findings (26 harness hits dropped). Product migration waves remain open on #2980.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/verify-source/contained-writes.test.ts` (9 pass)
- [x] `task verify:contained-writes` advisory; zero release-e2e / integration-e2e / parity-scenarios findings
- [x] `task verify:branch` / `task verify:forward-coverage`

## Linking

Implements part of #2980 (hygiene + docs only). Does **not** close #2980 or #2951.
