### PR TITLE
fix(engine): trailing no-op on _ts-build for go-task <3.52 (#3381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **engine:_ts-build: trailing no-op for go-task <3.52 (#3381).** Older go-task treats an untaken last if/fi as exit 1, so consumer deposits fail every non-runtime `task deft:*`. A colon after the outer fi keeps the skip-build path exit 0. Closes #3381.
+
 - **One SoT for advisory doctor fails; dirty copy no longer says address findings (#3379).** `deriveExitCode` and `cmdDoctor` share `DOCTOR_ADVISORY_FAIL_CHECKS`. A fail is a warning when `data.advisory` is true or the name is in that set. Dirty status / throttle hint names `--full` as re-probe only and says hard errors block writes, advisory warnings do not. Closes #3379. Refs #3372.
 - **`slice:record-existing` / `slice:list` print the live triage-cache slices log, not the leftover `.eval` path (#3386).** Closes #3386.
 - **UAT Shell residual after #3354: dest-form writers plant authz or kill-switch (#3382).** Under active UAT, residual dest forms (`cmake -E copy`, `script`, `gallery-dl -d`, `megadl --path`, `ncftpget`, `git apply --directory`, VCS checkout writers, editors) that write into `.deft/authz/**` or plant `.deft-directive-disable` / `.no-deft-directive` classify as settings deny (not unclassifiable allow). Unknown write-shaped dest flags (`-d` / `--path` / `--directory`) targeting those paths also fail closed. Ordinary dests such as `/tmp` stay unclassifiable. Already-denied `curl -o` / `nc -o` stay denied. Closes #3382. Refs #3354, #3039.

--- a/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
+++ b/packages/core/src/content-contracts/standards/taskfile_engine_dispatch.test.ts
@@ -252,6 +252,18 @@ writeFileSync(process.env.TEST_ENGINE_OUTER_OUT, JSON.stringify({
     expect(guardBlock).not.toMatch(/\[ -f "\{\{\.DEFT_ROOT\}\}\/packages\/cli\/dist\/bin\.js" \]/);
   });
 
+  it("_ts-build ends with a trailing no-op after the outer if/fi (#3381)", () => {
+    const engine = readTask(ENGINE_FILE);
+    const tsBuild = engine.match(/  _ts-build:\n[\s\S]*?(?=\n  [a-zA-Z_])/);
+    expect(tsBuild, "engine _ts-build task").not.toBeNull();
+    const body = tsBuild?.[0] ?? "";
+    expect(body).toMatch(
+      /fi\s*\n\s*: # no-op -- go-task <3\.52\.0 treats untaken last if\/fi as exit 1 \(#3381\)/,
+    );
+    expect(body).toMatch(/is-buildable-source/);
+    expect(body).not.toMatch(/is-buildable-source \|\| exit 0/);
+  });
+
   it("ts.yml routes monorepo scripts through Corepack-aware :engine:pm-run (#2410)", () => {
     const ts = readTask("ts.yml");
     expect(ts).toMatch(/:engine:pm-run/);

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -55,6 +55,7 @@ tasks:
           fi
           node "{{.TASKFILE_DIR}}/engine-pm-run.cjs" "{{.DEFT_ROOT}}" build --mark-warm
         fi
+        : # no-op -- go-task <3.52.0 treats untaken last if/fi as exit 1 (#3381)
 
   invoke:
     internal: true


### PR DESCRIPTION
## Summary

go-task before 3.52 treats an untaken last if/fi as script exit 1. engine:_ts-build still ended on that fi, so every non-runtime task deft:* failed on a consumer deposit.

This PR adds a trailing colon no-op after the outer fi. The consumer-deposit path still does not run pnpm / engine-pm-run build. The framework-source path still builds when stale and still skips when warm.

Authority: analysis + lock comment 5309667759.

## Related Issues

Closes #3381

## Checklist

- [x] /deft:change — N/A (2 files; not cross-cutting)
- [x] CHANGELOG.md — [Unreleased] Fixed
- [x] ROADMAP.md — N/A
- [x] Tests pass locally (pnpm exec vitest run packages/core/src/content-contracts; task check)

## Post-Merge

- [ ] Verify issue auto-close after squash merge
- [x] Branch protection already required
