### PR TITLE
chore(labels): migrate open issues onto #2609 taxonomy (#3128)

### DIFF
--- a/.github/ISSUE_LABELS.md
+++ b/.github/ISSUE_LABELS.md
@@ -218,8 +218,45 @@ Skill / SCM pointer: `content/scm/github.md` § Issue Labels (framework source) 
 
 ---
 
+## Open-issue migration (#3128)
+
+**When:** after this catalog is stable (post-#2609 Phase A).  
+**What:** retag **open** issues only (closed history not rewritten).
+
+### How it was run
+
+1. Dry-run then apply the one-shot script:
+
+   ```text
+   node .github/scripts/migrate-issue-labels-3128.mjs --dry-run
+   node .github/scripts/migrate-issue-labels-3128.mjs --apply
+   ```
+
+2. Report artifact: `.github/ISSUE_LABEL_MIGRATION_3128.json` (mode, twin/role counts, per-issue before/after).
+
+### What the script does
+
+| Pass | Action |
+|------|--------|
+| **Twins** | Open issues: `docs` → `documentation`, `skills` → `area:skills`, `installer` → `area:installer` (other labels preserved) |
+| **Roles (curated)** | Graph-informed set only (process board #886 → `status:tracker` without `epic`; product multi-ship roots → `epic`+`status:tracker`; known children → `status:child`; nested #1423 → epic+tracker+child) |
+| **Platform seeds** | `#412`, `#1422` → `platform:windows` |
+| **Machine mirror** | **Not** run by the script — optional separate `task triage:classify -- --mirror --apply` (open-only) |
+
+### False-positive policy
+
+- Skip unknown parents rather than invent `status:child` from title keywords.
+- Do not use mirror apply to invent `epic` / `status:child`.
+- Re-run is safe (idempotent adds; twin remove only when deprecated label still present).
+
+### Re-run / extend
+
+- Edit `ROLE_SCOPE` in the script for additional curated role stamps, then `--dry-run` / `--apply`.
+- Twin renames follow the twin table in this file; add rows there before extending the script.
+
 ## Changelog of this document
 
 | Date | Change |
 |------|--------|
+| 2026-08-05 | Open-issue migration notes + re-run instructions (#3128) |
 | 2026-08-05 | Initial catalog from #2609 Phase A (facets, epic/tracker/child, machine, platform, twins) |

--- a/.github/ISSUE_LABEL_MIGRATION_3128.json
+++ b/.github/ISSUE_LABEL_MIGRATION_3128.json
@@ -1,0 +1,2270 @@
+{
+  "generated_at": "2026-08-05T19:59:07.021Z",
+  "mode": "apply",
+  "repo": "deftai/directive",
+  "twin_ops": [
+    {
+      "number": 3007,
+      "title": "docs(security): maintainer AppSec review playbook (+ optional Grok Build adapter)",
+      "from": "docs",
+      "to": "documentation",
+      "labels": [
+        "documentation",
+        "enhancement",
+        "grok-build",
+        "hold",
+        "security",
+        "tooling"
+      ]
+    },
+    {
+      "number": 1567,
+      "title": "spec: refresh Directive product specification for current architecture",
+      "from": "docs",
+      "to": "documentation",
+      "labels": [
+        "design",
+        "documentation",
+        "source-of-truth",
+        "type:research"
+      ]
+    },
+    {
+      "number": 629,
+      "title": "chore(conventions): document migration-artifact exclusion pattern for consumer content-linting tests",
+      "from": "docs",
+      "to": "documentation",
+      "labels": [
+        "chore",
+        "documentation",
+        "operational"
+      ]
+    },
+    {
+      "number": 583,
+      "title": "feat(meta,skills): name governance pattern + add injection-quarantine directive for ingested origin content",
+      "from": "docs",
+      "to": "documentation",
+      "labels": [
+        "documentation",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 2436,
+      "title": "research(skills): SkillOpt control stack for skill optimization (gate, edit budget, reject buffer, slow/meta)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "patterns",
+        "type:research"
+      ]
+    },
+    {
+      "number": 2316,
+      "title": "chore(tests,determinism): harden review-surface-precedence propagation gates (scope agents marker arm to managed section; add preamble propagation contract gate)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "chore",
+        "determinism",
+        "harness",
+        "review-cycle",
+        "test-debt"
+      ]
+    },
+    {
+      "number": 2021,
+      "title": "Iterative fresh-agent epic refinement skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "Workflow",
+        "area:skills",
+        "enhancement",
+        "type:research"
+      ]
+    },
+    {
+      "number": 1812,
+      "title": "Add an intentional \"seed document\" step to project kickoff (let users supply an overview/outline/summary)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "Workflow",
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1615,
+      "title": "feat(skills,audit): rejection memos — record suppressed audit findings so they do not re-surface on subsequent runs",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1598,
+      "title": "Build skill should finish with an explicit commit/PR handoff state",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "agent-experience",
+        "area:skills",
+        "process"
+      ]
+    },
+    {
+      "number": 1582,
+      "title": "feat(skills): deft-directive-audit — four-phase repo audit skill (Discovery, Audit, Strategy, Task Plan)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1536,
+      "title": "docs(interfaces): React/Next.js external skill cross-references in interfaces/web.md + document external skill install pattern",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "documentation",
+        "interfaces"
+      ]
+    },
+    {
+      "number": 1535,
+      "title": "feat(skills): skills/catalog.yaml — versioned skill registry with tags, source type, and upstream pinning",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "agent-safety",
+        "area:skills",
+        "enhancement",
+        "security",
+        "skill-lifecycle",
+        "source-of-truth"
+      ]
+    },
+    {
+      "number": 1534,
+      "title": "feat(meta,skills): data-driven skill gap discovery — mine usage artifacts to surface missing skills empirically",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "agent-experience",
+        "agent-memory",
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "type:research"
+      ]
+    },
+    {
+      "number": 1533,
+      "title": "feat(pre-pr): explicit deslop step in deft-directive-pre-pr — remove AI-generated noise from diffs before review",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "agent-experience",
+        "area:skills",
+        "enhancement",
+        "review-cycle"
+      ]
+    },
+    {
+      "number": 1532,
+      "title": "feat(task,scripts): skill validation in task check — frontmatter, entry-file, and reference depth checks for skills/",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "ci-cd",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1513,
+      "title": "feat(build,meta): explicit knowledge codification step after work session — deft-directive-compound skill or task compound",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "agent-memory",
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1501,
+      "title": "feat(templates): domain verification skill template — scaffold for encoding manual verification workflows as agent skills",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1495,
+      "title": "bug(routing): refinement skill frontmatter over-claims triage-owned triggers (work the cache / triage)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "triage"
+      ]
+    },
+    {
+      "number": 1351,
+      "title": "grok-build / hybrid: orchestrator should pre-approve and inject GH credentials for sub-agents (follow-up from #1349 review-cycle handoff)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1317,
+      "title": "feat(skills,release): expand deft-directive-release skill to support consumer-mode (downstream projects, not just framework releases)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "Workflow",
+        "area:skills",
+        "enhancement",
+        "rfc",
+        "type:research"
+      ]
+    },
+    {
+      "number": 1307,
+      "title": "feat(autoresearch): skill-variant proposer — meta-loop component that reads frontier state and proposes targeted SKILL.md mutations",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "autoresearch",
+        "enhancement",
+        "research-strategy"
+      ]
+    },
+    {
+      "number": 1234,
+      "title": "feat(meta,patterns): llm-wiki — Karpathy wiki pattern + directive self-implementation",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "patterns"
+      ]
+    },
+    {
+      "number": 1199,
+      "title": "feat(security,scripts): extend cache scanner to cover externally-ingested skill content — skill-content quarantine",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "security"
+      ]
+    },
+    {
+      "number": 1198,
+      "title": "feat(security): document skill trust boundary + extend article-review security context with code-example injection defense",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "security"
+      ]
+    },
+    {
+      "number": 1090,
+      "title": "RFC: deft-directive-symphony -- cross-operator, cross-repo program orchestration tier above swarm",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "rfc",
+        "swarm",
+        "type:research"
+      ]
+    },
+    {
+      "number": 967,
+      "title": "consumer-side task check discoverability gap -- wire deft:check into install-generated scaffolding",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "documentation",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 963,
+      "title": "Absorb README/ROADMAP preload + swarm allocation response template into canonical skills",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "swarm"
+      ]
+    },
+    {
+      "number": 933,
+      "title": "feat(skills): add dependency-ordered article editing workflow",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 928,
+      "title": "feat(interview): add grilling loop before architecture interface design",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 894,
+      "title": "feat(skills): add deft-autoresearch measured-loop skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "autoresearch",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 864,
+      "title": "feat(patterns): deep-skill-design — small trigger interface hides large execution; Ousterhout's deep module principle applied to skills",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "patterns"
+      ]
+    },
+    {
+      "number": 837,
+      "title": "feat(skills): encode skill self-improvement trigger — after 5+ tool call tasks, agent SHOULD persist the workflow as a skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 831,
+      "title": "feat(patterns): add skill-curator pattern — idle-triggered background maintenance for agent-maintained skill libraries",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "patterns",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 830,
+      "title": "feat(skills): add skill pin mechanism — pinned skills immune to lifecycle demotion and agent modification",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 829,
+      "title": "feat(skills): add skill-usage telemetry sidecar — track view/use/patch counts per skill in one auditable file",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "monitoring",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 828,
+      "title": "feat(skills): add skill lifecycle states — active/stale/archived with usage-driven transitions",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 805,
+      "title": "feat(patterns): add typed-skill-boundary — skills used for orchestration must return schema-validated typed results",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "patterns",
+        "runtime-portability"
+      ]
+    },
+    {
+      "number": 769,
+      "title": "feat(skills,review-cycle): generalize deft-directive-review-cycle to multi-reviewer abstraction (Slizard + Greptile + future)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 758,
+      "title": "teach: add teach strategy and lessons-evolution follow-up",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "design",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 681,
+      "title": "feat(skills): apply Verbalized Sampling prompt pattern to directive brainstorming and ideation tasks",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "patterns"
+      ]
+    },
+    {
+      "number": 666,
+      "title": "feat(skills): add deft-kaizen skill — post-sprint retrospective and framework improvement loop",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 664,
+      "title": "feat(skills): add deft-subagent skill — intra-task subagent delegation protocol",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "swarm"
+      ]
+    },
+    {
+      "number": 660,
+      "title": "feat(skills): enhance deft-pre-pr — add acceptance-criteria verification step",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 637,
+      "title": "Document skill discovery in main directive",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "documentation"
+      ]
+    },
+    {
+      "number": 635,
+      "title": "EPIC: skill-system maturity + framework-rule determinism (umbrella for #75, #604, #607, #633, #634)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "determinism",
+        "enhancement",
+        "epic"
+      ]
+    },
+    {
+      "number": 628,
+      "title": "chore(sync): complete Phase 6c LegacyArtifacts review for v0.20.0 self-migration (120 sections deferred)",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "chore",
+        "operational"
+      ]
+    },
+    {
+      "number": 627,
+      "title": "feat(strategies): add strategies/delegate.md — controlled delegation framework for agent-driven implementation",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement",
+        "research-strategy"
+      ]
+    },
+    {
+      "number": 624,
+      "title": "feat(swarm): encode writes-single-threaded principle and named manager-child anti-patterns in deft-swarm",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 622,
+      "title": "feat(skills): clean-context reviewer principle and communication bridge filter for deft-review-cycle",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 620,
+      "title": "feat(skills): add tier field to SKILL.md frontmatter — atom / molecule / compound",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 619,
+      "title": "feat(skills): add atoms/molecules/compounds taxonomy and composition principles to deft-write-skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 608,
+      "title": "feat(strategies): research workflow overhaul — deft-research skill, problem-first framing, mid-research gate, structured output",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "research-strategy"
+      ]
+    },
+    {
+      "number": 607,
+      "title": "feat(main): upgrade failure-to-skill protocol — prose lessons decay, structural fixes don't",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 606,
+      "title": "feat(coding): add LLM evals as a fourth testing tier in testing.md for agent-centric projects",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "coding-standards",
+        "evals"
+      ]
+    },
+    {
+      "number": 605,
+      "title": "feat(strategies): add skillify as a named project development strategy",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 604,
+      "title": "feat(skills): add resolver eval and check-resolvable audit to directive's skill quality system",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 603,
+      "title": "feat(skills): incorporate skillify 10-step quality gate into deft-write-skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 597,
+      "title": "feat(meta): encode plain-English-over-structured-formats rationale in skill authoring guidance",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 592,
+      "title": "feat(skills): encode two-agent red-team verification pattern in deft-swarm",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "swarm"
+      ]
+    },
+    {
+      "number": 591,
+      "title": "feat(skills): add 4-phase structured output discipline to deft-build",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 589,
+      "title": "feat(skills): create deft-port skill for AI-assisted code porting between language pairs",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 554,
+      "title": "Add anti-patterns section to deft-sync skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 551,
+      "title": "research(skills): add explicit anti-slop rules to deft-build and deft-write-skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 550,
+      "title": "research(skills): deft-complete — dedicated completeness enforcement skill",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 549,
+      "title": "research(skills): configurable settings parameter block for directive skills — taste-skill pattern",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 548,
+      "title": "feat(verification): diff-as-regression-detection for SPECIFICATION.md and SKILL.md changes",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 450,
+      "title": "feat(skills): migrate operational workflows from markdown tree to skills",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "operational"
+      ]
+    },
+    {
+      "number": 406,
+      "title": "feat(test): integration test harness for agent-driven skill execution",
+      "from": "skills",
+      "to": "area:skills",
+      "labels": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1999,
+      "title": "Maintainer test tool: consumer-side upgrade rehearsal harness (clean → cold-start → install → capture → reset loop)",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1994,
+      "title": "Post-freeze npm CLI: port or alias `agents:refresh` (UPGRADING tells consumers to run it)",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1993,
+      "title": "Post-freeze upgrade UX: vendored .deft/core v0.56.0 → npm path is rough, under-signposted, and docs/CLI disagree",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1979,
+      "title": "Decide: delete the Go installer source + build pipeline (deferred ~2mo post-freeze)",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "ci-cd",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1660,
+      "title": "Build deft-install with -trimpath (reproducible binaries, no embedded build-machine paths)",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "ci-cd",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1560,
+      "title": "installer: maintainer mode should bootstrap Go, Node, and ghx",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "Workflow",
+        "agent-experience",
+        "area:installer",
+        "enhancement",
+        "tooling"
+      ]
+    },
+    {
+      "number": 1439,
+      "title": "SCM-agnostic auto-commit/PR of the vendored .deft/core deposit (Go installer, via scm.call adapter)",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "design",
+        "enhancement",
+        "vendored-deposit"
+      ]
+    },
+    {
+      "number": 945,
+      "title": "docs(brownfield): Option C direct-clone under-specifies embedded-repo handling; add gitignored-clone option",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "documentation"
+      ]
+    },
+    {
+      "number": 804,
+      "title": "reword quick-start when cloned manually section in README",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "documentation"
+      ]
+    },
+    {
+      "number": 523,
+      "title": "refactor(migrate): split migrate_vbrief.py below 500-line threshold (post-RC4 cleanup)",
+      "from": "installer",
+      "to": "area:installer",
+      "labels": [
+        "area:installer",
+        "refactor"
+      ]
+    }
+  ],
+  "twin_count": 79,
+  "role_ops": [
+    {
+      "number": 412,
+      "title": "feat(platform): add platform/ directory with PowerShell 5.1 encoding safety rules",
+      "add": [
+        "platform:windows"
+      ],
+      "remove": [],
+      "labels": [
+        "coding-standards",
+        "enhancement",
+        "platform:windows"
+      ]
+    },
+    {
+      "number": 635,
+      "title": "EPIC: skill-system maturity + framework-rule determinism (umbrella for #75, #604, #607, #633, #634)",
+      "add": [
+        "epic",
+        "status:tracker"
+      ],
+      "remove": [],
+      "labels": [
+        "determinism",
+        "enhancement",
+        "epic",
+        "skills",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 886,
+      "title": "GitHub repository mega-review: triage, governance, and workflow optimization",
+      "add": [
+        "status:tracker"
+      ],
+      "remove": [
+        "epic"
+      ],
+      "labels": [
+        "determinism",
+        "meta",
+        "process",
+        "status:tracker",
+        "triage",
+        "urgent"
+      ]
+    },
+    {
+      "number": 1140,
+      "title": "meta: design-pass churn on #1119 — multiple operator-driven iteration passes the framework didn't scaffold. Can directive make iterative design the norm?",
+      "add": [
+        "status:tracker"
+      ],
+      "remove": [],
+      "labels": [
+        "epic",
+        "meta",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 1422,
+      "title": "Agent guidance gap: safe read->edit->write round-trip for non-ASCII GitHub issue/PR bodies on Windows pwsh 7 (#798 'pwsh 7 exempt' is incomplete for gh stdout decode)",
+      "add": [
+        "platform:windows"
+      ],
+      "remove": [],
+      "labels": [
+        "documentation",
+        "harness",
+        "platform:windows"
+      ]
+    },
+    {
+      "number": 1423,
+      "title": "RFC: Autonomous auto-triage write-back cycle (SCM label mirror + agent triage comment + bootstrap mass-triage)",
+      "add": [
+        "epic",
+        "status:tracker",
+        "status:child"
+      ],
+      "remove": [],
+      "labels": [
+        "determinism",
+        "epic",
+        "status:child",
+        "status:tracker",
+        "triage"
+      ]
+    },
+    {
+      "number": 1545,
+      "title": "epic: runtime-portable multi-agent orchestration contracts",
+      "add": [
+        "epic",
+        "status:tracker"
+      ],
+      "remove": [],
+      "labels": [
+        "agent-experience",
+        "design",
+        "determinism",
+        "epic",
+        "runtime-portability",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 1589,
+      "title": "epic: spec reconstruction + drift guard - recover and keep project specs fresh (framework + vendored consumers)",
+      "add": [
+        "epic",
+        "status:tracker"
+      ],
+      "remove": [],
+      "labels": [
+        "design",
+        "determinism",
+        "enhancement",
+        "epic",
+        "source-of-truth",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 1789,
+      "title": "feat(vbrief,triage,docs): area:* convention rollout — schema mirror, issue:ingest population, scm/github.md docs (from #690)",
+      "add": [
+        "status:child"
+      ],
+      "remove": [],
+      "labels": [
+        "documentation",
+        "enhancement",
+        "source-of-truth",
+        "status:child",
+        "triage"
+      ]
+    },
+    {
+      "number": 2611,
+      "title": "feat(scm,setup): recommended minimal issue-label kit for consumer repos",
+      "add": [
+        "status:child"
+      ],
+      "remove": [],
+      "labels": [
+        "agent-experience",
+        "area:guidance",
+        "documentation",
+        "enhancement",
+        "scm",
+        "status:child"
+      ]
+    },
+    {
+      "number": 3124,
+      "title": "feat(session,triage): operator discovery for SCM label mirror (after #1423 Wave 2)",
+      "add": [
+        "status:child"
+      ],
+      "remove": [],
+      "labels": [
+        "agent-experience",
+        "enhancement",
+        "process",
+        "status:child",
+        "triage"
+      ]
+    },
+    {
+      "number": 3128,
+      "title": "chore(labels): migrate open directive issues onto #2609 taxonomy scheme",
+      "add": [
+        "status:child"
+      ],
+      "remove": [],
+      "labels": [
+        "enhancement",
+        "process",
+        "scm",
+        "status:child",
+        "triage"
+      ]
+    },
+    {
+      "number": 3129,
+      "title": "feat(triage): --author filter on triage:queue and triage:classify",
+      "add": [
+        "status:child"
+      ],
+      "remove": [],
+      "labels": [
+        "area:cli",
+        "enhancement",
+        "status:child"
+      ]
+    }
+  ],
+  "role_count": 13,
+  "notes": [
+    "Twins: docs→documentation, skills→area:skills, installer→area:installer (open only).",
+    "Roles: curated set only — skip unknown parents rather than stamp status:child from titles.",
+    "Machine mirror (triage:classify --mirror --apply) is optional and NOT run by this script.",
+    "Closed history not rewritten."
+  ],
+  "applied": 91,
+  "skipped": 11,
+  "results": [
+    {
+      "number": 406,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 412,
+      "before": [
+        "enhancement",
+        "coding-standards"
+      ],
+      "after": [
+        "coding-standards",
+        "enhancement",
+        "platform:windows"
+      ]
+    },
+    {
+      "number": 450,
+      "before": [
+        "skills",
+        "operational"
+      ],
+      "after": [
+        "area:skills",
+        "operational"
+      ]
+    },
+    {
+      "number": 523,
+      "before": [
+        "installer",
+        "refactor"
+      ],
+      "after": [
+        "area:installer",
+        "refactor"
+      ]
+    },
+    {
+      "number": 548,
+      "before": [
+        "skills"
+      ],
+      "after": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 549,
+      "before": [
+        "skills"
+      ],
+      "after": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 550,
+      "before": [
+        "skills"
+      ],
+      "after": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 551,
+      "before": [
+        "skills"
+      ],
+      "after": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 554,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 583,
+      "before": [
+        "enhancement",
+        "docs"
+      ],
+      "after": [
+        "documentation",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 589,
+      "before": [
+        "skills"
+      ],
+      "after": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 591,
+      "before": [
+        "skills"
+      ],
+      "after": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 592,
+      "before": [
+        "swarm",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "swarm"
+      ]
+    },
+    {
+      "number": 597,
+      "before": [
+        "skills"
+      ],
+      "after": [
+        "area:skills"
+      ]
+    },
+    {
+      "number": 603,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 604,
+      "before": [
+        "enhancement",
+        "skills",
+        "determinism"
+      ],
+      "after": [
+        "area:skills",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 605,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 606,
+      "before": [
+        "skills",
+        "coding-standards",
+        "evals"
+      ],
+      "after": [
+        "area:skills",
+        "coding-standards",
+        "evals"
+      ]
+    },
+    {
+      "number": 607,
+      "before": [
+        "enhancement",
+        "skills",
+        "determinism"
+      ],
+      "after": [
+        "area:skills",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 608,
+      "before": [
+        "skills",
+        "research-strategy"
+      ],
+      "after": [
+        "area:skills",
+        "research-strategy"
+      ]
+    },
+    {
+      "number": 619,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 620,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 622,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 624,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 627,
+      "before": [
+        "enhancement",
+        "skills",
+        "research-strategy"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "research-strategy"
+      ]
+    },
+    {
+      "number": 628,
+      "before": [
+        "chore",
+        "skills",
+        "operational"
+      ],
+      "after": [
+        "area:skills",
+        "chore",
+        "operational"
+      ]
+    },
+    {
+      "number": 629,
+      "before": [
+        "chore",
+        "docs",
+        "operational"
+      ],
+      "after": [
+        "chore",
+        "documentation",
+        "operational"
+      ]
+    },
+    {
+      "number": 635,
+      "before": [
+        "enhancement",
+        "skills",
+        "epic",
+        "determinism"
+      ],
+      "after": [
+        "area:skills",
+        "determinism",
+        "enhancement",
+        "epic",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 637,
+      "before": [
+        "documentation",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "documentation"
+      ]
+    },
+    {
+      "number": 660,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 664,
+      "before": [
+        "enhancement",
+        "swarm",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "swarm"
+      ]
+    },
+    {
+      "number": 666,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 681,
+      "before": [
+        "enhancement",
+        "patterns",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "patterns"
+      ]
+    },
+    {
+      "number": 758,
+      "before": [
+        "enhancement",
+        "design",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "design",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 769,
+      "before": [
+        "enhancement",
+        "skills",
+        "determinism"
+      ],
+      "after": [
+        "area:skills",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 804,
+      "before": [
+        "documentation",
+        "installer"
+      ],
+      "after": [
+        "area:installer",
+        "documentation"
+      ]
+    },
+    {
+      "number": 805,
+      "before": [
+        "enhancement",
+        "patterns",
+        "skills",
+        "runtime-portability"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "patterns",
+        "runtime-portability"
+      ]
+    },
+    {
+      "number": 828,
+      "before": [
+        "enhancement",
+        "skills",
+        "skill-lifecycle",
+        "metrics"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 829,
+      "before": [
+        "enhancement",
+        "skills",
+        "monitoring",
+        "skill-lifecycle",
+        "metrics"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "monitoring",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 830,
+      "before": [
+        "enhancement",
+        "skills",
+        "skill-lifecycle"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 831,
+      "before": [
+        "enhancement",
+        "patterns",
+        "skills",
+        "skill-lifecycle",
+        "metrics"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "patterns",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 837,
+      "before": [
+        "enhancement",
+        "skills",
+        "skill-lifecycle"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "skill-lifecycle"
+      ]
+    },
+    {
+      "number": 864,
+      "before": [
+        "enhancement",
+        "patterns",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "patterns"
+      ]
+    },
+    {
+      "number": 886,
+      "before": [
+        "epic",
+        "determinism",
+        "meta",
+        "triage",
+        "process",
+        "urgent"
+      ],
+      "after": [
+        "determinism",
+        "meta",
+        "process",
+        "status:tracker",
+        "triage",
+        "urgent"
+      ]
+    },
+    {
+      "number": 894,
+      "before": [
+        "enhancement",
+        "skills",
+        "autoresearch"
+      ],
+      "after": [
+        "area:skills",
+        "autoresearch",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 928,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 933,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 945,
+      "before": [
+        "documentation",
+        "installer"
+      ],
+      "after": [
+        "area:installer",
+        "documentation"
+      ]
+    },
+    {
+      "number": 963,
+      "before": [
+        "enhancement",
+        "swarm",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "swarm"
+      ]
+    },
+    {
+      "number": 967,
+      "before": [
+        "documentation",
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "documentation",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1090,
+      "before": [
+        "enhancement",
+        "swarm",
+        "rfc",
+        "skills",
+        "type:research"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "rfc",
+        "swarm",
+        "type:research"
+      ]
+    },
+    {
+      "number": 1140,
+      "before": [
+        "epic",
+        "meta"
+      ],
+      "after": [
+        "epic",
+        "meta",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 1198,
+      "before": [
+        "enhancement",
+        "skills",
+        "security"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "security"
+      ]
+    },
+    {
+      "number": 1199,
+      "before": [
+        "enhancement",
+        "skills",
+        "security"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "security"
+      ]
+    },
+    {
+      "number": 1234,
+      "before": [
+        "enhancement",
+        "patterns",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "patterns"
+      ]
+    },
+    {
+      "number": 1307,
+      "before": [
+        "enhancement",
+        "skills",
+        "research-strategy",
+        "autoresearch"
+      ],
+      "after": [
+        "area:skills",
+        "autoresearch",
+        "enhancement",
+        "research-strategy"
+      ]
+    },
+    {
+      "number": 1317,
+      "before": [
+        "enhancement",
+        "rfc",
+        "skills",
+        "type:research",
+        "Workflow"
+      ],
+      "after": [
+        "Workflow",
+        "area:skills",
+        "enhancement",
+        "rfc",
+        "type:research"
+      ]
+    },
+    {
+      "number": 1351,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1422,
+      "before": [
+        "documentation",
+        "harness"
+      ],
+      "after": [
+        "documentation",
+        "harness",
+        "platform:windows"
+      ]
+    },
+    {
+      "number": 1423,
+      "before": [
+        "determinism",
+        "triage"
+      ],
+      "after": [
+        "determinism",
+        "epic",
+        "status:child",
+        "status:tracker",
+        "triage"
+      ]
+    },
+    {
+      "number": 1439,
+      "before": [
+        "enhancement",
+        "design",
+        "installer",
+        "vendored-deposit"
+      ],
+      "after": [
+        "area:installer",
+        "design",
+        "enhancement",
+        "vendored-deposit"
+      ]
+    },
+    {
+      "number": 1495,
+      "before": [
+        "skills",
+        "triage"
+      ],
+      "after": [
+        "area:skills",
+        "triage"
+      ]
+    },
+    {
+      "number": 1501,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1513,
+      "before": [
+        "enhancement",
+        "skills",
+        "agent-memory"
+      ],
+      "after": [
+        "agent-memory",
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1532,
+      "before": [
+        "enhancement",
+        "ci-cd",
+        "skills",
+        "determinism"
+      ],
+      "after": [
+        "area:skills",
+        "ci-cd",
+        "determinism",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1533,
+      "before": [
+        "enhancement",
+        "skills",
+        "agent-experience",
+        "review-cycle"
+      ],
+      "after": [
+        "agent-experience",
+        "area:skills",
+        "enhancement",
+        "review-cycle"
+      ]
+    },
+    {
+      "number": 1534,
+      "before": [
+        "enhancement",
+        "skills",
+        "type:research",
+        "agent-experience",
+        "agent-memory",
+        "metrics"
+      ],
+      "after": [
+        "agent-experience",
+        "agent-memory",
+        "area:skills",
+        "enhancement",
+        "metrics",
+        "type:research"
+      ]
+    },
+    {
+      "number": 1535,
+      "before": [
+        "enhancement",
+        "skills",
+        "security",
+        "source-of-truth",
+        "agent-safety",
+        "skill-lifecycle"
+      ],
+      "after": [
+        "agent-safety",
+        "area:skills",
+        "enhancement",
+        "security",
+        "skill-lifecycle",
+        "source-of-truth"
+      ]
+    },
+    {
+      "number": 1536,
+      "before": [
+        "documentation",
+        "skills",
+        "interfaces"
+      ],
+      "after": [
+        "area:skills",
+        "documentation",
+        "interfaces"
+      ]
+    },
+    {
+      "number": 1545,
+      "before": [
+        "design",
+        "epic",
+        "determinism",
+        "agent-experience",
+        "runtime-portability"
+      ],
+      "after": [
+        "agent-experience",
+        "design",
+        "determinism",
+        "epic",
+        "runtime-portability",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 1560,
+      "before": [
+        "enhancement",
+        "installer",
+        "Workflow",
+        "agent-experience",
+        "tooling"
+      ],
+      "after": [
+        "Workflow",
+        "agent-experience",
+        "area:installer",
+        "enhancement",
+        "tooling"
+      ]
+    },
+    {
+      "number": 1567,
+      "before": [
+        "docs",
+        "design",
+        "type:research",
+        "source-of-truth"
+      ],
+      "after": [
+        "design",
+        "documentation",
+        "source-of-truth",
+        "type:research"
+      ]
+    },
+    {
+      "number": 1582,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1589,
+      "before": [
+        "enhancement",
+        "design",
+        "epic",
+        "determinism",
+        "source-of-truth"
+      ],
+      "after": [
+        "design",
+        "determinism",
+        "enhancement",
+        "epic",
+        "source-of-truth",
+        "status:tracker"
+      ]
+    },
+    {
+      "number": 1598,
+      "before": [
+        "skills",
+        "agent-experience",
+        "process"
+      ],
+      "after": [
+        "agent-experience",
+        "area:skills",
+        "process"
+      ]
+    },
+    {
+      "number": 1615,
+      "before": [
+        "enhancement",
+        "skills"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1660,
+      "before": [
+        "enhancement",
+        "ci-cd",
+        "installer"
+      ],
+      "after": [
+        "area:installer",
+        "ci-cd",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1789,
+      "before": [
+        "documentation",
+        "enhancement",
+        "triage",
+        "source-of-truth"
+      ],
+      "after": [
+        "documentation",
+        "enhancement",
+        "source-of-truth",
+        "status:child",
+        "triage"
+      ]
+    },
+    {
+      "number": 1812,
+      "before": [
+        "enhancement",
+        "skills",
+        "Workflow",
+        "area:skills"
+      ],
+      "after": [
+        "Workflow",
+        "area:skills",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1979,
+      "before": [
+        "enhancement",
+        "ci-cd",
+        "installer"
+      ],
+      "after": [
+        "area:installer",
+        "ci-cd",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1993,
+      "before": [
+        "enhancement",
+        "installer"
+      ],
+      "after": [
+        "area:installer",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1994,
+      "before": [
+        "enhancement",
+        "installer"
+      ],
+      "after": [
+        "area:installer",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 1999,
+      "before": [
+        "enhancement",
+        "installer"
+      ],
+      "after": [
+        "area:installer",
+        "enhancement"
+      ]
+    },
+    {
+      "number": 2021,
+      "before": [
+        "enhancement",
+        "skills",
+        "type:research",
+        "Workflow"
+      ],
+      "after": [
+        "Workflow",
+        "area:skills",
+        "enhancement",
+        "type:research"
+      ]
+    },
+    {
+      "number": 2316,
+      "before": [
+        "chore",
+        "skills",
+        "determinism",
+        "test-debt",
+        "review-cycle",
+        "harness"
+      ],
+      "after": [
+        "area:skills",
+        "chore",
+        "determinism",
+        "harness",
+        "review-cycle",
+        "test-debt"
+      ]
+    },
+    {
+      "number": 2436,
+      "before": [
+        "enhancement",
+        "patterns",
+        "skills",
+        "type:research"
+      ],
+      "after": [
+        "area:skills",
+        "enhancement",
+        "patterns",
+        "type:research"
+      ]
+    },
+    {
+      "number": 2611,
+      "before": [
+        "documentation",
+        "enhancement",
+        "agent-experience",
+        "scm",
+        "area:guidance"
+      ],
+      "after": [
+        "agent-experience",
+        "area:guidance",
+        "documentation",
+        "enhancement",
+        "scm",
+        "status:child"
+      ]
+    },
+    {
+      "number": 3007,
+      "before": [
+        "enhancement",
+        "docs",
+        "security",
+        "grok-build",
+        "tooling",
+        "hold"
+      ],
+      "after": [
+        "documentation",
+        "enhancement",
+        "grok-build",
+        "hold",
+        "security",
+        "tooling"
+      ]
+    },
+    {
+      "number": 3124,
+      "before": [
+        "enhancement",
+        "triage",
+        "agent-experience",
+        "process"
+      ],
+      "after": [
+        "agent-experience",
+        "enhancement",
+        "process",
+        "status:child",
+        "triage"
+      ]
+    },
+    {
+      "number": 3128,
+      "before": [
+        "enhancement",
+        "triage",
+        "process",
+        "scm"
+      ],
+      "after": [
+        "enhancement",
+        "process",
+        "scm",
+        "status:child",
+        "triage"
+      ]
+    },
+    {
+      "number": 3129,
+      "before": [
+        "enhancement",
+        "area:cli"
+      ],
+      "after": [
+        "area:cli",
+        "enhancement",
+        "status:child"
+      ]
+    }
+  ]
+}

--- a/.github/scripts/migrate-issue-labels-3128.mjs
+++ b/.github/scripts/migrate-issue-labels-3128.mjs
@@ -1,0 +1,277 @@
+/**
+ * One-shot open-issue label migration for deftai/directive (#3128).
+ * Applies #2609 twin renames + curated role/platform stamps.
+ *
+ * Usage:
+ *   node .github/scripts/migrate-issue-labels-3128.mjs --dry-run
+ *   node .github/scripts/migrate-issue-labels-3128.mjs --apply
+ *
+ * Requires: gh authenticated to deftai/directive.
+ */
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO = "deftai/directive";
+const APPLY = process.argv.includes("--apply");
+const DRY = !APPLY;
+
+function ghJson(args) {
+  const out = execFileSync("gh", args, { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 });
+  return JSON.parse(out);
+}
+
+function sleep(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* spin */
+  }
+}
+
+function searchOpenLabel(label) {
+  const q = `repo:${REPO} is:issue is:open label:"${label}"`;
+  const items = [];
+  let page = 1;
+  for (;;) {
+    const j = ghJson([
+      "api",
+      `search/issues?q=${encodeURIComponent(q)}&per_page=100&page=${page}`,
+    ]);
+    items.push(...(j.items || []));
+    if (!j.items?.length || items.length >= j.total_count) break;
+    page += 1;
+    if (page > 10) break;
+    sleep(800);
+  }
+  return items.map((i) => ({
+    number: i.number,
+    title: i.title,
+    labels: (i.labels || []).map((l) => l.name),
+  }));
+}
+
+function issueLabels(n) {
+  const j = ghJson(["api", `repos/${REPO}/issues/${n}`]);
+  return {
+    number: n,
+    title: j.title,
+    state: j.state,
+    labels: (j.labels || []).map((l) => l.name),
+  };
+}
+
+function setLabels(n, nextLabels) {
+  const body = JSON.stringify({ labels: nextLabels });
+  if (DRY) {
+    return { ok: true, dry: true };
+  }
+  execFileSync(
+    "gh",
+    ["api", "-X", "PATCH", `repos/${REPO}/issues/${n}`, "--input", "-"],
+    { input: body, encoding: "utf8" },
+  );
+  return { ok: true };
+}
+
+/** Twin: remove deprecated, ensure keep (preserve other labels). */
+function twinPlan(issue, remove, add) {
+  const set = new Set(issue.labels);
+  if (!set.has(remove)) return null;
+  set.delete(remove);
+  set.add(add);
+  return { number: issue.number, title: issue.title, from: remove, to: add, labels: [...set].sort() };
+}
+
+/** Ensure labels present; remove optional. */
+function ensurePlan(issue, add = [], remove = []) {
+  const set = new Set(issue.labels);
+  let changed = false;
+  for (const a of add) {
+    if (!set.has(a)) {
+      set.add(a);
+      changed = true;
+    }
+  }
+  for (const r of remove) {
+    if (set.has(r)) {
+      set.delete(r);
+      changed = true;
+    }
+  }
+  if (!changed) return null;
+  return {
+    number: issue.number,
+    title: issue.title,
+    add,
+    remove,
+    labels: [...set].sort(),
+  };
+}
+
+// --- Twin inventory ---
+const twins = [
+  { remove: "docs", add: "documentation" },
+  { remove: "skills", add: "area:skills" },
+  { remove: "installer", add: "area:installer" },
+];
+
+const twinOps = [];
+for (const t of twins) {
+  const issues = searchOpenLabel(t.remove);
+  for (const iss of issues) {
+    const plan = twinPlan(iss, t.remove, t.add);
+    if (plan) twinOps.push(plan);
+  }
+  sleep(500);
+}
+
+// --- Curated role / platform (graph-informed, skip rather than invent parents) ---
+// Process board: tracker without epic
+const rolePlans = [];
+
+function load(n) {
+  try {
+    return issueLabels(n);
+  } catch {
+    return null;
+  }
+}
+
+const ROLE_SCOPE = {
+  // Process mega-review: tracker, not product epic
+  886: { add: ["status:tracker"], remove: ["epic"] },
+  // Product multi-ship roots → epic + status:tracker
+  1423: { add: ["epic", "status:tracker", "status:child"], remove: [] }, // child of #886
+  2741: { add: ["epic", "status:tracker"], remove: [] },
+  2812: { add: ["epic", "status:tracker"], remove: [] },
+  2603: { add: ["epic", "status:tracker"], remove: [] },
+  1589: { add: ["epic", "status:tracker"], remove: [] },
+  1545: { add: ["epic", "status:tracker"], remove: [] },
+  635: { add: ["epic", "status:tracker"], remove: [] },
+  3081: { add: ["epic", "status:tracker"], remove: [] },
+  3082: { add: ["epic", "status:tracker"], remove: [] },
+  3078: { add: ["epic", "status:tracker"], remove: [] },
+  2769: { add: ["epic", "status:tracker"], remove: [] },
+  1285: { add: ["epic", "status:tracker"], remove: [] },
+  // Nested under taxonomy track / umbrella children
+  3128: { add: ["status:child"], remove: [] }, // child of #2609 (closed parent still graph-valid)
+  2611: { add: ["status:child"], remove: [] },
+  3124: { add: ["status:child"], remove: [] },
+  3129: { add: ["status:child"], remove: [] }, // plan entry under #886 triage track
+  1789: { add: ["status:child"], remove: [] }, // area:* rollout, coordinate with taxonomy
+  // Meta process trackers
+  1119: { add: ["status:tracker"], remove: [] },
+  1140: { add: ["status:tracker"], remove: [] },
+  1094: { add: ["status:tracker"], remove: [] },
+  2018: { add: ["status:tracker"], remove: [] },
+  // Platform-intrinsic open seeds (#2609)
+  412: { add: ["platform:windows"], remove: [] },
+  1422: { add: ["platform:windows"], remove: [] },
+};
+
+for (const [numStr, spec] of Object.entries(ROLE_SCOPE)) {
+  const n = Number(numStr);
+  const iss = load(n);
+  if (!iss || iss.state !== "open") continue;
+  const plan = ensurePlan(iss, spec.add, spec.remove);
+  if (plan) rolePlans.push(plan);
+  sleep(200);
+}
+
+const report = {
+  generated_at: new Date().toISOString(),
+  mode: DRY ? "dry-run" : "apply",
+  repo: REPO,
+  twin_ops: twinOps,
+  twin_count: twinOps.length,
+  role_ops: rolePlans,
+  role_count: rolePlans.length,
+  notes: [
+    "Twins: docs→documentation, skills→area:skills, installer→area:installer (open only).",
+    "Roles: curated set only — skip unknown parents rather than stamp status:child from titles.",
+    "Machine mirror (triage:classify --mirror --apply) is optional and NOT run by this script.",
+    "Closed history not rewritten.",
+  ],
+};
+
+const reportPath = join(process.cwd(), ".github", "ISSUE_LABEL_MIGRATION_3128.json");
+writeFileSync(reportPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+console.log(`Report: ${reportPath}`);
+console.log(`Twin ops: ${twinOps.length}; Role ops: ${rolePlans.length}; mode=${report.mode}`);
+
+const allOps = [
+  ...twinOps.map((o) => ({ kind: "twin", ...o })),
+  ...rolePlans.map((o) => ({ kind: "role", ...o })),
+];
+
+// Dedupe by issue number: merge label sets if both twin and role touch same issue
+const byNum = new Map();
+for (const o of allOps) {
+  const prev = byNum.get(o.number);
+  if (!prev) {
+    byNum.set(o.number, { number: o.number, title: o.title, labels: new Set(o.labels) });
+  } else {
+    for (const l of o.labels) prev.labels.add(l);
+    // twins already removed deprecated in o.labels; role uses full desired set after ensure
+    // Prefer intersection of intent: start from latest labels array which is complete set
+    prev.labels = new Set(o.labels);
+  }
+}
+
+// Rebuild correctly: start from live labels, apply all transforms
+function applyTransforms(issue) {
+  const set = new Set(issue.labels);
+  // twins
+  for (const t of twins) {
+    if (set.has(t.remove)) {
+      set.delete(t.remove);
+      set.add(t.add);
+    }
+  }
+  // role
+  const role = ROLE_SCOPE[issue.number];
+  if (role) {
+    for (const a of role.add) set.add(a);
+    for (const r of role.remove) set.delete(r);
+  }
+  const next = [...set].sort();
+  const same =
+    next.length === issue.labels.length && next.every((l) => issue.labels.includes(l));
+  return same ? null : next;
+}
+
+// Re-fetch and apply per unique number from twinOps + ROLE_SCOPE
+const targets = new Set([
+  ...twinOps.map((o) => o.number),
+  ...Object.keys(ROLE_SCOPE).map(Number),
+]);
+
+let applied = 0;
+let skipped = 0;
+const results = [];
+for (const n of [...targets].sort((a, b) => a - b)) {
+  const iss = load(n);
+  if (!iss || iss.state !== "open") {
+    skipped += 1;
+    continue;
+  }
+  const next = applyTransforms(iss);
+  if (!next) {
+    skipped += 1;
+    continue;
+  }
+  console.log(`#${n}: ${iss.labels.join(",")} -> ${next.join(",")}`);
+  setLabels(n, next);
+  applied += 1;
+  results.push({ number: n, before: iss.labels, after: next });
+  if (!DRY) sleep(350);
+}
+
+report.applied = applied;
+report.skipped = skipped;
+report.results = results;
+writeFileSync(reportPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+console.log(`Done. applied=${applied} skipped=${skipped} mode=${report.mode}`);
+if (DRY) {
+  console.log("Re-run with --apply to mutate labels.");
+}

--- a/.github/scripts/migrate-issue-labels-3128.mjs
+++ b/.github/scripts/migrate-issue-labels-3128.mjs
@@ -130,10 +130,17 @@ for (const t of twins) {
 const rolePlans = [];
 
 function load(n) {
+  // Fail closed on read errors (network/auth/rate-limit) so skips stay
+  // "closed or missing" only when GitHub returns a real 404 — not silent
+  // success after a transient failure (#3128 Greptile P1).
   try {
     return issueLabels(n);
-  } catch {
-    return null;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/\b404\b|Not Found/i.test(msg)) {
+      return null;
+    }
+    throw new Error(`load(#${n}) failed (not treating as skip): ${msg}`);
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Open-issue label migration onto maintainer taxonomy (#3128).** One-shot `node .github/scripts/migrate-issue-labels-3128.mjs` retags open issues: twin renames (`docs`→`documentation`, `skills`→`area:skills`, `installer`→`area:installer`), curated epic/tracker/child roles, and platform seeds. Dry-run report lands in `.github/ISSUE_LABEL_MIGRATION_3128.json`; ISSUE_LABELS.md documents re-run. Closes #3128. Refs #2609, #886.
 - **Maintainer issue label taxonomy catalog (#2609).** Adds a source of truth for issue-label facets, epic/tracker/child roles, machine labels, platform labels, and legacy-label decisions. Consumer kit and open-issue migration remain follow-up work. Closes #2609. Refs #886, #1423, #1789, #2611, #3128.
 - **Bootstrap mass-triage on classify label mirror (#3125 / #1423 Wave 2).** `task triage:classify -- --mirror` is the documented bootstrap mass entrypoint: **open-only** default (opt-in `--include-closed`), dry-run operator digest with totals + breakdown by state/rule/action + samples, `--json` aggregates, and batched rate-limit-aware `--apply` (`--batch-size` / `--delay-ms`) with partial-failure reporting and missing-label hints. Still never calls `triage:accept` / never writes `proposed/` xBRIEFs. Wave 3 (agent comments) remains on #1423. Closes #3125. Refs #1423, #3118, #1129.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,7 +352,7 @@ Maintainer taxonomy for **`deftai/directive` only** lives in [`.github/ISSUE_LAB
 - Machine labels (`triaged`, `triage:*`) used by SCM label mirror
 - Twin decisions (legacy vs forward names)
 
-Before inventing a label or applying epic/child roles, read that file. Portable **consumer** kit is **#2611** (not this full set). Open-issue migration onto the scheme is **#3128**.
+Before inventing a label or applying epic/child roles, read that file. Portable **consumer** kit is **#2611** (not this full set). Open-issue migration onto the scheme is **#3128** (one-shot: `node .github/scripts/migrate-issue-labels-3128.mjs --dry-run` then `--apply`; report in `.github/ISSUE_LABEL_MIGRATION_3128.json`).
 
 ## Adding a new triage / scope verb (#1150 / N10)
 

--- a/xbrief/active/2026-08-05-3128-chorelabels-migrate-open-directive-issues-onto-2609-taxonomy.xbrief.json
+++ b/xbrief/active/2026-08-05-3128-chorelabels-migrate-open-directive-issues-onto-2609-taxonomy.xbrief.json
@@ -1,0 +1,65 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF ingested from GitHub issue #3128",
+    "updated": "2026-08-05T19:56:59Z"
+  },
+  "plan": {
+    "title": "chore(labels): migrate open directive issues onto #2609 taxonomy scheme",
+    "status": "running",
+    "narratives": {
+      "Description": "chore(labels): migrate open directive issues onto #2609 taxonomy scheme",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3128",
+      "Overview": "## Summary\n\n**Migrate existing `deftai/directive` issues** onto the maintainer label scheme defined by **#2609** (catalog + `.github/ISSUE_LABELS.md`).\n\n#2609 owns **scheme + label catalog** (create/edit/delete labels, descriptions, twin decisions, machine/mirror names). This issue owns **applying that scheme to issues** (retag open work, role labels, limited cleanup on issues) so the Issues UI matches the doc.\n\n## Depends on\n\n- **#2609 Phase A** landed: ISSUE_LABELS.md exists; platform + machine labels created (or documented defer); twin decisions recorded.\n- Do **not** start bulk retag before the SoT file and catalog are stable.\n\n## Parent / plan\n\n- Parent taxonomy: **#2609**\n- Umbrella: **#886**\n- Plan order (updated): **#2609** → **this migration** → **#2611** → **#3124**\n\n(Consumer kit #2611 should not invent names that migration/mirror then contradict; migration after catalog keeps directive consistent first.)\n\n## In scope\n\n### 1. Role labels (graph-informed)\nUsing ISSUE_LABELS.md rules from #2609:\n\n- Product multi-ship roots → ensure `epic` + `status:tracker` (e.g. candidates like #1423, #2741 already partly correct)\n- Coordination-only boards → `status:tracker` (± no `epic` per doc)\n- Issues with formal parent link → `status:child`\n- Mid-level trackers under a parent → `status:tracker` + `status:child` when both roles apply\n- Leaves: no `epic`; not both tracker and pure-leaf confusion\n\nPrefer automation or scripted checklist driven by **parent links / known umbrella lists / current-shape**, not title keywords alone.\n\n### 2. Twin / deprecated labels on issues\nWhere #2609 decided merges (e.g. `docs` → `documentation`):\n\n- Retag **open** issues off deprecated names onto canonical ones\n- Do not require closed-history rewrite (optional later ops)\n\n### 3. Platform backfill (beyond #2609 seed)\nApply `platform:*` to additional **open** platform-intrinsic issues identified by checklist/heuristic (expand seed from #2609).\n\n### 4. Machine labels (optional pass)\nAfter catalog includes `triaged` / `triage:*`:\n\n- Optional: open-only `triage:classify -- --mirror --apply` for **classify matches only** (does not replace role retag)\n- Do not use mirror to invent `status:child` / `epic`\n\n### 5. Safety\n- Dry-run / report before mass apply (script output or checklist)\n- Rate-limit aware if using API\n- Document false-positive policy (skip rather than wrong-parent child stamps)\n\n## Out of scope\n\n- Defining the taxonomy (that is #2609)\n- Consumer kit (#2611) or discovery tip (#3124)\n- Full closed-history rewrite\n- Mirror engine features\n- Auto-relabel forever CI (unless tiny helper script checked in as one-shot)\n\n## Acceptance criteria\n\n- [ ] Blocked on #2609 Phase A (SoT + catalog)\n- [ ] Written migration plan (which labels move, which issues classes, dry-run report)\n- [ ] Open issues updated for agreed twin renames (or explicit exceptions list)\n- [ ] Known product epics / trackers / children in scope set have role labels per #2609 rules (documented scope set)\n- [ ] Platform backfill for agreed open set\n- [ ] Optional mirror apply pass documented if run\n- [ ] Short note in ISSUE_LABELS.md or CONTRIBUTING: how migration was done / how to re-run\n- [ ] CHANGELOG if user-visible process docs change\n\n## Related\n\n- **#2609** — scheme + catalog (parent)\n- **#2611** — consumer kit (after this or after #2609 catalog; plan prefers after migration so directive is clean first)\n- **#3124** — discovery after #2611\n- **#1423** / **#3126** — mirror apply is optional tool, not full migration\n- **#886** — umbrella\n\n## Non-goals\n\n- Perfect historical accuracy on all closed issues\n- Replacing current-shape / sub-issues as structure SoT\n\n---\n\n## Issue comment thread\n\n_The issue body is the original write-up; maintainer comments below may supersede it. Read the full thread before building a dispatch envelope (#2143)._\n\n### Comment by @MScottAdams (2026-08-05T18:08:30Z)\n\nParent taxonomy: #2609. Plan-sequence entry 2 of `label-taxonomy-migrate-kit-discovery-2026-08-05` (after #2609, before #2611).",
+      "Labels": "enhancement, triage, process, scm"
+    },
+    "items": [
+      {
+        "title": "Blocked on #2609 Phase A (SoT + catalog)",
+        "status": "proposed"
+      },
+      {
+        "title": "Written migration plan (which labels move, which issues classes, dry-run report)",
+        "status": "proposed"
+      },
+      {
+        "title": "Open issues updated for agreed twin renames (or explicit exceptions list)",
+        "status": "proposed"
+      },
+      {
+        "title": "Known product epics / trackers / children in scope set have role labels per #2609 rules (documented scope set)",
+        "status": "proposed"
+      },
+      {
+        "title": "Platform backfill for agreed open set",
+        "status": "proposed"
+      },
+      {
+        "title": "Optional mirror apply pass documented if run",
+        "status": "proposed"
+      },
+      {
+        "title": "Short note in ISSUE_LABELS.md or CONTRIBUTING: how migration was done / how to re-run",
+        "status": "proposed"
+      },
+      {
+        "title": "CHANGELOG if user-visible process docs change",
+        "status": "proposed"
+      }
+    ],
+    "tags": [
+      "enhancement",
+      "triage",
+      "process",
+      "scm"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3128",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3128: chore(labels): migrate open directive issues onto #2609 taxonomy scheme"
+      }
+    ],
+    "updated": "2026-08-05T19:56:59Z"
+  }
+}

--- a/xbrief/completed/2026-08-04-1423-rfc-autonomous-auto-triage-write-back-cycle-scm-label-mirror.xbrief.json
+++ b/xbrief/completed/2026-08-04-1423-rfc-autonomous-auto-triage-write-back-cycle-scm-label-mirror.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #1423",
-    "updated": "2026-08-04T22:57:47Z"
+    "updated": "2026-08-05T16:31:54Z"
   },
   "plan": {
     "title": "feat(triage): Tier-1 deterministic SCM label mirror from classify (Wave 1 of #1423)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Wave 1 only of #1423 design lock (2026-08-04). Implement deterministic Tier-1 SCM label mirror: run existing triage classify engine over cache, map outcomes to labels (triaged idempotency marker + action-derived labels via policy), dry-run default with --apply, github-only writes through SCM boundary / existing reconcile surfaces. MUST NOT call triage:accept or write proposed/ xBRIEFs. Waves 2-3 (mass bootstrap comments, agent Tier-2 comments) are OUT OF SCOPE.",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/1423",
@@ -20,7 +20,7 @@
       {
         "id": "1423-tier1-label-mirror-a1",
         "title": "Dry-run default prints digest of label adds/skips with zero SCM writes",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given 1423-tier1-label-mirror scope, when complete, then: Dry-run default prints digest of label adds/skips with zero SCM writes",
           "Traces": "AC-1"
@@ -29,7 +29,7 @@
       {
         "id": "1423-tier1-label-mirror-a2",
         "title": "--apply writes labels via SCM-safe path; re-run is no-op for already-triaged",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given 1423-tier1-label-mirror scope, when complete, then: --apply writes labels via SCM-safe path; re-run is no-op for already-triaged",
           "Traces": "AC-2"
@@ -38,7 +38,7 @@
       {
         "id": "1423-tier1-label-mirror-a3",
         "title": "Classify engine reused (#1129); no reimplementation of match DSL",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given 1423-tier1-label-mirror scope, when complete, then: Classify engine reused (#1129); no reimplementation of match DSL",
           "Traces": "AC-3"
@@ -47,7 +47,7 @@
       {
         "id": "1423-tier1-label-mirror-a4",
         "title": "Never invokes triage:accept or creates proposed/ xBRIEFs",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given 1423-tier1-label-mirror scope, when complete, then: Never invokes triage:accept or creates proposed/ xBRIEFs",
           "Traces": "AC-4"
@@ -56,7 +56,7 @@
       {
         "id": "1423-tier1-label-mirror-a5",
         "title": "Tests + CHANGELOG [Unreleased] for #1423 Wave 1",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given 1423-tier1-label-mirror scope, when complete, then: Tests + CHANGELOG [Unreleased] for #1423 Wave 1",
           "Traces": "AC-5"
@@ -76,7 +76,7 @@
       }
     ],
     "id": "1423-tier1-label-mirror",
-    "updated": "2026-08-04T22:57:47Z",
+    "updated": "2026-08-05T16:31:54Z",
     "metadata": {
       "kind": "story",
       "swarm": {
@@ -109,7 +109,26 @@
         "size": "medium",
         "file_scope_confidence": "medium",
         "model_tier": "high"
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3118,
+        "prBase": "master",
+        "mergeCommit": "5f057f08e0fc90e985f46e27d454bc42a925ce9c",
+        "deliveryBranch": "master",
+        "deliveryCommit": "ff1e3a7735c9fb5d73d220da153c7b8e5a654e8a",
+        "verifiedAt": "2026-08-05T16:31:54Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-05T16:31:54Z",
+      "capacityBucket": "agentic-debt"
     }
   }
 }

--- a/xbrief/completed/2026-08-04-npm-v12-install-security-defaults-docs.xbrief.json
+++ b/xbrief/completed/2026-08-04-npm-v12-install-security-defaults-docs.xbrief.json
@@ -1,0 +1,101 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Docs note for npm v12 install-time security defaults",
+    "updated": "2026-08-05T04:48:03Z"
+  },
+  "plan": {
+    "title": "docs: npm v12 install-time security defaults (scripts/git/remote opt-in)",
+    "status": "completed",
+    "id": "npm-v12-docs",
+    "narratives": {
+      "Description": "Document npm v12 install-time security defaults for Directive consumers and monorepo maintainers. Consumers use npm globally; the framework monorepo uses pnpm with allowBuilds for esbuild. Clarify that Directive published packages ship no install scripts, git/remote package sources are not used, and publish remains OIDC.",
+      "Origin": "Operator request after npm v12 GA announcement",
+      "Overview": "Add a short UPGRADING section (primary), a CONTRIBUTING monorepo note pointing at pnpm allowBuilds, optional README pointer, and CHANGELOG Unreleased.",
+      "UserStory": "As a Directive consumer or monorepo contributor, I want clear guidance when npm v12 blocks install scripts or non-registry sources by default, so that I know whether Directive requires allowlists and where install-script authority lives (pnpm allowBuilds vs npm allowScripts).",
+      "ImplementationPlan": "Step 1: Edit content/UPGRADING.md — insert a new ## npm v12 install-time security defaults section near the top (after legend) documenting allowScripts off, allow-git none, allow-remote none; consumer path npm i -g @deftai/directive needs no Directive-side allowlist (published packages have no install scripts); app trees with native modules use npm approve-scripts in the consumer project; monorepo contributors use pnpm + pnpm-workspace.yaml allowBuilds.esbuild. Step 2: Edit CONTRIBUTING.md under Windows-native Node/pnpm or a short Install scripts subsection — install-script SoT is pnpm allowBuilds, not npm allowScripts (pnpm layout breaks approve-scripts pinning). Step 3: Optional README Getting Started one-liner linking UPGRADING npm v12. Step 4: CHANGELOG.md [Unreleased] docs bullet. Verification: files contain the section headings; task verify:forward-coverage passes; no product code changes.",
+      "missing_traces_justification": "Docs-only story; AC items carry Traces."
+    },
+    "items": [
+      {
+        "id": "npm-v12-docs-a1",
+        "title": "UPGRADING.md npm v12 section",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given content/UPGRADING.md, when opened after this change, then a section documents npm v12 allowScripts/allow-git/allow-remote defaults and states that @deftai/directive global install does not require a Directive package allowScripts map",
+          "Traces": "AC-1"
+        }
+      },
+      {
+        "id": "npm-v12-docs-a2",
+        "title": "CONTRIBUTING monorepo pnpm allowBuilds note",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given CONTRIBUTING.md, when opened after this change, then monorepo install-script authority is described as pnpm allowBuilds (esbuild) rather than npm approve-scripts under the pnpm virtual store",
+          "Traces": "AC-2"
+        }
+      },
+      {
+        "id": "npm-v12-docs-a3",
+        "title": "CHANGELOG Unreleased",
+        "status": "completed",
+        "narrative": {
+          "Acceptance": "Given CHANGELOG.md [Unreleased], when opened after this change, then a docs bullet cites npm v12 install-time defaults guidance",
+          "Traces": "AC-3"
+        }
+      }
+    ],
+    "tags": [
+      "docs",
+      "npm",
+      "agent-experience"
+    ],
+    "references": [],
+    "updated": "2026-08-05T04:48:03Z",
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "content/UPGRADING.md",
+          "CONTRIBUTING.md",
+          "README.md",
+          "CHANGELOG.md"
+        ],
+        "verify_commands": [
+          "task verify:forward-coverage"
+        ],
+        "expected_outputs": [
+          "UPGRADING npm v12 section",
+          "CONTRIBUTING pnpm note",
+          "CHANGELOG"
+        ],
+        "depends_on": [],
+        "conflict_group": "npm-v12-docs",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "medium"
+      },
+      "completionProvenance": {
+        "repository": "deftai/directive",
+        "implementationCommit": null,
+        "prNumber": 3123,
+        "prBase": "master",
+        "mergeCommit": "ff1e3a7735c9fb5d73d220da153c7b8e5a654e8a",
+        "deliveryBranch": "master",
+        "deliveryCommit": "ff1e3a7735c9fb5d73d220da153c7b8e5a654e8a",
+        "verifiedAt": "2026-08-05T04:48:03Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-05T04:48:03Z",
+      "capacityBucket": "new-capability"
+    }
+  }
+}

--- a/xbrief/completed/2026-08-05-2609-featprocessscm-issue-label-taxonomy-platform-facet-public-do.xbrief.json
+++ b/xbrief/completed/2026-08-05-2609-featprocessscm-issue-label-taxonomy-platform-facet-public-do.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #2609",
-    "updated": "2026-08-05T18:31:13Z"
+    "updated": "2026-08-05T19:15:25Z"
   },
   "plan": {
     "title": "feat(process,scm): issue label taxonomy — platform facet, public docs, dedupe",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "feat(process,scm): issue label taxonomy — platform facet, public docs, dedupe",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/2609",
@@ -16,31 +16,31 @@
     "items": [
       {
         "title": "`.github/ISSUE_LABELS.md` with facets, **epic/tracker/child rules**, nested mid-node policy, machine facet, platform, deprecate list, PR≈story",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "CONTRIBUTING links to it",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Platform labels created + descriptions",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Machine labels documented (+ created or explicitly deferred)",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Twin decisions + typo fix + descriptions pass",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Skill pointer for **this** repo",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Cross-links: #2611, #1789, #1423, #3124, #886",
-        "status": "proposed"
+        "status": "completed"
       }
     ],
     "tags": [
@@ -62,6 +62,27 @@
         "title": "Issue #2611"
       }
     ],
-    "updated": "2026-08-05T18:31:13Z"
+    "updated": "2026-08-05T19:15:25Z",
+    "metadata": {
+      "completionProvenance": {
+        "repository": "deftai/directive",
+        "implementationCommit": null,
+        "prNumber": 3130,
+        "prBase": "master",
+        "mergeCommit": "5be5a7fbb996c620ac0b7aa449041224e50b7fd0",
+        "deliveryBranch": "master",
+        "deliveryCommit": "5be5a7fbb996c620ac0b7aa449041224e50b7fd0",
+        "verifiedAt": "2026-08-05T19:15:25Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-05T19:15:25Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }

--- a/xbrief/completed/2026-08-05-3125-feattriage-1423-wave-2-bootstrap-mass-triage-filters-digest.xbrief.json
+++ b/xbrief/completed/2026-08-05-3125-feattriage-1423-wave-2-bootstrap-mass-triage-filters-digest.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Wave 2 only of #1423 — bootstrap mass-triage on Wave 1 mirror (#3118 / #3125)",
-    "updated": "2026-08-05T16:45:43Z"
+    "updated": "2026-08-05T17:07:43Z"
   },
   "plan": {
     "title": "feat(triage): #1423 Wave 2 — bootstrap mass-triage (filters, digest, safe apply)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "Productize bootstrap mass-triage on top of shipped Wave 1 label mirror. Wave 1 walks the github-issue cache and plans or applies labels. Wave 2 adds safe brownfield job semantics: state filters with open-only default, operator digest with totals and breakdowns, batched rate-limit-aware apply. Never triage:accept. Dogfood on directive showed 686 planned with most closed; filters are load-bearing.",
       "Origin": "https://github.com/deftai/directive/issues/3125 (Wave 2 of #1423)",
@@ -20,7 +20,7 @@
       {
         "id": "3125-a1",
         "title": "Documented bootstrap/mass entrypoint on Wave 1 mirror",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given Wave 2 bootstrap mass-triage scope, when complete, then: Documented bootstrap/mass entrypoint on Wave 1 mirror",
           "Traces": "AC-1"
@@ -29,7 +29,7 @@
       {
         "id": "3125-a2",
         "title": "Default filter avoids mass-labeling all closed history (open-only or equally safe)",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given Wave 2 bootstrap mass-triage scope, when complete, then: Default filter avoids mass-labeling all closed history (open-only or equally safe)",
           "Traces": "AC-2"
@@ -38,7 +38,7 @@
       {
         "id": "3125-a3",
         "title": "Dry-run digest: totals + by state/rule/action + samples (+ JSON)",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given Wave 2 bootstrap mass-triage scope, when complete, then: Dry-run digest: totals + by state/rule/action + samples (+ JSON)",
           "Traces": "AC-3"
@@ -47,7 +47,7 @@
       {
         "id": "3125-a4",
         "title": "Apply batches writes, rate-limit aware, idempotent, partial failure report",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given Wave 2 bootstrap mass-triage scope, when complete, then: Apply batches writes, rate-limit aware, idempotent, partial failure report",
           "Traces": "AC-4"
@@ -56,7 +56,7 @@
       {
         "id": "3125-a5",
         "title": "Never triage:accept / never proposed/ xBRIEFs",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given Wave 2 bootstrap mass-triage scope, when complete, then: Never triage:accept / never proposed/ xBRIEFs",
           "Traces": "AC-5"
@@ -65,7 +65,7 @@
       {
         "id": "3125-a6",
         "title": "Tests + CHANGELOG for #3125 / #1423 Wave 2",
-        "status": "pending",
+        "status": "completed",
         "narrative": {
           "Acceptance": "Given Wave 2 bootstrap mass-triage scope, when complete, then: Tests + CHANGELOG for #3125 / #1423 Wave 2",
           "Traces": "AC-6"
@@ -90,7 +90,7 @@
       }
     ],
     "id": "3125-bootstrap-mass-triage",
-    "updated": "2026-08-05T16:45:43Z",
+    "updated": "2026-08-05T17:07:43Z",
     "metadata": {
       "kind": "story",
       "swarm": {
@@ -121,7 +121,26 @@
         "size": "medium",
         "file_scope_confidence": "high",
         "model_tier": "high"
-      }
+      },
+      "completionProvenance": {
+        "repository": null,
+        "implementationCommit": null,
+        "prNumber": 3126,
+        "prBase": "master",
+        "mergeCommit": "b4355365eceaf15077fe83b466a6743552977433",
+        "deliveryBranch": "master",
+        "deliveryCommit": "b4355365eceaf15077fe83b466a6743552977433",
+        "verifiedAt": "2026-08-05T17:07:43Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-05T17:07:43Z",
+      "capacityBucket": "new-capability"
     }
   }
 }


### PR DESCRIPTION
## Summary

**#3128** open-issue migration onto the #2609 maintainer taxonomy (already applied on the forge; this PR lands the script, report, and docs).

### Forge apply (done)
- **91** open issues updated via `node .github/scripts/migrate-issue-labels-3128.mjs --apply`
- Twins: `docs`→`documentation`, `skills`→`area:skills`, `installer`→`area:installer` (residual open: **0**)
- Roles: curated epic/tracker/child (e.g. #886 process board without `epic`; #1423 epic+tracker+child)
- Platform seeds: #412, #1422 → `platform:windows`
- Machine mirror: **not** run (optional)

### Repo
- One-shot script + `.github/ISSUE_LABEL_MIGRATION_3128.json` report
- ISSUE_LABELS.md migration section + CONTRIBUTING pointer
- CHANGELOG

## Test plan
- [x] Dry-run then apply
- [x] Residual twin labels = 0 on open issues
- [x] Spot check #886 / #1423 / #1422
- [ ] CI green

Closes #3128
Refs #2609, #886