### PR TITLE
fix(ci): treat unclaimed as no runner_name and add merge-gate twin (#3340)

### DIFF
--- a/.github/scripts/cancel-queued-ci-primary.py
+++ b/.github/scripts/cancel-queued-ci-primary.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Cancel still-queued Blacksmith primary jobs before GH-hosted failover (#2672 / #3168).
+"""Cancel still-unclaimed Blacksmith primary jobs before GH-hosted failover (#2672 / #3168 / #3340).
 
-Only cancels jobs that have not claimed a runner (status queued, or equivalent
-unclaimed waiting state). Never cancels in_progress jobs with a runner (#2652).
+Unclaimed means no runner_name. started_at or reusable-workflow caller
+in_progress is not a claim. Never cancels a job with runner_name (#2652).
 Jobs already cancelled without a claim need no cancel — failover is armed instead.
 """
 
@@ -15,15 +15,24 @@ import sys
 from typing import Any
 
 
-def is_cancelable_unclaimed(job: dict[str, Any]) -> bool:
-    """True when the job is still waiting for a runner and safe to cancel."""
-    status = str(job.get("status") or "")
-    started = job.get("started_at")
-    runner = job.get("runner_name")
-    if started or runner:
+def runner_claimed(job: dict[str, Any] | None) -> bool:
+    """True only when Actions assigned a runner_name. started_at is not a claim (#3340)."""
+    if job is None:
         return False
-    # queued is the primary arm path; waiting/requested are unclaimed equivalents.
-    return status in ("queued", "waiting", "requested")
+    runner = job.get("runner_name")
+    if runner is None:
+        return False
+    return bool(str(runner).strip())
+
+
+def is_cancelable_unclaimed(job: dict[str, Any]) -> bool:
+    """True when the job has no runner_name and is still waiting (#3340 / #2652)."""
+    status = str(job.get("status") or "")
+    if runner_claimed(job):
+        return False
+    # in_progress without runner_name is still unclaimed (reusable-workflow caller
+    # or started_at-only queue sit). Never cancel a completed job.
+    return status in ("queued", "waiting", "requested", "in_progress")
 
 
 def cancel_matching_primaries(

--- a/.github/scripts/classify-ci-job-state.py
+++ b/.github/scripts/classify-ci-job-state.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Classify a CI job's queue/start state for #2672 / #3168 capacity watchdog.
+"""Classify a CI job's queue/start state for #2672 / #3168 / #3340 capacity watchdog.
 
 States (stdout, one line):
   missing              — no job matching needle in the jobs payload
-  queued               — still queued with no runner claimed
-  started              — in_progress or has started_at/runner_name (no failover; #2652)
+  queued               — still unclaimed (no runner_name), including started_at-only
+  started              — runner_name set (no failover; #2652)
   done                 — completed after a runner claim, or completed success/failure
   cancelled_unclaimed  — completed cancelled/skipped with no runner ever claimed
                          (capacity death — arm failover like queued past budget; #3168)
@@ -17,6 +17,42 @@ import sys
 from typing import Any
 
 
+def runner_claimed(job: dict[str, Any] | None) -> bool:
+    """True only when Actions assigned a runner_name. started_at is not a claim (#3340)."""
+    if job is None:
+        return False
+    runner = job.get("runner_name")
+    if runner is None:
+        return False
+    return bool(str(runner).strip())
+
+
+def matching_jobs(needle: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Jobs whose name contains needle (case-insensitive)."""
+    needle_l = needle.lower()
+    return [
+        j
+        for j in (payload.get("jobs") or [])
+        if needle_l in str(j.get("name") or "").lower()
+    ]
+
+
+def select_suite_job(needle: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Prefer the reusable-workflow inner `/run` job over the caller wrapper (#3340)."""
+    matches = matching_jobs(needle, payload)
+    if not matches:
+        return None
+    inner = [j for j in matches if " / " in str(j.get("name") or "")]
+    pool = inner or matches
+    claimed = [j for j in pool if runner_claimed(j)]
+    if claimed:
+        return claimed[0]
+    completed = [j for j in pool if str(j.get("status") or "") == "completed"]
+    if completed:
+        return completed[0]
+    return pool[0]
+
+
 def classify_job(match: dict[str, Any] | None) -> str:
     """Return the capacity-watchdog state for a single Actions job object."""
     if match is None:
@@ -24,9 +60,7 @@ def classify_job(match: dict[str, Any] | None) -> str:
 
     status = str(match.get("status") or "")
     conclusion = str(match.get("conclusion") or "")
-    started = match.get("started_at")
-    runner = match.get("runner_name")
-    claimed = bool(started or runner)
+    claimed = runner_claimed(match)
 
     if status == "completed":
         # Capacity death: cancelled/skipped without ever claiming a runner (#3168).
@@ -35,26 +69,18 @@ def classify_job(match: dict[str, Any] | None) -> str:
             return "cancelled_unclaimed"
         return "done"
 
-    if status == "in_progress" or claimed:
+    if claimed:
         # True execution start — never auto-failover (#2652).
         return "started"
 
-    if status == "queued":
-        return "queued"
-
-    # waiting / requested / unknown without a claim → still capacity-stalled.
-    return "queued" if not claimed else "started"
+    # queued / in_progress / waiting / requested without runner_name are unclaimed.
+    # started_at or reusable-workflow caller in_progress is not a claim (#3340).
+    return "queued"
 
 
 def classify_jobs_payload(needle: str, payload: dict[str, Any]) -> str:
-    """Find first job whose name contains needle (case-insensitive) and classify it."""
-    needle_l = needle.lower()
-    jobs = payload.get("jobs") or []
-    match = next(
-        (j for j in jobs if needle_l in str(j.get("name") or "").lower()),
-        None,
-    )
-    return classify_job(match)
+    """Classify the authoritative matching job (inner `/run` preferred)."""
+    return classify_job(select_suite_job(needle, payload))
 
 
 def main() -> None:

--- a/.github/scripts/resolve-ci-authoritative-lane.py
+++ b/.github/scripts/resolve-ci-authoritative-lane.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Resolve the authoritative CI lane result for a required aggregator job (#2672 / #3168).
+"""Resolve the authoritative CI lane result for a required aggregator job (#2672 / #3168 / #3340).
 
 Env:
   REPO, RUN_ID, GH_TOKEN (via gh), WANT_FAILOVER, FAILOVER_RESULT,
@@ -18,6 +18,42 @@ import os
 import subprocess
 import sys
 import time
+
+
+def runner_claimed(job: dict | None) -> bool:
+    """True only when Actions assigned a runner_name. started_at is not a claim (#3340)."""
+    if job is None:
+        return False
+    runner = job.get("runner_name")
+    if runner is None:
+        return False
+    return bool(str(runner).strip())
+
+
+def select_primary_job(needle: str, payload: dict) -> dict | None:
+    """Prefer the reusable-workflow inner `/run` job over the caller wrapper (#3340)."""
+    matches = [
+        job
+        for job in (payload.get("jobs") or [])
+        if needle in str(job.get("name") or "").lower()
+    ]
+    if not matches:
+        return None
+    inner = [job for job in matches if " / " in str(job.get("name") or "")]
+    pool = inner or matches
+    claimed = [job for job in pool if runner_claimed(job)]
+    if claimed:
+        return claimed[0]
+    completed = [job for job in pool if str(job.get("status") or "") == "completed"]
+    if completed:
+        return completed[0]
+    return pool[0]
+
+
+def is_capacity_death(job: dict) -> bool:
+    """Cancelled/skipped without a runner_name is capacity death (#3168 / #3340)."""
+    conclusion = str(job.get("conclusion") or "")
+    return conclusion in ("cancelled", "skipped") and not runner_claimed(job)
 
 
 def gh_api(path: str) -> dict:
@@ -50,14 +86,7 @@ def main() -> int:
     deadline = time.time() + 6 * 60 * 60
     while time.time() < deadline:
         payload = gh_api(f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
-        match = next(
-            (
-                job
-                for job in (payload.get("jobs") or [])
-                if needle in str(job.get("name") or "").lower()
-            ),
-            None,
-        )
+        match = select_primary_job(needle, payload)
         if match is None:
             time.sleep(15)
             continue
@@ -74,11 +103,11 @@ def main() -> int:
                 print(f"Authoritative {label} green via Blacksmith primary (#2672)")
                 return 0
             # Capacity-death without failover arm is a graph bug (#3168) — fail loud.
-            if conclusion in ("cancelled", "skipped") and not (started or runner):
+            if is_capacity_death(match):
                 print(
                     f"::error::{label} Blacksmith primary {conclusion} without a "
                     f"runner claim and failover was not armed — capacity-watchdog/"
-                    f"capacity-arm should have set WANT_FAILOVER (#3168)",
+                    f"capacity-arm should have set WANT_FAILOVER (#3168/#3340)",
                     file=sys.stderr,
                 )
                 return 1

--- a/.github/scripts/test_cancel_queued_ci_primary.py
+++ b/.github/scripts/test_cancel_queued_ci_primary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit tests for cancel-queued-ci-primary.py (#2672 / #3168)."""
+"""Unit tests for cancel-queued-ci-primary.py (#2672 / #3168 / #3340)."""
 
 from __future__ import annotations
 
@@ -43,6 +43,40 @@ class TestIsCancelable(unittest.TestCase):
                 {
                     "status": "in_progress",
                     "started_at": "2026-08-06T12:00:00Z",
+                    "runner_name": "blacksmith-abc",
+                }
+            )
+        )
+
+    def test_in_progress_without_runner_is_cancelable(self) -> None:
+        """#3340 — started_at without runner_name is still unclaimed."""
+        self.assertTrue(
+            mod.is_cancelable_unclaimed(
+                {
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                }
+            )
+        )
+
+    def test_queued_with_started_at_no_runner_is_cancelable(self) -> None:
+        self.assertTrue(
+            mod.is_cancelable_unclaimed(
+                {
+                    "status": "queued",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                }
+            )
+        )
+
+    def test_claimed_queued_with_runner_not_cancelable(self) -> None:
+        self.assertFalse(
+            mod.is_cancelable_unclaimed(
+                {
+                    "status": "queued",
+                    "started_at": None,
                     "runner_name": "blacksmith-abc",
                 }
             )
@@ -112,6 +146,40 @@ class TestCancelMatching(unittest.TestCase):
         self.assertEqual(cancelled, [101])
         self.assertEqual(len(calls), 1)
         self.assertIn("repos/deftai/directive/actions/jobs/101/cancel", calls[0][-1])
+
+    def test_cancels_started_at_only_in_progress(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(argv: list[str], check: bool = False) -> Any:
+            calls.append(list(argv))
+            return None
+
+        payload = {
+            "jobs": [
+                {
+                    "id": 201,
+                    "name": "Merge gate (Blacksmith primary)",
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                },
+                {
+                    "id": 202,
+                    "name": "Merge gate (Blacksmith primary)",
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:21:00Z",
+                    "runner_name": "blacksmith-abc",
+                },
+            ]
+        }
+        cancelled = mod.cancel_matching_primaries(
+            "merge gate (blacksmith primary)",
+            payload,
+            repo="deftai/directive",
+            runner=fake_run,
+        )
+        self.assertEqual(cancelled, [201])
+        self.assertEqual(len(calls), 1)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_classify_ci_job_state.py
+++ b/.github/scripts/test_classify_ci_job_state.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit tests for classify-ci-job-state.py (#2672 / #3168)."""
+"""Unit tests for classify-ci-job-state.py (#2672 / #3168 / #3340)."""
 
 from __future__ import annotations
 
@@ -56,14 +56,89 @@ class TestClassifyJob(unittest.TestCase):
         }
         self.assertEqual(mod.classify_job(job), "started")
 
-    def test_started_from_started_at_alone(self) -> None:
+    def test_started_at_alone_is_unclaimed(self) -> None:
+        """#3340 — started_at without runner_name is still unclaimed."""
         job = {
             "name": "TypeScript (Blacksmith primary) / run",
             "status": "in_progress",
             "started_at": "2026-08-06T12:00:00Z",
             "runner_name": None,
         }
-        self.assertEqual(mod.classify_job(job), "started")
+        self.assertEqual(mod.classify_job(job), "queued")
+
+    def test_queued_with_started_at_no_runner_is_unclaimed(self) -> None:
+        job = {
+            "name": "Merge gate (Blacksmith primary)",
+            "status": "queued",
+            "started_at": "2026-08-13T15:20:00Z",
+            "runner_name": None,
+        }
+        self.assertEqual(mod.classify_job(job), "queued")
+
+    def test_empty_runner_name_is_unclaimed(self) -> None:
+        job = {
+            "name": "Go (Blacksmith primary) / run",
+            "status": "in_progress",
+            "started_at": "2026-08-13T15:20:00Z",
+            "runner_name": "  ",
+        }
+        self.assertEqual(mod.classify_job(job), "queued")
+        self.assertFalse(mod.runner_claimed(job))
+
+    def test_reusable_caller_in_progress_without_inner_runner_is_unclaimed(self) -> None:
+        """Caller in_progress is not a claim; inner still waiting → queued (#3340)."""
+        payload = {
+            "jobs": [
+                {
+                    "name": "TypeScript (Blacksmith primary)",
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                },
+                {
+                    "name": "TypeScript (Blacksmith primary) / run",
+                    "status": "queued",
+                    "started_at": None,
+                    "runner_name": None,
+                },
+            ]
+        }
+        self.assertEqual(
+            mod.classify_jobs_payload("typescript (blacksmith primary)", payload),
+            "queued",
+        )
+
+    def test_reusable_inner_runner_is_claimed(self) -> None:
+        payload = {
+            "jobs": [
+                {
+                    "name": "TypeScript (Blacksmith primary)",
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                },
+                {
+                    "name": "TypeScript (Blacksmith primary) / run",
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:21:00Z",
+                    "runner_name": "blacksmith-abc",
+                },
+            ]
+        }
+        self.assertEqual(
+            mod.classify_jobs_payload("typescript (blacksmith primary)", payload),
+            "started",
+        )
+
+    def test_cancelled_with_started_at_no_runner_is_capacity_death(self) -> None:
+        job = {
+            "name": "Merge gate (Blacksmith primary)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "started_at": "2026-08-13T15:20:00Z",
+            "runner_name": None,
+        }
+        self.assertEqual(mod.classify_job(job), "cancelled_unclaimed")
 
     def test_done_success(self) -> None:
         job = {

--- a/.github/scripts/test_resolve_ci_authoritative_lane.py
+++ b/.github/scripts/test_resolve_ci_authoritative_lane.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Unit tests for resolve-ci-authoritative-lane.py helpers (#3340)."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+def _load():
+    path = Path(__file__).with_name("resolve-ci-authoritative-lane.py")
+    spec = importlib.util.spec_from_file_location("resolve_ci_authoritative_lane", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+class TestRunnerClaimed(unittest.TestCase):
+    def test_started_at_alone_is_not_claimed(self) -> None:
+        self.assertFalse(
+            mod.runner_claimed(
+                {
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                }
+            )
+        )
+
+    def test_runner_name_is_claimed(self) -> None:
+        self.assertTrue(
+            mod.runner_claimed(
+                {
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": "blacksmith-abc",
+                }
+            )
+        )
+
+
+class TestCapacityDeath(unittest.TestCase):
+    def test_cancelled_with_started_at_no_runner(self) -> None:
+        self.assertTrue(
+            mod.is_capacity_death(
+                {
+                    "status": "completed",
+                    "conclusion": "cancelled",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                }
+            )
+        )
+
+    def test_cancelled_after_claim_is_not_capacity_death(self) -> None:
+        self.assertFalse(
+            mod.is_capacity_death(
+                {
+                    "status": "completed",
+                    "conclusion": "cancelled",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": "blacksmith-abc",
+                }
+            )
+        )
+
+
+class TestSelectPrimary(unittest.TestCase):
+    def test_prefers_inner_run_job(self) -> None:
+        payload = {
+            "jobs": [
+                {
+                    "name": "Merge gate (Blacksmith primary)",
+                    "status": "in_progress",
+                    "started_at": "2026-08-13T15:20:00Z",
+                    "runner_name": None,
+                },
+                {
+                    "name": "Merge gate (Blacksmith primary) / run",
+                    "status": "queued",
+                    "started_at": None,
+                    "runner_name": None,
+                },
+            ]
+        }
+        match = mod.select_primary_job("merge gate (blacksmith primary)", payload)
+        assert match is not None
+        self.assertIn(" / run", match["name"])
+        self.assertFalse(mod.runner_claimed(match))
+
+    def test_prefers_claimed_inner(self) -> None:
+        payload = {
+            "jobs": [
+                {
+                    "name": "Go (Blacksmith primary)",
+                    "status": "in_progress",
+                    "runner_name": None,
+                },
+                {
+                    "name": "Go (Blacksmith primary) / run",
+                    "status": "in_progress",
+                    "runner_name": "blacksmith-abc",
+                },
+            ]
+        }
+        match = mod.select_primary_job("go (blacksmith primary)", payload)
+        assert match is not None
+        self.assertEqual(match["runner_name"], "blacksmith-abc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ env:
   # tag was force-moved (supply-chain compromise signal).
   GHX_INSTALL_SH_SHA256: 08c768feb6d2bc485079898f7e76c2b07576cbb1188a356acf99dac0fc55d1cb
   GHX_INSTALL_PS1_SHA256: 5f67eab68970ecc55bb0fc1b8399ba6f3ce4b2aadeee39255d628e96d187a5ed
-  # #2672 / #3168: Blacksmith capacity-stall budget before GH-hosted failover.
-  # Arm when primary is still queued/missing past budget OR cancelled/skipped
-  # with no runner claimed. in_progress execution hangs are NOT failed over (#2652).
+  # #2672 / #3168 / #3340: Blacksmith capacity-stall budget before GH-hosted failover.
+  # Unclaimed = no runner_name (started_at or reusable-workflow caller in_progress
+  # is not a claim). Arm when a required primary is still unclaimed past budget
+  # OR cancelled/skipped with no runner. Claimed runners are NOT failed over (#2652).
   CI_CAPACITY_STALL_SECONDS: "1200"
   CI_CAPACITY_POLL_SECONDS: "30"
 
@@ -43,17 +44,19 @@ jobs:
   # -------------------------------------------------------------------------
   # Job / check name map (#3168) — branch-protection SoT is AGGREGATORS only.
   #
-  # | Role        | Workflow job id   | Display / check name                    | Required? |
-  # |-------------|-------------------|-----------------------------------------|-----------|
-  # | Primary TS  | ts-primary        | TypeScript (Blacksmith primary)         | no        |
-  # | Primary Go  | go-primary        | Go (Blacksmith primary)                 | no        |
-  # | Watchdog    | capacity-watchdog | Capacity watchdog                       | no        |
-  # | Arm decision| capacity-arm      | Capacity arm (failover decision)        | no        |
-  # | Failover TS | ts-failover       | TypeScript (GH-hosted failover)         | no        |
-  # | Failover Go | go-failover       | Go (GH-hosted failover)                 | no        |
-  # | Aggregator  | ts                | TypeScript (build + lint + test)        | YES       |
-  # | Aggregator  | go                | Go (test + build)                       | YES       |
-  # | Merge gate  | merge-gate        | Merge gate (task check)                 | (policy)  |
+  # | Role        | Workflow job id      | Display / check name                    | Required? |
+  # |-------------|----------------------|-----------------------------------------|-----------|
+  # | Primary TS  | ts-primary           | TypeScript (Blacksmith primary)         | no        |
+  # | Primary Go  | go-primary           | Go (Blacksmith primary)                 | no        |
+  # | Primary MG  | merge-gate-primary   | Merge gate (Blacksmith primary)         | no        |
+  # | Watchdog    | capacity-watchdog    | Capacity watchdog                       | no        |
+  # | Arm decision| capacity-arm         | Capacity arm (failover decision)        | no        |
+  # | Failover TS | ts-failover          | TypeScript (GH-hosted failover)         | no        |
+  # | Failover Go | go-failover          | Go (GH-hosted failover)                 | no        |
+  # | Failover MG | merge-gate-failover  | Merge gate (GH-hosted failover)         | no        |
+  # | Aggregator  | ts                   | TypeScript (build + lint + test)        | YES       |
+  # | Aggregator  | go                   | Go (test + build)                       | YES       |
+  # | Aggregator  | merge-gate           | Merge gate (task check)                 | YES       |
   #
   # Primary/failover lane names must never be branch-protection required checks.
   # -------------------------------------------------------------------------
@@ -77,11 +80,52 @@ jobs:
       suite: go
       runner: blacksmith-4vcpu-ubuntu-2404
 
+  merge-gate-primary:
+    name: Merge gate (Blacksmith primary)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch for relocation gates
+        run: git fetch origin master:refs/remotes/origin/master
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.52.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go (toolchain gate in task check)
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Setup uv (toolchain gate in task check)
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: task check:merge (merge chokepoint SoT — #1704)
+        run: task check:merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   # -------------------------------------------------------------------------
   # Capacity watchdog: GH-hosted, independent of primary job cancellation
   # (no needs: on primaries; cancel API targets only Blacksmith primary names).
   # ~20m budget for queued/missing; immediate arm on cancelled_unclaimed (#3168).
-  # Never failover in_progress with a claimed runner (#2652).
+  # Never skip while TS, Go, or merge-gate is unclaimed (#3340).
+  # Never failover a job with runner_name (#2652).
   # -------------------------------------------------------------------------
   capacity-watchdog:
     name: Capacity watchdog
@@ -91,6 +135,7 @@ jobs:
     outputs:
       ts_failover: ${{ steps.poll.outputs.ts_failover }}
       go_failover: ${{ steps.poll.outputs.go_failover }}
+      merge_failover: ${{ steps.poll.outputs.merge_failover }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Poll Blacksmith primary queue state
@@ -105,13 +150,15 @@ jobs:
           set -euo pipefail
           ts_failover=false
           go_failover=false
+          merge_failover=false
           echo "Stall budget=${STALL_BUDGET_SECONDS}s poll=${POLL_SECONDS}s run=${RUN_ID}"
 
           while true; do
             jobs_json="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")"
             ts_state="$(python3 .github/scripts/classify-ci-job-state.py "typescript (blacksmith primary)" "$jobs_json")"
             go_state="$(python3 .github/scripts/classify-ci-job-state.py "go (blacksmith primary)" "$jobs_json")"
-            echo "state ts=${ts_state} go=${go_state} elapsed=${SECONDS}s"
+            merge_state="$(python3 .github/scripts/classify-ci-job-state.py "merge gate (blacksmith primary)" "$jobs_json")"
+            echo "state ts=${ts_state} go=${go_state} merge=${merge_state} elapsed=${SECONDS}s"
 
             # #3168: cancelled/skipped without a runner claim = capacity death → arm now.
             if [[ "$ts_state" == "cancelled_unclaimed" ]]; then
@@ -120,38 +167,48 @@ jobs:
             if [[ "$go_state" == "cancelled_unclaimed" ]]; then
               go_failover=true
             fi
+            if [[ "$merge_state" == "cancelled_unclaimed" ]]; then
+              merge_failover=true
+            fi
 
-            # Stall budget for still-queued / not-yet-visible primaries.
+            # Stall budget for still-unclaimed / not-yet-visible primaries (#3340).
             if [[ ( "$ts_state" == "queued" || "$ts_state" == "missing" ) && "$SECONDS" -ge "$STALL_BUDGET_SECONDS" ]]; then
               ts_failover=true
             fi
             if [[ ( "$go_state" == "queued" || "$go_state" == "missing" ) && "$SECONDS" -ge "$STALL_BUDGET_SECONDS" ]]; then
               go_failover=true
             fi
+            if [[ ( "$merge_state" == "queued" || "$merge_state" == "missing" ) && "$SECONDS" -ge "$STALL_BUDGET_SECONDS" ]]; then
+              merge_failover=true
+            fi
 
-            # Pending = still waiting for a runner claim (or job to appear).
+            # Pending = still waiting for a runner_name (or job to appear).
             # started/done/cancelled_unclaimed are terminal for the poll loop.
             ts_pending=false
             go_pending=false
+            merge_pending=false
             if [[ "$ts_state" == "queued" || "$ts_state" == "missing" ]]; then
               ts_pending=true
             fi
             if [[ "$go_state" == "queued" || "$go_state" == "missing" ]]; then
               go_pending=true
             fi
+            if [[ "$merge_state" == "queued" || "$merge_state" == "missing" ]]; then
+              merge_pending=true
+            fi
 
-            if [[ "$ts_pending" == "false" && "$go_pending" == "false" ]]; then
-              echo "Both primary lanes claimed, finished, or capacity-cancelled; ts_failover=${ts_failover} go_failover=${go_failover}"
+            if [[ "$ts_pending" == "false" && "$go_pending" == "false" && "$merge_pending" == "false" ]]; then
+              echo "Required primaries claimed, finished, or capacity-cancelled; ts_failover=${ts_failover} go_failover=${go_failover} merge_failover=${merge_failover}"
               break
             fi
             if [[ "$SECONDS" -ge "$STALL_BUDGET_SECONDS" ]]; then
-              echo "Stall budget reached; ts_failover=${ts_failover} go_failover=${go_failover}"
+              echo "Stall budget reached; ts_failover=${ts_failover} go_failover=${go_failover} merge_failover=${merge_failover}"
               break
             fi
             sleep "$POLL_SECONDS"
           done
 
-          if [[ "$ts_failover" == "true" || "$go_failover" == "true" ]]; then
+          if [[ "$ts_failover" == "true" || "$go_failover" == "true" || "$merge_failover" == "true" ]]; then
             jobs_json="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")"
             if [[ "$ts_failover" == "true" ]]; then
               python3 .github/scripts/cancel-queued-ci-primary.py "typescript (blacksmith primary)" "$jobs_json"
@@ -159,18 +216,22 @@ jobs:
             if [[ "$go_failover" == "true" ]]; then
               python3 .github/scripts/cancel-queued-ci-primary.py "go (blacksmith primary)" "$jobs_json"
             fi
+            if [[ "$merge_failover" == "true" ]]; then
+              python3 .github/scripts/cancel-queued-ci-primary.py "merge gate (blacksmith primary)" "$jobs_json"
+            fi
           fi
 
           echo "ts_failover=${ts_failover}" >> "$GITHUB_OUTPUT"
           echo "go_failover=${go_failover}" >> "$GITHUB_OUTPUT"
-          echo "::notice title=capacity-watchdog (#3168)::ts_failover=${ts_failover} go_failover=${go_failover}"
+          echo "merge_failover=${merge_failover}" >> "$GITHUB_OUTPUT"
+          echo "::notice title=capacity-watchdog (#3168/#3340)::ts_failover=${ts_failover} go_failover=${go_failover} merge_failover=${merge_failover}"
 
   # -------------------------------------------------------------------------
-  # Capacity arm (#3168): durable failover decision. Passes through watchdog
-  # outputs on success; if the watchdog is cancelled/failed, re-classifies
-  # primaries and arms failover for queued/missing/cancelled_unclaimed so
-  # GH-hosted lanes are not skipped forever when the watchdog dies mid-graph.
-  # Never arms for started (claimed runner) — #2652.
+  # Capacity arm (#3168 / #3340): durable failover decision. Passes through
+  # watchdog outputs on success, then ALWAYS re-classifies required primaries
+  # so a same-run rerun cannot keep a stale skip while a job is still unclaimed.
+  # If the watchdog is cancelled/failed, the same re-classify path arms failover.
+  # Never arms for started (runner_name set) — #2652.
   # -------------------------------------------------------------------------
   capacity-arm:
     name: Capacity arm (failover decision)
@@ -180,6 +241,7 @@ jobs:
     outputs:
       ts_failover: ${{ steps.decide.outputs.ts_failover }}
       go_failover: ${{ steps.decide.outputs.go_failover }}
+      merge_failover: ${{ steps.decide.outputs.merge_failover }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Resolve failover arm flags
@@ -191,37 +253,48 @@ jobs:
           WATCHDOG_RESULT: ${{ needs.capacity-watchdog.result }}
           TS_FROM_WD: ${{ needs.capacity-watchdog.outputs.ts_failover }}
           GO_FROM_WD: ${{ needs.capacity-watchdog.outputs.go_failover }}
+          MERGE_FROM_WD: ${{ needs.capacity-watchdog.outputs.merge_failover }}
         run: |
           set -euo pipefail
           ts_failover=false
           go_failover=false
+          merge_failover=false
 
           if [[ "$WATCHDOG_RESULT" == "success" ]]; then
             ts_failover="${TS_FROM_WD:-false}"
             go_failover="${GO_FROM_WD:-false}"
-            echo "Pass-through from capacity-watchdog (success): ts=${ts_failover} go=${go_failover}"
+            merge_failover="${MERGE_FROM_WD:-false}"
+            echo "Pass-through from capacity-watchdog (success): ts=${ts_failover} go=${go_failover} merge=${merge_failover}"
           else
             echo "::warning title=capacity-arm (#3168)::capacity-watchdog result=${WATCHDOG_RESULT}; re-classifying primaries for failover recovery"
-            jobs_json="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")"
-            ts_state="$(python3 .github/scripts/classify-ci-job-state.py "typescript (blacksmith primary)" "$jobs_json")"
-            go_state="$(python3 .github/scripts/classify-ci-job-state.py "go (blacksmith primary)" "$jobs_json")"
-            echo "recovery state ts=${ts_state} go=${go_state}"
+          fi
 
-            # Recovery: arm for any capacity-death shape (queued/missing/cancelled_unclaimed).
-            # started/done → do not arm (#2652 / product result already known).
-            if [[ "$ts_state" == "queued" || "$ts_state" == "missing" || "$ts_state" == "cancelled_unclaimed" ]]; then
-              ts_failover=true
-            fi
-            if [[ "$go_state" == "queued" || "$go_state" == "missing" || "$go_state" == "cancelled_unclaimed" ]]; then
-              go_failover=true
-            fi
+          # #3340: re-evaluate every required Blacksmith job. Do not skip while
+          # TS, Go, or merge-gate is still unclaimed (same-run rerun included).
+          jobs_json="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")"
+          ts_state="$(python3 .github/scripts/classify-ci-job-state.py "typescript (blacksmith primary)" "$jobs_json")"
+          go_state="$(python3 .github/scripts/classify-ci-job-state.py "go (blacksmith primary)" "$jobs_json")"
+          merge_state="$(python3 .github/scripts/classify-ci-job-state.py "merge gate (blacksmith primary)" "$jobs_json")"
+          echo "re-eval state ts=${ts_state} go=${go_state} merge=${merge_state}"
 
-            if [[ "$ts_failover" == "true" ]]; then
-              python3 .github/scripts/cancel-queued-ci-primary.py "typescript (blacksmith primary)" "$jobs_json"
-            fi
-            if [[ "$go_failover" == "true" ]]; then
-              python3 .github/scripts/cancel-queued-ci-primary.py "go (blacksmith primary)" "$jobs_json"
-            fi
+          if [[ "$ts_state" == "queued" || "$ts_state" == "missing" || "$ts_state" == "cancelled_unclaimed" ]]; then
+            ts_failover=true
+          fi
+          if [[ "$go_state" == "queued" || "$go_state" == "missing" || "$go_state" == "cancelled_unclaimed" ]]; then
+            go_failover=true
+          fi
+          if [[ "$merge_state" == "queued" || "$merge_state" == "missing" || "$merge_state" == "cancelled_unclaimed" ]]; then
+            merge_failover=true
+          fi
+
+          if [[ "$ts_failover" == "true" ]]; then
+            python3 .github/scripts/cancel-queued-ci-primary.py "typescript (blacksmith primary)" "$jobs_json"
+          fi
+          if [[ "$go_failover" == "true" ]]; then
+            python3 .github/scripts/cancel-queued-ci-primary.py "go (blacksmith primary)" "$jobs_json"
+          fi
+          if [[ "$merge_failover" == "true" ]]; then
+            python3 .github/scripts/cancel-queued-ci-primary.py "merge gate (blacksmith primary)" "$jobs_json"
           fi
 
           # Normalize empty → false (use if/then so set -e does not abort on false [[ ]])
@@ -231,13 +304,17 @@ jobs:
           if [[ -z "$go_failover" || "$go_failover" == "null" ]]; then
             go_failover=false
           fi
+          if [[ -z "$merge_failover" || "$merge_failover" == "null" ]]; then
+            merge_failover=false
+          fi
 
           echo "ts_failover=${ts_failover}" >> "$GITHUB_OUTPUT"
           echo "go_failover=${go_failover}" >> "$GITHUB_OUTPUT"
-          if [[ "$ts_failover" == "true" || "$go_failover" == "true" ]]; then
-            echo "::notice title=failover_armed (#3168)::ts_failover=${ts_failover} go_failover=${go_failover}"
+          echo "merge_failover=${merge_failover}" >> "$GITHUB_OUTPUT"
+          if [[ "$ts_failover" == "true" || "$go_failover" == "true" || "$merge_failover" == "true" ]]; then
+            echo "::notice title=failover_armed (#3168/#3340)::ts_failover=${ts_failover} go_failover=${go_failover} merge_failover=${merge_failover}"
           else
-            echo "::notice title=failover_skipped (#3168)::ts_failover=${ts_failover} go_failover=${go_failover} reason=primaries_claimed_or_done"
+            echo "::notice title=failover_skipped (#3168/#3340)::ts_failover=${ts_failover} go_failover=${go_failover} merge_failover=${merge_failover} reason=primaries_claimed_or_done"
           fi
 
   # -------------------------------------------------------------------------
@@ -266,14 +343,11 @@ jobs:
       suite: go
       runner: ubuntu-latest
 
-  # -------------------------------------------------------------------------
-  # Merge chokepoint — authoritative `task check` monolith (#1704). Discrete
-  # lane jobs remain for capacity/failover signal; this job is the SoT that
-  # closes the enforcement gap vs local `task check` / `check:merge`.
-  # -------------------------------------------------------------------------
-  merge-gate:
-    name: Merge gate (task check)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+  merge-gate-failover:
+    name: Merge gate (GH-hosted failover)
+    needs: [capacity-arm]
+    if: always() && needs.capacity-arm.result == 'success' && needs.capacity-arm.outputs.merge_failover == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -315,20 +389,15 @@ jobs:
   # Authoritative aggregators — ONLY these jobs use the branch-protection
   # required check names. Primary/failover lane names must never collide.
   # When capacity-arm sets WANT_FAILOVER and GH-hosted failover succeeds, the
-  # aggregator is green even if the Blacksmith primary was cancelled (#3168).
+  # aggregator is green even if the Blacksmith primary was cancelled (#3168/#3340).
   # -------------------------------------------------------------------------
   ts:
     name: TypeScript (build + lint + test)
-    needs: [capacity-arm, ts-failover, merge-gate]
+    needs: [capacity-arm, ts-failover]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Require merge gate (task check SoT — #1704)
-        if: needs.merge-gate.result != 'success'
-        run: |
-          echo "::error title=Merge gate (#1704)::Merge gate (task check) must pass before the TypeScript required check can succeed."
-          exit 1
       - name: Resolve authoritative TypeScript result
         env:
           GH_TOKEN: ${{ github.token }}
@@ -356,6 +425,24 @@ jobs:
           FAILOVER_RESULT: ${{ needs.go-failover.result }}
           PRIMARY_NEEDLE: "go (blacksmith primary)"
           SUITE_LABEL: Go
+        run: python3 .github/scripts/resolve-ci-authoritative-lane.py
+
+  merge-gate:
+    name: Merge gate (task check)
+    needs: [capacity-arm, merge-gate-failover]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Resolve authoritative merge-gate result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          WANT_FAILOVER: ${{ needs.capacity-arm.outputs.merge_failover }}
+          FAILOVER_RESULT: ${{ needs.merge-gate-failover.result }}
+          PRIMARY_NEEDLE: "merge gate (blacksmith primary)"
+          SUITE_LABEL: Merge-gate
         run: python3 .github/scripts/resolve-ci-authoritative-lane.py
 
   windows-task-dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Blacksmith failover no longer skips while required jobs are unclaimed; merge-gate gets a GH-hosted twin (#3340).** Unclaimed means no `runner_name`. `started_at` or a reusable-workflow caller `in_progress` is not a claim. The capacity arm waits the stall budget, then cancels unclaimed TypeScript, Go, and merge-gate primaries and arms GH-hosted failover. The required merge-gate aggregator can go green on the twin. Same-run rerun re-evaluates the arm. Claimed runners are still never cancelled (#2652). Closes #3340. Refs #2672, #3168, #2652, #3333.
+
 - **verify:ac fails closed on stdout run-summary dest (#3322).** `DEFT_RUN_SUMMARY_PATH=-` evaluates the in-process verification attempts from this invocation instead of treating non-file dest as no evidence. File dest still reads the file; unset dest stays fail-open/silent.
 
 - **Go installer plants the #3324 consumer-deposit marker on `.deft/core` and `--legacy-layout` `deft/` (#3331).** After vendor or upgrade, `deft-install` writes `.deft-consumer-deposit` into the deposit root so `engine:invoke` does not treat a source-looking tarball as buildable framework source. Engine dispatch honor stays on #3324. Genuine source checkouts are unchanged. Refs #3324, #3329, #3282, #2022.

--- a/content/scm/github.md
+++ b/content/scm/github.md
@@ -393,9 +393,9 @@ Following a v1.0.0 release, commits:
 
 **Framework CI runners (#2672)**:
 - ! `deftai/directive` required CI prefers Blacksmith (`blacksmith-4vcpu-ubuntu-2404`) for TypeScript and Go cost
-- ! Capacity watchdog (~20 minute budget): if a Blacksmith primary job stays `queued` with `runner_name` null and no `started_at`, cancel that queued attempt (concurrency cancel-in-progress) and run the same suite on `ubuntu-latest`
-- ! Branch-protection required check names (`TypeScript (build + lint + test)`, `Go (test + build)`) live **only** on the aggregator jobs — never on primary/failover lane names
-- ⊗ Fail over `in_progress` jobs (execution hangs) — those stay timeout + fix (#2652); capacity failover is queue-stall only
+- ! Capacity watchdog (~20 minute budget): if a required Blacksmith job (TypeScript, Go, or merge-gate) stays unclaimed (`runner_name` null — `started_at` alone is not a claim), cancel that unclaimed attempt and run the same suite on `ubuntu-latest` (#3340)
+- ! Branch-protection required check names (`TypeScript (build + lint + test)`, `Go (test + build)`, `Merge gate (task check)`) live **only** on the aggregator jobs — never on primary/failover lane names
+- ⊗ Fail over a job that has `runner_name` (claimed execution hang) — those stay timeout + fix (#2652); capacity failover is unclaimed-queue stall only (#3340)
 - ! Consumer scaffolds and `npm-publish.yml` stay on GitHub-hosted `ubuntu-latest` (Blacksmith is opt-in for consumer orgs; npm `--provenance` requires GH-hosted)
 - ! Agents seeing `runner_capacity_stall` / `RUNNER_CAPACITY_STALL` MUST wait for auto-failover — ⊗ `--skip-ci` as a capacity remedy
 


### PR DESCRIPTION
## Summary

Unclaimed Blacksmith jobs now mean **no `runner_name`**. `started_at` or a reusable-workflow caller `in_progress` is not a claim.

Capacity watchdog and arm wait the stall budget while TypeScript, Go, or merge-gate is still unclaimed, then cancel unclaimed primaries and arm GH-hosted failover. Merge-gate has a GH-hosted twin and a required aggregator (`Merge gate (task check)`) so a cancelled unclaimed Blacksmith merge-gate can still go green. Same-run rerun re-evaluates the arm. Claimed runners are still never cancelled (#2652).

## Related Issues

Closes #3340
Refs #2672 #3168 #2652 #3333

## Checklist

- [x] `/deft:change <name>` — N/A (swarm-cohort #3340, CI helpers + workflow + CHANGELOG; not a new subsystem)
- [x] `CHANGELOG.md` — `[Unreleased]` Fixed entry for #3340
- [x] `ROADMAP.md` — N/A (bug residual of #2672/#3168)
- [x] Tests pass locally — `python -m unittest discover -s .github/scripts -q` (31 tests)

## Test plan

- [x] classify: queued/in_progress with `started_at` and no `runner_name` is unclaimed
- [x] classify: `runner_name` set is claimed; never cancelled
- [x] classify: reusable-workflow caller `in_progress` without inner runner does not skip the suite
- [x] cancel: started_at-only in_progress is cancelable; claimed runner is not
- [x] resolve: cancelled with started_at and no runner is capacity death
- [x] workflow: merge-gate primary + GH-hosted twin + required aggregator

## Post-Merge

- [ ] Verify issue auto-close for #3340 after squash merge
