### PR TITLE
feat(hooks): assist posture scratch writes without active xBRIEF (#1802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Ephemeral Task/spawn posture without active xBRIEF (#3080).** PreToolUse spawn classification gains a third posture beside implement and explore (#1185): `worker_role` / `subagent_type` ∈ {`ephemeral`, `docs`, `assist`} allows Multitask docs/analysis dispatch without `scope:activate` (`spawn-ephemeral-ready`). Unmarked `generalPurpose` still requires active scope (fail closed); implement envelope signals win over ephemeral markers. Deny text for missing active scope lists activate | explore | ephemeral recoveries. Docs: three postures in `content/commands.md` hook section. Does not weaken story-start / preflight for real implement; does not ship #1802 assist scratch writes. Closes #3080.
+- **Assist/research posture + allowlisted scratch writes without active xBRIEF (#1802).** Session **assist** posture (shared taxonomy with #3080 `ephemeral`/`docs`/`assist`) documents low-ceremony research notes: structural markers (`DEFT_SESSION_POSTURE=assist`, payload posture, role markers) plus path fence under `.deft-scratch/**` and `temp/**`. PreToolUse allows those direct writes without story-start or active scope (`write-assist-scratch-ready`); tracked product paths stay hard-gated; fail closed outside allowlist or without markers. Docs + deny recovery anti-pattern: do not fake `scope:activate` for Obsidian/scratch notes. Cohort twin of #3080 spawn posture. Closes #1802.
+
+- **Ephemeral Task/spawn posture without active xBRIEF (#3080).** PreToolUse spawn classification gains a third posture beside implement and explore (#1185): `worker_role` / `subagent_type` ∈ {`ephemeral`, `docs`, `assist`} allows Multitask docs/analysis dispatch without `scope:activate` (`spawn-ephemeral-ready`). Unmarked `generalPurpose` still requires active scope (fail closed); implement envelope signals win over ephemeral markers. Deny text for missing active scope lists activate | explore | ephemeral recoveries. Docs: three postures in `content/commands.md` hook section. Does not weaken story-start / preflight for real implement. Closes #3080.
 
 ### Changed
 

--- a/content/commands.md
+++ b/content/commands.md
@@ -279,7 +279,7 @@ When the workflow needs an Approach 1 monitor, scope the Cursor leaf `stop-at: p
 
 `directive init` and `deft update` idempotently merge Directive-owned entries into `.claude/settings.json`, `.grok/hooks/deft.json`, `.cursor/hooks.json`, and `.codex/hooks.json` while preserving unrelated settings. `SessionStart` refreshes resume bookkeeping on a non-blocking path. `PreToolUse` uses the lightweight `deft-hook` entrypoint rather than booting the full CLI router, reducing cold hook latency while retaining the same fail-closed ritual, scope, and runtime-authority decisions. Cursor `ApplyPatch` shares the direct-write registration, so each matched edit invokes one hook process. Cursor `preToolUse` deposits set `failClosed: true`, so allow decisions emit `{"permission":"allow"}` — empty stdout is treated as hook failure and would block Write tools. A second `PreToolUse` matcher covers spawn/Task tools (`Task`, `SubagentStart`, `spawn_subagent`, `start_agent`, `CreateAgent`) with the pre-`start_agent` gate stack for **implementation** spawns; explore and ephemeral postures skip active-xBRIEF (see three postures below).
 
-- **Spawn postures (#1185 / #3080):** PreToolUse classifies Task/spawn by **structural markers** (not free-text prompt NLP). Unmarked / default Multitask (`generalPurpose`) is treated as **implement** (fail closed).
+- **Spawn postures (#1185 / #3080):** PreToolUse classifies Task/spawn by **structural markers** (not free-text prompt NLP). Unmarked / default Multitask (`generalPurpose`) is treated as **implement** (fail closed). Session-level **assist** posture for direct scratch writes is the #1802 twin — see § Assist / research posture (#1802).
 
   | Posture | Markers | Active xBRIEF | Typical work |
   |---|---|---|---|
@@ -288,6 +288,8 @@ When the workflow needs an Approach 1 monitor, scope the Cursor leaf `stop-at: p
   | **Ephemeral** | `worker_role` (or `subagent_type`) ∈ {`ephemeral`, `docs`, `assist`} (#3080) | Not required | Brochure, pitch, disposable analysis notes |
 
   Gate order: explore allow (`spawn-explore-ready`) → ephemeral allow (`spawn-ephemeral-ready`) → else implementation stack (`inspectMutationGates`). If an ephemeral marker conflicts with implement envelope signals (`drive-to: merge-ready`, `worker_role: leaf-implementation`, swarm implement dispatch), **implement wins**. Ephemeral allowance does **not** authorize push/merge/deploy or skip `runtimeAuthority` / human-merge gates. **Anti-pattern:** invent a fake `scope:activate` only to dispatch brochure/docs work — use `worker_role: ephemeral` (or continue in the parent) instead. Deny text for missing active scope on implement spawns lists activate \| explore \| ephemeral recoveries.
+
+- **Assist scratch direct writes (#1802):** PreToolUse allows Write/Edit under allowlisted gitignored roots (`.deft-scratch/**`, `temp/**`) when assist/ephemeral classification applies (`DEFT_SESSION_POSTURE=assist`, payload posture, or #3080 role markers) — decision code `write-assist-scratch-ready`. Skips ritual + active-scope; does **not** unlock tracked product paths. Fail closed outside the allowlist or without structural markers. Deny recovery for in-repo scope-not-ready mentions the assist scratch path (do not invent fake `scope:activate` for notes). Full rules: § Assist / research posture (#1802).
 
 - **Read-only explore (#1185):** Prefer Grok role deposit `default_capability_mode = "read-only"` (see [issue #1185](https://github.com/deftai/directive/issues/1185)). Hooks also deny direct writes when `DEFT_HOOK_READ_ONLY=1` or the host payload signals read-only capability. Implementation and ephemeral spawns remain blocked in read-only posture unless explicitly marked explore.
 
@@ -315,6 +317,29 @@ Full always-on contract for the interactive session-start ritual and its gated v
 - ! At mutation boundaries (code-writing, scope lifecycle moves, `start_agent`, commits, pushes, PR-from-local-changes, release work): run the mutable quick tier then gated verifier below before proceeding.
 - ? Explicit read-only alignment only: `deft session:start -- --read-only` (no ritual-state write).
 - ~ Operators MAY still explicitly request full `deft session:start`, `deft triage:welcome`, sync, or doctor in read-only sessions.
+
+### Assist / research posture (#1802)
+
+Low-ceremony path for research and disposable local notes. Shared taxonomy with spawn postures (#3080 / #1185): session posture name is **`assist`**; spawn `worker_role` primary is **`ephemeral`** (aliases `docs`, `assist`).
+
+| Posture | Session ceremony | Direct write | Spawn (`Task`) |
+|---|---|---|---|
+| **Read-only research** | No mutation ritual | None / deny writes | `explore` only (#1185) |
+| **Assist / ephemeral** | No story-start; no active xBRIEF for scratch writes | Allowlisted scratch roots only (#1802) | `worker_role: ephemeral` (#3080) |
+| **Mutation / implement** | Full `session:start` + gated ritual + story/xBRIEF | Product paths + gates | Active xBRIEF required |
+
+- ! **Named assist intent:** declare non-implementation research/assist via structural markers — `DEFT_SESSION_POSTURE=assist` (or `research` / `research-notes` / `scratch` / `ephemeral` / `docs`), `DEFT_HOOK_ASSIST=1`, payload `posture` / `session_posture`, or spawn `worker_role` / `subagent_type` ∈ {`ephemeral`, `docs`, `assist`}. Prefer answering in chat; write scratch only when the operator asks for a file.
+- ! **Read-only research needs no mutation ceremony:** with no file writes (or only read tools), do **not** run gated session ritual / story-start / `git status` story gates as if starting implementation. Alignment load (AGENTS / USER / PROJECT-DEFINITION) still applies where session routing requires it.
+- ! **Operator language → assist:** phrases such as "Obsidian notes", "scratch only", "do not commit", "not a story/PR" map to assist posture. Default disposable notes to gitignored allowlisted roots so "do not commit" is structural.
+- ! **Allowlisted scratch roots (v1):** `.deft-scratch/**` (canonical) and `temp/**` (gitignored alias). PreToolUse allows direct Write/Edit under these roots when assist/ephemeral classification applies (`write-assist-scratch-ready`) — no active xBRIEF, no story-start, no full pre-`start_agent` gate stack. Compose with #3080 ephemeral spawn markers.
+- ! **Tracked / source still hard:** writes to product paths (`src/`, `packages/`, `content/`, app source, tracked `docs/` / `overview/`, …) under **any** posture still require mutation ceremony + existing write/scope gates. Labeling a change "research" does **not** bypass them. If the operator insists on a tracked path for notes, reclassify as mutation or obtain explicit override + normal gates; prefer redirect to `.deft-scratch/overview/` instead.
+- ⊗ Invent a fake `scope:activate` solely to capture disposable notes — use allowlisted scratch + assist posture (or continue in chat).
+- ⊗ Use assist posture for feature/bug/PR work; ⊗ write product code under scratch roots then smuggle into the tree; ⊗ treat assist as license to skip push/merge/human-merge gates.
+- ⊗ Rely on free-text prompt NLP alone as the gate classifier — path fence + structural markers only (fail closed on ambiguity).
+- ~ Offer to move finalized notes into committed docs via a **separate** mutation story if the operator wants them in-repo.
+- **Not this path:** `/deft:run:research` proposes a research vBRIEF (higher ceremony). Ceremony latency (#2990) is a separate track.
+
+Cross-link: spawn three postures and deny recoveries live under § Agent-host direct-write hooks (#2438, #2596) / Spawn postures (#1185 / #3080).
 
 ### Mutable ritual (mutation posture)
 

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ritualStatePath } from "../session/ritual-sentinel.js";
 import { fixtureCaseById, fixtureCasesFor, HOOK_FIXTURE_CASES } from "./fixtures/index.js";
 import {
+  ASSIST_SESSION_POSTURE_ENV,
   DIRECT_WRITE_TOOL_NAMES,
   decideHook,
   type HookPolicySeams,
@@ -12,6 +13,8 @@ import {
   hookShellCommand,
   hookToolName,
   hookWriteTargetPath,
+  isAllowlistedAssistScratchPath,
+  isAssistScratchWrite,
   isDirectWriteTool,
   isHookEvent,
   isHookHost,
@@ -314,6 +317,268 @@ describe("direct-write hook policy", () => {
     );
 
     expect(decision).toMatchObject({ verdict: "deny", code: "spawn-not-ready" });
+  });
+
+  describe("assist scratch writes (#1802)", () => {
+    const noScopeSeams = (): HookPolicySeams =>
+      readySeams({
+        inspectScope: () => ({
+          ready: false,
+          path: null,
+          message: "No active xBRIEF artifact was found under xbrief/active/",
+        }),
+        inspectRitual: () => ({
+          ...READY_RITUAL,
+          code: 1,
+          message: "ritual state missing",
+        }),
+      });
+
+    it("classifies allowlisted scratch roots and rejects tracked paths", () => {
+      expect(isAllowlistedAssistScratchPath("/project", ".deft-scratch/notes.md")).toBe(true);
+      expect(isAllowlistedAssistScratchPath("/project", "/project/.deft-scratch/a/b.md")).toBe(
+        true,
+      );
+      expect(isAllowlistedAssistScratchPath("/project", "temp/overview/x.md")).toBe(true);
+      expect(isAllowlistedAssistScratchPath("/project", "packages/core/src/hooks/dispatcher.ts")).toBe(
+        false,
+      );
+      expect(isAllowlistedAssistScratchPath("/project", "src/a.ts")).toBe(false);
+      expect(isAllowlistedAssistScratchPath("/project", "overview/notes.md")).toBe(false);
+      expect(isAllowlistedAssistScratchPath("/project", null)).toBe(false);
+      expect(isAllowlistedAssistScratchPath("/project", ".deft-scratch/../src/a.ts")).toBe(false);
+    });
+
+    it("requires assist/ephemeral classification with scratch path (fail closed without)", () => {
+      expect(
+        isAssistScratchWrite("/project", ".deft-scratch/notes.md", {
+          tool_input: { worker_role: "assist" },
+        }),
+      ).toBe(true);
+      expect(
+        isAssistScratchWrite(
+          "/project",
+          ".deft-scratch/notes.md",
+          {},
+          { [ASSIST_SESSION_POSTURE_ENV]: "assist" },
+        ),
+      ).toBe(true);
+      expect(
+        isAssistScratchWrite("/project", ".deft-scratch/notes.md", {
+          tool_input: { worker_role: "ephemeral" },
+        }),
+      ).toBe(true);
+      // Path alone without posture markers → mutation path (fail closed).
+      expect(isAssistScratchWrite("/project", ".deft-scratch/notes.md", {})).toBe(false);
+      // Assist without allowlisted path → false (tracked stays hard).
+      expect(
+        isAssistScratchWrite("/project", "packages/core/src/a.ts", {
+          tool_input: { worker_role: "assist" },
+        }),
+      ).toBe(false);
+      // Free-text NLP alone is not classification.
+      expect(
+        isAssistScratchWrite("/project", ".deft-scratch/notes.md", {
+          tool_input: { prompt: "for Obsidian do not commit" },
+        }),
+      ).toBe(false);
+    });
+
+    it("allows Write under .deft-scratch/ with assist posture without active scope or ritual", () => {
+      const inspectScope = vi.fn(() => ({
+        ready: false,
+        path: null,
+        message: "No active xBRIEF artifact was found under xbrief/active/",
+      }));
+      const inspectRitual = vi.fn(() => ({
+        ...READY_RITUAL,
+        code: 1,
+        message: "ritual state missing",
+      }));
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Write",
+            cwd: "/project",
+            posture: "assist",
+            tool_input: { file_path: "/project/.deft-scratch/notes.md" },
+          },
+        },
+        readySeams({ inspectScope, inspectRitual }),
+      );
+
+      expect(decision).toMatchObject({
+        verdict: "allow",
+        code: "write-assist-scratch-ready",
+      });
+      expect(inspectScope).not.toHaveBeenCalled();
+      expect(inspectRitual).not.toHaveBeenCalled();
+    });
+
+    it("allows Write under temp/ with ephemeral worker_role without active scope", () => {
+      const decision = decideHook(
+        {
+          host: "cursor",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Write",
+            tool_input: {
+              path: "temp/research/overview.md",
+              worker_role: "ephemeral",
+            },
+          },
+        },
+        noScopeSeams(),
+      );
+
+      expect(decision).toMatchObject({
+        verdict: "allow",
+        code: "write-assist-scratch-ready",
+      });
+    });
+
+    it("allows Write under .deft-scratch/ with DEFT_SESSION_POSTURE=assist", () => {
+      const decision = decideHook(
+        {
+          host: "grok",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            toolName: "Edit",
+            tool_input: { path: ".deft-scratch/obsidian/note.md" },
+          },
+          environ: { [ASSIST_SESSION_POSTURE_ENV]: "assist" },
+        },
+        noScopeSeams(),
+      );
+
+      expect(decision).toMatchObject({
+        verdict: "allow",
+        code: "write-assist-scratch-ready",
+      });
+    });
+
+    it("denies tracked product Write even with assist markers (AC5)", () => {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Write",
+            posture: "assist",
+            tool_input: {
+              file_path: "/project/packages/core/src/hooks/dispatcher.ts",
+              worker_role: "assist",
+            },
+          },
+        },
+        noScopeSeams(),
+      );
+
+      expect(decision).toMatchObject({ verdict: "deny", code: "ritual-not-ready" });
+    });
+
+    it("denies tracked product Write without active scope (no assist marker)", () => {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Write",
+            tool_input: {
+              file_path: "/project/packages/core/src/hooks/dispatcher.ts",
+            },
+          },
+        },
+        readySeams({
+          inspectScope: () => ({
+            ready: false,
+            path: null,
+            message: "No active xBRIEF artifact was found under xbrief/active/",
+          }),
+        }),
+      );
+
+      expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
+      expect(decision.message).toContain(".deft-scratch");
+      expect(decision.message).toMatch(/scope:activate|assist/i);
+    });
+
+    it("fails closed on ambiguous non-scratch Write without assist marker", () => {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Write",
+            // Operator said "for Obsidian" in free text only — not a structural marker.
+            tool_input: {
+              file_path: "/project/overview/notes.md",
+              prompt: "for Obsidian, do not commit",
+            },
+          },
+        },
+        readySeams({
+          inspectScope: () => ({
+            ready: false,
+            path: null,
+            message: "No active xBRIEF artifact was found under xbrief/active/",
+          }),
+        }),
+      );
+
+      expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
+    });
+
+    it("fails closed when scratch path has no assist/ephemeral classification", () => {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Write",
+            tool_input: { file_path: "/project/.deft-scratch/notes.md" },
+          },
+        },
+        readySeams({
+          inspectScope: () => ({
+            ready: false,
+            path: null,
+            message: "No active xBRIEF artifact was found under xbrief/active/",
+          }),
+        }),
+      );
+
+      // Path alone is not enough — need assist/ephemeral structural classification.
+      expect(decision).toMatchObject({ verdict: "deny", code: "scope-not-ready" });
+    });
+
+    it("still denies assist scratch Write under read-only posture", () => {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Write",
+            posture: "assist",
+            tool_input: { file_path: ".deft-scratch/notes.md" },
+          },
+          environ: { [READ_ONLY_HOOK_ENV]: "1" },
+        },
+        noScopeSeams(),
+      );
+
+      expect(decision).toMatchObject({ verdict: "deny", code: "read-only-deny" });
+    });
   });
 
   it("allows Write of xbrief/proposed/*.xbrief.json with no active scope (#2625)", () => {

--- a/packages/core/src/hooks/dispatcher.test.ts
+++ b/packages/core/src/hooks/dispatcher.test.ts
@@ -340,9 +340,9 @@ describe("direct-write hook policy", () => {
         true,
       );
       expect(isAllowlistedAssistScratchPath("/project", "temp/overview/x.md")).toBe(true);
-      expect(isAllowlistedAssistScratchPath("/project", "packages/core/src/hooks/dispatcher.ts")).toBe(
-        false,
-      );
+      expect(
+        isAllowlistedAssistScratchPath("/project", "packages/core/src/hooks/dispatcher.ts"),
+      ).toBe(false);
       expect(isAllowlistedAssistScratchPath("/project", "src/a.ts")).toBe(false);
       expect(isAllowlistedAssistScratchPath("/project", "overview/notes.md")).toBe(false);
       expect(isAllowlistedAssistScratchPath("/project", null)).toBe(false);

--- a/packages/core/src/hooks/dispatcher.ts
+++ b/packages/core/src/hooks/dispatcher.ts
@@ -55,7 +55,12 @@ import {
   missingToolNameMessage,
   record,
 } from "./classify/index.js";
-import { isEphemeralSpawn, isExploreSpawn, isReadOnlyHookContext } from "./readonly.js";
+import {
+  isAssistPosture,
+  isEphemeralSpawn,
+  isExploreSpawn,
+  isReadOnlyHookContext,
+} from "./readonly.js";
 import { type ActiveScopeInspection, inspectActiveScope } from "./scope.js";
 import { isDirectWriteTool, isMcpTool, isShellTool, isSpawnTool } from "./tools.js";
 
@@ -63,7 +68,9 @@ import { isDirectWriteTool, isMcpTool, isShellTool, isSpawnTool } from "./tools.
 // ./index.ts (#2950). Dispatcher is orchestration: classify → policy → decision.
 
 export {
+  ASSIST_SESSION_POSTURE_ENV,
   hookReadOnlyFromPayload,
+  isAssistPosture,
   isEphemeralSpawn,
   isExploreSpawn,
   isReadOnlyHookContext,
@@ -114,6 +121,8 @@ export type HookDecisionCode =
   | "ritual-not-ready"
   | "scope-not-ready"
   | "write-propose-ready"
+  /** Allowlisted assist/scratch write without active xBRIEF (#1802). */
+  | "write-assist-scratch-ready"
   | "write-ready"
   | "read-only-deny"
   | "spawn-explore-ready"
@@ -261,6 +270,51 @@ export function isProposedLifecycleWrite(projectRoot: string, targetPath: string
   const base = posix.includes("/") ? posix.slice(posix.lastIndexOf("/") + 1) : posix;
   if (!hasArtifactSuffix(base)) return false;
   return posix.startsWith("xbrief/proposed/") || posix.startsWith("vbrief/proposed/");
+}
+
+/**
+ * Canonical + gitignored assist scratch roots for low-ceremony disposable notes (#1802).
+ * Path fence only — not free-text "for Obsidian" NLP. Tracked trees (src/, packages/, …)
+ * are never listed here.
+ */
+export const ASSIST_SCRATCH_ROOT_PREFIXES = [".deft-scratch/", "temp/"] as const;
+
+/**
+ * True when the write target is under an allowlisted disposable scratch root (#1802).
+ * Fail closed on null/empty/unparseable targets and on path escape (`..`).
+ * Does not authorize tracked product paths even under assist posture.
+ */
+export function isAllowlistedAssistScratchPath(
+  projectRoot: string,
+  targetPath: string | null,
+): boolean {
+  if (targetPath === null || targetPath.trim().length === 0) return false;
+  const posix = toProjectRelativePosix(projectRoot, targetPath);
+  // resolve()+relative() collapses mid-path `..`; only outside-root `..` remains.
+  if (posix === ".." || posix.startsWith("../") || isAbsolute(posix)) return false;
+  if (isLexicalOutsideProjectRoot(posix)) return false;
+  for (const prefix of ASSIST_SCRATCH_ROOT_PREFIXES) {
+    if (posix === prefix.slice(0, -1) || posix.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Assist/ephemeral classification for scratch-write carve-out (#1802).
+ * Requires allowlisted path AND (assist posture markers OR ephemeral spawn markers).
+ * Path alone without posture markers fails closed to the mutation gate stack.
+ */
+export function isAssistScratchWrite(
+  projectRoot: string,
+  targetPath: string | null,
+  payload: unknown,
+  environ: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!isAllowlistedAssistScratchPath(projectRoot, targetPath)) return false;
+  // Structural classification only — compose with #3080 ephemeral markers.
+  if (isAssistPosture(payload, environ)) return true;
+  if (isEphemeralSpawn(payload)) return true;
+  return false;
 }
 
 function isWindowsDriveOnlyRoot(value: string): boolean {
@@ -692,6 +746,41 @@ function inspectMutationGates(
   options: { proposedLifecycleExempt: boolean },
 ): HookDecision {
   const projectRoot = resolve(input.projectRoot);
+  const environ = input.environ ?? process.env;
+
+  // Assist/scratch low-ceremony writes (#1802): allowlisted gitignored roots under
+  // assist/ephemeral classification skip ritual + active-scope (no fake scope:activate).
+  // Tracked product paths never match the path fence. Read-only still denied upstream.
+  if (!isSpawnTool(toolName)) {
+    const scratchTarget = hookWriteTargetPath(input.payload);
+    if (isAssistScratchWrite(projectRoot, scratchTarget, input.payload, environ)) {
+      const relPath =
+        scratchTarget !== null ? toProjectRelativePosix(projectRoot, scratchTarget) : null;
+      const authzDeny = authzForMutation(input, toolName, seams, {
+        isDirectWrite: true,
+        relPath,
+        scopePath: null,
+      });
+      if (authzDeny !== null) return authzDeny;
+      const runtimeDeny = runtimeAuthorityForDirectWrite(input, toolName, seams, null);
+      if (runtimeDeny !== null) return runtimeDeny;
+      return {
+        verdict: "allow",
+        code: "write-assist-scratch-ready",
+        event: input.event,
+        host: input.host,
+        toolName,
+        projectRoot,
+        message:
+          `Directive write gate allowed ${toolName} under allowlisted assist scratch ` +
+          "root (disposable notes; active scope and story-start not required). " +
+          "Tracked product paths still require mutation gates — do not smuggle source " +
+          "under .deft-scratch/ or temp/.",
+        scopePath: null,
+      };
+    }
+  }
+
   let ritual: VerifyResult;
   try {
     ritual = (
@@ -806,8 +895,14 @@ function inspectMutationGates(
         proposedPathHint =
           " Recovery: run `deft scope:activate -- <path>` for the approved xBRIEF, " +
           (options.proposedLifecycleExempt
-            ? "or Write a new proposal to xbrief/proposed/*.xbrief.json (planning exemption)."
-            : "then re-run the pre-start_agent gate stack.");
+            ? "or Write a new proposal to xbrief/proposed/*.xbrief.json (planning exemption), " +
+              "or for disposable research notes write under `.deft-scratch/` (or `temp/`) " +
+              "with assist/ephemeral posture (`DEFT_SESSION_POSTURE=assist` or " +
+              "`worker_role: assist` / ephemeral — see commands.md #1802 / #3080). " +
+              "Do not invent a fake scope only to capture Obsidian/scratch notes."
+            : "then re-run the pre-start_agent gate stack. " +
+              "For disposable research notes only: write under `.deft-scratch/` with " +
+              "assist posture (commands.md #1802) — do not fake `scope:activate` for notes.");
       }
       const denyCode = isSpawnTool(toolName) ? "spawn-not-ready" : "scope-not-ready";
       return deny(

--- a/packages/core/src/hooks/fixtures/README.md
+++ b/packages/core/src/hooks/fixtures/README.md
@@ -62,6 +62,7 @@ Agents, host adapters, and tests **must** key permission outcomes off `HookDecis
 | `ritual-not-ready` | deny | Gated session ritual not fresh |
 | `scope-not-ready` | deny | No active running scope for in-root write |
 | `write-propose-ready` | allow | Write to proposed lifecycle path allowed |
+| `write-assist-scratch-ready` | allow | Allowlisted assist/scratch write without active xBRIEF (#1802) |
 | `write-ready` | allow | Direct write allowed under ready gates |
 | `read-only-deny` | deny | `DEFT_HOOK_READ_ONLY` / read-only posture |
 | `spawn-explore-ready` | allow | Explore-class spawn allowed |

--- a/packages/core/src/hooks/readonly.test.ts
+++ b/packages/core/src/hooks/readonly.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  ASSIST_SESSION_POSTURE_ENV,
   hookReadOnlyFromPayload,
+  isAssistPosture,
   isEphemeralSpawn,
   isExploreSpawn,
   isReadOnlyHookContext,
@@ -89,6 +91,37 @@ describe("ephemeral spawn detection (#3080)", () => {
     expect(
       isEphemeralSpawn({
         tool_input: { worker_role: "ephemeral", driveTo: "merge" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("assist posture detection (#1802)", () => {
+  it("recognizes DEFT_SESSION_POSTURE env and DEFT_HOOK_ASSIST", () => {
+    expect(isAssistPosture({}, { [ASSIST_SESSION_POSTURE_ENV]: "assist" })).toBe(true);
+    expect(isAssistPosture({}, { [ASSIST_SESSION_POSTURE_ENV]: "research-notes" })).toBe(true);
+    expect(isAssistPosture({}, { DEFT_HOOK_ASSIST: "1" })).toBe(true);
+    expect(isAssistPosture({}, { [ASSIST_SESSION_POSTURE_ENV]: "mutation" })).toBe(false);
+    expect(isAssistPosture({}, {})).toBe(false);
+  });
+
+  it("recognizes payload posture and ephemeral role markers", () => {
+    expect(isAssistPosture({ posture: "assist" })).toBe(true);
+    expect(isAssistPosture({ session_posture: "scratch" })).toBe(true);
+    expect(isAssistPosture({ tool_input: { worker_role: "ephemeral" } })).toBe(true);
+    expect(isAssistPosture({ tool_input: { worker_role: "assist" } })).toBe(true);
+  });
+
+  it("fails closed on free-text / unmarked payloads (no NLP)", () => {
+    expect(isAssistPosture({ tool_input: { prompt: "for Obsidian, do not commit" } })).toBe(false);
+    expect(isAssistPosture({ tool_input: { subagent_type: "generalPurpose" } })).toBe(false);
+    expect(isAssistPosture(null)).toBe(false);
+  });
+
+  it("implement conflict on ephemeral spawn is not assist posture", () => {
+    expect(
+      isAssistPosture({
+        tool_input: { worker_role: "ephemeral", drive_to: "merge-ready" },
       }),
     ).toBe(false);
   });

--- a/packages/core/src/hooks/readonly.ts
+++ b/packages/core/src/hooks/readonly.ts
@@ -2,6 +2,23 @@ import { READ_ONLY_HOOK_ENV } from "./tools.js";
 
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 
+/** Session posture env for assist/research low-ceremony writes (#1802). */
+export const ASSIST_SESSION_POSTURE_ENV = "DEFT_SESSION_POSTURE";
+
+/** Explicit non-lifecycle assist markers (#3080 / #1802). Primary: ephemeral; aliases: docs, assist. */
+const EPHEMERAL_ROLE_MARKERS = new Set(["ephemeral", "docs", "assist"]);
+
+/** Assist/research session posture tokens (structural; not free-text NLP) (#1802). */
+const ASSIST_POSTURE_MARKERS = new Set([
+  "assist",
+  "ephemeral",
+  "docs",
+  "research",
+  "research-notes",
+  "research_notes",
+  "scratch",
+]);
+
 function record(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -33,6 +50,10 @@ function isReadOnlyCapability(value: string | null): boolean {
   if (value === null) return false;
   const normalized = value.toLowerCase().replace(/[_\s-]/g, "");
   return normalized === "readonly";
+}
+
+function normalizePostureToken(value: string): string {
+  return value.toLowerCase().replace(/[_\s]/g, "-");
 }
 
 /** Best-effort read-only explore signal from host payload (#1185). */
@@ -89,8 +110,39 @@ export function isExploreSpawn(payload: unknown): boolean {
   return workerRole?.toLowerCase() === "explore";
 }
 
-/** Explicit non-lifecycle assist markers (#3080). Primary: ephemeral; aliases: docs, assist. */
-const EPHEMERAL_ROLE_MARKERS = new Set(["ephemeral", "docs", "assist"]);
+/**
+ * Assist / research / ephemeral session posture for low-ceremony scratch writes (#1802).
+ * Structural markers only (env, payload posture fields, worker_role/subagent_type).
+ * Absent marker → false (fail closed). Compose with allowlisted scratch path fence.
+ */
+export function isAssistPosture(
+  payload: unknown,
+  environ: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const envPosture = (environ[ASSIST_SESSION_POSTURE_ENV] ?? "").trim();
+  if (envPosture.length > 0 && ASSIST_POSTURE_MARKERS.has(normalizePostureToken(envPosture))) {
+    return true;
+  }
+  // Explicit assist env override (truthy), separate from posture token names.
+  if (envTruthy(environ, "DEFT_HOOK_ASSIST")) return true;
+
+  const input = record(payload);
+  if (input === null) return false;
+  const toolInput = toolInputRecord(input) ?? input;
+  const posture =
+    fieldString(toolInput, "posture") ??
+    fieldString(toolInput, "session_posture") ??
+    fieldString(toolInput, "sessionPosture") ??
+    fieldString(input, "posture") ??
+    fieldString(input, "session_posture") ??
+    fieldString(input, "sessionPosture");
+  if (posture !== null && ASSIST_POSTURE_MARKERS.has(normalizePostureToken(posture))) {
+    return true;
+  }
+  // Shared taxonomy with #3080 ephemeral spawn markers.
+  if (isEphemeralSpawn(payload)) return true;
+  return false;
+}
 
 /**
  * Structural implement signals that win over an ephemeral marker (fail closed, #3080).


### PR DESCRIPTION
## Summary

Implements #1802 (cohort twin of #3080): **assist/research posture** + allowlisted gitignored scratch roots so disposable notes do not require story-start or active xBRIEF, while tracked product writes stay hard-gated.

### Behavior
- **Path fence:** `.deft-scratch/**` (canonical) and `temp/**`
- **Classification:** structural only — `DEFT_SESSION_POSTURE=assist`, payload `posture`/`session_posture`, `DEFT_HOOK_ASSIST=1`, or #3080 `worker_role`/`subagent_type` ∈ {`ephemeral`,`docs`,`assist`}
- **Allow:** Write/Edit under allowlist + assist/ephemeral → `write-assist-scratch-ready` (skips ritual + scope)
- **Deny:** tracked product paths under any posture; path alone without markers; free-text NLP alone
- **Docs:** `content/commands.md` assist vs mutation table; cross-link #3080 spawn postures; anti-pattern fake `scope:activate` for notes
- **Deny recovery:** scope-not-ready messages mention assist scratch path

### Tests
`pnpm exec vitest run packages/core/src/hooks` — scratch allow / tracked deny / fail-closed / read-only still blocks.

## Test plan
- [x] Unit: allow `.deft-scratch/` + assist without active scope
- [x] Unit: allow `temp/` + ephemeral worker_role
- [x] Unit: deny `packages/...` even with assist markers
- [x] Unit: fail closed outside allowlist / without markers
- [x] Unit: read-only still denies assist scratch writes

Closes #1802.