### PR TITLE
test(coverage): restore branches >= 85% after v0.89.0 hairline (#2986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vitest branch coverage restored above 85% (#2986).** Focused authz verb-classification / AFK-template / classify / evaluate edge tests, hooks read-only payload shapes, and authz CLI argv branches clear the v0.89.0 84.9% hairline so the next release Step 5 passes without a consecutive `--allow-coverage-debt` soft-pass. Closes #2986.
+
 ### Removed
 
 ## [0.89.0] - 2026-07-30

--- a/packages/cli/src/authz.test.ts
+++ b/packages/cli/src/authz.test.ts
@@ -262,4 +262,104 @@ describe("authz CLI (#2944)", () => {
     // Use grant with operations that mint to invalid path by using a file-as-root if possible.
     expect(main(["-h"])).toBe(0);
   });
+
+  it("covers remaining argv/template CLI branches (#2986)", () => {
+    const root = tempRoot();
+    const out: string[] = [];
+    const err: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((c) => {
+      out.push(String(c));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((c) => {
+      err.push(String(c));
+      return true;
+    });
+
+    // Leading -- separators + camelCase projectRoot + ops alias + format text.
+    expect(
+      main([
+        "--",
+        "grant",
+        "--",
+        "--projectRoot",
+        root,
+        "--ops",
+        "edit push",
+        "--cohort",
+        "c",
+        "--surfaces",
+        "src/**,pkg/**",
+        "--stories",
+        "1,2",
+        "--issues",
+        "10 11",
+        "--planRef",
+        "plan-1",
+        "--repo",
+        "o/r",
+        "--branch",
+        "feat",
+        "--expires-at",
+        "2099-01-01T00:00:00Z",
+        "--format",
+        "text",
+      ]),
+    ).toBe(0);
+    expect(out.join("")).toMatch(/grant minted/);
+
+    // grant- prefix id path maps to revoke with grantId preset.
+    expect(main(["grant-not-found", "--project-root", root])).toBe(1);
+
+    // Unknown template + closed-verb without target already covered; finish-loop surfaces path.
+    out.length = 0;
+    expect(
+      main([
+        "grant",
+        "--project-root",
+        root,
+        "--template",
+        "finish-loop",
+        "--surfaces",
+        "src/**",
+        "--stories",
+        "s1",
+        "--issues",
+        "99",
+        "--cohort",
+        "walk",
+        "--single-use",
+      ]),
+    ).toBe(0);
+    expect(out.join("")).toMatch(/finish-loop walk-away/);
+
+    // release-publish template with target (closed-verb branch of mintAfk).
+    out.length = 0;
+    expect(
+      main([
+        "grant",
+        "--project-root",
+        root,
+        "--template",
+        "release-publish",
+        "--target",
+        "0.50.0",
+        "--actor",
+        "op",
+      ]),
+    ).toBe(0);
+    expect(out.join("")).toMatch(/target surfaces=/);
+
+    // format json on show with inactive UAT.
+    out.length = 0;
+    const empty = tempRoot();
+    expect(main(["show", "--project-root", empty, "--format", "json"])).toBe(0);
+    expect(out.join("")).toMatch(/"uat"/);
+
+    // Unknown format falls back to text.
+    expect(main(["show", "--project-root", empty, "--format", "yaml"])).toBe(0);
+
+    // grant-id positional already tested; unknown flag is ignored without error.
+    expect(main(["show", "--project-root", empty, "--bogus-flag"])).toBe(0);
+  });
 });

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -110,4 +110,54 @@ describe("classifyShellAuthzOps (#2944)", () => {
       }),
     ).toContain("merge");
   });
+
+  it("covers gh flag forms and hook name variants (#2986)", () => {
+    // --flag=value form and remaining GH_VALUE_FLAGS spellings.
+    expect(classifyShellAuthzOps("gh --repo=owner/repo pr create --title t")).toContain("pr");
+    expect(classifyShellAuthzOps("gh --hostname github.com pr merge 1")).toContain("merge");
+    expect(classifyShellAuthzOps("gh -a app pr create --title t")).toContain("pr");
+    expect(classifyShellAuthzOps("gh --app app pr edit 3")).toContain("pr");
+    expect(classifyShellAuthzOps("gh --jq . pr ready 2")).toContain("pr");
+    expect(classifyShellAuthzOps("sudo gh pr create --title t")).toContain("pr");
+    expect(classifyShellAuthzOps("command gh pr merge 9")).toContain("merge");
+    expect(classifyShellAuthzOps("pytest")).toContain("test");
+    // Boolean short flags before resource are skipped without consuming a value.
+    expect(classifyShellAuthzOps("gh --json pr merge 4")).toContain("merge");
+
+    expect(
+      classifyHookAuthzOps({
+        toolName: "run_terminal_cmd",
+        shellCommand: "git push origin HEAD",
+        isDirectWrite: false,
+      }),
+    ).toContain("push");
+    expect(
+      classifyHookAuthzOps({
+        toolName: "pull_request_create",
+        shellCommand: null,
+        isDirectWrite: false,
+      }),
+    ).toEqual(["pr"]);
+    expect(
+      classifyHookAuthzOps({
+        toolName: "mcp__x__pr_create",
+        shellCommand: null,
+        isDirectWrite: false,
+      }),
+    ).toEqual(["pr"]);
+    expect(
+      classifyHookAuthzOps({
+        toolName: "issue_create",
+        shellCommand: null,
+        isDirectWrite: false,
+      }),
+    ).toEqual(["issue_mutation"]);
+    expect(
+      classifyHookAuthzOps({
+        toolName: "mcp__github__create_issue",
+        shellCommand: null,
+        isDirectWrite: false,
+      }),
+    ).toEqual(["issue_mutation"]);
+  });
 });

--- a/packages/core/src/authz/closed-verb.test.ts
+++ b/packages/core/src/authz/closed-verb.test.ts
@@ -10,14 +10,22 @@ import {
 } from "./closed-verb.js";
 import {
   assertNoIndependentSessionAuthMint,
+  isAfkTemplateName,
+  isClosedVerbTemplateName,
+  isFinishLoopTemplateName,
+  mintAfkTemplateGrant,
   mintClosedVerbTemplateGrant,
+  mintFinishLoopTemplateGrant,
   resolveClosedVerbTemplate,
+  resolveFinishLoopTemplate,
 } from "./templates.js";
 import type { HumanOriginGrant } from "./types.js";
 import {
   builtinReleaseVerbClassification,
+  getVerbRow,
   loadVerbClassification,
   parseVerbClassification,
+  resolveVerbClassificationPath,
 } from "./verb-classification.js";
 
 function grant(partial: {
@@ -471,6 +479,128 @@ describe("AFK templates (#1095)", () => {
     expect(guard.mintPath).toBe("mintHumanOriginGrant");
     expect(guard.sessionAuthIsAuthority).toBe(false);
   });
+
+  it("template name guards and finish-loop resolve edges (#2986)", () => {
+    expect(isClosedVerbTemplateName("release-cut")).toBe(true);
+    expect(isClosedVerbTemplateName("finish-loop")).toBe(false);
+    expect(isFinishLoopTemplateName(" Finish-Loop ")).toBe(true);
+    expect(isAfkTemplateName("release-publish")).toBe(true);
+    expect(isAfkTemplateName("nope")).toBe(false);
+
+    const fl = resolveFinishLoopTemplate({
+      now: new Date("2026-07-30T00:00:00Z"),
+      durationHours: 0.4,
+      surfaces: ["src/**"],
+    });
+    expect(fl.operations).toEqual(["edit", "push", "pr", "merge"]);
+    expect(fl.surfaces).toEqual(["src/**"]);
+    // durationHours < 1 floors to 1h via Math.max(1, floor(...)).
+    expect(fl.expiresAt).toMatch(/2026-07-30T01:00:00Z/);
+
+    const flExplicit = resolveFinishLoopTemplate({
+      expiresAt: "2099-01-01T00:00:00Z",
+    });
+    expect(flExplicit.expiresAt).toBe("2099-01-01T00:00:00Z");
+    expect(flExplicit.surfaces).toEqual([]);
+  });
+
+  it("mintAfkTemplateGrant dispatches finish-loop vs closed-verb vs rejects (#2986)", () => {
+    const root = mkdtempSync(join(tmpdir(), "authz-afk-"));
+    try {
+      const fl = mintAfkTemplateGrant({
+        projectRoot: root,
+        template: "finish-loop",
+        actor: "op",
+        durationHours: 2,
+        storyIds: ["s1"],
+        issueIds: [1],
+        cohortId: "c1",
+      });
+      expect(fl.origin.kind).toBe("operator-cli");
+      expect(fl.scope.operations).toEqual(["edit", "push", "pr", "merge"]);
+      expect(fl.scope.storyIds).toEqual(["s1"]);
+
+      const cut = mintAfkTemplateGrant({
+        projectRoot: root,
+        template: "release-cut",
+        target: "0.40.0",
+        actor: "op",
+      });
+      expect(cut.scope.operations).toEqual(["release-cut"]);
+      expect(cut.scope.surfaces).toEqual(expect.arrayContaining(["0.40.0", "v0.40.0"]));
+
+      expect(() => mintAfkTemplateGrant({ projectRoot: root, template: "not-a-template" })).toThrow(
+        /unknown AFK template/,
+      );
+      expect(() =>
+        mintAfkTemplateGrant({ projectRoot: root, template: "release-publish", target: "  " }),
+      ).toThrow(/non-empty --target/);
+      expect(() =>
+        mintAfkTemplateGrant({ projectRoot: root, template: "release-publish", target: null }),
+      ).toThrow(/non-empty --target/);
+
+      // Custom classification missing the template row fails closed.
+      expect(() =>
+        resolveClosedVerbTemplate({
+          template: "release-publish",
+          target: "1.0.0",
+          classification: parseVerbClassification({
+            schemaVersion: 1,
+            verbs: {
+              "release-cut": {
+                closure_set: [],
+                explicit_required: [],
+                irreversibility: "destructive",
+                wildcard_allowed: false,
+                recurring_allowed: false,
+                default_expiry: "not-hours",
+                skill: "s",
+                phase: "p",
+                authz_operations: ["release-cut"],
+                env_bypass: "DEFT_ALLOW_RELEASE_CUT",
+              },
+            },
+          }),
+        }),
+      ).toThrow(/missing row/);
+
+      // Non-Xh default_expiry falls through parseExpiryHours to 1h.
+      const odd = resolveClosedVerbTemplate({
+        template: "release-cut",
+        target: "1.0.0",
+        now: new Date("2026-07-30T00:00:00Z"),
+        classification: parseVerbClassification({
+          schemaVersion: 1,
+          verbs: {
+            "release-cut": {
+              closure_set: [],
+              explicit_required: [],
+              irreversibility: "destructive",
+              wildcard_allowed: false,
+              recurring_allowed: false,
+              default_expiry: "not-hours",
+              skill: "s",
+              phase: "p",
+              authz_operations: ["release-cut"],
+              env_bypass: "DEFT_ALLOW_RELEASE_CUT",
+            },
+          },
+        }),
+      });
+      expect(odd.expiresAt).toMatch(/2026-07-30T01:00:00Z/);
+
+      const flDirect = mintFinishLoopTemplateGrant({
+        projectRoot: root,
+        actor: "op",
+        expiresAt: "2099-06-01T00:00:00Z",
+        singleUse: true,
+      });
+      expect(flDirect.semantics.singleUse).toBe(true);
+      expect(flDirect.semantics.expiresAt).toBe("2099-06-01T00:00:00Z");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("verb-classification parse branches", () => {
@@ -557,5 +687,91 @@ describe("verb-classification parse branches", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("covers remaining schema field reject branches (#2986)", () => {
+    const baseRow = {
+      closure_set: [],
+      explicit_required: [],
+      irreversibility: "destructive",
+      wildcard_allowed: false,
+      recurring_allowed: false,
+      default_expiry: "1h",
+      skill: "s",
+      phase: "p",
+      authz_operations: ["deployment"],
+      env_bypass: "DEFT_ALLOW_X",
+    };
+    // Non-object verb row.
+    expect(() => parseVerbClassification({ schemaVersion: 1, verbs: { x: "nope" } })).toThrow(
+      /must be an object/,
+    );
+    // Missing / empty scalar fields.
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { x: { ...baseRow, irreversibility: "" } },
+      }),
+    ).toThrow(/irreversibility/);
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { x: { ...baseRow, wildcard_allowed: "yes" } },
+      }),
+    ).toThrow(/wildcard_allowed/);
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { x: { ...baseRow, recurring_allowed: "no" } },
+      }),
+    ).toThrow(/recurring_allowed/);
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { x: { ...baseRow, default_expiry: "  " } },
+      }),
+    ).toThrow(/default_expiry/);
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { x: { ...baseRow, skill: "" } },
+      }),
+    ).toThrow(/skill/);
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { x: { ...baseRow, phase: "" } },
+      }),
+    ).toThrow(/phase/);
+    // Empty-string array entries + empty verbs map + empty verb name.
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { x: { ...baseRow, closure_set: ["ok", "  "] } },
+      }),
+    ).toThrow(/non-empty strings/);
+    expect(() => parseVerbClassification({ schemaVersion: 1, verbs: {} })).toThrow(
+      /at least one row/,
+    );
+    expect(() =>
+      parseVerbClassification({
+        schemaVersion: 1,
+        verbs: { "  ": baseRow },
+      }),
+    ).toThrow(/verb name must be non-empty/);
+    // description optional string + case-insensitive getVerbRow.
+    const table = parseVerbClassification({
+      schemaVersion: 1,
+      description: "test table",
+      verbs: {
+        "Release-Publish": baseRow,
+      },
+    });
+    expect(table.description).toBe("test table");
+    expect(getVerbRow(table, "release-publish")?.env_bypass).toBe("DEFT_ALLOW_X");
+    expect(getVerbRow(table, "missing")).toBeNull();
+    // Non-Error JSON parse failure path is hard; empty projectRoot still resolves cwd candidates.
+    expect(resolveVerbClassificationPath("")).not.toBeNull();
+    expect(resolveVerbClassificationPath(null)).not.toBeNull();
   });
 });

--- a/packages/core/src/authz/evaluate-branches.test.ts
+++ b/packages/core/src/authz/evaluate-branches.test.ts
@@ -371,24 +371,23 @@ describe("evaluateAuthzMutation branch coverage (#2944)", () => {
     ).toBe("authz-inactive");
 
     // op not covered by grant (push grant, edit attempt).
+    const pushOnlyGrant = grant({
+      scope: {
+        planRef: null,
+        repo: null,
+        branch: null,
+        worktree: null,
+        surfaces: [],
+        operations: ["push"],
+        storyIds: [],
+        issueIds: [],
+        cohortId: "c",
+      },
+    });
     expect(
       evaluateAuthzMutation({
         state: uatState(),
-        grants: [
-          grant({
-            scope: {
-              planRef: null,
-              repo: null,
-              branch: null,
-              worktree: null,
-              surfaces: [],
-              operations: ["push"],
-              storyIds: [],
-              issueIds: [],
-              cohortId: "c",
-            },
-          }),
-        ],
+        grants: [pushOnlyGrant],
         op: "edit",
         path: "src/a.ts",
       }).code,

--- a/packages/core/src/authz/evaluate-branches.test.ts
+++ b/packages/core/src/authz/evaluate-branches.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { evaluateAuthzMutation, shouldConsumeSingleUseGrant } from "./evaluate.js";
+import { describeScope, evaluateAuthzMutation, shouldConsumeSingleUseGrant } from "./evaluate.js";
 import type { AuthzState, HumanOriginGrant } from "./types.js";
 
 function uatState(active = true): AuthzState {
@@ -312,5 +312,114 @@ describe("evaluateAuthzMutation branch coverage (#2944)", () => {
       path: "incidents/2026-uat.md",
     });
     expect(d.allowed).toBe(true);
+  });
+
+  it("empty cohortId under UAT is scope-deny; describeScope edges (#2986)", () => {
+    const emptyCohort = grant({
+      scope: {
+        planRef: "plan-x",
+        repo: null,
+        branch: null,
+        worktree: null,
+        surfaces: [],
+        operations: ["edit", "push"],
+        storyIds: [],
+        issueIds: [],
+        cohortId: "",
+      },
+    });
+    const d = evaluateAuthzMutation({
+      state: uatState(),
+      grants: [emptyCohort],
+      op: "edit",
+      path: "src/a.ts",
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.code).toBe("authz-grant-scope-deny");
+    expect(d.reason).toMatch(/named fix cohort|cohortId/);
+
+    const nullCohort = grant({
+      scope: {
+        planRef: null,
+        repo: null,
+        branch: null,
+        worktree: null,
+        surfaces: [],
+        operations: ["push"],
+        storyIds: [],
+        issueIds: [],
+        cohortId: null,
+      },
+    });
+    expect(
+      evaluateAuthzMutation({
+        state: uatState(),
+        grants: [nullCohort],
+        op: "push",
+        path: null,
+      }).allowed,
+    ).toBe(false);
+
+    // issue_mutation outside UAT takes the inactive allow branch.
+    expect(
+      evaluateAuthzMutation({
+        state: uatState(false),
+        grants: [],
+        op: "issue_mutation",
+        path: null,
+      }).code,
+    ).toBe("authz-inactive");
+
+    // op not covered by grant (push grant, edit attempt).
+    expect(
+      evaluateAuthzMutation({
+        state: uatState(),
+        grants: [
+          grant({
+            scope: {
+              planRef: null,
+              repo: null,
+              branch: null,
+              worktree: null,
+              surfaces: [],
+              operations: ["push"],
+              storyIds: [],
+              issueIds: [],
+              cohortId: "c",
+            },
+          }),
+        ],
+        op: "edit",
+        path: "src/a.ts",
+      }).code,
+    ).toBe("authz-grant-scope-deny");
+
+    expect(describeScope(null)).toBe("(none)");
+    expect(
+      describeScope({
+        planRef: null,
+        repo: null,
+        branch: null,
+        worktree: null,
+        surfaces: [],
+        operations: ["edit"],
+        storyIds: [],
+        issueIds: [],
+        cohortId: null,
+      }),
+    ).toMatch(/ops=\[edit\]/);
+    expect(
+      describeScope({
+        planRef: "p1",
+        repo: null,
+        branch: null,
+        worktree: null,
+        surfaces: ["src/**"],
+        operations: ["push"],
+        storyIds: [],
+        issueIds: [],
+        cohortId: "c1",
+      }),
+    ).toMatch(/cohort=c1/);
   });
 });

--- a/packages/core/src/hooks/readonly.test.ts
+++ b/packages/core/src/hooks/readonly.test.ts
@@ -34,3 +34,50 @@ describe("explore spawn detection (#1185)", () => {
     expect(isExploreSpawn({ workerRole: "leaf-implementation" })).toBe(false);
   });
 });
+
+describe("read-only payload shape edges (#2986)", () => {
+  it("reads capability from tool_call.arguments and nested booleans", () => {
+    expect(hookReadOnlyFromPayload(null)).toBe(false);
+    expect(hookReadOnlyFromPayload("string")).toBe(false);
+    expect(
+      hookReadOnlyFromPayload({
+        tool_call: { arguments: { capability_mode: "read only" } },
+      }),
+    ).toBe(true);
+    expect(
+      hookReadOnlyFromPayload({
+        toolCall: { arguments: { defaultCapabilityMode: "read-only" } },
+      }),
+    ).toBe(true);
+    expect(
+      hookReadOnlyFromPayload({
+        tool_input: { posture: "read_only" },
+      }),
+    ).toBe(true);
+    expect(
+      hookReadOnlyFromPayload({
+        session_posture: "read-only",
+      }),
+    ).toBe(true);
+    expect(
+      hookReadOnlyFromPayload({
+        sessionPosture: "read-only",
+      }),
+    ).toBe(true);
+    expect(hookReadOnlyFromPayload({ tool_input: { read_only: true } })).toBe(true);
+    expect(hookReadOnlyFromPayload({ toolInput: { readOnly: true } })).toBe(true);
+    expect(hookReadOnlyFromPayload({ read_only: true })).toBe(true);
+    // Empty / non-readonly capability strings stay false.
+    expect(hookReadOnlyFromPayload({ capability_mode: "  " })).toBe(false);
+    expect(hookReadOnlyFromPayload({ capabilityMode: "readonly" })).toBe(true);
+    // Env truthy variants.
+    expect(isReadOnlyHookContext({}, { [READ_ONLY_HOOK_ENV]: "true" })).toBe(true);
+    expect(isReadOnlyHookContext({}, { [READ_ONLY_HOOK_ENV]: "yes" })).toBe(true);
+    expect(isReadOnlyHookContext({}, { [READ_ONLY_HOOK_ENV]: "on" })).toBe(true);
+    expect(isReadOnlyHookContext({}, { [READ_ONLY_HOOK_ENV]: "0" })).toBe(false);
+    // explore via workerRole camelCase and non-object payload.
+    expect(isExploreSpawn({ workerRole: "explore" })).toBe(true);
+    expect(isExploreSpawn(null)).toBe(false);
+    expect(isExploreSpawn({ tool_input: { workerRole: "explore" } })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Restore Vitest branch coverage to >=85% after the v0.89.0 release Step 5 hairline (measured 84.88% branches). All four metrics now pass without `--allow-coverage-debt`.

## Changes

- Authz verb-classification schema reject branches + AFK template dispatch edges
- Authz shell/hook classify flag and tool-name variants
- Authz evaluate empty-cohort / describeScope edges
- Hooks read-only payload shape edges
- Authz CLI argv/template branch coverage
- CHANGELOG [Unreleased] entry for #2986

## Coverage (local `task check` / vitest --coverage)

| Metric | Value |
|--------|-------|
| Statements | 88.11% |
| Branches | 85.00% |
| Functions | 95.75% |
| Lines | 88.11% |

Closes #2986.