### PR TITLE
chore(labels): quarantine zero-open twins as legacy:* (lowercase)

### DIFF
--- a/.github/ISSUE_LABELS.md
+++ b/.github/ISSUE_LABELS.md
@@ -144,19 +144,43 @@ New surfaces: add `area:<slug>` here first, then create the label with a descrip
 
 ## Twin decisions (legacy → forward)
 
-Migration of open issues is **#3128**. Phase A **decides** which name wins.
+Migration of open issues is **#3128**. Phase A **decides** which name wins. Zero-open legacy twins and dead synonyms are **quarantined by rename** (not delete) so closed history keeps a searchable tag.
+
+### Quarantine policy (`legacy:*`)
+
+| Rule | Detail |
+|------|--------|
+| **Name form** | All **lowercase**: `legacy:<former-name>` (exact former string after the colon) |
+| **Colon wins** | When a colon facet and a non-colon twin both exist, **keep the `:` form** (newer/forward); quarantine the older non-colon name when open count is 0 |
+| **Neither colon** | Keep the catalog forward name (e.g. `documentation`); quarantine the other (e.g. `legacy:docs`) |
+| **Do not quarantine** | Machine set (`triaged`, `triage:*`), platform reserve, gates, standard disposition (`duplicate` / `wontfix` / `invalid`), support upgrade labels |
+| **Agent rule** | ⊗ Apply any `legacy:*` label on new work |
+
+### Live forward → quarantined (applied when open count was 0)
+
+| Keep (forward) | Quarantined label (was) |
+|----------------|-------------------------|
+| `documentation` | `legacy:docs` |
+| `area:skills` | `legacy:skills` |
+| `area:installer` | `legacy:installer` |
+| `area:release` | `legacy:release` |
+| `scm` / `ci-cd` | `legacy:github`, `legacy:github-actions` |
+| `ci-cd` / area surfaces | `legacy:packaging` |
+| `test-debt` / evals / harness | `legacy:testing` |
+| *(unused GH defaults)* | `legacy:help wanted`, `legacy:question` |
 
 | Keep | Deprecate / avoid new use | Notes |
 |------|---------------------------|--------|
-| `documentation` | `docs` | Prefer `documentation` for human docs work |
-| `area:skills` | `skills` | Surface facet |
-| `area:installer` | `installer` | Surface facet |
+| `documentation` | bare `docs` (now `legacy:docs`) | Prefer `documentation` for human docs work |
+| `area:skills` | bare `skills` (now `legacy:skills`) | Surface facet |
+| `area:installer` | bare `installer` (now `legacy:installer`) | Surface facet |
+| `area:release` | bare `release` (now `legacy:release`) | Surface facet |
 | `enhancement` | inventing `feat` as a type label | Type facet uses `enhancement` |
 | `rfc` | dual-stacking `type:research` without need | `type:research` OK for investigation; `rfc` for design discussion |
 | `UPGRADE ANNOUNCEMENT` | typo `UPGRADE ANNOUCEMENT` | Renamed; typo form must not return |
 | Machine set above | inventing extra `triage:*` | Closed set |
 
-Empty-description labels should gain short descriptions when touched; do not delete legacy twins in Phase A (removal/alias cleanup is migration judgment on **#3128**).
+Empty-description labels should gain short descriptions when touched.
 
 ---
 
@@ -166,7 +190,8 @@ Inventory ~85 labels at #2609 implement time. This section lists **canonical** n
 
 ### Type (selected)
 
-`bug`, `enhancement`, `rfc`, `epic`, `documentation`, `duplicate`, `invalid`, `wontfix`, `question`, `chore`, `refactor`, `type:research`
+`bug`, `enhancement`, `rfc`, `epic`, `documentation`, `duplicate`, `invalid`, `wontfix`, `chore`, `refactor`, `type:research`  
+*(do not use `legacy:question` on new work)*
 
 ### Area
 
@@ -198,11 +223,13 @@ Inventory ~85 labels at #2609 implement time. This section lists **canonical** n
 
 1. ! Before applying labels, read this file (or the issue body of #2609 if this file is missing on an old branch).
 2. ! Prefer existing catalog names; ⊗ invent new facet prefixes without amending this file.
-3. ! For multi-ship product roots: `epic` + `status:tracker` when both definitions hold.
-4. ! For parented leaves: `status:child` + type; ⊗ `epic` on pure children.
-5. ! Machine labels: closed set above; mirror is primary writer.
-6. ! Platform only for OS-intrinsic work.
-7. ~ Consumer projects: follow **#2611** kit when shipped — do not copy the full maintainer set by default.
+3. ! Prefer colon facet forms (`area:*`, `status:*`, `platform:*`, `triage:*`) over non-colon twins.
+4. ⊗ Apply any `legacy:*` label; those are closed-history quarantine only.
+5. ! For multi-ship product roots: `epic` + `status:tracker` when both definitions hold.
+6. ! For parented leaves: `status:child` + type; ⊗ `epic` on pure children.
+7. ! Machine labels: closed set above; mirror is primary writer.
+8. ! Platform only for OS-intrinsic work.
+9. ~ Consumer projects: follow **#2611** kit when shipped — do not copy the full maintainer set by default.
 
 Skill / SCM pointer: `content/scm/github.md` § Issue Labels (framework source) links here.
 
@@ -258,5 +285,6 @@ Skill / SCM pointer: `content/scm/github.md` § Issue Labels (framework source) 
 
 | Date | Change |
 |------|--------|
+| 2026-08-05 | Quarantine zero-open twins/synonyms as lowercase `legacy:<former>` (colon form wins) |
 | 2026-08-05 | Open-issue migration notes + re-run instructions (#3128) |
 | 2026-08-05 | Initial catalog from #2609 Phase A (facets, epic/tracker/child, machine, platform, twins) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Label quarantine: zero-open twins → lowercase `legacy:*`.** Renamed dead non-colon twins and unused defaults (e.g. `docs`→`legacy:docs`, `skills`→`legacy:skills`, `installer`→`legacy:installer`, `release`→`legacy:release`, plus `github` / `github-actions` / `packaging` / `testing` / unused GH defaults) so closed history stays filterable and new work cannot pick the bare names. Prefer colon facets (`area:*`, …). Catalog policy in `.github/ISSUE_LABELS.md`. Refs #2609, #3128.
 - **docs: npm v12 install-time security defaults.** UPGRADING documents `allowScripts` off, `--allow-git` / `--allow-remote` default none, Directive consumer path (no package allowlist for `@deftai/directive*`; app trees use `npm approve-scripts`), globals/`npx` config flags, monorepo pnpm `allowBuilds` (esbuild) as install-script SoT, and OIDC publish notes. CONTRIBUTING points monorepo install scripts at `allowBuilds`; README upgrade callout links the section.
 - **Label mirror defaults to open-only (#3125).** Wave 1 `--mirror` dry-run planned closed archive stamps via `universal:closed-never-triaged`; Wave 2 skips closed unless `--include-closed`, so brownfield dry-runs match open backlog scale instead of full closed history.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,7 +352,7 @@ Maintainer taxonomy for **`deftai/directive` only** lives in [`.github/ISSUE_LAB
 - Machine labels (`triaged`, `triage:*`) used by SCM label mirror
 - Twin decisions (legacy vs forward names)
 
-Before inventing a label or applying epic/child roles, read that file. Portable **consumer** kit is **#2611** (not this full set). Open-issue migration onto the scheme is **#3128** (one-shot: `node .github/scripts/migrate-issue-labels-3128.mjs --dry-run` then `--apply`; report in `.github/ISSUE_LABEL_MIGRATION_3128.json`).
+Before inventing a label or applying epic/child roles, read that file. Prefer **colon** facet names; never apply `legacy:*` (closed-history quarantine only). Portable **consumer** kit is **#2611** (not this full set). Open-issue migration onto the scheme is **#3128** (one-shot: `node .github/scripts/migrate-issue-labels-3128.mjs --dry-run` then `--apply`; report in `.github/ISSUE_LABEL_MIGRATION_3128.json`).
 
 ## Adding a new triage / scope verb (#1150 / N10)
 

--- a/xbrief/completed/2026-08-05-3128-chorelabels-migrate-open-directive-issues-onto-2609-taxonomy.xbrief.json
+++ b/xbrief/completed/2026-08-05-3128-chorelabels-migrate-open-directive-issues-onto-2609-taxonomy.xbrief.json
@@ -2,11 +2,11 @@
   "xBRIEFInfo": {
     "version": "0.8",
     "description": "Scope xBRIEF ingested from GitHub issue #3128",
-    "updated": "2026-08-05T19:56:59Z"
+    "updated": "2026-08-05T20:21:39Z"
   },
   "plan": {
     "title": "chore(labels): migrate open directive issues onto #2609 taxonomy scheme",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Description": "chore(labels): migrate open directive issues onto #2609 taxonomy scheme",
       "Origin": "Ingested from https://github.com/deftai/directive/issues/3128",
@@ -16,35 +16,35 @@
     "items": [
       {
         "title": "Blocked on #2609 Phase A (SoT + catalog)",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Written migration plan (which labels move, which issues classes, dry-run report)",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Open issues updated for agreed twin renames (or explicit exceptions list)",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Known product epics / trackers / children in scope set have role labels per #2609 rules (documented scope set)",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Platform backfill for agreed open set",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Optional mirror apply pass documented if run",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "Short note in ISSUE_LABELS.md or CONTRIBUTING: how migration was done / how to re-run",
-        "status": "proposed"
+        "status": "completed"
       },
       {
         "title": "CHANGELOG if user-visible process docs change",
-        "status": "proposed"
+        "status": "completed"
       }
     ],
     "tags": [
@@ -60,6 +60,27 @@
         "title": "Issue #3128: chore(labels): migrate open directive issues onto #2609 taxonomy scheme"
       }
     ],
-    "updated": "2026-08-05T19:56:59Z"
+    "updated": "2026-08-05T20:21:39Z",
+    "metadata": {
+      "completionProvenance": {
+        "repository": "deftai/directive",
+        "implementationCommit": null,
+        "prNumber": 3132,
+        "prBase": "master",
+        "mergeCommit": "804c68a0b599a78481edd96361e4c08bad999600",
+        "deliveryBranch": "master",
+        "deliveryCommit": "804c68a0b599a78481edd96361e4c08bad999600",
+        "verifiedAt": "2026-08-05T20:21:39Z",
+        "verifier": "scope:complete",
+        "disposition": "delivered",
+        "handoffState": "delivered",
+        "deployed": null,
+        "uatVerified": null
+      },
+      "deliveryDisposition": "delivered",
+      "handoffState": "delivered",
+      "completedAt": "2026-08-05T20:21:39Z",
+      "capacityBucket": "new-capability"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Quarantine **zero-open** legacy twins / dead synonyms by **rename** (not delete), all lowercase:

| Former | Now |
|--------|-----|
| `docs` | `legacy:docs` |
| `skills` | `legacy:skills` |
| `installer` | `legacy:installer` |
| `release` | `legacy:release` |
| `github` | `legacy:github` |
| `github-actions` | `legacy:github-actions` |
| `packaging` | `legacy:packaging` |
| `testing` | `legacy:testing` |
| `help wanted` | `legacy:help wanted` |
| `question` | `legacy:question` |

Policy: **colon form wins** when a twin exists; closed history keeps the renamed tag; agents must not apply `legacy:*`. Documented in `.github/ISSUE_LABELS.md`.

Forge renames already applied; this PR is catalog/docs.

## Test plan
- [x] Old names 404 on label API
- [x] `legacy:*` labels exist with LEGACY descriptions
- [ ] CI green

Refs #2609, #3128