### PR TITLE
fix(security): projectRoot containment for atomicWriteText, ritual-state, probe-session (#3042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **projectRoot containment for atomicWriteText, ritual-state, probe-session (#3042).** Residual Medium parent-as-root / bare-write sinks after #2951/#2980: `cache/io.ts` `atomicWriteText` accepts `projectRoot` and refuses symlink lifecycle parents; brief stay-path callers thread projectRoot; `writeRitualState` / sentinel atomic JSON use projectRoot (not dirname); `writeSession` drops bare open/write/rename for `assertWriteTargetSafe` + `containedWrite`. Regression tests force-add `xbrief/` and `.deft/` dir symlinks and assert fail-closed. Removes `probe-session.ts` from the contained-writes allowlist. Closes #3042. Refs #2951, #2980.
 - **Vitest branch coverage restored above 85% (#3027).** Focused OpenClaw pin install/doctor fix-path edges, github-auth mode failure and parseLogin branches, batch-promote path validation, and plan-sequence CLI argv/JSON edges clear the v0.91.0 84.91% hairline so release Step 5 passes without `--allow-coverage-debt`. Closes #3027.
 
 ### Removed

--- a/packages/core/src/cache/fetch.ts
+++ b/packages/core/src/cache/fetch.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { ContainedWriteError, containedWrite } from "../fs/contained-write.js";
 import {
   GhRestError,
@@ -66,9 +66,11 @@ export function writeOpenInventoryStamp(options: {
     fetched_at: utcIso(clock, fetchedAt),
     open_count: 0,
   };
+  // #3042: contain stamp write against project root (parent of cacheRoot).
   atomicWriteText(
     openInventoryStampPath(options.cacheRoot, options.source, options.repo),
     `${JSON.stringify(payload)}\n`,
+    { projectRoot: dirname(resolve(options.cacheRoot)) },
   );
 }
 

--- a/packages/core/src/cache/io.ts
+++ b/packages/core/src/cache/io.ts
@@ -3,25 +3,68 @@ import { mkdirSync, renameSync, rmSync, statSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { containedWrite } from "../fs/contained-write.js";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { pythonJsonLine } from "./json.js";
+
+export interface AtomicWriteTextOptions {
+  /**
+   * Project / checkout root used as the containment boundary (#3042).
+   * When set, refuses symlink parents and out-of-root targets before temp+rename.
+   * Prefer always passing this for product sinks (brief stay-path, agents refresh, cache).
+   * When omitted, falls back to parent-dir containment (legacy test / low-risk helpers).
+   */
+  readonly projectRoot?: string;
+}
 
 /**
  * Write text via tempfile + rename (mirrors Python `_atomic_write_text`).
- * #2951 Phase 2: temp payload write uses containedWrite under the parent dir.
+ * #2951 Phase 2: temp payload write uses containedWrite.
+ * #3042: when `projectRoot` is set, containment root is projectRoot (not dirname(path))
+ * so force-added lifecycle / cache directory symlinks fail closed.
  */
-export function atomicWriteText(path: string, text: string): void {
-  const dir = dirname(path);
+export function atomicWriteText(
+  path: string,
+  text: string,
+  options: AtomicWriteTextOptions = {},
+): void {
+  const targetAbs = resolve(path);
+  const dir = dirname(targetAbs);
+  const tmpBase = `${basename(targetAbs)}.${randomBytes(4).toString("hex")}.tmp`;
+  const tmp = join(dir, tmpBase);
+
+  if (options.projectRoot !== undefined) {
+    // Contain against projectRoot (parent-as-root fix #3042 / authz writeJsonContained pattern).
+    const root = resolve(options.projectRoot);
+    assertWriteTargetSafe(root, targetAbs);
+    try {
+      containedWrite({
+        root,
+        target: tmp,
+        data: text,
+        mode: "create",
+      });
+      renameSync(tmp, targetAbs);
+    } catch (err) {
+      try {
+        rmSync(tmp, { force: true });
+      } catch {
+        /* v8 ignore next -- best-effort cleanup */
+      }
+      throw err;
+    }
+    return;
+  }
+
+  // Legacy: parent-dir containment when no projectRoot (unit helpers / transitional call sites).
   mkdirSync(dir, { recursive: true });
-  const tmpName = `${basename(path)}.${randomBytes(4).toString("hex")}.tmp`;
-  const tmp = join(dir, tmpName);
   try {
     containedWrite({
       root: resolve(dir),
-      target: tmpName,
+      target: tmpBase,
       data: text,
       mode: "create",
     });
-    renameSync(tmp, path);
+    renameSync(tmp, targetAbs);
   } catch (err) {
     try {
       rmSync(tmp, { force: true });

--- a/packages/core/src/cache/operations.ts
+++ b/packages/core/src/cache/operations.ts
@@ -180,7 +180,9 @@ export function cachePut(
     });
   }
 
-  atomicWriteText(join(edir, "raw.json"), rawText);
+  // #3042: contain cache entry writes against project root (parent of cacheRoot).
+  const projectRoot = dirname(resolve(cacheRoot));
+  atomicWriteText(join(edir, "raw.json"), rawText, { projectRoot });
   const authoritativeSize = fileSize(join(edir, "raw.json"));
 
   const rendered = renderContent(source, raw);
@@ -189,7 +191,7 @@ export function cachePut(
   const contentPath = join(edir, "content.md");
   let contentWritten = false;
   if (scanResult.passed) {
-    atomicWriteText(contentPath, scanResult.transformed_content);
+    atomicWriteText(contentPath, scanResult.transformed_content, { projectRoot });
     contentWritten = true;
   } else if (existsSync(contentPath)) {
     try {
@@ -210,7 +212,7 @@ export function cachePut(
     clock,
   });
   validateMeta(meta);
-  atomicWriteText(join(edir, "meta.json"), pythonJsonDump(meta));
+  atomicWriteText(join(edir, "meta.json"), pythonJsonDump(meta), { projectRoot });
 
   appendAudit(
     {

--- a/packages/core/src/fs/appsec-3042-write-sinks.test.ts
+++ b/packages/core/src/fs/appsec-3042-write-sinks.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression: AppSec #3042 — projectRoot containment for residual parent-as-root
+ * and bare-write sinks (atomicWriteText, writeRitualState, writeSession).
+ * Force-added xbrief/ or .deft/ directory symlinks must fail closed with no
+ * outside overwrite.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { atomicWriteText } from "../cache/io.js";
+import { writeSession } from "../orchestration/probe-session.js";
+import { atomicWriteBrief } from "../scope/brief-io.js";
+import { newRitualStatePayload, ritualStep, writeRitualState } from "../session/ritual-sentinel.js";
+import { ContainedWriteError } from "./contained-write.js";
+import { ProjectionContainmentError } from "./projection-containment.js";
+
+const itSymlink = it.skipIf(process.platform === "win32");
+
+const temps: string[] = [];
+
+afterEach(() => {
+  while (temps.length > 0) {
+    const dir = temps.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function temp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+
+function isContainmentRefusal(err: unknown): boolean {
+  return (
+    err instanceof ProjectionContainmentError ||
+    err instanceof ContainedWriteError ||
+    (err instanceof Error &&
+      (/projection write refused|contained write refused|symlink/i.test(err.message) ||
+        /not nested under/i.test(err.message)))
+  );
+}
+
+describe("AppSec write sinks projectRoot containment (#3042)", () => {
+  itSymlink("atomicWriteText refuses an escaping xbrief/ directory symlink", () => {
+    const root = temp("deft-3042-atomic-root-");
+    const outsideDir = temp("deft-3042-atomic-escape-");
+    writeFileSync(join(outsideDir, "poisoned.xbrief.json"), "KEEP\n", "utf8");
+    symlinkSync(outsideDir, join(root, "xbrief"), "dir");
+
+    const target = join(root, "xbrief", "active", "escape.xbrief.json");
+    try {
+      atomicWriteText(target, '{"pwn":true}\n', { projectRoot: root });
+      expect.fail("expected containment refusal");
+    } catch (err) {
+      expect(isContainmentRefusal(err)).toBe(true);
+    }
+
+    expect(readFileSync(join(outsideDir, "poisoned.xbrief.json"), "utf8")).toBe("KEEP\n");
+    expect(existsSync(join(outsideDir, "active"))).toBe(false);
+  });
+
+  itSymlink("atomicWriteBrief stay-path refuses an escaping xbrief/ directory symlink", () => {
+    const root = temp("deft-3042-brief-root-");
+    const outsideDir = temp("deft-3042-brief-escape-");
+    writeFileSync(join(outsideDir, "poisoned.xbrief.json"), "KEEP\n", "utf8");
+    symlinkSync(outsideDir, join(root, "xbrief"), "dir");
+
+    const vbriefRoot = join(root, "xbrief");
+    // lexical path under symlink; force-create would land outside without projectRoot.
+    const target = join(vbriefRoot, "pending", "stay.xbrief.json");
+    const brief = {
+      xBRIEFInfo: { version: "0.8" },
+      plan: { title: "T", status: "pending", items: [] },
+    };
+
+    const result = atomicWriteBrief(target, brief, vbriefRoot, { projectRoot: root });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/refused|symlink|nested under|Failed to write/i);
+    }
+    expect(readFileSync(join(outsideDir, "poisoned.xbrief.json"), "utf8")).toBe("KEEP\n");
+    expect(existsSync(join(outsideDir, "pending"))).toBe(false);
+  });
+
+  itSymlink("writeRitualState refuses an escaping .deft/ directory symlink", () => {
+    const root = temp("deft-3042-ritual-root-");
+    const outsideDir = temp("deft-3042-ritual-escape-");
+    writeFileSync(join(outsideDir, "ritual-state.json"), "KEEP\n", "utf8");
+    symlinkSync(outsideDir, join(root, ".deft"), "dir");
+
+    const now = new Date("2026-08-02T00:00:00Z");
+    try {
+      writeRitualState(
+        root,
+        newRitualStatePayload({
+          sessionId: "s-3042",
+          gitHead: "deadbeef",
+          worktreePath: root,
+          startedAt: now,
+          quickSteps: { alignment: ritualStep({ ok: true, ts: now }) },
+        }),
+      );
+      expect.fail("expected containment refusal");
+    } catch (err) {
+      expect(isContainmentRefusal(err)).toBe(true);
+    }
+
+    expect(readFileSync(join(outsideDir, "ritual-state.json"), "utf8")).toBe("KEEP\n");
+  });
+
+  itSymlink("writeSession refuses an escaping .deft/ directory symlink", () => {
+    const root = temp("deft-3042-probe-root-");
+    const outsideDir = temp("deft-3042-probe-escape-");
+    writeFileSync(join(outsideDir, "probe-session.json"), "KEEP\n", "utf8");
+    symlinkSync(outsideDir, join(root, ".deft"), "dir");
+
+    const session = {
+      schema_version: 1,
+      state: "interrogate" as const,
+      target: "scope-a",
+      current_branch: "main",
+      resolved_decisions: [],
+      started_at: new Date("2026-08-02T00:00:00Z"),
+      completed_at: null,
+    };
+
+    try {
+      writeSession(root, session);
+      expect.fail("expected containment refusal");
+    } catch (err) {
+      expect(isContainmentRefusal(err)).toBe(true);
+    }
+
+    expect(readFileSync(join(outsideDir, "probe-session.json"), "utf8")).toBe("KEEP\n");
+  });
+
+  it("atomicWriteText with projectRoot writes inside a normal tree", () => {
+    const root = temp("deft-3042-ok-root-");
+    mkdirSync(join(root, "xbrief", "pending"), { recursive: true });
+    const target = join(root, "xbrief", "pending", "ok.txt");
+    atomicWriteText(target, "hello-3042\n", { projectRoot: root });
+    expect(readFileSync(target, "utf8")).toBe("hello-3042\n");
+  });
+});

--- a/packages/core/src/orchestration/probe-session.ts
+++ b/packages/core/src/orchestration/probe-session.ts
@@ -4,17 +4,10 @@
 
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import {
-  closeSync,
-  existsSync,
-  fdatasyncSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  writeSync,
-} from "node:fs";
+import { existsSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { containedWrite } from "../fs/contained-write.js";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 
 export const SCHEMA_VERSION = 1;
 export const SESSION_RELPATH = [".deft", "probe-session.json"] as const;
@@ -231,15 +224,16 @@ export function readSession(projectRoot: string): ProbeSession | null {
   };
 }
 
-/** Atomically persist session to .deft/probe-session.json. */
+/**
+ * Atomically persist session to .deft/probe-session.json.
+ * #3042: contain against projectRoot; refuse escaping `.deft` symlink parents
+ * (no bare open/write/rename).
+ */
 export function writeSession(projectRoot: string, session: ProbeSession): string {
-  const sessionFile = sessionPath(projectRoot);
-  mkdirSync(join(projectRoot, ".deft"), { recursive: true });
-  const tmpName = join(
-    projectRoot,
-    ".deft",
-    `.probe-session.${randomBytes(8).toString("hex")}.json.tmp`,
-  );
+  const root = resolve(projectRoot);
+  const sessionFile = sessionPath(root);
+  assertWriteTargetSafe(root, sessionFile);
+  const tmpName = join(root, ".deft", `.probe-session.${randomBytes(8).toString("hex")}.json.tmp`);
   const sortedPayload = sessionToDict(session);
   const sortedKeys = Object.keys(sortedPayload).sort();
   const sortedObj: Record<string, unknown> = {};
@@ -248,18 +242,22 @@ export function writeSession(projectRoot: string, session: ProbeSession): string
   }
   const finalContent = `${JSON.stringify(sortedObj, null, 2)}\n`;
 
-  const fd = openSync(tmpName, "w");
   try {
-    writeSync(fd, finalContent, undefined, "utf8");
+    containedWrite({
+      root,
+      target: tmpName,
+      data: finalContent,
+      mode: "create",
+    });
+    renameSync(tmpName, sessionFile);
+  } catch (err) {
     try {
-      fdatasyncSync(fd);
+      rmSync(tmpName, { force: true });
     } catch {
-      // best effort
+      /* best-effort cleanup */
     }
-  } finally {
-    closeSync(fd);
+    throw err;
   }
-  renameSync(tmpName, sessionFile);
   return sessionFile;
 }
 

--- a/packages/core/src/platform/agents-md.ts
+++ b/packages/core/src/platform/agents-md.ts
@@ -369,7 +369,7 @@ export function applyAgentsRefresh(
           AGENTS_REFRESH_WRITABLE_STATES.has(state) && typeof newContent === "string";
         return { state, path, wrote: false, writable };
       }
-      atomicWriteText(path, newContent);
+      atomicWriteText(path, newContent, { projectRoot });
       return { state, path, wrote: true, writable: true };
     },
     lockDeps,

--- a/packages/core/src/scope/brief-io.ts
+++ b/packages/core/src/scope/brief-io.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { atomicWriteText } from "../cache/io.js";
 import { hasArtifactSuffix } from "../layout/resolve.js";
 import { pythonJsonPretty } from "../vbrief-build/json.js";
@@ -80,13 +80,16 @@ export function atomicWriteBrief(
   filePath: string,
   data: JsonObject,
   vbriefRoot: string,
+  options: { readonly projectRoot?: string } = {},
 ): AtomicWriteBriefResult {
   const validationError = validateBriefForPersist(filePath, data, vbriefRoot);
   if (validationError !== null) {
     return { ok: false, message: validationError };
   }
+  // #3042: contain against projectRoot (parent of xbrief/), not dirname(filePath).
+  const projectRoot = options.projectRoot ?? dirname(resolve(vbriefRoot));
   try {
-    atomicWriteText(filePath, formatBriefJson(data));
+    atomicWriteText(filePath, formatBriefJson(data), { projectRoot });
     return { ok: true };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/scope/registry-artifact-sync.ts
+++ b/packages/core/src/scope/registry-artifact-sync.ts
@@ -201,7 +201,10 @@ export function syncRegistryArtifactAfterScopeMove(
       if (hooks.persist !== undefined) {
         hooks.persist(registryPath, registry as JsonObject);
       } else {
-        atomicWriteText(registryPath, formatBriefJson(registry));
+        // #3042: contain registry stay-path write against project root (parent of xbrief/).
+        atomicWriteText(registryPath, formatBriefJson(registry), {
+          projectRoot: dirname(resolve(vbriefRoot)),
+        });
       }
     }
   } catch (err: unknown) {

--- a/packages/core/src/scope/transition.ts
+++ b/packages/core/src/scope/transition.ts
@@ -198,7 +198,7 @@ export function runTransition(
 
     // #2578: stamp terminal status at the destination path in the same write as
     // folder placement — never leave a non-terminal status under completed/.
-    const writeResult = atomicWriteBrief(destPath, data, vbriefRoot);
+    const writeResult = atomicWriteBrief(destPath, data, vbriefRoot, { projectRoot });
     if (!writeResult.ok) {
       return { ok: false, message: writeResult.message };
     }
@@ -246,7 +246,7 @@ export function runTransition(
     };
   }
 
-  const writeResult = atomicWriteBrief(resolvedPath, data, vbriefRoot);
+  const writeResult = atomicWriteBrief(resolvedPath, data, vbriefRoot, { projectRoot });
   if (!writeResult.ok) {
     return { ok: false, message: writeResult.message };
   }

--- a/packages/core/src/session/ritual-sentinel.ts
+++ b/packages/core/src/session/ritual-sentinel.ts
@@ -1,14 +1,7 @@
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  statSync,
-} from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { containedWrite } from "../fs/contained-write.js";
+import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import {
   hasArtifactSuffix,
   LEGACY_ARTIFACT_DIR,
@@ -159,25 +152,34 @@ function validateSteps(
   return [steps, null];
 }
 
+/**
+ * Contained atomic JSON write for ritual/sentinel state (#3042).
+ * Containment root is projectRoot (not dirname(target)) so a force-added `.deft`
+ * directory symlink fails closed before temp+rename.
+ */
 function atomicWriteJson(
+  projectRoot: string,
   targetPath: string,
   payload: Record<string, unknown>,
   prefix: string,
 ): void {
-  const dir = join(targetPath, "..");
-  mkdirSync(dir, { recursive: true });
-  const tmpBase = `${prefix}${process.pid}.json.tmp`;
+  const root = resolve(projectRoot);
+  const abs = resolve(targetPath);
+  // Refuse leaf/parent symlinks on the final path before temp+rename publish.
+  assertWriteTargetSafe(root, abs);
+  const dir = dirname(abs);
+  const tmpBase = `${prefix}${process.pid}.${basename(abs)}.tmp`;
   const tmpName = join(dir, tmpBase);
   const text = `${stableJson(payload, 2)}\n`;
   try {
-    // #2980 wave D: ritual-state product write routes through containedWrite.
+    // #2980 wave D / #3042: product write routes through containedWrite under projectRoot.
     containedWrite({
-      root: resolve(dir),
-      target: tmpBase,
+      root,
+      target: tmpName,
       data: text,
       mode: "create",
     });
-    renameSync(tmpName, targetPath);
+    renameSync(tmpName, abs);
   } catch (err) {
     try {
       rmSync(tmpName, { force: true });
@@ -257,7 +259,7 @@ export function readRitualState(projectRoot: string): [RitualState | null, strin
 
 export function writeRitualState(projectRoot: string, payload: Record<string, unknown>): string {
   const stateFile = ritualStatePath(projectRoot);
-  atomicWriteJson(stateFile, payload, ".ritual-state.");
+  atomicWriteJson(projectRoot, stateFile, payload, ".ritual-state.");
   return stateFile;
 }
 
@@ -394,7 +396,7 @@ export function writeSentinel(
       .replace(`${LEGACY_ARTIFACT_DIR}/active/`, `${MIGRATED_ARTIFACT_DIR}/active/`),
     lastBranch: input.lastBranch,
   };
-  atomicWriteJson(sentinelFile, payload, ".last-session.");
+  atomicWriteJson(projectRoot, sentinelFile, payload, ".last-session.");
   return sentinelFile;
 }
 

--- a/packages/core/src/verify-source/contained-writes.ts
+++ b/packages/core/src/verify-source/contained-writes.ts
@@ -63,7 +63,7 @@ export const CONTAINED_WRITES_ALLOWLIST: readonly string[] = [
   "packages/core/src/intake/issue-ingest.ts",
   "packages/core/src/intake/reconcile-issues.ts",
   "packages/core/src/issue-sync/sync-from-xbrief.ts",
-  "packages/core/src/orchestration/probe-session.ts",
+  // probe-session.ts removed from allowlist after #3042 contained writeSession.
   "packages/core/src/orchestration/verify-judgment-gates.ts",
   "packages/core/src/platform/changelog-cli.ts",
   "packages/core/src/release/gh.ts",


### PR DESCRIPTION
## Summary

Close residual Medium containment gaps after #2951 / #2980: product writes that used parent-directory containment (or no containment) could be diverted outside the checkout via force-added lifecycle / .deft directory symlinks.

## Changes

1. **tomicWriteText** (packages/core/src/cache/io.ts) — optional projectRoot; when set, ssertWriteTargetSafe + containedWrite under projectRoot (not dirname(path)). Threaded through brief stay-path, cache put/stamp, agents refresh, registry sync.
2. **writeRitualState / sentinel** (
itual-sentinel.ts) — atomic JSON write contains against projectRoot (authz writeJsonContained pattern).
3. **writeSession** (probe-session.ts) — drop bare open/write/rename; use ssertWriteTargetSafe + containedWrite. Removed from contained-writes allowlist.

## Tests

- packages/core/src/fs/appsec-3042-write-sinks.test.ts — force-added xbrief/ and .deft/ dir symlink escapes fail closed (skipped on win32 without symlink privilege).
- Targeted + broader vitest for cache/session/orchestration/scope.
- 	ask check (exit 0); 	ask verify:contained-writes -- --enforce clean.

## Acceptance

- [x] Symlink lifecycle parents refused for the three sinks
- [x] Regression tests
- [x] Inventory does not re-list these as open product holes
- [x] CHANGELOG cites #3042

Closes #3042
