### PR TITLE
feat(scope): require per-criterion evidence on scope:complete (#3240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scope:complete` requires typed evidence or human disposition per acceptance criterion (#3240).** Non-terminal `plan.items` (and nested `subItems`/`items`) no longer auto-complete from merge ancestry alone. Each criterion needs either `evidence` (`kind` in `test|review|merge|deploy|smoke|uat|observed_behavior` + `pointer` + `recorded_at` + `recorded_by`) or `disposition` (`waived|deferred|not_applicable` + `reason` + human-origin `provenance` + `recorded_at`). `merge`/`review` alone cannot satisfy smoke/UAT/deploy/observed_behavior criteria (inferred from title/Acceptance text or explicit `requires`/`acceptanceAxis`). Fail-closed lists missing criteria; success output lists evidence/disposition per item. Core: `packages/core/src/scope/acceptance-evidence.ts` + `transition.ts` gate. Closes #3240. Refs #3237 Q3, #3041, #2862.
+
 ### Changed
 
 ### Fixed

--- a/packages/core/src/scope/acceptance-evidence.test.ts
+++ b/packages/core/src/scope/acceptance-evidence.test.ts
@@ -1,0 +1,251 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  evaluateAcceptanceEvidenceGate,
+  inferRequiredStrictAxes,
+  isEvidenceKindSuitable,
+} from "./acceptance-evidence.js";
+import { runTransition } from "./transition.js";
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "accept-ev-"));
+  for (const folder of ["proposed", "pending", "active", "completed", "cancelled"]) {
+    mkdirSync(join(root, "xbrief", folder), { recursive: true });
+  }
+  writeFileSync(
+    join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    JSON.stringify({
+      plan: {
+        title: "P",
+        status: "running",
+        policy: { deliveryBranch: "master", wipCap: 20 },
+      },
+    }),
+    "utf8",
+  );
+  return root;
+}
+
+const humanProv = {
+  kind: "operator-cli",
+  actor: "operator@example.com",
+  mintedAt: "2026-08-10T12:00:00Z",
+  mintedVia: "test",
+  eventRef: null as string | null,
+};
+
+const testEvidence = {
+  kind: "test",
+  pointer: "packages/core/src/scope/acceptance-evidence.test.ts",
+  recorded_at: "2026-08-10T12:00:00Z",
+  recorded_by: "vitest",
+};
+
+function writeActive(
+  root: string,
+  name: string,
+  items: unknown[],
+  extras: Record<string, unknown> = {},
+): string {
+  const path = join(root, "xbrief", "active", name);
+  writeFileSync(
+    path,
+    JSON.stringify({
+      xBRIEFInfo: { version: "0.8" },
+      plan: {
+        title: "t",
+        status: "running",
+        items,
+        ...extras,
+      },
+    }),
+    "utf8",
+  );
+  return path;
+}
+
+describe("acceptance evidence inference (#3240)", () => {
+  it("infers strict axes from title and Acceptance narrative", () => {
+    expect(
+      inferRequiredStrictAxes({
+        title: "Runtime smoke passes",
+        narrative: { Acceptance: "Smoke after deploy" },
+      }),
+    ).toEqual(expect.arrayContaining(["smoke", "deploy"]));
+    expect(inferRequiredStrictAxes({ title: "UAT sign-off" })).toEqual(["uat"]);
+    expect(inferRequiredStrictAxes({ requires: "observed_behavior" })).toEqual([
+      "observed_behavior",
+    ]);
+    expect(inferRequiredStrictAxes({ title: "Unit tests green" })).toEqual([]);
+  });
+
+  it("rejects merge/review for strict axes", () => {
+    expect(isEvidenceKindSuitable("merge", ["smoke"])).toBe(false);
+    expect(isEvidenceKindSuitable("review", ["uat"])).toBe(false);
+    expect(isEvidenceKindSuitable("smoke", ["smoke"])).toBe(true);
+    expect(isEvidenceKindSuitable("merge", [])).toBe(true);
+  });
+});
+
+describe("acceptance evidence gate (#3240)", () => {
+  let root = "";
+  afterEach(() => {
+    if (root.length > 0) {
+      rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("fails closed when pending criteria lack evidence and disposition", () => {
+    root = makeRepo();
+    const file = writeActive(root, "missing.xbrief.json", [
+      { title: "No evidence yet", status: "pending" },
+      { title: "Also pending", status: "running" },
+    ]);
+    const result = runTransition("complete", file);
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Acceptance evidence required|#3240/);
+    expect(result.message).toMatch(/No evidence yet/);
+    expect(result.message).toMatch(/Also pending/);
+    expect(readFileSync(file, "utf8")).toContain("running");
+    expect(result.acceptanceReports?.some((r) => r.outcome === "missing")).toBe(true);
+  });
+
+  it("rejects kind=merge alone for a smoke criterion", () => {
+    root = makeRepo();
+    const file = writeActive(root, "smoke-merge.xbrief.json", [
+      {
+        title: "Runtime smoke criterion",
+        status: "pending",
+        narrative: { Acceptance: "Smoke must pass in staging" },
+        evidence: {
+          kind: "merge",
+          pointer: "merge:abc123",
+          recorded_at: "2026-08-10T12:00:00Z",
+          recorded_by: "ci",
+        },
+      },
+    ]);
+    const result = runTransition("complete", file);
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/not suitable|merge\/review|smoke/i);
+    expect(readFileSync(file, "utf8")).toContain("pending");
+  });
+
+  it("allows waived disposition with human-origin provenance without full evidence", () => {
+    root = makeRepo();
+    const file = writeActive(root, "waived.xbrief.json", [
+      {
+        title: "Smoke deferred by operator",
+        status: "pending",
+        narrative: { Acceptance: "Smoke in prod" },
+        disposition: {
+          disposition: "waived",
+          reason: "UAT environment unavailable this release; tracked in ops runbook",
+          provenance: humanProv,
+          recorded_at: "2026-08-10T12:00:00Z",
+        },
+      },
+    ]);
+    const result = runTransition("complete", file, new Date("2026-08-10T13:00:00Z"));
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/disposition=waived|Acceptance criteria/);
+    const dest = join(root, "xbrief", "completed", "waived.xbrief.json");
+    const data = JSON.parse(readFileSync(dest, "utf8")) as {
+      plan: { status: string; items: Array<{ status: string; disposition: unknown }> };
+    };
+    expect(data.plan.status).toBe("completed");
+    expect(data.plan.items[0]?.status).toBe("completed");
+    expect(data.plan.items[0]?.disposition).toBeDefined();
+  });
+
+  it("rejects agent-origin disposition provenance", () => {
+    root = makeRepo();
+    const file = writeActive(root, "agent-waive.xbrief.json", [
+      {
+        title: "Should not waive",
+        status: "pending",
+        disposition: {
+          disposition: "waived",
+          reason: "agent says so",
+          provenance: { kind: "operator-cli", actor: "agent:worker" },
+          recorded_at: "2026-08-10T12:00:00Z",
+        },
+      },
+    ]);
+    const result = runTransition("complete", file);
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/human-origin/);
+  });
+
+  it("accepts suitable smoke evidence and lists criteria on success", () => {
+    root = makeRepo();
+    const file = writeActive(root, "smoke-ok.xbrief.json", [
+      {
+        title: "Smoke green",
+        status: "pending",
+        requires: "smoke",
+        evidence: {
+          kind: "smoke",
+          pointer: "ci:smoke-job#42",
+          recorded_at: "2026-08-10T12:00:00Z",
+          recorded_by: "ci",
+        },
+      },
+      {
+        title: "Unit tests",
+        status: "pending",
+        evidence: testEvidence,
+      },
+    ]);
+    const result = runTransition("complete", file);
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/Acceptance criteria/);
+    expect(result.message).toMatch(/kind=smoke/);
+    expect(result.message).toMatch(/kind=test/);
+    const dest = join(root, "xbrief", "completed", "smoke-ok.xbrief.json");
+    const data = JSON.parse(readFileSync(dest, "utf8")) as {
+      plan: { items: Array<{ status: string }> };
+    };
+    expect(data.plan.items.every((i) => i.status === "completed")).toBe(true);
+  });
+
+  it("evaluateAcceptanceEvidenceGate is pure and lists missing paths", () => {
+    const gate = evaluateAcceptanceEvidenceGate({
+      items: [
+        { title: "a", status: "pending" },
+        {
+          title: "b",
+          status: "completed",
+        },
+        {
+          title: "parent",
+          status: "pending",
+          evidence: testEvidence,
+          subItems: [{ title: "child", status: "proposed" }],
+        },
+      ],
+    });
+    expect(gate.ok).toBe(false);
+    expect(gate.message).toMatch(/items\[0]/);
+    expect(gate.message).toMatch(/items\[2\]\.subItems\[0\]/);
+  });
+
+  it("fail/cancel still auto-advance without acceptance evidence", () => {
+    root = makeRepo();
+    const failPath = writeActive(root, "fail-ok.xbrief.json", [{ title: "p", status: "pending" }]);
+    expect(runTransition("fail", failPath).ok).toBe(true);
+    const failed = JSON.parse(
+      readFileSync(join(root, "xbrief", "completed", "fail-ok.xbrief.json"), "utf8"),
+    ) as { plan: { items: Array<{ status: string }> } };
+    expect(failed.plan.items[0]?.status).toBe("failed");
+  });
+
+  it("empty items complete without evidence", () => {
+    root = makeRepo();
+    const file = writeActive(root, "empty.xbrief.json", []);
+    expect(runTransition("complete", file).ok).toBe(true);
+  });
+});

--- a/packages/core/src/scope/acceptance-evidence.test.ts
+++ b/packages/core/src/scope/acceptance-evidence.test.ts
@@ -87,6 +87,13 @@ describe("acceptance evidence inference (#3240)", () => {
     expect(isEvidenceKindSuitable("smoke", ["smoke"])).toBe(true);
     expect(isEvidenceKindSuitable("merge", [])).toBe(true);
   });
+
+  it("rejects single-axis evidence when multiple strict axes are required", () => {
+    // "Smoke after deploy" infers both axes — one kind cannot cover both (#3240 P1).
+    expect(isEvidenceKindSuitable("smoke", ["smoke", "deploy"])).toBe(false);
+    expect(isEvidenceKindSuitable("deploy", ["smoke", "deploy"])).toBe(false);
+    expect(isEvidenceKindSuitable("smoke", ["smoke", "smoke"])).toBe(true);
+  });
 });
 
 describe("acceptance evidence gate (#3240)", () => {
@@ -210,6 +217,26 @@ describe("acceptance evidence gate (#3240)", () => {
       plan: { items: Array<{ status: string }> };
     };
     expect(data.plan.items.every((i) => i.status === "completed")).toBe(true);
+  });
+
+  it("rejects smoke-only evidence when criterion text also requires deploy", () => {
+    root = makeRepo();
+    const file = writeActive(root, "smoke-deploy.xbrief.json", [
+      {
+        title: "Runtime smoke after deploy",
+        status: "pending",
+        narrative: { Acceptance: "Smoke must pass after deployment" },
+        evidence: {
+          kind: "smoke",
+          pointer: "ci:smoke-job#42",
+          recorded_at: "2026-08-10T12:00:00Z",
+          recorded_by: "ci",
+        },
+      },
+    ]);
+    const result = runTransition("complete", file);
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/not suitable|smoke|deploy/i);
   });
 
   it("evaluateAcceptanceEvidenceGate is pure and lists missing paths", () => {

--- a/packages/core/src/scope/acceptance-evidence.ts
+++ b/packages/core/src/scope/acceptance-evidence.ts
@@ -1,0 +1,436 @@
+/**
+ * Per-acceptance-criterion evidence / disposition for scope:complete (#3240 / epic #3237 Q3).
+ *
+ * Merge ancestry alone must not auto-complete acceptance items. Each non-terminal
+ * plan item needs either typed evidence or a human-origin disposition before complete
+ * may advance it. Kind suitability: merge/review alone cannot satisfy smoke, UAT,
+ * deploy, or observed_behavior requirements.
+ */
+
+import { isHumanOrigin } from "../authz/origin.js";
+import type { GrantOrigin } from "../authz/types.js";
+
+/** Closed evidence kinds (locked Q3). */
+export const ACCEPTANCE_EVIDENCE_KINDS = [
+  "test",
+  "review",
+  "merge",
+  "deploy",
+  "smoke",
+  "uat",
+  "observed_behavior",
+] as const;
+
+export type AcceptanceEvidenceKind = (typeof ACCEPTANCE_EVIDENCE_KINDS)[number];
+
+/** Closed dispositions (locked Q3). */
+export const ACCEPTANCE_DISPOSITIONS = ["waived", "deferred", "not_applicable"] as const;
+
+export type AcceptanceDispositionKind = (typeof ACCEPTANCE_DISPOSITIONS)[number];
+
+/**
+ * Axes that merge/review evidence alone cannot satisfy.
+ * Matches epic #3237 Q3 suitability rule.
+ */
+export const STRICT_ACCEPTANCE_AXES = ["deploy", "smoke", "uat", "observed_behavior"] as const;
+
+export type StrictAcceptanceAxis = (typeof STRICT_ACCEPTANCE_AXES)[number];
+
+const EVIDENCE_KIND_SET = new Set<string>(ACCEPTANCE_EVIDENCE_KINDS);
+const DISPOSITION_SET = new Set<string>(ACCEPTANCE_DISPOSITIONS);
+const STRICT_AXIS_SET = new Set<string>(STRICT_ACCEPTANCE_AXES);
+
+/** Item statuses that still represent unfinished acceptance work (#2862 / #3240). */
+const NON_TERMINAL_ITEM_STATUSES = new Set(["pending", "proposed", "running"]);
+
+export interface AcceptanceEvidenceRecord {
+  readonly kind: AcceptanceEvidenceKind;
+  readonly pointer: string;
+  readonly recorded_at: string;
+  readonly recorded_by: string;
+}
+
+export interface AcceptanceDispositionRecord {
+  readonly disposition: AcceptanceDispositionKind;
+  readonly reason: string;
+  /** Human-origin provenance (kind + actor required; other GrantOrigin fields optional). */
+  readonly provenance: Pick<GrantOrigin, "kind" | "actor"> & Partial<GrantOrigin>;
+  readonly recorded_at: string;
+  readonly resume_when?: string;
+}
+
+export interface CriterionAcceptanceReport {
+  readonly path: string;
+  readonly title: string;
+  readonly outcome: "evidence" | "disposition" | "already_terminal" | "missing" | "invalid";
+  readonly detail: string;
+  readonly evidence?: AcceptanceEvidenceRecord;
+  readonly disposition?: AcceptanceDispositionRecord;
+}
+
+export interface AcceptanceEvidenceGateResult {
+  readonly ok: boolean;
+  readonly message: string;
+  readonly reports: readonly CriterionAcceptanceReport[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function isAcceptanceEvidenceKind(value: unknown): value is AcceptanceEvidenceKind {
+  return typeof value === "string" && EVIDENCE_KIND_SET.has(value.trim().toLowerCase());
+}
+
+export function isAcceptanceDispositionKind(value: unknown): value is AcceptanceDispositionKind {
+  return typeof value === "string" && DISPOSITION_SET.has(value.trim().toLowerCase());
+}
+
+/**
+ * Infer strict axes a criterion requires from explicit fields and title/Acceptance text.
+ * Explicit `requires` / `requiredEvidenceKind` / `acceptanceAxis` wins when valid.
+ */
+export function inferRequiredStrictAxes(item: Record<string, unknown>): StrictAcceptanceAxis[] {
+  const explicit = [
+    item.requires,
+    item.requiredEvidenceKind,
+    item.required_evidence_kind,
+    item.acceptanceAxis,
+    item.acceptance_axis,
+  ];
+  for (const raw of explicit) {
+    if (typeof raw !== "string") continue;
+    const norm = raw.trim().toLowerCase().replace(/-/g, "_");
+    if (STRICT_AXIS_SET.has(norm)) {
+      return [norm as StrictAcceptanceAxis];
+    }
+  }
+
+  const narrative = asRecord(item.narrative);
+  const parts: string[] = [];
+  if (typeof item.title === "string") parts.push(item.title);
+  if (typeof item.id === "string") parts.push(item.id);
+  if (narrative !== null) {
+    for (const key of ["Acceptance", "acceptance", "Description", "description", "Test", "test"]) {
+      if (typeof narrative[key] === "string") parts.push(narrative[key] as string);
+    }
+  }
+  const text = parts.join("\n").toLowerCase();
+  const found: StrictAcceptanceAxis[] = [];
+  // Order: longer / more specific phrases first so "observed behavior" wins over generic.
+  if (
+    /\bobserved[_\s-]?behavior\b/.test(text) ||
+    /\bobserved behaviour\b/.test(text) ||
+    /\brunning behaviour\b/.test(text) ||
+    /\brunning behavior\b/.test(text)
+  ) {
+    found.push("observed_behavior");
+  }
+  if (/\buat\b/.test(text) || /\buser acceptance\b/.test(text)) {
+    found.push("uat");
+  }
+  if (/\bsmoke\b/.test(text)) {
+    found.push("smoke");
+  }
+  if (/\bdeploy(?:ment|ed|s)?\b/.test(text)) {
+    found.push("deploy");
+  }
+  return found;
+}
+
+/**
+ * Whether evidence.kind is suitable for the criterion's required strict axes.
+ * merge and review never satisfy smoke/UAT/deploy/observed_behavior.
+ */
+export function isEvidenceKindSuitable(
+  kind: AcceptanceEvidenceKind,
+  requiredAxes: readonly StrictAcceptanceAxis[],
+): boolean {
+  if (requiredAxes.length === 0) {
+    return true;
+  }
+  if (kind === "merge" || kind === "review") {
+    return false;
+  }
+  // Evidence kind must match at least one required axis (exact).
+  return requiredAxes.some((axis) => kind === axis);
+}
+
+function parseEvidence(raw: unknown):
+  | {
+      ok: true;
+      record: AcceptanceEvidenceRecord;
+    }
+  | {
+      ok: false;
+      message: string;
+    } {
+  const obj = asRecord(raw);
+  if (obj === null) {
+    return { ok: false, message: "evidence must be an object" };
+  }
+  const kindRaw = typeof obj.kind === "string" ? obj.kind.trim().toLowerCase() : "";
+  if (!isAcceptanceEvidenceKind(kindRaw)) {
+    return {
+      ok: false,
+      message:
+        `unknown or missing evidence.kind ${JSON.stringify(obj.kind)}; ` +
+        `allowed: ${ACCEPTANCE_EVIDENCE_KINDS.join("|")}`,
+    };
+  }
+  if (!isNonEmptyString(obj.pointer)) {
+    return { ok: false, message: "evidence.pointer is required (non-empty string)" };
+  }
+  if (!isNonEmptyString(obj.recorded_at)) {
+    return { ok: false, message: "evidence.recorded_at is required" };
+  }
+  if (!isNonEmptyString(obj.recorded_by)) {
+    return { ok: false, message: "evidence.recorded_by is required" };
+  }
+  return {
+    ok: true,
+    record: {
+      kind: kindRaw as AcceptanceEvidenceKind,
+      pointer: obj.pointer.trim(),
+      recorded_at: obj.recorded_at.trim(),
+      recorded_by: obj.recorded_by.trim(),
+    },
+  };
+}
+
+function parseDisposition(raw: unknown):
+  | {
+      ok: true;
+      record: AcceptanceDispositionRecord;
+    }
+  | {
+      ok: false;
+      message: string;
+    } {
+  const obj = asRecord(raw);
+  if (obj === null) {
+    return { ok: false, message: "disposition must be an object" };
+  }
+  const dispRaw = typeof obj.disposition === "string" ? obj.disposition.trim().toLowerCase() : "";
+  if (!isAcceptanceDispositionKind(dispRaw)) {
+    return {
+      ok: false,
+      message:
+        `unknown or missing disposition.disposition ${JSON.stringify(obj.disposition)}; ` +
+        `allowed: ${ACCEPTANCE_DISPOSITIONS.join("|")}`,
+    };
+  }
+  if (!isNonEmptyString(obj.reason)) {
+    return { ok: false, message: "disposition.reason is required" };
+  }
+  if (!isNonEmptyString(obj.recorded_at)) {
+    return { ok: false, message: "disposition.recorded_at is required" };
+  }
+  const provenance = asRecord(obj.provenance);
+  if (provenance === null) {
+    return { ok: false, message: "disposition.provenance is required (human-origin)" };
+  }
+  // Reuse authz human-origin gate (#2944) so agent-self stamps cannot waive criteria.
+  const originForCheck: GrantOrigin = {
+    kind: String(provenance.kind ?? ""),
+    actor: String(provenance.actor ?? ""),
+    mintedAt: typeof provenance.mintedAt === "string" ? provenance.mintedAt : "",
+    mintedVia: typeof provenance.mintedVia === "string" ? provenance.mintedVia : "",
+    eventRef: typeof provenance.eventRef === "string" ? provenance.eventRef : null,
+  };
+  if (!isHumanOrigin(originForCheck)) {
+    return {
+      ok: false,
+      message:
+        "disposition.provenance must be human-origin " +
+        "(kind operator-cli|operator-session|human-event + non-agent actor)",
+    };
+  }
+  const record: AcceptanceDispositionRecord = {
+    disposition: dispRaw as AcceptanceDispositionKind,
+    reason: obj.reason.trim(),
+    provenance: {
+      kind: originForCheck.kind,
+      actor: originForCheck.actor,
+      ...(originForCheck.mintedAt.length > 0 ? { mintedAt: originForCheck.mintedAt } : {}),
+      ...(originForCheck.mintedVia.length > 0 ? { mintedVia: originForCheck.mintedVia } : {}),
+      ...(originForCheck.eventRef !== null ? { eventRef: originForCheck.eventRef } : {}),
+    },
+    recorded_at: obj.recorded_at.trim(),
+  };
+  if (isNonEmptyString(obj.resume_when)) {
+    return {
+      ok: true,
+      record: { ...record, resume_when: obj.resume_when.trim() },
+    };
+  }
+  return { ok: true, record };
+}
+
+function itemLabel(item: Record<string, unknown>, path: string): string {
+  if (typeof item.title === "string" && item.title.trim().length > 0) {
+    return item.title.trim();
+  }
+  if (typeof item.id === "string" && item.id.trim().length > 0) {
+    return item.id.trim();
+  }
+  return path;
+}
+
+function evaluateOneItem(item: Record<string, unknown>, path: string): CriterionAcceptanceReport {
+  const title = itemLabel(item, path);
+  const status = String(item.status ?? "");
+  if (!NON_TERMINAL_ITEM_STATUSES.has(status)) {
+    return {
+      path,
+      title,
+      outcome: "already_terminal",
+      detail: `status=${status || "(empty)"} (not advanced)`,
+    };
+  }
+
+  const hasEvidence = item.evidence !== undefined && item.evidence !== null;
+  const hasDisposition = item.disposition !== undefined && item.disposition !== null;
+
+  if (hasEvidence && hasDisposition) {
+    return {
+      path,
+      title,
+      outcome: "invalid",
+      detail: "exactly one of evidence or disposition required; both present",
+    };
+  }
+
+  if (!hasEvidence && !hasDisposition) {
+    return {
+      path,
+      title,
+      outcome: "missing",
+      detail: "no evidence or disposition; scope:complete refuses to auto-complete (#3240)",
+    };
+  }
+
+  if (hasDisposition) {
+    const parsed = parseDisposition(item.disposition);
+    if (!parsed.ok) {
+      return { path, title, outcome: "invalid", detail: parsed.message };
+    }
+    return {
+      path,
+      title,
+      outcome: "disposition",
+      detail: `${parsed.record.disposition}: ${parsed.record.reason}`,
+      disposition: parsed.record,
+    };
+  }
+
+  const parsed = parseEvidence(item.evidence);
+  if (!parsed.ok) {
+    return { path, title, outcome: "invalid", detail: parsed.message };
+  }
+  const requiredAxes = inferRequiredStrictAxes(item);
+  if (!isEvidenceKindSuitable(parsed.record.kind, requiredAxes)) {
+    const axes = requiredAxes.length > 0 ? requiredAxes.join("|") : "(none)";
+    return {
+      path,
+      title,
+      outcome: "invalid",
+      detail:
+        `evidence.kind=${parsed.record.kind} is not suitable for required axis/axes [${axes}]; ` +
+        `merge/review alone cannot satisfy smoke|uat|deploy|observed_behavior (#3240)`,
+      evidence: parsed.record,
+    };
+  }
+  return {
+    path,
+    title,
+    outcome: "evidence",
+    detail: `${parsed.record.kind} @ ${parsed.record.pointer}`,
+    evidence: parsed.record,
+  };
+}
+
+function walkItems(items: unknown, pathPrefix: string, reports: CriterionAcceptanceReport[]): void {
+  if (!Array.isArray(items)) {
+    return;
+  }
+  items.forEach((item, index) => {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      return;
+    }
+    const obj = item as Record<string, unknown>;
+    const path = `${pathPrefix}[${index}]`;
+    reports.push(evaluateOneItem(obj, path));
+    walkItems(obj.subItems, `${path}.subItems`, reports);
+    walkItems(obj.items, `${path}.items`, reports);
+  });
+}
+
+/**
+ * Fail closed when any non-terminal plan item lacks suitable evidence or a human-origin disposition.
+ */
+export function evaluateAcceptanceEvidenceGate(
+  plan: Record<string, unknown>,
+): AcceptanceEvidenceGateResult {
+  const reports: CriterionAcceptanceReport[] = [];
+  walkItems(plan.items, "items", reports);
+
+  const blockers = reports.filter((r) => r.outcome === "missing" || r.outcome === "invalid");
+
+  if (blockers.length === 0) {
+    const lines = reports
+      .filter((r) => r.outcome === "evidence" || r.outcome === "disposition")
+      .map((r) => `  - ${r.path} "${r.title}": ${r.outcome} (${r.detail})`);
+    const summary =
+      lines.length > 0
+        ? `Acceptance evidence gate passed (#3240):\n${lines.join("\n")}`
+        : "Acceptance evidence gate passed (#3240): no non-terminal criteria";
+    return { ok: true, message: summary, reports };
+  }
+
+  const lines = blockers.map((r) => `  - ${r.path} "${r.title}": ${r.detail}`);
+  return {
+    ok: false,
+    message:
+      `Acceptance evidence required for scope:complete (#3240). ` +
+      `${blockers.length} criterion/criteria missing suitable evidence or disposition:\n` +
+      `${lines.join("\n")}\n` +
+      `Each non-terminal plan item needs evidence ` +
+      `{kind: test|review|merge|deploy|smoke|uat|observed_behavior, pointer, recorded_at, recorded_by} ` +
+      `or disposition {disposition: waived|deferred|not_applicable, reason, provenance (human-origin), recorded_at}. ` +
+      `merge/review alone cannot satisfy smoke|uat|deploy|observed_behavior criteria.`,
+    reports,
+  };
+}
+
+/**
+ * Format a short multi-line listing of evidence/disposition for every criterion
+ * (including already-terminal) for complete success output.
+ */
+export function formatAcceptanceCompletionListing(
+  reports: readonly CriterionAcceptanceReport[],
+): string {
+  if (reports.length === 0) {
+    return "Acceptance criteria: (none)";
+  }
+  const lines = reports.map((r) => {
+    if (r.outcome === "evidence" && r.evidence) {
+      return `  - ${r.path} "${r.title}": evidence kind=${r.evidence.kind} pointer=${r.evidence.pointer}`;
+    }
+    if (r.outcome === "disposition" && r.disposition) {
+      return (
+        `  - ${r.path} "${r.title}": disposition=${r.disposition.disposition} ` +
+        `reason=${r.disposition.reason}`
+      );
+    }
+    return `  - ${r.path} "${r.title}": ${r.outcome} (${r.detail})`;
+  });
+  return `Acceptance criteria:\n${lines.join("\n")}`;
+}

--- a/packages/core/src/scope/acceptance-evidence.ts
+++ b/packages/core/src/scope/acceptance-evidence.ts
@@ -148,6 +148,12 @@ export function inferRequiredStrictAxes(item: Record<string, unknown>): StrictAc
 /**
  * Whether evidence.kind is suitable for the criterion's required strict axes.
  * merge and review never satisfy smoke/UAT/deploy/observed_behavior.
+ *
+ * A single evidence.kind covers only that axis. When free-text inference yields
+ * multiple axes (e.g. "smoke after deploy"), every required axis must match the
+ * same kind — which is only possible when the axes are identical. Otherwise use
+ * explicit `requires` / `acceptanceAxis` for a single axis, split the criterion,
+ * or record a human-origin disposition (#3240 Greptile P1).
  */
 export function isEvidenceKindSuitable(
   kind: AcceptanceEvidenceKind,
@@ -159,8 +165,8 @@ export function isEvidenceKindSuitable(
   if (kind === "merge" || kind === "review") {
     return false;
   }
-  // Evidence kind must match at least one required axis (exact).
-  return requiredAxes.some((axis) => kind === axis);
+  // All required strict axes must be covered by this single evidence kind.
+  return requiredAxes.every((axis) => kind === axis);
 }
 
 function parseEvidence(raw: unknown):

--- a/packages/core/src/scope/delivery-evidence.test.ts
+++ b/packages/core/src/scope/delivery-evidence.test.ts
@@ -49,7 +49,8 @@ function writeCodeBearing(root: string, name = "story.xbrief.json"): string {
           kind: "story",
           swarm: { file_scope: ["packages/core/src/scope/transition.ts"] },
         },
-        items: [{ title: "t", status: "pending" }],
+        // Empty items: delivery gate isolation; acceptance evidence is #3240.
+        items: [],
       },
     }),
     "utf8",

--- a/packages/core/src/scope/index.ts
+++ b/packages/core/src/scope/index.ts
@@ -1,3 +1,4 @@
+export * from "./acceptance-evidence.js";
 export * from "./audit-log.js";
 export * from "./batch-promote.js";
 export * from "./constants.js";

--- a/packages/core/src/scope/transition.test.ts
+++ b/packages/core/src/scope/transition.test.ts
@@ -42,6 +42,16 @@ function writeFile(path: string, data: unknown): void {
   writeFileSync(path, formatBriefJson(data), "utf8");
 }
 
+/** Minimal #3240 evidence so complete may advance non-terminal items in lifecycle tests. */
+function aceEvidence(pointer: string) {
+  return {
+    kind: "test" as const,
+    pointer,
+    recorded_at: "2026-07-27T00:00:00Z",
+    recorded_by: "vitest",
+  };
+}
+
 describe("runTransition", () => {
   let root = "";
   afterEach(() => {
@@ -137,17 +147,22 @@ describe("runTransition", () => {
         status: "running",
         updated: staleEnvelope,
         items: [
-          { title: "pending-item", status: "pending" },
-          { title: "proposed-item", status: "proposed" },
-          { title: "running-item", status: "running" },
+          { title: "pending-item", status: "pending", evidence: aceEvidence("pending-item") },
+          { title: "proposed-item", status: "proposed", evidence: aceEvidence("proposed-item") },
+          { title: "running-item", status: "running", evidence: aceEvidence("running-item") },
           { title: "cancelled-item", status: "cancelled" },
           { title: "failed-item", status: "failed" },
           { title: "already-completed", status: "completed" },
           {
             title: "parent-with-sub",
             status: "pending",
+            evidence: aceEvidence("parent-with-sub"),
             subItems: [
-              { title: "sub-pending", status: "pending" },
+              {
+                title: "sub-pending",
+                status: "pending",
+                evidence: aceEvidence("sub-pending"),
+              },
               { title: "sub-cancelled", status: "cancelled" },
             ],
           },
@@ -194,7 +209,7 @@ describe("runTransition", () => {
       plan: {
         title: "v06",
         status: "running",
-        items: [{ title: "a", status: "pending" }],
+        items: [{ title: "a", status: "pending", evidence: aceEvidence("a") }],
       },
     });
     const fixed = new Date("2026-07-27T16:00:00.000Z");
@@ -280,8 +295,15 @@ describe("runTransition", () => {
           {
             title: "parent",
             status: "pending",
+            evidence: aceEvidence("parent"),
             // Nested under items[] (not only subItems) advances recursively.
-            items: [{ title: "child-pending", status: "pending" }],
+            items: [
+              {
+                title: "child-pending",
+                status: "pending",
+                evidence: aceEvidence("child-pending"),
+              },
+            ],
           },
           { title: "blocked-item", status: "blocked" },
         ],
@@ -317,10 +339,19 @@ describe("runTransition", () => {
       plan: {
         title: "junk",
         status: "running",
-        items: [null, "skip", ["arr"], { title: "ok", status: "pending" }],
+        items: [
+          null,
+          "skip",
+          ["arr"],
+          { title: "ok", status: "pending", evidence: aceEvidence("ok") },
+        ],
       },
     });
-    expect(runTransition("complete", junkPath, fixed).ok).toBe(false);
+    // Invalid array entries are skipped by the walker; non-object entries may still fail
+    // brief persist validation — either missing-evidence (#3240) or schema rejection is non-zero.
+    const junkResult = runTransition("complete", junkPath, fixed);
+    expect(junkResult.ok).toBe(false);
+    expect(junkResult.message.length).toBeGreaterThan(0);
   });
 
   it("does not leave non-terminal status in active/ during complete (#2578)", () => {

--- a/packages/core/src/scope/transition.ts
+++ b/packages/core/src/scope/transition.ts
@@ -7,6 +7,11 @@ import {
 } from "../fs/projection-containment.js";
 import { hasArtifactSuffix } from "../layout/resolve.js";
 import type { GitRunner } from "../session/git.js";
+import {
+  type CriterionAcceptanceReport,
+  evaluateAcceptanceEvidenceGate,
+  formatAcceptanceCompletionListing,
+} from "./acceptance-evidence.js";
 import { append, canonicalLogPath, newDecisionId } from "./audit-log.js";
 import { atomicWriteBrief, formatBriefJson, readBriefForMutation } from "./brief-io.js";
 import { stampCompletionMetadata } from "./capacity-stamp.js";
@@ -39,6 +44,8 @@ import type { WipCapCheck } from "./wip-cap-check.js";
 export interface TransitionResult {
   readonly ok: boolean;
   readonly message: string;
+  /** Per-criterion acceptance reports when complete ran the #3240 gate. */
+  readonly acceptanceReports?: readonly CriterionAcceptanceReport[];
 }
 
 /** Optional completion evidence / disposition for the delivery gate (#3041). */
@@ -48,6 +55,11 @@ export interface TransitionOptions {
   readonly runGit?: GitRunner;
   readonly verifier?: string;
   readonly assumeEvidenceValidated?: boolean;
+  /**
+   * Test-only escape hatch: skip the #3240 per-item acceptance evidence gate.
+   * Production callers MUST leave this false/undefined.
+   */
+  readonly skipAcceptanceEvidenceGate?: boolean;
 }
 
 /** Item statuses that still represent unfinished work and should advance on terminal transitions (#2862). */
@@ -225,12 +237,29 @@ export function runTransition(
     }
   }
 
+  // #3240: per-criterion typed evidence or human-origin disposition before auto-advance.
+  let acceptanceReports: readonly CriterionAcceptanceReport[] | undefined;
+  let acceptanceListing = "";
+  if (act === "complete" && options.skipAcceptanceEvidenceGate !== true) {
+    const acceptanceGate = evaluateAcceptanceEvidenceGate(planObj);
+    acceptanceReports = acceptanceGate.reports;
+    if (!acceptanceGate.ok) {
+      return {
+        ok: false,
+        message: acceptanceGate.message,
+        acceptanceReports: acceptanceGate.reports,
+      };
+    }
+    acceptanceListing = formatAcceptanceCompletionListing(acceptanceGate.reports);
+  }
+
   planObj.status = targetStatus;
   planObj.updated = nowIso;
   // Keep the envelope clock aligned with plan.updated on every mutating transition (#2862).
   stampEnvelopeUpdated(data, nowIso);
 
   // Reconcile the completing brief's own plan.items (mirrors #1527 / #2566 registry sync) (#2862).
+  // On complete, items only reach here when #3240 evidence/disposition gate passed.
   if (OWN_ITEMS_RECONCILE_ACTIONS.has(act)) {
     advanceNonTerminalOwnItems(planObj.items, targetStatus);
   }
@@ -291,12 +320,17 @@ export function runTransition(
         message:
           `${actionLabel} ${basename}: brief moved to ${targetFolder}/ but ` +
           `PROJECT-DEFINITION sync failed: ${pdSyncError}`,
+        acceptanceReports,
       };
     }
     syncSpecificationAfterScopeMove(data, resolvedPath, destPath, vbriefRoot, targetStatus);
+    const moveMsg =
+      `${actionLabel} ${basename}: ${currentFolder}/ -> ${targetFolder}/ (status: ${targetStatus})` +
+      (acceptanceListing.length > 0 ? `\n${acceptanceListing}` : "");
     return {
       ok: true,
-      message: `${actionLabel} ${basename}: ${currentFolder}/ -> ${targetFolder}/ (status: ${targetStatus})`,
+      message: moveMsg,
+      acceptanceReports,
     };
   }
 
@@ -312,9 +346,13 @@ export function runTransition(
   }
 
   const actionLabel = STAY_LABELS[act] ?? act.charAt(0).toUpperCase() + act.slice(1);
+  const stayMsg =
+    `${actionLabel} ${basename}: stays in ${currentFolder}/ (status: ${targetStatus})` +
+    (acceptanceListing.length > 0 ? `\n${acceptanceListing}` : "");
   return {
     ok: true,
-    message: `${actionLabel} ${basename}: stays in ${currentFolder}/ (status: ${targetStatus})`,
+    message: stayMsg,
+    acceptanceReports,
   };
 }
 


### PR DESCRIPTION
## Summary

scope:complete no longer auto-advances pending acceptance items from merge ancestry alone. Each non-terminal plan.items criterion must carry typed evidence or a human-origin disposition before complete may succeed (epic #3237 Q3 / #3240).

## Changes

- New packages/core/src/scope/acceptance-evidence.ts gate: closed evidence kinds (test|review|merge|deploy|smoke|uat|observed_behavior) and dispositions (waived|deferred|not_applicable with human-origin provenance via #2944 predicates).
- Wired into runTransition(complete) before item auto-advance (#2862 path now gated).
- Suitability: merge/review alone cannot satisfy smoke/UAT/deploy/observed_behavior (inferred from title/Acceptance text or explicit requires / acceptanceAxis).
- Success output lists evidence or disposition per criterion; failures list missing/invalid criteria.
- Tests for missing evidence, smoke+merge reject, waived human disposition, agent-origin reject, suitable smoke evidence.
- CHANGELOG [Unreleased] cites #3240.

## Test plan

- [x] pnpm exec vitest run packages/core/src/scope (377 passed)
- [x] biome check on changed files (clean)
- [x] tsc -b (clean)
- [ ] CI task check on PR

## Notes

- Fail/cancel still auto-advance items without evidence (not claiming acceptance).
- Legacy already-completed items without evidence are left alone (already_terminal).
- Honest partial completion via waived / deferred / not_applicable dispositions.

Tracking: #3240
Related: #3237 #3041 #2862
