### PR TITLE
fix(release-e2e): push-mirror 300s timeout + non-blank failure (#3004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **release:e2e push-mirror no longer dies on the generic 30s `runGit` timeout (#3004).** First full heads+tags mirror of a large repo (many tags / ~30MB pack) exceeded `packages/core/src/release/git.ts` default 30s, killing the push with empty stderr (`failed: `). `pushMirror` now uses a 300s timeout (same order as clone) and surfaces a non-blank timeout/exit reason; `spawnText` also fills empty stderr on signal/timeout kills. Closes #3004.
 - **Vitest branch coverage restored above 85% (#2986).** Focused authz verb-classification / AFK-template / classify / evaluate edge tests, hooks read-only payload shapes, and authz CLI argv branches clear the v0.89.0 84.9% hairline so the next release Step 5 passes without a consecutive `--allow-coverage-debt` soft-pass. Closes #2986.
 
 ### Removed

--- a/packages/core/src/release-e2e/coverage.test.ts
+++ b/packages/core/src/release-e2e/coverage.test.ts
@@ -42,6 +42,15 @@ describe("release-e2e branch coverage boost", () => {
     expect(ok).toBe(true);
   });
 
+  it("pushMirror empty-stderr failure includes timeout hint (#3004)", () => {
+    const [ok, reason] = pushMirror("/clone", {
+      runGit: () => ({ status: 128, stdout: "", stderr: "" }),
+    });
+    expect(ok).toBe(false);
+    expect(reason).toMatch(/no stderr/);
+    expect(reason).toMatch(/300000|timeout/i);
+  });
+
   it("generateRepoSlug seam override", () => {
     expect(generateRepoSlug({ generateRepoSlug: () => "custom-slug" })).toBe("custom-slug");
   });

--- a/packages/core/src/release-e2e/git-ops.ts
+++ b/packages/core/src/release-e2e/git-ops.ts
@@ -29,9 +29,7 @@ export function formatGitOpFailure(
     return `${op} failed: ${stderr}`;
   }
   const timeoutHint =
-    options.timeoutMs !== undefined
-      ? `; possible timeout after ${options.timeoutMs}ms`
-      : "";
+    options.timeoutMs !== undefined ? `; possible timeout after ${options.timeoutMs}ms` : "";
   return `${op} failed: no stderr (exit ${result.status ?? "null"}${timeoutHint})`;
 }
 

--- a/packages/core/src/release-e2e/git-ops.ts
+++ b/packages/core/src/release-e2e/git-ops.ts
@@ -1,6 +1,10 @@
 import { runGit as releaseRunGit } from "../release/git.js";
 import { spawnText } from "../release/spawn.js";
+import type { SpawnResult } from "../release/types.js";
 import type { E2ESeams } from "./types.js";
+
+/** Mirror push can exceed the generic release `runGit` 30s cap (#3004). Align with clone. */
+export const PUSH_MIRROR_TIMEOUT_MS = 300_000;
 
 function defaultRunGit(
   projectRoot: string,
@@ -12,6 +16,23 @@ function defaultRunGit(
     return seams.runGit(projectRoot, args, env);
   }
   return releaseRunGit(projectRoot, args, { spawnText: seams.spawnText ?? spawnText }, env);
+}
+
+/** Prefer stderr; never leave a blank reason after "failed:" (#3004). */
+export function formatGitOpFailure(
+  op: string,
+  result: SpawnResult,
+  options: { timeoutMs?: number } = {},
+): string {
+  const stderr = result.stderr.trim();
+  if (stderr.length > 0) {
+    return `${op} failed: ${stderr}`;
+  }
+  const timeoutHint =
+    options.timeoutMs !== undefined
+      ? `; possible timeout after ${options.timeoutMs}ms`
+      : "";
+  return `${op} failed: no stderr (exit ${result.status ?? "null"}${timeoutHint})`;
 }
 
 export function cloneRepoToTemp(
@@ -46,14 +67,30 @@ export function setOriginToTempRepo(
 }
 
 export function pushMirror(cloneDir: string, seams: E2ESeams = {}): [boolean, string] {
-  const result = defaultRunGit(
-    cloneDir,
-    ["push", "origin", "refs/heads/*:refs/heads/*", "refs/tags/*:refs/tags/*"],
-    undefined,
-    seams,
-  );
+  // Do not use default release runGit (30s) — full heads+tags mirror of directive
+  // routinely exceeds that on first push to an empty temp repo (#3004).
+  const pushArgs = [
+    "push",
+    "origin",
+    "refs/heads/*:refs/heads/*",
+    "refs/tags/*:refs/tags/*",
+  ] as const;
+  let result: SpawnResult;
+  if (seams.runGit) {
+    result = seams.runGit(cloneDir, [...pushArgs], undefined);
+  } else {
+    const spawn = seams.spawnText ?? spawnText;
+    result = spawn("git", ["-C", cloneDir, ...pushArgs], {
+      timeoutMs: PUSH_MIRROR_TIMEOUT_MS,
+    });
+  }
   if (result.status !== 0) {
-    return [false, `git push (heads+tags refspecs) failed: ${result.stderr.trim()}`];
+    return [
+      false,
+      formatGitOpFailure("git push (heads+tags refspecs)", result, {
+        timeoutMs: PUSH_MIRROR_TIMEOUT_MS,
+      }),
+    ];
   }
   return [true, "pushed heads + tags to temp origin"];
 }

--- a/packages/core/src/release/spawn.ts
+++ b/packages/core/src/release/spawn.ts
@@ -35,6 +35,17 @@ export function spawnText(
   if (status === null) {
     if (result.signal !== null && result.signal !== undefined) {
       status = 128;
+      // Timeout kills leave stderr empty; surface timeout so e2e never reports
+      // "failed: " with a blank reason (#3004 / #1867).
+      if (stderr.trim().length === 0) {
+        if (result.error) {
+          stderr = result.error.message;
+        } else if (options.timeoutMs !== undefined) {
+          stderr = `process terminated by signal ${result.signal} (timeout ${options.timeoutMs}ms)`;
+        } else {
+          stderr = `process terminated by signal ${result.signal}`;
+        }
+      }
     } else if (result.error) {
       status = 2;
       // ENOBUFS (stdout over maxBuffer) and similar spawn failures leave stderr

--- a/packages/core/src/vbrief-validate/extra-coverage.test.ts
+++ b/packages/core/src/vbrief-validate/extra-coverage.test.ts
@@ -323,7 +323,12 @@ describe("vbrief-validate extra coverage", () => {
       extra: true,
     });
     expect(findings.length).toBeGreaterThan(3);
-    expect(renderFinding(findings[0]!)).toContain("bare key");
+    const first = findings[0];
+    expect(first).toBeDefined();
+    if (first === undefined) {
+      throw new Error("expected at least one finding");
+    }
+    expect(renderFinding(first)).toContain("bare key");
 
     const root = mkdtempSync(join(tmpdir(), "vb-conf-full-"));
     mkdirSync(join(root, "xbrief"), { recursive: true });


### PR DESCRIPTION
## Summary

Fixes release:e2e push-mirror dying on the generic `runGit` 30s timeout when first full heads+tags mirror exceeds 30s (empty stderr → `failed: `).

## Changes

- `pushMirror` uses **300s** timeout (same order as clone), not release `runGit` 30s
- Non-blank failure reasons when stderr empty
- `spawnText` fills empty stderr on signal/timeout kills
- Unit test for empty-stderr timeout hint
- CHANGELOG

Closes #3004

## Test plan

- [x] `pnpm exec vitest run packages/core/src/release-e2e/...` (89 passed)
- [ ] Full `task release:e2e` after merge