### PR TITLE
docs(patterns,context): Code Mode + context partitioning (Wave 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Code Mode pattern (#2593).** `content/patterns/code-mode.md`: compact `search`/`describe` + sandboxed `execute` over large static tool catalogs; progressive discovery; job split (ephemeral compose vs named durable ops #2087 vs host explore); anti-patterns and non-goals; public citations. Pointers from `tool-design.md` complementarity and `llm-app.md` tool-call section. Wave 5 under #3179.
+
+- **Context partitioning + handles (#487).** Names human-curated context partitioning on Select strategy; prefer handles (paths, pack slices, xbrief ids, cache keys) over paste; RLM as optional qualified citation only (not identity rewrite). Short partition→recurse→combine in `long-horizon.md`. Cross-link Code Mode twin. Wave 5 under #3179.
+
 - **#3179 Wave 4 proposer path mapping.** Thin SoT maps skill/playbook propose path onto #1307 / #2436 / #2741 (consume, do not refile): evidence → staged proposal → deferred control bar → PR disposal. Closes Wave 4 mapping AC; dual-credits #2436 written-mapping AC. Path: docs/analysis/2026-08-13-3179-wave4-proposer-path-mapping.md.
 
 - **Continuous Improvement promotion triage (#607).** Learning asks the recurrable-failure question and triages one-off prose (`./lessons.md` inbox, re-read on load; ⊗ hand-edit generated `meta/lessons.md`) vs structural proposals via issue/PR under #3164 gates; optional #666 kaizen pointer; thin agents-entry mirror; agentsMdBudget raised for the pointer. Residual after #3202; does not re-land the Self-Improving stance section.

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -183,6 +183,11 @@ Load as needed:
 - Contains: prompt construction (delimiters, parameterized templates), explicit trust tiers (system > few-shot > user > retrieved > web), tool/function-call validation (confused-deputy mitigation), RAG hygiene (no LLM-write-back, provenance), output handling (schema validation, XSS sanitization), multi-agent orchestration (sub-agent-output-is-untrusted), LLM-specific observability
 - Source material: AI Agent Traps paper (`docs/ssrn-6372438.pdf`)
 
+**[patterns/code-mode.md](./content/patterns/code-mode.md)** - Code Mode: compact search + sandboxed execute (#2593)
+- Load: When designing host/MCP tool surfaces or connector-heavy agents where a large static tool catalog would bloat context; choosing code-orchestrated composition vs direct tool calling
+- Contains: progressive discovery (`search`/`describe` + `execute`), when-to-use, job split (ephemeral compose vs named durable ops #2087 vs host explore), anti-patterns, non-goals, public citations
+- Complements: `context/tool-design.md` (arg grammar), lean-context (#847), context partitioning (#487)
+
 **[patterns/role-as-overlay.md](./content/patterns/role-as-overlay.md)** - Role as overlay (#816)
 - Load: When the project applies a persona / role / stance to an LLM call (skill-defined reviewer / builder / summarizer roles, agent-level identities, per-call stance overrides) or designs a multi-turn agent that persists message history across turns
 - Contains: the role-as-system-overlay rule (never role-as-user-message), failure modes of role-injection-as-messages (history pollution, retrieval corruption, context-rot acceleration, false-memory propagation, resumption breakage), the call > session > agent precedence chain, the implementation contract for skills and sub-agent dispatch, and a provider-surface mapping (Anthropic `system`, OpenAI Chat `messages[0] role:system` / Responses `instructions`, Gemini `system_instruction`)
@@ -211,10 +216,11 @@ Load as needed:
 
 ### When Managing Context or Long Tasks
 
-- **[context/context.md](./content/context/context.md)** - Core context engineering strategies (Write, Select, Compress, Isolate)
+- **[context/context.md](./content/context/context.md)** - Core context engineering strategies (Write, Select, Compress, Isolate); human-curated context partitioning + prefer handles (#487)
 - **[context/working-memory.md](./content/context/working-memory.md)** - Scratchpad and externalization patterns with xBRIEF; `xbrief/plan.xbrief.json` + scope xBRIEF relationship
-- **[context/long-horizon.md](./content/context/long-horizon.md)** - Multi-session checkpoint/resume patterns; lifecycle folder conventions
-- **[context/tool-design.md](./content/context/tool-design.md)** - Designing AI-consumable tools; tool-surface grammar (flat params, nesting tax) (#3085)
+- **[context/long-horizon.md](./content/context/long-horizon.md)** - Multi-session checkpoint/resume; partition→recurse→combine for large surfaces
+- **[context/tool-design.md](./content/context/tool-design.md)** - Designing AI-consumable tools; tool-surface grammar (flat params, nesting tax) (#3085); Code Mode complementarity (#2593)
+- **[patterns/code-mode.md](./content/patterns/code-mode.md)** - Code Mode pattern: compact tool discovery + sandboxed execute (#2593)
 - **[context/deterministic-split.md](./content/context/deterministic-split.md)** - LLM vs deterministic responsibility boundaries
 - **[context/fractal-summaries.md](./content/context/fractal-summaries.md)** - Hierarchical memory compression (task → feature → release)
 - **[context/examples.md](./content/context/examples.md)** - Few-shot and behavioral example guidance

--- a/content/context/context.md
+++ b/content/context/context.md
@@ -32,11 +32,39 @@ Externalize intermediate state so it doesn't consume context window.
 
 Load only what's needed, when it's needed.
 
+Directive practices **human-curated context partitioning**: structure the
+world so agents can inspect an index (AGENTS.md → main.md → REFERENCES.md →
+skill scope / pack slices), then load only the slices the task needs. That is
+lazy load by design — partition first, then select — not "paste everything and
+hope attention holds."
+
 - ! **Follow [REFERENCES.md](../../REFERENCES.md)** for lazy-loading guidance
 - ~ Maintain lightweight references (file paths, line numbers, search queries) rather than full file contents
+- ~ Prefer **handles** over paste when the host can dereference: paths, pack
+  slices (`task packs:slice`), xBRIEF ids, cache keys, issue/PR numbers — pass
+  the handle and load on demand instead of inlining large contents
 - ~ Use **targeted retrieval**: `grep`, line ranges, `head`/`tail` — not whole-file reads
 - ⊗ **Speculatively loading files** "just in case"
 - ? Pre-fetch a file only when the next step certainly requires it
+
+**Related patterns (do not conflate):**
+
+- **Code Mode** ([patterns/code-mode.md](../patterns/code-mode.md), #2593) —
+  compact tool discovery + sandboxed execute so large *capability* catalogs
+  do not bloat the prompt. Context partitioning (this section) is about
+  *what docs and state* enter context; Code Mode is about *how tools are
+  invoked*.
+- **RLM (citation only):** Recursive Language Models are one recent research
+  framing of model-driven partition → recurse → combine over a prompt-as-
+  environment ([arxiv:2512.24601](https://arxiv.org/abs/2512.24601); popular
+  write-up: [raw.works/rlms-are-the-new-reasoning-models](https://raw.works/rlms-are-the-new-reasoning-models)).
+  Directive's human-curated partitions are **architecturally related**, not
+  an identity claim that "lazy load is an RLM." Headline claims such as
+  "100× context" are **benchmark-dependent and still being validated** —
+  treat them as motivation for partitioning, not as product guarantees.
+  Model-driven runtime partitioning (the model slices and re-queries without
+  a human-authored index) is a different instantiation from REFERENCES /
+  skill-scope curation.
 
 ## Strategy 3: Compress
 

--- a/content/context/long-horizon.md
+++ b/content/context/long-horizon.md
@@ -35,6 +35,18 @@ When tasks have dependencies, express them as vBRIEF edges:
 - ~ Carry the summary forward, not the full history
 - ≉ Re-reading entire conversation history when a checkpoint exists
 
+## Partition → recurse → combine
+
+For large codebases or long documents, **partition** the work into slices,
+**recurse** (or re-enter) with focused context per slice, then **combine**
+results at a higher checkpoint — rather than stuffing the whole surface into
+one window. This is the long-horizon form of human-curated context
+partitioning ([context.md](./context.md) Strategy 2 Select; research framing
+on #487). Prefer handles and slice summaries over pasting full subtree
+contents. Hierarchical compression of *what already happened* remains
+[fractal-summaries.md](./fractal-summaries.md); do not treat that file as a
+rebrand of external RLM identity.
+
 ## Progress Tracking
 
 - ~ Maintain `./vbrief/plan.vbrief.json` for multi-phase work — this is the session-level tactical plan (the *how right now*)

--- a/content/context/tool-design.md
+++ b/content/context/tool-design.md
@@ -87,7 +87,8 @@ use parallel invokes when multiple edits are needed.
 
 When composition is large (many steps, dynamic graphs), **do not** invent
 deeper nested tool packs. Prefer fewer tools via code abstraction / Code
-Mode / a host-side program (related: #1167, #2593) and multi-step token
+Mode / a host-side program (related: #1167, #2593; pattern:
+[patterns/code-mode.md](../patterns/code-mode.md)) and multi-step token
 breakpoints (#1170). Those reduce **how many** tools exist; this section
 shapes **how each remaining tool looks** at the dialect layer.
 
@@ -119,7 +120,7 @@ and consumer MCP / product-agent schemas:
 | Concern | Where it lives |
 |---------|----------------|
 | **How each tool's args sample** (this doc) | Flat grammar, low nesting tax |
-| **How many tools** exist | Code Mode / DSL / abstraction (#1167, #2593) |
+| **How many tools** exist | [Code Mode](../patterns/code-mode.md) / DSL / abstraction (#1167, #2593) — compact `search`/`describe` + sandboxed `execute` |
 | **When multi-step burns tokens** | Breakpoints / long-horizon (#1170) |
 | **Security of tool use** | `patterns/llm-app.md` (schema validate, least privilege) |
 | **Protocol / model-tier cost after shape** | Cost-envelope notes (e.g. #3078) |

--- a/content/packs/patterns/patterns-pack-0.1.json
+++ b/content/packs/patterns/patterns-pack-0.1.json
@@ -14,6 +14,16 @@
       "body": null
     },
     {
+      "id": "code-mode",
+      "title": "Code Mode \u2014 compact search + sandboxed execute (#2593)",
+      "description": "Pattern for **code-mediated tool use**: the model writes and runs code that orchestrates capabilities, instead of requesting each tool call separately against a large static catalog. The public surface stays tiny (typically `search` / `describe` for progressive discovery and `execute` for sandboxed capability calls); the broader capability graph lives behind that surface in typed code.",
+      "triggers": [
+        "code-mode"
+      ],
+      "path": "patterns/code-mode.md",
+      "body": null
+    },
+    {
       "id": "executor-layer-credentials",
       "title": "Executor-layer credentials (#806)",
       "description": "Secrets for privileged operations MUST be bound at the **invocation layer** (the orchestrator, the command definition, the trusted shim that wraps the capability) -- never inside the agent's context window, prompt, filesystem, or globally-inherited environment. The agent receives access to the **capability**, not the **credential**.",

--- a/content/patterns/code-mode.md
+++ b/content/patterns/code-mode.md
@@ -26,8 +26,9 @@ composition.
   **execution shape** for large capability graphs
 - Typed skill boundaries (#805), progressive disclosure (#2484), action-tiered
   capability envelopes (#2515)
-- Durable project automation SoT: **#2087** (named Task / npm / `just` /
-  thin runner / `deft` verbs) — not this pattern
+- Durable project automation SoT: **#2087** *RFC: Where does agent-authored
+  project automation live* (named Task / npm / `just` / thin runner /
+  `deft` verbs) — not this pattern. Companion of #2593 on that issue.
 
 ## The pattern
 
@@ -56,14 +57,14 @@ multi-turn tool round-trips.
 |------------------|----------------------------------|
 | Large connector or MCP graphs where full schemas blow the context budget | One or two well-known tools for a simple turn |
 | Multi-step composition with local branching, filters, or aggregation | A single deterministic gate or check (`task verify:*`) |
-| Progressive discovery of an unfamiliar capability surface | A **named durable** project op already owned by #2087 |
+| Progressive discovery of an unfamiliar capability surface | A **named durable** project op already owned by the #2087 automation-home RFC |
 | Ephemeral glue that may later **promote** to a named entrypoint | Host explore / editor tools for "build in this repo right now" |
 
 - ⊗ Force Code Mode for simple single-tool turns
 - ⊗ Register dozens of host tools that merely mirror every CLI verb to avoid
   writing a small compose surface
 - ~ Promote repeated successful compose scripts into a **named durable** form
-  (#2087 owns that SoT for Directive projects)
+  (#2087 automation-home RFC owns that SoT for Directive projects)
 
 ## Progressive discovery
 
@@ -83,20 +84,21 @@ Three jobs are easy to blur into "just call tools." Keep them distinct:
 | Job | Typical shape | Not the same as |
 |-----|---------------|-----------------|
 | Compose over a large API/tool world without schema bloat | **Code Mode:** compact `search` / `describe` + sandboxed `execute` | Dumping every MCP tool schema into the prompt |
-| Name, share, and re-run proven project ops | **Named durable entrypoints** (Task / npm / `just` / thin runner + tested logic or `deft` verbs) — see **#2087** | Freeform `execute` every time |
+| Name, share, and re-run proven project ops | **Named durable entrypoints** (Task / npm / `just` / thin runner + tested logic or `deft` verbs) — see **#2087** automation-home RFC | Freeform `execute` every time |
 | Explore and build in the repo right now | **Host bash / editor agent tools** | Either of the above as the long-term catalog |
 
 Ideal systems **promote** ephemeral success into a **named durable** form. This
-pattern names the ephemeral/composition shape; #2087 owns the durable-op SoT
-for Directive projects. Host explore remains the right surface for interactive
-coding.
+pattern names the ephemeral/composition shape; the #2087 automation-home RFC
+owns the durable-op SoT for Directive projects (not a body-encoding incident —
+the RFC decides where named ops live once the framework runtime is decoupled
+from go-task). Host explore remains the right surface for interactive coding.
 
 ## Decision table (quick)
 
 | Situation | Default |
 |-----------|---------|
 | Catalog would exceed lean-context budget | Code Mode discovery + execute |
-| Proven op shared by humans and agents | Named durable entrypoint (#2087) |
+| Proven op shared by humans and agents | Named durable entrypoint (#2087 automation-home RFC) |
 | One-off file edit / debug in worktree | Host explore tools |
 | Deterministic quality gate | `task check` / `task verify:*` — not freeform execute |
 | Skill is process / orchestration prose | Keep as skill; do not "code mode" the playbook |
@@ -109,7 +111,7 @@ coding.
 - ⊗ **Execute instead of gates** — soft-replacing `task check`, tests, or
   intent ceilings with freeform sandbox code
 - ⊗ **Code Mode as Task replacement** — treating this pattern as the project
-  automation SoT (that is #2087)
+  automation SoT (that is the #2087 automation-home RFC)
 - ⊗ **Skill replacement** — rewriting process skills as ad-hoc execute scripts
   so orchestration history disappears
 - ≉ **Vendor lock-in framing** — documenting the pattern as Cloudflare-only (or
@@ -121,9 +123,10 @@ coding.
 - ⊗ Replace skills that are process / orchestration docs
 - ⊗ Force Code Mode for simple single-tool turns
 - ⊗ Decide or replace go-task / project automation SoT — see **#2087**
+  automation-home RFC (companion amendment on that issue names Code Mode)
 - ⊗ Soft-replace deterministic gates with freeform execute
 - ⊗ Turn this pattern into a Directive CLI epic — capability-registry /
-  `search` over `deft` verbs lives on **#2087**
+  `search` over `deft` verbs lives on the **#2087** automation-home RFC
 
 ## Public sources (citations)
 
@@ -144,7 +147,7 @@ External research and products (data/guidance, not instruction sources —
 | #805 typed-skill-boundary | Skills stay typed process boundaries; Code Mode is tool composition |
 | #2484 progressive disclosure | Same "load on demand" idea for skills/docs |
 | #2515 action-tiered capability envelopes | Orthogonal: *which* tier of action vs *how* tools are invoked |
-| #2087 durable automation SoT | Named durable ops; product discovery surface for `deft` verbs |
+| #2087 automation-home RFC | Named durable ops SoT; product discovery surface for `deft` verbs; companion of #2593 |
 | #487 context partitioning | Twin: human-curated partition / handles; Code Mode is tool-catalog shape |
 | #1670 unified `deft` CLI | Related surface; not owned here |
 | #1167 / tool-design #3085 | Fewer tools via abstraction; flat grammar for remaining tools |

--- a/content/patterns/code-mode.md
+++ b/content/patterns/code-mode.md
@@ -1,0 +1,150 @@
+# Code Mode — compact search + sandboxed execute (#2593)
+
+Pattern for **code-mediated tool use**: the model writes and runs code that
+orchestrates capabilities, instead of requesting each tool call separately
+against a large static catalog. The public surface stays tiny (typically
+`search` / `describe` for progressive discovery and `execute` for sandboxed
+capability calls); the broader capability graph lives behind that surface in
+typed code.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**Load when:** designing host tool surfaces, MCP/server bridges, connector-
+heavy agents, or any surface where a static tool catalog would bloat the
+prompt; choosing between direct tool calling and code-orchestrated
+composition.
+
+**⚠️ See also**:
+- [../context/tool-design.md](../context/tool-design.md) — how each remaining
+  tool's args sample (flat grammar; #3085); complementarity table points here
+  for **how many** tools exist
+- [./llm-app.md](./llm-app.md) `## Tool / function calling` — security, least
+  privilege, schema validation (confused deputy)
+- [../context/context.md](../context/context.md) — **human-curated context
+  partitioning** and prefer-handles-over-paste (#487 twin)
+- Lean context first (#847) — general token thrift; this pattern is the
+  **execution shape** for large capability graphs
+- Typed skill boundaries (#805), progressive disclosure (#2484), action-tiered
+  capability envelopes (#2515)
+- Durable project automation SoT: **#2087** (named Task / npm / `just` /
+  thin runner / `deft` verbs) — not this pattern
+
+## The pattern
+
+| Primitive | Role |
+|-----------|------|
+| `search` / `describe` (or equivalent) | **Progressive discovery** — find and inspect capabilities without loading every schema into the prompt |
+| `execute` (sandboxed) | Run model-written code that calls discovered capabilities as typed methods / APIs |
+
+Capabilities appear as **typed methods in code**, not as hundreds of MCP tool
+definitions pasted into the system prompt. Control flow (loops, conditionals,
+retries, intermediate variables) stays in the sandbox instead of chatty
+multi-turn tool round-trips.
+
+- ~ Prefer Code Mode when the task needs **composition**, dependent calls,
+  progressive discovery, or non-trivial control flow over a large API/tool world
+- ≉ Dumping every MCP / host tool schema into the prompt "so the model can pick"
+- ~ Keep the **discovery surface compact**; grow capability knowledge on demand
+  via `search` / `describe`, not via catalog expansion
+- ! Validate and sandbox `execute` outputs and side effects — freeform code is
+  still untrusted input (`patterns/llm-app.md` tool-call rules; host sandbox
+  guidance on #542 / related isolation tracks)
+
+## When to use / when not to
+
+| Prefer Code Mode | Prefer direct tools / named ops |
+|------------------|----------------------------------|
+| Large connector or MCP graphs where full schemas blow the context budget | One or two well-known tools for a simple turn |
+| Multi-step composition with local branching, filters, or aggregation | A single deterministic gate or check (`task verify:*`) |
+| Progressive discovery of an unfamiliar capability surface | A **named durable** project op already owned by #2087 |
+| Ephemeral glue that may later **promote** to a named entrypoint | Host explore / editor tools for "build in this repo right now" |
+
+- ⊗ Force Code Mode for simple single-tool turns
+- ⊗ Register dozens of host tools that merely mirror every CLI verb to avoid
+  writing a small compose surface
+- ~ Promote repeated successful compose scripts into a **named durable** form
+  (#2087 owns that SoT for Directive projects)
+
+## Progressive discovery
+
+Progressive discovery is part of the pattern, not an optional extra:
+
+1. **Search** — locate candidates by name / tag / capability without full schemas
+2. **Describe** — load detail for the few candidates that matter
+3. **Execute** — orchestrate only those capabilities in sandboxed code
+
+This pairs with progressive disclosure of skills and docs (#2484) and lean
+context (#847): load signal on demand; do not pre-load the whole world.
+
+## Job split
+
+Three jobs are easy to blur into "just call tools." Keep them distinct:
+
+| Job | Typical shape | Not the same as |
+|-----|---------------|-----------------|
+| Compose over a large API/tool world without schema bloat | **Code Mode:** compact `search` / `describe` + sandboxed `execute` | Dumping every MCP tool schema into the prompt |
+| Name, share, and re-run proven project ops | **Named durable entrypoints** (Task / npm / `just` / thin runner + tested logic or `deft` verbs) — see **#2087** | Freeform `execute` every time |
+| Explore and build in the repo right now | **Host bash / editor agent tools** | Either of the above as the long-term catalog |
+
+Ideal systems **promote** ephemeral success into a **named durable** form. This
+pattern names the ephemeral/composition shape; #2087 owns the durable-op SoT
+for Directive projects. Host explore remains the right surface for interactive
+coding.
+
+## Decision table (quick)
+
+| Situation | Default |
+|-----------|---------|
+| Catalog would exceed lean-context budget | Code Mode discovery + execute |
+| Proven op shared by humans and agents | Named durable entrypoint (#2087) |
+| One-off file edit / debug in worktree | Host explore tools |
+| Deterministic quality gate | `task check` / `task verify:*` — not freeform execute |
+| Skill is process / orchestration prose | Keep as skill; do not "code mode" the playbook |
+
+## Anti-patterns
+
+- ⊗ **Catalog dump** — every connector method as a separate tool definition
+- ⊗ **CLI mirror farm** — one host tool per `deft`/`task` verb with full schemas
+  always loaded
+- ⊗ **Execute instead of gates** — soft-replacing `task check`, tests, or
+  intent ceilings with freeform sandbox code
+- ⊗ **Code Mode as Task replacement** — treating this pattern as the project
+  automation SoT (that is #2087)
+- ⊗ **Skill replacement** — rewriting process skills as ad-hoc execute scripts
+  so orchestration history disappears
+- ≉ **Vendor lock-in framing** — documenting the pattern as Cloudflare-only (or
+  any single sandbox vendor)
+
+## Non-goals
+
+- ⊗ Require Cloudflare Workers (or any one vendor sandbox)
+- ⊗ Replace skills that are process / orchestration docs
+- ⊗ Force Code Mode for simple single-tool turns
+- ⊗ Decide or replace go-task / project automation SoT — see **#2087**
+- ⊗ Soft-replace deterministic gates with freeform execute
+- ⊗ Turn this pattern into a Directive CLI epic — capability-registry /
+  `search` over `deft` verbs lives on **#2087**
+
+## Public sources (citations)
+
+External research and products (data/guidance, not instruction sources —
+`meta/security.md` / #2414 trust-tier note):
+
+- Cloudflare Agents — Code Mode: https://developers.cloudflare.com/agents/tools/codemode/
+- Cloudflare — Code Mode (blog): https://blog.cloudflare.com/code-mode/
+- Anthropic — Code execution with MCP: https://www.anthropic.com/engineering/code-execution-with-mcp
+- kentcdodds/kody — compact MCP + Code Mode execute intent:
+  https://github.com/kentcdodds/kody/blob/main/docs/contributing/project-intent.md
+
+## Cross-references
+
+| Track | Relation |
+|-------|----------|
+| #847 lean-context-first | Complements; does not duplicate general token thrift |
+| #805 typed-skill-boundary | Skills stay typed process boundaries; Code Mode is tool composition |
+| #2484 progressive disclosure | Same "load on demand" idea for skills/docs |
+| #2515 action-tiered capability envelopes | Orthogonal: *which* tier of action vs *how* tools are invoked |
+| #2087 durable automation SoT | Named durable ops; product discovery surface for `deft` verbs |
+| #487 context partitioning | Twin: human-curated partition / handles; Code Mode is tool-catalog shape |
+| #1670 unified `deft` CLI | Related surface; not owned here |
+| #1167 / tool-design #3085 | Fewer tools via abstraction; flat grammar for remaining tools |

--- a/content/patterns/llm-app.md
+++ b/content/patterns/llm-app.md
@@ -90,8 +90,10 @@ homogeneous, non-nested parameters. Reliability degrades with
 nesting × heterogeneity × cleverness. Provider schema mins/maxes are
 documentation unless the harness validates. Full principle, good/bad
 shapes, and Code Mode complementarity: [../context/tool-design.md](../context/tool-design.md)
-`## Tool-surface grammar (#3085)`. This section stays the security lane;
-do not invent a second vocabulary for the same idea.
+`## Tool-surface grammar (#3085)`. When the catalog itself is the tax, prefer
+[Code Mode](./code-mode.md) (#2593) — compact discovery + sandboxed execute —
+over deeper nested tool packs. This section stays the security lane; do not
+invent a second vocabulary for the same idea.
 
 ## RAG and retrieval
 


### PR DESCRIPTION
## Summary

Wave 5 consume under epic #3179: document **Code Mode** (#2593) and thin **context partitioning** residual (#487) in one PR.

### #2593 Code Mode
- New `content/patterns/code-mode.md`: compact `search`/`describe` + sandboxed `execute`, progressive discovery, job split (ephemeral compose vs named durable ops #2087 vs host explore), anti-patterns, non-goals, public citations
- Cross-links from `tool-design.md` complementarity table and `llm-app.md` tool-call section
- Patterns pack registration via `task packs:render-patterns`
- REFERENCES.md discoverability

### #487 Context partitioning (thin)
- `context.md` Strategy 2 Select: names **human-curated context partitioning**; prefer **handles** over paste
- RLM as optional citation only with qualified claims (not "lazy load is an RLM")
- Short partition→recurse→combine in `long-horizon.md`; no fractal-summaries rebrand

### CHANGELOG
- `[Unreleased]` entries for #2593 and #487

## Test plan
- [x] `git diff --check`
- [x] `task verify:branch`
- [x] Read new pattern + cross-links; patterns pack lists `code-mode`
- [ ] CI green
- [ ] Greptile clean

Closes #2593
Closes #487

Epic: #3179 Wave 5 consume (pass-5 hygiene after merge)