### PR TITLE
feat(session): wire consumer evidence into ceremony-dial evaluation (#3358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Ceremony-dial evaluation reads a consumer evidence source (#3358).** Session:start maps stamped #3323 clause count (and optional host-tier / failing-gate env) into `taskSize`/`modelTier` so evaluation is not permanently `insufficient evidence (size=- modelTier=-)`. Rapid default and decline threshold stay unchanged when no evidence exists. Closes #3358. Refs #3319, #3274, #3214, #3323.
+
 ### Changed
 
 ### Fixed

--- a/packages/core/src/session/ceremony-dial-evidence.test.ts
+++ b/packages/core/src/session/ceremony-dial-evidence.test.ts
@@ -168,6 +168,16 @@ describe("collectCeremonyDialConsumerEvidence (#3358)", () => {
     expect(evidence.modelTier).toBe("frontier");
   });
 
+  it("falls through an empty ceremony-tier env to a valid host hint", () => {
+    const evidence = collectCeremonyDialConsumerEvidence(tempRoot(), {
+      env: {
+        [ENV_CEREMONY_MODEL_TIER]: " ",
+        [ENV_HOST_MODEL_TIER]: "mid",
+      },
+    });
+    expect(evidence.modelTier).toBe("mid");
+  });
+
   it("ignores an unparsable failing-gate env instead of inventing a size", () => {
     const evidence = collectCeremonyDialConsumerEvidence(tempRoot(), {
       env: { [ENV_FAILING_GATE_COUNT]: "nope" },

--- a/packages/core/src/session/ceremony-dial-evidence.test.ts
+++ b/packages/core/src/session/ceremony-dial-evidence.test.ts
@@ -1,0 +1,221 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  collectCeremonyDialConsumerEvidence,
+  ENV_FAILING_GATE_COUNT,
+  ENV_HOST_MODEL_TIER,
+  formatCeremonyDialEvidenceLine,
+  mergeCeremonyDialInputsWithConsumerEvidence,
+  taskSizeFromClauseCount,
+  taskSizeFromFailingGateCount,
+} from "./ceremony-dial-evidence.js";
+
+const temps: string[] = [];
+afterEach(() => {
+  for (const d of temps.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "dial-evidence-"));
+  temps.push(root);
+  return root;
+}
+
+function writeBrief(
+  root: string,
+  folder: "active" | "pending",
+  name: string,
+  acceptance: Record<string, unknown>,
+): void {
+  const dir = join(root, "xbrief", folder);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, name),
+    JSON.stringify({
+      xBRIEFInfo: { version: "0.8" },
+      plan: { title: "T", status: "running", acceptance },
+    }),
+    "utf8",
+  );
+}
+
+describe("taskSizeFromClauseCount (#3358)", () => {
+  it("stays null when no clauses exist — rapid default unchanged", () => {
+    expect(taskSizeFromClauseCount(0)).toBeNull();
+    expect(taskSizeFromClauseCount(-1)).toBeNull();
+    expect(taskSizeFromClauseCount(Number.NaN)).toBeNull();
+  });
+
+  it("maps stamped clause counts to size bands", () => {
+    expect(taskSizeFromClauseCount(1)).toBe("S");
+    expect(taskSizeFromClauseCount(2)).toBe("M");
+    expect(taskSizeFromClauseCount(3)).toBe("M");
+    expect(taskSizeFromClauseCount(4)).toBe("L");
+    expect(taskSizeFromClauseCount(6)).toBe("L");
+    expect(taskSizeFromClauseCount(7)).toBe("XL");
+  });
+});
+
+describe("taskSizeFromFailingGateCount (#3358)", () => {
+  it("stays null on zero — does not invent a size", () => {
+    expect(taskSizeFromFailingGateCount(0)).toBeNull();
+  });
+
+  it("maps a positive failing-gate count to M/L", () => {
+    expect(taskSizeFromFailingGateCount(1)).toBe("M");
+    expect(taskSizeFromFailingGateCount(2)).toBe("M");
+    expect(taskSizeFromFailingGateCount(3)).toBe("L");
+  });
+});
+
+describe("collectCeremonyDialConsumerEvidence (#3358)", () => {
+  it("returns null inputs when the consumer has no stamped clauses or host env", () => {
+    const evidence = collectCeremonyDialConsumerEvidence(tempRoot(), { env: {} });
+    expect(evidence.taskSize).toBeNull();
+    expect(evidence.modelTier).toBeNull();
+    expect(evidence.clauseCount).toBeNull();
+    expect(evidence.reasons).toEqual([]);
+    expect(formatCeremonyDialEvidenceLine(evidence)).toBeNull();
+  });
+
+  it("reads stamped clause count from an active brief as a size proxy", () => {
+    const root = tempRoot();
+    writeBrief(root, "active", "story.xbrief.json", {
+      none_stated: true,
+      clauses: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+      ],
+    });
+    const evidence = collectCeremonyDialConsumerEvidence(root, { env: {} });
+    expect(evidence.clauseCount).toBe(3);
+    expect(evidence.taskSize).toBe("M");
+    expect(evidence.reasons.some((r) => r.includes("clauseCount=3"))).toBe(true);
+    expect(formatCeremonyDialEvidenceLine(evidence)).toContain("taskSize=M");
+  });
+
+  it("accepts a numeric clause_count stamp when clauses[] is absent", () => {
+    const root = tempRoot();
+    writeBrief(root, "active", "stamped.xbrief.json", { clause_count: 4 });
+    const evidence = collectCeremonyDialConsumerEvidence(root, { env: {} });
+    expect(evidence.clauseCount).toBe(4);
+    expect(evidence.taskSize).toBe("L");
+  });
+
+  it("uses pending when active has no clauses", () => {
+    const root = tempRoot();
+    writeBrief(root, "pending", "queued.xbrief.json", {
+      clauses: [{ id: 1, text: "one" }],
+    });
+    const evidence = collectCeremonyDialConsumerEvidence(root, { env: {} });
+    expect(evidence.clauseCount).toBe(1);
+    expect(evidence.taskSize).toBe("S");
+  });
+
+  it("takes the max stamped count across briefs", () => {
+    const root = tempRoot();
+    writeBrief(root, "active", "small.xbrief.json", {
+      clauses: [{ id: 1, text: "one" }],
+    });
+    writeBrief(root, "pending", "hard.xbrief.json", {
+      clauses: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+      ],
+    });
+    const evidence = collectCeremonyDialConsumerEvidence(root, { env: {} });
+    expect(evidence.clauseCount).toBe(4);
+    expect(evidence.taskSize).toBe("L");
+  });
+
+  it("ignores malformed briefs instead of inventing a size", () => {
+    const root = tempRoot();
+    const dir = join(root, "xbrief", "active");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "broken.xbrief.json"), "{not-json", "utf8");
+    const evidence = collectCeremonyDialConsumerEvidence(root, { env: {} });
+    expect(evidence.taskSize).toBeNull();
+    expect(evidence.clauseCount).toBeNull();
+  });
+
+  it("reads a host-supplied model-tier env", () => {
+    const evidence = collectCeremonyDialConsumerEvidence(tempRoot(), {
+      env: { [ENV_HOST_MODEL_TIER]: "mid" },
+    });
+    expect(evidence.modelTier).toBe("mid");
+    expect(evidence.reasons.some((r) => r.includes("modelTier=mid"))).toBe(true);
+  });
+
+  it("ignores an unparsable failing-gate env instead of inventing a size", () => {
+    const evidence = collectCeremonyDialConsumerEvidence(tempRoot(), {
+      env: { [ENV_FAILING_GATE_COUNT]: "nope" },
+    });
+    expect(evidence.failingGateCount).toBeNull();
+    expect(evidence.taskSize).toBeNull();
+  });
+
+  it("raises size from a failing-gate count the harness can supply", () => {
+    const evidence = collectCeremonyDialConsumerEvidence(tempRoot(), {
+      env: { [ENV_FAILING_GATE_COUNT]: "3" },
+    });
+    expect(evidence.failingGateCount).toBe(3);
+    expect(evidence.taskSize).toBe("L");
+  });
+
+  it("records a same-size failing-gate count without raising further", () => {
+    const root = tempRoot();
+    writeBrief(root, "active", "story.xbrief.json", {
+      clauses: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+      ],
+    });
+    const evidence = collectCeremonyDialConsumerEvidence(root, {
+      env: { [ENV_FAILING_GATE_COUNT]: "2" },
+    });
+    expect(evidence.taskSize).toBe("M");
+    expect(evidence.reasons.some((r) => r.includes("failingGateCount=2"))).toBe(true);
+  });
+
+  it("keeps the larger of clause-count and failing-gate size", () => {
+    const root = tempRoot();
+    writeBrief(root, "active", "story.xbrief.json", {
+      clauses: [{ id: 1, text: "one" }],
+    });
+    const evidence = collectCeremonyDialConsumerEvidence(root, {
+      env: { [ENV_FAILING_GATE_COUNT]: "3" },
+    });
+    expect(evidence.taskSize).toBe("L");
+    expect(evidence.clauseCount).toBe(1);
+  });
+});
+
+describe("mergeCeremonyDialInputsWithConsumerEvidence (#3358)", () => {
+  it("fills only missing fields so explicit CLI inputs still win", () => {
+    const evidence = {
+      taskSize: "L" as const,
+      modelTier: "low" as const,
+      clauseCount: 4,
+      failingGateCount: null,
+      reasons: ["taskSize=L from stamped clauseCount=4"],
+    };
+    expect(
+      mergeCeremonyDialInputsWithConsumerEvidence(
+        { taskSize: "S", modelTier: null, projectShape: "project" },
+        evidence,
+      ),
+    ).toEqual({ taskSize: "S", modelTier: "low", projectShape: "project" });
+  });
+});

--- a/packages/core/src/session/ceremony-dial-evidence.test.ts
+++ b/packages/core/src/session/ceremony-dial-evidence.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { ENV_CEREMONY_MODEL_TIER } from "../policy/ceremony-dial.js";
 import {
   collectCeremonyDialConsumerEvidence,
   ENV_FAILING_GATE_COUNT,
@@ -155,6 +156,16 @@ describe("collectCeremonyDialConsumerEvidence (#3358)", () => {
     });
     expect(evidence.modelTier).toBe("mid");
     expect(evidence.reasons.some((r) => r.includes("modelTier=mid"))).toBe(true);
+  });
+
+  it("lets ceremony-specific model-tier env win over the generic host hint", () => {
+    const evidence = collectCeremonyDialConsumerEvidence(tempRoot(), {
+      env: {
+        [ENV_HOST_MODEL_TIER]: "low",
+        [ENV_CEREMONY_MODEL_TIER]: "frontier",
+      },
+    });
+    expect(evidence.modelTier).toBe("frontier");
   });
 
   it("ignores an unparsable failing-gate env instead of inventing a size", () => {

--- a/packages/core/src/session/ceremony-dial-evidence.ts
+++ b/packages/core/src/session/ceremony-dial-evidence.ts
@@ -1,0 +1,226 @@
+/**
+ * Consumer-environment evidence for ceremony-dial escalation (#3358).
+ *
+ * Session:start left `taskSize` and `modelTier` null unless CLI flags or
+ * provisional env/verb/file hints were set. Consumer runs then always
+ * declined with "insufficient evidence (size=- modelTier=-)".
+ *
+ * This module fills at least one input the consumer environment can supply:
+ *   1. stamped #3323 clause count on active/pending briefs (size proxy)
+ *   2. host-supplied model-tier env (`DEFT_HOST_MODEL_TIER` and aliases)
+ *   3. failing-gate count env (mid-session size proxy)
+ *
+ * ⊗ Change the rapid default or decline threshold when no evidence exists.
+ * Explicit CLI / session inputs still win at the merge site.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type CeremonyDialInputs,
+  type CeremonyModelTier,
+  type CeremonyTaskSize,
+  ENV_CEREMONY_MODEL_HINT,
+  ENV_CEREMONY_MODEL_TIER,
+  normalizeCeremonyModelTier,
+} from "../policy/ceremony-dial.js";
+
+/** Host-supplied model-tier hint when `DEFT_CEREMONY_MODEL_TIER` is unset. */
+export const ENV_HOST_MODEL_TIER = "DEFT_HOST_MODEL_TIER";
+/** Mid-session failing-gate count the consumer/harness can supply. */
+export const ENV_FAILING_GATE_COUNT = "DEFT_FAILING_GATE_COUNT";
+
+const LIFECYCLE_DIRS = ["active", "pending"] as const;
+
+export interface CeremonyDialConsumerEvidence {
+  readonly taskSize: CeremonyTaskSize | null;
+  readonly modelTier: CeremonyModelTier | null;
+  readonly clauseCount: number | null;
+  readonly failingGateCount: number | null;
+  readonly reasons: readonly string[];
+}
+
+export function taskSizeFromClauseCount(count: number): CeremonyTaskSize | null {
+  if (!Number.isFinite(count) || count <= 0) return null;
+  if (count === 1) return "S";
+  if (count <= 3) return "M";
+  if (count <= 6) return "L";
+  return "XL";
+}
+
+export function taskSizeFromFailingGateCount(count: number): CeremonyTaskSize | null {
+  if (!Number.isFinite(count) || count <= 0) return null;
+  if (count <= 2) return "M";
+  return "L";
+}
+
+function rankSize(size: CeremonyTaskSize): number {
+  switch (size) {
+    case "S":
+      return 0;
+    case "M":
+      return 1;
+    case "L":
+      return 2;
+    case "XL":
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+function maxSize(a: CeremonyTaskSize | null, b: CeremonyTaskSize | null): CeremonyTaskSize | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return rankSize(a) >= rankSize(b) ? a : b;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function clauseCountFromBrief(raw: unknown): number | null {
+  const root = asRecord(raw);
+  const plan = asRecord(root?.plan);
+  const acceptance = asRecord(plan?.acceptance);
+  if (acceptance === null) return null;
+  if (Array.isArray(acceptance.clauses) && acceptance.clauses.length > 0) {
+    return acceptance.clauses.length;
+  }
+  const stamped = acceptance.clause_count;
+  if (typeof stamped === "number" && Number.isFinite(stamped) && stamped > 0) {
+    return stamped;
+  }
+  return null;
+}
+
+function parseNonNegativeInt(raw: unknown): number | null {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
+    return Math.trunc(raw);
+  }
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.trunc(n);
+}
+
+/** Max stamped clause count across `xbrief/{active,pending}` (#3323). */
+export function readStampedClauseCount(projectRoot: string): {
+  readonly count: number;
+  readonly source: string;
+} | null {
+  let best: { count: number; source: string } | null = null;
+  for (const dir of LIFECYCLE_DIRS) {
+    const folder = join(projectRoot, "xbrief", dir);
+    if (!existsSync(folder)) continue;
+    let names: string[] = [];
+    try {
+      names = readdirSync(folder);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (!name.endsWith(".xbrief.json") || name === "PROJECT-DEFINITION.xbrief.json") {
+        continue;
+      }
+      const path = join(folder, name);
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+        const count = clauseCountFromBrief(parsed);
+        if (count === null) continue;
+        if (best === null || count > best.count) {
+          best = { count, source: `xbrief/${dir}/${name}` };
+        }
+      } catch {
+        // fail-open — a malformed brief is not an evidence source
+      }
+    }
+  }
+  return best;
+}
+
+export function collectCeremonyDialConsumerEvidence(
+  projectRoot: string,
+  options: { readonly env?: NodeJS.ProcessEnv } = {},
+): CeremonyDialConsumerEvidence {
+  const env = options.env ?? process.env;
+  const reasons: string[] = [];
+
+  const stamped = readStampedClauseCount(projectRoot);
+  const clauseCount = stamped?.count ?? null;
+  let taskSize: CeremonyTaskSize | null = null;
+  if (stamped !== null) {
+    const fromClauses = taskSizeFromClauseCount(stamped.count);
+    if (fromClauses !== null) {
+      taskSize = fromClauses;
+      reasons.push(
+        `taskSize=${fromClauses} from stamped clauseCount=${stamped.count} (${stamped.source})`,
+      );
+    }
+  }
+
+  const failingGateCount = parseNonNegativeInt(env[ENV_FAILING_GATE_COUNT]);
+  if (failingGateCount !== null) {
+    const fromGates = taskSizeFromFailingGateCount(failingGateCount);
+    if (fromGates !== null) {
+      const next = maxSize(taskSize, fromGates);
+      if (next !== taskSize) {
+        taskSize = next;
+        reasons.push(`taskSize=${next} from failingGateCount=${failingGateCount}`);
+      } else if (taskSize === fromGates) {
+        reasons.push(`failingGateCount=${failingGateCount} (size already ${taskSize})`);
+      }
+    }
+  }
+
+  const modelTier = normalizeCeremonyModelTier(
+    env[ENV_HOST_MODEL_TIER] ?? env[ENV_CEREMONY_MODEL_TIER] ?? env[ENV_CEREMONY_MODEL_HINT],
+  );
+  if (modelTier !== null) {
+    reasons.push(`modelTier=${modelTier} from host env`);
+  }
+
+  return {
+    taskSize,
+    modelTier,
+    clauseCount,
+    failingGateCount,
+    reasons,
+  };
+}
+
+/** Explicit non-null wins; consumer evidence fills only missing fields. */
+export function mergeCeremonyDialInputsWithConsumerEvidence(
+  explicit: CeremonyDialInputs | undefined,
+  evidence: CeremonyDialConsumerEvidence,
+): CeremonyDialInputs {
+  return {
+    taskSize: explicit?.taskSize ?? evidence.taskSize ?? null,
+    modelTier: explicit?.modelTier ?? evidence.modelTier ?? null,
+    projectShape: explicit?.projectShape ?? null,
+  };
+}
+
+export function formatCeremonyDialEvidenceLine(
+  evidence: CeremonyDialConsumerEvidence,
+): string | null {
+  if (evidence.reasons.length === 0) return null;
+  return `[deft ceremony-dial] evidence: ${evidence.reasons.join("; ")}`;
+}
+
+export function ceremonyDialEvidenceToDict(
+  evidence: CeremonyDialConsumerEvidence,
+): Record<string, unknown> {
+  return {
+    taskSize: evidence.taskSize,
+    modelTier: evidence.modelTier,
+    clauseCount: evidence.clauseCount,
+    failingGateCount: evidence.failingGateCount,
+    reasons: [...evidence.reasons],
+  };
+}

--- a/packages/core/src/session/ceremony-dial-evidence.ts
+++ b/packages/core/src/session/ceremony-dial-evidence.ts
@@ -176,9 +176,10 @@ export function collectCeremonyDialConsumerEvidence(
     }
   }
 
-  const modelTier = normalizeCeremonyModelTier(
-    env[ENV_CEREMONY_MODEL_TIER] ?? env[ENV_CEREMONY_MODEL_HINT] ?? env[ENV_HOST_MODEL_TIER],
-  );
+  const modelTier =
+    normalizeCeremonyModelTier(env[ENV_CEREMONY_MODEL_TIER]) ??
+    normalizeCeremonyModelTier(env[ENV_CEREMONY_MODEL_HINT]) ??
+    normalizeCeremonyModelTier(env[ENV_HOST_MODEL_TIER]);
   if (modelTier !== null) {
     reasons.push(`modelTier=${modelTier} from host env`);
   }

--- a/packages/core/src/session/ceremony-dial-evidence.ts
+++ b/packages/core/src/session/ceremony-dial-evidence.ts
@@ -64,8 +64,6 @@ function rankSize(size: CeremonyTaskSize): number {
       return 2;
     case "XL":
       return 3;
-    default:
-      return 0;
   }
 }
 
@@ -179,7 +177,7 @@ export function collectCeremonyDialConsumerEvidence(
   }
 
   const modelTier = normalizeCeremonyModelTier(
-    env[ENV_HOST_MODEL_TIER] ?? env[ENV_CEREMONY_MODEL_TIER] ?? env[ENV_CEREMONY_MODEL_HINT],
+    env[ENV_CEREMONY_MODEL_TIER] ?? env[ENV_CEREMONY_MODEL_HINT] ?? env[ENV_HOST_MODEL_TIER],
   );
   if (modelTier !== null) {
     reasons.push(`modelTier=${modelTier} from host env`);

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,5 +1,6 @@
 export * from "./ac-pass-banking.js";
 export * from "./active-cli.js";
+export * from "./ceremony-dial-evidence.js";
 export * from "./compact-ritual.js";
 export * from "./deposit-sha.js";
 export * from "./effort-budget.js";

--- a/packages/core/src/session/session-start.test.ts
+++ b/packages/core/src/session/session-start.test.ts
@@ -605,3 +605,102 @@ describe("runSessionStart start-tier provenance + evaluation events (#3319)", ()
     expect(existsSync(join(root, ".deft-run-summary.json"))).toBe(false);
   });
 });
+
+describe("runSessionStart consumer evidence (#3358)", () => {
+  function writeActiveClauses(root: string, count: number): void {
+    mkdirSync(join(root, "xbrief", "active"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "active", "story.xbrief.json"),
+      JSON.stringify({
+        xBRIEFInfo: { version: "0.8" },
+        plan: {
+          title: "T",
+          status: "running",
+          acceptance: {
+            none_stated: true,
+            clauses: Array.from({ length: count }, (_, i) => ({
+              id: i + 1,
+              text: `clause ${i + 1}`,
+            })),
+          },
+        },
+      }),
+      "utf8",
+    );
+  }
+
+  it("stays rapid when no stamped clauses or host env exist", () => {
+    const root = tempRoot();
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      env: {},
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const dial = result.payload.ceremony_dial as {
+      depth: string;
+      inputs: { taskSize: string | null; modelTier: string | null };
+      consumer_evidence: { taskSize: string | null; clauseCount: number | null };
+    };
+    expect(dial.depth).toBe("rapid");
+    expect(dial.inputs.taskSize).toBeNull();
+    expect(dial.inputs.modelTier).toBeNull();
+    expect(dial.consumer_evidence.clauseCount).toBeNull();
+  });
+
+  it("escalates from stamped clause count instead of a vacuous decline", () => {
+    const root = tempRoot();
+    writeActiveClauses(root, 3);
+    const out = join(root, "summary.jsonl");
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      env: { [ENV_RUN_SUMMARY_PATH]: out },
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const dial = result.payload.ceremony_dial as {
+      depth: string;
+      inputs: { taskSize: string | null };
+      consumer_evidence: { clauseCount: number | null; taskSize: string | null };
+    };
+    expect(dial.inputs.taskSize).toBe("M");
+    expect(dial.depth).toBe("standard");
+    expect(dial.consumer_evidence.clauseCount).toBe(3);
+    expect(result.lines.some((l) => l.includes("evidence:") && l.includes("clauseCount=3"))).toBe(
+      true,
+    );
+    const events = readFileSync(out, "utf8")
+      .trim()
+      .split("\n")
+      .map(
+        (l) => JSON.parse(l) as { event: string; payload: { outcome?: string; reason?: string } },
+      );
+    const evals = events.filter((e) => e.event === "dial_escalation_evaluation");
+    expect(evals).toHaveLength(1);
+    expect(evals[0]?.payload.outcome).toBe("escalated");
+    expect(String(evals[0]?.payload.reason)).toContain("size=M");
+    expect(String(evals[0]?.payload.reason)).not.toContain("size=-");
+  });
+
+  it("does not override an explicit CLI size with stamped clauses", () => {
+    const root = tempRoot();
+    writeActiveClauses(root, 4);
+    const result = runSessionStart(root, {
+      ...baseOptions(root, () => userMdResult()),
+      env: {},
+      ceremonyDialInputs: {
+        taskSize: "S",
+        modelTier: "frontier",
+        projectShape: "project",
+      },
+      runStalenessTickler: () => ({ lines: [], prompted: false }),
+    });
+    expect(result.code).toBe(0);
+    const dial = result.payload.ceremony_dial as {
+      depth: string;
+      inputs: { taskSize: string | null };
+    };
+    expect(dial.inputs.taskSize).toBe("S");
+    expect(dial.depth).toBe("rapid");
+  });
+});

--- a/packages/core/src/session/session-start.ts
+++ b/packages/core/src/session/session-start.ts
@@ -70,6 +70,12 @@ import { type ResolveUserMdResult, resolveUserMdPath } from "../user-config/reso
 import { emitSessionValueReadback } from "../value/readback.js";
 import { verifyRequiredTools } from "../verify-env/verify-tools.js";
 import {
+  ceremonyDialEvidenceToDict,
+  collectCeremonyDialConsumerEvidence,
+  formatCeremonyDialEvidenceLine,
+  mergeCeremonyDialInputsWithConsumerEvidence,
+} from "./ceremony-dial-evidence.js";
+import {
   type DetectHardEffortBudgetInput,
   effortBudgetToDict,
   type HardEffortBudget,
@@ -1101,8 +1107,21 @@ export function runSessionStart(
   // missing size/tier/shape from env/verb/files/deposit BEFORE resolve — never
   // block on plan-item effort (post-planning only). Cold incomplete size is
   // tier-conditional (#3263): mid/low → standard; frontier/unknown → rapid.
+  // #3358: fill at least one consumer-supplied input (stamped clause count,
+  // host-tier env, failing-gate count) so evaluation is not permanently
+  // size=- / modelTier=-. ⊗ Change rapid default when no evidence exists.
+  const consumerDialEvidence = collectCeremonyDialConsumerEvidence(projectRoot, {
+    env: options.env,
+  });
+  const dialInputsWithEvidence =
+    options.ceremonyDial === undefined
+      ? mergeCeremonyDialInputsWithConsumerEvidence(
+          options.ceremonyDialInputs,
+          consumerDialEvidence,
+        )
+      : (options.ceremonyDialInputs ?? {});
   const { inputs: resolvedDialInputs, provisional: provisionalDial } =
-    resolveSessionCeremonyDialInputs(projectRoot, options.ceremonyDialInputs, {
+    resolveSessionCeremonyDialInputs(projectRoot, dialInputsWithEvidence, {
       ...options.ceremonyDialHints,
       env: options.env,
     });
@@ -1166,6 +1185,10 @@ export function runSessionStart(
   }
   if (provisionalDial.reasons.length > 0 && options.ceremonyDial === undefined) {
     lines.push(`[deft ceremony-dial] provisional: ${provisionalDial.reasons.join("; ")}`);
+  }
+  const evidenceLine = formatCeremonyDialEvidenceLine(consumerDialEvidence);
+  if (evidenceLine !== null && options.ceremonyDial === undefined) {
+    lines.push(evidenceLine);
   }
 
   // Resolve USER.md via the shared first-hit-wins resolver so the alignment
@@ -1538,6 +1561,7 @@ export function runSessionStart(
       projectShape: provisionalDial.projectShape,
       reasons: [...provisionalDial.reasons],
     },
+    consumer_evidence: ceremonyDialEvidenceToDict(consumerDialEvidence),
   };
   const preflightDict =
     toolchainPreflightResult !== null ? toolchainPreflightToDict(toolchainPreflightResult) : null;


### PR DESCRIPTION
## Summary

Ceremony-dial escalation evaluation no longer stays permanently at
`insufficient evidence (size=- modelTier=-)` in consumer runs.

Session:start now fills at least one input the consumer environment can
supply:

- stamped #3323 clause count already present on existing
  `xbrief/{active,pending}` briefs (size proxy; does not create lifecycle
  folders)
- optional host model-tier env (`DEFT_HOST_MODEL_TIER` as fallback after
  `DEFT_CEREMONY_MODEL_TIER` / `DEFT_MODEL`)
- optional failing-gate count env (`DEFT_FAILING_GATE_COUNT`)

Explicit CLI inputs still win. When no evidence exists, the rapid default
and decline threshold are unchanged.

## Related Issues

Closes #3358

## Checklist

- [x] `/deft:change <name>` — N/A: scoped session evidence fill; not a new
      cross-cutting subsystem
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A: #3358 is not a tracked ROADMAP row
- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/session`;
      lint + `tsc -b`)

## Test plan

- [x] `pnpm exec vitest run packages/core/src/session`
- [x] `pnpm exec biome check` on changed session files
- [x] `pnpm run lint` (warnings only; exit 0)
- [x] `pnpm run build`
