### PR TITLE
fix(doctor): one SoT for advisory fails; dirty copy does not prescribe writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One SoT for advisory doctor fails; dirty copy no longer says address findings (#3379).** `deriveExitCode` and `cmdDoctor` share `DOCTOR_ADVISORY_FAIL_CHECKS`. A fail is a warning when `data.advisory` is true or the name is in that set. Dirty status / throttle hint names `--full` as re-probe only and says hard errors block writes, advisory warnings do not. Closes #3379. Refs #3372.
 - **`slice:record-existing` / `slice:list` print the live triage-cache slices log, not the leftover `.eval` path (#3386).** Closes #3386.
 - **UAT Shell residual after #3354: dest-form writers plant authz or kill-switch (#3382).** Under active UAT, residual dest forms (`cmake -E copy`, `script`, `gallery-dl -d`, `megadl --path`, `ncftpget`, `git apply --directory`, VCS checkout writers, editors) that write into `.deft/authz/**` or plant `.deft-directive-disable` / `.no-deft-directive` classify as settings deny (not unclassifiable allow). Unknown write-shaped dest flags (`-d` / `--path` / `--directory`) targeting those paths also fail closed. Ordinary dests such as `/tmp` stay unclassifiable. Already-denied `curl -o` / `nc -o` stay denied. Closes #3382. Refs #3354, #3039.
 

--- a/packages/core/src/doctor/checks.test.ts
+++ b/packages/core/src/doctor/checks.test.ts
@@ -18,7 +18,9 @@ import {
   checkStaleXbriefSchemaDeposit,
   checkTypescript7SideBySide,
   checkXbriefEnvelopeMajorVersion,
+  DOCTOR_ADVISORY_FAIL_CHECKS,
   deriveExitCode,
+  isDoctorAdvisoryFail,
   runChecks,
   runChecksImpl,
   scanXbriefEnvelopeVersions,
@@ -34,6 +36,22 @@ describe("checks", () => {
     expect(
       deriveExitCode([{ name: "completed-open-items", status: "fail", detail: "advisory" }], []),
     ).toBe(0);
+    expect(deriveExitCode([{ name: "legacy-layout", status: "fail", detail: "legacy" }], [])).toBe(
+      0,
+    );
+  });
+
+  it("treats data.advisory true as exit-exempt even when the name is not in the set (#3379)", () => {
+    const synthetic = {
+      name: "synthetic-advisory-only",
+      status: "fail" as const,
+      detail: "advisory bit only",
+      data: { advisory: true },
+    };
+    expect(DOCTOR_ADVISORY_FAIL_CHECKS.has(synthetic.name)).toBe(false);
+    expect(isDoctorAdvisoryFail(synthetic.name, synthetic.data)).toBe(true);
+    expect(deriveExitCode([synthetic], [])).toBe(0);
+    expect(deriveExitCode([{ ...synthetic, data: {} }], [])).toBe(1);
   });
 
   it("fails closed when completed/ plan.status is running (#3242)", () => {
@@ -55,6 +73,8 @@ describe("checks", () => {
       );
       const result = checkCompletedLifecycleConsistency(root);
       expect(result.status).toBe("fail");
+      expect(result.data?.advisory).not.toBe(true);
+      expect(DOCTOR_ADVISORY_FAIL_CHECKS.has(result.name)).toBe(false);
       expect(result.detail).toContain("completed/drift.xbrief.json");
       expect(result.detail).toContain("plan.status=running");
       expect(result.detail).toContain("folder=completed");
@@ -86,6 +106,7 @@ describe("checks", () => {
       expect(itemsCheck.status).toBe("fail");
       expect(itemsCheck.detail).toContain("pending");
       expect(itemsCheck.detail).toContain("completed/open.xbrief.json");
+      expect(itemsCheck.data?.advisory).toBe(true);
       expect(deriveExitCode([itemsCheck], [])).toBe(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -308,9 +329,10 @@ describe("checks", () => {
     expect(result.detail).toContain("UPGRADING.md");
     expect(result.data?.legacy_layout).toBe(true);
     expect(result.data?.legacy_layout_kind).toBe("orphan-deft-version");
+    expect(result.data?.advisory).toBe(true);
   });
 
-  it("runChecksImpl flags a legacy orphan .deft/VERSION layout (exit 1)", () => {
+  it("runChecksImpl flags a legacy orphan .deft/VERSION layout as advisory", () => {
     const root = mkdtempSync(join(tmpdir(), "deft-doc-legacy-"));
     try {
       mkdirSync(join(root, ".deft"), { recursive: true });
@@ -326,6 +348,13 @@ describe("checks", () => {
       const result = runChecksImpl(root, { isDir });
       const legacy = result.checks.find((c) => c.name === "legacy-layout");
       expect(legacy?.status).toBe("fail");
+      expect(legacy?.data?.advisory).toBe(true);
+      expect(legacy).toBeDefined();
+      if (legacy === undefined) {
+        return;
+      }
+      expect(deriveExitCode([legacy], [])).toBe(0);
+      // Sibling hard fail (claimed .deft/core/ is absent) still exits 1.
       expect(result.exitCode).toBe(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -492,6 +521,7 @@ describe("checkGitignoreCoverage (#2206)", () => {
   it("fails when canonical entries are missing", () => {
     const result = checkGitignoreCoverage("/proj", seamsFor("node_modules/\n"));
     expect(result.status).toBe("fail");
+    expect(result.data?.advisory).toBe(true);
     const missing = result.data?.missing as string[];
     expect(missing.length).toBeGreaterThan(0);
     expect(missing).toContain(".deft-cache/");

--- a/packages/core/src/doctor/checks.ts
+++ b/packages/core/src/doctor/checks.ts
@@ -56,6 +56,34 @@ export const XBRIEF_ENVELOPE_MIGRATE_COMMAND = "deft migrate:xbrief" as const;
 /** Doctor check name for envelope major mismatch (Q5 Option 2, #3243). */
 export const XBRIEF_ENVELOPE_MAJOR_CHECK = "xbrief-envelope-version" as const;
 
+/**
+ * One SoT for advisory (exit-exempt) check fails (#3379).
+ * Union of the previous `deriveExitCode` / `cmdDoctor` name lists.
+ * A fail is advisory when `data.advisory === true` or the name is in this set.
+ */
+export const DOCTOR_ADVISORY_FAIL_CHECKS: ReadonlySet<string> = new Set([
+  "legacy-layout",
+  "canonical-vendored-npm-signpost",
+  "manifest-version-reportable",
+  "gitignore-coverage",
+  "stale-xbrief-schema-deposit",
+  "typescript-7-side-by-side",
+  "completed-open-items",
+  "coverage-check-resume-policy",
+]);
+
+/** True when a check fail must stay a warning (not lastErrorCount / exit 1). */
+export function isDoctorAdvisoryFail(
+  name: string,
+  data?: Readonly<Record<string, unknown>> | null,
+): boolean {
+  return data?.advisory === true || DOCTOR_ADVISORY_FAIL_CHECKS.has(name);
+}
+
+function stampAdvisory(data: Record<string, unknown>): Record<string, unknown> {
+  return { ...data, advisory: true };
+}
+
 export interface CheckSeams {
   readonly readText?: (path: string) => string | null;
   readonly isFile?: (path: string) => boolean;
@@ -774,13 +802,13 @@ export function checkLegacyLayout(projectRoot: string, seams: CheckSeams = {}): 
       name: "legacy-layout",
       status: "fail",
       detail: dualLayoutSignpostLine(dualLayout),
-      data: {
+      data: stampAdvisory({
         legacy_layout: true,
         legacy_layout_kind: dualLayout.kind,
         evidence: [...dualLayout.evidence],
         upgrading_doc_url: UPGRADING_DOC_URL,
         go_bridge_releases_url: GO_BRIDGE_RELEASES_URL,
-      },
+      }),
     };
   }
   const detection = detectLegacyLayout(projectRoot, legacySeams);
@@ -796,13 +824,13 @@ export function checkLegacyLayout(projectRoot: string, seams: CheckSeams = {}): 
     name: "legacy-layout",
     status: "fail",
     detail: legacyLayoutSignpostLine(detection),
-    data: {
+    data: stampAdvisory({
       legacy_layout: true,
       legacy_layout_kind: detection.kind,
       evidence: [...detection.evidence],
       upgrading_doc_url: UPGRADING_DOC_URL,
       go_bridge_releases_url: GO_BRIDGE_RELEASES_URL,
-    },
+    }),
   };
 }
 
@@ -852,14 +880,14 @@ export function checkCanonicalVendoredNpmSignpost(
     name: "canonical-vendored-npm-signpost",
     status: "fail",
     detail,
-    data: {
+    data: stampAdvisory({
       canonical_vendored: true,
       npm_managed: false,
       manifest_path: manifestPath,
       sentinel_key: NPM_MANAGED_SENTINEL_KEY,
       sentinel_value: NPM_MANAGED_SENTINEL_VALUE,
       upgrading_doc_url: UPGRADING_DOC_URL,
-    },
+    }),
   };
 }
 
@@ -921,14 +949,14 @@ export function checkManifestVersionReportable(
         "so the framework version is unreportable. This happens on legacy `deft-install` deposits " +
         `made without a release pin (#2294). Run \`${CANONICAL_UPGRADE_COMMAND}\` then \`directive update\` ` +
         `to obtain a pinned npm-managed manifest. See ${UPGRADING_DOC_URL}.`,
-      data: {
+      data: stampAdvisory({
         manifest_path: manifestPath,
         version: null,
         source: reportable.source,
         sha: reportable.sha,
         upgrade_command: CANONICAL_UPGRADE_COMMAND,
         upgrading_doc_url: UPGRADING_DOC_URL,
-      },
+      }),
     };
   }
   return {
@@ -1027,11 +1055,11 @@ export function checkStaleXbriefSchemaDeposit(
     detail:
       `Stale deposited schema at ${STALE_VBRIEF_CORE_SCHEMA_REL} still carries the legacy ${LEGACY_INFO_ROOT_KEY} root key on an already-migrated xbrief/ layout. ` +
       "Run `directive update` to refresh deposited schema files — not `deft migrate:xbrief` (no vbrief/ tree remains to convert).",
-    data: {
+    data: stampAdvisory({
       schema_path: schemaPath,
       convergence_state: convergence.state,
       suggested_fix: "directive update",
-    },
+    }),
   };
 }
 
@@ -1190,11 +1218,11 @@ export function checkTypescript7SideBySide(
       "typescript resolves to 7.x without the @typescript/typescript6 alias while typescript-eslint and eslint are present. " +
       "Until TS 7.1, use the side-by-side alias pattern in languages/typescript.md § TypeScript 7 side-by-side (pre-7.1) " +
       "(Cartograph #111: keep typescript on npm:@typescript/typescript6 and install TS 7 under @typescript/native).",
-    data: {
+    data: stampAdvisory({
       package_json_path: packageJsonPath,
       typescript: typescriptValue,
       suggested_fix: "languages/typescript.md#typescript-7-side-by-side-pre-71",
-    },
+    }),
   };
 }
 
@@ -1247,11 +1275,11 @@ export function checkGitignoreCoverage(projectRoot: string, seams: CheckSeams = 
       `missing (${missing.slice(0, 3).join(", ")}${missing.length > 3 ? ", …" : ""}). ` +
       "Run `directive update` to add the missing entries (idempotent, safe on re-run). " +
       `Full missing list: ${JSON.stringify(missing)}.`,
-    data: {
+    data: stampAdvisory({
       gitignore_path: gitignorePath,
       missing,
       suggested_fix: "directive update",
-    },
+    }),
   };
 }
 
@@ -1377,20 +1405,10 @@ export function checkCoverageCheckResumePolicy(projectRoot: string): CheckResult
 }
 
 export function deriveExitCode(checks: readonly CheckResult[], errors: readonly string[]): number {
-  const exitExempt = new Set([
-    "canonical-vendored-npm-signpost",
-    "manifest-version-reportable",
-    "gitignore-coverage",
-    "stale-xbrief-schema-deposit",
-    "typescript-7-side-by-side",
-    "coverage-check-resume-policy",
-    // Historical pre-#2862 completed/ corpora; hard fail is scope:complete (#3242).
-    "completed-open-items",
-  ]);
   if (errors.length > 0 || checks.some((c) => c.status === "error")) {
     return 2;
   }
-  if (checks.some((c) => c.status === "fail" && !exitExempt.has(c.name))) {
+  if (checks.some((c) => c.status === "fail" && !isDoctorAdvisoryFail(c.name, c.data))) {
     return 1;
   }
   return 0;

--- a/packages/core/src/doctor/doctor-state.test.ts
+++ b/packages/core/src/doctor/doctor-state.test.ts
@@ -3,7 +3,10 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  DOCTOR_DIRTY_REPROBE_HINT,
+  DOCTOR_HARD_ERROR_NOTE,
   decideThrottle,
+  dirtyDoctorHint,
   formatIsoZ,
   readState,
   renderDoctorStatusLine,
@@ -100,6 +103,11 @@ describe("doctor-state", () => {
     const line = renderDoctorStatusLine(dirty);
     expect(line).toContain("1 error");
     expect(line).not.toContain("1 errors");
+    expect(line).toContain(DOCTOR_HARD_ERROR_NOTE);
+    expect(line).toContain(DOCTOR_DIRTY_REPROBE_HINT);
+    expect(line).not.toContain("address findings");
+    expect(dirtyDoctorHint()).toBe(`${DOCTOR_HARD_ERROR_NOTE}; ${DOCTOR_DIRTY_REPROBE_HINT}`);
+    expect(dirtyDoctorHint()).not.toContain("address findings");
   });
 
   it("readState returns null for corrupt json", () => {

--- a/packages/core/src/doctor/doctor-state.ts
+++ b/packages/core/src/doctor/doctor-state.ts
@@ -142,6 +142,15 @@ export function formatIsoZ(when: Date | null): string {
   return formatUtcIso(when);
 }
 
+/** Dirty doctor / ritual copy: --full re-probes only; do not prescribe a write (#3379). */
+export const DOCTOR_HARD_ERROR_NOTE =
+  "these are hard errors (advisory warnings do not block writes)";
+export const DOCTOR_DIRTY_REPROBE_HINT = "run `deft doctor --full` to re-probe only";
+
+export function dirtyDoctorHint(): string {
+  return `${DOCTOR_HARD_ERROR_NOTE}; ${DOCTOR_DIRTY_REPROBE_HINT}`;
+}
+
 export function renderDoctorStatusLine(decision: ThrottleDecision, now = new Date()): string {
   const ageH = Math.max(Math.floor(decision.ageHours), 0);
   if (decision.dirty) {
@@ -149,7 +158,7 @@ export function renderDoctorStatusLine(decision: ThrottleDecision, now = new Dat
     const warns = Math.max(decision.lastFindingCount - decision.lastErrorCount, 0);
     const errPhrase = `${errs} error${errs !== 1 ? "s" : ""}`;
     const warnPhrase = `${warns} warning${warns !== 1 ? "s" : ""}`;
-    return `[doctor] ran ${ageH}h ago, ${errPhrase} / ${warnPhrase} -- UNRESOLVED; run \`deft doctor --full\` to re-probe or address findings.`;
+    return `[doctor] ran ${ageH}h ago, ${errPhrase} / ${warnPhrase} -- UNRESOLVED; ${DOCTOR_HARD_ERROR_NOTE}. ${DOCTOR_DIRTY_REPROBE_HINT}.`;
   }
   const remainingMs = (decision.nextEligibleAt?.getTime() ?? now.getTime()) - now.getTime();
   const remainingH = Math.max(Math.floor(remainingMs / 3_600_000), 0);

--- a/packages/core/src/doctor/main.test.ts
+++ b/packages/core/src/doctor/main.test.ts
@@ -41,17 +41,33 @@ describe("cmdDoctor", () => {
 
   it("honours throttle skip when dirty", () => {
     const now = new Date("2026-01-01T12:00:00Z");
-    const exit = cmdDoctor(["--json"], {
-      whichFn: () => "/usr/bin/x",
-      readState: () => ({
-        lastRunAt: new Date("2026-01-01T10:00:00Z"),
-        lastExitCode: 1,
-        lastFindingCount: 2,
-        lastErrorCount: 1,
-      }),
-      now: () => now,
-    });
+    const stdout: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      stdout.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    let exit: number;
+    try {
+      exit = cmdDoctor(["--json"], {
+        whichFn: () => "/usr/bin/x",
+        readState: () => ({
+          lastRunAt: new Date("2026-01-01T10:00:00Z"),
+          lastExitCode: 1,
+          lastFindingCount: 2,
+          lastErrorCount: 1,
+        }),
+        now: () => now,
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
     expect(exit).toBe(1);
+    const payload = JSON.parse(stdout.join("")) as { hint?: string };
+    expect(payload.hint).toContain("re-probe only");
+    expect(payload.hint).toContain("hard errors");
+    expect(payload.hint).toContain("advisory warnings do not block writes");
+    expect(payload.hint).not.toContain("address findings");
   });
 
   it("bypasses throttle with --full", () => {
@@ -779,6 +795,7 @@ describe("cmdDoctor completed-open-items advisory mapping (#3372)", () => {
     root: string,
     framework: string,
     argv: string[] = ["--full", "--json", "--project-root", root],
+    extraSeams: DoctorSeams = {},
   ): {
     exit: number;
     lastErrorCount: number;
@@ -805,6 +822,7 @@ describe("cmdDoctor completed-open-items advisory mapping (#3372)", () => {
           lastErrorCount = payload.errorCount;
           return null;
         },
+        ...extraSeams,
       });
     } finally {
       process.stdout.write = origWrite;
@@ -899,5 +917,43 @@ describe("cmdDoctor completed-open-items advisory mapping (#3372)", () => {
     expect(finding).toBeDefined();
     expect(finding?.severity).toBe("error");
     expect(String(finding?.message)).toContain("completed/bad.xbrief.json");
+  });
+
+  it("maps a synthetic data.advisory fail (name not in the set) to a warning (#3379)", () => {
+    const { root, framework } = makeConsumer();
+    const synthetic = {
+      name: "synthetic-advisory-only",
+      status: "fail",
+      detail: "advisory bit only",
+      data: { advisory: true },
+    };
+    const seams: DoctorSeams = {
+      runChecks: () => ({
+        project_root: root,
+        install_root: null,
+        exit_code: 0,
+        checks: [synthetic],
+        errors: [],
+      }),
+    };
+    const { exit, lastErrorCount, payload } = runDoctorJson(
+      root,
+      framework,
+      ["--full", "--json", "--project-root", root],
+      seams,
+    );
+    expect(exit).toBe(0);
+    expect(lastErrorCount).toBe(0);
+    expect(payload.ok).toBe(true);
+    const finding = payload.findings?.find(
+      (f) =>
+        f.install_check === "synthetic-advisory-only" ||
+        f.check === "install-integrity:synthetic-advisory-only",
+    );
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("warning");
+    const ritual = runDoctorJson(root, framework, ["--json", "--project-root", root], seams);
+    expect(ritual.exit).toBe(0);
+    expect(ritual.lastErrorCount).toBe(0);
   });
 });

--- a/packages/core/src/doctor/main.ts
+++ b/packages/core/src/doctor/main.ts
@@ -41,6 +41,7 @@ import { probeAgentHooksLive } from "../verify-env/agent-hooks-live-probe.js";
 import { agentsRefreshPlan, hasV3ManagedMarker } from "./agents-md.js";
 import {
   checkXbriefEnvelopeMajorVersion,
+  DOCTOR_ADVISORY_FAIL_CHECKS,
   runChecks,
   XBRIEF_ENVELOPE_MAJOR_CHECK,
   XBRIEF_ENVELOPE_MIGRATE_COMMAND,
@@ -56,6 +57,7 @@ import {
 } from "./constants.js";
 import {
   decideThrottle,
+  dirtyDoctorHint,
   formatIsoZ,
   readState,
   renderDoctorStatusLine,
@@ -246,9 +248,7 @@ export function cmdDoctor(args: readonly string[], seams: DoctorSeams = {}): num
         },
         seams,
       );
-      const hint = decision.dirty
-        ? "run `deft doctor --full` to re-probe or address findings"
-        : "--full forces";
+      const hint = decision.dirty ? dirtyDoctorHint() : "--full forces";
       if (jsonMode) {
         const payload = {
           status: "throttle-skipped",
@@ -851,22 +851,14 @@ function runInstallIntegrityChecks(
           return null;
         }
       });
-    const result = runChecks(projectRoot, { isDir, isFile, readText });
-    // Exit-exempt check fails stay warnings so lastErrorCount stays 0
-    // (gated ritual / PreToolUse). Keep completed-lifecycle-consistency hard.
-    const warningOnFail = new Set([
-      "legacy-layout",
-      "canonical-vendored-npm-signpost",
-      "manifest-version-reportable",
-      "gitignore-coverage",
-      "stale-xbrief-schema-deposit",
-      "typescript-7-side-by-side",
-      "completed-open-items",
-    ]);
+    const result = (seams.runChecks ?? runChecks)(projectRoot, { isDir, isFile, readText });
+    // Advisory fails stay warnings so lastErrorCount stays 0
+    // (gated ritual / PreToolUse). Hard stays hard: completed-lifecycle-consistency.
     for (const entry of (result.checks as Array<Record<string, unknown>>) ?? []) {
       const name = String(entry.name ?? "install-integrity");
       const status = String(entry.status ?? "");
       const detail = String(entry.detail ?? "");
+      const data = (entry.data as Record<string, unknown>) ?? {};
       // Authoritative envelope-major emission is runXbriefEnvelopeVersionCheck
       // (runs for framework repo + consumers). Skip install-integrity duplicate.
       if (name === XBRIEF_ENVELOPE_MAJOR_CHECK) {
@@ -880,7 +872,7 @@ function runInstallIntegrityChecks(
         sink.info(`${name}: skip -- ${detail}`);
         continue;
       }
-      if (warningOnFail.has(name) && status === "fail") {
+      if (status === "fail" && (data.advisory === true || DOCTOR_ADVISORY_FAIL_CHECKS.has(name))) {
         sink.warn(`${name}: ${detail}`);
         addFinding({
           severity: "warning",
@@ -888,7 +880,7 @@ function runInstallIntegrityChecks(
           check: `install-integrity:${name}`,
           install_check: name,
           status,
-          data: (entry.data as Record<string, unknown>) ?? {},
+          data,
         });
         continue;
       }

--- a/packages/core/src/doctor/types.ts
+++ b/packages/core/src/doctor/types.ts
@@ -178,6 +178,18 @@ export interface DoctorSeams {
    * its `plan` object; returns [] when no project definition is present.
    */
   readonly detectPlanExtensionShadows?: (projectRoot: string) => readonly ShadowedPlanExtension[];
+  /**
+   * Override install-integrity `runChecks` for tests (#3379). Default is
+   * `runChecks` from `./checks.js`.
+   */
+  readonly runChecks?: (
+    projectRoot: string,
+    seams?: {
+      readonly readText?: (path: string) => string | null;
+      readonly isFile?: (path: string) => boolean;
+      readonly isDir?: (path: string) => boolean;
+    },
+  ) => Record<string, unknown>;
   /** Read-only agent-host hook registration probe (#2438). */
   readonly evaluateAgentHooks?: (projectRoot: string) => AgentHookHealthResult;
   /** Live hook spawn probe for doctor --full (#2852). */


### PR DESCRIPTION
## Summary

One SoT for advisory doctor fails. `deriveExitCode` and `cmdDoctor` both import `DOCTOR_ADVISORY_FAIL_CHECKS`. A fail is a warning when `data.advisory` is true or the name is in that set. Dirty doctor / ritual copy names `--full` as re-probe only and says hard errors block writes; advisory warnings do not.

Authority: residual-lock comment on #3379. Does not re-special-case `completed-open-items`.

## Test plan

- [x] `pnpm exec vitest run packages/core/src/doctor` (408 tests)
- [x] `task check` (exit 0)

Closes #3379
