### PR TITLE
fix(check): consumer gate integrity for verify:orphan-active (#3070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Consumer `task check` no longer dies on missing `verify:orphan-active` with opaque go-task 200/201 (#3070).** Check-graph Taskfile includes (`verify`, `toolchain`, `vbrief`) are non-optional so a missing `tasks/verify.yml` fails loud at load. The check orchestrator and `deft doctor` probe CONSUMER_CHECK_GATES integrity before shelling gates and emit deposit-repair guidance (`deft update`) instead of `Task "verify:orphan-active" does not exist`. Content-contract + fixture cover incomplete deposits. Closes #3070.
+
 ### Removed
 
 ## [0.93.0] - 2026-08-03

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,12 +84,16 @@ includes:
   deployments:
     taskfile: ./tasks/deployments.yml
     optional: true
+  # check-graph namespaces (#3070): must NOT be optional. CONSUMER_CHECK_GATES /
+  # check:consumer depend on these includes; optional silent omit yields opaque
+  # go-task "Task does not exist" (exit 200/201). Fail loud when the file is
+  # missing so operators get a clear deposit-repair signal (`deft update`).
   toolchain:
     taskfile: ./tasks/toolchain.yml
-    optional: true
+    optional: false
   verify:
     taskfile: ./tasks/verify.yml
-    optional: true
+    optional: false
   coverage:
     taskfile: ./tasks/coverage.yml
     optional: true
@@ -134,9 +138,10 @@ includes:
   migrate:
     taskfile: ./tasks/migrate.yml
     optional: true
+  # check-graph namespace (#3070): vbrief:validate is on CONSUMER_CHECK_GATES.
   vbrief:
     taskfile: ./tasks/vbrief.yml
-    optional: true
+    optional: false
   xbrief:
     taskfile: ./tasks/xbrief.yml
     optional: true

--- a/packages/core/src/check/cached-orchestrator.ts
+++ b/packages/core/src/check/cached-orchestrator.ts
@@ -7,6 +7,10 @@ import {
 } from "../cache/task-cache/index.js";
 import type { TaskRunResult } from "../cache/task-cache/types.js";
 import { readCorePackageVersion } from "../engine-version.js";
+import {
+  evaluateConsumerGateIntegrity,
+  formatConsumerGateIntegrityFailure,
+} from "./consumer-gate-integrity.js";
 import { type CheckOrchestratorSeams, resolveCheckTarget } from "./context.js";
 import { checkGateId, checkGateSpawnArgs, gatesForCheckTarget } from "./gate-lists.js";
 
@@ -55,6 +59,17 @@ export function dispatchCachedTaskCheck(
   const cwd = target === "check:framework-source" ? resolvedFramework : resolvedProject;
   const gates = gatesForCheckTarget(target);
   const codeVersion = readCorePackageVersion();
+
+  // #3070: fail loud with deposit-repair guidance when consumer check-graph
+  // includes (e.g. tasks/verify.yml for verify:orphan-active) are missing,
+  // instead of opaque go-task "Task does not exist" exit 200/201.
+  if (target === "check:consumer") {
+    const integrity = evaluateConsumerGateIntegrity(resolvedFramework);
+    if (!integrity.ok) {
+      process.stderr.write(formatConsumerGateIntegrityFailure(integrity));
+      return 2;
+    }
+  }
 
   const registryLint = lintShippedRegistry();
   if (!registryLint.ok) {

--- a/packages/core/src/check/consumer-gate-integrity.test.ts
+++ b/packages/core/src/check/consumer-gate-integrity.test.ts
@@ -1,0 +1,239 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CHECK_GRAPH_REQUIRED_NAMESPACES,
+  CONSUMER_GATE_INTEGRITY_RECOVERY,
+  checkGraphOptionalIncludeViolations,
+  evaluateConsumerGateIntegrity,
+  formatConsumerGateIntegrityFailure,
+  gateLocalName,
+  gateNamespace,
+  includeTaskfileRel,
+  parseTaskfileIncludes,
+  requiredNamespacesForGates,
+  taskDefinedInTaskfileYaml,
+} from "./consumer-gate-integrity.js";
+import { CONSUMER_CHECK_GATES, checkGateId } from "./gate-lists.js";
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..", "..");
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const d of tempDirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function tempDeposit(): string {
+  const dir = mkdtempSync(join(tmpdir(), "deft-3070-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("gate id helpers (#3070)", () => {
+  it("splits namespaced gates", () => {
+    expect(gateNamespace("verify:orphan-active")).toBe("verify");
+    expect(gateLocalName("verify:orphan-active")).toBe("orphan-active");
+    expect(includeTaskfileRel("verify")).toBe("tasks/verify.yml");
+  });
+
+  it("treats bare root tasks as non-namespaced", () => {
+    expect(gateNamespace("doctor")).toBeNull();
+    expect(gateLocalName("doctor")).toBe("doctor");
+    expect(gateNamespace("verify-strategy-output")).toBeNull();
+  });
+
+  it("derives required namespaces from CONSUMER_CHECK_GATES", () => {
+    const ns = requiredNamespacesForGates();
+    expect(ns).toContain("verify");
+    expect(ns).toContain("toolchain");
+    expect(ns).toContain("vbrief");
+    for (const required of CHECK_GRAPH_REQUIRED_NAMESPACES) {
+      expect(ns).toContain(required);
+    }
+  });
+});
+
+describe("taskDefinedInTaskfileYaml (#3070)", () => {
+  it("detects top-level task keys", () => {
+    const yaml = `version: '3'\ntasks:\n  orphan-active:\n    cmds: [echo ok]\n  nested:\n    cmds: []\n`;
+    expect(taskDefinedInTaskfileYaml(yaml, "orphan-active")).toBe(true);
+    expect(taskDefinedInTaskfileYaml(yaml, "missing")).toBe(false);
+  });
+});
+
+describe("parseTaskfileIncludes (#3070)", () => {
+  it("reads taskfile path and optional flag", () => {
+    const text = `
+version: '3'
+includes:
+  verify:
+    taskfile: ./tasks/verify.yml
+    optional: true
+  swarm:
+    taskfile: ./tasks/swarm.yml
+    optional: false
+  toolchain:
+    taskfile: ./tasks/toolchain.yml
+`;
+    const map = parseTaskfileIncludes(text);
+    expect(map.get("verify")).toEqual({ taskfile: "./tasks/verify.yml", optional: true });
+    expect(map.get("swarm")).toEqual({ taskfile: "./tasks/swarm.yml", optional: false });
+    expect(map.get("toolchain")?.optional).toBe(false);
+  });
+});
+
+describe("evaluateConsumerGateIntegrity (#3070)", () => {
+  it("passes against the real framework checkout", () => {
+    const result = evaluateConsumerGateIntegrity(repoRoot);
+    expect(result.ok, formatConsumerGateIntegrityFailure(result)).toBe(true);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("every CONSUMER_CHECK_GATES id is covered by the integrity pass on shipped tree", () => {
+    const result = evaluateConsumerGateIntegrity(repoRoot);
+    expect(result.ok).toBe(true);
+    for (const gate of CONSUMER_CHECK_GATES.map(checkGateId)) {
+      expect(result.findings.find((f) => f.gateId === gate)).toBeUndefined();
+    }
+  });
+
+  it("skips (ok) when root Taskfile is absent", () => {
+    const dir = tempDeposit();
+    const result = evaluateConsumerGateIntegrity(dir);
+    expect(result.ok).toBe(true);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("fails loud when tasks/verify.yml is missing (regression fixture)", () => {
+    const dir = tempDeposit();
+    mkdirSync(join(dir, "tasks"), { recursive: true });
+    writeFileSync(
+      join(dir, "Taskfile.yml"),
+      `version: '3'
+includes:
+  verify:
+    taskfile: ./tasks/verify.yml
+    optional: true
+  toolchain:
+    taskfile: ./tasks/toolchain.yml
+    optional: true
+  vbrief:
+    taskfile: ./tasks/vbrief.yml
+    optional: true
+tasks:
+  doctor:
+    cmds: [echo doctor]
+  verify-strategy-output:
+    cmds: [echo strategy]
+`,
+      "utf8",
+    );
+    // toolchain + vbrief present; verify.yml intentionally missing
+    writeFileSync(
+      join(dir, "tasks", "toolchain.yml"),
+      "version: '3'\ntasks:\n  check-consumer:\n    cmds: [echo ok]\n",
+      "utf8",
+    );
+    writeFileSync(
+      join(dir, "tasks", "vbrief.yml"),
+      "version: '3'\ntasks:\n  validate:\n    cmds: [echo ok]\n",
+      "utf8",
+    );
+
+    const result = evaluateConsumerGateIntegrity(dir);
+    expect(result.ok).toBe(false);
+    const orphan = result.findings.find((f) => f.gateId === "verify:orphan-active");
+    expect(orphan).toBeDefined();
+    expect(orphan?.kind).toBe("missing-include-file");
+    expect(orphan?.detail).toMatch(/verify\.yml/);
+    expect(result.recovery).toBe(CONSUMER_GATE_INTEGRITY_RECOVERY);
+    const formatted = formatConsumerGateIntegrityFailure(result);
+    expect(formatted).toContain("consumer gate integrity failed");
+    expect(formatted).toContain("deft update");
+    expect(formatted).not.toMatch(/exit status 20[01]/);
+  });
+
+  it("fails when verify.yml exists but orphan-active task is absent", () => {
+    const dir = tempDeposit();
+    mkdirSync(join(dir, "tasks"), { recursive: true });
+    writeFileSync(
+      join(dir, "Taskfile.yml"),
+      `version: '3'
+includes:
+  verify:
+    taskfile: ./tasks/verify.yml
+    optional: false
+  toolchain:
+    taskfile: ./tasks/toolchain.yml
+  vbrief:
+    taskfile: ./tasks/vbrief.yml
+tasks:
+  doctor:
+    cmds: [echo doctor]
+  verify-strategy-output:
+    cmds: [echo strategy]
+`,
+      "utf8",
+    );
+    writeFileSync(
+      join(dir, "tasks", "verify.yml"),
+      "version: '3'\ntasks:\n  branch:\n    cmds: [echo branch]\n  cache-fresh:\n    cmds: [echo cache]\n  wip-cap:\n    cmds: [echo wip]\n",
+      "utf8",
+    );
+    writeFileSync(
+      join(dir, "tasks", "toolchain.yml"),
+      "version: '3'\ntasks:\n  check-consumer:\n    cmds: [echo ok]\n",
+      "utf8",
+    );
+    writeFileSync(
+      join(dir, "tasks", "vbrief.yml"),
+      "version: '3'\ntasks:\n  validate:\n    cmds: [echo ok]\n",
+      "utf8",
+    );
+
+    const result = evaluateConsumerGateIntegrity(dir);
+    expect(result.ok).toBe(false);
+    expect(result.findings.some((f) => f.gateId === "verify:orphan-active")).toBe(true);
+    expect(result.findings.find((f) => f.gateId === "verify:orphan-active")?.kind).toBe(
+      "missing-task-definition",
+    );
+  });
+});
+
+describe("checkGraphOptionalIncludeViolations (#3070)", () => {
+  it("flags optional: true on check-graph namespaces", () => {
+    const text = `
+includes:
+  verify:
+    taskfile: ./tasks/verify.yml
+    optional: true
+  toolchain:
+    taskfile: ./tasks/toolchain.yml
+    optional: false
+  vbrief:
+    taskfile: ./tasks/vbrief.yml
+    optional: true
+`;
+    const bad = checkGraphOptionalIncludeViolations(text, ["verify", "toolchain", "vbrief"]);
+    expect(bad.some((b) => b.startsWith("verify"))).toBe(true);
+    expect(bad.some((b) => b.startsWith("vbrief"))).toBe(true);
+    expect(bad.some((b) => b.startsWith("toolchain"))).toBe(false);
+  });
+
+  it("framework Taskfile keeps check-graph includes non-optional", () => {
+    const text = readRepoTaskfile();
+    const bad = checkGraphOptionalIncludeViolations(text);
+    expect(bad, `optional check-graph includes: ${bad.join("; ")}`).toEqual([]);
+  });
+});
+
+function readRepoTaskfile(): string {
+  return readFileSync(join(repoRoot, "Taskfile.yml"), "utf8");
+}

--- a/packages/core/src/check/consumer-gate-integrity.ts
+++ b/packages/core/src/check/consumer-gate-integrity.ts
@@ -1,0 +1,327 @@
+/**
+ * Consumer check-graph integrity (#3070).
+ *
+ * CONSUMER_CHECK_GATES lists Taskfile tasks that must resolve in a vendored
+ * deposit. When optional Taskfile includes silently omit `tasks/verify.yml`
+ * (etc.), go-task fails with opaque exit 200/201 ("Task does not exist").
+ *
+ * This module:
+ *  1. Maps each gate to its include namespace / root Taskfile surface
+ *  2. Proves shipped files define those tasks (static + runtime)
+ *  3. Emits a deposit-repair recovery message instead of opaque go-task errors
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { type CheckGateSpec, CONSUMER_CHECK_GATES, checkGateId } from "./gate-lists.js";
+
+/** Include namespaces required by the consumer check graph (Taskfile includes). */
+export const CHECK_GRAPH_REQUIRED_NAMESPACES = ["verify", "toolchain", "vbrief"] as const;
+
+export type CheckGraphNamespace = (typeof CHECK_GRAPH_REQUIRED_NAMESPACES)[number];
+
+export const CONSUMER_GATE_INTEGRITY_RECOVERY =
+  "Incomplete Deft deposit: check-graph Taskfile include(s) missing or incomplete. " +
+  "Run `deft update` (or `npm i -g @deftai/directive@latest` then `deft update`) " +
+  "to restore `.deft/core/tasks/` (including `tasks/verify.yml` for `verify:orphan-active`). " +
+  "See UPGRADING.md.";
+
+export interface ConsumerGateIntegrityFinding {
+  readonly gateId: string;
+  readonly kind: "missing-include-file" | "missing-task-definition" | "missing-root-taskfile";
+  readonly detail: string;
+  readonly expectedPath?: string;
+}
+
+export interface ConsumerGateIntegrityResult {
+  readonly ok: boolean;
+  readonly findings: readonly ConsumerGateIntegrityFinding[];
+  readonly recovery: string;
+}
+
+export interface ConsumerGateIntegritySeams {
+  readonly exists?: (path: string) => boolean;
+  readonly readText?: (path: string) => string | null;
+  /** Override gate list under test (defaults to CONSUMER_CHECK_GATES). */
+  readonly gates?: readonly CheckGateSpec[];
+}
+
+/** Namespace for a namespaced task (`verify:orphan-active` → `verify`); null for root tasks. */
+export function gateNamespace(gateId: string): string | null {
+  const colon = gateId.indexOf(":");
+  if (colon <= 0) {
+    return null;
+  }
+  return gateId.slice(0, colon);
+}
+
+/** Local task name inside an include (`verify:orphan-active` → `orphan-active`). */
+export function gateLocalName(gateId: string): string {
+  const colon = gateId.indexOf(":");
+  if (colon <= 0) {
+    return gateId;
+  }
+  return gateId.slice(colon + 1);
+}
+
+/** Relative path of the include Taskfile for a namespace. */
+export function includeTaskfileRel(namespace: string): string {
+  return `tasks/${namespace}.yml`;
+}
+
+/**
+ * Namespaces that CONSUMER_CHECK_GATES require via `ns:task` form.
+ * Root-only gates (doctor, verify-strategy-output) do not add a namespace.
+ */
+export function requiredNamespacesForGates(
+  gates: readonly CheckGateSpec[] = CONSUMER_CHECK_GATES,
+): readonly string[] {
+  const seen = new Set<string>();
+  for (const spec of gates) {
+    const ns = gateNamespace(checkGateId(spec));
+    if (ns !== null) {
+      seen.add(ns);
+    }
+  }
+  return [...seen].sort();
+}
+
+/** True when `localName` is a top-level task key under a Taskfile `tasks:` section. */
+export function taskDefinedInTaskfileYaml(text: string, localName: string): boolean {
+  // go-task task keys are indented two spaces under `tasks:`.
+  // Match `  orphan-active:` / `  check-consumer:` etc., not nested keys.
+  const escaped = localName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^ {2}${escaped}\\s*:`, "m");
+  return re.test(text.replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
+}
+
+/**
+ * Parse root Taskfile `includes:` entries: map namespace → { taskfile, optional }.
+ * Minimal line parser (avoids a YAML dependency); sufficient for go-task include shape.
+ */
+export function parseTaskfileIncludes(
+  text: string,
+): ReadonlyMap<string, { readonly taskfile: string; readonly optional: boolean }> {
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const result = new Map<string, { taskfile: string; optional: boolean }>();
+  let inIncludes = false;
+  let includesIndent = 0;
+  let currentNs: string | null = null;
+  let currentTaskfile: string | null = null;
+  let currentOptional = true; // go-task default when omitted is false, but our deposit historically used true
+
+  const flush = () => {
+    if (currentNs !== null && currentTaskfile !== null) {
+      result.set(currentNs, { taskfile: currentTaskfile, optional: currentOptional });
+    }
+    currentNs = null;
+    currentTaskfile = null;
+    currentOptional = false;
+  };
+
+  for (const raw of lines) {
+    const stripped = raw.trim();
+    if (!stripped || stripped.startsWith("#")) {
+      continue;
+    }
+    const indent = raw.length - raw.trimStart().length;
+
+    if (!inIncludes) {
+      if (/^includes\s*:/.test(stripped) && indent === 0) {
+        inIncludes = true;
+        includesIndent = indent;
+      }
+      continue;
+    }
+
+    if (indent <= includesIndent && !stripped.startsWith("#")) {
+      flush();
+      inIncludes = false;
+      // fall through if a new top-level key; re-check next iteration naturally
+      if (/^includes\s*:/.test(stripped)) {
+        inIncludes = true;
+        includesIndent = indent;
+      }
+      continue;
+    }
+
+    // Namespace key at includes+2 (typically 2 spaces): `  verify:`
+    if (indent === includesIndent + 2 && /^[A-Za-z_][\w-]*\s*:/.test(stripped)) {
+      flush();
+      currentNs = stripped.replace(/:\s*(?:#.*)?$/, "").trim();
+      currentTaskfile = null;
+      currentOptional = false;
+      continue;
+    }
+
+    if (currentNs === null) {
+      continue;
+    }
+
+    // Properties at includes+4: taskfile / optional
+    if (indent >= includesIndent + 4) {
+      const taskfileMatch = stripped.match(/^taskfile\s*:\s*["']?([^"'#]+?)["']?\s*(?:#.*)?$/i);
+      if (taskfileMatch?.[1]) {
+        currentTaskfile = taskfileMatch[1].trim();
+        continue;
+      }
+      const optionalMatch = stripped.match(/^optional\s*:\s*(true|false)\s*(?:#.*)?$/i);
+      if (optionalMatch?.[1]) {
+        currentOptional = optionalMatch[1].toLowerCase() === "true";
+      }
+    }
+  }
+  flush();
+  return result;
+}
+
+/**
+ * Assert every consumer check gate resolves against `frameworkRoot` Taskfile + includes.
+ * When the root Taskfile is absent, returns ok with no findings (caller/spawn handles that).
+ */
+export function evaluateConsumerGateIntegrity(
+  frameworkRoot: string,
+  seams: ConsumerGateIntegritySeams = {},
+): ConsumerGateIntegrityResult {
+  const root = resolve(frameworkRoot);
+  const exists = seams.exists ?? ((p: string) => existsSync(p));
+  const readText =
+    seams.readText ??
+    ((p: string): string | null => {
+      try {
+        if (!existsSync(p)) {
+          return null;
+        }
+        return readFileSync(p, "utf8");
+      } catch {
+        return null;
+      }
+    });
+  const gates = seams.gates ?? CONSUMER_CHECK_GATES;
+  const findings: ConsumerGateIntegrityFinding[] = [];
+
+  const rootTaskfile = join(root, "Taskfile.yml");
+  if (!exists(rootTaskfile)) {
+    // Incomplete / non-deposit path: do not invent a Taskfile; let spawn fail as before.
+    return { ok: true, findings: [], recovery: CONSUMER_GATE_INTEGRITY_RECOVERY };
+  }
+
+  const rootText = readText(rootTaskfile);
+  if (rootText === null) {
+    findings.push({
+      gateId: "*",
+      kind: "missing-root-taskfile",
+      detail: `Taskfile.yml unreadable at ${rootTaskfile}`,
+      expectedPath: rootTaskfile,
+    });
+    return { ok: false, findings, recovery: CONSUMER_GATE_INTEGRITY_RECOVERY };
+  }
+
+  const includes = parseTaskfileIncludes(rootText);
+  const yamlCache = new Map<string, string | null>();
+  const readCached = (abs: string): string | null => {
+    if (yamlCache.has(abs)) {
+      return yamlCache.get(abs) ?? null;
+    }
+    const t = readText(abs);
+    yamlCache.set(abs, t);
+    return t;
+  };
+  yamlCache.set(rootTaskfile, rootText);
+
+  for (const spec of gates) {
+    const gateId = checkGateId(spec);
+    const ns = gateNamespace(gateId);
+    const local = gateLocalName(gateId);
+
+    if (ns === null) {
+      // Root Taskfile task (doctor, verify-strategy-output, …)
+      if (!taskDefinedInTaskfileYaml(rootText, local)) {
+        findings.push({
+          gateId,
+          kind: "missing-task-definition",
+          detail: `Root task "${local}" not defined in Taskfile.yml (required by consumer check gate "${gateId}")`,
+          expectedPath: rootTaskfile,
+        });
+      }
+      continue;
+    }
+
+    const rel = includeTaskfileRel(ns);
+    const includeMeta = includes.get(ns);
+    const relFromInclude = includeMeta?.taskfile ? includeMeta.taskfile.replace(/^\.\//, "") : rel;
+    const includeAbs = join(root, relFromInclude);
+
+    if (!exists(includeAbs)) {
+      findings.push({
+        gateId,
+        kind: "missing-include-file",
+        detail:
+          `Missing Taskfile include file for namespace "${ns}" (gate "${gateId}"): ` +
+          `${relFromInclude}. Optional silent omit of this include causes go-task ` +
+          `"Task \\"${gateId}\\" does not exist" (exit 200/201).`,
+        expectedPath: includeAbs,
+      });
+      continue;
+    }
+
+    const includeText = readCached(includeAbs);
+    if (includeText === null) {
+      findings.push({
+        gateId,
+        kind: "missing-include-file",
+        detail: `Unreadable Taskfile include for namespace "${ns}": ${relFromInclude}`,
+        expectedPath: includeAbs,
+      });
+      continue;
+    }
+
+    if (!taskDefinedInTaskfileYaml(includeText, local)) {
+      findings.push({
+        gateId,
+        kind: "missing-task-definition",
+        detail: `Task "${local}" not defined in ${relFromInclude} (required by consumer check gate "${gateId}")`,
+        expectedPath: includeAbs,
+      });
+    }
+  }
+
+  return {
+    ok: findings.length === 0,
+    findings,
+    recovery: CONSUMER_GATE_INTEGRITY_RECOVERY,
+  };
+}
+
+/** Format integrity failure for stderr (check orchestrator / doctor). */
+export function formatConsumerGateIntegrityFailure(result: ConsumerGateIntegrityResult): string {
+  const lines = [
+    "check: consumer gate integrity failed (#3070)",
+    ...result.findings.map((f) => `  - ${f.gateId}: ${f.detail}`),
+    `  recovery: ${result.recovery}`,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Namespaces that must not be `optional: true` on the root Taskfile when the
+ * check graph depends on them — silent omit is the #3070 failure mode.
+ */
+export function checkGraphOptionalIncludeViolations(
+  rootTaskfileText: string,
+  namespaces: readonly string[] = requiredNamespacesForGates(),
+): readonly string[] {
+  const includes = parseTaskfileIncludes(rootTaskfileText);
+  const bad: string[] = [];
+  for (const ns of namespaces) {
+    const meta = includes.get(ns);
+    if (meta === undefined) {
+      bad.push(`${ns} (include entry missing)`);
+      continue;
+    }
+    if (meta.optional) {
+      bad.push(`${ns} (optional: true — check-graph includes must fail loud when file is missing)`);
+    }
+  }
+  return bad;
+}

--- a/packages/core/src/check/gate-lists.test.ts
+++ b/packages/core/src/check/gate-lists.test.ts
@@ -21,7 +21,10 @@ describe("gate-lists (#2791)", () => {
   it("spawns public WIP-cap with --allow-over-cap after --", () => {
     const spec = FRAMEWORK_CHECK_GATES.find((g) => checkGateId(g) === "verify:wip-cap");
     expect(spec).toBeDefined();
-    expect(checkGateSpawnArgs(spec!, "/repo/Taskfile.yml")).toEqual([
+    if (spec === undefined) {
+      throw new Error("expected verify:wip-cap gate");
+    }
+    expect(checkGateSpawnArgs(spec, "/repo/Taskfile.yml")).toEqual([
       "verify:wip-cap",
       "--taskfile",
       "/repo/Taskfile.yml",

--- a/packages/core/src/check/gate-lists.test.ts
+++ b/packages/core/src/check/gate-lists.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  CONSUMER_CHECK_GATES,
   checkGateId,
   checkGateSpawnArgs,
   FRAMEWORK_CHECK_GATES,
@@ -41,5 +42,13 @@ describe("gate-lists (#2791)", () => {
     const consumer = gatesForCheckTarget("check:consumer");
     const wip = consumer.find((g) => checkGateId(g) === "verify:wip-cap");
     expect(wip).toBe("verify:wip-cap");
+  });
+
+  it("keeps verify:orphan-active on the consumer gate list (#3070)", () => {
+    const ids = CONSUMER_CHECK_GATES.map(checkGateId);
+    expect(ids).toContain("verify:orphan-active");
+    expect(gatesForCheckTarget("check:consumer").map(checkGateId)).toContain(
+      "verify:orphan-active",
+    );
   });
 });

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -1,5 +1,21 @@
 export { dispatchCachedTaskCheck } from "./cached-orchestrator.js";
 export {
+  CHECK_GRAPH_REQUIRED_NAMESPACES,
+  CONSUMER_GATE_INTEGRITY_RECOVERY,
+  type ConsumerGateIntegrityFinding,
+  type ConsumerGateIntegrityResult,
+  type ConsumerGateIntegritySeams,
+  checkGraphOptionalIncludeViolations,
+  evaluateConsumerGateIntegrity,
+  formatConsumerGateIntegrityFailure,
+  gateLocalName,
+  gateNamespace,
+  includeTaskfileRel,
+  parseTaskfileIncludes,
+  requiredNamespacesForGates,
+  taskDefinedInTaskfileYaml,
+} from "./consumer-gate-integrity.js";
+export {
   type CheckGateSpec,
   CONSUMER_CHECK_GATES,
   checkGateId,

--- a/packages/core/src/check/orchestrator.test.ts
+++ b/packages/core/src/check/orchestrator.test.ts
@@ -1,5 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   dispatchTaskCheck,
   isFrameworkRepoRoot,
@@ -8,6 +10,16 @@ import {
 } from "./orchestrator.js";
 
 const repoRoot = join(import.meta.dirname, "..", "..", "..", "..");
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const d of tempDirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
 
 describe("isFrameworkSourceContext", () => {
   it("returns true when framework and project roots are the same path", () => {
@@ -116,6 +128,51 @@ describe("dispatchTaskCheck", () => {
     const project = "/home/user/consumer";
     dispatchTaskCheck(framework, project, { spawnFn, useTaskCache: false });
     expect(calls[0]?.cwd).toBe(resolve(project));
+  });
+
+  it("fails with deposit-repair guidance when consumer deposit lacks verify.yml (#3070)", () => {
+    const framework = mkdtempSync(join(tmpdir(), "deft-3070-fw-"));
+    tempDirs.push(framework);
+    mkdirSync(join(framework, "tasks"), { recursive: true });
+    writeFileSync(
+      join(framework, "Taskfile.yml"),
+      `version: '3'
+includes:
+  verify:
+    taskfile: ./tasks/verify.yml
+    optional: true
+  toolchain:
+    taskfile: ./tasks/toolchain.yml
+  vbrief:
+    taskfile: ./tasks/vbrief.yml
+tasks:
+  doctor:
+    cmds: [echo doctor]
+  verify-strategy-output:
+    cmds: [echo strategy]
+`,
+      "utf8",
+    );
+    writeFileSync(
+      join(framework, "tasks", "toolchain.yml"),
+      "version: '3'\ntasks:\n  check-consumer:\n    cmds: [echo ok]\n",
+      "utf8",
+    );
+    writeFileSync(
+      join(framework, "tasks", "vbrief.yml"),
+      "version: '3'\ntasks:\n  validate:\n    cmds: [echo ok]\n",
+      "utf8",
+    );
+
+    const calls: unknown[] = [];
+    const spawnFn = () => {
+      calls.push("spawned");
+      return { status: 0 };
+    };
+    const project = join(tmpdir(), "consumer-project");
+    const code = dispatchTaskCheck(framework, project, { spawnFn, useTaskCache: false });
+    expect(code).toBe(2);
+    expect(calls).toHaveLength(0);
   });
 
   it("uses a custom task binary when provided via seams", () => {

--- a/packages/core/src/check/orchestrator.ts
+++ b/packages/core/src/check/orchestrator.ts
@@ -15,6 +15,10 @@
 import { spawnSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import { dispatchCachedTaskCheck } from "./cached-orchestrator.js";
+import {
+  evaluateConsumerGateIntegrity,
+  formatConsumerGateIntegrityFailure,
+} from "./consumer-gate-integrity.js";
 import { type CheckOrchestratorSeams, resolveCheckTarget } from "./context.js";
 
 export type { CheckOrchestratorOptions, CheckOrchestratorSeams } from "./context.js";
@@ -46,6 +50,16 @@ export function dispatchTaskCheck(
 
   const target = resolveCheckTarget(resolvedFramework, resolvedProject);
   const cwd = target === "check:framework-source" ? resolvedFramework : resolvedProject;
+
+  // #3070: pre-flight consumer check-graph integrity (same path as cached
+  // orchestrator) so uncached aggregate shelling also fails with recovery text.
+  if (target === "check:consumer") {
+    const integrity = evaluateConsumerGateIntegrity(resolvedFramework);
+    if (!integrity.ok) {
+      process.stderr.write(formatConsumerGateIntegrityFailure(integrity));
+      return 2;
+    }
+  }
 
   const spawn = seams.spawnFn ?? defaultSpawn;
   const result = spawn(taskBin, [target, "--taskfile", taskfilePath], {

--- a/packages/core/src/content-contracts/standards/consumer_check_gate_integrity.test.ts
+++ b/packages/core/src/content-contracts/standards/consumer_check_gate_integrity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Content/deposit integrity for CONSUMER_CHECK_GATES (#3070).
+ *
+ * Guards the shipped Taskfile.yml + tasks/ tree so every consumer check gate
+ * (including verify:orphan-active) resolves without optional silent omit.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  checkGraphOptionalIncludeViolations,
+  evaluateConsumerGateIntegrity,
+  formatConsumerGateIntegrityFailure,
+  requiredNamespacesForGates,
+} from "../../check/consumer-gate-integrity.js";
+import { CONSUMER_CHECK_GATES, checkGateId } from "../../check/gate-lists.js";
+import { repoRoot } from "./_helpers.js";
+
+describe("consumer check-gate integrity (#3070)", () => {
+  it("every CONSUMER_CHECK_GATES entry resolves in the shipped Taskfile+includes", () => {
+    const result = evaluateConsumerGateIntegrity(repoRoot());
+    expect(result.ok, formatConsumerGateIntegrityFailure(result)).toBe(true);
+  });
+
+  it("ships verify:orphan-active on the consumer gate list", () => {
+    expect(CONSUMER_CHECK_GATES.map(checkGateId)).toContain("verify:orphan-active");
+  });
+
+  it("makes check-graph namespaces non-optional in root Taskfile.yml", () => {
+    const text = readFileSync(join(repoRoot(), "Taskfile.yml"), "utf8");
+    const bad = checkGraphOptionalIncludeViolations(text, requiredNamespacesForGates());
+    expect(bad, `optional check-graph includes: ${bad.join("; ")}`).toEqual([]);
+  });
+
+  it("Taskfile check:consumer deps include verify:orphan-active", () => {
+    const text = readFileSync(join(repoRoot(), "Taskfile.yml"), "utf8");
+    expect(text).toMatch(/check:consumer:[\s\S]*?verify:orphan-active/);
+  });
+
+  it("content package prepack ships tasks/ (incl. verify.yml) with Taskfile", () => {
+    const pkg = readFileSync(join(repoRoot(), "packages", "content", "package.json"), "utf8");
+    expect(pkg).toContain("Taskfile.yml");
+    expect(pkg).toContain("tasks");
+    expect(pkg).toMatch(/'\.githooks',\s*'Taskfile\.yml',\s*'tasks'/);
+  });
+});

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -2,6 +2,10 @@ import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { VBRIEF_VERSION } from "@deftai/directive-types";
 import { evaluate as evaluateAgentsMdAdvisory } from "../agents-md-advisory/evaluate.js";
+import {
+  evaluateConsumerGateIntegrity,
+  formatConsumerGateIntegrityFailure,
+} from "../check/consumer-gate-integrity.js";
 import { contentRoot } from "../content-root.js";
 import { resolveProjectDefinitionPath } from "../layout/resolve.js";
 import {
@@ -478,6 +482,12 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
   if (!jsonMode) {
     sink.blank();
   }
+  sink.info("Checking consumer check-graph integrity (verify:orphan-active and peers)...");
+  runConsumerCheckGraphIntegrity(projectRoot, frameworkRoot, sink, addFinding, seams);
+
+  if (!jsonMode) {
+    sink.blank();
+  }
   sink.info("Checking OpenClaw always-pin skills...");
   runOpenClawSkillPinsCheck(sink, addFinding, {
     frameworkRoot,
@@ -896,6 +906,67 @@ function runAgentsMdAdvisoryCheck(
     // bullet when findings are rendered (CWE-116).
     const detail = `${exc instanceof Error ? exc.name : "Error"}: ${exc}`.replace(/\r?\n/g, " ");
     const message = `${checkName}: probe failed -- ${detail}`;
+    sink.warn(message);
+    addFinding({ severity: "warning", message, check: checkName });
+  }
+}
+
+/**
+ * Consumer check-graph integrity (#3070): every CONSUMER_CHECK_GATES entry
+ * (including `verify:orphan-active`) must resolve against the deposited
+ * Taskfile includes. Missing `tasks/verify.yml` previously failed only at
+ * go-task shell time with opaque exit 200/201.
+ */
+function runConsumerCheckGraphIntegrity(
+  projectRoot: string,
+  frameworkRoot: string,
+  sink: ReturnType<typeof createPlainSink>,
+  addFinding: (f: Finding) => void,
+  seams: DoctorSeams,
+): void {
+  const checkName = "consumer-check-graph-integrity";
+  if (runningInsideDeftRepo(projectRoot, seams)) {
+    // Still prove the source checkout ships a resolvable consumer gate set.
+    const integrity = evaluateConsumerGateIntegrity(frameworkRoot);
+    if (integrity.ok) {
+      sink.success(
+        `${checkName}: source checkout resolves CONSUMER_CHECK_GATES (incl. verify:orphan-active)`,
+      );
+      return;
+    }
+    const message = formatConsumerGateIntegrityFailure(integrity).trim();
+    sink.error(message);
+    addFinding({
+      severity: "error",
+      message,
+      check: checkName,
+      suggestion: "deft update",
+      status: "fail",
+    });
+    return;
+  }
+  try {
+    const depositRoot = frameworkRoot;
+    const integrity = evaluateConsumerGateIntegrity(depositRoot);
+    if (integrity.ok) {
+      sink.success(
+        `${checkName}: deposit resolves CONSUMER_CHECK_GATES (incl. verify:orphan-active)`,
+      );
+      return;
+    }
+    // Incomplete deposit is an error for consumers — check:consumer would hard-fail.
+    const message = formatConsumerGateIntegrityFailure(integrity).trim();
+    sink.error(message);
+    addFinding({
+      severity: "error",
+      message,
+      check: checkName,
+      suggestion: integrity.recovery,
+      status: "fail",
+      findings: integrity.findings,
+    });
+  } catch (exc) {
+    const message = `${checkName}: probe failed -- ${exc instanceof Error ? exc.name : "Error"}: ${exc}`;
     sink.warn(message);
     addFinding({ severity: "warning", message, check: checkName });
   }


### PR DESCRIPTION
## Summary

Fixes consumer `task deft:check` failing with opaque go-task exit 200/201 when `tasks/verify.yml` is missing under an optional `verify:` include while `CONSUMER_CHECK_GATES` / `check:consumer` still list `verify:orphan-active`.

## Changes

- Make check-graph Taskfile includes (`verify`, `toolchain`, `vbrief`) **non-optional** so missing files fail loud at load time
- Add `evaluateConsumerGateIntegrity` so every `CONSUMER_CHECK_GATES` entry resolves against shipped Taskfile + includes
- Wire integrity preflight into check orchestrator (cached + uncached) with deposit-repair guidance (`deft update`)
- Doctor probe validates `verify:orphan-active` and the full consumer gate set
- Regression fixture + content-contract tests for incomplete deposits
- CHANGELOG `[Unreleased]` cites #3070

## Test plan

- [x] vitest packages/core/src/check (incl. integrity fixture)
- [x] Content contract consumer_check_gate_integrity.test.ts
- [x] task verify:orphan-active -- --skip-gh
- [x] task verify:branch / encoding / content-manifest / forward-coverage
- [ ] CI full task check

Closes #3070