### PR TITLE
feat(policy): .deft-directive-disable test kill-switch (#3039)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Same as managed below; `task verify:story-ready`, `task scope:promote -- <path>`
 
 ! Brief release-notes — `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § CHANGELOG entry style (#1242).
 ! Controlled English for docs/issues/PRs — `content/docs/writing-ste100.md` (#2927). ⊗ Full STE cert; ⊗ big-bang rewrite; ⊗ red CI style gate v1.
-! Per-project opt-out — root `.no-deft-directive` (#2926) skips install/session/setup (`content/docs/no-deft-directive.md`); flag wins locally over org force-on; flag+deposit → doctor warns, init/update fail closed.
+! Per-project opt-out — root `.no-deft-directive` (#2926) skips install/session/setup (`content/docs/no-deft-directive.md`); flag wins locally over org force-on; flag+deposit → doctor warns, init/update fail closed. Temporary kill-switch `.deft-directive-disable` (#3039) — deposit OK; delete + NEW agent session (`content/docs/deft-directive-disable.md`).
 
 ## Contextual guardrails (runtime-detect lazy-load)
 
@@ -160,12 +160,17 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=375324eaa627 refreshed=2026-08-02T02:30:33Z session=19b97de11432 -->
+<!-- deft:managed-section v3 sha=fb5bed9c3fe3 refreshed=2026-08-02T04:51:18Z session=9f13a50fbcc0 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ! If any .deft/core/.agents/skills/ path referenced in this file cannot be read (missing file, stale path from a previous framework version, or a deprecation redirect stub), read .deft/core/QUICK-START.md instead and follow it. QUICK-START refreshes this section idempotently for the current framework version.
+
+## Temporary test kill-switch (#3039)
+
+! Before further Directive process load, check root `.deft-directive-disable` (presence = flag). If present → stop DD load; recovery = delete file + NEW agent session. Deposit OK; not `.no-deft-directive` (#2926). Docs: `.deft/core/docs/deft-directive-disable.md`.
+⊗ Claim full operation while the flag exists or after delete without a NEW agent session.
 
 ## Session routing (#2176)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Temporary test kill-switch `.deft-directive-disable` (#3039).** Root-only gitignored flag disables Directive **enforcement** (host SessionStart / PreToolUse / compact hooks, `session:start` ritual write, doctor short-circuit) while allowing the deposit to remain — distinct from permanent `.no-deft-directive` (#2926). Shared detector in `packages/core/src/policy/deft-directive-disable.ts`; recovery requires **delete the file** and a **new agent session**. Doctor reports `disabled-test-kill-switch` (not flag+deposit dirty). AGENTS always-on contract via agents-entry; deposit gitignore baseline includes the flag path. Docs: `content/docs/deft-directive-disable.md`. Consumer note: A/B and DevHammer “without DD enforcement” arm. Closes #3039.
+
 ### Changed
 
 - **Through-merge / drive-to:merge-ready must dispatch a worker; N=1 uses swarm path (#3032).** AGENTS.md and `agents-entry` now carry always-on `!` / `⊗` bullets: parent conversation MUST NOT implement product code or babysit fix/CI loops when background subagent/worktree dispatch is available; parent MUST dispatch a `drive-to: merge-ready` worker (worktree, preflight, pre-pr, review-cycle, merge/`scope:complete`) even when cohort size is 1. Swarm Phase 0 + core-ops anti-patterns encode the same rule; skill-pin-policy cross-refs the false-negative class; lessons pack records the #3027 recurrence. Contract markers in `agents_entry_contract`. Refs #1880 Gap C/D, #2508, #954.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Temporary test kill-switch `.deft-directive-disable` (#3039).** Root-only gitignored flag disables Directive **enforcement** (host SessionStart / PreToolUse / compact hooks, `session:start` ritual write, doctor short-circuit) while allowing the deposit to remain — distinct from permanent `.no-deft-directive` (#2926). Shared detector in `packages/core/src/policy/deft-directive-disable.ts`; recovery requires **delete the file** and a **new agent session**. Doctor reports `disabled-test-kill-switch` (not flag+deposit dirty). AGENTS always-on contract via agents-entry; deposit gitignore baseline includes the flag path. Docs: `content/docs/deft-directive-disable.md`. Consumer note: A/B and DevHammer “without DD enforcement” arm. Closes #3039.
+- **Temporary test kill-switch `.deft-directive-disable` (#3039).** Root-only **local (untracked)** flag disables Directive **enforcement** (host SessionStart / PreToolUse / compact hooks, `session:start` ritual write, doctor short-circuit) while allowing the deposit to remain — distinct from permanent `.no-deft-directive` (#2926). A **tracked/committed** flag is misconfig: doctor warns and enforcement stays on (repo content cannot disable hooks for clones). Shared detector in `packages/core/src/policy/deft-directive-disable.ts`; recovery requires **delete the file** and a **new agent session**. Doctor reports `disabled-test-kill-switch` when active. AGENTS always-on contract via agents-entry; deposit gitignore baseline includes the flag path. Docs: `content/docs/deft-directive-disable.md`. Consumer note: A/B and DevHammer “without DD enforcement” arm. Closes #3039.
 
 ### Changed
 

--- a/content/QUICK-START.md
+++ b/content/QUICK-START.md
@@ -155,7 +155,7 @@ Read and follow `../AGENTS.md`. This starts the normal first-session flow (user 
 
 **Writing pointer:** For docs, issues, and PR prose that maintainers or agents author, follow [docs/writing-ste100.md](./docs/writing-ste100.md) (short controlled English; #2927).
 
-**Opt-out pointer:** Projects that must not use Directive should commit root [`.no-deft-directive`](./docs/no-deft-directive.md) so session/doctor/init/setup skip install and ritual (#2926).
+**Opt-out pointer:** Projects that must not use Directive should commit root [`.no-deft-directive`](./docs/no-deft-directive.md) so session/doctor/init/setup skip install and ritual (#2926). Temporary local kill-switch (deposit OK): [`.deft-directive-disable`](./docs/deft-directive-disable.md) (#3039).
 
 **Contributor pointer (non-blocking):** Working on Deft itself (a `deftai/directive` source checkout)? See [CONTRIBUTING.md](../CONTRIBUTING.md) and use the maintainer install path (`deft-install --yes --upgrade --maintainer --repo-root . --json`). The repo's root `AGENTS.md` has contributor instructions — you do not need the consumer first-session flow above.
 

--- a/content/docs/deft-directive-disable.md
+++ b/content/docs/deft-directive-disable.md
@@ -1,0 +1,96 @@
+# Temporary kill-switch: `.deft-directive-disable`
+
+Use a **root file flag** to turn Directive **enforcement** off for local testing (A/B, DevHammer, ceremony vs loop) **without** permanent project opt-out and **without** deleting the deposit.
+
+Tracker: [#3039](https://github.com/deftai/directive/issues/3039).
+
+**Not** permanent opt-out — that is [`.no-deft-directive`](./no-deft-directive.md) (#2926).
+
+## Filename and location
+
+```text
+.deft-directive-disable
+```
+
+- **Exact name:** lowercase `.deft-directive-disable`
+- **Location:** project / workspace **root only**
+- **Content:** empty file or a short `#` comment. Presence is the flag. No schema.
+- **Git:** **Must be gitignored** (deposit baseline includes this entry). Committed flag is a misconfig; doctor **warns** only.
+
+## Distinct from permanent opt-out
+
+| File | Intent |
+|------|--------|
+| [`.no-deft-directive`](./no-deft-directive.md) | Permanent: project does not use Directive. Flag + deposit is **inconsistent**. |
+| `.deft-directive-disable` | Temporary: testing kill-switch. **Deposit OK**. |
+
+## Behavior
+
+| Surface | When flag present |
+|---------|-------------------|
+| **Doctor** | Status **disabled (test kill-switch)**; **not** the #2926 flag+deposit dirty path; prints full recovery (file gone + new session). |
+| **Agent** | Always-on AGENTS contract: stop further Directive process load; echo recovery. |
+| **CLI** (`session:start`, ritual paths) | Disabled + recovery; no ritual write / no half-DD automation. |
+| **Host hooks** | SessionStart / PreToolUse / compact skip ritual and enforcement. |
+
+Deposit (`.deft/core`) **may remain**. Init/update are not blocked by this flag alone (unlike permanent opt-out).
+
+## Recovery (hysteresis)
+
+Directive is **fully operational** only when:
+
+1. **`.deft-directive-disable` is absent**, and
+2. A **new agent session** has been started after the file was removed
+
+Canonical recovery message:
+
+```text
+Directive is DISABLED for this project via root `.deft-directive-disable` (test/local kill-switch).
+Deposit may still be present; enforcement (hooks, session ritual, automation) will not run.
+
+To fully re-enable Directive:
+  1. Delete the file:  rm .deft-directive-disable   (or equivalent)
+  2. Start a NEW agent session (reload AGENTS / host skills / hooks)
+Until both are done, Directive is not fully operational.
+```
+
+## Precedence
+
+1. `.deft-directive-disable` → test kill-switch (deposit OK; recovery = delete + new session)
+2. `.no-deft-directive` → permanent opt-out (#2926)
+3. Else normal Directive
+
+If **both** flags are present: one combined message; permanent install semantics still apply for init/update.
+
+## Consumer note (A/B / DevHammer)
+
+Typical arm for “without Directive enforcement”:
+
+```bash
+# Ensure ignore entry exists (init/update baseline)
+# Then:
+touch .deft-directive-disable
+# Start a new agent session — enforcement off; deposit may stay.
+```
+
+Re-enable:
+
+```bash
+rm .deft-directive-disable
+# Start a NEW agent session
+```
+
+## Non-goals (v1)
+
+- ⊗ Auto-delete `.deft/` or uninstall deposit
+- ⊗ Replace or weaken `.no-deft-directive`
+- ⊗ Rewrite AGENTS to a stub on disable
+- ⊗ Org-remote kill switch
+- ⊗ Nested monorepo package roots
+- ⊗ `DEFT_DISABLED=1` env (optional later)
+
+## Related
+
+- [no-deft-directive.md](./no-deft-directive.md) — permanent opt-out
+- [getting-started.md](./getting-started.md) — install and first project
+- `session:start`, `doctor`, host hooks (SessionStart / PreToolUse / compact)

--- a/content/docs/deft-directive-disable.md
+++ b/content/docs/deft-directive-disable.md
@@ -15,7 +15,7 @@ Tracker: [#3039](https://github.com/deftai/directive/issues/3039).
 - **Exact name:** lowercase `.deft-directive-disable`
 - **Location:** project / workspace **root only**
 - **Content:** empty file or a short `#` comment. Presence is the flag. No schema.
-- **Git:** **Must be gitignored** (deposit baseline includes this entry). Committed flag is a misconfig; doctor **warns** only.
+- **Git:** **Must be gitignored** (deposit baseline includes this entry). Committed / tracked flag is a misconfig: doctor **warns**, and enforcement is **not** disabled (repo-controlled content must not turn off hooks for clones).
 
 ## Distinct from permanent opt-out
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -145,3 +145,5 @@ Full command reference for every triage and cache verb lives in [`commands.md` Â
 **Writing:** For docs, issues, and PR prose, follow [writing-ste100.md](./writing-ste100.md) (short controlled English; #2927).
 
 **Opt out:** To mark a repo as not using Directive, add root [`.no-deft-directive`](./no-deft-directive.md) (#2926). Tools skip install and session ritual when that file is present.
+
+**Temporary test kill-switch:** For local A/B or DevHammer without permanent opt-out, use root [`.deft-directive-disable`](./deft-directive-disable.md) (#3039). Deposit may stay; re-enable by deleting the file and starting a new agent session.

--- a/content/docs/no-deft-directive.md
+++ b/content/docs/no-deft-directive.md
@@ -82,6 +82,7 @@ When `deft-directive-setup` runs:
 
 ## Related
 
+- [deft-directive-disable.md](./deft-directive-disable.md) — **temporary** test/local kill-switch (deposit OK; not this flag)
 - [getting-started.md](./getting-started.md) — install and first project
 - [product-signal.md](./product-signal.md) — optional partner signal (defaults off; flag still wins locally)
 - `session:start`, `doctor`, `directive init`, `directive update`

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -5,6 +5,11 @@ Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
 
 ! If any .deft/core/.agents/skills/ path referenced in this file cannot be read (missing file, stale path from a previous framework version, or a deprecation redirect stub), read .deft/core/QUICK-START.md instead and follow it. QUICK-START refreshes this section idempotently for the current framework version.
 
+## Temporary test kill-switch (#3039)
+
+! Before further Directive process load, check root `.deft-directive-disable` (presence = flag). If present → stop DD load; recovery = delete file + NEW agent session. Deposit OK; not `.no-deft-directive` (#2926). Docs: `.deft/core/docs/deft-directive-disable.md`.
+⊗ Claim full operation while the flag exists or after delete without a NEW agent session.
+
 ## Session routing (#2176)
 
 ! **Read-only default** until mutation intent: load AGENTS.md / main.md / USER.md / `xbrief/PROJECT-DEFINITION.xbrief.json`; resolve USER.md via `deft session:start` (`USER.md resolved …`; win32 `%APPDATA%\deft\USER.md`; unix `~/.config/deft/USER.md`; ⊗ invent `~/.config/deft` on Windows #2544); confirm Deft alignment + addressing-name; ⊗ no mutable `deft session:start` / triage welcome / sync / branch-policy unless asked or implementation-ready (#2176) — `.deft/core/commands.md` § Session routing. Bootstrap: cold-start → README § Cold-start (#2273) ⊗ never `.deft/core/`; pre-cutover → setup Pre-Cutover (#2068); missing USER.md / PROJECT-DEFINITION → setup Phase 1/2 (#1813) ⊗ before answering; else main → USER → PROJECT-DEFINITION; ~ sync. Mutation → `deft session:start` then `deft verify:session-ritual -- --tier=gated` (#1149). ? `deft session:start -- --read-only` (#2176).

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -97,6 +97,7 @@ const PROPAGATION_POLICY_KEY_MARKERS = [
 ] as const;
 
 const PROPAGATION_HEADER_MARKERS = [
+  "## Temporary test kill-switch (#3039)",
   "## Session routing (#2176)",
   "## Session-start ritual (#1149)",
   "## Unmanaged project header (#2065)",
@@ -110,6 +111,14 @@ const PROPAGATION_HEADER_MARKERS = [
   "### Story Start Gate",
   "## Contextual guardrails (runtime-detect lazy-load)",
   "## Content packs",
+] as const;
+
+/** Always-on temporary kill-switch (#3039) — check before further DD process load. */
+const DEFT_DIRECTIVE_DISABLE_MARKERS = [
+  "Temporary test kill-switch (#3039)",
+  ".deft-directive-disable",
+  "NEW agent session",
+  "no-deft-directive",
 ] as const;
 
 /** Always-on through-merge dispatch doctrine (#3032) — parent must not implement. */
@@ -719,6 +728,11 @@ describe("test_agents_entry_contract", () => {
   it("through_merge_dispatch_markers_present_in_both_files", () => {
     expect(missingMarkers(template, THROUGH_MERGE_DISPATCH_MARKERS)).toEqual([]);
     expect(missingMarkers(agents, THROUGH_MERGE_DISPATCH_MARKERS)).toEqual([]);
+  });
+
+  it("deft_directive_disable_markers_present_in_both_files", () => {
+    expect(missingMarkers(template, DEFT_DIRECTIVE_DISABLE_MARKERS)).toEqual([]);
+    expect(missingMarkers(agents, DEFT_DIRECTIVE_DISABLE_MARKERS)).toEqual([]);
   });
 
   it("portable_shell_orientation_markers_present_in_both_files", () => {

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -294,6 +294,7 @@ describe("checkGitignoreCoverage (#2206)", () => {
       ".deft/ritual-state.json",
       ".deft/last-session.json",
       ".deft/routing.local.json",
+      ".deft-directive-disable",
       "vbrief/.triage-cache/candidates.jsonl",
       "vbrief/.triage-cache/summary-history.jsonl",
       "vbrief/.triage-cache/scope-lifecycle.jsonl",

--- a/packages/core/src/doctor/deft-directive-disable.test.ts
+++ b/packages/core/src/doctor/deft-directive-disable.test.ts
@@ -25,9 +25,10 @@ function tempRoot(): string {
 }
 
 describe("cmdDoctor — .deft-directive-disable short-circuit (#3039)", () => {
-  it("exits 0 with recovery message when the kill-switch is present", () => {
+  it("exits 0 with recovery message when an untracked kill-switch is present", () => {
     const root = tempRoot();
     writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
+    // Temp dirs are not a git worktree → ls-files empty → active kill-switch.
     const stdout: string[] = [];
     const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
       chunk: string | Uint8Array,

--- a/packages/core/src/doctor/deft-directive-disable.test.ts
+++ b/packages/core/src/doctor/deft-directive-disable.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
+import {
+  DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
+  DEFT_DIRECTIVE_DISABLE_STATUS,
+} from "../policy/deft-directive-disable.js";
+import { cmdDoctor } from "./main.js";
+
+const temps: string[] = [];
+
+afterEach(() => {
+  for (const t of temps.splice(0)) {
+    rmSync(t, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "doctor-disable-"));
+  temps.push(root);
+  return root;
+}
+
+describe("cmdDoctor — .deft-directive-disable short-circuit (#3039)", () => {
+  it("exits 0 with recovery message when the kill-switch is present", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
+    const stdout: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    const code = cmdDoctor(["--project-root", root, "--full"]);
+    stdoutSpy.mockRestore();
+    expect(code).toBe(0);
+    const out = stdout.join("");
+    expect(out).toContain(".deft-directive-disable");
+    expect(out).toContain("NEW agent session");
+    expect(out).toContain("rm .deft-directive-disable");
+  });
+
+  it("allows deposit to remain without #2926 inconsistent dirty path", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
+    mkdirSync(join(root, CANONICAL_INSTALL_ROOT), { recursive: true });
+    const stdout: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    const code = cmdDoctor(["--project-root", root, "--json"]);
+    stdoutSpy.mockRestore();
+    expect(code).toBe(0);
+    const payload = JSON.parse(stdout.join("")) as {
+      status: string;
+      disabled: boolean;
+      kill_switch: boolean;
+      inconsistent: boolean;
+      deposit_present: boolean;
+      disabled_via: string;
+    };
+    expect(payload.status).toBe(DEFT_DIRECTIVE_DISABLE_STATUS);
+    expect(payload.disabled).toBe(true);
+    expect(payload.kill_switch).toBe(true);
+    expect(payload.inconsistent).toBe(false);
+    expect(payload.deposit_present).toBe(true);
+    expect(payload.disabled_via).toBe(DEFT_DIRECTIVE_DISABLE_FLAG_NAME);
+  });
+
+  it("emits JSON disabled-test-kill-switch status", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "# test\n", "utf8");
+    const stdout: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    const code = cmdDoctor(["--project-root", root, "--json"]);
+    stdoutSpy.mockRestore();
+    expect(code).toBe(0);
+    const payload = JSON.parse(stdout.join("")) as {
+      status: string;
+      message: string;
+    };
+    expect(payload.status).toBe(DEFT_DIRECTIVE_DISABLE_STATUS);
+    expect(payload.message).toContain("Deposit may still be present");
+  });
+});

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -10,6 +10,7 @@ import {
   DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING,
   detectDeftDirectiveDisable,
   formatDeftDirectiveDisableMessage,
+  isDeftDirectiveDisableActive,
 } from "../policy/deft-directive-disable.js";
 import {
   detectNoDeftDirective,
@@ -132,15 +133,16 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
   // #3039: temporary test kill-switch. Active (untracked) → disabled short-circuit.
   // Tracked/committed flag → warn only and continue normal doctor (no enforcement bypass).
   const killSwitch = detectDeftDirectiveDisable(projectRoot, { skipTrackedCache: true });
-  if (killSwitch.present && killSwitch.trackedByGit && !killSwitch.active) {
-    if (jsonMode) {
-      // Fall through to normal doctor after optional surface; emit warning finding
-      // by writing once then continuing — use stderr path for human mode below.
-    } else if (!quietMode) {
+  if (
+    killSwitch.present &&
+    killSwitch.trackedByGit &&
+    !isDeftDirectiveDisableActive(projectRoot, { skipTrackedCache: true })
+  ) {
+    if (!jsonMode && !quietMode) {
       process.stderr.write(`${DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING}\n`);
     }
     // Continue into full doctor; do not short-circuit.
-  } else if (killSwitch.active) {
+  } else if (isDeftDirectiveDisableActive(projectRoot, { skipTrackedCache: true })) {
     const optOutAlso = detectNoDeftDirective(projectRoot);
     const message = formatDeftDirectiveDisableMessage({
       permanentOptOutAlsoPresent: optOutAlso.present,

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -129,23 +129,23 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
   const whichFn = seams.whichFn ?? defaultWhich;
   const nowFn = seams.now ?? (() => new Date());
 
-  // #3039: temporary test kill-switch — explicit disabled status; deposit OK
-  // (not the #2926 flag+deposit dirty path). Recovery = delete file + new session.
-  const killSwitch = detectDeftDirectiveDisable(projectRoot);
-  if (killSwitch.present) {
+  // #3039: temporary test kill-switch. Active (untracked) → disabled short-circuit.
+  // Tracked/committed flag → warn only and continue normal doctor (no enforcement bypass).
+  const killSwitch = detectDeftDirectiveDisable(projectRoot, { skipTrackedCache: true });
+  if (killSwitch.present && killSwitch.trackedByGit && !killSwitch.active) {
+    if (jsonMode) {
+      // Fall through to normal doctor after optional surface; emit warning finding
+      // by writing once then continuing — use stderr path for human mode below.
+    } else if (!quietMode) {
+      process.stderr.write(`${DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING}\n`);
+    }
+    // Continue into full doctor; do not short-circuit.
+  } else if (killSwitch.active) {
     const optOutAlso = detectNoDeftDirective(projectRoot);
     const message = formatDeftDirectiveDisableMessage({
       permanentOptOutAlsoPresent: optOutAlso.present,
-      trackedByGit: killSwitch.trackedByGit,
+      trackedByGit: false,
     });
-    const findings: Array<Record<string, unknown>> = [];
-    if (killSwitch.trackedByGit) {
-      findings.push({
-        severity: "warning",
-        message: DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING,
-        check: "deft-directive-disable-tracked",
-      });
-    }
     if (jsonMode) {
       const payload = {
         status: DEFT_DIRECTIVE_DISABLE_STATUS,
@@ -154,19 +154,14 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
         kill_switch: true,
         inconsistent: false,
         deposit_present: killSwitch.depositPresent,
-        tracked_by_git: killSwitch.trackedByGit,
+        tracked_by_git: false,
         permanent_opt_out_also_present: optOutAlso.present,
         message,
-        ...(findings.length > 0 ? { findings } : {}),
       };
       process.stdout.write(`${pythonJsonDump(payload)}\n`);
     } else if (!quietMode) {
       process.stdout.write(`${message}\n`);
-      if (killSwitch.trackedByGit) {
-        process.stderr.write(`${DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING}\n`);
-      }
     }
-    // Kill-switch is intentional local state (exit 0). Tracked flag is warn-only.
     return 0;
   }
 

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -5,6 +5,13 @@ import { evaluate as evaluateAgentsMdAdvisory } from "../agents-md-advisory/eval
 import { contentRoot } from "../content-root.js";
 import { resolveProjectDefinitionPath } from "../layout/resolve.js";
 import {
+  DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
+  DEFT_DIRECTIVE_DISABLE_STATUS,
+  DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING,
+  detectDeftDirectiveDisable,
+  formatDeftDirectiveDisableMessage,
+} from "../policy/deft-directive-disable.js";
+import {
   detectNoDeftDirective,
   NO_DEFT_DIRECTIVE_DISABLED_MESSAGE,
   NO_DEFT_DIRECTIVE_FLAG_NAME,
@@ -121,6 +128,47 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
   const consumerContext = resolve(projectRoot) !== resolve(frameworkRoot);
   const whichFn = seams.whichFn ?? defaultWhich;
   const nowFn = seams.now ?? (() => new Date());
+
+  // #3039: temporary test kill-switch — explicit disabled status; deposit OK
+  // (not the #2926 flag+deposit dirty path). Recovery = delete file + new session.
+  const killSwitch = detectDeftDirectiveDisable(projectRoot);
+  if (killSwitch.present) {
+    const optOutAlso = detectNoDeftDirective(projectRoot);
+    const message = formatDeftDirectiveDisableMessage({
+      permanentOptOutAlsoPresent: optOutAlso.present,
+      trackedByGit: killSwitch.trackedByGit,
+    });
+    const findings: Array<Record<string, unknown>> = [];
+    if (killSwitch.trackedByGit) {
+      findings.push({
+        severity: "warning",
+        message: DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING,
+        check: "deft-directive-disable-tracked",
+      });
+    }
+    if (jsonMode) {
+      const payload = {
+        status: DEFT_DIRECTIVE_DISABLE_STATUS,
+        disabled: true,
+        disabled_via: DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
+        kill_switch: true,
+        inconsistent: false,
+        deposit_present: killSwitch.depositPresent,
+        tracked_by_git: killSwitch.trackedByGit,
+        permanent_opt_out_also_present: optOutAlso.present,
+        message,
+        ...(findings.length > 0 ? { findings } : {}),
+      };
+      process.stdout.write(`${pythonJsonDump(payload)}\n`);
+    } else if (!quietMode) {
+      process.stdout.write(`${message}\n`);
+      if (killSwitch.trackedByGit) {
+        process.stderr.write(`${DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING}\n`);
+      }
+    }
+    // Kill-switch is intentional local state (exit 0). Tracked flag is warn-only.
+    return 0;
+  }
 
   // #2926: official root opt-out — short-circuit Directive doctor when clean;
   // diagnose flag+deposit inconsistency (warn; exit dirty).

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -666,6 +666,12 @@ describe("direct-write hook policy", () => {
       },
       readySeams({
         sessionStart,
+        detectDeftDirectiveDisable: () => ({
+          present: false,
+          flagPath: "/project/.deft-directive-disable",
+          depositPresent: false,
+          trackedByGit: false,
+        }),
         detectNoDeftDirective: () => ({
           present: true,
           flagPath: "/project/.no-deft-directive",
@@ -680,6 +686,113 @@ describe("direct-write hook policy", () => {
     expect(sessionStart).not.toHaveBeenCalled();
   });
 
+  it("skips SessionStart when .deft-directive-disable is present even with deposit (#3039)", () => {
+    const sessionStart = vi.fn(() => {
+      throw new Error("sessionStart must not run under kill-switch");
+    });
+    const markCompactStale = vi.fn(() => {
+      throw new Error("compact must not run under kill-switch");
+    });
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "session.start",
+        projectRoot: "/project",
+        payload: {},
+      },
+      readySeams({
+        sessionStart,
+        markCompactStale,
+        detectDeftDirectiveDisable: () => ({
+          present: true,
+          flagPath: "/project/.deft-directive-disable",
+          depositPresent: true,
+          trackedByGit: false,
+        }),
+        detectNoDeftDirective: () => ({
+          present: false,
+          flagPath: "/project/.no-deft-directive",
+          depositPresent: true,
+          inconsistent: false,
+        }),
+      }),
+    );
+
+    expect(decision).toMatchObject({ verdict: "allow", code: "session-start-disabled" });
+    expect(decision.message).toContain(".deft-directive-disable");
+    expect(decision.message).toContain("NEW agent session");
+    expect(decision.message).toContain("Deposit may still be present");
+    expect(sessionStart).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits PreToolUse and compact under .deft-directive-disable (#3039)", () => {
+    const markCompactStale = vi.fn(() => {
+      throw new Error("compact must not run under kill-switch");
+    });
+    const killSeams = readySeams({
+      markCompactStale,
+      detectDeftDirectiveDisable: () => ({
+        present: true,
+        flagPath: "/project/.deft-directive-disable",
+        depositPresent: true,
+        trackedByGit: false,
+      }),
+    });
+
+    const compact = decideHook(
+      {
+        host: "cursor",
+        event: "session.compact",
+        projectRoot: "/project",
+        payload: {},
+      },
+      killSeams,
+    );
+    expect(compact).toMatchObject({ verdict: "allow", code: "directive-disabled" });
+    expect(markCompactStale).not.toHaveBeenCalled();
+
+    const tool = decideHook(
+      {
+        host: "cursor",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: { tool_name: "Write", tool_input: { path: "/project/x.ts" } },
+      },
+      killSeams,
+    );
+    expect(tool).toMatchObject({ verdict: "allow", code: "directive-disabled" });
+    expect(tool.message).toContain("rm .deft-directive-disable");
+  });
+
+  it("combines kill-switch and permanent opt-out messages when both flags present (#3039)", () => {
+    const decision = decideHook(
+      {
+        host: "grok",
+        event: "session.start",
+        projectRoot: "/project",
+        payload: {},
+      },
+      readySeams({
+        sessionStart: vi.fn(() => ({ code: 0, stdout: "", stderr: "" })),
+        detectDeftDirectiveDisable: () => ({
+          present: true,
+          flagPath: "/project/.deft-directive-disable",
+          depositPresent: true,
+          trackedByGit: false,
+        }),
+        detectNoDeftDirective: () => ({
+          present: true,
+          flagPath: "/project/.no-deft-directive",
+          depositPresent: true,
+          inconsistent: true,
+        }),
+      }),
+    );
+    expect(decision.verdict).toBe("allow");
+    expect(decision.message).toContain(".deft-directive-disable");
+    expect(decision.message).toContain(".no-deft-directive");
+  });
+
   it("skips SessionStart bookkeeping on inconsistent opt-out without blocking (#2926)", () => {
     const sessionStart = vi.fn(() => ({ code: 0, stdout: "", stderr: "" }));
     const decision = decideHook(
@@ -691,6 +804,12 @@ describe("direct-write hook policy", () => {
       },
       readySeams({
         sessionStart,
+        detectDeftDirectiveDisable: () => ({
+          present: false,
+          flagPath: "/project/.deft-directive-disable",
+          depositPresent: true,
+          trackedByGit: false,
+        }),
         detectNoDeftDirective: () => ({
           present: true,
           flagPath: "/project/.no-deft-directive",

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -671,6 +671,7 @@ describe("direct-write hook policy", () => {
           flagPath: "/project/.deft-directive-disable",
           depositPresent: false,
           trackedByGit: false,
+          active: false,
         }),
         detectNoDeftDirective: () => ({
           present: true,
@@ -686,7 +687,7 @@ describe("direct-write hook policy", () => {
     expect(sessionStart).not.toHaveBeenCalled();
   });
 
-  it("skips SessionStart when .deft-directive-disable is present even with deposit (#3039)", () => {
+  it("skips SessionStart when local kill-switch is active even with deposit (#3039)", () => {
     const sessionStart = vi.fn(() => {
       throw new Error("sessionStart must not run under kill-switch");
     });
@@ -708,6 +709,7 @@ describe("direct-write hook policy", () => {
           flagPath: "/project/.deft-directive-disable",
           depositPresent: true,
           trackedByGit: false,
+          active: true,
         }),
         detectNoDeftDirective: () => ({
           present: false,
@@ -725,7 +727,31 @@ describe("direct-write hook policy", () => {
     expect(sessionStart).not.toHaveBeenCalled();
   });
 
-  it("short-circuits PreToolUse and compact under .deft-directive-disable (#3039)", () => {
+  it("does not bypass gates when kill-switch flag is tracked by git (#3039)", () => {
+    const sessionStart = vi.fn(() => ({ code: 0, stdout: "ok\n", stderr: "" }));
+    const decision = decideHook(
+      {
+        host: "cursor",
+        event: "session.start",
+        projectRoot: "/project",
+        payload: {},
+      },
+      readySeams({
+        sessionStart,
+        detectDeftDirectiveDisable: () => ({
+          present: true,
+          flagPath: "/project/.deft-directive-disable",
+          depositPresent: true,
+          trackedByGit: true,
+          active: false,
+        }),
+      }),
+    );
+    expect(decision).toMatchObject({ verdict: "allow", code: "session-start" });
+    expect(sessionStart).toHaveBeenCalled();
+  });
+
+  it("short-circuits PreToolUse and compact under active kill-switch (#3039)", () => {
     const markCompactStale = vi.fn(() => {
       throw new Error("compact must not run under kill-switch");
     });
@@ -736,6 +762,7 @@ describe("direct-write hook policy", () => {
         flagPath: "/project/.deft-directive-disable",
         depositPresent: true,
         trackedByGit: false,
+        active: true,
       }),
     });
 
@@ -779,6 +806,7 @@ describe("direct-write hook policy", () => {
           flagPath: "/project/.deft-directive-disable",
           depositPresent: true,
           trackedByGit: false,
+          active: true,
         }),
         detectNoDeftDirective: () => ({
           present: true,
@@ -809,6 +837,7 @@ describe("direct-write hook policy", () => {
           flagPath: "/project/.deft-directive-disable",
           depositPresent: true,
           trackedByGit: false,
+          active: false,
         }),
         detectNoDeftDirective: () => ({
           present: true,

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -833,18 +833,19 @@ function inspectMutationGates(
 export function decideHook(input: HookDispatchInput, seams: HookPolicySeams = {}): HookDecision {
   const projectRoot = resolve(input.projectRoot);
 
-  // #3039: root `.deft-directive-disable` wins for enforcement short-circuit
-  // (SessionStart / compact / PreToolUse). Deposit may remain; recovery = delete + new session.
-  // Precedence over #2926 for this path; both flags → combined message.
+  // #3039: local (untracked) `.deft-directive-disable` wins for enforcement
+  // short-circuit (SessionStart / compact / PreToolUse). Deposit may remain.
+  // Tracked/committed flags do NOT bypass gates (repo-controlled content must
+  // not disable enforcement for clones) — doctor warns instead.
   {
     const detectKill = seams.detectDeftDirectiveDisable ?? detectDeftDirectiveDisable;
     const kill = detectKill(projectRoot);
-    if (kill.present) {
+    if (kill.active) {
       const detectOptOut = seams.detectNoDeftDirective ?? detectNoDeftDirective;
       const optOut = detectOptOut(projectRoot);
       const message = formatDeftDirectiveDisableMessage({
         permanentOptOutAlsoPresent: optOut.present,
-        trackedByGit: kill.trackedByGit,
+        trackedByGit: false,
       });
       return {
         verdict: "allow",

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -15,6 +15,10 @@ import {
   utcIso,
 } from "../authz/index.js";
 import { hasArtifactSuffix } from "../layout/resolve.js";
+import {
+  detectDeftDirectiveDisable,
+  formatDeftDirectiveDisableMessage,
+} from "../policy/deft-directive-disable.js";
 import { evaluateIntentCeilingFromEnv, type IntentCeilingOp } from "../policy/intent-ceiling.js";
 import {
   detectNoDeftDirective,
@@ -92,6 +96,8 @@ export type HookDecisionCode =
   | "session-start"
   | "session-start-disabled"
   | "session-start-degraded"
+  /** Enforcement skipped: root `.deft-directive-disable` test kill-switch (#3039). */
+  | "directive-disabled"
   | "session-compact-rearm"
   | "session-compact-rearm-degraded"
   | "session-compact-noop"
@@ -151,6 +157,8 @@ export interface HookPolicySeams {
   readonly sessionStart?: (projectRoot: string) => { code: number; stdout: string; stderr: string };
   /** Test seam for #2926 root opt-out on SessionStart. */
   readonly detectNoDeftDirective?: typeof detectNoDeftDirective;
+  /** Test seam for #3039 root test kill-switch (precedence over #2926 for enforcement). */
+  readonly detectDeftDirectiveDisable?: typeof detectDeftDirectiveDisable;
   readonly markCompactStale?: (projectRoot: string) => {
     changed: boolean;
     statePath: string;
@@ -824,6 +832,33 @@ function inspectMutationGates(
 /** Decide a normalized event using only the P0 direct-write policy. */
 export function decideHook(input: HookDispatchInput, seams: HookPolicySeams = {}): HookDecision {
   const projectRoot = resolve(input.projectRoot);
+
+  // #3039: root `.deft-directive-disable` wins for enforcement short-circuit
+  // (SessionStart / compact / PreToolUse). Deposit may remain; recovery = delete + new session.
+  // Precedence over #2926 for this path; both flags → combined message.
+  {
+    const detectKill = seams.detectDeftDirectiveDisable ?? detectDeftDirectiveDisable;
+    const kill = detectKill(projectRoot);
+    if (kill.present) {
+      const detectOptOut = seams.detectNoDeftDirective ?? detectNoDeftDirective;
+      const optOut = detectOptOut(projectRoot);
+      const message = formatDeftDirectiveDisableMessage({
+        permanentOptOutAlsoPresent: optOut.present,
+        trackedByGit: kill.trackedByGit,
+      });
+      return {
+        verdict: "allow",
+        code: input.event === "session.start" ? "session-start-disabled" : "directive-disabled",
+        event: input.event,
+        host: input.host,
+        toolName: null,
+        projectRoot,
+        message,
+        scopePath: null,
+      };
+    }
+  }
+
   if (input.event === "session.compact") {
     try {
       const result = (seams.markCompactStale ?? markRitualStaleAfterCompact)(projectRoot);

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -18,6 +18,7 @@ import { hasArtifactSuffix } from "../layout/resolve.js";
 import {
   detectDeftDirectiveDisable,
   formatDeftDirectiveDisableMessage,
+  isDeftDirectiveDisableActive,
 } from "../policy/deft-directive-disable.js";
 import { evaluateIntentCeilingFromEnv, type IntentCeilingOp } from "../policy/intent-ceiling.js";
 import {
@@ -840,7 +841,11 @@ export function decideHook(input: HookDispatchInput, seams: HookPolicySeams = {}
   {
     const detectKill = seams.detectDeftDirectiveDisable ?? detectDeftDirectiveDisable;
     const kill = detectKill(projectRoot);
-    if (kill.active) {
+    const killActive =
+      seams.detectDeftDirectiveDisable !== undefined
+        ? kill.active
+        : isDeftDirectiveDisableActive(projectRoot);
+    if (killActive) {
       const detectOptOut = seams.detectNoDeftDirective ?? detectNoDeftDirective;
       const optOut = detectOptOut(projectRoot);
       const message = formatDeftDirectiveDisableMessage({

--- a/packages/core/src/hooks/fixtures/README.md
+++ b/packages/core/src/hooks/fixtures/README.md
@@ -50,7 +50,8 @@ Agents, host adapters, and tests **must** key permission outcomes off `HookDecis
 | Code | Typical verdict | Meaning |
 |------|-----------------|---------|
 | `session-start` | allow | SessionStart completed / noop success path |
-| `session-start-disabled` | allow | SessionStart skipped by policy / opt-out |
+| `session-start-disabled` | allow | SessionStart skipped by policy / opt-out / test kill-switch |
+| `directive-disabled` | allow | PreToolUse/compact skipped by `.deft-directive-disable` (#3039) |
 | `session-start-degraded` | allow | SessionStart best-effort path with degraded note |
 | `session-compact-rearm` | allow | Compact event rearmed ritual state |
 | `session-compact-rearm-degraded` | allow | Compact rearm degraded |

--- a/packages/core/src/init-deposit/gitignore.test.ts
+++ b/packages/core/src/init-deposit/gitignore.test.ts
@@ -110,6 +110,7 @@ describe("ensureInitGitignoreLines", () => {
     const root = freshRoot("gitignore-cli-");
     ensureInitGitignoreLines(root, { printf: () => {} });
     expect(CANONICAL_GITIGNORE_BASELINE).toContain(".deft/.cli/");
+    expect(CANONICAL_GITIGNORE_BASELINE).toContain(".deft-directive-disable");
     expect(readGitignore(root)).toContain(".deft/.cli/");
   });
 

--- a/packages/core/src/init-deposit/gitignore.ts
+++ b/packages/core/src/init-deposit/gitignore.ts
@@ -14,6 +14,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { containedWrite } from "../fs/contained-write.js";
 import { assertWriteTargetSafe, ProjectionContainmentError } from "../fs/projection-containment.js";
+import { DEFT_DIRECTIVE_DISABLE_GITIGNORE_LINE } from "../policy/deft-directive-disable.js";
 import {
   FORBIDDEN_BLANKET_EVAL_LINES,
   stripGitignoreInlineComment,
@@ -38,7 +39,7 @@ export const CANONICAL_GITIGNORE_BASELINE: readonly string[] = [
   ".deft/last-session.json",
   ".deft/routing.local.json",
   // Temporary test/local kill-switch — must stay untracked (#3039).
-  ".deft-directive-disable",
+  DEFT_DIRECTIVE_DISABLE_GITIGNORE_LINE,
   "vbrief/.triage-cache/candidates.jsonl",
   "vbrief/.triage-cache/summary-history.jsonl",
   "vbrief/.triage-cache/scope-lifecycle.jsonl",

--- a/packages/core/src/init-deposit/gitignore.ts
+++ b/packages/core/src/init-deposit/gitignore.ts
@@ -37,6 +37,8 @@ export const CANONICAL_GITIGNORE_BASELINE: readonly string[] = [
   ".deft/ritual-state.json",
   ".deft/last-session.json",
   ".deft/routing.local.json",
+  // Temporary test/local kill-switch — must stay untracked (#3039).
+  ".deft-directive-disable",
   "vbrief/.triage-cache/candidates.jsonl",
   "vbrief/.triage-cache/summary-history.jsonl",
   "vbrief/.triage-cache/scope-lifecycle.jsonl",

--- a/packages/core/src/policy/deft-directive-disable.test.ts
+++ b/packages/core/src/policy/deft-directive-disable.test.ts
@@ -1,0 +1,142 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
+import {
+  createDeftDirectiveDisableFlag,
+  DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
+  DEFT_DIRECTIVE_DISABLE_GITIGNORE_LINE,
+  DEFT_DIRECTIVE_DISABLE_ONE_LINE,
+  DEFT_DIRECTIVE_DISABLE_RECOVERY_MESSAGE,
+  DEFT_DIRECTIVE_DISABLE_STATUS,
+  DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING,
+  deftDirectiveDisableFlagPath,
+  detectDeftDirectiveDisable,
+  formatDeftDirectiveDisableMessage,
+  isDeftDirectiveDisablePresent,
+  removeDeftDirectiveDisableFlag,
+} from "./deft-directive-disable.js";
+
+const temps: string[] = [];
+
+afterEach(() => {
+  for (const t of temps.splice(0)) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-directive-disable-"));
+  temps.push(root);
+  return root;
+}
+
+describe("detectDeftDirectiveDisable (#3039)", () => {
+  it("reports absent when the flag file is missing", () => {
+    const root = tempRoot();
+    const state = detectDeftDirectiveDisable(root);
+    expect(state.present).toBe(false);
+    expect(state.depositPresent).toBe(false);
+    expect(state.trackedByGit).toBe(false);
+    expect(state.flagPath).toBe(deftDirectiveDisableFlagPath(root));
+    expect(isDeftDirectiveDisablePresent(root)).toBe(false);
+  });
+
+  it("detects an empty root flag file as present", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
+    const state = detectDeftDirectiveDisable(root);
+    expect(state.present).toBe(true);
+    expect(isDeftDirectiveDisablePresent(root)).toBe(true);
+  });
+
+  it("detects a short-comment flag file as present", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "# A/B arm\n", "utf8");
+    expect(detectDeftDirectiveDisable(root).present).toBe(true);
+  });
+
+  it("does not treat a same-named directory as the flag", () => {
+    const root = tempRoot();
+    mkdirSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME));
+    expect(detectDeftDirectiveDisable(root).present).toBe(false);
+  });
+
+  it("reports deposit present without treating it as inconsistent", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
+    mkdirSync(join(root, CANONICAL_INSTALL_ROOT), { recursive: true });
+    const state = detectDeftDirectiveDisable(root);
+    expect(state.present).toBe(true);
+    expect(state.depositPresent).toBe(true);
+    // No inconsistent field — deposit OK under kill-switch.
+  });
+
+  it("honors injectable seams without touching the filesystem", () => {
+    const root = "/virtual/project";
+    const files = new Set([resolve(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME)]);
+    const dirs = new Set([join(root, CANONICAL_INSTALL_ROOT)]);
+    const state = detectDeftDirectiveDisable(root, {
+      isFile: (p) => files.has(p),
+      isDir: (p) => dirs.has(p),
+      isGitTracked: () => true,
+    });
+    expect(state.present).toBe(true);
+    expect(state.depositPresent).toBe(true);
+    expect(state.trackedByGit).toBe(true);
+  });
+
+  it("documents recovery wording and gitignore constant", () => {
+    expect(DEFT_DIRECTIVE_DISABLE_FLAG_NAME).toBe(".deft-directive-disable");
+    expect(DEFT_DIRECTIVE_DISABLE_GITIGNORE_LINE).toBe(".deft-directive-disable");
+    expect(DEFT_DIRECTIVE_DISABLE_STATUS).toBe("disabled-test-kill-switch");
+    expect(DEFT_DIRECTIVE_DISABLE_RECOVERY_MESSAGE).toContain("rm .deft-directive-disable");
+    expect(DEFT_DIRECTIVE_DISABLE_RECOVERY_MESSAGE).toContain("NEW agent session");
+    expect(DEFT_DIRECTIVE_DISABLE_ONE_LINE).toContain("test/local kill-switch");
+    expect(DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING).toContain("gitignored");
+  });
+});
+
+describe("formatDeftDirectiveDisableMessage (#3039)", () => {
+  it("includes recovery steps by default", () => {
+    const msg = formatDeftDirectiveDisableMessage();
+    expect(msg).toContain("Delete the file");
+    expect(msg).toContain("NEW agent session");
+  });
+
+  it("combines permanent opt-out when both flags present", () => {
+    const msg = formatDeftDirectiveDisableMessage({ permanentOptOutAlsoPresent: true });
+    expect(msg).toContain(".no-deft-directive");
+    expect(msg).toContain("permanent opt-out");
+  });
+
+  it("appends tracked-by-git warning", () => {
+    const msg = formatDeftDirectiveDisableMessage({ trackedByGit: true });
+    expect(msg).toContain(DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING);
+  });
+
+  it("supports one-line mode", () => {
+    const msg = formatDeftDirectiveDisableMessage({ oneLine: true });
+    expect(msg).toBe(DEFT_DIRECTIVE_DISABLE_ONE_LINE);
+  });
+});
+
+describe("create/removeDeftDirectiveDisableFlag (#3039)", () => {
+  it("creates an empty flag and removes it", () => {
+    const root = tempRoot();
+    const path = createDeftDirectiveDisableFlag(root);
+    expect(path).toBe(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME));
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf8")).toBe("");
+    expect(removeDeftDirectiveDisableFlag(root)).toBe(true);
+    expect(existsSync(path)).toBe(false);
+    expect(removeDeftDirectiveDisableFlag(root)).toBe(false);
+  });
+
+  it("writes an optional short rationale as a comment", () => {
+    const root = tempRoot();
+    const path = createDeftDirectiveDisableFlag(root, { rationale: "DevHammer A arm" });
+    expect(readFileSync(path, "utf8")).toBe("# DevHammer A arm\n");
+  });
+});

--- a/packages/core/src/policy/deft-directive-disable.test.ts
+++ b/packages/core/src/policy/deft-directive-disable.test.ts
@@ -1,10 +1,9 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
 import {
-  createDeftDirectiveDisableFlag,
   DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
   DEFT_DIRECTIVE_DISABLE_GITIGNORE_LINE,
   DEFT_DIRECTIVE_DISABLE_ONE_LINE,
@@ -14,8 +13,7 @@ import {
   deftDirectiveDisableFlagPath,
   detectDeftDirectiveDisable,
   formatDeftDirectiveDisableMessage,
-  isDeftDirectiveDisablePresent,
-  removeDeftDirectiveDisableFlag,
+  isDeftDirectiveDisableActive,
 } from "./deft-directive-disable.js";
 
 const temps: string[] = [];
@@ -37,24 +35,28 @@ describe("detectDeftDirectiveDisable (#3039)", () => {
     const root = tempRoot();
     const state = detectDeftDirectiveDisable(root);
     expect(state.present).toBe(false);
+    expect(state.active).toBe(false);
     expect(state.depositPresent).toBe(false);
     expect(state.trackedByGit).toBe(false);
     expect(state.flagPath).toBe(deftDirectiveDisableFlagPath(root));
-    expect(isDeftDirectiveDisablePresent(root)).toBe(false);
+    expect(isDeftDirectiveDisableActive(root)).toBe(false);
   });
 
-  it("detects an empty root flag file as present", () => {
+  it("activates on an empty untracked root flag file", () => {
     const root = tempRoot();
     writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
-    const state = detectDeftDirectiveDisable(root);
+    const state = detectDeftDirectiveDisable(root, {
+      isGitTracked: () => false,
+    });
     expect(state.present).toBe(true);
-    expect(isDeftDirectiveDisablePresent(root)).toBe(true);
+    expect(state.active).toBe(true);
+    expect(isDeftDirectiveDisableActive(root, { isGitTracked: () => false })).toBe(true);
   });
 
   it("detects a short-comment flag file as present", () => {
     const root = tempRoot();
     writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "# A/B arm\n", "utf8");
-    expect(detectDeftDirectiveDisable(root).present).toBe(true);
+    expect(detectDeftDirectiveDisable(root, { isGitTracked: () => false }).present).toBe(true);
   });
 
   it("does not treat a same-named directory as the flag", () => {
@@ -67,10 +69,29 @@ describe("detectDeftDirectiveDisable (#3039)", () => {
     const root = tempRoot();
     writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
     mkdirSync(join(root, CANONICAL_INSTALL_ROOT), { recursive: true });
-    const state = detectDeftDirectiveDisable(root);
+    const state = detectDeftDirectiveDisable(root, { isGitTracked: () => false });
     expect(state.present).toBe(true);
     expect(state.depositPresent).toBe(true);
-    // No inconsistent field — deposit OK under kill-switch.
+    expect(state.active).toBe(true);
+  });
+
+  it("does not activate when the flag is tracked by git (misconfig)", () => {
+    const root = "/virtual/project";
+    const files = new Set([resolve(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME)]);
+    const state = detectDeftDirectiveDisable(root, {
+      isFile: (p) => files.has(p),
+      isDir: () => false,
+      isGitTracked: () => true,
+    });
+    expect(state.present).toBe(true);
+    expect(state.trackedByGit).toBe(true);
+    expect(state.active).toBe(false);
+    expect(
+      isDeftDirectiveDisableActive(root, {
+        isFile: (p) => files.has(p),
+        isGitTracked: () => true,
+      }),
+    ).toBe(false);
   });
 
   it("honors injectable seams without touching the filesystem", () => {
@@ -80,11 +101,11 @@ describe("detectDeftDirectiveDisable (#3039)", () => {
     const state = detectDeftDirectiveDisable(root, {
       isFile: (p) => files.has(p),
       isDir: (p) => dirs.has(p),
-      isGitTracked: () => true,
+      isGitTracked: () => false,
     });
     expect(state.present).toBe(true);
     expect(state.depositPresent).toBe(true);
-    expect(state.trackedByGit).toBe(true);
+    expect(state.active).toBe(true);
   });
 
   it("documents recovery wording and gitignore constant", () => {
@@ -95,6 +116,7 @@ describe("detectDeftDirectiveDisable (#3039)", () => {
     expect(DEFT_DIRECTIVE_DISABLE_RECOVERY_MESSAGE).toContain("NEW agent session");
     expect(DEFT_DIRECTIVE_DISABLE_ONE_LINE).toContain("test/local kill-switch");
     expect(DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING).toContain("gitignored");
+    expect(DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING).toContain("NOT disabled");
   });
 });
 
@@ -119,24 +141,5 @@ describe("formatDeftDirectiveDisableMessage (#3039)", () => {
   it("supports one-line mode", () => {
     const msg = formatDeftDirectiveDisableMessage({ oneLine: true });
     expect(msg).toBe(DEFT_DIRECTIVE_DISABLE_ONE_LINE);
-  });
-});
-
-describe("create/removeDeftDirectiveDisableFlag (#3039)", () => {
-  it("creates an empty flag and removes it", () => {
-    const root = tempRoot();
-    const path = createDeftDirectiveDisableFlag(root);
-    expect(path).toBe(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME));
-    expect(existsSync(path)).toBe(true);
-    expect(readFileSync(path, "utf8")).toBe("");
-    expect(removeDeftDirectiveDisableFlag(root)).toBe(true);
-    expect(existsSync(path)).toBe(false);
-    expect(removeDeftDirectiveDisableFlag(root)).toBe(false);
-  });
-
-  it("writes an optional short rationale as a comment", () => {
-    const root = tempRoot();
-    const path = createDeftDirectiveDisableFlag(root, { rationale: "DevHammer A arm" });
-    expect(readFileSync(path, "utf8")).toBe("# DevHammer A arm\n");
   });
 });

--- a/packages/core/src/policy/deft-directive-disable.ts
+++ b/packages/core/src/policy/deft-directive-disable.ts
@@ -2,26 +2,29 @@
  * Temporary test/local kill-switch for Directive enforcement (#3039).
  *
  * Presence of root `.deft-directive-disable` means Directive **enforcement** is
- * OFF (hooks, session ritual, automation) while the deposit may remain.
+ * OFF (hooks, session ritual, automation) while the deposit may remain — **only
+ * when the file is not tracked by git**. A committed flag is misconfig: doctor
+ * warns and enforcement stays ON (repository-controlled content must not disable
+ * hooks for downstream clones).
+ *
  * Distinct from `.no-deft-directive` (#2926 permanent opt-out): flag+deposit is
  * **not** inconsistent here.
  *
  * Product choices (v1):
  * - Flag is **root-only** (workspace root the tool opened).
- * - Flag **must be gitignored** (canonical baseline); committed flag → doctor warns.
+ * - Flag **must be gitignored** (canonical baseline); committed flag → doctor
+ *   warns and does **not** short-circuit enforcement.
  * - Deposit presence is **OK**.
  * - Full re-enable requires: delete the file **and** start a **new** agent session.
- * - Precedence: this flag first, then `.no-deft-directive`, else normal Directive.
+ * - Precedence: active kill-switch first, then `.no-deft-directive`, else normal.
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync, unlinkSync } from "node:fs";
+import { statSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { containedWrite } from "../fs/contained-write.js";
-import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
 
-/** Canonical root-only filename (lowercase). Presence = flag. */
+/** Canonical root-only filename (lowercase). Presence = candidate flag. */
 export const DEFT_DIRECTIVE_DISABLE_FLAG_NAME = ".deft-directive-disable";
 
 /** Gitignore entry the deposit must ensure (same as flag name). */
@@ -44,20 +47,30 @@ export const DEFT_DIRECTIVE_DISABLE_RECOVERY_MESSAGE =
 export const DEFT_DIRECTIVE_DISABLE_ONE_LINE =
   "Directive disabled via `.deft-directive-disable` (test/local kill-switch; deposit OK)";
 
-/** Doctor/status label when the kill-switch is active. */
+/** Doctor/status label when the kill-switch is active (local / untracked). */
 export const DEFT_DIRECTIVE_DISABLE_STATUS = "disabled-test-kill-switch" as const;
 
 /**
  * Warning when the kill-switch file is tracked by git (should be gitignored).
+ * Tracked flags do **not** disable enforcement.
  */
 export const DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING =
-  "Misconfig: `.deft-directive-disable` is tracked by git. The flag must be gitignored (local kill-switch only). Untrack it and ensure `.gitignore` covers the path.";
+  "Misconfig: `.deft-directive-disable` is tracked by git. The flag must be gitignored (local kill-switch only). Untrack it and ensure `.gitignore` covers the path. Enforcement is NOT disabled while the flag is tracked.";
+
+/** Cap git probe so hot-path hooks never hang on a slow VCS call. */
+const GIT_TRACKED_PROBE_TIMEOUT_MS = 1500;
+
+/** Process-local cache: avoid re-spawning git on every PreToolUse while the flag is present. */
+const trackedProbeCache = new Map<string, { readonly tracked: boolean; readonly atMs: number }>();
+const TRACKED_PROBE_CACHE_TTL_MS = 30_000;
 
 export interface DeftDirectiveDisableSeams {
   readonly isFile?: (path: string) => boolean;
   readonly isDir?: (path: string) => boolean;
   /** Return true when `git ls-files` lists the flag (tracked). */
   readonly isGitTracked?: (projectRoot: string, relPath: string) => boolean;
+  /** Skip tracked probe + cache (tests / doctor full re-check). */
+  readonly skipTrackedCache?: boolean;
 }
 
 export interface DeftDirectiveDisableState {
@@ -69,6 +82,11 @@ export interface DeftDirectiveDisableState {
    * Always false when the flag is absent or when the probe cannot run.
    */
   readonly trackedByGit: boolean;
+  /**
+   * True when the kill-switch is **active** for enforcement short-circuit:
+   * present and **not** tracked by git.
+   */
+  readonly active: boolean;
 }
 
 function defaultIsFile(path: string): boolean {
@@ -88,16 +106,26 @@ function defaultIsDir(path: string): boolean {
 }
 
 function defaultIsGitTracked(projectRoot: string, relPath: string): boolean {
+  const cacheKey = `${projectRoot}\0${relPath}`;
+  const now = Date.now();
+  const cached = trackedProbeCache.get(cacheKey);
+  if (cached !== undefined && now - cached.atMs < TRACKED_PROBE_CACHE_TTL_MS) {
+    return cached.tracked;
+  }
+  let tracked = false;
   try {
     const out = execFileSync("git", ["ls-files", "--", relPath], {
       cwd: projectRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: GIT_TRACKED_PROBE_TIMEOUT_MS,
     });
-    return out.trim().length > 0;
+    tracked = out.trim().length > 0;
   } catch {
-    return false;
+    tracked = false;
   }
+  trackedProbeCache.set(cacheKey, { tracked, atMs: now });
+  return tracked;
 }
 
 /** Absolute path to the root kill-switch flag file. */
@@ -109,6 +137,8 @@ export function deftDirectiveDisableFlagPath(projectRoot: string): string {
  * Detect root `.deft-directive-disable`. Presence is file-existence only
  * (empty or short comment OK). Deposit presence is reported but never treated
  * as inconsistent (#3039 vs #2926).
+ *
+ * Enforcement short-circuit uses `state.active` (present && !trackedByGit).
  */
 export function detectDeftDirectiveDisable(
   projectRoot: string,
@@ -120,23 +150,43 @@ export function detectDeftDirectiveDisable(
   const isGitTracked = seams.isGitTracked ?? defaultIsGitTracked;
   const present = isFile(flagPath);
   const depositPresent = isDir(join(projectRoot, CANONICAL_INSTALL_ROOT));
-  const trackedByGit = present
-    ? isGitTracked(projectRoot, DEFT_DIRECTIVE_DISABLE_FLAG_NAME)
-    : false;
+  let trackedByGit = false;
+  if (present) {
+    if (seams.skipTrackedCache && seams.isGitTracked === undefined) {
+      // Fresh probe without reading process cache (doctor / one-shot CLI).
+      try {
+        const out = execFileSync("git", ["ls-files", "--", DEFT_DIRECTIVE_DISABLE_FLAG_NAME], {
+          cwd: projectRoot,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: GIT_TRACKED_PROBE_TIMEOUT_MS,
+        });
+        trackedByGit = out.trim().length > 0;
+      } catch {
+        trackedByGit = false;
+      }
+    } else {
+      trackedByGit = isGitTracked(projectRoot, DEFT_DIRECTIVE_DISABLE_FLAG_NAME);
+    }
+  }
   return {
     present,
     flagPath,
     depositPresent,
     trackedByGit,
+    active: present && !trackedByGit,
   };
 }
 
-/** True when the root test kill-switch flag file exists. */
-export function isDeftDirectiveDisablePresent(
+/**
+ * True when the local (untracked) kill-switch is active for enforcement
+ * short-circuit. Tracked flags return false so hooks stay enforced.
+ */
+export function isDeftDirectiveDisableActive(
   projectRoot: string,
   seams: DeftDirectiveDisableSeams = {},
 ): boolean {
-  return detectDeftDirectiveDisable(projectRoot, seams).present;
+  return detectDeftDirectiveDisable(projectRoot, seams).active;
 }
 
 /**
@@ -165,48 +215,4 @@ export function formatDeftDirectiveDisableMessage(
     parts.push(DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING);
   }
   return parts.join("\n\n");
-}
-
-/**
- * Create the root kill-switch flag. Optional one-line rationale becomes a `#` comment.
- * Does not remove an existing deposit.
- */
-export function createDeftDirectiveDisableFlag(
-  projectRoot: string,
-  options: { rationale?: string } = {},
-): string {
-  const path = deftDirectiveDisableFlagPath(projectRoot);
-  if (defaultIsDir(path)) {
-    throw new Error(
-      `${DEFT_DIRECTIVE_DISABLE_FLAG_NAME} exists as a directory at ${path}; remove it before creating the kill-switch flag file.`,
-    );
-  }
-  const rationale = options.rationale?.trim() ?? "";
-  const body = rationale.length > 0 ? `# ${rationale}\n` : "";
-  containedWrite({
-    root: resolve(projectRoot),
-    target: path,
-    data: body,
-    mode: "replace",
-  });
-  return path;
-}
-
-/**
- * Remove the root kill-switch flag when present.
- * @returns true when a file was removed.
- */
-export function removeDeftDirectiveDisableFlag(projectRoot: string): boolean {
-  const path = deftDirectiveDisableFlagPath(projectRoot);
-  if (!existsSync(path)) {
-    return false;
-  }
-  assertWriteTargetSafe(projectRoot, path);
-  if (defaultIsDir(path)) {
-    throw new Error(
-      `${DEFT_DIRECTIVE_DISABLE_FLAG_NAME} exists as a directory at ${path}; remove the directory manually before re-enabling Directive.`,
-    );
-  }
-  unlinkSync(path);
-  return true;
 }

--- a/packages/core/src/policy/deft-directive-disable.ts
+++ b/packages/core/src/policy/deft-directive-disable.ts
@@ -1,0 +1,212 @@
+/**
+ * Temporary test/local kill-switch for Directive enforcement (#3039).
+ *
+ * Presence of root `.deft-directive-disable` means Directive **enforcement** is
+ * OFF (hooks, session ritual, automation) while the deposit may remain.
+ * Distinct from `.no-deft-directive` (#2926 permanent opt-out): flag+deposit is
+ * **not** inconsistent here.
+ *
+ * Product choices (v1):
+ * - Flag is **root-only** (workspace root the tool opened).
+ * - Flag **must be gitignored** (canonical baseline); committed flag → doctor warns.
+ * - Deposit presence is **OK**.
+ * - Full re-enable requires: delete the file **and** start a **new** agent session.
+ * - Precedence: this flag first, then `.no-deft-directive`, else normal Directive.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync, unlinkSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { containedWrite } from "../fs/contained-write.js";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
+import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
+
+/** Canonical root-only filename (lowercase). Presence = flag. */
+export const DEFT_DIRECTIVE_DISABLE_FLAG_NAME = ".deft-directive-disable";
+
+/** Gitignore entry the deposit must ensure (same as flag name). */
+export const DEFT_DIRECTIVE_DISABLE_GITIGNORE_LINE = DEFT_DIRECTIVE_DISABLE_FLAG_NAME;
+
+/**
+ * Canonical recovery message when Directive is disabled by the test kill-switch.
+ * Surfaces (doctor, agent, CLI, hooks) share this wording.
+ */
+export const DEFT_DIRECTIVE_DISABLE_RECOVERY_MESSAGE =
+  "Directive is DISABLED for this project via root `.deft-directive-disable` (test/local kill-switch).\n" +
+  "Deposit may still be present; enforcement (hooks, session ritual, automation) will not run.\n" +
+  "\n" +
+  "To fully re-enable Directive:\n" +
+  "  1. Delete the file:  rm .deft-directive-disable   (or equivalent)\n" +
+  "  2. Start a NEW agent session (reload AGENTS / host skills / hooks)\n" +
+  "Until both are done, Directive is not fully operational.";
+
+/** One-line summary for log lines and short CLI output. */
+export const DEFT_DIRECTIVE_DISABLE_ONE_LINE =
+  "Directive disabled via `.deft-directive-disable` (test/local kill-switch; deposit OK)";
+
+/** Doctor/status label when the kill-switch is active. */
+export const DEFT_DIRECTIVE_DISABLE_STATUS = "disabled-test-kill-switch" as const;
+
+/**
+ * Warning when the kill-switch file is tracked by git (should be gitignored).
+ */
+export const DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING =
+  "Misconfig: `.deft-directive-disable` is tracked by git. The flag must be gitignored (local kill-switch only). Untrack it and ensure `.gitignore` covers the path.";
+
+export interface DeftDirectiveDisableSeams {
+  readonly isFile?: (path: string) => boolean;
+  readonly isDir?: (path: string) => boolean;
+  /** Return true when `git ls-files` lists the flag (tracked). */
+  readonly isGitTracked?: (projectRoot: string, relPath: string) => boolean;
+}
+
+export interface DeftDirectiveDisableState {
+  readonly present: boolean;
+  readonly flagPath: string;
+  readonly depositPresent: boolean;
+  /**
+   * True when the flag file is tracked by git (misconfig — should be gitignored).
+   * Always false when the flag is absent or when the probe cannot run.
+   */
+  readonly trackedByGit: boolean;
+}
+
+function defaultIsFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function defaultIsDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function defaultIsGitTracked(projectRoot: string, relPath: string): boolean {
+  try {
+    const out = execFileSync("git", ["ls-files", "--", relPath], {
+      cwd: projectRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Absolute path to the root kill-switch flag file. */
+export function deftDirectiveDisableFlagPath(projectRoot: string): string {
+  return resolve(projectRoot, DEFT_DIRECTIVE_DISABLE_FLAG_NAME);
+}
+
+/**
+ * Detect root `.deft-directive-disable`. Presence is file-existence only
+ * (empty or short comment OK). Deposit presence is reported but never treated
+ * as inconsistent (#3039 vs #2926).
+ */
+export function detectDeftDirectiveDisable(
+  projectRoot: string,
+  seams: DeftDirectiveDisableSeams = {},
+): DeftDirectiveDisableState {
+  const flagPath = deftDirectiveDisableFlagPath(projectRoot);
+  const isFile = seams.isFile ?? defaultIsFile;
+  const isDir = seams.isDir ?? defaultIsDir;
+  const isGitTracked = seams.isGitTracked ?? defaultIsGitTracked;
+  const present = isFile(flagPath);
+  const depositPresent = isDir(join(projectRoot, CANONICAL_INSTALL_ROOT));
+  const trackedByGit = present
+    ? isGitTracked(projectRoot, DEFT_DIRECTIVE_DISABLE_FLAG_NAME)
+    : false;
+  return {
+    present,
+    flagPath,
+    depositPresent,
+    trackedByGit,
+  };
+}
+
+/** True when the root test kill-switch flag file exists. */
+export function isDeftDirectiveDisablePresent(
+  projectRoot: string,
+  seams: DeftDirectiveDisableSeams = {},
+): boolean {
+  return detectDeftDirectiveDisable(projectRoot, seams).present;
+}
+
+/**
+ * Full operator-facing message for the kill-switch, optionally combined with
+ * permanent opt-out when both flags are present.
+ */
+export function formatDeftDirectiveDisableMessage(
+  options: {
+    readonly permanentOptOutAlsoPresent?: boolean;
+    readonly trackedByGit?: boolean;
+    readonly oneLine?: boolean;
+  } = {},
+): string {
+  const parts: string[] = [];
+  if (options.oneLine) {
+    parts.push(DEFT_DIRECTIVE_DISABLE_ONE_LINE);
+  } else {
+    parts.push(DEFT_DIRECTIVE_DISABLE_RECOVERY_MESSAGE);
+  }
+  if (options.permanentOptOutAlsoPresent) {
+    parts.push(
+      "Also present: root `.no-deft-directive` (permanent opt-out). Install/update fail-closed semantics still apply for that flag.",
+    );
+  }
+  if (options.trackedByGit) {
+    parts.push(DEFT_DIRECTIVE_DISABLE_TRACKED_WARNING);
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * Create the root kill-switch flag. Optional one-line rationale becomes a `#` comment.
+ * Does not remove an existing deposit.
+ */
+export function createDeftDirectiveDisableFlag(
+  projectRoot: string,
+  options: { rationale?: string } = {},
+): string {
+  const path = deftDirectiveDisableFlagPath(projectRoot);
+  if (defaultIsDir(path)) {
+    throw new Error(
+      `${DEFT_DIRECTIVE_DISABLE_FLAG_NAME} exists as a directory at ${path}; remove it before creating the kill-switch flag file.`,
+    );
+  }
+  const rationale = options.rationale?.trim() ?? "";
+  const body = rationale.length > 0 ? `# ${rationale}\n` : "";
+  containedWrite({
+    root: resolve(projectRoot),
+    target: path,
+    data: body,
+    mode: "replace",
+  });
+  return path;
+}
+
+/**
+ * Remove the root kill-switch flag when present.
+ * @returns true when a file was removed.
+ */
+export function removeDeftDirectiveDisableFlag(projectRoot: string): boolean {
+  const path = deftDirectiveDisableFlagPath(projectRoot);
+  if (!existsSync(path)) {
+    return false;
+  }
+  assertWriteTargetSafe(projectRoot, path);
+  if (defaultIsDir(path)) {
+    throw new Error(
+      `${DEFT_DIRECTIVE_DISABLE_FLAG_NAME} exists as a directory at ${path}; remove the directory manually before re-enabling Directive.`,
+    );
+  }
+  unlinkSync(path);
+  return true;
+}

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -37,6 +37,7 @@ export * from "./agents-md-advisory.js";
 export * from "./autonomy.js";
 export * from "./capacity.js";
 export * from "./decisions.js";
+export * from "./deft-directive-disable.js";
 export * from "./disclosure.js";
 export * from "./host-hooks.js";
 export * from "./hotfix-criteria.js";

--- a/packages/core/src/session/session-start-deft-directive-disable.test.ts
+++ b/packages/core/src/session/session-start-deft-directive-disable.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CANONICAL_INSTALL_ROOT } from "../init-deposit/constants.js";
+import {
+  DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
+  DEFT_DIRECTIVE_DISABLE_STATUS,
+} from "../policy/deft-directive-disable.js";
+import { NO_DEFT_DIRECTIVE_FLAG_NAME } from "../policy/no-deft-directive.js";
+import { runSessionStart } from "./session-start.js";
+
+const temps: string[] = [];
+
+afterEach(() => {
+  for (const t of temps.splice(0)) {
+    rmSync(t, { recursive: true, force: true });
+  }
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "session-disable-"));
+  temps.push(root);
+  return root;
+}
+
+describe("runSessionStart — .deft-directive-disable short-circuit (#3039)", () => {
+  it("skips the session ritual when the kill-switch is present", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
+    const result = runSessionStart(root, {
+      writeHistory: false,
+      verifyTools: () => {
+        throw new Error("verifyTools must not run when kill-switch is present");
+      },
+      runTriageWelcome: () => {
+        throw new Error("triage welcome must not run when kill-switch is present");
+      },
+      runGit: () => {
+        throw new Error("git must not run when kill-switch is present");
+      },
+    });
+    expect(result.code).toBe(0);
+    expect(result.payload.disabled).toBe(true);
+    expect(result.payload.disabled_via).toBe(DEFT_DIRECTIVE_DISABLE_FLAG_NAME);
+    expect(result.payload.status).toBe(DEFT_DIRECTIVE_DISABLE_STATUS);
+    expect(result.payload.ready).toBe(false);
+    expect(result.payload.inconsistent).toBe(false);
+    expect(String(result.payload.message)).toContain("NEW agent session");
+    expect(result.lines.join("\n")).toContain("rm .deft-directive-disable");
+  });
+
+  it("allows deposit to remain without dirty exit", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "# A/B\n", "utf8");
+    mkdirSync(join(root, CANONICAL_INSTALL_ROOT), { recursive: true });
+    const result = runSessionStart(root, { writeHistory: false });
+    expect(result.code).toBe(0);
+    expect(result.payload.deposit_present).toBe(true);
+    expect(result.payload.inconsistent).toBe(false);
+    expect(result.payload.ready).toBe(false);
+  });
+
+  it("combines permanent opt-out when both flags present", () => {
+    const root = tempRoot();
+    writeFileSync(join(root, DEFT_DIRECTIVE_DISABLE_FLAG_NAME), "", "utf8");
+    writeFileSync(join(root, NO_DEFT_DIRECTIVE_FLAG_NAME), "", "utf8");
+    const result = runSessionStart(root, { writeHistory: false });
+    expect(result.code).toBe(0);
+    expect(result.payload.disabled_via).toBe(DEFT_DIRECTIVE_DISABLE_FLAG_NAME);
+    expect(result.payload.permanent_opt_out_also_present).toBe(true);
+    expect(result.lines.join("\n")).toContain(".no-deft-directive");
+  });
+});

--- a/packages/core/src/session/session-start-hook.test.ts
+++ b/packages/core/src/session/session-start-hook.test.ts
@@ -50,6 +50,26 @@ describe("session start hook", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it("skips sentinel write when .deft-directive-disable is present (#3039)", () => {
+    const root = mkdtempSync(join(tmpdir(), "hook-kill-switch-"));
+    writeFileSync(join(root, ".deft-directive-disable"), "", "utf8");
+    mkdirSync(join(root, ".deft", "core"), { recursive: true });
+    const writeSentinelFn = vi.fn(() => {
+      throw new Error("sentinel must not run under kill-switch");
+    });
+    const result = runSessionStartHookWrite(root, {
+      detectBranchFn: () => "feat/x",
+      detectLatestActiveVbriefFn: () => "xbrief/active/a.xbrief.json",
+      resolveVersionFn: () => "0.9.0",
+      writeSentinelFn,
+    });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(".deft-directive-disable");
+    expect(result.stdout).toContain("NEW agent session");
+    expect(writeSentinelFn).not.toHaveBeenCalled();
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it("returns exit 1 and skips write when opt-out is inconsistent with deposit (#2926)", () => {
     const root = mkdtempSync(join(tmpdir(), "hook-opt-out-inc-"));
     writeFileSync(join(root, ".no-deft-directive"), "", "utf8");

--- a/packages/core/src/session/session-start-hook.ts
+++ b/packages/core/src/session/session-start-hook.ts
@@ -28,14 +28,15 @@ export function runSessionStartHookWrite(
   options: SessionStartHookOptions = {},
 ): { code: number; stdout: string; stderr: string } {
   const detectKill = options.detectDeftDirectiveDisableFn ?? detectDeftDirectiveDisable;
-  // #3039: test kill-switch wins for enforcement — skip ritual bookkeeping (deposit OK).
+  // #3039: local (untracked) kill-switch — skip ritual bookkeeping (deposit OK).
+  // Tracked flags do not short-circuit (enforcement stays on).
   const kill = detectKill(projectRoot);
-  if (kill.present) {
+  if (kill.active) {
     const detectOptOut = options.detectNoDeftDirectiveFn ?? detectNoDeftDirective;
     const optOut = detectOptOut(projectRoot);
     const message = formatDeftDirectiveDisableMessage({
       permanentOptOutAlsoPresent: optOut.present,
-      trackedByGit: kill.trackedByGit,
+      trackedByGit: false,
     });
     return {
       code: 0,

--- a/packages/core/src/session/session-start-hook.ts
+++ b/packages/core/src/session/session-start-hook.ts
@@ -2,6 +2,7 @@ import { resolveVersion } from "../doctor/paths.js";
 import {
   detectDeftDirectiveDisable,
   formatDeftDirectiveDisableMessage,
+  isDeftDirectiveDisableActive,
 } from "../policy/deft-directive-disable.js";
 import {
   detectNoDeftDirective,
@@ -31,7 +32,11 @@ export function runSessionStartHookWrite(
   // #3039: local (untracked) kill-switch — skip ritual bookkeeping (deposit OK).
   // Tracked flags do not short-circuit (enforcement stays on).
   const kill = detectKill(projectRoot);
-  if (kill.active) {
+  const killActive =
+    options.detectDeftDirectiveDisableFn !== undefined
+      ? kill.active
+      : isDeftDirectiveDisableActive(projectRoot);
+  if (killActive) {
     const detectOptOut = options.detectNoDeftDirectiveFn ?? detectNoDeftDirective;
     const optOut = detectOptOut(projectRoot);
     const message = formatDeftDirectiveDisableMessage({

--- a/packages/core/src/session/session-start-hook.ts
+++ b/packages/core/src/session/session-start-hook.ts
@@ -1,5 +1,9 @@
 import { resolveVersion } from "../doctor/paths.js";
 import {
+  detectDeftDirectiveDisable,
+  formatDeftDirectiveDisableMessage,
+} from "../policy/deft-directive-disable.js";
+import {
   detectNoDeftDirective,
   NO_DEFT_DIRECTIVE_DISABLED_MESSAGE,
   NO_DEFT_DIRECTIVE_INCONSISTENT_MESSAGE,
@@ -14,6 +18,8 @@ export interface SessionStartHookOptions {
   readonly writeSentinelFn?: typeof writeSentinel;
   /** Test seam for #2926 opt-out detection. */
   readonly detectNoDeftDirectiveFn?: typeof detectNoDeftDirective;
+  /** Test seam for #3039 test kill-switch detection. */
+  readonly detectDeftDirectiveDisableFn?: typeof detectDeftDirectiveDisable;
 }
 
 /** Write ``.deft/last-session.json`` from current git state (#1269). */
@@ -21,6 +27,23 @@ export function runSessionStartHookWrite(
   projectRoot: string,
   options: SessionStartHookOptions = {},
 ): { code: number; stdout: string; stderr: string } {
+  const detectKill = options.detectDeftDirectiveDisableFn ?? detectDeftDirectiveDisable;
+  // #3039: test kill-switch wins for enforcement — skip ritual bookkeeping (deposit OK).
+  const kill = detectKill(projectRoot);
+  if (kill.present) {
+    const detectOptOut = options.detectNoDeftDirectiveFn ?? detectNoDeftDirective;
+    const optOut = detectOptOut(projectRoot);
+    const message = formatDeftDirectiveDisableMessage({
+      permanentOptOutAlsoPresent: optOut.present,
+      trackedByGit: kill.trackedByGit,
+    });
+    return {
+      code: 0,
+      stdout: `${message}\n`,
+      stderr: "",
+    };
+  }
+
   const detectOptOut = options.detectNoDeftDirectiveFn ?? detectNoDeftDirective;
   // #2926: root opt-out wins — host SessionStart must not write ritual bookkeeping.
   const optOut = detectOptOut(projectRoot);

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -732,14 +732,14 @@ export function runSessionStart(
   const environment = (options.probeEnvironment ?? detectEnvironmentContext)();
   const ceremonyTier = options.ceremonyTier ?? COLD_CEREMONY_TIER;
 
-  // #3039: temporary test kill-switch — skip ritual write; deposit may remain.
-  // Recovery requires delete + new session. Precedence over #2926 for enforcement.
+  // #3039: local (untracked) test kill-switch — skip ritual write; deposit may remain.
+  // Recovery requires delete + new session. Tracked flags do not short-circuit.
   const killSwitch = detectDeftDirectiveDisable(projectRoot);
-  if (killSwitch.present) {
+  if (killSwitch.active) {
     const optOutAlso = detectNoDeftDirective(projectRoot);
     const message = formatDeftDirectiveDisableMessage({
       permanentOptOutAlsoPresent: optOutAlso.present,
-      trackedByGit: killSwitch.trackedByGit,
+      trackedByGit: false,
     });
     const lines = message.split("\n");
     return {
@@ -753,7 +753,7 @@ export function runSessionStart(
         kill_switch: true,
         inconsistent: false,
         deposit_present: killSwitch.depositPresent,
-        tracked_by_git: killSwitch.trackedByGit,
+        tracked_by_git: false,
         permanent_opt_out_also_present: optOutAlso.present,
         posture,
         environment: environmentContextToDict(environment),

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -8,6 +8,12 @@ import {
   environmentContextToDict,
   formatEnvironmentContext,
 } from "../platform/shell-context.js";
+import {
+  DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
+  DEFT_DIRECTIVE_DISABLE_STATUS,
+  detectDeftDirectiveDisable,
+  formatDeftDirectiveDisableMessage,
+} from "../policy/deft-directive-disable.js";
 import { disclosureLine } from "../policy/disclosure.js";
 import {
   detectNoDeftDirective,
@@ -725,6 +731,37 @@ export function runSessionStart(
   const runGit = options.runGit ?? defaultGitRunner;
   const environment = (options.probeEnvironment ?? detectEnvironmentContext)();
   const ceremonyTier = options.ceremonyTier ?? COLD_CEREMONY_TIER;
+
+  // #3039: temporary test kill-switch — skip ritual write; deposit may remain.
+  // Recovery requires delete + new session. Precedence over #2926 for enforcement.
+  const killSwitch = detectDeftDirectiveDisable(projectRoot);
+  if (killSwitch.present) {
+    const optOutAlso = detectNoDeftDirective(projectRoot);
+    const message = formatDeftDirectiveDisableMessage({
+      permanentOptOutAlsoPresent: optOutAlso.present,
+      trackedByGit: killSwitch.trackedByGit,
+    });
+    const lines = message.split("\n");
+    return {
+      code: 0,
+      payload: {
+        ready: false,
+        exit_code: 0,
+        disabled: true,
+        disabled_via: DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
+        status: DEFT_DIRECTIVE_DISABLE_STATUS,
+        kill_switch: true,
+        inconsistent: false,
+        deposit_present: killSwitch.depositPresent,
+        tracked_by_git: killSwitch.trackedByGit,
+        permanent_opt_out_also_present: optOutAlso.present,
+        posture,
+        environment: environmentContextToDict(environment),
+        message,
+      },
+      lines,
+    };
+  }
 
   // #2926: official root opt-out wins locally — skip Directive session ritual.
   // disabled = skip ritual (exit 0 clean / 1 inconsistent). ready stays false so

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -13,6 +13,7 @@ import {
   DEFT_DIRECTIVE_DISABLE_STATUS,
   detectDeftDirectiveDisable,
   formatDeftDirectiveDisableMessage,
+  isDeftDirectiveDisableActive,
 } from "../policy/deft-directive-disable.js";
 import { disclosureLine } from "../policy/disclosure.js";
 import {
@@ -734,8 +735,8 @@ export function runSessionStart(
 
   // #3039: local (untracked) test kill-switch — skip ritual write; deposit may remain.
   // Recovery requires delete + new session. Tracked flags do not short-circuit.
-  const killSwitch = detectDeftDirectiveDisable(projectRoot);
-  if (killSwitch.active) {
+  if (isDeftDirectiveDisableActive(projectRoot)) {
+    const killSwitch = detectDeftDirectiveDisable(projectRoot);
     const optOutAlso = detectNoDeftDirective(projectRoot);
     const message = formatDeftDirectiveDisableMessage({
       permanentOptOutAlsoPresent: optOutAlso.present,

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -21703,9 +21703,9 @@
       },
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
-        "managedMaxLines": 116,
+        "managedMaxLines": 121,
         "unmanagedMaxLines": 162,
-        "absoluteMaxBytes": 9400,
+        "absoluteMaxBytes": 9800,
         "skillFrontmatterTier": "daily-core",
         "skillFrontmatterMaxBytes": 2260
       },


### PR DESCRIPTION
## Summary

Implements temporary test/local kill-switch via root **`.deft-directive-disable`** (#3039), distinct from permanent `.no-deft-directive` (#2926).

## What

- Shared detector: `packages/core/src/policy/deft-directive-disable.ts`
- Wire: host hooks (SessionStart / compact / PreToolUse), `session:start` + SessionStart hook write, doctor short-circuit as `disabled-test-kill-switch` (deposit OK, not #2926 dirty)
- Gitignore baseline includes `.deft-directive-disable` (deposit ensures ignore)
- AGENTS always-on pin via `agents-entry` + refresh
- Docs: `content/docs/deft-directive-disable.md` + cross-links
- Recovery: delete file **and** NEW agent session
- Precedence: disable first, then permanent opt-out, else normal

## Tests

- Unit/hook/doctor/session tests for detection + short-circuit
- Permanent opt-out path unchanged
- `task check` green

## Consumer note

A/B and DevHammer can arm "without DD enforcement" with a gitignored local flag without removing the deposit.

Closes #3039