### PR TITLE
docs(context): tool-surface grammar — flat params, nesting tax (#3085)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tool-surface grammar guidance (#3085).** Prefer flat, homogeneous tool params; treat nesting × heterogeneity × cleverness as a reliability and token tax. Lands in context tool-design with a cross-link from the LLM-app tool-calling section (security lane stays separate). Pattern only — no mass tool migration. Tracking #3085.
+
 - **Decision log dogfood: patterns portfolio pilot dispose (#1396 / #3200).** `xbrief/decisions/2026-08-09-patterns-portfolio-pilot-dispose.decision.json` records operator shortlist/park for the patterns `no_match` pilot (P1 #852/#3085; park classes). Refs #3198, #3201, #886.
 
 - **Structured agent decision log — `task decision:write` / `task decision:list` (#1396).** Lightweight `deft.decision.v1` JSON under `xbrief/decisions/` (dual location: standalone cross-cutting files + optional scope xBRIEF `plan.narratives.Decisions` pointer). Required fields: decision, governing rule, alternatives, why winner, confidence, scope refs, timestamp, revisit trigger. Guidance-only significance filter for build/pre-pr/portfolio; no hard complete-hook. Dogfood seeds: SCM label-mirror first mass-apply policy (#1423) and portfolio dispose-into-decision-log (#3198/#3201). Docs: `content/docs/decision-log.md`. Leaves `docs/decisions/ADR-*.md` as the heavyweight architecture lane. Closes #1396. Refs #3198, #3201, #1423, #1513.

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -214,7 +214,7 @@ Load as needed:
 - **[context/context.md](./content/context/context.md)** - Core context engineering strategies (Write, Select, Compress, Isolate)
 - **[context/working-memory.md](./content/context/working-memory.md)** - Scratchpad and externalization patterns with xBRIEF; `xbrief/plan.xbrief.json` + scope xBRIEF relationship
 - **[context/long-horizon.md](./content/context/long-horizon.md)** - Multi-session checkpoint/resume patterns; lifecycle folder conventions
-- **[context/tool-design.md](./content/context/tool-design.md)** - Designing AI-consumable tools
+- **[context/tool-design.md](./content/context/tool-design.md)** - Designing AI-consumable tools; tool-surface grammar (flat params, nesting tax) (#3085)
 - **[context/deterministic-split.md](./content/context/deterministic-split.md)** - LLM vs deterministic responsibility boundaries
 - **[context/fractal-summaries.md](./content/context/fractal-summaries.md)** - Hierarchical memory compression (task → feature → release)
 - **[context/examples.md](./content/context/examples.md)** - Few-shot and behavioral example guidance

--- a/content/context/tool-design.md
+++ b/content/context/tool-design.md
@@ -4,6 +4,16 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 Principles for designing tools that agents can use effectively.
 
+**Load when:** authoring host tools, MCP/server tool schemas, skill-facing
+task surfaces, or any agent-callable parameter shape. Also load when a
+tool call fails in ways that look like "the model is dumb" but may be
+dialect sampling cost.
+
+**⚠️ See also**:
+- [patterns/llm-app.md](../patterns/llm-app.md) `## Tool / function calling` — security, least privilege, validation (confused deputy)
+- [patterns/tool-call-taxonomy.md](../patterns/tool-call-taxonomy.md) — explore / commit / verify activity buckets (orthogonal)
+- [deterministic-split.md](./deterministic-split.md) — what must not be an LLM step at all
+
 ---
 
 ## Minimal, Non-Overlapping Tool Sets
@@ -11,6 +21,110 @@ Principles for designing tools that agents can use effectively.
 - ~ Provide the **smallest set of tools** that covers required capabilities
 - ≉ Offering multiple tools that do the same thing with slight variations
 - ~ Each tool should have a **single, clear purpose**
+
+## Tool-surface grammar (#3085)
+
+A tool "call" is **dialect sampling** in the token stream. The model does
+not decide to call a tool as a special act. It continues the completion
+loop under a harness dialect (`function_calls` / `invoke` / JSON args /
+provider-specific tags). Schema design is a first-order **reliability and
+cost** surface, not cosmetics.
+
+**Rule of thumb:** reliability degrades with
+**nesting × heterogeneity × cleverness**.
+
+Source framing (practitioner ablation, not product UI): Can Bölük
+([@_can1357](https://x.com/_can1357/status/2084104053651317140), 2026-08-03).
+The post's emoji / plaintext "control group" is **not** a product
+recommendation. At roughly ten or more tools, native tool-calls win on
+ergonomics; still design the **thinnest grammar** you can get away with.
+
+### Prefer flat, homogeneous params
+
+- ~ Prefer **flat scalar/string parameters** over nested objects and
+  arrays-as-escaped-JSON inside a single parameter value
+- ~ Prefer a **homogeneous** parameter set (similar types, predictable
+  names) over mixed clever packing (object + freeform JSON string +
+  parallel batch bag in one tool)
+- ~ When the host owns the tools, prefer a **vector / flat** shape (one
+  named field per logical input) over "batch JSON in a string" when that
+  batch only exists to save parallel tool-call round-trips
+- ≉ Nested argument bags that force the model to emit valid escaped JSON
+  for complex objects when plain scalar parameters would suffice
+- ≉ Heterogeneous mega-tools that pack unrelated concerns into one clever
+  payload "for flexibility"
+- ! Treat provider schema fields (`minimum`, `maximum`, `enum`, long
+  descriptions) as **documentation the harness may show**. Validation is
+  the application's job unless the harness (or provider) actually rejects
+  invalid args — do not assume the model "must" obey schema mins/maxes
+- ! Validate tool arguments in the harness before side effects
+  (`patterns/llm-app.md` tool-call rules). A flat grammar still needs a
+  validator and common dialect failure handling (leaked call text,
+  truncated invoke blocks, wrong tool name tokens)
+
+### Good vs bad shapes (sketch)
+
+Bad — nested / heterogeneous / JSON-in-string:
+
+```text
+apply_batch({
+  "ops": "[{\"path\":\"a.ts\",\"edits\":[{\"start\":1,\"end\":2,\"text\":\"...\"}]}]"
+})
+```
+
+The model must sample valid escaped JSON for a nested array. One quote
+or brace error fails the turn. High nesting × high cleverness.
+
+Better — flat / homogeneous (host-owned tools):
+
+```text
+edit_file(path="a.ts", start_line=1, end_line=2, text="...")
+```
+
+Scalars and strings after named parameters. The dialect delimiter ends
+the value; no JSON escape maze for the common case. Repeat the tool or
+use parallel invokes when multiple edits are needed.
+
+When composition is large (many steps, dynamic graphs), **do not** invent
+deeper nested tool packs. Prefer fewer tools via code abstraction / Code
+Mode / a host-side program (related: #1167, #2593) and multi-step token
+breakpoints (#1170). Those reduce **how many** tools exist; this section
+shapes **how each remaining tool looks** at the dialect layer.
+
+### Authoring checklist (Directive + consumers)
+
+Use for Directive-owned task/skill tool surfaces, documented host schemas,
+and consumer MCP / product-agent schemas:
+
+| Prefer | Avoid |
+|--------|--------|
+| Flat named scalars/strings | Nested object trees as required args |
+| One clear purpose per tool | Mega-tools with optional clever branches |
+| Homogeneous repeated fields | Mixed types + freeform JSON bags |
+| Host validation + repair | Trusting provider schema as enforcement |
+| Code / DSL for multi-step | Deeper nesting to "express workflows" |
+
+- ~ Document constraints in parameter descriptions for human and model
+  readers, then **enforce in code**
+- ≉ Shipping emoji/plaintext tool channels as a product default (control
+  group only in the source post)
+- ≉ Migrating every existing tool in one pass — land the principle first;
+  reshape high-failure surfaces when measured failure rates justify it
+- ? Keep a short failure catalog of dialect errors for your harness
+  (sibling track: #3086) so "won't fix" provider quirks become harness
+  duties
+
+### Complementarity
+
+| Concern | Where it lives |
+|---------|----------------|
+| **How each tool's args sample** (this doc) | Flat grammar, low nesting tax |
+| **How many tools** exist | Code Mode / DSL / abstraction (#1167, #2593) |
+| **When multi-step burns tokens** | Breakpoints / long-horizon (#1170) |
+| **Security of tool use** | `patterns/llm-app.md` (schema validate, least privilege) |
+| **Protocol / model-tier cost after shape** | Cost-envelope notes (e.g. #3078) |
+
+---
 
 ## Token-Efficient Outputs
 
@@ -25,6 +139,8 @@ Principles for designing tools that agents can use effectively.
 - ! **Tool descriptions** should state what the tool does, when to use it, and what it returns
 - ~ **Parameters** should be self-documenting — use descriptive names and include constraints in descriptions
 - ≉ Relying on the agent to infer parameter semantics from names alone
+- ~ Keep descriptions short enough to load on demand; put deep examples in
+  linked docs, not in every tool definition (token tax — see also #865)
 
 ## Error Messages
 

--- a/content/patterns/llm-app.md
+++ b/content/patterns/llm-app.md
@@ -28,6 +28,7 @@ also #480 for the framework-side defenses against the same trap classes).
 - [../tools/telemetry.md](../tools/telemetry.md) — `## LLM-specific observability (#481)` extends general telemetry guidance for LLM calls
 - [../patterns/multi-agent.md](./multi-agent.md) — credential separation pattern for swarm workers (orthogonal identity track)
 - [./agent-skill-supply-chain.md](./agent-skill-supply-chain.md) — inbound supply-chain controls for skills, plugins, and MCP servers (#1937)
+- [../context/tool-design.md](../context/tool-design.md) `## Tool-surface grammar (#3085)` — flat params; nesting × heterogeneity tax
 
 ## Prompt construction
 
@@ -83,6 +84,14 @@ the model's.
 - ~ SHOULD log all tool invocations with inputs and outputs for audit trail (queryable, separate from app logs — see `## LLM-specific observability`)
 - ~ SHOULD implement a denylist of tool-argument patterns known to be dangerous (`rm -rf /`, `DROP TABLE`, shell metacharacters in path arguments) as a defense-in-depth probe BEFORE schema validation
 - ⊗ MUST NOT grant tools the ability to modify their own definitions, spawn new tools, or escalate their own permission scope mid-session
+
+**Argument-surface grammar (reliability / tokens, not authz):** prefer flat,
+homogeneous, non-nested parameters. Reliability degrades with
+nesting × heterogeneity × cleverness. Provider schema mins/maxes are
+documentation unless the harness validates. Full principle, good/bad
+shapes, and Code Mode complementarity: [../context/tool-design.md](../context/tool-design.md)
+`## Tool-surface grammar (#3085)`. This section stays the security lane;
+do not invent a second vocabulary for the same idea.
 
 ## RAG and retrieval
 


### PR DESCRIPTION
## Summary

Encode **tool-surface grammar** for Directive and consumer agent apps: prefer flat, homogeneous, non-nested tool parameters. Reliability degrades with nesting × heterogeneity × cleverness (Can Bölük framing; not an emoji-tool product recommendation).

## Changes

- Extend `content/context/tool-design.md` with named principle, prefer/avoid rules, good vs bad param shapes, authoring checklist, complementarity vs Code Mode / fewer tools (#1167, #2593) and multi-step breakpoints (#1170)
- Cross-link from `content/patterns/llm-app.md` tool/function calling (security lane stays separate; no second vocabulary)
- CHANGELOG `[Unreleased]` + REFERENCES pointer for load-on-demand discovery

## Non-goals (honored)

- No mass migration of existing host tools
- No emoji/plaintext tool channel as product default
- No provider dialect catalog product

## Test plan

- [x] Preflight active xBRIEF #3085
- [x] Manual re-read of changed docs vs acceptance sketch
- [x] `task verify:forward-coverage` (docs-only; no new source)
- [x] Relative link targets exist for new cross-links
- [ ] CI `task check` on PR

Tracking: #3085