### PR TITLE
feat(policy): evidence-based branch-sync detector and typed baseBranch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shared branch-sync detector with typed `plan.policy.baseBranch` (#3388).** Dest is `deliveryBranch`. Source is dest-ref typed `baseBranch` (`task policy:show --field=baseBranch`); a PR checkout cannot invent the source. Unset source equals dest and is not a sync. The public detector fetches, then requires PR base == dest and head already on `origin/<baseBranch>` (tip or ancestor). Dest fallback matches deliveryBranch (`main` before `master`). `origin/develop` is never identity. Core-guard uses this predicate and passes loudly on matching sync PRs; mixed feature PRs still fail. Closes #3388. Refs #3377.
 - **`pr-monitor` escalates on sustained `ci_absent_required` instead of polling to cap (#3389).** After a one-poll grace (first-poll absence is normal), consecutive absent required contexts exit `ABSENT-REQUIRED` and name the missing checks. Pending check-runs still wait. Consumes #3234; does not redefine it. Closes #3389.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Shared branch-sync detector with typed `plan.policy.baseBranch` (#3388).** Dest is `deliveryBranch`. Source is dest-ref typed `baseBranch` (`task policy:show --field=baseBranch`); a PR checkout cannot invent the source. Unset source equals dest and is not a sync. The public detector fetches, then requires PR base == dest and head already on `origin/<baseBranch>` (tip or ancestor). Dest fallback matches deliveryBranch (`main` before `master`). `origin/develop` is never identity. Core-guard uses this predicate and passes loudly on matching sync PRs; mixed feature PRs still fail. Closes #3388. Refs #3377.
+- **Shared branch-sync detector with typed `plan.policy.baseBranch` (#3388).** Dest is `deliveryBranch`. Source is dest-ref typed `baseBranch` (`task policy:show --field=baseBranch`); a PR checkout cannot invent the source. Dest-ref fetch is fail-closed. Unset source equals dest and is not a sync. The public detector fetches, then requires PR base == dest and head already on `origin/<baseBranch>` (tip or ancestor). Dest fallback matches deliveryBranch (`main` before `master`). `origin/develop` is never identity. Core-guard uses this predicate and passes loudly on matching sync PRs; mixed feature PRs still fail. Closes #3388. Refs #3377.
 - **`pr-monitor` escalates on sustained `ci_absent_required` instead of polling to cap (#3389).** After a one-poll grace (first-poll absence is normal), consecutive absent required contexts exit `ABSENT-REQUIRED` and name the missing checks. Pending check-runs still wait. Consumes #3234; does not redefine it. Closes #3389.
 
 ### Changed

--- a/packages/core/src/init-deposit/hygiene.test.ts
+++ b/packages/core/src/init-deposit/hygiene.test.ts
@@ -11,11 +11,13 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { detectBranchSync, formatBranchSyncExemptionMessage } from "../policy/branch-sync.js";
 import {
   assertInstallerAllowlistHonors1430,
   CONSUMER_GUARD_MUST_FIRE,
   classifyMixedCoreAndApp,
   classifyMixedCoreAndAppContentAware,
+  classifyMixedCoreAndAppForPr,
   depositStagePaths,
   findPackageAbsentDepositPaths,
   findPackageAbsentDepositPathsSync,
@@ -164,6 +166,46 @@ describe("upgrade co-travel allowlist (#3127)", () => {
     ]);
     expect(result.wouldFail).toBe(true);
     expect(result.app).toContain("docs/playbooks/my-product.md");
+  });
+
+  it("loudly exempts a matching sync PR via the public detector (#3388)", () => {
+    const sync = detectBranchSync({
+      dest: "master",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "already-on-develop",
+      projectRoot: "/tmp",
+      runGit: (_cwd, args) => {
+        if (args[0] === "fetch" || args[0] === "merge-base") {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        return { code: 1, stdout: "", stderr: "" };
+      },
+    });
+    const result = classifyMixedCoreAndAppForPr([".deft/core/VERSION", "src/app.ts"], sync);
+    expect(result.wouldFail).toBe(false);
+    expect(result.loudMessage).toBe(formatBranchSyncExemptionMessage("develop"));
+  });
+
+  it("still fails a feature PR that mixes core with app (#3388)", () => {
+    const notSync = detectBranchSync({
+      dest: "master",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "feature-sha",
+      projectRoot: "/tmp",
+      runGit: (_cwd, args) => {
+        if (args[0] === "fetch") return { code: 0, stdout: "", stderr: "" };
+        if (args[0] === "merge-base") return { code: 1, stdout: "", stderr: "" };
+        return { code: 1, stdout: "", stderr: "" };
+      },
+    });
+    const result = classifyMixedCoreAndAppForPr([".deft/core/VERSION", "src/app.ts"], notSync);
+    expect(result.wouldFail).toBe(true);
+    expect(result.loudMessage).toBeNull();
+    expect(result.app).toEqual(["src/app.ts"]);
   });
 });
 

--- a/packages/core/src/init-deposit/hygiene.ts
+++ b/packages/core/src/init-deposit/hygiene.ts
@@ -15,6 +15,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, rmSync } from "node:fs";
 import { readdir, rm, stat } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { applyCoreGuardWithBranchSync, type BranchSyncDetection } from "../policy/branch-sync.js";
 import { gitPorcelain } from "../story-ready/git.js";
 import { CANONICAL_INSTALL_ROOT, type InitDepositIo } from "./constants.js";
 import { CONSUMER_SKILL_DISCOVERY_INVENTORY } from "./skill-discovery-deposit.js";
@@ -815,6 +816,20 @@ export function classifyMixedCoreAndApp(
     app,
     wouldFail: core.length > 0 && app.length > 0,
   };
+}
+
+/**
+ * Path classifier plus the shared #3388 sync predicate. Feature mixes still
+ * fail; a matching sync PR passes with a loud exemption message.
+ */
+export function classifyMixedCoreAndAppForPr(
+  changedPaths: readonly string[],
+  sync: BranchSyncDetection,
+  matchers: readonly InstallerManagedMatcher[] = installerManagedMatchers(),
+): MixedCoreAndAppClassification & { loudMessage: string | null } {
+  const base = classifyMixedCoreAndApp(changedPaths, matchers);
+  const applied = applyCoreGuardWithBranchSync(base, sync);
+  return { ...base, wouldFail: applied.wouldFail, loudMessage: applied.loudMessage };
 }
 
 /**

--- a/packages/core/src/init-deposit/scaffold.test.ts
+++ b/packages/core/src/init-deposit/scaffold.test.ts
@@ -223,6 +223,17 @@ describe("init-deposit scaffold", () => {
       expect(guard).toContain("runs-on: ubuntu-latest");
     });
 
+    it("embeds the #3388 evidence-based sync exemption", () => {
+      const guard = depositGuard();
+      expect(guard).toContain("#3388");
+      expect(guard).toContain("BASE_REF:");
+      expect(guard).toContain("merge-base");
+      expect(guard).toContain("--is-ancestor");
+      expect(guard).toContain("sync PR detected: all commits already guard-checked on");
+      expect(guard).not.toMatch(/head\s*==\s*['"]develop['"]/);
+      expect(guard).not.toContain("origin/develop");
+    });
+
     it("assertCoreGuardWorkflowLoadable refuses column-0 run body and mega-lines", () => {
       expect(() => assertCoreGuardWorkflowLoadable("name: other\n")).toThrow(
         /name: deft-core-guard/,

--- a/packages/core/src/init-deposit/scaffold.ts
+++ b/packages/core/src/init-deposit/scaffold.ts
@@ -16,6 +16,7 @@ import {
   ProjectionContainmentError,
 } from "../fs/projection-containment.js";
 import { agentsRefreshPlan } from "../platform/agents-md.js";
+import { renderCoreGuardBranchSyncIfBlock } from "../policy/branch-sync.js";
 import { MIGRATED_ARTIFACT_DIR } from "../xbrief-migrate/constants.js";
 import { CANONICAL_INSTALL_ROOT, type InitDepositIo } from "./constants.js";
 import { assertInstallerAllowlistHonors1430, installerManagedGuardErePatterns } from "./hygiene.js";
@@ -957,9 +958,10 @@ function coreGuardWorkflowContent(): string {
   assertInstallerAllowlistHonors1430();
   const baseSha = githubActionsExpr("github.event.pull_request.base.sha");
   const headSha = githubActionsExpr("github.event.pull_request.head.sha");
+  const baseRef = githubActionsExpr("github.event.pull_request.base.ref");
   return (
     "name: deft-core-guard\n\n" +
-    "# Deft framework guard (#1430 / #3127 / #3193 / #3345): a single PR should not mix changes to the\n" +
+    "# Deft framework guard (#1430 / #3127 / #3193 / #3345 / #3388): a single PR should not mix changes to the\n" +
     "# vendored framework payload (.deft/core/**) with true application/product files.\n" +
     "# One upgrade PR MAY include deposit + installer-managed paths + package.json pin/lock\n" +
     "# + .deft/GENERATION.json when package.json is @deftai/directive* dependency-key pin-only\n" +
@@ -981,6 +983,7 @@ function coreGuardWorkflowContent(): string {
     "        env:\n" +
     `          BASE_SHA: ${baseSha}\n` +
     `          HEAD_SHA: ${headSha}\n` +
+    `          BASE_REF: ${baseRef}\n` +
     "        run: |\n" +
     "          set -eu\n" +
     '          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")\n' +
@@ -989,6 +992,8 @@ function coreGuardWorkflowContent(): string {
     "          core=$(printf '%s\\n' \"$changed\" | grep -E '^\\.deft/core/' || true)\n" +
     `${coreGuardAllowlistShell()}\n` +
     '          if [ -n "$core" ] && [ -n "$app" ]; then\n' +
+    "            # Evidence-based branch-sync exemption (#3388). Not name-only.\n" +
+    `${renderCoreGuardBranchSyncIfBlock(CORE_GUARD_RUN_INDENT)}\n` +
     '            echo "::error title=deft-core guard (#1430)::This PR changes the vendored framework payload (.deft/core/**) AND non-framework files. Split the framework update into its own PR."\n' +
     '            echo "--- framework (.deft/core/**) changes ---"; printf \'%s\\n\' "$core"\n' +
     '            echo "--- non-framework changes ---"; printf \'%s\\n\' "$app"\n' +

--- a/packages/core/src/policy/base-branch.test.ts
+++ b/packages/core/src/policy/base-branch.test.ts
@@ -1,0 +1,148 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GitRunner } from "../session/git.js";
+import {
+  FIELD_BASE_BRANCH,
+  FIELD_BASE_BRANCH_CLI_ALIAS,
+  inspectBaseBranch,
+  ORIGIN_DEVELOP_HINT,
+  resolveBaseBranch,
+} from "./base-branch.js";
+import { DEFAULT_DELIVERY_BRANCH_FALLBACK } from "./delivery-branch.js";
+import { inspectOnePolicy } from "./index.js";
+
+function makeProject(policy?: Record<string, unknown>): string {
+  const root = mkdtempSync(join(tmpdir(), "base-branch-"));
+  mkdirSync(join(root, "xbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    JSON.stringify({
+      plan: {
+        title: "P",
+        status: "running",
+        policy: policy ?? {},
+      },
+    }),
+    "utf8",
+  );
+  return root;
+}
+
+const silentGit: GitRunner = () => ({ code: 1, stdout: "", stderr: "" });
+
+function gitWithDevelop(exists: boolean): GitRunner {
+  return (_cwd, args) => {
+    if (exists && args[0] === "show-ref" && args.includes("refs/remotes/origin/develop")) {
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return { code: 1, stdout: "", stderr: "" };
+  };
+}
+
+describe("resolveBaseBranch (#3388)", () => {
+  let root = "";
+  afterEach(() => {
+    if (root.length > 0) {
+      rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("reads typed plan.policy.baseBranch", () => {
+    root = makeProject({ baseBranch: "develop", deliveryBranch: "master" });
+    const result = resolveBaseBranch(root, silentGit);
+    expect(result.branch).toBe("develop");
+    expect(result.dest).toBe("master");
+    expect(result.source).toBe("typed");
+    expect(result.typed).toBe(true);
+    expect(result.developHint).toBeNull();
+  });
+
+  it("unset baseBranch equals dest", () => {
+    root = makeProject({ deliveryBranch: "release" });
+    const result = resolveBaseBranch(root, silentGit);
+    expect(result.branch).toBe("release");
+    expect(result.dest).toBe("release");
+    expect(result.source).toBe("equals-dest");
+    expect(result.typed).toBe(false);
+  });
+
+  it("never uses origin/develop as source when unset", () => {
+    root = makeProject({ deliveryBranch: "master" });
+    const result = resolveBaseBranch(root, gitWithDevelop(true));
+    expect(result.branch).toBe("master");
+    expect(result.typed).toBe(false);
+    expect(result.developHint).toBe(ORIGIN_DEVELOP_HINT);
+  });
+
+  it("omits develop hint when baseBranch is typed", () => {
+    root = makeProject({ baseBranch: "integration", deliveryBranch: "master" });
+    const result = resolveBaseBranch(root, gitWithDevelop(true));
+    expect(result.developHint).toBeNull();
+  });
+
+  it("omits develop hint when origin/develop is absent", () => {
+    root = makeProject({ deliveryBranch: "master" });
+    const result = resolveBaseBranch(root, gitWithDevelop(false));
+    expect(result.developHint).toBeNull();
+  });
+
+  it("rejects empty typed baseBranch and equals dest", () => {
+    root = makeProject({ baseBranch: "   ", deliveryBranch: "main" });
+    const result = resolveBaseBranch(root, silentGit);
+    expect(result.source).toBe("default-on-error");
+    expect(result.branch).toBe("main");
+    expect(result.typed).toBe(false);
+  });
+
+  it("field constant is plan.policy.baseBranch", () => {
+    expect(FIELD_BASE_BRANCH).toBe("plan.policy.baseBranch");
+    expect(FIELD_BASE_BRANCH_CLI_ALIAS).toBe("baseBranch");
+  });
+
+  it("inspectBaseBranch without projectRoot equals dest fallback", () => {
+    const field = inspectBaseBranch(null);
+    expect(field.name).toBe(FIELD_BASE_BRANCH);
+    expect(field.current).toBe(DEFAULT_DELIVERY_BRANCH_FALLBACK);
+    expect(field.source).toBe("equals-dest");
+  });
+
+  it("policy:show alias baseBranch resolves", () => {
+    root = makeProject({ baseBranch: "develop", deliveryBranch: "master" });
+    const field = inspectOnePolicy(FIELD_BASE_BRANCH_CLI_ALIAS, root);
+    expect(field?.name).toBe(FIELD_BASE_BRANCH);
+    expect(field?.current).toBe("develop");
+    expect(field?.source).toBe("typed");
+  });
+
+  it("missing project definition equals dest", () => {
+    root = mkdtempSync(join(tmpdir(), "base-branch-none-"));
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    const result = resolveBaseBranch(root, silentGit);
+    expect(result.source).toBe("equals-dest");
+    expect(result.branch).toBe(DEFAULT_DELIVERY_BRANCH_FALLBACK);
+  });
+
+  it("non-object plan equals dest", () => {
+    root = mkdtempSync(join(tmpdir(), "base-branch-badplan-"));
+    mkdirSync(join(root, "xbrief"), { recursive: true });
+    writeFileSync(
+      join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+      JSON.stringify({ plan: "nope" }),
+      "utf8",
+    );
+    const result = resolveBaseBranch(root, silentGit);
+    expect(result.source).toBe("equals-dest");
+    expect(result.error).toMatch(/not an object/);
+  });
+
+  it("inspectBaseBranch with projectRoot uses resolved dest as default", () => {
+    root = makeProject({ deliveryBranch: "release" });
+    const field = inspectBaseBranch(null, root);
+    expect(field.current).toBe("release");
+    expect(field.default).toBe("release");
+    expect(field.source).toBe("equals-dest");
+  });
+});

--- a/packages/core/src/policy/base-branch.ts
+++ b/packages/core/src/policy/base-branch.ts
@@ -1,0 +1,153 @@
+/**
+ * Typed plan.policy.baseBranch (#3388).
+ *
+ * Integration-branch source for the shared branch-sync detector. Distinct from
+ * deliveryBranch (dest). Unset or invalid baseBranch resolves to dest so sync
+ * is a no-op. origin/develop is never identity; it may only emit a hint.
+ */
+
+import { defaultGitRunner, type GitRunner } from "../session/git.js";
+import { DEFAULT_DELIVERY_BRANCH_FALLBACK, resolveDeliveryBranch } from "./delivery-branch.js";
+import { readPlanPolicy } from "./plan-extensions.js";
+import { loadProjectDefinition } from "./resolve.js";
+
+export const FIELD_BASE_BRANCH = "plan.policy.baseBranch";
+export const FIELD_BASE_BRANCH_CLI_ALIAS = "baseBranch";
+
+/** Nudge only — never used as dest or source identity (#3388 / #3377 Q1). */
+export const ORIGIN_DEVELOP_HINT =
+  "origin/develop exists; set plan.policy.baseBranch if this repo uses an integration branch";
+
+export type BaseBranchSource = "typed" | "equals-dest" | "default-on-error";
+
+export interface BaseBranchResult {
+  readonly branch: string;
+  readonly dest: string;
+  readonly source: BaseBranchSource;
+  readonly typed: boolean;
+  readonly error: string | null;
+  readonly developHint: string | null;
+}
+
+function originRefExists(projectRoot: string, branch: string, runGit: GitRunner): boolean {
+  const check = runGit(projectRoot, [
+    "show-ref",
+    "--verify",
+    "--quiet",
+    `refs/remotes/origin/${branch}`,
+  ]);
+  return check.code === 0;
+}
+
+function developHintIfEligible(
+  projectRoot: string,
+  typed: boolean,
+  runGit: GitRunner,
+): string | null {
+  if (typed) return null;
+  if (!originRefExists(projectRoot, "develop", runGit)) return null;
+  return ORIGIN_DEVELOP_HINT;
+}
+
+/**
+ * Resolve plan.policy.baseBranch (#3388).
+ *
+ * Unset or invalid values equal dest (deliveryBranch). origin/develop is never
+ * substituted as the source.
+ */
+export function resolveBaseBranch(
+  projectRoot: string,
+  runGit: GitRunner = defaultGitRunner,
+): BaseBranchResult {
+  const dest =
+    resolveDeliveryBranch(projectRoot, runGit).branch || DEFAULT_DELIVERY_BRANCH_FALLBACK;
+  const [data, err] = loadProjectDefinition(projectRoot);
+  if (data === null) {
+    return {
+      branch: dest,
+      dest,
+      source: "equals-dest",
+      typed: false,
+      error: err,
+      developHint: developHintIfEligible(projectRoot, false, runGit),
+    };
+  }
+
+  const plan = data.plan;
+  if (typeof plan !== "object" || plan === null || Array.isArray(plan)) {
+    return {
+      branch: dest,
+      dest,
+      source: "equals-dest",
+      typed: false,
+      error: "PROJECT-DEFINITION 'plan' is not an object",
+      developHint: developHintIfEligible(projectRoot, false, runGit),
+    };
+  }
+
+  const policyBlock = readPlanPolicy(plan);
+  if (
+    typeof policyBlock === "object" &&
+    policyBlock !== null &&
+    !Array.isArray(policyBlock) &&
+    "baseBranch" in policyBlock
+  ) {
+    const raw = (policyBlock as Record<string, unknown>).baseBranch;
+    if (typeof raw !== "string" || raw.trim().length === 0) {
+      return {
+        branch: dest,
+        dest,
+        source: "default-on-error",
+        typed: false,
+        error: `plan.policy.baseBranch must be a non-empty string; got ${typeof raw}`,
+        developHint: developHintIfEligible(projectRoot, false, runGit),
+      };
+    }
+    return {
+      branch: raw.trim(),
+      dest,
+      source: "typed",
+      typed: true,
+      error: null,
+      developHint: null,
+    };
+  }
+
+  return {
+    branch: dest,
+    dest,
+    source: "equals-dest",
+    typed: false,
+    error: null,
+    developHint: developHintIfEligible(projectRoot, false, runGit),
+  };
+}
+
+export interface BaseBranchPolicyField {
+  readonly name: string;
+  readonly current: string;
+  readonly default: string;
+  readonly source: string;
+}
+
+/** Inspector row for `task policy:show --field=baseBranch` (#3388). */
+export function inspectBaseBranch(
+  _data: Record<string, unknown> | null,
+  projectRoot?: string,
+): BaseBranchPolicyField {
+  if (projectRoot === undefined || projectRoot.length === 0) {
+    return {
+      name: FIELD_BASE_BRANCH,
+      current: DEFAULT_DELIVERY_BRANCH_FALLBACK,
+      default: DEFAULT_DELIVERY_BRANCH_FALLBACK,
+      source: "equals-dest",
+    };
+  }
+  const resolved = resolveBaseBranch(projectRoot);
+  return {
+    name: FIELD_BASE_BRANCH,
+    current: resolved.branch,
+    default: resolved.dest,
+    source: resolved.source,
+  };
+}

--- a/packages/core/src/policy/branch-sync.test.ts
+++ b/packages/core/src/policy/branch-sync.test.ts
@@ -6,6 +6,7 @@ import type { GitRunner } from "../session/git.js";
 import {
   applyCoreGuardWithBranchSync,
   BRANCH_SYNC_EXEMPTION_PREFIX,
+  BRANCH_SYNC_POLICY_BLOB,
   coreGuardBranchSyncPythonBody,
   detectBranchSync,
   detectBranchSyncFromProject,
@@ -34,20 +35,51 @@ function gitForSync(options: {
   readonly fetchOk?: boolean;
   readonly headOnIntegration?: boolean;
   readonly originDevelop?: boolean;
+  readonly destRefPolicy?: Record<string, unknown> | null;
+  readonly originHead?: string | null;
+  readonly originBranches?: readonly string[];
+  readonly localBranches?: readonly string[];
 }): GitRunner {
   return (_cwd, args) => {
     if (args[0] === "fetch") {
       return { code: options.fetchOk === false ? 1 : 0, stdout: "", stderr: "" };
     }
+    if (args[0] === "show" && typeof args[1] === "string" && args[1].includes(":")) {
+      if (options.destRefPolicy === null) {
+        return { code: 128, stdout: "", stderr: "missing dest-ref policy" };
+      }
+      const policy = options.destRefPolicy ?? {};
+      return {
+        code: 0,
+        stdout: JSON.stringify({ plan: { title: "P", status: "running", policy } }),
+        stderr: "",
+      };
+    }
     if (args[0] === "merge-base" && args.includes("--is-ancestor")) {
       return { code: options.headOnIntegration === false ? 1 : 0, stdout: "", stderr: "" };
     }
-    if (
-      options.originDevelop &&
-      args[0] === "show-ref" &&
-      args.includes("refs/remotes/origin/develop")
-    ) {
-      return { code: 0, stdout: "", stderr: "" };
+    if (args[0] === "symbolic-ref") {
+      if (options.originHead) {
+        return { code: 0, stdout: options.originHead, stderr: "" };
+      }
+      return { code: 1, stdout: "", stderr: "" };
+    }
+    if (args[0] === "show-ref") {
+      const ref = args[args.length - 1] ?? "";
+      if (options.originDevelop && ref === "refs/remotes/origin/develop") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      for (const branch of options.originBranches ?? []) {
+        if (ref === `refs/remotes/origin/${branch}`) {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+      }
+      for (const branch of options.localBranches ?? []) {
+        if (ref === `refs/heads/${branch}`) {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+      }
+      return { code: 1, stdout: "", stderr: "" };
     }
     return { code: 1, stdout: "", stderr: "" };
   };
@@ -68,7 +100,11 @@ describe("detectBranchSync (#3388)", () => {
       projectRoot: root,
       prBase: "master",
       headSha: "abc",
-      runGit: gitForSync({ originDevelop: true, headOnIntegration: true }),
+      runGit: gitForSync({
+        destRefPolicy: { deliveryBranch: "master" },
+        originDevelop: true,
+        headOnIntegration: true,
+      }),
     });
     expect(result.isSync).toBe(false);
     expect(result.reason).toBe("source-equals-dest");
@@ -84,7 +120,11 @@ describe("detectBranchSync (#3388)", () => {
       projectRoot: root,
       prBase: "master",
       headSha: "abc",
-      runGit: gitForSync({ originDevelop: true, headOnIntegration: true }),
+      runGit: gitForSync({
+        destRefPolicy: { deliveryBranch: "master" },
+        originDevelop: true,
+        headOnIntegration: true,
+      }),
     });
     expect(result.source).not.toBe("develop");
     expect(result.isSync).toBe(false);
@@ -174,17 +214,55 @@ describe("detectBranchSync (#3388)", () => {
     expect(result.isSync).toBe(false);
   });
 
-  it("project loader uses typed baseBranch", () => {
-    root = makeProject({ baseBranch: "develop", deliveryBranch: "master" });
+  it("project loader uses dest-ref typed baseBranch", () => {
+    root = makeProject({ baseBranch: "attacker", deliveryBranch: "master" });
     const result = detectBranchSyncFromProject({
       projectRoot: root,
       prBase: "master",
       headSha: "abc",
-      runGit: gitForSync({ headOnIntegration: true }),
+      runGit: gitForSync({
+        destRefPolicy: { baseBranch: "develop", deliveryBranch: "master" },
+        headOnIntegration: true,
+      }),
     });
     expect(result.isSync).toBe(true);
     expect(result.sourceTyped).toBe(true);
     expect(result.source).toBe("develop");
+  });
+
+  it("ignores working-tree baseBranch when dest-ref has none", () => {
+    root = makeProject({ baseBranch: "attacker", deliveryBranch: "master" });
+    const result = detectBranchSyncFromProject({
+      projectRoot: root,
+      prBase: "master",
+      headSha: "abc",
+      runGit: gitForSync({
+        destRefPolicy: { deliveryBranch: "master" },
+        headOnIntegration: true,
+      }),
+    });
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("source-equals-dest");
+    expect(result.source).toBe("master");
+    expect(result.sourceTyped).toBe(false);
+  });
+
+  it("git dest fallback prefers origin/main over master", () => {
+    root = makeProject({ deliveryBranch: "master" });
+    const result = detectBranchSyncFromProject({
+      projectRoot: root,
+      prBase: "main",
+      headSha: "abc",
+      runGit: gitForSync({
+        destRefPolicy: null,
+        originBranches: ["main"],
+        headOnIntegration: true,
+      }),
+    });
+    expect(result.dest).toBe("main");
+    expect(result.source).toBe("main");
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("source-equals-dest");
   });
 });
 
@@ -237,6 +315,9 @@ describe("deposited core-guard detector fragment (#3388)", () => {
     expect(body).toContain("merge-base");
     expect(body).toContain("--is-ancestor");
     expect(body).toContain(BRANCH_SYNC_EXEMPTION_PREFIX);
+    expect(body).toContain(`origin/' + pr_base + ':${BRANCH_SYNC_POLICY_BLOB}'`);
+    expect(body).toContain("('main', 'master')");
+    expect(body).not.toContain("pathlib");
     expect(body).not.toMatch(/head\s*==\s*['"]develop['"]/);
     expect(body).not.toContain("origin/develop");
   });

--- a/packages/core/src/policy/branch-sync.test.ts
+++ b/packages/core/src/policy/branch-sync.test.ts
@@ -36,12 +36,17 @@ function gitForSync(options: {
   readonly headOnIntegration?: boolean;
   readonly originDevelop?: boolean;
   readonly destRefPolicy?: Record<string, unknown> | null;
+  readonly destFetchFailTargets?: readonly string[];
   readonly originHead?: string | null;
   readonly originBranches?: readonly string[];
   readonly localBranches?: readonly string[];
 }): GitRunner {
   return (_cwd, args) => {
     if (args[0] === "fetch") {
+      const target = args[args.length - 1] ?? "";
+      if (options.destFetchFailTargets?.includes(target)) {
+        return { code: 1, stdout: "", stderr: "dest fetch failed" };
+      }
       return { code: options.fetchOk === false ? 1 : 0, stdout: "", stderr: "" };
     }
     if (args[0] === "show" && typeof args[1] === "string" && args[1].includes(":")) {
@@ -247,6 +252,23 @@ describe("detectBranchSync (#3388)", () => {
     expect(result.sourceTyped).toBe(false);
   });
 
+  it("failed dest fetch is not a sync even with a dest-ref blob", () => {
+    root = makeProject({ baseBranch: "develop", deliveryBranch: "master" });
+    const result = detectBranchSyncFromProject({
+      projectRoot: root,
+      prBase: "master",
+      headSha: "abc",
+      runGit: gitForSync({
+        destRefPolicy: { baseBranch: "develop", deliveryBranch: "master" },
+        destFetchFailTargets: ["master"],
+        headOnIntegration: true,
+      }),
+    });
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("source-equals-dest");
+    expect(result.sourceTyped).toBe(false);
+  });
+
   it("git dest fallback prefers origin/main over master", () => {
     root = makeProject({ deliveryBranch: "master" });
     const result = detectBranchSyncFromProject({
@@ -317,6 +339,9 @@ describe("deposited core-guard detector fragment (#3388)", () => {
     expect(body).toContain(BRANCH_SYNC_EXEMPTION_PREFIX);
     expect(body).toContain(`origin/' + pr_base + ':${BRANCH_SYNC_POLICY_BLOB}'`);
     expect(body).toContain("('main', 'master')");
+    expect(body).toContain(
+      "if git('fetch', '--quiet', 'origin', pr_base).returncode != 0: sys.exit(1)",
+    );
     expect(body).not.toContain("pathlib");
     expect(body).not.toMatch(/head\s*==\s*['"]develop['"]/);
     expect(body).not.toContain("origin/develop");

--- a/packages/core/src/policy/branch-sync.test.ts
+++ b/packages/core/src/policy/branch-sync.test.ts
@@ -1,0 +1,265 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GitRunner } from "../session/git.js";
+import {
+  applyCoreGuardWithBranchSync,
+  BRANCH_SYNC_EXEMPTION_PREFIX,
+  coreGuardBranchSyncPythonBody,
+  detectBranchSync,
+  detectBranchSyncFromProject,
+  formatBranchSyncExemptionMessage,
+  renderCoreGuardBranchSyncIfBlock,
+} from "./branch-sync.js";
+
+function makeProject(policy?: Record<string, unknown>): string {
+  const root = mkdtempSync(join(tmpdir(), "branch-sync-"));
+  mkdirSync(join(root, "xbrief"), { recursive: true });
+  writeFileSync(
+    join(root, "xbrief", "PROJECT-DEFINITION.xbrief.json"),
+    JSON.stringify({
+      plan: {
+        title: "P",
+        status: "running",
+        policy: policy ?? {},
+      },
+    }),
+    "utf8",
+  );
+  return root;
+}
+
+function gitForSync(options: {
+  readonly fetchOk?: boolean;
+  readonly headOnIntegration?: boolean;
+  readonly originDevelop?: boolean;
+}): GitRunner {
+  return (_cwd, args) => {
+    if (args[0] === "fetch") {
+      return { code: options.fetchOk === false ? 1 : 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "merge-base" && args.includes("--is-ancestor")) {
+      return { code: options.headOnIntegration === false ? 1 : 0, stdout: "", stderr: "" };
+    }
+    if (
+      options.originDevelop &&
+      args[0] === "show-ref" &&
+      args.includes("refs/remotes/origin/develop")
+    ) {
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return { code: 1, stdout: "", stderr: "" };
+  };
+}
+
+describe("detectBranchSync (#3388)", () => {
+  let root = "";
+  afterEach(() => {
+    if (root.length > 0) {
+      rmSync(root, { recursive: true, force: true });
+      root = "";
+    }
+  });
+
+  it("unset source equals dest is not a sync", () => {
+    root = makeProject({ deliveryBranch: "master" });
+    const result = detectBranchSyncFromProject({
+      projectRoot: root,
+      prBase: "master",
+      headSha: "abc",
+      runGit: gitForSync({ originDevelop: true, headOnIntegration: true }),
+    });
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("source-equals-dest");
+    expect(result.source).toBe("master");
+    expect(result.dest).toBe("master");
+    expect(result.sourceTyped).toBe(false);
+    expect(result.developHint).toMatch(/origin\/develop exists/);
+  });
+
+  it("origin/develop is never used as source identity", () => {
+    root = makeProject({ deliveryBranch: "master" });
+    const result = detectBranchSyncFromProject({
+      projectRoot: root,
+      prBase: "master",
+      headSha: "abc",
+      runGit: gitForSync({ originDevelop: true, headOnIntegration: true }),
+    });
+    expect(result.source).not.toBe("develop");
+    expect(result.isSync).toBe(false);
+  });
+
+  it("typed source equal to dest is not a sync", () => {
+    const result = detectBranchSync({
+      dest: "master",
+      source: "master",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "abc",
+      projectRoot: "/tmp",
+      runGit: gitForSync({}),
+    });
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("source-equals-dest");
+  });
+
+  it("requires PR base to be dest", () => {
+    const result = detectBranchSync({
+      dest: "master",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "develop",
+      headSha: "abc",
+      projectRoot: "/tmp",
+      runGit: gitForSync({ headOnIntegration: true }),
+    });
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("base-is-not-dest");
+  });
+
+  it("fetch failure is not a sync", () => {
+    const result = detectBranchSync({
+      dest: "master",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "abc",
+      projectRoot: "/tmp",
+      runGit: gitForSync({ fetchOk: false }),
+    });
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("fetch-failed");
+  });
+
+  it("head not on origin/source is not a sync", () => {
+    const result = detectBranchSync({
+      dest: "master",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "feature-sha",
+      projectRoot: "/tmp",
+      runGit: gitForSync({ headOnIntegration: false }),
+    });
+    expect(result.isSync).toBe(false);
+    expect(result.reason).toBe("head-not-on-integration");
+  });
+
+  it("head on origin/source after fetch is a sync", () => {
+    const result = detectBranchSync({
+      dest: "master",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "already-on-develop",
+      projectRoot: "/tmp",
+      runGit: gitForSync({ headOnIntegration: true }),
+    });
+    expect(result.isSync).toBe(true);
+    expect(result.reason).toBe("sync");
+    expect(result.message).toBe(formatBranchSyncExemptionMessage("develop"));
+  });
+
+  it("does not implement a name-only head==develop exemption", () => {
+    const result = detectBranchSync({
+      dest: "master",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "unrelated-feature",
+      projectRoot: "/tmp",
+      runGit: gitForSync({ headOnIntegration: false }),
+    });
+    expect(result.isSync).toBe(false);
+  });
+
+  it("project loader uses typed baseBranch", () => {
+    root = makeProject({ baseBranch: "develop", deliveryBranch: "master" });
+    const result = detectBranchSyncFromProject({
+      projectRoot: root,
+      prBase: "master",
+      headSha: "abc",
+      runGit: gitForSync({ headOnIntegration: true }),
+    });
+    expect(result.isSync).toBe(true);
+    expect(result.sourceTyped).toBe(true);
+    expect(result.source).toBe("develop");
+  });
+});
+
+describe("applyCoreGuardWithBranchSync (#3388)", () => {
+  const sync = detectBranchSync({
+    dest: "master",
+    source: "develop",
+    sourceTyped: true,
+    prBase: "master",
+    headSha: "abc",
+    projectRoot: "/tmp",
+    runGit: gitForSync({ headOnIntegration: true }),
+  });
+  const notSync = detectBranchSync({
+    dest: "master",
+    source: "develop",
+    sourceTyped: true,
+    prBase: "master",
+    headSha: "feature",
+    projectRoot: "/tmp",
+    runGit: gitForSync({ headOnIntegration: false }),
+  });
+
+  it("passes loudly on a matching sync PR", () => {
+    const applied = applyCoreGuardWithBranchSync({ wouldFail: true }, sync);
+    expect(applied.wouldFail).toBe(false);
+    expect(applied.loudMessage).toBe(formatBranchSyncExemptionMessage("develop"));
+    expect(applied.loudMessage).toContain(BRANCH_SYNC_EXEMPTION_PREFIX);
+  });
+
+  it("still fails a mixed feature PR", () => {
+    const applied = applyCoreGuardWithBranchSync({ wouldFail: true }, notSync);
+    expect(applied.wouldFail).toBe(true);
+    expect(applied.loudMessage).toBeNull();
+  });
+
+  it("does not invent a pass when there is no mix", () => {
+    const applied = applyCoreGuardWithBranchSync({ wouldFail: false }, sync);
+    expect(applied.wouldFail).toBe(false);
+    expect(applied.loudMessage).toBeNull();
+  });
+});
+
+describe("deposited core-guard detector fragment (#3388)", () => {
+  it("embeds fetch + ancestor evidence and the loud message", () => {
+    const body = coreGuardBranchSyncPythonBody().join("\n");
+    expect(body).toContain("baseBranch");
+    expect(body).toContain("deliveryBranch");
+    expect(body).toContain("fetch");
+    expect(body).toContain("merge-base");
+    expect(body).toContain("--is-ancestor");
+    expect(body).toContain(BRANCH_SYNC_EXEMPTION_PREFIX);
+    expect(body).not.toMatch(/head\s*==\s*['"]develop['"]/);
+    expect(body).not.toContain("origin/develop");
+  });
+
+  it("renders an if-block that exits 0 only on detector success", () => {
+    const block = renderCoreGuardBranchSyncIfBlock("          ");
+    expect(block).toContain('if python3 - "$HEAD_SHA" "$BASE_REF"');
+    expect(block).toContain("then");
+    expect(block).toContain("exit 0");
+    expect(block).toContain("fi");
+  });
+
+  it("empty dest or source is not a sync", () => {
+    const emptyDest = detectBranchSync({
+      dest: "   ",
+      source: "develop",
+      sourceTyped: true,
+      prBase: "master",
+      headSha: "abc",
+      projectRoot: "/tmp",
+      runGit: gitForSync({}),
+    });
+    expect(emptyDest.isSync).toBe(false);
+    expect(emptyDest.reason).toBe("source-equals-dest");
+  });
+});

--- a/packages/core/src/policy/branch-sync.ts
+++ b/packages/core/src/policy/branch-sync.ts
@@ -1,0 +1,188 @@
+/**
+ * Shared branch-sync detector (#3388 / #3377 Wave 1).
+ *
+ * Dest = deliveryBranch. Source = typed baseBranch (unset equals dest → not a
+ * sync). Predicate: PR base is dest AND head is already on origin/<source>
+ * after fetch (tip or ancestor). Name-only and label-only exemptions are not
+ * implemented. origin/develop is never load-bearing identity.
+ *
+ * This module is the only is-this-a-sync source for later children (#3390/#3391)
+ * and for core-guard.
+ */
+
+import { defaultGitRunner, type GitRunner, gitIsAncestor } from "../session/git.js";
+import { resolveBaseBranch } from "./base-branch.js";
+import { resolveDeliveryBranch } from "./delivery-branch.js";
+
+export const BRANCH_SYNC_EXEMPTION_PREFIX =
+  "sync PR detected: all commits already guard-checked on";
+
+export type BranchSyncReason =
+  | "source-equals-dest"
+  | "base-is-not-dest"
+  | "fetch-failed"
+  | "head-not-on-integration"
+  | "sync";
+
+export interface BranchSyncDetection {
+  readonly isSync: boolean;
+  readonly dest: string;
+  readonly source: string;
+  readonly sourceTyped: boolean;
+  readonly reason: BranchSyncReason;
+  readonly message: string;
+  readonly developHint: string | null;
+}
+
+export interface DetectBranchSyncInput {
+  readonly dest: string;
+  readonly source: string;
+  readonly sourceTyped: boolean;
+  readonly prBase: string;
+  readonly headSha: string;
+  readonly projectRoot: string;
+  readonly developHint?: string | null;
+  readonly runGit?: GitRunner;
+}
+
+export function formatBranchSyncExemptionMessage(integrationBranch: string): string {
+  return `${BRANCH_SYNC_EXEMPTION_PREFIX} ${integrationBranch}`;
+}
+
+function notSync(
+  input: DetectBranchSyncInput,
+  reason: Exclude<BranchSyncReason, "sync">,
+): BranchSyncDetection {
+  return {
+    isSync: false,
+    dest: input.dest,
+    source: input.source,
+    sourceTyped: input.sourceTyped,
+    reason,
+    message: "",
+    developHint: input.developHint ?? null,
+  };
+}
+
+/**
+ * Evidence-based sync predicate (#3388 Q3). Fetch first. Do not trust PR
+ * branch names or labels.
+ */
+export function detectBranchSync(input: DetectBranchSyncInput): BranchSyncDetection {
+  const dest = input.dest.trim();
+  const source = input.source.trim();
+  if (source.length === 0 || dest.length === 0 || source === dest) {
+    return notSync({ ...input, dest, source }, "source-equals-dest");
+  }
+  if (input.prBase.trim() !== dest) {
+    return notSync({ ...input, dest, source }, "base-is-not-dest");
+  }
+
+  const runGit = input.runGit ?? defaultGitRunner;
+  const fetched = runGit(input.projectRoot, ["fetch", "--quiet", "origin", source]);
+  if (fetched.code !== 0) {
+    return notSync({ ...input, dest, source }, "fetch-failed");
+  }
+
+  const onIntegration = gitIsAncestor(input.projectRoot, input.headSha, `origin/${source}`, runGit);
+  if (onIntegration !== true) {
+    return notSync({ ...input, dest, source }, "head-not-on-integration");
+  }
+
+  return {
+    isSync: true,
+    dest,
+    source,
+    sourceTyped: input.sourceTyped,
+    reason: "sync",
+    message: formatBranchSyncExemptionMessage(source),
+    developHint: input.developHint ?? null,
+  };
+}
+
+/** Load dest/source from project policy, then run {@link detectBranchSync}. */
+export function detectBranchSyncFromProject(options: {
+  readonly projectRoot: string;
+  readonly prBase: string;
+  readonly headSha: string;
+  readonly runGit?: GitRunner;
+}): BranchSyncDetection {
+  const runGit = options.runGit ?? defaultGitRunner;
+  const dest = resolveDeliveryBranch(options.projectRoot, runGit).branch;
+  const base = resolveBaseBranch(options.projectRoot, runGit);
+  return detectBranchSync({
+    dest,
+    source: base.branch,
+    sourceTyped: base.typed,
+    prBase: options.prBase,
+    headSha: options.headSha,
+    projectRoot: options.projectRoot,
+    developHint: base.developHint,
+    runGit,
+  });
+}
+
+export interface CoreGuardSyncExemption {
+  readonly wouldFail: boolean;
+  readonly loudMessage: string | null;
+}
+
+/**
+ * Core-guard mix result after the shared sync predicate. Sync PRs pass
+ * loudly; mixed feature PRs still fail.
+ */
+export function applyCoreGuardWithBranchSync(
+  classification: { readonly wouldFail: boolean },
+  sync: BranchSyncDetection,
+): CoreGuardSyncExemption {
+  if (!classification.wouldFail) {
+    return { wouldFail: false, loudMessage: null };
+  }
+  if (sync.isSync) {
+    return { wouldFail: false, loudMessage: formatBranchSyncExemptionMessage(sync.source) };
+  }
+  return { wouldFail: true, loudMessage: null };
+}
+
+/** Compact Python body for the deposited deft-core-guard (#3388). */
+export function coreGuardBranchSyncPythonBody(): readonly string[] {
+  return [
+    "import json, pathlib, subprocess, sys",
+    "head_sha, pr_base = sys.argv[1], sys.argv[2]",
+    "def git(*a):",
+    "    return subprocess.run(['git', *a], capture_output=True, text=True)",
+    "dest = source = None",
+    "p = pathlib.Path('xbrief/PROJECT-DEFINITION.xbrief.json')",
+    "if p.is_file():",
+    "    try:",
+    "        plan = json.loads(p.read_text(encoding='utf-8')).get('plan')",
+    "    except Exception:",
+    "        plan = None",
+    "    if isinstance(plan, dict):",
+    "        pol = plan.get('x-directive/policy') or plan.get('policy') or {}",
+    "        if isinstance(pol, dict):",
+    "            d, s = pol.get('deliveryBranch'), pol.get('baseBranch')",
+    "            if isinstance(d, str) and d.strip(): dest = d.strip()",
+    "            if isinstance(s, str) and s.strip(): source = s.strip()",
+    "if not dest:",
+    "    r = git('symbolic-ref', 'refs/remotes/origin/HEAD', '--short')",
+    "    dest = r.stdout.strip().split('/', 1)[-1] if r.returncode == 0 and r.stdout.strip() else 'master'",
+    "if not source: source = dest",
+    "if source == dest or pr_base != dest: sys.exit(1)",
+    "if git('fetch', '--quiet', 'origin', source).returncode != 0: sys.exit(1)",
+    "if git('merge-base', '--is-ancestor', head_sha, 'origin/' + source).returncode != 0: sys.exit(1)",
+    `print('${BRANCH_SYNC_EXEMPTION_PREFIX} ' + source)`,
+  ];
+}
+
+/** Indented `if` block: detector success exits 0 (loud print); else fall through. */
+export function renderCoreGuardBranchSyncIfBlock(indent: string): string {
+  return [
+    `${indent}if python3 - "$HEAD_SHA" "$BASE_REF" <<'PY'`,
+    ...coreGuardBranchSyncPythonBody().map((line) => `${indent}${line}`),
+    `${indent}PY`,
+    `${indent}then`,
+    `${indent}  exit 0`,
+    `${indent}fi`,
+  ].join("\n");
+}

--- a/packages/core/src/policy/branch-sync.ts
+++ b/packages/core/src/policy/branch-sync.ts
@@ -11,8 +11,12 @@
  */
 
 import { defaultGitRunner, type GitRunner, gitIsAncestor } from "../session/git.js";
-import { resolveBaseBranch } from "./base-branch.js";
-import { resolveDeliveryBranch } from "./delivery-branch.js";
+import { ORIGIN_DEVELOP_HINT } from "./base-branch.js";
+import { resolveGitDefaultDeliveryBranch } from "./delivery-branch.js";
+import { readPlanPolicy } from "./plan-extensions.js";
+
+/** Dest-ref blob used for dest/source. Never the PR working tree (#3388 P1). */
+export const BRANCH_SYNC_POLICY_BLOB = "xbrief/PROJECT-DEFINITION.xbrief.json";
 
 export const BRANCH_SYNC_EXEMPTION_PREFIX =
   "sync PR detected: all commits already guard-checked on";
@@ -100,7 +104,73 @@ export function detectBranchSync(input: DetectBranchSyncInput): BranchSyncDetect
   };
 }
 
-/** Load dest/source from project policy, then run {@link detectBranchSync}. */
+function parseTypedPolicyBranches(jsonText: string): {
+  dest: string | null;
+  source: string | null;
+} {
+  try {
+    const data = JSON.parse(jsonText) as unknown;
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      return { dest: null, source: null };
+    }
+    const policyBlock = readPlanPolicy((data as Record<string, unknown>).plan);
+    if (typeof policyBlock !== "object" || policyBlock === null || Array.isArray(policyBlock)) {
+      return { dest: null, source: null };
+    }
+    const rec = policyBlock as Record<string, unknown>;
+    const destRaw = rec.deliveryBranch;
+    const sourceRaw = rec.baseBranch;
+    return {
+      dest: typeof destRaw === "string" && destRaw.trim().length > 0 ? destRaw.trim() : null,
+      source:
+        typeof sourceRaw === "string" && sourceRaw.trim().length > 0 ? sourceRaw.trim() : null,
+    };
+  } catch {
+    return { dest: null, source: null };
+  }
+}
+
+export interface DestRefSyncPolicy {
+  readonly dest: string;
+  readonly source: string;
+  readonly sourceTyped: boolean;
+  readonly developHint: string | null;
+}
+
+/**
+ * Load dest/source from origin/<prBase>, not the PR checkout.
+ *
+ * A feature PR that rewrites working-tree baseBranch cannot become a sync.
+ */
+export function resolveSyncPolicyFromDestRef(options: {
+  readonly projectRoot: string;
+  readonly prBase: string;
+  readonly runGit?: GitRunner;
+}): DestRefSyncPolicy {
+  const runGit = options.runGit ?? defaultGitRunner;
+  const prBase = options.prBase.trim();
+  runGit(options.projectRoot, ["fetch", "--quiet", "origin", prBase]);
+  const shown = runGit(options.projectRoot, [
+    "show",
+    `origin/${prBase}:${BRANCH_SYNC_POLICY_BLOB}`,
+  ]);
+  const parsed =
+    shown.code === 0 && shown.stdout.length > 0
+      ? parseTypedPolicyBranches(shown.stdout)
+      : { dest: null, source: null };
+  const dest = parsed.dest ?? resolveGitDefaultDeliveryBranch(options.projectRoot, runGit);
+  const sourceTyped = parsed.source !== null;
+  const source = parsed.source ?? dest;
+  const developHint =
+    sourceTyped ||
+    runGit(options.projectRoot, ["show-ref", "--verify", "--quiet", "refs/remotes/origin/develop"])
+      .code !== 0
+      ? null
+      : ORIGIN_DEVELOP_HINT;
+  return { dest, source, sourceTyped, developHint };
+}
+
+/** Load dest/source from dest-ref policy, then run {@link detectBranchSync}. */
 export function detectBranchSyncFromProject(options: {
   readonly projectRoot: string;
   readonly prBase: string;
@@ -108,16 +178,19 @@ export function detectBranchSyncFromProject(options: {
   readonly runGit?: GitRunner;
 }): BranchSyncDetection {
   const runGit = options.runGit ?? defaultGitRunner;
-  const dest = resolveDeliveryBranch(options.projectRoot, runGit).branch;
-  const base = resolveBaseBranch(options.projectRoot, runGit);
+  const policy = resolveSyncPolicyFromDestRef({
+    projectRoot: options.projectRoot,
+    prBase: options.prBase,
+    runGit,
+  });
   return detectBranchSync({
-    dest,
-    source: base.branch,
-    sourceTyped: base.typed,
+    dest: policy.dest,
+    source: policy.source,
+    sourceTyped: policy.sourceTyped,
     prBase: options.prBase,
     headSha: options.headSha,
     projectRoot: options.projectRoot,
-    developHint: base.developHint,
+    developHint: policy.developHint,
     runGit,
   });
 }
@@ -147,15 +220,16 @@ export function applyCoreGuardWithBranchSync(
 /** Compact Python body for the deposited deft-core-guard (#3388). */
 export function coreGuardBranchSyncPythonBody(): readonly string[] {
   return [
-    "import json, pathlib, subprocess, sys",
+    "import json, subprocess, sys",
     "head_sha, pr_base = sys.argv[1], sys.argv[2]",
     "def git(*a):",
     "    return subprocess.run(['git', *a], capture_output=True, text=True)",
     "dest = source = None",
-    "p = pathlib.Path('xbrief/PROJECT-DEFINITION.xbrief.json')",
-    "if p.is_file():",
+    "git('fetch', '--quiet', 'origin', pr_base)",
+    `shown = git('show', 'origin/' + pr_base + ':${BRANCH_SYNC_POLICY_BLOB}')`,
+    "if shown.returncode == 0:",
     "    try:",
-    "        plan = json.loads(p.read_text(encoding='utf-8')).get('plan')",
+    "        plan = json.loads(shown.stdout).get('plan')",
     "    except Exception:",
     "        plan = None",
     "    if isinstance(plan, dict):",
@@ -166,7 +240,19 @@ export function coreGuardBranchSyncPythonBody(): readonly string[] {
     "            if isinstance(s, str) and s.strip(): source = s.strip()",
     "if not dest:",
     "    r = git('symbolic-ref', 'refs/remotes/origin/HEAD', '--short')",
-    "    dest = r.stdout.strip().split('/', 1)[-1] if r.returncode == 0 and r.stdout.strip() else 'master'",
+    "    if r.returncode == 0 and r.stdout.strip():",
+    "        dest = r.stdout.strip().split('/', 1)[-1]",
+    "    else:",
+    "        for n in ('main', 'master'):",
+    "            if git('show-ref', '--verify', '--quiet', 'refs/remotes/origin/' + n).returncode == 0:",
+    "                dest = n",
+    "                break",
+    "        if not dest:",
+    "            for n in ('main', 'master'):",
+    "                if git('show-ref', '--verify', '--quiet', 'refs/heads/' + n).returncode == 0:",
+    "                    dest = n",
+    "                    break",
+    "        if not dest: dest = 'master'",
     "if not source: source = dest",
     "if source == dest or pr_base != dest: sys.exit(1)",
     "if git('fetch', '--quiet', 'origin', source).returncode != 0: sys.exit(1)",

--- a/packages/core/src/policy/branch-sync.ts
+++ b/packages/core/src/policy/branch-sync.ts
@@ -149,7 +149,20 @@ export function resolveSyncPolicyFromDestRef(options: {
 }): DestRefSyncPolicy {
   const runGit = options.runGit ?? defaultGitRunner;
   const prBase = options.prBase.trim();
-  runGit(options.projectRoot, ["fetch", "--quiet", "origin", prBase]);
+  const fetched = runGit(options.projectRoot, ["fetch", "--quiet", "origin", prBase]);
+  if (fetched.code !== 0) {
+    const dest = resolveGitDefaultDeliveryBranch(options.projectRoot, runGit);
+    const developHint =
+      runGit(options.projectRoot, [
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/remotes/origin/develop",
+      ]).code === 0
+        ? ORIGIN_DEVELOP_HINT
+        : null;
+    return { dest, source: dest, sourceTyped: false, developHint };
+  }
   const shown = runGit(options.projectRoot, [
     "show",
     `origin/${prBase}:${BRANCH_SYNC_POLICY_BLOB}`,
@@ -225,7 +238,7 @@ export function coreGuardBranchSyncPythonBody(): readonly string[] {
     "def git(*a):",
     "    return subprocess.run(['git', *a], capture_output=True, text=True)",
     "dest = source = None",
-    "git('fetch', '--quiet', 'origin', pr_base)",
+    "if git('fetch', '--quiet', 'origin', pr_base).returncode != 0: sys.exit(1)",
     `shown = git('show', 'origin/' + pr_base + ':${BRANCH_SYNC_POLICY_BLOB}')`,
     "if shown.returncode == 0:",
     "    try:",

--- a/packages/core/src/policy/delivery-branch.test.ts
+++ b/packages/core/src/policy/delivery-branch.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_DELIVERY_BRANCH_FALLBACK,
   FIELD_DELIVERY_BRANCH,
   resolveDeliveryBranch,
+  resolveGitDefaultDeliveryBranch,
 } from "./delivery-branch.js";
 
 function makeProject(policy?: Record<string, unknown>): string {
@@ -65,6 +66,20 @@ describe("resolveDeliveryBranch (#3041)", () => {
 
   it("field constant is plan.policy.deliveryBranch", () => {
     expect(FIELD_DELIVERY_BRANCH).toBe("plan.policy.deliveryBranch");
+  });
+
+  it("git dest fallback prefers origin/main then master (#3388)", () => {
+    root = makeProject({ deliveryBranch: "ignored-by-git-only" });
+    const runGit: GitRunner = (_cwd, args) => {
+      if (args.includes("refs/remotes/origin/main")) {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 1, stdout: "", stderr: "" };
+    };
+    expect(resolveGitDefaultDeliveryBranch(root, runGit)).toBe("main");
+    expect(resolveGitDefaultDeliveryBranch(root, () => ({ code: 1, stdout: "", stderr: "" }))).toBe(
+      DEFAULT_DELIVERY_BRANCH_FALLBACK,
+    );
   });
 
   it("rejects empty typed deliveryBranch and falls back", () => {

--- a/packages/core/src/policy/delivery-branch.ts
+++ b/packages/core/src/policy/delivery-branch.ts
@@ -67,6 +67,14 @@ function defaultBranchCandidates(projectRoot: string, runGit: GitRunner): string
   return candidates;
 }
 
+/** Git-only dest when dest-ref policy has no typed deliveryBranch (#3388). */
+export function resolveGitDefaultDeliveryBranch(
+  projectRoot: string,
+  runGit: GitRunner = defaultGitRunner,
+): string {
+  return defaultBranchCandidates(projectRoot, runGit)[0] ?? DEFAULT_DELIVERY_BRANCH_FALLBACK;
+}
+
 /**
  * Resolve the project's delivery branch (#3041).
  *

--- a/packages/core/src/policy/delivery-branch.ts
+++ b/packages/core/src/policy/delivery-branch.ts
@@ -1,9 +1,9 @@
 /**
  * Typed plan.policy.deliveryBranch (#3041).
  *
- * Distinct from swarm/PR `baseBranch` (integration target for PRs / finalize
- * sweep PRs). deliveryBranch is where shipped work must land for a delivered
- * completion disposition.
+ * Distinct from typed `plan.policy.baseBranch` (#3388), the integration-branch
+ * source for the shared branch-sync detector. deliveryBranch is dest: where
+ * shipped work must land for a delivered completion disposition.
  */
 
 import { defaultGitRunner, type GitRunner } from "../session/git.js";

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -14,6 +14,11 @@ import {
   inspectAcPassBanking,
 } from "./ac-pass-banking.js";
 import {
+  FIELD_BASE_BRANCH,
+  FIELD_BASE_BRANCH_CLI_ALIAS,
+  inspectBaseBranch,
+} from "./base-branch.js";
+import {
   FIELD_CEREMONY_DIAL,
   FIELD_CEREMONY_DIAL_CLI_ALIAS,
   inspectCeremonyDial,
@@ -81,6 +86,8 @@ import { DEFAULT_WIP_CAP } from "./wip.js";
 export * from "./ac-pass-banking.js";
 export * from "./agents-md-advisory.js";
 export * from "./autonomy.js";
+export * from "./base-branch.js";
+export * from "./branch-sync.js";
 export * from "./capacity.js";
 export * from "./ceremony-dial.js";
 export * from "./ceremony-dial-escalation.js";
@@ -525,6 +532,19 @@ function inspectDeliveryBranchField(
   };
 }
 
+function inspectBaseBranchField(
+  data: Record<string, unknown> | null,
+  projectRoot?: string,
+): PolicyField {
+  const field = inspectBaseBranch(data, projectRoot);
+  return {
+    name: field.name,
+    current: field.current,
+    default: field.default,
+    source: field.source,
+  };
+}
+
 function inspectMinGreptileConfidenceField(
   data: Record<string, unknown> | null,
   projectRoot?: string,
@@ -597,6 +617,7 @@ const REGISTERED_POLICIES: readonly Inspector[] = [
   inspectTriageLabelMirrorField,
   inspectSwarmSubagentBackend,
   inspectDeliveryBranchField,
+  inspectBaseBranchField,
   inspectMinGreptileConfidenceField,
   inspectHostHooksField,
   inspectHostSlashCommandsField,
@@ -649,13 +670,15 @@ export function inspectOnePolicy(name: string, projectRoot: string): PolicyField
                             ? FIELD_HOTFIX_CRITERIA
                             : name === FIELD_DELIVERY_BRANCH_CLI_ALIAS
                               ? FIELD_DELIVERY_BRANCH
-                              : name === FIELD_MIN_GREPTILE_CONFIDENCE_CLI_ALIAS
-                                ? FIELD_MIN_GREPTILE_CONFIDENCE
-                                : name === FIELD_CEREMONY_DIAL_CLI_ALIAS
-                                  ? FIELD_CEREMONY_DIAL
-                                  : name === FIELD_AC_PASS_BANKING_CLI_ALIAS
-                                    ? FIELD_AC_PASS_BANKING
-                                    : name;
+                              : name === FIELD_BASE_BRANCH_CLI_ALIAS
+                                ? FIELD_BASE_BRANCH
+                                : name === FIELD_MIN_GREPTILE_CONFIDENCE_CLI_ALIAS
+                                  ? FIELD_MIN_GREPTILE_CONFIDENCE
+                                  : name === FIELD_CEREMONY_DIAL_CLI_ALIAS
+                                    ? FIELD_CEREMONY_DIAL
+                                    : name === FIELD_AC_PASS_BANKING_CLI_ALIAS
+                                      ? FIELD_AC_PASS_BANKING
+                                      : name;
   for (const field of inspectAllPolicies(projectRoot)) {
     if (field.name === normalized) return field;
   }

--- a/packages/core/src/policy/resolve.test.ts
+++ b/packages/core/src/policy/resolve.test.ts
@@ -391,8 +391,9 @@ describe("inspectAllPolicies", () => {
     writeProjectDef(r, {});
     // deliveryBranch (#3041) + minGreptileConfidence (#3095) + hostSlashCommands (#3054)
     // + openClawProductCommands (#3064) + hostSkillDiscovery (#75) + triageLabelMirror (#1423)
-    // + coverageDebt + checkResume (#3189) + ceremonyDial (#3214) + acPassBanking (#3285).
-    expect(inspectAllPolicies(r)).toHaveLength(26);
+    // + coverageDebt + checkResume (#3189) + ceremonyDial (#3214) + acPassBanking (#3285)
+    // + baseBranch (#3388).
+    expect(inspectAllPolicies(r)).toHaveLength(27);
   });
 
   it("surfaces typed allowDirectCommits", () => {
@@ -449,6 +450,7 @@ describe("inspectAllPolicies", () => {
     expect(registeredPolicyNames()).toContain("plan.policy.hostSkillDiscovery");
     expect(registeredPolicyNames()).toContain(FIELD_MIN_GREPTILE_CONFIDENCE);
     expect(registeredPolicyNames()).toContain("plan.policy.acPassBanking");
+    expect(registeredPolicyNames()).toContain("plan.policy.baseBranch");
   });
 
   it("python repr helpers match Python style", () => {


### PR DESCRIPTION
## Summary

Wave 1 of #3377. Shared branch-sync detector for later measure/warn, `scm:sync-default`, and core-guard.

- Dest = `plan.policy.deliveryBranch`
- Source = typed `plan.policy.baseBranch` (`task policy:show --field=baseBranch`)
- Unset source equals dest and is not a sync
- Predicate: PR base is dest AND head is already on `origin/<baseBranch>` after fetch (tip or ancestor)
- `origin/develop` is never load-bearing identity (optional hint only)
- Core-guard uses this API and passes loudly on matching sync PRs
- Mixed feature PRs still fail

## Test plan

- [x] Targeted vitest on `packages/core/src/policy` and `packages/core/src/init-deposit`
- [x] `task verify:ac` clause walk + stated vitest command
- [x] `task check` (merge chokepoint; 13512 passed)

Tracking: #3388
Refs: #3377
