### PR TITLE
chore(xbrief): complete cohort scopes after merge (#3103 #3105 #3110)

### DIFF
--- a/xbrief/completed/2026-08-04-3103-coverage-debt-restore-vitest-branches-85-8499-at-v0940-prefl.xbrief.json
+++ b/xbrief/completed/2026-08-04-3103-coverage-debt-restore-vitest-branches-85-8499-at-v0940-prefl.xbrief.json
@@ -1,0 +1,112 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3103",
+    "updated": "2026-08-04T16:17:31Z"
+  },
+  "plan": {
+    "title": "coverage-debt: restore Vitest branches >=85% (84.99% at v0.94.0 preflight)",
+    "status": "completed",
+    "narratives": {
+      "Description": "Release Step 5 / task check failed the Vitest branch coverage hairline at 84.99% on the v0.94.0 cut while other metrics already met 85%. This story restores all four Vitest metrics to >=85% and closes the coverage-debt ledger issue so soft-pass is no longer needed.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3103",
+      "Overview": "## Summary\n\nRelease Step 5 / `task check` Vitest **branch** coverage hairline on the v0.94.0 cut.\n\n## Measured (local `task check` 2026-08-03)\n\n- Statements: 88.19%\n- Branches: **84.99%** (sole metric below 85%)\n- Functions: 95.81%\n- Lines: 88.19%\n\n## Hatch\n\n`coverage-debt` / `--allow-coverage-debt` — release-scoped open-issue ledger hatch (#2866 / #2573). Branch-only trigger; other metrics already ≥ 85%.\n\n## Acceptance\n\nRestore **all four** Vitest metrics (lines, functions, branches, statements) to ≥ 85% and close this issue. Do not soft-pass again while this issue remains open.",
+      "Labels": "test-debt, release, testing",
+      "UserStory": "As a release operator, I want Vitest branch coverage at or above 85%, so that task check and release Step 5 pass without the coverage-debt hatch.",
+      "ImplementationPlan": "1. Reproduce branch coverage shortfall with task check / vitest coverage and identify files/branches below the gate. 2. Add or tighten unit tests for the uncovered branches (prefer high-ROI modules near the hairline). 3. Confirm statements, branches, functions, and lines all report >=85%. 4. CHANGELOG [Unreleased] note for #3103. 5. Do not re-open the coverage-debt hatch while this issue remains open.",
+      "missing_traces_justification": "Story AC items carry narrative.Traces (AC-N); origin is GitHub issue body ingested via issue:ingest."
+    },
+    "items": [
+      {
+        "id": "3103-coverage-debt-branches-a1",
+        "title": "All four Vitest metrics (lines, functions, branches, statements) report >=85% under the same task check path used at release.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3103-coverage-debt-branches, when implementation is complete, then: All four Vitest metrics (lines, functions, branches, statements) report >=85% under the same task check path used at release.",
+          "Traces": "AC-1"
+        }
+      },
+      {
+        "id": "3103-coverage-debt-branches-a2",
+        "title": "No reliance on --allow-coverage-debt / coverage-debt hatch for this shortfall while the issue is open.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3103-coverage-debt-branches, when implementation is complete, then: No reliance on --allow-coverage-debt / coverage-debt hatch for this shortfall while the issue is open.",
+          "Traces": "AC-2"
+        }
+      },
+      {
+        "id": "3103-coverage-debt-branches-a3",
+        "title": "Targeted tests land with the coverage lift; CHANGELOG [Unreleased] mentions #3103.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3103-coverage-debt-branches, when implementation is complete, then: Targeted tests land with the coverage lift; CHANGELOG [Unreleased] mentions #3103.",
+          "Traces": "AC-3"
+        }
+      }
+    ],
+    "tags": [
+      "test-debt",
+      "testing",
+      "release"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3103",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3103: coverage-debt: restore Vitest branches >=85% (84.99% at v0.94.0 preflight)"
+      }
+    ],
+    "updated": "2026-08-04T16:17:31Z",
+    "id": "3103-coverage-debt-branches",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/session/verify-session-ritual.test.ts",
+          "packages/core/src/session/verify-session-ritual-branches.test.ts",
+          "packages/core/src/doctor/agent-hooks.test.ts",
+          "packages/core/src/verify-env/agent-hook-readiness.test.ts",
+          "packages/cli/src/verify-hooks-installed.test.ts",
+          "packages/core/src/session/session-ready.test.ts",
+          "packages/core/src/verify-env/agent-hooks-live-probe.test.ts"
+        ],
+        "verify_commands": [
+          "task check",
+          "task verify:forward-coverage"
+        ],
+        "expected_outputs": [
+          "Vitest branches >=85%",
+          "All four coverage metrics >=85%",
+          "CHANGELOG [Unreleased] for #3103"
+        ],
+        "depends_on": [],
+        "conflict_group": "coverage-3103",
+        "size": "medium",
+        "file_scope_confidence": "medium",
+        "model_tier": "medium"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3113,
+        "prBase": null,
+        "mergeCommit": "e6a39172b68ac7fc3ddaa81c756179511a3c8bb6",
+        "deliveryBranch": "master",
+        "deliveryCommit": "e6a39172b68ac7fc3ddaa81c756179511a3c8bb6",
+        "verifiedAt": "2026-08-04T16:17:31Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-04T16:17:31Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}

--- a/xbrief/completed/2026-08-04-3105-fix-deftcheckpoint-host-wrappers-point-at-output-continuexbr.xbrief.json
+++ b/xbrief/completed/2026-08-04-3105-fix-deftcheckpoint-host-wrappers-point-at-output-continuexbr.xbrief.json
@@ -1,0 +1,111 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3105",
+    "updated": "2026-08-04T15:53:30Z"
+  },
+  "plan": {
+    "title": "fix: /deft:checkpoint host wrappers point at output continue.xbrief.json",
+    "status": "completed",
+    "narratives": {
+      "Description": "Multi-host slash deposit for /deft:checkpoint incorrectly points wrappers at xbrief/continue.xbrief.json (checkpoint output) instead of resilience/continue-here.md (instruction doc). First invocation fails on clean consumers. /deft:continue already targets continue-here.md correctly. Packaging must deposit the correct target so deft update does not reintroduce the bug.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3105",
+      "Overview": "## Summary\nIn `@deftai/directive` / content **0.94.0**, multi-host slash deposit for `/deft:checkpoint` writes wrappers that say:\n\n```markdown\nRead and follow `xbrief/continue.xbrief.json` ...\n```\n\nThat path is the **output** of checkpoint, not the instruction doc. First invocation fails when the file does not exist yet.\n\n`/deft:continue` correctly points at `resilience/continue-here.md`.\n\n## Repro\n1. `deft update` to 0.94.0 on a clean consumer\n2. Open `.claude/commands/deft-checkpoint.md` (also cursor/codex/grok)\n3. Observe target is `xbrief/continue.xbrief.json`\n\n## Expected\nCheckpoint wrappers should load `resilience/continue-here.md` (same strategy doc as continue; save path still documented in description/commands.md).\n\n## Consumer workaround\nenterprize #64 fixed the four deposited wrappers after Greptile P1 on the upgrade PR. Next `deft update` may re-introduce the bad target until packaging is fixed.\n\n## Seen on\n- enterprize upgrade 0.90.0 → 0.94.0 (2026-08-03/04)\n- Greptile confidence recovered 4/5 → 5/5 after consumer fix",
+      "Labels": "bug, tooling, packaging",
+      "UserStory": "As a consumer operator running /deft:checkpoint, I want the deposited host wrappers to load the continue-here strategy doc, so that first invocation works before xbrief/continue.xbrief.json exists.",
+      "ImplementationPlan": "1. Locate the slash generator / deposit source that emits deft-checkpoint wrappers across hosts. 2. Change the managed body target from xbrief/continue.xbrief.json to resilience/continue-here.md (match continue). 3. Keep save-path documentation in description/commands.md. 4. Add/adjust tests in slash-deposit or generator suite. 5. CHANGELOG [Unreleased] for #3105.",
+      "missing_traces_justification": "Story AC items carry narrative.Traces (AC-N); origin is GitHub issue body ingested via issue:ingest."
+    },
+    "items": [
+      {
+        "id": "3105-checkpoint-wrapper-target-a1",
+        "title": "Deposited /deft:checkpoint wrappers (claude/cursor/codex/grok) read resilience/continue-here.md, not xbrief/continue.xbrief.json.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3105-checkpoint-wrapper-target, when implementation is complete, then: Deposited /deft:checkpoint wrappers (claude/cursor/codex/grok) read resilience/continue-here.md, not xbrief/continue.xbrief.json.",
+          "Traces": "AC-1"
+        }
+      },
+      {
+        "id": "3105-checkpoint-wrapper-target-a2",
+        "title": "First invocation succeeds when continue.xbrief.json does not exist yet.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3105-checkpoint-wrapper-target, when implementation is complete, then: First invocation succeeds when continue.xbrief.json does not exist yet.",
+          "Traces": "AC-2"
+        }
+      },
+      {
+        "id": "3105-checkpoint-wrapper-target-a3",
+        "title": "Automated test covers checkpoint wrapper target; CHANGELOG [Unreleased] mentions #3105.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3105-checkpoint-wrapper-target, when implementation is complete, then: Automated test covers checkpoint wrapper target; CHANGELOG [Unreleased] mentions #3105.",
+          "Traces": "AC-3"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "tooling",
+      "packaging"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3105",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3105: fix: /deft:checkpoint host wrappers point at output continue.xbrief.json"
+      }
+    ],
+    "updated": "2026-08-04T15:53:30Z",
+    "id": "3105-checkpoint-wrapper-target",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/init-deposit/slash-deposit.ts",
+          "packages/core/src/init-deposit/slash-deposit.test.ts",
+          "packages/core/src/slash/product-set.ts",
+          "packages/core/src/slash/product-set.test.ts",
+          "packages/core/src/slash/emitters.test.ts",
+          "content/commands.md"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/init-deposit/slash-deposit.test.ts",
+          "task verify:forward-coverage"
+        ],
+        "expected_outputs": [
+          "Checkpoint wrappers target resilience/continue-here.md",
+          "Regression test for wrapper target",
+          "CHANGELOG [Unreleased] for #3105"
+        ],
+        "depends_on": [],
+        "conflict_group": "slash-checkpoint-3105",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3112,
+        "prBase": "master",
+        "mergeCommit": "bf43062d75eef52e15a1c230f8a6cd708be5776f",
+        "deliveryBranch": "master",
+        "deliveryCommit": "bf43062d75eef52e15a1c230f8a6cd708be5776f",
+        "verifiedAt": "2026-08-04T15:53:30Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-04T15:53:30Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}

--- a/xbrief/completed/2026-08-04-3110-fixsecurity-uat-self-approval-via-ungated-authzgrant-shell-c.xbrief.json
+++ b/xbrief/completed/2026-08-04-3110-fixsecurity-uat-self-approval-via-ungated-authzgrant-shell-c.xbrief.json
@@ -1,0 +1,135 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3110",
+    "updated": "2026-08-04T17:49:51Z"
+  },
+  "plan": {
+    "title": "fix(security): UAT self-approval via ungated authz:grant shell (classifyShellAuthzOps fail-open)",
+    "status": "completed",
+    "narratives": {
+      "Description": "AppSec high: under an active UAT lease, classifyShellAuthzOps returns empty for authz:grant / authz:uat-suspend, PreToolUse fails open (shell-op-unclassifiable), and default CLI mint stamps operator-cli without TTY confirm. Empty activeGrantIds then activates the grant and unlocks product mutations — full Wave 1 bypass. Dispatch-envelope self-mint is covered; CLI self-mint via shell is not.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3110",
+      "Overview": "## Summary\n\n**AppSec finding (high)** — Under an active UAT lease, an agent can self-mint human-origin grants (and related authz ops) via the ungated `authz:grant` / `authz:uat-suspend` CLI path through Shell/Bash. PreToolUse fails open because `classifyShellAuthzOps` returns `[]` (`shell-op-unclassifiable`), so product Write/push/PR/merge unlock without Wave 1 human approval.\n\n## Severity\n\n**high**\n\n## Location\n\n- `packages/core/src/authz/classify.ts` (`classifyShellAuthzOps` → empty → fail-open)\n- CLI mint path: `authz:grant` / `authz:uat-start` / `authz:uat-suspend` / `authz:revoke` (default stamps `operator-cli` / actor `operator` with no TTY confirm)\n- Related: PreToolUse shell classification + active-grant / UAT lease gates\n\n## Impact\n\nUnder an active UAT lease:\n\n1. Agent runs `deft authz:grant` (or `authz:uat-suspend`) through Shell/Bash.\n2. `classifyShellAuthzOps` returns `[]` → PreToolUse **fails open** (`shell-op-unclassifiable`).\n3. Default CLI mint stamps **operator-cli** / actor **operator** with **no TTY confirm**.\n4. With empty `activeGrantIds`, the new grant **activates** and unlocks product Write / push / PR / merge.\n\n**Result:** Full bypass of Wave 1 human-approval for product mutations.\n\n## Remediation\n\n1. **Classify** `authz:grant` / `authz:uat-start` / `authz:uat-suspend` / `authz:revoke` as **settings** (deny under UAT without a prior human grant).\n2. **Require TTY / `--confirm`** for mint (no silent operator-cli stamp from agent shell).\n3. **Block shell writes** under `.deft/authz/`.\n\n## Evidence\n\nVitest PoC on `ac3c4bb0`:\n\n- `Bash authz:grant` → `allow` / `shell-op-unclassifiable`\n- After `mintHumanOriginGrant` without `pinActive`, `Write` + `git push` → `allow`\n- Existing incident regression covers **dispatch-envelope** self-mint only — **not** CLI self-mint via shell.\n\n## Commit (finding base)\n\n`ac3c4bb07f2bdca38b0611f4b220c9e5c959cd1c`\n\n## Acceptance criteria\n\n- [ ] Shell invocations of `authz:grant`, `authz:uat-start`, `authz:uat-suspend`, and `authz:revoke` are classified (settings / deny under UAT without prior human grant) — not `shell-op-unclassifiable` fail-open\n- [ ] CLI mint requires TTY or explicit `--confirm`; agent/non-TTY shell cannot silently mint operator-cli grants\n- [ ] Shell writes under `.deft/authz/` are blocked under UAT (or equivalent containment)\n- [ ] Vitest regression: Bash/`Shell` → `authz:grant` under UAT with empty active grants does **not** unlock Write / push / PR / merge\n- [ ] Existing dispatch-envelope self-mint regression remains green; new case covers **CLI self-mint** path\n\n## Notes\n\nParent epic context: layered authz stack (#2948) / human-origin grants + UAT lease (#2955). This is residual fail-open on the **shell-classified CLI mint** path, not the dispatch-envelope path already gated.\r\n\n",
+      "Labels": "bug, security",
+      "UserStory": "As a security operator under an active UAT lease, I want authz:grant and related shell ops classified and gated, so that agents cannot self-mint operator-cli grants and unlock product Write/push/PR/merge without Wave 1 human approval.",
+      "ImplementationPlan": "1. Classify authz:grant, authz:uat-start, authz:uat-suspend, authz:revoke as settings (deny under UAT without prior human grant). 2. Require TTY or --confirm for mint; block silent operator-cli stamp from non-TTY agent shell. 3. Block shell writes under .deft/authz/. 4. Add Vitest regression: Bash/Shell authz:grant under UAT with empty active grants must not unlock Write/push/PR/merge. 5. Keep dispatch-envelope self-mint regression green. 6. CHANGELOG [Unreleased] for #3110.",
+      "missing_traces_justification": "Story AC items carry narrative.Traces (AC-N); origin is GitHub issue body ingested via issue:ingest."
+    },
+    "items": [
+      {
+        "id": "3110-authz-grant-shell-failopen-a1",
+        "title": "Shell authz:grant / uat-start / uat-suspend / revoke are classified (settings); not shell-op-unclassifiable fail-open under UAT.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3110-authz-grant-shell-failopen, when implementation is complete, then: Shell authz:grant / uat-start / uat-suspend / revoke are classified (settings); not shell-op-unclassifiable fail-open under UAT.",
+          "Traces": "AC-1"
+        }
+      },
+      {
+        "id": "3110-authz-grant-shell-failopen-a2",
+        "title": "CLI mint requires TTY or explicit --confirm; non-TTY agent shell cannot silently mint operator-cli grants.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3110-authz-grant-shell-failopen, when implementation is complete, then: CLI mint requires TTY or explicit --confirm; non-TTY agent shell cannot silently mint operator-cli grants.",
+          "Traces": "AC-2"
+        }
+      },
+      {
+        "id": "3110-authz-grant-shell-failopen-a3",
+        "title": "Shell writes under .deft/authz/ blocked under UAT (or equivalent containment).",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3110-authz-grant-shell-failopen, when implementation is complete, then: Shell writes under .deft/authz/ blocked under UAT (or equivalent containment).",
+          "Traces": "AC-3"
+        }
+      },
+      {
+        "id": "3110-authz-grant-shell-failopen-a4",
+        "title": "Vitest regression covers CLI self-mint path; dispatch-envelope regression remains green.",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given the story scope for 3110-authz-grant-shell-failopen, when implementation is complete, then: Vitest regression covers CLI self-mint path; dispatch-envelope regression remains green.",
+          "Traces": "AC-4"
+        }
+      }
+    ],
+    "tags": [
+      "bug",
+      "security"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3110",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3110: fix(security): UAT self-approval via ungated authz:grant shell (classifyShellAuthzOps fail-open)"
+      }
+    ],
+    "updated": "2026-08-04T17:49:51Z",
+    "id": "3110-authz-grant-shell-failopen",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "packages/core/src/authz/actions.test.ts",
+          "packages/core/src/authz/actions.ts",
+          "packages/core/src/authz/classify.test.ts",
+          "packages/core/src/authz/classify.ts",
+          "packages/core/src/authz/closed-verb.test.ts",
+          "packages/core/src/authz/closed-verb.ts",
+          "packages/core/src/authz/evaluate-branches.test.ts",
+          "packages/core/src/authz/evaluate.test.ts",
+          "packages/core/src/authz/evaluate.ts",
+          "packages/core/src/authz/incident-regression.test.ts",
+          "packages/core/src/authz/index.ts",
+          "packages/core/src/authz/origin.test.ts",
+          "packages/core/src/authz/origin.ts",
+          "packages/core/src/authz/paths.ts",
+          "packages/core/src/authz/store.test.ts",
+          "packages/core/src/authz/store.ts",
+          "packages/core/src/authz/templates.ts",
+          "packages/core/src/authz/types.ts",
+          "packages/core/src/authz/verb-classification.ts",
+          "packages/core/src/hooks/dispatcher.ts",
+          "packages/core/src/hooks/dispatcher.test.ts"
+        ],
+        "verify_commands": [
+          "pnpm exec vitest run packages/core/src/authz",
+          "task verify:forward-coverage"
+        ],
+        "expected_outputs": [
+          "classifyShellAuthzOps maps authz grant/suspend/revoke to settings",
+          "CLI mint TTY/--confirm gate",
+          "CLI self-mint regression test",
+          "CHANGELOG [Unreleased] for #3110"
+        ],
+        "depends_on": [],
+        "conflict_group": "authz-3110",
+        "size": "medium",
+        "file_scope_confidence": "high",
+        "model_tier": "high"
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3111,
+        "prBase": null,
+        "mergeCommit": "27829c206cd6fa5eacf025449e0d48ec628a7e1d",
+        "deliveryBranch": "master",
+        "deliveryCommit": "27829c206cd6fa5eacf025449e0d48ec628a7e1d",
+        "verifiedAt": "2026-08-04T17:49:51Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-04T17:49:51Z",
+      "capacityBucket": "technical-debt"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Lifecycle close-out for the through-merge cohort that already landed on master:

| Issue | PR | Merge |
|-------|-----|-------|
| #3103 coverage-debt | #3113 | `e6a39172` |
| #3105 checkpoint wrappers | #3112 | `bf43062d` |
| #3110 authz UAT self-mint | #3111 | `27829c20` |

Adds the three `xbrief/completed/` artifacts with `plan.status=completed` and delivery provenance. No product code changes.

## Test plan
- [x] Files only under `xbrief/completed/`
- [x] Each brief `plan.status` is `completed` with pr/merge evidence