### PR TITLE
test(coverage): restore Vitest branches >=85% after v0.96.0 hairline (#3144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vitest branch coverage restored above 85% (#3144).** Focused autonomy policy resolve/validate/recommend edges, pending-decisions backlog parse/summarize branches, triageScopeIgnores matchers, and feedback:file CLI/offline paths clear the v0.96.0 84.89% hairline so release Step 5 passes without `--allow-coverage-debt`. Closes #3144.
 - **Cache archive: parse `www.github.com` lifecycle URIs with repo identity (#1137 residual / PR #3142).** Open-scope protection for multi-repo caches no longer drops owner/repo when lifecycle refs use `www.github.com` (or leading-zero issue path segments). Keeps archive protection repo-scoped instead of bare `#N` fallback. Refs #1137, #3141.
 - **`vbrief:activate` containment root is the project checkout (#3147).** Legacy `task vbrief:activate` used the destination folder as the `containedWrite` root, so a dest-folder symlink whose realpath is outside the checkout was treated as contained and could divert the write (and unlink the pending source) outside the tree. The activator now runs `assertProjectionContained` on the destination before mkdir/write (parity with `scope:activate` / #2447) and uses `projectRoot` as the containment root. Vitest covers refuse + no outside write + pending preserved. Closes #3147. Refs #2447, #3077, #2980.
 

--- a/packages/core/src/policy/autonomy-branches.test.ts
+++ b/packages/core/src/policy/autonomy-branches.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Branch coverage for plan.policy.autonomy (#3144 coverage-debt hairline).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AUTONOMY_ACTION_ADVANCE,
+  AUTONOMY_ACTION_HOLD,
+  AUTONOMY_ACTION_RETREAT,
+  DEFAULT_AUTONOMY_LEVEL,
+  recommendAutonomyLevel,
+  resolveAutonomy,
+  validateAutonomy,
+} from "./autonomy.js";
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-autonomy-br-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("validateAutonomy branches (#3144)", () => {
+  it("accepts null/undefined as empty errors", () => {
+    expect(validateAutonomy(null)).toEqual([]);
+    expect(validateAutonomy(undefined)).toEqual([]);
+  });
+
+  it("rejects non-object payloads", () => {
+    expect(validateAutonomy("x").some((e) => e.includes("must be an object"))).toBe(true);
+    expect(validateAutonomy([]).some((e) => e.includes("must be an object"))).toBe(true);
+  });
+
+  it("validates enabled, defaultLevel, minSampleSize, and rate fields", () => {
+    const errors = validateAutonomy({
+      enabled: "yes",
+      defaultLevel: "warp",
+      minSampleSize: -1,
+      advanceOverrideRateMax: 2,
+      retreatOverrideRate: -0.1,
+      reworkBaseline: "high",
+      gates: "not-object",
+    });
+    expect(errors.some((e) => e.includes("enabled must be a boolean"))).toBe(true);
+    expect(errors.some((e) => e.includes("defaultLevel must be one of"))).toBe(true);
+    expect(errors.some((e) => e.includes("minSampleSize"))).toBe(true);
+    expect(errors.some((e) => e.includes("advanceOverrideRateMax"))).toBe(true);
+    expect(errors.some((e) => e.includes("retreatOverrideRate"))).toBe(true);
+    expect(errors.some((e) => e.includes("reworkBaseline"))).toBe(true);
+    expect(errors.some((e) => e.includes("gates must be an object"))).toBe(true);
+  });
+
+  it("validates gate map keys and levels", () => {
+    const errors = validateAutonomy({
+      gates: {
+        "": "observe",
+        "merge-ready": "nope",
+        ok: "execute",
+      },
+    });
+    expect(errors.some((e) => e.includes("keys must be non-empty"))).toBe(true);
+    expect(errors.some((e) => e.includes('gates["merge-ready"]'))).toBe(true);
+    expect(errors.some((e) => e.includes('gates["ok"]'))).toBe(false);
+  });
+
+  it("accepts a well-formed autonomy object", () => {
+    expect(
+      validateAutonomy({
+        enabled: false,
+        defaultLevel: "observe",
+        minSampleSize: 10,
+        advanceOverrideRateMax: 0.05,
+        retreatOverrideRate: 0.2,
+        reworkBaseline: 0.15,
+        gates: { "l4-owner": "escalate" },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("resolveAutonomy branches (#3144)", () => {
+  it("returns default when PROJECT-DEFINITION is missing", () => {
+    const root = tempRoot();
+    const pol = resolveAutonomy(root);
+    expect(pol.source).toBe("default");
+    expect(pol.default_level).toBe(DEFAULT_AUTONOMY_LEVEL);
+    expect(pol.error).not.toBeNull();
+    expect(pol.configured).toBe(false);
+  });
+
+  it("returns default when autonomy key is absent", () => {
+    const root = tempRoot();
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({ plan: { policy: { wipCap: 20 } } }),
+    );
+    const pol = resolveAutonomy(root);
+    expect(pol.source).toBe("default");
+    expect(pol.error).toBeNull();
+  });
+
+  it("returns default-on-error for invalid autonomy payload", () => {
+    const root = tempRoot();
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({ plan: { policy: { autonomy: { defaultLevel: "warp" } } } }),
+    );
+    const pol = resolveAutonomy(root);
+    expect(pol.source).toBe("default-on-error");
+    expect(pol.error).toMatch(/defaultLevel/);
+  });
+
+  it("resolves typed autonomy with gate levels and overrides", () => {
+    const root = tempRoot();
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({
+        plan: {
+          policy: {
+            autonomy: {
+              enabled: false,
+              defaultLevel: "observe",
+              minSampleSize: 12,
+              advanceOverrideRateMax: 0.01,
+              retreatOverrideRate: 0.3,
+              reworkBaseline: 0.2,
+              gates: { "l4-owner": "execute", "pr-watch": "observe" },
+            },
+          },
+        },
+      }),
+    );
+    const pol = resolveAutonomy(root);
+    expect(pol.source).toBe("typed");
+    expect(pol.enabled).toBe(false);
+    expect(pol.default_level).toBe("observe");
+    expect(pol.min_sample_size).toBe(12);
+    expect(pol.advance_override_max).toBe(0.01);
+    expect(pol.retreat_override_rate).toBe(0.3);
+    expect(pol.rework_baseline).toBe(0.2);
+    expect(pol.gate_levels["l4-owner"]).toBe("execute");
+    expect(pol.gate_levels["pr-watch"]).toBe("observe");
+    expect(pol.configured).toBe(true);
+  });
+
+  it("uses defaults for omitted optional fields on a valid object", () => {
+    const root = tempRoot();
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({ plan: { policy: { autonomy: { gates: {} } } } }),
+    );
+    const pol = resolveAutonomy(root);
+    expect(pol.source).toBe("typed");
+    expect(pol.enabled).toBe(true);
+    expect(pol.default_level).toBe(DEFAULT_AUTONOMY_LEVEL);
+    expect(pol.min_sample_size).toBe(20);
+  });
+});
+
+describe("recommendAutonomyLevel branches (#3144)", () => {
+  it("retreats on high override rate", () => {
+    const r = recommendAutonomyLevel("escalate", {
+      override_rate: 0.5,
+      rework_rate: 0,
+      sample_size: 5,
+      gate_id: "g1",
+    });
+    expect(r.action).toBe(AUTONOMY_ACTION_RETREAT);
+    expect(r.recommended_level).toBe("observe");
+    expect(r.gate_id).toBe("g1");
+    expect(r.advisory).toBe(true);
+  });
+
+  it("holds at observe when retreat is triggered at the floor", () => {
+    const r = recommendAutonomyLevel("observe", {
+      override_rate: 0.9,
+      rework_rate: 0,
+      sample_size: 1,
+      p0_reversal: true,
+    });
+    expect(r.action).toBe(AUTONOMY_ACTION_HOLD);
+    expect(r.recommended_level).toBe("observe");
+    expect(r.rationale).toMatch(/P0 reversal/);
+  });
+
+  it("retreats on P0 reversal from escalate", () => {
+    const r = recommendAutonomyLevel("escalate", {
+      override_rate: 0,
+      rework_rate: 0,
+      sample_size: 50,
+      p0_reversal: true,
+    });
+    expect(r.action).toBe(AUTONOMY_ACTION_RETREAT);
+    expect(r.recommended_level).toBe("observe");
+  });
+
+  it("advances when criteria are met", () => {
+    const r = recommendAutonomyLevel("observe", {
+      override_rate: 0,
+      rework_rate: 0,
+      sample_size: 25,
+    });
+    expect(r.action).toBe(AUTONOMY_ACTION_ADVANCE);
+    expect(r.recommended_level).toBe("escalate");
+  });
+
+  it("holds at execute when advance criteria met at the ceiling", () => {
+    const r = recommendAutonomyLevel("execute", {
+      override_rate: 0,
+      rework_rate: 0,
+      sample_size: 50,
+    });
+    expect(r.action).toBe(AUTONOMY_ACTION_HOLD);
+    expect(r.recommended_level).toBe("execute");
+    expect(r.rationale).toMatch(/most permissive/);
+  });
+
+  it("holds when sample size is below min", () => {
+    const r = recommendAutonomyLevel("observe", {
+      override_rate: 0,
+      rework_rate: 0,
+      sample_size: 5,
+    });
+    expect(r.action).toBe(AUTONOMY_ACTION_HOLD);
+    expect(r.rationale).toMatch(/advance criteria not met/);
+  });
+
+  it("maps invalid current level to policy default", () => {
+    const r = recommendAutonomyLevel("warp-speed", {
+      override_rate: 0,
+      rework_rate: 0,
+      sample_size: 5,
+    });
+    expect(r.current_level).toBe(DEFAULT_AUTONOMY_LEVEL);
+  });
+});

--- a/packages/core/src/policy/decisions-branches.test.ts
+++ b/packages/core/src/policy/decisions-branches.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Branch coverage for pending human-decisions backlog (#3144 coverage-debt hairline).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_PENDING_DECISIONS_THRESHOLD,
+  pendingDecisionsLogPath,
+  pendingDecisionsNudgeLine,
+  readDecisionEvents,
+  summarizeDecisionBacklog,
+} from "./decisions.js";
+
+const roots: string[] = [];
+const NOW = new Date("2026-08-06T12:00:00Z");
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "deft-decisions-br-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("readDecisionEvents branches (#3144)", () => {
+  it("returns empty when the log is missing", () => {
+    const root = tempRoot();
+    expect(readDecisionEvents(root)).toEqual([]);
+  });
+
+  it("skips blank, malformed, non-object, and decision_id-less lines", () => {
+    const root = tempRoot();
+    const path = pendingDecisionsLogPath(root);
+    mkdirSync(join(root, "xbrief", ".audit"), { recursive: true });
+    writeFileSync(
+      path,
+      [
+        "",
+        "   ",
+        "not-json",
+        JSON.stringify(["array"]),
+        JSON.stringify({ status: "pending" }),
+        JSON.stringify({ decision_id: "ok-1", status: "pending", kind: "gate" }),
+        JSON.stringify({ decision_id: 42, status: "pending" }),
+      ].join("\n"),
+    );
+    const events = readDecisionEvents(root);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.decision_id).toBe("ok-1");
+  });
+
+  it("honors an explicit log path override", () => {
+    const root = tempRoot();
+    const custom = join(root, "custom.jsonl");
+    writeFileSync(
+      custom,
+      `${JSON.stringify({ decision_id: "c1", status: "pending", kind: "review" })}\n`,
+    );
+    expect(readDecisionEvents(root, custom)).toHaveLength(1);
+  });
+});
+
+describe("summarizeDecisionBacklog branches (#3144)", () => {
+  it("counts pending kinds and uses unspecified when kind missing", () => {
+    const backlog = summarizeDecisionBacklog(tempRoot(), {
+      now: NOW,
+      events: [
+        { decision_id: "a", status: "pending", kind: "gate" },
+        { decision_id: "b", status: "pending" },
+        { decision_id: "b", status: "pending", kind: "merge" },
+        { decision_id: "c", status: "resolved", timestamp: "2026-08-05T00:00:00Z" },
+      ],
+    });
+    expect(backlog.pending_count).toBe(2);
+    expect(backlog.by_kind.gate).toBe(1);
+    expect(backlog.by_kind.merge).toBe(1);
+    expect(backlog.resolved_in_window).toBe(1);
+  });
+
+  it("applies window filter, override rate, and p0 reversal", () => {
+    const backlog = summarizeDecisionBacklog(tempRoot(), {
+      now: NOW,
+      window_days: 7,
+      events: [
+        {
+          decision_id: "r1",
+          status: "resolved",
+          timestamp: "2026-08-05T00:00:00Z",
+          override: true,
+          p0_reversal: true,
+        },
+        {
+          decision_id: "r2",
+          status: "resolved",
+          timestamp: "2026-08-01T00:00:00Z",
+          override: false,
+        },
+        {
+          decision_id: "old",
+          status: "resolved",
+          timestamp: "2026-06-01T00:00:00Z",
+          override: true,
+        },
+        {
+          decision_id: "bad-ts",
+          status: "resolved",
+          timestamp: "not-a-date",
+          override: true,
+        },
+        {
+          decision_id: "future",
+          status: "resolved",
+          timestamp: "2026-08-20T00:00:00Z",
+          override: true,
+        },
+        { decision_id: "still", status: "pending", kind: "gate" },
+      ],
+    });
+    expect(backlog.pending_count).toBe(1);
+    expect(backlog.resolved_in_window).toBe(2);
+    expect(backlog.override_count).toBe(1);
+    expect(backlog.p0_reversal_in_window).toBe(true);
+    expect(backlog.override_rate).toBeCloseTo(0.5);
+  });
+
+  it("returns zero override rate when no resolved events", () => {
+    const backlog = summarizeDecisionBacklog(tempRoot(), {
+      now: NOW,
+      events: [{ decision_id: "p", status: "pending", kind: "gate" }],
+    });
+    expect(backlog.override_rate).toBe(0);
+    expect(backlog.resolved_in_window).toBe(0);
+  });
+
+  it("skips empty decision_id when building latest map", () => {
+    const backlog = summarizeDecisionBacklog(tempRoot(), {
+      events: [
+        { decision_id: "", status: "pending" },
+        { decision_id: "x", status: "pending", kind: "gate" },
+      ],
+    });
+    expect(backlog.pending_count).toBe(1);
+  });
+});
+
+describe("pendingDecisionsNudgeLine branches (#3144)", () => {
+  it("returns empty at or under threshold", () => {
+    expect(pendingDecisionsNudgeLine(DEFAULT_PENDING_DECISIONS_THRESHOLD)).toBe("");
+    expect(pendingDecisionsNudgeLine(0)).toBe("");
+    expect(pendingDecisionsNudgeLine(3, 5)).toBe("");
+  });
+
+  it("emits tier-1 nudge above threshold", () => {
+    const line = pendingDecisionsNudgeLine(9, 5);
+    expect(line).toMatch(/\[TIER-1\]/);
+    expect(line).toMatch(/9 decision/);
+    expect(line).toMatch(/threshold 5/);
+  });
+});

--- a/packages/core/src/triage/queue/scope-ignores-filter.test.ts
+++ b/packages/core/src/triage/queue/scope-ignores-filter.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Branch coverage for triageScopeIgnores matchers (#3144 coverage-debt hairline).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  hasActiveScopeIgnores,
+  isCachedIssueScopeIgnored,
+  isRawIssueScopeIgnored,
+  type ScopeIgnores,
+} from "./scope-ignores-filter.js";
+
+function emptyIgnores(): ScopeIgnores {
+  return { labels: new Set(), milestones: new Set(), authors: new Set() };
+}
+
+describe("hasActiveScopeIgnores (#3144)", () => {
+  it("is false when all sets empty", () => {
+    expect(hasActiveScopeIgnores(emptyIgnores())).toBe(false);
+  });
+
+  it("is true when any ignore set is non-empty", () => {
+    expect(hasActiveScopeIgnores({ ...emptyIgnores(), labels: new Set(["wontfix"]) })).toBe(true);
+    expect(hasActiveScopeIgnores({ ...emptyIgnores(), milestones: new Set(["parked"]) })).toBe(
+      true,
+    );
+    expect(hasActiveScopeIgnores({ ...emptyIgnores(), authors: new Set(["bot"]) })).toBe(true);
+  });
+});
+
+describe("isRawIssueScopeIgnored (#3144)", () => {
+  it("returns false with empty ignores", () => {
+    expect(
+      isRawIssueScopeIgnored(
+        { user: { login: "alice" }, labels: [{ name: "bug" }], milestone: { title: "m1" } },
+        emptyIgnores(),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches author ignore", () => {
+    const ignores: ScopeIgnores = {
+      ...emptyIgnores(),
+      authors: new Set(["dependabot"]),
+    };
+    expect(isRawIssueScopeIgnored({ user: { login: "dependabot" }, labels: [] }, ignores)).toBe(
+      true,
+    );
+    expect(isRawIssueScopeIgnored({ user: { login: "alice" }, labels: [] }, ignores)).toBe(false);
+  });
+
+  it("matches label ignore", () => {
+    const ignores: ScopeIgnores = {
+      ...emptyIgnores(),
+      labels: new Set(["duplicate", "wontfix"]),
+    };
+    expect(
+      isRawIssueScopeIgnored({ labels: [{ name: "bug" }, { name: "duplicate" }] }, ignores),
+    ).toBe(true);
+    expect(isRawIssueScopeIgnored({ labels: [{ name: "bug" }] }, ignores)).toBe(false);
+  });
+
+  it("matches milestone ignore when present", () => {
+    const ignores: ScopeIgnores = {
+      ...emptyIgnores(),
+      milestones: new Set(["icebox"]),
+    };
+    expect(isRawIssueScopeIgnored({ labels: [], milestone: { title: "icebox" } }, ignores)).toBe(
+      true,
+    );
+    expect(isRawIssueScopeIgnored({ labels: [], milestone: { title: "now" } }, ignores)).toBe(
+      false,
+    );
+    expect(isRawIssueScopeIgnored({ labels: [], milestone: null }, ignores)).toBe(false);
+  });
+});
+
+describe("isCachedIssueScopeIgnored (#3144)", () => {
+  it("returns false with empty ignores", () => {
+    expect(
+      isCachedIssueScopeIgnored(
+        { labels: ["bug"], author: "alice", milestone: "m1" },
+        emptyIgnores(),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches author only when author is non-empty", () => {
+    const ignores: ScopeIgnores = { ...emptyIgnores(), authors: new Set(["bot"]) };
+    expect(isCachedIssueScopeIgnored({ labels: [], author: "bot" }, ignores)).toBe(true);
+    expect(isCachedIssueScopeIgnored({ labels: [], author: "" }, ignores)).toBe(false);
+    expect(isCachedIssueScopeIgnored({ labels: [] }, ignores)).toBe(false);
+    expect(isCachedIssueScopeIgnored({ labels: [], author: "human" }, ignores)).toBe(false);
+  });
+
+  it("matches labels", () => {
+    const ignores: ScopeIgnores = {
+      ...emptyIgnores(),
+      labels: new Set(["meta"]),
+    };
+    expect(isCachedIssueScopeIgnored({ labels: ["bug", "meta"] }, ignores)).toBe(true);
+    expect(isCachedIssueScopeIgnored({ labels: ["bug"] }, ignores)).toBe(false);
+  });
+
+  it("matches milestone only when non-empty", () => {
+    const ignores: ScopeIgnores = {
+      ...emptyIgnores(),
+      milestones: new Set(["later"]),
+    };
+    expect(isCachedIssueScopeIgnored({ labels: [], milestone: "later" }, ignores)).toBe(true);
+    expect(isCachedIssueScopeIgnored({ labels: [], milestone: "" }, ignores)).toBe(false);
+    expect(isCachedIssueScopeIgnored({ labels: [] }, ignores)).toBe(false);
+    expect(isCachedIssueScopeIgnored({ labels: [], milestone: "now" }, ignores)).toBe(false);
+  });
+});

--- a/packages/core/src/value/feedback-file.test.ts
+++ b/packages/core/src/value/feedback-file.test.ts
@@ -296,4 +296,119 @@ describe("feedback-file CLI", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("parses equals-form flags and rejects unknown options (#3144)", () => {
+    const parsed = parseFeedbackFileArgs([
+      "--summary=Equals summary",
+      "--context=ctx-eq",
+      "--expected=pass",
+      "--actual=fail",
+      "--notes=session-eq",
+      "--repo=other/repo",
+      "--project-root=/tmp/x",
+      "--dry-run",
+      "--json",
+    ]);
+    expect(parsed.summary).toBe("Equals summary");
+    expect(parsed.context).toBe("ctx-eq");
+    expect(parsed.expected).toBe("pass");
+    expect(parsed.actual).toBe("fail");
+    expect(parsed.sessionNotes).toBe("session-eq");
+    expect(parsed.repo).toBe("other/repo");
+    expect(parsed.projectRoot).toBe("/tmp/x");
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.json).toBe(true);
+    expect(parseFeedbackFileArgs(["--bogus"]).error).toMatch(/unrecognized/);
+  });
+
+  it("skips dedup when DEFT_NO_NETWORK=1 and dry-runs after confirm (#3144)", () => {
+    const root = makeConsumerProject();
+    const prev = process.env.DEFT_NO_NETWORK;
+    process.env.DEFT_NO_NETWORK = "1";
+    try {
+      const draft = runFeedbackFile({
+        summary: "Offline draft",
+        projectRoot: root,
+        confirm: false,
+      });
+      expect(draft.outcome).toBe("draft");
+      expect(draft.message).toMatch(/duplicate detection skipped/);
+
+      const dry = runFeedbackFile({
+        summary: "Offline confirm",
+        projectRoot: root,
+        confirm: true,
+        dryRun: true,
+      });
+      expect(dry.outcome).toBe("draft");
+      expect(dry.exitCode).toBe(0);
+      expect(dry.message).toMatch(/Dry run/);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.DEFT_NO_NETWORK;
+      } else {
+        process.env.DEFT_NO_NETWORK = prev;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("emits json CLI output and falls back when html_url is missing (#3144)", () => {
+    const root = makeConsumerProject();
+    try {
+      const code = feedbackFileMain(["--summary", "Json path", "--project-root", root, "--json"]);
+      expect(code).toBe(1);
+
+      const filed = runFeedbackFile({
+        summary: "No url filed",
+        projectRoot: root,
+        confirm: true,
+        seams: {
+          runGhApiFn: (args: readonly string[]) => {
+            if (args.includes("POST")) {
+              return {
+                returncode: 0,
+                stdout: JSON.stringify({ number: 77 }),
+                stderr: "",
+              };
+            }
+            return { returncode: 0, stdout: "[]", stderr: "" };
+          },
+        },
+      });
+      expect(filed.outcome).toBe("filed");
+      expect(filed.issueUrl).toContain("/issues/77");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns config error when project root cannot be resolved (#3144)", () => {
+    const result = runFeedbackFile({
+      summary: "No root",
+      projectRoot: join(tmpdir(), "deft-feedback-missing-root-xyz"),
+      confirm: true,
+    });
+    expect(result.outcome).toBe("error-config");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("handles empty-title duplicate needle and missing issue html_url (#3144)", () => {
+    expect(findDuplicateIssue("deftai/directive", "   ", {})).toBeNull();
+    const match = findDuplicateIssue("deftai/directive", "Gap title", {
+      runGhApiFn: vi.fn(() => ({
+        returncode: 0,
+        stdout: JSON.stringify([
+          { title: "Gap title", html_url: "" },
+          { title: 123 },
+          {
+            title: "[framework-gap] Gap title",
+            html_url: "https://github.com/deftai/directive/issues/9",
+          },
+        ]),
+        stderr: "",
+      })),
+    });
+    expect(match?.url).toContain("/issues/9");
+  });
 });


### PR DESCRIPTION
## Summary
Restore Vitest **all four** coverage metrics to **>= 85%** after the v0.96.0 release Step 5 hairline (branches 84.89%).

## Changes
- Autonomy policy branch tests (`validateAutonomy` / `resolveAutonomy` / `recommendAutonomyLevel`)
- Pending-decisions backlog parse/summarize/nudge edges
- `triageScopeIgnores` raw + cached matchers
- `feedback:file` CLI equals-form, offline/dry-run, json, config, and duplicate edges
- CHANGELOG `[Unreleased]` for #3144

## Coverage (local `task check`)
| Metric | Before | After |
|--------|--------|-------|
| Statements | >=85% | **88.6%** |
| Branches | **84.89%** | **85.09%** |
| Functions | >=85% | **95.96%** |
| Lines | >=85% | **88.6%** |

No production code changes; no threshold lowers; no `--allow-coverage-debt`.

Closes #3144