### PR TITLE
fix(slash): point /deft:checkpoint wrappers at continue-here.md (#3105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **/deft:checkpoint host wrappers load continue-here strategy, not save-path output (#3105).** Multi-host slash deposit for `/deft:checkpoint` pointed thin wrappers at `xbrief/continue.xbrief.json` (checkpoint *output*). First invoke failed on clean consumers when that file did not exist yet. Wrappers now load `resilience/continue-here.md` (same instruction doc as `/deft:continue`); description and `commands.md` still document the save path. Closes #3105.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- **/deft:checkpoint host wrappers load continue-here strategy, not save-path output (#3105).** Multi-host slash deposit for `/deft:checkpoint` pointed thin wrappers at `xbrief/continue.xbrief.json` (checkpoint *output*). First invoke failed on clean consumers when that file did not exist yet. Wrappers now load `resilience/continue-here.md` (same instruction doc as `/deft:continue`); description and `commands.md` still document the save path. Closes #3105.
+- **/deft:checkpoint host wrappers load continue-here strategy, not save-path output (#3105).** Multi-host slash deposit for `/deft:checkpoint` pointed thin wrappers at `xbrief/continue.xbrief.json` (checkpoint *output*). First invoke failed on clean consumers when that file did not exist yet. Wrappers now load `resilience/continue-here.md` (same instruction doc as `/deft:continue`); description and `commands.md` still document the save path. Strategy doc write target aligned to `./xbrief/continue.xbrief.json` (legacy vbrief path read-accepted). Closes #3105.
 
 ### Removed
 

--- a/content/commands.md
+++ b/content/commands.md
@@ -55,7 +55,7 @@ When the user types a product slash command, agents MUST route to the correspond
 These commands are NOT migrated — they operate on shared xBRIEF session abstractions usable across Deft products:
 
 - `/deft:continue` — Resume from continue checkpoint ([resilience/continue-here.md](./resilience/continue-here.md))
-- `/deft:checkpoint` — Save session state to `./xbrief/continue.xbrief.json`
+- `/deft:checkpoint` — Save session state to `./xbrief/continue.xbrief.json` (same strategy doc: [resilience/continue-here.md](./resilience/continue-here.md); wrappers load that path, not the save-file output)
 
 ### Deprecation aliases (prior `/deft:*` product forms)
 

--- a/content/conventions/rule-ownership.json
+++ b/content/conventions/rule-ownership.json
@@ -212,11 +212,11 @@
     },
     {
       "id": "resilience-session-continuity",
-      "text": "Persist to `./vbrief/continue.vbrief.json` in vBRIEF format",
+      "text": "Persist to `./xbrief/continue.xbrief.json` in xBRIEF format",
       "owner_file": "content/resilience/continue-here.md",
       "owner_section": "## Continue Checkpoint Contents",
       "authority": "MUST",
-      "last_verified": "2026-04-28"
+      "last_verified": "2026-08-04"
     },
     {
       "id": "context-engineering-write-strategy",

--- a/content/resilience/continue-here.md
+++ b/content/resilience/continue-here.md
@@ -25,14 +25,14 @@ Sessions end. Work must not be lost. A fresh session must resume from **exactly*
 
 ## Continue Checkpoint Contents
 
-Persist to `./vbrief/continue.vbrief.json` in vBRIEF format:
+Persist to `./xbrief/continue.xbrief.json` in xBRIEF format (legacy `./vbrief/continue.vbrief.json` is read-accepted until migrated):
 
-- ! **Completed** — what's already done (vBRIEF items with `completed` status)
-- ! **Remaining** — what's left (vBRIEF items with `pending` status)
-- ! **Decisions** — choices made during this session (vBRIEF narratives)
+- ! **Completed** — what's already done (xBRIEF items with `completed` status)
+- ! **Remaining** — what's left (xBRIEF items with `pending` status)
+- ! **Decisions** — choices made during this session (xBRIEF narratives)
 - ~ **Hazards** — what was tricky, what to watch out for (narrative)
 - ! **Resume point** — the exact first thing to do when resuming (narrative on the next `pending` item)
-- ! **Scope vBRIEF reference** — when scope vBRIEFs exist, MUST include `planRef` to the scope vBRIEF(s) the agent was working on (enables the resuming agent to load the durable scope record)
+- ! **Scope xBRIEF reference** — when scope xBRIEFs exist, MUST include `planRef` to the scope xBRIEF(s) the agent was working on (enables the resuming agent to load the durable scope record)
 
 ## Resume Protocol
 
@@ -47,8 +47,8 @@ Persist to `./vbrief/continue.vbrief.json` in vBRIEF format:
 
 - ! Continue checkpoints are **ephemeral** — consumed on resume, not permanent records
 - ~ Durable learnings from the session → persist to [meta/lessons.md](../../meta/lessons.md)
-- ~ Durable state → persist to the task's vBRIEF plan file or scope vBRIEF(s) in lifecycle folders
-- ! Scope vBRIEFs (`./vbrief/{proposed,pending,active,completed,cancelled}/`) are **durable** — they persist across sessions and are shared between agents; do not conflate them with ephemeral continue checkpoints
+- ~ Durable state → persist to the task's xBRIEF plan file or scope xBRIEF(s) in lifecycle folders
+- ! Scope xBRIEFs (`./xbrief/{proposed,pending,active,completed,cancelled}/`; legacy `./vbrief/` read-accepted) are **durable** — they persist across sessions and are shared between agents; do not conflate them with ephemeral continue checkpoints
 - ⊗ Accumulate stale continue checkpoints — clean up after resume
 
 ---
@@ -59,4 +59,4 @@ Persist to `./vbrief/continue.vbrief.json` in vBRIEF format:
 - ⊗ Re-reading full conversation history instead of the continue checkpoint
 - ⊗ Losing in-flight decisions because they weren't persisted
 - ⊗ Starting over from scratch after an interruption
-- ⊗ Creating `continue-{ULID}.json` — the file is singular: `continue.vbrief.json`
+- ⊗ Creating `continue-{ULID}.json` — the file is singular: `continue.xbrief.json`

--- a/packages/core/src/init-deposit/slash-deposit.test.ts
+++ b/packages/core/src/init-deposit/slash-deposit.test.ts
@@ -45,6 +45,16 @@ describe("writeSlashCommandDeposit (#3054)", () => {
       expect(existsSync(sample)).toBe(true);
       const body = readFileSync(sample, "utf8");
       expect(isThinWrapperMarkdown(body, "resilience/continue-here.md")).toBe(true);
+
+      // #3105: checkpoint wrappers load the strategy doc, not the save-path output file.
+      const checkpoint = join(root, layout.relativeDir, "deft-checkpoint.md");
+      expect(existsSync(checkpoint)).toBe(true);
+      const checkpointBody = readFileSync(checkpoint, "utf8");
+      expect(isThinWrapperMarkdown(checkpointBody, "resilience/continue-here.md")).toBe(true);
+      expect(checkpointBody).toContain("Read and follow `resilience/continue-here.md`");
+      expect(checkpointBody).not.toContain("Read and follow `xbrief/continue.xbrief.json`");
+      // Description frontmatter still documents the save path (commands.md parity).
+      expect(checkpointBody).toMatch(/description:.*xbrief\/continue\.xbrief\.json/);
     }
     expect(lines.some((l) => l.includes("Installed Directive slash commands"))).toBe(true);
   });

--- a/packages/core/src/slash/product-set.test.ts
+++ b/packages/core/src/slash/product-set.test.ts
@@ -72,6 +72,16 @@ describe("slash product-set (#3052 / #55 L2)", () => {
     expect(getProductCommand("/missing")).toBeUndefined();
   });
 
+  it("loads /deft:checkpoint via continue-here strategy, not the save-path output (#3105)", () => {
+    const checkpoint = getProductCommand("/deft:checkpoint");
+    expect(checkpoint?.dispatchPath).toBe("resilience/continue-here.md");
+    // Save path stays documented on the product description (and commands.md).
+    expect(checkpoint?.description).toMatch(/xbrief\/continue\.xbrief\.json/);
+    // Same instruction doc as /deft:continue; do not dispatch at the ephemeral output file.
+    expect(getProductCommand("/deft:continue")?.dispatchPath).toBe("resilience/continue-here.md");
+    expect(checkpoint?.dispatchPath).not.toBe("xbrief/continue.xbrief.json");
+  });
+
   it("rejects logical ids without a leading slash", () => {
     expect(() => logicalIdToFilenameStem("deft:continue")).toThrow(/must start with/);
   });

--- a/packages/core/src/slash/product-set.ts
+++ b/packages/core/src/slash/product-set.ts
@@ -131,9 +131,12 @@ export const PRODUCT_COMMANDS: readonly ProductCommand[] = Object.freeze([
   {
     logicalId: "/deft:checkpoint",
     filenameStem: "deft-checkpoint",
+    // description documents the save path; wrappers load the strategy doc (same as continue).
+    // ⊗ Point dispatchPath at xbrief/continue.xbrief.json — that file is the checkpoint *output*,
+    // not the instruction doc; first invoke fails when it does not exist yet (#3105).
     description: "Save session state to xbrief/continue.xbrief.json",
     dispatchKind: "session",
-    dispatchPath: "xbrief/continue.xbrief.json",
+    dispatchPath: "resilience/continue-here.md",
   },
 ] satisfies readonly ProductCommand[]);
 


### PR DESCRIPTION
## Summary
`/deft:checkpoint` multi-host thin wrappers were depositing a load pointer at `xbrief/continue.xbrief.json` (the checkpoint **output**). On a clean consumer the file does not exist yet, so first invoke fails. `/deft:continue` already loads `resilience/continue-here.md`.

## Changes
- Product table: `dispatchPath` for `/deft:checkpoint` → `resilience/continue-here.md` (same strategy as continue)
- Description + `commands.md` still document the save path `xbrief/continue.xbrief.json`
- Regression tests in product-set + slash-deposit
- CHANGELOG [Unreleased]

## Acceptance
- [x] AC-1: Deposited checkpoint wrappers (claude/cursor/codex/grok) read `resilience/continue-here.md`
- [x] AC-2: First invocation no longer requires pre-existing `continue.xbrief.json`
- [x] AC-3: Automated tests + CHANGELOG #3105

## Test plan
- [x] `pnpm exec vitest run packages/core/src/slash packages/core/src/init-deposit`
- [x] `pnpm run lint` / `pnpm run build`
- [x] `task verify:forward-coverage`

Closes #3105