### PR TITLE
test(coverage): restore Vitest branches >=85% after v0.94.0 hairline (#3103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **/deft:checkpoint host wrappers load continue-here strategy, not save-path output (#3105).** Multi-host slash deposit for `/deft:checkpoint` pointed thin wrappers at `xbrief/continue.xbrief.json` (checkpoint *output*). First invoke failed on clean consumers when that file did not exist yet. Wrappers now load `resilience/continue-here.md` (same instruction doc as `/deft:continue`); description and `commands.md` still document the save path. Strategy doc write target aligned to `./xbrief/continue.xbrief.json` (legacy vbrief path read-accepted). Closes #3105.
+- **Vitest branch coverage restored above 85% (#3103).** Focused L4 owner gate parse/config CLI edges and min-Greptile confidence policy reader branches clear the v0.94.0 84.99% hairline so release Step 5 passes without `--allow-coverage-debt`. Closes #3103.
 
 ### Removed
 

--- a/packages/cli/src/verify-l4-owner.test.ts
+++ b/packages/cli/src/verify-l4-owner.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { parseVerifyL4OwnerArgs, run } from "./verify-l4-owner.js";
 
@@ -8,6 +11,42 @@ describe("verify-l4-owner CLI (#3090)", () => {
     expect(args.reviewCycle).toBe("done");
     expect(args.emitJson).toBe(true);
     expect(args.error).toBeUndefined();
+  });
+
+  it("covers equals-form flags and missing-value errors (#3103)", () => {
+    const ok = parseVerifyL4OwnerArgs([
+      "--pr=7",
+      "--repo=acme/widgets",
+      "--head-sha=deadbeef",
+      "--project-root=/tmp/p",
+      "--review-cycle=skipped:no-pr",
+      "--json",
+    ]);
+    expect(ok).toMatchObject({
+      pr: 7,
+      repo: "acme/widgets",
+      headSha: "deadbeef",
+      projectRoot: "/tmp/p",
+      reviewCycle: "skipped:no-pr",
+      emitJson: true,
+    });
+
+    expect(parseVerifyL4OwnerArgs(["--pr"]).error).toMatch(/--pr: expected one argument/);
+    expect(parseVerifyL4OwnerArgs(["--pr", "0"]).error).toMatch(/invalid --pr/);
+    expect(parseVerifyL4OwnerArgs(["--pr=abc"]).error).toMatch(/invalid --pr/);
+    expect(parseVerifyL4OwnerArgs(["--repo"]).error).toMatch(/--repo: expected one argument/);
+    expect(parseVerifyL4OwnerArgs(["--head-sha"]).error).toMatch(
+      /--head-sha: expected one argument/,
+    );
+    expect(parseVerifyL4OwnerArgs(["--project-root"]).error).toMatch(
+      /--project-root: expected one argument/,
+    );
+    expect(parseVerifyL4OwnerArgs(["--review-cycle"]).error).toMatch(
+      /--review-cycle: expected one argument/,
+    );
+    expect(parseVerifyL4OwnerArgs(["--nope"]).error).toMatch(/unrecognized argument/);
+    expect(parseVerifyL4OwnerArgs(["positional"]).error).toMatch(/unrecognized argument/);
+    expect(parseVerifyL4OwnerArgs(["-h"]).help).toBe(true);
   });
 
   it("help exits 0", () => {
@@ -21,6 +60,55 @@ describe("verify-l4-owner CLI (#3090)", () => {
     const err = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     expect(run([])).toBe(2);
     expect(err.mock.calls.join("")).toContain("--pr is required");
+    err.mockRestore();
+  });
+
+  it("parse error path exits 2 with usage hint (#3103)", () => {
+    const err = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(run(["--pr"])).toBe(2);
+    expect(err.mock.calls.join("")).toMatch(/expected one argument|--help/);
+    err.mockRestore();
+  });
+
+  it("emits JSON for done and stderr for illegal freeform (#3103)", () => {
+    const root = mkdtempSync(join(tmpdir(), "l4-cli-json-"));
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const err = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    expect(
+      run([
+        "--pr",
+        "12",
+        "--repo",
+        "acme/widgets",
+        "--project-root",
+        root,
+        "--review-cycle",
+        "done",
+        "--json",
+      ]),
+    ).toBe(0);
+    expect(out.mock.calls.join("")).toMatch(/"path": "done"/);
+
+    out.mockClear();
+    err.mockClear();
+    // Freeform is rejected before any GitHub fetch (no network seam needed).
+    expect(
+      run([
+        "--pr",
+        "12",
+        "--repo",
+        "acme/widgets",
+        "--project-root",
+        root,
+        "--review-cycle",
+        "started",
+      ]),
+    ).toBe(1);
+    expect(err.mock.calls.join("")).toMatch(/illegal freeform|review_cycle/);
+    expect(out).not.toHaveBeenCalled();
+
+    out.mockRestore();
     err.mockRestore();
   });
 });

--- a/packages/core/src/policy/min-greptile-confidence.test.ts
+++ b/packages/core/src/policy/min-greptile-confidence.test.ts
@@ -12,7 +12,9 @@ import {
   FIELD_MIN_GREPTILE_CONFIDENCE,
   FIELD_MIN_GREPTILE_CONFIDENCE_CLI_ALIAS,
   formatMinConfidenceRequirement,
+  inspectMinGreptileConfidence,
   meetsMinGreptileConfidence,
+  readMinGreptileConfidenceFromPolicyBlock,
   resolveMinGreptileConfidence,
   validateMinGreptileConfidence,
 } from "./min-greptile-confidence.js";
@@ -147,6 +149,41 @@ describe("resolveMinGreptileConfidence (#3095)", () => {
     expect(byAlias?.current).toBe(5);
     expect(byAlias?.source).toBe("typed");
     expect(byPath?.current).toBe(5);
+  });
+
+  it("readMinGreptileConfidenceFromPolicyBlock covers absent and invalid nests (#3103)", () => {
+    expect(readMinGreptileConfidenceFromPolicyBlock(null)).toBeUndefined();
+    expect(readMinGreptileConfidenceFromPolicyBlock([])).toBeUndefined();
+    expect(readMinGreptileConfidenceFromPolicyBlock("x")).toBeUndefined();
+    expect(readMinGreptileConfidenceFromPolicyBlock({})).toBeUndefined();
+    expect(readMinGreptileConfidenceFromPolicyBlock({ review: null })).toBeUndefined();
+    expect(readMinGreptileConfidenceFromPolicyBlock({ review: [] })).toBeUndefined();
+    expect(readMinGreptileConfidenceFromPolicyBlock({ review: {} })).toBeUndefined();
+    expect(readMinGreptileConfidenceFromPolicyBlock({ review: { minGreptileConfidence: 4 } })).toBe(
+      4,
+    );
+  });
+
+  it("inspectMinGreptileConfidence projects current/default/source (#3103)", () => {
+    root = makeProject({ review: { minGreptileConfidence: 5 } });
+    const field = inspectMinGreptileConfidence(null, root);
+    expect(field).toMatchObject({
+      name: FIELD_MIN_GREPTILE_CONFIDENCE,
+      current: 5,
+      default: DEFAULT_CONSUMER_MIN_GREPTILE_CONFIDENCE,
+      source: "typed",
+    });
+  });
+
+  it("empty string projectRoot falls through to consumer default (#3103)", () => {
+    expect(resolveMinGreptileConfidence("")).toMatchObject({
+      min: DEFAULT_CONSUMER_MIN_GREPTILE_CONFIDENCE,
+      source: "default",
+    });
+    expect(resolveMinGreptileConfidence(null)).toMatchObject({
+      min: DEFAULT_CONSUMER_MIN_GREPTILE_CONFIDENCE,
+      source: "default",
+    });
   });
 });
 

--- a/packages/core/src/review-monitor/l4-owner.test.ts
+++ b/packages/core/src/review-monitor/l4-owner.test.ts
@@ -234,15 +234,27 @@ describe("evaluateL4OwnerGate (#3090)", () => {
 
   it("CONFIG when repo cannot be resolved (#3103)", () => {
     const root = mkdtempSync(join(tmpdir(), "l4-norepo-"));
-    const result = evaluateL4OwnerGate({
-      pr: 3,
-      projectRoot: root,
-      // no --repo and temp dir is not a git worktree
-      seams: { fetchComments: () => [] },
-    });
-    expect(result.exitCode).toBe(2);
-    expect(result.path).toBe("config");
-    expect(result.message).toMatch(/could not resolve owner\/repo/);
+    // Isolate from process-inherited DEFT_TRIAGE_REPO so resolveRepo falls through
+    // to git remote (temp dir is not a git worktree) and returns null.
+    const prevTriageRepo = process.env.DEFT_TRIAGE_REPO;
+    delete process.env.DEFT_TRIAGE_REPO;
+    try {
+      const result = evaluateL4OwnerGate({
+        pr: 3,
+        projectRoot: root,
+        // omit --repo; temp dir is not a git worktree
+        seams: { fetchComments: () => [] },
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.path).toBe("config");
+      expect(result.message).toMatch(/could not resolve owner\/repo/);
+    } finally {
+      if (prevTriageRepo === undefined) {
+        delete process.env.DEFT_TRIAGE_REPO;
+      } else {
+        process.env.DEFT_TRIAGE_REPO = prevTriageRepo;
+      }
+    }
   });
 
   it("CONFIG when GitHub lease fetch errors (#3103)", () => {

--- a/packages/core/src/review-monitor/l4-owner.test.ts
+++ b/packages/core/src/review-monitor/l4-owner.test.ts
@@ -38,11 +38,17 @@ describe("parseReviewCycleEvidence (#3090)", () => {
     });
   });
 
+  it("treats null/undefined/blank as absent evidence (#3103)", () => {
+    expect(parseReviewCycleEvidence(null)).toEqual({ ok: true, value: null });
+    expect(parseReviewCycleEvidence(undefined)).toEqual({ ok: true, value: null });
+    expect(parseReviewCycleEvidence("   ")).toEqual({ ok: true, value: null });
+  });
+
   it("rejects freeform started/pending/initiated", () => {
-    for (const bad of ["started", "pending", "initiated", "START"]) {
+    for (const bad of ["started", "pending", "initiated", "START", "start", "in_progress"]) {
       const r = parseReviewCycleEvidence(bad);
       expect(r.ok).toBe(false);
-      if (!r.ok) expect(r.reason).toContain("illegal freeform");
+      if (!r.ok) expect(r.reason).toMatch(/illegal freeform|unknown review_cycle/);
     }
   });
 
@@ -51,9 +57,16 @@ describe("parseReviewCycleEvidence (#3090)", () => {
     expect(r.ok).toBe(false);
   });
 
-  it("rejects non-numeric in_progress pr", () => {
-    const r = parseReviewCycleEvidence("in_progress:abc#parent-retained");
-    expect(r.ok).toBe(false);
+  it("rejects malformed in_progress and skipped forms (#3103)", () => {
+    expect(parseReviewCycleEvidence("in_progress:abc#parent-retained").ok).toBe(false);
+    expect(parseReviewCycleEvidence("in_progress:12#").ok).toBe(false);
+    expect(parseReviewCycleEvidence("in_progress:#monitor").ok).toBe(false);
+    expect(parseReviewCycleEvidence("in_progress:0#monitor").ok).toBe(false);
+    expect(parseReviewCycleEvidence("skipped:").ok).toBe(false);
+    expect(parseReviewCycleEvidence("skipped:   ").ok).toBe(false);
+    const unknown = parseReviewCycleEvidence("maybe-later");
+    expect(unknown.ok).toBe(false);
+    if (!unknown.ok) expect(unknown.reason).toContain("unknown review_cycle");
   });
 });
 
@@ -63,6 +76,14 @@ describe("parseInProgressEvidence", () => {
       pr: 12,
       ref: "parent-retained",
     });
+  });
+
+  it("returns null for non-matching shapes (#3103)", () => {
+    expect(parseInProgressEvidence("done")).toBeNull();
+    expect(parseInProgressEvidence("in_progress:")).toBeNull();
+    expect(parseInProgressEvidence("in_progress:#ref")).toBeNull();
+    expect(parseInProgressEvidence("in_progress:12#")).toBeNull();
+    expect(parseInProgressEvidence("in_progress:abc#x")).toBeNull();
   });
 });
 
@@ -199,5 +220,69 @@ describe("evaluateL4OwnerGate (#3090)", () => {
     expect(json.path).toBe("none");
     expect(json.ready).toBe(false);
     expect(json.exit_code).toBe(1);
+  });
+
+  it("CONFIG when project-root is not a directory (#3103)", () => {
+    const result = evaluateL4OwnerGate({
+      pr: 1,
+      projectRoot: join(tmpdir(), "l4-missing-root-does-not-exist-xyz"),
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.path).toBe("config");
+    expect(result.message).toContain("not a directory");
+  });
+
+  it("CONFIG when repo cannot be resolved (#3103)", () => {
+    const root = mkdtempSync(join(tmpdir(), "l4-norepo-"));
+    const result = evaluateL4OwnerGate({
+      pr: 3,
+      projectRoot: root,
+      // no --repo and temp dir is not a git worktree
+      seams: { fetchComments: () => [] },
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.path).toBe("config");
+    expect(result.message).toMatch(/could not resolve owner\/repo/);
+  });
+
+  it("CONFIG when GitHub lease fetch errors (#3103)", () => {
+    const root = mkdtempSync(join(tmpdir(), "l4-gh-err-"));
+    const result = evaluateL4OwnerGate({
+      pr: 9,
+      projectRoot: root,
+      repo: "acme/widgets",
+      seams: {
+        fetchComments: () => ({ error: "rate limited" }),
+      },
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.path).toBe("config");
+    expect(result.message).toContain("rate limited");
+  });
+
+  it("PASS lease without review_cycle stamps in_progress ref (#3103)", () => {
+    const root = mkdtempSync(join(tmpdir(), "l4-lease-ref-"));
+    const result = evaluateL4OwnerGate({
+      pr: 12,
+      projectRoot: root,
+      repo: "deftai/directive",
+      headSha: "abc123",
+      now: NOW,
+      seams: {
+        fetchComments: () => [
+          {
+            id: 1,
+            body: activeLeaseComment("alice", "monitor-pr-12"),
+            htmlUrl: "",
+            updatedAt: NOW.toISOString(),
+            authorLogin: "alice",
+            authorAssociation: "MEMBER",
+          },
+        ],
+      },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.path).toBe("lease");
+    expect(result.reviewCycle).toBe("in_progress:12#monitor-pr-12");
   });
 });

--- a/packages/core/src/verify-env/agent-hook-readiness.test.ts
+++ b/packages/core/src/verify-env/agent-hook-readiness.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentHookInspection } from "../init-deposit/agent-hooks.js";
 import { DEFAULT_HOST_HOOKS_POLICY } from "../policy/host-hooks.js";
@@ -158,8 +159,9 @@ describe("evaluateAgentHookReadiness", () => {
     });
 
     expect(result.code).toBe(0);
+    // evaluateAgentHookReadiness resolve()s the project root before probe (win32: C:\project).
     expect(probe).toHaveBeenCalledWith(
-      "/project",
+      resolve("/project"),
       expect.objectContaining({ hosts: ["claude", "cursor"] }),
     );
     expect(result.hosts.find((entry) => entry.host === "codex")).toMatchObject({
@@ -223,7 +225,7 @@ describe("evaluateAgentHookReadiness", () => {
     expect(result.liveStatus).toBe("disabled");
     expect(result.hosts.every((entry) => entry.functionality === "disabled")).toBe(true);
     expect(result.message).not.toContain("Codex trust:");
-    expect(probe).toHaveBeenCalledWith("/project", expect.objectContaining({ hosts: [] }));
+    expect(probe).toHaveBeenCalledWith(resolve("/project"), expect.objectContaining({ hosts: [] }));
   });
 
   it("preserves missing and drifted structural registration states", () => {


### PR DESCRIPTION
## Summary

Restore Vitest **branch** coverage above the 85% floor after the v0.94.0 hairline miss (84.99%).

## Coverage (local `vitest run --coverage`)

| Metric | Before (issue) | After |
| --- | --- | --- |
| Statements | 88.19% | 88.45% |
| Branches | **84.99%** | **85.23%** |
| Functions | 95.81% | 95.86% |
| Lines | 88.19% | 88.45% |

All four metrics ≥ 85% without `--allow-coverage-debt`.

## Changes

- L4 owner gate: parse/config edges + CLI argv/JSON paths (`verify-l4-owner`, `l4-owner`)
- Min-Greptile confidence: policy block reader + inspect projection edges
- Agent-hook readiness: win32-stable `resolve()` path expectations in probe assertions
- CHANGELOG [Unreleased] for #3103

## Test plan

- [x] Full suite + coverage green locally (branches 85.23%)
- [x] `task verify:branch` / `task verify:forward-coverage`
- [ ] CI green
- [ ] Greptile CLEAN (min confidence 5)

Closes #3103