### PR TITLE
feat(pr-monitor): escalate on sustained ci_absent_required (#3389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`pr-monitor` escalates on sustained `ci_absent_required` instead of polling to cap (#3389).** After a one-poll grace (first-poll absence is normal), consecutive absent required contexts exit `ABSENT-REQUIRED` and name the missing checks. Pending check-runs still wait. Consumes #3234; does not redefine it. Closes #3389.
+
 ### Changed
 
 ### Fixed

--- a/packages/core/src/pr-monitor/absent-required.test.ts
+++ b/packages/core/src/pr-monitor/absent-required.test.ts
@@ -63,6 +63,26 @@ describe("readAbsentRequiredContexts", () => {
     ).toBeNull();
   });
 
+  it("does not treat ci_failures as absent even when failures mention ci_absent_required", () => {
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        failures: [
+          "Required status-check contexts absent on HEAD (ci_absent_required): Greptile Review",
+          "CI failed",
+        ],
+        partial_data: {
+          ci: {
+            ready_state: "ci_failures",
+            absent_required: ["Greptile Review"],
+            pending_required: [],
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
   it("falls back to failures when partial_data.ci is missing", () => {
     expect(
       readAbsentRequiredContexts({

--- a/packages/core/src/pr-monitor/absent-required.test.ts
+++ b/packages/core/src/pr-monitor/absent-required.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAbsentRequiredMessage,
+  readAbsentRequiredContexts,
+  shouldEscalateAbsentRequired,
+} from "./absent-required.js";
+import { ABSENT_REQUIRED_GRACE_POLLS } from "./constants.js";
+
+function absentPayload(contexts: readonly string[]): Record<string, unknown> {
+  return {
+    via: "primary",
+    merge_ready: false,
+    failures: [
+      `Required status-check contexts absent on HEAD (ci_absent_required): ${contexts.join(", ")}`,
+    ],
+    partial_data: {
+      ci: {
+        ready_state: "ci_absent_required",
+        absent_required: [...contexts],
+        pending_required: [],
+      },
+    },
+  };
+}
+
+describe("readAbsentRequiredContexts", () => {
+  it("reads #3234 ci_absent_required contexts", () => {
+    expect(readAbsentRequiredContexts(absentPayload(["Greptile Review"]))).toEqual([
+      "Greptile Review",
+    ]);
+  });
+
+  it("returns null on first-class pending required runs", () => {
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        failures: ["waiting"],
+        partial_data: {
+          ci: {
+            ready_state: "not_ready_yet",
+            absent_required: [],
+            pending_required: ["Greptile Review"],
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not treat pending_required as absent even if ready_state is absent", () => {
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        partial_data: {
+          ci: {
+            ready_state: "ci_absent_required",
+            absent_required: ["Greptile Review"],
+            pending_required: ["TypeScript (build + lint + test)"],
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to failures when partial_data.ci is missing", () => {
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        failures: ["Required status-check contexts absent on HEAD (ci_absent_required): x"],
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns empty contexts when ci_absent_required has a non-list absent_required", () => {
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        partial_data: {
+          ci: {
+            ready_state: "ci_absent_required",
+            absent_required: "Greptile Review",
+            pending_required: "nope",
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignores non-object partial_data and ci wrappers", () => {
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        failures: "not-a-list",
+        partial_data: [],
+      }),
+    ).toBeNull();
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        failures: ["other"],
+        partial_data: { ci: ["not-an-object"] },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when neither ci ready_state nor failure mentions absent", () => {
+    expect(
+      readAbsentRequiredContexts({
+        via: "primary",
+        merge_ready: false,
+        failures: ["blocked"],
+        partial_data: { ci: { ready_state: "blocked", absent_required: [] } },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("shouldEscalateAbsentRequired", () => {
+  it("does not escalate on the first-poll grace window", () => {
+    expect(shouldEscalateAbsentRequired(ABSENT_REQUIRED_GRACE_POLLS)).toBe(false);
+    expect(shouldEscalateAbsentRequired(1)).toBe(false);
+  });
+
+  it("escalates once consecutive polls pass the grace window", () => {
+    expect(shouldEscalateAbsentRequired(ABSENT_REQUIRED_GRACE_POLLS + 1)).toBe(true);
+    expect(shouldEscalateAbsentRequired(2)).toBe(true);
+  });
+});
+
+describe("formatAbsentRequiredMessage", () => {
+  it("names missing contexts", () => {
+    expect(formatAbsentRequiredMessage(["Greptile Review", "terraform-plan"])).toBe(
+      "ABSENT-REQUIRED: Greptile Review, terraform-plan",
+    );
+  });
+
+  it("uses a distinct fallback when the context list is empty", () => {
+    expect(formatAbsentRequiredMessage([])).toContain("ABSENT-REQUIRED");
+  });
+});

--- a/packages/core/src/pr-monitor/absent-required.ts
+++ b/packages/core/src/pr-monitor/absent-required.ts
@@ -43,6 +43,9 @@ export function readAbsentRequiredContexts(
     if (readyState === "ci_absent_required") {
       return stringList(ci.absent_required);
     }
+    // Structured CI present but not absent-required (e.g. ci_failures).
+    // Do not let failure-text mention of ci_absent_required override it.
+    return null;
   }
 
   const failures = Array.isArray(payload.failures) ? payload.failures.map(String) : [];

--- a/packages/core/src/pr-monitor/absent-required.ts
+++ b/packages/core/src/pr-monitor/absent-required.ts
@@ -1,0 +1,69 @@
+import { ABSENT_REQUIRED_GRACE_POLLS } from "./constants.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function ciFromPayload(payload: Record<string, unknown>): Record<string, unknown> | null {
+  const partial = asRecord(payload.partial_data);
+  if (partial === null) {
+    return null;
+  }
+  return asRecord(partial.ci);
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+/**
+ * Consume #3234 `ci_absent_required` from a readiness payload.
+ * Returns missing context names, or null when the poll is not absent-required.
+ * Pending required check-runs are a wait, not an absence.
+ */
+export function readAbsentRequiredContexts(
+  payload: Record<string, unknown>,
+): readonly string[] | null {
+  const ci = ciFromPayload(payload);
+  if (ci !== null) {
+    const pending = stringList(ci.pending_required);
+    if (pending.length > 0) {
+      return null;
+    }
+    const readyState = ci.ready_state;
+    if (readyState === "not_ready_yet") {
+      return null;
+    }
+    if (readyState === "ci_absent_required") {
+      return stringList(ci.absent_required);
+    }
+  }
+
+  const failures = Array.isArray(payload.failures) ? payload.failures.map(String) : [];
+  if (failures.some((failure) => failure.includes("ci_absent_required"))) {
+    return [];
+  }
+  return null;
+}
+
+/** True once consecutive absent polls have passed the first-poll grace window. */
+export function shouldEscalateAbsentRequired(
+  consecutivePolls: number,
+  gracePolls: number = ABSENT_REQUIRED_GRACE_POLLS,
+): boolean {
+  return consecutivePolls > gracePolls;
+}
+
+/** Distinct exit naming that lists the missing required contexts. */
+export function formatAbsentRequiredMessage(contexts: readonly string[]): string {
+  if (contexts.length === 0) {
+    return "ABSENT-REQUIRED: required status-check context never appeared";
+  }
+  return `ABSENT-REQUIRED: ${contexts.join(", ")}`;
+}

--- a/packages/core/src/pr-monitor/constants.ts
+++ b/packages/core/src/pr-monitor/constants.ts
@@ -3,6 +3,14 @@ export const EXIT_CLEAN = 0;
 export const EXIT_CAP_REACHED = 1;
 export const EXIT_CONFIG_ERROR = 2;
 export const EXIT_PR_TERMINAL = 3;
+/** Sustained required-context absence (#3389). Distinct from CAP-REACHED. */
+export const EXIT_ABSENT_REQUIRED = 4;
+
+/**
+ * First-poll absence is normal (check-runs take time after a head push).
+ * Escalate on the next consecutive `ci_absent_required` poll (#3389).
+ */
+export const ABSENT_REQUIRED_GRACE_POLLS = 1;
 
 /** Adaptive cadence (seconds, repeats). Last repeat is a soft ceiling. */
 export const DEFAULT_CADENCE: ReadonlyArray<readonly [number, number]> = [

--- a/packages/core/src/pr-monitor/coverage-boost.test.ts
+++ b/packages/core/src/pr-monitor/coverage-boost.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import * as computeMod from "../pr-merge-readiness/compute.js";
-import { EXIT_CAP_REACHED, EXIT_CLEAN, EXIT_CONFIG_ERROR, EXIT_PR_TERMINAL } from "./constants.js";
+import {
+  EXIT_ABSENT_REQUIRED,
+  EXIT_CAP_REACHED,
+  EXIT_CLEAN,
+  EXIT_CONFIG_ERROR,
+  EXIT_PR_TERMINAL,
+} from "./constants.js";
 import { parseMonitorArgs, runMonitor } from "./main.js";
 import { formatPollStatus, monitor, summaryLabelForExit } from "./monitor.js";
 import { callReadiness, readinessExitToPoll } from "./readiness.js";
@@ -98,6 +104,7 @@ describe("coverage boost", () => {
     expect(summaryLabelForExit(EXIT_CAP_REACHED)).toBe("CAP-REACHED");
     expect(summaryLabelForExit(EXIT_PR_TERMINAL)).toBe("PR-TERMINAL");
     expect(summaryLabelForExit(EXIT_CONFIG_ERROR)).toBe("CONFIG-ERROR");
+    expect(summaryLabelForExit(EXIT_ABSENT_REQUIRED)).toBe("ABSENT-REQUIRED");
     expect(summaryLabelForExit(99)).toBe("UNKNOWN");
   });
 

--- a/packages/core/src/pr-monitor/index.ts
+++ b/packages/core/src/pr-monitor/index.ts
@@ -1,6 +1,13 @@
+export {
+  formatAbsentRequiredMessage,
+  readAbsentRequiredContexts,
+  shouldEscalateAbsentRequired,
+} from "./absent-required.js";
 export { cadenceIntervalAfterPoll, cadenceIntervals } from "./cadence.js";
 export {
+  ABSENT_REQUIRED_GRACE_POLLS,
   DEFAULT_CADENCE,
+  EXIT_ABSENT_REQUIRED,
   EXIT_CAP_REACHED,
   EXIT_CLEAN,
   EXIT_CONFIG_ERROR,

--- a/packages/core/src/pr-monitor/main.test.ts
+++ b/packages/core/src/pr-monitor/main.test.ts
@@ -131,6 +131,30 @@ describe("runMonitor CLI", () => {
     stdout.mockRestore();
     stderr.mockRestore();
   });
+
+  it("prints ABSENT-REQUIRED missing contexts (#3389)", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    runMonitor(["1363", "--repo", "deftai/directive"], {
+      monitorFn: () => ({
+        exitCode: 4,
+        payload: {
+          via: "primary",
+          merge_ready: false,
+          failures: [
+            "Required status-check contexts absent on HEAD (ci_absent_required): Greptile Review",
+          ],
+          monitor_absent_required: ["Greptile Review"],
+        },
+        pollCount: 2,
+      }),
+    });
+    const out = String(stdout.mock.calls.map((c) => c[0]).join(""));
+    expect(out).toContain("monitor result: ABSENT-REQUIRED");
+    expect(out).toContain("missing: Greptile Review");
+    stdout.mockRestore();
+    stderr.mockRestore();
+  });
 });
 
 describe("integration monitor with runGh", () => {

--- a/packages/core/src/pr-monitor/main.ts
+++ b/packages/core/src/pr-monitor/main.ts
@@ -200,6 +200,10 @@ export function runMonitor(argv: readonly string[], options: RunMonitorOptions =
     if (typeof err === "string" && err.length > 0) {
       lines.push(`  error: ${err}`);
     }
+    const missingRaw = payload.monitor_absent_required;
+    if (Array.isArray(missingRaw) && missingRaw.length > 0) {
+      lines.push(`  missing: ${missingRaw.map(String).join(", ")}`);
+    }
     const failuresRaw = payload.failures;
     if (Array.isArray(failuresRaw)) {
       failuresRaw.forEach((fail, index) => {

--- a/packages/core/src/pr-monitor/monitor.test.ts
+++ b/packages/core/src/pr-monitor/monitor.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { fakeRunGhForMonitor } from "../pr-merge-readiness/test-gh-fixtures.helpers.js";
 import { cadenceIntervalAfterPoll, cadenceIntervals } from "./cadence.js";
-import { DEFAULT_CADENCE, EXIT_CAP_REACHED, EXIT_CLEAN, EXIT_PR_TERMINAL } from "./constants.js";
+import {
+  DEFAULT_CADENCE,
+  EXIT_ABSENT_REQUIRED,
+  EXIT_CAP_REACHED,
+  EXIT_CLEAN,
+  EXIT_PR_TERMINAL,
+} from "./constants.js";
 import {
   formatPollStatus,
   isTerminalPrState,
@@ -467,6 +473,153 @@ describe("monitor loop", () => {
     expect(emitted).toContain("poll #5");
   });
 
+  it("does not escalate on first-poll ci_absent_required (#3389)", () => {
+    let reads = 0;
+    const clockFn = {
+      now(): number {
+        reads += 1;
+        if (reads <= 2) return 0;
+        return 1000;
+      },
+    };
+    const result = monitor(3389, "deftai/directive", {
+      capMinutes: 0.001,
+      cadence: [[1, 5]],
+      sleepFn: () => undefined,
+      clockFn,
+      callReadinessFn: makeCallLog({
+        via: "primary",
+        merge_ready: false,
+        failures: [
+          "Required status-check contexts absent on HEAD (ci_absent_required): Greptile Review",
+        ],
+        partial_data: {
+          ci: {
+            ready_state: "ci_absent_required",
+            absent_required: ["Greptile Review"],
+            pending_required: [],
+          },
+        },
+      }),
+    });
+    expect(result.exitCode).toBe(EXIT_CAP_REACHED);
+    expect(result.pollCount).toBe(1);
+  });
+
+  it("escalates after consecutive ci_absent_required past the grace window (#3389)", () => {
+    const clock = new FakeClock();
+    const advancingSleep = (s: number) => {
+      clock.value += s;
+    };
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const absent = {
+      via: "primary",
+      merge_ready: false,
+      failures: [
+        "Required status-check contexts absent on HEAD (ci_absent_required): Greptile Review",
+      ],
+      partial_data: {
+        ci: {
+          ready_state: "ci_absent_required",
+          absent_required: ["Greptile Review"],
+          pending_required: [],
+        },
+      },
+    };
+    const result = monitor(3389, "deftai/directive", {
+      capMinutes: 120,
+      cadence: [[1, 10]],
+      sleepFn: advancingSleep,
+      clockFn: clock,
+      callReadinessFn: makeCallLog(absent, absent, absent),
+    });
+    const emitted = stderr.mock.calls.map((c) => String(c[0])).join("");
+    stderr.mockRestore();
+
+    expect(result.exitCode).toBe(EXIT_ABSENT_REQUIRED);
+    expect(result.pollCount).toBe(2);
+    expect(result.payload.monitor_absent_required).toEqual(["Greptile Review"]);
+    expect(emitted).toContain("ABSENT-REQUIRED: Greptile Review");
+  });
+
+  it("still waits when required check-runs are pending (#3389)", () => {
+    const clock = new FakeClock();
+    const advancingSleep = (s: number) => {
+      clock.value += s;
+    };
+    const result = monitor(3389, "deftai/directive", {
+      capMinutes: 1,
+      cadence: [[1, 10]],
+      sleepFn: advancingSleep,
+      clockFn: clock,
+      callReadinessFn: (): PollResult => ({
+        exitCode: 1,
+        payload: {
+          via: "primary",
+          merge_ready: false,
+          failures: ["CI pending"],
+          partial_data: {
+            ci: {
+              ready_state: "not_ready_yet",
+              absent_required: [],
+              pending_required: ["Greptile Review"],
+            },
+          },
+        },
+        rawStdout: "",
+        rawStderr: "",
+      }),
+    });
+    expect(result.exitCode).toBe(EXIT_CAP_REACHED);
+    expect(result.pollCount).toBeGreaterThan(1);
+  });
+
+  it("resets the absent streak when a later poll is no longer absent (#3389)", () => {
+    const clock = new FakeClock();
+    const advancingSleep = (s: number) => {
+      clock.value += s;
+    };
+    const absent = {
+      via: "primary",
+      merge_ready: false,
+      failures: [
+        "Required status-check contexts absent on HEAD (ci_absent_required): Greptile Review",
+      ],
+      partial_data: {
+        ci: {
+          ready_state: "ci_absent_required",
+          absent_required: ["Greptile Review"],
+          pending_required: [],
+        },
+      },
+    };
+    const pending = {
+      via: "primary",
+      merge_ready: false,
+      failures: ["CI pending"],
+      partial_data: {
+        ci: {
+          ready_state: "not_ready_yet",
+          absent_required: [],
+          pending_required: ["Greptile Review"],
+        },
+      },
+    };
+    const result = monitor(3389, "deftai/directive", {
+      capMinutes: 120,
+      cadence: [[1, 10]],
+      sleepFn: advancingSleep,
+      clockFn: clock,
+      callReadinessFn: makeCallLog(absent, pending, {
+        via: "primary",
+        merge_ready: true,
+        failures: [],
+      }),
+    });
+    expect(result.exitCode).toBe(EXIT_CLEAN);
+    expect(result.pollCount).toBe(3);
+  });
+
   it("fails closed via maxPolls when clock never advances (#2652)", () => {
     const clock = new FakeClock();
     const result = monitor(2652, "deftai/directive", {
@@ -482,5 +635,108 @@ describe("monitor loop", () => {
     expect(result.exitCode).toBe(EXIT_CAP_REACHED);
     expect(result.pollCount).toBeGreaterThan(0);
     expect(result.pollCount).toBeLessThan(500);
+  });
+
+  it("early-escalates Greptile decline comment + no check-run (#3389)", () => {
+    const HEAD = "abc1234567890def1234567890abcdef12345678";
+    const declineBody =
+      "<!-- greptile-status -->\n" +
+      "Declined to review: pull request exceeds the maximum size. " +
+      "Greptile Review check-run will not be posted.\n";
+    const runGh = (cmd: readonly string[]) => {
+      const joined = cmd.join(" ");
+      if (joined.includes("graphql")) {
+        return {
+          returncode: 0,
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+        };
+      }
+      if (joined.includes("headRefOid")) {
+        return { returncode: 0, stdout: `${HEAD}\n`, stderr: "" };
+      }
+      if (joined.includes("/comments")) {
+        return { returncode: 0, stdout: declineBody, stderr: "" };
+      }
+      if (joined.includes("/check-runs")) {
+        return {
+          returncode: 0,
+          stdout: JSON.stringify({
+            check_runs: [
+              {
+                name: "TypeScript (build + lint + test)",
+                status: "completed",
+                conclusion: "success",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (joined.includes("/rules/branches/")) {
+        return {
+          returncode: 0,
+          stdout: JSON.stringify([
+            {
+              type: "required_status_checks",
+              parameters: {
+                required_status_checks: [{ context: "Greptile Review" }],
+              },
+            },
+          ]),
+          stderr: "",
+        };
+      }
+      if (joined.includes("/protection")) {
+        return { returncode: 1, stdout: "", stderr: "HTTP 404: Not Found" };
+      }
+      if (joined.includes("/pulls/")) {
+        return {
+          returncode: 0,
+          stdout: JSON.stringify({
+            state: "open",
+            merged: false,
+            mergeable: true,
+            mergeable_state: "clean",
+            head: { sha: HEAD },
+            base: { ref: "master" },
+          }),
+          stderr: "",
+        };
+      }
+      return { returncode: 1, stdout: "", stderr: `unexpected: ${joined}` };
+    };
+
+    const clock = new FakeClock();
+    const advancingSleep = (s: number) => {
+      clock.value += s;
+    };
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const result = monitor(3389, "deftai/directive", {
+      capMinutes: 120,
+      cadence: [[1, 10]],
+      sleepFn: advancingSleep,
+      clockFn: clock,
+      runGh,
+    });
+    const emitted = stderr.mock.calls.map((c) => String(c[0])).join("");
+    stderr.mockRestore();
+
+    expect(result.exitCode).toBe(EXIT_ABSENT_REQUIRED);
+    expect(result.exitCode).not.toBe(EXIT_CAP_REACHED);
+    expect(result.pollCount).toBe(2);
+    expect(result.payload.monitor_absent_required).toEqual(["Greptile Review"]);
+    expect(emitted).toContain("ABSENT-REQUIRED: Greptile Review");
   });
 });

--- a/packages/core/src/pr-monitor/monitor.ts
+++ b/packages/core/src/pr-monitor/monitor.ts
@@ -1,6 +1,12 @@
+import {
+  formatAbsentRequiredMessage,
+  readAbsentRequiredContexts,
+  shouldEscalateAbsentRequired,
+} from "./absent-required.js";
 import { cadenceIntervalAfterPoll, cadenceIntervals } from "./cadence.js";
 import {
   DEFAULT_CADENCE,
+  EXIT_ABSENT_REQUIRED,
   EXIT_CAP_REACHED,
   EXIT_CLEAN,
   EXIT_CONFIG_ERROR,
@@ -187,6 +193,7 @@ export function monitor(
   let lastPayload: Record<string, unknown> = {};
   let lastExit = EXIT_CAP_REACHED;
   let priorCadenceSeconds = cadenceIntervalAfterPoll(1, cadence);
+  let consecutiveAbsentRequired = 0;
 
   while (true) {
     pollIndex += 1;
@@ -219,6 +226,25 @@ export function monitor(
       return { exitCode: EXIT_PR_TERMINAL, payload: lastPayload, pollCount: pollIndex };
     }
 
+    const absentContexts = readAbsentRequiredContexts(lastPayload);
+    if (absentContexts !== null) {
+      consecutiveAbsentRequired += 1;
+      if (shouldEscalateAbsentRequired(consecutiveAbsentRequired)) {
+        const message = formatAbsentRequiredMessage(absentContexts);
+        process.stderr.write(`[monitor_pr] ${message}\n`);
+        return {
+          exitCode: EXIT_ABSENT_REQUIRED,
+          payload: {
+            ...lastPayload,
+            monitor_absent_required: [...absentContexts],
+          },
+          pollCount: pollIndex,
+        };
+      }
+    } else {
+      consecutiveAbsentRequired = 0;
+    }
+
     const elapsedAfterPoll = clockFn.now() - startedAt;
     const remaining = capSeconds - elapsedAfterPoll;
     if (remaining <= 0) {
@@ -245,6 +271,8 @@ export const summaryLabelForExit = (exitCode: number): string => {
       return "PR-TERMINAL";
     case EXIT_CONFIG_ERROR:
       return "CONFIG-ERROR";
+    case EXIT_ABSENT_REQUIRED:
+      return "ABSENT-REQUIRED";
     default:
       return "UNKNOWN";
   }

--- a/packages/core/src/pr-wait-mergeable/classify.test.ts
+++ b/packages/core/src/pr-wait-mergeable/classify.test.ts
@@ -65,4 +65,15 @@ describe("classifyMonitorOutcome", () => {
   it("maps unknown monitor exit to config error", () => {
     expect(classifyMonitorOutcome(99, {})).toEqual(["config-error", EXIT_CONFIG_ERROR]);
   });
+
+  it("maps ABSENT-REQUIRED exit 4 to timeout-or-escalation (#3389)", () => {
+    expect(classifyMonitorOutcome(4, { monitor_result: "ABSENT-REQUIRED" })).toEqual([
+      "absent-required",
+      EXIT_TIMEOUT_OR_ESCALATION,
+    ]);
+    expect(classifyMonitorOutcome(1, { monitor_result: "ABSENT-REQUIRED" })).toEqual([
+      "absent-required",
+      EXIT_TIMEOUT_OR_ESCALATION,
+    ]);
+  });
 });

--- a/packages/core/src/pr-wait-mergeable/classify.ts
+++ b/packages/core/src/pr-wait-mergeable/classify.ts
@@ -13,10 +13,16 @@ export function classifyMonitorOutcome(
     if (monitorPayload.monitor_result === "CAP-REACHED") {
       return ["cap-reached", EXIT_TIMEOUT_OR_ESCALATION] as const;
     }
+    if (monitorPayload.monitor_result === "ABSENT-REQUIRED") {
+      return ["absent-required", EXIT_TIMEOUT_OR_ESCALATION] as const;
+    }
     return ["config-error", EXIT_CONFIG_ERROR] as const;
   }
   if (monitorReturncode === 2) {
     return ["config-error", EXIT_CONFIG_ERROR] as const;
+  }
+  if (monitorReturncode === 4) {
+    return ["absent-required", EXIT_TIMEOUT_OR_ESCALATION] as const;
   }
   if (monitorReturncode === 3) {
     const readiness =


### PR DESCRIPTION
## Summary

`pr-monitor` now consumes #3234 `ci_absent_required` instead of polling until the minute cap.

After a one-poll grace (first-poll absence is normal after a head push), consecutive absent required contexts exit `ABSENT-REQUIRED` and name the missing checks. Pending required check-runs still wait. CLEAN, PR-terminal, and config-error paths are unchanged.

Regression: required context `Greptile Review` + decline comment + no check-run early-escalates.

## Related Issues

Closes #3389
Refs #3377
Refs #3234

## Checklist

- [x] `/deft:change <name>` — N/A: single-story swarm child covered by active xBRIEF #3389; not cross-cutting architecture
- [x] `CHANGELOG.md` — added entry under `[Unreleased]`
- [x] `ROADMAP.md` — N/A: child story, not a tracked ROADMAP line
- [x] Tests pass locally — `pnpm exec vitest run packages/core/src/pr-monitor` 72/72

## Test plan

- [x] First-poll `ci_absent_required` does not escalate
- [x] Consecutive absence past grace exits `ABSENT-REQUIRED` with missing names
- [x] Pending required check-runs still wait to cap
- [x] Greptile decline comment + no check-run early-escalates
- [x] CLEAN / PR-terminal / CONFIG-ERROR paths unchanged
