### PR TITLE
docs(decision-log): dogfood patterns portfolio pilot dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Decision log dogfood: patterns portfolio pilot dispose (#1396 / #3200).** `xbrief/decisions/2026-08-09-patterns-portfolio-pilot-dispose.decision.json` records operator shortlist/park for the patterns `no_match` pilot (P1 #852/#3085; park classes). Refs #3198, #3201, #886.
+
 - **Structured agent decision log — `task decision:write` / `task decision:list` (#1396).** Lightweight `deft.decision.v1` JSON under `xbrief/decisions/` (dual location: standalone cross-cutting files + optional scope xBRIEF `plan.narratives.Decisions` pointer). Required fields: decision, governing rule, alternatives, why winner, confidence, scope refs, timestamp, revisit trigger. Guidance-only significance filter for build/pre-pr/portfolio; no hard complete-hook. Dogfood seeds: SCM label-mirror first mass-apply policy (#1423) and portfolio dispose-into-decision-log (#3198/#3201). Docs: `content/docs/decision-log.md`. Leaves `docs/decisions/ADR-*.md` as the heavyweight architecture lane. Closes #1396. Refs #3198, #3201, #1423, #1513.
 
 ### Changed

--- a/xbrief/decisions/2026-08-09-patterns-portfolio-pilot-dispose.decision.json
+++ b/xbrief/decisions/2026-08-09-patterns-portfolio-pilot-dispose.decision.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": "deft.decision.v1",
+  "id": "patterns-portfolio-pilot-dispose",
+  "decision": "Dispose the 2026-08-07 patterns portfolio pilot (#3200): accept shortlist order P1 #852 (goal-gate) and #3085 (tool-surface grammar); P2 agent-app pack #839→#841→#840→#842 and #978 under epic #2741; P3 #3066 under epic #3082 and #971/#973 after #852. Keep #3086 on escalate/interrupt (not park-as-content). Park agent-app atoms without pack index, memory atoms under #2741/#978, older multi-agent scatter for revisit after #3155/#2705, web-stack opinions, hold/rfc planned pattern rows, and research-bias items until a product epic pulls them. Do not treat the brief markdown as SoT.",
+  "governingRule": {
+    "description": "Portfolio briefs are propose-not-apply; operator dispose of shortlist/park MUST land in structured decision log via task decision:write.",
+    "path": "content/skills/deft-directive-portfolio-priority/SKILL.md",
+    "rfc2119": "MUST"
+  },
+  "alternativesConsidered": [
+    {
+      "option": "Leave pilot shortlist/park only in the analysis markdown and #3198 comment",
+      "whyNot": "Next session re-litigates the same 92-issue patterns no_match portfolio; brief is proposal not dispose"
+    },
+    {
+      "option": "Auto-load P1 into plan-sequence without human dispose",
+      "whyNot": "Violates propose-not-apply; portfolio skill non-goal"
+    },
+    {
+      "option": "Deep-dive entire patterns no_match set before any park",
+      "whyNot": "Blocks forward motion; pack/index discipline is the point of the pilot"
+    },
+    {
+      "option": "Park #3085 with other patterns content",
+      "whyNot": "Tool-surface grammar pairs with live escalate #3086 harness reliability; high leverage P1"
+    }
+  ],
+  "whyWinner": "Accepts the pilot's family matrix as operator disposition so multi-agent handoff has a durable shortlist/park and revisit triggers without SCM label writes or auto-promote.",
+  "confidence": "high",
+  "activeScopeRefs": [],
+  "timestamp": "2026-08-09T17:19:45Z",
+  "revisitTrigger": "Re-open when capacity exists for #852 or #3085, or after a fresh portfolio skill pass on patterns shows material conflict with this shortlist. Re-open multi-agent park class after #3155/#2705 decisions. Do not reverse park classes from title-only reads.",
+  "tags": [
+    "portfolio",
+    "patterns",
+    "dispose",
+    "dogfood"
+  ],
+  "relatedIssues": [
+    3200,
+    3198,
+    3201,
+    852,
+    3085,
+    3086,
+    839,
+    841,
+    840,
+    842,
+    978,
+    2741,
+    3082,
+    3066,
+    971,
+    973,
+    886,
+    1396
+  ]
+}\n


### PR DESCRIPTION
## Summary

Land the **operator dispose** of the patterns portfolio pilot as a structured decision log record (#1396 surface already shipped).

- `xbrief/decisions/2026-08-09-patterns-portfolio-pilot-dispose.decision.json` — shortlist P1 #852/#3085, pack P2, park classes; #3086 interrupt
- CHANGELOG Unreleased dogfood line

No product code. Completes the brief → human dispose → decision log loop for #3200.

## Test plan

- [x] `task decision:list -- --query patterns` shows the record locally
- [ ] CI green (docs-only)
- [ ] File present on master after merge

Tracking: #3200, #3198, #3201, #1396