### PR TITLE
test(coverage): restore Vitest branches >=85% after v0.90.0 hairline (#3003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vitest branch coverage restored above 85% (#3003).** Focused session-ready, process-cost, OpenClaw pin-assess, and release-e2e failure-formatting edge tests clear the v0.90.0 84.99% hairline so release Step 5 passes without `--allow-coverage-debt`. Closes #3003.
 - **release:e2e push-mirror no longer dies on the generic 30s `runGit` timeout (#3004).** First full heads+tags mirror of a large repo (many tags / ~30MB pack) exceeded `packages/core/src/release/git.ts` default 30s, killing the push with empty stderr (`failed: `). `pushMirror` now uses a 300s timeout (same order as clone) and surfaces a non-blank timeout/exit reason; `spawnText` also fills empty stderr on signal/timeout kills. Closes #3004.
 - **Vitest branch coverage restored above 85% (#2986).** Focused authz verb-classification / AFK-template / classify / evaluate edge tests, hooks read-only payload shapes, and authz CLI argv branches clear the v0.89.0 84.9% hairline so the next release Step 5 passes without a consecutive `--allow-coverage-debt` soft-pass. Closes #2986.
 

--- a/packages/core/src/doctor/openclaw-skills.test.ts
+++ b/packages/core/src/doctor/openclaw-skills.test.ts
@@ -125,6 +125,32 @@ describe("assessOpenClawPins (#3001)", () => {
     const assessment = assessOpenClawPins(skills);
     expect(assessment.divergent).toContain("deft-directive-build");
   });
+
+  it("classifies plain file path as divergent (#3003)", () => {
+    const skills = join(makeTemp("oc-file-"), "skills");
+    mkdirSync(skills, { recursive: true });
+    writeFileSync(join(skills, "deft-directive-build"), "not-a-dir", "utf8");
+    const assessment = assessOpenClawPins(skills);
+    expect(assessment.divergent).toContain("deft-directive-build");
+    expect(assessment.missing).not.toContain("deft-directive-build");
+  });
+});
+
+describe("listInScopeSkillsDirs edges (#3003)", () => {
+  it("skips workspace-* names that are not directories", () => {
+    const state = makeTemp("oc-scope-file-");
+    writeFileSync(join(state, "workspace-notdir"), "x", "utf8");
+    const dirs = listInScopeSkillsDirs(state, true);
+    expect(dirs).toEqual([resolveMainSkillsDir(state)]);
+  });
+
+  it("dedupes main skills when already listed", () => {
+    const state = makeTemp("oc-scope-dedupe-");
+    mkdirSync(join(state, "workspace-main-ish"), { recursive: true });
+    const dirs = listInScopeSkillsDirs(state, true);
+    const main = resolveMainSkillsDir(state);
+    expect(dirs.filter((d) => d === main)).toHaveLength(1);
+  });
 });
 
 describe("installOpenClawPin (#3001)", () => {

--- a/packages/core/src/release-e2e/coverage.test.ts
+++ b/packages/core/src/release-e2e/coverage.test.ts
@@ -20,7 +20,7 @@ import { runWorkerEntrypoint } from "./entrypoint-worker.js";
 import { generateRepoSlug, parseE2EFlags } from "./flags.js";
 import * as ghOps from "./gh-ops.js";
 import * as gitOps from "./git-ops.js";
-import { pushMirror, setOriginToTempRepo } from "./git-ops.js";
+import { formatGitOpFailure, pushMirror, setOriginToTempRepo } from "./git-ops.js";
 import * as mainModule from "./main.js";
 import { cmdReleaseE2e, runE2e } from "./main.js";
 import * as rehearsalModule from "./rehearsal.js";
@@ -49,6 +49,18 @@ describe("release-e2e branch coverage boost", () => {
     expect(ok).toBe(false);
     expect(reason).toMatch(/no stderr/);
     expect(reason).toMatch(/300000|timeout/i);
+  });
+
+  it("formatGitOpFailure prefers stderr over timeout hint (#3003)", () => {
+    expect(
+      formatGitOpFailure(
+        "git push",
+        { status: 1, stdout: "", stderr: "  denied  " },
+        {
+          timeoutMs: 1000,
+        },
+      ),
+    ).toBe("git push failed: denied");
   });
 
   it("generateRepoSlug seam override", () => {

--- a/packages/core/src/session/process-cost.test.ts
+++ b/packages/core/src/session/process-cost.test.ts
@@ -154,6 +154,43 @@ describe("emitSessionRitualBlockedProcessCost (#2994)", () => {
     expect((record?.payload.detail as string).endsWith("...")).toBe(true);
   });
 
+  it("omits empty detail and default code when code provided (#3003)", () => {
+    const root = tempRoot();
+    const log = join(root, "events.jsonl");
+    const record = emitSessionRitualBlockedProcessCost(
+      { toolName: "Write", code: "ritual-stale", detail: "" },
+      { projectRoot: root, logPath: log },
+    );
+    expect(record).not.toBeNull();
+    expect(record?.payload).toEqual({
+      tool_name: "Write",
+      code: "ritual-stale",
+    });
+    expect(record?.payload).not.toHaveProperty("detail");
+    expect(record?.payload).not.toHaveProperty("recovery_tier");
+  });
+
+  it("includes non-skipped steps without skipped flag (#3003)", () => {
+    const root = tempRoot();
+    const log = join(root, "events.jsonl");
+    const record = emitSessionStartProcessCost(
+      {
+        ceremonyTier: "cold",
+        durationMs: 5,
+        exitCode: 0,
+        steps: [
+          { name: "alignment", duration_ms: 2, skipped: false },
+          { name: "branch_policy", duration_ms: 3 },
+        ],
+      },
+      { projectRoot: root, logPath: log },
+    );
+    expect(record?.payload.steps).toEqual([
+      { name: "alignment", duration_ms: 2 },
+      { name: "branch_policy", duration_ms: 3 },
+    ]);
+  });
+
   it("returns null without throwing on failure", () => {
     const root = tempRoot();
     const bad = join(root, "file-not-dir");

--- a/packages/core/src/session/session-ready.test.ts
+++ b/packages/core/src/session/session-ready.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   inferSessionReadyRepo,
   isCacheFreshFailure,
+  isGatedVerifyActuallyReady,
   runSessionReady,
   SESSION_READY_FAILED,
   SESSION_READY_FAST_PATH,
@@ -42,6 +43,14 @@ describe("isCacheFreshFailure", () => {
 
   it("does not match doctor-only failures", () => {
     expect(isCacheFreshFailure("session ritual gated step 'doctor' failed")).toBe(false);
+  });
+});
+
+describe("isGatedVerifyActuallyReady (#3003 hairline)", () => {
+  it("requires code 0 and not bypassed", () => {
+    expect(isGatedVerifyActuallyReady(okVerify())).toBe(true);
+    expect(isGatedVerifyActuallyReady(okVerify({ bypassed: true, wouldFailCode: 1 }))).toBe(false);
+    expect(isGatedVerifyActuallyReady(failVerify("nope"))).toBe(false);
   });
 });
 
@@ -289,5 +298,72 @@ describe("runSessionReady (#2993)", () => {
     expect(result.path).toBe(SESSION_READY_FAILED);
     expect(result.message).toContain("rate limited");
     expect(result.message).toContain("cache fetch-all");
+  });
+
+  it("skipCacheRecovery leaves cache_fresh as blocker without fetch (#3003)", () => {
+    const inspectRitual = vi
+      .fn()
+      .mockReturnValueOnce(failVerify("gated"))
+      .mockReturnValueOnce(okVerify({ tier: "quick" }));
+    const verifyRitual = vi.fn(() => failVerify("session ritual gated step 'cache_fresh' failed"));
+    const fetchAll = vi.fn();
+
+    const result = runSessionReady("/proj", {
+      inspectRitual,
+      verifyRitual,
+      fetchAll,
+      repo: "o/r",
+      skipCacheRecovery: true,
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.path).toBe(SESSION_READY_FAILED);
+    expect(fetchAll).not.toHaveBeenCalled();
+    expect(result.message).toContain("cache_fresh");
+  });
+
+  it("surfaces non-Error fetch throw as string cause (#3003)", () => {
+    const inspectRitual = vi
+      .fn()
+      .mockReturnValueOnce(failVerify("gated"))
+      .mockReturnValueOnce(okVerify({ tier: "quick" }));
+    const verifyRitual = vi.fn(() => failVerify("session ritual gated step 'cache_fresh' failed"));
+    const fetchAll = vi.fn(() => {
+      throw "boom-string";
+    });
+
+    const result = runSessionReady("/proj", {
+      inspectRitual,
+      verifyRitual,
+      fetchAll,
+      repo: "o/r",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("boom-string");
+  });
+
+  it("uses empty bypass message fallback when verify message blank (#3003)", () => {
+    const inspectRitual = vi
+      .fn()
+      .mockReturnValueOnce(failVerify("gated"))
+      .mockReturnValueOnce(okVerify({ tier: "quick" }));
+    const verifyRitual = vi.fn(() =>
+      okVerify({
+        bypassed: true,
+        wouldFailCode: 1,
+        message: "   ",
+      }),
+    );
+
+    const result = runSessionReady("/proj", {
+      inspectRitual,
+      verifyRitual,
+      fetchAll: vi.fn(),
+      repo: "a/b",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.message).toMatch(/bypassed|DEFT_SESSION_RITUAL_SKIP/i);
   });
 });


### PR DESCRIPTION
## Summary

Restore Vitest branch coverage to >=85% after the v0.90.0 84.99% hairline (#3003).

## Changes

- session-ready: isGatedVerifyActuallyReady, skipCacheRecovery, non-Error fetch throw, blank bypass message
- process-cost: empty detail omit, non-skipped steps without skipped flag
- openclaw-skills: plain-file divergent pin, workspace-* non-dir skip
- release-e2e: formatGitOpFailure prefers stderr
- CHANGELOG

## Coverage (local vitest --coverage)

| Metric | Value |
|--------|-------|
| Statements | 88.14% |
| Branches | 85.00% |
| Functions | 95.75% |
| Lines | 88.14% |

Closes #3003.