### PR TITLE
fix(deps): pin postcss@8.5.25 for Dependabot alert #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dependabot high: PostCSS path traversal via sourceMappingURL (alert #8).** Force `postcss@8.5.25` (>= 8.5.18 patched) through the pnpm 11 workspace override so the vite/vitest transitive pin clears the vulnerable `<= 8.5.17` range. Same pattern as the prior esbuild / brace-expansion pins in `pnpm-workspace.yaml`.
+
 ### Removed
 
 ## [0.90.0] - 2026-07-31

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   esbuild: ^0.28.1
   brace-expansion@2: 2.1.2
   brace-expansion@5: 5.0.7
+  postcss: 8.5.25
 
 importers:
 
@@ -825,8 +826,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -859,8 +860,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   process-nextick-args@2.0.1:
@@ -1716,7 +1717,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   normalize-path@3.0.0: {}
 
@@ -1737,9 +1738,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1944,7 +1945,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.25
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,10 @@ overrides:
   # and minimatch@10 (archiver + test-exclude). Pin both major lines.
   "brace-expansion@2": "2.1.2"
   "brace-expansion@5": "5.0.7"
+  # Dependabot high: PostCSS path traversal via sourceMappingURL auto-loading
+  # of arbitrary .map files (alert #8). Transitive via vite <- vitest.
+  # Patched range: >= 8.5.18 (pin latest stable 8.5.25).
+  postcss: "8.5.25"
 
 # pnpm 11 defaults to strictDepBuilds and blocks dependency build scripts
 # unless explicitly allowed via the `allowBuilds` map (it replaced the old
@@ -29,3 +33,4 @@ minimumReleaseAgeExclude:
   - vite@7.3.6
   - brace-expansion@2.1.2
   - brace-expansion@5.0.7
+  - postcss@8.5.25


### PR DESCRIPTION
## Summary

Clears the only open Dependabot alert (**#8**, high): PostCSS path traversal via `sourceMappingURL` auto-loading of arbitrary `.map` files (`postcss <= 8.5.17`).

- Pin `postcss@8.5.25` in `pnpm-workspace.yaml` overrides (pnpm 11 home for overrides)
- Refresh `pnpm-lock.yaml` so the vite/vitest transitive resolves to the patched line
- CHANGELOG `[Unreleased]` Fixed entry

Other listed alerts (#1, #3–#7) are already **fixed**.

## Test plan

- [x] `pnpm why postcss` reports only `8.5.25`
- [x] focused vitest smoke green
- [ ] CI merge gate green

Refs Dependabot alert #8.