### PR TITLE
fix(policy,session): emit ceremony-dial escalation-evaluation events (#3319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ceremony-dial escalation evaluations emit a run-summary event (#3319).** Every evaluation records tier, outcome (`escalated`|`declined`), and reason so a decline is distinct from never-evaluated. Session-start surfaces start-tier provenance; an external or operator pin states that #3274 cold-start selection is bypassed and names unset-the-pin as remediation. Emitter stays fail-open when `DEFT_RUN_SUMMARY_PATH` is unset. Does not change thresholds or the default tier. Closes #3319. Refs #3282, #3274, #3263, #3214.
+
 - **Rule Authority and Thin Fail-Closed now reachable from agent entry surfaces (#3313).** Pointer-sufficient citations in agents-entry, preamble, and refreshed managed AGENTS.md. Contract markers gate both headers. Does not copy main.md bodies. Closes #3313.
 
 - **UAT Shell residual after #3288: versioned/alt write bins plant authz grants and kill-switch (#3311).** Under active UAT, residual bins (`gpg2`/`gpg1`/`rage`/`xh`/`httpie`/`wcurl`/`curlie`/`uudecode`/`iconv`/`gtar`/`star`/`gnutar`/`pax`) that write into `.deft/authz/**` or plant `.deft-directive-disable` / `.no-deft-directive` classify as settings deny (not unclassifiable allow). Dest flags cover `-o`/`--output`/`--output-file`/`--download-dir` and tar-family `-C`. Ordinary non-authz dests such as `/tmp` stay unclassifiable. Already-denied `gpg`/`age`/`http`/`curl`/`tar` peers stay denied. Closes #3311. Refs #3288, #3245, #3039.

--- a/packages/cli/src/session-start.ts
+++ b/packages/cli/src/session-start.ts
@@ -387,6 +387,7 @@ export function run(argv: readonly string[]): number {
               config: { enabled: true, override: args.ceremonyDepthOverride },
               inputs: args.ceremonyDialInputs,
             }),
+            ceremonyDialStartTierProvenance: "external-pin" as const,
           }
         : {}),
     });

--- a/packages/core/src/policy/ceremony-dial-escalation.test.ts
+++ b/packages/core/src/policy/ceremony-dial-escalation.test.ts
@@ -1,0 +1,232 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_RUN_SUMMARY_PATH } from "../run-summary/types.js";
+import { escalateCeremonyDial, selectCeremonyDepth } from "./ceremony-dial.js";
+import {
+  emitCeremonyDialEscalationEvaluation,
+  evaluateCeremonyDialEscalation,
+  evaluateSessionStartCeremonyDialEscalation,
+  formatCeremonyDialPinBypassLine,
+  isCeremonyStartTierPinned,
+  resolveCeremonyStartTierProvenance,
+} from "./ceremony-dial-escalation.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const d of temps.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("ceremony-dial start-tier provenance (#3319)", () => {
+  it("treats matrix/default selection as cold-start", () => {
+    const selection = selectCeremonyDepth({
+      inputs: { modelTier: "frontier", projectShape: "project" },
+    });
+    expect(resolveCeremonyStartTierProvenance({ selection, injectedSelection: false })).toBe(
+      "cold-start",
+    );
+    expect(isCeremonyStartTierPinned("cold-start")).toBe(false);
+    expect(formatCeremonyDialPinBypassLine("cold-start")).toBeNull();
+  });
+
+  it("treats injected override as external-pin and names unset-the-pin", () => {
+    const selection = selectCeremonyDepth({
+      config: { override: "rapid" },
+      inputs: { modelTier: "mid", projectShape: "project" },
+    });
+    const provenance = resolveCeremonyStartTierProvenance({
+      selection,
+      injectedSelection: true,
+    });
+    expect(provenance).toBe("external-pin");
+    const line = formatCeremonyDialPinBypassLine(provenance);
+    expect(line).toContain("#3274 cold-start selection is bypassed (external-pin)");
+    expect(line).toContain("Unset the pin");
+    expect(line).toContain("--ceremony-depth");
+  });
+
+  it("treats policy override as operator pin", () => {
+    const selection = selectCeremonyDepth({
+      config: { override: "rapid" },
+    });
+    expect(resolveCeremonyStartTierProvenance({ selection, injectedSelection: false })).toBe(
+      "operator",
+    );
+    const line = formatCeremonyDialPinBypassLine("operator");
+    expect(line).toContain("operator pin");
+    expect(line).toContain("plan.policy.ceremonyDial.override");
+  });
+
+  it("honors an explicit provenance hint", () => {
+    const selection = selectCeremonyDepth({ config: { override: "standard" } });
+    expect(
+      resolveCeremonyStartTierProvenance({
+        selection,
+        injectedSelection: true,
+        hint: "operator",
+      }),
+    ).toBe("operator");
+  });
+});
+
+describe("evaluateCeremonyDialEscalation (#3319)", () => {
+  it("emits escalated when evidence raises depth", () => {
+    const ev = evaluateCeremonyDialEscalation({
+      from: "rapid",
+      to: "standard",
+      inputs: { taskSize: "M", modelTier: "frontier" },
+    });
+    expect(ev.outcome).toBe("escalated");
+    expect(ev.tier).toBe("standard");
+    expect(ev.reason).toContain("rapid -> standard");
+    expect(ev.reason).toContain("size=M");
+  });
+
+  it("emits declined when evidence does not raise depth", () => {
+    const ev = evaluateCeremonyDialEscalation({
+      from: "rapid",
+      to: "rapid",
+      inputs: { taskSize: "S", modelTier: "frontier" },
+    });
+    expect(ev.outcome).toBe("declined");
+    expect(ev.tier).toBe("rapid");
+    expect(ev.reason).toContain("insufficient evidence");
+    expect(ev.outcome).not.toBe("escalated");
+  });
+
+  it("session-start helper compares cold-start floor to selected depth", () => {
+    const raised = selectCeremonyDepth({
+      inputs: { taskSize: "M", modelTier: "frontier", projectShape: "project" },
+    });
+    const ev = evaluateSessionStartCeremonyDialEscalation({ selection: raised });
+    expect(ev.outcome).toBe("escalated");
+    expect(ev.from).toBe("rapid");
+    expect(ev.to).toBe("standard");
+
+    const stayed = selectCeremonyDepth({
+      inputs: { taskSize: "S", modelTier: "frontier", projectShape: "project" },
+    });
+    expect(evaluateSessionStartCeremonyDialEscalation({ selection: stayed }).outcome).toBe(
+      "declined",
+    );
+  });
+
+  it("does not change thresholds: mid incomplete-size stays at standard floor", () => {
+    const mid = selectCeremonyDepth({
+      inputs: { modelTier: "mid", projectShape: "project" },
+    });
+    expect(mid.depth).toBe("standard");
+    const ev = evaluateSessionStartCeremonyDialEscalation({ selection: mid });
+    expect(ev.outcome).toBe("declined");
+    expect(ev.tier).toBe("standard");
+  });
+});
+
+describe("emitCeremonyDialEscalationEvaluation fail-open (#3319)", () => {
+  it("appends tier/outcome/reason when DEFT_RUN_SUMMARY_PATH is set", () => {
+    const root = mkdtempSync(join(tmpdir(), "dial-eval-emit-"));
+    temps.push(root);
+    const out = join(root, "summary.jsonl");
+    emitCeremonyDialEscalationEvaluation({
+      projectRoot: root,
+      sessionId: "sess-eval",
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+      evaluation: {
+        tier: "rapid",
+        outcome: "declined",
+        reason: "insufficient evidence to raise above rapid (size=- modelTier=-)",
+        from: "rapid",
+        to: "rapid",
+      },
+    });
+    const line = JSON.parse(readFileSync(out, "utf8").trim()) as {
+      event: string;
+      payload: { tier: string; outcome: string; reason: string };
+    };
+    expect(line.event).toBe("dial_escalation_evaluation");
+    expect(line.payload.tier).toBe("rapid");
+    expect(line.payload.outcome).toBe("declined");
+    expect(line.payload.reason).toContain("insufficient evidence");
+  });
+
+  it("is silent when DEFT_RUN_SUMMARY_PATH is unset", () => {
+    const root = mkdtempSync(join(tmpdir(), "dial-eval-silent-"));
+    temps.push(root);
+    emitCeremonyDialEscalationEvaluation({
+      projectRoot: root,
+      sessionId: "sess-silent",
+      env: {},
+      evaluation: {
+        tier: "rapid",
+        outcome: "escalated",
+        reason: "x",
+        from: "rapid",
+        to: "standard",
+      },
+    });
+    expect(() => readFileSync(join(root, ".deft-run-summary.json"), "utf8")).toThrow();
+  });
+});
+
+describe("escalateCeremonyDial evaluation events (#3319)", () => {
+  function makeProject(): string {
+    const root = mkdtempSync(join(tmpdir(), "dial-escalate-eval-"));
+    temps.push(root);
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({
+        plan: { title: "P", status: "running", policy: {} },
+      }),
+      "utf8",
+    );
+    return root;
+  }
+
+  it("emits declined when escalate is evaluated without --confirm", () => {
+    const root = makeProject();
+    const out = join(root, "summary.jsonl");
+    const result = escalateCeremonyDial(root, {
+      to: "standard",
+      reason: "size=M",
+      sessionId: "sess-preview",
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+    });
+    expect(result.changed).toBe(false);
+    const line = JSON.parse(readFileSync(out, "utf8").trim()) as {
+      event: string;
+      payload: { outcome: string; reason: string; tier: string };
+    };
+    expect(line.event).toBe("dial_escalation_evaluation");
+    expect(line.payload.outcome).toBe("declined");
+    expect(line.payload.reason).toContain("need --confirm");
+  });
+
+  it("emits escalated plus dial_transition when confirm applies a raise", () => {
+    const root = makeProject();
+    const out = join(root, "summary.jsonl");
+    const result = escalateCeremonyDial(root, {
+      to: "standard",
+      reason: "size=M",
+      confirm: true,
+      sessionId: "sess-apply",
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+    });
+    expect(result.exitCode).toBe(0);
+    const events = readFileSync(out, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as { event: string; payload: { outcome?: string } });
+    expect(events.some((e) => e.event === "dial_escalation_evaluation")).toBe(true);
+    expect(events.some((e) => e.event === "dial_transition")).toBe(true);
+    const evaluation = events.find((e) => e.event === "dial_escalation_evaluation");
+    expect(evaluation?.payload.outcome).toBe("escalated");
+  });
+});

--- a/packages/core/src/policy/ceremony-dial-escalation.test.ts
+++ b/packages/core/src/policy/ceremony-dial-escalation.test.ts
@@ -229,4 +229,26 @@ describe("escalateCeremonyDial evaluation events (#3319)", () => {
     const evaluation = events.find((e) => e.event === "dial_escalation_evaluation");
     expect(evaluation?.payload.outcome).toBe("escalated");
   });
+
+  it("names persist failure in the declined reason when confirm cannot apply", () => {
+    const root = mkdtempSync(join(tmpdir(), "dial-escalate-noconfig-"));
+    temps.push(root);
+    const out = join(root, "summary.jsonl");
+    const result = escalateCeremonyDial(root, {
+      to: "standard",
+      reason: "size=M",
+      confirm: true,
+      sessionId: "sess-persist-fail",
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+    });
+    expect(result.exitCode).not.toBe(0);
+    const line = JSON.parse(readFileSync(out, "utf8").trim()) as {
+      event: string;
+      payload: { outcome: string; reason: string };
+    };
+    expect(line.event).toBe("dial_escalation_evaluation");
+    expect(line.payload.outcome).toBe("declined");
+    expect(line.payload.reason).toContain("persist failed");
+    expect(line.payload.reason).toMatch(/exit \d+/);
+  });
 });

--- a/packages/core/src/policy/ceremony-dial-escalation.ts
+++ b/packages/core/src/policy/ceremony-dial-escalation.ts
@@ -1,0 +1,147 @@
+/**
+ * Ceremony-dial escalation evaluation + start-tier provenance (#3319).
+ *
+ * Observability only: does not change escalate-on-evidence thresholds or the
+ * default start tier. A declined evaluation is distinct from never-evaluated.
+ */
+
+import { RunSummaryEmitter } from "../run-summary/emit.js";
+import type { DialEscalationEvaluationOutcome } from "../run-summary/types.js";
+import {
+  type CeremonyDepth,
+  type CeremonyDialInputs,
+  type CeremonyDialSelection,
+  type CeremonyModelTier,
+  selectCeremonyColdStartDepth,
+} from "./ceremony-dial.js";
+
+export const CEREMONY_START_TIER_PROVENANCES = ["cold-start", "external-pin", "operator"] as const;
+export type CeremonyStartTierProvenance = (typeof CEREMONY_START_TIER_PROVENANCES)[number];
+
+export const CEREMONY_DEPTH_RANK: Readonly<Record<CeremonyDepth, number>> = {
+  minimal: 0,
+  rapid: 1,
+  standard: 2,
+  elevated: 3,
+};
+
+export interface ResolveCeremonyStartTierProvenanceInput {
+  readonly selection: CeremonyDialSelection;
+  /** True when session:start received a pre-resolved selection (CLI/harness). */
+  readonly injectedSelection: boolean;
+  readonly hint?: CeremonyStartTierProvenance;
+}
+
+export function resolveCeremonyStartTierProvenance(
+  input: ResolveCeremonyStartTierProvenanceInput,
+): CeremonyStartTierProvenance {
+  if (input.hint !== undefined) {
+    return input.hint;
+  }
+  if (input.selection.source === "override") {
+    return input.injectedSelection ? "external-pin" : "operator";
+  }
+  return "cold-start";
+}
+
+export function isCeremonyStartTierPinned(provenance: CeremonyStartTierProvenance): boolean {
+  return provenance === "external-pin" || provenance === "operator";
+}
+
+/** Session-start fail-closed line when a pin bypasses #3274 cold-start selection. */
+export function formatCeremonyDialPinBypassLine(
+  provenance: CeremonyStartTierProvenance,
+): string | null {
+  if (!isCeremonyStartTierPinned(provenance)) {
+    return null;
+  }
+  const pinLabel = provenance === "external-pin" ? "external-pin" : "operator pin";
+  return (
+    `[deft ceremony-dial] #3274 cold-start selection is bypassed (${pinLabel}). ` +
+    "Unset the pin (--ceremony-depth or plan.policy.ceremonyDial.override) to exercise #3274."
+  );
+}
+
+export interface CeremonyDialEscalationEvaluation {
+  readonly tier: CeremonyDepth;
+  readonly outcome: DialEscalationEvaluationOutcome;
+  readonly reason: string;
+  readonly from: CeremonyDepth;
+  readonly to: CeremonyDepth;
+}
+
+export interface EvaluateCeremonyDialEscalationInput {
+  readonly from: CeremonyDepth;
+  readonly to: CeremonyDepth;
+  readonly inputs?: CeremonyDialInputs;
+}
+
+/**
+ * Pure escalate-on-evidence evaluation. `to > from` → escalated; else declined.
+ * Does not persist a transition.
+ */
+export function evaluateCeremonyDialEscalation(
+  input: EvaluateCeremonyDialEscalationInput,
+): CeremonyDialEscalationEvaluation {
+  const size = input.inputs?.taskSize ?? null;
+  const modelTier = input.inputs?.modelTier ?? null;
+  const evidence = `size=${size ?? "-"} modelTier=${modelTier ?? "-"}`;
+  const raised = CEREMONY_DEPTH_RANK[input.to] > CEREMONY_DEPTH_RANK[input.from];
+  if (raised) {
+    return {
+      tier: input.to,
+      outcome: "escalated",
+      reason: `evidence raised ${input.from} -> ${input.to} (${evidence})`,
+      from: input.from,
+      to: input.to,
+    };
+  }
+  return {
+    tier: input.from,
+    outcome: "declined",
+    reason: `insufficient evidence to raise above ${input.from} (${evidence})`,
+    from: input.from,
+    to: input.to,
+  };
+}
+
+/** Cold-start vs selected depth at session:start (unpinned path only). */
+export function evaluateSessionStartCeremonyDialEscalation(input: {
+  readonly selection: CeremonyDialSelection;
+  readonly modelTier?: CeremonyModelTier | null;
+}): CeremonyDialEscalationEvaluation {
+  const modelTier = input.modelTier ?? input.selection.inputs.modelTier;
+  const from = selectCeremonyColdStartDepth(modelTier);
+  return evaluateCeremonyDialEscalation({
+    from,
+    to: input.selection.depth,
+    inputs: input.selection.inputs,
+  });
+}
+
+export interface EmitCeremonyDialEscalationEvaluationOptions {
+  readonly projectRoot: string;
+  readonly sessionId: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly evaluation: CeremonyDialEscalationEvaluation;
+}
+
+/** Fail-open emit of a #3319 evaluation event. */
+export function emitCeremonyDialEscalationEvaluation(
+  options: EmitCeremonyDialEscalationEvaluationOptions,
+): void {
+  try {
+    const emitter = new RunSummaryEmitter({
+      projectRoot: options.projectRoot,
+      sessionId: options.sessionId,
+      env: options.env,
+    });
+    emitter.emitDialEscalationEvaluation({
+      tier: options.evaluation.tier,
+      outcome: options.evaluation.outcome,
+      reason: options.evaluation.reason,
+    });
+  } catch {
+    // fail-open
+  }
+}

--- a/packages/core/src/policy/ceremony-dial.test.ts
+++ b/packages/core/src/policy/ceremony-dial.test.ts
@@ -398,6 +398,10 @@ describe("resolveCeremonyDial + policy surface", () => {
       inputs: { taskSize: "S", modelTier: "frontier", projectShape: "project" },
     });
     expect(formatCeremonyDialStatusLine(s)).toContain("depth=rapid");
+    expect(formatCeremonyDialStatusLine(s)).not.toContain("provenance=");
+    expect(formatCeremonyDialStatusLine(s, { startTierProvenance: "cold-start" })).toContain(
+      "provenance=cold-start",
+    );
     expect(ceremonyDialToDict(s).depth).toBe("rapid");
   });
 });

--- a/packages/core/src/policy/ceremony-dial.ts
+++ b/packages/core/src/policy/ceremony-dial.ts
@@ -525,7 +525,12 @@ export function resolveCeremonyDial(
 }
 
 /** Human-readable status line for session:start / policy:show. */
-export function formatCeremonyDialStatusLine(selection: CeremonyDialSelection): string {
+export function formatCeremonyDialStatusLine(
+  selection: CeremonyDialSelection,
+  extras?: {
+    readonly startTierProvenance?: string;
+  },
+): string {
   const parts = [
     `[deft ceremony-dial] depth=${selection.depth}`,
     `source=${selection.source}`,
@@ -533,6 +538,10 @@ export function formatCeremonyDialStatusLine(selection: CeremonyDialSelection): 
     `modelTier=${selection.inputs.modelTier ?? "-"}`,
     `projectShape=${selection.inputs.projectShape ?? "-"}`,
   ];
+  if (extras?.startTierProvenance !== undefined && extras.startTierProvenance.length > 0) {
+    parts.push(`start-tier=${selection.depth}`);
+    parts.push(`provenance=${extras.startTierProvenance}`);
+  }
   if (selection.composition.rapidStrategy) {
     parts.push(`compose=${selection.composition.rapidStrategy}`);
   }
@@ -1279,7 +1288,46 @@ export function escalateCeremonyDial(
 ): EscalateCeremonyDialResult {
   const prior = resolveCeremonyDial(projectRoot);
   const from = prior.depth;
+  const emitEscalationEvaluation = (applied: boolean): void => {
+    if (options.emitRunSummary === false) {
+      return;
+    }
+    try {
+      const audit = readCeremonyDialAudit(projectRoot);
+      const rawSid = (audit.raw as { session_id?: unknown } | null)?.session_id;
+      const sid =
+        options.sessionId ??
+        (typeof rawSid === "string" && rawSid.length > 0
+          ? rawSid
+          : `dial-${Date.now().toString(36)}`);
+      const rank: Record<CeremonyDepth, number> = {
+        minimal: 0,
+        rapid: 1,
+        standard: 2,
+        elevated: 3,
+      };
+      const raised = rank[options.to] > rank[from];
+      const outcome = applied && raised ? "escalated" : "declined";
+      const reason =
+        options.confirm === true
+          ? options.reason
+          : `${options.reason}; not applied (need --confirm)`;
+      const emitter = new RunSummaryEmitter({
+        projectRoot,
+        sessionId: sid,
+        env: options.env,
+      });
+      emitter.emitDialEscalationEvaluation({
+        tier: outcome === "escalated" ? options.to : from,
+        outcome,
+        reason,
+      });
+    } catch {
+      // fail-open
+    }
+  };
   if (options.confirm !== true) {
+    emitEscalationEvaluation(false);
     return {
       exitCode: 1,
       from,
@@ -1299,6 +1347,7 @@ export function escalateCeremonyDial(
     note: options.note ?? `escalate: ${options.reason}`,
   });
   if (setResult.exitCode !== 0) {
+    emitEscalationEvaluation(false);
     return {
       exitCode: setResult.exitCode,
       from,
@@ -1310,6 +1359,8 @@ export function escalateCeremonyDial(
         .filter((l) => l.length > 0),
     };
   }
+  // #3319: evaluation event on every escalate path (applied or not).
+  emitEscalationEvaluation(true);
   // #3282: event-driven dial_transition line (fail-open).
   if (options.emitRunSummary !== false) {
     try {

--- a/packages/core/src/policy/ceremony-dial.ts
+++ b/packages/core/src/policy/ceremony-dial.ts
@@ -1288,7 +1288,7 @@ export function escalateCeremonyDial(
 ): EscalateCeremonyDialResult {
   const prior = resolveCeremonyDial(projectRoot);
   const from = prior.depth;
-  const emitEscalationEvaluation = (applied: boolean): void => {
+  const emitEscalationEvaluation = (applied: boolean, reasonSuffix?: string): void => {
     if (options.emitRunSummary === false) {
       return;
     }
@@ -1308,10 +1308,14 @@ export function escalateCeremonyDial(
       };
       const raised = rank[options.to] > rank[from];
       const outcome = applied && raised ? "escalated" : "declined";
-      const reason =
+      const baseReason =
         options.confirm === true
           ? options.reason
           : `${options.reason}; not applied (need --confirm)`;
+      const reason =
+        reasonSuffix !== undefined && reasonSuffix.length > 0
+          ? `${baseReason}; ${reasonSuffix}`
+          : baseReason;
       const emitter = new RunSummaryEmitter({
         projectRoot,
         sessionId: sid,
@@ -1347,7 +1351,13 @@ export function escalateCeremonyDial(
     note: options.note ?? `escalate: ${options.reason}`,
   });
   if (setResult.exitCode !== 0) {
-    emitEscalationEvaluation(false);
+    const persistDetail = oneLineAuditToken(
+      setResult.stdout.trim().split("\n")[0] ?? `exit ${setResult.exitCode}`,
+    );
+    emitEscalationEvaluation(
+      false,
+      `persist failed (exit ${setResult.exitCode}): ${persistDetail}`,
+    );
     return {
       exitCode: setResult.exitCode,
       from,

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -83,6 +83,7 @@ export * from "./agents-md-advisory.js";
 export * from "./autonomy.js";
 export * from "./capacity.js";
 export * from "./ceremony-dial.js";
+export * from "./ceremony-dial-escalation.js";
 export * from "./check-resume.js";
 export * from "./coverage-debt.js";
 export * from "./decisions.js";

--- a/packages/core/src/run-summary/emit.ts
+++ b/packages/core/src/run-summary/emit.ts
@@ -14,6 +14,7 @@ import { assertWriteTargetSafe } from "../fs/projection-containment.js";
 import { type ResolveRunSummaryDestinationOptions, resolveRunSummaryDestination } from "./path.js";
 import {
   type CheckInvocationRunSummaryPayload,
+  type DialEscalationEvaluationRunSummaryPayload,
   type DialTransitionRunSummaryPayload,
   RUN_SUMMARY_SCHEMA_VERSION,
   RUN_SUMMARY_STDOUT_PREFIX,
@@ -205,6 +206,12 @@ export class RunSummaryEmitter {
 
   emitDialTransition(payload: DialTransitionRunSummaryPayload): EmitRunSummaryResult {
     return this.emit("dial_transition", payload);
+  }
+
+  emitDialEscalationEvaluation(
+    payload: DialEscalationEvaluationRunSummaryPayload,
+  ): EmitRunSummaryResult {
+    return this.emit("dial_escalation_evaluation", payload);
   }
 
   emitCheckInvocation(payload: CheckInvocationRunSummaryPayload): EmitRunSummaryResult {

--- a/packages/core/src/run-summary/index.ts
+++ b/packages/core/src/run-summary/index.ts
@@ -13,6 +13,8 @@ export {
   type CheckGateOutcome,
   type CheckInvocationRunSummaryPayload,
   DEFAULT_RUN_SUMMARY_BASENAME,
+  type DialEscalationEvaluationOutcome,
+  type DialEscalationEvaluationRunSummaryPayload,
   type DialTransitionRunSummaryPayload,
   ENV_RUN_SUMMARY_PATH,
   RUN_SUMMARY_EVENT_KINDS,

--- a/packages/core/src/run-summary/run-summary.test.ts
+++ b/packages/core/src/run-summary/run-summary.test.ts
@@ -209,4 +209,70 @@ describe("RunSummaryEmitter (#3282)", () => {
     expect(lines).toHaveLength(2);
     expect(lines.some((l) => "stale" in l)).toBe(false);
   });
+
+  it("emits dial_escalation_evaluation with tier, outcome, and reason (#3319)", () => {
+    const root = freshRoot("run-summary-eval-");
+    const out = join(root, "summary.jsonl");
+    const emitter = new RunSummaryEmitter({
+      projectRoot: root,
+      sessionId: "sess-eval",
+      frameworkVersion: "0.0.0",
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+    });
+    const declined = emitter.emitDialEscalationEvaluation({
+      tier: "rapid",
+      outcome: "declined",
+      reason: "insufficient evidence to raise above rapid (size=- modelTier=-)",
+    });
+    const escalated = emitter.emitDialEscalationEvaluation({
+      tier: "standard",
+      outcome: "escalated",
+      reason: "evidence raised rapid -> standard (size=M modelTier=frontier)",
+    });
+    expect(declined.emitted).toBe(true);
+    expect(escalated.emitted).toBe(true);
+    const lines = readFileSync(out, "utf8")
+      .trim()
+      .split("\n")
+      .map(
+        (l) =>
+          JSON.parse(l) as {
+            event: string;
+            payload: { tier: string; outcome: string; reason: string };
+          },
+      );
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.event).toBe("dial_escalation_evaluation");
+    expect(lines[0]?.payload).toEqual({
+      outcome: "declined",
+      reason: "insufficient evidence to raise above rapid (size=- modelTier=-)",
+      tier: "rapid",
+    });
+    expect(lines[1]?.payload.outcome).toBe("escalated");
+    expect(lines[1]?.payload.tier).toBe("standard");
+    expect(lines[0]?.payload.outcome).not.toBe(lines[1]?.payload.outcome);
+  });
+
+  it("stays silent for dial_escalation_evaluation when path is unset (#3319)", () => {
+    const root = freshRoot("run-summary-eval-silent-");
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const emitter = new RunSummaryEmitter({
+      projectRoot: root,
+      sessionId: "s",
+      frameworkVersion: "0.0.0",
+      env: {},
+      gitignoreCovers: () => false,
+      writeStdout: (line) => stdout.push(line),
+      writeStderr: (line) => stderr.push(line),
+    });
+    const result = emitter.emitDialEscalationEvaluation({
+      tier: "rapid",
+      outcome: "declined",
+      reason: "no evidence",
+    });
+    expect(result.emitted).toBe(false);
+    expect(stdout).toEqual([]);
+    expect(stderr).toEqual([]);
+  });
 });

--- a/packages/core/src/run-summary/types.ts
+++ b/packages/core/src/run-summary/types.ts
@@ -23,6 +23,7 @@ export const RUN_SUMMARY_WRITE_WARNING =
 export const RUN_SUMMARY_EVENT_KINDS = [
   "session_start",
   "dial_transition",
+  "dial_escalation_evaluation",
   "check_invocation",
 ] as const;
 
@@ -59,6 +60,16 @@ export interface DialTransitionRunSummaryPayload {
   readonly evidence?: string;
 }
 
+/** One evaluation of escalate-on-evidence (#3319). Absence of this event ≠ declined. */
+export type DialEscalationEvaluationOutcome = "escalated" | "declined";
+
+export interface DialEscalationEvaluationRunSummaryPayload {
+  /** Ceremony depth considered (the start/current tier under evaluation). */
+  readonly tier: string;
+  readonly outcome: DialEscalationEvaluationOutcome;
+  readonly reason: string;
+}
+
 export interface CheckGateOutcome {
   readonly id: string;
   readonly status: "run" | "skipped" | "failed";
@@ -78,6 +89,7 @@ export interface CheckInvocationRunSummaryPayload {
 export type RunSummaryPayload =
   | SessionStartRunSummaryPayload
   | DialTransitionRunSummaryPayload
+  | DialEscalationEvaluationRunSummaryPayload
   | CheckInvocationRunSummaryPayload;
 
 export type RunSummaryLine = RunSummaryBaseFields & {

--- a/packages/core/src/session/session-start.test.ts
+++ b/packages/core/src/session/session-start.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { clearRegistryCache, DEFAULT_EVENT_LOG, readEvents } from "../lifecycle/events.js";
 import type { EnvironmentContext } from "../platform/shell-context.js";
 import { selectCeremonyDepth } from "../policy/ceremony-dial.js";
+import { ENV_RUN_SUMMARY_PATH } from "../run-summary/types.js";
 import type { ResolveUserMdResult } from "../user-config/resolve-user-md.js";
 import type { GitRunResult } from "./git.js";
 import {
@@ -497,5 +498,110 @@ describe("runSessionStart ceremony dial (#3214)", () => {
     expect(result.code).toBe(0);
     expect(result.lines.some((l) => l.includes("coverageDebt.mode=hatch"))).toBe(true);
     expect(result.lines.some((l) => l.includes("reserved"))).toBe(true);
+  });
+});
+
+describe("runSessionStart start-tier provenance + evaluation events (#3319)", () => {
+  it("surfaces external-pin provenance and #3274 bypass with unset-the-pin remediation", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      ceremonyDial: STANDARD_DIAL,
+      ceremonyDialStartTierProvenance: "external-pin",
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const text = result.lines.join("\n");
+    expect(text).toContain("start-tier=standard");
+    expect(text).toContain("provenance=external-pin");
+    expect(text).toContain("#3274 cold-start selection is bypassed (external-pin)");
+    expect(text).toContain("Unset the pin");
+    const dial = result.payload.ceremony_dial as {
+      start_tier: string;
+      start_tier_provenance: string;
+    };
+    expect(dial.start_tier).toBe("standard");
+    expect(dial.start_tier_provenance).toBe("external-pin");
+  });
+
+  it("emits a declined evaluation event when #3274 stays at the cold-start floor", () => {
+    const root = tempRoot();
+    const out = join(root, "summary.jsonl");
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+      ceremonyDialInputs: {
+        taskSize: "S",
+        modelTier: "frontier",
+        projectShape: "project",
+      },
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    expect(result.lines.join("\n")).toContain("provenance=cold-start");
+    const events = readFileSync(out, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as { event: string; payload: Record<string, unknown> });
+    const evals = events.filter((e) => e.event === "dial_escalation_evaluation");
+    expect(evals).toHaveLength(1);
+    expect(evals[0]?.payload.outcome).toBe("declined");
+    expect(evals[0]?.payload.tier).toBe("rapid");
+    expect(String(evals[0]?.payload.reason)).toContain("insufficient evidence");
+  });
+
+  it("emits an escalated evaluation event when provisional evidence raises depth", () => {
+    const root = tempRoot();
+    const out = join(root, "summary.jsonl");
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+      ceremonyDialHints: { verb: "implement" },
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const events = readFileSync(out, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as { event: string; payload: Record<string, unknown> });
+    const evals = events.filter((e) => e.event === "dial_escalation_evaluation");
+    expect(evals).toHaveLength(1);
+    expect(evals[0]?.payload.outcome).toBe("escalated");
+    expect(evals[0]?.payload.tier).toBe("standard");
+  });
+
+  it("emits no evaluation event when the start tier is pinned", () => {
+    const root = tempRoot();
+    const out = join(root, "summary.jsonl");
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+      ceremonyDial: STANDARD_DIAL,
+      ceremonyDialStartTierProvenance: "external-pin",
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const events = readFileSync(out, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as { event: string });
+    expect(events.some((e) => e.event === "session_start")).toBe(true);
+    expect(events.some((e) => e.event === "dial_escalation_evaluation")).toBe(false);
+  });
+
+  it("stays silent when DEFT_RUN_SUMMARY_PATH is unset", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      env: {},
+      ceremonyDialInputs: {
+        taskSize: "S",
+        modelTier: "frontier",
+        projectShape: "project",
+      },
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    expect(existsSync(join(root, ".deft-run-summary.json"))).toBe(false);
   });
 });

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -27,6 +27,7 @@ import {
 } from "../policy/ceremony-dial.js";
 import {
   type CeremonyStartTierProvenance,
+  emitCeremonyDialEscalationEvaluation,
   evaluateSessionStartCeremonyDialEscalation,
   formatCeremonyDialPinBypassLine,
   isCeremonyStartTierPinned,
@@ -1617,13 +1618,13 @@ export function runSessionStart(
       // #3319: evaluate escalate-on-evidence only when #3274 is live. A pin
       // emits nothing so never-evaluated stays distinguishable from declined.
       if (!isCeremonyStartTierPinned(startTierProvenance)) {
-        const evaluation = evaluateSessionStartCeremonyDialEscalation({
-          selection: ceremonyDialSelection,
-        });
-        emitter.emitDialEscalationEvaluation({
-          tier: evaluation.tier,
-          outcome: evaluation.outcome,
-          reason: evaluation.reason,
+        emitCeremonyDialEscalationEvaluation({
+          projectRoot,
+          sessionId: coldSessionId,
+          env: options.env,
+          evaluation: evaluateSessionStartCeremonyDialEscalation({
+            selection: ceremonyDialSelection,
+          }),
         });
       }
     } catch {

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -25,6 +25,13 @@ import {
   resolveCeremonyDial,
   resolveSessionCeremonyDialInputs,
 } from "../policy/ceremony-dial.js";
+import {
+  type CeremonyStartTierProvenance,
+  evaluateSessionStartCeremonyDialEscalation,
+  formatCeremonyDialPinBypassLine,
+  isCeremonyStartTierPinned,
+  resolveCeremonyStartTierProvenance,
+} from "../policy/ceremony-dial-escalation.js";
 import { maybeFormatCoverageCheckResumeDisclosure } from "../policy/coverage-debt.js";
 import {
   DEFT_DIRECTIVE_DISABLE_FLAG_NAME,
@@ -249,6 +256,11 @@ export interface SessionStartOptions {
    * loads plan.policy.ceremonyDial and applies inputs (after provisional fill).
    */
   readonly ceremonyDial?: CeremonyDialSelection;
+  /**
+   * #3319: start-tier provenance hint. CLI `--ceremony-depth` / harness pin
+   * should pass `external-pin`. Policy override is inferred as `operator`.
+   */
+  readonly ceremonyDialStartTierProvenance?: CeremonyStartTierProvenance;
   /**
    * #3282: done-gate toolchain preflight seams (tests inject result or probe).
    * When omitted, runs live preflight after verify_tools on cold path.
@@ -1095,6 +1107,11 @@ export function runSessionStart(
     });
   const ceremonyDialSelection: CeremonyDialSelection =
     options.ceremonyDial ?? resolveCeremonyDial(projectRoot, { inputs: resolvedDialInputs });
+  const startTierProvenance = resolveCeremonyStartTierProvenance({
+    selection: ceremonyDialSelection,
+    injectedSelection: options.ceremonyDial !== undefined,
+    hint: options.ceremonyDialStartTierProvenance,
+  });
   const effectiveDeferrals = mergeCeremonyDialDeferrals(deferrals, ceremonyDialSelection);
   const skipFatPath = ceremonyDialSelection.profile.skipFatPath;
 
@@ -1137,7 +1154,15 @@ export function runSessionStart(
     instant,
   );
   const lines: string[] = [];
-  lines.push(formatCeremonyDialStatusLine(ceremonyDialSelection));
+  lines.push(
+    formatCeremonyDialStatusLine(ceremonyDialSelection, {
+      startTierProvenance,
+    }),
+  );
+  const pinBypassLine = formatCeremonyDialPinBypassLine(startTierProvenance);
+  if (pinBypassLine !== null) {
+    lines.push(pinBypassLine);
+  }
   if (provisionalDial.reasons.length > 0 && options.ceremonyDial === undefined) {
     lines.push(`[deft ceremony-dial] provisional: ${provisionalDial.reasons.join("; ")}`);
   }
@@ -1504,6 +1529,8 @@ export function runSessionStart(
   const coldSessionId = (options.newSessionId ?? randomUUID)();
   const dialDict = {
     ...ceremonyDialToDict(ceremonyDialSelection),
+    start_tier: ceremonyDialSelection.depth,
+    start_tier_provenance: startTierProvenance,
     provisional: {
       taskSize: provisionalDial.taskSize,
       modelTier: provisionalDial.modelTier,
@@ -1587,6 +1614,18 @@ export function runSessionStart(
             }
           : {}),
       });
+      // #3319: evaluate escalate-on-evidence only when #3274 is live. A pin
+      // emits nothing so never-evaluated stays distinguishable from declined.
+      if (!isCeremonyStartTierPinned(startTierProvenance)) {
+        const evaluation = evaluateSessionStartCeremonyDialEscalation({
+          selection: ceremonyDialSelection,
+        });
+        emitter.emitDialEscalationEvaluation({
+          tier: evaluation.tier,
+          outcome: evaluation.outcome,
+          reason: evaluation.reason,
+        });
+      }
     } catch {
       // fail-open
     }


### PR DESCRIPTION
## Summary

Emit a run-summary event for every ceremony-dial escalation evaluation (tier, outcome `escalated|declined`, reason) so a declined evaluation is distinct from never-evaluated. Surface start-tier provenance on the session-start status line. When the dial is externally or operator pinned, session:start states that #3274 cold-start selection is bypassed and names unset-the-pin as remediation.

Emitter stays fail-open when `DEFT_RUN_SUMMARY_PATH` is unset. Escalation thresholds and the default tier are unchanged. This is observability, not a behavioural revert of #3274.

## Related Issues

Closes #3319

Refs #3282, #3274, #3263, #3214

## Checklist

- [x] `/deft:change` — N/A: solo framework story fully covered by `task check` (not a cross-cutting architecture change)
- [x] `CHANGELOG.md` — [Unreleased] entry cites #3319
- [x] `ROADMAP.md` — N/A (bug fix, not a tracked ROADMAP item)
- [x] Tests pass locally (`task check` green)

## Test plan

- [x] `pnpm exec vitest run packages/core/src/run-summary packages/core/src/session`
- [x] Targeted ceremony-dial escalation + session-start pin-disclosure tests
- [x] Full `task check`
