### PR TITLE
docs(discoverability): always-on pointer for structured decision log (#3211)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=63f1c02a12f4 refreshed=2026-08-07T16:10:03Z session=1759e40a4670 -->
+<!-- deft:managed-section v3 sha=8d82d291bc34 refreshed=2026-08-09T20:22:31Z session=026df50fe21c -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -252,6 +252,9 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 ## Value feedback and attribution (#1709)
 
 ! `plan.policy.valueFeedback.enabled` defaults OFF — `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; `deft value:show`; `deft feedback:file`; `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709).
+
+## Structured decision log (#1396 / #3211)
+! Significant choices → `deft decision:write`; re-load → `deft decision:list` / `xbrief/decisions/`; depth `.deft/core/docs/decision-log.md` (not triage/ADRs/lessons).
 
 ## Eval and framework health (#1703)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Decision log cold-path discoverability (#3211).** Always-on AGENTS managed pointer (`agents-entry` → `task agents:refresh`): significant choices → `decision:write`; re-load → `decision:list` / `xbrief/decisions/`; depth `docs/decision-log.md`. Level-0 `REFERENCES.md` row + hard links from `inter-run-learning.md` (not a second memory product; distinct from triage/ADRs/lessons). Closes #3211. Refs #1396, #2741, #2742.
+
 - **Goal-gate determinism pattern (#852).** New `content/patterns/goal-gate-determinism.md`: skills and playbooks MUST rigidize goals, acceptance criteria, quality gates, exit/handoff, scope, stop conditions, and preserve constraints; execution path stays flexible guidance. Dual grade (execution vs implementation), spurious-pass ratchet, skill design checklist. Discovery via `REFERENCES.md`; light anchors on write-skill + build skill, fail-loud (#1006) and verification cross-links. Doctrine SoT for content-manifest v2 durability (#1669); does not rewrite every skill. Tracking #852. Refs #782, #805, #603, #1006, #1874.
 
 - **Tool-surface grammar guidance (#3085).** Prefer flat, homogeneous tool params; treat nesting × heterogeneity × cleverness as a reliability and token tax. Lands in context tool-design with a cross-link from the LLM-app tool-calling section (security lane stays separate). Pattern only — no mass tool migration. Tracking #3085.

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -219,7 +219,8 @@ Load as needed:
 - **[context/fractal-summaries.md](./content/context/fractal-summaries.md)** - Hierarchical memory compression (task → feature → release)
 - **[context/examples.md](./content/context/examples.md)** - Few-shot and behavioral example guidance
 - **[docs/inter-run-learning.md](./content/docs/inter-run-learning.md)** - Inter-run learning surface pointer (#2742 / epic #2741); hot/cold/operator-gated contract over USER.md, packs, triage cache, session ritual, decision/continue — load before inventing agent-memory patterns
-- Load: When tasks are complex, multi-phase, multi-session, or when context budget / cross-run memory is a concern
+- **[docs/decision-log.md](./content/docs/decision-log.md)** - Structured agent decision log (#1396 / #3211); `task decision:write` / `task decision:list`, `xbrief/decisions/`, intent debt, dispose, revisit trigger — cold-path SoT for durable *why* (not triage, ADRs, or lessons)
+- Load: When tasks are complex, multi-phase, multi-session, or when context budget / cross-run memory is a concern; when recovering or recording significant choices
 
 ### When Verifying Agent Work
 

--- a/content/docs/decision-log.md
+++ b/content/docs/decision-log.md
@@ -103,7 +103,12 @@ Cross-cutting process/architecture decisions often have empty `activeScopeRefs`.
 - `xbrief/decisions/2026-08-08-scm-label-mirror-first-mass-apply.decision.json`
 - `xbrief/decisions/2026-08-09-portfolio-dispose-into-decision-log.decision.json`
 
+## Cold-path discovery (#3211)
+
+! Always-on AGENTS managed pointer (via `content/templates/agents-entry.md` + `task agents:refresh`), Level-0 `REFERENCES.md` under context/long tasks, and [`inter-run-learning.md`](./inter-run-learning.md) link this surface so a fresh session can name `decision:list` without loading build or pre-pr skills.
+
 ## See also
 
 - [`xbrief/decisions/README.md`](../../xbrief/decisions/README.md)
 - `task decision:write` / `task decision:list` in [`commands.md`](../commands.md)
+- [`inter-run-learning.md`](./inter-run-learning.md) (cold memory SoTs; this log is the durable *why* lane)

--- a/content/docs/inter-run-learning.md
+++ b/content/docs/inter-run-learning.md
@@ -12,10 +12,13 @@ Canonical contract (Wave 0 design for [#2742](https://github.com/deftai/directiv
 
 That note inventories Directive memory SoTs (`USER.md` Personal, lessons/packs, triage cache, session ritual, decision/continue), defines **hot / cold / operator-gated** tiers with freeze and budget rules, lists non-goals, and retargets #688, #978, #832–#835, and #479.
 
+**Structured decision log (#1396 / cold-path #3211):** single durable *why* events — not a second memory product. Record significant choices with `task decision:write`; re-load with `task decision:list` or `xbrief/decisions/`; depth [`content/docs/decision-log.md`](./decision-log.md). Distinct from triage labels, heavyweight `docs/decisions/ADR-*.md`, and lessons (#1513).
+
 ## Rules (discovery only)
 
 - ! Prefer the design note vocabulary over free-floating “agent-memory contracts” or Mem0-default RAG for Directive core.
 - ! Attach Wave 1+ pattern work (#832–#834, #835, #479) to the tiers and SoTs in the design note.
+- ! For significant architecture/product/security/process choices, use the decision log (`decision:write` / `decision:list`) rather than inventing parallel intent-debt storage.
 - ⊗ Revive `x-vbrief/agent-memory` / `swarm/agent-memory.md` (#2700 solution shape abandoned).
 - ⊗ Implement mid-session mutable always-in hot memory without freeze-at-session-start.
 
@@ -24,4 +27,5 @@ That note inventories Directive memory SoTs (`USER.md` Personal, lessons/packs, 
 - Session ritual: `content/commands.md` § Session-start ritual  
 - Continue checkpoints: `content/resilience/continue-here.md`  
 - Prompt assembly (freeze mechanism): `content/patterns/prompt-assembly-layer-ordering.md`  
+- Structured decision log: [`content/docs/decision-log.md`](./decision-log.md) (`task decision:write` / `task decision:list`, #1396)  
 - Skills Index: `REFERENCES.md` → When Managing Context or Long Tasks

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -91,6 +91,9 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ! `plan.policy.valueFeedback.enabled` defaults OFF — `deft policy:show --field=valueFeedback` / `deft policy:enable-value-feedback -- --confirm`; `deft value:show`; `deft feedback:file`; `.deft/core/.agents/skills/deft-directive-feedback/SKILL.md` (#1709).
 
+## Structured decision log (#1396 / #3211)
+! Significant choices → `deft decision:write`; re-load → `deft decision:list` / `xbrief/decisions/`; depth `.deft/core/docs/decision-log.md` (not triage/ADRs/lessons).
+
 ## Eval and framework health (#1703)
 
 ! `deft eval:health` when orienting or after gate/policy changes (Tier 0; 4-hour debounce). Release: `deft eval:run` / `deft eval:report`; skill routing: `deft eval:triggers` (#1586 / #1703).


### PR DESCRIPTION
## Summary

Cold-path discoverability for the #1396 structured decision log so a fresh session can name `decision:write` / `decision:list` without loading build or pre-pr skills.

## Changes

- Always-on AGENTS managed pointer via `content/templates/agents-entry.md` + `agents:refresh` (#1309)
- Level-0 `REFERENCES.md` row under context / long tasks
- Hard links from `content/docs/inter-run-learning.md` (not a second memory product)
- `content/docs/decision-log.md` cold-path discovery note
- CHANGELOG `[Unreleased]` consumer-visible entry

## Acceptance

- [x] Fresh agent reading AGENTS managed section can name `task decision:list` / `deft decision:list`
- [x] REFERENCES + inter-run-learning point at decision-log surface
- [x] agents-entry SoT refreshed into AGENTS managed section
- [x] CHANGELOG note

## Test plan

- [x] `task xbrief:preflight` exit 0
- [x] `verify:agents-md-budget` (managed 135/135)
- [x] full `task check -- --allow-over-cap` exit 0

Closes #3211

Refs #1396 #2741 #2742