### PR TITLE
fix(install): plant consumer-deposit marker on Go deposits (#3331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Go installer plants the #3324 consumer-deposit marker on `.deft/core` and `--legacy-layout` `deft/` (#3331).** After vendor or upgrade, `deft-install` writes `.deft-consumer-deposit` into the deposit root so `engine:invoke` does not treat a source-looking tarball as buildable framework source. Engine dispatch honor stays on #3324. Genuine source checkouts are unchanged. Refs #3324, #3329, #3282, #2022.
+
 - **Run-summary emits a tool/turn denominator so #3286 Later share is evaluable (#3320).** The #3282 stream now carries `total_tool_turns` (event `tool_turn_denominator`, or harness env `DEFT_TOTAL_TOOL_TURNS` stamped onto production events). `eval:report` prints ritual+gate share when that field is present and **trigger unevaluable** when it is absent — it does not invent a ratio from check counts. Emitter stays fail-open when `DEFT_RUN_SUMMARY_PATH` is unset. Closes #3320. Refs #3286, #3282, #3265.
 
 - **Ceremony-dial escalation evaluations emit a run-summary event (#3319).** Every evaluation records tier, outcome (`escalated`|`declined`), and reason so a decline is distinct from never-evaluated. Session-start surfaces start-tier provenance; an external or operator pin states that #3274 cold-start selection is bypassed and names unset-the-pin as remediation. Emitter stays fail-open when `DEFT_RUN_SUMMARY_PATH` is unset. Does not change thresholds or the default tier. Closes #3319. Refs #3282, #3274, #3263, #3214.

--- a/cmd/deft-install/deposit.go
+++ b/cmd/deft-install/deposit.go
@@ -68,6 +68,16 @@ const frameworkSelfTestRelPath = ".deft/core/tests"
 // to pruneFrameworkSelfTests (#1474, which prunes the Python self-test suite).
 const vendoredTSPackagesRelPath = ".deft/core/packages"
 
+// consumerDepositMarkerFile is the #3324 identity file engine-invoke honors
+// at DEFT_ROOT. The installer plants it after every vendor/update so a
+// source-looking tarball under .deft/core or legacy deft/ is not classified
+// as buildable framework source (#3331). Content matches the #3324 fixture
+// ("1\n") so hasConsumerDepositMarker treats presence as sufficient.
+const (
+	consumerDepositMarkerFile    = ".deft-consumer-deposit"
+	consumerDepositMarkerContent = "1\n"
+)
+
 // vendoredTSTestFileRe matches a basename that vitest's default include glob
 // (**/*.{test,spec}.?(c|m)[jt]s?(x)) would discover as a test file:
 // *.test.{ts,tsx,js,jsx,cts,mts,cjs,mjs} and the *.spec.* equivalents,
@@ -401,6 +411,33 @@ func depositNeutralization(w *Wizard, projectDir string) {
 	if _, err := pruneVendoredTSTests(w, projectDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not prune vendored TypeScript test files: %v\n", err)
 	}
+}
+
+// plantConsumerDepositMarker writes the #3324 consumer-deposit marker into
+// deftDir (canonical .deft/core or --legacy-layout deft/). Fail-closed: an
+// empty or missing deposit dir is an error so install cannot succeed unmarked.
+// Idempotent when the file already has the expected contents. Does not touch
+// the consumer project root or a genuine source checkout (#3331).
+func plantConsumerDepositMarker(w *Wizard, deftDir string) (bool, error) {
+	if strings.TrimSpace(deftDir) == "" {
+		return false, fmt.Errorf("plantConsumerDepositMarker: deftDir must not be empty")
+	}
+	info, err := os.Stat(deftDir)
+	if err != nil {
+		return false, fmt.Errorf("plantConsumerDepositMarker: deposit dir %s: %w", deftDir, err)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("plantConsumerDepositMarker: %s is not a directory", deftDir)
+	}
+	path := filepath.Join(deftDir, consumerDepositMarkerFile)
+	if data, readErr := os.ReadFile(path); readErr == nil && string(data) == consumerDepositMarkerContent {
+		return false, nil
+	}
+	if err := os.WriteFile(path, []byte(consumerDepositMarkerContent), 0o644); err != nil {
+		return false, fmt.Errorf("could not plant consumer-deposit marker: %w", err)
+	}
+	w.printf("Planted consumer-deposit marker (%s) so engine:invoke uses the global CLI (#3331).\n", consumerDepositMarkerFile)
+	return true, nil
 }
 
 // pruneFrameworkSelfTests removes the vendored framework self-test suite

--- a/cmd/deft-install/deposit_test.go
+++ b/cmd/deft-install/deposit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -1175,6 +1176,167 @@ func TestCoreGuard_GithooksClassifyInstallerManaged(t *testing.T) {
 	if guardWouldFail(changed) {
 		t.Error("guard must PASS a framework-deposit PR mixing .deft/core/** with .githooks/* (#1478)")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Consumer-deposit marker (#3331)
+// ---------------------------------------------------------------------------
+
+func assertConsumerDepositMarker(t *testing.T, deftDir string) {
+	t.Helper()
+	path := filepath.Join(deftDir, consumerDepositMarkerFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("deposit missing %s: %v", consumerDepositMarkerFile, err)
+	}
+	if string(data) != consumerDepositMarkerContent {
+		t.Fatalf("marker content = %q, want %q", string(data), consumerDepositMarkerContent)
+	}
+}
+
+func TestPlantConsumerDepositMarker_CanonicalCore(t *testing.T) {
+	tmp := t.TempDir()
+	core := filepath.Join(tmp, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Source-looking payload (GitHub tarball): root package.json + packages/cli.
+	if err := os.WriteFile(filepath.Join(core, "package.json"), []byte(`{"name":"looks-like-source","scripts":{"build":"tsc -b"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(core, "packages", "cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := plantConsumerDepositMarker(newDepositWizard(), core)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true on first plant")
+	}
+	assertConsumerDepositMarker(t, core)
+	if pathExists(filepath.Join(tmp, consumerDepositMarkerFile)) {
+		t.Error("must not plant the marker at the consumer project root")
+	}
+}
+
+func TestPlantConsumerDepositMarker_LegacyDeft(t *testing.T) {
+	tmp := t.TempDir()
+	legacy := filepath.Join(tmp, LegacyFrameworkSubdir)
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "package.json"), []byte(`{"name":"looks-like-source","scripts":{"build":"tsc -b"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := plantConsumerDepositMarker(newDepositWizard(), legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true on first plant into legacy deft/")
+	}
+	assertConsumerDepositMarker(t, legacy)
+	if pathExists(filepath.Join(tmp, consumerDepositMarkerFile)) {
+		t.Error("must not plant the marker at the consumer project root")
+	}
+}
+
+func TestPlantConsumerDepositMarker_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	core := filepath.Join(tmp, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	w := newDepositWizard()
+	if _, err := plantConsumerDepositMarker(w, core); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := plantConsumerDepositMarker(w, core)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("expected changed=false when the marker is already present")
+	}
+	assertConsumerDepositMarker(t, core)
+}
+
+func TestPlantConsumerDepositMarker_RejectsEmptyDeftDir(t *testing.T) {
+	if _, err := plantConsumerDepositMarker(newDepositWizard(), ""); err == nil {
+		t.Fatal("empty deftDir must fail closed")
+	}
+}
+
+func TestPlantConsumerDepositMarker_RejectsMissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-deposit")
+	if _, err := plantConsumerDepositMarker(newDepositWizard(), missing); err == nil {
+		t.Fatal("missing deposit dir must fail closed")
+	}
+}
+
+func TestPlantConsumerDepositMarker_HonoredByEngineInvoke(t *testing.T) {
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tests run from cmd/deft-install; engine-invoke lives at repo-root/tasks.
+	invoke := filepath.Join(filepath.Dir(filepath.Dir(root)), "tasks", "engine-invoke.cjs")
+	if _, err := os.Stat(invoke); err != nil {
+		t.Skip("engine-invoke.cjs not found; #3324 honor path not in this tree")
+	}
+
+	tmp := t.TempDir()
+	legacy := filepath.Join(tmp, LegacyFrameworkSubdir)
+	if err := os.MkdirAll(filepath.Join(legacy, "packages", "cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "package.json"), []byte(`{"name":"looks-like-source","scripts":{"build":"tsc -b"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "packages", "cli", "package.json"), []byte(`{"name":"@deftai/directive-cli"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := exec.Command("node", invoke, "is-buildable-source", legacy)
+	if out, err := before.CombinedOutput(); err != nil {
+		t.Fatalf("unmarked legacy deft/ must look buildable before plant; err=%v out=%s", err, out)
+	}
+
+	if _, err := plantConsumerDepositMarker(newDepositWizard(), legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	marker := exec.Command("node", invoke, "deposit-marker", legacy)
+	if out, err := marker.CombinedOutput(); err != nil {
+		t.Fatalf("engine-invoke must honor planted marker; err=%v out=%s", err, out)
+	}
+	buildable := exec.Command("node", invoke, "is-buildable-source", legacy)
+	if out, err := buildable.CombinedOutput(); err == nil {
+		t.Fatalf("marked legacy deft/ must not be buildable source; out=%s", out)
+	}
+}
+
+func TestPlantConsumerDepositMarker_RepairsWrongContent(t *testing.T) {
+	tmp := t.TempDir()
+	core := filepath.Join(tmp, ".deft", "core")
+	if err := os.MkdirAll(core, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(core, consumerDepositMarkerFile)
+	if err := os.WriteFile(stale, []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := plantConsumerDepositMarker(newDepositWizard(), core)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("expected changed=true when repairing stale marker content")
+	}
+	assertConsumerDepositMarker(t, core)
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/deft-install/e2e_upgrade_test.go
+++ b/cmd/deft-install/e2e_upgrade_test.go
@@ -116,6 +116,9 @@ func TestEndToEnd_VendoredUpgrade_DoctorInvariants(t *testing.T) {
 	if _, err := WriteInstallManifest(result.ProjectDir, result.DeftDir, fields); err != nil {
 		t.Fatalf("WriteInstallManifest: %v", err)
 	}
+	if _, err := plantConsumerDepositMarker(w, result.DeftDir); err != nil {
+		t.Fatalf("plantConsumerDepositMarker: %v", err)
+	}
 	if err := WriteAgentsMD(w, result.ProjectDir); err != nil {
 		t.Fatalf("WriteAgentsMD: %v", err)
 	}
@@ -162,6 +165,9 @@ func TestEndToEnd_VendoredUpgrade_DoctorInvariants(t *testing.T) {
 	if bare == "0.0.0-dev" {
 		t.Errorf("vbrief/.deft-version was not regenerated (still the stale 0.0.0-dev)")
 	}
+
+	// #3331: file-swap upgrade must leave the consumer-deposit marker in core.
+	assertConsumerDepositMarker(t, core)
 }
 
 // deriveTagFromManifestForTest extracts the bare semver the doctor's

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -414,6 +414,16 @@ func install(debug bool, branch string, legacyLayout bool, nonInteractive, upgra
 		removeOrphanDeftVersion(w, result)
 	}
 
+	// #3331: plant the #3324 consumer-deposit marker on the just-written
+	// payload (canonical .deft/core or --legacy-layout deft/) so engine:invoke
+	// does not treat a source-looking tarball as buildable framework source.
+	// After VendorDeft / UpdateDeft so a file-swap cannot wipe the marker.
+	// Fail-closed: an unmarked deposit is not a successful install.
+	if _, err := plantConsumerDepositMarker(w, result.DeftDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
 	if err := WriteAgentsMD(w, result.ProjectDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1


### PR DESCRIPTION
## Summary

Go installer residual of #3324: after vendor or upgrade, `deft-install` plants `.deft-consumer-deposit` into the deposit root for both canonical `.deft/core` and `--legacy-layout` `deft/`.

`engine:invoke` already honors that marker (PR #3329 / #3324). This PR does not rewrite dispatch, `tasks/engine.yml`, or `tasks/engine-invoke.cjs`. A genuine source checkout is unchanged.

## Related Issues

Closes #3331
Refs #3324 #3329 #3282 #2022

## Checklist

- [x] `/deft:change` -- N/A (2 product files + tests + CHANGELOG; not cross-cutting)
- [x] `CHANGELOG.md` -- added entry under `[Unreleased]`
- [x] `ROADMAP.md` -- N/A
- [x] Tests pass locally (`go test ./cmd/deft-install/`)

## Test plan

- `go test ./cmd/deft-install/` pins plant on canonical core, legacy `deft/`, idempotence, fail-closed missing dir, stale-content repair, upgrade re-plant, and `engine-invoke` honor of the planted file.