### PR TITLE
docs(process): maintainer issue label taxonomy catalog (#2609)

### DIFF
--- a/.github/ISSUE_LABELS.md
+++ b/.github/ISSUE_LABELS.md
@@ -1,0 +1,225 @@
+# Issue label taxonomy (deftai/directive)
+
+**Audience:** maintainers and agents working **in this repository only**.  
+**Not** the portable consumer starter kit — that is **#2611** (implement after this catalog is stable).
+
+**Source of truth:** this file. Platform labels, machine/mirror labels, facet rules, and twin decisions live here. Do not invent ad hoc labels outside this catalog for new work.
+
+**Related:** #2609 (this taxonomy), #3128 (open-issue migration onto the scheme), #2611 (consumer kit), #1423 / #3118 / #3126 (SCM label mirror), #1789 / #690 (`area:*`), #886 (triage umbrella).
+
+---
+
+## Facet discipline
+
+| Facet | Labels | Role |
+|-------|--------|------|
+| **Type** | `bug`, `enhancement`, `rfc`, `epic`, `documentation`, … | What kind of issue |
+| **Area** | Prefer **`area:*`** forward (#1789) | Product surface; resolve legacy twins over time |
+| **Platform** | `platform:windows`, `platform:macos`, `platform:linux` | OS-intrinsic only |
+| **Status / role** | `status:blocked`, `status:tracker`, **`status:child`**, `status:superseded-pending`, … | Lifecycle / queue role |
+| **Audience / ranking** | `urgent`, `adoption-blocker`, `agent-experience`, … | Earn keep; used sparingly |
+| **Machine / mirror** | `triaged`, `triage:deferred`, `triage:archived`, `triage:lifecycle-linked`, `triage:needs-human` | Closed set; primary writer = mirror apply |
+
+An issue may wear **multiple facets** (e.g. `enhancement` + `area:cli` + `status:child` + `platform:windows`).
+
+---
+
+## Type: when to apply `epic`
+
+**Definition:** Apply **`epic`** only when this issue is a **multi-ship product initiative** — multiple independent or sequenced shippable units, and **this issue is the plan identity** for that product capability.
+
+**Apply `epic` when ALL hold:**
+
+1. Success needs **2+ shippable units by design** (waves / children / PRs over time) — not one story split into two tiny tasks.
+2. Theme is **product/platform capability** (not a pure process grab-bag).
+3. This issue **names** that initiative (children hang under it).
+4. Close condition is "program done," not "one PR merged."
+
+**Do NOT apply `epic` when:**
+
+- One story / one PR (or one xBRIEF) would honestly finish it — use `enhancement` / `bug` / etc.
+- Only a coordination/process board — prefer **`status:tracker`** without `epic` (e.g. mega-review boards).
+- Issue is a **child** of a larger initiative — use **`status:child`**, never `epic`.
+- "Has two children" alone is **not** sufficient (two chores are not an epic).
+
+**Examples (directive):**
+
+- **Yes:** multi-wave product programs (e.g. inter-run memory, 1.0 readiness, Product Insights, label-mirror program **#1423**).
+- **No:** a single Wave story, discovery packaging, or a residual one-PR fix.
+
+---
+
+## Status: `status:tracker` vs `status:child`
+
+| Label | Means | Not |
+|-------|--------|-----|
+| **`status:tracker`** | This issue is a **coordination home** (plan, waves, current-shape / child list) | "Product epic" by itself; "root of the repo" |
+| **`status:child`** | This issue has a **parent** in the graph | "Which parent"; "leaf only" |
+
+**Product multi-ship root:** usually **`epic` + `status:tracker`**.  
+**Process board:** **`status:tracker`**, `epic` optional/discouraged.  
+**Leaf story:** type + **`status:child`** if parented; type only if standalone.
+
+### Nested trackers / trackers under epics
+
+Trees are normal. **Do not encode depth** (no `tracker-l2`).
+
+**Allow mid-nodes to wear both** `status:tracker` and `status:child` (coordinates **and** has a parent):
+
+```text
+#886  status:tracker                    (process board)
+  └─ #1423  epic + status:tracker + status:child
+        └─ #3125  status:child + enhancement   one story → one PR
+```
+
+| Pattern | Labels on mid/root |
+|---------|-------------------|
+| Root product epic | `epic` + `status:tracker` |
+| Nested product epic | `epic` + `status:tracker` + `status:child` |
+| Nested thin wave tracker | `status:tracker` + `status:child` (no `epic`) |
+| Leaf | `status:child` + type |
+| Standalone story | type only |
+
+**Mutually exclusive:** do **not** put `epic` on pure children.  
+**Filters:** leaves ≈ `status:child` without `status:tracker`; nested trackers ≈ both status labels. Structure and parent id still come from **links + current-shape**, not labels alone.
+
+---
+
+## PR ↔ one story
+
+- Prefer **one issue ↔ one story ↔ one PR**.
+- Epic/tracker stays open across many PRs; **each child** closes with its PR.
+- Epics are **not** the PR unit.
+
+---
+
+## Machine / mirror labels
+
+Closed set. Mirror apply (`task triage:classify -- --mirror` / `--apply`) is the **primary writer**. Humans may add/remove for repair; do not invent new `triage:*` names outside this table.
+
+| Label | Role |
+|-------|------|
+| `triaged` | Idempotency — classify/mirror already ran |
+| `triage:deferred` | Suggested / applied `actionLabels.defer` |
+| `triage:archived` | Suggested / applied `actionLabels.archive` |
+| `triage:lifecycle-linked` | Suggested / applied `actionLabels.accept` |
+| `triage:needs-human` | Suggested / applied `actionLabels.escalate` |
+
+Do **not** overload human labels (`hold`, `rfc`, …) via `actionLabels`. Consumer kits (**#2611**) may ship a **subset** of this machine set.
+
+Config surface: `plan.policy.triageLabelMirror` (see #1423 Wave 1 / #3118).
+
+---
+
+## Platform facet
+
+| Label | When |
+|-------|------|
+| `platform:windows` | Bug or work is **intrinsic** to Windows (encoding, paths, PS, installers on win32) |
+| `platform:macos` | Intrinsic to macOS |
+| `platform:linux` | Intrinsic to Linux |
+
+Do **not** use platform labels for "I happened to repro on Windows." Multi-platform bugs get multiple platform labels only when the failure mode is OS-specific on each.
+
+Open-issue seed backfill is **#3128** (migration), not Phase A.
+
+---
+
+## Area facet (`area:*`)
+
+Forward convention (**#1789** / **#690**): prefer `area:*` over legacy unprefixed twins.
+
+| Keep (forward) | Prefer over |
+|----------------|-------------|
+| `area:cli` | ad-hoc CLI tags |
+| `area:guidance` | — |
+| `area:installer` | bare `installer` (legacy twin) |
+| `area:release` | bare `release` when meaning surface (see twin table) |
+| `area:skills` | bare `skills` (legacy twin) |
+| `area:vbrief` | — |
+
+New surfaces: add `area:<slug>` here first, then create the label with a description.
+
+---
+
+## Twin decisions (legacy → forward)
+
+Migration of open issues is **#3128**. Phase A **decides** which name wins.
+
+| Keep | Deprecate / avoid new use | Notes |
+|------|---------------------------|--------|
+| `documentation` | `docs` | Prefer `documentation` for human docs work |
+| `area:skills` | `skills` | Surface facet |
+| `area:installer` | `installer` | Surface facet |
+| `enhancement` | inventing `feat` as a type label | Type facet uses `enhancement` |
+| `rfc` | dual-stacking `type:research` without need | `type:research` OK for investigation; `rfc` for design discussion |
+| `UPGRADE ANNOUNCEMENT` | typo `UPGRADE ANNOUCEMENT` | Renamed; typo form must not return |
+| Machine set above | inventing extra `triage:*` | Closed set |
+
+Empty-description labels should gain short descriptions when touched; do not delete legacy twins in Phase A (removal/alias cleanup is migration judgment on **#3128**).
+
+---
+
+## Catalog snapshot (Phase A)
+
+Inventory ~85 labels at #2609 implement time. This section lists **canonical** names by facet. Full live list: `gh label list --repo deftai/directive`.
+
+### Type (selected)
+
+`bug`, `enhancement`, `rfc`, `epic`, `documentation`, `duplicate`, `invalid`, `wontfix`, `question`, `chore`, `refactor`, `type:research`
+
+### Area
+
+`area:cli`, `area:guidance`, `area:installer`, `area:release`, `area:skills`, `area:vbrief`
+
+### Platform (created Phase A)
+
+`platform:windows`, `platform:macos`, `platform:linux`
+
+### Status / role
+
+`status:blocked`, `status:tracker`, `status:child`, `status:superseded-pending`, `hold`, `fixed-pending-merge`
+
+### Machine / mirror (created or confirmed Phase A)
+
+`triaged`, `triage:deferred`, `triage:archived`, `triage:lifecycle-linked`, `triage:needs-human`
+
+### Ranking / audience (selected)
+
+`urgent`, `adoption-blocker`, `agent-experience`, `blocks-merge`, `blocks-release-tag`, `Upgrade Blocker`
+
+### Process / workflow (selected)
+
+`process` (if present), `Workflow`, `triage`, `swarm`, `meta`, `scm`, `determinism`, `source-of-truth`, …
+
+---
+
+## Agent rules (this repo)
+
+1. ! Before applying labels, read this file (or the issue body of #2609 if this file is missing on an old branch).
+2. ! Prefer existing catalog names; ⊗ invent new facet prefixes without amending this file.
+3. ! For multi-ship product roots: `epic` + `status:tracker` when both definitions hold.
+4. ! For parented leaves: `status:child` + type; ⊗ `epic` on pure children.
+5. ! Machine labels: closed set above; mirror is primary writer.
+6. ! Platform only for OS-intrinsic work.
+7. ~ Consumer projects: follow **#2611** kit when shipped — do not copy the full maintainer set by default.
+
+Skill / SCM pointer: `content/scm/github.md` § Issue Labels (framework source) links here.
+
+---
+
+## Non-goals (Phase A)
+
+- Full-backlog auto-relabel (see **#3128**)
+- Fail-closed unlabeled creates
+- Consumer kit packaging (**#2611**) or discovery packaging (**#3124**)
+- Encoding parent id as `child-of-N` labels
+- Depth labels for nested trackers
+
+---
+
+## Changelog of this document
+
+| Date | Change |
+|------|--------|
+| 2026-08-05 | Initial catalog from #2609 Phase A (facets, epic/tracker/child, machine, platform, twins) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Maintainer issue label taxonomy catalog (#2609).** Public SoT at `.github/ISSUE_LABELS.md`: facets (type / `area:*` / platform / status role / machine-mirror), epic vs `status:tracker` / `status:child` (including nested mid-nodes), PR↔story rule, machine closed set (`triaged`, `triage:*`), platform facet, and twin decisions. CONTRIBUTING + `content/scm/github.md` point at the catalog. Creates platform + machine + `status:child` labels; renames typo `UPGRADE ANNOUCEMENT` → `UPGRADE ANNOUNCEMENT`. Consumer kit remains #2611; open-issue migration is #3128. Closes #2609. Refs #886, #1423, #1789, #2611, #3128.
+- **Maintainer issue label taxonomy catalog (#2609).** Adds a source of truth for issue-label facets, epic/tracker/child roles, machine labels, platform labels, and legacy-label decisions. Consumer kit and open-issue migration remain follow-up work. Closes #2609. Refs #886, #1423, #1789, #2611, #3128.
 - **Bootstrap mass-triage on classify label mirror (#3125 / #1423 Wave 2).** `task triage:classify -- --mirror` is the documented bootstrap mass entrypoint: **open-only** default (opt-in `--include-closed`), dry-run operator digest with totals + breakdown by state/rule/action + samples, `--json` aggregates, and batched rate-limit-aware `--apply` (`--batch-size` / `--delay-ms`) with partial-failure reporting and missing-label hints. Still never calls `triage:accept` / never writes `proposed/` xBRIEFs. Wave 3 (agent comments) remains on #1423. Closes #3125. Refs #1423, #3118, #1129.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Maintainer issue label taxonomy catalog (#2609).** Public SoT at `.github/ISSUE_LABELS.md`: facets (type / `area:*` / platform / status role / machine-mirror), epic vs `status:tracker` / `status:child` (including nested mid-nodes), PR↔story rule, machine closed set (`triaged`, `triage:*`), platform facet, and twin decisions. CONTRIBUTING + `content/scm/github.md` point at the catalog. Creates platform + machine + `status:child` labels; renames typo `UPGRADE ANNOUCEMENT` → `UPGRADE ANNOUNCEMENT`. Consumer kit remains #2611; open-issue migration is #3128. Closes #2609. Refs #886, #1423, #1789, #2611, #3128.
 - **Bootstrap mass-triage on classify label mirror (#3125 / #1423 Wave 2).** `task triage:classify -- --mirror` is the documented bootstrap mass entrypoint: **open-only** default (opt-in `--include-closed`), dry-run operator digest with totals + breakdown by state/rule/action + samples, `--json` aggregates, and batched rate-limit-aware `--apply` (`--batch-size` / `--delay-ms`) with partial-failure reporting and missing-label hints. Still never calls `triage:accept` / never writes `proposed/` xBRIEFs. Wave 3 (agent comments) remains on #1423. Closes #3125. Refs #1423, #3118, #1129.
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,6 +343,17 @@ same bare-`{{.CLI_ARGS}}` shape, so the workarounds above apply to every
 limitation in their summary when a multi-word value is a plausible
 operator input.
 
+## Issue labels (this repo) (#2609)
+
+Maintainer taxonomy for **`deftai/directive` only** lives in [`.github/ISSUE_LABELS.md`](.github/ISSUE_LABELS.md):
+
+- Facets (type, `area:*`, platform, status role, machine/mirror)
+- When to apply `epic` vs `status:tracker` / `status:child`
+- Machine labels (`triaged`, `triage:*`) used by SCM label mirror
+- Twin decisions (legacy vs forward names)
+
+Before inventing a label or applying epic/child roles, read that file. Portable **consumer** kit is **#2611** (not this full set). Open-issue migration onto the scheme is **#3128**.
+
 ## Adding a new triage / scope verb (#1150 / N10)
 
 Every `task triage:*` and `task scope:*` verb is documented in one place:

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -361,11 +361,15 @@ Agent `edit_files` operations can fail when structured file sections contain Uni
 
 ### Issue Labels
 
-**Priority**: `priority:critical` (production down), `priority:high` (major broken), `priority:medium` (important, not blocking), `priority:low` (nice to have)
+**Framework source (`deftai/directive`):** use the maintainer catalog [`.github/ISSUE_LABELS.md`](../../.github/ISSUE_LABELS.md) (#2609) — facets, epic/tracker/child rules, platform, and machine/mirror labels (`triaged`, `triage:*`). Do not invent labels outside that catalog. Consumer minimal kit is **#2611** (after the maintainer catalog lands).
 
-**Type**: `bug`, `feat`, `docs`, `refactor`, `test`, `chore`
+**Generic consumer guidance** (when no project taxonomy file exists):
 
-**Status**: `status:blocked`, `status:in-progress`, `status:needs-info`, `status:wontfix`
+**Type**: `bug`, `enhancement`, `documentation`, `refactor`, `chore` (prefer existing repo names over inventing `feat` / bare `docs` twins)
+
+**Status**: `status:blocked`, `status:tracker`, `status:child` (parented work), project-specific holds
+
+**Platform** (when OS-intrinsic): `platform:windows`, `platform:macos`, `platform:linux`
 
 ### Post-1.0.0 Issue Linking
 

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -361,7 +361,7 @@ Agent `edit_files` operations can fail when structured file sections contain Uni
 
 ### Issue Labels
 
-**Framework source (`deftai/directive`):** use the maintainer catalog [`.github/ISSUE_LABELS.md`](../../.github/ISSUE_LABELS.md) (#2609) — facets, epic/tracker/child rules, platform, and machine/mirror labels (`triaged`, `triage:*`). Do not invent labels outside that catalog. Consumer minimal kit is **#2611** (after the maintainer catalog lands).
+**Framework source (`deftai/directive`):** use the maintainer catalog at repo-root `.github/ISSUE_LABELS.md` (#2609) — facets, epic/tracker/child rules, platform, and machine/mirror labels (`triaged`, `triage:*`). That path is **repository-only** (not deposited under `.deft/core/`); browse the live file on GitHub rather than a relative path from this shipped guide. Do not invent labels outside that catalog. Consumer minimal kit is **#2611** (after the maintainer catalog lands).
 
 **Generic consumer guidance** (when no project taxonomy file exists):
 

--- a/xbrief/active/2026-08-05-2609-featprocessscm-issue-label-taxonomy-platform-facet-public-do.xbrief.json
+++ b/xbrief/active/2026-08-05-2609-featprocessscm-issue-label-taxonomy-platform-facet-public-do.xbrief.json
@@ -1,0 +1,67 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #2609",
+    "updated": "2026-08-05T18:31:13Z"
+  },
+  "plan": {
+    "title": "feat(process,scm): issue label taxonomy — platform facet, public docs, dedupe",
+    "status": "running",
+    "narratives": {
+      "Description": "feat(process,scm): issue label taxonomy — platform facet, public docs, dedupe",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/2609",
+      "Overview": "## Summary\n\n`deftai/directive` has ~**85** labels with mixed conventions, near-duplicates, empty descriptions, and **no platform facet**. Agents are told to pick existing labels but there is no public taxonomy for facets, when to apply them, machine vs human labels, or epic/tracker/child roles.\n\nThis issue owns the **maintainer** taxonomy for **this repo only**. Companion **#2611** = portable **consumer** minimal kit (implement after this; before **#3124**). Do not ship the full maintainer set as default vendored content.\n\n## Plan position\n\n`label-taxonomy-then-mirror-discovery-2026-08-05`: **#2609 (current)** → #2611 → #3124.\n\n**Gate:** amend complete (this body). Implement Phase A when operator green-lights code.\n\n## Amendment log\n\n| Date | Change |\n|------|--------|\n| 2026-08-05 | Mirror/machine facet; epic/child links; inventory refresh; plan order |\n| 2026-08-05 | **Epic / tracker / child apply rules**; nested trackers; PR≈one story; consumer carry is thin (#2611) |\n\n## Problems\n\n1. No platform facet (`platform:windows` / `macos` / `linux`).\n2. Dual taxonomies (`docs` vs `documentation`, `skills` vs `area:skills`, …); `area:*` exists (#690/#1789) but legacy twins dominate.\n3. Naming drift (kebab, prefixes, Title Case, typo `UPGRADE ANNOUCEMENT`).\n4. Empty label descriptions.\n5. No public SoT (`.github/ISSUE_LABELS.md`).\n6. Machine labels from **#1423** mirror (`triaged`, optional `triage:*`) undefined in taxonomy.\n7. Epic/tracker/child usage is ad hoc; agents over-apply `epic` or cannot filter standalone vs child work.\n\n## Facet discipline\n\n| Facet | Labels | Role |\n|-------|--------|------|\n| **Type** | `bug`, `enhancement`, `rfc`, `epic`, `documentation` | What kind of issue |\n| **Area** | Prefer **`area:*`** forward (#1789) | Surface; resolve duals over time |\n| **Platform** | `platform:windows`, `platform:macos`, `platform:linux` | OS-intrinsic only |\n| **Status / role** | `status:blocked`, `status:tracker`, **`status:child`**, … | Lifecycle / queue role |\n| **Audience / ranking** | `urgent`, `adoption-blocker`, `agent-experience`, … | Earn keep |\n| **Machine / mirror** | `triaged`, optional `triage:deferred`, `triage:archived`, `triage:lifecycle-linked`, `triage:needs-human` | Closed set; primary writer = mirror apply |\n\n## Type: when to apply `epic`\n\n**Definition:** Apply **`epic`** only when this issue is a **multi-ship product initiative** — multiple independent or sequenced shippable units, and **this issue is the plan identity** for that product capability.\n\n**Apply `epic` when ALL hold:**\n1. Success needs **2+ shippable units by design** (waves/children/PRs over time) — not one story split into two tiny tasks.\n2. Theme is **product/platform capability** (not pure process grab-bag).\n3. This issue **names** that initiative (children hang under it).\n4. Close condition is “program done,” not “one PR merged.”\n\n**Do NOT apply `epic` when:**\n- One story / one PR (or one xBRIEF) would honestly finish it → use `enhancement` / `bug` / …\n- Only coordination/process board → prefer **`status:tracker`** without `epic` (e.g. mega-review boards).\n- Issue is a **child** of a larger initiative → **`status:child`**, never `epic`.\n- “Has two children” alone — **not** sufficient (two chores ≠ epic).\n\n**Examples (directive):**\n- **Yes:** #2741 inter-run memory; #2812 1.0 readiness; #2603 Product Insights; **#1423** label-mirror program (should gain `epic`+`status:tracker`).\n- **No:** #3125 Wave 2 story; #3124 discovery; single residual #3116.\n\n## Status: `status:tracker` vs `status:child`\n\n| Label | Means | Not |\n|-------|--------|-----|\n| **`status:tracker`** | This issue is a **coordination home** (plan, waves, current-shape / child list) | “Product epic” by itself; “root of repo” |\n| **`status:child`** | This issue has a **parent** in the graph | “Which parent”; “leaf only” |\n\n**Product multi-ship root:** usually **`epic` + `status:tracker`**.  \n**Process board:** **`status:tracker`**, `epic` optional/discouraged.  \n**Leaf story:** type + **`status:child`** if parented; type only if standalone.\n\n### Nested trackers / trackers under epics\n\nTrees are normal. **Do not encode depth** (`tracker-l2`).\n\n**Allow mid-nodes to wear both** `status:tracker` and `status:child` (coordinates **and** has a parent):\n\n```text\n#886  status:tracker              (process board)\n  └── #1423  epic + status:tracker + status:child\n        └── #3125  status:child + enhancement   ← one story ≈ one PR\n```\n\n| Pattern | Labels on mid/root |\n|---------|-------------------|\n| Root product epic | `epic` + `status:tracker` |\n| Nested product epic | `epic` + `status:tracker` + `status:child` |\n| Nested thin wave tracker | `status:tracker` + `status:child` (no `epic`) |\n| Leaf | `status:child` + type |\n| Standalone story | type only |\n\n**Mutually exclusive:** do **not** put `epic` on pure children.  \n**Filters:** leaves ≈ `status:child` without `status:tracker`; nested trackers ≈ both status labels; structure/parent id still from **links + current-shape**, not labels alone.\n\n## PR ≈ one story\n\n- Prefer **one issue ≈ one story ≈ one PR**.\n- Epic/tracker stays open across many PRs; **each child** closes with its PR.\n- Epics are **not** the PR unit.\n\n## Machine / mirror labels\n\n| Label | Role |\n|-------|------|\n| `triaged` | Idempotency — classify/mirror ran |\n| `triage:deferred` | Suggested `actionLabels.defer` |\n| `triage:archived` | Suggested `actionLabels.archive` |\n| `triage:lifecycle-linked` | Suggested `actionLabels.accept` |\n| `triage:needs-human` | Suggested `actionLabels.escalate` |\n\nClosed set in ISSUE_LABELS.md; mirror must not invent names. Do not overload human `hold`/`rfc` via actionLabels. **#2611** may ship a **subset** for consumers.\n\n## Platform facet\n\n`platform:windows` / `platform:macos` / `platform:linux` — OS-intrinsic only. Refresh open seed backfill at implement (#1422, #412, …).\n\n## Public SoT + cleanup\n\n- **`.github/ISSUE_LABELS.md`** + **CONTRIBUTING.md** pointer.\n- Twin decisions (docs/documentation, installer/area:installer, …); typo `UPGRADE ANNOUCEMENT`; descriptions on kept labels.\n- Phase A = this issue core; B templates; C labels.yml sync optional.\n\n## Non-goals\n\n- Full-backlog auto-relabel; fail-closed unlabeled creates.\n- Consumer kit (#2611) or discovery impl (#3124).\n- Encoding parent id as `child-of-N` labels.\n- Depth labels for nested trackers.\n\n## Acceptance criteria\n\n- [ ] `.github/ISSUE_LABELS.md` with facets, **epic/tracker/child rules**, nested mid-node policy, machine facet, platform, deprecate list, PR≈story\n- [ ] CONTRIBUTING links to it\n- [ ] Platform labels created + descriptions\n- [ ] Machine labels documented (+ created or explicitly deferred)\n- [ ] Twin decisions + typo fix + descriptions pass\n- [ ] Skill pointer for **this** repo\n- [ ] Cross-links: #2611, #1789, #1423, #3124, #886\n\n## Related\n\n#2611 (consumer kit after this), #3124 (discovery after #2611), #1423/#3118/#3126 (mirror), #1789/#690 (area:*), #886 (umbrella).\n\n## Source\n\n2026-07-16 taxonomy discussion; 2026-08-05 plan + epic/tracker/child design discussion.\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @MScottAdams (2026-07-16T19:00:34Z)\n\n## Related consumer track\n\nFiled companion for **consumer** repos (minimal starter kit — not this repo's full taxonomy): #2611\n\n| Issue | Audience |\n|-------|----------|\n| #2609 (this) | `deftai/directive` maintainer taxonomy |\n| #2611 | Portable minimal kit + guidance for user/consumer projects |\n\n\n### Comment by @MScottAdams (2026-08-05T17:28:59Z)\n\n## Plan entry (2026-08-05) — current sequence head\n\nOrdered plan `label-taxonomy-then-mirror-discovery-2026-08-05`:\n\n1. **#2609 (this)** — **current**\n2. #2611 — consumer kit (before #3124)\n3. #3124 — mirror discovery\n\n**Gate before implement:** amend this issue first (body/comment) for:\n- Machine/mirror labels (`triaged`, optional `triage:*` action stamps) vs human facets\n- Cross-links: #1423 / #3125–#3126 / #3124 / #1789 / #2611\n- Refresh label count (~85), twin list, platform seed issue IDs\n- `area:*` decision aligned with #1789\n\nDo **not** invent ad hoc mirror labels outside the taxonomy SoT this issue will own.\n\n### Comment by @MScottAdams (2026-08-05T17:34:51Z)\n\n## Amendment applied (2026-08-05) — implement on hold\n\nBody updated only (no implementation in this pass).\n\n**Added:** machine/mirror facet (`triaged` / `triage:*`), epic-child **links not labels**, #1423/#3124/#2611/#1789 cross-links, inventory/seed refresh notes, plan-sequence position.\n\n**Still next before code:** use this body as SoT; implement when you green-light Phase A.\n\n### Comment by @MScottAdams (2026-08-05T17:58:44Z)\n\n## Body updated (2026-08-05)\n\nFull body rewrite incorporating:\n- Epic apply rules (not “2 children = epic”)\n- `status:tracker` / `status:child` + nested mid-nodes (tracker+child allowed)\n- PR ≈ one story\n- Machine/mirror facet\n- Plan: #2609 → #2611 → #3124\n\nImplement still gated on operator green-light for Phase A code.\n\n### Comment by @MScottAdams (2026-08-05T18:08:29Z)\n\n## Migration child filed\n\n**#3128** — migrate open `deftai/directive` issues onto this taxonomy (role labels, twin renames on issues, platform backfill, optional mirror apply).\n\n**Order:** this issue Phase A (scheme + catalog) → **#3128** → #2611 → #3124.\n\n#3128 is blocked until ISSUE_LABELS.md + catalog are stable.",
+      "Labels": "documentation, enhancement, agent-experience, process, scm"
+    },
+    "items": [
+      {
+        "title": "`.github/ISSUE_LABELS.md` with facets, **epic/tracker/child rules**, nested mid-node policy, machine facet, platform, deprecate list, PR≈story",
+        "status": "proposed"
+      },
+      {
+        "title": "CONTRIBUTING links to it",
+        "status": "proposed"
+      },
+      {
+        "title": "Platform labels created + descriptions",
+        "status": "proposed"
+      },
+      {
+        "title": "Machine labels documented (+ created or explicitly deferred)",
+        "status": "proposed"
+      },
+      {
+        "title": "Twin decisions + typo fix + descriptions pass",
+        "status": "proposed"
+      },
+      {
+        "title": "Skill pointer for **this** repo",
+        "status": "proposed"
+      },
+      {
+        "title": "Cross-links: #2611, #1789, #1423, #3124, #886",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "documentation",
+      "enhancement",
+      "agent-experience",
+      "process",
+      "scm"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/2609",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #2609: feat(process,scm): issue label taxonomy — platform facet, public docs, dedupe"
+      },
+      {
+        "uri": "https://github.com/deftai/directive/issues/2611",
+        "type": "x-xbrief/refs",
+        "title": "Issue #2611"
+      }
+    ],
+    "updated": "2026-08-05T18:31:13Z"
+  }
+}


### PR DESCRIPTION
## Summary

Phase A of **#2609**: maintainer issue label taxonomy for `deftai/directive` only.

- Add public SoT [`.github/ISSUE_LABELS.md`](.github/ISSUE_LABELS.md) (facets, epic/tracker/child, machine set, platform, twin decisions, agent rules)
- Point CONTRIBUTING + `content/scm/github.md` at the catalog
- CHANGELOG `[Unreleased]`
- **Live forge ops (not in git):** create `platform:*`, `status:child`, machine `triaged` / `triage:*`; rename typo `UPGRADE ANNOUCEMENT` → `UPGRADE ANNOUNCEMENT`; fill empty descriptions on high-traffic labels

## Out of scope (next plan entries)

- **#3128** open-issue migration onto the scheme
- **#2611** consumer kit
- **#3129** author filters
- **#3124** discovery

## Test plan

- [x] Catalog documents epic vs tracker/child + machine closed set
- [x] Labels exist on `deftai/directive` (API verify)
- [x] Typo rename verified (old name 404)
- [ ] CI green on PR

Closes #2609
Refs #886, #1423, #1789, #2611, #3128