### PR TITLE
feat(triage): Tier-1 deterministic SCM label mirror (#1423 Wave 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Tier-1 deterministic SCM label mirror from classify (#1423 Wave 1).** `task triage:classify -- --mirror` classifies the github-issue cache with the existing #1129 engine and mirrors outcomes as SCM labels (`triaged` idempotency marker + optional `plan.policy.triageLabelMirror` action map). Dry-run by default; `--apply` writes through the SCM label client and cross-repo mutation boundary (compose #1288, do not reimplement). Re-run is a no-op for already-triaged issues. Never calls `triage:accept` / never writes `proposed/` xBRIEFs. Waves 2–3 (bootstrap mass-triage, agent Tier-2 comments) remain open on #1423. Refs #1129, #1288, #1420, #886.
 - **Upgrade SCM release handoff after deposit (#1604).** Successful framework deposit is no longer a silent stop after a local framework-only commit. `deft-directive-sync` leads with npm + `directive update` / `deft update` + doctor, demotes submodule to legacy, and finishes Phase 8 SCM handoff in exactly one terminal state: `released` | `pr-open` | `blocked:<reason>`. Policy-aware PR vs direct-commit paths honor `requireHumanMerge`. UPGRADING documents the handoff; content-contract tests pin stop-after-commit as a failure mode. Closes #1604.
 
 ### Changed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -954,7 +954,7 @@ tasks:
           CLI_ARGS: "{{.CLI_ARGS}}"
 
   triage:classify:
-    desc: "Inspect / validate the auto-classification surface (#1129 / D10). -- task triage:classify -- [--list | --validate]"
+    desc: "Inspect / validate auto-classification + Tier-1 SCM label mirror (#1129 / #1423). -- task triage:classify -- [--list | --validate | --mirror [--apply]]"
     cmds:
       - task: triage-classify:classify
         vars:

--- a/content/commands.md
+++ b/content/commands.md
@@ -478,6 +478,7 @@ Directive does not guess your mix. Either you name the next units in order (**or
 - `task triage:reset -- <issue>` -- append a reset record so a candidate can be reconsidered.
 - `task triage:bulk-accept|bulk-reject|bulk-defer|bulk-needs-ac` -- apply predictable decisions over filtered cached candidates.
 - `task triage:summary`, `task triage:scope`, `task triage:scope-drift`, `task triage:subscribe`, `task triage:unsubscribe`, `task triage:classify`, `task triage:welcome`, and `task triage:smoketest` -- supporting workflow and onboarding commands.
+- `task triage:classify -- --mirror [--apply] [--repo owner/name] [--json]` -- **Tier-1 deterministic SCM label mirror (#1423 Wave 1).** Runs the existing classify engine over the github-issue cache and mirrors outcomes as labels (`triaged` idempotency marker + optional `plan.policy.triageLabelMirror.actionLabels`). Dry-run by default (prints a digest of planned adds/skips with zero SCM writes); `--apply` writes via the SCM label client / repo-mutation boundary (same surface family as `vbrief:reconcile:labels`). Re-run is a no-op for issues already carrying `triaged`. **Never** calls `triage:accept` and **never** writes `proposed/` xBRIEFs. Waves 2–3 (bootstrap mass-triage, agent Tier-2 comments) are out of scope for this flag.
 
 ### Cache Tasks
 

--- a/packages/cli/src/triage-classify.test.ts
+++ b/packages/cli/src/triage-classify.test.ts
@@ -52,6 +52,8 @@ describe("parseArgs", () => {
       projectRoot: ".",
       doList: false,
       doValidate: false,
+      doMirror: false,
+      apply: false,
     });
   });
 
@@ -61,6 +63,18 @@ describe("parseArgs", () => {
       projectRoot: "/tmp/x",
     });
     expect(parseArgs(["--validate"])).toMatchObject({ doValidate: true });
+  });
+
+  it("parses --mirror and --apply", () => {
+    expect(parseArgs(["--mirror", "--apply", "--repo", "o/r"])).toMatchObject({
+      doMirror: true,
+      apply: true,
+      repo: "o/r",
+    });
+  });
+
+  it("rejects --apply without --mirror", () => {
+    expect(parseArgs(["--apply"]).error).toContain("--mirror");
   });
 
   it("rejects unknown flags", () => {
@@ -91,6 +105,40 @@ describe("run", () => {
       policy: { triageAutoClassify: [{ match: {}, action: "defer", reason: "??" }] },
     });
     expect(silentRun(["--validate", "--project-root", root])).toBe(1);
+  });
+
+  it("dry-run --mirror prints digest without network (#1423)", () => {
+    const root = buildRepo();
+    const cacheDir = join(root, ".deft-cache", "github-issue", "acme", "demo", "7");
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      join(cacheDir, "raw.json"),
+      JSON.stringify({
+        number: 7,
+        state: "open",
+        body: "BLOCKED pending design",
+        labels: [],
+        updated_at: "2026-08-01T00:00:00Z",
+      }),
+      "utf8",
+    );
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    expect(run(["--mirror", "--project-root", root])).toBe(0);
+    const text = out.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("dry-run");
+    expect(text).toMatch(/planned=|Would add labels:/);
+    out.mockRestore();
+  });
+
+  it("--mirror --json emits structured outcome", () => {
+    const root = buildRepo();
+    const out = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    expect(run(["--mirror", "--json", "--project-root", root])).toBe(0);
+    const text = out.mock.calls.map((c) => String(c[0])).join("");
+    const parsed = JSON.parse(text) as { dry_run: boolean; scanned: number };
+    expect(parsed.dry_run).toBe(true);
+    expect(typeof parsed.scanned).toBe("number");
+    out.mockRestore();
   });
 });
 

--- a/packages/cli/src/triage-classify.ts
+++ b/packages/cli/src/triage-classify.ts
@@ -2,21 +2,39 @@
 import { statSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { listProject, validateProject } from "@deftai/directive-core/dist/triage/classify/index.js";
+import {
+  type LabelMirrorOptions,
+  labelMirrorOutcomeToJson,
+  listProject,
+  mirrorLabels,
+  renderLabelMirrorReport,
+  validateProject,
+} from "@deftai/directive-core/dist/triage/classify/index.js";
+import type { LabelClient } from "@deftai/directive-core/dist/vbrief-reconcile/types.js";
 
-interface ParsedArgs {
+export interface ParsedArgs {
   projectRoot: string;
   doList: boolean;
   doValidate: boolean;
+  doMirror: boolean;
+  apply: boolean;
+  json: boolean;
+  repo: string | null;
+  allowCrossRepo: boolean;
   error?: string;
 }
 
-/** Parse triage-classify CLI args, mirroring the Python argparse surface. */
+/** Parse triage-classify CLI args (#1129 + #1423 Wave 1 mirror flags). */
 export function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     projectRoot: ".",
     doList: false,
     doValidate: false,
+    doMirror: false,
+    apply: false,
+    json: false,
+    repo: null,
+    allowCrossRepo: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -24,6 +42,23 @@ export function parseArgs(argv: string[]): ParsedArgs {
       parsed.doList = true;
     } else if (arg === "--validate") {
       parsed.doValidate = true;
+    } else if (arg === "--mirror") {
+      parsed.doMirror = true;
+    } else if (arg === "--apply") {
+      parsed.apply = true;
+    } else if (arg === "--json") {
+      parsed.json = true;
+    } else if (arg === "--allow-cross-repo") {
+      parsed.allowCrossRepo = true;
+    } else if (arg === "--repo") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { ...parsed, error: "argument --repo: expected one argument" };
+      }
+      parsed.repo = value;
+      i += 1;
+    } else if (arg?.startsWith("--repo=")) {
+      parsed.repo = arg.slice("--repo=".length);
     } else if (arg === "--project-root") {
       const value = argv[i + 1];
       if (value === undefined) {
@@ -39,11 +74,22 @@ export function parseArgs(argv: string[]): ParsedArgs {
       return { ...parsed, error: `unrecognized arguments: ${arg}` };
     }
   }
+  if (parsed.apply && !parsed.doMirror) {
+    return {
+      ...parsed,
+      error: "--apply requires --mirror (Tier-1 label mirror, #1423)",
+    };
+  }
   return parsed;
 }
 
+export interface RunOptions {
+  /** Injected LabelClient for tests (apply path). */
+  readonly labelClient?: LabelClient;
+}
+
 /** Run the CLI and return the process exit code. */
-export function run(argv: string[]): number {
+export function run(argv: string[], options: RunOptions = {}): number {
   const args = parseArgs(argv);
   if (args.error !== undefined) {
     process.stderr.write(`ERR: ${args.error}\n`);
@@ -77,6 +123,23 @@ export function run(argv: string[]): number {
     return result.code;
   }
 
+  if (args.doMirror) {
+    const mirrorOpts: LabelMirrorOptions = {
+      dryRun: !args.apply,
+      repo: args.repo,
+      allowCrossRepo: args.allowCrossRepo,
+      ...(options.labelClient !== undefined ? { client: options.labelClient } : {}),
+    };
+    const [code, outcome] = mirrorLabels(projectRoot, mirrorOpts);
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(labelMirrorOutcomeToJson(outcome), null, 2)}\n`);
+    } else {
+      process.stdout.write(renderLabelMirrorReport(outcome));
+    }
+    return code;
+  }
+
+  // Default / --list: print effective rules
   process.stdout.write(listProject(projectRoot));
   return 0;
 }

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -92,6 +92,7 @@ export const FIELD_TRIAGE_SCOPE_IGNORES = "plan.policy.triageScopeIgnores";
 export const FIELD_TRIAGE_RANKING_LABELS = "plan.policy.triageRankingLabels";
 export const FIELD_TRIAGE_AUTO_CLASSIFY = "plan.policy.triageAutoClassify";
 export const FIELD_TRIAGE_HOLD_MARKERS = "plan.policy.triageHoldMarkers";
+export const FIELD_TRIAGE_LABEL_MIRROR = "plan.policy.triageLabelMirror";
 export const FIELD_SWARM_SUBAGENT_BACKEND = "plan.policy.swarmSubagentBackend";
 // deliveryBranch also exported from delivery-branch.js via export *
 
@@ -102,6 +103,13 @@ export const DEFAULT_TRIAGE_SCOPE_VALUE: readonly Record<string, unknown>[] = [
 export const DEFAULT_TRIAGE_SCOPE_IGNORES_VALUE: readonly unknown[] = [];
 export const DEFAULT_TRIAGE_RANKING_LABELS_VALUE: readonly string[] = [];
 export const DEFAULT_TRIAGE_AUTO_CLASSIFY_VALUE: readonly unknown[] = [];
+/** Default for #1423 Tier-1 label mirror: enabled with `triaged` idempotency marker. */
+export const DEFAULT_TRIAGE_LABEL_MIRROR_VALUE: Readonly<Record<string, unknown>> = {
+  enabled: true,
+  idempotencyLabel: "triaged",
+  alwaysLabels: ["triaged"],
+  actionLabels: {},
+};
 
 export const KNOWN_SUBAGENT_BACKEND_IDS = new Set(["composer", "cursor-cloud", "grok-build"]);
 
@@ -197,6 +205,33 @@ function inspectWipCap(data: Record<string, unknown> | null): PolicyField {
     name: FIELD_WIP_CAP,
     current: DEFAULT_WIP_CAP,
     default: DEFAULT_WIP_CAP,
+    source: "default",
+  };
+}
+
+function inspectTriageLabelMirrorField(data: Record<string, unknown> | null): PolicyField {
+  const policyBlock = getPolicyBlock(data);
+  if ("triageLabelMirror" in policyBlock) {
+    const raw = policyBlock.triageLabelMirror;
+    if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+      return {
+        name: FIELD_TRIAGE_LABEL_MIRROR,
+        current: raw,
+        default: { ...DEFAULT_TRIAGE_LABEL_MIRROR_VALUE },
+        source: "typed",
+      };
+    }
+    return {
+      name: FIELD_TRIAGE_LABEL_MIRROR,
+      current: { ...DEFAULT_TRIAGE_LABEL_MIRROR_VALUE },
+      default: { ...DEFAULT_TRIAGE_LABEL_MIRROR_VALUE },
+      source: "default-on-error",
+    };
+  }
+  return {
+    name: FIELD_TRIAGE_LABEL_MIRROR,
+    current: { ...DEFAULT_TRIAGE_LABEL_MIRROR_VALUE },
+    default: { ...DEFAULT_TRIAGE_LABEL_MIRROR_VALUE },
     source: "default",
   };
 }
@@ -481,6 +516,7 @@ const REGISTERED_POLICIES: readonly Inspector[] = [
     listFieldInspector(data, "triageHoldMarkers", FIELD_TRIAGE_HOLD_MARKERS, defaultHoldMarkers(), {
       emptyIsTyped: true,
     }),
+  inspectTriageLabelMirrorField,
   inspectSwarmSubagentBackend,
   inspectDeliveryBranchField,
   inspectMinGreptileConfidenceField,

--- a/packages/core/src/policy/resolve.test.ts
+++ b/packages/core/src/policy/resolve.test.ts
@@ -390,8 +390,8 @@ describe("inspectAllPolicies", () => {
     roots.push(r);
     writeProjectDef(r, {});
     // deliveryBranch (#3041) + minGreptileConfidence (#3095) + hostSlashCommands (#3054)
-    // + openClawProductCommands (#3064) + hostSkillDiscovery (#75).
-    expect(inspectAllPolicies(r)).toHaveLength(21);
+    // + openClawProductCommands (#3064) + hostSkillDiscovery (#75) + triageLabelMirror (#1423).
+    expect(inspectAllPolicies(r)).toHaveLength(22);
   });
 
   it("surfaces typed allowDirectCommits", () => {

--- a/packages/core/src/triage/classify/index.ts
+++ b/packages/core/src/triage/classify/index.ts
@@ -875,7 +875,9 @@ export function validateProject(projectRoot: string): {
   const rel = projectDefinitionPath(root);
   const classifyErrs = validateTriageAutoClassifyOnPlan(plan, rel);
   const holderErrs = validateTriageHoldMarkersOnPlan(plan, rel);
-  const errors = [...classifyErrs, ...holderErrs];
+  // label-mirror validates plan.policy.triageLabelMirror (#1423); imported via re-export graph.
+  const mirrorErrs = validateTriageLabelMirrorOnPlanFromModule(plan, rel);
+  const errors = [...classifyErrs, ...holderErrs, ...mirrorErrs];
   if (errors.length > 0) {
     const lines = errors.map((err) => `FAIL: ${err}`);
     lines.push("");
@@ -887,7 +889,7 @@ export function validateProject(projectRoot: string): {
   return {
     code: 0,
     stdout:
-      "OK: triageAutoClassify[] + triageHoldMarkers[] valid " +
+      "OK: triageAutoClassify[] + triageHoldMarkers[] + triageLabelMirror valid " +
       `(${rules.length} rules, ${markers.length} hold markers).\n`,
     stderr: "",
   };
@@ -900,3 +902,30 @@ export function listProject(projectRoot: string): string {
   const markers = resolveHoldMarkers({ projectRoot: root });
   return `${renderList(rules, { holdMarkers: markers })}\n`;
 }
+
+// ---------------------------------------------------------------------------
+// Tier-1 label mirror (#1423 Wave 1)
+// Re-export after the classify engine so label-mirror's live bindings to
+// classifyIssue / resolveClassifyRules resolve once this module has evaluated.
+// ---------------------------------------------------------------------------
+
+export {
+  type ClassifyAction,
+  DEFAULT_IDEMPOTENCY_LABEL,
+  defaultLabelMirrorPolicy,
+  desiredLabelsForClassification,
+  type LabelMirrorItem,
+  type LabelMirrorOptions,
+  type LabelMirrorOutcome,
+  type LabelMirrorPolicy,
+  type LabelMirrorStatus,
+  labelMirrorOutcomeToJson,
+  mirrorLabels,
+  type ResolvedLabelMirrorPolicy,
+  renderLabelMirrorReport,
+  resolveLabelMirrorPolicy,
+  validateLabelMirrorPolicy,
+  validateTriageLabelMirrorOnPlan,
+} from "./label-mirror.js";
+
+import { validateTriageLabelMirrorOnPlan as validateTriageLabelMirrorOnPlanFromModule } from "./label-mirror.js";

--- a/packages/core/src/triage/classify/index.ts
+++ b/packages/core/src/triage/classify/index.ts
@@ -905,27 +905,77 @@ export function listProject(projectRoot: string): string {
 
 // ---------------------------------------------------------------------------
 // Tier-1 label mirror (#1423 Wave 1)
-// Re-export after the classify engine so label-mirror's live bindings to
-// classifyIssue / resolveClassifyRules resolve once this module has evaluated.
+// label-mirror.ts does not import this module (avoids ESM/SLizard cycle).
+// Public mirrorLabels injects the classify engine into the pure implementation.
 // ---------------------------------------------------------------------------
+
+import {
+  type ClassifyAction,
+  DEFAULT_IDEMPOTENCY_LABEL,
+  defaultLabelMirrorPolicy,
+  desiredLabelsForClassification,
+  type LabelMirrorEngine,
+  type LabelMirrorItem,
+  type LabelMirrorOptions as LabelMirrorOptionsCore,
+  type LabelMirrorOutcome,
+  type LabelMirrorPolicy,
+  type LabelMirrorStatus,
+  labelMirrorOutcomeToJson,
+  mirrorLabels as mirrorLabelsCore,
+  type ResolvedLabelMirrorPolicy,
+  renderLabelMirrorReport,
+  resolveLabelMirrorPolicy,
+  validateLabelMirrorPolicy,
+  validateTriageLabelMirrorOnPlan as validateTriageLabelMirrorOnPlanFromModule,
+} from "./label-mirror.js";
 
 export {
   type ClassifyAction,
   DEFAULT_IDEMPOTENCY_LABEL,
   defaultLabelMirrorPolicy,
   desiredLabelsForClassification,
+  type LabelMirrorEngine,
   type LabelMirrorItem,
-  type LabelMirrorOptions,
   type LabelMirrorOutcome,
   type LabelMirrorPolicy,
   type LabelMirrorStatus,
   labelMirrorOutcomeToJson,
-  mirrorLabels,
   type ResolvedLabelMirrorPolicy,
   renderLabelMirrorReport,
   resolveLabelMirrorPolicy,
   validateLabelMirrorPolicy,
-  validateTriageLabelMirrorOnPlan,
-} from "./label-mirror.js";
+  validateTriageLabelMirrorOnPlanFromModule as validateTriageLabelMirrorOnPlan,
+};
 
-import { validateTriageLabelMirrorOnPlan as validateTriageLabelMirrorOnPlanFromModule } from "./label-mirror.js";
+/** Public options: engine is optional (defaults to this module's classify API). */
+export type LabelMirrorOptions = Omit<LabelMirrorOptionsCore, "engine"> & {
+  readonly engine?: LabelMirrorEngine;
+};
+
+function defaultLabelMirrorEngine(): LabelMirrorEngine {
+  return {
+    classifyIssue: (issue, options) =>
+      classifyIssue(issue as GitHubIssue, {
+        rules: options?.rules as ClassifyRule[] | undefined,
+        holdMarkers: options?.holdMarkers,
+        vbriefReferenced: options?.vbriefReferenced,
+        hasTriageDecision: options?.hasTriageDecision,
+        now: options?.now,
+      }),
+    resolveClassifyRules,
+    resolveHoldMarkers,
+    extractReferencedIssues,
+  };
+}
+
+/** Tier-1 label mirror with the #1129 classify engine bound in. */
+export function mirrorLabels(
+  projectRoot: string,
+  options: LabelMirrorOptions = {},
+): [number, LabelMirrorOutcome] {
+  const { engine, ...rest } = options;
+  return mirrorLabelsCore(projectRoot, {
+    ...rest,
+    engine: engine ?? defaultLabelMirrorEngine(),
+  });
+}

--- a/packages/core/src/triage/classify/index.ts
+++ b/packages/core/src/triage/classify/index.ts
@@ -968,6 +968,8 @@ function defaultLabelMirrorEngine(): LabelMirrorEngine {
   };
 }
 
+export { extractReferencedRepoIssueKeys } from "./label-mirror.js";
+
 /** Tier-1 label mirror with the #1129 classify engine bound in. */
 export function mirrorLabels(
   projectRoot: string,

--- a/packages/core/src/triage/classify/label-mirror.test.ts
+++ b/packages/core/src/triage/classify/label-mirror.test.ts
@@ -12,7 +12,7 @@ import {
   renderLabelMirrorReport,
   resolveLabelMirrorPolicy,
   validateLabelMirrorPolicy,
-} from "./label-mirror.js";
+} from "./index.js";
 
 const temps: string[] = [];
 afterEach(() => {
@@ -282,16 +282,6 @@ describe("mirrorLabels", () => {
       labels: [],
     });
     const client = new FakeLabelClient();
-    // Force project repo via explicit --repo that differs
-    const [code, outcome] = mirrorLabels(root, {
-      dryRun: false,
-      client,
-      repo: "acme/demo",
-      allowCrossRepo: false,
-      useLiveLabels: true,
-    });
-    // filtered by --repo so scanned may be 0; use unfiltered but without matching project repo
-    // Re-run without repo filter:
     const [code2, outcome2] = mirrorLabels(root, {
       dryRun: false,
       client,
@@ -302,8 +292,59 @@ describe("mirrorLabels", () => {
     expect(client.applyCalls).toHaveLength(0);
     expect(outcome2.errors).toBeGreaterThan(0);
     expect(outcome2.items.some((i) => i.status === "error")).toBe(true);
-    // silence unused
-    expect(code === 0 || code === 1).toBe(true);
-    expect(outcome.scanned).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not apply project xBRIEF number refs to a foreign-repo same number (#1423 P1)", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    // Active xBRIEF references acme/demo#42 only via github-issue URI
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: {
+          title: "S",
+          status: "running",
+          items: [],
+          references: [
+            {
+              type: "x-xbrief/github-issue",
+              uri: "https://github.com/acme/demo/issues/42",
+            },
+          ],
+        },
+      }),
+      "utf8",
+    );
+    // Foreign repo shares issue number 42 but has no hold-marker / no match
+    // without the false-positive vbrief-referenced rule.
+    writeCachedIssue(root, "other/victim", 42, {
+      number: 42,
+      state: "open",
+      body: "unrelated issue with a substantial body that is not dormant",
+      labels: [],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    // Project-repo sibling with same number should match vbrief-referenced
+    writeCachedIssue(root, "acme/demo", 42, {
+      number: 42,
+      state: "open",
+      body: "referenced scope work with enough body text to avoid dormant",
+      labels: [],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    const [, outcome] = mirrorLabels(root, {
+      dryRun: true,
+      useLiveLabels: false,
+      repo: "other/victim",
+      // Force project repo resolution to acme/demo so foreign is not project
+      allowCrossRepo: true,
+    });
+    // Foreign #42 must NOT be classified as accept via universal:vbrief-referenced
+    const foreign = outcome.items.find((i) => i.repo === "other/victim" && i.issue_number === 42);
+    expect(foreign).toBeDefined();
+    expect(foreign?.action).not.toBe("accept");
+    expect(foreign?.ruleKind).not.toBe("universal:vbrief-referenced");
   });
 });

--- a/packages/core/src/triage/classify/label-mirror.test.ts
+++ b/packages/core/src/triage/classify/label-mirror.test.ts
@@ -297,7 +297,7 @@ describe("mirrorLabels", () => {
   it("does not apply project xBRIEF number refs to a foreign-repo same number (#1423 P1)", () => {
     const root = tmpRoot();
     writeProject(root);
-    // Active xBRIEF references acme/demo#42 only via github-issue URI
+    // Active xBRIEF references issue 42
     mkdirSync(join(root, "xbrief", "active"), { recursive: true });
     writeFileSync(
       join(root, "xbrief", "active", "story.xbrief.json"),
@@ -317,8 +317,9 @@ describe("mirrorLabels", () => {
       }),
       "utf8",
     );
-    // Foreign repo shares issue number 42 but has no hold-marker / no match
-    // without the false-positive vbrief-referenced rule.
+    // Multi-repo cache: same issue number in foreign + project-like repo.
+    // With unresolved project identity, multi-repo fail-closed means neither
+    // gets number-only refs (no false-positive accept on foreign).
     writeCachedIssue(root, "other/victim", 42, {
       number: 42,
       state: "open",
@@ -326,7 +327,6 @@ describe("mirrorLabels", () => {
       labels: [],
       updated_at: "2026-08-01T00:00:00Z",
     });
-    // Project-repo sibling with same number should match vbrief-referenced
     writeCachedIssue(root, "acme/demo", 42, {
       number: 42,
       state: "open",
@@ -337,14 +337,50 @@ describe("mirrorLabels", () => {
     const [, outcome] = mirrorLabels(root, {
       dryRun: true,
       useLiveLabels: false,
-      repo: "other/victim",
-      // Force project repo resolution to acme/demo so foreign is not project
       allowCrossRepo: true,
     });
-    // Foreign #42 must NOT be classified as accept via universal:vbrief-referenced
     const foreign = outcome.items.find((i) => i.repo === "other/victim" && i.issue_number === 42);
     expect(foreign).toBeDefined();
     expect(foreign?.action).not.toBe("accept");
     expect(foreign?.ruleKind).not.toBe("universal:vbrief-referenced");
+  });
+
+  it("still applies xBRIEF refs on single-repo cache when project identity is unresolved", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: {
+          title: "S",
+          status: "running",
+          items: [],
+          references: [
+            {
+              type: "x-xbrief/github-issue",
+              uri: "https://github.com/acme/demo/issues/77",
+            },
+          ],
+        },
+      }),
+      "utf8",
+    );
+    writeCachedIssue(root, "acme/demo", 77, {
+      number: 77,
+      state: "open",
+      body: "referenced scope work with enough body text to avoid dormant rule",
+      labels: [],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    const [, outcome] = mirrorLabels(root, {
+      dryRun: true,
+      useLiveLabels: false,
+    });
+    const item = outcome.items.find((i) => i.issue_number === 77);
+    expect(item?.status).toBe("planned");
+    expect(item?.action).toBe("accept");
+    expect(item?.ruleKind).toBe("universal:vbrief-referenced");
   });
 });

--- a/packages/core/src/triage/classify/label-mirror.test.ts
+++ b/packages/core/src/triage/classify/label-mirror.test.ts
@@ -294,10 +294,9 @@ describe("mirrorLabels", () => {
     expect(outcome2.items.some((i) => i.status === "error")).toBe(true);
   });
 
-  it("does not apply project xBRIEF number refs to a foreign-repo same number (#1423 P1)", () => {
+  it("applies repo-qualified xBRIEF refs only to the matching repo (#1423 P1)", () => {
     const root = tmpRoot();
     writeProject(root);
-    // Active xBRIEF references issue 42
     mkdirSync(join(root, "xbrief", "active"), { recursive: true });
     writeFileSync(
       join(root, "xbrief", "active", "story.xbrief.json"),
@@ -317,9 +316,6 @@ describe("mirrorLabels", () => {
       }),
       "utf8",
     );
-    // Multi-repo cache: same issue number in foreign + project-like repo.
-    // With unresolved project identity, multi-repo fail-closed means neither
-    // gets number-only refs (no false-positive accept on foreign).
     writeCachedIssue(root, "other/victim", 42, {
       number: 42,
       state: "open",
@@ -340,9 +336,11 @@ describe("mirrorLabels", () => {
       allowCrossRepo: true,
     });
     const foreign = outcome.items.find((i) => i.repo === "other/victim" && i.issue_number === 42);
-    expect(foreign).toBeDefined();
-    expect(foreign?.action).not.toBe("accept");
+    const project = outcome.items.find((i) => i.repo === "acme/demo" && i.issue_number === 42);
     expect(foreign?.ruleKind).not.toBe("universal:vbrief-referenced");
+    expect(foreign?.action).not.toBe("accept");
+    expect(project?.action).toBe("accept");
+    expect(project?.ruleKind).toBe("universal:vbrief-referenced");
   });
 
   it("does not let --repo filter re-enable foreign xBRIEF refs on multi-repo cache", () => {
@@ -391,44 +389,5 @@ describe("mirrorLabels", () => {
     expect(foreign).toBeDefined();
     expect(foreign?.ruleKind).not.toBe("universal:vbrief-referenced");
     expect(foreign?.action).not.toBe("accept");
-  });
-
-  it("still applies xBRIEF refs on single-repo cache when project identity is unresolved", () => {
-    const root = tmpRoot();
-    writeProject(root);
-    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
-    writeFileSync(
-      join(root, "xbrief", "active", "story.xbrief.json"),
-      JSON.stringify({
-        xBRIEFInfo: { version: "0.8" },
-        plan: {
-          title: "S",
-          status: "running",
-          items: [],
-          references: [
-            {
-              type: "x-xbrief/github-issue",
-              uri: "https://github.com/acme/demo/issues/77",
-            },
-          ],
-        },
-      }),
-      "utf8",
-    );
-    writeCachedIssue(root, "acme/demo", 77, {
-      number: 77,
-      state: "open",
-      body: "referenced scope work with enough body text to avoid dormant rule",
-      labels: [],
-      updated_at: "2026-08-01T00:00:00Z",
-    });
-    const [, outcome] = mirrorLabels(root, {
-      dryRun: true,
-      useLiveLabels: false,
-    });
-    const item = outcome.items.find((i) => i.issue_number === 77);
-    expect(item?.status).toBe("planned");
-    expect(item?.action).toBe("accept");
-    expect(item?.ruleKind).toBe("universal:vbrief-referenced");
   });
 });

--- a/packages/core/src/triage/classify/label-mirror.test.ts
+++ b/packages/core/src/triage/classify/label-mirror.test.ts
@@ -1,0 +1,309 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { LabelClient } from "../../vbrief-reconcile/types.js";
+import {
+  DEFAULT_IDEMPOTENCY_LABEL,
+  defaultLabelMirrorPolicy,
+  desiredLabelsForClassification,
+  labelMirrorOutcomeToJson,
+  mirrorLabels,
+  renderLabelMirrorReport,
+  resolveLabelMirrorPolicy,
+  validateLabelMirrorPolicy,
+} from "./label-mirror.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  while (temps.length > 0) {
+    const t = temps.pop();
+    if (t !== undefined) {
+      rmSync(t, { recursive: true, force: true });
+    }
+  }
+});
+
+function tmpRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-label-mirror-"));
+  temps.push(root);
+  return root;
+}
+
+function writeProject(root: string, policy?: Record<string, unknown>): void {
+  mkdirSync(join(root, "xbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    JSON.stringify({
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "T",
+        status: "running",
+        items: [],
+        ...(policy !== undefined ? { "x-directive/policy": policy } : {}),
+      },
+    }),
+    "utf8",
+  );
+}
+
+function writeCachedIssue(
+  root: string,
+  repo: string,
+  issueNumber: number,
+  issue: Record<string, unknown>,
+): void {
+  const [owner, name] = repo.split("/", 2);
+  const dir = join(
+    root,
+    ".deft-cache",
+    "github-issue",
+    owner ?? "",
+    name ?? "",
+    String(issueNumber),
+  );
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "raw.json"), JSON.stringify(issue), "utf8");
+}
+
+class FakeLabelClient implements LabelClient {
+  labels = new Map<string, string[]>();
+  applyCalls: Array<[string, number, string[], string[]]> = [];
+  fetchCalls: Array<[string, number]> = [];
+
+  fetchLabels(repo: string, issueNumber: number): string[] {
+    this.fetchCalls.push([repo, issueNumber]);
+    return [...(this.labels.get(`${repo}:${issueNumber}`) ?? [])];
+  }
+
+  apply(
+    repo: string,
+    issueNumber: number,
+    add: readonly string[],
+    remove: readonly string[],
+  ): void {
+    this.applyCalls.push([repo, issueNumber, [...add], [...remove]]);
+    const key = `${repo}:${issueNumber}`;
+    const cur = new Set(this.labels.get(key) ?? []);
+    for (const a of add) cur.add(a);
+    for (const r of remove) cur.delete(r);
+    this.labels.set(key, [...cur].sort());
+  }
+}
+
+describe("validateLabelMirrorPolicy", () => {
+  it("accepts null/undefined", () => {
+    expect(validateLabelMirrorPolicy(undefined).errors).toEqual([]);
+    expect(validateLabelMirrorPolicy(null).errors).toEqual([]);
+  });
+
+  it("rejects non-object", () => {
+    expect(validateLabelMirrorPolicy([]).errors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects bad actionLabels keys", () => {
+    const { errors } = validateLabelMirrorPolicy({
+      actionLabels: { nope: ["x"] },
+    });
+    expect(errors.some((e) => e.includes("nope"))).toBe(true);
+  });
+
+  it("accepts valid policy", () => {
+    const { errors } = validateLabelMirrorPolicy({
+      enabled: true,
+      idempotencyLabel: "triaged",
+      alwaysLabels: ["triaged"],
+      actionLabels: { defer: ["status:deferred"] },
+    });
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("desiredLabelsForClassification", () => {
+  it("includes idempotency + action labels", () => {
+    const policy = resolveLabelMirrorPolicy({
+      override: {
+        alwaysLabels: ["triaged"],
+        actionLabels: { defer: ["status:deferred"], accept: ["enhancement"] },
+      },
+    });
+    expect(desiredLabelsForClassification("defer", policy)).toEqual(["status:deferred", "triaged"]);
+    expect(desiredLabelsForClassification("accept", policy)).toEqual(["enhancement", "triaged"]);
+  });
+
+  it("defaults to triaged only", () => {
+    const policy = defaultLabelMirrorPolicy();
+    expect(policy.idempotencyLabel).toBe(DEFAULT_IDEMPOTENCY_LABEL);
+    expect(desiredLabelsForClassification("archive", policy)).toEqual(["triaged"]);
+  });
+});
+
+describe("mirrorLabels", () => {
+  it("dry-run plans labels with zero SCM writes", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    // Hold-marker match → defer
+    writeCachedIssue(root, "acme/demo", 1, {
+      number: 1,
+      state: "open",
+      body: "BLOCKED do not implement yet",
+      labels: [],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    const client = new FakeLabelClient();
+    const [code, outcome] = mirrorLabels(root, {
+      dryRun: true,
+      client,
+      // force cache labels even if client provided
+      useLiveLabels: false,
+    });
+    expect(code).toBe(0);
+    expect(outcome.dry_run).toBe(true);
+    expect(client.applyCalls).toHaveLength(0);
+    expect(client.fetchCalls).toHaveLength(0);
+    expect(outcome.planned).toBe(1);
+    expect(outcome.items[0]?.status).toBe("planned");
+    expect(outcome.items[0]?.add).toContain("triaged");
+    expect(outcome.items[0]?.action).toBe("defer");
+  });
+
+  it("skips already-triaged issues (idempotent)", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    writeCachedIssue(root, "acme/demo", 2, {
+      number: 2,
+      state: "open",
+      body: "BLOCKED",
+      labels: [{ name: "triaged" }],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    const [code, outcome] = mirrorLabels(root, { dryRun: true, useLiveLabels: false });
+    expect(code).toBe(0);
+    expect(outcome.skipped_already_triaged).toBe(1);
+    expect(outcome.planned).toBe(0);
+    expect(outcome.items[0]?.status).toBe("skipped_already_triaged");
+  });
+
+  it("--apply writes labels via LabelClient; re-run is no-op", () => {
+    const root = tmpRoot();
+    writeProject(root, {
+      triageLabelMirror: {
+        actionLabels: { defer: ["status:deferred"] },
+      },
+    });
+    writeCachedIssue(root, "acme/demo", 3, {
+      number: 3,
+      state: "open",
+      body: "HOLDING for later",
+      labels: [],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    // Seed git remote resolution by writing a fake origin? repo guard needs project repo.
+    // Use allowCrossRepo for fixture without git remote.
+    const client = new FakeLabelClient();
+    const [code1, outcome1] = mirrorLabels(root, {
+      dryRun: false,
+      client,
+      allowCrossRepo: true,
+      useLiveLabels: true,
+    });
+    expect(code1).toBe(0);
+    expect(outcome1.applied).toBe(1);
+    expect(client.applyCalls).toHaveLength(1);
+    expect(client.applyCalls[0]?.[2].sort()).toEqual(["status:deferred", "triaged"]);
+
+    // Re-run: live labels now include triaged → skip
+    const [code2, outcome2] = mirrorLabels(root, {
+      dryRun: false,
+      client,
+      allowCrossRepo: true,
+      useLiveLabels: true,
+    });
+    expect(code2).toBe(0);
+    expect(outcome2.applied).toBe(0);
+    expect(outcome2.skipped_already_triaged).toBe(1);
+    expect(client.applyCalls).toHaveLength(1); // no second apply
+  });
+
+  it("never mutates on dry-run even when client is provided", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    writeCachedIssue(root, "acme/demo", 4, {
+      number: 4,
+      state: "closed",
+      body: "done",
+      labels: [],
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+    const client = new FakeLabelClient();
+    mirrorLabels(root, { dryRun: true, client, useLiveLabels: false });
+    expect(client.applyCalls).toHaveLength(0);
+  });
+
+  it("respects enabled: false", () => {
+    const root = tmpRoot();
+    writeProject(root, { triageLabelMirror: { enabled: false } });
+    writeCachedIssue(root, "acme/demo", 5, {
+      number: 5,
+      state: "open",
+      body: "BLOCKED",
+      labels: [],
+    });
+    const [code, outcome] = mirrorLabels(root, { dryRun: true });
+    expect(code).toBe(0);
+    expect(outcome.items[0]?.status).toBe("skipped_disabled");
+  });
+
+  it("render + json shapes are stable", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    writeCachedIssue(root, "acme/demo", 6, {
+      number: 6,
+      state: "open",
+      body: "BLOCKED",
+      labels: [],
+    });
+    const [, outcome] = mirrorLabels(root, { dryRun: true, useLiveLabels: false });
+    const report = renderLabelMirrorReport(outcome);
+    expect(report).toContain("dry-run");
+    expect(report).toContain("Would add labels:");
+    const json = labelMirrorOutcomeToJson(outcome);
+    expect(json.dry_run).toBe(true);
+    expect(Array.isArray(json.items)).toBe(true);
+  });
+
+  it("refuses cross-repo apply without allowCrossRepo", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    writeCachedIssue(root, "other/victim", 99, {
+      number: 99,
+      state: "open",
+      body: "BLOCKED",
+      labels: [],
+    });
+    const client = new FakeLabelClient();
+    // Force project repo via explicit --repo that differs
+    const [code, outcome] = mirrorLabels(root, {
+      dryRun: false,
+      client,
+      repo: "acme/demo",
+      allowCrossRepo: false,
+      useLiveLabels: true,
+    });
+    // filtered by --repo so scanned may be 0; use unfiltered but without matching project repo
+    // Re-run without repo filter:
+    const [code2, outcome2] = mirrorLabels(root, {
+      dryRun: false,
+      client,
+      allowCrossRepo: false,
+      useLiveLabels: true,
+    });
+    expect(code2).toBe(1);
+    expect(client.applyCalls).toHaveLength(0);
+    expect(outcome2.errors).toBeGreaterThan(0);
+    expect(outcome2.items.some((i) => i.status === "error")).toBe(true);
+    // silence unused
+    expect(code === 0 || code === 1).toBe(true);
+    expect(outcome.scanned).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/core/src/triage/classify/label-mirror.test.ts
+++ b/packages/core/src/triage/classify/label-mirror.test.ts
@@ -345,6 +345,54 @@ describe("mirrorLabels", () => {
     expect(foreign?.ruleKind).not.toBe("universal:vbrief-referenced");
   });
 
+  it("does not let --repo filter re-enable foreign xBRIEF refs on multi-repo cache", () => {
+    const root = tmpRoot();
+    writeProject(root);
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: {
+          title: "S",
+          status: "running",
+          items: [],
+          references: [
+            {
+              type: "x-xbrief/github-issue",
+              uri: "https://github.com/acme/demo/issues/55",
+            },
+          ],
+        },
+      }),
+      "utf8",
+    );
+    writeCachedIssue(root, "other/victim", 55, {
+      number: 55,
+      state: "open",
+      body: "foreign same number with enough body text",
+      labels: [],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    writeCachedIssue(root, "acme/demo", 55, {
+      number: 55,
+      state: "open",
+      body: "project same number with enough body text",
+      labels: [],
+      updated_at: "2026-08-01T00:00:00Z",
+    });
+    const [, outcome] = mirrorLabels(root, {
+      dryRun: true,
+      useLiveLabels: false,
+      repo: "other/victim",
+      allowCrossRepo: true,
+    });
+    const foreign = outcome.items.find((i) => i.repo === "other/victim" && i.issue_number === 55);
+    expect(foreign).toBeDefined();
+    expect(foreign?.ruleKind).not.toBe("universal:vbrief-referenced");
+    expect(foreign?.action).not.toBe("accept");
+  });
+
   it("still applies xBRIEF refs on single-repo cache when project identity is unresolved", () => {
     const root = tmpRoot();
     writeProject(root);

--- a/packages/core/src/triage/classify/label-mirror.ts
+++ b/packages/core/src/triage/classify/label-mirror.ts
@@ -4,32 +4,72 @@
  * Classifies cached issues with the existing #1129 engine, then mirrors the
  * outcome as SCM labels (dry-run default, --apply to write). Never accepts into
  * the xBRIEF lifecycle and never writes proposed/ scopes.
+ *
+ * Intentionally does NOT import from ./index.js (SLizard P1 cycle). The classify
+ * engine is injected via LabelMirrorEngine / mirrorLabels() wrapper in index.ts.
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { resolveProjectDefinitionPath } from "../../layout/resolve.js";
 import { readPlanPolicy } from "../../policy/plan-extensions.js";
 import { ScmLabelClient } from "../../vbrief-reconcile/labels.js";
 import { isRepoMutationAllowed } from "../../vbrief-reconcile/repo-guard.js";
 import type { LabelClient } from "../../vbrief-reconcile/types.js";
 import { latestDecisions, readAuditLog } from "../actions/candidates-log.js";
 import { resolveCandidatesLogPath } from "../cache-path.js";
+import { resolveRepo } from "../queue/repo.js";
 import { iterCachedIssues } from "../summary/index.js";
-import type { ClassificationResult, GitHubIssue } from "./index.js";
-import {
-  classifyIssue,
-  extractReferencedIssues,
-  loadProjectDefinitionForCli,
-  resolveClassifyRules,
-  resolveHoldMarkers,
-  VALID_ACTIONS,
-} from "./index.js";
 
 export const DEFAULT_IDEMPOTENCY_LABEL = "triaged";
 export const CACHE_DIR_NAME = ".deft-cache";
 export const CACHE_SOURCE = "github-issue";
 
+const VALID_ACTIONS: ReadonlySet<string> = new Set(["defer", "archive", "escalate", "accept"]);
+
 export type ClassifyAction = "defer" | "archive" | "escalate" | "accept";
+
+/** Minimal issue shape used by the mirror (matches classify GitHubIssue). */
+export interface MirrorGitHubIssue {
+  readonly number?: number;
+  readonly state?: string;
+  readonly body?: string | null;
+  readonly labels?: ReadonlyArray<{ name?: string } | string>;
+  readonly updated_at?: string;
+  readonly created_at?: string;
+}
+
+export interface MirrorClassificationResult {
+  readonly action: string;
+  readonly reason: string;
+  readonly ruleIndex: number;
+  readonly ruleSource: string;
+  readonly ruleKind: string;
+  readonly resumeOn: string | null;
+}
+
+/** Injected classify engine — avoids a runtime import cycle with classify/index.ts. */
+export interface LabelMirrorEngine {
+  readonly classifyIssue: (
+    issue: MirrorGitHubIssue,
+    options?: {
+      rules?: readonly unknown[];
+      holdMarkers?: string[] | null;
+      vbriefReferenced?: ReadonlySet<number> | null;
+      hasTriageDecision?: boolean;
+      now?: Date;
+    },
+  ) => MirrorClassificationResult | null;
+  readonly resolveClassifyRules: (options?: {
+    projectRoot?: string;
+    projectDefinition?: Record<string, unknown> | null;
+  }) => readonly unknown[];
+  readonly resolveHoldMarkers: (options?: {
+    projectRoot?: string;
+    projectDefinition?: Record<string, unknown> | null;
+  }) => string[];
+  readonly extractReferencedIssues: (projectRoot?: string) => Set<number>;
+}
 
 export interface LabelMirrorPolicy {
   /** When false, mirror is a no-op (default true when policy object is used). */
@@ -97,6 +137,8 @@ export interface LabelMirrorOptions {
   /** Prefer live SCM labels when true (default: !dryRun). Cache labels used for dry-run. */
   readonly useLiveLabels?: boolean;
   readonly now?: Date;
+  /** Required: classify engine (provided by classify/index mirrorLabels wrapper). */
+  readonly engine: LabelMirrorEngine;
 }
 
 function asStringList(value: unknown): string[] | null {
@@ -111,6 +153,10 @@ function asStringList(value: unknown): string[] | null {
     out.push(item);
   }
   return out;
+}
+
+function sanitizeReportFragment(value: string): string {
+  return value.replace(/\r?\n/g, " ");
 }
 
 /** Validate plan.policy.triageLabelMirror payload. */
@@ -182,6 +228,24 @@ export function defaultLabelMirrorPolicy(): ResolvedLabelMirrorPolicy {
   };
 }
 
+function loadProjectDefinition(projectRoot: string): Record<string, unknown> | null {
+  let path: string;
+  try {
+    path = resolveProjectDefinitionPath(projectRoot);
+  } catch {
+    path = join(projectRoot, "xbrief", "PROJECT-DEFINITION.xbrief.json");
+  }
+  try {
+    const raw = readFileSync(path, { encoding: "utf8" });
+    const data: unknown = JSON.parse(raw);
+    return typeof data === "object" && data !== null && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Resolve effective label-mirror policy from PROJECT-DEFINITION or inline object. */
 export function resolveLabelMirrorPolicy(options?: {
   projectRoot?: string;
@@ -194,7 +258,7 @@ export function resolveLabelMirrorPolicy(options?: {
   const data =
     options?.projectDefinition !== undefined
       ? options.projectDefinition
-      : loadProjectDefinitionForCli(options?.projectRoot ?? process.cwd());
+      : loadProjectDefinition(options?.projectRoot ?? process.cwd());
   if (data === null) {
     return defaultLabelMirrorPolicy();
   }
@@ -261,7 +325,7 @@ export function desiredLabelsForClassification(
   return [...desired].sort();
 }
 
-function issueLabelNames(issue: GitHubIssue): string[] {
+function issueLabelNames(issue: MirrorGitHubIssue): string[] {
   const raw = issue.labels ?? [];
   const names: string[] = [];
   if (!Array.isArray(raw)) {
@@ -284,7 +348,7 @@ function readCachedRawIssue(
   cacheRoot: string,
   repo: string,
   issueNumber: number,
-): GitHubIssue | null {
+): MirrorGitHubIssue | null {
   const [owner, name] = repo.split("/", 2);
   const rawPath = join(
     cacheRoot,
@@ -302,7 +366,7 @@ function readCachedRawIssue(
     if (typeof data !== "object" || data === null || Array.isArray(data)) {
       return null;
     }
-    return data as GitHubIssue;
+    return data as MirrorGitHubIssue;
   } catch {
     return null;
   }
@@ -329,10 +393,11 @@ function decisionMapHas(
 /**
  * Run Tier-1 label mirror over the github-issue cache.
  * Dry-run by default (no SCM writes). Pass dryRun: false to apply.
+ * Requires options.engine (classify/index wrapper injects it).
  */
 export function mirrorLabels(
   projectRoot: string,
-  options: LabelMirrorOptions = {},
+  options: LabelMirrorOptions,
 ): [number, LabelMirrorOutcome] {
   const root = resolve(projectRoot);
   const dryRun = options.dryRun ?? true;
@@ -340,6 +405,7 @@ export function mirrorLabels(
   const cacheRoot = options.cacheRoot ?? join(root, CACHE_DIR_NAME);
   const useLiveLabels = options.useLiveLabels ?? !dryRun;
   const client = options.client ?? (useLiveLabels || !dryRun ? new ScmLabelClient() : undefined);
+  const engine = options.engine;
 
   const items: LabelMirrorItem[] = [];
   const outcomeBase = {
@@ -379,15 +445,19 @@ export function mirrorLabels(
     ];
   }
 
-  const rules = resolveClassifyRules({ projectRoot: root });
-  const holdMarkers = resolveHoldMarkers({ projectRoot: root });
-  // Soft-fail when no xbrief layout yet (empty cache bootstrap / sparse fixtures).
-  let vbriefReferenced: Set<number> = new Set();
+  const rules = engine.resolveClassifyRules({ projectRoot: root });
+  const holdMarkers = engine.resolveHoldMarkers({ projectRoot: root });
+  // Number-only xBRIEF refs are project-repo scoped (#1423 Greptile P1). Soft-fail
+  // when no xbrief layout yet (empty cache bootstrap / sparse fixtures).
+  let projectVbriefReferenced: Set<number> = new Set();
   try {
-    vbriefReferenced = extractReferencedIssues(root);
+    projectVbriefReferenced = engine.extractReferencedIssues(root);
   } catch {
-    vbriefReferenced = new Set();
+    projectVbriefReferenced = new Set();
   }
+  // Project identity for xBRIEF ref scoping must NOT use --repo (that flag is a
+  // scan filter only). resolveRepo(null, root) uses git remote / PROJECT-DEFINITION.
+  const projectRepo = resolveRepo(null, root);
   const decisions = loadLatestDecisionMap(root);
   const now = options.now ?? new Date();
 
@@ -429,7 +499,6 @@ export function mirrorLabels(
       try {
         current = client.fetchLabels(repo, issueNumber);
       } catch (exc) {
-        // Fall back to cache labels on fetch failure so dry-run-style planning can still report.
         current = issueLabelNames(issue);
         if (!dryRun) {
           errors += 1;
@@ -469,8 +538,14 @@ export function mirrorLabels(
       continue;
     }
 
-    const classification: ClassificationResult | null = classifyIssue(issue, {
-      rules,
+    // Only apply number-only xBRIEF refs when this cache entry is the project repo.
+    // Cross-repo same-number collisions must not inherit project references (#1423 P1).
+    const sameAsProject =
+      projectRepo !== null && repo.trim().toLowerCase() === projectRepo.trim().toLowerCase();
+    const vbriefReferenced = sameAsProject ? projectVbriefReferenced : null;
+
+    const classification = engine.classifyIssue(issue, {
+      rules: rules as never,
       holdMarkers,
       vbriefReferenced,
       hasTriageDecision: decisionMapHas(decisions, repo, issueNumber),
@@ -641,9 +716,8 @@ export function renderLabelMirrorReport(outcome: LabelMirrorOutcome): string {
     for (const item of plannedOrApplied) {
       const actionPart = item.action !== null ? ` action=${item.action}` : "";
       const rulePart = item.ruleKind !== null ? ` rule=${item.ruleKind}` : "";
-      lines.push(
-        `- ${item.repo}#${item.issue_number}:${actionPart}${rulePart} +${item.add.join(", +")}`,
-      );
+      const addPart = sanitizeReportFragment(item.add.join(", +"));
+      lines.push(`- ${item.repo}#${item.issue_number}:${actionPart}${rulePart} +${addPart}`);
     }
   }
 
@@ -663,7 +737,8 @@ export function renderLabelMirrorReport(outcome: LabelMirrorOutcome): string {
     lines.push("");
     lines.push("Errors:");
     for (const item of errs) {
-      lines.push(`- ${item.repo}#${item.issue_number}: ${item.message ?? "unknown error"}`);
+      const msg = sanitizeReportFragment(item.message ?? "unknown error");
+      lines.push(`- ${item.repo}#${item.issue_number}: ${msg}`);
     }
   }
 

--- a/packages/core/src/triage/classify/label-mirror.ts
+++ b/packages/core/src/triage/classify/label-mirror.ts
@@ -9,16 +9,20 @@
  * engine is injected via LabelMirrorEngine / mirrorLabels() wrapper in index.ts.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { resolveProjectDefinitionPath } from "../../layout/resolve.js";
+import { referenceTypeMatches } from "@deftai/directive-types";
+import {
+  hasArtifactSuffix,
+  resolveLifecycleRoot,
+  resolveProjectDefinitionPath,
+} from "../../layout/resolve.js";
 import { readPlanPolicy } from "../../policy/plan-extensions.js";
 import { ScmLabelClient } from "../../vbrief-reconcile/labels.js";
 import { isRepoMutationAllowed } from "../../vbrief-reconcile/repo-guard.js";
 import type { LabelClient } from "../../vbrief-reconcile/types.js";
 import { latestDecisions, readAuditLog } from "../actions/candidates-log.js";
 import { resolveCandidatesLogPath } from "../cache-path.js";
-import { resolveRepo } from "../queue/repo.js";
 import { iterCachedIssues } from "../summary/index.js";
 
 export const DEFAULT_IDEMPOTENCY_LABEL = "triaged";
@@ -68,7 +72,86 @@ export interface LabelMirrorEngine {
     projectRoot?: string;
     projectDefinition?: Record<string, unknown> | null;
   }) => string[];
-  readonly extractReferencedIssues: (projectRoot?: string) => Set<number>;
+  /** Optional; label-mirror prefers repo-qualified keys and only needs numbers as fallback. */
+  readonly extractReferencedIssues?: (projectRoot?: string) => Set<number>;
+}
+
+/**
+ * Repo-qualified xBRIEF github-issue keys (`owner/name\\0number`).
+ * Unlike number-only extractReferencedIssues, this never collides across repos.
+ */
+export function extractReferencedRepoIssueKeys(
+  projectRoot?: string,
+  lifecycleFolders: readonly string[] = ["pending", "active"],
+): Set<string> {
+  const referenced = new Set<string>();
+  let root: string;
+  try {
+    root = resolveLifecycleRoot(projectRoot ?? process.cwd());
+  } catch {
+    return referenced;
+  }
+  for (const folder of lifecycleFolders) {
+    const folderPath = join(root, folder);
+    let entries: string[];
+    try {
+      entries = readdirSync(folderPath).filter((f) => hasArtifactSuffix(f));
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      try {
+        const raw = readFileSync(join(folderPath, name), { encoding: "utf8" });
+        const data: unknown = JSON.parse(raw);
+        if (typeof data !== "object" || data === null || Array.isArray(data)) {
+          continue;
+        }
+        const plan = (data as Record<string, unknown>).plan;
+        if (typeof plan !== "object" || plan === null || Array.isArray(plan)) {
+          continue;
+        }
+        const refs = (plan as Record<string, unknown>).references ?? [];
+        if (!Array.isArray(refs)) {
+          continue;
+        }
+        for (const ref of refs) {
+          if (typeof ref !== "object" || ref === null || Array.isArray(ref)) {
+            continue;
+          }
+          const r = ref as Record<string, unknown>;
+          if (!referenceTypeMatches(String(r.type ?? ""), "github-issue")) {
+            continue;
+          }
+          const uri = r.uri;
+          if (typeof uri !== "string") {
+            continue;
+          }
+          const cleaned = uri.trim().replace(/\/+$/, "");
+          const parts =
+            cleaned
+              .split("://")
+              .pop()
+              ?.split("/")
+              .filter((p) => p.length > 0) ?? [];
+          if (
+            parts.length >= 4 &&
+            parts[parts.length - 2] === "issues" &&
+            /^\d+$/.test(parts[parts.length - 1] ?? "")
+          ) {
+            const owner = parts[parts.length - 4] ?? "";
+            const repoName = parts[parts.length - 3] ?? "";
+            const n = Number.parseInt(parts[parts.length - 1] ?? "", 10);
+            if (owner.length > 0 && repoName.length > 0 && Number.isFinite(n)) {
+              referenced.add(`${owner}/${repoName}\0${n}`.toLowerCase());
+            }
+          }
+        }
+      } catch {
+        // tolerate corrupt artifacts
+      }
+    }
+  }
+  return referenced;
 }
 
 export interface LabelMirrorPolicy {
@@ -447,44 +530,16 @@ export function mirrorLabels(
 
   const rules = engine.resolveClassifyRules({ projectRoot: root });
   const holdMarkers = engine.resolveHoldMarkers({ projectRoot: root });
-  // Number-only xBRIEF refs are project-repo scoped (#1423 Greptile P1). Soft-fail
-  // when no xbrief layout yet (empty cache bootstrap / sparse fixtures).
-  let projectVbriefReferenced: Set<number>;
-  try {
-    projectVbriefReferenced = engine.extractReferencedIssues(root);
-  } catch {
-    projectVbriefReferenced = new Set();
-  }
-  // Project identity for xBRIEF ref scoping must NOT use --repo (that flag is a
-  // scan filter only). resolveRepo(null, root) uses git remote / PROJECT-DEFINITION.
-  const projectRepo = resolveRepo(null, root);
+  // Repo-qualified xBRIEF keys avoid number-only collisions across multi-repo
+  // caches and do not require project identity (#1423 Greptile P1 class).
+  const referencedKeys = extractReferencedRepoIssueKeys(root);
   const decisions = loadLatestDecisionMap(root);
   const now = options.now ?? new Date();
 
-  // Unfiltered cache inventory drives xBRIEF-ref eligibility. The optional --repo
-  // flag is a scan filter only and MUST NOT shrink multi-repo identity to a
-  // single foreign slug (Greptile P1: filtered foreign inherits project refs).
-  const allPairs = iterCachedIssues(cacheRoot);
-  let pairs = allPairs;
+  let pairs = iterCachedIssues(cacheRoot);
   if (options.repo !== undefined && options.repo !== null && options.repo.trim().length > 0) {
     const want = options.repo.trim().toLowerCase();
-    pairs = allPairs.filter(([repo]) => repo.toLowerCase() === want);
-  }
-
-  // Repos allowed to use number-only xBRIEF refs:
-  // - when project repo is known: only that slug
-  // - when unknown and the unfiltered cache is a single repo: that repo
-  // - when unknown multi-repo (even if --repo filters to one): none
-  const reposAllowedVbriefRefs = new Set<string>();
-  if (projectRepo !== null && projectRepo.trim().length > 0) {
-    reposAllowedVbriefRefs.add(projectRepo.trim().toLowerCase());
-  } else {
-    const uniqueRepos = new Set(allPairs.map(([repo]) => repo.toLowerCase()));
-    if (uniqueRepos.size === 1) {
-      for (const r of uniqueRepos) {
-        reposAllowedVbriefRefs.add(r);
-      }
-    }
+    pairs = pairs.filter(([repo]) => repo.toLowerCase() === want);
   }
 
   let planned = 0;
@@ -558,11 +613,11 @@ export function mirrorLabels(
       continue;
     }
 
-    // Only apply number-only xBRIEF refs for allowed repos (see reposAllowedVbriefRefs).
-    // Cross-repo same-number collisions must not inherit project references (#1423 P1).
-    const vbriefReferenced = reposAllowedVbriefRefs.has(repo.toLowerCase())
-      ? projectVbriefReferenced
-      : null;
+    // Pass number set only when this exact repo+number is referenced from xBRIEF.
+    const key = `${repo.toLowerCase()}\0${issueNumber}`;
+    const vbriefReferenced = referencedKeys.has(key)
+      ? new Set<number>([issueNumber])
+      : new Set<number>();
 
     const classification = engine.classifyIssue(issue, {
       rules: rules as never,

--- a/packages/core/src/triage/classify/label-mirror.ts
+++ b/packages/core/src/triage/classify/label-mirror.ts
@@ -461,21 +461,25 @@ export function mirrorLabels(
   const decisions = loadLatestDecisionMap(root);
   const now = options.now ?? new Date();
 
-  let pairs = iterCachedIssues(cacheRoot);
+  // Unfiltered cache inventory drives xBRIEF-ref eligibility. The optional --repo
+  // flag is a scan filter only and MUST NOT shrink multi-repo identity to a
+  // single foreign slug (Greptile P1: filtered foreign inherits project refs).
+  const allPairs = iterCachedIssues(cacheRoot);
+  let pairs = allPairs;
   if (options.repo !== undefined && options.repo !== null && options.repo.trim().length > 0) {
     const want = options.repo.trim().toLowerCase();
-    pairs = pairs.filter(([repo]) => repo.toLowerCase() === want);
+    pairs = allPairs.filter(([repo]) => repo.toLowerCase() === want);
   }
 
   // Repos allowed to use number-only xBRIEF refs:
   // - when project repo is known: only that slug
-  // - when unknown and the scan set is a single repo: that repo (legitimate bootstrap)
-  // - when unknown multi-repo: none (fail closed on number collisions)
+  // - when unknown and the unfiltered cache is a single repo: that repo
+  // - when unknown multi-repo (even if --repo filters to one): none
   const reposAllowedVbriefRefs = new Set<string>();
   if (projectRepo !== null && projectRepo.trim().length > 0) {
     reposAllowedVbriefRefs.add(projectRepo.trim().toLowerCase());
   } else {
-    const uniqueRepos = new Set(pairs.map(([repo]) => repo.toLowerCase()));
+    const uniqueRepos = new Set(allPairs.map(([repo]) => repo.toLowerCase()));
     if (uniqueRepos.size === 1) {
       for (const r of uniqueRepos) {
         reposAllowedVbriefRefs.add(r);

--- a/packages/core/src/triage/classify/label-mirror.ts
+++ b/packages/core/src/triage/classify/label-mirror.ts
@@ -1,0 +1,733 @@
+/**
+ * Tier-1 deterministic SCM label mirror (#1423 Wave 1).
+ *
+ * Classifies cached issues with the existing #1129 engine, then mirrors the
+ * outcome as SCM labels (dry-run default, --apply to write). Never accepts into
+ * the xBRIEF lifecycle and never writes proposed/ scopes.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { readPlanPolicy } from "../../policy/plan-extensions.js";
+import { ScmLabelClient } from "../../vbrief-reconcile/labels.js";
+import { isRepoMutationAllowed } from "../../vbrief-reconcile/repo-guard.js";
+import type { LabelClient } from "../../vbrief-reconcile/types.js";
+import { latestDecisions, readAuditLog } from "../actions/candidates-log.js";
+import { resolveCandidatesLogPath } from "../cache-path.js";
+import { iterCachedIssues } from "../summary/index.js";
+import type { ClassificationResult, GitHubIssue } from "./index.js";
+import {
+  classifyIssue,
+  extractReferencedIssues,
+  loadProjectDefinitionForCli,
+  resolveClassifyRules,
+  resolveHoldMarkers,
+  VALID_ACTIONS,
+} from "./index.js";
+
+export const DEFAULT_IDEMPOTENCY_LABEL = "triaged";
+export const CACHE_DIR_NAME = ".deft-cache";
+export const CACHE_SOURCE = "github-issue";
+
+export type ClassifyAction = "defer" | "archive" | "escalate" | "accept";
+
+export interface LabelMirrorPolicy {
+  /** When false, mirror is a no-op (default true when policy object is used). */
+  readonly enabled?: boolean;
+  /** Idempotency marker; issues already carrying this label are skipped. Default: triaged. */
+  readonly idempotencyLabel?: string;
+  /** Labels always applied on a successful classification (default: [idempotencyLabel]). */
+  readonly alwaysLabels?: readonly string[];
+  /** Map classify action -> additional labels to apply. */
+  readonly actionLabels?: Readonly<Partial<Record<ClassifyAction, readonly string[]>>>;
+}
+
+export interface ResolvedLabelMirrorPolicy {
+  readonly enabled: boolean;
+  readonly idempotencyLabel: string;
+  readonly alwaysLabels: readonly string[];
+  readonly actionLabels: Readonly<Partial<Record<ClassifyAction, readonly string[]>>>;
+}
+
+export type LabelMirrorStatus =
+  | "planned"
+  | "applied"
+  | "unchanged"
+  | "skipped_already_triaged"
+  | "skipped_no_match"
+  | "skipped_unreadable"
+  | "skipped_disabled"
+  | "error";
+
+export interface LabelMirrorItem {
+  readonly repo: string;
+  readonly issue_number: number;
+  readonly action: string | null;
+  readonly reason: string | null;
+  readonly ruleKind: string | null;
+  readonly current: readonly string[];
+  readonly desired: readonly string[];
+  readonly add: readonly string[];
+  readonly status: LabelMirrorStatus;
+  readonly message?: string;
+}
+
+export interface LabelMirrorOutcome {
+  readonly project_root: string;
+  readonly dry_run: boolean;
+  readonly scanned: number;
+  readonly planned: number;
+  readonly applied: number;
+  readonly unchanged: number;
+  readonly skipped_already_triaged: number;
+  readonly skipped_no_match: number;
+  readonly skipped_unreadable: number;
+  readonly errors: number;
+  readonly items: readonly LabelMirrorItem[];
+  readonly policy: ResolvedLabelMirrorPolicy;
+}
+
+export interface LabelMirrorOptions {
+  readonly dryRun?: boolean;
+  readonly repo?: string | null;
+  readonly cacheRoot?: string;
+  readonly client?: LabelClient;
+  readonly allowCrossRepo?: boolean;
+  readonly repoAllowlist?: readonly string[];
+  /** Prefer live SCM labels when true (default: !dryRun). Cache labels used for dry-run. */
+  readonly useLiveLabels?: boolean;
+  readonly now?: Date;
+}
+
+function asStringList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || item.trim().length === 0) {
+      return null;
+    }
+    out.push(item);
+  }
+  return out;
+}
+
+/** Validate plan.policy.triageLabelMirror payload. */
+export function validateLabelMirrorPolicy(raw: unknown): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  if (raw === undefined || raw === null) {
+    return { errors, warnings };
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    errors.push("plan.policy.triageLabelMirror must be an object");
+    return { errors, warnings };
+  }
+  const obj = raw as Record<string, unknown>;
+  if ("enabled" in obj && typeof obj.enabled !== "boolean") {
+    errors.push("plan.policy.triageLabelMirror.enabled must be a boolean when set");
+  }
+  if ("idempotencyLabel" in obj) {
+    if (typeof obj.idempotencyLabel !== "string" || obj.idempotencyLabel.trim().length === 0) {
+      errors.push("plan.policy.triageLabelMirror.idempotencyLabel must be a non-empty string");
+    }
+  }
+  if ("alwaysLabels" in obj) {
+    const list = asStringList(obj.alwaysLabels);
+    if (list === null) {
+      errors.push("plan.policy.triageLabelMirror.alwaysLabels must be a list of non-empty strings");
+    }
+  }
+  if ("actionLabels" in obj) {
+    const al = obj.actionLabels;
+    if (typeof al !== "object" || al === null || Array.isArray(al)) {
+      errors.push("plan.policy.triageLabelMirror.actionLabels must be an object");
+    } else {
+      for (const [key, value] of Object.entries(al as Record<string, unknown>)) {
+        if (!VALID_ACTIONS.has(key)) {
+          errors.push(
+            `plan.policy.triageLabelMirror.actionLabels.${key}: action must be one of ${[...VALID_ACTIONS].sort().join(", ")}`,
+          );
+          continue;
+        }
+        const list = asStringList(value);
+        if (list === null) {
+          errors.push(
+            `plan.policy.triageLabelMirror.actionLabels.${key} must be a list of non-empty strings`,
+          );
+        }
+      }
+    }
+  }
+  const known = new Set(["enabled", "idempotencyLabel", "alwaysLabels", "actionLabels"]);
+  const extra = Object.keys(obj)
+    .filter((k) => !known.has(k))
+    .sort();
+  if (extra.length > 0) {
+    warnings.push(
+      `plan.policy.triageLabelMirror: ignoring unrecognised key(s) ${extra.join(", ")}`,
+    );
+  }
+  return { errors, warnings };
+}
+
+/** Default resolved policy when triageLabelMirror is absent. */
+export function defaultLabelMirrorPolicy(): ResolvedLabelMirrorPolicy {
+  return {
+    enabled: true,
+    idempotencyLabel: DEFAULT_IDEMPOTENCY_LABEL,
+    alwaysLabels: [DEFAULT_IDEMPOTENCY_LABEL],
+    actionLabels: {},
+  };
+}
+
+/** Resolve effective label-mirror policy from PROJECT-DEFINITION or inline object. */
+export function resolveLabelMirrorPolicy(options?: {
+  projectRoot?: string;
+  projectDefinition?: Record<string, unknown> | null;
+  override?: LabelMirrorPolicy | null;
+}): ResolvedLabelMirrorPolicy {
+  if (options?.override !== undefined && options.override !== null) {
+    return materializePolicy(options.override);
+  }
+  const data =
+    options?.projectDefinition !== undefined
+      ? options.projectDefinition
+      : loadProjectDefinitionForCli(options?.projectRoot ?? process.cwd());
+  if (data === null) {
+    return defaultLabelMirrorPolicy();
+  }
+  const plan = data.plan;
+  if (typeof plan !== "object" || plan === null || Array.isArray(plan)) {
+    return defaultLabelMirrorPolicy();
+  }
+  const policy = readPlanPolicy(plan);
+  if (typeof policy !== "object" || policy === null || Array.isArray(policy)) {
+    return defaultLabelMirrorPolicy();
+  }
+  const raw = (policy as Record<string, unknown>).triageLabelMirror;
+  if (raw === undefined || raw === null) {
+    return defaultLabelMirrorPolicy();
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return defaultLabelMirrorPolicy();
+  }
+  return materializePolicy(raw as LabelMirrorPolicy);
+}
+
+function materializePolicy(raw: LabelMirrorPolicy): ResolvedLabelMirrorPolicy {
+  const idempotencyLabel =
+    typeof raw.idempotencyLabel === "string" && raw.idempotencyLabel.trim().length > 0
+      ? raw.idempotencyLabel.trim()
+      : DEFAULT_IDEMPOTENCY_LABEL;
+  const alwaysFromPolicy = asStringList(raw.alwaysLabels ?? null);
+  const alwaysLabels =
+    alwaysFromPolicy !== null ? alwaysFromPolicy : [idempotencyLabel].filter((x) => x.length > 0);
+  const actionLabels: Partial<Record<ClassifyAction, readonly string[]>> = {};
+  const al = raw.actionLabels;
+  if (typeof al === "object" && al !== null && !Array.isArray(al)) {
+    for (const action of VALID_ACTIONS) {
+      const list = asStringList((al as Record<string, unknown>)[action]);
+      if (list !== null && list.length > 0) {
+        actionLabels[action as ClassifyAction] = list;
+      }
+    }
+  }
+  return {
+    enabled: raw.enabled !== false,
+    idempotencyLabel,
+    alwaysLabels,
+    actionLabels,
+  };
+}
+
+/** Labels to apply for a classified action (always + action-mapped). */
+export function desiredLabelsForClassification(
+  action: string,
+  policy: ResolvedLabelMirrorPolicy,
+): string[] {
+  const desired = new Set<string>(policy.alwaysLabels);
+  const mapped = policy.actionLabels[action as ClassifyAction];
+  if (mapped !== undefined) {
+    for (const label of mapped) {
+      desired.add(label);
+    }
+  }
+  // Always include the idempotency marker even if alwaysLabels was customized empty.
+  if (policy.idempotencyLabel.length > 0) {
+    desired.add(policy.idempotencyLabel);
+  }
+  return [...desired].sort();
+}
+
+function issueLabelNames(issue: GitHubIssue): string[] {
+  const raw = issue.labels ?? [];
+  const names: string[] = [];
+  if (!Array.isArray(raw)) {
+    return names;
+  }
+  for (const item of raw) {
+    if (typeof item === "object" && item !== null && "name" in item) {
+      const name = item.name;
+      if (typeof name === "string" && name.length > 0) {
+        names.push(name);
+      }
+    } else if (typeof item === "string" && item.length > 0) {
+      names.push(item);
+    }
+  }
+  return names;
+}
+
+function readCachedRawIssue(
+  cacheRoot: string,
+  repo: string,
+  issueNumber: number,
+): GitHubIssue | null {
+  const [owner, name] = repo.split("/", 2);
+  const rawPath = join(
+    cacheRoot,
+    CACHE_SOURCE,
+    owner ?? "",
+    name ?? "",
+    String(issueNumber),
+    "raw.json",
+  );
+  if (!existsSync(rawPath)) {
+    return null;
+  }
+  try {
+    const data: unknown = JSON.parse(readFileSync(rawPath, { encoding: "utf8" }));
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      return null;
+    }
+    return data as GitHubIssue;
+  } catch {
+    return null;
+  }
+}
+
+/** Load latest decisions as Map keyed by `repo\0number` for hasTriageDecision. */
+function loadLatestDecisionMap(projectRoot: string): ReadonlyMap<string, string> {
+  try {
+    const path = resolveCandidatesLogPath(projectRoot);
+    return latestDecisions(readAuditLog(path));
+  } catch {
+    return new Map();
+  }
+}
+
+function decisionMapHas(
+  map: ReadonlyMap<string, string>,
+  repo: string,
+  issueNumber: number,
+): boolean {
+  return map.has(`${repo}\0${issueNumber}`);
+}
+
+/**
+ * Run Tier-1 label mirror over the github-issue cache.
+ * Dry-run by default (no SCM writes). Pass dryRun: false to apply.
+ */
+export function mirrorLabels(
+  projectRoot: string,
+  options: LabelMirrorOptions = {},
+): [number, LabelMirrorOutcome] {
+  const root = resolve(projectRoot);
+  const dryRun = options.dryRun ?? true;
+  const policy = resolveLabelMirrorPolicy({ projectRoot: root });
+  const cacheRoot = options.cacheRoot ?? join(root, CACHE_DIR_NAME);
+  const useLiveLabels = options.useLiveLabels ?? !dryRun;
+  const client = options.client ?? (useLiveLabels || !dryRun ? new ScmLabelClient() : undefined);
+
+  const items: LabelMirrorItem[] = [];
+  const outcomeBase = {
+    project_root: root,
+    dry_run: dryRun,
+    policy,
+  };
+
+  if (!policy.enabled) {
+    return [
+      0,
+      {
+        ...outcomeBase,
+        scanned: 0,
+        planned: 0,
+        applied: 0,
+        unchanged: 0,
+        skipped_already_triaged: 0,
+        skipped_no_match: 0,
+        skipped_unreadable: 0,
+        errors: 0,
+        items: [
+          {
+            repo: "",
+            issue_number: 0,
+            action: null,
+            reason: null,
+            ruleKind: null,
+            current: [],
+            desired: [],
+            add: [],
+            status: "skipped_disabled",
+            message: "plan.policy.triageLabelMirror.enabled is false",
+          },
+        ],
+      },
+    ];
+  }
+
+  const rules = resolveClassifyRules({ projectRoot: root });
+  const holdMarkers = resolveHoldMarkers({ projectRoot: root });
+  // Soft-fail when no xbrief layout yet (empty cache bootstrap / sparse fixtures).
+  let vbriefReferenced: Set<number> = new Set();
+  try {
+    vbriefReferenced = extractReferencedIssues(root);
+  } catch {
+    vbriefReferenced = new Set();
+  }
+  const decisions = loadLatestDecisionMap(root);
+  const now = options.now ?? new Date();
+
+  let pairs = iterCachedIssues(cacheRoot);
+  if (options.repo !== undefined && options.repo !== null && options.repo.trim().length > 0) {
+    const want = options.repo.trim().toLowerCase();
+    pairs = pairs.filter(([repo]) => repo.toLowerCase() === want);
+  }
+
+  let planned = 0;
+  let applied = 0;
+  let unchanged = 0;
+  let skippedAlready = 0;
+  let skippedNoMatch = 0;
+  let skippedUnreadable = 0;
+  let errors = 0;
+
+  for (const [repo, issueNumber] of pairs) {
+    const issue = readCachedRawIssue(cacheRoot, repo, issueNumber);
+    if (issue === null) {
+      skippedUnreadable += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: null,
+        reason: null,
+        ruleKind: null,
+        current: [],
+        desired: [],
+        add: [],
+        status: "skipped_unreadable",
+        message: "missing or unreadable raw.json",
+      });
+      continue;
+    }
+
+    let current: string[];
+    if (useLiveLabels && client !== undefined) {
+      try {
+        current = client.fetchLabels(repo, issueNumber);
+      } catch (exc) {
+        // Fall back to cache labels on fetch failure so dry-run-style planning can still report.
+        current = issueLabelNames(issue);
+        if (!dryRun) {
+          errors += 1;
+          items.push({
+            repo,
+            issue_number: issueNumber,
+            action: null,
+            reason: null,
+            ruleKind: null,
+            current,
+            desired: [],
+            add: [],
+            status: "error",
+            message: `fetchLabels failed: ${exc instanceof Error ? exc.message : String(exc)}`,
+          });
+          continue;
+        }
+      }
+    } else {
+      current = issueLabelNames(issue);
+    }
+
+    if (current.includes(policy.idempotencyLabel)) {
+      skippedAlready += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: null,
+        reason: null,
+        ruleKind: null,
+        current: [...current].sort(),
+        desired: [...current].sort(),
+        add: [],
+        status: "skipped_already_triaged",
+        message: `already has ${policy.idempotencyLabel}`,
+      });
+      continue;
+    }
+
+    const classification: ClassificationResult | null = classifyIssue(issue, {
+      rules,
+      holdMarkers,
+      vbriefReferenced,
+      hasTriageDecision: decisionMapHas(decisions, repo, issueNumber),
+      now,
+    });
+
+    if (classification === null) {
+      skippedNoMatch += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: null,
+        reason: null,
+        ruleKind: null,
+        current: [...current].sort(),
+        desired: [],
+        add: [],
+        status: "skipped_no_match",
+      });
+      continue;
+    }
+
+    const desired = desiredLabelsForClassification(classification.action, policy);
+    const currentSet = new Set(current);
+    const add = desired.filter((label) => !currentSet.has(label)).sort();
+
+    if (add.length === 0) {
+      unchanged += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: classification.action,
+        reason: classification.reason,
+        ruleKind: classification.ruleKind,
+        current: [...current].sort(),
+        desired,
+        add: [],
+        status: "unchanged",
+      });
+      continue;
+    }
+
+    if (dryRun) {
+      planned += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: classification.action,
+        reason: classification.reason,
+        ruleKind: classification.ruleKind,
+        current: [...current].sort(),
+        desired,
+        add,
+        status: "planned",
+      });
+      continue;
+    }
+
+    // --apply path: SCM boundary + write
+    const mutateGate = isRepoMutationAllowed(repo, root, {
+      allowCrossRepo: options.allowCrossRepo,
+      allowlist: options.repoAllowlist,
+      explicitRepo: options.repo ?? null,
+    });
+    if (!mutateGate.allowed) {
+      errors += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: classification.action,
+        reason: classification.reason,
+        ruleKind: classification.ruleKind,
+        current: [...current].sort(),
+        desired,
+        add,
+        status: "error",
+        message: mutateGate.reason ?? `refusing cross-repo mutation on ${repo}`,
+      });
+      continue;
+    }
+
+    if (client === undefined) {
+      errors += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: classification.action,
+        reason: classification.reason,
+        ruleKind: classification.ruleKind,
+        current: [...current].sort(),
+        desired,
+        add,
+        status: "error",
+        message: "no LabelClient available for apply",
+      });
+      continue;
+    }
+
+    try {
+      client.apply(repo, issueNumber, add, []);
+      applied += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: classification.action,
+        reason: classification.reason,
+        ruleKind: classification.ruleKind,
+        current: [...current].sort(),
+        desired,
+        add,
+        status: "applied",
+      });
+    } catch (exc) {
+      errors += 1;
+      items.push({
+        repo,
+        issue_number: issueNumber,
+        action: classification.action,
+        reason: classification.reason,
+        ruleKind: classification.ruleKind,
+        current: [...current].sort(),
+        desired,
+        add,
+        status: "error",
+        message: exc instanceof Error ? exc.message : String(exc),
+      });
+    }
+  }
+
+  const outcome: LabelMirrorOutcome = {
+    ...outcomeBase,
+    scanned: pairs.length,
+    planned,
+    applied,
+    unchanged,
+    skipped_already_triaged: skippedAlready,
+    skipped_no_match: skippedNoMatch,
+    skipped_unreadable: skippedUnreadable,
+    errors,
+    items,
+  };
+  return [errors > 0 ? 1 : 0, outcome];
+}
+
+/** Human-readable digest for dry-run / apply reports. */
+export function renderLabelMirrorReport(outcome: LabelMirrorOutcome): string {
+  const lines: string[] = [];
+  const mode = outcome.dry_run ? "dry-run" : "apply";
+  lines.push(`triage:classify --mirror (${mode})`);
+  lines.push(
+    `scanned=${outcome.scanned} planned=${outcome.planned} applied=${outcome.applied} ` +
+      `unchanged=${outcome.unchanged} already_triaged=${outcome.skipped_already_triaged} ` +
+      `no_match=${outcome.skipped_no_match} unreadable=${outcome.skipped_unreadable} ` +
+      `errors=${outcome.errors}`,
+  );
+  lines.push(
+    `idempotencyLabel=${outcome.policy.idempotencyLabel} alwaysLabels=${JSON.stringify(outcome.policy.alwaysLabels)}`,
+  );
+  lines.push("");
+
+  const plannedOrApplied = outcome.items.filter(
+    (i) => i.status === "planned" || i.status === "applied",
+  );
+  lines.push(outcome.dry_run ? "Would add labels:" : "Added labels:");
+  if (plannedOrApplied.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const item of plannedOrApplied) {
+      const actionPart = item.action !== null ? ` action=${item.action}` : "";
+      const rulePart = item.ruleKind !== null ? ` rule=${item.ruleKind}` : "";
+      lines.push(
+        `- ${item.repo}#${item.issue_number}:${actionPart}${rulePart} +${item.add.join(", +")}`,
+      );
+    }
+  }
+
+  const already = outcome.items.filter((i) => i.status === "skipped_already_triaged");
+  if (already.length > 0) {
+    lines.push("");
+    lines.push(`Skipped (already ${outcome.policy.idempotencyLabel}): ${already.length}`);
+  }
+
+  const noMatch = outcome.items.filter((i) => i.status === "skipped_no_match");
+  if (noMatch.length > 0) {
+    lines.push(`Skipped (no classify match): ${noMatch.length}`);
+  }
+
+  const errs = outcome.items.filter((i) => i.status === "error");
+  if (errs.length > 0) {
+    lines.push("");
+    lines.push("Errors:");
+    for (const item of errs) {
+      lines.push(`- ${item.repo}#${item.issue_number}: ${item.message ?? "unknown error"}`);
+    }
+  }
+
+  if (outcome.dry_run && plannedOrApplied.length > 0) {
+    lines.push("");
+    lines.push("Dry-run -- re-run with --mirror --apply to write these labels via SCM.");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+/** JSON-serializable outcome (stable key order not required). */
+export function labelMirrorOutcomeToJson(outcome: LabelMirrorOutcome): Record<string, unknown> {
+  return {
+    project_root: outcome.project_root,
+    dry_run: outcome.dry_run,
+    scanned: outcome.scanned,
+    planned: outcome.planned,
+    applied: outcome.applied,
+    unchanged: outcome.unchanged,
+    skipped_already_triaged: outcome.skipped_already_triaged,
+    skipped_no_match: outcome.skipped_no_match,
+    skipped_unreadable: outcome.skipped_unreadable,
+    errors: outcome.errors,
+    policy: {
+      enabled: outcome.policy.enabled,
+      idempotencyLabel: outcome.policy.idempotencyLabel,
+      alwaysLabels: [...outcome.policy.alwaysLabels],
+      actionLabels: Object.fromEntries(
+        Object.entries(outcome.policy.actionLabels).map(([k, v]) => [k, [...(v ?? [])]]),
+      ),
+    },
+    items: outcome.items.map((i) => ({
+      repo: i.repo,
+      issue_number: i.issue_number,
+      action: i.action,
+      reason: i.reason,
+      ruleKind: i.ruleKind,
+      current: [...i.current],
+      desired: [...i.desired],
+      add: [...i.add],
+      status: i.status,
+      ...(i.message !== undefined ? { message: i.message } : {}),
+    })),
+  };
+}
+
+/** Validate triageLabelMirror on a plan object (vbrief_validate hook). */
+export function validateTriageLabelMirrorOnPlan(plan: unknown, filepath: string): string[] {
+  const out: string[] = [];
+  if (typeof plan !== "object" || plan === null || Array.isArray(plan)) {
+    return out;
+  }
+  const policy = readPlanPolicy(plan);
+  const raw =
+    typeof policy === "object" && policy !== null && !Array.isArray(policy)
+      ? (policy as Record<string, unknown>).triageLabelMirror
+      : undefined;
+  if (raw === undefined || raw === null) {
+    return out;
+  }
+  const { errors } = validateLabelMirrorPolicy(raw);
+  for (const err of errors) {
+    out.push(`${filepath}: ${err} (#1423)`);
+  }
+  return out;
+}

--- a/packages/core/src/triage/classify/label-mirror.ts
+++ b/packages/core/src/triage/classify/label-mirror.ts
@@ -449,7 +449,7 @@ export function mirrorLabels(
   const holdMarkers = engine.resolveHoldMarkers({ projectRoot: root });
   // Number-only xBRIEF refs are project-repo scoped (#1423 Greptile P1). Soft-fail
   // when no xbrief layout yet (empty cache bootstrap / sparse fixtures).
-  let projectVbriefReferenced: Set<number> = new Set();
+  let projectVbriefReferenced: Set<number>;
   try {
     projectVbriefReferenced = engine.extractReferencedIssues(root);
   } catch {
@@ -465,6 +465,22 @@ export function mirrorLabels(
   if (options.repo !== undefined && options.repo !== null && options.repo.trim().length > 0) {
     const want = options.repo.trim().toLowerCase();
     pairs = pairs.filter(([repo]) => repo.toLowerCase() === want);
+  }
+
+  // Repos allowed to use number-only xBRIEF refs:
+  // - when project repo is known: only that slug
+  // - when unknown and the scan set is a single repo: that repo (legitimate bootstrap)
+  // - when unknown multi-repo: none (fail closed on number collisions)
+  const reposAllowedVbriefRefs = new Set<string>();
+  if (projectRepo !== null && projectRepo.trim().length > 0) {
+    reposAllowedVbriefRefs.add(projectRepo.trim().toLowerCase());
+  } else {
+    const uniqueRepos = new Set(pairs.map(([repo]) => repo.toLowerCase()));
+    if (uniqueRepos.size === 1) {
+      for (const r of uniqueRepos) {
+        reposAllowedVbriefRefs.add(r);
+      }
+    }
   }
 
   let planned = 0;
@@ -538,11 +554,11 @@ export function mirrorLabels(
       continue;
     }
 
-    // Only apply number-only xBRIEF refs when this cache entry is the project repo.
+    // Only apply number-only xBRIEF refs for allowed repos (see reposAllowedVbriefRefs).
     // Cross-repo same-number collisions must not inherit project references (#1423 P1).
-    const sameAsProject =
-      projectRepo !== null && repo.trim().toLowerCase() === projectRepo.trim().toLowerCase();
-    const vbriefReferenced = sameAsProject ? projectVbriefReferenced : null;
+    const vbriefReferenced = reposAllowedVbriefRefs.has(repo.toLowerCase())
+      ? projectVbriefReferenced
+      : null;
 
     const classification = engine.classifyIssue(issue, {
       rules: rules as never,

--- a/packages/core/src/triage/help/registry-data.ts
+++ b/packages/core/src/triage/help/registry-data.ts
@@ -282,17 +282,38 @@ export const registryData = {
     },
     "task triage:classify": {
       name: "task triage:classify",
-      summary: "Inspect / validate auto-classification surface",
-      refs: "(D10 / #1129)",
+      summary: "Inspect / validate auto-classification surface; Tier-1 SCM label mirror",
+      refs: "(D10 / #1129, #1423 Wave 1)",
       description:
-        "Inspect or validate the auto-classification rule set. --list renders effective rules (framework universal first, consumer overrides next). --validate exits non-zero on a malformed plan.policy.triageAutoClassify.",
-      usage: "task triage:classify -- [--list | --validate]",
+        "Inspect or validate the auto-classification rule set. --list renders effective rules (framework universal first, consumer overrides next). --validate exits non-zero on a malformed plan.policy.triageAutoClassify or triageLabelMirror. --mirror runs the Tier-1 deterministic SCM label mirror over the github-issue cache (dry-run default; --apply writes via SCM boundary). Never calls triage:accept / never writes proposed/ xBRIEFs.",
+      usage:
+        "task triage:classify -- [--list | --validate | --mirror [--apply] [--repo owner/name] [--json] [--allow-cross-repo]]",
       flags: [
         ["--list", "(default)", "Print effective rules + hold markers."],
-        ["--validate", "(off)", "Validate plan.policy.triageAutoClassify."],
+        ["--validate", "(off)", "Validate plan.policy.triageAutoClassify + triageLabelMirror."],
+        [
+          "--mirror",
+          "(off)",
+          "Tier-1 label mirror: classify cache → planned/applied labels (dry-run default).",
+        ],
+        ["--apply", "(off)", "With --mirror: write labels via SCM (requires github SCM boundary)."],
+        ["--repo owner/name", "(all cached)", "Limit mirror to one repo."],
+        ["--json", "(off)", "With --mirror: structured JSON outcome."],
+        ["--allow-cross-repo", "(off)", "With --mirror --apply: allow non-project repos (#2601)."],
       ],
-      examples: ["task triage:classify -- --list", "task triage:classify -- --validate"],
-      see_also: ["task triage:bootstrap", "task triage:queue", "#1119 / D10"],
+      examples: [
+        "task triage:classify -- --list",
+        "task triage:classify -- --validate",
+        "task triage:classify -- --mirror",
+        "task triage:classify -- --mirror --apply --repo owner/name",
+      ],
+      see_also: [
+        "task triage:bootstrap",
+        "task triage:queue",
+        "task vbrief:reconcile:labels",
+        "#1119 / D10",
+        "#1423",
+      ],
       placeholder: false,
     },
     "task triage:bootstrap": {

--- a/packages/types/src/policy.ts
+++ b/packages/types/src/policy.ts
@@ -37,6 +37,19 @@ export interface PlanPolicy {
   readonly triageRankingLabels?: readonly string[];
   readonly triageAutoClassify?: readonly unknown[];
   readonly triageHoldMarkers?: readonly string[];
+  /**
+   * Tier-1 SCM label mirror from classify outcomes (#1423 Wave 1).
+   * Maps classify actions to labels; always applies the idempotency marker
+   * (`triaged` by default). Dry-run default on `task triage:classify -- --mirror`.
+   */
+  readonly triageLabelMirror?: {
+    readonly enabled?: boolean;
+    readonly idempotencyLabel?: string;
+    readonly alwaysLabels?: readonly string[];
+    readonly actionLabels?: Readonly<
+      Partial<Record<"defer" | "archive" | "escalate" | "accept", readonly string[]>>
+    >;
+  };
   readonly swarmSubagentBackend?: string | null;
   readonly projectionProviders?: Record<string, ProjectionProviderPolicy>;
   /** Per-host Directive hook deposit toggles (#2752). Default: all true. */
@@ -91,6 +104,7 @@ export const REGISTERED_POLICY_FIELD_NAMES = [
   "plan.policy.triageRankingLabels",
   "plan.policy.triageAutoClassify",
   "plan.policy.triageHoldMarkers",
+  "plan.policy.triageLabelMirror",
   "plan.policy.swarmSubagentBackend",
   "plan.policy.engineSkewWindow",
   "plan.policy.requireHumanMerge",

--- a/tasks/triage-classify.yml
+++ b/tasks/triage-classify.yml
@@ -22,7 +22,7 @@ vars:
 
 tasks:
   classify:
-    desc: "Inspect / validate plan.policy.triageAutoClassify[] + triageHoldMarkers[] (#1129 / D10). -- task triage:classify -- [--list | --validate]"
+    desc: "Inspect / validate triageAutoClassify + triageLabelMirror; Tier-1 SCM label mirror (#1129 / #1423). -- task triage:classify -- [--list | --validate | --mirror [--apply]]"
     internal: true
     deps: [":engine:_ts-build"]
     dir: '{{.USER_WORKING_DIR}}'


### PR DESCRIPTION
## Summary

Wave 1 of #1423: **Tier-1 deterministic SCM label mirror**.

- `task triage:classify -- --mirror` classifies the github-issue cache with the existing #1129 engine and plans SCM labels (`triaged` idempotency marker + optional `plan.policy.triageLabelMirror.actionLabels`).
- Dry-run by default (digest of adds/skips, zero SCM writes).
- `--apply` writes via `ScmLabelClient` + cross-repo mutation boundary (#2601 / #1288 compose).
- Re-run is a no-op when `triaged` is already present.
- **Never** calls `triage:accept` / **never** writes `proposed/` xBRIEFs.

## Out of scope (remain on #1423)

- Wave 2: bootstrap mass-triage phase
- Wave 3: agent Tier-2 triage comments

## Policy

```json
{
  "triageLabelMirror": {
    "enabled": true,
    "idempotencyLabel": "triaged",
    "alwaysLabels": ["triaged"],
    "actionLabels": { "defer": ["status:deferred"] }
  }
}
```

## Test plan

- [x] `pnpm exec vitest run packages/core/src/triage/classify packages/cli/src/triage-classify.test.ts` (87 tests)
- [x] dry-run fixture: planned labels without network
- [x] apply + re-run no-op with FakeLabelClient
- [x] `task verify:forward-coverage`

Tracking: #1423
Refs: #1129, #1288, #1420, #886