### PR TITLE
chore(xbrief): scope:complete #1694 and #1695 after PR #3022

### DIFF
--- a/xbrief/completed/2026-08-01-1694-bugtriageonboarding-wipcap-onboarding-nudge-contradicts-test.xbrief.json
+++ b/xbrief/completed/2026-08-01-1694-bugtriageonboarding-wipcap-onboarding-nudge-contradicts-test.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #1694",
-    "updated": "2026-08-01T02:11:52Z"
+    "updated": "2026-08-01T03:07:18Z"
   },
   "plan": {
     "title": "bug(triage,onboarding): wipCap onboarding nudge contradicts test_policy_omits_wip_cap on deft's own repo (unsatisfiable nudge + self-check trap)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "bug(triage,onboarding): wipCap onboarding nudge contradicts test_policy_omits_wip_cap on deft's own repo (unsatisfiable nudge + self-check trap)",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1694",
@@ -16,7 +16,7 @@
     "items": [
       {
         "title": "#1695 — codify the general rule in coding standards + `patterns/in-band-signaling.md`",
-        "status": "proposed"
+        "status": "completed"
       }
     ],
     "tags": [
@@ -31,6 +31,10 @@
         "title": "Issue #1694: bug(triage,onboarding): wipCap onboarding nudge contradicts test_policy_omits_wip_cap on deft's own repo (unsatisfiable nudge + self-check trap)"
       }
     ],
-    "updated": "2026-08-01T02:11:52Z"
+    "updated": "2026-08-01T03:07:18Z",
+    "metadata": {
+      "completedAt": "2026-08-01T03:07:18Z",
+      "capacityBucket": "technical-debt"
+    }
   }
 }

--- a/xbrief/completed/2026-08-01-1695-metacoding-standards-codify-no-in-band-signaling-absence-is.xbrief.json
+++ b/xbrief/completed/2026-08-01-1695-metacoding-standards-codify-no-in-band-signaling-absence-is.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #1695",
-    "updated": "2026-08-01T02:11:54Z"
+    "updated": "2026-08-01T03:07:50Z"
   },
   "plan": {
     "title": "meta(coding-standards): codify 'no in-band signaling / absence is not a decision' — separate value from decision-provenance",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "meta(coding-standards): codify 'no in-band signaling / absence is not a decision' — separate value from decision-provenance",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1695",
@@ -27,6 +27,10 @@
         "title": "Issue #1695: meta(coding-standards): codify 'no in-band signaling / absence is not a decision' — separate value from decision-provenance"
       }
     ],
-    "updated": "2026-08-01T02:11:54Z"
+    "updated": "2026-08-01T03:07:50Z",
+    "metadata": {
+      "completedAt": "2026-08-01T03:07:50Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
Post-merge lifecycle hygiene for the #1694/#1695 cohort.

`task scope:complete` for both active scopes after https://github.com/deftai/directive/pull/3022 merged.