### PR TITLE
test(coverage): restore Vitest branches >=85% after v0.100.0 hairline (#3287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vitest branch coverage restored above 85% (#3287).** Focused branch tests for literal-acceptance safety/capture edges, value readback pure helpers, and story-quality residual paths clear the v0.100.0 84.96% hairline so release Step 5 passes without `--allow-coverage-debt`. Measured: statements/lines 88.41%, branches 85.08%, functions 96.00%. Closes #3287.
+
 ### Removed
 
 ## [0.100.0] - 2026-08-11

--- a/packages/core/src/literal-acceptance/capture-branches.test.ts
+++ b/packages/core/src/literal-acceptance/capture-branches.test.ts
@@ -47,9 +47,10 @@ describe("captureLiteralAcceptanceCommands branch matrix (#3287)", () => {
     ].join("\n");
     const detailed = captureLiteralAcceptanceCommandsDetailed(text);
     const cmds = detailed.commands.map((c) => c.command);
-    // Fence under non-acceptance heading with requireRegion still may capture
-    // globally via labeled/fenced passes — assert acceptance-region captures exist.
-    expect(cmds.some((c) => c.includes("task doctor") || c.includes("pnpm"))).toBe(true);
+    // Fenced capture under Acceptance region + shell/text langs.
+    expect(cmds).toEqual(expect.arrayContaining(["task doctor", "pnpm test", "pnpm run test"]));
+    // Non-shell fence lang without CLI shape is not inventively captured.
+    expect(cmds.some((c) => c.includes("print"))).toBe(false);
   });
 
   it("handles ~~~ fences and fence langs with spaces as non-fences", () => {

--- a/packages/core/src/literal-acceptance/capture-branches.test.ts
+++ b/packages/core/src/literal-acceptance/capture-branches.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureLiteralAcceptanceCommands,
+  captureLiteralAcceptanceCommandsDetailed,
+  formatRejectedLedger,
+} from "./capture.js";
+
+/**
+ * Capture-path branch matrix for fence / label / normalize edges (#3287 / #3267).
+ */
+describe("captureLiteralAcceptanceCommands branch matrix (#3287)", () => {
+  it("strips surrounding backticks and preserves path tokens", () => {
+    const cmds = captureLiteralAcceptanceCommands("verify: `task check`");
+    expect(cmds.map((c) => c.command)).toContain("task check");
+  });
+
+  it("rejects oversized and multi-line command blobs", () => {
+    const long = `verify: task check ${"x".repeat(520)}`;
+    expect(captureLiteralAcceptanceCommands(long)).toEqual([]);
+    const multi = "verify: task check\nstill going";
+    // labeled line alone still captures the first line; ensure no invented multi-line blob
+    const detailed = captureLiteralAcceptanceCommandsDetailed(multi);
+    for (const c of detailed.commands) {
+      expect(c.command.includes("\n")).toBe(false);
+    }
+  });
+
+  it("extracts shell-looking commands under acceptance headings with fences", () => {
+    const text = [
+      "## Overview",
+      "```bash",
+      "task check",
+      "```",
+      "## Acceptance",
+      "```sh",
+      "$ task doctor",
+      "> pnpm test",
+      "# comment only",
+      "",
+      "```",
+      "```python",
+      "print(1)",
+      "```",
+      "```text",
+      "pnpm run test",
+      "```",
+    ].join("\n");
+    const detailed = captureLiteralAcceptanceCommandsDetailed(text);
+    const cmds = detailed.commands.map((c) => c.command);
+    // Fence under non-acceptance heading with requireRegion still may capture
+    // globally via labeled/fenced passes — assert acceptance-region captures exist.
+    expect(cmds.some((c) => c.includes("task doctor") || c.includes("pnpm"))).toBe(true);
+  });
+
+  it("handles ~~~ fences and fence langs with spaces as non-fences", () => {
+    const text = ["~~~bash", "task check", "~~~", "```bash with args", "task doctor", "```"].join(
+      "\n",
+    );
+    const cmds = captureLiteralAcceptanceCommands(text);
+    expect(cmds.some((c) => c.command === "task check")).toBe(true);
+  });
+
+  it("parses numbered and bullet labeled lines plus mid-line verify:", () => {
+    const text = [
+      "1. verify: task check",
+      "2) command: task doctor",
+      "- run: pnpm test",
+      "* check: task help",
+      "Also run: verify: task --version",
+      "$ task verify:branch",
+      "> pnpm --version",
+    ].join("\n");
+    const cmds = captureLiteralAcceptanceCommands(text).map((c) => c.command);
+    expect(cmds).toEqual(
+      expect.arrayContaining([
+        "task check",
+        "task doctor",
+        "pnpm test",
+        "task help",
+        "task --version",
+        "task verify:branch",
+        "pnpm --version",
+      ]),
+    );
+  });
+
+  it("extracts inline backtick spans next to verify/run language", () => {
+    const text = "Please run `task check` before done and verify `pnpm test`.";
+    const cmds = captureLiteralAcceptanceCommands(text).map((c) => c.command);
+    expect(cmds).toEqual(expect.arrayContaining(["task check", "pnpm test"]));
+  });
+
+  it("dedupes identical command+cwd+exit and records rejected ledger lines", () => {
+    const text = [
+      "verify: task check",
+      "verify: task check",
+      "verify: task scope:promote -- x",
+      "verify: task scope:promote -- x",
+    ].join("\n");
+    const detailed = captureLiteralAcceptanceCommandsDetailed(text);
+    expect(detailed.commands.filter((c) => c.command === "task check")).toHaveLength(1);
+    expect(detailed.rejected.filter((r) => r.command.includes("scope:promote")).length).toBe(1);
+    const ledger = formatRejectedLedger(detailed.rejected);
+    expect(ledger).toMatch(/rejected|scope:promote|literal/i);
+  });
+
+  it("recognizes done-gate / verification region headings for fence capture", () => {
+    const text = [
+      "## Done gate",
+      "```console",
+      "task check",
+      "```",
+      "## Run verbatim",
+      "```pwsh",
+      "task doctor",
+      "```",
+      "## Check",
+      "```cmd",
+      "true",
+      "```",
+    ].join("\n");
+    const cmds = captureLiteralAcceptanceCommands(text).map((c) => c.command);
+    expect(cmds.length).toBeGreaterThan(0);
+  });
+
+  it("looksLikeShellCommand accepts flag and multi-word CLI shapes", () => {
+    const text = "verify: vitest run --coverage\nverify: Not A Sentence About Testing";
+    const cmds = captureLiteralAcceptanceCommands(text).map((c) => c.command);
+    expect(cmds).toContain("vitest run --coverage");
+  });
+});

--- a/packages/core/src/literal-acceptance/safety-branches.test.ts
+++ b/packages/core/src/literal-acceptance/safety-branches.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { evaluateCommandSafety, isExecutableLiteralSource } from "./safety.js";
+
+/**
+ * Branch matrix for literal-AC safety allowlists (#3287 / #3267).
+ * Targets residual package-manager / vitest / wrapper edges that sit below
+ * the global 85% branch floor.
+ */
+describe("evaluateCommandSafety branch matrix (#3287)", () => {
+  it("refuses empty, oversized, path-like first tokens, and non-allowlisted bins", () => {
+    expect(evaluateCommandSafety("").ok).toBe(false);
+    expect(evaluateCommandSafety("   ").ok).toBe(false);
+    expect(evaluateCommandSafety("x".repeat(501)).reason).toMatch(/500/);
+    expect(evaluateCommandSafety("./local-bin run").reason).toMatch(/path-like|allowlist/i);
+    expect(evaluateCommandSafety("C:\\tools\\bin run").reason).toMatch(/path-like|allowlist/i);
+    expect(evaluateCommandSafety("python -m pytest").ok).toBe(false);
+    expect(evaluateCommandSafety("curl https://example.com").ok).toBe(false);
+  });
+
+  it("requires wrapper verbs to carry a verification subcommand", () => {
+    expect(evaluateCommandSafety("task").ok).toBe(false);
+    expect(evaluateCommandSafety("deft").ok).toBe(false);
+    expect(evaluateCommandSafety("directive").ok).toBe(false);
+    expect(evaluateCommandSafety("task help").ok).toBe(true);
+    expect(evaluateCommandSafety("task -h").ok).toBe(true);
+    expect(evaluateCommandSafety("task -v").ok).toBe(true);
+    expect(evaluateCommandSafety("task test").ok).toBe(true);
+    expect(evaluateCommandSafety("task verify branch").ok).toBe(true);
+    expect(evaluateCommandSafety("task verify-session-ritual").ok).toBe(true);
+  });
+
+  it("covers package-manager empty rest and restricted subcommands", () => {
+    expect(evaluateCommandSafety("pnpm").ok).toBe(false);
+    expect(evaluateCommandSafety("npm").ok).toBe(false);
+    expect(evaluateCommandSafety("yarn").ok).toBe(false);
+    expect(evaluateCommandSafety("bun").ok).toBe(false);
+    expect(evaluateCommandSafety("pnpm test").ok).toBe(true);
+    expect(evaluateCommandSafety("pnpm test --filter core").ok).toBe(true);
+    expect(evaluateCommandSafety("npm run test").ok).toBe(true);
+    expect(evaluateCommandSafety("pnpm run check").ok).toBe(true);
+    expect(evaluateCommandSafety("npm --version").ok).toBe(true);
+    expect(evaluateCommandSafety("yarn -v").ok).toBe(true);
+    expect(evaluateCommandSafety("pnpm install").ok).toBe(false);
+    expect(evaluateCommandSafety("npm publish").ok).toBe(false);
+  });
+
+  it("covers npx allowlist and denials", () => {
+    expect(evaluateCommandSafety("npx").ok).toBe(false);
+    expect(evaluateCommandSafety("npx --version").ok).toBe(true);
+    expect(evaluateCommandSafety("npx -v").ok).toBe(true);
+    expect(evaluateCommandSafety("npx --help").ok).toBe(true);
+    expect(evaluateCommandSafety("npx -h").ok).toBe(true);
+    expect(evaluateCommandSafety("npx vitest").ok).toBe(false); // bare vitest → watch denied
+    expect(evaluateCommandSafety("npx vitest run").ok).toBe(true);
+    expect(evaluateCommandSafety("npx vitest run packages/core").ok).toBe(true);
+    expect(evaluateCommandSafety("npx exec something").ok).toBe(false);
+    expect(evaluateCommandSafety("npx cowsay hi").ok).toBe(false);
+  });
+
+  it("covers package-manager exec vitest variants and non-vitest denials", () => {
+    expect(evaluateCommandSafety("pnpm exec vitest").ok).toBe(false); // bare watch
+    expect(evaluateCommandSafety("pnpm exec vitest run").ok).toBe(true);
+    expect(evaluateCommandSafety("pnpm exec vitest run --coverage").ok).toBe(true);
+    expect(evaluateCommandSafety("npm exec vitest run").ok).toBe(true);
+    expect(evaluateCommandSafety("pnpm exec node -e 1").ok).toBe(false);
+    expect(evaluateCommandSafety("pnpm exec deft doctor").ok).toBe(false);
+  });
+
+  it("covers run vitest package-manager form", () => {
+    expect(evaluateCommandSafety("pnpm run vitest").ok).toBe(true);
+    expect(evaluateCommandSafety("pnpm run vitest run packages/core").ok).toBe(true);
+    expect(evaluateCommandSafety("npm run vitest -- --run").ok).toBe(true);
+  });
+
+  it("covers vitest first-token run/version and hang-mode denials", () => {
+    expect(evaluateCommandSafety("vitest").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest run").ok).toBe(true);
+    expect(evaluateCommandSafety("vitest run packages/core/src").ok).toBe(true);
+    expect(evaluateCommandSafety("vitest --run").ok).toBe(true);
+    expect(evaluateCommandSafety("vitest --version").ok).toBe(true);
+    expect(evaluateCommandSafety("vitest -v").ok).toBe(true);
+    expect(evaluateCommandSafety("vitest watch").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest ui").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest browser").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest --watch").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest --ui").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest --browser").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest dev").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest run --watch").ok).toBe(false);
+    expect(evaluateCommandSafety("vitest related foo").ok).toBe(false);
+  });
+
+  it("allows bare true/false and classifies executable sources", () => {
+    expect(evaluateCommandSafety("true").ok).toBe(true);
+    expect(evaluateCommandSafety("false").ok).toBe(true);
+    expect(isExecutableLiteralSource("explicit")).toBe(true);
+    expect(isExecutableLiteralSource("verify_commands")).toBe(true);
+    expect(isExecutableLiteralSource("task_statement")).toBe(false);
+    expect(isExecutableLiteralSource("unknown")).toBe(false);
+  });
+});

--- a/packages/core/src/literal-acceptance/safety-branches.test.ts
+++ b/packages/core/src/literal-acceptance/safety-branches.test.ts
@@ -12,7 +12,11 @@ describe("evaluateCommandSafety branch matrix (#3287)", () => {
     expect(evaluateCommandSafety("   ").ok).toBe(false);
     expect(evaluateCommandSafety("x".repeat(501)).reason).toMatch(/500/);
     expect(evaluateCommandSafety("./local-bin run").reason).toMatch(/path-like|allowlist/i);
-    expect(evaluateCommandSafety("C:\\tools\\bin run").reason).toMatch(/path-like|allowlist/i);
+    // Path-like first token with slash (platform-neutral; avoids win32-only fixtures).
+    expect(evaluateCommandSafety("/usr/local/bin/task check").reason).toMatch(
+      /path-like|allowlist/i,
+    );
+    expect(evaluateCommandSafety("tools:bin run").reason).toMatch(/path-like|allowlist/i);
     expect(evaluateCommandSafety("python -m pytest").ok).toBe(false);
     expect(evaluateCommandSafety("curl https://example.com").ok).toBe(false);
   });

--- a/packages/core/src/session/branches.test.ts
+++ b/packages/core/src/session/branches.test.ts
@@ -300,7 +300,8 @@ describe("session branches", () => {
     vi.restoreAllMocks();
   });
 
-  it("runSessionStart triage exception path", () => {
+  // Linux CI full-suite can exceed the 5s default under load (merge-gate flake on #3287).
+  it("runSessionStart triage exception path", { timeout: 15_000 }, () => {
     const { root, head } = initRepo();
     const result = runSessionStart(root, {
       now: new Date("2026-06-09T01:00:00Z"),

--- a/packages/core/src/value/readback-branches.test.ts
+++ b/packages/core/src/value/readback-branches.test.ts
@@ -59,15 +59,25 @@ describe("value readback pure helpers (#3287)", () => {
       /Off-flow signal \(bypass\)/,
     );
 
+    // Distinct detail vs capability so detail-precedence is observable.
     expect(
       formatAttributedSessionLine(
         evt("adoption:unused-capability", {
-          detail: "swarm",
-          capability: "swarm",
+          detail: "detail-wins",
+          capability: "capability-fallback",
           signal_class: "adoption",
         }),
       ),
-    ).toMatch(/Unused capability.*swarm/);
+    ).toMatch(/Unused capability.*detail-wins/);
+    expect(
+      formatAttributedSessionLine(
+        evt("adoption:unused-capability", {
+          detail: "detail-wins",
+          capability: "capability-fallback",
+          signal_class: "adoption",
+        }),
+      ),
+    ).not.toMatch(/capability-fallback/);
     expect(
       formatAttributedSessionLine(
         evt("adoption:unused-capability", { capability: "triage", signal_class: "adoption" }),

--- a/packages/core/src/value/readback-branches.test.ts
+++ b/packages/core/src/value/readback-branches.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { BehavioralEventRecord } from "../lifecycle/events.js";
+import {
+  formatAttributedSessionLine,
+  formatValueShowReport,
+  parseValueShowArgs,
+  parseWindowMs,
+  selectSessionAttribution,
+} from "./readback.js";
+
+function evt(
+  event: string,
+  payload: Record<string, unknown> = {},
+  detected_at = "2026-08-01T12:00:00Z",
+  id = "e1",
+): BehavioralEventRecord {
+  return {
+    event,
+    id,
+    detected_at,
+    payload,
+  } as BehavioralEventRecord;
+}
+
+/**
+ * Pure-helper branch matrix for value readback (#3287 / #1709).
+ * Hits format / parse / selection edges that sat below the 85% branch floor.
+ */
+describe("value readback pure helpers (#3287)", () => {
+  it("formats every attributed event class with and without detail tails", () => {
+    expect(
+      formatAttributedSessionLine(
+        evt("value:gate-catch", {
+          source: "verify:branch",
+          detail: "blocked",
+          signal_class: "value",
+        }),
+      ),
+    ).toMatch(/Gate catch.*blocked/);
+    expect(formatAttributedSessionLine(evt("value:gate-catch", { signal_class: "value" }))).toMatch(
+      /Gate catch \(gate\)/,
+    );
+
+    expect(
+      formatAttributedSessionLine(
+        evt("value:wip-cap-protect", { count: 3, cap: 20, signal_class: "value" }),
+      ),
+    ).toMatch(/3\/20/);
+    expect(
+      formatAttributedSessionLine(evt("value:wip-cap-protect", { signal_class: "value" })),
+    ).toMatch(/WIP cap protected/);
+
+    expect(
+      formatAttributedSessionLine(
+        evt("bypass:off-flow", { source: "hook", detail: "skip", signal_class: "bypass" }),
+      ),
+    ).toMatch(/Off-flow.*skip/);
+    expect(formatAttributedSessionLine(evt("bypass:off-flow", { signal_class: "bypass" }))).toMatch(
+      /Off-flow signal \(bypass\)/,
+    );
+
+    expect(
+      formatAttributedSessionLine(
+        evt("adoption:unused-capability", {
+          detail: "swarm",
+          capability: "swarm",
+          signal_class: "adoption",
+        }),
+      ),
+    ).toMatch(/Unused capability.*swarm/);
+    expect(
+      formatAttributedSessionLine(
+        evt("adoption:unused-capability", { capability: "triage", signal_class: "adoption" }),
+      ),
+    ).toMatch(/Unused capability.*triage/);
+    expect(
+      formatAttributedSessionLine(evt("adoption:unused-capability", { signal_class: "adoption" })),
+    ).toMatch(/Unused capability\./);
+
+    expect(
+      formatAttributedSessionLine(
+        evt("friction:directive-gap", {
+          source: "cli",
+          detail: "missing",
+          signal_class: "friction",
+        }),
+      ),
+    ).toMatch(/Directive gap.*missing/);
+    expect(
+      formatAttributedSessionLine(evt("friction:directive-gap", { signal_class: "friction" })),
+    ).toMatch(/Directive gap \(friction\)/);
+
+    // default branch + numeric payload fields + signal_class fallback from event prefix
+    expect(
+      formatAttributedSessionLine(
+        evt("value:other-signal", { count: 7, source: "x" } as Record<string, unknown>),
+      ),
+    ).toMatch(/\[value\] value:other-signal/);
+    expect(formatAttributedSessionLine(evt("mystery:event", { signal_class: "value" }))).toMatch(
+      /\[value\] mystery:event/,
+    );
+  });
+
+  it("selects highest-priority attribution and prefers newer ties", () => {
+    expect(selectSessionAttribution([])).toBeNull();
+    const selected = selectSessionAttribution([
+      evt("friction:directive-gap", { signal_class: "friction" }, "2026-08-01T10:00:00Z", "f"),
+      evt("value:gate-catch", { signal_class: "value" }, "2026-08-01T09:00:00Z", "v"),
+      evt("bypass:off-flow", { signal_class: "bypass" }, "2026-08-01T11:00:00Z", "b"),
+    ]);
+    expect(selected?.id).toBe("v");
+
+    const newer = selectSessionAttribution([
+      evt("value:gate-catch", { signal_class: "value" }, "2026-08-01T09:00:00Z", "old"),
+      evt("value:gate-catch", { signal_class: "value" }, "2026-08-01T12:00:00Z", "new"),
+    ]);
+    expect(newer?.id).toBe("new");
+
+    // invalid / missing detected_at still sorts (null → 0)
+    const withBad = selectSessionAttribution([
+      evt("value:gate-catch", { signal_class: "value" }, "not-a-date", "bad"),
+      evt("value:gate-catch", { signal_class: "value" }, "2026-08-01T12:00:00Z", "good"),
+    ]);
+    expect(withBad?.id).toBe("good");
+  });
+
+  it("parses window tokens and falls back for invalid values", () => {
+    expect(parseWindowMs(undefined)).toBe(7 * 86_400_000);
+    expect(parseWindowMs("")).toBe(7 * 86_400_000);
+    expect(parseWindowMs("  ")).toBe(7 * 86_400_000);
+    expect(parseWindowMs("bogus")).toBe(7 * 86_400_000);
+    expect(parseWindowMs("0d")).toBe(7 * 86_400_000);
+    expect(parseWindowMs("-3d")).toBe(7 * 86_400_000);
+    expect(parseWindowMs("2d")).toBe(2 * 86_400_000);
+    expect(parseWindowMs("3h")).toBe(3 * 3_600_000);
+    expect(parseWindowMs("15m")).toBe(15 * 60_000);
+    expect(parseWindowMs("10D")).toBe(10 * 86_400_000);
+  });
+
+  it("parses value:show argv shapes including error paths", () => {
+    expect(parseValueShowArgs(["--format", "json"]).format).toBe("json");
+    expect(parseValueShowArgs(["--format", "text"]).format).toBe("text");
+    expect(parseValueShowArgs(["--format=json"]).format).toBe("json");
+    expect(parseValueShowArgs(["--format=yaml"]).error).toMatch(/expects text\|json/);
+    expect(parseValueShowArgs(["--format", "yaml"]).error).toMatch(/expects text\|json/);
+    expect(parseValueShowArgs(["--window", "30d"]).window).toBe("30d");
+    expect(parseValueShowArgs(["--window"]).error).toMatch(/--window requires/);
+    expect(parseValueShowArgs(["--window=14d"]).window).toBe("14d");
+    expect(parseValueShowArgs(["--project-root", "/tmp/x"]).projectRoot).toBe("/tmp/x");
+    expect(parseValueShowArgs(["--project-root"]).error).toMatch(/--project-root requires/);
+    expect(parseValueShowArgs(["--project-root=/tmp/y"]).projectRoot).toBe("/tmp/y");
+    expect(parseValueShowArgs(["--unknown"]).error).toMatch(/unrecognized/);
+  });
+
+  it("formats empty and non-empty value:show reports", () => {
+    const empty = formatValueShowReport({
+      windowLabel: "7d",
+      windowMs: 7 * 86_400_000,
+      total: 0,
+      byClass: { value: 0, bypass: 0, adoption: 0, friction: 0 },
+      byEvent: {},
+      recent: [],
+    });
+    expect(empty).toMatch(/No attributed signals/);
+
+    const populated = formatValueShowReport({
+      windowLabel: "7d",
+      windowMs: 7 * 86_400_000,
+      total: 3,
+      byClass: { value: 2, bypass: 1, adoption: 0, friction: 0 },
+      byEvent: { "value:gate-catch": 2, "bypass:off-flow": 1 },
+      recent: [],
+    });
+    expect(populated).toMatch(/total/);
+    expect(populated).toMatch(/value=2/);
+    expect(populated).toMatch(/bypass=1/);
+    expect(populated).toMatch(/value:gate-catch: 2/);
+  });
+});

--- a/packages/core/src/vbrief-validation/story-quality-extra-branches.test.ts
+++ b/packages/core/src/vbrief-validation/story-quality-extra-branches.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  asStrList,
+  itemHasAcceptance,
+  itemHasTraces,
+  itemsHaveAcceptance,
+  missingRequiredSwarmFields,
+  storyQualityIssues,
+} from "./story-quality.js";
+
+const BASE = {
+  title: "Auth model",
+  description:
+    "Auth model persistence stores user identity and session state. The story covers focused model changes plus matching unit tests for save and load behavior.",
+  implementationPlan:
+    "- Update the src/auth model persistence code so valid payloads are saved through the model boundary.\n" +
+    "- Add focused tests for successful persistence and a missing-record fixture in tests/auth/model.",
+  userStory:
+    "As an auth maintainer, I want persisted user records, so that login state survives requests.",
+  acceptanceTexts: [
+    "Given a valid user payload, when the auth model saves it, then the user record persists.",
+    "Given an existing user, when the auth model loads it, then the saved identity returns.",
+  ],
+  acceptanceCountJustification: "",
+  swarm: {
+    file_scope: ["src/auth/model.ts", "tests/auth/model.test.ts"],
+    verify_commands: ["npm test -- auth/model"],
+    expected_outputs: ["ok"],
+    depends_on: [],
+    conflict_group: "auth",
+    size: "M",
+    file_scope_confidence: "high",
+    model_tier: "medium",
+    parallel_safe: true,
+  },
+};
+
+/**
+ * Residual story-quality branches for the #3287 coverage hairline.
+ */
+describe("story-quality residual branches (#3287)", () => {
+  it("covers asStrList non-array/non-string and empty trim", () => {
+    expect(asStrList(undefined)).toEqual([]);
+    expect(asStrList("")).toEqual([]);
+    expect(asStrList("   ")).toEqual([]);
+    expect(asStrList({ a: 1 })).toEqual([]);
+  });
+
+  it("covers nested acceptance/traces false paths and empty arrays", () => {
+    expect(itemHasAcceptance({ narrative: { Acceptance: "   " } })).toBe(false);
+    expect(itemHasAcceptance({ narrative: null })).toBe(false);
+    expect(itemHasAcceptance({ narrative: [] as unknown as object })).toBe(false);
+    expect(itemHasAcceptance({ items: [null, "x", { narrative: {} }] })).toBe(false);
+    expect(itemHasAcceptance({ items: "not-array" as unknown as object[] })).toBe(false);
+    expect(itemHasTraces({ narrative: { Traces: "  " } })).toBe(false);
+    expect(itemHasTraces({ narrative: "x" as unknown as object })).toBe(false);
+    expect(itemHasTraces({ items: [{ narrative: { Traces: "" } }] })).toBe(false);
+    expect(itemsHaveAcceptance([])).toBe(false);
+    expect(itemsHaveAcceptance([{ narrative: {} }])).toBe(false);
+  });
+
+  it("covers broad file_scope root variants and generic verify command", () => {
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        swarm: { ...BASE.swarm, file_scope: ["backend"] },
+      }).some((i) => i.includes("broad file_scope")),
+    ).toBe(true);
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        swarm: { ...BASE.swarm, file_scope: ["frontend/"] },
+      }).some((i) => i.includes("broad file_scope")),
+    ).toBe(true);
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        swarm: { ...BASE.swarm, file_scope: ["docs/*"] },
+      }).some((i) => i.includes("broad file_scope")),
+    ).toBe(true);
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        swarm: { ...BASE.swarm, verify_commands: ["task check"] },
+      }).some((i) => i.includes("generic verify command")),
+    ).toBe(true);
+  });
+
+  it("covers missing swarm string fields and userStory nullish", () => {
+    expect(
+      missingRequiredSwarmFields({
+        file_scope: ["a"],
+        verify_commands: ["b"],
+        expected_outputs: ["c"],
+        // depends_on omitted
+        conflict_group: "  ",
+        size: "",
+        file_scope_confidence: 1 as unknown as string,
+        model_tier: null as unknown as string,
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        "plan.metadata.swarm.depends_on",
+        "plan.metadata.swarm.conflict_group",
+        "plan.metadata.swarm.size",
+        "plan.metadata.swarm.file_scope_confidence",
+        "plan.metadata.swarm.model_tier",
+      ]),
+    );
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        userStory: null as unknown as string,
+      }).some((i) => i.includes("UserStory must match")),
+    ).toBe(true);
+  });
+
+  it("covers sentenceCount edge terminators and stepCount bullet vs prose", () => {
+    // version-like periods are not sentence boundaries; pad word count above 20
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        description:
+          "Uses v1.2.3 API surface for auth model persistence across requests. " +
+          "Second concrete sentence covers load fixtures and identity return paths carefully.",
+      }),
+    ).not.toContain("plan.narratives.Description must contain at least two concrete sentences");
+
+    // prose-only plan without bullets falls back to sentence count (<2 steps)
+    expect(
+      storyQualityIssues({
+        ...BASE,
+        implementationPlan: "Only one prose sentence about the model path and test evidence.",
+      }).some((i) => i.includes("two concrete steps")),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Restore Vitest coverage after the v0.100.0 branch hairline (84.96% → **85.08%**).

Release Step 5 filed coverage-debt #3287 when branches alone fell 0.04pp under the 85% floor. This PR adds focused regression tests only (no production code changes):

- `literal-acceptance/safety-branches.test.ts` — package-manager / vitest / wrapper allowlist edges
- `literal-acceptance/capture-branches.test.ts` — fence, labeled-line, and normalize capture edges
- `value/readback-branches.test.ts` — format / parse / selection pure helpers
- `vbrief-validation/story-quality-extra-branches.test.ts` — residual story-quality branches

## Measured (task check / vitest --coverage)

| Metric | Before | After | Threshold |
|--------|--------|-------|-----------|
| Statements | 88.36% | **88.42%** | 85% |
| Branches | **84.96%** | **85.08%** | 85% |
| Functions | 96.00% | **96.00%** | 85% |
| Lines | 88.36% | **88.42%** | 85% |

No `--allow-coverage-debt` required.

## Test plan

- [x] `pnpm exec vitest run` on new test files (27 passed)
- [x] Full `task check` green (branches 85.08%)
- [ ] CI green on PR
- [ ] Greptile CLEAN

Closes #3287