### PR TITLE
fix(doctor): OpenClaw always-pins prefer copy over symlink (#3008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Dependabot high: PostCSS path traversal via sourceMappingURL (alert #8).** Force `postcss@8.5.25` (>= 8.5.18 patched) through the pnpm 11 workspace override so the vite/vitest transitive pin clears the vulnerable `<= 8.5.17` range. Same pattern as the prior esbuild / brace-expansion pins in `pnpm-workspace.yaml`.
+- **OpenClaw always-pins prefer real copies, not content-package symlinks (#3008).** OpenClaw 2026.7.x skips skills that resolve outside the workspace skills root (`symlink-escape`). `deft doctor --fix` now **copies** pins by default; escaping symlinks are assessed as **divergent** so fix/`--force` can replace them. Docs: `content/docs/openclaw-agent-host.md`. Closes #3008. Refs #3001.
 
 ### Removed
 

--- a/content/docs/openclaw-agent-host.md
+++ b/content/docs/openclaw-agent-host.md
@@ -142,9 +142,9 @@ When OpenClaw signals are present (`OPENCLAW` / `DEFT_PROBE_OPENCLAW` / `DEFT_AG
 deft doctor --fix
 ```
 
-Doctor links (preferred) or copies the four pin directories from the installed content package (`@deftai/directive-content` / `content/skills/…`) into the main OpenClaw skills root. It does **not** delete other user skills (e.g. a local `vbrief` skill stays). Divergent same-named directories are left alone unless you pass `--force` or confirm on a TTY.
+Doctor **copies** the four pin directories from the installed content package (`@deftai/directive-content` / `content/skills/…`) into the main OpenClaw skills root as **real directories** (#3008). It does **not** symlink into the npm tree — OpenClaw 2026.7.x skips workspace skills that resolve outside the skills root (`reason=symlink-escape`), which made pre-#3008 symlink installs look healthy in doctor while `openclaw skills list` never loaded the pins. It does **not** delete other user skills (e.g. a local `vbrief` skill stays). Divergent same-named directories **and escaping symlinks** are left alone unless you pass `--force` or confirm on a TTY (then replaced with a real copy).
 
-After a successful wire: **restart the OpenClaw gateway or start a new session** so host `available_skills` refreshes.
+After a successful wire: **restart the OpenClaw gateway or start a new session** so host `available_skills` refreshes. Confirm with `openclaw skills list` that the four always-pins are **ready**, not skipped.
 
 ### Multi-seat / crew workspaces
 

--- a/packages/core/src/doctor/openclaw-skills.test.ts
+++ b/packages/core/src/doctor/openclaw-skills.test.ts
@@ -153,13 +153,27 @@ describe("listInScopeSkillsDirs edges (#3003)", () => {
   });
 });
 
-describe("installOpenClawPin (#3001)", () => {
-  it("symlinks or copies a missing pin", () => {
+describe("installOpenClawPin (#3001 / #3008)", () => {
+  it("copies a missing pin by default (OpenClaw symlink-escape safe)", () => {
     const root = makeTemp("oc-install-");
     const content = makeContentPackage(root);
     const skills = join(root, "skills");
     const source = resolvePinSourceDir(content, "deft-directive-build");
     const result = installOpenClawPin("deft-directive-build", source, skills);
+    expect(result.method).toBe("copy");
+    expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toContain(
+      "deft-directive-build",
+    );
+  });
+
+  it("can still prefer symlink when preferSymlink is true", () => {
+    const root = makeTemp("oc-install-sym-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    const result = installOpenClawPin("deft-directive-build", source, skills, {
+      preferSymlink: true,
+    });
     expect(["symlink", "copy"]).toContain(result.method);
     expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toContain(
       "deft-directive-build",
@@ -178,7 +192,7 @@ describe("installOpenClawPin (#3001)", () => {
     expect(readFileSync(join(skills, "deft-directive-build", "OTHER.md"), "utf8")).toBe("user");
   });
 
-  it("replaces divergent target with force", () => {
+  it("replaces divergent target with force using copy", () => {
     const root = makeTemp("oc-force-");
     const content = makeContentPackage(root);
     const skills = join(root, "skills");
@@ -186,7 +200,7 @@ describe("installOpenClawPin (#3001)", () => {
     writeFileSync(join(skills, "deft-directive-build", "OTHER.md"), "user", "utf8");
     const source = resolvePinSourceDir(content, "deft-directive-build");
     const result = installOpenClawPin("deft-directive-build", source, skills, { force: true });
-    expect(["symlink", "copy"]).toContain(result.method);
+    expect(result.method).toBe("copy");
     expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toContain(
       "deft-directive-build",
     );
@@ -200,6 +214,55 @@ describe("installOpenClawPin (#3001)", () => {
     const source = resolvePinSourceDir(content, "deft-directive-pre-pr");
     installOpenClawPin("deft-directive-pre-pr", source, skills);
     expect(readFileSync(join(skills, "vbrief", "SKILL.md"), "utf8")).toContain("user skill");
+  });
+});
+
+describe("escaping symlink pins (#3008)", () => {
+  it("classifies content-package symlink as divergent, not present", () => {
+    const root = makeTemp("oc-escape-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    mkdirSync(skills, { recursive: true });
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    // Prefer symlink into content package (the pre-#3008 install shape).
+    installOpenClawPin("deft-directive-build", source, skills, { preferSymlink: true });
+    // On platforms that can symlink, assessment must not treat escape as present.
+    const assessment = assessOpenClawPins(skills);
+    if (assessment.present.includes("deft-directive-build")) {
+      // Symlink failed and fell back to copy — already OpenClaw-safe.
+      expect(assessment.divergent).not.toContain("deft-directive-build");
+    } else {
+      expect(assessment.divergent).toContain("deft-directive-build");
+    }
+  });
+
+  it("force-replaces escaping symlink with a real copy", () => {
+    const root = makeTemp("oc-escape-fix-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    mkdirSync(skills, { recursive: true });
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    // Force a symlink into the content package (the broken pre-#3008 shape).
+    const target = join(skills, "deft-directive-build");
+    try {
+      symlinkSync(source, target, "dir");
+    } catch {
+      try {
+        symlinkSync(source, target, "junction");
+      } catch {
+        // Platform cannot symlink — copy-default install is already safe.
+        const fallback = installOpenClawPin("deft-directive-build", source, skills);
+        expect(fallback.method).toBe("copy");
+        return;
+      }
+    }
+    const mid = assessOpenClawPins(skills);
+    expect(mid.divergent).toContain("deft-directive-build");
+    const result = installOpenClawPin("deft-directive-build", source, skills, { force: true });
+    expect(result.method).toBe("copy");
+    const post = assessOpenClawPins(skills);
+    expect(post.present).toContain("deft-directive-build");
+    expect(post.divergent).not.toContain("deft-directive-build");
   });
 });
 
@@ -376,8 +439,8 @@ describe("runOpenClawSkillPinsCheck (#3001)", () => {
   });
 });
 
-describe("symlink pin body is accepted as present", () => {
-  it("treats symlink-to-content as present", () => {
+describe("symlink pin body OpenClaw load policy (#3008)", () => {
+  it("treats symlink-to-content-package as divergent (symlink-escape)", () => {
     const root = makeTemp("oc-link-");
     const content = makeContentPackage(root);
     const skills = join(root, "skills");
@@ -386,10 +449,16 @@ describe("symlink pin body is accepted as present", () => {
     try {
       symlinkSync(source, join(skills, "deft-directive-swarm"), "dir");
     } catch {
-      // Windows without symlink privilege: skip assertion path
-      symlinkSync(source, join(skills, "deft-directive-swarm"), "junction");
+      try {
+        symlinkSync(source, join(skills, "deft-directive-swarm"), "junction");
+      } catch {
+        // No symlink privilege — nothing to assert for escape classification.
+        return;
+      }
     }
     const assessment = assessOpenClawPins(skills);
-    expect(assessment.present).toContain("deft-directive-swarm");
+    // Escaping content-package link is not OpenClaw-loadable (#3008).
+    expect(assessment.divergent).toContain("deft-directive-swarm");
+    expect(assessment.present).not.toContain("deft-directive-swarm");
   });
 });

--- a/packages/core/src/doctor/openclaw-skills.ts
+++ b/packages/core/src/doctor/openclaw-skills.ts
@@ -1,10 +1,16 @@
 /**
- * OpenClaw always-pin skill detect + doctor --fix wire (#3001).
+ * OpenClaw always-pin skill detect + doctor --fix wire (#3001 / #3008).
  *
  * When OpenClaw signals are present, doctor checks the main workspace skills
  * root for the four always-pin skills (#2508). Missing pins emit a warning with
- * remediation `deft doctor --fix`. Under fixMode, pins are symlinked (preferred)
- * or copied from the installed content package into the target skills dir.
+ * remediation `deft doctor --fix`. Under fixMode, pins are **copied** into the
+ * workspace skills root (not symlinked into the npm content package).
+ *
+ * OpenClaw 2026.7.x rejects workspace skills that resolve outside the configured
+ * skills root (`reason=symlink-escape`). A pin that is only a symlink into
+ * `@deftai/directive-content` therefore looks "present" on disk while the host
+ * never loads it (#3008). Prefer real directory copies; treat escaping
+ * symlinks as divergent so `--fix` can replace them.
  *
  * Multi-seat (`workspace-*`) targets only when `--openclaw-all-agents` is set.
  */
@@ -15,12 +21,13 @@ import {
   lstatSync,
   mkdirSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
   symlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import { contentRoot } from "../content-root.js";
 import type { OutputSink } from "./output.js";
 import type { DoctorSeams, Finding } from "./types.js";
@@ -230,11 +237,35 @@ function skillHasBody(
 }
 
 /**
+ * True when `path` is a symlink whose resolved real path is outside `skillsDir`
+ * (OpenClaw `symlink-escape` / #3008).
+ */
+export function isEscapingSkillSymlink(
+  skillsDir: string,
+  path: string,
+  seams: Pick<OpenClawSkillPinsSeams, "lstatKind"> = {},
+): boolean {
+  const lstatKind = seams.lstatKind ?? defaultLstatKind;
+  if (lstatKind(path) !== "symlink") return false;
+  try {
+    const skillsReal = realpathSync(skillsDir);
+    const pathReal = realpathSync(path);
+    const rel = relative(skillsReal, pathReal);
+    // Outside root, or walks up with ".."
+    return rel === "" || rel.startsWith(`..${sep}`) || rel.startsWith("..") || rel === "..";
+  } catch {
+    // Broken symlink / unreadable realpath — treat as escape / unusable.
+    return true;
+  }
+}
+
+/**
  * Assess which always-pins are present / missing / divergent in a skills root.
  *
- * - present: directory (or symlink) with SKILL.md
+ * - present: real directory (or non-escaping symlink) with SKILL.md
  * - missing: path does not exist
- * - divergent: path exists but is not a usable pin (file, empty dir, broken link)
+ * - divergent: path exists but is not a usable OpenClaw pin (file, empty dir,
+ *   broken link, or **escaping symlink** into content package — #3008)
  */
 export function assessOpenClawPins(
   skillsDir: string,
@@ -254,6 +285,11 @@ export function assessOpenClawPins(
     const kind = lstatKind(target);
     if (kind === "missing") {
       missing.push(skillId);
+      continue;
+    }
+    // Escaping symlink: SKILL.md may resolve, but OpenClaw skips load (#3008).
+    if (kind === "symlink" && isEscapingSkillSymlink(skillsDir, target, { lstatKind })) {
+      divergent.push(skillId);
       continue;
     }
     if (skillHasBody(target, isFile, isDir)) {
@@ -295,8 +331,14 @@ function defaultCopyDir(src: string, dst: string): void {
 }
 
 /**
- * Install one pin into a skills root. Prefer symlink; copy on failure.
- * Never deletes user skills. Divergent targets require force or TTY confirm.
+ * Install one pin into a skills root.
+ *
+ * Default: **copy** into the workspace skills root (#3008). OpenClaw rejects
+ * skills that resolve outside the workspace skills root via symlink-escape, so
+ * symlinking into the npm content package leaves pins unloaded while doctor
+ * reports "present". Opt into legacy symlink-first with `preferSymlink: true`
+ * (still falls back to copy). Never deletes unrelated user skills. Divergent
+ * targets (including escaping symlinks) require force or TTY confirm.
  */
 export function installOpenClawPin(
   skillId: OpenClawAlwaysPinSkill,
@@ -305,6 +347,8 @@ export function installOpenClawPin(
   options: {
     force?: boolean;
     allowOverwrite?: boolean;
+    /** When true, try symlink first (legacy #3001). Default false — copy (#3008). */
+    preferSymlink?: boolean;
   } = {},
   seams: OpenClawSkillPinsSeams = {},
 ): PinInstallResult {
@@ -325,6 +369,7 @@ export function installOpenClawPin(
 
   const target = join(skillsDir, skillId);
   const force = options.force === true || options.allowOverwrite === true;
+  const preferSymlink = options.preferSymlink === true;
 
   if (!isDir(sourceDir) || !isFile(join(sourceDir, "SKILL.md"))) {
     return {
@@ -340,7 +385,8 @@ export function installOpenClawPin(
 
   const kind = lstatKind(target);
   if (kind !== "missing") {
-    if (skillHasBody(target, isFile, isDir)) {
+    const escaping = kind === "symlink" && isEscapingSkillSymlink(skillsDir, target, { lstatKind });
+    if (!escaping && skillHasBody(target, isFile, isDir)) {
       return {
         skillId,
         method: "already-present",
@@ -354,28 +400,34 @@ export function installOpenClawPin(
         method: "skipped",
         target,
         source: sourceDir,
-        detail: "divergent target exists; re-run with --force or confirm on TTY to replace",
+        detail: escaping
+          ? "escaping symlink (OpenClaw symlink-escape); re-run with --force to replace with a real copy (#3008)"
+          : "divergent target exists; re-run with --force or confirm on TTY to replace",
       };
     }
     removePath(target);
   }
 
-  try {
-    symlinkDir(sourceDir, target);
-    return { skillId, method: "symlink", target, source: sourceDir };
-  } catch {
+  if (preferSymlink) {
     try {
-      copyDir(sourceDir, target);
-      return { skillId, method: "copy", target, source: sourceDir };
-    } catch (err) {
-      return {
-        skillId,
-        method: "skipped",
-        target,
-        source: sourceDir,
-        detail: `install failed: ${err instanceof Error ? err.message : String(err)}`,
-      };
+      symlinkDir(sourceDir, target);
+      return { skillId, method: "symlink", target, source: sourceDir };
+    } catch {
+      // fall through to copy
     }
+  }
+
+  try {
+    copyDir(sourceDir, target);
+    return { skillId, method: "copy", target, source: sourceDir };
+  } catch (err) {
+    return {
+      skillId,
+      method: "skipped",
+      target,
+      source: sourceDir,
+      detail: `install failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 }
 

--- a/xbrief/active/2026-08-01-3008-doctor-openclaw-always-pins-symlink-install-rejected-by-open.xbrief.json
+++ b/xbrief/active/2026-08-01-3008-doctor-openclaw-always-pins-symlink-install-rejected-by-open.xbrief.json
@@ -1,0 +1,25 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3008",
+    "updated": "2026-08-01T00:48:37Z"
+  },
+  "plan": {
+    "title": "doctor OpenClaw always-pins: symlink install rejected by OpenClaw symlink-escape",
+    "status": "running",
+    "narratives": {
+      "Description": "doctor OpenClaw always-pins: symlink install rejected by OpenClaw symlink-escape",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3008",
+      "Overview": "## Summary\n`deft doctor --fix` OpenClaw always-pin install (#3001) prefers **symlinks** from `$OPENCLAW_STATE_DIR/workspace/skills/<pin>` → `@deftai/directive-content/skills/<pin>`.\n\nOn OpenClaw **2026.7.2-beta.4**, those pins are **not loaded**:\n\n```\n[skills] Skipping escaped skill path outside its configured root:\n  source=openclaw-workspace\n  root=~/.openclaw/workspace-*/skills\n  reason=symlink-escape\n  resolved=~/.local/lib/node_modules/@deftai/directive/node_modules/@deftai/directive-content/skills/...\n```\n\nDoctor still reports **present** (lstat + SKILL.md via symlink resolves), so the host looks healthy while the agent never sees the skills.\n\n## Expected\nAlways-pins should be **ready** in `openclaw skills list` after `deft doctor --full --fix`.\n\n## Actual\n- Disk: symlink present; `deft doctor` ✓\n- OpenClaw: skips as `symlink-escape`\n- Only non-escaping workspace dirs load (e.g. local `vbrief/`, enterprize thin-attach stub dirs)\n\n## Workaround that works\nReplace pin symlinks with **real directory copies** under the workspace skills root (or thin-attach stubs that are real dirs pointing at deposit via absolute path in SKILL.md text — not FS symlinks outside root).\n\n## Suggested fix\n1. Prefer **copy** on OpenClaw hosts (detect OpenClaw + known symlink-escape policy), or\n2. Attempt symlink then **verify** with a load-policy check / document that OpenClaw requires copy, or\n3. Install thin real-dir stubs (SKILL.md only) instead of whole-tree symlink to content package.\n\n## Environment\n- OpenClaw 2026.7.2-beta.4\n- Directive 0.90.0\n- WSL Linux host\n\nRefs: #3001, #2874, #2968"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3008",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3008: doctor OpenClaw always-pins: symlink install rejected by OpenClaw symlink-escape"
+      }
+    ],
+    "updated": "2026-08-01T00:48:37Z"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes OpenClaw always-pin install false-green (#3008): pre-#3008 `deft doctor --fix` preferred **symlinks** into `@deftai/directive-content`, which OpenClaw 2026.7.x rejects as `symlink-escape` while doctor still reported pins present.

- Default install method is now **copy** into the workspace skills root
- Escaping content-package symlinks are assessed as **divergent** so `--force` / TTY can replace them
- Docs: `content/docs/openclaw-agent-host.md`
- Tests for copy-default, escape classification, force replace

## Test plan

- [x] `vitest` `openclaw-skills.test.ts` (24 tests)
- [ ] CI green

Closes #3008
Refs #3001