### PR TITLE
fix(init-deposit): core-guard upgrade co-travel for pin + GENERATION (#3127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core-guard allowlist: upgrade co-travel for package pin + GENERATION.json (#3127).** Expand `installerManagedMatchers()` (TS deposit + Go parity) so a single framework-upgrade PR may include `.deft/core/**`, existing installer-managed deposits, `package.json` / lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`), and `.deft/GENERATION.json` without tripping `no-mixed-core-and-app`. Mixing core with true app/product paths still fails. UPGRADING documents the one-upgrade-PR shape; commit hygiene notes the co-travel unit. Closes #3127. Refs #1430, #3117, #1440.
+
 ### Removed
 
 ## [0.95.0] - 2026-08-05

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -137,6 +137,14 @@ func installerManagedMatchers() []installerManagedMatcher {
 		{exact: "greptile.json"},
 		{exact: codeqlConfigRelPath},
 		{exact: coreGuardWorkflowRelPath},
+		// Upgrade co-travel unit (#3127): npm pin + lock follow-through and the
+		// freshness live stamp (#3117). Path-level allow for v1; true app paths
+		// still fail when mixed with .deft/core/** (#1430).
+		{exact: "package.json"},
+		{exact: "package-lock.json"},
+		{exact: "pnpm-lock.yaml"},
+		{exact: "yarn.lock"},
+		{exact: ".deft/GENERATION.json"},
 		{exact: "vbrief/.deft-version"},
 		{exact: "vbrief/vbrief.md"},
 		{prefix: "vbrief/schemas/"},

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -568,6 +568,12 @@ func upgradeOnlyChangeSet() []string {
 		"greptile.json",
 		codeqlConfigRelPath,
 		coreGuardWorkflowRelPath,
+		// Upgrade co-travel (#3127): pin + lock + freshness stamp.
+		"package.json",
+		"package-lock.json",
+		"pnpm-lock.yaml",
+		"yarn.lock",
+		".deft/GENERATION.json",
 		"vbrief/.deft-version",
 		"vbrief/vbrief.md",
 		"vbrief/schemas/scope.schema.json",
@@ -577,6 +583,34 @@ func upgradeOnlyChangeSet() []string {
 		changed = append(changed, "vbrief/"+sub+"/.gitkeep")
 	}
 	return changed
+}
+
+// TestCoreGuard_UpgradeCoTravelPinAndGeneration pins #3127: pin + GENERATION
+// co-travel with .deft/core/**; true app paths still fail.
+func TestCoreGuard_UpgradeCoTravelPinAndGeneration(t *testing.T) {
+	pass := []string{
+		".deft/core/VERSION",
+		"package.json",
+		"package-lock.json",
+		".deft/GENERATION.json",
+		"AGENTS.md",
+	}
+	if guardWouldFail(pass) {
+		t.Error("guard must PASS upgrade unit: core + pin + lock + GENERATION + allowlisted stubs")
+	}
+	_, managed, app := classifyChangedPaths(pass)
+	if len(app) != 0 {
+		t.Errorf("upgrade co-travel set must leave app empty; got app=%v managed=%v", app, managed)
+	}
+
+	fail := []string{".deft/core/VERSION", "package.json", ".deft/GENERATION.json", "src/main.py"}
+	if !guardWouldFail(fail) {
+		t.Error("guard must FAIL when core mixes with true app path even if pin+GENERATION present")
+	}
+	_, _, appFail := classifyChangedPaths(fail)
+	if len(appFail) != 1 || appFail[0] != "src/main.py" {
+		t.Errorf("expected only src/main.py as app; got %v", appFail)
+	}
 }
 
 // TestCoreGuard_UpgradeOnlyChangeSetAllowed pins acceptance criterion (a): an

--- a/cmd/deft-install/hygiene.go
+++ b/cmd/deft-install/hygiene.go
@@ -320,9 +320,11 @@ func printCommitGuidance(w *Wizard, paths []string, staged bool) {
 		return
 	}
 	addCmd := "git add " + strings.Join(paths, " ")
-	w.printf("\nCommit hygiene (#1453, #1671): keep the framework deposit in its OWN branch/PR.\n")
-	w.printf("Do NOT use `git add -A` -- mixing the payload with your own files trips the\n")
+	w.printf("\nCommit hygiene (#1453, #1671, #3127): keep the framework upgrade in its OWN branch/PR.\n")
+	w.printf("Do NOT use `git add -A` -- mixing the payload with product/app files trips the\n")
 	w.printf("deft-core-guard CI check.\n")
+	w.printf("One upgrade PR MAY co-travel: .deft/core/** + installer-managed deposits + package.json\n")
+	w.printf("pin/lock + .deft/GENERATION.json. True app/product paths still require a separate PR.\n")
 	if staged {
 		w.printf("The installer already staged ONLY these framework + installer-managed paths:\n")
 		w.printf("  %s\n", addCmd)
@@ -331,7 +333,7 @@ func printCommitGuidance(w *Wizard, paths []string, staged bool) {
 		w.printf("  %s\n", addCmd)
 	}
 	w.printf("Then take the framework deposit through the full PR lifecycle so deft-core-guard\n")
-	w.printf("evaluates a clean, standalone PR:\n")
+	w.printf("evaluates a clean, standalone upgrade PR:\n")
 	w.printf("  1. Branch: git switch -c %s\n", commitHygieneBranchName)
 	w.printf("  2. Commit: git commit -m \"chore(deft): update framework payload\"\n")
 	w.printf("  3. Push:   git push -u origin %s\n", commitHygieneBranchName)

--- a/content/UPGRADING.md
+++ b/content/UPGRADING.md
@@ -260,6 +260,27 @@ The `deft-directive-sync` skill (and any agent following this upgrade path) MUST
 - ! Missing global CLI → remediate with `npm i -g @deftai/directive@latest` (not GitHub release-asset archaeology).
 - ! Git submodule update remains **legacy / back-compat only**; npm + `directive update` / `deft update` is the primary path.
 
+### One upgrade PR shape (#3127)
+
+A normal framework upgrade is **one PR**, not two stacked PRs. The deposited `deft-core-guard` (`no-mixed-core-and-app`, #1430) allowlists the upgrade co-travel unit so deposit + pin + freshness stamp land together:
+
+| Include in the upgrade PR | Why |
+| --- | --- |
+| `.deft/core/**` | Framework deposit payload |
+| Existing installer-managed deposits (`AGENTS.md`, hooks, skill stubs, slash commands, Taskfile include, `xbrief/.deft-version`, …) | Already framework-adjacent |
+| `package.json` + lockfile (`package-lock.json` / `pnpm-lock.yaml` / `yarn.lock`) when the change is the `@deftai/directive` pin (and lock follow-through) | npm pin doctor compares to deposit; part of the upgrade unit |
+| `.deft/GENERATION.json` | Live freshness stamp from `init` / `update` (#3117) |
+
+| Keep out of the upgrade PR | Why |
+| --- | --- |
+| Application source, tests, product docs | True app/product work — guard still fails if mixed with `.deft/core/**` |
+| Consumer kit narrative / host prose not deposited by Directive | Not installer-managed |
+| Arbitrary playbooks, cast, features | Product scope, not upgrade |
+
+**Do not** split a routine version bump into “deposit-only” then “pin/GENERATION” PRs — that re-creates engine / deposit / pin skew between merges. **Do** keep product feature work on a separate branch/PR from the framework upgrade.
+
+Refs: [#3127](https://github.com/deftai/directive/issues/3127), [#1430](https://github.com/deftai/directive/issues/1430), [#3117](https://github.com/deftai/directive/issues/3117).
+
 Machine-readable skill exit line (for agents/operators):
 
 ```text

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -84,6 +84,81 @@ describe(".prettierignore allowlist (#2629)", () => {
   });
 });
 
+describe("upgrade co-travel allowlist (#3127)", () => {
+  const pinAndStampPaths = [
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    ".deft/GENERATION.json",
+  ] as const;
+
+  it("treats package pin, lockfiles, and GENERATION.json as installer-managed", () => {
+    for (const path of pinAndStampPaths) {
+      expect(isInstallerManagedPath(path)).toBe(true);
+    }
+  });
+
+  it("embeds pin + GENERATION in the deposited guard ERE", () => {
+    const ere = installerManagedGuardEre();
+    expect(ere).toContain("package\\.json");
+    expect(ere).toContain("package-lock\\.json");
+    expect(ere).toContain("pnpm-lock\\.yaml");
+    expect(ere).toContain("yarn\\.lock");
+    expect(ere).toContain("\\.deft/GENERATION\\.json");
+  });
+
+  it("passes core + pin + GENERATION + already-allowed stubs (upgrade unit)", () => {
+    const result = classifyMixedCoreAndApp([
+      ".deft/core/VERSION",
+      ".deft/core/main.md",
+      "AGENTS.md",
+      "xbrief/.deft-version",
+      "package.json",
+      "package-lock.json",
+      "pnpm-lock.yaml",
+      ".deft/GENERATION.json",
+    ]);
+    expect(result.core.length).toBeGreaterThan(0);
+    expect(result.app).toHaveLength(0);
+    expect(result.wouldFail).toBe(false);
+    expect(result.installerManaged).toEqual(
+      expect.arrayContaining([
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        ".deft/GENERATION.json",
+        "AGENTS.md",
+        "xbrief/.deft-version",
+      ]),
+    );
+  });
+
+  it("still fails when core mixes with true app/product paths", () => {
+    const result = classifyMixedCoreAndApp([
+      ".deft/core/VERSION",
+      "package.json",
+      ".deft/GENERATION.json",
+      "src/app.ts",
+    ]);
+    expect(result.wouldFail).toBe(true);
+    expect(result.app).toEqual(["src/app.ts"]);
+    expect(result.installerManaged).toEqual(
+      expect.arrayContaining(["package.json", ".deft/GENERATION.json"]),
+    );
+  });
+
+  it("still refuses consumer kit / product docs mixed with core", () => {
+    const result = classifyMixedCoreAndApp([
+      ".deft/core/main.md",
+      "package.json",
+      "docs/playbooks/my-product.md",
+    ]);
+    expect(result.wouldFail).toBe(true);
+    expect(result.app).toContain("docs/playbooks/my-product.md");
+  });
+});
+
 describe("xbrief/ allowlist parity (#2277)", () => {
   const xbriefLifecycleDirs = ["proposed", "pending", "active", "completed", "cancelled"] as const;
 

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -593,7 +593,9 @@ export function printCommitGuidance(
 ): void {
   if (paths.length === 0) return;
   const addCmd = `git add ${paths.join(" ")}`;
-  io.printf("\nCommit hygiene (#1453, #1671, #3127): keep the framework upgrade in its OWN branch/PR.\n");
+  io.printf(
+    "\nCommit hygiene (#1453, #1671, #3127): keep the framework upgrade in its OWN branch/PR.\n",
+  );
   io.printf("Do NOT use `git add -A` -- mixing the payload with product/app files trips the\n");
   io.printf("deft-core-guard CI check.\n");
   io.printf(

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -8,7 +8,7 @@
  * and scope briefs are never installer-managed; if they reappear in
  * `installerManagedMatchers()`, unit tests and deposit-time assert fail closed.
  *
- * Refs #1576, #1453, #1430, #3029, #3030.
+ * Refs #1576, #1453, #1430, #3029, #3030, #3127, #3117.
  */
 
 import { execFileSync } from "node:child_process";
@@ -93,6 +93,16 @@ export function installerManagedMatchers(): InstallerManagedMatcher[] {
     { exact: CODEQL_CONFIG_REL },
     { exact: CORE_GUARD_WORKFLOW_REL },
     { exact: "Taskfile.yml" },
+    // Upgrade co-travel unit (#3127): npm pin + lock follow-through and the
+    // freshness live stamp (#3117) are part of a normal framework upgrade, not
+    // product feature work. Path-level allow for v1 (stricter “only
+    // @deftai/directive version changed” is a follow-on if needed).
+    // Mixing .deft/core/** with true app/product paths still fails (#1430).
+    { exact: "package.json" },
+    { exact: "package-lock.json" },
+    { exact: "pnpm-lock.yaml" },
+    { exact: "yarn.lock" },
+    { exact: ".deft/GENERATION.json" },
     // Legacy vbrief/ tree -- retained for not-yet-migrated consumers.
     { exact: "vbrief/.deft-version" },
     { exact: "vbrief/vbrief.md" },
@@ -583,9 +593,15 @@ export function printCommitGuidance(
 ): void {
   if (paths.length === 0) return;
   const addCmd = `git add ${paths.join(" ")}`;
-  io.printf("\nCommit hygiene (#1453, #1671): keep the framework deposit in its OWN branch/PR.\n");
-  io.printf("Do NOT use `git add -A` -- mixing the payload with your own files trips the\n");
+  io.printf("\nCommit hygiene (#1453, #1671, #3127): keep the framework upgrade in its OWN branch/PR.\n");
+  io.printf("Do NOT use `git add -A` -- mixing the payload with product/app files trips the\n");
   io.printf("deft-core-guard CI check.\n");
+  io.printf(
+    "One upgrade PR MAY co-travel: .deft/core/** + installer-managed deposits + package.json\n",
+  );
+  io.printf(
+    "pin/lock + .deft/GENERATION.json. True app/product paths still require a separate PR.\n",
+  );
   if (staged) {
     io.printf("The installer already staged ONLY these framework + installer-managed paths:\n");
     io.printf(`  ${addCmd}\n`);
@@ -594,7 +610,7 @@ export function printCommitGuidance(
     io.printf(`  ${addCmd}\n`);
   }
   io.printf("Then take the framework deposit through the full PR lifecycle so deft-core-guard\n");
-  io.printf("evaluates a clean, standalone PR:\n");
+  io.printf("evaluates a clean, standalone upgrade PR:\n");
   io.printf(`  1. Branch: git switch -c ${COMMIT_HYGIENE_BRANCH_NAME}\n`);
   io.printf('  2. Commit: git commit -m "chore(deft): update framework payload"\n');
   io.printf(`  3. Push:   git push -u origin ${COMMIT_HYGIENE_BRANCH_NAME}\n`);

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -607,11 +607,12 @@ function coreGuardWorkflowContent(): string {
   const headSha = githubActionsExpr("github.event.pull_request.head.sha");
   return (
     "name: deft-core-guard\n\n" +
-    "# Deft framework guard (#1430): a single PR should not mix changes to the\n" +
-    "# vendored framework payload (.deft/core/**) with changes to your own project\n" +
-    "# files. Framework updates come from `deft-install` / upgrade and should\n" +
-    "# land in their own PR so reviewers (and bot reviewers) can treat them as\n" +
-    "# packaged, machine-managed assets. Delete this file if you do not want the guard.\n" +
+    "# Deft framework guard (#1430 / #3127): a single PR should not mix changes to the\n" +
+    "# vendored framework payload (.deft/core/**) with true application/product files.\n" +
+    "# One upgrade PR MAY include deposit + installer-managed paths + package.json pin/lock\n" +
+    "# + .deft/GENERATION.json. Framework updates come from `deft update` / install and should\n" +
+    "# land without product feature work so reviewers treat the payload as machine-managed.\n" +
+    "# Delete this file if you do not want the guard.\n" +
     "on:\n" +
     "  pull_request:\n\n" +
     "permissions:\n" +


### PR DESCRIPTION
## Summary

Expand the deposited `no-mixed-core-and-app` / deft-core-guard allowlist so a normal framework upgrade is **one PR**: deposit + `@deftai/directive` pin/lock + `.deft/GENERATION.json` (+ already-allowed installer-managed paths). True app/product files mixed with `.deft/core/**` still fail.

## Changes

- `installerManagedMatchers()` (TS + Go parity): allowlist `package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `.deft/GENERATION.json`
- Classifier + guard ERE tests: upgrade unit **passes**; core + app **fails**
- UPGRADING: document one-upgrade-PR shape under SCM handoff (#3127)
- Commit hygiene guidance (TS + Go) notes co-travel unit
- CHANGELOG [Unreleased]

## Acceptance

- [x] Deposit + pin + GENERATION (+ stubs) passes core-guard classification
- [x] Core + real app/product paths still fail
- [x] Docs state intended upgrade PR shape
- [x] No requirement to land two stacked PRs for a normal version bump

## Test plan

- [x] `vitest run packages/core/src/init-deposit/hygiene.test.ts`
- [x] `vitest run packages/core/src/init-deposit`
- [x] biome/lint clean on touched files
- [ ] CI `task check` on PR

Closes #3127
Refs #1430, #3117, #1440