### PR TITLE
test(coverage): restore Vitest branches >=85% after v0.91.0 hairline (#3027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vitest branch coverage restored above 85% (#3027).** Focused OpenClaw pin install/doctor fix-path edges, github-auth mode failure and parseLogin branches, batch-promote path validation, and plan-sequence CLI argv/JSON edges clear the v0.91.0 84.91% hairline so release Step 5 passes without `--allow-coverage-debt`. Closes #3027.
+
 ### Removed
 
 ## [0.91.0] - 2026-08-01

--- a/packages/cli/src/plan-sequence.test.ts
+++ b/packages/cli/src/plan-sequence.test.ts
@@ -66,4 +66,66 @@ describe("plan-sequence CLI (#2402)", () => {
     writeFileSync(arrayFile, "[1,2,3]");
     expect(planSequenceMain(["set", "--project-root", root, "--file", arrayFile])).toBe(1);
   });
+
+  it("covers argv/flag and JSON emit branches (#3027)", () => {
+    const root = mkdtempSync(join(tmpdir(), "ps-cli-branches-"));
+    roots.push(root);
+
+    expect(planSequenceMain([])).toBe(2);
+    expect(planSequenceMain(["nope"])).toBe(2);
+    expect(planSequenceMain(["set", "--unknown"])).toBe(2);
+    expect(planSequenceMain(["set", "--project-root"])).toBe(2);
+    expect(planSequenceMain(["set", "--file"])).toBe(2);
+    expect(planSequenceMain(["set", "--from-json"])).toBe(2);
+    expect(planSequenceMain(["current", "--project-root", root])).toBe(1);
+    expect(planSequenceMain(["advance", "--project-root", root])).toBe(1);
+    expect(planSequenceMain(["clear", "--project-root", root])).toBe(0);
+
+    const inline = JSON.stringify({
+      sequence_id: "inline",
+      sequence_kind: "checklist",
+      authorized_by: "t",
+      entries: [{ id: "a", kind: "task" }],
+    });
+    expect(
+      planSequenceMain([
+        "set",
+        `--project-root=${root}`,
+        "--from-json",
+        inline,
+        "--json",
+      ]),
+    ).toBe(0);
+    expect(planSequenceMain(["current", "--project-root", root, "--json"])).toBe(0);
+    expect(planSequenceMain(["advance", "--project-root", root, "--json"])).toBe(0);
+    // exhausted after advance past single entry
+    expect(planSequenceMain(["current", "--project-root", root])).toBe(0);
+    expect(planSequenceMain(["clear", "--project-root", root])).toBe(0);
+    // already absent
+    expect(planSequenceMain(["clear", "--project-root", root])).toBe(0);
+
+    // Full sequence object with current_index uses parsePlanSequence path
+    const fullFile = join(root, "full.json");
+    writeFileSync(
+      fullFile,
+      JSON.stringify({
+        sequence_id: "full",
+        sequence_kind: "delivery",
+        authorized_by: "t",
+        entries: [
+          { id: "p1", kind: "pr", issue: 1 },
+          { id: "p2", kind: "pr", issue: 2 },
+        ],
+        current_index: 0,
+        batching_allowed: true,
+        continuation_past_final: false,
+        exhausted: false,
+        created_at: "2026-08-01T00:00:00Z",
+        updated_at: "2026-08-01T00:00:00Z",
+      }),
+    );
+    expect(planSequenceMain(["set", `--file=${fullFile}`, "--project-root", root])).toBe(0);
+    expect(planSequenceMain(["current", "--project-root", root])).toBe(0);
+    expect(planSequenceMain(["set", "--project-root", root])).toBe(1);
+  });
 });

--- a/packages/cli/src/plan-sequence.test.ts
+++ b/packages/cli/src/plan-sequence.test.ts
@@ -88,13 +88,7 @@ describe("plan-sequence CLI (#2402)", () => {
       entries: [{ id: "a", kind: "task" }],
     });
     expect(
-      planSequenceMain([
-        "set",
-        `--project-root=${root}`,
-        "--from-json",
-        inline,
-        "--json",
-      ]),
+      planSequenceMain(["set", `--project-root=${root}`, "--from-json", inline, "--json"]),
     ).toBe(0);
     expect(planSequenceMain(["current", "--project-root", root, "--json"])).toBe(0);
     expect(planSequenceMain(["advance", "--project-root", root, "--json"])).toBe(0);

--- a/packages/core/src/doctor/openclaw-skills.test.ts
+++ b/packages/core/src/doctor/openclaw-skills.test.ts
@@ -1,4 +1,13 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -314,6 +323,152 @@ describe("escaping symlink pins (#3008)", () => {
     expect(readFileSync(join(skills, "deft-directive-build", "KEEP.md"), "utf8")).toBe("keep-me");
     expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toBe("# old\n");
   });
+
+  it("skips when exclusive install lock is held (#3027 lock branch)", () => {
+    const root = makeTemp("oc-lock-held-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    mkdirSync(skills, { recursive: true });
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    const lockDir = join(skills, "deft-directive-build.deft-lock");
+    mkdirSync(lockDir, { recursive: true });
+    const result = installOpenClawPin("deft-directive-build", source, skills);
+    expect(result.method).toBe("skipped");
+    expect(result.detail).toMatch(/another doctor process/i);
+  });
+
+  it("reclaims a stale exclusive lock older than 10 minutes (#3027)", () => {
+    const root = makeTemp("oc-lock-stale-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    mkdirSync(skills, { recursive: true });
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    const lockDir = join(skills, "deft-directive-build.deft-lock");
+    mkdirSync(lockDir, { recursive: true });
+    const stale = Date.now() - 11 * 60 * 1000;
+    utimesSync(lockDir, new Date(stale), new Date(stale));
+    const result = installOpenClawPin("deft-directive-build", source, skills);
+    expect(result.method).toBe("copy");
+    expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toContain(
+      "deft-directive-build",
+    );
+  });
+
+  it("short-circuits already-present under lock when package body matches (#3027)", () => {
+    const root = makeTemp("oc-lock-present-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    installOpenClawPin("deft-directive-build", source, skills);
+    const again = installOpenClawPin("deft-directive-build", source, skills);
+    expect(again.method).toBe("already-present");
+  });
+
+  it("restores backup when rename into target fails after force replace (#3027)", () => {
+    const root = makeTemp("oc-rename-fail-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    installOpenClawPin("deft-directive-build", source, skills);
+    writeFileSync(join(skills, "deft-directive-build", "SKILL.md"), "# old\n", "utf8");
+    writeFileSync(join(skills, "deft-directive-build", "KEEP.md"), "keep", "utf8");
+    const result = installOpenClawPin(
+      "deft-directive-build",
+      source,
+      skills,
+      { force: true },
+      {
+        renamePath: (from, to) => {
+          // Fail only staging → target; allow target→backup and backup restore.
+          if (from.includes(".deft-installing-")) {
+            throw new Error("rename denied");
+          }
+          renameSync(from, to);
+        },
+      },
+    );
+    expect(result.method).toBe("skipped");
+    expect(result.detail).toMatch(/rename denied/);
+    // Prior body restored after failed staging swap.
+    expect(readFileSync(join(skills, "deft-directive-build", "KEEP.md"), "utf8")).toBe("keep");
+    expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toBe("# old\n");
+  });
+
+  it("skips incomplete source and falls back from preferSymlink (#3027)", () => {
+    const root = makeTemp("oc-src-miss-");
+    const skills = join(root, "skills");
+    mkdirSync(skills, { recursive: true });
+    const incomplete = join(root, "incomplete-src");
+    mkdirSync(incomplete, { recursive: true });
+    const missing = installOpenClawPin(
+      "deft-directive-build",
+      incomplete,
+      skills,
+    );
+    expect(missing.method).toBe("skipped");
+    expect(missing.detail).toMatch(/source pin missing/i);
+
+    const content = makeContentPackage(root);
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    const viaSymlink = installOpenClawPin(
+      "deft-directive-build",
+      source,
+      skills,
+      { preferSymlink: true },
+      {
+        symlinkDir: () => {
+          throw new Error("symlink unavailable");
+        },
+      },
+    );
+    expect(viaSymlink.method).toBe("copy");
+  });
+
+  it("skips when staging copy fails and when stale without force (#3027)", () => {
+    const root = makeTemp("oc-copy-fail-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    installOpenClawPin("deft-directive-build", source, skills);
+    writeFileSync(join(skills, "deft-directive-build", "SKILL.md"), "# stale\n", "utf8");
+
+    const stale = installOpenClawPin("deft-directive-build", source, skills, {
+      force: false,
+      refreshStale: false,
+    });
+    expect(stale.method).toBe("skipped");
+    expect(stale.detail).toMatch(/stale pin/i);
+
+    const copyFail = installOpenClawPin(
+      "deft-directive-build",
+      source,
+      skills,
+      { force: true },
+      {
+        copyDir: () => {
+          throw new Error("disk full");
+        },
+      },
+    );
+    expect(copyFail.method).toBe("skipped");
+    expect(copyFail.detail).toMatch(/disk full/);
+  });
+
+  it("refreshes stale pin when refreshStale is set (#3027)", () => {
+    const root = makeTemp("oc-refresh-stale-");
+    const content = makeContentPackage(root);
+    const skills = join(root, "skills");
+    const source = resolvePinSourceDir(content, "deft-directive-build");
+    installOpenClawPin("deft-directive-build", source, skills);
+    writeFileSync(join(skills, "deft-directive-build", "SKILL.md"), "# stale\n", "utf8");
+    const refreshed = installOpenClawPin("deft-directive-build", source, skills, {
+      refreshStale: true,
+    });
+    expect(refreshed.method).toBe("copy");
+    expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toContain(
+      "deft-directive-build",
+    );
+  });
 });
 
 describe("runOpenClawSkillPinsCheck (#3001)", () => {
@@ -487,6 +642,131 @@ describe("runOpenClawSkillPinsCheck (#3001)", () => {
     );
     expect(findings[0]?.status).toBe("missing");
     expect(String(findings[0]?.message)).toContain("workspace-scotty");
+  });
+
+  it("TTY decline skips wire; force replaces divergent; TTY yes on divergent (#3027)", () => {
+    const home = makeTemp("oc-tty-");
+    const skills = join(home, ".openclaw", "workspace", "skills");
+    mkdirSync(skills, { recursive: true });
+    const content = makeContentPackage(home);
+
+    // Decline path
+    const findingsDecline: Finding[] = [];
+    runOpenClawSkillPinsCheck(
+      createPlainSink({ write: () => undefined }),
+      (f) => findingsDecline.push(f),
+      {
+        frameworkRoot: home,
+        fixMode: true,
+        jsonMode: false,
+        force: false,
+        allAgents: false,
+        seams: {
+          env: { DEFT_PROBE_OPENCLAW: "1" },
+          homeDir: () => home,
+          contentRootFor: () => content,
+          isTty: () => true,
+          readYn: () => false,
+        },
+      },
+    );
+    expect(findingsDecline[0]?.status).toBe("missing");
+
+    // Divergent file path (not a skill dir body)
+    writeFileSync(join(skills, "deft-directive-build"), "not-a-dir", "utf8");
+    const findingsForce: Finding[] = [];
+    runOpenClawSkillPinsCheck(
+      createPlainSink({ write: () => undefined }),
+      (f) => findingsForce.push(f),
+      {
+        frameworkRoot: home,
+        fixMode: true,
+        jsonMode: true,
+        force: true,
+        allAgents: false,
+        seams: {
+          env: { DEFT_PROBE_OPENCLAW: "1" },
+          homeDir: () => home,
+          contentRootFor: () => content,
+          isTty: () => false,
+        },
+      },
+    );
+    expect(findingsForce[0]?.status).toBe("fixed");
+    expect(readFileSync(join(skills, "deft-directive-build", "SKILL.md"), "utf8")).toContain(
+      "deft-directive-build",
+    );
+
+    // Non-stale divergent (empty dir, no SKILL.md): TTY yes → replace
+    rmSync(join(skills, "deft-directive-pre-pr"), { recursive: true, force: true });
+    mkdirSync(join(skills, "deft-directive-pre-pr"), { recursive: true });
+    const findingsTtyYes: Finding[] = [];
+    let prompts = 0;
+    runOpenClawSkillPinsCheck(
+      createPlainSink({ write: () => undefined }),
+      (f) => findingsTtyYes.push(f),
+      {
+        frameworkRoot: home,
+        fixMode: true,
+        jsonMode: false,
+        force: false,
+        allAgents: false,
+        seams: {
+          env: { DEFT_PROBE_OPENCLAW: "1" },
+          homeDir: () => home,
+          contentRootFor: () => content,
+          isTty: () => true,
+          readYn: (prompt) => {
+            prompts += 1;
+            // Wire-missing prompt first (default true path); then divergent confirm
+            return true;
+          },
+        },
+      },
+    );
+    expect(prompts).toBeGreaterThan(0);
+    expect(
+      findingsTtyYes[0]?.status === "fixed" || findingsTtyYes[0]?.status === "present",
+    ).toBe(true);
+  });
+
+  it("allAgents present path and assess file/other divergent kinds (#3027)", () => {
+    const home = makeTemp("oc-present-all-");
+    const content = makeContentPackage(home);
+    for (const seat of ["workspace", "workspace-a"]) {
+      const skills = join(home, ".openclaw", seat, "skills");
+      for (const id of OPENCLAW_ALWAYS_PIN_SKILLS) {
+        writeSkill(skills, id, `# ${id}\n`);
+      }
+    }
+    const findings: Finding[] = [];
+    runOpenClawSkillPinsCheck(
+      createPlainSink({ write: () => undefined }),
+      (f) => findings.push(f),
+      {
+        frameworkRoot: home,
+        fixMode: false,
+        jsonMode: true,
+        force: false,
+        allAgents: true,
+        seams: {
+          env: { OPENCLAW: "1" },
+          homeDir: () => home,
+          contentRootFor: () => content,
+        },
+      },
+    );
+    expect(findings[0]?.status).toBe("present");
+    expect(String(findings[0]?.message)).toMatch(/main \+ workspace-\*/i);
+
+    const skills = join(home, "skills-assess");
+    mkdirSync(skills, { recursive: true });
+    writeFileSync(join(skills, "deft-directive-build"), "file-not-dir", "utf8");
+    mkdirSync(join(skills, "deft-directive-pre-pr"), { recursive: true });
+    // empty dir → no SKILL.md
+    const assessment = assessOpenClawPins(skills, {}, { contentBase: content });
+    expect(assessment.divergent).toContain("deft-directive-build");
+    expect(assessment.divergent).toContain("deft-directive-pre-pr");
   });
 });
 

--- a/packages/core/src/doctor/openclaw-skills.test.ts
+++ b/packages/core/src/doctor/openclaw-skills.test.ts
@@ -400,11 +400,7 @@ describe("escaping symlink pins (#3008)", () => {
     mkdirSync(skills, { recursive: true });
     const incomplete = join(root, "incomplete-src");
     mkdirSync(incomplete, { recursive: true });
-    const missing = installOpenClawPin(
-      "deft-directive-build",
-      incomplete,
-      skills,
-    );
+    const missing = installOpenClawPin("deft-directive-build", incomplete, skills);
     expect(missing.method).toBe("skipped");
     expect(missing.detail).toMatch(/source pin missing/i);
 
@@ -716,7 +712,7 @@ describe("runOpenClawSkillPinsCheck (#3001)", () => {
           homeDir: () => home,
           contentRootFor: () => content,
           isTty: () => true,
-          readYn: (prompt) => {
+          readYn: (_prompt) => {
             prompts += 1;
             // Wire-missing prompt first (default true path); then divergent confirm
             return true;
@@ -725,9 +721,9 @@ describe("runOpenClawSkillPinsCheck (#3001)", () => {
       },
     );
     expect(prompts).toBeGreaterThan(0);
-    expect(
-      findingsTtyYes[0]?.status === "fixed" || findingsTtyYes[0]?.status === "present",
-    ).toBe(true);
+    expect(findingsTtyYes[0]?.status === "fixed" || findingsTtyYes[0]?.status === "present").toBe(
+      true,
+    );
   });
 
   it("allAgents present path and assess file/other divergent kinds (#3027)", () => {

--- a/packages/core/src/intake/github-auth-modes.test.ts
+++ b/packages/core/src/intake/github-auth-modes.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+  FAILURE_API_UNREACHABLE,
+  FAILURE_GH_AUTH,
   FAILURE_INVALID_MODE,
+  FAILURE_MISSING_INJECTED_TOKEN,
+  FAILURE_REPO_ACCESS,
   findInjectedToken,
+  githubAuthModesMain,
   inferGithubAuthMode,
+  resultToDict,
   validateGithubAuth,
+  validateGithubAuthForWorker,
+  validateHostGhMode,
+  validateInjectedTokenMode,
 } from "./github-auth-modes.js";
-import { RUNTIME_MODE_CLOUD_HEADLESS } from "./platform-capabilities.js";
+import {
+  RUNTIME_MODE_CLOUD_HEADLESS,
+  RUNTIME_MODE_CURSOR_NATIVE_SANDBOX,
+} from "./platform-capabilities.js";
 
 describe("github-auth-modes", () => {
   it("finds injected token env vars", () => {
@@ -31,5 +43,307 @@ describe("github-auth-modes", () => {
       runGh: () => ({ returncode: 0, stdout: '{"login":"octo"}', stderr: "", args: [] }),
     });
     expect(result.ok).toBe(true);
+  });
+
+  it("defaultRunGh path fails closed when live gh is unavailable (#3027)", () => {
+    // No runGh seam → defaultRunGh spawns live `gh` (not ghx/call). Force a
+    // missing binary so the spawnSync catch / non-zero branch is exercised.
+    const result = validateGithubAuth("host-gh", {
+      environ: { PATH: "" },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.detail.length).toBeGreaterThan(0);
+  });
+
+  it("validates injected-token mode when token present (#3027)", () => {
+    const result = validateGithubAuth("injected-token", {
+      environ: { GH_TOKEN: "ghs_test_not_real" },
+      runGh: () => ({ returncode: 0, stdout: '{"login":"bot"}', stderr: "", args: [] }),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.login).toBe("bot");
+  });
+
+  it("injected-token missing token fails closed (#3027)", () => {
+    const result = validateInjectedTokenMode({});
+    expect(result.ok).toBe(false);
+    expect(result.failureKind).toBe(FAILURE_MISSING_INJECTED_TOKEN);
+  });
+
+  it("injected-token auth status failure includes sandbox remediation (#3027)", () => {
+    const result = validateInjectedTokenMode(
+      { GH_TOKEN: "t" },
+      {
+        runtimeMode: RUNTIME_MODE_CURSOR_NATIVE_SANDBOX,
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 1, stdout: "", stderr: "nope", args: [...args] };
+          }
+          return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.failureKind).toBe(FAILURE_GH_AUTH);
+    expect(result.remediation).toMatch(/sandbox/i);
+  });
+
+  it("injected-token API unreachable and repo-access branches (#3027)", () => {
+    const unreachable = validateInjectedTokenMode(
+      { GITHUB_TOKEN: "t" },
+      {
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && args[1] === "user") {
+            return { returncode: 1, stdout: "", stderr: "timeout", args: [...args] };
+          }
+          return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(unreachable.failureKind).toBe(FAILURE_API_UNREACHABLE);
+
+    const noRepo = validateInjectedTokenMode(
+      { GH_ENTERPRISE_TOKEN: "t" },
+      {
+        repo: "owner/name",
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && String(args[1]).startsWith("repos/")) {
+            return { returncode: 1, stdout: "", stderr: "404", args: [...args] };
+          }
+          return { returncode: 0, stdout: '{"login":"u"}', stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(noRepo.failureKind).toBe(FAILURE_REPO_ACCESS);
+    expect(noRepo.login).toBe("u");
+    expect(noRepo.remediation).toMatch(/repo-access|repository/i);
+  });
+
+  it("host-gh mode auth failure and bare-string login parse (#3027)", () => {
+    const badAuth = validateHostGhMode(
+      {},
+      {
+        runGh: () => ({ returncode: 1, stdout: "", stderr: "auth", args: [] }),
+      },
+    );
+    expect(badAuth.ok).toBe(false);
+    expect(badAuth.failureKind).toBe(FAILURE_GH_AUTH);
+
+    let step = 0;
+    const ok = validateHostGhMode(
+      {},
+      {
+        repo: "deftai/directive",
+        runGh: (args) => {
+          step += 1;
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "logged in", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && args[1] === "user") {
+            // bare string login path in parseLogin
+            return { returncode: 0, stdout: '"octocat"', stderr: "", args: [...args] };
+          }
+          return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(ok.ok).toBe(true);
+    expect(ok.login).toBe("octocat");
+    expect(step).toBeGreaterThanOrEqual(2);
+  });
+
+  it("host-gh invalid repo slug throws via validation path (#3027)", () => {
+    expect(() =>
+      validateHostGhMode(
+        {},
+        {
+          repo: "not-a-slug",
+          runGh: () => ({ returncode: 0, stdout: '{"login":"x"}', stderr: "", args: [] }),
+        },
+      ),
+    ).toThrow(/invalid repository slug/);
+  });
+
+  it("host-gh API unreachable and repo-access failure branches (#3027)", () => {
+    const unreachable = validateHostGhMode(
+      {},
+      {
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && args[1] === "user") {
+            return { returncode: 1, stdout: "", stderr: "timeout", args: [...args] };
+          }
+          return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(unreachable.failureKind).toBe(FAILURE_API_UNREACHABLE);
+
+    const noRepo = validateHostGhMode(
+      {},
+      {
+        repo: "owner/name",
+        runtimeMode: RUNTIME_MODE_CURSOR_NATIVE_SANDBOX,
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && args[1] === "user") {
+            return { returncode: 0, stdout: '{"login":"u"}', stderr: "", args: [...args] };
+          }
+          return { returncode: 1, stdout: "", stderr: "403", args: [...args] };
+        },
+      },
+    );
+    expect(noRepo.failureKind).toBe(FAILURE_REPO_ACCESS);
+    expect(noRepo.login).toBe("u");
+    expect(noRepo.remediation).toMatch(/sandbox/i);
+    expect(noRepo.remediation).toMatch(/repo-access|repository/i);
+  });
+
+  it("parseLogin empty and non-login object paths via host-gh (#3027)", () => {
+    const emptyLogin = validateHostGhMode(
+      {},
+      {
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && args[1] === "user") {
+            return { returncode: 0, stdout: "   ", stderr: "", args: [...args] };
+          }
+          return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(emptyLogin.ok).toBe(true);
+    expect(emptyLogin.login).toBeNull();
+
+    const noLoginField = validateHostGhMode(
+      {},
+      {
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && args[1] === "user") {
+            return { returncode: 0, stdout: '{"id":1}', stderr: "", args: [...args] };
+          }
+          return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(noLoginField.ok).toBe(true);
+    expect(noLoginField.login).toBeNull();
+
+    const bareText = validateHostGhMode(
+      {},
+      {
+        runGh: (args) => {
+          if (args[0] === "auth") {
+            return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+          }
+          if (args[0] === "api" && args[1] === "user") {
+            return { returncode: 0, stdout: "not-json-login", stderr: "", args: [...args] };
+          }
+          return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+        },
+      },
+    );
+    expect(bareText.login).toBe("not-json-login");
+  });
+
+  it("validateGithubAuthForWorker infers mode and resultToDict/cli emit (#3027)", () => {
+    const worker = validateGithubAuthForWorker("host-gh", {
+      runGh: () => ({ returncode: 1, stdout: "", stderr: "auth", args: [] }),
+    });
+    expect(worker.ok).toBe(false);
+    expect(worker.failureKind).toBe(FAILURE_GH_AUTH);
+
+    const dict = resultToDict(worker);
+    expect(dict.ok).toBe(false);
+    expect(dict.github_auth_mode).toBe("host-gh");
+    expect(dict.failure_kind).toBe(FAILURE_GH_AUTH);
+
+    const exitOk = githubAuthModesMain({
+      githubAuthMode: "injected-token",
+      json: true,
+      runGh: () => ({ returncode: 0, stdout: '{"login":"bot"}', stderr: "", args: [] }),
+      // token required for injected path
+    });
+    // missing token without environ → fails
+    expect(exitOk).toBe(1);
+
+    const exitWithToken = githubAuthModesMain({
+      githubAuthMode: "injected-token",
+      json: false,
+      runGh: (args) => {
+        if (args[0] === "auth") {
+          return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+        }
+        return { returncode: 0, stdout: '{"login":"bot"}', stderr: "", args: [...args] };
+      },
+    });
+    // still missing token in process.env typically; may fail
+    expect([0, 1]).toContain(exitWithToken);
+
+    // Force token via validateInjected success path already covered; exercise
+    // CLI with injected env by using host-gh success for exit 0.
+    const exitHost = githubAuthModesMain({
+      githubAuthMode: "host-gh",
+      json: false,
+      runGh: (args) => {
+        if (args[0] === "auth") {
+          return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
+        }
+        if (args[0] === "api" && args[1] === "user") {
+          return { returncode: 0, stdout: '{"login":"h"}', stderr: "", args: [...args] };
+        }
+        return { returncode: 0, stdout: "{}", stderr: "", args: [...args] };
+      },
+    });
+    expect(exitHost).toBe(0);
+  });
+
+  it("infers injected mode for cloud headless and prints remediation on CLI fail (#3027)", () => {
+    expect(
+      inferGithubAuthMode({
+        runtimeMode: RUNTIME_MODE_CLOUD_HEADLESS,
+      } as never),
+    ).toBe("injected-token");
+
+    const failRemediation = validateHostGhMode(
+      {},
+      {
+        runtimeMode: RUNTIME_MODE_CURSOR_NATIVE_SANDBOX,
+        runGh: () => ({ returncode: 1, stdout: "", stderr: "auth", args: [] }),
+      },
+    );
+    expect(failRemediation.remediation).toMatch(/sandbox/i);
+
+    // CLI non-json path prints remediation when present
+    const code = githubAuthModesMain({
+      githubAuthMode: "host-gh",
+      json: false,
+      runGh: () => ({ returncode: 1, stdout: "", stderr: "nope", args: [] }),
+    });
+    expect(code).toBe(1);
+
+    // null mode uses runtime report inference
+    const inferred = validateGithubAuthForWorker(null, {
+      runtimeReport: {
+        runtimeMode: RUNTIME_MODE_CLOUD_HEADLESS,
+      } as never,
+      runGh: () => ({ returncode: 1, stdout: "", stderr: "x", args: [] }),
+    });
+    expect(inferred.githubAuthMode).toBe("injected-token");
   });
 });

--- a/packages/core/src/intake/github-auth-modes.test.ts
+++ b/packages/core/src/intake/github-auth-modes.test.ts
@@ -273,30 +273,15 @@ describe("github-auth-modes", () => {
     expect(dict.github_auth_mode).toBe("host-gh");
     expect(dict.failure_kind).toBe(FAILURE_GH_AUTH);
 
-    const exitOk = githubAuthModesMain({
-      githubAuthMode: "injected-token",
-      json: true,
+    // Empty environ: injected path fails closed even when CI process.env has GH_TOKEN.
+    const missing = validateGithubAuth("injected-token", {
+      environ: {},
       runGh: () => ({ returncode: 0, stdout: '{"login":"bot"}', stderr: "", args: [] }),
-      // token required for injected path
     });
-    // missing token without environ → fails
-    expect(exitOk).toBe(1);
+    expect(missing.ok).toBe(false);
+    expect(missing.failureKind).toBe(FAILURE_MISSING_INJECTED_TOKEN);
 
-    const exitWithToken = githubAuthModesMain({
-      githubAuthMode: "injected-token",
-      json: false,
-      runGh: (args) => {
-        if (args[0] === "auth") {
-          return { returncode: 0, stdout: "ok", stderr: "", args: [...args] };
-        }
-        return { returncode: 0, stdout: '{"login":"bot"}', stderr: "", args: [...args] };
-      },
-    });
-    // still missing token in process.env typically; may fail
-    expect([0, 1]).toContain(exitWithToken);
-
-    // Force token via validateInjected success path already covered; exercise
-    // CLI with injected env by using host-gh success for exit 0.
+    // CLI host-gh success path (does not depend on process token env).
     const exitHost = githubAuthModesMain({
       githubAuthMode: "host-gh",
       json: false,
@@ -311,6 +296,14 @@ describe("github-auth-modes", () => {
       },
     });
     expect(exitHost).toBe(0);
+
+    // CLI json emit path
+    const exitJson = githubAuthModesMain({
+      githubAuthMode: "host-gh",
+      json: true,
+      runGh: () => ({ returncode: 1, stdout: "", stderr: "auth", args: [] }),
+    });
+    expect(exitJson).toBe(1);
   });
 
   it("infers injected mode for cloud headless and prints remediation on CLI fail (#3027)", () => {

--- a/packages/core/src/scope/batch-promote.test.ts
+++ b/packages/core/src/scope/batch-promote.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -167,5 +167,61 @@ describe("batchPromote (#3011)", () => {
     expect(result.skipped.length).toBeGreaterThan(0);
     expect(result.exitCode).toBe(1);
     expect(result.ok).toBe(false);
+  });
+
+  it("ignores blank explicit paths and promotes relative in-tree paths (#3027)", () => {
+    const root = freshRoot();
+    writeProposed(root, "2026-07-31-rel.xbrief.json", "Rel");
+    const result = batchPromote({
+      projectRoot: root,
+      files: ["", "  ", "xbrief/proposed/2026-07-31-rel.xbrief.json"],
+    });
+    expect(result.promoted).toBe(1);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("refuses missing explicit paths with exit 2 (#3027)", () => {
+    const root = freshRoot();
+    const result = batchPromote({
+      projectRoot: root,
+      files: [join(root, "xbrief", "proposed", "nope.xbrief.json")],
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.messages.some((m) => m.includes("File not found"))).toBe(true);
+  });
+
+  it("refuses non-artifact paths under project root (#3027)", () => {
+    const root = freshRoot();
+    const junk = join(root, "xbrief", "proposed", "readme.md");
+    writeFileSync(junk, "# no", "utf8");
+    const result = batchPromote({ projectRoot: root, files: [junk] });
+    expect(result.exitCode).toBe(2);
+    expect(result.messages.some((m) => m.includes("Not a vBRIEF"))).toBe(true);
+  });
+
+  it("refuses out-of-project explicit paths (#3027)", () => {
+    const root = freshRoot();
+    const outside = join(root, "..", "outside-3027.xbrief.json");
+    writeFileSync(outside, JSON.stringify({ plan: { title: "out", status: "proposed" } }), "utf8");
+    try {
+      const result = batchPromote({ projectRoot: root, files: [outside] });
+      expect(result.exitCode).toBe(2);
+      expect(result.messages.some((m) => m.includes("escapes project root"))).toBe(true);
+    } finally {
+      try {
+        rmSync(outside, { force: true });
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it("returns exit 2 when project root cannot be resolved (#3027)", () => {
+    const result = batchPromote({
+      projectRoot: join(tmpdir(), `no-project-${Date.now()}`),
+      files: [],
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.messages.some((m) => m.includes("project root"))).toBe(true);
   });
 });

--- a/xbrief/active/2026-08-02-3027-coverage-debt-restore-vitest-branches-85-8491-at-v0910-prefl.xbrief.json
+++ b/xbrief/active/2026-08-02-3027-coverage-debt-restore-vitest-branches-85-8491-at-v0910-prefl.xbrief.json
@@ -1,0 +1,34 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3027",
+    "updated": "2026-08-02T02:14:00Z"
+  },
+  "plan": {
+    "title": "coverage-debt: restore Vitest branches >=85% (84.91% at v0.91.0 preflight)",
+    "status": "running",
+    "narratives": {
+      "Description": "coverage-debt: restore Vitest branches >=85% (84.91% at v0.91.0 preflight)",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3027",
+      "Overview": "## Summary\nv0.91.0 release Step 5 failed on Vitest branch coverage hairline: **84.91%** vs global threshold **85%**.\n\n## Recurrence\nSame class as #2986 / #3003 (84.9x% hairlines at release preflight).\n\n## Acceptance\n- [ ] Restore Vitest branches >= 85% on master without hatch\n- [ ] Or document permanent threshold policy change\n\n## Use\n`--allow-coverage-debt=#N` hatch for the v0.91.0 cut only."
+    },
+    "items": [
+      {
+        "title": "Restore Vitest branches >= 85% on master without hatch",
+        "status": "proposed"
+      },
+      {
+        "title": "Or document permanent threshold policy change",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3027",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3027: coverage-debt: restore Vitest branches >=85% (84.91% at v0.91.0 preflight)"
+      }
+    ],
+    "updated": "2026-08-02T02:14:00Z"
+  }
+}


### PR DESCRIPTION
## Summary
Restore Vitest global branch coverage above the 85% threshold after the v0.91.0 release preflight hairline (84.91%).

## Changes
- Edge tests for OpenClaw pin install lock/stale/rename/refresh + doctor fix-path TTY/force branches
- Edge tests for github-auth mode failure, parseLogin, and CLI remediation paths
- Edge tests for batch-promote path validation (relative, missing, non-artifact, out-of-tree)
- Edge tests for plan-sequence CLI argv/JSON emit/exhausted branches
- CHANGELOG [Unreleased] Fixed entry

## Measurement
`npx vitest run --coverage` → Branches **85.05%** (32062/37697), exit 0 (no `--allow-coverage-debt`).

## Tracking
Tracking: #3027