### PR TITLE
fix(verify-ac): emit walk-level fingerprints on failing acceptance walks (#3397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Failing verify:ac walks emit a walk-level verification fingerprint (#3397).** A fail then a later pass with a different command set on the same check id flags; an honest same-command product fix does not. Shrinking command-set delta is included on the flag. The #3322 detector stays. Closes #3397. Refs #3322, #3396.
 - **engine:_ts-build: trailing no-op for go-task <3.52 (#3381).** Older go-task treats an untaken last if/fi as exit 1, so consumer deposits fail every non-runtime `task deft:*`. A colon after the outer fi keeps the skip-build path exit 0. Closes #3381.
-
 - **One SoT for advisory doctor fails; dirty copy no longer says address findings (#3379).** `deriveExitCode` and `cmdDoctor` share `DOCTOR_ADVISORY_FAIL_CHECKS`. A fail is a warning when `data.advisory` is true or the name is in that set. Dirty status / throttle hint names `--full` as re-probe only and says hard errors block writes, advisory warnings do not. Closes #3379. Refs #3372.
 - **`slice:record-existing` / `slice:list` print the live triage-cache slices log, not the leftover `.eval` path (#3386).** Closes #3386.
 - **UAT Shell residual after #3354: dest-form writers plant authz or kill-switch (#3382).** Under active UAT, residual dest forms (`cmake -E copy`, `script`, `gallery-dl -d`, `megadl --path`, `ncftpget`, `git apply --directory`, VCS checkout writers, editors) that write into `.deft/authz/**` or plant `.deft-directive-disable` / `.no-deft-directive` classify as settings deny (not unclassifiable allow). Unknown write-shaped dest flags (`-d` / `--path` / `--directory`) targeting those paths also fail closed. Ordinary dests such as `/tmp` stay unclassifiable. Already-denied `curl -o` / `nc -o` stay denied. Closes #3382. Refs #3354, #3039.

--- a/packages/core/src/verify-ac/evaluate.test.ts
+++ b/packages/core/src/verify-ac/evaluate.test.ts
@@ -8,6 +8,7 @@ import {
   emitVerifyAcAttempts,
   evaluateProductOracleIntegrity,
   mergeOracleVerdict,
+  methodFingerprintForWalk,
   resetInProcessVerificationBuffer,
   VERIFY_AC_CHECK_ID_PREFIX,
   verifyAcCheckId,
@@ -49,6 +50,242 @@ describe("verifyAcCheckId (#3337)", () => {
       "verify:ac/3337-verify-ac-scope-check-ids",
     );
     expect(verifyAcCheckId("story-a")).not.toBe(verifyAcCheckId("story-b"));
+  });
+});
+
+describe("emitVerifyAcAttempts (#3397 fail-side fingerprints)", () => {
+  it("emits a walk-level verification event when the walk fails", () => {
+    const root = mkdtempSync(join(tmpdir(), "oracle-fail-walk-"));
+    const path = join(root, "summary.jsonl");
+    const cwd = join(root, "app");
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-fail",
+      env: { [ENV_RUN_SUMMARY_PATH]: path },
+      runs: [
+        {
+          command: "pnpm exec vitest run packages/core/src/verify-ac",
+          cwd,
+          exitCode: 1,
+          stdout: "",
+          stderr: "failed",
+          ok: false,
+          detail: "fail",
+        },
+        {
+          command: "task check",
+          cwd,
+          exitCode: 1,
+          stdout: "",
+          stderr: "failed",
+          ok: false,
+          detail: "fail",
+        },
+        {
+          command: "task verify:forward-coverage",
+          cwd,
+          exitCode: 1,
+          stdout: "",
+          stderr: "failed",
+          ok: false,
+          detail: "fail",
+        },
+      ],
+    });
+    const lines = readFileSync(path, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .map(
+        (row) =>
+          JSON.parse(row) as {
+            event: string;
+            payload: { outcome: string; method_fingerprint: string };
+          },
+      );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.event).toBe("verification");
+    expect(lines[0]?.payload.outcome).toBe("fail");
+    expect(lines[0]?.payload.method_fingerprint).toBe(
+      methodFingerprintForWalk(
+        [
+          "pnpm exec vitest run packages/core/src/verify-ac",
+          "task check",
+          "task verify:forward-coverage",
+        ],
+        cwd,
+      ),
+    );
+    expect(lines[0]?.payload.method_fingerprint).not.toContain(cwd);
+  });
+
+  it("flags the field sequence: 3-command fail then 1-no-op pass", () => {
+    const root = mkdtempSync(join(tmpdir(), "oracle-field-seq-"));
+    const path = join(root, "summary.jsonl");
+    const env = { [ENV_RUN_SUMMARY_PATH]: path, DEFT_SESSION_ID: "sess-field" };
+    const cwd = "/app";
+    const failCmds = ["vitest run a", "vitest run b", "vitest run c"];
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-field",
+      env,
+      runs: failCmds.map((command) => ({
+        command,
+        cwd,
+        exitCode: 1,
+        stdout: "",
+        stderr: "failed",
+        ok: false,
+        detail: "fail",
+      })),
+    });
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-field",
+      env,
+      runs: [
+        {
+          command: "true",
+          cwd,
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          ok: true,
+          detail: "ok",
+        },
+      ],
+    });
+    const verdict = evaluateProductOracleIntegrity({ projectRoot: root, env });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.unresolved).toHaveLength(1);
+    expect(verdict.unresolved[0]?.failed_method).toBe(methodFingerprintForWalk(failCmds, cwd));
+    expect(verdict.unresolved[0]?.passed_method).toBe(methodFingerprintForWalk(["true"], cwd));
+    expect(verdict.unresolved[0]?.resolved_command_count_delta).toBe(-2);
+    expect(verdict.message.startsWith("UNRESOLVED product-oracle discrepancy (#3322)")).toBe(true);
+    const merged = mergeOracleVerdict(
+      { ok: true, code: 0, message: "verify:ac passed (#3284) [rung=stated]" },
+      verdict,
+    );
+    expect(merged.message.startsWith("UNRESOLVED product-oracle discrepancy")).toBe(true);
+    expect(merged.message).toMatch(/command_count_delta=-2/);
+  });
+
+  it("hashes mixed cwds so the walk method differs from a single-cwd list", () => {
+    const root = mkdtempSync(join(tmpdir(), "oracle-mixed-cwd-"));
+    const path = join(root, "summary.jsonl");
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-cwd",
+      env: { [ENV_RUN_SUMMARY_PATH]: path },
+      runs: [
+        {
+          command: "true",
+          cwd: "/app",
+          exitCode: 1,
+          stdout: "",
+          stderr: "failed",
+          ok: false,
+          detail: "fail",
+        },
+        {
+          command: "true",
+          cwd: "/other",
+          exitCode: 1,
+          stdout: "",
+          stderr: "failed",
+          ok: false,
+          detail: "fail",
+        },
+      ],
+    });
+    const line = JSON.parse(readFileSync(path, "utf8").trim()) as {
+      payload: { method_fingerprint: string };
+    };
+    expect(line.payload.method_fingerprint).toBe(
+      methodFingerprintForWalk(["true", "true"], "/app\0/other"),
+    );
+    expect(line.payload.method_fingerprint).not.toBe(
+      methodFingerprintForWalk(["true", "true"], "/app"),
+    );
+  });
+
+  it("does not flag an honest same-command product fix", () => {
+    const root = mkdtempSync(join(tmpdir(), "oracle-honest-"));
+    const path = join(root, "summary.jsonl");
+    const env = { [ENV_RUN_SUMMARY_PATH]: path, DEFT_SESSION_ID: "sess-honest" };
+    const cwd = "/app";
+    const cmds = ["vitest run a", "vitest run b", "vitest run c"];
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-honest",
+      env,
+      runs: cmds.map((command) => ({
+        command,
+        cwd,
+        exitCode: 1,
+        stdout: "",
+        stderr: "failed",
+        ok: false,
+        detail: "fail",
+      })),
+    });
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-honest",
+      env,
+      runs: cmds.map((command) => ({
+        command,
+        cwd,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        ok: true,
+        detail: "ok",
+      })),
+    });
+    const verdict = evaluateProductOracleIntegrity({ projectRoot: root, env });
+    expect(verdict.ok).toBe(true);
+    expect(verdict.unresolved).toEqual([]);
+    expect(verdict.flagged).toEqual([]);
+  });
+
+  it("flags a shrinking command set even when the first command stays", () => {
+    const root = mkdtempSync(join(tmpdir(), "oracle-shrink-"));
+    const path = join(root, "summary.jsonl");
+    const env = { [ENV_RUN_SUMMARY_PATH]: path, DEFT_SESSION_ID: "sess-shrink" };
+    const cwd = "/app";
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-shrink",
+      env,
+      runs: ["vitest run a", "vitest run b", "vitest run c"].map((command) => ({
+        command,
+        cwd,
+        exitCode: 1,
+        stdout: "",
+        stderr: "failed",
+        ok: false,
+        detail: "fail",
+      })),
+    });
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-shrink",
+      env,
+      runs: [
+        {
+          command: "vitest run a",
+          cwd,
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          ok: true,
+          detail: "ok",
+        },
+      ],
+    });
+    const verdict = evaluateProductOracleIntegrity({ projectRoot: root, env });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.unresolved[0]?.resolved_command_count_delta).toBe(-2);
   });
 });
 
@@ -169,6 +406,14 @@ describe("evaluateProductOracleIntegrity (#3322)", () => {
           ok: false,
           detail: "fail",
         },
+      ],
+    });
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-stdout",
+      env,
+      writeStdout: () => undefined,
+      runs: [
         {
           command: "json-v2",
           cwd: root,
@@ -310,6 +555,14 @@ describe("evaluateProductOracleIntegrity (#3322)", () => {
           ok: false,
           detail: "fail",
         },
+      ],
+    });
+    emitVerifyAcAttempts({
+      projectRoot: root,
+      sessionId: "sess-same",
+      env,
+      scopeKey: "story-a",
+      runs: [
         {
           command: "json-v2",
           cwd: root,

--- a/packages/core/src/verify-ac/evaluate.ts
+++ b/packages/core/src/verify-ac/evaluate.ts
@@ -159,6 +159,8 @@ export function emitVerifyAcAttempts(options: {
     // Per-command emit was blind to a shrinking list that kept the first command (#3397).
     const commands = options.runs.map((run) => run.command);
     const firstCwd = options.runs[0]?.cwd ?? "";
+    // Hash the cwd key (joined only when cwds differ) so cwd paths never enter
+    // the fingerprint; commandCountFromFingerprint can still count commands.
     const cwdKey = options.runs.every((run) => run.cwd === firstCwd)
       ? firstCwd
       : options.runs.map((run) => run.cwd).join("\0");

--- a/packages/core/src/verify-ac/evaluate.ts
+++ b/packages/core/src/verify-ac/evaluate.ts
@@ -8,7 +8,7 @@
  * dest as no evidence.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { LiteralAcceptanceRunResult } from "../literal-acceptance/types.js";
@@ -46,10 +46,23 @@ export interface OracleIntegrityResultFields {
 }
 
 function formatUnresolved(flag: FlaggedMethodChangePass): string {
+  const delta =
+    typeof flag.resolved_command_count_delta === "number"
+      ? ` command_count_delta=${flag.resolved_command_count_delta}`
+      : "";
   return (
     `check_id=${flag.check_id} fail method=${flag.failed_method} ` +
-    `then pass method=${flag.passed_method} without independent re-derivation`
+    `then pass method=${flag.passed_method} without independent re-derivation${delta}`
   );
+}
+
+/**
+ * Walk-level method fingerprint: command list + cwd hash (#3397 / #3322).
+ * Same shape for fail and pass so an honest product fix does not flag.
+ */
+export function methodFingerprintForWalk(commands: readonly string[], cwd: string): string {
+  const cwdHash = createHash("sha256").update(cwd, "utf8").digest("hex");
+  return `${commands.join("\0")}\0${cwdHash}`;
 }
 
 /** Stable prefix for product-oracle check ids emitted by verify:ac (#3322 / #3337). */
@@ -90,7 +103,8 @@ function inProcessVerificationText(): string | null {
 }
 
 /**
- * Record each executed acceptance command as a verification event (#3322).
+ * Record one walk-level verification event for the executed command set (#3322 / #3397).
+ * Fail and pass use the same method_fingerprint shape (command list + cwd hash).
  * Fail-open: missing dest / write errors never change the AC result.
  * Stdout dest also appends to the same-process buffer so evaluate can
  * inspect this invocation without re-reading a file.
@@ -141,15 +155,21 @@ export function emitVerifyAcAttempts(options: {
       env,
       writeStdout: options.writeStdout,
     });
-    for (const run of options.runs) {
-      const emitted = emitter.emitVerification({
-        check_id: checkId,
-        method_fingerprint: `${run.command}\0${run.cwd}`,
-        outcome: run.ok ? "pass" : "fail",
-      });
-      if (dest.kind === "stdout" && emitted.line !== null) {
-        inProcessVerificationLines.push(JSON.stringify(emitted.line));
-      }
+    // One walk-level event: the method is the command set, not each command.
+    // Per-command emit was blind to a shrinking list that kept the first command (#3397).
+    const commands = options.runs.map((run) => run.command);
+    const firstCwd = options.runs[0]?.cwd ?? "";
+    const cwdKey = options.runs.every((run) => run.cwd === firstCwd)
+      ? firstCwd
+      : options.runs.map((run) => run.cwd).join("\0");
+    const outcome = options.runs.every((run) => run.ok) ? "pass" : "fail";
+    const emitted = emitter.emitVerification({
+      check_id: checkId,
+      method_fingerprint: methodFingerprintForWalk(commands, cwdKey),
+      outcome,
+    });
+    if (dest.kind === "stdout" && emitted.line !== null) {
+      inProcessVerificationLines.push(JSON.stringify(emitted.line));
     }
   } catch {
     // fail-open

--- a/packages/core/src/verify-ac/flag.test.ts
+++ b/packages/core/src/verify-ac/flag.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseRunSummaryJsonl } from "../run-summary/index.js";
+import { methodFingerprintForWalk } from "./evaluate.js";
 import {
   commandCountFromFingerprint,
   flagPassAfterFailFromJsonl,
@@ -91,6 +92,12 @@ describe("flagPassAfterFailWithMethodChange (#3322)", () => {
     expect(commandCountFromFingerprint("a\0b\0C:\\work")).toBe(2);
     expect(commandCountFromFingerprint("one\0two\0three")).toBe(3);
     expect(commandCountFromFingerprint("a\0b\0c\0deadbeef")).toBe(3);
+  });
+
+  it("counts commands from a mixed-cwd walk fingerprint (cwd is hashed, not listed)", () => {
+    const mixed = methodFingerprintForWalk(["true", "false"], "/app\0/other");
+    expect(commandCountFromFingerprint(mixed)).toBe(2);
+    expect(mixed.split("\0")).toHaveLength(3);
   });
 
   it("treats recorded independent re-derivation as resolved", () => {

--- a/packages/core/src/verify-ac/flag.test.ts
+++ b/packages/core/src/verify-ac/flag.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { parseRunSummaryJsonl } from "../run-summary/index.js";
 import {
+  commandCountFromFingerprint,
   flagPassAfterFailFromJsonl,
   flagPassAfterFailWithMethodChange,
   readVerificationAttempts,
@@ -64,6 +65,32 @@ describe("flagPassAfterFailWithMethodChange (#3322)", () => {
       },
     ]);
     expect(unresolvedMethodChangePasses(flagged)).toHaveLength(1);
+  });
+
+  it("includes resolved_command_count_delta when the walk shrinks (#3397)", () => {
+    const flagged = flagPassAfterFailFromJsonl(
+      jsonl([
+        {
+          check_id: "eq",
+          method_fingerprint: "vitest run a\0vitest run b\0vitest run c\0deadbeef",
+          outcome: "fail",
+        },
+        {
+          check_id: "eq",
+          method_fingerprint: "true\0deadbeef",
+          outcome: "pass",
+        },
+      ]),
+    );
+    expect(flagged[0]?.resolved_command_count_delta).toBe(-2);
+  });
+
+  it("reads command counts from walk fingerprints and legacy method ids", () => {
+    expect(commandCountFromFingerprint("diff-v1")).toBe(1);
+    expect(commandCountFromFingerprint("true\0/app")).toBe(1);
+    expect(commandCountFromFingerprint("a\0b\0C:\\work")).toBe(2);
+    expect(commandCountFromFingerprint("one\0two\0three")).toBe(3);
+    expect(commandCountFromFingerprint("a\0b\0c\0deadbeef")).toBe(3);
   });
 
   it("treats recorded independent re-derivation as resolved", () => {

--- a/packages/core/src/verify-ac/flag.ts
+++ b/packages/core/src/verify-ac/flag.ts
@@ -23,6 +23,23 @@ export interface FlaggedMethodChangePass {
   readonly failed_method: string;
   readonly passed_method: string;
   readonly independent_rederivation: boolean;
+  /** Pass count minus fail count when both fingerprints carry a command list (#3397). */
+  readonly resolved_command_count_delta?: number;
+}
+
+/** Command count encoded in a walk fingerprint (`cmd\0cmd\0cwd-or-hash`). */
+export function commandCountFromFingerprint(fingerprint: string): number {
+  const parts = fingerprint.split("\0");
+  if (parts.length <= 1) {
+    return 1;
+  }
+  const last = parts[parts.length - 1] ?? "";
+  const lastIsCwdOrHash =
+    /^[0-9a-f]{8,64}$/i.test(last) ||
+    last.includes("/") ||
+    last.includes("\\") ||
+    last.includes(":");
+  return lastIsCwdOrHash ? Math.max(1, parts.length - 1) : parts.length;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -99,11 +116,15 @@ export function flagPassAfterFailWithMethodChange(
     }
     const other = [...prior].find((method) => method !== attempt.method_fingerprint);
     if (other !== undefined) {
+      const delta =
+        commandCountFromFingerprint(attempt.method_fingerprint) -
+        commandCountFromFingerprint(other);
       flagged.push({
         check_id: attempt.check_id,
         failed_method: other,
         passed_method: attempt.method_fingerprint,
         independent_rederivation: attempt.independent_rederivation,
+        ...(delta !== 0 ? { resolved_command_count_delta: delta } : {}),
       });
     }
     if (attempt.independent_rederivation || other === undefined) {

--- a/packages/core/src/verify-ac/index.test.ts
+++ b/packages/core/src/verify-ac/index.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  commandCountFromFingerprint,
   deriveAcceptanceClauses,
   emitVerifyAcAttempts,
   evaluateProductOracleIntegrity,
   flagPassAfterFailFromJsonl,
   mergeOracleVerdict,
+  methodFingerprintForWalk,
   stampDerivedClausesOnAcceptance,
   VERIFY_AC_CHECK_ID_PREFIX,
   verifyAcCheckId,
@@ -17,6 +19,8 @@ describe("verify-ac public exports (#3322 / #3323 / #3337)", () => {
     expect(typeof evaluateProductOracleIntegrity).toBe("function");
     expect(typeof mergeOracleVerdict).toBe("function");
     expect(typeof emitVerifyAcAttempts).toBe("function");
+    expect(typeof methodFingerprintForWalk).toBe("function");
+    expect(typeof commandCountFromFingerprint).toBe("function");
     expect(typeof deriveAcceptanceClauses).toBe("function");
     expect(typeof walkAcceptanceClauses).toBe("function");
     expect(typeof stampDerivedClausesOnAcceptance).toBe("function");

--- a/packages/core/src/verify-ac/index.ts
+++ b/packages/core/src/verify-ac/index.ts
@@ -24,12 +24,14 @@ export {
   emitVerifyAcAttempts,
   evaluateProductOracleIntegrity,
   mergeOracleVerdict,
+  methodFingerprintForWalk,
   type OracleIntegrityResultFields,
   type ProductOracleIntegrityVerdict,
   VERIFY_AC_CHECK_ID_PREFIX,
   verifyAcCheckId,
 } from "./evaluate.js";
 export {
+  commandCountFromFingerprint,
   type FlaggedMethodChangePass,
   flagPassAfterFailFromJsonl,
   flagPassAfterFailWithMethodChange,


### PR DESCRIPTION
## Summary

Failing `verify:ac` walks now emit one walk-level `verification` event with the same method fingerprint shape as a pass (command list + cwd hash). The existing #3322 detector then flags `fail(fp1) -> pass(fp2)` on the same check id when the command set changed. An honest same-command product fix does not flag. Shrinking command-set delta is included on the flag payload.

## Related Issues

Closes #3397
Refs #3322, #3396

## Test plan

- [x] `pnpm exec vitest run packages/core/src/verify-ac` (51 passed)
- [x] `task ts:check-lane` — 13493 passed, 141 skipped; coverage 88.7% / 85.24% branches
- [x] Field-sequence fixture: 3-command fail then 1-no-op pass flags and leads output
- [x] Honest same-command pass does not flag

## Checklist

- [x] `/deft:change` — N/A (7 files, verify-ac + CHANGELOG only; not cross-cutting)
- [x] `CHANGELOG.md` — `[Unreleased]` entry for #3397
- [x] `ROADMAP.md` — N/A
- [x] Tests pass locally