### PR TITLE
sec(codeql): isolate process.execPath from engine-invoke shell sink (#3175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CodeQL shell-command-injection-from-environment cleared in engine-invoke (#3175 / alert #74).** `buildSpawnPlan` keeps vendored and global paths disjoint so `process.execPath` is only the non-shell vendored Node command and never joins the win32 `cmd.exe /c` string (path-insensitive AbsolutePathSource → shell-interpreted sink). Call site hard-codes `shell: false`. Regression tests pin the isolation. Closes #3175. Refs CodeQL alert #74, #2911, #2547.
 - **CodeQL polynomial-redos in xBRIEF markdown meta parse (#3174).** `parseMarkdownMeta` no longer uses nested `\s*(.+)\s*` / heading regexes for frontmatter `id`/`style` and ATX H1/H2; linear `frontmatterField` + shared `parseMarkdownHeading` clear security-and-quality alerts #84–#87. Adversarial long-space unit tests guard the path. Closes #3174.
 - **Consumer-check-contract rejects backgrounded full checks (#3145).** 	ask check & / deft check& no longer count as composed full-check invocation (shell returns before enforcement; exit status not propagated). Greptile conf residual on PR #3151. Refs #3145.
 - **AGENTS.md budget ratchet for post-dual-stop managed growth (#3165 residual).** Raises plan.policy.agentsMdBudget managedMaxLines 125→135 and absoluteMaxBytes 10350→12000 so merge-gate matches current managed region (131 lines / ~11.3 KB) after dual-stop/envelope content landed without a budget bump. Trims trailing blank in init-deposit gitignore formatter noise from #3146. Refs #645, #3146, #2442, #3153.

--- a/tasks/engine-invoke.cjs
+++ b/tasks/engine-invoke.cjs
@@ -113,12 +113,13 @@ function main() {
   // stdio inherit (not pipe): piped stdout/stderr deadlocks when the child emits
   // more than the OS pipe buffer before exit — observed as greenfield smoke
   // hanging then CI SIGTERM exit 143 with no output (#2554 / #2547).
+  // shell:false is a literal at the call site (not plan.shell) so static
+  // analyzers see a non-shell spawn; win32 global still uses a quoted cmd.exe
+  // wrapper inside buildSpawnPlan, never shell:true (#2911 / #3175).
   const result = spawnSync(plan.command, plan.args, {
     stdio: "inherit",
     env: childEnv,
-    // Never shell:true — even on win32 global (subprocess-scm-01 / #2911). The
-    // win32 .cmd shim is reached through a tightly quoted cmd.exe wrapper below.
-    shell: plan.shell,
+    shell: false,
     // CREATE_NO_WINDOW: hide console windows from Cursor Task / nested shells (#2563).
     windowsHide: true,
   });
@@ -135,6 +136,11 @@ function main() {
  * quoted so metacharacters stay inside a single argv token — aligned with
  * tasks/engine-pm-run.cjs executeAllowlisted().
  *
+ * Vendored vs global branches are deliberately disjoint (#3175 / CodeQL alert
+ * #74): process.execPath (AbsolutePathSource) is only the vendored non-shell
+ * command and must never flow into the win32 cmd.exe `/c` string, where it
+ * would be shell-interpreted as part of a constructed command line.
+ *
  * @param {string} mode
  * @param {string} target
  * @param {string[]} argv
@@ -143,26 +149,25 @@ function main() {
  */
 function buildSpawnPlan(mode, target, argv, opts = {}) {
   const platform = opts.platform || process.platform;
-  const nodePath = opts.nodePath || process.execPath;
 
-  let execPath;
-  let execArgv;
   if (mode === "vendored") {
-    execPath = nodePath;
-    execArgv = [target, ...argv];
-  } else if (mode === "global") {
-    execPath = target;
-    execArgv = argv;
-  } else {
-    return null;
+    // Non-shell: Node binary + script path + operator argv. process.execPath is
+    // only used here as the executable name with shell:false — never joined into
+    // a cmd.exe command line (CodeQL js/shell-command-injection-from-environment).
+    const nodePath = opts.nodePath || process.execPath;
+    return { command: nodePath, args: [target, ...argv], shell: false };
   }
 
-  if (mode === "global" && platform === "win32") {
-    const commandLine = [execPath, ...execArgv].map(quoteWin32Arg).join(" ");
-    return { command: "cmd.exe", args: ["/d", "/s", "/c", commandLine], shell: false };
+  if (mode === "global") {
+    if (platform === "win32") {
+      // Only the global shim name/path and operator argv — no process.execPath.
+      const commandLine = [target, ...argv].map(quoteWin32Arg).join(" ");
+      return { command: "cmd.exe", args: ["/d", "/s", "/c", commandLine], shell: false };
+    }
+    return { command: target, args: argv, shell: false };
   }
 
-  return { command: execPath, args: execArgv, shell: false };
+  return null;
 }
 
 if (require.main === module) {

--- a/tasks/engine-invoke.test.cjs
+++ b/tasks/engine-invoke.test.cjs
@@ -186,3 +186,33 @@ describe("buildSpawnPlan — other paths keep shell:false", () => {
     assert.equal(buildSpawnPlan("bogus", "deft", ["release"], WIN32), null);
   });
 });
+
+describe("buildSpawnPlan — CodeQL absolute-path isolation (#3175 / alert #74)", () => {
+  it("never places nodePath/process.execPath into the win32 cmd.exe command line", () => {
+    const evilNode = String.raw`C:\Program Files\nodejs\node.exe`;
+    const plan = buildSpawnPlan("global", "deft", ["release", "--summary", "ok"], {
+      platform: "win32",
+      nodePath: evilNode,
+    });
+    assert.equal(plan.shell, false);
+    assert.equal(plan.command, "cmd.exe");
+    assert.deepEqual(plan.args.slice(0, 3), ["/d", "/s", "/c"]);
+    // Global win32 must only join target + operator argv — not the Node binary.
+    assert.equal(plan.args[3].includes(evilNode), false);
+    assert.equal(plan.args[3].includes("Program Files"), false);
+    assert.equal(plan.args[3].includes("node.exe"), false);
+    assert.deepEqual(splitCmdTokens(plan.args[3]), ["deft", "release", "--summary", "ok"]);
+  });
+
+  it("uses nodePath only as the non-shell vendored command (never cmd.exe)", () => {
+    const nodePath = String.raw`C:\Program Files\nodejs\node.exe`;
+    const plan = buildSpawnPlan("vendored", String.raw`C:\repo\packages\cli\dist\bin.js`, ["session:start"], {
+      platform: "win32",
+      nodePath,
+    });
+    assert.equal(plan.shell, false);
+    assert.equal(plan.command, nodePath);
+    assert.notEqual(plan.command, "cmd.exe");
+    assert.deepEqual(plan.args, [String.raw`C:\repo\packages\cli\dist\bin.js`, "session:start"]);
+  });
+});

--- a/xbrief/active/2026-08-06-3175-seccodeql-clear-shell-command-injection-from-environment-in.xbrief.json
+++ b/xbrief/active/2026-08-06-3175-seccodeql-clear-shell-command-injection-from-environment-in.xbrief.json
@@ -1,0 +1,74 @@
+{
+  "xBRIEFInfo": {
+    "version": "0.8",
+    "description": "Scope xBRIEF for #3175 CodeQL shell-command-injection in engine-invoke.cjs",
+    "updated": "2026-08-06T21:27:55Z"
+  },
+  "plan": {
+    "id": "3175-codeql-engine-invoke-shell",
+    "title": "sec(codeql): clear shell-command-injection-from-environment in engine-invoke.cjs (alert #74)",
+    "status": "running",
+    "narratives": {
+      "Description": "Open CodeQL alert #74 flags js/shell-command-injection-from-environment in tasks/engine-invoke.cjs where a shell command depends on an uncontrolled absolute path from the environment. Fix the sink safely without breaking vendored/global CLI engine invoke.",
+      "ImplementationPlan": "1. Edit tasks/engine-invoke.cjs (and tests if present) to avoid shelling uncontrolled env paths — prefer execFile/spawn with fixed argv and validated paths.\n2. Add or extend a focused regression test or script smoke for engine-invoke.\n3. CHANGELOG [Unreleased] Security/Fixed for #3175; confirm code-scanning alert #74 closes after merge.",
+      "UserStory": "As a maintainer, I want the engine-invoke CodeQL shell-injection warning cleared, so that Task/CLI bridging does not appear as an env-injection sink.",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/3175",
+      "Overview": "Code scanning alert 74; warning; CWE-078/088.",
+      "Labels": "bug, security"
+    },
+    "items": [
+      {
+        "title": "Clear shell-command-injection alert #74",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given CodeQL alert #74 on tasks/engine-invoke.cjs, when the fix lands on master, then js/shell-command-injection-from-environment no longer fires on that sink (or is dismissed with documented false-positive rationale after safe hardening)."
+        }
+      },
+      {
+        "title": "Preserve engine invoke behavior",
+        "status": "proposed",
+        "narrative": {
+          "Acceptance": "Given vendored and global CLI invoke paths, when engine-invoke runs via task, then normal session/engine verbs still work."
+        }
+      }
+    ],
+    "metadata": {
+      "kind": "story",
+      "swarm": {
+        "readiness": "ready",
+        "parallel_safe": true,
+        "file_scope": [
+          "tasks/engine-invoke.cjs",
+          "tasks/engine-invoke.test.cjs"
+        ],
+        "verify_commands": [
+          "node --test tasks/engine-invoke.test.cjs",
+          "task check"
+        ],
+        "expected_outputs": [
+          "CodeQL alert #74 cleared",
+          "CHANGELOG #3175",
+          "PR through merge"
+        ],
+        "depends_on": [],
+        "conflict_group": "codeql-engine-invoke",
+        "size": "small",
+        "file_scope_confidence": "high",
+        "model_tier": "standard",
+        "missing_traces_justification": "CodeQL alert remediation #3175."
+      }
+    },
+    "tags": [
+      "bug",
+      "security"
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/3175",
+        "type": "x-xbrief/github-issue",
+        "title": "Issue #3175"
+      }
+    ],
+    "updated": "2026-08-06T21:27:55Z"
+  }
+}


### PR DESCRIPTION
## Summary

Clears CodeQL **js/shell-command-injection-from-environment** alert **#74** on `tasks/engine-invoke.cjs`.

`buildSpawnPlan` previously shared an `execPath` variable across vendored and global modes. Path-insensitive analysis treated `process.execPath` (AbsolutePathSource) as flowing into the win32 `cmd.exe /c` command-line string even though runtime control flow never does that. Branches are now disjoint:

- **vendored**: `process.execPath` is only the non-shell `spawnSync` command (`shell: false`)
- **global / win32**: `cmd.exe /d /s /c` command line is built only from the global shim target + operator argv (still tightly quoted per #2911)

Call site hard-codes `shell: false` (literal, not `plan.shell`).

## Test plan

- [x] `node --test tasks/engine-invoke.test.cjs` (15 pass, including #3175 isolation cases)
- [x] `task verify:forward-coverage`
- [x] Existing win32 injection quoting cases retained (#2911)
- [ ] Code scanning alert #74 closes after merge re-scan

## Notes

- Pre-existing biome format errors on unrelated `consumer-check-contract` / architecture files exist on master tip and are out of scope.
- Greptile bar only (not SLizard) per cohort binding.

Closes #3175.
