### PR TITLE
feat(slash,#3052): thin-wrapper generator core and token-budget tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Host-agnostic slash-command thin-wrapper generator core (#3052).** New `packages/core/src/slash` module freezes the epic #55 LockedDecisions L2 product set (exactly 13 canonical commands), owns the logical-id ↔ hyphen-filename map (L4), and emits host-agnostic thin-wrapper IR + markdown templates (frontmatter description + short dispatch pointer only — no inlined strategy/skill bodies). Unit tests cover template shape, non-inlining, stable output, `count === 13`, and token-budget constraints (idle ~0; catalog ≤ ~1k tok; invoke body ≤ ~100 tok). Emitters (#3053) consume `generateThinWrappers()` / `listProductCommands()` without duplicating the name table. Public surface: `@deftai/directive-core` `slash` namespace and `@deftai/directive-core/slash` subpath. Out of scope: host path layouts, init/update deposit, native legacy aliases. Refs #55.
+
 ### Changed
 
 ### Fixed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/story-ready/index.d.ts",
       "default": "./dist/story-ready/index.js"
     },
+    "./slash": {
+      "types": "./dist/slash/index.d.ts",
+      "default": "./dist/slash/index.js"
+    },
     "./branch": {
       "types": "./dist/branch/index.d.ts",
       "default": "./dist/branch/index.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ export * as resolution from "./resolution/index.js";
 export * as scm from "./scm/index.js";
 export * as scope from "./scope/index.js";
 export * as session from "./session/index.js";
+export * as slash from "./slash/index.js";
 export * as slice from "./slice/index.js";
 export * as storyReady from "./story-ready/index.js";
 export * as swarm from "./swarm/index.js";

--- a/packages/core/src/slash/generator.test.ts
+++ b/packages/core/src/slash/generator.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateTokens,
+  generateThinWrapper,
+  generateThinWrappers,
+  isThinWrapperMarkdown,
+  MAX_CATALOG_TOKENS,
+  MAX_DESCRIPTION_TOKENS,
+  MAX_WRAPPER_BODY_TOKENS,
+  measureTokenBudget,
+  renderThinWrapperBody,
+  renderThinWrapperFile,
+} from "./generator.js";
+import { listProductCommands, PRODUCT_COMMAND_COUNT, type ProductCommand } from "./product-set.js";
+
+describe("slash thin-wrapper generator (#3052 / #55 L5)", () => {
+  it("emits one thin wrapper per product command (count === 13)", () => {
+    const wrappers = generateThinWrappers();
+    expect(wrappers).toHaveLength(PRODUCT_COMMAND_COUNT);
+    expect(wrappers.map((w) => w.logicalId)).toEqual(listProductCommands().map((c) => c.logicalId));
+  });
+
+  it("uses stable output for the product set", () => {
+    const a = generateThinWrappers();
+    const b = generateThinWrappers();
+    expect(a).toEqual(b);
+    expect(a.map((w) => w.fileMarkdown)).toEqual(b.map((w) => w.fileMarkdown));
+  });
+
+  it("renders frontmatter description + short dispatch body (template shape)", () => {
+    const cmd = listProductCommands().find((c) => c.logicalId === "/deft:directive:run:map");
+    expect(cmd).toBeDefined();
+    const file = renderThinWrapperFile(cmd as ProductCommand);
+    expect(file.startsWith("---\n")).toBe(true);
+    expect(file).toMatch(/^description:\s.+/m);
+    expect(file).toContain("strategies/map.md");
+    expect(file).toContain("Read and follow");
+    expect(file).toContain("$ARGUMENTS");
+    expect(isThinWrapperMarkdown(file, "strategies/map.md")).toBe(true);
+  });
+
+  it("includes argument-hint frontmatter when the product entry has a hint", () => {
+    const interview = listProductCommands().find(
+      (c) => c.logicalId === "/deft:directive:run:interview",
+    );
+    expect(interview?.argumentHint).toBe("<name>");
+    const file = renderThinWrapperFile(interview as ProductCommand);
+    expect(file).toMatch(/^argument-hint:\s"<name>"$/m);
+  });
+
+  it("does not inline strategy or skill bodies", () => {
+    const wrappers = generateThinWrappers();
+    for (const w of wrappers) {
+      // Thin pointer only — no phase/workflow dump markers.
+      expect(w.bodyMarkdown).not.toMatch(/^##\s+(Phase|Workflow|Steps|Acceptance)\b/m);
+      expect(w.fileMarkdown).not.toMatch(/^##\s+(Phase|Workflow|Steps|Acceptance)\b/m);
+      // Body must reference the path without embedding multi-k content.
+      expect(w.bodyMarkdown).toContain(w.dispatchPath);
+      expect(
+        w.bodyMarkdown.split("\n").filter((line) => line.trim().length > 0).length,
+      ).toBeLessThanOrEqual(6);
+      expect(isThinWrapperMarkdown(w.fileMarkdown, w.dispatchPath)).toBe(true);
+    }
+
+    // Probe dispatches to the skill path; body must not paste skill SKILL.md bulk.
+    const probe = wrappers.find((w) => w.logicalId === "/deft:directive:run:probe");
+    expect(probe).toBeDefined();
+    expect(probe?.bodyMarkdown).toContain("skills/deft-directive-probe/SKILL.md");
+    expect(probe?.bodyMarkdown.toLowerCase()).not.toContain("adversarial one-question-per-turn");
+  });
+
+  it("keeps filename IR aligned with logical ids for emitters", () => {
+    for (const w of generateThinWrappers()) {
+      expect(w.filename).toBe(`${w.filenameStem}.md`);
+      expect(w.filenameStem.length).toBeGreaterThan(0);
+      expect(w.filename.endsWith(".md")).toBe(true);
+    }
+    const ir = generateThinWrapper(
+      listProductCommands().find((c) => c.logicalId === "/deft:continue") as ProductCommand,
+    );
+    expect(ir.filename).toBe("deft-continue.md");
+    expect(ir.dispatchKind).toBe("resilience");
+  });
+
+  it("enforces token-budget constraints (body, description, catalog)", () => {
+    const wrappers = generateThinWrappers();
+    const report = measureTokenBudget(wrappers);
+    expect(report.commandCount).toBe(13);
+    expect(report.withinBodyBudget).toBe(true);
+    expect(report.withinDescriptionBudget).toBe(true);
+    expect(report.withinCatalogBudget).toBe(true);
+    expect(report.ok).toBe(true);
+    expect(report.maxBodyTokens).toBeLessThanOrEqual(MAX_WRAPPER_BODY_TOKENS);
+    expect(report.maxDescriptionTokens).toBeLessThanOrEqual(MAX_DESCRIPTION_TOKENS);
+    expect(report.catalogTokens).toBeLessThanOrEqual(MAX_CATALOG_TOKENS);
+
+    for (const w of wrappers) {
+      expect(w.estimatedBodyTokens).toBeLessThanOrEqual(MAX_WRAPPER_BODY_TOKENS);
+      // Invoke band is roughly 40–100; allow thinner pointers down to a few tokens.
+      expect(w.estimatedBodyTokens).toBeGreaterThan(10);
+      expect(w.estimatedDescriptionTokens).toBe(estimateTokens(w.description));
+    }
+  });
+
+  it("rejects fat markdown as non-thin", () => {
+    const fat = [
+      "---",
+      "description: fat",
+      "---",
+      "",
+      "## Phase 1",
+      "Read and follow `strategies/interview.md`.",
+      "A".repeat(800),
+      "",
+    ].join("\n");
+    expect(isThinWrapperMarkdown(fat, "strategies/interview.md")).toBe(false);
+  });
+
+  it("exposes an emitter-consumable IR without requiring a second name table", () => {
+    // #3053 can map IR → host files using only generateThinWrappers() output.
+    const ir = generateThinWrappers();
+    const byFilename = new Map(ir.map((w) => [w.filename, w]));
+    expect(byFilename.size).toBe(13);
+    expect(byFilename.get("deft-directive-run-interview.md")?.logicalId).toBe(
+      "/deft:directive:run:interview",
+    );
+    expect(renderThinWrapperBody(listProductCommands()[0] as ProductCommand)).toContain(
+      "commands.md",
+    );
+  });
+});

--- a/packages/core/src/slash/generator.ts
+++ b/packages/core/src/slash/generator.ts
@@ -1,0 +1,214 @@
+/**
+ * Host-agnostic thin-wrapper generator for product slash commands (#3052 / epic #55).
+ *
+ * Emits IR + markdown templates that per-host emitters (#3053) format into native
+ * command/prompt/workflow files. Wrappers stay thin (L5): frontmatter description +
+ * short dispatch pointer — never inlined strategy/skill/commands.md bodies.
+ *
+ * ## Token / context budgets (from #55 token design rules)
+ *
+ * | When | Target |
+ * |---|---|
+ * | Idle (user never invokes `/deft…`) | ~0 from command files |
+ * | Catalog (`/` menu: name + description × N) | ≤ ~1k tok for the product set |
+ * | Single invoke | ~40–100 tok thin wrapper body |
+ * | After dispatch | cost of the target strategy/skill (unchanged) |
+ *
+ * Multi-host deposit does not multiply tokens in one session: each host reads only
+ * its own command directory. Real spend is the loaded artifact after invoke.
+ */
+
+import {
+  listProductCommands,
+  logicalIdToFilename,
+  logicalIdToFilenameStem,
+  PRODUCT_COMMAND_COUNT,
+  type ProductCommand,
+} from "./product-set.js";
+
+/** Rough UTF-8 bytes-per-token estimate (aligned with agents-md-budget). */
+export const BYTES_PER_TOKEN_ESTIMATE = 4;
+
+/** L5: invoke wrapper body budget (≈100 tokens). */
+export const MAX_WRAPPER_BODY_TOKENS = 100;
+
+/** Per-command catalog description hard cap for tests (order-of-magnitude 20–50). */
+export const MAX_DESCRIPTION_TOKENS = 50;
+
+/** Full product-set description catalog budget (≤ ~1k tok). */
+export const MAX_CATALOG_TOKENS = 1000;
+
+/**
+ * Host-agnostic intermediate representation for one thin wrapper.
+ *
+ * Emitters consume this shape without re-listing product names.
+ */
+export interface ThinWrapperIR {
+  /** Canonical slash id, e.g. `/deft:directive:run:interview`. */
+  readonly logicalId: string;
+  /** Hyphen stem without extension. */
+  readonly filenameStem: string;
+  /** On-disk filename including `.md`. */
+  readonly filename: string;
+  /** Catalog description (host frontmatter `description`). */
+  readonly description: string;
+  readonly dispatchKind: ProductCommand["dispatchKind"];
+  /** Content-root-relative primary load path. */
+  readonly dispatchPath: string;
+  readonly argumentHint?: string;
+  /** Body markdown only (no frontmatter). */
+  readonly bodyMarkdown: string;
+  /** Full file: YAML frontmatter + body (host-agnostic template). */
+  readonly fileMarkdown: string;
+  /** Estimated body tokens (UTF-8 bytes / {@link BYTES_PER_TOKEN_ESTIMATE}). */
+  readonly estimatedBodyTokens: number;
+  /** Estimated description tokens. */
+  readonly estimatedDescriptionTokens: number;
+}
+
+/** Aggregate token budget report for the product set. */
+export interface TokenBudgetReport {
+  readonly commandCount: number;
+  readonly catalogTokens: number;
+  readonly maxBodyTokens: number;
+  readonly maxDescriptionTokens: number;
+  readonly withinBodyBudget: boolean;
+  readonly withinDescriptionBudget: boolean;
+  readonly withinCatalogBudget: boolean;
+  readonly ok: boolean;
+}
+
+/** Estimate tokens from a UTF-8 string (bytes / 4). */
+export function estimateTokens(text: string): number {
+  return Math.ceil(Buffer.byteLength(text, "utf8") / BYTES_PER_TOKEN_ESTIMATE);
+}
+
+/**
+ * Render the thin body only: short dispatch pointer, no inlined target content.
+ *
+ * Keeps invoke cost in the ~40–100 token band (L5).
+ */
+export function renderThinWrapperBody(command: ProductCommand): string {
+  const lines = [
+    `Read and follow \`${command.dispatchPath}\` (content-relative; deposit under \`.deft/core/\` when installed).`,
+    "Honor `$ARGUMENTS` as documented for this command.",
+    "Do not inline the strategy, skill, or commands.md body here.",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Render host-agnostic file markdown: description frontmatter + thin body.
+ *
+ * Per-host emitters may re-shape frontmatter keys; the body semantics stay shared.
+ */
+export function renderThinWrapperFile(command: ProductCommand): string {
+  const body = renderThinWrapperBody(command);
+  const frontmatterLines = [`description: ${yamlSingleLine(command.description)}`];
+  if (command.argumentHint !== undefined) {
+    frontmatterLines.push(`argument-hint: ${yamlSingleLine(command.argumentHint)}`);
+  }
+  return `---\n${frontmatterLines.join("\n")}\n---\n\n${body}`;
+}
+
+function yamlSingleLine(value: string): string {
+  // Descriptions are product-controlled short ASCII; quote when needed for YAML safety.
+  if (/[:#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value) || value === "") {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+/** Build {@link ThinWrapperIR} for one product command. */
+export function generateThinWrapper(command: ProductCommand): ThinWrapperIR {
+  const bodyMarkdown = renderThinWrapperBody(command);
+  const fileMarkdown = renderThinWrapperFile(command);
+  return {
+    logicalId: command.logicalId,
+    filenameStem: command.filenameStem,
+    filename: logicalIdToFilename(command.logicalId),
+    description: command.description,
+    dispatchKind: command.dispatchKind,
+    dispatchPath: command.dispatchPath,
+    argumentHint: command.argumentHint,
+    bodyMarkdown,
+    fileMarkdown,
+    estimatedBodyTokens: estimateTokens(bodyMarkdown),
+    estimatedDescriptionTokens: estimateTokens(command.description),
+  };
+}
+
+/**
+ * Generate thin wrappers for the full L2 product set (stable order, count === 13).
+ *
+ * This is the primary API for #3053 emitters.
+ */
+export function generateThinWrappers(
+  commands: readonly ProductCommand[] = listProductCommands(),
+): readonly ThinWrapperIR[] {
+  return commands.map(generateThinWrapper);
+}
+
+/** Measure catalog + per-wrapper body budgets for the generated set. */
+export function measureTokenBudget(
+  wrappers: readonly ThinWrapperIR[] = generateThinWrappers(),
+): TokenBudgetReport {
+  const catalogTokens = wrappers.reduce((sum, w) => sum + w.estimatedDescriptionTokens, 0);
+  const maxBodyTokens = wrappers.reduce((max, w) => Math.max(max, w.estimatedBodyTokens), 0);
+  const maxDescriptionTokens = wrappers.reduce(
+    (max, w) => Math.max(max, w.estimatedDescriptionTokens),
+    0,
+  );
+  const withinBodyBudget = wrappers.every((w) => w.estimatedBodyTokens <= MAX_WRAPPER_BODY_TOKENS);
+  const withinDescriptionBudget = wrappers.every(
+    (w) => w.estimatedDescriptionTokens <= MAX_DESCRIPTION_TOKENS,
+  );
+  const withinCatalogBudget = catalogTokens <= MAX_CATALOG_TOKENS;
+  return {
+    commandCount: wrappers.length,
+    catalogTokens,
+    maxBodyTokens,
+    maxDescriptionTokens,
+    withinBodyBudget,
+    withinDescriptionBudget,
+    withinCatalogBudget,
+    ok:
+      wrappers.length === PRODUCT_COMMAND_COUNT &&
+      withinBodyBudget &&
+      withinDescriptionBudget &&
+      withinCatalogBudget,
+  };
+}
+
+/**
+ * Structural check that a wrapper file looks like a thin pointer template.
+ * Used by unit tests and available to emitters for deposit validation.
+ */
+export function isThinWrapperMarkdown(fileMarkdown: string, dispatchPath: string): boolean {
+  if (!fileMarkdown.startsWith("---\n")) {
+    return false;
+  }
+  const close = fileMarkdown.indexOf("\n---\n", 4);
+  if (close < 0) {
+    return false;
+  }
+  const frontmatter = fileMarkdown.slice(4, close);
+  if (!/^description:\s.+/m.test(frontmatter)) {
+    return false;
+  }
+  const body = fileMarkdown.slice(close + 5);
+  if (!body.includes(dispatchPath)) {
+    return false;
+  }
+  // Fat-body guard: refuse multi-kilobyte dumps / obvious strategy section headers.
+  if (estimateTokens(body) > MAX_WRAPPER_BODY_TOKENS) {
+    return false;
+  }
+  if (/^##\s+(Phase|Workflow|Steps|Acceptance)\b/m.test(body)) {
+    return false;
+  }
+  return true;
+}
+
+/** Re-export mapping helpers for emitter convenience without a second import path. */
+export { logicalIdToFilename, logicalIdToFilenameStem, PRODUCT_COMMAND_COUNT };

--- a/packages/core/src/slash/index.test.ts
+++ b/packages/core/src/slash/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import * as slash from "./index.js";
+
+describe("slash public surface (#3052)", () => {
+  it("re-exports product table and generator APIs for emitters", () => {
+    expect(slash.PRODUCT_COMMAND_COUNT).toBe(13);
+    expect(slash.listProductCommands()).toHaveLength(13);
+    expect(slash.generateThinWrappers()).toHaveLength(13);
+    expect(slash.measureTokenBudget().ok).toBe(true);
+    expect(slash.logicalIdToFilenameStem("/deft:continue")).toBe("deft-continue");
+    expect(typeof slash.renderThinWrapperFile).toBe("function");
+    expect(typeof slash.isThinWrapperMarkdown).toBe("function");
+  });
+});

--- a/packages/core/src/slash/index.ts
+++ b/packages/core/src/slash/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Host-agnostic slash-command generator core (#3052 / epic #55).
+ *
+ * Product command table + thin-wrapper IR/templates for multi-host emitters.
+ * Does not write `.claude/commands/` (etc.) — that is #3054 deposit work.
+ * Per-host format layouts are #3053.
+ */
+
+export {
+  BYTES_PER_TOKEN_ESTIMATE,
+  estimateTokens,
+  generateThinWrapper,
+  generateThinWrappers,
+  isThinWrapperMarkdown,
+  MAX_CATALOG_TOKENS,
+  MAX_DESCRIPTION_TOKENS,
+  MAX_WRAPPER_BODY_TOKENS,
+  measureTokenBudget,
+  renderThinWrapperBody,
+  renderThinWrapperFile,
+  type ThinWrapperIR,
+  type TokenBudgetReport,
+} from "./generator.js";
+export {
+  getProductCommand,
+  listProductCommands,
+  logicalIdToFilename,
+  logicalIdToFilenameStem,
+  PRODUCT_COMMAND_COUNT,
+  PRODUCT_COMMANDS,
+  type ProductCommand,
+  type SlashDispatchKind,
+} from "./product-set.js";

--- a/packages/core/src/slash/product-set.test.ts
+++ b/packages/core/src/slash/product-set.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  getProductCommand,
+  listProductCommands,
+  logicalIdToFilename,
+  logicalIdToFilenameStem,
+  PRODUCT_COMMAND_COUNT,
+  PRODUCT_COMMANDS,
+} from "./product-set.js";
+
+/** L2 locked list from epic #55 LockedDecisions (pass-3 handoff). */
+const LOCKED_LOGICAL_IDS = [
+  "/deft:directive:change",
+  "/deft:directive:change:apply",
+  "/deft:directive:change:verify",
+  "/deft:directive:change:archive",
+  "/deft:directive:run:interview",
+  "/deft:directive:run:yolo",
+  "/deft:directive:run:map",
+  "/deft:directive:run:discuss",
+  "/deft:directive:run:research",
+  "/deft:directive:run:speckit",
+  "/deft:directive:run:probe",
+  "/deft:continue",
+  "/deft:checkpoint",
+] as const;
+
+describe("slash product-set (#3052 / #55 L2)", () => {
+  it("freezes exactly 13 canonical product commands", () => {
+    expect(PRODUCT_COMMAND_COUNT).toBe(13);
+    expect(PRODUCT_COMMANDS).toHaveLength(13);
+    expect(listProductCommands()).toHaveLength(PRODUCT_COMMAND_COUNT);
+  });
+
+  it("matches LockedDecisions L2 logical ids in stable order", () => {
+    expect(PRODUCT_COMMANDS.map((c) => c.logicalId)).toEqual([...LOCKED_LOGICAL_IDS]);
+  });
+
+  it("maps logical ids to hyphen filename stems (L4 examples)", () => {
+    expect(logicalIdToFilenameStem("/deft:directive:run:interview")).toBe(
+      "deft-directive-run-interview",
+    );
+    expect(logicalIdToFilenameStem("/deft:directive:change:apply")).toBe(
+      "deft-directive-change-apply",
+    );
+    expect(logicalIdToFilenameStem("/deft:continue")).toBe("deft-continue");
+    expect(logicalIdToFilename("/deft:checkpoint")).toBe("deft-checkpoint.md");
+  });
+
+  it("keeps filenameStem aligned with the L4 transform for every entry", () => {
+    for (const cmd of PRODUCT_COMMANDS) {
+      expect(cmd.filenameStem).toBe(logicalIdToFilenameStem(cmd.logicalId));
+    }
+  });
+
+  it("does not include legacy deprecation-alias logical ids (L3)", () => {
+    const ids = new Set(PRODUCT_COMMANDS.map((c) => c.logicalId));
+    expect(ids.has("/deft:change")).toBe(false);
+    expect(ids.has("/deft:run:interview")).toBe(false);
+    expect(ids.has("/deft:run:probe")).toBe(false);
+  });
+
+  it("assigns one primary dispatch path per command", () => {
+    for (const cmd of PRODUCT_COMMANDS) {
+      expect(cmd.dispatchPath.length).toBeGreaterThan(0);
+      expect(cmd.description.length).toBeGreaterThan(0);
+    }
+    expect(getProductCommand("/deft:directive:run:probe")?.dispatchPath).toBe(
+      "skills/deft-directive-probe/SKILL.md",
+    );
+    expect(getProductCommand("/deft:directive:run:interview")?.dispatchKind).toBe("strategy");
+    expect(getProductCommand("/missing")).toBeUndefined();
+  });
+
+  it("rejects logical ids without a leading slash", () => {
+    expect(() => logicalIdToFilenameStem("deft:continue")).toThrow(/must start with/);
+  });
+});

--- a/packages/core/src/slash/product-set.ts
+++ b/packages/core/src/slash/product-set.ts
@@ -1,0 +1,167 @@
+/**
+ * Locked product slash-command table for native multi-host registration (#3052 / epic #55).
+ *
+ * Authoritative locks: LockedDecisions L1–L10 on #55 (especially L1 names, L2 set of 13,
+ * L3 no native aliases, L4 logical-id ↔ hyphen filename map).
+ *
+ * Emitters (#3053) and deposit (#3054) MUST consume this table (or the generator IR built
+ * from it) — do not maintain a second product name list.
+ */
+
+/** Primary load path on slash invoke (L5: one clear artifact). */
+export type SlashDispatchKind = "strategy" | "skill" | "commands" | "resilience" | "session";
+
+/**
+ * One canonical product slash command (L2).
+ *
+ * `logicalId` is the external slash form (host display / autocomplete).
+ * `filenameStem` is the portable on-disk name without extension (L4).
+ * `dispatchPath` is content-root-relative; emitters may prefix deposit roots
+ * (e.g. `.deft/core/`) without changing this table.
+ */
+export interface ProductCommand {
+  readonly logicalId: string;
+  readonly filenameStem: string;
+  readonly description: string;
+  readonly dispatchKind: SlashDispatchKind;
+  readonly dispatchPath: string;
+  readonly argumentHint?: string;
+}
+
+/** Locked product-set cardinality (L2). */
+export const PRODUCT_COMMAND_COUNT = 13 as const;
+
+/**
+ * Canonical L2 product command set — exactly 13 entries, stable order.
+ *
+ * ⊗ Expand without a product decision that amends L2 on #55.
+ * ⊗ Emit native alias files for legacy `/deft:change` forms (L3).
+ */
+export const PRODUCT_COMMANDS: readonly ProductCommand[] = Object.freeze([
+  {
+    logicalId: "/deft:directive:change",
+    filenameStem: "deft-directive-change",
+    description: "Create a scoped change proposal under history/changes/",
+    dispatchKind: "commands",
+    dispatchPath: "commands.md",
+    argumentHint: "<name>",
+  },
+  {
+    logicalId: "/deft:directive:change:apply",
+    filenameStem: "deft-directive-change-apply",
+    description: "Implement tasks from the active change proposal",
+    dispatchKind: "commands",
+    dispatchPath: "commands.md",
+  },
+  {
+    logicalId: "/deft:directive:change:verify",
+    filenameStem: "deft-directive-change-verify",
+    description: "Verify the active change against acceptance criteria",
+    dispatchKind: "commands",
+    dispatchPath: "commands.md",
+  },
+  {
+    logicalId: "/deft:directive:change:archive",
+    filenameStem: "deft-directive-change-archive",
+    description: "Archive the completed change under history/archive/",
+    dispatchKind: "commands",
+    dispatchPath: "commands.md",
+  },
+  {
+    logicalId: "/deft:directive:run:interview",
+    filenameStem: "deft-directive-run-interview",
+    description: "Structured interview with Light/Full sizing gate",
+    dispatchKind: "strategy",
+    dispatchPath: "strategies/interview.md",
+    argumentHint: "<name>",
+  },
+  {
+    logicalId: "/deft:directive:run:yolo",
+    filenameStem: "deft-directive-run-yolo",
+    description: "Auto-pilot interview; agent picks options",
+    dispatchKind: "strategy",
+    dispatchPath: "strategies/yolo.md",
+    argumentHint: "<name>",
+  },
+  {
+    logicalId: "/deft:directive:run:map",
+    filenameStem: "deft-directive-run-map",
+    description: "Brownfield codebase mapping strategy",
+    dispatchKind: "strategy",
+    dispatchPath: "strategies/map.md",
+  },
+  {
+    logicalId: "/deft:directive:run:discuss",
+    filenameStem: "deft-directive-run-discuss",
+    description: "Feynman-style alignment and decision locking",
+    dispatchKind: "strategy",
+    dispatchPath: "strategies/discuss.md",
+    argumentHint: "<topic>",
+  },
+  {
+    logicalId: "/deft:directive:run:research",
+    filenameStem: "deft-directive-run-research",
+    description: "Research domain before planning (don't hand-roll)",
+    dispatchKind: "strategy",
+    dispatchPath: "strategies/research.md",
+    argumentHint: "<domain>",
+  },
+  {
+    logicalId: "/deft:directive:run:speckit",
+    filenameStem: "deft-directive-run-speckit",
+    description: "Five-phase large/complex specification workflow",
+    dispatchKind: "strategy",
+    dispatchPath: "strategies/speckit.md",
+    argumentHint: "<name>",
+  },
+  {
+    logicalId: "/deft:directive:run:probe",
+    filenameStem: "deft-directive-run-probe",
+    description: "Adversarial one-question plan stress-testing",
+    dispatchKind: "skill",
+    dispatchPath: "skills/deft-directive-probe/SKILL.md",
+  },
+  {
+    logicalId: "/deft:continue",
+    filenameStem: "deft-continue",
+    description: "Resume from the continue checkpoint",
+    dispatchKind: "resilience",
+    dispatchPath: "resilience/continue-here.md",
+  },
+  {
+    logicalId: "/deft:checkpoint",
+    filenameStem: "deft-checkpoint",
+    description: "Save session state to xbrief/continue.xbrief.json",
+    dispatchKind: "session",
+    dispatchPath: "xbrief/continue.xbrief.json",
+  },
+] satisfies readonly ProductCommand[]);
+
+/**
+ * Map a canonical logical slash id to the portable hyphen filename stem (L4).
+ *
+ * `/deft:directive:run:interview` → `deft-directive-run-interview`
+ * `/deft:continue` → `deft-continue`
+ */
+export function logicalIdToFilenameStem(logicalId: string): string {
+  const trimmed = logicalId.trim();
+  if (!trimmed.startsWith("/")) {
+    throw new Error(`logicalId must start with '/': ${logicalId}`);
+  }
+  return trimmed.slice(1).replace(/:/g, "-");
+}
+
+/** Filename with `.md` extension for host command deposit (L4). */
+export function logicalIdToFilename(logicalId: string): string {
+  return `${logicalIdToFilenameStem(logicalId)}.md`;
+}
+
+/** Frozen product table for emitters (#3053) — single source of truth. */
+export function listProductCommands(): readonly ProductCommand[] {
+  return PRODUCT_COMMANDS;
+}
+
+/** Look up one product command by logical id, or undefined. */
+export function getProductCommand(logicalId: string): ProductCommand | undefined {
+  return PRODUCT_COMMANDS.find((c) => c.logicalId === logicalId);
+}


### PR DESCRIPTION
## Summary

Host-agnostic **slash-command thin-wrapper generator core** for epic #55 Wave 1.

- Freezes LockedDecisions **L2 product set** (exactly **13** canonical commands)
- Owns logical-id ↔ hyphen-filename map (**L4**)
- Emits thin-wrapper IR + markdown templates (frontmatter description + short dispatch only — **no** inlined strategy/skill bodies)
- Token-budget unit tests: idle ~0; catalog ≤ ~1k tok; invoke body ≤ ~100 tok
- Emitters (#3053) consume `generateThinWrappers()` / `listProductCommands()` without a second name table

Public surface: `@deftai/directive-core` `slash` namespace and `@deftai/directive-core/slash` subpath.

## Out of scope (later waves)

- Per-host emitters / path layouts → **#3053**
- init/update multi-host deposit → **#3054**
- Docs / git policy dogfood → **#3055**
- Native legacy alias files (L3) — not emitted

## Product set (L2)

1. `/deft:directive:change`
2. `/deft:directive:change:apply`
3. `/deft:directive:change:verify`
4. `/deft:directive:change:archive`
5. `/deft:directive:run:interview`
6. `/deft:directive:run:yolo`
7. `/deft:directive:run:map`
8. `/deft:directive:run:discuss`
9. `/deft:directive:run:research`
10. `/deft:directive:run:speckit`
11. `/deft:directive:run:probe`
12. `/deft:continue`
13. `/deft:checkpoint`

## Token / context notes (#55 design rules)

| When | Expected cost |
|---|---|
| Idle (user never invokes `/deft…`) | ~0 from command files |
| Catalog (name + description × 13) | ≤ ~1k tok |
| Single slash invoke | ~40–100 tok thin wrapper body |
| After dispatch | target strategy/skill cost (unchanged) |

Multi-host deposit does not multiply tokens in one session (each host reads its own command dir).

## Test plan

- [x] `pnpm exec vitest run packages/core/src/slash` (17 tests)
- [x] `task verify:forward-coverage`
- [x] `task check -- --allow-over-cap`

## Tracking

Tracking: #3052
Refs #55