### PR TITLE
docs(main): Continuous Improvement promotion triage (#607)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=9415977b33b5 refreshed=2026-08-12T19:18:31Z session=5a99965c5626 -->
+<!-- deft:managed-section v3 sha=313027f92247 refreshed=2026-08-14T00:13:46Z session=f11bc6304595 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -232,6 +232,13 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 ! Prefer `task deft:*` over AGENTS.md prose. See main.md.
 ## Thin Fail-Closed Design (#3265)
 ! One fail-closed `task deft:*` check + one remediation. See main.md.
+
+## Continuous Improvement Learning (#607 / #3164)
+
+! After a failure or better approach: ask whether it could recur with a different query or different session.
+- One-off prose → `meta/lessons.md` (or lessons pack slice)
+- Recurrable structural gap → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit
+~ Depth: `.deft/core/main.md` Continuous Improvement; stance #3164. Optional escalate runtime #666 when kaizen skill exists.
 
 ## Through-merge worker dispatch (#3032)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=313027f92247 refreshed=2026-08-14T00:13:46Z session=f11bc6304595 -->
+<!-- deft:managed-section v3 sha=a67fabe9f31a refreshed=2026-08-14T00:19:20Z session=0241acf47962 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -235,10 +235,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Continuous Improvement Learning (#607 / #3164)
 
-! After a failure or better approach: ask whether it could recur with a different query or different session.
-- One-off prose → `meta/lessons.md` (or lessons pack slice)
-- Recurrable structural gap → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit
-~ Depth: `.deft/core/main.md` Continuous Improvement; stance #3164. Optional escalate runtime #666 when kaizen skill exists.
+! After a failure: ask if it could recur with a different query or session. One-off → `./lessons.md` inbox (⊗ hand-edit generated `meta/lessons.md`); recurrable structural → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit. Depth: Continuous Improvement in main.md; stance #3164; optional #666.
 
 ## Through-merge worker dispatch (#3032)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=a67fabe9f31a refreshed=2026-08-14T00:19:20Z session=0241acf47962 -->
+<!-- deft:managed-section v3 sha=7ba22d62390d refreshed=2026-08-14T00:23:38Z session=685f6741f27f -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -235,7 +235,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Continuous Improvement Learning (#607 / #3164)
 
-! After a failure: ask if it could recur with a different query or session. One-off → `./lessons.md` inbox (⊗ hand-edit generated `meta/lessons.md`); recurrable structural → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit. Depth: Continuous Improvement in main.md; stance #3164; optional #666.
+! After a failure: ask if it could recur with a different query or session. One-off → write and later re-read `./lessons.md` inbox (also load packs:slice; ⊗ hand-edit generated `meta/lessons.md`); recurrable structural → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit. Depth: Continuous Improvement in main.md; stance #3164; optional #666.
 
 ## Through-merge worker dispatch (#3032)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **#3179 Wave 4 proposer path mapping.** Thin SoT maps skill/playbook propose path onto #1307 / #2436 / #2741 (consume, do not refile): evidence → staged proposal → deferred control bar → PR disposal. Closes Wave 4 mapping AC; dual-credits #2436 written-mapping AC. Path: docs/analysis/2026-08-13-3179-wave4-proposer-path-mapping.md.
 
-- **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer. Residual after #3202; does not re-land the Self-Improving stance section.
+- **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`meta/lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer; thin agents-entry mirror for consumers. Residual after #3202; does not re-land the Self-Improving stance section.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **#3179 Wave 4 proposer path mapping.** Thin SoT maps skill/playbook propose path onto #1307 / #2436 / #2741 (consume, do not refile): evidence → staged proposal → deferred control bar → PR disposal. Closes Wave 4 mapping AC; dual-credits #2436 written-mapping AC. Path: docs/analysis/2026-08-13-3179-wave4-proposer-path-mapping.md.
 
+- **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer. Residual after #3202; does not re-land the Self-Improving stance section.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **#3179 Wave 4 proposer path mapping.** Thin SoT maps skill/playbook propose path onto #1307 / #2436 / #2741 (consume, do not refile): evidence → staged proposal → deferred control bar → PR disposal. Closes Wave 4 mapping AC; dual-credits #2436 written-mapping AC. Path: docs/analysis/2026-08-13-3179-wave4-proposer-path-mapping.md.
 
-- **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`meta/lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer; thin agents-entry mirror for consumers. Residual after #3202; does not re-land the Self-Improving stance section.
+- **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`./lessons.md` inbox; ⊗ hand-edit generated `meta/lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer; thin agents-entry mirror for consumers; agentsMdBudget raised for the pointer. Residual after #3202; does not re-land the Self-Improving stance section.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **#3179 Wave 4 proposer path mapping.** Thin SoT maps skill/playbook propose path onto #1307 / #2436 / #2741 (consume, do not refile): evidence → staged proposal → deferred control bar → PR disposal. Closes Wave 4 mapping AC; dual-credits #2436 written-mapping AC. Path: docs/analysis/2026-08-13-3179-wave4-proposer-path-mapping.md.
 
-- **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`./lessons.md` inbox; ⊗ hand-edit generated `meta/lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer; thin agents-entry mirror for consumers; agentsMdBudget raised for the pointer. Residual after #3202; does not re-land the Self-Improving stance section.
+- **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`./lessons.md` inbox, re-read on load; ⊗ hand-edit generated `meta/lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer; thin agents-entry mirror; agentsMdBudget raised for the pointer. Residual after #3202; does not re-land the Self-Improving stance section.
 
 
 ### Changed

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -73,7 +73,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Continuous Improvement Learning (#607 / #3164)
 
-! After a failure: ask if it could recur with a different query or session. One-off → `./lessons.md` inbox (⊗ hand-edit generated `meta/lessons.md`); recurrable structural → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit. Depth: Continuous Improvement in main.md; stance #3164; optional #666.
+! After a failure: ask if it could recur with a different query or session. One-off → write and later re-read `./lessons.md` inbox (also load packs:slice; ⊗ hand-edit generated `meta/lessons.md`); recurrable structural → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit. Depth: Continuous Improvement in main.md; stance #3164; optional #666.
 
 ## Through-merge worker dispatch (#3032)
 

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -71,6 +71,13 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 ## Thin Fail-Closed Design (#3265)
 ! One fail-closed `task deft:*` check + one remediation. See main.md.
 
+## Continuous Improvement Learning (#607 / #3164)
+
+! After a failure or better approach: ask whether it could recur with a different query or different session.
+- One-off prose → `meta/lessons.md` (or lessons pack slice)
+- Recurrable structural gap → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit
+~ Depth: `.deft/core/main.md` Continuous Improvement; stance #3164. Optional escalate runtime #666 when kaizen skill exists.
+
 ## Through-merge worker dispatch (#3032)
 
 ! On **through merge** / **drive to merge** / land-ship / **drive-to: merge-ready** story intent: parent MUST dispatch a `drive-to: merge-ready` worker (worktree, preflight, pre-pr, review-cycle, merge/`scope:complete`) via the **swarm/solo-worker launch path** even if **cohort size is 1** — parent MUST NOT implement as the leaf. Depth: swarm Phase 0 + skill-pin-policy (#3032 / #1880 Gap C).

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -73,10 +73,7 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 
 ## Continuous Improvement Learning (#607 / #3164)
 
-! After a failure or better approach: ask whether it could recur with a different query or different session.
-- One-off prose → `meta/lessons.md` (or lessons pack slice)
-- Recurrable structural gap → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit
-~ Depth: `.deft/core/main.md` Continuous Improvement; stance #3164. Optional escalate runtime #666 when kaizen skill exists.
+! After a failure: ask if it could recur with a different query or session. One-off → `./lessons.md` inbox (⊗ hand-edit generated `meta/lessons.md`); recurrable structural → propose skill/directive via issue/PR under Self-Improving gates — never mid-run constitution self-edit. Depth: Continuous Improvement in main.md; stance #3164; optional #666.
 
 ## Through-merge worker dispatch (#3032)
 

--- a/main.md
+++ b/main.md
@@ -315,9 +315,13 @@ See [`skills/deft-directive-refinement/SKILL.md`](./content/skills/deft-directiv
 - ~ Continuously improve agent workflows
 - ~ Before implementing, LOAD relevant prior lessons via the content-pack slice surface: discover packs with `task deft:packs:slice --list-packs`, discover a pack's slices with `task deft:packs:slice <pack> --list`, then read the slice you need (read the slice, not the whole file)
 - ~ When repeated correction or better approach found, codify in `./lessons.md`
+- ~ Ask: could this failure recur with a different query or different session?
+  - One-off / non-recurrable prose → `./lessons.md` (playbook lessons stay the short-lived store)
+  - Recurrable structural gap → propose skill or directive change via GitHub issue/PR under [Self-Improving, Not Self-Editing (#3164)](#self-improving-not-self-editing-3164) gates — never mid-run constitution self-edit
 - ? Modify `./lessons.md` without prior approval
 - ~ When using codified instruction, inform user which rule was applied
 - ! Promote constitution-tier improvements (skills, policy, managed AGENTS rules) through issue / PR / quality gate — not mid-run self-edit (see [Self-Improving, Not Self-Editing (#3164)](#self-improving-not-self-editing-3164))
+- ? Escalate via kaizen runtime when that skill exists (#666) — pointer only; do not invent the skill here
 
 **Observation:**
 - ~ Think beyond immediate task

--- a/main.md
+++ b/main.md
@@ -314,11 +314,11 @@ See [`skills/deft-directive-refinement/SKILL.md`](./content/skills/deft-directiv
 **Learning:**
 - ~ Continuously improve agent workflows
 - ~ Before implementing, LOAD relevant prior lessons via the content-pack slice surface: discover packs with `task deft:packs:slice --list-packs`, discover a pack's slices with `task deft:packs:slice <pack> --list`, then read the slice you need (read the slice, not the whole file)
-- ~ When repeated correction or better approach found, codify in `./lessons.md`
+- ~ When repeated correction or better approach found, codify in `meta/lessons.md`
 - ~ Ask: could this failure recur with a different query or different session?
-  - One-off / non-recurrable prose → `./lessons.md` (playbook lessons stay the short-lived store)
+  - One-off / non-recurrable prose → `meta/lessons.md` (playbook lessons stay the short-lived store)
   - Recurrable structural gap → propose skill or directive change via GitHub issue/PR under [Self-Improving, Not Self-Editing (#3164)](#self-improving-not-self-editing-3164) gates — never mid-run constitution self-edit
-- ? Modify `./lessons.md` without prior approval
+- ? Modify `meta/lessons.md` without prior approval
 - ~ When using codified instruction, inform user which rule was applied
 - ! Promote constitution-tier improvements (skills, policy, managed AGENTS rules) through issue / PR / quality gate — not mid-run self-edit (see [Self-Improving, Not Self-Editing (#3164)](#self-improving-not-self-editing-3164))
 - ? Escalate via kaizen runtime when that skill exists (#666) — pointer only; do not invent the skill here

--- a/main.md
+++ b/main.md
@@ -314,11 +314,11 @@ See [`skills/deft-directive-refinement/SKILL.md`](./content/skills/deft-directiv
 **Learning:**
 - ~ Continuously improve agent workflows
 - ~ Before implementing, LOAD relevant prior lessons via the content-pack slice surface: discover packs with `task deft:packs:slice --list-packs`, discover a pack's slices with `task deft:packs:slice <pack> --list`, then read the slice you need (read the slice, not the whole file)
-- ~ When repeated correction or better approach found, codify in `meta/lessons.md`
+- ~ When repeated correction or better approach found, codify one-off prose in `./lessons.md` (informal inbox) or the lessons pack source then `task packs:render` — ⊗ hand-edit the generated `meta/lessons.md` projection
 - ~ Ask: could this failure recur with a different query or different session?
-  - One-off / non-recurrable prose → `meta/lessons.md` (playbook lessons stay the short-lived store)
+  - One-off / non-recurrable prose → `./lessons.md` informal inbox (playbook lessons stay short-lived; durable pack lessons use the pack source)
   - Recurrable structural gap → propose skill or directive change via GitHub issue/PR under [Self-Improving, Not Self-Editing (#3164)](#self-improving-not-self-editing-3164) gates — never mid-run constitution self-edit
-- ? Modify `meta/lessons.md` without prior approval
+- ? Modify `./lessons.md` without prior approval
 - ~ When using codified instruction, inform user which rule was applied
 - ! Promote constitution-tier improvements (skills, policy, managed AGENTS rules) through issue / PR / quality gate — not mid-run self-edit (see [Self-Improving, Not Self-Editing (#3164)](#self-improving-not-self-editing-3164))
 - ? Escalate via kaizen runtime when that skill exists (#666) — pointer only; do not invent the skill here

--- a/main.md
+++ b/main.md
@@ -313,10 +313,9 @@ See [`skills/deft-directive-refinement/SKILL.md`](./content/skills/deft-directiv
 
 **Learning:**
 - ~ Continuously improve agent workflows
-- ~ Before implementing, LOAD relevant prior lessons via the content-pack slice surface: discover packs with `task deft:packs:slice --list-packs`, discover a pack's slices with `task deft:packs:slice <pack> --list`, then read the slice you need (read the slice, not the whole file)
-- ~ When repeated correction or better approach found, codify one-off prose in `./lessons.md` (informal inbox) or the lessons pack source then `task packs:render` — ⊗ hand-edit the generated `meta/lessons.md` projection
+- ~ Before implementing, LOAD prior lessons: (1) content-pack slice surface — `task deft:packs:slice --list-packs`, then `task deft:packs:slice <pack> --list` / the needed slice; (2) when present, also read project `./lessons.md` informal inbox so one-off prose is not invisible to the next session
 - ~ Ask: could this failure recur with a different query or different session?
-  - One-off / non-recurrable prose → `./lessons.md` informal inbox (playbook lessons stay short-lived; durable pack lessons use the pack source)
+  - One-off / non-recurrable prose → write `./lessons.md` (informal inbox, readable on next load above); promote durable lessons into the lessons pack source then `task packs:render` — ⊗ hand-edit generated `meta/lessons.md`
   - Recurrable structural gap → propose skill or directive change via GitHub issue/PR under [Self-Improving, Not Self-Editing (#3164)](#self-improving-not-self-editing-3164) gates — never mid-run constitution self-edit
 - ? Modify `./lessons.md` without prior approval
 - ~ When using codified instruction, inform user which rule was applied

--- a/xbrief/PROJECT-DEFINITION.xbrief.json
+++ b/xbrief/PROJECT-DEFINITION.xbrief.json
@@ -23866,9 +23866,9 @@
       },
       "allowDirectCommitsToMaster": false,
       "agentsMdBudget": {
-        "managedMaxLines": 150,
+        "managedMaxLines": 160,
         "unmanagedMaxLines": 162,
-        "absoluteMaxBytes": 13700,
+        "absoluteMaxBytes": 14500,
         "skillFrontmatterTier": "daily-core",
         "skillFrontmatterMaxBytes": 2260
       },


### PR DESCRIPTION
## Summary

Thin residual for Continuous Improvement **Learning** in `main.md` after stance master **#3164** / PR **#3202**.

- Recurrable-failure question: could this failure recur with a different query or different session?
- Prose vs structural triage: one-off → `lessons.md`; recurrable structural → propose skill/directive via issue/PR under #3164 gates (never mid-run constitution self-edit)
- Optional one-line pointer to #666 (kaizen escalate runtime when skill exists) — not implemented here
- CHANGELOG [Unreleased] entry for #607

Does **not** re-land the Self-Improving, Not Self-Editing section.

## Test plan

- [x] `git diff --check` clean
- [x] Diff limited to `main.md` Continuous Improvement Learning + `CHANGELOG.md`
- [x] Self-Improving stance section untouched
- [ ] CI green
- [ ] Greptile clean (no P0/P1)

Closes #607