### PR TITLE
fix(security): projectRoot containment for triage welcome atomicWrite (#3077)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **projectRoot containment for triage welcome atomicWrite (#3077).** Residual Medium parent-as-root gap after #3042/#2980: `packages/core/src/triage/welcome/writers.ts` `atomicWrite` used `containedWrite({ root: dirname(path) })`, so a force-added `xbrief/` directory symlink could divert `writeTriageScope` / `writeWipCap` / `writeWipCapDecision` (and `triage:welcome --onboard`) outside the checkout. Containment root is now `projectRoot` via `assertWriteTargetSafe` + `containedWrite`; escaping/symlink `xbrief` parents fail closed before temp+rename. Regression tests cover fixture outside PROJECT-DEFINITION JSON. Closes #3077. Refs #3042, #2951, #2980.
 
 ### Removed
 

--- a/packages/core/src/triage/welcome/writers.test.ts
+++ b/packages/core/src/triage/welcome/writers.test.ts
@@ -1,8 +1,17 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { ContainedWriteError } from "../../fs/contained-write.js";
+import { ProjectionContainmentError } from "../../fs/projection-containment.js";
 import { DEFAULT_WIP_CAP } from "./constants.js";
 import {
   appendAuditEntry,
@@ -129,6 +138,16 @@ describe("welcome writers", () => {
 
 const itSymlink = it.skipIf(process.platform === "win32");
 
+function isContainmentRefusal(err: unknown): boolean {
+  return (
+    err instanceof ProjectionContainmentError ||
+    err instanceof ContainedWriteError ||
+    (err instanceof Error &&
+      (/projection write refused|contained write refused|symlink/i.test(err.message) ||
+        /not nested under/i.test(err.message)))
+  );
+}
+
 describe("welcome audit containment (#2470)", () => {
   itSymlink("refuses audit append when policy-changes.log is a symlink outside the project", () => {
     const projectDir = mkdtempSync(join(tmpdir(), "writers-contain-proj-"));
@@ -145,4 +164,77 @@ describe("welcome audit containment (#2470)", () => {
       rmSync(escapeTarget, { recursive: true, force: true });
     }
   });
+});
+
+describe("welcome PROJECT-DEFINITION projectRoot containment (#3077)", () => {
+  itSymlink(
+    "writeTriageScope refuses an escaping xbrief/ directory symlink (no outside JSON write)",
+    () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "writers-3077-proj-"));
+      const outsideDir = mkdtempSync(join(tmpdir(), "writers-3077-escape-"));
+      const outsidePd = join(outsideDir, "PROJECT-DEFINITION.xbrief.json");
+      const keepBody = JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: { policy: { keep: true } },
+      });
+      try {
+        writeFileSync(outsidePd, keepBody, "utf8");
+        // Layout accepts when .xbrief.json marker exists under followed link.
+        writeFileSync(join(outsideDir, "marker.xbrief.json"), "{}", "utf8");
+        symlinkSync(outsideDir, join(projectDir, "xbrief"), "dir");
+
+        try {
+          writeTriageScope(projectDir, subscriptionPreset("small"), {
+            presetLabel: "small",
+            actor: "test-3077",
+          });
+          expect.fail("expected containment refusal");
+        } catch (err) {
+          expect(isContainmentRefusal(err)).toBe(true);
+        }
+
+        expect(readFileSync(outsidePd, "utf8")).toBe(keepBody);
+        expect(existsSync(join(outsideDir, "meta"))).toBe(false);
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+        rmSync(outsideDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  itSymlink(
+    "writeWipCap / writeWipCapDecision refuse escaping xbrief/ and leave outside JSON intact",
+    () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "writers-3077-wip-proj-"));
+      const outsideDir = mkdtempSync(join(tmpdir(), "writers-3077-wip-escape-"));
+      const outsidePd = join(outsideDir, "PROJECT-DEFINITION.xbrief.json");
+      const keepBody = JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: { policy: {} },
+      });
+      try {
+        writeFileSync(outsidePd, keepBody, "utf8");
+        writeFileSync(join(outsideDir, "marker.xbrief.json"), "{}", "utf8");
+        symlinkSync(outsideDir, join(projectDir, "xbrief"), "dir");
+
+        try {
+          writeWipCap(projectDir, 8, { actor: "test-3077" });
+          expect.fail("expected containment refusal for writeWipCap");
+        } catch (err) {
+          expect(isContainmentRefusal(err)).toBe(true);
+        }
+        try {
+          writeWipCapDecision(projectDir, { acceptedDefault: true, actor: "test-3077" });
+          expect.fail("expected containment refusal for writeWipCapDecision");
+        } catch (err) {
+          expect(isContainmentRefusal(err)).toBe(true);
+        }
+
+        expect(readFileSync(outsidePd, "utf8")).toBe(keepBody);
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+        rmSync(outsideDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/packages/core/src/triage/welcome/writers.ts
+++ b/packages/core/src/triage/welcome/writers.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { containedWrite } from "../../fs/contained-write.js";
+import { assertWriteTargetSafe } from "../../fs/projection-containment.js";
 import {
   hasArtifactSuffix,
   resolveLifecycleFolder,
@@ -58,21 +59,29 @@ export function appendAuditEntry(projectRoot: string, entry: string): string {
   return logPath;
 }
 
-function atomicWrite(_projectRoot: string, path: string, data: Record<string, unknown>): void {
-  const dir = dirname(path);
-  mkdirSync(dir, { recursive: true });
+/**
+ * Atomically write PROJECT-DEFINITION JSON under projectRoot containment (#3077).
+ * Containment root is projectRoot (not dirname(path)) so a force-added `xbrief/`
+ * directory symlink fails closed before temp+rename — same class as #3042.
+ */
+function atomicWrite(projectRoot: string, path: string, data: Record<string, unknown>): void {
+  const root = resolve(projectRoot);
+  const targetAbs = resolve(path);
+  // Refuse leaf/parent symlinks and out-of-root targets before temp+rename.
+  assertWriteTargetSafe(root, targetAbs);
+  const dir = dirname(targetAbs);
   const payload = `${JSON.stringify(data, null, 2)}\n`;
   const tmpName = `.${Date.now()}.tmp`;
   const tmp = join(dir, tmpName);
   try {
-    // #2980 wave D: temp payload write uses containedWrite under the parent dir.
+    // #2980 wave D / #3077: product write routes through containedWrite under projectRoot.
     containedWrite({
-      root: resolve(dir),
-      target: tmpName,
+      root,
+      target: tmp,
       data: payload,
       mode: "create",
     });
-    renameSync(tmp, path);
+    renameSync(tmp, targetAbs);
   } catch (err) {
     try {
       rmSync(tmp, { force: true });


### PR DESCRIPTION
## Summary

Closes #3077.

`atomicWrite` in triage welcome writers used parent-as-root containment (`containedWrite({ root: dirname(path) })`). A force-added or committed `xbrief/` directory symlink pointing outside the checkout escaped containment and could let `writeTriageScope` / `writeWipCap` / `writeWipCapDecision` (paths used by `triage:welcome --onboard`) create or overwrite outside PROJECT-DEFINITION JSON.

Same residual class as #3042 / #2951 / #2980.

## Changes

- Contain against **projectRoot** via `assertWriteTargetSafe` + `containedWrite({ root: projectRoot })`
- Drop unused `_projectRoot` discard; refuse escaping / symlink `xbrief` parents before temp write + rename
- Regression tests: fixture `xbrief` dir symlink outside leaves outside JSON untouched
- CHANGELOG cites #3077
- `verify:contained-writes --enforce` clean (sink was already on containedWrite; root is now correct)

## Test plan

- [x] `pnpm exec vitest run packages/core/src/triage/welcome` (63 passed; 3 symlink tests skipped on win32, run on CI Linux)
- [x] `task verify:contained-writes -- --enforce`
- [x] `task ts:lint` (exit 0; pre-existing warnings only)
- [x] Targeted writers coverage ~92% stmts / ~88% branches

Refs #3042, #2951, #2980