### PR TITLE
fix(pr-monitor): pass projectRoot for minGreptileConfidence resolve (#3095 residual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **fix(pr-monitor): pass --project-root from CLI and pr-wait-mergeable cascade into confidence policy resolve (#3102).** Residual from #3095: production remote-monitor path no longer silently uses an unrelated cwd for minGreptileConfidence. Closes residual of #3095.
+
 - **Triage cache + `issue:ingest` surface #1152 Current shape comments (#1870).** Umbrella/tracker issues no longer plan from body-only cache or body-only Overview: `cache:fetch-all` fetches comment threads for epic/meta/tracker-like issues, `content.md` appends the canonical maintainer-authored `## Current shape (as of pass-N)` section (same selector as `task umbrella:current-shape`), and `current-shape.json` sidecar stores body + permalink. `issue:ingest` materializes `plan.narratives.CurrentShape` plus an `x-xbrief/current-shape` reference to the comment permalink (still keeps full #2143 comment thread in Overview). Non-maintainer forgeries ignored (#2307). Closes #1870. Refs #1152, #1649, #2143.
 
 - **Umbrella body checkboxes + §1152 current-shape auto-sync to child state (#1649).** `task vbrief:reconcile:umbrellas` now (1) reconciles issue-body `- [ ] #N` / `- [x] #N` checkboxes via forge open/closed, (2) resolves children from both `x-*/plan` and `x-*/github-issue` refs (hand-filed / `issue:emit` epics no longer compute a 0-child shape), (3) prefers forge issue state over xBRIEF lifecycle folder for open/closed with folder fallback, and (4) runs best-effort after successful `pr:wait-mergeable-and-merge` (in addition to `scope:complete`). Idempotent; skips body writes when already correct. Closes #1649. Refs #1152, #1289, #1284.

--- a/packages/core/src/pr-monitor/main.test.ts
+++ b/packages/core/src/pr-monitor/main.test.ts
@@ -27,6 +27,25 @@ describe("parseMonitorArgs", () => {
       repo: "deftai/directive",
       capMinutes: 30,
       emitJson: true,
+      projectRoot: null,
+    });
+  });
+
+  it("parses --project-root for remote-monitor policy resolve (#3102)", () => {
+    expect(
+      parseMonitorArgs([
+        "1363",
+        "--repo",
+        "deftai/directive",
+        "--project-root",
+        "/tmp/consumer",
+        "--json",
+      ]),
+    ).toMatchObject({
+      prNumber: 1363,
+      repo: "deftai/directive",
+      projectRoot: "/tmp/consumer",
+      emitJson: true,
     });
   });
 

--- a/packages/core/src/pr-monitor/main.ts
+++ b/packages/core/src/pr-monitor/main.ts
@@ -16,6 +16,8 @@ export interface ParsedMonitorArgs {
   readonly repo: string | null;
   readonly capMinutes: number;
   readonly emitJson: boolean;
+  /** Project root for minGreptileConfidence (#3095 / #3102). Null = default cwd at run. */
+  readonly projectRoot: string | null;
   readonly error?: string;
 }
 
@@ -24,6 +26,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
   let repo: string | null = null;
   let capMinutes = 60;
   let emitJson = false;
+  let projectRoot: string | null = null;
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -37,6 +40,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
           repo,
           capMinutes,
           emitJson,
+          projectRoot,
           error: "argument --repo: expected one argument",
         };
       }
@@ -44,6 +48,22 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
       i += 1;
     } else if (arg?.startsWith("--repo=")) {
       repo = arg.slice("--repo=".length);
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return {
+          prNumber,
+          repo,
+          capMinutes,
+          emitJson,
+          projectRoot,
+          error: "argument --project-root: expected one argument",
+        };
+      }
+      projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      projectRoot = arg.slice("--project-root=".length);
     } else if (arg === "--cap-minutes") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -52,6 +72,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
           repo,
           capMinutes,
           emitJson,
+          projectRoot,
           error: "argument --cap-minutes: expected one argument",
         };
       }
@@ -62,6 +83,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
           repo,
           capMinutes,
           emitJson,
+          projectRoot,
           error: `invalid --cap-minutes value: ${value}`,
         };
       }
@@ -76,6 +98,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
           repo,
           capMinutes,
           emitJson,
+          projectRoot,
           error: `invalid --cap-minutes value: ${value}`,
         };
       }
@@ -86,6 +109,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
         repo,
         capMinutes,
         emitJson,
+        projectRoot,
         error: `unrecognized arguments: ${arg}`,
       };
     } else if (prNumber === null) {
@@ -96,6 +120,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
           repo,
           capMinutes,
           emitJson,
+          projectRoot,
           error: `invalid PR number: ${arg}`,
         };
       }
@@ -106,6 +131,7 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
         repo,
         capMinutes,
         emitJson,
+        projectRoot,
         error: `unrecognized arguments: ${arg}`,
       };
     }
@@ -117,10 +143,11 @@ export function parseMonitorArgs(argv: readonly string[]): ParsedMonitorArgs {
       repo,
       capMinutes,
       emitJson,
+      projectRoot,
       error: "the following arguments are required: pr_number",
     };
   }
-  return { prNumber, repo, capMinutes, emitJson };
+  return { prNumber, repo, capMinutes, emitJson, projectRoot };
 }
 
 export interface RunMonitorOptions {
@@ -145,6 +172,9 @@ export function runMonitor(argv: readonly string[], options: RunMonitorOptions =
   const { exitCode, payload, pollCount } = monitorFn(args.prNumber as number, repo, {
     capMinutes: args.capMinutes,
     runGh: options.runGh,
+    // CLI --project-root or cwd: production remote-monitor path must not silently
+    // resolve minGreptileConfidence from an unrelated cwd (#3095 residual / #3102).
+    projectRoot: args.projectRoot ?? process.cwd(),
   });
 
   const summaryLabel = summaryLabelForExit(exitCode);

--- a/packages/core/src/pr-monitor/monitor.ts
+++ b/packages/core/src/pr-monitor/monitor.ts
@@ -165,7 +165,12 @@ export function monitor(
   const clockFn = options.clockFn ?? systemMonotonicClock;
   const sleepFn = options.sleepFn ?? defaultSleep;
   const callReadinessFn =
-    options.callReadinessFn ?? ((n, r) => callReadiness(n, r, { runGh: options.runGh }));
+    options.callReadinessFn ??
+    ((n, r) =>
+      callReadiness(n, r, {
+        runGh: options.runGh,
+        projectRoot: options.projectRoot ?? process.cwd(),
+      }));
 
   const startedAt = clockFn.now();
   const intervalSchedule = cadenceIntervals(cadence);

--- a/packages/core/src/pr-monitor/readiness.ts
+++ b/packages/core/src/pr-monitor/readiness.ts
@@ -37,7 +37,9 @@ export function callReadiness(
   try {
     process.stderr.write = captureWrite;
     const runGh = options.runGh ?? defaultRunGh;
-    const result = computeGateResult(prNumber, repo, runGh);
+    const result = computeGateResult(prNumber, repo, runGh, {
+      projectRoot: options.projectRoot ?? process.cwd(),
+    });
     const payload = gateResultToDict(result);
     const exitCode = exitCodeFor(result);
     return {

--- a/packages/core/src/pr-monitor/types.ts
+++ b/packages/core/src/pr-monitor/types.ts
@@ -22,6 +22,12 @@ export interface MonitorOptions {
   readonly clockFn?: MonotonicClock;
   readonly callReadinessFn?: CallReadinessFn;
   readonly runGh?: RunGhFn;
+  /**
+   * Project root for plan.policy.review.minGreptileConfidence (#3095).
+   * When pr-monitor targets a remote repo from a different cwd, pass the
+   * monitored project's root so confidence policy is not resolved from cwd.
+   */
+  readonly projectRoot?: string | null;
 }
 
 export interface MonitorRunResult {
@@ -33,4 +39,6 @@ export interface MonitorRunResult {
 export interface CallReadinessOptions {
   readonly runGh?: RunGhFn;
   readonly timeoutMs?: number;
+  /** Project root for minGreptileConfidence resolve (#3095). */
+  readonly projectRoot?: string | null;
 }

--- a/packages/core/src/pr-wait-mergeable/cascade.ts
+++ b/packages/core/src/pr-wait-mergeable/cascade.ts
@@ -156,7 +156,9 @@ export function waitMergeableAndMerge(
     });
   }
 
-  const [monRc, monStdout, monStderr] = monitorFn(prNumber, repo, options.capMinutes);
+  const [monRc, monStdout, monStderr] = monitorFn(prNumber, repo, options.capMinutes, {
+    projectRoot,
+  });
   const monitorPayload = parseMonitorPayload(monStdout);
   const [outcome, monitorExit] = classifyMonitorOutcome(monRc, monitorPayload);
 

--- a/packages/core/src/pr-wait-mergeable/main.test.ts
+++ b/packages/core/src/pr-wait-mergeable/main.test.ts
@@ -34,6 +34,22 @@ describe("parseWaitMergeableArgs", () => {
       cascadeMode: false,
       requireMasterCiGreen: false,
       baseBranch: null,
+      projectRoot: null,
+    });
+  });
+
+  it("parses --project-root for remote confidence policy (#3102)", () => {
+    expect(
+      parseWaitMergeableArgs([
+        "1370",
+        "--repo",
+        "deftai/directive",
+        "--project-root",
+        "/tmp/consumer-project",
+      ]),
+    ).toMatchObject({
+      prNumber: 1370,
+      projectRoot: "/tmp/consumer-project",
     });
   });
 

--- a/packages/core/src/pr-wait-mergeable/main.ts
+++ b/packages/core/src/pr-wait-mergeable/main.ts
@@ -21,6 +21,8 @@ export interface ParsedWaitMergeableArgs {
   readonly cascadeMode: boolean;
   readonly requireMasterCiGreen: boolean;
   readonly baseBranch: string | null;
+  /** Project root for minGreptileConfidence (#3095 / #3102). Null = cwd at run. */
+  readonly projectRoot: string | null;
   readonly error?: string;
 }
 
@@ -33,6 +35,7 @@ export function parseWaitMergeableArgs(argv: readonly string[]): ParsedWaitMerge
   let cascadeMode = false;
   let requireMasterCiGreen = false;
   let baseBranch: string | null = null;
+  let projectRoot: string | null = null;
 
   const baseReturn = (): Omit<ParsedWaitMergeableArgs, "error"> => ({
     prNumber,
@@ -43,6 +46,7 @@ export function parseWaitMergeableArgs(argv: readonly string[]): ParsedWaitMerge
     cascadeMode,
     requireMasterCiGreen,
     baseBranch,
+    projectRoot,
   });
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -62,6 +66,15 @@ export function parseWaitMergeableArgs(argv: readonly string[]): ParsedWaitMerge
       i += 1;
     } else if (arg?.startsWith("--base-branch=")) {
       baseBranch = arg.slice("--base-branch=".length);
+    } else if (arg === "--project-root") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...baseReturn(), error: "argument --project-root: expected one argument" };
+      }
+      projectRoot = value;
+      i += 1;
+    } else if (arg?.startsWith("--project-root=")) {
+      projectRoot = arg.slice("--project-root=".length);
     } else if (arg === "--repo") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -173,6 +186,9 @@ export function runWaitMergeable(
     cascadeMode: args.cascadeMode,
     requireMasterCiGreen: args.requireMasterCiGreen,
     baseBranch: args.baseBranch,
+    // Explicit CLI root (or cwd) so remote-target cascade does not resolve
+    // minGreptileConfidence from an unrelated directory (#3102).
+    projectRoot: args.projectRoot ?? process.cwd(),
   });
 
   const summaryLabel = summaryLabelForExit(result.exitCode);

--- a/packages/core/src/pr-wait-mergeable/types.ts
+++ b/packages/core/src/pr-wait-mergeable/types.ts
@@ -19,6 +19,11 @@ export type ProtectedCheckFn = (
   protectedIssues: readonly number[],
 ) => SubprocessTriple;
 
-export type MonitorFn = (prNumber: number, repo: string, capMinutes: number) => SubprocessTriple;
+export type MonitorFn = (
+  prNumber: number,
+  repo: string,
+  capMinutes: number,
+  options?: { readonly projectRoot?: string },
+) => SubprocessTriple;
 
 export type MergeFn = (prNumber: number, repo: string | null) => SubprocessTriple;

--- a/packages/core/src/pr-wait-mergeable/wrappers.ts
+++ b/packages/core/src/pr-wait-mergeable/wrappers.ts
@@ -141,6 +141,12 @@ export function runProtectedCheck(
 export interface RunMonitorOptions {
   readonly nodeExecutable?: string;
   readonly timeout?: number;
+  /**
+   * Project root for plan.policy.review.minGreptileConfidence when the
+   * cascade cwd is not the monitored project (#3095 residual / #3102).
+   * Defaults to process.cwd() when omitted.
+   */
+  readonly projectRoot?: string;
 }
 
 /** Invoke pr-monitor CLI with --json and return (returncode, stdout, stderr). */
@@ -156,6 +162,7 @@ export function runMonitor(
   }
   const node = options.nodeExecutable ?? process.execPath;
   const timeoutSec = options.timeout ?? capMinutes * 60 + 60;
+  const projectRoot = options.projectRoot ?? process.cwd();
   const cmd: string[] = [
     scriptPath,
     String(prNumber),
@@ -163,6 +170,8 @@ export function runMonitor(
     repo,
     "--cap-minutes",
     String(capMinutes),
+    "--project-root",
+    projectRoot,
     "--json",
   ];
   // Stream the monitor's per-poll heartbeat live (a buffered poll looks like a

--- a/xbrief/completed/2026-08-03-3095-greptile-confidence-5-dogfood-consumer-lever.xbrief.json
+++ b/xbrief/completed/2026-08-03-3095-greptile-confidence-5-dogfood-consumer-lever.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF for GitHub issue #3095 — dogfood Greptile CLEAN 5/5 + consumer min-confidence policy",
-    "updated": "2026-08-03T19:16:56Z"
+    "updated": "2026-08-03T20:06:14Z"
   },
   "plan": {
     "title": "feat(policy,review): dogfood Greptile CLEAN requires 5/5; consumers get per-project min-confidence lever",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Directive dogfood CLEAN requires Greptile confidence 5/5 (not merely >3/4/5). Consumers get typed plan.policy.review.minGreptileConfidence (or equivalent); default remains >3. Align pr:watch, merge-ready, review-cycle Step 6, greptile.md, swarm poller.",
       "Origin": "https://github.com/deftai/directive/issues/3095",
@@ -46,8 +46,27 @@
           "content/tools/greptile.md",
           "CHANGELOG.md"
         ]
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3099,
+        "prBase": null,
+        "mergeCommit": "658dc7697b5da783e72af685a2817224cbe2d5cd",
+        "deliveryBranch": "master",
+        "deliveryCommit": "658dc7697b5da783e72af685a2817224cbe2d5cd",
+        "verifiedAt": "2026-08-03T20:06:14Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-03T20:06:14Z",
+      "capacityBucket": "new-capability"
     },
-    "updated": "2026-08-03T19:16:56Z"
+    "updated": "2026-08-03T20:06:14Z"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up residual from #3099 / #3095: pass `projectRoot` through `pr-monitor` readiness so confidence policy is not resolved from an unrelated cwd when monitoring a remote target.

Greptile held conf=4 on the last pre-merge tip for this gap; the main dogfood/policy work already landed in #3099.

## Test plan

- [x] pr-monitor unit tests pass
- [ ] CI green

Related: #3095