### PR TITLE
docs: always-on writing bar (clarity, simplicity, brevity) (#3368)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Same as managed below; `task verify:story-ready`, `task scope:promote -- <path>`
 ## CHANGELOG entry style (#1242)
 
 ! Brief release-notes — `docs/analysis/2026-07-02-agents-md-incident-rule-rationale.md` § CHANGELOG entry style (#1242).
-! Controlled English for docs/issues/PRs — `content/docs/writing-ste100.md` (#2927). ⊗ Full STE cert; ⊗ big-bang rewrite; ⊗ red CI style gate v1.
+! Clarity, simplicity, brevity in documents and user communications, including sub-agent status and handbacks. Cut ceremony, not required fields. STE how: `content/docs/writing-ste100.md` (#2927). ⊗ Full STE; ⊗ historical rewrite; ⊗ red CI style gate; ⊗ prefacing the rule.
 ! Per-project opt-out — root `.no-deft-directive` (#2926) skips install/session/setup (`content/docs/no-deft-directive.md`); flag wins locally over org force-on; flag+deposit → doctor warns, init/update fail closed. Temporary kill-switch `.deft-directive-disable` (#3039) — deposit OK; delete + NEW agent session (`content/docs/deft-directive-disable.md`).
 
 ## Contextual guardrails (runtime-detect lazy-load)
@@ -160,7 +160,7 @@ Same `!` / `⊗` rules as managed below; `task issue:ingest` (#2143).
 
 Note: root-relative paths (this repo IS deft/); run `task agents:refresh` after agents-entry edits (#1309).
 
-<!-- deft:managed-section v3 sha=7ba22d62390d refreshed=2026-08-14T00:23:38Z session=685f6741f27f -->
+<!-- deft:managed-section v3 sha=3e7f077fd037 refreshed=2026-08-14T19:52:03Z session=66f590ef7036 -->
 # Deft — AI Development Framework
 
 Deft is installed in .deft/core/. Full guidelines: .deft/core/main.md
@@ -232,6 +232,8 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 ! Prefer `task deft:*` over AGENTS.md prose. See main.md.
 ## Thin Fail-Closed Design (#3265)
 ! One fail-closed `task deft:*` check + one remediation. See main.md.
+## Writing bar (#3368)
+! Clarity, simplicity, brevity in documents and user communications, including sub-agent status and handbacks. Cut ceremony, not required fields. STE how: `.deft/core/docs/writing-ste100.md` (#2927). ⊗ Full STE; ⊗ historical rewrite; ⊗ red CI style gate; ⊗ prefacing the rule.
 
 ## Continuous Improvement Learning (#607 / #3164)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> Always-on writing bar: clarity, simplicity, brevity for documents and communications (#3368).
+
 ### Added
+
+- **Always-on writing bar: clarity, simplicity, brevity (#3368).** Standing outcome bar for documents and user communications, including sub-agent status and handbacks. Agents-entry and the worker preamble name the three words. The depth page keeps the four STE mechanics plus ceremony-vs-fields, product-content voice, and no-reasoning-scope carve-outs. Not an [AXIOM], skill pin, or red CI style gate. Version blurb and GitHub/Slack Key Changes must name this bar. Closes #3368. Refs #2927, #3313.
 
 - **Ceremony-dial evaluation reads a consumer evidence source (#3358).** Session:start maps stamped #3323 clause count (and optional host-tier / failing-gate env) into `taskSize`/`modelTier` so evaluation is not permanently `insufficient evidence (size=- modelTier=-)`. Rapid default and decline threshold stay unchanged when no evidence exists. Closes #3358. Refs #3319, #3274, #3214, #3323.
 

--- a/content/docs/writing-ste100.md
+++ b/content/docs/writing-ste100.md
@@ -1,12 +1,14 @@
 # Controlled English for docs and issues
 
-Directive uses a short **controlled-English** bar for product docs, issues, PRs, and agent-facing prose.
+Directive's writing bar is **clarity, simplicity, and brevity**.
 
-**ASD-STE100** is Simplified Technical English (aerospace controlled language). Here it means a practical subset. It is not a certification program.
+Use that outcome bar for documents and user communications, including sub-agent status and handbacks.
+
+**ASD-STE100** is Simplified Technical English (aerospace controlled language). Here it means a practical subset. It is not a certification program. The four rules below are the how.
 
 Legend (RFC2119): `!`=MUST, `~`=SHOULD, `≉`=SHOULD NOT, `⊗`=MUST NOT, `?`=MAY.
 
-Tracker: [#2927](https://github.com/deftai/directive/issues/2927).
+Tracker: [#3368](https://github.com/deftai/directive/issues/3368). Mechanics from [#2927](https://github.com/deftai/directive/issues/2927).
 
 ---
 
@@ -17,9 +19,23 @@ Tracker: [#2927](https://github.com/deftai/directive/issues/2927).
 3. **One term = one meaning.** Keep product terms stable (`xbrief`, host, skill pack, swarm, deposit). Do not reuse one word for two concepts.
 4. **First-use definitions.** Define a tech term the first time it appears when the reader may not know it.
 
-! Apply these four rules to **new and touched** prose that maintainers or agents author for this repo.
+! Apply these four rules to documents and user communications, including sub-agent status and handbacks — not only new-and-touched files.
 
 ~ Prefer clarity over ceremony. When a product term already has a glossary or category note, reuse that meaning.
+
+---
+
+## Ceremony vs required fields
+
+! Cut ceremony, not required protocol fields. Keep these complete:
+
+- `DONE` / `BLOCKED` / `FAILED` status lines
+- Allocation context
+- SHAs
+- Exit codes
+- Evidence cites
+
+⊗ Drop a required field to look brief.
 
 ---
 
@@ -29,6 +45,19 @@ Tracker: [#2927](https://github.com/deftai/directive/issues/2927).
 - Product docs (including `content/docs/` and related guides)
 - GitHub issues, PRs, and review comments that maintainers or agents author here
 - Skill and strategy prose where clarity matters for agent load
+- Sub-agent status, handbacks, and sibling reports
+
+! The bar governs communication **about** the work, not the work itself.
+
+! Product content with its own specified voice (fiction, game dialogue, marketing, brand copy) follows the scope's style requirements. No toggle: this is a scoping sentence, not a config flag.
+
+---
+
+## Reasoning is out of scope
+
+! The bar does not govern reasoning itself. Thinking budgets are harness knobs (effort tier, per-role routing #1739), not prose rules.
+
+⊗ Extend the bar to thinking. Terse reasoning trades correctness for style.
 
 ---
 
@@ -37,6 +66,8 @@ Tracker: [#2927](https://github.com/deftai/directive/issues/2927).
 - ⊗ Full ASD-STE100 dictionary compliance or formal STE tooling certification
 - ⊗ A big-bang rewrite of the historical issue corpus
 - ⊗ A red CI style gate in v1 that blocks merges on style nitpicks
+- ⊗ A second `[AXIOM]` label
+- ⊗ Prefacing the rule ("per the writing bar…")
 
 Process expectation only: follow the bar by default. Do not invent a merge blocker from this page alone.
 
@@ -46,8 +77,11 @@ Process expectation only: follow the bar by default. Do not invent a merge block
 
 | Issue | Role |
 |-------|------|
+| [#3368](https://github.com/deftai/directive/issues/3368) | Always-on outcome bar (clarity, simplicity, brevity) |
+| [#2927](https://github.com/deftai/directive/issues/2927) | Four STE mechanics (closed) |
 | [#740](https://github.com/deftai/directive/issues/740) | Plain-English UX pass (closed; interview-focused) |
 | [#865](https://github.com/deftai/directive/issues/865) | Every rule is a token tax |
 | [#847](https://github.com/deftai/directive/issues/847) | Lean context first |
 | [#2484](https://github.com/deftai/directive/issues/2484) | Progressive disclosure for large skills |
 | [#2905](https://github.com/deftai/directive/issues/2905) | Category terms (host vs skill pack vs practice layer) |
+| [#1739](https://github.com/deftai/directive/issues/1739) | Per-role routing (thinking budgets; not this bar) |

--- a/content/templates/agent-prompt-preamble.md
+++ b/content/templates/agent-prompt-preamble.md
@@ -537,7 +537,7 @@ Principle: `main.md` `## Thin Fail-Closed Design (#3265)`.
 
 ## 10.56 Writing bar — clarity, simplicity, brevity (#3368)
 
-! Clarity, simplicity, brevity in documents and user communications, including sub-agent status and handbacks. Cut ceremony, not required fields. Depth: `content/docs/writing-ste100.md` (#2927 / #3368). ⊗ Full STE; ⊗ historical rewrite; ⊗ red CI style gate; ⊗ prefacing the rule.
+! Clarity, simplicity, brevity in documents and user communications, including sub-agent status and handbacks. Cut ceremony, not required fields. Depth: `.deft/core/docs/writing-ste100.md` (#2927 / #3368). ⊗ Full STE; ⊗ historical rewrite; ⊗ red CI style gate; ⊗ prefacing the rule.
 
 ## 10.6 Dual stop for multi-iteration worker loops (#2442)
 

--- a/content/templates/agent-prompt-preamble.md
+++ b/content/templates/agent-prompt-preamble.md
@@ -535,6 +535,10 @@ The parent monitor watches the heartbeat file directly (three-state exit 0 ok / 
 Principle: `main.md` `## Rule Authority [AXIOM]`.
 Principle: `main.md` `## Thin Fail-Closed Design (#3265)`.
 
+## 10.56 Writing bar — clarity, simplicity, brevity (#3368)
+
+! Clarity, simplicity, brevity in documents and user communications, including sub-agent status and handbacks. Cut ceremony, not required fields. Depth: `content/docs/writing-ste100.md` (#2927 / #3368). ⊗ Full STE; ⊗ historical rewrite; ⊗ red CI style gate; ⊗ prefacing the rule.
+
 ## 10.6 Dual stop for multi-iteration worker loops (#2442)
 
 Multi-iteration implement, pre-PR, repair, and monitor loops require **two** stops: **success** (goal / AC / checker met) and **failure or budget** (max iterations, no-progress, or time/token budget). Single-turn tasks are exempt. Principle and defaults: `main.md` `## Dual Stop Rule (#2442)`; build skill dual-stop table; swarm Phase 4 / core-ops.

--- a/content/templates/agents-entry.md
+++ b/content/templates/agents-entry.md
@@ -70,6 +70,8 @@ Legacy `vbrief/` read-accepted; `deft migrate:xbrief` for `xbrief/` (v0.6→v0.8
 ! Prefer `task deft:*` over AGENTS.md prose. See main.md.
 ## Thin Fail-Closed Design (#3265)
 ! One fail-closed `task deft:*` check + one remediation. See main.md.
+## Writing bar (#3368)
+! Clarity, simplicity, brevity in documents and user communications, including sub-agent status and handbacks. Cut ceremony, not required fields. STE how: `.deft/core/docs/writing-ste100.md` (#2927). ⊗ Full STE; ⊗ historical rewrite; ⊗ red CI style gate; ⊗ prefacing the rule.
 
 ## Continuous Improvement Learning (#607 / #3164)
 

--- a/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
+++ b/packages/core/src/content-contracts/skills/agents_entry_contract.test.ts
@@ -107,6 +107,7 @@ const PROPAGATION_HEADER_MARKERS = [
   "## Skill pin policy (#2508)",
   "## Rule Authority [AXIOM]",
   "## Thin Fail-Closed Design (#3265)",
+  "## Writing bar (#3368)",
   "## Through-merge worker dispatch (#3032)",
   "## Mid-scope gate capability tier (#3158 / #954)",
   "## WIP cap",
@@ -138,6 +139,14 @@ const DEFT_DIRECTIVE_DISABLE_MARKERS = [
 const RULE_AUTHORITY_THIN_FAIL_CLOSED_POINTER_MARKERS = [
   "Prefer `task deft:*` over AGENTS.md prose",
   "One fail-closed `task deft:*` check + one remediation",
+] as const;
+
+/** Always-on writing bar (#3368) — three words must stay in the line. */
+const WRITING_BAR_MARKERS = [
+  "Clarity, simplicity, brevity",
+  "documents and user communications",
+  "sub-agent status and handbacks",
+  "writing-ste100.md",
 ] as const;
 
 const THROUGH_MERGE_DISPATCH_MARKERS = [
@@ -357,6 +366,27 @@ const POINTER_RELOCATED_RULES: readonly PointerRuleSpec[] = [
       "pre-`start_agent` gate stack (#1149/#1348)",
       "deft verify:cache-fresh` is gate-stack step 3",
     ],
+  },
+  {
+    id: "writing-bar-3368",
+    shape: "doc",
+    header: "Writing bar (#3368)",
+    canonicalHome: "docs/writing-ste100.md",
+    pointerHints: [
+      "Clarity, simplicity, brevity",
+      "documents and user communications",
+      "sub-agent status and handbacks",
+      "writing-ste100.md",
+      "#3368",
+    ],
+    canonicalBodyMarkers: [
+      "clarity, simplicity, and brevity",
+      "Short sentences",
+      "does not govern reasoning",
+      "fiction, game dialogue, marketing",
+      "DONE",
+    ],
+    retiredFullTextMarkers: [],
   },
   {
     id: "human-merge-1193",
@@ -746,6 +776,11 @@ describe("test_agents_entry_contract", () => {
   it("rule_authority_thin_fail_closed_pointer_bodies_present_in_both_files", () => {
     expect(missingMarkers(template, RULE_AUTHORITY_THIN_FAIL_CLOSED_POINTER_MARKERS)).toEqual([]);
     expect(missingMarkers(agents, RULE_AUTHORITY_THIN_FAIL_CLOSED_POINTER_MARKERS)).toEqual([]);
+  });
+
+  it("writing_bar_markers_present_in_both_files", () => {
+    expect(missingMarkers(template, WRITING_BAR_MARKERS)).toEqual([]);
+    expect(missingMarkers(agents, WRITING_BAR_MARKERS)).toEqual([]);
   });
 
   it("through_merge_dispatch_markers_present_in_both_files", () => {


### PR DESCRIPTION
## Summary

Make **clarity, simplicity, and brevity** a standing writing bar for documents and user communications, including sub-agent status and handbacks.

- `agents-entry.md` now carries one standing `!` line with the three words inline (consumer path `.deft/core/docs/writing-ste100.md`) and an `agents_entry_contract` marker.
- Worker preamble §10.56 is pointer-sufficient so workers see the three words without opening the depth page.
- `writing-ste100.md` names the outcome bar, keeps the four STE mechanics, and states ceremony-vs-fields, product-content voice, and no-reasoning-scope carve-outs.
- Maintainer AGENTS.md unmanaged header replaces the old #2927 STE bullet and cites `content/docs/writing-ste100.md`.
- CHANGELOG `[Unreleased]` **### Added** is a highlighted bold entry. The version `>` blurb is seeded so GitHub/Slack Key Changes name the writing bar.

Not an `[AXIOM]`. Not a skill pin. Not a red CI style gate.

## Related Issues

Closes #3368

## Checklist

- [x] `/deft:change <name>` — N/A (single-story docs/guidance; one xBRIEF, not a cross-cutting architecture change)
- [x] `CHANGELOG.md` — highlighted `[Unreleased]` ### Added entry citing #3368
- [x] `ROADMAP.md` — N/A (not a tracked ROADMAP item)
- [x] Tests pass locally (`task check`: 13434 passed, 141 skipped)

## Test plan

- `task agents:refresh` (local `DEFT_ROOT`) updated the managed AGENTS section
- `task verify:ac` — 4/4 derived clauses verified
- `task verify:agents-md-budget` — managed 156/160, unmanaged 162/162
- `task check` — 13434 passed, 141 skipped
- `task verify:encoding` / `task verify:forward-coverage` / `task verify:branch`

## Post-Merge

- [ ] **Verify issue auto-close**: After squash merge, confirm #3368 closed. If still open, close manually citing this PR (#167).
